### PR TITLE
caffe2 - easy - Create test_util to make it easier to write C++ unit tests

### DIFF
--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -1,0 +1,22 @@
+#include "caffe2/core/tensor.h"
+#include "caffe2/core/workspace.h"
+
+#include "test_utils.h"
+
+namespace caffe2 {
+namespace testing {
+
+const caffe2::Tensor& getTensor(
+    const caffe2::Workspace& workspace,
+    const std::string& name) {
+  return workspace.GetBlob(name)->Get<caffe2::Tensor>();
+}
+
+caffe2::Tensor* createTensor(
+    const std::string& name,
+    caffe2::Workspace* workspace) {
+  return BlobGetMutableTensor(workspace->CreateBlob(name), caffe2::CPU);
+}
+
+} // namespace testing
+} // namespace caffe2

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -1,0 +1,35 @@
+#ifndef CAFFE2_UTILS_TEST_UTILS_H_
+#define CAFFE2_UTILS_TEST_UTILS_H_
+
+#include "caffe2/core/tensor.h"
+#include "caffe2/core/workspace.h"
+
+// Utilities that make it easier to write caffe2 C++ unit tests.
+// These utils are designed to be concise and easy to use. They may sacrifice
+// performance and should only be used in tests/non production code.
+namespace caffe2 {
+namespace testing {
+
+// Asserts that the numeric values of two tensors are the same.
+template <typename T>
+void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2) {
+  CAFFE_ENFORCE_EQ(tensor1.sizes(), tensor2.sizes());
+  for (auto idx = 0; idx < tensor1.numel(); ++idx) {
+    CAFFE_ENFORCE_EQ(tensor1.data<T>()[idx], tensor2.data<T>()[idx]);
+  }
+}
+
+// Read a tensor from the workspace.
+const caffe2::Tensor& getTensor(
+    const caffe2::Workspace& workspace,
+    const std::string& name);
+
+// Create a new tensor in the workspace.
+caffe2::Tensor* createTensor(
+    const std::string& name,
+    caffe2::Workspace* workspace);
+
+} // namespace testing
+} // namespace caffe2
+
+#endif // CAFFE2_UTILS_TEST_UTILS_H_


### PR DESCRIPTION
Summary:
Currently it looks like many of the simple operations such as comparing tensors, creating tensors, fetching tensors... are too verbose and took effort to write correctly in unit tests.
Easy to use utilities are often more important to increase productivity writing unit tests. While caffe2 python unit tests are relatively easier to write at the moment, the C++ side seems lacking.
In this change I create a test_util, started with assertsTensorEquals, getTensor, createTensor, and we can start putting more easy to use utilities there.

Differential Revision: D13370461
