### PR TITLE
[TensorIterator reduction improvement for mixed-precision sum on GPU]

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -475,6 +475,7 @@ std::unique_ptr<TensorIterator> TensorIterator::reduce_op(Tensor& out, const Ten
   auto builder = TensorIterator::Builder();
   builder.add_output(out);
   builder.add_input(a);
+  builder.dont_compute_common_dtype();
   builder.iter_->resize_outputs_ = false;
   builder.iter_->is_reduction_ = true;
   return builder.build();

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -115,6 +115,13 @@ void TensorIterator::compute_types() {
             type.device_type() == kCUDA && op.tensor.type().device_type() == kCPU) {
           // don't cast CPU scalars in CUDA ops that directly support them
           op.type = &op.tensor.type();
+        } else if (promote_gpu_output_dtypes_ && op.tensor.defined() &&
+            !op.is_output && op.tensor.type().scalarType() == kHalf &&
+            type.scalarType() == kFloat && type.device_type() == kCUDA &&
+            op.tensor.type().device_type() == kCUDA) {
+          // allow input tensor type upcasting for fp16 to fp32 in fused kernel
+          // on GPU
+          op.type = &op.tensor.type();
         } else {
           op.type = &type;
         }
@@ -475,7 +482,7 @@ std::unique_ptr<TensorIterator> TensorIterator::reduce_op(Tensor& out, const Ten
   auto builder = TensorIterator::Builder();
   builder.add_output(out);
   builder.add_input(a);
-  builder.dont_compute_common_dtype();
+  builder.iter_->promote_gpu_output_dtypes_ = true;
   builder.iter_->resize_outputs_ = false;
   builder.iter_->is_reduction_ = true;
   return builder.build();

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -206,6 +206,9 @@ struct CAFFE2_API TensorIterator {
   /// reductions.
   bool should_accumulate() const { return accumulate_; }
 
+  /// If the kernel should promote the output type.
+  bool should_promote_output() const { return promote_output_types_; }
+
 protected:
   void mark_outputs();
   void compute_shape();
@@ -228,6 +231,7 @@ protected:
   bool is_reduction_ = false;
   bool compute_common_dtype_ = true;
   bool allow_cpu_scalars_ = false;
+  bool promote_output_types_ = false;
 };
 
 struct TensorIterator::Builder {
@@ -246,6 +250,10 @@ struct TensorIterator::Builder {
 
   void dont_compute_common_dtype() {
     iter_->compute_common_dtype_ = false;
+  }
+
+  void promote_output_types() {
+    iter_->promote_output_types_ = true;
   }
 
   void dont_resize_outputs() {

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -206,9 +206,6 @@ struct CAFFE2_API TensorIterator {
   /// reductions.
   bool should_accumulate() const { return accumulate_; }
 
-  /// If the kernel should promote the output type.
-  bool should_promote_output() const { return promote_output_types_; }
-
 protected:
   void mark_outputs();
   void compute_shape();

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -228,7 +228,7 @@ protected:
   bool is_reduction_ = false;
   bool compute_common_dtype_ = true;
   bool allow_cpu_scalars_ = false;
-  bool promote_output_types_ = false;
+  bool promote_gpu_output_dtypes_ = false;
 };
 
 struct TensorIterator::Builder {
@@ -247,10 +247,6 @@ struct TensorIterator::Builder {
 
   void dont_compute_common_dtype() {
     iter_->compute_common_dtype_ = false;
-  }
-
-  void promote_output_types() {
-    iter_->promote_output_types_ = true;
   }
 
   void dont_resize_outputs() {

--- a/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
@@ -11,9 +11,9 @@
 
 namespace at { namespace native {
 
-template <typename scalar_t, typename acc_t=scalar_t>
+template <typename scalar_t, typename acc_t=scalar_t, typename out_t=scalar_t>
 void sum_kernel_impl(TensorIterator& iter) {
-  gpu_reduce_kernel<scalar_t>(iter, []GPU_LAMBDA(acc_t a, acc_t b) -> acc_t {
+  gpu_reduce_kernel<scalar_t, out_t>(iter, []GPU_LAMBDA(acc_t a, acc_t b) -> acc_t {
     return a + b;
   });
 }
@@ -25,7 +25,7 @@ void sum_kernel_impl<int16_t, int16_t>(TensorIterator& iter) {
   // compiler segfaults:
   // https://bugs.llvm.org/show_bug.cgi?id=39602
   // To work around it, use int32 as the accumulate type.
-  gpu_reduce_kernel<int16_t>(iter, []GPU_LAMBDA(int32_t a, int32_t b) -> int32_t {
+  gpu_reduce_kernel<int16_t, int16_t>(iter, []GPU_LAMBDA(int32_t a, int32_t b) -> int32_t {
     return a + b;
   });
 }
@@ -33,7 +33,7 @@ void sum_kernel_impl<int16_t, int16_t>(TensorIterator& iter) {
 
 template <typename scalar_t, typename acc_t=scalar_t>
 void prod_kernel_impl(TensorIterator& iter) {
-  gpu_reduce_kernel<scalar_t>(iter, []GPU_LAMBDA(acc_t a, acc_t b) -> acc_t {
+  gpu_reduce_kernel<scalar_t, scalar_t>(iter, []GPU_LAMBDA(acc_t a, acc_t b) -> acc_t {
     return a * b;
   }, 1);
 }
@@ -41,6 +41,9 @@ void prod_kernel_impl(TensorIterator& iter) {
 static void sum_kernel_cuda(TensorIterator& iter) {
   if (iter.type().scalarType() == kHalf) {
     return sum_kernel_impl<at::Half, float>(iter);
+  } else if (iter.type(1).scalarType() == kHalf && iter.type().scalarType() == kFloat) {
+    // type promotion that does cast and reduction in a single kernel
+    return sum_kernel_impl<at::Half, float, float>(iter);
   }
   AT_DISPATCH_ALL_TYPES(iter.type(), "sum", [&]() {
     sum_kernel_impl<scalar_t>(iter);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1525,26 +1525,16 @@ class TestCuda(TestCase):
     def test_sum_cpu_gpu_mismatch(self):
         x = torch.randn(20, dtype=torch.float32, device='cuda')
         y = torch.randn(1, dtype=torch.float32)
-        try:
+        with self.assertRaisesRegex(RuntimeError, 'expected type'
+                                    ' torch.FloatTensor but got'
+                                    ' torch.cuda.FloatTensor'):
             torch.sum(x, dim=[0], dtype=torch.float32, out=y)
-            self.assertEqual(y, 20)
-        except RuntimeError as e:
-            reason = e.args[0]
-            if 'torch.FloatTensor' in reason and 'torch.cuda.FloatTensor' in reason:
-                pass
-            else:
-                raise(e)
         # makeing sure half to float promotion is also properly working.
         x = x.half()
-        try:
+        with self.assertRaisesRegex(RuntimeError, 'expected type'
+                                    ' torch.FloatTensor but got'
+                                    ' torch.cuda.HalfTensor'):
             torch.sum(x, dim=[0], dtype=torch.float32, out=y)
-            self.assertEqual(y, 20)
-        except RuntimeError as e:
-            reason = e.args[0]
-            if 'torch.FloatTensor' in reason and 'torch.cuda.HalfTensor' in reason:
-                pass
-            else:
-                raise(e)
 
     @skipIfRocm
     def test_sum_noncontig(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1522,6 +1522,16 @@ class TestCuda(TestCase):
         self.assertEqual(gpu_tensor0[0], 2)
 
     @skipIfRocm
+    def test_sum_cpu_gpu_mismatch(self):
+        x = torch.randn(20, device='cuda')
+        y = torch.randn(1)
+        try:
+          torch.sum(x, dim=[0], dtype=torch.float32, out=y)
+          self.assertEqual(y, 20)
+        except RuntimeError as e:
+          pass
+
+    @skipIfRocm
     def test_sum_noncontig(self):
         x = torch.randn(1, 75, 57, 20, device='cuda').permute(0, 3, 1, 2)
         y = x.cpu()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1526,25 +1526,25 @@ class TestCuda(TestCase):
         x = torch.randn(20, dtype=torch.float32, device='cuda')
         y = torch.randn(1, dtype=torch.float32)
         try:
-          torch.sum(x, dim=[0], dtype=torch.float32, out=y)
-          self.assertEqual(y, 20)
+            torch.sum(x, dim=[0], dtype=torch.float32, out=y)
+            self.assertEqual(y, 20)
         except RuntimeError as e:
-          reason = e.args[0]
-          if 'torch.FloatTensor' in reason and 'torch.cuda.FloatTensor' in reason:
-            pass
-          else:
-            raise(e)
+            reason = e.args[0]
+            if 'torch.FloatTensor' in reason and 'torch.cuda.FloatTensor' in reason:
+                pass
+            else:
+                raise(e)
         # makeing sure half to float promotion is also properly working.
         x = x.half()
         try:
-          torch.sum(x, dim=[0], dtype=torch.float32, out=y)
-          self.assertEqual(y, 20)
+            torch.sum(x, dim=[0], dtype=torch.float32, out=y)
+            self.assertEqual(y, 20)
         except RuntimeError as e:
-          reason = e.args[0]
-          if 'torch.FloatTensor' in reason and 'torch.cuda.HalfTensor' in reason:
-            pass
-          else:
-            raise(e)
+            reason = e.args[0]
+            if 'torch.FloatTensor' in reason and 'torch.cuda.HalfTensor' in reason:
+                pass
+            else:
+                raise(e)
 
     @skipIfRocm
     def test_sum_noncontig(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1523,13 +1523,28 @@ class TestCuda(TestCase):
 
     @skipIfRocm
     def test_sum_cpu_gpu_mismatch(self):
-        x = torch.randn(20, device='cuda')
-        y = torch.randn(1)
+        x = torch.randn(20, dtype=torch.float32, device='cuda')
+        y = torch.randn(1, dtype=torch.float32)
         try:
           torch.sum(x, dim=[0], dtype=torch.float32, out=y)
           self.assertEqual(y, 20)
         except RuntimeError as e:
-          pass
+          reason = e.args[0]
+          if 'torch.FloatTensor' in reason and 'torch.cuda.FloatTensor' in reason:
+            pass
+          else:
+            raise(e)
+        # makeing sure half to float promotion is also properly working.
+        x = x.half()
+        try:
+          torch.sum(x, dim=[0], dtype=torch.float32, out=y)
+          self.assertEqual(y, 20)
+        except RuntimeError as e:
+          reason = e.args[0]
+          if 'torch.FloatTensor' in reason and 'torch.cuda.HalfTensor' in reason:
+            pass
+          else:
+            raise(e)
 
     @skipIfRocm
     def test_sum_noncontig(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1536,6 +1536,7 @@ class TestCuda(TestCase):
 
         x = torch.ones(65504, device='cuda', dtype=torch.float16)
         self.assertEqual(x.sum(), 65504)
+        self.assertEqual(x.sum(dtype=torch.float32), 65504)
 
         a = torch.zeros(1203611).bernoulli_(0.0005)
         x = a.to(device='cuda', dtype=torch.float16)


### PR DESCRIPTION
Removes cast of half to float in torch.sum, with float16 input tensor and
float32 output tensor, instead we cast data when loading input in kernel.

This supposingly would save a kernel launch as well as a full global memory load
on promoted data type (float).

