### PR TITLE
 Implement Device as a type in the script

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -82,6 +82,7 @@ namespace c10 {
   _(aten, copy_)                   \
   _(aten, _set_item)               \
   _(aten, index_put_)              \
+  _(aten, device)                  \
   FORALL_ATEN_BASE_SYMBOLS(_)      \
   _(onnx, Add)                     \
   _(onnx, Concat)                  \

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -72,6 +72,8 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       return printList(out, v.toGenericList(), "[", "]");
     case IValue::Tag::Future:
       return out << "Future";
+    case IValue::Tag::Device:
+      return out << v.toDevice();
   }
   AT_ERROR("Tag not found\n");
 }

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -31,6 +31,7 @@ _(GeneratorType) \
 _(BoolType) \
 _(OptionalType) \
 _(VarType) \
+_(DeviceObjType) \
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -38,7 +39,7 @@ enum class TypeKind {
 #undef DEFINE_TYPE
 };
 
-const char * typeKindToString(TypeKind kind);
+CAFFE2_API const char * typeKindToString(TypeKind kind);
 
 #define DEFINE_IS_SUBCLASS(_kind) \
   bool isSubclass(const TypeKind kind) const override { \
@@ -69,10 +70,8 @@ public:
   virtual bool operator==(const Type& rhs) const = 0;
 
   // subtyping relation. By default, we return true for the case
-  // when the type is exactly equal
-  virtual bool isSubtypeOf(const TypePtr rhs) const {
-    return *this == *rhs;
-  }
+  // when the type is exactly equal or if this <: T where rhs = Optional[T]
+  virtual bool isSubtypeOf(const TypePtr rhs) const;
 
   // If this class can be cast to the kind passed in
   // This removes the need for RTTI
@@ -255,12 +254,6 @@ struct CAFFE2_API DynamicType : public Type {
 
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
-  }
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    return Type::isSubtypeOf(rhs);
   }
   std::string str() const override {
     return "Tensor";
@@ -505,12 +498,6 @@ struct CAFFE2_API ListType : public SingleElementType<TypeKind::ListType, ListTy
     ss << "List[" << getElementType()->python_str() << "]";
     return ss.str();
   }
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    return Type::isSubtypeOf(rhs);
-  }
   TypePtr createWithContained(std::vector<TypePtr> contained_types) const override {
     return create(contained_types.at(0));
   }
@@ -566,13 +553,10 @@ struct CAFFE2_API TupleType : public Type {
     });
   }
   bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
     // co-variant rules for tuples
     return compare(*rhs, [](const TypePtr a, const TypePtr b) {
       return a->isSubtypeOf(b);
-    });
+    }) || Type::isSubtypeOf(rhs);
   }
   bool requires_grad() const override {
     return std::any_of(elements_.begin(), elements_.end(),
@@ -648,12 +632,6 @@ using NumberTypePtr = std::shared_ptr<NumberType>;
 struct CAFFE2_API NumberType : public Type {
   static NumberTypePtr create() {
     return NumberTypePtr(new NumberType()); // NOLINT(modernize-make-shared)
-  }
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    return Type::isSubtypeOf(rhs);
   }
   DEFINE_IS_SUBCLASS(NumberType);
   bool operator==(const Type& rhs) const override {
@@ -747,12 +725,6 @@ struct CAFFE2_API BoolType : public Type {
   std::string str() const override {
     return "bool";
   }
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    return Type::isSubtypeOf(rhs) || rhs->kind() == TypeKind::BoolType;
-  }
   static const TypeKind Kind = TypeKind::BoolType;
   // global singleton
   static BoolTypePtr get();
@@ -777,12 +749,6 @@ struct CAFFE2_API StringType : public Type {
   }
   std::string python_str() const override {
     return "str";
-  }
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    return Type::isSubtypeOf(rhs);
   }
   static const TypeKind Kind = TypeKind::StringType;
   // global singleton
@@ -828,12 +794,6 @@ struct CAFFE2_API GeneratorType : public Type {
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return this->isSubtypeOf(rhs_->getElementType());
-    }
-    return Type::isSubtypeOf(rhs);
-  }
   std::string str() const override {
     return "Generator";
   }
@@ -843,6 +803,28 @@ struct CAFFE2_API GeneratorType : public Type {
 private:
   GeneratorType()
   : Type(TypeKind::GeneratorType) {}
+};
+
+struct DeviceObjType;
+using DeviceObjTypePtr = std::shared_ptr<DeviceObjType>;
+// This type represents a Generator
+struct CAFFE2_API DeviceObjType : public Type {
+  static DeviceObjTypePtr create() {
+    return DeviceObjTypePtr(new DeviceObjType()); // NOLINT(modernize-make-shared)
+  }
+  DEFINE_IS_SUBCLASS(DeviceObjType);
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  std::string str() const override {
+    return "Device";
+  }
+  static const TypeKind Kind = TypeKind::DeviceObjType;
+  // global singleton
+  static DeviceObjTypePtr get();
+private:
+  DeviceObjType()
+  : Type(TypeKind::DeviceObjType) {}
 };
 
 

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -38,6 +38,8 @@ enum class TypeKind {
 #undef DEFINE_TYPE
 };
 
+const char * typeKindToString(TypeKind kind);
+
 #define DEFINE_IS_SUBCLASS(_kind) \
   bool isSubclass(const TypeKind kind) const override { \
     return kind == TypeKind::_kind; \

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -91,6 +91,10 @@ StringTypePtr StringType::get() {
   static auto value = StringType::create();
   return value;
 }
+DeviceObjTypePtr DeviceObjType::get() {
+  static auto value = DeviceObjType::create();
+  return value;
+}
 OptionalTypePtr OptionalType::ofTensor() {
   static auto value = OptionalType::create(DynamicType::get());
   return value;
@@ -133,6 +137,8 @@ TypePtr inferTypeFrom(const IValue& value) {
     return ListType::ofFloats();
   } else if (value.isTuple()) {
     return TupleType::create(fmap(value.toTuple()->elements(), inferTypeFrom));
+  } else if (value.isDevice()) {
+    return DeviceObjType::get();
   }
   AT_ASSERTM(false, "Unhandled IValue kind in inferTypeFrom");
 }
@@ -317,6 +323,13 @@ const char * typeKindToString(TypeKind kind) {
   }
 #undef CASE_TYPE
   return "";
+}
+
+bool Type::isSubtypeOf(const TypePtr rhs) const {
+  if(auto rhs_ = rhs->cast<OptionalType>()) {
+    return this->isSubtypeOf(rhs_->getElementType());
+  }
+  return *this == *rhs;
 }
 
 } // namespace c10

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -309,4 +309,14 @@ CAFFE2_API TypePtr evalTypeVariables(TypePtr type, std::unordered_map<std::strin
   }
 }
 
