### PR TITLE
[REVIEW ONLY] Add AutogradMetaInterface and make AutogradMeta a subclass of it

### DIFF
--- a/aten/src/ATen/core/TensorImpl.cpp
+++ b/aten/src/ATen/core/TensorImpl.cpp
@@ -10,11 +10,19 @@
 namespace at {
 
 Tensor& TensorImpl::grad() {
-  AT_ERROR("grad is not implemented for Tensor");
+  if (autograd_meta()) {
+    return autograd_meta()->grad();
+  } else {
+    AT_ERROR("grad is not implemented for Tensor");
+  }
 }
 
 const Tensor& TensorImpl::grad() const {
-  AT_ERROR("grad is not implemented for Tensor");
+  if (autograd_meta()) {
+    return autograd_meta()->grad();
+  } else {
+    AT_ERROR("grad is not implemented for Tensor");
+  }
 }
 
 TensorImpl::TensorImpl(TensorTypeId type_id, const caffe2::TypeMeta& data_type, Allocator *allocator, bool is_variable)

--- a/aten/src/ATen/core/VariableHooksInterface.h
+++ b/aten/src/ATen/core/VariableHooksInterface.h
@@ -9,6 +9,16 @@ namespace at {
   struct Type;
 }
 
+namespace at {
+struct AutogradMetaInterface {
+  virtual void set_requires_grad(bool requires_grad) = 0;
+  virtual bool requires_grad() const = 0;
+  virtual Tensor& grad() = 0;
+  virtual const Tensor& grad() const = 0;
+  virtual ~AutogradMetaInterface() = 0;
+};
+}
+
 // NB: Registry class not actually in the namespace detail, due to limitations
 // of Registry.h
 namespace at {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -293,7 +293,7 @@ struct TORCH_API Variable : public at::Tensor {
 //                            Variable::AutogradMeta
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-struct TORCH_API Variable::AutogradMeta {
+struct TORCH_API Variable::AutogradMeta : public at::AutogradMetaInterface {
   std::string name;
 
   Variable grad_;
@@ -319,8 +319,6 @@ struct TORCH_API Variable::AutogradMeta {
   // state are still thread-safe. Used by grad_fn and
   // grad_accumulator.
   std::mutex mutex_;
-
-  virtual ~AutogradMeta() {}
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Currently, `set_requires_grad()`/`requires_grad()`/`grad()` work on Variable because we do the right dispatch to `data_` in VariableImpl's implementation of those functions. In the near future, we will be removing `data_` and VariableImpl, and TensorImpl needs to know how to handle those functions on its own (because there will no longer be a subclass of TensorImpl that handles them).

In this PR, we achieve this by introducing an `AutogradMetaInterface` class to ATen that contains stubs for `set_requires_grad()`/`requires_grad()`/`grad()`, and the autograd metadata pointer in TensorImpl is always of `AutogradMetaInterface` type, so that TensorImpl can directly call on those functions. The concrete implementations of those functions are in `AutogradMeta` which lives in variable.h.

This is the 4th PR mentioned in https://github.com/pytorch/pytorch/issues/13638, posting only for collecting reviews.