### PR TITLE
Concatenate directly into shared memory when constructing batches for numpy

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -830,13 +830,13 @@ class TestDataLoader(TestCase):
         self.assertEqual(_utils.collate.default_collate([t_in]).is_shared(), False)
         self.assertEqual(_utils.collate.default_collate([n_in]).is_shared(), False)
 
-        old = torch.utils.data.dataloader._use_shared_memory
+        old = _utils.collate._use_shared_memory
         try:
-            torch.utils.data.dataloader._use_shared_memory = True
+            _utils.collate._use_shared_memory = True
             self.assertEqual(_utils.collate.default_collate([t_in]).is_shared(), True)
             self.assertEqual(_utils.collate.default_collate([n_in]).is_shared(), True)
         finally:
-            torch.utils.data.dataloader._use_shared_memory = old
+            _utils.collate._use_shared_memory = old
 
 
 class StringDataset(Dataset):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -827,14 +827,14 @@ class TestDataLoader(TestCase):
 
         self.assertEqual(t_in.is_shared(), False)
 
-        self.assertEqual(default_collate([t_in]).is_shared(), False)
-        self.assertEqual(default_collate([n_in]).is_shared(), False)
+        self.assertEqual(_utils.collate.default_collate([t_in]).is_shared(), False)
+        self.assertEqual(_utils.collate.default_collate([n_in]).is_shared(), False)
 
         old = torch.utils.data.dataloader._use_shared_memory
         try:
             torch.utils.data.dataloader._use_shared_memory = True
-            self.assertEqual(default_collate([t_in]).is_shared(), True)
-            self.assertEqual(default_collate([n_in]).is_shared(), True)
+            self.assertEqual(_utils.collate.default_collate([t_in]).is_shared(), True)
+            self.assertEqual(_utils.collate.default_collate([n_in]).is_shared(), True)
         finally:
             torch.utils.data.dataloader._use_shared_memory = old
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -819,6 +819,20 @@ class TestDataLoader(TestCase):
         arr = np.array([[[object(), object(), object()]]])
         self.assertRaises(TypeError, lambda: _utils.collate.default_collate(arr))
 
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_shared_tensor(self):
+        import unittest.mock
+        import numpy as np
+        t_in = torch.zeros(1)
+        n_in = np.zeros(1)
+
+        self.assertEqual(t_in.is_shared(), False)
+
+        self.assertEqual(default_collate([t_in]).is_shared(), False)
+        self.assertEqual(default_collate([n_in]).is_shared(), False)
+        with unittest.mock.patch('torch.utils.data.dataloader._use_shared_memory', True):
+            self.assertEqual(default_collate([t_in]).is_shared(), True)
+            self.assertEqual(default_collate([n_in]).is_shared(), True)
 
 class StringDataset(Dataset):
     def __init__(self):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -821,7 +821,6 @@ class TestDataLoader(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
     def test_default_collate_shared_tensor(self):
-        import unittest.mock
         import numpy as np
         t_in = torch.zeros(1)
         n_in = np.zeros(1)
@@ -830,9 +829,15 @@ class TestDataLoader(TestCase):
 
         self.assertEqual(default_collate([t_in]).is_shared(), False)
         self.assertEqual(default_collate([n_in]).is_shared(), False)
-        with unittest.mock.patch('torch.utils.data.dataloader._use_shared_memory', True):
+
+        old = torch.utils.data.dataloader._use_shared_memory
+        try:
+            torch.utils.data.dataloader._use_shared_memory = True
             self.assertEqual(default_collate([t_in]).is_shared(), True)
             self.assertEqual(default_collate([n_in]).is_shared(), True)
+        finally:
+            torch.utils.data.dataloader._use_shared_memory = old
+
 
 class StringDataset(Dataset):
     def __init__(self):

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -49,7 +49,7 @@ def default_collate(batch):
             if np_str_obj_array_pattern.search(elem.dtype.str) is not None:
                 raise TypeError(error_msg_fmt.format(elem.dtype))
 
-            return torch.stack([torch.from_numpy(b) for b in batch], 0)
+            return default_collate([torch.from_numpy(b) for b in batch])
         if elem.shape == ():  # scalars
             py_type = float if elem.dtype.name.startswith('float') else int
             return numpy_type_map[elem.dtype.name](list(map(py_type, batch)))


### PR DESCRIPTION
Since #1323 tensors are shared with shared memory, but this feature is not active for numpy.
This PR fix this.