### PR TITLE
Enable tests for CPU tensors in test_distributed.py

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -533,7 +533,6 @@ class _DistTestBase(object):
 
         self._barrier()
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_sum(self):
         group, group_id, rank = self._init_global_test()
@@ -565,7 +564,6 @@ class _DistTestBase(object):
             rank_to_GPU,
         )
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_product(self):
         group, group_id, rank = self._init_global_test()
@@ -579,19 +577,16 @@ class _DistTestBase(object):
             reduce((lambda x, y: x * y), [10] * (len(group) - 1), 2),
         )
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_min(self):
         group, group_id, rank = self._init_global_test()
         self._test_reduce_helper(group, group_id, rank, dist.ReduceOp.MIN, 1010, 1, 1)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_max(self):
         group, group_id, rank = self._init_global_test()
         self._test_reduce_helper(group, group_id, rank, dist.ReduceOp.MAX, -1, 10, 10)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     @skip_if_small_worldsize
     def test_reduce_group_sum(self):
@@ -606,7 +601,6 @@ class _DistTestBase(object):
             2 + (10 * (len(group) - 1)),
         )
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     @skip_if_small_worldsize
     def test_reduce_group_product(self):
@@ -621,21 +615,18 @@ class _DistTestBase(object):
             reduce((lambda x, y: x * y), [10] * (len(group) - 1), 2),
         )
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     @skip_if_small_worldsize
     def test_reduce_group_min(self):
         group, group_id, rank = self._init_group_test()
         self._test_reduce_helper(group, group_id, rank, dist.ReduceOp.MIN, 1010, 1, 1)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     @skip_if_small_worldsize
     def test_reduce_group_max(self):
         group, group_id, rank = self._init_group_test()
         self._test_reduce_helper(group, group_id, rank, dist.ReduceOp.MAX, -1, 10, 10)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_full_group_sum(self):
         group, group_id, rank = self._init_full_group_test()
@@ -649,7 +640,6 @@ class _DistTestBase(object):
             2 + (10 * (len(group) - 1)),
         )
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_full_group_product(self):
         group, group_id, rank = self._init_full_group_test()
@@ -663,13 +653,11 @@ class _DistTestBase(object):
             reduce((lambda x, y: x * y), [10] * (len(group) - 1), 2),
         )
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_full_group_min(self):
         group, group_id, rank = self._init_full_group_test()
         self._test_reduce_helper(group, group_id, rank, dist.ReduceOp.MIN, 1010, 1, 1)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support reduce")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_reduce_full_group_max(self):
         group, group_id, rank = self._init_full_group_test()
@@ -862,20 +850,17 @@ class _DistTestBase(object):
 
         self._barrier()
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support scatter")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support scatter")
     def test_scatter(self):
         group, group_id, rank = self._init_global_test()
         self._test_scatter_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support scatter")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support scatter")
     @skip_if_small_worldsize
     def test_scatter_group(self):
         group, group_id, rank = self._init_group_test()
         self._test_scatter_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support scatter")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support scatter")
     def test_scatter_full_group(self):
         group, group_id, rank = self._init_full_group_test()
@@ -896,20 +881,17 @@ class _DistTestBase(object):
 
         self._barrier()
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_gather(self):
         group, group_id, rank = self._init_global_test()
         self._test_gather_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     @skip_if_small_worldsize
     def test_gather_group(self):
         group, group_id, rank = self._init_group_test()
         self._test_gather_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_gather_full_group(self):
         group, group_id, rank = self._init_full_group_test()
@@ -933,7 +915,7 @@ class _DistTestBase(object):
 
         self._barrier()
 
-    @unittest.skipIf(BACKEND != "mpi", "Only MPI supports CPU all gather")
+    @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_all_gather(self):
         group, group_id, rank = self._init_global_test()
         self._test_all_gather_helper(group, group_id, rank)
@@ -948,13 +930,11 @@ class _DistTestBase(object):
         self._test_all_gather_helper(group, group_id, rank, True, rank_to_GPU)
 
     @skip_if_small_worldsize
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_all_gather_group(self):
         group, group_id, rank = self._init_group_test()
         self._test_all_gather_helper(group, group_id, rank)
 