+
+const char * typeKindToString(TypeKind kind) {
+#define CASE_TYPE(T) case TypeKind::T: return #T;
+  switch(kind) {
+    C10_FORALL_TYPES(CASE_TYPE)
+  }
+#undef CASE_TYPE
+  return "";
+}
+
 } // namespace c10

--- a/c10/Device.cpp
+++ b/c10/Device.cpp
@@ -32,7 +32,7 @@ DeviceType parse_type(const std::string& device_string) {
     return device->second;
   }
   AT_ERROR(
-      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, or hip device type at start of device string");
+      "Expected one of cpu, cuda, mkldnn, opengl, opencl, ideep, or hip device type at start of device string: ", device_string);
 }
 } // namespace
 

--- a/test/expect/TestJit.test_constant_prop_rand.expect
+++ b/test/expect/TestJit.test_constant_prop_rand.expect
@@ -1,6 +1,6 @@
 graph() {
   %0 : int = prim::Constant[value=1]()
-  %1 : int[] = prim::Constant[value=[0, -1]]()
+  %1 : Device = prim::Constant[value="cpu"]()
   %2 : int = prim::Constant[value=0]()
   %3 : int = prim::Constant[value=6]()
   %4 : int = prim::Constant[value=2]()

--- a/test/expect/TestJit.test_inplace_copy.expect
+++ b/test/expect/TestJit.test_inplace_copy.expect
@@ -10,7 +10,7 @@ graph(%0 : Double(4, 4)) {
   %9 : int[] = prim::ListConstruct(%4, %8)
   %10 : int = prim::Constant[value=7]()
   %11 : int = prim::Constant[value=0]()
-  %12 : int[] = prim::Constant[value=[0, -1]]()
+  %12 : Device = prim::Constant[value="cpu"]()
   %13 : Double(4, 4) = aten::zeros(%9, %10, %11, %12)
   %14 : Double(4, 4) = aten::expand_as(%0, %13)
   return (%14);

--- a/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
@@ -3,7 +3,7 @@ graph(%x : Tensor) {
   %2 : int = prim::Constant[value=4]()
   %3 : int = prim::Constant[value=6]()
   %4 : int = prim::Constant[value=0]()
-  %5 : int[] = prim::Constant[value=[0, -1]]()
+  %5 : Device = prim::Constant[value="cpu"]()
   %6 : int = prim::Constant[value=1]()
   %7 : int[] = prim::ListConstruct(%2, %1)
   %8 : Tensor = aten::zeros(%7, %3, %4, %5)

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -1,5 +1,5 @@
 graph(%x : Tensor) {
-  %6 : int[] = prim::Constant[value=[0, -1]](), scope: TracedModule
+  %6 : Device = prim::Constant[value="cpu"](), scope: TracedModule
   %5 : int = prim::Constant[value=0](), scope: TracedModule
   %4 : int = prim::Constant[value=7](), scope: TracedModule
   %2 : int = prim::Constant[value=3](), scope: TracedModule

--- a/test/expect/TestScript.test_constant_pooling.expect
+++ b/test/expect/TestScript.test_constant_pooling.expect
@@ -9,7 +9,7 @@ graph(%cond : Tensor) {
   %d : string = prim::Constant[value="abc"]()
   %e : string = prim::Constant[value="bcd"]()
   %10 : int = prim::Constant[value=6]()
-  %11 : int[] = prim::Constant[value=[0, -1]]()
+  %11 : Device = prim::Constant[value="cpu"]()
   %12 : bool = prim::TensorToBool(%cond)
   %c : int, %y : Tensor = prim::If(%12)
     block0() {

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3129,6 +3129,13 @@ class TestScript(JitTestCase):
         self.assertTrue(same_device(gpu, gpu))
         self.assertFalse(same_device(cpu, gpu))
 
+    @unittest.skipIf(not RUN_CUDA, "device tests require CUDA")
+    def test_tensor_to_device(self):
+        def to_device(x):
+            return x.to(device="cuda").to(device=torch.device("cpu"))
+
+        self.checkScript(to_device, (torch.ones(3, 4),))
+
     def test_generic_list_errors(self):
         with self.assertRaisesRegex(RuntimeError, "previously matched to type"):
             @torch.jit.script

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -211,7 +211,6 @@ def argument_order(decl):
 
 def gen_jit_dispatch(declarations, out, template_path):
     REGISTER_ATEN_OPS_CPP = CodeTemplate.from_file(template_path + '/register_aten_ops.cpp')
-    ATEN_INTERNED_STRINGS_H = CodeTemplate.from_file(template_path + '/aten_interned_strings.h')
 
     ops = []
 
@@ -367,23 +366,6 @@ def gen_jit_dispatch(declarations, out, template_path):
         }
         write(out, 'register_aten_ops_%d.cpp' % i, REGISTER_ATEN_OPS_CPP, env)
 
-    # NB: Operate on aten_decls, not jit_decls, because VariableType is
-    # a client for these symbols as well
-    # NB: This means we DON'T generate interned strings for inplace ops.
-    # Change this when you do!
-    # NB: Keep this code synchronized with the code in
-    # tool/autograd/gen_variable_type.py
-    # NB: Some operations have inplace versions, but NOT non-inplace
-    # versions! Thus uninplace_api_name() is mandatory (if you remove
-    # it, you will get missing symbols.)
-    names = set(uninplace_api_name(decl['api_name']) for decl in aten_decls)
-    # NB: This grabs non keyword arguments too, but it's harmless
-    attrs = set(arg['name'] for decl in aten_decls for arg in decl['arguments'])
-    strings_env = {
-        'aten_symbols': ["_(aten, {}) \\".format(n) for n in sorted(names)],
-        'attr_symbols': ["_(attr, {}) \\".format(n) for n in sorted(attrs)]
-    }
-    write(out, 'aten_interned_strings.h', ATEN_INTERNED_STRINGS_H, strings_env)
 
 default_map = {'{}': 'None', 'nullptr': 'None', 'c10::nullopt': 'None'}
 

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -78,12 +78,12 @@ def jit_type_of(arg):
 # map from aten 'simple_type' to the function that will turn a tensor into
 # that type
 FROM_IVALUE = {
-    'Device': '{}.to<at::Device>()',
+    'Device': '{}.toDevice()',
     'IntList': '{}.toIntList()->elements()',
-    'Layout': '{}.to<at::Layout>()',
+    'Layout': '{}.toLayout()',
     'Scalar': '{}.toScalar()',
     'Scalar?': '{}.toOptional<Scalar>()',
-    'ScalarType': '{}.to<at::ScalarType>()',
+    'ScalarType': '{}.toScalarType()',
     'Tensor': '{}.toTensor()',
     'TensorList': '{}.toTensorList()->elements()',
     'bool': '{}.toBool()',
@@ -332,7 +332,7 @@ def gen_jit_dispatch(declarations, out, template_path):
             {'name': 'layout', 'simple_type': 'Layout', 'default': 'strided', 'kwarg_only': True},
             # device is specified as an IntList of { at::Device::Type, device_id }
             {'name': 'device', 'simple_type': 'Device', 'kwarg_only': True,
-                'default': '[cpu, -1]'},
+                'default': '\\"cpu\\"'},
         ]
 
     for decl in jit_decls:

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -88,7 +88,6 @@ add_custom_command(
   "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_0.cpp"
   "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_1.cpp"
   "${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_2.cpp"
-  "${TORCH_SRC_DIR}/csrc/jit/generated/aten_interned_strings.h"
   COMMAND
   ${PYCMD} tools/setup_helpers/generate_code.py
     --declarations-path "${CMAKE_BINARY_DIR}/aten/src/ATen/Declarations.yaml"
@@ -122,7 +121,6 @@ add_custom_command(
   "${TOOLS_PATH}/autograd/utils.py"
   "${TOOLS_PATH}/jit/gen_jit_dispatch.py"
   "${TOOLS_PATH}/jit/templates/register_aten_ops.cpp"
-  "${TOOLS_PATH}/jit/templates/aten_interned_strings.h"
   WORKING_DIRECTORY "${TORCH_ROOT}")
 
 set(TORCH_SRCS

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -46,6 +46,11 @@ Value* insertConstant(
   } else if(val.isString()) {
     n->s_(attr::value, val.toString()->string());
     n->output()->setType(StringType::get());
+  } else if(val.isDevice()) {
+    std::stringstream ss;
+    ss << val.toDevice();
+    n->s_(attr::value, ss.str());
+    n->output()->setType(DeviceObjType::get());
   } else if(val.isNone()) {
     n->destroy();
     n = g.create(prim::None);
@@ -118,6 +123,12 @@ RegisterOperators reg({
           auto s = node->s(attr::value);
           return [s](Stack& stack) {
             push(stack, s);
+            return 0;
+          };
+        } else if (type == DeviceObjType::get()) {
+          auto d = c10::Device(node->s(attr::value));
+          return [d](Stack& stack) {
+            push(stack, d);
             return 0;
           };
         } else {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -656,19 +656,19 @@ bool Node::isNondeterministic() const {
     "aten::poisson(Tensor self, Generator generator) -> Tensor",
     "aten::rrelu(Tensor self, Scalar lower, Scalar upper, bool training, Generator generator) -> Tensor",
     "aten::rrelu_with_noise(Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, Generator generator) -> Tensor",
-    "aten::rand(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
+    "aten::rand(int[] size, *, int dtype, int layout, Device device) -> Tensor",
     "aten::rand_like(Tensor self) -> Tensor",
-    "aten::rand_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
-    "aten::randint(int high, int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-    "aten::randint(int low, int high, int[] size, *, int dtype, int layout, int[] device) -> Tensor",
+    "aten::rand_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
+    "aten::randint(int high, int[] size, *, int dtype, int layout, Device device) -> Tensor",
+    "aten::randint(int low, int high, int[] size, *, int dtype, int layout, Device device) -> Tensor",
     "aten::randint_like(Tensor self, int high) -> Tensor",
     "aten::randint_like(Tensor self, int low, int high) -> Tensor",
-    "aten::randint_like(Tensor self, int high, *, int dtype, int layout, int[] device) -> Tensor",
-    "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, int[] device) -> Tensor",
-    "aten::randn(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
+    "aten::randint_like(Tensor self, int high, *, int dtype, int layout, Device device) -> Tensor",
+    "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, Device device) -> Tensor",
+    "aten::randn(int[] size, *, int dtype, int layout, Device device) -> Tensor",
     "aten::randn_like(Tensor self) -> Tensor",
-    "aten::randn_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
-    "aten::randperm(int n, *, int dtype, int layout, int[] device) -> Tensor"
+    "aten::randn_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
+    "aten::randperm(int n, *, int dtype, int layout, Device device) -> Tensor"
   };
 
   if (nondeterministic_ops.find(this) == nullptr) {

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -628,6 +628,12 @@ struct PythonPrintPass {
       stmt << "CONSTANTS.c" << getOrAddTensorConstant(v.toTensor());
     } else if(v.isString()) {
       printQuotedString(stmt, v.toStringRef());
+    } else if(v.isDevice()) {
+      std::stringstream ss;
+      ss << v.toDevice();
+      stmt << "torch.device(";
+      printQuotedString(stmt, ss.str());
+      stmt << ")";
     } else if(v.isTensorList()) {
       stmt << "[";
       const char* delim = "";

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1010,14 +1010,14 @@ class ShapePropagator {
     //   - has ScalarType dtype, Layeout layout and Device device arguments
     static const register_formula_for like_factories_with_options{
         {
-            "aten::empty_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::full_like(Tensor self, Scalar fill_value, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::ones_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::rand_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::randint_like(Tensor self, int high, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::randn_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::zeros_like(Tensor self, *, int dtype, int layout, int[] device) -> Tensor",
+            "aten::empty_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::full_like(Tensor self, Scalar fill_value, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::ones_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::rand_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::randint_like(Tensor self, int high, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::randint_like(Tensor self, int low, int high, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::randn_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::zeros_like(Tensor self, *, int dtype, int layout, Device device) -> Tensor",
         },
         [](Node* node) -> type_vec_t {
           if (auto type =
@@ -1038,14 +1038,14 @@ class ShapePropagator {
     //   arguments
     static const register_formula_for size_factories_with_options{
         {
-            "aten::empty(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::full(int[] size, Scalar fill_value, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::ones(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::rand(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::randn(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::zeros(int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::randint(int high, int[] size, *, int dtype, int layout, int[] device) -> Tensor",
-            "aten::randint(int low, int high, int[] size, *, int dtype, int layout, int[] device) -> Tensor",
+            "aten::empty(int[] size, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::full(int[] size, Scalar fill_value, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::ones(int[] size, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::rand(int[] size, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::randn(int[] size, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::zeros(int[] size, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::randint(int high, int[] size, *, int dtype, int layout, Device device) -> Tensor",
+            "aten::randint(int low, int high, int[] size, *, int dtype, int layout, Device device) -> Tensor",
         },
         [](Node* node) -> type_vec_t {
           if (auto maybe_size = node->get<std::vector<int64_t>>(attr::size)) {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -8,6 +8,7 @@
 #include "torch/csrc/jit/operator.h"
 #include "torch/csrc/utils/pybind.h"
 #include "torch/csrc/utils/auto_gil.h"
+#include "torch/csrc/Device.h"
 
 #include <c10/util/Exception.h>
 
@@ -147,6 +148,10 @@ inline IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_
       }
       case TypeKind::StringType:
         return ConstantString::create(py::cast<std::string>(obj));
+      case TypeKind::DeviceObjType: {
+        auto device = reinterpret_cast<THPDevice*>(obj.ptr());
+        return device->device;
+      }
       case TypeKind::ListType: {
         const auto& elem_type = type->expect<ListType>()->getElementType();
         switch(elem_type->kind()) {

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -430,44 +430,8 @@ void initPythonIRBindings(PyObject * module_) {
       s << t;
       return s.str();
     })
-    .def("kind",[](Type& t_) {
-      Type * t = &t_;
-      switch(t->kind()) {
-        case TypeKind::DynamicType:
-          return "DynamicType";
-        case TypeKind::TensorType:
-          return "TensorType";
-        case TypeKind::OptionalType:
-          return "OptionalType";
-        case TypeKind::NumberType:
-          return "NumberType";
-        case TypeKind::NoneType:
-          return "NoneType";
-        case TypeKind::UndefinedTensorType:
-          return "UndefinedTensorType";
-        case TypeKind::CompleteTensorType:
-          return "CompleteTensorType";
-        case TypeKind::TupleType:
-          return "TupleType";
-        case TypeKind::ListType:
-          return "ListType";
-        case TypeKind::IntType:
-          return "IntType";
-        case TypeKind::FloatType:
-          return "FloatType";
-        case TypeKind::StringType:
-          return "StringType";
-        case TypeKind::GeneratorType:
-          return "GeneratorType";
-        case TypeKind::BoolType:
-          return "BoolType";
-        case TypeKind::VarType:
-          return "VarType";
-        case TypeKind::FutureType:
-          return "FutureType";
-        }
-        // not reachable, but some compilers complain
-        AT_ERROR("Unknown Type Kind");
+    .def("kind",[](const Type& t) {
+      return typeKindToString(t.kind());
     })
     .def("sizes",[](Type& t) {
       return t.expect<CompleteTensorType>()->sizes();

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -178,13 +178,28 @@ RegisterOperators reg({
           };
         }),
     Operator(
-        "prim::device(Tensor a) -> int[]",
+        "aten::device(str a) -> Device",
         [](const Node* node) -> Operation {
           return [](Stack& stack) {
-            at::Tensor a;
-            pop(stack, a);
-            push(stack, std::vector<int64_t>({static_cast<int64_t>(a.device().type()),
-                                              a.device().index()}));
+            push(stack, c10::Device(pop(stack).toStringRef()));
+            return 0;
+          };
+        }),
+    Operator(
+        "aten::eq(Device a, Device b) -> bool",
+        [](const Node* node) -> Operation {
+          return [](Stack& stack) {
+            auto a = pop(stack).toDevice();
+            auto b = pop(stack).toDevice();
+            push(stack, a == b);
+            return 0;
+          };
+        }),
+    Operator(
+        "prim::device(Tensor a) -> Device",
+        [](const Node* node) -> Operation {
+          return [](Stack& stack) {
+            push(stack, pop(stack).toTensor().device());
             return 0;
           };
         }),

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -481,7 +481,7 @@ Value* tryConvertToType(
     Graph& graph,
     TypePtr concrete_type,
     Value* value,
-    bool convert_tensors_to_nums) {
+    bool allow_conversions) {
   // Allow homogeneous tuples to be casted implicitly to lists of appropriate
   // types
   if (convertibleToList(value->type(), concrete_type) &&
@@ -502,14 +502,21 @@ Value* tryConvertToType(
     }
   }
 
-  //implicit conversion of tensors to scalars
-  if(convert_tensors_to_nums && concrete_type->isSubtypeOf(NumberType::get())
+  //implicit conversions
+  if(allow_conversions) {
+     if(concrete_type->isSubtypeOf(NumberType::get())
       && value->type()->isSubtypeOf(DynamicType::get())) {
       auto n = graph.createImplicitTensorToNum(concrete_type, value);
       value = graph.insertNode(n)
         ->setSourceLocation(std::make_shared<SourceRange>(loc))
         ->output();
+    }
+    if (value->type()->isSubtypeOf(StringType::get()) &&
+        DeviceObjType::get()->isSubtypeOf(concrete_type))  {
+      return graph.insert(aten::device, { value }, {}, loc);
+    }
   }
+
   return value;
 }
 
@@ -519,7 +526,7 @@ Value* tryMatchArgument(
     const SourceRange& loc,
     const NamedValue& named_value,
     std::function<std::ostream&()> err,
-    bool convert_tensors_to_nums,
+    bool allow_conversions,
     TypeEnv & type_env) {
   Value* value = named_value.value(graph);
 
@@ -542,7 +549,7 @@ Value* tryMatchArgument(
   }
   const auto concrete_type = *matched_type.type;
 
-  value = tryConvertToType(loc, graph, concrete_type, value, convert_tensors_to_nums);
+  value = tryConvertToType(loc, graph, concrete_type, value, allow_conversions);
 
   if(!value->type()->isSubtypeOf(concrete_type)) {
     err() << "expected a value of type " << concrete_type->str() << " for argument '" << arg.name() << "' but found "
@@ -605,7 +612,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
     at::ArrayRef<NamedValue> args,
     at::ArrayRef<NamedValue> kwargs,
     std::ostream& failure_messages,
-    bool convert_tensors_to_nums) {
+    bool allow_conversions) {
   auto err = [&]() -> std::ostream& {
     failure_messages << "\nfor operator " << schema << ":\n";
     return failure_messages;
@@ -643,7 +650,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
               loc,
               at::ArrayRef<NamedValue>(args).slice(used_args),
               err,
-              convert_tensors_to_nums,
+              allow_conversions,
               type_env);
           if (!list)
             return c10::nullopt;
@@ -674,7 +681,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
       return c10::nullopt;
     }
     Value* positional = tryMatchArgument(
-        arg, graph, loc, *v, err, convert_tensors_to_nums, type_env);
+        arg, graph, loc, *v, err, allow_conversions, type_env);
     if (!positional)
       return c10::nullopt;
     positional_inputs.push_back(positional);
@@ -768,7 +775,7 @@ Value* emitBuiltinCall(
   std::stringstream failure_messages;
   //first we try to match the schema without any conversion
   //if no schema matches then insert ImplicitTensorToNum
-  for (bool convert_tensors_to_nums : {false, true}) {
+  for (bool allow_conversions : {false, true}) {
     // clear previous error messages
     failure_messages.str("");
     for (const std::shared_ptr<Operator>& op : variants) {
@@ -780,7 +787,7 @@ Value* emitBuiltinCall(
           inputs,
           attributes,
           failure_messages,
-          convert_tensors_to_nums);
+          allow_conversions);
       if (matched_schema) {
         return emitBuiltinNode(*matched_schema, loc, graph, name);
       }
@@ -795,7 +802,7 @@ Value* emitBuiltinCall(
               attributes,
               failure_messages,
               nullptr,
-              convert_tensors_to_nums)) {
+              allow_conversions)) {
         return packOutputs(graph, *result);
       }
     }
@@ -1081,7 +1088,7 @@ private:
         TypePtr type = DynamicType::get();
         if (!schema.is_varret()) {
           type = schema.returns().at(return_type_idx).type();
-          r = tryConvertToType(range, *graph, type, r, /*convert_tensors_to_nums=*/false);
+          r = tryConvertToType(range, *graph, type, r, /*allow_conversions=*/false);
           if (!r->type()->isSubtypeOf(type)) {
             throw ErrorReport(return_stmt.range()) << "Return value at position "
               << return_type_idx << " was annotated as having type " << type->str()
@@ -2016,7 +2023,7 @@ private:
           *graph,
           type,
           emitExpr(apply.inputs()[1], type),
-          /*convert_tensors_to_nums=*/true);
+          /*allow_conversions=*/true);
       if (!expr->type()->isSubtypeOf(type)) {
         throw ErrorReport(apply.inputs())
             << "expected an expression of type " << type->python_str()
@@ -2646,6 +2653,7 @@ const std::unordered_map<std::string, TypePtr> &ident_to_type_lut() {
     {"float", FloatType::get()},
     {"bool", BoolType::get()},
     {"str", StringType::get()},
+    {"Device", DeviceObjType::get()},
     // technically this is not a python type but we need it when
     // parsing serialized methods that use implicit converions to Scalar
     {"number", NumberType::get()},

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -220,7 +220,7 @@ TORCH_API c10::optional<MatchedSchema> tryMatchSchema(
   at::ArrayRef<NamedValue> inputs,
   at::ArrayRef<NamedValue> attributes,
   std::ostream& failure_messages,
-  bool convert_tensors_to_nums);
+  bool allow_conversions);
 
 TORCH_API Value* emitBuiltinCall(
   const SourceRange& loc,

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -343,9 +343,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
       return toSimple(g.insertConstant(IValue(), loc));
     } else if (THPDevice_Check(obj.ptr())) {
       auto device = reinterpret_cast<THPDevice*>(obj.ptr());
-      std::vector<int64_t> v = {static_cast<int64_t>(device->device.type()),
-                                device->device.index()};
-      return toSimple(g.insertConstant(std::move(v)));
+      return toSimple(g.insertConstant(device->device));
     } else if (THPLayout_Check(obj.ptr())) {
       auto layout = reinterpret_cast<THPLayout*>(obj.ptr());
       const auto v = static_cast<int64_t>(layout->layout);

--- a/torch/csrc/jit/script/parse_string_literal.h
+++ b/torch/csrc/jit/script/parse_string_literal.h
@@ -1,0 +1,88 @@
+#pragma once
+#include "torch/csrc/jit/script/lexer.h"
+#include "torch/csrc/jit/script/error_report.h"
+#include "c10/util/Optional.h"
+
+namespace torch {
+namespace jit {
+namespace script {
+
+inline bool isCharCount(char c, const std::string& str, size_t start, int len) {
+  //count checks from [start, start + len)
+  return start + len <= str.size() && std::count(str.begin() + start, str.begin() + start + len, c) == len;
+}
+
+inline static bool isOctal(char c) {
+  return c >= '0' && c < '8';
+}
+
+inline c10::optional<char> parseOctal(const std::string& str, size_t pos) {
+  //\xxx where x are 0-7
+  if (pos + 3 >= str.size())
+    return c10::nullopt;
+  size_t c = 0;
+  for(size_t i = 1, b = 64; i < 4; ++i, b /= 8) {
+    int d = str[pos + i];
+    if (d < '0' || d > '7')
+      return c10::nullopt;
+    c += b * (d - '0');
+  }
+  if(c >= 256)
+    return c10::nullopt;
+  return c;
+}
+
+inline std::string parseStringLiteral(const SourceRange& range, const std::string &str) {
+  int quote_len = isCharCount(str[0], str, 0, 3) ? 3 : 1;
+  auto ret_str = str.substr(quote_len, str.size() - quote_len * 2);
+  size_t pos = ret_str.find('\\');
+  while(pos != std::string::npos) {
+    //invariant: pos has to escape a character because it is a valid string
+    char c = ret_str[pos + 1];
+    size_t to_erase = 2;
+    switch (ret_str[pos + 1]) {
+      case '\\':
+      case '\'':
+      case '\"':
+      case '\n':
+        break;
+      case 'a':
+        c = '\a';
+        break;
+      case 'b':
+        c = '\b';
+        break;
+      case 'f':
+        c = '\f';
+        break;
+      case 'n':
+        c = '\n';
+        break;
+      case 'v':
+        c = '\v';
+        break;
+      case 't':
+        c = '\t';
+        break;
+      case 'h':
+        throw ErrorReport(range)
+            << "unsupported hex specifier";
+      default:
+        // \0NN
+        if (auto v = parseOctal(str, pos + 1)) {
+          to_erase = 4;
+          c = *v;
+        } else {
+          throw ErrorReport(range)
+              << " ill formed octal specifier";
+        }
+    }
+    ret_str.replace(pos, to_erase, /* num copies */ 1, c);
+    pos = ret_str.find('\\', pos + 1);
+  }
+  return ret_str;
+}
+
+} // namespace script
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -3,6 +3,7 @@
 #include "tree.h"
 #include "tree_views.h"
 #include "c10/util/Optional.h"
+#include "torch/csrc/jit/script/parse_string_literal.h"
 
 namespace torch {
 namespace jit {
@@ -122,7 +123,7 @@ struct Parser {
         prefix = ListLiteral::create(list.range(), List<Expr>(list));
       } break;
       case TK_STRINGLITERAL: {
-        prefix = parseStringLiteral();
+        prefix = parseConcatenatedStringLiterals();
       } break;
       default: {
         Ident name = parseIdent();
@@ -236,87 +237,12 @@ struct Parser {
     return Const::create(t.range, t.text());
   }
 
-  bool isCharCount(char c, const std::string& str, size_t start, int len) {
-    //count checks from [start, start + len)
-    return start + len <= str.size() && std::count(str.begin() + start, str.begin() + start + len, c) == len;
-  }
-
-  static bool isOctal(char c) {
-    return c >= '0' && c < '8';
-  }
-
-  c10::optional<char> parseOctal(const std::string& str, size_t pos) {
-    //\xxx where x are 0-7
-    if (pos + 3 >= str.size())
-      return c10::nullopt;
-    size_t c = 0;
-    for(size_t i = 1, b = 64; i < 4; ++i, b /= 8) {
-      int d = str[pos + i];
-      if (d < '0' || d > '7')
-        return c10::nullopt;
-      c += b * (d - '0');
-    }
-    if(c >= 256)
-      return c10::nullopt;
-    return c;
-  }
-  std::string parseString(const SourceRange& range, const std::string &str) {
-    int quote_len = isCharCount(str[0], str, 0, 3) ? 3 : 1;
-    auto ret_str = str.substr(quote_len, str.size() - quote_len * 2);
-    size_t pos = ret_str.find('\\');
-    while(pos != std::string::npos) {
-      //invariant: pos has to escape a character because it is a valid string
-      char c = ret_str[pos + 1];
-      size_t to_erase = 2;
-      switch (ret_str[pos + 1]) {
-        case '\\':
-        case '\'':
-        case '\"':
-        case '\n':
-          break;
-        case 'a':
-          c = '\a';
-          break;
-        case 'b':
-          c = '\b';
-          break;
-        case 'f':
-          c = '\f';
-          break;
-        case 'n':
-          c = '\n';
-          break;
-        case 'v':
-          c = '\v';
-          break;
-        case 't':
-          c = '\t';
-          break;
-        case 'h':
-          throw ErrorReport(range)
-              << "unsupported hex specifier";
-        default:
-          // \0NN
-          if (auto v = parseOctal(str, pos + 1)) {
-            to_erase = 4;
-            c = *v;
-          } else {
-            throw ErrorReport(range)
-                << " ill formed octal specifier";
-          }
-      }
-      ret_str.replace(pos, to_erase, /* num copies */ 1, c);
-      pos = ret_str.find('\\', pos + 1);
-    }
-    return ret_str;
-  }
-
-  StringLiteral parseStringLiteral() {
+  StringLiteral parseConcatenatedStringLiterals() {
     auto range = L.cur().range;
     std::stringstream ss;
     while(L.cur().kind == TK_STRINGLITERAL) {
       auto literal_range = L.cur().range;
-      ss << parseString(literal_range, L.next().text());
+      ss << parseStringLiteral(literal_range, L.next().text());
     }
     return StringLiteral::create(range, ss.str());
   }

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -73,10 +73,7 @@ void addInputs(Node *n, const char * name, at::Generator * value)            {
   n->addInput(undef_gen);
 }
 void addInputs(Node *n, const char * name, at::Device value) {
-  std::vector<int64_t> device = {
-      static_cast<int64_t>(value.type()),
-      static_cast<int64_t>(value.index())};
-  detail::genericAddInput(n, std::move(device));
+  detail::genericAddInput(n, value);
 }
 void addInputs(Node *n, const char * name, at::Layout value) {
   detail::genericAddInput(n, static_cast<int64_t>(value));

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -510,6 +510,8 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                 elif n.kindOf("value") == "is":
                     value = torch.stack([torch.tensor(v) for v in n["value"]]) if n["value"] else []
                     return g.op("Constant", value_t=value)
+                elif n.output().type().kind() == "DeviceObjType":
+                    return None
                 else:
                     raise RuntimeError("Unsupported prim::Constant kind: `{}`. Send a bug report.".format(
                         n.kindOf("value")))


### PR DESCRIPTION
[ note:  stacked on expect files changes, will unstack once they land ]
This adds DeviceObjType (cannot use DeviceType it is already an enum)
to the type hierarchy and an isDevice/toDevice pair to IValue.
Previous hacks which used an int[] to represent Device are removed
and at::Device is used instead.

Note: the behavior or .to is only a subset of python, we need to
fix the aten op so that it accepts Option[Device] and Optional[ScalarType].