### PR TITLE
[C++ Frontend] Prototype for stateful datasets

### DIFF
--- a/torch/csrc/api/include/torch/data/datasets/map.h
+++ b/torch/csrc/api/include/torch/data/datasets/map.h
@@ -28,8 +28,12 @@ struct MapDataset : BatchDataset<
 
   /// Gets a batch from the source dataset and applies the transform to it,
   /// returning the result.
-  OutputBatchType get_batch(BatchRequestType indices) override {
-    return transform.apply_batch(dataset.get_batch(indices));
+  optional<OutputBatchType> get_batch(BatchRequestType indices) override {
+    if (auto batch = dataset.get_batch(indices)) {
+      return transform.apply_batch(std::move(*batch));
+    } else {
+      return nullopt;
+    }
   }
 
   /// Returns the size of the source dataset.

--- a/torch/csrc/api/include/torch/data/datasets/mnist.h
+++ b/torch/csrc/api/include/torch/data/datasets/mnist.h
@@ -25,7 +25,7 @@ class TORCH_API MNIST : public Dataset<MNIST> {
   explicit MNIST(const std::string& root, Mode mode = Mode::kTrain);
 
   /// Returns the `Example` at the given `index`.
-  Example<> get(size_t index) override;
+  optional<Example<>> get(size_t index) override;
 
   /// Returns the size of the dataset.
   optional<size_t> size() const override;

--- a/torch/csrc/api/include/torch/data/datasets/shared.h
+++ b/torch/csrc/api/include/torch/data/datasets/shared.h
@@ -33,7 +33,7 @@ class SharedBatchDataset : public BatchDataset<
       : dataset_(std::move(shared_dataset)) {}
 
   /// Calls `get_batch` on the underlying dataset.
-  BatchType get_batch(BatchRequestType request) override {
+  optional<BatchType> get_batch(BatchRequestType request) override {
     return dataset_->get_batch(std::move(request));
   }
 

--- a/torch/csrc/api/include/torch/data/datasets/tensor.h
+++ b/torch/csrc/api/include/torch/data/datasets/tensor.h
@@ -21,7 +21,7 @@ struct TensorDataset : public Dataset<TensorDataset, TensorExample> {
   explicit TensorDataset(torch::Tensor tensor) : tensor(std::move(tensor)) {}
 
   /// Returns a single `TensorExample`.
-  TensorExample get(size_t index) override {
+  optional<TensorExample> get(size_t index) override {
     return tensor[index];
   }
 

--- a/torch/csrc/api/include/torch/data/detail/queue.h
+++ b/torch/csrc/api/include/torch/data/detail/queue.h
@@ -66,7 +66,7 @@ class Queue {
   /// is assumed to be used to drain the queue during shutdown of a
   /// `DataLoader`.
   size_t clear() {
-    std::lock_guard<std::mutex> lock(this->mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     const auto size = queue_.size();
     while (!queue_.empty()) {
       queue_.pop();
@@ -74,9 +74,14 @@ class Queue {
     return size;
   }
 
+  size_t size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.size();
+  }
+
  private:
   std::queue<T> queue_;
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   std::condition_variable cv_;
 };
 } // namespace detail

--- a/torch/csrc/api/include/torch/data/iterator.h
+++ b/torch/csrc/api/include/torch/data/iterator.h
@@ -136,7 +136,7 @@ class Iterator {
   using value_type = Batch;
   using pointer = Batch*;
   using reference = Batch&;
-  using iterator_category = std::output_iterator_tag;
+  using iterator_category = std::input_iterator_tag;
 
   explicit Iterator(std::unique_ptr<detail::IteratorImpl<Batch>> impl)
       : impl_(std::move(impl)) {}

--- a/torch/csrc/api/src/data/datasets/mnist.cpp
+++ b/torch/csrc/api/src/data/datasets/mnist.cpp
@@ -100,8 +100,8 @@ MNIST::MNIST(const std::string& root, Mode mode)
     : images_(read_images(root, mode == Mode::kTrain)),
       targets_(read_targets(root, mode == Mode::kTrain)) {}
 
-Example<> MNIST::get(size_t index) {
-  return {images_[index], targets_[index]};
+optional<Example<>> MNIST::get(size_t index) {
+  return Example<>(images_[index], targets_[index]);
 }
 
 optional<size_t> MNIST::size() const {


### PR DESCRIPTION
A prototype for allowing stateful datasets in the C++ dataloader. Very rough right now, didn't figure everything out yet.

The fundamental idea is that `get_batch` in the base dataset changes its return type to `optional<T>` instead of `T`, and the dataloader handles exhaustion of individual workers and exhausts itself when all workers have exhausted.

There are things I don't like yet: 

1. The API is quite intrusive to existing datasets. I explored a different approach first where you'd have an `ExhaustibleDataset` which you could derive from, and the base `BatchDataset` class didn't change. We may want to revisit this. It was just a bit more complicated and I wanted an MVP first
2. While I added a `reset()` method to the base dataset class, I still need to think about how to reset each dataset in each worker thread. Right now, there's no way to communicate point-to-point between the main thread and a particular worker thread, and just enqueing `n` "reset yourself" messages for `n` worker threads doesn't work because it's not guaranteed that each worker would see one of them.

CC @jaliyae @soumith @apaszke 