### PR TITLE
[JIT] apply() for ScriptModules

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5425,6 +5425,114 @@ a")
         with self.assertRaisesRegex(RuntimeError, "did you forget to add it __constants__"):
             M()
 
+    class DerivedStateModule(torch.jit.ScriptModule):
+        def __init__(self):
+            super(TestScript.DerivedStateModule, self).__init__()
+            self.param = torch.nn.Parameter(torch.ones(3, 4, dtype=torch.float))
+            self.register_buffer('derived', torch.neg(self.param).detach())
+
+            # This is a flag so we can test that the pack method was called
+            self.register_buffer('pack_called', torch.zeros(1, dtype=torch.long))
+            # This is a flag so we can test that the unpack method was called
+            self.register_buffer('unpack_called', torch.zeros(1, dtype=torch.long))
+
+        @torch.jit.script_method
+        def _pack(self):
+            self.pack_called.set_(torch.ones(1, dtype=torch.long))
+            self.derived.set_(torch.rand(1, dtype=torch.float).detach())
+
+        @torch.jit.script_method
+        def _unpack(self):
+            self.unpack_called.set_(torch.ones(1, dtype=torch.long))
+            self.derived.set_(torch.neg(self.param).detach())
+
+        @torch.jit.script_method
+        def forward(self, x):
+            return x + self.derived
+
+    def test_pack_unpack_state(self):
+        sm = TestScript.DerivedStateModule()
+        x = torch.rand(3, 4, dtype=torch.float)
+        torch.testing.assert_allclose(sm(x), x + torch.neg(torch.ones(3, 4, dtype=torch.float)))
+
+        # Test save path
+        self.assertFalse(sm.pack_called.item())
+        self.assertFalse(sm.unpack_called.item())
+        torch._C._recursively_call_method(sm, '_pack')
+        imported = self.getExportImportCopy(sm)
+        torch._C._recursively_call_method(sm, '_unpack')
+        torch._C._recursively_call_method(imported, '_unpack')
+        self.assertTrue(sm.pack_called.item()) # pack was called before serialization
+        self.assertTrue(sm.unpack_called.item()) # Unpack was called after serialization
+                                                 # so as to leave the module in an initialized state
+
+        torch.testing.assert_allclose(sm.derived, torch.neg(sm.param))
+
+        # Test load paths
+        self.assertTrue(imported.unpack_called.item())
+        torch.testing.assert_allclose(imported(x), x + torch.neg(torch.ones(3, 4, dtype=torch.float)))
+
+    def test_pack_unpack_nested(self):
+        class SubSubMod(torch.jit.ScriptModule):
+            def __init__(self):
+                super(SubSubMod, self).__init__()
+                self.register_buffer('buf', torch.ones(3, 4) * 3)
+
+            @torch.jit.script_method
+            def _pack(self):
+                self.buf.set_(torch.zeros(1, dtype=torch.double))
+
+            @torch.jit.script_method
+            def _unpack(self):
+                self.buf.set_(torch.ones(3, 4, dtype=torch.double) * 3)
+
+            @torch.jit.script_method
+            def forward(self, x):
+                return x + self.buf
+
+        class SubMod(torch.jit.ScriptModule):
+            def __init__(self):
+                super(SubMod, self).__init__()
+                self.register_buffer('buf', torch.ones(3, 4) * 2)
+                self.ssm = SubSubMod()
+
+            @torch.jit.script_method
+            def _pack(self):
+                self.buf.set_(torch.zeros(1, dtype=torch.double))
+
+            @torch.jit.script_method
+            def _unpack(self):
+                self.buf.set_(torch.ones(3, 4, dtype=torch.double) * 2)
+
+            @torch.jit.script_method
+            def forward(self, x):
+                return self.ssm(x + self.buf)
+
+        class Mod(torch.jit.ScriptModule):
+            def __init__(self):
+                super(Mod, self).__init__()
+                self.submod = SubMod()
+                self.register_buffer('buf', torch.ones(3, 4) * 1)
+
+            @torch.jit.script_method
+            def _pack(self):
+                self.buf.set_(torch.zeros(1, dtype=torch.double))
+
+            @torch.jit.script_method
+            def _unpack(self):
+                self.buf.set_(torch.ones(3, 4, dtype=torch.double))
+
+            @torch.jit.script_method
+            def forward(self, x):
+                return self.submod(x + self.buf)
+
+        m = Mod()
+        torch.testing.assert_allclose(m(torch.zeros(3, 4)), torch.ones(3, 4) * 6)
+        torch._C._recursively_call_method(m, '_pack')
+        torch.testing.assert_allclose(m(torch.zeros(3, 4)), torch.zeros(3, 4))
+        torch._C._recursively_call_method(m, '_unpack')
+        torch.testing.assert_allclose(m(torch.zeros(3, 4)), torch.ones(3, 4) * 6)
+
     def test_script_module_not_tuple(self):
         class M(torch.jit.ScriptModule):
             __constants__ = ['mods']

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5462,9 +5462,10 @@ a")
         imported = self.getExportImportCopy(sm)
         torch._C._recursively_call_method(sm, '_unpack')
         torch._C._recursively_call_method(imported, '_unpack')
