### PR TITLE
Add EmptyNameScope to allow you jump out from current scope.

### DIFF
--- a/caffe2/python/scope.py
+++ b/caffe2/python/scope.py
@@ -87,6 +87,23 @@ def DeviceScope(scope, node_name=None):
 
 
 @contextlib.contextmanager
+def EmptyNameScope():
+    """
+    Allow users to 'disable' the name scope behaviour.
+
+    This sets the CurrentNameScope() to None, so that the field is
+    not set in CreateOperator(...), etc.
+    """
+    old_scope = CurrentNameScope()
+    try:
+        _threadlocal_scope.namescope = ''
+        yield
+    finally:
+        _threadlocal_scope.namescope = old_scope
+        return
+
+
+@contextlib.contextmanager
 def EmptyDeviceScope():
     """
     Allow users to 'disable' the device scope behaviour (so it can be

--- a/caffe2/python/scope_test.py
+++ b/caffe2/python/scope_test.py
@@ -55,6 +55,14 @@ class TestScope(unittest.TestCase):
 
         self.assertEquals(scope.CurrentNameScope(), "")
 
+    def testEmptyNamescopeBasic(self):
+        self.assertEquals(scope.CurrentNameScope(), "")
+
+        with scope.NameScope("test_scope"):
+            with scope.EmptyNameScope():
+                self.assertEquals(scope.CurrentNameScope(), "")
+            self.assertEquals(scope.CurrentNameScope(), "test_scope/")
+
     def testDevicescopeBasic(self):
         self.assertEquals(scope.CurrentDeviceScope(), None)
 


### PR DESCRIPTION
Summary:
adding a empty name scope to allow people jump out from current namescope.

This could be useful when you want to access blob from parent or sibling scope.
