### PR TITLE
[Deprecate THCState] Move cudaDeviceProp to ATen

### DIFF
--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -10,17 +10,18 @@ namespace at { namespace cuda {
 
 namespace {
 
-static DeviceIndex num_gpus = -1;
-static std::once_flag init_flag;
-static std::deque<std::once_flag> device_flags;
-static std::vector<cudaDeviceProp> device_properties;
+DeviceIndex num_gpus = -1;
+std::once_flag init_flag;
+std::deque<std::once_flag> device_flags;
+std::vector<cudaDeviceProp> device_properties;
 
-static void initDevicePropertiesVector() {
+void initDevicePropertiesVector() {
   num_gpus = c10::cuda::device_count();
   device_flags.resize(num_gpus);
+  device_properties.resize(num_gpus);
 }
 
-static void initDeviceProperty(DeviceIndex device_index) {
+void initDeviceProperty(DeviceIndex device_index) {
   cudaDeviceProp device_prop;
   AT_CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_index));
   device_properties[device_index] = device_prop;

--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -15,7 +15,7 @@ std::once_flag init_flag;
 std::deque<std::once_flag> device_flags;
 std::vector<cudaDeviceProp> device_properties;
 
-void initDevicePropertiesVector() {
+void initCUDAContextVectors() {
   num_gpus = c10::cuda::device_count();
   device_flags.resize(num_gpus);
   device_properties.resize(num_gpus);
@@ -40,7 +40,7 @@ cudaDeviceProp* getCurrentDeviceProperties() {
 }
 
 cudaDeviceProp* getDeviceProperties(int64_t device) {
-  std::call_once(init_flag, initDevicePropertiesVector);
+  std::call_once(init_flag, initCUDAContextVectors);
   if (device == -1) device = c10::cuda::current_device();
   AT_ASSERT(device >= 0 && device < num_gpus);
   std::call_once(device_flags[device], initDeviceProperty, device);

--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -5,17 +5,42 @@
 
 namespace at { namespace cuda {
 
+namespace {
+
+static DeviceIndex num_gpus = -1;
+static std::once_flag init_flag;
+static std::deque<std::once_flag> device_flags;
+static std::vector<cudaDeviceProp> device_properties;
+
+static void initDevicePropertiesVector() {
+  num_gpus = c10::cuda::device_count();
+  device_flags.resize(num_gpus);
+}
+
+static void initDeviceProperty(DeviceIndex device_index) {
+  cudaDeviceProp device_prop;
+  AT_CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_index));
+  device_properties[device_index] = device_prop;
+}
+
+} // anonymous namespace
+
 /* Device info */
 int warp_size() {
   return getCurrentDeviceProperties()->warpSize;
 }
 
 cudaDeviceProp* getCurrentDeviceProperties() {
-  return THCState_getCurrentDeviceProperties(at::globalContext().getTHCState());
+  auto device = c10::cuda::current_device();
+  return getDeviceProperties(device);
 }
 
 cudaDeviceProp* getDeviceProperties(int64_t device) {
-  return THCState_getDeviceProperties(at::globalContext().getTHCState(), (int)device);
+  std::call_once(init_flag, initDevicePropertiesVector);
+  if (device == -1) device = c10::cuda::current_device();
+  AT_ASSERT(device >= 0 && device < num_gpus);
+  std::call_once(device_flags[device], initDeviceProperty, device);
+  return &device_properties[device];
 }
 
 Allocator* getCUDADeviceAllocator() {

--- a/aten/src/ATen/cuda/CUDAContext.cpp
+++ b/aten/src/ATen/cuda/CUDAContext.cpp
@@ -2,6 +2,9 @@
 #include <THC/THCGeneral.hpp>
 
 #include <ATen/cuda/CUDAConfig.h>
+#include <mutex>
+#include <deque>
+#include <vector>
 
 namespace at { namespace cuda {
 

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -93,8 +93,7 @@ bool CUDAHooks::compiledWithMIOpen() const {
 
 bool CUDAHooks::supportsDilatedConvolutionWithCuDNN() const {
 #if AT_CUDNN_ENABLED()
-  cudaDeviceProp* prop =
-      THCState_getCurrentDeviceProperties(globalContext().getTHCState());
+  cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
   // NOTE: extra parenthesis around numbers disable clang warnings about
   // dead code
   return (

--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -5,6 +5,7 @@
 #include <THC/THCReduceApplyUtils.cuh>
 #include <THC/THCTensorTypeUtils.cuh>
 #include <THC/THCTensorCopy.hpp>
+#include <ATen/cuda/CUDAContext.h>
 
 //
 // This file contains pointwise operation functions and kernels that
@@ -170,7 +171,7 @@ inline bool getApplyGrid(THCState* state, uint64_t totalElements, dim3& grid, in
   if (curDevice == -1) return false;
 
   uint64_t numBlocks = THCCeilDiv(totalElements, static_cast<uint64_t>(THC_APPLY_THREADS_PER_BLOCK));
-  uint64_t maxGridX = THCState_getDeviceProperties(state, curDevice)->maxGridSize[0];
+  uint64_t maxGridX = at::cuda::getDeviceProperties(curDevice)->maxGridSize[0];
   if (numBlocks > maxGridX)
       numBlocks = maxGridX;
 
@@ -266,7 +267,7 @@ bool THC_pointwiseApply1(THCState* state,
     aInfo.collapseDims();
 #if CUDA_VERSION < 9000
     if (!aInfo.isContiguous()) {
-        grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+        grid.x = min(at::cuda::getCurrentDeviceProperties()->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
     }
 #endif
     HANDLE_A_CASE(unsigned int, aInfo.dims);
@@ -291,7 +292,7 @@ bool THC_pointwiseApply1(THCState* state,
     } else {
 
 #if CUDA_VERSION < 9000
-        grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+        grid.x = min(at::cuda::getCurrentDeviceProperties()->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
 #endif
       OffsetInfo<ScalarTypeA, uint64_t, -1>
         aOffset(aInfo);
@@ -434,7 +435,7 @@ bool THC_pointwiseApply2(THCState* state,
     bInfo.collapseDims();
 #if CUDA_VERSION < 9000
     if (!(aInfo.isContiguous() && bInfo.isContiguous()))
-        grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+        grid.x = min(at::cuda::getCurrentDeviceProperties()->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
 #endif
 
     HANDLE_A_CASE(unsigned int, aInfo.dims, bInfo.dims);
@@ -466,7 +467,7 @@ bool THC_pointwiseApply2(THCState* state,
           aOffset, bOffset, (uint64_t) totalElements, op);
     } else {
 #if CUDA_VERSION < 9000
-      grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+      grid.x = min(at::cuda::getCurrentDeviceProperties()->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
 #endif
       OffsetInfo<ScalarTypeA, uint64_t, -1>
         aOffset(aInfo);
@@ -651,7 +652,7 @@ bool THC_pointwiseApply3(THCState* state,
 
 #if CUDA_VERSION < 9000
       if (!(aInfo.isContiguous() && bInfo.isContiguous() && cInfo.isContiguous()))
-          grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+          grid.x = min(at::cuda::getCurrentDeviceProperties()->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
 #endif
     HANDLE_A_CASE(unsigned int, aInfo.dims, bInfo.dims, cInfo.dims);
   } else {
@@ -689,7 +690,7 @@ bool THC_pointwiseApply3(THCState* state,
           aOffset, bOffset, cOffset, (uint64_t) totalElements, op);
     } else {
 #if CUDA_VERSION < 9000
-      grid.x = min(THCState_getCurrentDeviceProperties(state)->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
+      grid.x = min(at::cuda::getCurrentDeviceProperties()->multiProcessorCount * THC_APPLY_BLOCKS_PER_SM , grid.x);
 #endif
 
       OffsetInfo<ScalarTypeA, uint64_t, -1>

--- a/aten/src/THC/THCBlas.cu
+++ b/aten/src/THC/THCBlas.cu
@@ -1,6 +1,7 @@
 #include <THC/THCBlas.h>
 #include <THC/THCGeneral.h>
 #include <TH/THHalf.h>
+#include <ATen/cuda/CUDAContext.h>
 
 #include <algorithm>
 
@@ -304,7 +305,7 @@ void THCudaBlas_Hgemm(THCState *state, char transa, char transb, int64_t m, int6
                                   a, CUDA_R_16F, i_lda, b, CUDA_R_16F,
                                   i_ldb, &fBeta, c, CUDA_R_16F, i_ldc));
 #else
-      cudaDeviceProp* prop = THCState_getCurrentDeviceProperties(state);
+      cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
       if (prop->major >= 5){
         THCublasCheck(cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH));
 	THCublasCheck(cublasGemmEx(handle, opa, opb,

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -56,9 +56,6 @@ void THCudaInit(THCState* state)
   state->resourcesPerDevice = (THCCudaResourcesPerDevice*)
     calloc(numDevices, sizeof(THCCudaResourcesPerDevice));
 
-  state->deviceProperties =
-    (struct cudaDeviceProp*)malloc(numDevices * sizeof(struct cudaDeviceProp));
-
   state->rngState = (THCRNGState*)malloc(sizeof(THCRNGState));
   THCRandom_init(state, numDevices, device);
 
@@ -80,14 +77,13 @@ void THCudaInit(THCState* state)
   for (int i = 0; i < numDevices; ++i) {
     THCCudaResourcesPerDevice* res = THCState_getDeviceResourcePtr(state, i);
     THCudaCheck(cudaSetDevice(i));
-    THCudaCheck(cudaGetDeviceProperties(&state->deviceProperties[i], i));
 
     /* The scratch space that we want to have available per each device is
        based on the number of SMs available per device. We guarantee a
        minimum of 128kb of space per device, but to future-proof against
        future architectures that may have huge #s of SMs, we guarantee that
        we have at least 16 bytes for each SM. */
-    int numSM = state->deviceProperties[i].multiProcessorCount;
+    int numSM = at::cuda::getDeviceProperties(i)->multiProcessorCount;
     size_t sizePerStream =
       MIN_GLOBAL_SCRATCH_SPACE_PER_DEVICE >= numSM * MIN_GLOBAL_SCRATCH_SPACE_PER_SM_STREAM ?
       MIN_GLOBAL_SCRATCH_SPACE_PER_DEVICE :
@@ -104,7 +100,6 @@ void THCudaShutdown(THCState* state)
   THCRandom_shutdown(state);
 
   free(state->rngState);
-  free(state->deviceProperties);
 
   int deviceCount = 0;
   int prevDev = -1;
@@ -175,20 +170,6 @@ int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAccess)
     THCudaCheck(cudaSetDevice(prevDev));
   }
   return state->p2pAccessEnabled[dev][devToAccess];
-}
-
-struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* state)
-{
-  int curDev = -1;
-  THCudaCheck(cudaGetDevice(&curDev));
-
-  return &(state->deviceProperties[curDev]);
-}
-
-struct cudaDeviceProp* THCState_getDeviceProperties(THCState* state, int device)
-{
-  THAssert(device >= 0 && device < state->numDevices);
-  return &(state->deviceProperties[device]);
 }
 
 struct THCRNGState* THCState_getRngState(THCState *state)

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -6,6 +6,7 @@
 #include <THC/THCGeneral.hpp>
 
 #include <c10/cuda/CUDAStream.h>
+#include <ATen/cuda/CUDAContext.h>
 
 #include <THC/THCCachingAllocator.h>
 #include <stdlib.h>

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -73,9 +73,6 @@ THC_API void THCudaShutdown(THCState* state);
 /* 1; otherwise, 0. */
 THC_API int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAccess);
 
-THC_API struct cudaDeviceProp* THCState_getCurrentDeviceProperties(THCState* state);
-THC_API struct cudaDeviceProp* THCState_getDeviceProperties(THCState* state, int device);
-
 THC_API struct THCRNGState* THCState_getRngState(THCState* state);
 THC_API THAllocator* THCState_getCudaHostAllocator(THCState* state);
 

--- a/aten/src/THC/THCGeneral.hpp
+++ b/aten/src/THC/THCGeneral.hpp
@@ -5,7 +5,6 @@
 /* Global state of THC. */
 struct THCState {
   struct THCRNGState* rngState;
-  struct cudaDeviceProp* deviceProperties;
   /* Set of all allocated resources. blasHandles and sparseHandles do not have
      a default and must be explicitly initialized. We always initialize 1
      blasHandle and 1 sparseHandle but we can use more.

--- a/aten/src/THC/THCTensorMath.cuh
+++ b/aten/src/THC/THCTensorMath.cuh
@@ -1,6 +1,8 @@
 #ifndef THC_TENSORMATH_CUH
 #define THC_TENSORMATH_CUH
 
+#include "ATen/cuda/CUDAContext.h"
+
 // Copy the kth diagonal of a matrix B to a vector A.
 template <typename T>
 __global__ void THCTensor_copyFromDiagonal(T* a, T* b, ptrdiff_t start, ptrdiff_t size, ptrdiff_t strideSum, ptrdiff_t strideA) {
@@ -36,7 +38,7 @@ inline bool getCatGrid(THCState* state, ptrdiff_t nTensors, dim3& grid) {
 
   // Assume a reasonable number of SMs if no state is available
   int numSM =
-        state ? THCState_getCurrentDeviceProperties(state)->multiProcessorCount : 15;
+        state ? at::cuda::getCurrentDeviceProperties()->multiProcessorCount : 15;
   //X dim of grid for cat array cooperates on a single tensor in the cat.
   //Given half of the GPU, full utilization will always occur.
   grid = dim3( 2LL * numSM, (long long) nTensors );

--- a/aten/src/THC/THCTensorSort.cu
+++ b/aten/src/THC/THCTensorSort.cu
@@ -1,4 +1,5 @@
 #include <THC/THCTensorSort.cuh>
+#include <ATen/cuda/CUDAContext.h>
 
 void THCudaLongTensor_fillSliceWithIndex(THCState* state,
                                          THCudaLongTensor* t,
@@ -17,7 +18,7 @@ void THCudaLongTensor_fillSliceWithIndex(THCState* state,
     }
 
     int64_t maxThreads =
-      THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
     int64_t numThreads = sliceSize;
     if (numThreads > maxThreads) {
       numThreads = maxThreads;

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorIndex.cu"
 #else
 
+#include "ATen/cuda/CUDAContext.h"
+
 // Check tensor dimensions for index operations, and return the slice size.
 // src can be nullptr in case of indexFill: in that case it is ignored.
 static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
@@ -121,7 +123,7 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
   cudaStream_t stream = THCState_getCurrentStream(state);
   int indContig = THCudaLongTensor_isContiguous(state, indices);
 
-  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
+  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
 #define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM) \
   indexCopySmallIndex<TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM>       \
@@ -309,7 +311,7 @@ void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTe
   cudaStream_t stream = THCState_getCurrentStream(state);
   int indContig = THCudaLongTensor_isContiguous(state, indices);
 
-  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
+  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
 #define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM) \
   indexAddSmallIndex<TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM> \
@@ -431,7 +433,7 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
   cudaStream_t stream = THCState_getCurrentStream(state);
   int indContig = THCudaLongTensor_isContiguous(state, indices);
 
-  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
+  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
 #define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, IDX_DIM)  \
   indexFillSmallIndex<TENSOR_TYPE, TYPE, DST_DIM, IDX_DIM> \
@@ -554,7 +556,7 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
   int64_t srcSelectDimSize = THCTensor_(sizeLegacyNoScalars)(state, src, dim);
   ptrdiff_t sliceSize = dstTotalSize / numIndices;
 
-  int mpc = THCState_getCurrentDeviceProperties(state)->multiProcessorCount;
+  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
 #define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM) \
   indexSelectSmallIndex<TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM>     \

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMath.cu"
 #else
 
+#include "ATen/cuda/CUDAContext.h"
+
 void THCTensor_(fill)(THCState* state, THCTensor *self_, scalar_t value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
@@ -334,7 +336,7 @@ void THCTensor_(diag)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
     THCTensor_(resize1d)(state, self_, size);
     if (size > 0) {
       int64_t strideSelf = THCTensor_(stride)(state, self_, 0);
-      const dim3 threads(min((int64_t)THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock, (int64_t)size));
+      const dim3 threads(min((int64_t)at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, (int64_t)size));
       dim3 grid(min((int64_t)1024, (int64_t)THCCeilDiv(size, (int64_t)threads.x)));
       int64_t start = (k >= 0 ? k * stride1 : -k * stride0);
       THCTensor_copyFromDiagonal<scalar_t><<<grid, threads, 0, THCState_getCurrentStream(state)>>>
@@ -349,7 +351,7 @@ void THCTensor_(diag)(THCState *state, THCTensor *self_, THCTensor *src_, int64_
     if (size > 0) {
       int64_t stride0 = THCTensor_(stride)(state, self_, 0);
       int64_t stride1 = THCTensor_(stride)(state, self_, 1);
-      const dim3 threads(min((int64_t)THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock, (int64_t)size));
+      const dim3 threads(min((int64_t)at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, (int64_t)size));
       dim3 grid(min((int64_t)1024, (int64_t)THCCeilDiv(size, (ptrdiff_t)threads.x)));
       ptrdiff_t start = (k >= 0 ? k * stride1 : -k * stride0);
       THCTensor_copyToDiagonal<scalar_t><<<grid, threads, 0, THCState_getCurrentStream(state)>>>

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMathBlas.cu"
 #else
 
+#include "ATen/cuda/CUDAContext.h"
+
 #define ERROR_ONLY_FP_TYPES(func) \
   THError("%s for CUDA tensors only supports floating-point types. Try converting the tensors with .float()", func);
 
@@ -688,7 +690,7 @@ void THCTensor_(baddbmm)(THCState *state, THCTensor *result, scalar_t beta, THCT
   }
 #else
 #ifndef __HIP_PLATFORM_HCC__
-  cudaDeviceProp* prop = THCState_getCurrentDeviceProperties(state);
+  cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
   if (prop->major >= 5){
 #endif
 

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorRandom.cu"
 #else
 
+#include "ATen/cuda/CUDAContext.h"
+
 #define NUM_BLOCKS min((int)THCCeilDiv(size, (ptrdiff_t) BLOCK_SIZE), MAX_NUM_BLOCKS)
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
@@ -113,7 +115,7 @@ void THCTensor_(renormRows)(struct THCState* state,
   int64_t rows = THCTensor_(size)(state, t, 0);
   int64_t cols = THCTensor_(size)(state, t, 1);
 
-  cudaDeviceProp* props = THCState_getCurrentDeviceProperties(state);
+  cudaDeviceProp* props = at::cuda::getCurrentDeviceProperties();
   THAssert(props != NULL);
 
   int numSM = props->multiProcessorCount;
@@ -175,7 +177,7 @@ void THCTensor_(multinomial)(struct THCState *state,
   THCudaLongTensor_resize2d(state, self, numDist, n_sample);
 
   // get current device properties
-  cudaDeviceProp* props = THCState_getCurrentDeviceProperties(state);
+  cudaDeviceProp* props = at::cuda::getCurrentDeviceProperties();
   THAssert(props != NULL);
   int numSM = props->multiProcessorCount;
   int maxThreads = props->maxThreadsPerBlock;

--- a/aten/src/THCUNN/FeatureLPPooling.cu
+++ b/aten/src/THCUNN/FeatureLPPooling.cu
@@ -5,6 +5,7 @@
 #include <THC/THCDeviceUtils.cuh>
 #include <THC/THCNumerics.cuh>
 #include <THC/THCTensorTypeUtils.cuh>
+#include <ATen/cuda/CUDAContext.h>
 
 #define OUTPUT_FEATURES_PER_THREAD 32
 #define MAX_WARPS_PER_RUN 4
@@ -397,7 +398,7 @@ runFeatureLPPoolingUpdateOutput(THCState* state,
   cudaStream_t stream =
     THCState_getCurrentStream(state);
   const cudaDeviceProp* deviceProperties =
-    THCState_getCurrentDeviceProperties(state);
+    at::cuda::getCurrentDeviceProperties();
 
   int outputFeatures = ((input.getSize(1) - width) / stride) + 1;
 
@@ -526,7 +527,7 @@ runFeatureLPPoolingUpdateGradInput(THCState* state,
   cudaStream_t stream =
     THCState_getCurrentStream(state);
   const cudaDeviceProp* deviceProperties =
-    THCState_getCurrentDeviceProperties(state);
+    at::cuda::getCurrentDeviceProperties();
 
   for (int i = 0; i < 4; ++i) {
     THAssert(gradOutput.getSize(i) == output.getSize(i));

--- a/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/aten/src/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -4,6 +4,7 @@
 
 #include <THCUNN/common.h>
 #include <THCUNN/generic/pooling_shape.h>
+#include <ATen/cuda/CUDAContext.h>
 
 static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
                          THCState *state,
@@ -175,8 +176,8 @@ void THNN_(SpatialDilatedMaxPooling_updateGradInput)(
   grid.x = blocks;
   grid.y = batchSize;
   grid.z = nInputPlane;
-  uint64_t maxGridY = THCState_getCurrentDeviceProperties(state)->maxGridSize[1];
-  uint64_t maxGridZ = THCState_getCurrentDeviceProperties(state)->maxGridSize[2];
+  uint64_t maxGridY = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
+  uint64_t maxGridZ = at::cuda::getCurrentDeviceProperties()->maxGridSize[2];
   if (maxGridY < grid.y) grid.y = maxGridY;
   if (maxGridZ < grid.z) grid.z = maxGridZ;
   MaxPoolBackward<scalar_t, accreal> <<< grid, BACKWARD_THREADS, 0, THCState_getCurrentStream(state) >>>

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/upsampling.h>
+#include <ATen/cuda/CUDAContext.h>
 
 static inline void THNN_(SpatialUpSamplingBicubic_shapeCheck)
                         (THCState *state,
@@ -62,7 +63,7 @@ void THNN_(SpatialUpSamplingBicubic_updateOutput)(
 
   const int num_output_elements = outputHeight * outputWidth;
   const int max_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
 
   // Launch kernel
   cudaStream_t stream = THCState_getCurrentStream(state);
@@ -103,7 +104,7 @@ void THNN_(SpatialUpSamplingBicubic_updateGradInput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   bicubic_interp2d_backward_kernel<scalar_t ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
   num_threads, 0, stream>>>(num_kernels, rheight, rwidth, align_corners, in_data, out_data);

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/upsampling.h>
+#include "ATen/cuda/CUDAContext.h"
 
 static inline void THNN_(SpatialUpSamplingBilinear_shapeCheck)
                         (THCState *state,
@@ -59,7 +60,7 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
    0 , stream>>>(num_kernels, rheight, rwidth, align_corners, idata, odata);
@@ -94,7 +95,7 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel_backward<scalar_t ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
   num_threads, 0, stream>>>(num_kernels, rheight, rwidth, align_corners, data1, data2);

--- a/aten/src/THCUNN/generic/SpatialUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingNearest.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/common.h>
+#include "ATen/cuda/CUDAContext.h"
 
 static inline void THNN_(SpatialUpSamplingNearest_shapeCheck)
                         (THCState *state,
@@ -58,7 +59,7 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
   THCDeviceTensor<scalar_t, 4> odata = toDeviceTensor<scalar_t, 4>(state, output);
 
   const int num_kernels = outputHeight * outputWidth;
-  const int num_threads = THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  const int num_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   nearest_neighbor_4d_kernel<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads,
 	 0, stream>>>(num_kernels, idata, odata);
@@ -89,7 +90,7 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
   THCDeviceTensor<scalar_t, 4> data2 = toDeviceTensor<scalar_t, 4>(state, gradOutput);
 
   const int num_kernels = outputHeight * outputWidth;
-  const int num_threads = THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  const int num_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
 
   nearest_neighbor_4d_kernel_backward<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads),

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/upsampling.h>
+#include "ATen/cuda/CUDAContext.h"
 
 static inline void THNN_(TemporalUpSamplingLinear_shapeCheck)
                         (THCState *state,
@@ -53,7 +54,7 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
    0 , stream>>>(num_kernels, rwidth, align_corners, idata, odata);
@@ -84,7 +85,7 @@ void THNN_(TemporalUpSamplingLinear_updateGradInput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel_backward<scalar_t ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
   num_threads, 0, stream>>>(num_kernels, rwidth, align_corners, data1, data2);

--- a/aten/src/THCUNN/generic/TemporalUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingNearest.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/common.h>
+#include "ATen/cuda/CUDAContext.h"
 
 static inline void THNN_(TemporalUpSamplingNearest_shapeCheck)
                         (THCState *state,
@@ -50,7 +51,7 @@ void THNN_(TemporalUpSamplingNearest_updateOutput)(
   THCDeviceTensor<scalar_t, 3> odata = toDeviceTensor<scalar_t, 3>(state, output);
 
   const int num_kernels = outputWidth;
-  const int num_threads = THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  const int num_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   nearest_neighbor_3d_kernel<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads,
 	 0, stream>>>(num_kernels, idata, odata);
@@ -77,7 +78,7 @@ void THNN_(TemporalUpSamplingNearest_updateGradInput)(
   THCDeviceTensor<scalar_t, 3> data2 = toDeviceTensor<scalar_t, 3>(state, gradOutput);
 
   const int num_kernels = outputWidth;
-  const int num_threads = THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  const int num_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
 
   nearest_neighbor_3d_kernel_backward<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads),

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingNearest.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingNearest.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/common.h>
+#include "ATen/cuda/CUDAContext.h"
 
 static inline void THNN_(VolumetricUpSamplingNearest_shapeCheck)
                         (THCState *state,
@@ -63,7 +64,7 @@ void THNN_(VolumetricUpSamplingNearest_updateOutput)(
   THCDeviceTensor<scalar_t, 5> odata = toDeviceTensor<scalar_t, 5>(state, output);
 
   const int num_kernels = outputDepth * outputHeight * outputWidth;
-  const int num_threads = THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  const int num_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   nearest_neighbor_5d_kernel<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads,
 	 0, stream>>>(num_kernels, idata, odata);
@@ -96,7 +97,7 @@ void THNN_(VolumetricUpSamplingNearest_updateGradInput)(
   THCDeviceTensor<scalar_t, 5> data1 = toDeviceTensor<scalar_t, 5>(state, gradInput);
   THCDeviceTensor<scalar_t, 5> data2 = toDeviceTensor<scalar_t, 5>(state, gradOutput);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
-  const int num_threads = THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+  const int num_threads = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   nearest_neighbor_5d_kernel_backward<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads),
 	  num_threads, 0, stream>>>(num_kernels, data1, data2);

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -3,6 +3,7 @@
 #else
 
 #include <THCUNN/upsampling.h>
+#include "ATen/cuda/CUDAContext.h"
 
 static inline void THNN_(VolumetricUpSamplingTrilinear_shapeCheck)
                         (THCState *state,
@@ -63,7 +64,7 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel<scalar_t, accreal> <<<THCCeilDiv(num_kernels, num_threads), num_threads ,
    0 , stream>>>(num_kernels, rdepth, rheight, rwidth, align_corners, idata, odata);
@@ -101,7 +102,7 @@ void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
   const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
-    THCState_getCurrentDeviceProperties(state)->maxThreadsPerBlock;
+    at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = THCState_getCurrentStream(state);
   caffe_gpu_interp2_kernel_backward<scalar_t ,accreal> <<<THCCeilDiv(num_kernels, num_threads),
   num_threads, 0, stream>>>(num_kernels, rdepth, rheight, rwidth, align_corners, data1, data2);


### PR DESCRIPTION
This PR moves `deviceProperties` from `THCState` struct to `CUDAContext` in ATen and hence, takes one more step towards removing `THCState`.