### PR TITLE
Expunge occurrences of type() from scalar_test

### DIFF
--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -77,11 +77,11 @@ TEST(TestScalar, TestScalar) {
   ASSERT_EQ(t.strides()[0], 4);
   ASSERT_EQ(t.strides()[1], 1);
 
-  Type& T = CPU(Float);
-  Tensor x = randn({1, 10}, T);
-  Tensor prev_h = randn({1, 20}, T);
-  Tensor W_h = randn({20, 20}, T);
-  Tensor W_x = randn({20, 10}, T);
+  TensorOptions options = dtype(kFloat);
+  Tensor x = randn({1, 10}, options);
+  Tensor prev_h = randn({1, 20}, options);
+  Tensor W_h = randn({20, 20}, options);
+  Tensor W_x = randn({20, 10}, options);
   Tensor i2h = at::mm(W_x, x.t());
   Tensor h2h = at::mm(W_h, prev_h.t());
   Tensor next_h = i2h.add(h2h);
@@ -95,15 +95,15 @@ TEST(TestScalar, TestScalar) {
     auto r = CUDA(Float).copy(next_h);
     ASSERT_TRUE(CPU(Float).copy(r).equal(next_h));
   }
-  ASSERT_NO_THROW(randn({10, 10, 2}, T));
+  ASSERT_NO_THROW(randn({10, 10, 2}, options));
 
   // check Scalar.toTensor on Scalars backed by different data types
-  ASSERT_EQ(scalar_to_tensor(bar).type().scalarType(), kDouble);
-  ASSERT_EQ(scalar_to_tensor(what).type().scalarType(), kLong);
+  ASSERT_EQ(scalar_to_tensor(bar).scalar_type(), kDouble);
+  ASSERT_EQ(scalar_to_tensor(what).scalar_type(), kLong);
   ASSERT_EQ(
-      scalar_to_tensor(ones({})._local_scalar()).type().scalarType(), kDouble);
+      scalar_to_tensor(ones({})._local_scalar()).scalar_type(), kDouble);
 
-  if (x.type().scalarType() != ScalarType::Half) {
+  if (x.scalar_type() != ScalarType::Half) {
     AT_DISPATCH_ALL_TYPES(x.type(), "foo", [&] {
       scalar_t s = 1;
       std::stringstream ss;
@@ -116,10 +116,10 @@ TEST(TestScalar, TestScalar) {
 
   // test direct C-scalar type conversions
   {
-    auto x = ones({1, 2}, T);
+    auto x = ones({1, 2}, options);
     ASSERT_ANY_THROW(x.item<float>());
   }
-  auto float_one = ones({}, T);
+  auto float_one = ones({}, options);
   ASSERT_EQ(float_one.item<float>(), 1);
   ASSERT_EQ(float_one.item<int32_t>(), 1);
   ASSERT_EQ(float_one.item<at::Half>(), 1);


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14421 Expunge direct device index handling from tensor_conversion_dispatch&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13221302/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14543 Expunge uses of type() from EmbeddingBag.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13257847/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14544 Expunge use of type() in Distributions.cpp&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13258252/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14545 Expunge occurrences of type() from scalar_test**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13258513/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14546 Expunge use of type() from SparseTensor.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13258512/)

Self explanatory

Differential Revision: [D13258513](https://our.internmc.facebook.com/intern/diff/D13258513/)