### PR TITLE
Result type abstraction and its implementation for most unary CPU ops

### DIFF
--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -494,7 +494,7 @@ struct CAFFE2_API TensorImpl : public c10::intrusive_ptr_target {
    * in Python represent).
    *
    * Otherwise, they behave like their non-wrapped equivalents.
-   * See [Result type computation] in TensorIterator.h.
+   * See ResultType.h.
    *
    * Why did we opt for wrapped numbers, as opposed to just having
    * an extra function add(Tensor, Scalar)?  This helps greatly reduce

--- a/aten/src/ATen/native/ResultType.cpp
+++ b/aten/src/ATen/native/ResultType.cpp
@@ -56,4 +56,18 @@ Type& resultType(TensorList tensors) {
   return at::globalContext().getNonVariableType(backend, result_type);
 }
 
+Type& resultTypeForOutput(Tensor output, TensorList inputs) {
+  SmallVector<Tensor, 4> tensors(inputs.begin(), inputs.end());
+  tensors.emplace_back(output);
+  Type& result_type = resultType(tensors);
+  if (output.defined() && result_type != output.type()) {
+    AT_ERROR(
+        "Cannot store result of type ",
+        result_type.toString(),
+        " to an output of type ",
+        output.type().toString());
+  }
+  return result_type;
+}
+
 }  // namespace at

--- a/aten/src/ATen/native/ResultType.cpp
+++ b/aten/src/ATen/native/ResultType.cpp
@@ -1,0 +1,59 @@
+#include <ATen/native/ResultType.h>
+
+#include <ATen/ATen.h>
+
+namespace at {
+
+namespace {
+
+template <typename F>
+static std::tuple<ScalarType, Backend>
+compute_result_type(TensorList tensors, const F& predicate) {
+  auto result_type = ScalarType::Undefined;
+  auto backend = Backend::Undefined;
+  for (auto& tensor : tensors) {
+    if (!tensor.defined()) continue;
+    if (!predicate(tensor)) continue;
+    auto dtype = tensor.type().scalarType();;
+    result_type = (result_type == ScalarType::Undefined
+        ? dtype
+        : promoteTypes(result_type, dtype));
+    if (backend == Backend::Undefined) {
+      backend = tensor.type().backend();
+    } else if (backend != tensor.type().backend()) {
+      AT_ERROR(
+          "Cannot run operations between backends ",
+          backend,
+          " and ",
+          tensor.type().backend());
+    }
+  }
+  return std::make_tuple(result_type, backend);
+}
+
+} // anonymous namespace
+
+Type& resultType(TensorList tensors) {
+  auto result_type = ScalarType::Undefined;
+  auto backend = Backend::Undefined;
+  std::tie(result_type, backend) = compute_result_type(tensors, [](const Tensor& t) {
+    return t.dim() > 0;
+  });
+  if (result_type == ScalarType::Undefined) {
+    std::tie(result_type, backend) = compute_result_type(tensors, [](const Tensor& t) {
+      return !t.unsafeGetTensorImpl()->is_wrapped_number();
+    });
+  }
+  if (result_type == ScalarType::Undefined) {
+    std::tie(result_type, backend) = compute_result_type(tensors, [](const Tensor& t) {
+      return true;
+    });
+  }
+
+  AT_ASSERT(result_type != ScalarType::Undefined);
+  AT_ASSERT(backend != Backend::Undefined);
+
+  return at::globalContext().getNonVariableType(backend, result_type);
+}
+
+}  // namespace at

--- a/aten/src/ATen/native/ResultType.h
+++ b/aten/src/ATen/native/ResultType.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <c10/core/ScalarType.h>
+
+// Type determination rules for mixed-type operations.
+//
+// The result type is computed using the operands with the following precedence:
+//
+// 1) Tensors with dim 1 or higher
+// 2) Tensors with dim 0 that aren't wrapped numbers (e.g. `tensor(5)`)
+// 3) Tensors with dim 0 that are wrapped numbers (e.g. `5`)
+//
+// So if there are any tensors of dim 1 or higher, then 0-dim tensors do not
+// affect the result type. This behavior was chosen to preserve backwards
+// compatibility and is *likely to change* in the near future.
+// (See https://github.com/pytorch/pytorch/issues/9515)
+
+namespace at {
+
+struct Type;
+
+CAFFE2_API Type& resultType(TensorList tensors);
+
+}  // namespace at

