### PR TITLE
Skipping two c10d tests only if there are multi-GPUs

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1564,6 +1564,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         )
 
     @skip_if_not_nccl
+    @skip_if_not_multigpu
     def test_queue_reduction(self):
         # Set up process group.
         store = c10d.FileStore(self.file.name, self.world_size)
@@ -1591,6 +1592,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
                          torch.ones(10) * (self.world_size + 1) * len(devices) / 2.0)
 
     @skip_if_not_nccl
+    @skip_if_not_multigpu
     def test_sync_reduction(self):
         # Set up process group.
         store = c10d.FileStore(self.file.name, self.world_size)


### PR DESCRIPTION
Otherwise, these tests will fail, even though they are never meant to run on single GPU machines.