### PR TITLE
[jit] Allow DCE to clean up some mutable ops

### DIFF
--- a/test/expect/TestScript.test_mutable_dce.expect
+++ b/test/expect/TestScript.test_mutable_dce.expect
@@ -1,0 +1,14 @@
+graph() {
+  %0 : int = prim::Constant[value=1]()
+  %1 : int[] = prim::Constant[value=[0, -1]]()
+  %2 : int = prim::Constant[value=0]()
+  %3 : int = prim::Constant[value=6]()
+  %4 : int = prim::Constant[value=2]()
+  %5 : int = prim::Constant[value=3]()
+  %6 : int[] = prim::ListConstruct(%4, %5)
+  %a.1 : Tensor = aten::rand(%6, %3, %2, %1)
+  %8 : int[] = prim::ListConstruct(%4, %5)
+  %9 : Tensor = aten::rand(%8, %3, %2, %1)
+  %a : Tensor = aten::add_(%a.1, %9, %0)
+  return (%a);
+}

--- a/test/expect/TestScript.test_mutable_dce_block.expect
+++ b/test/expect/TestScript.test_mutable_dce_block.expect
@@ -1,0 +1,30 @@
+graph() {
+  %0 : int = prim::Constant[value=1]()
+  %1 : int[] = prim::Constant[value=[0, -1]]()
+  %2 : int = prim::Constant[value=0]()
+  %3 : int = prim::Constant[value=6]()
+  %4 : int = prim::Constant[value=2]()
+  %5 : int = prim::Constant[value=3]()
+  %6 : int[] = prim::ListConstruct(%4, %5)
+  %a.1 : Tensor = aten::rand(%6, %3, %2, %1)
+  %8 : int[] = prim::ListConstruct(%4, %5)
+  %9 : Tensor = aten::rand(%8, %3, %2, %1)
+  %a.2 : Tensor = aten::add_(%a.1, %9, %0)
+  %11 : int[] = prim::ListConstruct(%4, %5)
+  %b.1 : Tensor = aten::rand(%11, %3, %2, %1)
+  %13 : int[] = prim::ListConstruct(%4, %5)
+  %14 : Tensor = aten::zeros(%13, %3, %2, %1)
+  %15 : Tensor = aten::gt(%a.2, %14)
+  %16 : bool = prim::TensorToBool(%15)
+  %b : Tensor = prim::If(%16)
+    block0() {
+      %18 : int[] = prim::ListConstruct(%4, %5)
+      %19 : Tensor = aten::rand(%18, %3, %2, %1)
+      %b.2 : Tensor = aten::add_(%b.1, %19, %0)
+      -> (%b.2)
+    }
+    block1() {
+      -> (%b.1)
+    }
+  return (%b);
+}

--- a/test/expect/TestScript.test_mutable_dce_graph_input.expect
+++ b/test/expect/TestScript.test_mutable_dce_graph_input.expect
@@ -1,0 +1,12 @@
+graph(%a.1 : Tensor) {
+  %1 : int = prim::Constant[value=1]()
+  %2 : int[] = prim::Constant[value=[0, -1]]()
+  %3 : int = prim::Constant[value=0]()
+  %4 : int = prim::Constant[value=6]()
+  %5 : int = prim::Constant[value=2]()
+  %6 : int = prim::Constant[value=3]()
+  %7 : int[] = prim::ListConstruct(%5, %6)
+  %8 : Tensor = aten::rand(%7, %4, %3, %2)
+  %a : Tensor = aten::add_(%a.1, %8, %1)
+  return ();
+}

