### PR TITLE
Fix clamp when min/max are both None

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -68,6 +68,8 @@ Tensor& _clamp_out_cpu(
     _th_clamp_max_out(result, self, *max);
   } else if (min) {
     _th_clamp_min_out(result, self, *min);
+  } else {
+    AT_ERROR("At least one of 'min' or 'max' must not be None");
   }
   return result;
 }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -46,15 +46,7 @@ Tensor clamp_min(const Tensor& self, Scalar min) {
 }
 
 Tensor& _clamp__cpu(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
-  if (min && max) {
-    return _th_clamp_out(self, self, *min, *max);
-  } else if (max) {
-    return _th_clamp_max_out(self, self, *max);
-  } else if (min) {
-    return _th_clamp_min_out(self, self, *min);
-  } else {
-    AT_ERROR("At least one of 'min' or 'max' must not be None");
-  }
+  return _clamp_out_cpu(self, self, min, max);
 }
 
 Tensor& _clamp_out_cpu(

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -53,7 +53,7 @@ Tensor& _clamp__cpu(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
   } else if (min) {
     return _th_clamp_min_out(self, self, *min);
   } else {
-    return self;
+    AT_ERROR("At least one of 'min' or 'max' must not be None");
   }
 }
 

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -10,7 +10,7 @@ Tensor& _clamp__cuda(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
   } else if (min) {
     return _th_clamp_min_out(self, self, *min);
   } else {
-    return self;
+    AT_ERROR("At least one of 'min' or 'max' must not be None");
   }
 }
 

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -3,15 +3,7 @@
 namespace at { namespace native {
 
 Tensor& _clamp__cuda(Tensor& self, optional<Scalar> min, optional<Scalar> max) {
-  if (min && max) {
-    return _th_clamp_out(self, self, *min, *max);
-  } else if (max) {
-    return _th_clamp_max_out(self, self, *max);
-  } else if (min) {
-    return _th_clamp_min_out(self, self, *min);
-  } else {
-    AT_ERROR("At least one of 'min' or 'max' must not be None");
-  }
+  return _clamp_out_cuda(self, self, min, max);
 }
 
 Tensor& _clamp_out_cuda(

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -25,6 +25,8 @@ Tensor& _clamp_out_cuda(
     _th_clamp_max_out(result, self, *max);
   } else if (min) {
     _th_clamp_min_out(result, self, *min);
+  } else {
+    AT_ERROR("At least one of 'min' or 'max' must not be None");
   }
   return result;
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1722,6 +1722,10 @@ class _TestTorchMixin(object):
         torch.clamp(m1, max=max_val, out=out)
         self.assertEqual(out, res1)
 
+        with self.assertRaisesRegex(
+                RuntimeError, 'At least one of \'min\' or \'max\' must not be None'):
+            m1.clamp()  # Must specify min or max
+
     def test_pow(self):
         # [res] torch.pow([res,] x)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1722,9 +1722,11 @@ class _TestTorchMixin(object):
         torch.clamp(m1, max=max_val, out=out)
         self.assertEqual(out, res1)
 
-        with self.assertRaisesRegex(
-                RuntimeError, 'At least one of \'min\' or \'max\' must not be None'):
-            m1.clamp()  # Must specify min or max
+        error_msg = 'At least one of \'min\' or \'max\' must not be None'
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            m1.clamp()
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            m1.clamp_()
 
     def test_pow(self):
         # [res] torch.pow([res,] x)


### PR DESCRIPTION
Before this PR, tensor.clamp() would return an empty tensor if min and
max were not specified. This is a regression from 0.4.1, which would
throw an error. This PR restores that error message.

Fixes #14470

Test Plan:
Added new test to
`python test/test_torch.py TestTorch.test_clamp` for this case.

