### PR TITLE
Implement torch.tril_indices and torch.triu_indices (#12653)

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -564,7 +564,7 @@ Tensor tril_indices(
   }
 
   // create an empty Tensor with correct soize
-  auto result = at::empty({n_indices, 2}, at::kLong);
+  auto result = at::empty({n_indices, 2}, options.device(DeviceType::CPU));
 
   AT_DISPATCH_ALL_TYPES(result.type(), "tril_indices", [&]() -> void {
     // fill the Tensor with correct values
@@ -587,7 +587,7 @@ Tensor tril_indices(
     }
   });
 
-  return result;
+  return result.to(options.device());
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ zeros ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -514,6 +514,12 @@ Tensor& range_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
   return at::_th_range_out(result, start, end, step);
 }
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triangle ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tensor tril_indices(int64_t row, int64_t col, int64_t offset, const TensorOptions& options) {
+  return native::ones({row, col}, options).tril(offset).nonzero();
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ zeros ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor zeros(IntList size, const TensorOptions& options) {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -571,7 +571,7 @@ Tensor tril_indices(
   auto n_indices = get_tril_size(row, col, offset);
 
   // create an empty Tensor with correct soize
-  auto result = at::empty({n_indices, 2}, options.device(DeviceType::CPU));
+  auto result = at::empty({n_indices, 2}, options);
 
   // The following three design options result in very little performance
   // differences. Hence, the 3rd option is taken for simpler code. Refer to
@@ -607,7 +607,7 @@ Tensor tril_indices(
     }
   });
 
-  return result.transpose(0, 1).to(options.device());
+  return result.transpose(0, 1);
 }
 
 
@@ -619,7 +619,7 @@ Tensor triu_indices(
   auto n_indices = row * col - get_tril_size(row, col, offset - 1);
 
   // create an empty Tensor with correct soize
-  auto result = at::empty({n_indices, 2}, options.device(DeviceType::CPU));
+  auto result = at::empty({n_indices, 2}, options);
 
   AT_DISPATCH_ALL_TYPES(result.type(), "triu_indices", [&]() -> void {
     // fill the Tensor with correct values
@@ -646,7 +646,7 @@ Tensor triu_indices(
     }
   });
 
-  return result.transpose(0, 1).to(options.device());
+  return result.transpose(0, 1);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ zeros ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2669,6 +2669,8 @@
 
 - func: tril_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options={}) -> Tensor
 
+- func: triu_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options={}) -> Tensor
+
 - func: trace(Tensor self) -> Tensor
   variants: method, function
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2667,6 +2667,8 @@
 - func: tril(Tensor self, int64_t diagonal=0) -> Tensor
   variants: method, function
 
+- func: tril_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options={}) -> Tensor
+
 - func: trace(Tensor self) -> Tensor
   variants: method, function
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2667,9 +2667,9 @@
 - func: tril(Tensor self, int64_t diagonal=0) -> Tensor
   variants: method, function
 
-- func: tril_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options={}) -> Tensor
+- func: tril_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options=at::kLong) -> Tensor
 
-- func: triu_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options={}) -> Tensor
+- func: triu_indices(int64_t row, int64_t col, int64_t offset=0, TensorOptions options=at::kLong) -> Tensor
 
 - func: trace(Tensor self) -> Tensor
   variants: method, function

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2120,19 +2120,18 @@ class TestCuda(TestCase):
                 z = x + y
 
     def test_tril_and_triu_indices(self):
+        device = torch.device('cuda:0')
         self.assertEqual(
             torch.ones(
-                253, 257, dtype=torch.long, device=torch.device('cuda:0'))
-                .tril(61).nonzero(),
+                253, 257, dtype=torch.long, device=device).tril(61).nonzero(),
             torch.tril_indices(
-                253, 257, 61, dtype=torch.long, device=torch.device('cuda:0')))
+                253, 257, 61, dtype=torch.long, device=device))
 
         self.assertEqual(
             torch.ones(
-                257, 3, dtype=torch.float32, device=torch.device('cuda:0'))
-                .triu(36).nonzero(),
+                257, 3, dtype=torch.float32, device=device).triu(36).nonzero(),
             torch.triu_indices(
-                257, 3, 36, dtype=torch.float32, device=torch.device('cuda:0')))
+                257, 3, 36, dtype=torch.float32, device=device))
 
 
 def load_ignore_file():

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2122,14 +2122,14 @@ class TestCuda(TestCase):
     def test_tril_and_triu_indices(self):
         device = torch.device('cuda:0')
         self.assertEqual(
-            torch.ones(
-                253, 257, dtype=torch.long, device=device).tril(61).nonzero(),
+            torch.ones(253, 257, dtype=torch.long, device=device)
+                 .tril(61).nonzero().transpose(0, 1),
             torch.tril_indices(
                 253, 257, 61, dtype=torch.long, device=device))
 
         self.assertEqual(
-            torch.ones(
-                257, 3, dtype=torch.float32, device=device).triu(36).nonzero(),
+            torch.ones(257, 3, dtype=torch.float32, device=device)
+                 .triu(36).nonzero().transpose(0, 1),
             torch.triu_indices(
                 257, 3, 36, dtype=torch.float32, device=device))
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2119,6 +2119,21 @@ class TestCuda(TestCase):
                 y = torch.randn(2, 1, device='cuda')
                 z = x + y
 
+    def test_tril_and_triu_indices(self):
+        self.assertEqual(
+            torch.ones(
+                253, 257, dtype=torch.long, device=torch.device('cuda:0'))
+                .tril(61).nonzero(),
+            torch.tril_indices(
+                253, 257, 61, dtype=torch.long, device=torch.device('cuda:0')))
+
+        self.assertEqual(
+            torch.ones(
+                257, 3, dtype=torch.float32, device=torch.device('cuda:0'))
+                .triu(36).nonzero(),
+            torch.triu_indices(
+                257, 3, 36, dtype=torch.float32, device=torch.device('cuda:0')))
+
 
 def load_ignore_file():
     from os.path import join, dirname

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2119,6 +2119,17 @@ class TestCuda(TestCase):
                 y = torch.randn(2, 1, device='cuda')
                 z = x + y
 