--- a/test/expect/TestScript.test_mutable_dce_list.expect
+++ b/test/expect/TestScript.test_mutable_dce_list.expect
@@ -1,0 +1,17 @@
+graph(%a : Tensor) {
+  %1 : int = prim::Constant[value=1]()
+  %2 : int[] = prim::Constant[value=[0, -1]]()
+  %3 : int = prim::Constant[value=6]()
+  %4 : int = prim::Constant[value=0]()
+  %5 : int = prim::Constant[value=2]()
+  %6 : int = prim::Constant[value=3]()
+  %l : Tensor[] = prim::ListConstruct()
+  %8 : Tensor[] = aten::append(%l, %a)
+  %c.1 : Tensor = aten::select(%l, %4)
+  %10 : int[] = prim::ListConstruct(%5, %6)
+  %b : Tensor = aten::rand(%10, %3, %4, %2)
+  %12 : int[] = prim::ListConstruct(%5, %6)
+  %13 : Tensor = aten::rand(%12, %3, %4, %2)
+  %c : Tensor = aten::add_(%c.1, %13, %1)
+  return (%b);
+}

--- a/test/expect/TestScript.test_mutable_dce_loop.expect
+++ b/test/expect/TestScript.test_mutable_dce_loop.expect
@@ -1,0 +1,25 @@
+graph(%a : Tensor) {
+  %1 : int[] = prim::Constant[value=[0, -1]]()
+  %2 : int = prim::Constant[value=6]()
+  %i.1 : int = prim::Constant[value=0]()
+  %4 : int = prim::Constant[value=2]()
+  %5 : int = prim::Constant[value=3]()
+  %6 : int = prim::Constant[value=9223372036854775807]()
+  %7 : int = prim::Constant[value=1]()
+  %l : Tensor[] = prim::ListConstruct()
+  %9 : Tensor[] = aten::append(%l, %a)
+  %10 : int[] = prim::ListConstruct(%4, %5)
+  %b : Tensor = aten::rand(%10, %2, %i.1, %1)
+  %12 : bool = aten::lt(%i.1, %7)
+  %i : int = prim::Loop(%6, %12, %i.1)
+    block0(%14 : int, %15 : int) {
+      %c.1 : Tensor = aten::select(%l, %i.1)
+      %17 : int[] = prim::ListConstruct(%4, %5)
+      %18 : Tensor = aten::rand(%17, %2, %i.1, %1)
+      %c : Tensor = aten::add_(%c.1, %18, %7)
+      %i.2 : int = aten::add(%15, %7)
+      %21 : bool = aten::lt(%i.2, %7)
+      -> (%21, %i.2)
+    }
+  return (%b);
+}

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8864,6 +8864,68 @@ a")
 
         self.checkScript(fn, (torch.ones(2, 4, 2), torch.ones(2, 4, 2)))
 
