### PR TITLE
Revert existing no_grad_embedding_renorm_ from aten

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -309,7 +309,6 @@ _(aten, embedding_backward) \
 _(aten, embedding_bag) \
 _(aten, embedding_dense_backward) \
 _(aten, embedding_renorm) \
-_(aten, no_grad_embedding_renorm) \
 _(aten, embedding_sparse_backward) \
 _(aten, empty) \
 _(aten, empty_like) \

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -178,13 +178,5 @@ Tensor & embedding_renorm_cpu_(
   return self;
 }
 
-// This is a workaround to not being able to call with.no_grad():
-// in script. No derivatives are set when calling no_grad_embedding_renorm_cpu_
-// TODO: remove when script supports set_grad_enabled
-Tensor & no_grad_embedding_renorm_cpu_(
-    Tensor & self, const Tensor & indices, double max_norm, double norm_type) {
-  return embedding_renorm_cpu_(self, indices, max_norm, norm_type);
-}
-
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -385,12 +385,5 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   return self;
 }
 
-// This is a workaround to not being able to call with.no_grad():
-// in script. No derivatives are set when calling no_grad_embedding_renorm_cuda_
-// TODO: remove when script supports set_grad_enabled
-Tensor & no_grad_embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
-                                double max_norm, double norm_type) {
-  return embedding_renorm_cuda_(self, indices, max_norm, norm_type);
-}
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -639,11 +639,6 @@
     CPU: embedding_renorm_cpu_
     CUDA: embedding_renorm_cuda_
 
-- func: no_grad_embedding_renorm_(Tensor self, IndexTensor indices, double max_norm, double norm_type) -> Tensor
-  dispatch:
-    CPU: no_grad_embedding_renorm_cpu_
-    CUDA: no_grad_embedding_renorm_cuda_
-
 - func: embedding_sparse_backward(Tensor grad, IndexTensor indices, int64_t num_weights, int64_t padding_idx, bool scale_grad_by_freq) -> Tensor
 
 # NOTE [ embedding_bag Native Functions ]

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -898,9 +898,6 @@
 - name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
   self: not_implemented("embedding_renorm")
 
-- name: no_grad_embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
-  output_differentiability: [False, False, False, False]
-
 - name: kl_div(Tensor self, Tensor target, int64_t reduction)
   self: kl_div_backward(grad, self, target, reduction)
   target: kl_div_target_backward(grad, self, target, reduction)

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -1,6 +1,7 @@
 #include "torch/csrc/autograd/profiler.h"
 #include "torch/csrc/jit/custom_operator.h"
 #include "torch/csrc/jit/operator.h"
+#include "torch/csrc/api/include/torch/utils.h"
 #include "../ATen/ExpandUtils.h"
 
 #include <sstream>
@@ -94,7 +95,27 @@ RegisterOperators reg({
             push(stack, at::infer_size(a, b));
             return 0;
           };
-        })
+        }),
+    Operator(
+      "aten::no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor",
+      [](const Node* node) {
+        return [](Stack& stack) {
+          at::Tensor weight;
+          at::Tensor input;
+          double max_norm;
+          double norm_type;
+          pop(stack, weight, input, max_norm, norm_type);
+
+          // TODO: remove when script supports setting grad mode
+          torch::NoGradGuard no_grad;
+
+          at::Tensor result = at::embedding_renorm_(weight, input, max_norm, norm_type);
+          push(stack, result);
+
+          return 0;
+        };
+      }),
+
 });
 }
 } // namespace jit

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -97,7 +97,7 @@ RegisterOperators reg({
           };
         }),
     Operator(
-      "aten::no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor",
+      "aten::_no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor",
       [](const Node* node) {
         return [](Stack& stack) {
           at::Tensor weight;

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1387,7 +1387,7 @@ def _get_builtin_table():
     _builtin_table[id(_unwrap_optional)] = "aten::_unwrap_optional"
     _builtin_table[id(cudnn.is_acceptable)] = "aten::cudnn_is_acceptable"
     _builtin_table[id(torch._C._infer_size)] = "aten::_infer_size"
-    _builtin_table[id(torch.nn.functional.no_grad_embedding_renorm_)] = "aten::no_grad_embedding_renorm_"
+    _builtin_table[id(torch.nn.functional._no_grad_embedding_renorm_)] = "aten::_no_grad_embedding_renorm_"
 
     return _builtin_table
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1387,6 +1387,7 @@ def _get_builtin_table():
     _builtin_table[id(_unwrap_optional)] = "aten::_unwrap_optional"
     _builtin_table[id(cudnn.is_acceptable)] = "aten::cudnn_is_acceptable"
     _builtin_table[id(torch._C._infer_size)] = "aten::_infer_size"
+    _builtin_table[id(torch.nn.functional.no_grad_embedding_renorm_)] = "aten::no_grad_embedding_renorm_"
 
     return _builtin_table
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1345,6 +1345,12 @@ def bilinear(input1, input2, weight, bias=None):
     return torch.bilinear(input1, input2, weight, bias)
 
 
+def no_grad_embedding_renorm_(weight, input, max_norm, norm_type):
+    # type: (Tensor, Tensor, float, float) -> Tensor
+    with torch.no_grad():
+        return torch.embedding_renorm_(weight, input, max_norm, norm_type)
+
+
 @torch._jit_internal.weak_script
 def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2.,
               scale_grad_by_freq=False, sparse=False):
@@ -1425,7 +1431,7 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2.,
         # with torch.no_grad():
         #   torch.nembedding_renorm_
         # remove once script supports set_grad_enabled
-        torch.no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
+        no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
     return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
 
 
@@ -1555,7 +1561,7 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
         # with torch.no_grad():
         #   torch.nembedding_renorm_
         # remove once script supports set_grad_enabled
-        torch.no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
+        no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
 
     ret, _, _, _ = torch.embedding_bag(
         weight,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1345,7 +1345,7 @@ def bilinear(input1, input2, weight, bias=None):
     return torch.bilinear(input1, input2, weight, bias)
 
 
-def no_grad_embedding_renorm_(weight, input, max_norm, norm_type):
+def _no_grad_embedding_renorm_(weight, input, max_norm, norm_type):
     # type: (Tensor, Tensor, float, float) -> Tensor
     with torch.no_grad():
         return torch.embedding_renorm_(weight, input, max_norm, norm_type)
@@ -1431,7 +1431,7 @@ def embedding(input, weight, padding_idx=None, max_norm=None, norm_type=2.,
         # with torch.no_grad():
         #   torch.nembedding_renorm_
         # remove once script supports set_grad_enabled
-        no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
+        _no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
     return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
 
 
@@ -1561,7 +1561,7 @@ def embedding_bag(input, weight, offsets=None, max_norm=None, norm_type=2,
         # with torch.no_grad():
         #   torch.nembedding_renorm_
         # remove once script supports set_grad_enabled
-        no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
+        _no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
 
     ret, _, _, _ = torch.embedding_bag(
         weight,


### PR DESCRIPTION
Remove no_grad_embedding_renorm_ from aten. Setting the derivatives of the inputs to false has different semantics from calling with no_grad(), because it will not error if an input is modified and then has it's grad accessed. 

Instead, make a custom op, and use NoGradGuard. 