### PR TITLE
add .code property to ScriptModule

### DIFF
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -683,6 +683,12 @@ void initJitScriptBindings(PyObject* module) {
         std::vector<at::Tensor> tensors;
         PythonPrint(ss, self, tensors, true);
         return std::make_pair(ss.str(), tensors);
+      })
+      .def_property_readonly("code", [](Module& self) {
+        std::ostringstream ss;
+        std::vector<at::Tensor> tensors;
+        PythonPrint(ss, self, tensors, false);
+        return ss.str();
       });
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())


### PR DESCRIPTION
simple change to allow `print(foo.code)` to give a pretty-printed description of all the methods on a module.