+    def test_tril_and_triu_indices(self):
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.triu_indices(
+                1, 1, device='cuda', layout=torch.strided))
+
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.tril_indices(
+                1, 1, device='cuda', layout=torch.strided))
+
 
 def load_ignore_file():
     from os.path import join, dirname

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2119,20 +2119,6 @@ class TestCuda(TestCase):
                 y = torch.randn(2, 1, device='cuda')
                 z = x + y
 
-    def test_tril_and_triu_indices(self):
-        device = torch.device('cuda:0')
-        self.assertEqual(
-            torch.ones(253, 257, dtype=torch.long, device=device)
-                 .tril(61).nonzero().transpose(0, 1),
-            torch.tril_indices(
-                253, 257, 61, dtype=torch.long, device=device))
-
-        self.assertEqual(
-            torch.ones(257, 3, dtype=torch.float32, device=device)
-                 .triu(36).nonzero().transpose(0, 1),
-            torch.triu_indices(
-                257, 3, 36, dtype=torch.float32, device=device))
-
 
 def load_ignore_file():
     from os.path import join, dirname

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3757,260 +3757,65 @@ class _TestTorchMixin(object):
         torch.tril(x, out=res2)
         self.assertEqual(res1, res2, 0)
 
-    def test_tril_indices(self):
-        # test 1 X 1 matrix
-        ti = torch.tril_indices(1, 1)
-        self.assertEqual(torch.tensor([[0, 0]]), ti)
+    def _compare_trilu_indices(self, row, col, offset=0, dtype=torch.uint8):
+        if row == 0 or col == 0:
+            # have to handle this separately as tril and triu does not take
+            # empty matrix as input
+            self.assertEqual(
+                torch.empty(0, 2, dtype=dtype),
+                torch.tril_indices(row, col, offset, dtype=dtype))
 
-        # test 3 X 3 matrix, offset = 0
-        ti = torch.tril_indices(3, 3)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0],
-                [1, 0], [1, 1],
-                [2, 0], [2, 1], [2, 2]]),
-            ti)
+            self.assertEqual(
+                torch.empty(0, 2, dtype=dtype),
+                torch.triu_indices(row, col, offset, dtype=dtype))
 
-        # test 3 X 3 matrix, offset = 1
-        ti = torch.tril_indices(3, 3, 1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1],
-                [1, 0], [1, 1], [1, 2],
-                [2, 0], [2, 1], [2, 2]]),
-            ti)
+        else:
+            self.assertEqual(
+                torch.ones(row, col, dtype=dtype)
+                     .tril(offset).nonzero(),
+                torch.tril_indices(row, col, offset, dtype=dtype))
 
-        # test 3 X 3 matrix, offset = 2
-        ti = torch.tril_indices(3, 3, 2)
-        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
+            self.assertEqual(
+                torch.ones(row, col, dtype=dtype)
+                     .triu(offset).nonzero(),
+                torch.triu_indices(row, col, offset, dtype=dtype))
 