-        self.assertTrue(sm.pack_called.item()) # pack was called before serialization
-        self.assertTrue(sm.unpack_called.item()) # Unpack was called after serialization
-                                                 # so as to leave the module in an initialized state
+        # ensure pack was called before serialization
+        self.assertTrue(sm.pack_called.item())
+        # ensure unpack was called after serialization so as to leave the module in an initialized state
+        self.assertTrue(sm.unpack_called.item())
 
         torch.testing.assert_allclose(sm.derived, torch.neg(sm.param))
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5458,10 +5458,10 @@ a")
         # Test save path
         self.assertFalse(sm.pack_called.item())
         self.assertFalse(sm.unpack_called.item())
-        torch._C._recursively_call_method(sm, '_pack')
+        sm.apply(lambda s: s._pack())
         imported = self.getExportImportCopy(sm)
-        torch._C._recursively_call_method(sm, '_unpack')
-        torch._C._recursively_call_method(imported, '_unpack')
+        sm.apply(lambda s: s._unpack())
+        imported.apply(lambda s: s._unpack())
         # ensure pack was called before serialization
         self.assertTrue(sm.pack_called.item())
         # ensure unpack was called after serialization so as to leave the module in an initialized state
@@ -5529,9 +5529,9 @@ a")
 
         m = Mod()
         torch.testing.assert_allclose(m(torch.zeros(3, 4)), torch.ones(3, 4) * 6)
-        torch._C._recursively_call_method(m, '_pack')
+        m.apply(lambda s: s._pack())
         torch.testing.assert_allclose(m(torch.zeros(3, 4)), torch.zeros(3, 4))
-        torch._C._recursively_call_method(m, '_unpack')
+        m.apply(lambda s: s._unpack())
         torch.testing.assert_allclose(m(torch.zeros(3, 4)), torch.ones(3, 4) * 6)
 
     def test_script_module_not_tuple(self):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -756,6 +756,7 @@ void initJitScriptBindings(PyObject* module) {
   });
   m.def("_jit_import_methods", import_methods);
   m.def("_jit_set_emit_module_hook", setEmitModuleHook);
+  m.def("_recursively_call_method", recursivelyCallMethod);
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -688,7 +688,8 @@ void initJitScriptBindings(PyObject* module) {
         std::vector<at::Tensor> tensors;
         PythonPrint(ss, self, tensors, false);
         return ss.str();
-      });
+      })
+      .def("apply", &Module::apply);
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
     .def("graph", [&](Method& self) {
@@ -756,7 +757,6 @@ void initJitScriptBindings(PyObject* module) {
   });
   m.def("_jit_import_methods", import_methods);
   m.def("_jit_set_emit_module_hook", setEmitModuleHook);
-  m.def("_recursively_call_method", recursivelyCallMethod);
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -470,6 +470,20 @@ struct Module {
   bool optimize;
 };
 
+static inline void recursivelyCallMethod(std::shared_ptr<Module> mod, const std::string& method_name) {
+  for (auto &submodule : mod->get_modules()) {
+    recursivelyCallMethod(submodule.value().module, method_name);
+    if (auto *method = submodule.value().module->find_method(method_name)) {
+      Stack inputs;
+      method->run(inputs);
+    }
+  }
+  if (auto *method = mod->find_method(method_name)) {
+    Stack inputs;
+    method->run(inputs);
+  }
+}
+
 // returns c10::nullopt and fills in failure_messages if the callee does not
 // match the functions schema
 c10::optional<std::vector<Value*>> try_emit_call_to(


### PR DESCRIPTION
This can be use to initialize state that is not necessarily eligible for serialization/is implementation-specific. Concretely, I'm going to use this to pack the weight matrices for quantized Linear modules according to the FBGEMM APIs
