### PR TITLE
Only append a prefix of operator_def to an exception

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -219,8 +219,8 @@ unique_ptr<OperatorBase> _CreateOperator(
       "'. Verify that implementation for the corresponding device exist. It "
       "might also happen if the binary is not linked with the operator "
       "implementation code. If Python frontend is used it might happen if "
-      "dyndep.InitOpsLibrary call is missing. Operator def: ",
-      ProtoDebugString(operator_def));
+      "dyndep.InitOpsLibrary call is missing. Operator def prefix: ",
+      ProtoDebugString(operator_def).substr(0, 128));
   return op;
 }
 

--- a/caffe2/utils/proto_utils.cc
+++ b/caffe2/utils/proto_utils.cc
@@ -120,7 +120,13 @@ class IfstreamInputStream : public ::google::protobuf::io::CopyingInputStream {
 }  // namespace
 
 C10_EXPORT string ProtoDebugString(const MessageLite& proto) {
-  return proto.SerializeAsString();
+  string serialized = proto.SerializeAsString();
+  for (char& c : serialized) {
+    if (c < 0x20 || c >= 0x7f) {
+      c = '?';
+    }
+  }
+  return serialized;
 }
 
 C10_EXPORT bool ParseProtoFromLargeString(


### PR DESCRIPTION
Summary:
When we fail to instantiate an operator, we throw an exception with the full
debug string of the operator def.  In one case, this was a multi-megabyte
string that our Android test runner could not send back to the test harness.
It seems fairly unlikely that such a long message would be required, so trim
it down to something more reasonable.  The length of 128 was chosen based
soley on intuition.

Differential Revision: D13385541
