### PR TITLE
Put back linker flag for OpenMP to prevent build break on ppc64le

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -334,6 +334,7 @@ if(OPENMP_FOUND)
     message(STATUS "Compiling with OpenMP")
   endif()
   target_compile_options(torch INTERFACE ${OpenMP_CXX_FLAGS})
+  target_link_libraries(torch -fopenmp)
   #cmake only check for separate OpenMP library on AppleClang 7+
   #https://github.com/Kitware/CMake/blob/42212f7539040139ecec092547b7d58ef12a4d72/Modules/FindOpenMP.cmake#L252
   if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")


### PR DESCRIPTION
See #14539