### PR TITLE
[jit] guard mm batching with mutable ops

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9080,6 +9080,23 @@ a")
 
         self.assertExpectedGraph(foo.graph)
 
+    def test_mutable_mm_batching(self):
+        def foo(a1, a2, a3, a4, a5, a6, a7, a8, in_place):
+            firstmm = torch.mm(a1, a2)
+            firstmmView = firstmm
+            firstmmView += in_place
+            firstmm = firstmm.t()
+            add1 = firstmm + torch.mm(a3, a4)
+            add2 = torch.mm(a5, a6) + torch.mm(a7, a8)
+            add3 = torch.mm(a1, a4) + torch.mm(a2, a3)
+            add4 = torch.mm(a5, a8) + torch.mm(a6, a7)
+
+            foo = add1 + add2
+            bar = add3 + add4
+            return foo + bar
+
+        self.checkScript(foo, [torch.rand(5, 5) for _i in range(9)])
+
 
 class MnistNet(nn.Module):
     def __init__(self):

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -20,7 +20,7 @@ bool shouldAnnotate(const Value* v) {
 }
 } // namespace
 
-AliasDb::AliasDb(std::shared_ptr<Graph> graph) : graph_(graph) {
+AliasDb::AliasDb(Graph* graph) : graph_(graph) {
   analyze(graph_);
 
   // Build helper indices
@@ -202,7 +202,7 @@ void AliasDb::dump() const {
   }
 }
 
-void AliasDb::analyze(std::shared_ptr<Graph> graph) {
+void AliasDb::analyze(Graph* graph) {
   // Assign aliases to the graph's inputs, assuming that all inputs of a given
   // type may alias to each other.
   const auto tensorAlias = getFreshAlias(/*isGraphInput=*/true);

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -26,7 +26,7 @@ namespace jit {
  */
 class AliasDb {
  public:
-  explicit AliasDb(std::shared_ptr<Graph> graph);
+  explicit AliasDb(Graph* graph);
 
   // Does `n` use or write to any wildcard aliases?
   bool hasWildcard(const Node* n) const;
@@ -53,7 +53,7 @@ class AliasDb {
   void dump() const;
 
  private:
-  void analyze(std::shared_ptr<Graph> graph);
+  void analyze(Graph* graph);
   void analyze(Block* block);
   void analyze(Node* node);
 
@@ -77,7 +77,7 @@ class AliasDb {
   bool hasWildcardImpl(const Node* n) const;
   bool writesTo(Node* n, const Value* v) const;
 
-  std::shared_ptr<Graph> graph_;
+  Graph* graph_;
   Symbol latestSymbol_ = Symbol::fromQualString("alias::0");
   std::unordered_map<const Value*, AliasInfo> valueToAlias_;
   std::unordered_map<Symbol, std::unordered_set<const Value*>> aliasToValue_;
@@ -87,6 +87,9 @@ class AliasDb {
 };
 
 inline TORCH_API AliasDb AliasAnalysis(std::shared_ptr<Graph> graph) {
+  return AliasDb(graph.get());
+}
+inline TORCH_API AliasDb AliasAnalysis(Graph* graph) {
   return AliasDb(graph);
 }
 } // namespace jit

--- a/torch/csrc/jit/passes/common_subexpression_elimination.cpp
+++ b/torch/csrc/jit/passes/common_subexpression_elimination.cpp
@@ -23,8 +23,9 @@ void EliminateCommonSubexpression(
   std::unordered_set<Node*, HashNode, EqualNode> subexprs;
   for (auto it = block->nodes().begin(); it != block->nodes().end(); ++ it) {
     auto node = *it;
-    if (node->kind() == prim::PythonOp || node->kind() == prim::Print ||
-        aliasDb.hasWriters(node) || aliasDb.hasWildcard(node)) {
+    if (node->isNondeterministic() || node->kind() == prim::PythonOp ||
+        node->kind() == prim::Print || aliasDb.hasWriters(node) ||
+        aliasDb.hasWildcard(node)) {
       // Do NOT have enough information to do CSE on these nodes.
       continue;
     }


### PR DESCRIPTION
This PR makes the BatchMM pass safe with respect to mutable ops. Basically, we move all the nodes to be contiguous before executing the merge, similar in principle to the graph fuser or autodiff subgraph creation.

Also fixes a CSE bug where we were eliminating common nondeterministic subexprs (!)