-        # test 3 X 3 matrix, offset = 200
-        ti = torch.tril_indices(3, 3, 200)
-        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
-
-        # test 3 X 3 matrix, offset = -1
-        ti = torch.tril_indices(3, 3, -1)
-        self.assertEqual(
-            torch.tensor([
-                [1, 0],
-                [2, 0], [2, 1]]),
-            ti)
-
-        # test 3 X 3 matrix, offset = -2
-        ti = torch.tril_indices(3, 3, -2)
-        self.assertEqual(torch.tensor([[2, 0]]), ti)
-
-        # test 3 X 3 matrix, offset = -200
-        ti = torch.tril_indices(3, 3, -200)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 3 matrix, offset = 0
-        ti = torch.tril_indices(0, 3, 0)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 3 X 0 matrix, offset = 0
-        ti = torch.tril_indices(3, 0, 0)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 0 matrix, offset = 0
-        ti = torch.tril_indices(0, 0, 0)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 0 matrix, offset = 10
-        ti = torch.tril_indices(0, 0, 10)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 0 matrix, offset = -10
-        ti = torch.tril_indices(0, 0, -10)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 3 X 6 matrix, offset = 0
-        ti = torch.tril_indices(3, 6, 0)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0],
-                [1, 0], [1, 1],
-                [2, 0], [2, 1], [2, 2]]),
-            ti)
-
-        # test 3 X 6 matrix, offset = 1
-        ti = torch.tril_indices(3, 6, 1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1],
-                [1, 0], [1, 1], [1, 2],
-                [2, 0], [2, 1], [2, 2], [2, 3]]),
-            ti)
-
-        # test 3 X 6 matrix, offset = -2
-        ti = torch.tril_indices(3, 6, -2)
-        self.assertEqual(torch.tensor([[2, 0]]), ti)
-
-        # test 4 X 3 matrix, offset = 0
-        ti = torch.tril_indices(4, 3, 0)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0],
-                [1, 0], [1, 1],
-                [2, 0], [2, 1], [2, 2],
-                [3, 0], [3, 1], [3, 2]]),
-            ti)
-
-        # test 4 X 3 matrix, offset = 1
-        ti = torch.tril_indices(4, 3, 1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1],
-                [1, 0], [1, 1], [1, 2],
-                [2, 0], [2, 1], [2, 2],
-                [3, 0], [3, 1], [3, 2]]),
-            ti)
-
-        # test 4 X 3 matrix, offset = -1
-        ti = torch.tril_indices(4, 3, -1)
-        self.assertEqual(
-            torch.tensor([
-                [1, 0],
-                [2, 0], [2, 1],
-                [3, 0], [3, 1], [3, 2]]),
-            ti)
-
-        # test 3 X 3 matrix with type float64, offset = 0
-        ti = torch.tril_indices(3, 3, dtype=torch.float64)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0],
-                [1, 0], [1, 1],
-                [2, 0], [2, 1], [2, 2]],
-                dtype=torch.float64),
-            ti)
-
-    def test_triu_indices(self):
-        # test 1 X 1 matrix
-        ti = torch.triu_indices(1, 1)
-        self.assertEqual(torch.tensor([[0, 0]]), ti)
-
-        # test 3 X 3 matrix, offset = 0
-        ti = torch.triu_indices(3, 3)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2],
-                        [1, 1], [1, 2],
-                                [2, 2]]),
-            ti)
-
-        # test 3 X 3 matrix, offset = -1
-        ti = torch.triu_indices(3, 3, -1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2],
-                [1, 0], [1, 1], [1, 2],
-                        [2, 1], [2, 2]]),
-            ti)
-
-        # test 3 X 3 matrix, offset = 2
-        ti = torch.triu_indices(3, 3, -2)
-        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
-
-        # test 3 X 3 matrix, offset = -200
-        ti = torch.triu_indices(3, 3, -200)
-        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
-
-        # test 3 X 3 matrix, offset = 1
-        ti = torch.triu_indices(3, 3, 1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 1], [0, 2],
-                        [1, 2]]),
-            ti)
-
-        # test 3 X 3 matrix, offset = 2
-        ti = torch.triu_indices(3, 3, 2)
-        self.assertEqual(torch.tensor([[0, 2]]), ti)
-
-        # test 3 X 3 matrix, offset = 200
-        ti = torch.triu_indices(3, 3, 200)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 3 matrix, offset = 0
-        ti = torch.triu_indices(0, 3, 0)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 3 X 0 matrix, offset = 0
-        ti = torch.triu_indices(3, 0, 0)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 0 matrix, offset = 0
-        ti = torch.triu_indices(0, 0, 0)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 0 matrix, offset = 10
-        ti = torch.triu_indices(0, 0, 10)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 0 X 0 matrix, offset = -10
-        ti = torch.triu_indices(0, 0, -10)
-        self.assertEqual(torch.empty(0, 2), ti)
-
-        # test 6 X 3 matrix, offset = 0
-        ti = torch.triu_indices(6, 3, 0)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2],
-                        [1, 1], [1, 2],
-                                [2, 2]]),
-            ti)
-
-        # test 6 X 3 matrix, offset = 2
-        ti = torch.triu_indices(6, 3, 2)
-        self.assertEqual(torch.tensor([[0, 2]]), ti)
-
-        # test 6 X 3 matrix, offset = -1
-        ti = torch.triu_indices(6, 3, -1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2],
-                [1, 0], [1, 1], [1, 2],
-                        [2, 1], [2, 2],
-                                [3, 2]]),
-            ti)
-
-        # test 3 X 4 matrix, offset = 0
-        ti = torch.triu_indices(3, 4, 0)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2], [0, 3],
-                        [1, 1], [1, 2], [1, 3],
-                                [2, 2], [2, 3]]),
-            ti)
-
-        # test 3 X 4 matrix, offset = 1
-        ti = torch.triu_indices(3, 4, 1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 1], [0, 2], [0, 3],
-                        [1, 2], [1, 3],
-                                [2, 3]]),
-            ti)
-
-        # test 3 X 4 matrix, offset = -1
-        ti = torch.triu_indices(3, 4, -1)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2], [0, 3],
-                [1, 0], [1, 1], [1, 2], [1, 3],
-                        [2, 1], [2, 2], [2, 3]]),
-            ti)
-
-        # test 3 X 3 matrix with type float64, offset = 0
-        ti = torch.triu_indices(3, 3, dtype=torch.float64)
-        self.assertEqual(
-            torch.tensor([
-                [0, 0], [0, 1], [0, 2],
-                        [1, 1], [1, 2],
-                                [2, 2]],
-                dtype=torch.float64),
-            ti)
+    def test_tril_and_triu_indices(self):
+        self._compare_trilu_indices(1, 1)
+        self._compare_trilu_indices(3, 3)
+        self._compare_trilu_indices(3, 3, offset=1)
+        self._compare_trilu_indices(3, 3, offset=2)
+        self._compare_trilu_indices(3, 3, offset=200)
+        self._compare_trilu_indices(3, 3, offset=-1)
+        self._compare_trilu_indices(3, 3, offset=-2)
+        self._compare_trilu_indices(3, 3, offset=-200)
+        self._compare_trilu_indices(0, 3, offset=0)
+        self._compare_trilu_indices(0, 3, offset=1)
+        self._compare_trilu_indices(0, 3, offset=-1)
+        self._compare_trilu_indices(3, 0, offset=0)
+        self._compare_trilu_indices(3, 0, offset=1)
+        self._compare_trilu_indices(3, 0, offset=-1)
+        self._compare_trilu_indices(0, 0, offset=0)
+        self._compare_trilu_indices(0, 0, offset=1)
+        self._compare_trilu_indices(0, 0, offset=-1)
+        self._compare_trilu_indices(3, 6, offset=0)
+        self._compare_trilu_indices(3, 6, offset=1)
+        self._compare_trilu_indices(3, 6, offset=3)
+        self._compare_trilu_indices(3, 6, offset=9)
+        self._compare_trilu_indices(3, 6, offset=-1)
+        self._compare_trilu_indices(3, 6, offset=-3)
+        self._compare_trilu_indices(3, 6, offset=-9)
+        self._compare_trilu_indices(6, 3, offset=0)
+        self._compare_trilu_indices(6, 3, offset=1)
+        self._compare_trilu_indices(6, 3, offset=3)
+        self._compare_trilu_indices(6, 3, offset=9)
+        self._compare_trilu_indices(6, 3, offset=-1)
+        self._compare_trilu_indices(6, 3, offset=-3)
+        self._compare_trilu_indices(6, 3, offset=-9)
+        self._compare_trilu_indices(258, 253, offset=1, dtype=torch.float32)
+        self._compare_trilu_indices(257, 258, offset=1, dtype=torch.float64)
+        self._compare_trilu_indices(258, 258, offset=1, dtype=torch.short)
+        self._compare_trilu_indices(3, 513, offset=1, dtype=torch.long)
 
     def test_triu(self):
         x = torch.rand(SIZE, SIZE)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3784,6 +3784,10 @@ class _TestTorchMixin(object):
         ti = torch.tril_indices(3, 3, 2)
         self.assertEqual(torch.ones(3, 3).nonzero(), ti)
 
