### PR TITLE
Remove use of hipify_caffe2, in favor of file path test.

### DIFF
--- a/tools/amd_build/build_pytorch_amd.py
+++ b/tools/amd_build/build_pytorch_amd.py
@@ -10,6 +10,7 @@ from pyHIPIFY import hipify_python
 amd_build_dir = os.path.dirname(os.path.realpath(__file__))
 proj_dir = os.path.dirname(os.path.dirname(amd_build_dir))
 
+# Keep this synchronized with is_pytorch_file in hipify_python.py
 includes = [
     "aten/*",
     "torch/*",


### PR DESCRIPTION
This is towards unifying build_pytorch_amd.py and build_caffe2_amd.py
scripts.  There is only one use of hipify_caffe2 left, which is just
to control which files actually get HIPified.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

