### PR TITLE
Improve _get_next_net_name function to run at constant time

### DIFF
--- a/caffe2/python/core.py
+++ b/caffe2/python/core.py
@@ -1386,7 +1386,7 @@ def _recover_record_by_prefix(names, prefix=''):
 
 
 class Net(object):
-    _net_names_used = set()
+    _net_names_used = {}
     operator_registry_ = {}
 
     @staticmethod
@@ -1400,12 +1400,11 @@ class Net(object):
         name = basename = '/'.join(
             x for x in [Net.current_prefix(), basename] if x
         )
-        next_idx = 1
-        while name in Net._net_names_used:
-            name = basename + '_' + str(next_idx)
-            next_idx += 1
-        Net._net_names_used |= set([name])
-        return name
+        next_idx = Net._net_names_used.get(name, 0)
+        Net._net_names_used[name] = next_idx + 1
+        result = name if next_idx == 0 else name + '_' + str(next_idx)
+        Net._net_names_used[result] = 1
+        return result
 
     def __init__(self, name_or_proto):
         """


### PR DESCRIPTION
Summary:
Currently, the run-time complexity of _get_next_net_name function is O(N), where N is the number of time it is being called. Thus, the total time complexity of N calls would be O(N^2).  In scenarios where thousands of nets being generated, the execution will be really slow.

This change would improve the run-time complexity to o(1) by cashing the next_idx information in a dictionary. It preserves the existing behavior by always generating the same sequence of net names as before.

Differential Revision: D13248843
