### PR TITLE
[sparse] sparse.max(), sparse.min()

### DIFF
--- a/aten/src/ATen/SparseTensorUtils.h
+++ b/aten/src/ATen/SparseTensorUtils.h
@@ -10,8 +10,7 @@ using IntTensor = Tensor;
 using SparseType = Type;
 
 enum class CoalesceReductionType : std::uint8_t {
-  SUM = 0,
-  MAX,
+  MAX = 0,
   MIN,
 };
 

--- a/aten/src/ATen/SparseTensorUtils.h
+++ b/aten/src/ATen/SparseTensorUtils.h
@@ -9,6 +9,13 @@ using LongTensor = Tensor;
 using IntTensor = Tensor;
 using SparseType = Type;
 
+enum class CoalesceReductionType : std::uint8_t {
+  SUM = 0,
+  MAX,
+  MIN,
+};
+
+
 // This is an internal utility function for getting at the SparseTensorImpl,
 // so that we can write sparse tensor specific accessors for special fields
 // in SparseTensor.  You should only use this for writing low level

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -506,6 +506,9 @@ public:
   int64_t dense_dim() const;
   int64_t _dimV() const;
   int64_t _nnz() const;
+  Tensor coalesce_sum() const;
+  Tensor coalesce_max() const;
+  Tensor coalesce_min() const;
   Tensor coalesce() const;
   bool is_coalesced() const;
   Tensor _indices() const;

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -507,8 +507,8 @@ public:
   int64_t _dimV() const;
   int64_t _nnz() const;
   Tensor coalesce_sum() const;
