### PR TITLE
Add torch.casting and torch._can_cast

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/Device.h>
+#include <c10/core/Casting.h>
 #include <c10/core/Layout.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/ScalarType.h>

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -4,6 +4,7 @@
 #include <c10/core/Allocator.h>
 #include <ATen/core/Deprecated.h>
 #include <ATen/core/Generator.h>
+#include <c10/core/Casting.h>
 #include <c10/core/Layout.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/ScalarType.h>

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -72,6 +72,8 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       return printList(out, v.toGenericList(), "[", "]");
     case IValue::Tag::Future:
       return out << "Future";
+    case IValue::Tag::Casting:
+      return out << v.toCasting();
     case IValue::Tag::Device:
       return out << v.toDevice();
   }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/core/Casting.h>
 #include <ATen/core/Scalar.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/TensorImpl.h>
@@ -102,6 +103,7 @@ using GenericList = List<IValue>;
   _(Blob) \
   _(GenericList) \
   _(Future) \
+  _(Casting) \
   _(Device)
 
 struct CAFFE2_API IValue final {
@@ -410,6 +412,18 @@ struct CAFFE2_API IValue final {
     return static_cast<at::ScalarType>(toInt());
   }
 
+  // Casting
+  IValue(c10::Casting c) : tag(Tag::Casting), is_intrusive_ptr(false) {
+    payload.as_casting = c;
+  }
+  bool isCasting() const {
+    return Tag::Casting == tag;
+  }
+  c10::Casting toCasting() const {
+    AT_ASSERT(isCasting());
+    return payload.as_casting;
+  }
+
   // Layout
   at::Layout toLayout() const {
     return static_cast<at::Layout>(toInt());
@@ -489,6 +503,7 @@ struct CAFFE2_API IValue final {
     double as_double;
     bool as_bool;
     c10::intrusive_ptr_target* as_intrusive_ptr;
+    c10::Casting as_casting;
     struct {
       DeviceType type;
       DeviceIndex index;
@@ -627,6 +642,7 @@ DEFINE_TO(c10::intrusive_ptr<ivalue::Future>, toFuture)
 DEFINE_TO(IValue, toIValue)
 DEFINE_TO(c10::Device, toDevice)
 DEFINE_TO(at::ScalarType, toScalarType)
+DEFINE_TO(c10::Casting, toCasting)
 DEFINE_TO(at::Layout, toLayout)
 
 // note: when adding a DEFINE_TO case here you should also add a

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -27,6 +27,7 @@ _(FutureType) \
 _(IntType) \
 _(NoneType) \
 _(StringType) \
+_(CastingType) \
 _(GeneratorType) \
 _(BoolType) \
 _(OptionalType) \
@@ -781,6 +782,28 @@ struct CAFFE2_API NoneType : public Type {
 private:
   NoneType()
   : Type(TypeKind::NoneType) {}
+};
+
+struct CastingType;
+using CastingTypePtr = std::shared_ptr<CastingType>;
+// This type represents a Casting
+struct CAFFE2_API CastingType : public Type {
+  static CastingTypePtr create() {
+    return CastingTypePtr(new CastingType()); // NOLINT(modernize-make-shared)
+  }
+  DEFINE_IS_SUBCLASS(CastingType);
+  bool operator==(const Type& rhs) const override {
+    return rhs.kind() == kind();
+  }
+  std::string str() const override {
+    return "Casting";
+  }
+  static const TypeKind Kind = TypeKind::CastingType;
+  // global singleton
+  static CastingTypePtr get();
+private:
+  CastingType()
+  : Type(TypeKind::CastingType) {}
 };
 
 struct GeneratorType;

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -83,6 +83,10 @@ NoneTypePtr NoneType::get() {
   static auto value = NoneType::create();
   return value;
 }
+CastingTypePtr CastingType::get() {
+  static auto value = CastingType::create();
+  return value;
+}
 GeneratorTypePtr GeneratorType::get() {
   static auto value = GeneratorType::create();
   return value;

--- a/aten/src/ATen/native/Casting.cpp
+++ b/aten/src/ATen/native/Casting.cpp
@@ -1,0 +1,9 @@
+#include "ATen/ATen.h"
+
+namespace at { namespace native {
+
+bool _can_cast(ScalarType from, ScalarType to, Casting casting) {
+  return canCast(from, to, casting);
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -338,6 +338,9 @@
 - func: broadcast_tensors(TensorList tensors) -> TensorList
   device_guard: false
 
+- func: _can_cast(ScalarType from, ScalarType to, Casting casting=Casting::Promote) -> bool
+  variants: function
+
 - func: cat(TensorList tensors, int64_t dim=0) -> Tensor
 
 - func: cat_out(Tensor result, TensorList tensors, int64_t dim=0) -> Tensor

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/Device.h>
+#include <c10/core/Casting.h>
 #include <c10/core/Layout.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/ScalarType.h>

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -4,6 +4,7 @@
 #include <c10/core/Allocator.h>
 #include <ATen/core/Deprecated.h>
 #include <ATen/core/Generator.h>
+#include <c10/core/Casting.h>
 #include <c10/core/Layout.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/ScalarType.h>

--- a/c10/core/Casting.cpp
+++ b/c10/core/Casting.cpp
@@ -1,0 +1,5 @@
+#include <c10/core/Casting.h>
+
+namespace c10 {
+
+} // namespace c10

--- a/c10/core/Casting.h
+++ b/c10/core/Casting.h
@@ -65,4 +65,8 @@ static inline optional<Casting> parsePyCastingValue(const std::string& value) {
   return nullopt;
 }
 
+static inline const char* castingValueErrorMessage() {
+  return "casting must be one of 'no', 'promote', or 'unsafe'";
+}
+
 } // namespace c10

--- a/c10/core/Casting.h
+++ b/c10/core/Casting.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <c10/core/ScalarType.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
+
+#include <iostream>
+
+namespace c10 {
+
+/**
+ * Casting option for converting between types.
+ */
+enum class Casting : int8_t { No, Promote, Unsafe, NumOptions };
+
+static inline bool canCast(ScalarType from, ScalarType to, Casting casting) {
+  switch (casting) {
+    case Casting::No:
+      return (to == from);
+    case Casting::Promote:
+      return (to == promoteTypes(from, to));
+    case Casting::Unsafe:
+      return true;
+    default:
+      throw std::runtime_error("Unknown casting");
+  }
+}
+
+inline std::ostream& operator<<(std::ostream& stream, Casting casting) {
+  switch (casting) {
+    case Casting::No:
+      return stream << "no";
+    case Casting::Promote:
+      return stream << "promote";
+    case Casting::Unsafe:
+      return stream << "unsafe";
+    default:
+      throw std::runtime_error("invalid casting value");
+  }
+}
+
+static inline optional<Casting> parseCastingValue(const std::string& value) {
+  static const std::string kScope = "Casting::";
+  int val_pos =
+      (value.compare(0, kScope.length(), kScope) == 0) ? kScope.length() : 0;
+  if (value.compare(val_pos, string::npos, "No") == 0) {
+    return Casting::No;
+  } else if (value.compare(val_pos, string::npos, "Promote") == 0) {
+    return Casting::Promote;
+  } else if (value.compare(val_pos, string::npos, "Unsafe") == 0) {
+    return Casting::Unsafe;
+  }
+  return nullopt;
+}
+
+static inline optional<Casting> parsePyCastingValue(const std::string& value) {
+  if (value == "no") {
+    return Casting::No;
+  } else if (value == "promote") {
+    return Casting::Promote;
+  } else if (value == "unsafe") {
+    return Casting::Unsafe;
+  }
+  return nullopt;
+}
+
+} // namespace c10

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9458,6 +9458,73 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         with self.assertRaisesRegex(RuntimeError, "expected both inputs to be on same device"):
             torch.tensor(2).to("cuda:1") // torch.tensor(3).to("cuda:0")
 
+    def test_can_cast_promote(self):
+        self.assertTrue(torch._can_cast(torch.int8, torch.int16, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int8, torch.int64, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.int32, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.int64, casting='promote'))
+
+        self.assertFalse(torch._can_cast(torch.int16, torch.int8, casting='promote'))
+        self.assertFalse(torch._can_cast(torch.int64, torch.int8, casting='promote'))
+        self.assertFalse(torch._can_cast(torch.int64, torch.int32, casting='promote'))
+
+        self.assertFalse(torch._can_cast(torch.uint8, torch.int8, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.uint8, torch.int16, casting='promote'))
+
+        self.assertTrue(torch._can_cast(torch.float16, torch.float32, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.float16, torch.float32, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.float32, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.float64, casting='promote'))
+
+        self.assertFalse(torch._can_cast(torch.float32, torch.float16, casting='promote'))
+        self.assertFalse(torch._can_cast(torch.float64, torch.float16, casting='promote'))
+        self.assertFalse(torch._can_cast(torch.float64, torch.float32, casting='promote'))
+
+        self.assertTrue(torch._can_cast(torch.int8, torch.float16, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int16, torch.float16, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int16, torch.float32, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.float16, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.float32, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.float64, casting='promote'))
+        self.assertTrue(torch._can_cast(torch.int64, torch.float16, casting='promote'))
+
+        self.assertFalse(torch._can_cast(torch.float32, torch.int32, casting='promote'))
+        self.assertFalse(torch._can_cast(torch.float16, torch.int64, casting='promote'))
+
+        # Default is promote
+        self.assertFalse(torch._can_cast(torch.float16, torch.int64))
+        self.assertTrue(torch._can_cast(torch.int64, torch.float16))
+
+    def test_can_cast_unsafe(self):
+        self.assertTrue(torch._can_cast(torch.int32, torch.int16, casting='unsafe'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.int32, casting='unsafe'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.int64, casting='unsafe'))
+
+        self.assertTrue(torch._can_cast(torch.uint8, torch.int8, casting='unsafe'))
+
+        self.assertTrue(torch._can_cast(torch.float32, torch.float16, casting='unsafe'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.float32, casting='unsafe'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.float64, casting='unsafe'))
+
+        self.assertTrue(torch._can_cast(torch.float32, torch.int16, casting='unsafe'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.int32, casting='unsafe'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.int64, casting='unsafe'))
+
+    def test_can_cast_no_cast(self):
+        self.assertFalse(torch._can_cast(torch.int32, torch.int16, casting='no'))
+        self.assertTrue(torch._can_cast(torch.int32, torch.int32, casting='no'))
+        self.assertFalse(torch._can_cast(torch.int32, torch.int64, casting='no'))
+
+        self.assertFalse(torch._can_cast(torch.uint8, torch.int64, casting='no'))
+
+        self.assertFalse(torch._can_cast(torch.float32, torch.float16, casting='no'))
+        self.assertTrue(torch._can_cast(torch.float32, torch.float32, casting='no'))
+        self.assertFalse(torch._can_cast(torch.float32, torch.float64, casting='no'))
+
+        self.assertFalse(torch._can_cast(torch.float32, torch.int16, casting='no'))
+        self.assertFalse(torch._can_cast(torch.float32, torch.int32, casting='no'))
+        self.assertFalse(torch._can_cast(torch.float32, torch.int64, casting='no'))
+
 # Functions to test negative dimension wrapping
 METHOD = 1
 INPLACE_METHOD = 2

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -250,6 +250,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         'const THPLayout &': 'layout',
         'const Device &': 'device',
         'optional<ScalarType>': 'scalartypeOptional',
+        'Casting': 'casting',
         'int64_t': 'toInt64',
         'bool': 'toBool',
         'double': 'toDouble',
@@ -266,6 +267,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
         'const THPLayout &': 'layoutWithDefault',
         'const Device &': 'deviceWithDefault',
         'ScalarType': 'scalartypeWithDefault',
+        'Casting': 'castingWithDefault',
     }
 
     def emit_single_dispatch(declaration, out_idx, base_env):

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -7,6 +7,7 @@
 
 #include "Functions.h"
 #include <ATen/Utils.h>
+#include <c10/core/Casting.h>
 #include <c10/core/TensorOptions.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/WrapDimUtilsMulti.h>
@@ -21,6 +22,7 @@
 
 // ${generated_comment}
 
+using at::Casting;
 using at::Tensor;
 using at::Scalar;
 using at::IntList;

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -17,6 +17,7 @@
 namespace torch { namespace autograd {
 
 struct Variable;
+using at::Casting;
 using at::Context;
 using at::Device;
 using at::Generator;

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -29,7 +29,7 @@ from ..autograd.gen_autograd import RETURNS_VIEWS_OF_INPUT
 #      | Type[] # a dynamically sized list[ of a type
 #      | Scalar[N] # a homogenous fixed size scalar list, single scalars can expand to this list
 #      | (Type1, Type2, ...) # a heterogenous tuple
-#      | Layout | ScalarType | Device | Generator # special singleton types for built-in concepts in tensor lib
+#      | Layout | ScalarType | Casting | Device | Generator # special singleton types for built-in concepts in tensor lib
 
 # clean up the variety of C++ types in the ATen declarations
 # to be in the restricted set of types that the IR represents
@@ -54,6 +54,7 @@ TYPE_MAP = {
     'Layout': 'Layout',
     'Device': 'Device',
     'ScalarType': 'ScalarType',
+    'Casting': 'Casting',
     'int64_t': 'int',
     'double': 'float',
     'bool': 'bool',
@@ -91,6 +92,7 @@ FROM_IVALUE = {
     'int64_t': '{}.toInt()',
     'std::string': '{}.toString()->string()',
     'Generator': 'nullptr',
+    'Casting': '{}.toCasting()',
     'std::array<bool,2>': 'as_bool_array<2>({}.toIntList()->elements())',
     'std::array<bool,3>': 'as_bool_array<3>({}.toIntList()->elements())',
     'std::array<bool,4>': 'as_bool_array<4>({}.toIntList()->elements())',

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -25,11 +25,11 @@ from ..autograd.gen_autograd import RETURNS_VIEWS_OF_INPUT
 # Scalar = int | float | bool # int is the largest int (int64_t),
 # float is the largest float (double) we don't have the others because they are never held in tensors
 # Type = Scalar # primitive numbers
-#      | Tensor # any tensor, as defined by at::Tensor
-#      | Type[] # a dynamically sized list[ of a type
-#      | Scalar[N] # a homogenous fixed size scalar list, single scalars can expand to this list
-#      | (Type1, Type2, ...) # a heterogenous tuple
-#      | Layout | ScalarType | Casting | Device | Generator # special singleton types for built-in concepts in tensor lib
+#     | Tensor # any tensor, as defined by at::Tensor
+#     | Type[] # a dynamically sized list[ of a type
+#     | Scalar[N] # a homogenous fixed size scalar list, single scalars can expand to this list
+#     | (Type1, Type2, ...) # a heterogenous tuple
+#     | Layout | ScalarType | Casting | Device | Generator # special singleton types for built-in concepts in tensor lib
 
 # clean up the variety of C++ types in the ATen declarations
 # to be in the restricted set of types that the IR represents

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -491,6 +491,7 @@ if (BUILD_PYTHON)
   endif()
 
   set(TORCH_PYTHON_SRCS
+    ${TORCH_SRC_DIR}/csrc/Casting.cpp
     ${TORCH_SRC_DIR}/csrc/DataLoader.cpp
     ${TORCH_SRC_DIR}/csrc/Device.cpp
     ${TORCH_SRC_DIR}/csrc/Dtype.cpp

--- a/torch/csrc/Casting.cpp
+++ b/torch/csrc/Casting.cpp
@@ -1,0 +1,119 @@
+#include "torch/csrc/Casting.h"
+
+#include "torch/csrc/Exceptions.h"
+#include "torch/csrc/utils/object_ptr.h"
+#include "torch/csrc/utils/python_arg_parser.h"
+#include "torch/csrc/utils/python_strings.h"
+#include "torch/csrc/utils/python_numbers.h"
+#include "torch/csrc/utils/pybind.h"
+
+#include <c10/core/Casting.h>
+#include <c10/util/Exception.h>
+
+#include <cstring>
+#include <limits>
+#include <structmember.h>
+#include <sstream>
+
+PyObject *THPCasting_New(c10::Casting casting)
+{
+  auto type = (PyTypeObject*)&THPCastingType;
+  auto self = THPObjectPtr{type->tp_alloc(type, 0)};
+  if (!self) throw python_error();
+  auto self_ = reinterpret_cast<THPCasting*>(self.get());
+  self_->casting = casting;
+  return self.release();
+}
+
+PyObject *THPCasting_repr(THPCasting *self)
+{
+  std::ostringstream oss;
+  oss << "casting(" << self->casting << ")";
+  return THPUtils_packString(oss.str().c_str());
+}
+
+PyObject *THPCasting_str(THPCasting *self)
+{
+  std::ostringstream oss;
+  oss << self->casting;
+  return THPUtils_packString(oss.str().c_str());
+}
+
+PyObject *THPCasting_pynew(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+  HANDLE_TH_ERRORS
+  static torch::PythonArgParser parser({
+    "Casting(Casting casting)",
+    "Casting(std::string casting)"
+  });
+  torch::ParsedArgs<1> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+  if (r.idx == 0 || r.idx == 1) {
+    return THPCasting_New(r.casting(0));
+  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+static Py_ssize_t THPCasting_hash(THPCasting *self)
+{
+  HANDLE_TH_ERRORS
+  return static_cast<Py_ssize_t>(
+      std::hash<std::size_t>{}(static_cast<std::size_t>(self->casting)) %
+      std::numeric_limits<Py_ssize_t>::max());
+  END_HANDLE_TH_ERRORS_RET(-1)
+}
+
+typedef PyObject *(*getter)(PyObject *, void *);
+
+PyTypeObject THPCastingType = {
+  PyVarObject_HEAD_INIT(nullptr, 0)
+  "torch.casting",                       /* tp_name */
+  sizeof(THPCasting),                    /* tp_basicsize */
+  0,                                     /* tp_itemsize */
+  0,                                     /* tp_dealloc */
+  0,                                     /* tp_print */
+  0,                                     /* tp_getattr */
+  0,                                     /* tp_setattr */
+  0,                                     /* tp_reserved */
+  (reprfunc)THPCasting_repr,             /* tp_repr */
+  0,                                     /* tp_as_number */
+  0,                                     /* tp_as_sequence */
+  0,                                     /* tp_as_mapping */
+  (hashfunc)THPCasting_hash,             /* tp_hash  */
+  0,                                     /* tp_call */
+  (reprfunc)THPCasting_str,              /* tp_str */
+  0,                                     /* tp_getattro */
+  0,                                     /* tp_setattro */
+  0,                                     /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT,                    /* tp_flags */
+  nullptr,                               /* tp_doc */
+  0,                                     /* tp_traverse */
+  0,                                     /* tp_clear */
+  0,                                     /* tp_richcompare */
+  0,                                     /* tp_weaklistoffset */
+  0,                                     /* tp_iter */
+  0,                                     /* tp_iternext */
+  0,                                     /* tp_methods */
+  0,                                     /* tp_members */
+  0,                                     /* tp_getset */
+  0,                                     /* tp_base */
+  0,                                     /* tp_dict */
+  0,                                     /* tp_descr_get */
+  0,                                     /* tp_descr_set */
+  0,                                     /* tp_dictoffset */
+  0,                                     /* tp_init */
+  0,                                     /* tp_alloc */
+  THPCasting_pynew,                      /* tp_new */
+};
+
+void THPCasting_init(PyObject *module)
+{
+  if (PyType_Ready(&THPCastingType) < 0) {
+    throw python_error();
+  }
+  Py_INCREF(&THPCastingType);
+  if (PyModule_AddObject(module, "casting", (PyObject *)&THPCastingType) != 0) {
+    throw python_error();
+  }
+}

--- a/torch/csrc/Casting.cpp
+++ b/torch/csrc/Casting.cpp
@@ -71,39 +71,39 @@ PyTypeObject THPCastingType = {
   "torch.casting",                       /* tp_name */
   sizeof(THPCasting),                    /* tp_basicsize */
   0,                                     /* tp_itemsize */
-  0,                                     /* tp_dealloc */
-  0,                                     /* tp_print */
-  0,                                     /* tp_getattr */
-  0,                                     /* tp_setattr */
-  0,                                     /* tp_reserved */
+  nullptr,                               /* tp_dealloc */
+  nullptr,                               /* tp_print */
+  nullptr,                               /* tp_getattr */
+  nullptr,                               /* tp_setattr */
+  nullptr,                               /* tp_reserved */
   (reprfunc)THPCasting_repr,             /* tp_repr */
-  0,                                     /* tp_as_number */
-  0,                                     /* tp_as_sequence */
-  0,                                     /* tp_as_mapping */
+  nullptr,                               /* tp_as_number */
+  nullptr,                               /* tp_as_sequence */
+  nullptr,                               /* tp_as_mapping */
   (hashfunc)THPCasting_hash,             /* tp_hash  */
-  0,                                     /* tp_call */
+  nullptr,                               /* tp_call */
   (reprfunc)THPCasting_str,              /* tp_str */
-  0,                                     /* tp_getattro */
-  0,                                     /* tp_setattro */
-  0,                                     /* tp_as_buffer */
+  nullptr,                               /* tp_getattro */
+  nullptr,                               /* tp_setattro */
+  nullptr,                               /* tp_as_buffer */
   Py_TPFLAGS_DEFAULT,                    /* tp_flags */
   nullptr,                               /* tp_doc */
-  0,                                     /* tp_traverse */
-  0,                                     /* tp_clear */
-  0,                                     /* tp_richcompare */
+  nullptr,                               /* tp_traverse */
+  nullptr,                               /* tp_clear */
+  nullptr,                               /* tp_richcompare */
   0,                                     /* tp_weaklistoffset */
-  0,                                     /* tp_iter */
-  0,                                     /* tp_iternext */
-  0,                                     /* tp_methods */
-  0,                                     /* tp_members */
-  0,                                     /* tp_getset */
-  0,                                     /* tp_base */
-  0,                                     /* tp_dict */
-  0,                                     /* tp_descr_get */
-  0,                                     /* tp_descr_set */
+  nullptr,                               /* tp_iter */
+  nullptr,                               /* tp_iternext */
+  nullptr,                               /* tp_methods */
+  nullptr,                               /* tp_members */
+  nullptr,                               /* tp_getset */
+  nullptr,                               /* tp_base */
+  nullptr,                               /* tp_dict */
+  nullptr,                               /* tp_descr_get */
+  nullptr,                               /* tp_descr_set */
   0,                                     /* tp_dictoffset */
-  0,                                     /* tp_init */
-  0,                                     /* tp_alloc */
+  nullptr,                               /* tp_init */
+  nullptr,                               /* tp_alloc */
   THPCasting_pynew,                      /* tp_new */
 };
 

--- a/torch/csrc/Casting.h
+++ b/torch/csrc/Casting.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "torch/csrc/python_headers.h"
+
+#include <c10/core/Casting.h>
+
+struct THPCasting {
+  PyObject_HEAD
+  c10::Casting casting;
+};
+
+extern PyTypeObject THPCastingType;
+
+inline bool THPCasting_Check(PyObject *obj) {
+  return Py_TYPE(obj) == &THPCastingType;
+}
+
+PyObject * THPCasting_New(c10::Casting casting);
+
+void THPCasting_init(PyObject *module);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -18,6 +18,7 @@
 #include <pybind11/stl.h>
 
 #include <torch/csrc/THP.h>
+#include <torch/csrc/Casting.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/Dtype.h>
@@ -567,6 +568,7 @@ PyObject* initModule() {
   THPSize_init(module);
   THPDtype_init(module);
   THPDTypeInfo_init(module);
+  THPCasting_init(module);
   THPLayout_init(module);
   THPDevice_init(module);
   ASSERT_TRUE(THPVariable_initModule(module));

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -133,7 +133,7 @@ RegisterOperators reg({
             return 0;
           };
         } else if (type == CastingType::get()) {
-          auto c = c10::parsePyCastingValue(node->s(attr::value)).value();
+          auto c = *c10::parsePyCastingValue(node->s(attr::value));
           return [c](Stack& stack) {
             push(stack, c);
             return 0;

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -48,6 +48,11 @@ Value* insertConstant(
   } else if(val.isString()) {
     n->s_(attr::value, val.toString()->string());
     n->output()->setType(StringType::get());
+  } else if(val.isCasting()) {
+    std::stringstream ss;
+    ss << val.toCasting();
+    n->s_(attr::value, ss.str());
+    n->output()->setType(CastingType::get());
   } else if(val.isDevice()) {
     std::stringstream ss;
     ss << val.toDevice();
@@ -125,6 +130,12 @@ RegisterOperators reg({
           auto s = node->s(attr::value);
           return [s](Stack& stack) {
             push(stack, s);
+            return 0;
+          };
+        } else if (type == CastingType::get()) {
+          auto c = c10::parsePyCastingValue(node->s(attr::value)).value();
+          return [c](Stack& stack) {
+            push(stack, c);
             return 0;
           };
         } else if (type == DeviceObjType::get()) {

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -299,7 +299,7 @@ struct SchemaParser {
     }
     auto casting = c10::parseCastingValue(text);
     if (casting) {
-      return casting.value();
+      return *casting;
     }
     throw ErrorReport(range) << "unexpected casting value";
   }

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/auto_gil.h>
+#include <torch/csrc/Casting.h>
 #include <torch/csrc/Device.h>
 
 #include <c10/util/Exception.h>
@@ -148,6 +149,10 @@ inline IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_
       }
       case TypeKind::StringType:
         return ConstantString::create(py::cast<std::string>(obj));
+      case TypeKind::CastingType: {
+        auto casting = reinterpret_cast<THPCasting*>(obj.ptr());
+        return casting->casting;
+      }
       case TypeKind::DeviceObjType: {
         auto device = reinterpret_cast<THPDevice*>(obj.ptr());
         return device->device;

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -81,6 +81,9 @@ void addInputs(Node *n, const char * name, at::Layout value) {
 void addInputs(Node *n, const char * name, at::ScalarType value) {
   detail::genericAddInput(n, static_cast<int64_t>(value));
 }
+void addInputs(Node *n, const char * name, at::Casting value) {
+  detail::genericAddInput(n, value);
+}
 
 void addInputs(Node *n, const char * name, at::TensorList value) {
   Graph *g = n->owningGraph();

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -208,6 +208,7 @@ TORCH_API void addInputs(Node *n, const char * name, const at::TensorOptions& va
 TORCH_API void addInputs(Node *n, const char * name, at::Device value);
 TORCH_API void addInputs(Node *n, const char * name, at::Layout value);
 TORCH_API void addInputs(Node *n, const char * name, at::ScalarType value);
+TORCH_API void addInputs(Node *n, const char * name, at::Casting value);
 TORCH_API void addInputs(Node *n, const char * name, at::Generator * value);
 
 template<size_t N>

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -252,7 +252,7 @@ void FunctionParameter::set_default_str(const std::string& str) {
     if (!casting) {
       throw std::runtime_error("invalid default casting string: " + str);
     }
-    default_casting = casting.value();
+    default_casting = *casting;
   } else if (type_ == ParameterType::LAYOUT) {
     if (str == "None") {
       default_layout = nullptr;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -400,7 +400,7 @@ inline c10::Casting PythonArgs::casting(int i) {
   if (!casting) {
     throw torch::ValueError("Invalid casting value '%s'", val.c_str());
   }
-  return casting.value();
+  return *casting;
 }
 
 inline c10::Casting PythonArgs::castingWithDefault(int i, c10::Casting default_casting) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -398,7 +398,7 @@ inline c10::Casting PythonArgs::casting(int i) {
   std::string val = string(i);
   c10::optional<c10::Casting> casting = c10::parsePyCastingValue(val);
   if (!casting) {
-    throw torch::ValueError("Invalid casting value '%s'", val.c_str());
+    throw torch::ValueError(c10::castingValueErrorMessage());
   }
   return *casting;
 }


### PR DESCRIPTION
Summary:

Implementation of *casting* param as outlined in #9515.

**`torch.casting`**, when passed to a function, defines casting rules that the function must apply. It can take one of the following values:
- `no`: no casting may take place
- `promote`: inputs can be promoted as allowed by `torch._promote_types`
- `unsafe`: any casting can take place to satisfy to the output requirement

`casting='promote'` is expected to be the default for most functions supporting type casts. NumPy's `casting='safe'` will be skipped in PyTorch in favor of `promote`.

**`torch._can_cast`** will determine if a type can be casted to another
according to given casting safety rule. This will in return be used
in operations to support input promotion/demotion.

```
torch.pow(x, y, dtype=torch.float32, casting='promote')
```

TODO: private as `_can_cast` for now
TODO: will add docs for both in a separate PR

The API for casting is similar to NumPy's casting and can_cast:
https://docs.scipy.org/doc/numpy/reference/generated/numpy.can_cast.html

Tested:

- New tests torch_test for added functionality.
- I did a small smoke test for JIT with the following: https://github.com/tugrulates/pytorch/commit/1923f238237b0ef75268c9427cf538dbaf748549

JIT can't store `torch._can_cast` (no Tensor input or output). I will add the unittests for `casting` constant type in JIT when adding it to the first operator with this param.

