### PR TITLE
Export complete subgraph io info when calling onnxGetBackendCompatibility

### DIFF
--- a/caffe2/onnx/helper.cc
+++ b/caffe2/onnx/helper.cc
@@ -20,6 +20,18 @@ void DummyName::Reset(const std::unordered_set<std::string> &used_names) {
   counter_ = 0;
 }
 
+::ONNX_NAMESPACE::TypeProto ExtraTypeProto(
+    const ::ONNX_NAMESPACE::TensorProto& tensor) {
+  ::ONNX_NAMESPACE::TypeProto t;
+  auto* tensor_type = t.mutable_tensor_type();
+  tensor_type->set_elem_type(tensor.data_type());
+  auto* shape = tensor_type->mutable_shape();
+  for (const auto d : tensor.dims()) {
+    shape->add_dim()->set_dim_value(d);
+  }
+  return t;
+}
+
 NodeProto MakeNode(
     const std::string& type,
     const std::vector<std::string>& inputs,

--- a/caffe2/onnx/helper.h
+++ b/caffe2/onnx/helper.h
@@ -29,6 +29,9 @@ class CAFFE2_API DummyName {
   size_t counter_{0};
 };
 
+::ONNX_NAMESPACE::TypeProto ExtraTypeProto(
+    const ::ONNX_NAMESPACE::TensorProto& tensor);
+
 inline AttributeProto MakeAttribute(
     const std::string& name,
     const std::vector<int64_t>& vals) {


### PR DESCRIPTION
Summary: We need to send complete IO info when doing `onnxGetBackendCompatibility` to backend like Glow. Previously we are missing some info because sometimes we generate more than one nodes from one C2 op. This fixes the issue.

Differential Revision: D13352049
