### PR TITLE
Expunge use of type() in Distributions.cpp

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -130,7 +130,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);
     using self_t = scalar_t;
-    if (p_.type().scalarType() == kDouble) {
+    if (p_.scalar_type() == kDouble) {
       auto p = std::get<0>(expand_inplace(self, p_.to(kCPU)));
       CPU_tensor_apply2<self_t, double>(
         self, p, [generator](self_t& ret_val, double& p_val) {
@@ -189,7 +189,7 @@ Tensor _standard_gamma_grad_cpu(const Tensor& self, const Tensor& output) {
  */
 
 Tensor _s_poisson_cpu(const Tensor& lambda, Generator *gen) {
-  Tensor ret = at::zeros(lambda.sizes(), lambda.type());
+  Tensor ret = at::zeros(lambda.sizes(), lambda.options());
   AT_DISPATCH_FLOATING_TYPES(ret.type(), "poisson", [&] {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);
@@ -203,7 +203,7 @@ Tensor _s_poisson_cpu(const Tensor& lambda, Generator *gen) {
 }
 
 Tensor _s_gamma_cpu(const Tensor& alpha, Generator *gen) {
-  Tensor ret = at::zeros(alpha.sizes(), alpha.type());
+  Tensor ret = at::zeros(alpha.sizes(), alpha.options());
   AT_DISPATCH_FLOATING_TYPES(ret.type(), "gamma", [&] {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14421 Expunge direct device index handling from tensor_conversion_dispatch&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13221302/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14543 Expunge uses of type() from EmbeddingBag.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13257847/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14544 Expunge use of type() in Distributions.cpp**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13258252/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14545 Expunge occurrences of type() from scalar_test&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13258513/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14546 Expunge use of type() from SparseTensor.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13258512/)

Modern usage is options().  This doesn't have a functional
difference, because all call sites were CPU only (where
getting the device index right doesn't matter.)

Differential Revision: [D13258252](https://our.internmc.facebook.com/intern/diff/D13258252/)