### PR TITLE
Alignas Array struct

### DIFF
--- a/aten/src/ATen/cuda/Array.h
+++ b/aten/src/ATen/cuda/Array.h
@@ -7,7 +7,7 @@
 namespace at { namespace cuda {
 
 template <typename T, int size>
-struct alignas(size*sizeof(T)) Array {
+struct alignas(16) Array {
   T data[size];
 
   C10_HOST_DEVICE T operator[](int i) const {

--- a/aten/src/ATen/cuda/Array.h
+++ b/aten/src/ATen/cuda/Array.h
@@ -7,7 +7,7 @@
 namespace at { namespace cuda {
 
 template <typename T, int size>
-struct Array {
+struct alignas(size*sizeof(T)) Array {
   T data[size];
 
   C10_HOST_DEVICE T operator[](int i) const {

--- a/aten/src/ATen/cuda/Array.h
+++ b/aten/src/ATen/cuda/Array.h
@@ -7,7 +7,11 @@
 namespace at { namespace cuda {
 
 template <typename T, int size>
+#ifndef __HIP_PLATFORM_HCC__
 struct alignas(16) Array {
+#else
+struct Array {
+#endif
   T data[size];
 
   C10_HOST_DEVICE T operator[](int i) const {


### PR DESCRIPTION
This PR aligns the Array struct such that cuda vector performance improvements can be utilized.

I tested this by using it on our Philox header. Note how the vector store instruction gets used for cuda vector types and when using alignas on Array, vs when not using alignas on Array.

With cuda vector type (uint4, uint2, float4): https://godbolt.org/z/UaWOmR
With alignas: https://godbolt.org/z/Eeh0t5
Without alignas: https://godbolt.org/z/QT63gq
