### PR TITLE
Support torch.load with encoding

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7915,6 +7915,34 @@ class _TestTorchMixin(object):
                 f.seek(0)
                 c = torch.load(handle)
             self._test_serialization_assert(b, c)
+        # test non-ascii encoding of bytes arrays/strings
+        # The following bytes are produced by serializing
+        #   [u'żąąóżąż'.encode('utf-8'), torch.zeros(1, dtype=torch.float), 2]
+        # in Python 2.7.12 and PyTorch 0.4.1
+        serialized = (
+            b'\x80\x02\x8a\nl\xfc\x9cF\xf9 j\xa8P\x19.\x80\x02M\xe9\x03.'
+            b'\x80\x02}q\x01(U\x10protocol_versionq\x02M\xe9\x03U\n'
+            b'type_sizesq\x03}q\x04(U\x03intq\x05K\x04U\x05shortq\x06K\x02U'
+            b'\x04longq\x07K\x04uU\rlittle_endianq\x08\x88u.\x80\x02]q'
+            b'\x01(U\x0e\xc5\xbc\xc4\x85\xc4\x85\xc3\xb3\xc5\xbc\xc4\x85'
+            b'\xc5\xbcq\x02ctorch._utils\n_rebuild_tensor_v2\nq\x03((U'
+            b'\x07storageq\x04ctorch\nFloatStorage\nq\x05U\x0845640624q'
+            b'\x06U\x03cpuq\x07\x8a\x01\x01NtQK\x00K\x01\x85K\x01\x85'
+            b'\x89NtRq\x08K\x02e.\x80\x02]q\x01U\x0845640624q\x02a.\x01\x00'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        )
+        buf = io.BytesIO(serialized)
+        if PY3:
+            with self.assertRaisesRegex(UnicodeDecodeError, "'ascii' codec can't decode byte"):
+                loaded = torch.load(buf)
+            buf.seek(0)
+            loaded_utf8 = torch.load(buf, encoding='utf-8')
+            self.assertEqual(loaded_utf8, [u'żąąóżąż', torch.zeros(1, dtype=torch.float), 2])
+            buf.seek(0)
+            loaded_bytes = torch.load(buf, encoding='bytes')
+        else:
+            loaded_bytes = torch.load(buf)
+        self.assertEqual(loaded_bytes, [u'żąąóżąż'.encode('utf-8'), torch.zeros(1, dtype=torch.float), 2])
 
     def test_serialization_filelike(self):
         # Test serialization (load and save) with a filelike object

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import sys
 import io
 import os

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -338,7 +338,7 @@ def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
 
     .. note::
         In Python 3, when loading files saved by Python 2, you may encounter
-        ``UnicodeDecodeError: ‘ascii’ codec can’t decode byte 0x...``. This is
+        ``UnicodeDecodeError: 'ascii' codec can't decode byte 0x...``. This is
         caused by the difference of handling in byte strings in Python2 and
         Python 3. You may use extra ``encoding`` keyword argument to specify how
         these objects should be loaded, e.g., ``encoding='latin1'`` decodes them

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -288,7 +288,7 @@ def _save(obj, f, pickle_module, pickle_protocol):
         serialized_storages[key]._write_file(f, _should_read_directly(f))
 
 