--- a/aten/src/ATen/native/ResultType.h
+++ b/aten/src/ATen/native/ResultType.h
@@ -14,11 +14,16 @@
 // affect the result type. This behavior was chosen to preserve backwards
 // compatibility and is *likely to change* in the near future.
 // (See https://github.com/pytorch/pytorch/issues/9515)
+//
+// If an operation needs to produce an output of a specific type, this will
+// raise an error if the operation arguments yield a different type.
 
 namespace at {
 
 struct Type;
 
 CAFFE2_API Type& resultType(TensorList tensors);
+
+CAFFE2_API Type& resultTypeForOutput(Tensor output, TensorList inputs);
 
 }  // namespace at

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -32,20 +32,7 @@
 //     return a + b;
 //   });
 //
-// Note [Result type computation]
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// TensorIterator handles limited mixed-type operations. The result type is
-// computed using promoteTypes on the scalar types of the operands with the
-// following precedence:
-//
-// 1) Tensors with dim 1 or higher
-// 2) Tensors with dim 0 that aren't wrapped numbers (e.g. `tensor(5)`)
-// 3) Tensors with dim 0 that are wrapped numbers (e.g. `5`)
-//
-// So if there are any tensors of dim 1 or higher, then 0-dim tensors do not
-// affect the result type. This behavior was chosen to preserve backwards
-// compatibility and is *likely to change* in the near future.
-// (See https://github.com/pytorch/pytorch/issues/9515)
+// See ResultType.h for type conversion rules.
 //
 // Note that TensorIterator currently supports type conversions on 0-dim
 // tensors. Other type conversions will raise an exception.

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/wrapdim_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/dlconvertor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/native_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/result_type_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/scalar_tensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_parallel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/undefined_tensor_test.cpp

--- a/aten/src/ATen/test/result_type_test.cpp
+++ b/aten/src/ATen/test/result_type_test.cpp
@@ -1,0 +1,73 @@
+#include "gtest/gtest.h"
+
+#include "ATen/ATen.h"
+#include "ATen/native/ResultType.h"
+
+using namespace at;
+
+void testResultType(Type& weakType, Type& strongType, Type& promotedType) {
+  auto strongWrapped = ones({}, strongType).mul(5);
+  strongWrapped.unsafeGetTensorImpl()->set_wrapped_number(true);
+  auto strongScalar = ones({}, strongType).mul(5);
+  auto strongTensor = ones({3, 3}, strongType).mul(5);
+
+  auto weakWrapped = ones({}, weakType).mul(5);
+  weakWrapped.unsafeGetTensorImpl()->set_wrapped_number(true);
+  auto weakScalar = ones({}, weakType).mul(5);
+  auto weakTensor = ones({3, 3}, weakType).mul(5);
+
+  // Single argument
+  EXPECT_EQ(weakType, resultType(weakWrapped));
+  EXPECT_EQ(weakType, resultType(weakScalar));
+  EXPECT_EQ(weakType, resultType(weakTensor));
+
+  // Wrapped scalars only
+  EXPECT_EQ(weakType, resultType({weakWrapped, weakWrapped}));
+  EXPECT_EQ(strongType, resultType({strongWrapped, strongWrapped}));
+  EXPECT_EQ(strongType, resultType({strongWrapped, weakWrapped}));
+  EXPECT_EQ(strongType, resultType({weakWrapped, strongWrapped}));
+
+  // 0-dim only promotion
+  EXPECT_EQ(weakType, resultType({weakScalar, weakScalar}));
+  EXPECT_EQ(strongType, resultType({strongScalar, strongScalar}));
+  EXPECT_EQ(strongType, resultType({strongScalar, weakScalar}));
+  EXPECT_EQ(strongType, resultType({weakScalar, strongScalar}));
+
+  // Non 0-dim tensor only promotion
+  EXPECT_EQ(weakType, resultType({weakTensor, weakTensor}));
+  EXPECT_EQ(strongType, resultType({strongTensor, strongTensor}));
+  EXPECT_EQ(strongType, resultType({strongTensor, weakTensor}));
+  EXPECT_EQ(strongType, resultType({weakTensor, strongTensor}));
+
+  // 0-dim precedes wrapped scalars
+  EXPECT_EQ(weakType, resultType({weakScalar, strongWrapped}));
+  EXPECT_EQ(weakType, resultType({strongWrapped, weakScalar}));
+
+  // Non 0-dim precedes 0-dim
+  EXPECT_EQ(weakType, resultType({weakTensor, strongScalar}));
+  EXPECT_EQ(weakType, resultType({strongScalar, weakTensor}));
+
+  // Associativity
+  EXPECT_EQ(weakType, resultType({weakTensor, strongScalar, weakWrapped}));
+  EXPECT_EQ(weakType, resultType({weakWrapped, weakTensor, strongScalar}));
+  EXPECT_EQ(strongType, resultType({weakTensor, strongScalar, strongTensor}));
+  EXPECT_EQ(strongType, resultType({strongTensor, weakTensor, strongScalar}));
+}
+
+TEST(TestResultType, ResultTypeTestCPU) {
+  testResultType(CPU(kInt), CPU(kFloat), CPU(kFloat));
+}
+
+TEST(TestResultType, ResultTypeTestGPU) {
+  if (at::hasCUDA()) {
+    testResultType(CUDA(kInt), CUDA(kFloat), CUDA(kFloat));
+  }
+}
+
+TEST(TestResultType, ResultTypeTestFailBackendMismatch) {
+  if (at::hasCUDA()) {
+    auto cpuTensor = ones({3, 3}, CPU(kInt)).mul(5);
+    auto cudaTensor = ones({3, 3}, CUDA(kInt)).mul(5);
+    EXPECT_THROW(resultType({cpuTensor, cudaTensor}), c10::Error);
+  }
+}

