### PR TITLE
Move global-constructor to lazily initialized (mobile restriction)

### DIFF
--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -135,7 +135,7 @@ struct CAFFE2_API Type {
     return backendToDeviceType(backend());
   }
 
-  virtual Tensor copy(const Tensor & src, bool non_blocking=false, optional<Device> to_device={}) const = 0;
+  virtual Tensor copy(const Tensor & src, bool non_blocking=false, c10::optional<Device> to_device={}) const = 0;
   virtual Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const = 0;
 
   virtual void backward(

--- a/aten/src/ATen/core/interned_strings.cpp
+++ b/aten/src/ATen/core/interned_strings.cpp
@@ -13,6 +13,11 @@
 
 namespace c10 {
 
+const std::string& domain_prefix() {
+  static const std::string _domain_prefix = "org.pytorch.";
+  return _domain_prefix;
+}
+
 Symbol InternedStrings::symbol(const std::string& s) {
   std::lock_guard<std::mutex> guard(mutex_);
   return _symbol(s);
@@ -103,17 +108,17 @@ Symbol Symbol::ns() const {
 }
 
 std::string Symbol::domainString() const {
-  return domain_prefix + ns().toUnqualString();
+  return domain_prefix() + ns().toUnqualString();
 }
 
 Symbol Symbol::fromDomainAndUnqualString(const std::string & d, const std::string & s) {
-  if (d.compare(0, domain_prefix.size(), domain_prefix) != 0) {
+  if (d.compare(0, domain_prefix().size(), domain_prefix()) != 0) {
     std::ostringstream ss;
     ss << "Symbol: domain string is expected to be prefixed with '"
-       << domain_prefix << "', e.g. 'org.pytorch.aten'";
+       << domain_prefix() << "', e.g. 'org.pytorch.aten'";
     throw std::runtime_error(ss.str());
   }
-  std::string qualString = d.substr(domain_prefix.size()) + "::" + s;
+  std::string qualString = d.substr(domain_prefix().size()) + "::" + s;
   return fromQualString(qualString);
 }
 

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -183,7 +183,7 @@ namespace c10 {
 
 using unique_t = uint32_t;
 
-static const std::string domain_prefix = "org.pytorch.";
+const std::string& domain_prefix();
 
 // A Symbol is like an interned string, but with a little extra
 // structure; it is namespaced via SymbolNamespace and the resulting

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -106,7 +106,7 @@ struct CAFFE2_API Type {
     return backendToDeviceType(backend());
   }
 
-  virtual Tensor copy(const Tensor & src, bool non_blocking=false, optional<Device> to_device={}) const = 0;
+  virtual Tensor copy(const Tensor & src, bool non_blocking=false, c10::optional<Device> to_device={}) const = 0;
   virtual Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking=false) const = 0;
 
   virtual void backward(


### PR DESCRIPTION
Summary: this fixes the build for mobile

Differential Revision: D13267458
