### PR TITLE
Increase test timeout

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1099,7 +1099,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
         # Sleep on one of the processes to trigger barrier timeout
         if self.rank == 0:
-            time.sleep(0.6)
+            time.sleep(1.0)
 
         # The barrier will now time out
         with self.assertRaisesRegex(RuntimeError, " (Timed out|closed) "):


### PR DESCRIPTION
It is possible that some sort of contention causes process scheduling
delays which in turn cause the timeout to *not* be hit.

Increased sleep here will decrease the probability of this happening.

Fixes #14555.

