### PR TITLE
Improve build time of register_symbols.cpp without compiler hacks

### DIFF
--- a/aten/src/ATen/core/CMakeLists.txt
+++ b/aten/src/ATen/core/CMakeLists.txt
@@ -6,12 +6,6 @@ FILE(GLOB ATen_CORE_SRCS "*.cpp")
 FILE(GLOB ATen_CORE_TEST_SRCS "*_test.cpp")
 EXCLUDE(ATen_CORE_SRCS "${ATen_CORE_SRCS}" ${ATen_CORE_TEST_SRCS})
 
-# see the source file for explanation
-set_source_files_properties(
-  ${CMAKE_CURRENT_SOURCE_DIR}/register_symbols.cpp
-  PROPERTIES COMPILE_FLAGS -O0
-  )
-
 # Pass to parent
 set(ATen_CORE_HEADERS ${ATen_CORE_HEADERS} PARENT_SCOPE)
 set(ATen_CORE_SRCS ${ATen_CORE_SRCS} PARENT_SCOPE)

--- a/aten/src/ATen/core/register_symbols.cpp
+++ b/aten/src/ATen/core/register_symbols.cpp
@@ -1,16 +1,38 @@
 #include "ATen/core/interned_strings_class.h"
 
-// This file is compiled with -O0 because the fully-macro-expanded
-// function is huge and only called once at startup.
-
 namespace c10 {
+
+namespace {
+
+struct Entry {
+  const char* const qual_name;
+  const char* const unqual_name;
+  const Symbol sym;
+  const Symbol ns_sym;
+};
+
+constexpr Entry entries[] = {
+#define SYMBOL_ENTRY(n, s) {#n "::" #s, #s, n::s, namespaces::n},
+
+    FORALL_NS_SYMBOLS(SYMBOL_ENTRY)
+#undef SYMBOL_ENTRY
+};
+
+} // namespace
+
 InternedStrings::InternedStrings()
     : sym_to_info_(static_cast<size_t>(_keys::num_symbols)) {
-#define REGISTER_SYMBOL(n, s)        \
-  string_to_sym_[#n "::" #s] = n::s; \
-  sym_to_info_[n::s] = {namespaces::n, #n "::" #s, #s};
-
-  FORALL_NS_SYMBOLS(REGISTER_SYMBOL)
-#undef REGISTER_SYMBOL
+  // Instead of a loop, this could be done by expanding the
+  // assignments directly into FORALL_NS_SYMBOLS, but it would create
+  // a huge function (thanks to all the std::string constructors and
+  // operator[]s) which would take several minutes to optimize. A
+  // static C array of constexpr-constructible structs takes instead
+  // no time to compile.
+  for (const auto& entry : entries) {
+    string_to_sym_[entry.qual_name] = entry.sym;
+    sym_to_info_[entry.sym] = {
+        entry.ns_sym, entry.qual_name, entry.unqual_name};
+  }
 }
+
 } // namespace c10


### PR DESCRIPTION
Summary:
In optimized modes the compiler tries to inline all the
`unordered_map::operator[]` calls, creating a massive amount of code
which takes several minutes to optimize. Instead, create a table of
PODs and populate the maps using a simple loop.

Differential Revision: D13382948
