### PR TITLE
disable optimizations for InternedStrings::InternedStrings

### DIFF
--- a/aten/src/ATen/core/register_symbols.cpp
+++ b/aten/src/ATen/core/register_symbols.cpp
@@ -3,6 +3,13 @@
 // This file is compiled with -O0 because the fully-macro-expanded
 // function is huge and only called once at startup.
 
+#if defined(__clang__)
+#pragma clang optimize off
+#elif defined(__GNUC__)
+#pragma GCC push_options
+#pragma GCC optimize("O0")
+#endif
+
 namespace c10 {
 InternedStrings::InternedStrings()
     : sym_to_info_(static_cast<size_t>(_keys::num_symbols)) {
@@ -14,3 +21,9 @@ InternedStrings::InternedStrings()
 #undef REGISTER_SYMBOL
 }
 } // namespace c10
+
+#if defined(__clang__)
+#pragma clang optimize on
+#elif defined(__GNUC__)
+#pragma GCC pop_options
+#endif


### PR DESCRIPTION
Summary:
This file takes more than 30 minutes to compile under
`mode/dbgo-asan-ubsan`, and while the comment states `-O0` is used, it is only
set in `CMakeLists.txt`, not in buck TARGETS.

Differential Revision: D13376157
