### PR TITLE
race condition fix of calling mutable_data inside a openmp region

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op.h
@@ -45,7 +45,8 @@ class ConvDNNLowPAcc16Op final : public ConvDNNLowPOp<std::uint8_t, ReluFused> {
   void DispatchFBGEMM(
       PackAMatrix& packA,
       const std::uint8_t* col_buffer_quantized_data,
-      vector<std::int32_t>* Y_int32);
+      vector<std::int32_t>* Y_int32,
+      uint8_t* Y_uint8_data);
 
   void ConvOutlier_(
       const std::uint8_t* col_buffer,

--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -107,7 +107,11 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
   bool RunOnDeviceWithOrderNHWCAndType_();
 
   template <typename PackAMatrix, fbgemm::QuantizationGranularity Q_GRAN>
-  void DispatchFBGEMM(PackAMatrix& packA, vector<std::int32_t>* Y_int32);
+  void DispatchFBGEMM(
+      PackAMatrix& packA,
+      vector<std::int32_t>* Y_int32,
+      uint8_t* Y_uint8_data,
+      float* Y_float_data);
 
   template <typename InType>
   void ConvNHWCCore_(


### PR DESCRIPTION
Summary:
Fix race condition introduced in D13188595 .
Let's reminder ourselves "never call mutable_data from an OpenMP region!!!"

Differential Revision: D13387692