+        # test 3 X 3 matrix, offset = 200
+        ti = torch.tril_indices(3, 3, 200)
+        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
+
         # test 3 X 3 matrix, offset = -1
         ti = torch.tril_indices(3, 3, -1)
         self.assertEqual(
@@ -3795,6 +3799,30 @@ class _TestTorchMixin(object):
         # test 3 X 3 matrix, offset = -2
         ti = torch.tril_indices(3, 3, -2)
         self.assertEqual(torch.tensor([[2, 0]]), ti)
+
+        # test 3 X 3 matrix, offset = -200
+        ti = torch.tril_indices(3, 3, -200)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 3 matrix, offset = 0
+        ti = torch.tril_indices(0, 3, 0)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 3 X 0 matrix, offset = 0
+        ti = torch.tril_indices(3, 0, 0)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 0 matrix, offset = 0
+        ti = torch.tril_indices(0, 0, 0)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 0 matrix, offset = 10
+        ti = torch.tril_indices(0, 0, 10)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 0 matrix, offset = -10
+        ti = torch.tril_indices(0, 0, -10)
+        self.assertEqual(torch.empty(0, 2), ti)
 
     def test_triu(self):
         x = torch.rand(SIZE, SIZE)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3781,6 +3781,7 @@ class _TestTorchMixin(object):
                 torch.triu_indices(row, col, offset, dtype=dtype))
 
     def test_tril_and_triu_indices(self):
+
         self._compare_trilu_indices(1, 1)
         self._compare_trilu_indices(3, 3)
         self._compare_trilu_indices(3, 3, offset=1)
@@ -3816,6 +3817,30 @@ class _TestTorchMixin(object):
         self._compare_trilu_indices(257, 258, offset=1, dtype=torch.float64)
         self._compare_trilu_indices(258, 258, offset=1, dtype=torch.short)
         self._compare_trilu_indices(3, 513, offset=1, dtype=torch.long)
+
+        x = torch.ones(
+            3, 3, dtype=torch.long, device='cpu', layout=torch.strided)
+        l = x.tril(0).nonzero().transpose(0, 1)
+        u = x.triu(0).nonzero().transpose(0, 1)
+        self.assertEqual(l, torch.tril_indices(3, 3))
+        self.assertEqual(l, torch.tril_indices(3, 3, device='cpu'))
+        self.assertEqual(
+            l, torch.tril_indices(3, 3, device='cpu', layout=torch.strided))
+
+        self.assertEqual(u, torch.triu_indices(3, 3))
+        self.assertEqual(u, torch.triu_indices(3, 3, device='cpu'))
+        self.assertEqual(
+            u, torch.triu_indices(3, 3, device='cpu', layout=torch.strided))
+
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.triu_indices(
+                1, 1, device='cpu', layout=torch.sparse_coo))
+
+        self.assertRaises(
+            RuntimeError,
+            lambda: torch.tril_indices(
+                1, 1, device='cpu', layout=torch.sparse_coo))
 
     def test_triu(self):
         x = torch.rand(SIZE, SIZE)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3757,6 +3757,45 @@ class _TestTorchMixin(object):
         torch.tril(x, out=res2)
         self.assertEqual(res1, res2, 0)
 
+    def test_tril_indices(self):
+        # test 1 X 1 matrix
+        ti = torch.tril_indices(1, 1)
+        self.assertEqual(torch.tensor([[0, 0]]), ti)
+
+        # test 3 X 3 matrix, offset = 0
+        ti = torch.tril_indices(3, 3)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0],
+                [1, 0], [1, 1],
+                [2, 0], [2, 1], [2, 2]]),
+            ti)
+
+        # test 3 X 3 matrix, offset = 1
+        ti = torch.tril_indices(3, 3, 1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1],
+                [1, 0], [1, 1], [1, 2],
+                [2, 0], [2, 1], [2, 2]]),
+            ti)
+
+        # test 3 X 3 matrix, offset = 2
+        ti = torch.tril_indices(3, 3, 2)
+        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
+
+        # test 3 X 3 matrix, offset = -1
+        ti = torch.tril_indices(3, 3, -1)
+        self.assertEqual(
+            torch.tensor([
+                [1, 0],
+                [2, 0], [2, 1]]),
+            ti)
+
+        # test 3 X 3 matrix, offset = -2
+        ti = torch.tril_indices(3, 3, -2)
+        self.assertEqual(torch.tensor([[2, 0]]), ti)
+
     def test_triu(self):
         x = torch.rand(SIZE, SIZE)
         res1 = torch.triu(x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3824,6 +3824,57 @@ class _TestTorchMixin(object):
         ti = torch.tril_indices(0, 0, -10)
         self.assertEqual(torch.empty(0, 2), ti)
 
+        # test 3 X 6 matrix, offset = 0
+        ti = torch.tril_indices(3, 6, 0)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0],
+                [1, 0], [1, 1],
+                [2, 0], [2, 1], [2, 2]]),
+            ti)
+
+        # test 3 X 6 matrix, offset = 1
+        ti = torch.tril_indices(3, 6, 1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1],
+                [1, 0], [1, 1], [1, 2],
+                [2, 0], [2, 1], [2, 2], [2, 3]]),
+            ti)
+
+        # test 3 X 6 matrix, offset = -2
+        ti = torch.tril_indices(3, 6, -2)
+        self.assertEqual(torch.tensor([[2, 0]]), ti)
+
+        # test 4 X 3 matrix, offset = 0
+        ti = torch.tril_indices(4, 3, 0)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0],
+                [1, 0], [1, 1],
+                [2, 0], [2, 1], [2, 2],
+                [3, 0], [3, 1], [3, 2]]),
+            ti)
+
+        # test 4 X 3 matrix, offset = 1
+        ti = torch.tril_indices(4, 3, 1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1],
+                [1, 0], [1, 1], [1, 2],
+                [2, 0], [2, 1], [2, 2],
+                [3, 0], [3, 1], [3, 2]]),
+            ti)
+
+        # test 4 X 3 matrix, offset = -1
+        ti = torch.tril_indices(4, 3, -1)
+        self.assertEqual(
+            torch.tensor([
+                [1, 0],
+                [2, 0], [2, 1],
+                [3, 0], [3, 1], [3, 2]]),
+            ti)
+
         # test 3 X 3 matrix with type float64, offset = 0
         ti = torch.tril_indices(3, 3, dtype=torch.float64)
         self.assertEqual(
@@ -3831,6 +3882,133 @@ class _TestTorchMixin(object):
                 [0, 0],
                 [1, 0], [1, 1],
                 [2, 0], [2, 1], [2, 2]],