-def load(f, map_location=None, pickle_module=pickle):
+def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
     """Loads an object saved with :func:`torch.save` from a file.
 
     :meth:`torch.load` uses Python's unpickling facilities but treats storages,
@@ -327,11 +327,23 @@ def load(f, map_location=None, pickle_module=pickle):
             locations
         pickle_module: module used for unpickling metadata and objects (has to
             match the pickle_module used to serialize file)
+        pickle_load_args: optional keyword arguments passed over to
+            ``pickle_module.load`` and ``pickle_module.Unpickler``, e.g.,
+            ``encoding=...``.
 
     .. note::
         When you call :meth:`torch.load()` on a file which contains GPU tensors, those tensors
         will be loaded to GPU by default. You can call `torch.load(.., map_location='cpu')`
         and then :meth:`load_state_dict` to avoid GPU RAM surge when loading a model checkpoint.
+
+    .. note::
+        In Python 3, when loading files saved by Python 2, you may encounter
+        ``UnicodeDecodeError: ‘ascii’ codec can’t decode byte 0x...``. This is
+        caused by the difference of handling in byte strings in Python2 and
+        Python 3. You may use extra ``encoding`` keyword argument to specify how
+        these objects should be loaded, e.g., ``encoding='latin1'`` decodes them
+        to strings using ``latin1`` encoding, and ``encoding='bytes'`` keeps them
+        as byte arrays which can be decoded later with ``byte_array.decode(...)``.
 
     Example:
         >>> torch.load('tensors.pt')
@@ -355,13 +367,13 @@ def load(f, map_location=None, pickle_module=pickle):
         new_fd = True
         f = open(f, 'rb')
     try:
-        return _load(f, map_location, pickle_module)
+        return _load(f, map_location, pickle_module, **pickle_load_args)
     finally:
         if new_fd:
             f.close()
 
 
-def _load(f, map_location, pickle_module):
+def _load(f, map_location, pickle_module, **pickle_load_args):
     deserialized_objects = {}
 
     if map_location is None:
@@ -440,24 +452,24 @@ def _load(f, map_location, pickle_module):
 
             tar.extract('storages', path=tmpdir)
             with open(os.path.join(tmpdir, 'storages'), 'rb', 0) as f:
-                num_storages = pickle_module.load(f)
+                num_storages = pickle_module.load(f, **pickle_load_args)
                 for i in range(num_storages):
-                    args = pickle_module.load(f)
+                    args = pickle_module.load(f, **pickle_load_args)
                     key, location, storage_type = args
                     obj = storage_type._new_with_file(f)
                     obj = restore_location(obj, location)
                     deserialized_objects[key] = obj
 
-                storage_views = pickle_module.load(f)
+                storage_views = pickle_module.load(f, **pickle_load_args)
                 for target_cdata, root_cdata, offset, size in storage_views:
                     root = deserialized_objects[root_cdata]
                     deserialized_objects[target_cdata] = root[offset:offset + size]
 
             tar.extract('tensors', path=tmpdir)
             with open(os.path.join(tmpdir, 'tensors'), 'rb', 0) as f:
-                num_tensors = pickle_module.load(f)
+                num_tensors = pickle_module.load(f, **pickle_load_args)
                 for _ in range(num_tensors):
-                    args = pickle_module.load(f)
+                    args = pickle_module.load(f, **pickle_load_args)
                     key, storage_id, original_tensor_type = args
                     storage = deserialized_objects[storage_id]
                     tensor_type = storage_to_tensor_type(storage)
@@ -471,16 +483,27 @@ def _load(f, map_location, pickle_module):
                     deserialized_objects[key] = tensor
 
             pickle_file = tar.extractfile('pickle')
-            unpickler = pickle_module.Unpickler(pickle_file)
+            unpickler = pickle_module.Unpickler(pickle_file, **pickle_load_args)
             unpickler.persistent_load = persistent_load
             result = unpickler.load()
             return result
 
     deserialized_objects = {}
 
+    def maybe_decode_ascii(bytes_str):
+        # When using encoding='bytes' in Py3, some **internal** keys stored as
+        # strings in Py2 are loaded as bytes. This function decodes them with
+        # ascii encoding, one that Py3 uses by default.
+        #
+        # NOTE: This should only be used on internal keys (e.g., `typename` and
+        #       `location` in `persistent_load` below!
+        if isinstance(bytes_str, bytes):
+            return bytes_str.decode('ascii')
+        return bytes_str
+
     def persistent_load(saved_id):
         assert isinstance(saved_id, tuple)
-        typename = saved_id[0]
+        typename = maybe_decode_ascii(saved_id[0])
         data = saved_id[1:]
 
         if typename == 'module':
@@ -490,6 +513,7 @@ def _load(f, map_location, pickle_module):
             return data[0]
         elif typename == 'storage':
             data_type, root_key, location, size, view_metadata = data
+            location = maybe_decode_ascii(location)
             if root_key not in deserialized_objects:
                 deserialized_objects[root_key] = restore_location(
                     data_type(size), location)
@@ -516,19 +540,19 @@ def _load(f, map_location, pickle_module):
             # if not a tarfile, reset file offset and proceed
             f.seek(0)
 
-    magic_number = pickle_module.load(f)
+    magic_number = pickle_module.load(f, **pickle_load_args)
     if magic_number != MAGIC_NUMBER:
         raise RuntimeError("Invalid magic number; corrupt file?")
-    protocol_version = pickle_module.load(f)
+    protocol_version = pickle_module.load(f, **pickle_load_args)
     if protocol_version != PROTOCOL_VERSION:
         raise RuntimeError("Invalid protocol version: %s" % protocol_version)
 
-    _sys_info = pickle_module.load(f)
-    unpickler = pickle_module.Unpickler(f)
+    _sys_info = pickle_module.load(f, **pickle_load_args)
+    unpickler = pickle_module.Unpickler(f, **pickle_load_args)
     unpickler.persistent_load = persistent_load
     result = unpickler.load()
 
-    deserialized_storage_keys = pickle_module.load(f)
+    deserialized_storage_keys = pickle_module.load(f, **pickle_load_args)
 
     offset = f.tell() if f_should_read_directly else None
     for key in deserialized_storage_keys:


### PR DESCRIPTION
Addresses a common compatibility issue when loading Py2 checkpoints in Py3 regarding to bytes.

E.g., 
[1] https://github.com/pytorch/pytorch/issues/5994,
[2] https://github.com/CSAILVision/places365/issues/25,
[3] https://discuss.pytorch.org/t/how-to-load-a-saved-model-trained-on-pytorch-0-3-1-python-2-7-on-pyorch-1-0-python-3-7/31212