+    def test_mutable_dce(self):
+        @torch.jit.script
+        def foo():
+            a = torch.rand(2, 3)
+            a += torch.rand(2, 3)
+            b = torch.rand(2, 3)
+            b += torch.rand(2, 3)
+            # b should be cleaned up but not a
+            return a
+
+        self.assertExpectedGraph(foo.graph)
+
+    def test_mutable_dce_block(self):
+        @torch.jit.script
+        def foo():
+            a = torch.rand(2, 3)
+            a += torch.rand(2, 3)
+            b = torch.rand(2, 3)
+            if bool(a > torch.zeros(2, 3)):
+                b += torch.rand(2, 3)
+                a += torch.rand(2, 3)
+            # a should be cleaned up but not b
+            return b
+
+        self.assertExpectedGraph(foo.graph)
+
+    def test_mutable_dce_graph_input(self):
+        @torch.jit.script
+        def foo(a):
+            a += torch.rand(2, 3)
+            # shouldn't clean up `a` even though it's not used in the output
+
+        self.assertExpectedGraph(foo.graph)
+
+    def test_mutable_dce_list(self):
+        @torch.jit.script
+        def foo(a):
+            l = []
+            l.append(a)
+            c = l[0]
+            b = torch.rand(2, 3)
+            c += torch.rand(2, 3)
+            return b
+
+        self.assertExpectedGraph(foo.graph)
+
+    def test_mutable_dce_loop(self):
+        @torch.jit.script
+        def foo(a):
+            l = []
+            l.append(a)
+            i = 0
+            b = torch.rand(2, 3)
+            while i < 1:
+                dead = torch.rand(2, 3)
+                c = l[0]
+                c += torch.rand(2, 3)
+                i += 1
+            return b
+
+        self.assertExpectedGraph(foo.graph)
+
 
 class MnistNet(nn.Module):
     def __init__(self):

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -96,7 +96,7 @@ void validateBlock(Block *b, onnx_torch::OperatorExportTypes operator_export_typ
 
 void validateGraph(const std::shared_ptr<Graph>& graph, onnx_torch::OperatorExportTypes operator_export_type) {
   validateBlock(graph->block(), operator_export_type);
-  EliminateDeadCode(graph);
+  EliminateDeadCode(graph->block());
 }
 
 class EncoderBase {

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -96,7 +96,7 @@ void initJITBindings(PyObject *module) {
    .def("_jit_pass_onnx_peephole", PeepholeOptimizeONNX)
    .def("_jit_pass_fuse", FuseGraph)
    .def("_jit_pass_dce", [](std::shared_ptr<Graph>& g) {
-     return EliminateDeadCode(g); // overload resolution
+     return EliminateDeadCode(g->block()); // overload resolution
    })
    .def("_jit_pass_cse", [](std::shared_ptr<Graph>& g) {
      return EliminateCommonSubexpression(g); // overload resolution

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -599,6 +599,7 @@ public:
   enum class MoveSide { BEFORE, AFTER };
   bool tryMove(Node* movePoint, MoveSide moveSide, const AliasDb& aliasDb, bool dryRun);
   void move(Node* movePoint, MoveSide moveSide);
+  bool isBeforeOrAfter(const Node* n, MoveSide moveSide) const;
 
   std::pair<Value*, const Argument&> findInput(Symbol name);
   void findSchema() const;
@@ -807,6 +808,12 @@ public:
   const_graph_node_list nodes() const {
     const auto & block = *block_;
     return block.nodes();
+  }
+  Node * param_node() {
+    return block_->param_node();
+  }
+  const Node * param_node() const {
+    return block_->param_node();
   }
   Node * return_node() {
     return block_->return_node();

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -26,15 +26,20 @@ namespace jit {
  */
 class AliasDb {
  public:
-  AliasDb(std::shared_ptr<Graph> graph) : graph_(graph) {
-    analyze(graph_);
-  }
+  explicit AliasDb(std::shared_ptr<Graph> graph);
 
-  // Does `n` contain any wildcard aliases?
+  // Does `n` use or write to any wildcard aliases?
   bool hasWildcard(const Node* n) const;
+
+  const std::unordered_set<const Node*>& getWildcardNodes() const {
+    return wildcardNodes_;
+  }
 
   // Does `n` write to any alias sets?
   bool hasWrites(Node* n) const;
+
+  // Does `n` write to a value that may alias one of the graph inputs?
+  bool writesToInputAlias(Node* n) const;
 
   // Get all nodes that write to any alias set inputed/outputed by `n`
   std::unordered_set<Node*> getWritersForNode(const Node* n) const;
@@ -60,19 +65,25 @@ class AliasDb {
   void analyzeChunk(Node* node);
   void analyzeBroadcastingChunk(Node* node);
 
-  Symbol getFreshAlias() const;
+  Symbol getFreshAlias(bool isGraphInput = false);
   void addAlias(const Value* value, AliasInfo alias);
   void addAlias(const Value* value, Symbol alias);
   void addAlias(const Value* value, const Value* from);
   void mapAliases(at::ArrayRef<Value*> to, at::ArrayRef<Value*> from);
   void giveFreshAlias(const Value* value);
 
+  bool hasUsesAfter(Symbol alias, const Node* n) const;
+  void buildWildcardIndex(const Block* b);
+  bool hasWildcardImpl(const Node* n) const;
   bool writesTo(Node* n, const Value* v) const;
 
   std::shared_ptr<Graph> graph_;
-  mutable Symbol latestSymbol_ = Symbol::fromQualString("alias::0");
+  Symbol latestSymbol_ = Symbol::fromQualString("alias::0");
   std::unordered_map<const Value*, AliasInfo> valueToAlias_;
+  std::unordered_map<Symbol, std::unordered_set<const Value*>> aliasToValue_;
   std::unordered_map<Symbol, std::unordered_set<Node*>> aliasToWrites_;
+  std::unordered_set<const Node*> wildcardNodes_;
+  std::unordered_set<Symbol> graphInputAliases_;
 };
 
 inline TORCH_API AliasDb AliasAnalysis(std::shared_ptr<Graph> graph) {

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -24,7 +24,7 @@ void EliminateCommonSubexpression(
   for (auto it = block->nodes().begin(); it != block->nodes().end(); ++ it) {
     auto node = *it;
     if (node->kind() == prim::PythonOp || node->kind() == prim::Print ||
-        aliasDb.hasWriters(node)) {
+        aliasDb.hasWriters(node) || aliasDb.hasWildcard(node)) {
       // Do NOT have enough information to do CSE on these nodes.
       continue;
     }

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -125,7 +125,7 @@ void ConstantPropagation(Node* n, const AliasDb& aliasDb, bool recurse) {
       });
   bool supported_node = !n->kind().is_onnx() &&
       skip_list.count(n->kind()) == 0 && !n->isNondeterministic() &&
-      !aliasDb.hasWriters(n);
+      !aliasDb.hasWriters(n) && !aliasDb.hasWildcard(n);
   auto run_blocks = [&]() {
     if (recurse) {
       for (Block * block : n->blocks()) {

--- a/torch/csrc/jit/passes/dead_code_elimination.h
+++ b/torch/csrc/jit/passes/dead_code_elimination.h
@@ -4,6 +4,12 @@
 
 namespace torch { namespace jit {
 
+// If given a top-level graph, DCE will construct do alias analysis that allows
+// for "smarter" dead code elimination (we will eliminate mutable ops if we can
+// prove the mutated values are not used). Otherwise, we will not allow DCE to
+// eliminate mutable ops.
+//
+// So, prefer to use the graph version if you can.
 TORCH_API void EliminateDeadCode(const std::shared_ptr<Graph>& graph);
 TORCH_API void EliminateDeadCode(Block *block, bool recurse=true);
 

--- a/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
@@ -2,53 +2,51 @@
 
 #include "torch/csrc/jit/ir.h"
 #include "torch/csrc/jit/passes/dead_code_elimination.h"
+#include "torch/csrc/jit/passes/utils/subgraph_utils.h"
 
-namespace torch { namespace jit {
+namespace torch {
+namespace jit {
 
 namespace {
 
-bool canRunWithAutograd(Node *node) {
+bool canRunWithAutograd(Node* node) {
   return node->kind() != prim::FusionGroup;
 }
 
-void inlineNode(Node *node) {
-  WithInsertPoint insert_guard { node };
-  Graph * graph = node->owningGraph();
+void InlineAutodiffSubgraphs(Block* block, size_t threshold);
+
+graph_node_list::iterator scanNode(Node* node, size_t threshold) {
+  auto next_node = ++node->iterator();
+
+  for (Block* block : node->blocks()) {
+    InlineAutodiffSubgraphs(block, threshold);
+  }
+
+  if (node->kind() != prim::DifferentiableGraph) {
+    return next_node;
+  }
+
   auto subgraph = node->g(attr::Subgraph);
-  std::unordered_map<Value*, Value*> input_map;
-
-  size_t num_inputs = node->inputs().size();
-  JIT_ASSERT(num_inputs == subgraph->inputs().size());
-  for (size_t i = 0; i < num_inputs; ++i) {
-    input_map[subgraph->inputs()[i]] = node->inputs()[i];
+  int64_t subgraph_size =
+      std::distance(subgraph->nodes().begin(), subgraph->nodes().end());
+  if (subgraph_size >= static_cast<int64_t>(threshold)) {
+    return next_node;
   }
 
-  for (Node * subnode : subgraph->nodes()) {
-    Node * new_node = graph->insertNode(graph->createClone(subnode, [&](Value * v) { return input_map.at(v); }));
-    for (size_t i = 0; i < subnode->outputs().size(); ++i) {
-      input_map[subnode->output(i)] = new_node->output(i);
-    }
+  if (!std::all_of(
+          subgraph->nodes().begin(),
+          subgraph->nodes().end(),
+          canRunWithAutograd)) {
+    return next_node;
   }
 
-  size_t num_outputs = node->outputs().size();
-  JIT_ASSERT(num_outputs <= subgraph->outputs().size() &&
-             num_outputs == static_cast<size_t>(node->i(attr::f_real_outputs)));
-  for (size_t i = 0; i < num_outputs; ++i) {
-    node->output(i)->replaceAllUsesWith(input_map.at(subgraph->outputs()[i]));
-  }
+  SubgraphUtils::unmergeSubgraph(node);
+  return next_node;
 }
 
-void InlineAutodiffSubgraphs(Block *block, size_t threshold) {
-  for (Node * node : block->nodes()) {
-    for (Block * block : node->blocks()) {
-      InlineAutodiffSubgraphs(block, threshold);
-    }
-    if (node->kind() != prim::DifferentiableGraph) continue;
-    auto subgraph = node->g(attr::Subgraph);
-    int64_t subgraph_size = std::distance(subgraph->nodes().begin(), subgraph->nodes().end());
-    if (subgraph_size >= static_cast<int64_t>(threshold)) continue;
-    if (!std::all_of(subgraph->nodes().begin(), subgraph->nodes().end(), canRunWithAutograd)) continue;
-    inlineNode(node);
+void InlineAutodiffSubgraphs(Block* block, size_t threshold) {
+  for (auto it = block->nodes().begin(); it != block->nodes().end();) {
+    it = scanNode(*it, threshold);
   }
 }
 
@@ -59,4 +57,5 @@ void InlineAutodiffSubgraphs(std::shared_ptr<Graph>& graph, size_t threshold) {
   EliminateDeadCode(graph);
 }
 
-}} // namespace torch::jit
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -157,7 +157,7 @@ static void EnsureNoTuples(Block* block) {
 
 void LowerAllTuples(std::shared_ptr<Graph>& graph) {
   LowerAllTuples(graph->block());
-  EliminateDeadCode(graph);
+  EliminateDeadCode(graph->block());
   EnsureNoTuples(graph->block());
 }
 

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -206,7 +206,7 @@ class ShapePropagator {
         std::any_of(writers.cbegin(), writers.cend(), [&](const Node* writer) {
           return writer->isBefore(node);
         });
-    if (hasWritersBefore) {
+    if (hasWritersBefore || aliasDb_.hasWildcard(node)) {
       // If something could have written to a value used by this node, we can't
       // guarantee the result is the same when running it in isolation.
       dependsOnMutationMemo_[node] = true;
@@ -702,7 +702,6 @@ class ShapePropagator {
           return {};
         }};
 
- 
     static const auto any_tensor_type = [](Node* node) -> TensorTypePtr {
       for (Value* input : node->inputs()) {
         if (auto type = input->type()->cast<TensorType>()) {

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -57,7 +57,8 @@ std::vector<Node*> unmergeSubgraph(Node* subgraphNode) {
 
   // Replace uses of group outputs and destroy the group
   const auto subgraphOutputs = subgraph->outputs();
-  for (size_t i = 0; i < subgraphOutputs.size(); ++i) {
+  JIT_ASSERT(subgraphOutputs.size() >= subgraphNode->outputs().size());
+  for (size_t i = 0; i < subgraphNode->outputs().size(); ++i) {
     const auto outerOutput = innerToOuter.at(subgraphOutputs[i]);
     subgraphNode->outputs()[i]->replaceAllUsesWith(outerOutput);
   }


### PR DESCRIPTION
This PR makes DCE a little smarter in the presence of mutable ops. Previously mutable ops could never be cleaned up, now they can be cleaned up if we can prove there are no live uses of any alias sets that the op writes to.

This behavior is optional; if you pass DCE a block instead of a graph, it will do the same thing as before. Also changed `InlineAutographSubgraph` to use the common subgraph utils.

Tested on traced ResNet, and it gets rid of the dead code.