### PR TITLE
Enable fp16 for MIOPEN operators in Caffe2

### DIFF
--- a/caffe2/operators/hip/activation_ops_miopen.h
+++ b/caffe2/operators/hip/activation_ops_miopen.h
@@ -45,7 +45,7 @@ class MIOPENActivationOp final : public MIOPENActivationOpBase {
   }
 
   bool RunOnDevice() override {
-    return DispatchHelper<TensorTypes<float>>::call(this, Input(0));
+    return DispatchHelper<TensorTypes<float, at::Half>>::call(this, Input(0));
   }
 
   template <typename T>
@@ -100,7 +100,7 @@ class MIOPENActivationGradientOp final : public MIOPENActivationOpBase {
   }
 
   bool RunOnDevice() override {
-    return DispatchHelper<TensorTypes<float>>::call(this, Input(0));
+    return DispatchHelper<TensorTypes<float, at::Half>>::call(this, Input(0));
   }
 
   template <typename T>

--- a/caffe2/operators/hip/conv_op_miopen.hip
+++ b/caffe2/operators/hip/conv_op_miopen.hip
@@ -370,8 +370,15 @@ bool MIOPENConvOp::RunOnDevice() {
         float, // B
         float, // Math
         float>(); // Y
+    } else if (Input(0).IsType<at::Half>()) {
+    return DoRunWithType<
+        at::Half, // X
+        at::Half, // W
+        at::Half, // B
+        at::Half, // Math
+        at::Half>(); // Y
   } else {
-    LOG(FATAL) << "Only float (32bit) is supported by "
+    LOG(FATAL) << "Only float (32bit) and Half are supported by "
                << "miopen convolution, but input " << debug_def().input(0)
                << " has [" << Input(0).meta().name() << "]";
   }
@@ -621,6 +628,16 @@ bool MIOPENConvGradientOp::RunOnDevice() {
         float, // dX
         float, // dW
         float>(); // db
+    } else if (Input(0).IsType<at::Half>()){
+    return DoRunWithType<
+        at::Half, //  X
+        at::Half, // dY
+        at::Half, //  W
+        at::Half, //  b
+        at::Half, // Math
+        at::Half, // dX
+        at::Half, // dW
+        at::Half>(); // db
   } else {
     LOG(FATAL) << "Unsupported input types";
   }

--- a/caffe2/operators/hip/elu_op_miopen.hip
+++ b/caffe2/operators/hip/elu_op_miopen.hip
@@ -22,7 +22,7 @@ class MIOPENActivationOp<miopenActivationELU> final
   }
 
   bool RunOnDevice() override {
-    return DispatchHelper<TensorTypes<float>>::call(this, Input(0));
+    return DispatchHelper<TensorTypes<float, at::Half>>::call(this, Input(0));
   }
 
   template <typename T>
@@ -85,7 +85,7 @@ class MIOPENActivationGradientOp<miopenActivationELU> final
   }
 
   bool RunOnDevice() override {
-    return DispatchHelper<TensorTypes<float>>::call(this, Input(0));
+    return DispatchHelper<TensorTypes<float, at::Half>>::call(this, Input(0));
   }
 
   template <typename T>

--- a/caffe2/operators/hip/local_response_normalization_op_miopen.hip
+++ b/caffe2/operators/hip/local_response_normalization_op_miopen.hip
@@ -158,6 +158,8 @@ bool MIOPEN_LRNOP::RunOnDevice() {
 
   if (X.IsType<float>()) {
     return DoRunWithType<float, float>();
+  } else if (X.IsType<at::Half>()) {
+    return DoRunWithType<at::Half, float>();
   } else {
     CAFFE_THROW("Unsupported input type");
   }
@@ -234,6 +236,8 @@ bool MIOPENLRNGradientOp::RunOnDevice() {
 
   if (dY.IsType<float>()) {
     return DoRunWithType<float, float>();
+  } else if (dY.IsType<at::Half>()) {
+    return DoRunWithType<at::Half, float>();
   } else {
     CAFFE_THROW("Unsupported input type");
   }

--- a/caffe2/operators/hip/pool_op_miopen.hip
+++ b/caffe2/operators/hip/pool_op_miopen.hip
@@ -117,6 +117,8 @@ class MIOPENPoolOp : public ConvPoolOpBase<HIPContext> {
     // TODO enable fp16
     if (X.IsType<float>()) {
       return DoRunWithType<float, float>();
+    } else if (X.IsType<at::Half>()){
+      return DoRunWithType<at::Half, float>();
     } else {
       LOG(FATAL) << "Unsupported input types";
     }
@@ -289,6 +291,8 @@ class MIOPENPoolGradientOp : public ConvPoolOpBase<HIPContext> {
 
     if (X.IsType<float>()) {
       return DoRunWithType<float, float>();
+    } else if (X.IsType<at::Half>()) {
+      return DoRunWithType<at::Half, float>();
     } else {
       LOG(FATAL) << "Unsupported input types";
     }

--- a/caffe2/operators/hip/spatial_batch_norm_op_miopen.hip
+++ b/caffe2/operators/hip/spatial_batch_norm_op_miopen.hip
@@ -252,6 +252,8 @@ bool MIOpenSpatialBNOp::RunOnDevice() {
   }
   if (Input(0).IsType<float>()) {
     return DoRunWithType<float, float>();
+  } else if (Input(0).IsType<at::Half>()){
+    return DoRunWithType<at::Half, float>();
   } else {
     LOG(FATAL) << "Unsupported input types";
   }
@@ -336,6 +338,8 @@ bool MIOpenSpatialBNGradientOp::RunOnDevice() {
   }
   if (Input(0).IsType<float>()) {
     return DoRunWithType<float, float>();
+  } else if (Input(0).IsType<at::Half>()) {
+    return DoRunWithType<at::Half, float>();
   } else {
     LOG(FATAL) << "Unsupported input types";
   }


### PR DESCRIPTION
This PR enables fp16 MIOPEN operators in Caffe2.