+                dtype=torch.float64),
+            ti)
+
+    def test_triu_indices(self):
+        # test 1 X 1 matrix
+        ti = torch.triu_indices(1, 1)
+        self.assertEqual(torch.tensor([[0, 0]]), ti)
+
+        # test 3 X 3 matrix, offset = 0
+        ti = torch.triu_indices(3, 3)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2],
+                        [1, 1], [1, 2],
+                                [2, 2]]),
+            ti)
+
+        # test 3 X 3 matrix, offset = -1
+        ti = torch.triu_indices(3, 3, -1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2],
+                [1, 0], [1, 1], [1, 2],
+                        [2, 1], [2, 2]]),
+            ti)
+
+        # test 3 X 3 matrix, offset = 2
+        ti = torch.triu_indices(3, 3, -2)
+        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
+
+        # test 3 X 3 matrix, offset = -200
+        ti = torch.triu_indices(3, 3, -200)
+        self.assertEqual(torch.ones(3, 3).nonzero(), ti)
+
+        # test 3 X 3 matrix, offset = 1
+        ti = torch.triu_indices(3, 3, 1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 1], [0, 2],
+                        [1, 2]]),
+            ti)
+
+        # test 3 X 3 matrix, offset = 2
+        ti = torch.triu_indices(3, 3, 2)
+        self.assertEqual(torch.tensor([[0, 2]]), ti)
+
+        # test 3 X 3 matrix, offset = 200
+        ti = torch.triu_indices(3, 3, 200)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 3 matrix, offset = 0
+        ti = torch.triu_indices(0, 3, 0)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 3 X 0 matrix, offset = 0
+        ti = torch.triu_indices(3, 0, 0)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 0 matrix, offset = 0
+        ti = torch.triu_indices(0, 0, 0)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 0 matrix, offset = 10
+        ti = torch.triu_indices(0, 0, 10)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 0 X 0 matrix, offset = -10
+        ti = torch.triu_indices(0, 0, -10)
+        self.assertEqual(torch.empty(0, 2), ti)
+
+        # test 6 X 3 matrix, offset = 0
+        ti = torch.triu_indices(6, 3, 0)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2],
+                        [1, 1], [1, 2],
+                                [2, 2]]),
+            ti)
+
+        # test 6 X 3 matrix, offset = 2
+        ti = torch.triu_indices(6, 3, 2)
+        self.assertEqual(torch.tensor([[0, 2]]), ti)
+
+        # test 6 X 3 matrix, offset = -1
+        ti = torch.triu_indices(6, 3, -1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2],
+                [1, 0], [1, 1], [1, 2],
+                        [2, 1], [2, 2],
+                                [3, 2]]),
+            ti)
+
+        # test 3 X 4 matrix, offset = 0
+        ti = torch.triu_indices(3, 4, 0)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2], [0, 3],
+                        [1, 1], [1, 2], [1, 3],
+                                [2, 2], [2, 3]]),
+            ti)
+
+        # test 3 X 4 matrix, offset = 1
+        ti = torch.triu_indices(3, 4, 1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 1], [0, 2], [0, 3],
+                        [1, 2], [1, 3],
+                                [2, 3]]),
+            ti)
+
+        # test 3 X 4 matrix, offset = -1
+        ti = torch.triu_indices(3, 4, -1)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2], [0, 3],
+                [1, 0], [1, 1], [1, 2], [1, 3],
+                        [2, 1], [2, 2], [2, 3]]),
+            ti)
+
+        # test 3 X 3 matrix with type float64, offset = 0
+        ti = torch.triu_indices(3, 3, dtype=torch.float64)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0], [0, 1], [0, 2],
+                        [1, 1], [1, 2],
+                                [2, 2]],
                 dtype=torch.float64),
             ti)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3824,6 +3824,16 @@ class _TestTorchMixin(object):
         ti = torch.tril_indices(0, 0, -10)
         self.assertEqual(torch.empty(0, 2), ti)
 
