### PR TITLE
Adding version-script to exclude protobuf symbols from so's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,13 @@ if(NOT APPLE AND UNIX)
   list(APPEND Caffe2_DEPENDENCY_LIBS dl)
 endif()
 
+# On Linux and Windows machines, exclude protobbuf symbols from shared libraries
+if(NOT APPLE)
+  set(VERSION_SCRIPT_OPTION "-Wl,--version-script=${CMAKE_CURRENT_LIST_DIR}/tools/pytorch.version")
+else(NOT APPLE)
+  set(VERSION_SCRIPT_OPTION "")
+endif(NOT APPLE)
+
 # Prefix path to Caffe2 headers.
 # If a directory containing installed Caffe2 headers was inadvertently
 # added to the list of include directories, prefixing

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -213,7 +213,7 @@ endif()
 
 if(NOT BUILD_ATEN_ONLY)
   caffe2_interface_library(caffe2_protos caffe2_protos_whole)
-  target_link_libraries(caffe2 PRIVATE caffe2_protos_whole)
+  target_link_libraries(caffe2 PRIVATE caffe2_protos_whole "${VERSION_SCRIPT_OPTION}")
   if (${CAFFE2_LINK_LOCAL_PROTOBUF})
     target_link_libraries(caffe2 INTERFACE protobuf::libprotobuf)
   else()
@@ -345,7 +345,7 @@ if(USE_CUDA)
   # order of the libraries in the linker call matters here when statically
   # linking; libculibos and cublas must be last.
   target_link_libraries(
-      caffe2_gpu PUBLIC caffe2 ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS})
+      caffe2_gpu PUBLIC caffe2 ${Caffe2_PUBLIC_CUDA_DEPENDENCY_LIBS} "${VERSION_SCRIPT_OPTION}")
 
   # See Note [Supporting both static and dynamic libraries on Window]
   # TODO: I'm actually not sure why this is necessary, because caffe2_gpu

--- a/modules/detectron/CMakeLists.txt
+++ b/modules/detectron/CMakeLists.txt
@@ -19,11 +19,11 @@ if (BUILD_CAFFE2_OPS)
         ${Detectron_CPU_SRCS}
         ${Detectron_GPU_SRCS})
 
-    target_link_libraries(caffe2_detectron_ops_gpu caffe2_gpu ${OpenMP_link})
+target_link_libraries(caffe2_detectron_ops_gpu caffe2_gpu ${OpenMP_link} "${VERSION_SCRIPT_OPTION}")
     install(TARGETS caffe2_detectron_ops_gpu DESTINATION lib)
   elseif(NOT IOS_PLATFORM)
     add_library(caffe2_detectron_ops SHARED ${Detectron_CPU_SRCS})
-    target_link_libraries(caffe2_detectron_ops caffe2 ${OpenMP_link})
+    target_link_libraries(caffe2_detectron_ops caffe2 ${OpenMP_link} "${VERSION_SCRIPT_OPTION}")
     install(TARGETS caffe2_detectron_ops DESTINATION lib)
   endif()
 endif()

--- a/modules/module_test/CMakeLists.txt
+++ b/modules/module_test/CMakeLists.txt
@@ -10,6 +10,6 @@ if (BUILD_TEST)
       caffe2_module_test_dynamic
       ${CMAKE_CURRENT_SOURCE_DIR}/module_test_dynamic.cc)
 
-  target_link_libraries(caffe2_module_test_dynamic caffe2_library)
+  target_link_libraries(caffe2_module_test_dynamic caffe2_library "${VERSION_SCRIPT_OPTION}")
   install(TARGETS caffe2_module_test_dynamic DESTINATION lib)
 endif()

--- a/modules/observers/CMakeLists.txt
+++ b/modules/observers/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(caffe2_observers
     "${CMAKE_CURRENT_SOURCE_DIR}/observer_config.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/perf_observer.cc"
     )
-target_link_libraries(caffe2_observers PUBLIC caffe2_library)
+target_link_libraries(caffe2_observers PUBLIC caffe2_library "${VERSION_SCRIPT_OPTION}")
 target_include_directories(caffe2_observers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_compile_options(caffe2_observers PRIVATE "-DCAFFE2_BUILD_OBSERVER_LIB")
 install(TARGETS caffe2_observers DESTINATION lib)

--- a/modules/rocksdb/CMakeLists.txt
+++ b/modules/rocksdb/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 # which is the main lib of Caffe2. If your library explicitly depends on cuda,
 # then you will need to depend on the caffe2_gpu_library as well.
 add_library(caffe2_rocksdb ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb.cc)
-target_link_libraries(caffe2_rocksdb PUBLIC caffe2_library)
+target_link_libraries(caffe2_rocksdb PUBLIC caffe2_library "${VERSION_SCRIPT_OPTION}")
 target_link_libraries(caffe2_rocksdb PRIVATE ${RocksDB_LIBRARIES})
 target_include_directories(caffe2_rocksdb PRIVATE ${RocksDB_INCLUDE_DIR})
 install(TARGETS caffe2_rocksdb DESTINATION lib)

--- a/tools/pytorch.version
+++ b/tools/pytorch.version
@@ -1,31 +1,12 @@
 {
      global:
-         _TH*;
-         __TH*;
-         TH*;
-         *THP*;
-         *THCP*;
-         PyInit*;
-         init*;
-         state;
-	 _ZGVZN2at*;
-         _ZN2at*;
-	 _ZNK2at*Type*;
-	 _ZNK2at*Tensor*;
-	 _ZNK2at*Storage*;
-	 _ZNK2at*Scalar*;
-	 _ZNK2at*CUDA*;
-	 *2at7Context*;
-	 _ZTIN2at*;
-	 _ZTIZN2at*;
-	 _ZTSN2at*;
-	 _ZTSPN2at*;
-	 _ZTSZN2at*;
-	 _ZTVN2at*;
-	 _ZZN2at*;
-	 _Z*torch*;
-	 _Z*Tensor*;
-	 _Z*tensor*;
-     local:
          *;
+         *caffe2*protobuf*;
+         *onnx*protobuf*;
+         *torch*protobuf*;
+         *protobuf*caffe2*;
+         *protobuf*onnx*;
+         *protobuf*torch*;
+     local:
+         *protobuf*;
  };

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -324,7 +324,13 @@ if (MSVC)
   target_link_libraries(torch onnx onnx_library)
 endif()
 
-target_link_libraries(torch caffe2_library)
+if (NOT APPLE)
+  # On Linux and Windows machines hide protobuf symbols with a version-script
+  target_link_libraries(torch caffe2_library "-Wl,--version-script=${CMAKE_CURRENT_LIST_DIR}/../tools/pytorch.version")
+else (NOT APPLE)
+  target_link_libraries(torch caffe2_library)
+endif(NOT APPLE)
+
 
 find_package(OpenMP)
 if(OPENMP_FOUND)


### PR DESCRIPTION
I think I also need to do this for libcaffe2. Is there any harm in always excluding these symbols (i.e. not only when building the binaries)?