### PR TITLE
Back out "Fix include paths for TensorOptions, DefaultTensorOptions, OptionsGuard"

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -20,5 +20,5 @@
 #include "ATen/core/Scalar.h"
 #include <c10/core/Storage.h>
 #include "ATen/core/TensorMethods.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 #include <c10/util/Exception.h>

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -2,7 +2,7 @@
 
 #include "Context.h"
 
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 
 #include <thread>
 #include <mutex>

--- a/aten/src/ATen/InitialTensorOptions.h
+++ b/aten/src/ATen/InitialTensorOptions.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 
 namespace at {
 

--- a/aten/src/ATen/TensorOptions.h
+++ b/aten/src/ATen/TensorOptions.h
@@ -1,2 +1,2 @@
 #pragma once
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>

--- a/aten/src/ATen/core/DefaultTensorOptions.h
+++ b/aten/src/ATen/core/DefaultTensorOptions.h
@@ -1,0 +1,1 @@
+#include <c10/core/DefaultTensorOptions.h>

--- a/aten/src/ATen/core/TensorImpl.h
+++ b/aten/src/ATen/core/TensorImpl.h
@@ -6,7 +6,7 @@
 
 #include <c10/core/Backend.h>
 #include <c10/core/Storage.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 #include <c10/core/TensorTypeId.h>
 #include <c10/core/TensorTypeIdRegistration.h>
 #include <ATen/core/context_base.h>

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -5,7 +5,7 @@
 #include <c10/macros/Macros.h>
 #include "ATen/core/SparseTensorRef.h"
 #include "ATen/core/Type.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 
 namespace at {
 

--- a/aten/src/ATen/core/TensorOptions.h
+++ b/aten/src/ATen/core/TensorOptions.h
@@ -1,0 +1,1 @@
+#include <c10/core/TensorOptions.h>

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -12,7 +12,7 @@
 #include <c10/Half.h>
 #include <c10/core/TensorTypeIdRegistration.h>
 #include "ATen/core/Reduction.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 
 #include <c10/util/Optional.h>
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -11,7 +11,7 @@
 #include "ATen/NativeFunctions.h"
 #include <c10/core/ScalarType.h>
 #include "ATen/core/Deprecated.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 #include <TH/THRandom.h>
 #include "TH/THGenerator.hpp"
 #include "c10/util/Exception.h"

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -11,7 +11,7 @@
 #include "ATen/core/Deprecated.h"
 #include "ATen/NativeFunctions.h"
 #include "ATen/DeviceGuard.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 #include "ATen/core/Reduction.h"
 #include "c10/util/Optional.h"
 

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -5,7 +5,7 @@
 #include <ATen/Context.h>
 #include <c10/core/ScalarType.h>
 #include <ATen/core/TensorMethods.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 
 #include <array>
 #include <functional>

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -5,7 +5,7 @@
 #include <c10/macros/Macros.h>
 #include "ATen/core/SparseTensorRef.h"
 #include "ATen/core/Type.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 
 namespace at {
 

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -12,7 +12,7 @@
 #include <c10/Half.h>
 #include <c10/core/TensorTypeIdRegistration.h>
 #include "ATen/core/Reduction.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 
 #include <c10/util/Optional.h>
 

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -11,7 +11,7 @@
 #include "ATen/core/SparseTensorRef.h"
 #include "c10/core/Storage.h"
 #include "ATen/Tensor.h"
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 #include "ATen/DeviceGuard.h"
 #include "ATen/SparseTensorUtils.h"
 

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -6,7 +6,7 @@
 
 #include <ATen/core/UndefinedTensorImpl.h>
 #include <c10/util/intrusive_ptr.h>
-#include "c10/core/TensorOptions.h"
+#include "ATen/core/TensorOptions.h"
 
 namespace caffe2 {
 

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -4,7 +4,7 @@
 
 #include <ATen/Context.h>
 #include <ATen/Functions.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 
 #include <string>
 #include <vector>

--- a/test/cpp/api/tensor_options_cuda.cpp
+++ b/test/cpp/api/tensor_options_cuda.cpp
@@ -4,7 +4,7 @@
 #include <ATen/DeviceGuard.h>
 #include <ATen/Functions.h>
 #include <c10/core/ScalarType.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 
 #include <torch/cuda.h>
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -7,7 +7,7 @@
 
 #include "Functions.h"
 #include <ATen/Utils.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/SparseTensorUtils.h>

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -4,7 +4,7 @@
 #include <torch/types.h>
 #include <torch/utils.h>
 
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 #include <c10/util/Exception.h>
 
 #include <memory>

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -11,7 +11,7 @@
 
 #include <ATen/Device.h>
 #include <ATen/Parallel.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 #include <c10/util/Exception.h>
 
 #include <cstddef>

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -15,7 +15,7 @@
 
 #include <ATen/DeviceGuard.h>
 #include <ATen/ExpandUtils.h>
-#include <c10/core/TensorOptions.h>
+#include <ATen/core/TensorOptions.h>
 
 #include <vector>
 #include <tuple>


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#14744 Back out "Fix include paths for TensorOptions, DefaultTensorOptions, OptionsGuard"**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13318596/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14745 Back out "Move TensorOptions, DefaultTensorOptions and OptionsGuard to c10"&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13318594/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14746 Move TensorOptions, DefaultTensorOptions to c10&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13318644/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14747 Fix include paths for TensorOptions, DefaultTensorOptions, OptionsGuard&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13318645/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #14658 Remove TensorImpl -> context_base dependency&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13288655/)

Original commit changeset: d236d5351ecf

Differential Revision: [D13318596](https://our.internmc.facebook.com/intern/diff/D13318596/)