+        # test 3 X 3 matrix with type float64, offset = 0
+        ti = torch.tril_indices(3, 3, dtype=torch.float64)
+        self.assertEqual(
+            torch.tensor([
+                [0, 0],
+                [1, 0], [1, 1],
+                [2, 0], [2, 1], [2, 2]],
+                dtype=torch.float64),
+            ti)
+
     def test_triu(self):
         x = torch.rand(SIZE, SIZE)
         res1 = torch.triu(x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3762,22 +3762,22 @@ class _TestTorchMixin(object):
             # have to handle this separately as tril and triu does not take
             # empty matrix as input
             self.assertEqual(
-                torch.empty(0, 2, dtype=dtype),
+                torch.empty(0, 2, dtype=dtype).transpose(0, 1),
                 torch.tril_indices(row, col, offset, dtype=dtype))
 
             self.assertEqual(
-                torch.empty(0, 2, dtype=dtype),
+                torch.empty(0, 2, dtype=dtype).transpose(0, 1),
                 torch.triu_indices(row, col, offset, dtype=dtype))
 
         else:
             self.assertEqual(
                 torch.ones(row, col, dtype=dtype)
-                     .tril(offset).nonzero(),
+                     .tril(offset).nonzero().transpose(0, 1),
                 torch.tril_indices(row, col, offset, dtype=dtype))
 
             self.assertEqual(
                 torch.ones(row, col, dtype=dtype)
-                     .triu(offset).nonzero(),
+                     .triu(offset).nonzero().transpose(0, 1),
                 torch.triu_indices(row, col, offset, dtype=dtype))
 
     def test_tril_and_triu_indices(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3757,7 +3757,7 @@ class _TestTorchMixin(object):
         torch.tril(x, out=res2)
         self.assertEqual(res1, res2, 0)
 
-    def _compare_trilu_indices(self, row, col, offset=0, dtype=torch.uint8):
+    def _compare_trilu_indices(self, row, col, offset=0, dtype=torch.long):
         if row == 0 or col == 0:
             # have to handle this separately as tril and triu does not take
             # empty matrix as input
@@ -3781,7 +3781,6 @@ class _TestTorchMixin(object):
                 torch.triu_indices(row, col, offset, dtype=dtype))
 
     def test_tril_and_triu_indices(self):
-
         self._compare_trilu_indices(1, 1)
         self._compare_trilu_indices(3, 3)
         self._compare_trilu_indices(3, 3, offset=1)
@@ -3817,6 +3816,8 @@ class _TestTorchMixin(object):
         self._compare_trilu_indices(257, 258, offset=1, dtype=torch.float64)
         self._compare_trilu_indices(258, 258, offset=1, dtype=torch.short)
         self._compare_trilu_indices(3, 513, offset=1, dtype=torch.long)
+        self._compare_trilu_indices(513, 3, offset=1, dtype=torch.int)
+        self._compare_trilu_indices(513, 0, offset=1, dtype=torch.double)
 
         x = torch.ones(
             3, 3, dtype=torch.long, device='cpu', layout=torch.strided)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -229,7 +229,8 @@ def group_declarations_by_name(declarations, should_bind_fn):
 
 def get_type_default(declaration):
     if declaration['name'].startswith('randperm') or \
-            declaration['name'].endswith('indices'):
+            declaration['name'] == 'tril_indices' or \
+            declaration['name'] == 'triu_indices':
         return 'torch.int64'
     else:
         return 'None'

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -228,7 +228,8 @@ def group_declarations_by_name(declarations, should_bind_fn):
 
 
 def get_type_default(declaration):
-    if declaration['name'].startswith('randperm'):
+    if declaration['name'].startswith('randperm') or \
+            declaration['name'].endswith('indices'):
         return 'torch.int64'
     else:
         return 'None'

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4987,7 +4987,7 @@ Example::
 # as common args.
 add_docstr(torch.tril_indices,
            r"""
-tril_indices(row, column, offset=0, dtype=None) -> Tensor
+tril_indices(row, column, offset=0, dtype=torch.long, device='cpu', layout=torch.strided) -> Tensor
 
 Returns the indices of the lower triangular part of a :attr:`row`-by-
 :attr:`column` matrix in a 2-by-N Tensor, where the first row contains row
@@ -5004,29 +5004,32 @@ diagonal, and similarly a negative value excludes just as many diagonals below
 the main diagonal. The main diagonal are the set of indices
 :math:`\lbrace (i, i) \rbrace` for :math:`i \in [0, \min\{d_{1}, d_{2}\} - 1]`
 where :math:`d_{1}, d_{2}` are the dimensions of the matrix.
-""" + r"""
+
 Args:
-    row int64_t: number of rows in the 2-D matrix.
-    column int64_t: number of columns in the 2-D matrix.
-    offset int64_t: diagonal offset from the main diagonal.
-    {dtype}
+    row (``int...``): number of rows in the 2-D matrix.
+    column (``int...``): number of columns in the 2-D matrix.
+    offset (``int...``): diagonal offset from the main diagonal.
+    dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
+        Default: if ``None``, ``torch.long``.
+    device (:class:`torch.device`, optional): currently only support ``cpu``.
+    layout (:class:`torch.layout`, optional): currently only support ``torch.strided``.
 
 Example::
     >>> a = torch.tril_indices(3, 3)
     >>> a
-    tensor([[0., 1., 1., 2., 2., 2.],
-            [0., 0., 1., 0., 1., 2.]])
+    tensor([[0, 1, 1, 2, 2, 2],
+            [0, 0, 1, 0, 1, 2]])
 
     >>> a = torch.tril_indices(4, 3, -1)
     >>> a
-    tensor([[1., 2., 2., 3., 3., 3.],
-            [0., 0., 1., 0., 1., 2.]])
+    tensor([[1, 2, 2, 3, 3, 3],
+            [0, 0, 1, 0, 1, 2]])
 
     >>> a = torch.tril_indices(4, 3, 1)
     >>> a
-    tensor([[0., 0., 1., 1., 1., 2., 2., 2., 3., 3., 3.],
-            [0., 1., 0., 1., 2., 0., 1., 2., 0., 1., 2.]])
-""".format(**factory_common_args))
+    tensor([[0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3],
+            [0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 2]])
+""")
 
 add_docstr(torch.triu,
            r"""
@@ -5093,7 +5096,7 @@ Example::
 # as common args.
 add_docstr(torch.triu_indices,
            r"""
-triu_indices(row, column, offset=0, dtype=None) -> Tensor
+triu_indices(row, column, offset=0, dtype=torch.long, device='cpu', layout=torch.strided) -> Tensor
 
 Returns the indices of the upper triangular part of a :attr:`row` by
 :attr:`column` matrix in a 2-by-N Tensor, where the first row contains row
@@ -5110,29 +5113,32 @@ diagonal, and similarly a negative value includes just as many diagonals below
 the main diagonal. The main diagonal are the set of indices
 :math:`\lbrace (i, i) \rbrace` for :math:`i \in [0, \min\{d_{1}, d_{2}\} - 1]`
 where :math:`d_{1}, d_{2}` are the dimensions of the matrix.
-""" + r"""
+
 Args:
-    row int64_t: number of rows in the 2-D matrix
-    column int64_t: number of columns in the 2-D matrix
-    offset int64_t: diagonal offset from the main diagonal
-    {dtype}
+    row (``int...``): number of rows in the 2-D matrix.
+    column (``int...``): number of columns in the 2-D matrix.
+    offset (``int...``): diagonal offset from the main diagonal.
+    dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
+        Default: if ``None``, ``torch.long``.
+    device (:class:`torch.device`, optional): currently only support ``cpu``.
+    layout (:class:`torch.layout`, optional): currently only support ``torch.strided``.
 
 Example::
     >>> a = torch.triu_indices(3, 3)
     >>> a
-    tensor([[0., 0., 0., 1., 1., 2.],
-            [0., 1., 2., 1., 2., 2.]])
+    tensor([[0, 0, 0, 1, 1, 2],
+            [0, 1, 2, 1, 2, 2]])
 
     >>> a = torch.triu_indices(4, 3, -1)
     >>> a
-    tensor([[0., 0., 0., 1., 1., 1., 2., 2., 3.],
-            [0., 1., 2., 0., 1., 2., 1., 2., 2.]])
+    tensor([[0, 0, 0, 1, 1, 1, 2, 2, 3],
+            [0, 1, 2, 0, 1, 2, 1, 2, 2]])
 
     >>> a = torch.triu_indices(4, 3, 1)
     >>> a
-    tensor([[0., 0., 1.],
-            [1., 2., 2.]])
-""".format(**factory_common_args))
+    tensor([[0, 0, 1],
+            [1, 2, 2]])
+""")
 
 add_docstr(torch.trtrs,
            r"""

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4987,7 +4987,7 @@ Example::
 # as common args.
 add_docstr(torch.tril_indices,
            r"""
-tril_indices(row, column, offset=0, dtype=None, device=None) -> Tensor
+tril_indices(row, column, offset=0, dtype=None) -> Tensor
 
 Returns the indices of the lower triangular part of a :attr:`row`-by-
 :attr:`column` matrix in a 2-by-N Tensor, where the first row contains row
@@ -5010,7 +5010,6 @@ Args:
     column int64_t: number of columns in the 2-D matrix.
     offset int64_t: diagonal offset from the main diagonal.
     {dtype}
-    {device}
 
 Example::
     >>> a = torch.tril_indices(3, 3)
@@ -5094,7 +5093,7 @@ Example::
 # as common args.
 add_docstr(torch.triu_indices,
            r"""
-triu_indices(row, column, offset=0, dtype=None, device=None) -> Tensor
+triu_indices(row, column, offset=0, dtype=None) -> Tensor
 
 Returns the indices of the upper triangular part of a :attr:`row` by
 :attr:`column` matrix in a 2-by-N Tensor, where the first row contains row
@@ -5117,7 +5116,6 @@ Args:
     column int64_t: number of columns in the 2-D matrix
     offset int64_t: diagonal offset from the main diagonal
     {dtype}
-    {device}
 
 Example::
     >>> a = torch.triu_indices(3, 3)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4989,8 +4989,10 @@ add_docstr(torch.tril_indices,
            r"""
 tril_indices(row, column, offset=0, dtype=None, device=None) -> Tensor
 
-Returns the indices of the lower triangular part of a :attr:`row` by
-:attr:`column` matrix. Indices are ordered based on rows and then columns.
+Returns the indices of the lower triangular part of a :attr:`row`-by-
+:attr:`column` matrix in a 2-by-N Tensor, where the first row contains row
+coordinates of all indices and the second row contains column coordinates.
+Indices are ordered based on rows and then columns.
 
 The lower triangular part of the matrix is defined as the elements on and
 below the diagonal.
@@ -5013,22 +5015,18 @@ Args:
 Example::
     >>> a = torch.tril_indices(3, 3)
     >>> a
-    tensor([[0, 0],
-            [1, 0], [1, 1],
-            [2, 0], [2, 1], [2, 2]])
+    tensor([[0., 1., 1., 2., 2., 2.],
+            [0., 0., 1., 0., 1., 2.]])
 
     >>> a = torch.tril_indices(4, 3, -1)
     >>> a
-    tensor([[1, 0],
-            [2, 0], [2, 1],
-            [3, 0], [3, 1], [3, 2]])
+    tensor([[1., 2., 2., 3., 3., 3.],
+            [0., 0., 1., 0., 1., 2.]])
 
     >>> a = torch.tril_indices(4, 3, 1)
     >>> a
-    tensor([[0, 0], [0, 1],
-            [1, 0], [1, 1], [1, 2],
-            [2, 0], [2, 1], [2, 2],
-            [3, 0], [3, 1], [3, 2]])
+    tensor([[0., 0., 1., 1., 1., 2., 2., 2., 3., 3., 3.],
+            [0., 1., 0., 1., 2., 0., 1., 2., 0., 1., 2.]])
 """.format(**factory_common_args))
 
 add_docstr(torch.triu,
@@ -5099,7 +5097,9 @@ add_docstr(torch.triu_indices,
 triu_indices(row, column, offset=0, dtype=None, device=None) -> Tensor
 
 Returns the indices of the upper triangular part of a :attr:`row` by
-:attr:`column` matrix. Indices are ordered based on rows and then columns.
+:attr:`column` matrix in a 2-by-N Tensor, where the first row contains row
+coordinates of all indices and the second row contains column coordinates.
+Indices are ordered based on rows and then columns.
 
 The upper triangular part of the matrix is defined as the elements on and
 above the diagonal.
@@ -5122,21 +5122,18 @@ Args:
 Example::
     >>> a = torch.triu_indices(3, 3)
     >>> a
-    tensor([[0, 0], [0, 1], [0, 2],
-                    [1, 1], [1, 2],
-                            [2, 2]])
+    tensor([[0., 0., 0., 1., 1., 2.],
+            [0., 1., 2., 1., 2., 2.]])
 
     >>> a = torch.triu_indices(4, 3, -1)
     >>> a
-    tensor([[0, 0], [0, 1], [0, 2],
-            [1, 0], [1, 1], [1, 2],
-                    [2, 1], [2, 2],
-                            [3, 2]])
+    tensor([[0., 0., 0., 1., 1., 1., 2., 2., 3.],
+            [0., 1., 2., 0., 1., 2., 1., 2., 2.]])
 
     >>> a = torch.triu_indices(4, 3, 1)
     >>> a
-    tensor([[0, 1], [0, 2],
-                    [1, 2]])
+    tensor([[0., 0., 1.],
+            [1., 2., 2.]])
 """.format(**factory_common_args))
 
 add_docstr(torch.trtrs,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4983,6 +4983,54 @@ Example::
             [-0.0614, -0.7344, -1.3164,  0.0000,  0.0000,  0.0000]])
 """)
 
+# docstr is split in two parts to avoid format mis-captureing :math: braces '{}'
+# as common args.
+add_docstr(torch.tril_indices,
+           r"""
+tril_indices(row, column, offset=0, dtype=None, device=None) -> Tensor
+
+Returns the indices of the lower triangular part of a :attr:`row` by
+:attr:`column` matrix. Indices are ordered based on rows and then columns.
+
+The lower triangular part of the matrix is defined as the elements on and
+below the diagonal.
+
+The argument :attr:`offset` controls which diagonal to consider. If
+:attr:`offset` = 0, all elements on and below the main diagonal are
+retained. A positive value includes just as many diagonals above the main
+diagonal, and similarly a negative value excludes just as many diagonals below
+the main diagonal. The main diagonal are the set of indices
+:math:`\lbrace (i, i) \rbrace` for :math:`i \in [0, \min\{d_{1}, d_{2}\} - 1]`
+where :math:`d_{1}, d_{2}` are the dimensions of the matrix.
+""" + r"""
+Args:
+    row int64_t: number of rows in the 2-D matrix.
+    column int64_t: number of columns in the 2-D matrix.
+    offset int64_t: diagonal offset from the main diagonal.
+    {dtype}
+    {device}
+
+Example::
+    >>> a = torch.tril_indices(3, 3)
+    >>> a
+    tensor([[0, 0],
+            [1, 0], [1, 1],
+            [2, 0], [2, 1], [2, 2]])
+
+    >>> a = torch.tril_indices(4, 3, -1)
+    >>> a
+    tensor([[1, 0],
+            [2, 0], [2, 1],
+            [3, 0], [3, 1], [3, 2]])
+
+    >>> a = torch.tril_indices(4, 3, 1)
+    >>> a
+    tensor([[0, 0], [0, 1],
+            [1, 0], [1, 1], [1, 2],
+            [2, 0], [2, 1], [2, 2],
+            [3, 0], [3, 1], [3, 2]])
+""".format(**factory_common_args))
+
 add_docstr(torch.triu,
            r"""
 triu(input, diagonal=0, out=None) -> Tensor
@@ -5043,6 +5091,53 @@ Example::
             [ 0.4333,  0.3146,  0.0000,  0.0000,  0.0000,  0.0000],
             [-0.9888,  1.0679, -1.3337,  0.0000,  0.0000,  0.0000]])
 """)
+
+# docstr is split in two parts to avoid format mis-captureing :math: braces '{}'
+# as common args.
+add_docstr(torch.triu_indices,
+           r"""
+triu_indices(row, column, offset=0, dtype=None, device=None) -> Tensor
+
+Returns the indices of the upper triangular part of a :attr:`row` by
+:attr:`column` matrix. Indices are ordered based on rows and then columns.
+
+The upper triangular part of the matrix is defined as the elements on and
+above the diagonal.
+
+The argument :attr:`offset` controls which diagonal to consider. If
+:attr:`offset` = 0, all elements on and above the main diagonal are
+retained. A positive value excludes just as many diagonals above the main
+diagonal, and similarly a negative value includes just as many diagonals below
+the main diagonal. The main diagonal are the set of indices
+:math:`\lbrace (i, i) \rbrace` for :math:`i \in [0, \min\{d_{1}, d_{2}\} - 1]`
+where :math:`d_{1}, d_{2}` are the dimensions of the matrix.
+""" + r"""
+Args:
+    row int64_t: number of rows in the 2-D matrix
+    column int64_t: number of columns in the 2-D matrix
+    offset int64_t: diagonal offset from the main diagonal
+    {dtype}
+    {device}
+
+Example::
+    >>> a = torch.triu_indices(3, 3)
+    >>> a
+    tensor([[0, 0], [0, 1], [0, 2],
+                    [1, 1], [1, 2],
+                            [2, 2]])
+
+    >>> a = torch.triu_indices(4, 3, -1)
+    >>> a
+    tensor([[0, 0], [0, 1], [0, 2],
+            [1, 0], [1, 1], [1, 2],
+                    [2, 1], [2, 2],
+                            [3, 2]])
+
+    >>> a = torch.triu_indices(4, 3, 1)
+    >>> a
+    tensor([[0, 1], [0, 2],
+                    [1, 2]])
+""".format(**factory_common_args))
 
 add_docstr(torch.trtrs,
            r"""

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5006,9 +5006,10 @@ the main diagonal. The main diagonal are the set of indices
 where :math:`d_{1}, d_{2}` are the dimensions of the matrix.
 
 Args:
-    row (``int...``): number of rows in the 2-D matrix.
-    column (``int...``): number of columns in the 2-D matrix.
-    offset (``int...``): diagonal offset from the main diagonal.
+    row (``int``): number of rows in the 2-D matrix.
+    column (``int``): number of columns in the 2-D matrix.
+    offset (``int``): diagonal offset from the main diagonal.
+        Default: if not provided, 0.
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         Default: if ``None``, ``torch.long``.
     device (:class:`torch.device`, optional): currently only support ``cpu``.
@@ -5115,9 +5116,10 @@ the main diagonal. The main diagonal are the set of indices
 where :math:`d_{1}, d_{2}` are the dimensions of the matrix.
 
 Args:
-    row (``int...``): number of rows in the 2-D matrix.
-    column (``int...``): number of columns in the 2-D matrix.
-    offset (``int...``): diagonal offset from the main diagonal.
+    row (``int``): number of rows in the 2-D matrix.
+    column (``int``): number of columns in the 2-D matrix.
+    offset (``int``): diagonal offset from the main diagonal.
+        Default: if not provided, 0.
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         Default: if ``None``, ``torch.long``.
     device (:class:`torch.device`, optional): currently only support ``cpu``.


### PR DESCRIPTION
This is an optimized implementation that does the following:

1. created an empty Tensor of correct size.
2. fill the Tensor with correct values.

The following three designs to fill in the Tensor result in roughly the same performance. Hence, the 2nd option is taken for simpler code, and to return contiguous tensors.

1. Sequential: fill row coordinates first, then columns. This results in two for-loop and more arithmetic operations.
2. Interleaved: fill in index coordinates one by one, which jumps between the two output Tensor rows in every iteration.
3. Transpose: create a n X 2 Tensor, fill the Tensor sequentially, and then transpose it.

<img width="352" alt="screen shot 2018-12-10 at 3 54 39 pm" src="https://user-images.githubusercontent.com/16999635/49769172-07bd3580-fc94-11e8-8164-41839185e9f9.png">


NOTE:

This implementation returns a 2D tensor, instead of a tuple of two tensors. It means that users will not be able to do the following:

```python
x = torch.ones(3, 3)
i = torch.tril_indices(3, 3)
x[i]  # need to first convert the 2D tensor into a tuple of two 1D tensors.
```


