### PR TITLE
Replace non-printable-ascii characters in ProtoDebugString

### DIFF
--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -120,7 +120,13 @@ class IfstreamInputStream : public ::google::protobuf::io::CopyingInputStream {
 }  // namespace
 
 C10_EXPORT string ProtoDebugString(const MessageLite& proto) {
-  return proto.SerializeAsString();
+  string serialized = proto.SerializeAsString();
+  for (char& c : serialized) {
+    if (c < 0x20 || c >= 0x7f) {
+      c = '?';
+    }
+  }
+  return serialized;
 }
 
 C10_EXPORT bool ParseProtoFromLargeString(


### PR DESCRIPTION
Summary:
When ProtoBuf-Lite is in use, ProtoDebugString just calls SerializeAsString.
This produces binary output, which is not a very suitable "debug" string.
Specifically, we've observed it causing problems when calling code tries to
add the debug string to a Java exception message (which requires valid UTF-8).
Now, we replace all non-ASCII bytes with "?".

This is not a very fast implementation, but generating debug strings shouldn't
be a performance-sensitive operation in any application.

Differential Revision: D13385540
