### PR TITLE
[jit][nn] make register_parameter to simply set attr when value is None

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10061,6 +10061,18 @@ nn_functional_single_grad = frozenset('test_nn_' + name for name in [
 ])
 
 
+# additional modules test
+# TODO: delete this list once we make all nn_tests work
+additional_module_tests = [
+    dict(
+        module_name='BatchNorm1d',
+        constructor_args=(10, 1e-3, 0.3, False),
+        input_size=(4, 10),
+        desc='not_affine',
+    ),
+]
+
+
 def add_autograd_test(
         name,
         self_size,
@@ -10441,7 +10453,7 @@ for test in autograd_method_tests:
 for test in nn_functional_tests:
     add_nn_functional_test(*test)
 
-for test in module_tests + new_module_tests:
+for test in module_tests + new_module_tests + additional_module_tests:
     add_nn_module_test(**test)
 
 if __name__ == '__main__':

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -13,7 +13,7 @@ from ..._jit_internal import weak_module, weak_script_method
 @weak_module
 class _BatchNorm(Module):
     _version = 2
-    __constants__ = ['training', 'track_running_stats', 'momentum', 'eps']
+    __constants__ = ['training', 'track_running_stats', 'momentum', 'eps', 'weight', 'bias']
 
     def __init__(self, num_features, eps=1e-5, momentum=0.1, affine=True,
                  track_running_stats=True):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -144,7 +144,8 @@ class Module(object):
             raise KeyError("attribute '{}' already exists".format(name))
 
         if param is None:
-            self._parameters[name] = None
+            setattr(self, name, None)
+            # self._parameters[name] = None
         elif not isinstance(param, Parameter):
             raise TypeError("cannot assign '{}' object to parameter '{}' "
                             "(torch.nn.Parameter or None required)"

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -145,7 +145,6 @@ class Module(object):
 
         if param is None:
             setattr(self, name, None)
-            # self._parameters[name] = None
         elif not isinstance(param, Parameter):
             raise TypeError("cannot assign '{}' object to parameter '{}' "
                             "(torch.nn.Parameter or None required)"
@@ -553,7 +552,8 @@ class Module(object):
                 raise TypeError("cannot assign '{}' as parameter '{}' "
                                 "(torch.nn.Parameter or None expected)"
                                 .format(torch.typename(value), name))
-            self.register_parameter(name, value)
+            remove_from(self._parameters)
+            object.__setattr__(self, name, value)
         else:
             modules = self.__dict__.get('_modules')
             if isinstance(value, Module):


### PR DESCRIPTION
This PR is a proposal to change the behavior of `register_parameter`, instead of accepting `None` in `self._parameters` list, we simply set it to module attributes. In almost all uses of `self._parameters` None values are filtered out already. 

This is also used for jit to avoid parameter to be `Optional[Tensor]` for all parameters, otherwise we need to do every `is None` check and possibly unwraps before using the paramter. 