-    @unittest.skipIf(BACKEND == "gloo", "Gloo does not support gather")
     @unittest.skipIf(BACKEND == "nccl", "Nccl does not support CPU tensors")
     def test_all_gather_full_group(self):
         group, group_id, rank = self._init_full_group_test()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1052,21 +1052,25 @@ def gather(tensor,
         if gather_list is None:
             raise RuntimeError("gather_list is a required argument in gather "
                                "destination")
+        input_tensors = [tensor]
+        output_tensors = [gather_list]
     else:
         if gather_list:
             raise RuntimeError("non-empty gather_list can be given only "
                                "to gather destination")
+        input_tensors = [tensor]
+        output_tensors = []
 
     opts = GatherOptions()
     opts.rootRank = dst
 
     if group == GroupMember.WORLD:
         _check_default_pg()
-        work = _default_pg.gather([gather_list], [tensor], opts)
+        work = _default_pg.gather(output_tensors, input_tensors, opts)
     else:
         group_dst_rank = _get_group_rank(group, dst)
         opts.rootRank = group_dst_rank
-        work = group.gather([gather_list], [tensor], opts)
+        work = group.gather(output_tensors, input_tensors, opts)
 
     if async_op:
         return work
@@ -1109,21 +1113,25 @@ def scatter(tensor,
         if scatter_list is None:
             raise RuntimeError("scatter_list is a required argument in "
                                "scatter source")
+        input_tensors = [scatter_list]
+        output_tensors = [tensor]
     else:
         if scatter_list:
             raise RuntimeError("non-empty can be given only to scatter "
                                "source")
+        input_tensors = []
+        output_tensors = [tensor]
 
     opts = ScatterOptions()
     opts.rootRank = src
 
     if group == GroupMember.WORLD:
         _check_default_pg()
-        work = _default_pg.scatter([tensor], [scatter_list], opts)
+        work = _default_pg.scatter(output_tensors, input_tensors, opts)
     else:
         group_src_rank = _get_group_rank(group, src)
         opts.rootRank = group_src_rank
-        work = group.scatter([tensor], [scatter_list], opts)
+        work = group.scatter(output_tensors, input_tensors, opts)
 
     if async_op:
         return work

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -477,10 +477,6 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
   }
   checkSingleTensor(inputTensors);
 
-  if (inputTensors.size() != 1) {
-    throw std::runtime_error("Gather: multi-GPU collective is not supported");
-  }
-
   if (groupRank_ != opts.rootRank) {
     if (outputTensors.size() > 0) {
       throw std::runtime_error(
@@ -549,10 +545,6 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
     return nullptr;
   }
   checkSingleTensor(outputTensors);
-
-  if (outputTensors.size() != 1) {
-    throw std::runtime_error("Scatter: multi-GPU collective is not supported");
-  }
 
   if (groupRank_ != opts.rootRank) {
     if (inputTensors.size() > 0) {

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -477,17 +477,20 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
   }
   checkSingleTensor(inputTensors);
 
-  if (outputTensors.size() != 1) {
+  if (inputTensors.size() != 1) {
     throw std::runtime_error("Gather: multi-GPU collective is not supported");
   }
 
   if (groupRank_ != opts.rootRank) {
-    if (outputTensors[0].size() > 0) {
+    if (outputTensors.size() > 0) {
       throw std::runtime_error(
           "Gather: number of output tensors should be 0 "
           "for non-root");
     }
   } else {
+    if (outputTensors.size() != 1) {
+      throw std::runtime_error("Gather: multi-GPU collective is not supported");
+    }
     if (static_cast<size_t>(groupSize_) != outputTensors[0].size()) {
       throw std::runtime_error(
           "Gather: number of output tensors should equal "
@@ -546,17 +549,21 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
     return nullptr;
   }
   checkSingleTensor(outputTensors);
-  if (inputTensors.size() != 1) {
+
+  if (outputTensors.size() != 1) {
     throw std::runtime_error("Scatter: multi-GPU collective is not supported");
   }
 
   if (groupRank_ != opts.rootRank) {
-    if (inputTensors[0].size() > 0) {
+    if (inputTensors.size() > 0) {
       throw std::runtime_error(
           "Scatter: number of input tensors should be 0 "
           "for non-root");
     }
   } else {
+    if (inputTensors.size() != 1) {
+      throw std::runtime_error("Scatter: multi-GPU collective is not supported");
+    }
     if (static_cast<size_t>(groupSize_) != inputTensors[0].size()) {
       throw std::runtime_error(
           "Scatter: number of input tensors should equal "


### PR DESCRIPTION
These were not enabled after adding support in the Gloo backend. The
argument checks in ProcessGroupGloo raised an error in two cases:

* If the input tensor list to scatter was ``[None]`` on processes other
  than the source process.
* If the output tensor list to gather was ``[None]`` on processes other
  than the destination process.

This commit prepares these arguments explicitly instead of boxing them
at the process group call site.

This fixes #14536.
