### PR TITLE
Remove methods from _th_triu_ and _th_addcmul_.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2162,6 +2162,8 @@
 [[
   name: _th_triu_
   cname: triu
+  variants:
+    - function
   return: self
   arguments:
     - THTensor* self
@@ -2473,6 +2475,7 @@
         - THTensor* tensor1
         - THTensor* tensor2
     - cname: spaddcmul
+      variants: function
       return: argument 0
       arguments:
         - THTensor* self

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -269,7 +269,6 @@ public:
 
   //example
   //Tensor * add(Tensor & b);
-  Tensor & _th_triu_(int64_t diagonal=0);
   Tensor abs() const;
   Tensor & abs_();
   Tensor acos() const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -57,9 +57,6 @@ inline void Tensor::set_data(Tensor new_data) {
 }
 
 // all static inline to allow for inlining of the non-dynamic part of dispatch
-inline Tensor & Tensor::_th_triu_(int64_t diagonal) {
-    return type()._th_triu_(*this, diagonal);
-}
 inline Tensor Tensor::abs() const {
     return type().abs(*this);
 }

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -174,9 +174,6 @@ struct CAFFE2_API Type {
 
   // example
   // virtual Tensor * add(Tensor & a, Tensor & b) = 0;
-  virtual Tensor & _th_triu_(Tensor & self, int64_t diagonal) const = 0;
-  virtual Tensor & s__th_addcmul_(Tensor & self, const Tensor & tensor1, const Tensor & tensor2, Scalar value) const = 0;
-  virtual Tensor & _th_addcmul_(Tensor & self, const Tensor & tensor1, const Tensor & tensor2, Scalar value) const = 0;
   virtual Tensor abs(const Tensor & self) const = 0;
   virtual Tensor & abs_(Tensor & self) const = 0;
   virtual Tensor acos(const Tensor & self) const = 0;

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -134,7 +134,7 @@ Tensor & tril_(Tensor& self, int64_t diagonal) {
 }
 
 Tensor & triu_(Tensor& self, int64_t diagonal) {
-  return self._th_triu_(diagonal);
+  return at::_th_triu_(self, diagonal);
 }
 
 Tensor & digamma_(Tensor& self) {


### PR DESCRIPTION
These somehow slipped through when we moved all of Declarations.cwrap to functions.

