### PR TITLE
[DataLoader] add method to get related info (e.g., dataset) in worker  

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -7,6 +7,7 @@ torch.utils.data
 .. autoclass:: ConcatDataset
 .. autoclass:: Subset
 .. autoclass:: DataLoader
+.. autofunction:: torch.utils.data.get_worker_info
 .. autofunction:: torch.utils.data.random_split
 .. autoclass:: torch.utils.data.Sampler
 .. autoclass:: torch.utils.data.SequentialSampler

--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -1,4 +1,4 @@
 from .sampler import Sampler, SequentialSampler, RandomSampler, SubsetRandomSampler, WeightedRandomSampler, BatchSampler
 from .distributed import DistributedSampler
 from .dataset import Dataset, TensorDataset, ConcatDataset, Subset, random_split
-from .dataloader import DataLoader
+from .dataloader import DataLoader, get_worker_info

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -13,6 +13,8 @@ import threading
 from torch._six import queue
 
 
+get_worker_info = _utils.worker.get_worker_info
+
 # This function used to be defined in this file. However, it was moved to
 # _utils/collate.py. Although it is rather hard to access this from user land
 # (one has to explicitly directly `import torch.utils.data.dataloader`), there


### PR DESCRIPTION
This is now based on top of #15331 . Please only review the last commit.

Add `torch.utils.data.get_worker_info`. I'm copying the docstring here
```
    Returns the information about the current
    :class:`~torch.utils.data.DataLoader` iterator worker process.
     When called in a worker, this returns an object guaranteed to have the
    following attributes:

    * :attr:`id`: the current worker id.
    * :attr:`seed`: the random seed set for the current worker. This value is
      determined by main process RNG and the worker id. See
      :class:`torch.utils.data.DataLoader`'s documentation for more details.
    * :attr:`dataset`: the copy of the dataset object in **this** process. Note
      that this will be a different object in a different process than the one
      in main process.

     When called in the main process, this returns ``None``.

     .. note::
        When used in a :attr:`worker_init_fn` passed over to
        :class:`~torch.utils.data.DataLoader`, this method can be useful to
        set up each worker process differently. E.g., the :attr:`worker_init_fn`
        can use the worker ``id`` to configure the ``dataset`` object to only
        read a specific fraction of a sharded dataset.
```

Issue:  #13023, ``More Flexible `worker_init_fn` ``