### PR TITLE
Fix old tensor CopyFrom usage in boolean mask operator

### DIFF
--- a/caffe2/operators/boolean_mask_ops.cu
+++ b/caffe2/operators/boolean_mask_ops.cu
@@ -100,7 +100,7 @@ class BooleanMaskOp<CUDAContext> final : public Operator<CUDAContext> {
           destData);
 
       if (OutputSize() == 2) {
-        Output(1)->CopyFrom(indices_, &context_);
+        Output(1)->CopyFrom(indices_, /* async */ true);
       }
     }
 


### PR DESCRIPTION
```
warning: address of 'this->context_' will always evaluate to 'true' [-Wpointer-bool-conversion]
        Output(1)->CopyFrom(indices_, &context_);
```