### PR TITLE
Disable randn_like fusion in the JIT

### DIFF
--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -59,7 +59,9 @@ bool isSimpleMap(Node *node) {
     "aten::neg(Tensor self) -> Tensor",
     "aten::pow(Tensor self, Tensor exponent) -> Tensor",
     "aten::pow(Tensor self, Scalar exponent) -> Tensor",
-    "aten::rand_like(Tensor self) -> Tensor",
+    // See https://github.com/pytorch/pytorch/issues/14674 and make sure you
+    // won't make the same mistake before you reenable this.
+    //"aten::rand_like(Tensor self) -> Tensor",
     "aten::reciprocal(Tensor self) -> Tensor",
     "aten::relu(Tensor self) -> Tensor",
     "aten::remainder(Tensor self, Tensor other) -> Tensor",


### PR DESCRIPTION
Fixes #14674. We won't have time for a proper fix before the release, so at least disable fusion of nodes that trigger incorrect behavior.