--- a/aten/src/ATen/test/result_type_test.cpp
+++ b/aten/src/ATen/test/result_type_test.cpp
@@ -52,6 +52,14 @@ void testResultType(Type& weakType, Type& strongType, Type& promotedType) {
   EXPECT_EQ(weakType, resultType({weakWrapped, weakTensor, strongScalar}));
   EXPECT_EQ(strongType, resultType({weakTensor, strongScalar, strongTensor}));
   EXPECT_EQ(strongType, resultType({strongTensor, weakTensor, strongScalar}));
+
+  // Output type enforcement
+  EXPECT_EQ(strongType, resultTypeForOutput(strongTensor, weakWrapped));
+  EXPECT_EQ(strongType, resultTypeForOutput(strongTensor, weakScalar));
+  EXPECT_EQ(strongType, resultTypeForOutput(strongTensor, weakTensor));
+  EXPECT_EQ(weakType, resultTypeForOutput(weakTensor, strongWrapped));
+  EXPECT_EQ(weakType, resultTypeForOutput(weakTensor, strongScalar));
+  EXPECT_THROW(resultTypeForOutput(weakTensor, strongTensor), c10::Error);
 }
 
 TEST(TestResultType, ResultTypeTestCPU) {

--- a/aten/tools/run_tests.sh
+++ b/aten/tools/run_tests.sh
@@ -14,6 +14,7 @@ VALGRIND=${VALGRIND:=ON}
 ./apply_utils_test
 ./dlconvertor_test
 ./native_test
+./result_type_test
 ./scalar_tensor_test
 ./undefined_tensor_test
 if [[ -x ./cudnn_test ]]; then


### PR DESCRIPTION
This introduces the first batch of functions that can promote inputs with mixed type operands.

```
>>> a = torch.ones(3, dtype=torch.float32)
>>> c = torch.ones([], dtype=torch.float64)
>>> torch.sin(a, out=c).dtype
torch.float64
```

Operations can pick some or all of its operands to determine a final type and each operands then adjusts the computation to produce that type.

If the operands is working on an output (inplace or out_), it can pass an optional output Tensor to resultType to enforce promotion and disallow demotion.

The plan is to change most (if not all) ops supports resultType at native implementation layer.

pytorch/pytorch#9515
