### PR TITLE
Delete compiledWithMIOpen

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -125,10 +125,6 @@ bool CUDAHooks::compiledWithCuDNN() const {
   return AT_CUDNN_ENABLED();
 }
 
-bool CUDAHooks::compiledWithMIOpen() const {
-  return AT_ROCM_ENABLED();
-}
-
 bool CUDAHooks::supportsDilatedConvolutionWithCuDNN() const {
 #if AT_CUDNN_ENABLED()
   cudaDeviceProp* prop =

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -19,7 +19,6 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   Allocator* getPinnedMemoryAllocator() const override;
   void registerCUDATypes(Context*) const override;
   bool compiledWithCuDNN() const override;
-  bool compiledWithMIOpen() const override;
   bool supportsDilatedConvolutionWithCuDNN() const override;
   long versionCuDNN() const override;
   double batchnormMinEpsilonCuDNN() const override;

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -90,10 +90,6 @@ struct CAFFE2_API CUDAHooksInterface {
     return false;
   }
 
-  virtual bool compiledWithMIOpen() const {
-    return false;
-  }
-
   virtual bool supportsDilatedConvolutionWithCuDNN() const {
     return false;
   }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -124,7 +124,6 @@ auto ConvParams::use_cudnn(const at::Tensor& input) const -> bool {
 auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
 
   return ((input.type().scalarType() == at::kFloat) || (input.type().scalarType() == at::kHalf))
-         && detail::getCUDAHooks().compiledWithMIOpen()
          && input.is_cuda()
          && input.dim() <= MIOPEN_DIM_MAX
          && !(groups > 1 && is_dilated()) // MIOpen currently does not support dilation with groups of size > 1

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -269,7 +269,6 @@ Tensor batch_norm(
                && weight.defined() && bias.defined()
                && ((running_mean.defined() && running_var.defined())
                  || (!running_mean.defined() && !running_var.defined() && training))
-               && detail::getCUDAHooks().compiledWithMIOpen()
                );
 
   if (use_miopen) {


### PR DESCRIPTION
ROCm always comes with MIOpen, so there's no point in testing
for this.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