-  Tensor coalesce_max() const;
-  Tensor coalesce_min() const;
+  std::tuple<Tensor,Tensor> coalesce_max() const;
+  std::tuple<Tensor,Tensor> coalesce_min() const;
   Tensor coalesce() const;
   bool is_coalesced() const;
   Tensor _indices() const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -739,6 +739,15 @@ inline int64_t Tensor::_dimV() const {
 inline int64_t Tensor::_nnz() const {
     return type()._nnz(*this);
 }
+inline Tensor Tensor::coalesce_sum() const {
+    return type().coalesce_sum(*this);
+}
+inline Tensor Tensor::coalesce_max() const {
+    return type().coalesce_max(*this);
+}
+inline Tensor Tensor::coalesce_min() const {
+    return type().coalesce_min(*this);
+}
 inline Tensor Tensor::coalesce() const {
     return type().coalesce(*this);
 }

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -742,10 +742,10 @@ inline int64_t Tensor::_nnz() const {
 inline Tensor Tensor::coalesce_sum() const {
     return type().coalesce_sum(*this);
 }
-inline Tensor Tensor::coalesce_max() const {
+inline std::tuple<Tensor,Tensor> Tensor::coalesce_max() const {
     return type().coalesce_max(*this);
 }
-inline Tensor Tensor::coalesce_min() const {
+inline std::tuple<Tensor,Tensor> Tensor::coalesce_min() const {
     return type().coalesce_min(*this);
 }
 inline Tensor Tensor::coalesce() const {

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -416,6 +416,9 @@ struct CAFFE2_API Type {
   virtual int64_t dense_dim(const Tensor & self) const = 0;
   virtual int64_t _dimV(const Tensor & self) const = 0;
   virtual int64_t _nnz(const Tensor & self) const = 0;
+  virtual Tensor coalesce_sum(const Tensor & self) const = 0;
+  virtual Tensor coalesce_max(const Tensor & self) const = 0;
+  virtual Tensor coalesce_min(const Tensor & self) const = 0;
   virtual Tensor coalesce(const Tensor & self) const = 0;
   virtual bool is_coalesced(const Tensor & self) const = 0;
   virtual Tensor _indices(const Tensor & self) const = 0;

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -417,8 +417,8 @@ struct CAFFE2_API Type {
   virtual int64_t _dimV(const Tensor & self) const = 0;
   virtual int64_t _nnz(const Tensor & self) const = 0;
   virtual Tensor coalesce_sum(const Tensor & self) const = 0;
-  virtual Tensor coalesce_max(const Tensor & self) const = 0;
-  virtual Tensor coalesce_min(const Tensor & self) const = 0;
+  virtual std::tuple<Tensor,Tensor> coalesce_max(const Tensor & self) const = 0;
+  virtual std::tuple<Tensor,Tensor> coalesce_min(const Tensor & self) const = 0;
   virtual Tensor coalesce(const Tensor & self) const = 0;
   virtual bool is_coalesced(const Tensor & self) const = 0;
   virtual Tensor _indices(const Tensor & self) const = 0;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1886,13 +1886,13 @@
 
 - func: _sparse_max(Tensor self, int64_t dim) -> Tensor
 
-- func: _sparse_max_sparse_dim(Tensor self, int64_t dim) -> Tensor
+- func: _sparse_max_sparse_dim(Tensor self, int64_t dim) -> (Tensor, Tensor)
 
 - func: _sparse_min(Tensor self) -> Tensor
 
 - func: _sparse_min(Tensor self, int64_t dim) -> Tensor
 
-- func: _sparse_min_sparse_dim(Tensor self, int64_t dim) -> Tensor
+- func: _sparse_min_sparse_dim(Tensor self, int64_t dim) -> (Tensor, Tensor)
 
 - func: norm(Tensor self, Scalar p=2) -> Tensor
   variants: function, method
@@ -2228,14 +2228,14 @@
     SparseCUDA: coalesce_sum_cuda
   requires_tensor: True
 
-- func: coalesce_max(Tensor self) -> Tensor
+- func: coalesce_max(Tensor self) -> (Tensor, Tensor)
   variants: method
   dispatch:
     SparseCPU: coalesce_max_cpu
     SparseCUDA: coalesce_max_cuda
   requires_tensor: True
 
-- func: coalesce_min(Tensor self) -> Tensor
+- func: coalesce_min(Tensor self) -> (Tensor, Tensor)
   variants: method
   dispatch:
     SparseCPU: coalesce_min_cpu

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1879,8 +1879,8 @@
 
 - func: _sparse_sum_backward(Tensor grad, Tensor self, IntList dim) -> Tensor
   dispatch:
-      SparseCPU: _sparse_sum_backward_cpu
-      SparseCUDA: _sparse_sum_backward_cuda
+    SparseCPU: _sparse_sum_backward_cpu
+    SparseCUDA: _sparse_sum_backward_cuda
 
 - func: _sparse_max(Tensor self) -> Tensor
 
@@ -1893,6 +1893,11 @@
 - func: _sparse_min(Tensor self, int64_t dim) -> Tensor
 
 - func: _sparse_min_sparse_dim(Tensor self, int64_t dim) -> (Tensor, Tensor)
+
+- func: _sparse_maxmin_sparse_dim_backward(Tensor grad, Tensor reduction_indices, Tensor self, int64_t dim) -> Tensor
+  dispatch:
+    SparseCPU: _sparse_maxmin_sparse_dim_backward_cpu
+    SparseCUDA: _sparse_maxmin_sparse_dim_backward_cuda
 
 - func: norm(Tensor self, Scalar p=2) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1882,6 +1882,18 @@
       SparseCPU: _sparse_sum_backward_cpu
       SparseCUDA: _sparse_sum_backward_cuda
 
+- func: _sparse_max(Tensor self) -> Tensor
+
+- func: _sparse_max(Tensor self, int64_t dim) -> Tensor
+
+- func: _sparse_max_sparse_dim(Tensor self, int64_t dim) -> Tensor
+
+- func: _sparse_min(Tensor self) -> Tensor
+
+- func: _sparse_min(Tensor self, int64_t dim) -> Tensor
+
+- func: _sparse_min_sparse_dim(Tensor self, int64_t dim) -> Tensor
+
 - func: norm(Tensor self, Scalar p=2) -> Tensor
   variants: function, method
 
@@ -2209,13 +2221,33 @@
   device_guard: False
 
 
+- func: coalesce_sum(Tensor self) -> Tensor
+  variants: method
+  dispatch:
+    SparseCPU: coalesce_sum_cpu
+    SparseCUDA: coalesce_sum_cuda
+  requires_tensor: True
+
+- func: coalesce_max(Tensor self) -> Tensor
+  variants: method
+  dispatch:
+    SparseCPU: coalesce_max_cpu
+    SparseCUDA: coalesce_max_cuda
+  requires_tensor: True
+
+- func: coalesce_min(Tensor self) -> Tensor
+  variants: method
+  dispatch:
+    SparseCPU: coalesce_min_cpu
+    SparseCUDA: coalesce_min_cuda
+  requires_tensor: True
+
 - func: coalesce(Tensor self) -> Tensor
   variants: method
   dispatch:
     SparseCPU: coalesce_sparse_cpu
     SparseCUDA: coalesce_sparse_cuda
   requires_tensor: True
-
 
 - func: is_coalesced(Tensor self) -> bool
   variants: method

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -456,7 +456,7 @@ SparseTensor coalesce_sum_cpu(const SparseTensor& self) {
 
   auto new_nnz = at::empty({1}, indices.options());
 
-  AT_DISPATCH_ALL_TYPES(values.type(), "coalesce", [&] {
+  AT_DISPATCH_ALL_TYPES(values.type(), "coalesce_sum_cpu", [&] {
     coalesce_reduction_kernel_cpu<scalar_t>(
       values,
       indices,
@@ -520,7 +520,7 @@ SparseTensor coalesce_max_cpu(const SparseTensor& self) {
 
   auto new_nnz = at::empty({1}, indices.options());
 
-  AT_DISPATCH_ALL_TYPES(values.type(), "coalesce", [&] {
+  AT_DISPATCH_ALL_TYPES(values.type(), "coalesce_max_cpu", [&] {
     coalesce_reduction_kernel_cpu<scalar_t>(
       values,
       indices,
@@ -580,7 +580,7 @@ SparseTensor coalesce_min_cpu(const SparseTensor& self) {
 
   auto new_nnz = at::empty({1}, indices.options());
 
-  AT_DISPATCH_ALL_TYPES(values.type(), "coalesce", [&] {
+  AT_DISPATCH_ALL_TYPES(values.type(), "coalesce_min_cpu", [&] {
     coalesce_reduction_kernel_cpu<scalar_t>(
       values,
       indices,

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -327,7 +327,7 @@ __device__ void coalesce_values_kernel(
 }
 
 template <typename scalar_t>
-__device__ scalar_t coalesce_sum_op(scalar_t a, scalar_t b) {
+__device__ __forceinline__ scalar_t coalesce_sum_op(scalar_t a, scalar_t b) {
   return a + b;
 }
 
@@ -354,7 +354,7 @@ __global__ void coalesce_sum_kernel(
 }
 
 template <typename scalar_t>
-__device__ scalar_t coalesce_max_op(scalar_t a, scalar_t b) {
+__device__ __forceinline__ scalar_t coalesce_max_op(scalar_t a, scalar_t b) {
   return a > b ? a : b;
 }
 
@@ -381,7 +381,7 @@ __global__ void coalesce_max_kernel(
 }
 
 template <typename scalar_t>
-__device__ scalar_t coalesce_min_op(scalar_t a, scalar_t b) {
+__device__ __forceinline__ scalar_t coalesce_min_op(scalar_t a, scalar_t b) {
   return a < b ? a : b;
 }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -327,7 +327,7 @@ __global__ void coalesce_sum_kernel(
 }
 
 template <typename scalar_t, typename func_t>
-__device__ void coalesce_values_max_min_kernel(
+__device__ void coalesce_values_maxmin_kernel(
   int64_t* segment_offsets,
   int64_t* value_indices,
   int64_t* reduction_indices,
@@ -408,7 +408,7 @@ __global__ void coalesce_max_kernel(
   int64_t* segment_offsets, int64_t* value_indices, int64_t* reduction_indices, scalar_t* values,
   scalar_t* newValues, int64_t nnz, int64_t newNnz, int64_t stride
 ) {
-  coalesce_values_max_min_kernel(
+  coalesce_values_maxmin_kernel(
     segment_offsets, value_indices, reduction_indices,
     values, newValues, nnz, newNnz, stride,
     coalesce_max_op<scalar_t>
@@ -420,7 +420,7 @@ __global__ void coalesce_min_kernel(
   int64_t* segment_offsets, int64_t* value_indices, int64_t* reduction_indices, scalar_t* values,
   scalar_t* newValues, int64_t nnz, int64_t newNnz, int64_t stride
 ) {
-  coalesce_values_max_min_kernel(
+  coalesce_values_maxmin_kernel(
     segment_offsets, value_indices, reduction_indices,
     values, newValues, nnz, newNnz, stride,
     coalesce_min_op<scalar_t>

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -278,13 +278,8 @@ __global__ void indexSparseIntersectionKernel(
 //   }
 // }
 
-template <typename scalar_t>
-__device__ scalar_t coalesce_sum_op(scalar_t a, scalar_t b) {
-  return a + b;
-}
-
 template <typename scalar_t, typename func_t>
-__device__ void coalesceValuesKernel(
+__device__ void coalesce_values_kernel(
   int64_t *segment_offsets,
   int64_t *value_indices,
   scalar_t *values,
@@ -314,26 +309,26 @@ __device__ void coalesceValuesKernel(
       const int valueRow = ((int) value_indices[row]) * stride;
 
       #pragma unroll
-      for (int ii = 0; ii < SZ; ii++)
-      {
+      for (int ii = 0; ii < SZ; ii++){
         int featureDim = startFeature + ii * WARP_SIZE;
-        if (featureDim < stride)
-        {
-          // tmp[ii] += static_cast<cuda_accscalar_t>(values[valueRow + featureDim]);
+        if (featureDim < stride){
           tmp[ii] = op(tmp[ii], static_cast<scalar_t>(values[valueRow + featureDim]));
         }
       }
     }
     #pragma unroll
-    for (int ii = 0; ii < SZ; ii++)
-    {
+    for (int ii = 0; ii < SZ; ii++){
       int featureDim = startFeature + ii * WARP_SIZE;
-      if (featureDim < stride)
-      {
+      if (featureDim < stride){
         newValues[newValueRow + featureDim] = static_cast<scalar_t>(tmp[ii]);
       }
     }
   }
+}
+
+template <typename scalar_t>
+__device__ scalar_t coalesce_sum_op(scalar_t a, scalar_t b) {
+  return a + b;
 }
 
 template <typename scalar_t>
@@ -346,7 +341,7 @@ __global__ void coalesce_sum_kernel(
   int64_t newNnz,
   int64_t stride
 ) {
-  coalesceValuesKernel(
+  coalesce_values_kernel(
     segment_offsets,
     value_indices,
     values,
@@ -355,6 +350,60 @@ __global__ void coalesce_sum_kernel(
     newNnz,
     stride,
     coalesce_sum_op<scalar_t>
+  );
+}
+
+template <typename scalar_t>
+__device__ scalar_t coalesce_max_op(scalar_t a, scalar_t b) {
+  return a > b ? a : b;
+}
+
+template <typename scalar_t>
+__global__ void coalesce_max_kernel(
+  int64_t *segment_offsets,
+  int64_t *value_indices,
+  scalar_t *values,
+  scalar_t *newValues,
+  int64_t nnz,
+  int64_t newNnz,
+  int64_t stride
+) {
+  coalesce_values_kernel(
+    segment_offsets,
+    value_indices,
+    values,
+    newValues,
+    nnz,
+    newNnz,
+    stride,
+    coalesce_max_op<scalar_t>
+  );
+}
+
+template <typename scalar_t>
+__device__ scalar_t coalesce_min_op(scalar_t a, scalar_t b) {
+  return a < b ? a : b;
+}
+
+template <typename scalar_t>
+__global__ void coalesce_min_kernel(
+  int64_t *segment_offsets,
+  int64_t *value_indices,
+  scalar_t *values,
+  scalar_t *newValues,
+  int64_t nnz,
+  int64_t newNnz,
+  int64_t stride
+) {
+  coalesce_values_kernel(
+    segment_offsets,
+    value_indices,
+    values,
+    newValues,
+    nnz,
+    newNnz,
+    stride,
+    coalesce_min_op<scalar_t>
   );
 }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -250,6 +250,10 @@ __global__ void indexSparseIntersectionKernel(
   *resultNnz = r_i;
 }
 
+// --------------------------------------------------------------------
+// coalesce sum kernel
+// --------------------------------------------------------------------
+
 // template <typename Dtype, typename Acctype>
 // __global__ void coalesceValuesKernel_gridStrided(
 //   long *segment_offsets, long *value_indices,
@@ -326,6 +330,9 @@ __global__ void coalesce_sum_kernel(
   }
 }
 
+// --------------------------------------------------------------------
+// coalesce max / min kernel
+// --------------------------------------------------------------------
 template <typename scalar_t, typename func_t>
 __device__ void coalesce_values_maxmin_kernel(
   int64_t* segment_offsets,
@@ -368,10 +375,11 @@ __device__ void coalesce_values_maxmin_kernel(
           if (is_filled[ii] == 0) {
             // fill tmp with input values to set proper bounds for max / min reduction
             tmp[ii] = static_cast<scalar_t>(values[valueRow + featureDim]);
+            reduced_from[ii] = value_indices[row];
             is_filled[ii] = 1;
           }
           else {
-            op(tmp, ii, static_cast<scalar_t>(values[valueRow + featureDim]), reduced_from, row);
+            op(tmp, ii, static_cast<scalar_t>(values[valueRow + featureDim]), reduced_from, value_indices[row]);
           }
         }
       }

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -106,7 +106,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, int64_t> sparse_coalesce_comm
   return std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor, int64_t>(uniqueOffsets, origIndices, newValues, newIndices, indices1D, newNnz);
 }
 
-SparseTensor sparse_coalesce_sum_cuda(const SparseTensor& self) {
+SparseTensor coalesce_sum_cuda(const SparseTensor& self) {
   int64_t nnz = self._nnz();
 
   if (self.is_coalesced()) {
@@ -168,13 +168,13 @@ SparseTensor sparse_coalesce_sum_cuda(const SparseTensor& self) {
 }
 
 SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
-  return sparse_coalesce_sum_cuda(self);
+  return coalesce_sum_cuda(self);
 }
 
 // --------------------------------------------------------------------
 // coalesce max
 // --------------------------------------------------------------------
-SparseTensor sparse_coalesce_max_cuda(const SparseTensor& self) {
+SparseTensor coalesce_max_cuda(const SparseTensor& self) {
   int64_t nnz = self._nnz();
 
   if (self.is_coalesced()) {
@@ -238,7 +238,7 @@ SparseTensor sparse_coalesce_max_cuda(const SparseTensor& self) {
 // --------------------------------------------------------------------
 // coalesce min
 // --------------------------------------------------------------------
-SparseTensor sparse_coalesce_min_cuda(const SparseTensor& self) {
+SparseTensor coalesce_min_cuda(const SparseTensor& self) {
   int64_t nnz = self._nnz();
 
   if (self.is_coalesced()) {

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -142,4 +142,6 @@ Functions
 
 .. autofunction:: torch.sparse.addmm
 .. autofunction:: torch.sparse.mm
+.. autofunction:: torch.sparse.max
+.. autofunction:: torch.sparse.min
 .. autofunction:: torch.sparse.sum

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -1059,6 +1059,10 @@ class TestSparse(TestCase):
                 run_tests(lambda x: sparse_ops[i](x, test_dim[0]),
                           lambda x: dense_ops[i](x, test_dim[0]), bound_val[i], S)
 
+                S_not_hybrid = self._gen_sparse(4, nnz, with_size)[0]
+                run_tests(lambda x: sparse_ops[i](x, test_dim[0]),
+                          lambda x: dense_ops[i](x, test_dim[0]), bound_val[i], S_not_hybrid)
+
         # test for errors
         S = self._gen_sparse(sparse_dims, nnz, with_size)[0]
         empty_S = torch.sparse_coo_tensor(size=with_size)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -864,6 +864,12 @@
 - name: _sparse_sum(Tensor self, IntList dim)
   self: at::_sparse_sum_backward(grad, self, dim)
 
+- name: _sparse_max_sparse_dim(Tensor self, int64_t dim)
+  self: at::_sparse_maxmin_sparse_dim_backward(grad, result1, self, dim)
+
+- name: _sparse_min_sparse_dim(Tensor self, int64_t dim)
+  self: at::_sparse_maxmin_sparse_dim_backward(grad, result1, self, dim)
+
 - name: _standard_gamma(Tensor self, Generator generator)
   self: grad * _standard_gamma_grad(self, result)
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -22,7 +22,7 @@ SKIP_PYTHON_BINDINGS = [
     '.*_forward_out', '_unsafe_view', 'tensor', '_?sparse_coo_tensor.*',
     '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
     '_sparse_add_out', '_sparse_div.*', '_sparse_mul.*', '_sparse_sub.*',
-    'index',
+    'index', 'coalesce_sum', 'coalesce_max', 'coalesce_min',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*',
     '_th_.*', '_thnn_.*',

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -23,6 +23,7 @@ SKIP_PYTHON_BINDINGS = [
     '_arange.*', '_range.*', '_linspace.*', '_logspace.*',
     '_sparse_add_out', '_sparse_div.*', '_sparse_mul.*', '_sparse_sub.*',
     'index', 'coalesce_sum', 'coalesce_max', 'coalesce_min',
+    '_sparse_max_sparse_dim', '_sparse_min_sparse_dim',
     '_indexCopy_', 'max_values', 'min_values', 'argmax', 'argmin',
     '_cumsum.*', '_cumprod.*', '_sum.*', '_prod.*',
     '_th_.*', '_thnn_.*',

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -138,6 +138,8 @@ def max(input, dim=None):
     r"""
     Returns the max of each row of SparseTensor :attr:`input` in the given
     dimensions :attr:`dim`. Currently it only supports one dimension reduction.
+    Unlike :func:`torch.max`, when :attr:`dim` is defined, this function only
+    ouputs the reduced Tensor instead of a tuple of (max, max_indices).
 
     The reduced :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting an output
     tensor having one fewer dimensions than :attr:`input`.
@@ -148,6 +150,42 @@ def max(input, dim=None):
     Args:
         input (Tensor): the input SparseTensor
         dim (int): the dimension to reduce. Default: reduce over all dims.
+
+    Example::
+
+        >>> nnz = 3
+        >>> dims = [3, 3, 2, 2]
+        >>> I = torch.cat([torch.randint(0, dims[0], size=(nnz,)),
+                           torch.randint(0, dims[1], size=(nnz,))], 0).reshape(2, nnz)
+        >>> V = torch.randn(nnz, dims[2], dims[3])
+        >>> size = torch.Size(dims)
+        >>> S = torch.sparse_coo_tensor(I, V, size)
+        >>> S
+        tensor(indices=tensor([[0, 1, 1],
+                               [2, 1, 2]]),
+               values=tensor([[[ 1.7238, -0.3070],
+                               [ 0.6081, -0.4609]],
+
+                              [[-1.5113, -0.6456],
+                               [ 1.1479, -1.6221]],
+
+                              [[ 0.4596, -0.1392],
+                               [ 0.8057, -0.1902]]]),
+               size=(3, 3, 2, 2), nnz=3, layout=torch.sparse_coo)
+
+        # when reduce over a sparse_dim, return a SparseTensor
+        >>> torch.sparse.max(S, 0)
+        tensor(indices=tensor([[1, 2]]),
+               values=tensor([[[-1.5113, -0.6456],
+                               [ 1.1479, -1.6221]],
+
+                              [[ 1.7238, -0.1392],
+                               [ 0.8057, -0.1902]]]),
+               size=(3, 2, 2), nnz=2, layout=torch.sparse_coo)
+
+        # when reduce over all dims, return a dense Tensor
+        >>> torch.sparse.max(S)
+        tensor(1.7238)
     """
     if dim is not None:
         return torch._sparse_max(input, dim)
@@ -159,6 +197,8 @@ def min(input, dim=None):
     r"""
     Returns the min of each row of SparseTensor :attr:`input` in the given
     dimensions :attr:`dim`. Currently it only supports one dimension reduction.
+    Unlike :func:`torch.min`, when :attr:`dim` is defined, this function only
+    ouputs the reduced Tensor instead of a tuple of (min, min_indices).
 
     The reduced :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting an output
     tensor having one fewer dimensions than :attr:`input`.
@@ -169,6 +209,42 @@ def min(input, dim=None):
     Args:
         input (Tensor): the input SparseTensor
         dim (int): the dimension to reduce. Default: reduce over all dims.
+
+    Example::
+
+        >>> nnz = 3
+        >>> dims = [3, 3, 2, 2]
+        >>> I = torch.cat([torch.randint(0, dims[0], size=(nnz,)),
+                           torch.randint(0, dims[1], size=(nnz,))], 0).reshape(2, nnz)
+        >>> V = torch.randn(nnz, dims[2], dims[3])
+        >>> size = torch.Size(dims)
+        >>> S = torch.sparse_coo_tensor(I, V, size)
+        >>> S
+        tensor(indices=tensor([[1, 0, 2],
+                               [2, 1, 1]]),
+               values=tensor([[[ 0.0155,  1.4717],
+                               [-0.9080,  1.2962]],
+
+                              [[ 0.5194,  0.3214],
+                               [ 1.3452, -0.5076]],
+
+                              [[-0.4205, -0.6785],
+                               [ 0.3130,  2.6872]]]),
+               size=(3, 3, 2, 2), nnz=3, layout=torch.sparse_coo)
+
+        # when reduce over a sparse_dim, return a SparseTensor
+        >>> torch.sparse.min(S, 0)
+        tensor(indices=tensor([[1, 2]]),
+               values=tensor([[[-0.4205, -0.6785],
+                               [ 0.3130, -0.5076]],
+
+                              [[ 0.0155,  1.4717],
+                               [-0.9080,  1.2962]]]),
+               size=(3, 2, 2), nnz=2, layout=torch.sparse_coo)
+
+        # when reduce over all dims, return a dense Tensor
+        >>> torch.sparse.min(S)
+        tensor(-0.9080)
     """
     if dim is not None:
         return torch._sparse_min(input, dim)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -123,12 +123,54 @@ def sum(input, dim=None, dtype=None):
         tensor([-2.6596, -1.1450])
     """
     if dtype is None:
-        if dim:
+        if dim is not None:
             return torch._sparse_sum(input, dim)
         else:
             return torch._sparse_sum(input)
     else:
-        if dim:
+        if dim is not None:
             return torch._sparse_sum(input, dim, dtype=dtype)
         else:
             return torch._sparse_sum(input, dtype=dtype)
+
+
+def max(input, dim=None):
+    r"""
+    Returns the max of each row of SparseTensor :attr:`input` in the given
+    dimensions :attr:`dim`. Currently it only supports one dimension reduction.
+
+    The reduced :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting an output
+    tensor having one fewer dimensions than :attr:`input`.
+
+    During backward, only gradients at ``nnz`` locations of :attr:`input`
+    will propagate back. Note that the gradients of :attr:`input` is coalesced.
+
+    Args:
+        input (Tensor): the input SparseTensor
+        dim (int): the dimension to reduce. Default: reduce over all dims.
+    """
+    if dim is not None:
+        return torch._sparse_max(input, dim)
+    else:
+        return torch._sparse_max(input)
+
+
+def min(input, dim=None):
+    r"""
+    Returns the min of each row of SparseTensor :attr:`input` in the given
+    dimensions :attr:`dim`. Currently it only supports one dimension reduction.
+
+    The reduced :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting an output
+    tensor having one fewer dimensions than :attr:`input`.
+
+    During backward, only gradients at ``nnz`` locations of :attr:`input`
+    will propagate back. Note that the gradients of :attr:`input` is coalesced.
+
+    Args:
+        input (Tensor): the input SparseTensor
+        dim (int): the dimension to reduce. Default: reduce over all dims.
+    """
+    if dim is not None:
+        return torch._sparse_min(input, dim)
+    else:
+        return torch._sparse_min(input)


### PR DESCRIPTION
- add `sparse.max()` and `sparse.min()` that supports single dim / global reduction on SparseTensor. In single dim reduction, unlike `torch.max()` and `torch.min()` that will return a tuple of `(max, max_indices)`, here only returns a `max` or `min`
- add autograd support, here the strategy is to store reduce_from indices, and during the backward, scatter grad values to grad-of-input according to indices
- add other two coalesce reductions: `coalesce_max` and `coalesce_min`