### PR TITLE
Enable performance-unnecessary-value-param in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,7 @@ Checks: '
   ,-modernize-use-auto
   ,-modernize-use-default-member-init
   ,-modernize-use-using
+  ,performance-unnecessary-value-param
   '
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'torch/csrc/.*'

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -240,7 +240,8 @@ TEST_F(ModuleTest, CallingCloneOnModuleThatDoesNotOverrideCloneThrows) {
 TEST_F(ModuleTest, CallingCloneOnModuleThatDoesOverrideCloneDoesNotThrow) {
   struct Cloneable : Module {
     std::shared_ptr<Module> clone(
-        torch::optional<torch::Device> device = torch::nullopt) const override {
+        const torch::optional<torch::Device>& device =
+            torch::nullopt) const override {
       return nullptr;
     }
   };

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -40,7 +40,7 @@ fi
 # otherwise we'd have to build ONNX protos as part of this CI job.
 time python tools/clang_tidy.py          \
   --verbose                              \
-  --paths torch/csrc                     \
+  --paths torch/csrc/                    \
   --diff "$BASE_BRANCH"                  \
   -g"-torch/csrc/distributed/Module.cpp" \
   -g"-torch/csrc/jit/export.cpp"         \

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -51,8 +51,8 @@ struct python_error : public std::exception {
 
   python_error(python_error&& other) {
     type = std::move(other.type);
-    value = std::move(other.value);
-    traceback = std::move(other.traceback);
+    value = other.value;
+    traceback = other.traceback;
     other.type = nullptr;
     other.value = nullptr;
     other.traceback = nullptr;

--- a/torch/csrc/api/include/torch/nn/cloneable.h
+++ b/torch/csrc/api/include/torch/nn/cloneable.h
@@ -32,7 +32,7 @@ class Cloneable : public virtual Module {
   /// and submodules in the cloned module are different from those in the
   /// original module.
   std::shared_ptr<Module> clone(
-      optional<Device> device = nullopt) const override {
+      const optional<Device>& device = nullopt) const override {
     NoGradGuard no_grad;
 
     const auto& self = static_cast<const Derived&>(*this);
@@ -75,7 +75,7 @@ class Cloneable : public virtual Module {
   }
 
  private:
-  void clone_(Module& other, optional<Device> device) final {
+  void clone_(Module& other, const optional<Device>& device) final {
     // Here we are *pretty* certain that `other's` type is `Derived` (because it
     // was registered under the same name as `this`), but you never know what
     // crazy things `reset()` does, so `dynamic_cast` just to be safe.

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -109,7 +109,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///   easier-to-use polymorphic interface.
   /// \endrst
   virtual std::shared_ptr<Module> clone(
-      optional<Device> device = nullopt) const;
+      const optional<Device>& device = nullopt) const;
 
   /// Applies the `function` to the `Module` and recursively to every submodule.
   /// The function must accept a `Module&`.
@@ -121,7 +121,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///     std::cout << module.name() << std::endl;
   ///   });
   /// \endrst
-  void apply(ModuleApplyFunction function);
+  void apply(const ModuleApplyFunction& function);
 
   /// Applies the `function` to the `Module` and recursively to every submodule.
   /// The function must accept a `const Module&`.
@@ -133,7 +133,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///     std::cout << module.name() << std::endl;
   ///   });
   /// \endrst
-  void apply(ConstModuleApplyFunction function) const;
+  void apply(const ConstModuleApplyFunction& function) const;
 
   /// Applies the `function` to the `Module` and recursively to every submodule.
   /// The function must accept a `const std::string&` for the key of the module,
@@ -149,7 +149,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///   });
   /// \endrst
   void apply(
-      NamedModuleApplyFunction function,
+      const NamedModuleApplyFunction& function,
       std::string name_prefix = std::string());
 
   /// Applies the `function` to the `Module` and recursively to every submodule.
@@ -166,7 +166,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///   });
   /// \endrst
   void apply(
-      ConstNamedModuleApplyFunction function,
+      const ConstNamedModuleApplyFunction& function,
       std::string name_prefix = std::string()) const;
 
   /// Applies the `function` to the `Module` and recursively to every submodule.
@@ -179,7 +179,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///     std::cout << module->name() << std::endl;
   ///   });
   /// \endrst
-  void apply(ModulePointerApplyFunction function) const;
+  void apply(const ModulePointerApplyFunction& function) const;
 
   /// Applies the `function` to the `Module` and recursively to every submodule.
   /// The function must accept a `const std::string&` for the key of the module,
@@ -197,7 +197,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   ///   });
   /// \endrst
   void apply(
-      NamedModulePointerApplyFunction function,
+      const NamedModulePointerApplyFunction& function,
       std::string name_prefix = std::string()) const;
 
   /// Returns the parameters of this `Module` and if `recurse` is true, also
@@ -465,7 +465,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   // Private methods.
 
   /// Used in the implementation of `Cloneable`.
-  virtual void clone_(Module& other, optional<Device> device);
+  virtual void clone_(Module& other, const optional<Device>& device);
 
   /// The implementation of the various `to()` methods.
   template <typename... Ts>
@@ -475,7 +475,7 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   /// `Module`'s children (thus not including the module itself).
   void apply_to_submodules(
       const NamedModulePointerApplyFunction& function,
-      std::string name_name_prefix = std::string()) const;
+      const std::string& name_prefix = std::string()) const;
 
   /// Returns a shared_ptr to `this` in a safe (checked) way.
   std::shared_ptr<Module> shared_from_this_checked() const;

--- a/torch/csrc/api/include/torch/nn/modules/batchnorm.h
+++ b/torch/csrc/api/include/torch/nn/modules/batchnorm.h
@@ -59,11 +59,14 @@ class TORCH_API BatchNormImpl : public torch::nn::Cloneable<BatchNormImpl> {
   /// The module must be constructed with `stateful = true` when calling this
   /// method, as the module will otherwise not store running statistics. If you
   /// want to supply the mean and variance yourself, use `pure_forward`.
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 
   /// Applies batch normalization on the `input` using the given `mean` and
   /// `variance` statistics.
-  Tensor pure_forward(Tensor input, Tensor mean, Tensor variance);
+  Tensor pure_forward(
+      const Tensor& input,
+      const Tensor& mean,
+      const Tensor& variance);
 
   /// The options with which this module was constructed.
   BatchNormOptions options;

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -17,7 +17,7 @@ struct ConvOptions {
   ConvOptions(
       int64_t input_channels,
       int64_t output_channels,
-      ExpandingArray<D> kernel_size) : 
+      ExpandingArray<D> kernel_size) :
 		input_channels_(input_channels),
 		output_channels_(output_channels),
 		kernel_size_(std::move(kernel_size)) {}
@@ -106,7 +106,7 @@ class ConvImpl : public torch::nn::Cloneable<Derived> {
 class TORCH_API Conv1dImpl : public ConvImpl<1, Conv1dImpl> {
  public:
   using ConvImpl<1, Conv1dImpl>::ConvImpl;
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 };
 
 /// `ConvOptions` specialized for 1-D convolution.
@@ -126,7 +126,7 @@ TORCH_MODULE(Conv1d);
 class TORCH_API Conv2dImpl : public ConvImpl<2, Conv2dImpl> {
  public:
   using ConvImpl<2, Conv2dImpl>::ConvImpl;
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 };
 
 /// `ConvOptions` specialized for 2-D convolution.
@@ -146,7 +146,7 @@ TORCH_MODULE(Conv2d);
 class TORCH_API Conv3dImpl : public ConvImpl<3, Conv3dImpl> {
  public:
   using ConvImpl<3, Conv3dImpl>::ConvImpl;
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 };
 
 /// `ConvOptions` specialized for 3-D convolution.

--- a/torch/csrc/api/include/torch/nn/modules/dropout.h
+++ b/torch/csrc/api/include/torch/nn/modules/dropout.h
@@ -41,7 +41,7 @@ class TORCH_API DropoutImpl : public detail::DropoutImplBase<DropoutImpl> {
   using detail::DropoutImplBase<DropoutImpl>::DropoutImplBase;
   /// During training, applies a noise mask to the input tensor.
   /// During evaluation, applies an identity function.
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 };
 
 /// Applies spatial [Dropout](https://arxiv.org/abs/1207.0580) to inputs with
@@ -58,7 +58,7 @@ class TORCH_API FeatureDropoutImpl : public detail::DropoutImplBase<FeatureDropo
   using detail::DropoutImplBase<FeatureDropoutImpl>::DropoutImplBase;
   /// During training, applies a noise mask to the input tensor.
   /// During evaluation, applies an identity function.
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 };
 
 /// A `ModuleHolder` subclass for `DropoutImpl`.

--- a/torch/csrc/api/include/torch/nn/modules/embedding.h
+++ b/torch/csrc/api/include/torch/nn/modules/embedding.h
@@ -30,7 +30,7 @@ class TORCH_API EmbeddingImpl : public torch::nn::Cloneable<EmbeddingImpl> {
 
   /// Performs a lookup on the embedding table stored in `weight` using the
   /// `indices` supplied and returns the result.
-  Tensor forward(Tensor indices);
+  Tensor forward(const Tensor& indices);
 
   /// The `Options` used to configure this `Embedding` module.
   /// Changes to `EmbeddingOptions` *after construction* have no effect.

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -31,7 +31,7 @@ class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
 
   /// Transforms the `input` tensor by multiplying with the `weight` and
   /// optionally adding the `bias`, if `with_bias` is true in the options.
-  Tensor forward(Tensor input);
+  Tensor forward(const Tensor& input);
 
   /// The options used to configure this module.
   LinearOptions options;

--- a/torch/csrc/api/include/torch/nn/modules/rnn.h
+++ b/torch/csrc/api/include/torch/nn/modules/rnn.h
@@ -60,7 +60,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   enum class CuDNNMode { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
 
   explicit RNNImplBase(
-      RNNOptionsBase options_,
+      const RNNOptionsBase& options_,
       optional<CuDNNMode> cudnn_mode = nullopt,
       int64_t number_of_gates = 1);
 
@@ -113,7 +113,7 @@ class RNNImplBase : public torch::nn::Cloneable<Derived> {
   /// RNN function as first argument.
   RNNOutput generic_forward(
       std::function<RNNFunctionSignature> function,
-      Tensor input,
+      const Tensor& input,
       Tensor state);
 
   /// Returns a flat vector of all weights, with layer weights following each
@@ -175,13 +175,13 @@ class TORCH_API RNNImpl : public detail::RNNImplBase<RNNImpl> {
  public:
   RNNImpl(int64_t input_size, int64_t hidden_size)
       : RNNImpl(RNNOptions(input_size, hidden_size)) {}
-  explicit RNNImpl(RNNOptions options);
+  explicit RNNImpl(const RNNOptions& options);
 
   /// Applies the `RNN` module to an input sequence and input state.
   /// The `input` should follow a `(sequence, batch, features)` layout unless
   /// `batch_first` is true, in which case the layout should be `(batch,
   /// sequence, features)`.
-  RNNOutput forward(Tensor input, Tensor state = {});
+  RNNOutput forward(const Tensor& input, Tensor state = {});
 
   RNNOptions options;
 };
@@ -203,13 +203,13 @@ class TORCH_API LSTMImpl : public detail::RNNImplBase<LSTMImpl> {
  public:
   LSTMImpl(int64_t input_size, int64_t hidden_size)
       : LSTMImpl(LSTMOptions(input_size, hidden_size)) {}
-  explicit LSTMImpl(LSTMOptions options);
+  explicit LSTMImpl(const LSTMOptions& options);
 
   /// Applies the `LSTM` module to an input sequence and input state.
   /// The `input` should follow a `(sequence, batch, features)` layout unless
   /// `batch_first` is true, in which case the layout should be `(batch,
   /// sequence, features)`.
-  RNNOutput forward(Tensor input, Tensor state = {});
+  RNNOutput forward(const Tensor& input, Tensor state = {});
 };
 
 /// A `ModuleHolder` subclass for `LSTMImpl`.
@@ -229,13 +229,13 @@ class TORCH_API GRUImpl : public detail::RNNImplBase<GRUImpl> {
  public:
   GRUImpl(int64_t input_size, int64_t hidden_size)
       : GRUImpl(GRUOptions(input_size, hidden_size)) {}
-  explicit GRUImpl(GRUOptions options);
+  explicit GRUImpl(const GRUOptions& options);
 
   /// Applies the `GRU` module to an input sequence and input state.
   /// The `input` should follow a `(sequence, batch, features)` layout unless
   /// `batch_first` is true, in which case the layout should be `(batch,
   /// sequence, features)`.
-  RNNOutput forward(Tensor input, Tensor state = {});
+  RNNOutput forward(const Tensor& input, Tensor state = {});
 };
 
 /// A `ModuleHolder` subclass for `GRUImpl`.

--- a/torch/csrc/api/include/torch/nn/modules/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/sequential.h
@@ -104,7 +104,7 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   /// Special cloning function for `Sequential` because it does not use
   /// `reset()`.
   std::shared_ptr<Module> clone(
-      optional<Device> device = nullopt) const override {
+      const optional<Device>& device = nullopt) const override {
     auto clone = std::make_shared<SequentialImpl>();
     for (const auto& module : modules_) {
       clone->push_back(module.clone(device));

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -74,7 +74,7 @@ const std::string& Module::name() const noexcept {
   return *name_;
 }
 
-std::shared_ptr<Module> Module::clone(optional<Device> device) const {
+std::shared_ptr<Module> Module::clone(const optional<Device>& device) const {
   AT_ERROR(
       "clone() has not been implemented for ",
       name(),
@@ -83,7 +83,7 @@ std::shared_ptr<Module> Module::clone(optional<Device> device) const {
       "> instead of torch::nn::Module to inherit the ability to clone.");
 }
 
-void Module::apply(ModuleApplyFunction function) {
+void Module::apply(const ModuleApplyFunction& function) {
   function(*this);
   apply_to_submodules(
       [&function](const std::string&, const std::shared_ptr<Module>& module) {
@@ -91,7 +91,7 @@ void Module::apply(ModuleApplyFunction function) {
       });
 }
 
-void Module::apply(ConstModuleApplyFunction function) const {
+void Module::apply(const ConstModuleApplyFunction& function) const {
   function(*this);
   apply_to_submodules(
       [&function](const std::string&, const std::shared_ptr<Module>& module) {
@@ -99,7 +99,9 @@ void Module::apply(ConstModuleApplyFunction function) const {
       });
 }
 
-void Module::apply(NamedModuleApplyFunction function, std::string name_prefix) {
+void Module::apply(
+    const NamedModuleApplyFunction& function,
+    std::string name_prefix) {
   function(/*name=*/name_prefix, *this);
   apply_to_submodules(
       [&function](
@@ -110,7 +112,7 @@ void Module::apply(NamedModuleApplyFunction function, std::string name_prefix) {
 }
 
 void Module::apply(
-    ConstNamedModuleApplyFunction function,
+    const ConstNamedModuleApplyFunction& function,
     std::string name_prefix) const {
   function(/*name=*/name_prefix, *this);
   apply_to_submodules(
@@ -121,7 +123,7 @@ void Module::apply(
       std::move(name_prefix));
 }
 
-void Module::apply(ModulePointerApplyFunction function) const {
+void Module::apply(const ModulePointerApplyFunction& function) const {
   function(shared_from_this_checked());
   apply_to_submodules(
       [&function](const std::string&, const std::shared_ptr<Module>& module) {
@@ -130,7 +132,7 @@ void Module::apply(ModulePointerApplyFunction function) const {
 }
 
 void Module::apply(
-    NamedModulePointerApplyFunction function,
+    const NamedModulePointerApplyFunction& function,
     std::string name_prefix) const {
   function(
       /*name=*/name_prefix, shared_from_this_checked());
@@ -319,13 +321,13 @@ Tensor& Module::register_buffer(std::string name, Tensor tensor) {
   return buffers_.insert(std::move(name), std::move(tensor));
 }
 
-void Module::clone_(Module& other, optional<Device> device) {}
+void Module::clone_(Module& other, const optional<Device>& device) {}
 
 void Module::apply_to_submodules(
     const NamedModulePointerApplyFunction& function,
-    std::string name_name_prefix) const {
+    const std::string& name_prefix) const {
   for (const auto& child : children_) {
-    auto qualified_name = join_name(name_name_prefix, child.key());
+    auto qualified_name = join_name(name_prefix, child.key());
     function(qualified_name, child.value());
     child.value()->apply_to_submodules(function, std::move(qualified_name));
   }

--- a/torch/csrc/api/src/nn/modules/batchnorm.cpp
+++ b/torch/csrc/api/src/nn/modules/batchnorm.cpp
@@ -33,7 +33,7 @@ void BatchNormImpl::reset() {
   }
 }
 
-Tensor BatchNormImpl::forward(Tensor input) {
+Tensor BatchNormImpl::forward(const Tensor& input) {
   AT_CHECK(
       options.stateful_,
       "Calling BatchNorm::forward is only permitted when "
@@ -42,7 +42,10 @@ Tensor BatchNormImpl::forward(Tensor input) {
   return pure_forward(input, running_mean, running_variance);
 }
 
-Tensor BatchNormImpl::pure_forward(Tensor input, Tensor mean, Tensor variance) {
+Tensor BatchNormImpl::pure_forward(
+    const Tensor& input,
+    const Tensor& mean,
+    const Tensor& variance) {
   if (is_training()) {
     const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
     AT_CHECK(

--- a/torch/csrc/api/src/nn/modules/conv.cpp
+++ b/torch/csrc/api/src/nn/modules/conv.cpp
@@ -59,7 +59,7 @@ void ConvImpl<D, Derived>::reset() {
   }
 }
 
-Tensor Conv1dImpl::forward(Tensor input) {
+Tensor Conv1dImpl::forward(const Tensor& input) {
   if (options.transposed_) {
     return torch::conv_transpose1d(
         input,
@@ -81,7 +81,7 @@ Tensor Conv1dImpl::forward(Tensor input) {
       options.groups_);
 }
 
-Tensor Conv2dImpl::forward(Tensor input) {
+Tensor Conv2dImpl::forward(const Tensor& input) {
   if (options.transposed_) {
     return torch::conv_transpose2d(
         input,
@@ -103,7 +103,7 @@ Tensor Conv2dImpl::forward(Tensor input) {
       options.groups_);
 }
 
-Tensor Conv3dImpl::forward(Tensor input) {
+Tensor Conv3dImpl::forward(const Tensor& input) {
   if (options.transposed_) {
     return torch::conv_transpose3d(
         input,

--- a/torch/csrc/api/src/nn/modules/dropout.cpp
+++ b/torch/csrc/api/src/nn/modules/dropout.cpp
@@ -26,11 +26,11 @@ template class DropoutImplBase<FeatureDropoutImpl>;
 
 DropoutOptions::DropoutOptions(double rate) : rate_(rate) {}
 
-Tensor DropoutImpl::forward(Tensor input) {
+Tensor DropoutImpl::forward(const Tensor& input) {
   return torch::dropout(input, options.rate_, this->is_training());
 }
 
-Tensor FeatureDropoutImpl::forward(Tensor input) {
+Tensor FeatureDropoutImpl::forward(const Tensor& input) {
   return torch::feature_dropout(input, options.rate_, this->is_training());
 }
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/embedding.cpp
+++ b/torch/csrc/api/src/nn/modules/embedding.cpp
@@ -25,7 +25,7 @@ void EmbeddingImpl::reset() {
   weight.normal_(0, 1);
 }
 
-Tensor EmbeddingImpl::forward(Tensor input) {
+Tensor EmbeddingImpl::forward(const Tensor& input) {
   return torch::embedding(weight, /*indices=*/input);
 }
 } // namespace nn

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -28,7 +28,7 @@ void LinearImpl::reset() {
   }
 }
 
-Tensor LinearImpl::forward(Tensor input) {
+Tensor LinearImpl::forward(const Tensor& input) {
   AT_ASSERT(!options.with_bias_ || bias.defined());
   return torch::linear(input, weight, bias);
 }

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -54,12 +54,12 @@ void InputArchive::read(const std::string& key, InputArchive& archive) {
 
 void InputArchive::load_from(const std::string& filename,
     c10::optional<torch::Device> device /*= c10::nullopt*/) {
-  module_ = torch::jit::load(filename, device);
+  module_ = torch::jit::load(filename, std::move(device));
 }
 
 void InputArchive::load_from(std::istream& stream,
     c10::optional<torch::Device> device /*= c10::nullopt*/) {
-  module_ = torch::jit::load(stream, device);
+  module_ = torch::jit::load(stream, std::move(device));
 }
 } // namespace serialize
 } // namespace torch

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -71,7 +71,7 @@ inline void rebase_history(std::vector<Variable>&& vars, std::shared_ptr<Functio
       if (var.defined()) {
         // TODO: eliminate const_cast
         auto output_nr = grad_fn->add_input_metadata(var);
-        var.rebase_history({grad_fn, output_nr});
+        var.rebase_history({std::move(grad_fn), output_nr});
       } else {
         grad_fn->add_input_metadata(Function::undefined_input());
       }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -306,7 +306,7 @@ static variable_list call_pre_hooks(Function& fn, variable_list inputs) {
   return inputs;
 }
 
-static variable_list call_post_hooks(Function& fn, variable_list outputs, variable_list inputs) {
+static variable_list call_post_hooks(Function& fn, variable_list outputs, const variable_list& inputs) {
   for (const auto& hook : fn.post_hooks()) {
     outputs = (*hook)(outputs, inputs);
   }

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -28,11 +28,11 @@ struct TORCH_API Error : public Function {
 // NYI, grad_fn=<Error> will be printed if we use Error, which is confusing. So
 // special case with a new NotImplemented function here.
 struct TORCH_API NotImplemented : public Error {
-  NotImplemented(std::string forward_fn, edge_list&& next_edges)
+  NotImplemented(const std::string& forward_fn, edge_list&& next_edges)
     : Error("derivative for " + forward_fn + " is not implemented",
             std::move(next_edges)) {}
 
-  NotImplemented(std::string forward_fn)
+  NotImplemented(const std::string& forward_fn)
     : Error("derivative for " + forward_fn + " is not implemented") {}
 };
 

--- a/torch/csrc/autograd/functions/pybind.h
+++ b/torch/csrc/autograd/functions/pybind.h
@@ -22,7 +22,7 @@ public:
     return true;
   }
   static handle cast(std::shared_ptr<torch::autograd::Function> src, return_value_policy /* policy */, handle /* parent */) {
-    auto fn = functionToPyObject(src);
+    auto fn = functionToPyObject(std::move(src));
     return handle(fn);
   }
 };

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -10,7 +10,7 @@
 namespace torch { namespace autograd {
 
 variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
-                           function_constructor ctr) {
+                           const function_constructor& ctr) {
   variable_list result;
   result.reserve(outputs.size());
   if (!any_variable_requires_grad(inputs)) {

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -20,7 +20,7 @@ using function_constructor = std::function<std::shared_ptr<Function>(edge_list&&
  * grad_fn if necessary.
  */
 TORCH_API variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
-                                     function_constructor ctr);
+                                     const function_constructor& ctr);
 
 ///  Checks that inputs contains exactly `args` items and that the first `required_args`
 /// items are not nullptr. If not specified, `required_args` defaults to `args`.

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -198,7 +198,7 @@ struct DefaultFunctionType {
   PyTypeObject type;
 };
 
-PyObject* functionToPyObject(std::shared_ptr<Function> cdata)
+PyObject* functionToPyObject(const std::shared_ptr<Function>& cdata)
 {
   static DefaultFunctionType default_type;
 

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -61,6 +61,6 @@ PyTypeObject* createForwardFunctionPyTypeObject(PyTypeObject& type, const char* 
 }
 
 void registerCppFunction(const std::type_info& type, PyTypeObject* pytype);
-PyObject* functionToPyObject(std::shared_ptr<Function> cdata);
+PyObject* functionToPyObject(const std::shared_ptr<Function>& cdata);
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -882,7 +882,7 @@ PyObject* THPFunction_register_hook(THPFunction *self, PyObject *hook)
 
 static PyObject *unpack_saved_variables(
     THPFunction *self,
-    std::function<PyObject*(const Variable&)> unpack_fn)
+    const std::function<PyObject*(const Variable&)>& unpack_fn)
 {
   THPUtils_assert(!self->has_freed_buffers, ERR_BACKWARD_TWICE);
   auto& saved_variables = self->saved_variables;

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -596,11 +596,11 @@ inline void Variable::backward(
     c10::optional<Tensor> gradient,
     bool keep_graph,
     bool create_graph) const {
-  get()->backward(gradient, keep_graph, create_graph);
+  get()->backward(std::move(gradient), keep_graph, create_graph);
 }
 
 inline void Variable::set_data(Tensor new_data) const {
-  get()->set_data(new_data);
+  get()->set_data(std::move(new_data));
 }
 
 inline void Variable::set_gradient_edge(Edge edge) noexcept {

--- a/torch/csrc/jit/batched/BatchTensor.cpp
+++ b/torch/csrc/jit/batched/BatchTensor.cpp
@@ -8,12 +8,12 @@ BatchTensor::BatchTensor(at::Tensor data, at::Tensor mask, at::Tensor dims){
       + std::to_string(data.dim()) + ", mask.dim(): " + std::to_string(mask.dim())
       + ", dims.size(0): " + std::to_string(dims.size(0)));
   }
-  this->data = data;
-  this->mask = mask;
-  this->dims = dims;
+  this->data = std::move(data);
+  this->mask = std::move(mask);
+  this->dims = std::move(dims);
 }
 
-BatchTensor::BatchTensor(at::Tensor data, int64_t batch_size){
+BatchTensor::BatchTensor(const at::Tensor& data, int64_t batch_size){
   dims = at::empty(data.dim(), data.options().dtype(at::kByte));
   dims.fill_(0);
   std::vector<int64_t> sizes(data.dim() + 1, -1);
@@ -25,7 +25,7 @@ BatchTensor::BatchTensor(at::Tensor data, int64_t batch_size){
   mask.fill_(1);
 }
 
-BatchTensor::BatchTensor(const std::vector<at::Tensor> datalist, at::Tensor dims) {
+BatchTensor::BatchTensor(const std::vector<at::Tensor>& datalist, at::Tensor dims) {
   auto bs = datalist.size();
   std::vector<int64_t> sizes(dims.size(0) + 1, 0), mask_sizes(dims.size(0) + 1, 0);
   sizes[0] = bs;
@@ -52,7 +52,7 @@ BatchTensor::BatchTensor(const std::vector<at::Tensor> datalist, at::Tensor dims
     data_item += datalist[i];
     mask_item.fill_(1);
   }
-  this->dims = dims;
+  this->dims = std::move(dims);
 }
 
 std::vector<at::Tensor> BatchTensor::examples() {

--- a/torch/csrc/jit/batched/BatchTensor.h
+++ b/torch/csrc/jit/batched/BatchTensor.h
@@ -10,8 +10,8 @@ struct BatchTensor {
 public:
   BatchTensor(at::Tensor data, at::Tensor mask, at::Tensor dims);
   // expand a tensor to a batchtensor given batch_size
-  BatchTensor(at::Tensor data, int64_t batch_size);
-  BatchTensor(const std::vector<at::Tensor> datalist, at::Tensor dims);
+  BatchTensor(const at::Tensor& data, int64_t batch_size);
+  BatchTensor(const std::vector<at::Tensor>& datalist, at::Tensor dims);
   const char * toString() const {
     return "BatchTensor";
   }

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -9,7 +9,7 @@ namespace torch { namespace jit {
 // IValue -> Constant node
 Value* insertConstant(
     Graph& g,
-    IValue val,
+    const IValue& val,
     c10::optional<SourceRange> loc,
     c10::optional<ScopePtr> scope) {
   Node * n = g.create(prim::Constant);

--- a/torch/csrc/jit/constants.h
+++ b/torch/csrc/jit/constants.h
@@ -22,7 +22,7 @@ struct TORCH_API constant_not_supported_error : public std::runtime_error {
 // closely related to the implementation of prim::Constant that is also in constants.cpp
 TORCH_API Value* insertConstant(
     Graph& g,
-    IValue val,
+    const IValue& val,
     c10::optional<SourceRange> loc = c10::nullopt,
     c10::optional<ScopePtr> scope = c10::nullopt);
 

--- a/torch/csrc/jit/fuser/codegen.cpp
+++ b/torch/csrc/jit/fuser/codegen.cpp
@@ -11,11 +11,11 @@
 
 #if USE_CUDA_FUSER
   #include <torch/csrc/jit/fuser/cuda/resource_strings.h>
-#endif 
+#endif
 
 #if USE_CPU_FUSER
   #include <torch/csrc/jit/fuser/cpu/resource_strings.h>
-#endif 
+#endif
 
 #include <tuple>
 #include <iostream>
@@ -47,7 +47,7 @@ static std::string scalarValue(const bool v) {
 }
 
 // Note: The NAN, NEG_INFINITY and POS_INFINITY strings map to device-specific
-// implementations of these special values. These macros are found in the 
+// implementations of these special values. These macros are found in the
 // resource strings for each device.
 static std::string scalarValue(const double v) {
   std::ostringstream out;
@@ -89,7 +89,7 @@ static const char* calcScalarTypeName(const at::ScalarType type) {
 }
 
 
-static std::string variableType(const std::shared_ptr<c10::Type> t) {
+static std::string variableType(const std::shared_ptr<c10::Type>& t) {
   if (t->kind() == TypeKind::IntType) {
     return "int";
   } else if (t->kind() == TypeKind::FloatType) {
@@ -104,7 +104,7 @@ static std::string variableType(const std::shared_ptr<c10::Type> t) {
   throw std::runtime_error("unknown scalar type during JIT fusion code generation");
 }
 
-static std::string typeCastedValueName(const std::shared_ptr<c10::Type> t, const at::ScalarType outtype, const std::string& vn) {
+static std::string typeCastedValueName(const std::shared_ptr<c10::Type>& t, const at::ScalarType outtype, const std::string& vn) {
   if (t->kind() == TypeKind::IntType || t->kind() == TypeKind::BoolType) {
     if (! isIntegralType(outtype)) {
       return std::string("((") + calcScalarTypeName(outtype) + ") " + vn + ")";
@@ -272,7 +272,7 @@ std::tuple<
   std::string
 , std::vector<PartitionDesc>
 , std::vector<PartitionDesc>
-, bool> 
+, bool>
 generateKernel(
   const std::string& name
 , const Graph& graph
@@ -376,7 +376,7 @@ generateKernel(
   bool has_random = false;
   // Generates code for intermediate nodes
   // Note: Concat and Chunk are implicitly generated
-  // Note: Random number generation is only supported for CUDA kernels. 
+  // Note: Random number generation is only supported for CUDA kernels.
   for (const auto& n : graph.nodes()) {
     // Note: FusedConcat nodes work by narrowing the output Tensors before the kernel runs
     if (n->kind() == prim::FusedConcat) continue;

--- a/torch/csrc/jit/fuser/kernel_spec.h
+++ b/torch/csrc/jit/fuser/kernel_spec.h
@@ -53,19 +53,16 @@ private:
  // TODO: allow abstract kernels to use multiple generated kernels
  // TODO: allow abstract kernels to reuse generated kernels from common pool
 struct TORCH_API KernelSpec {
-  KernelSpec(
-    const int64_t _key
-  , std::shared_ptr<Graph> _graph)
-  : key_{_key}
-  , graph_{_graph}
-  , code_{_graph}
-  , nInputs_{_graph->inputs().size()}
-  , inputBroadcastGroups_{}
-  , inputChunks_{}
-  , kernels_{}
-  { }
+  KernelSpec(const int64_t _key, const std::shared_ptr<Graph>& _graph)
+      : key_{_key},
+        graph_{_graph},
+        code_{_graph},
+        nInputs_{_graph->inputs().size()},
+        inputBroadcastGroups_{},
+        inputChunks_{},
+        kernels_{} {}
 
-   // Getters
+  // Getters
   int64_t key() const { return key_; }
   std::shared_ptr<Graph> graph() const { return graph_; }
   const Code& code() const { return code_; }

--- a/torch/csrc/jit/fuser/tensor_desc.h
+++ b/torch/csrc/jit/fuser/tensor_desc.h
@@ -43,7 +43,7 @@ struct TORCH_API TensorDesc {
   TensorDesc(const at::Tensor& t)
   : TensorDesc(t.type().scalarType(), t.sizes(), t.strides()) {}
 
-  TensorDesc(CompleteTensorTypePtr type)
+  TensorDesc(const CompleteTensorTypePtr& type)
   : TensorDesc(type->scalarType(), type->sizes(), type->strides()) {}
 
   // number of dimensions after contiguity compression
@@ -91,7 +91,7 @@ inline std::ostream& operator<<(std::ostream& out, const TensorDesc& d) {
 }
 
 } // namespace fuser
-} // namespace jit 
+} // namespace jit
 } // namespace torch
 
 #endif // USE_CUDA_FUSER || USE_CPU_FUSER

--- a/torch/csrc/jit/hooks_for_testing.cpp
+++ b/torch/csrc/jit/hooks_for_testing.cpp
@@ -6,12 +6,12 @@ namespace jit {
 
 static std::function<void(std::shared_ptr<script::Module> module)> emit_module_callback;
 TORCH_API void didFinishEmitModule(std::shared_ptr<script::Module> module) {
-  if(emit_module_callback)
-    emit_module_callback(module);
-
+  if(emit_module_callback) {
+    emit_module_callback(std::move(module));
+  }
 }
 TORCH_API void setEmitModuleHook(std::function<void(std::shared_ptr<script::Module> module)> cb) {
-  emit_module_callback = cb;
+  emit_module_callback = std::move(cb);
 }
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/import_method.cpp
+++ b/torch/csrc/jit/import_method.cpp
@@ -13,7 +13,7 @@ struct ModuleAccessorValue : public script::SugaredValue {
     return "module";
   }
   // select an attribute on it, e.g. `this.field`
-  std::shared_ptr<SugaredValue> attr(SourceRange loc, script::Method & m, const std::string& field) override {
+  std::shared_ptr<SugaredValue> attr(const SourceRange& loc, script::Method & m, const std::string& field) override {
     if(script::NamedModule* v = module->find_module(field)) {
       return std::make_shared<ModuleAccessorValue>(v->module);
     } else if(script::NamedParameter* v = module->find_parameter(field)) {
@@ -34,7 +34,7 @@ struct OpsValue : public script::SugaredValue {
   std::string kind() const override {
     return "ops";
   }
-  std::shared_ptr<SugaredValue> attr(SourceRange loc, script::Method & m, const std::string& field) override {
+  std::shared_ptr<SugaredValue> attr(const SourceRange& loc, script::Method & m, const std::string& field) override {
     return std::make_shared<script::BuiltinModule>(field, version_);
   }
   size_t version_;
@@ -45,7 +45,7 @@ struct ConstantValue : public script::SugaredValue {
   : value_(std::move(value)) {}
   IValue value_;
   std::string kind() const override { return "constant"; }
-  Value * asValue(SourceRange loc, script::Method & m) override {
+  Value * asValue(const SourceRange& loc, script::Method & m) override {
     return m.graph()->insertConstant(value_);
   }
 };
@@ -60,7 +60,7 @@ struct ConstantTableValue : public script::SugaredValue {
     return "CONSTANTS";
   }
   // select an attribute on it, e.g. `this.field`
-  std::shared_ptr<SugaredValue> attr(SourceRange loc, script::Method & m, const std::string& field) override {
+  std::shared_ptr<SugaredValue> attr(const SourceRange& loc, script::Method & m, const std::string& field) override {
     const char* field_s = field.c_str();
     char* end;
     int64_t offset = std::strtoll(field_s + 1, &end, 10);

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -264,7 +264,7 @@ public:
     return scope_;
   }
   void setScope(ScopePtr scope) {
-    scope_ = scope;
+    scope_ = std::move(scope);
   }
   std::string scopeName() const {
     if (!scope_) {
@@ -676,12 +676,12 @@ struct Block {
   }
   Value * addInput(std::string name="") {
     Value * v = input_->addOutput();
-    v->setUniqueName(name);
+    v->setUniqueName(std::move(name));
     return v;
   }
   Value* insertInput(size_t i, std::string name = "") {
     Value* v = input_->insertOutput(i);
-    v->setUniqueName(name);
+    v->setUniqueName(std::move(name));
     return v;
   }
   void eraseInput(size_t i) {
@@ -829,7 +829,7 @@ public:
     return current_scope_;
   }
   void set_current_scope(ScopePtr scope) {
-    current_scope_ = scope;
+    current_scope_ = std::move(scope);
   }
   Value * addInput(std::string name="") {
     return block_->addInput(std::move(name));
@@ -876,7 +876,7 @@ public:
   // use node_map to translate inputs of n to inputs of the cloned node
   // if copy_blocks is false, it will not recursively clone the nested blocks
   // this node contains.
-  TORCH_API Node * createClone(Node * n, std::function<Value*(Value*)> value_map, bool copy_blocks=true);
+  TORCH_API Node * createClone(Node * n, const std::function<Value*(Value*)>& value_map, bool copy_blocks=true);
 
   TORCH_API Value* insertConstant(
       IValue val,
@@ -893,7 +893,7 @@ public:
       Symbol opname,
       at::ArrayRef<NamedValue> args,
       at::ArrayRef<NamedValue> kwargs = {},
-      c10::optional<SourceRange> range = {});
+      const c10::optional<SourceRange>& range = {});
 
   Node * appendNode(Node * n) {
     return block_->appendNode(n);
@@ -976,7 +976,7 @@ struct WithCurrentScope : public ResourceGuard {
     g.set_current_scope(prev_scope);
   })
   , prev_scope(g.current_scope()) {
-    g.set_current_scope(scope);
+    g.set_current_scope(std::move(scope));
   }
 private:
   ScopePtr prev_scope;
@@ -990,9 +990,9 @@ inline Value::Value(Node * node_, size_t offset_)
   node_->graph_->all_values.emplace(this);
 }
 
-inline Value* Value::setType(const TypePtr type) {
+inline Value* Value::setType(TypePtr type) {
   JIT_ASSERT(type);
-  type_ = type;
+  type_ = std::move(type);
   for (Use & use : uses_) {
     use.user->schema_ = nullptr;
   }

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -7,6 +7,11 @@
 #include <torch/csrc/jit/passes/python_print.h>
 #include <torch/csrc/jit/script/error_report.h>
 
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
 namespace torch { namespace jit {
 
 namespace script {
@@ -290,7 +295,7 @@ struct SchemaParser {
     L.expect(TK_NONE);
     return IValue();
   }
-  IValue parseDefaultValue(TypePtr arg_type, c10::optional<int32_t> arg_N) {
+  IValue parseDefaultValue(const TypePtr& arg_type, c10::optional<int32_t> arg_N) {
     auto range = L.cur().range;
     switch(arg_type->kind()) {
       case TypeKind::DynamicType:
@@ -328,7 +333,7 @@ struct SchemaParser {
     return IValue(); // silence warnings
   }
 
-  void parseList(int begin, int sep, int end, std::function<void()> callback) {
+  void parseList(int begin, int sep, int end, const std::function<void()>& callback) {
     auto r = L.cur().range;
     if (begin != TK_NOTHING)
       L.expect(begin);

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -5,7 +5,7 @@
 namespace torch {
 namespace jit {
 namespace {
-bool shouldAnnotate(TypePtr type) {
+bool shouldAnnotate(const TypePtr& type) {
   return type->isSubtypeOf(DynamicType::get()) ||
       type->kind() == TypeKind::ListType ||
       type->kind() == TypeKind::TupleType ||
@@ -202,7 +202,7 @@ void AliasDb::dump() const {
   }
 }
 
-void AliasDb::analyze(std::shared_ptr<Graph> graph) {
+void AliasDb::analyze(const std::shared_ptr<Graph>& graph) {
   // Assign aliases to the graph's inputs, assuming that all inputs of a given
   // type may alias to each other.
   const auto tensorAlias = getFreshAlias(/*isGraphInput=*/true);

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -53,7 +53,7 @@ class AliasDb {
   void dump() const;
 
  private:
-  void analyze(std::shared_ptr<Graph> graph);
+  void analyze(const std::shared_ptr<Graph>& graph);
   void analyze(Block* block);
   void analyze(Node* node);
 

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.cpp
@@ -168,7 +168,7 @@ class SubgraphSlicer {
 } // anonymous namespace
 
 std::vector<Node*> CreateAutodiffSubgraphs(
-    std::shared_ptr<Graph> graph,
+    const std::shared_ptr<Graph>& graph,
     size_t threshold) {
   std::vector<Node*> diff_nodes;
   SubgraphSlicer(graph->block(), graph, threshold).run(diff_nodes);

--- a/torch/csrc/jit/passes/create_autodiff_subgraphs.h
+++ b/torch/csrc/jit/passes/create_autodiff_subgraphs.h
@@ -12,6 +12,6 @@ namespace torch { namespace jit {
 // threshold - minimum number of nodes that will appear in a block
 // returns all differentiable blocks that have been found
 TORCH_API std::vector<Node*> CreateAutodiffSubgraphs(
-    std::shared_ptr<Graph> graph,
+    const std::shared_ptr<Graph>& graph,
     size_t threshold = 2);
 }}

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -10,7 +10,7 @@ namespace jit {
 class DeadCodeEliminator {
  public:
   explicit DeadCodeEliminator(std::shared_ptr<Graph> graph)
-      : aliasDb_(AliasAnalysis(graph)) {}
+      : aliasDb_(AliasAnalysis(std::move(graph))) {}
   DeadCodeEliminator(bool collect_only = false)
       : collect_only_(collect_only) {}
 

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -125,7 +125,7 @@ private:
 
 void createTensorToParameterNameMap(
     const script::Module& module,
-    QualifiedNamePtr prefix,
+    const QualifiedNamePtr& prefix,
     std::unordered_map<at::Tensor*, QualifiedNamePtr>& result) {
 
   for (const auto& elem : module.get_parameters()) {
@@ -615,7 +615,7 @@ struct PythonPrintPass {
       std::ostream& stmt,
       const char* the_type,
       size_t list_size,
-      IValue the_list) {
+      const IValue& the_list) {
     if(list_size == 0) {
       stmt << "annotate(List[" << the_type << "], [])";
     } else {
@@ -623,7 +623,7 @@ struct PythonPrintPass {
     }
   }
 
-  void printConstant(std::ostream& stmt, IValue v) {
+  void printConstant(std::ostream& stmt, const IValue& v) {
     if(v.isTensor()) {
       stmt << "CONSTANTS.c" << getOrAddTensorConstant(v.toTensor());
     } else if(v.isString()) {
@@ -813,7 +813,7 @@ struct PythonPrintPass {
     return out;
   }
 
-  void printDefaultValue(std::ostream& stmt, IValue value) {
+  void printDefaultValue(std::ostream& stmt, const IValue& value) {
     if (value.isTensor() && !value.toTensor().defined()) {
       // XXX - because undefined tensors are not stored as None, we need special handling.
       // otherwise they get printed as CONSTANTS.c0 and then cannot be recreated because
@@ -827,7 +827,7 @@ struct PythonPrintPass {
   void printFunctionDefinition(
       Graph& graph,
       const std::string& name,
-      const std::vector<c10::optional<IValue>> defaults = {},
+      const std::vector<c10::optional<IValue>>& defaults = {},
       const std::vector<std::string>& param_names = {}) {
 
     used_names_.clear(); // each graph can reuse local names

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -52,7 +52,7 @@ void RemoveInplaceOps(Block* block) {
 }
 }
 
-void RemoveInplaceOps(std::shared_ptr<Graph> graph) {
+void RemoveInplaceOps(const std::shared_ptr<Graph>& graph) {
   RemoveInplaceOps(graph->block());
 }
 } // namespace jit

--- a/torch/csrc/jit/passes/remove_inplace_ops.h
+++ b/torch/csrc/jit/passes/remove_inplace_ops.h
@@ -2,9 +2,11 @@
 
 #include <torch/csrc/jit/ir.h>
 
+#include <memory>
+
 namespace torch {
 namespace jit {
 // see .cpp for docs
-TORCH_API void RemoveInplaceOps(std::shared_ptr<Graph> graph);
+TORCH_API void RemoveInplaceOps(const std::shared_ptr<Graph>& graph);
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -44,7 +44,7 @@ bool isValidReturnForRunning(Value* v) {
 class ShapePropagator {
  public:
   explicit ShapePropagator(std::shared_ptr<Graph> graph)
-      : aliasDb_(AliasAnalysis(graph)) {}
+      : aliasDb_(AliasAnalysis(std::move(graph))) {}
 
   void PropagateShapeOnBlock(Block* block, bool insert_expands = true) {
     for (Node* node : block->nodes()) {
@@ -1583,7 +1583,7 @@ class ShapePropagator {
 };
 } // anonymous namespace
 
-void PropagateInputShapes(std::shared_ptr<Graph> graph) {
+void PropagateInputShapes(const std::shared_ptr<Graph>& graph) {
   ShapePropagator(graph).PropagateShapeOnBlock(graph->block());
 }
 
@@ -1608,7 +1608,7 @@ void EraseShapeInformation(Block * b) {
 
 } // anonymous namespace
 
-void EraseShapeInformation(std::shared_ptr<Graph> graph) {
+void EraseShapeInformation(const std::shared_ptr<Graph>& graph) {
   EraseShapeInformation(graph->block());
 }
 

--- a/torch/csrc/jit/passes/shape_analysis.h
+++ b/torch/csrc/jit/passes/shape_analysis.h
@@ -7,7 +7,7 @@ namespace torch { namespace jit {
 
 struct Graph;
 
-TORCH_API void EraseShapeInformation(std::shared_ptr<Graph> graph);
-TORCH_API void PropagateInputShapes(std::shared_ptr<Graph> graph);
+TORCH_API void EraseShapeInformation(const std::shared_ptr<Graph>& graph);
+TORCH_API void PropagateInputShapes(const std::shared_ptr<Graph>& graph);
 
 }}

--- a/torch/csrc/jit/passes/to_batch.cpp
+++ b/torch/csrc/jit/passes/to_batch.cpp
@@ -5,7 +5,7 @@ namespace torch { namespace jit {
 
 std::unordered_map<std::string, std::vector<std::shared_ptr<Graph>>> ToBatch::batch_operator_table;
 
-std::shared_ptr<Graph> ToBatch::getBatchOperator(std::string name, int64_t num_inputs){
+std::shared_ptr<Graph> ToBatch::getBatchOperator(const std::string& name, int64_t num_inputs){
   if(batch_operator_table.find(name) == batch_operator_table.end()){
     throw std::runtime_error("function " + name + " is not supported in batched tensor yet");
   }

--- a/torch/csrc/jit/passes/to_batch.h
+++ b/torch/csrc/jit/passes/to_batch.h
@@ -19,7 +19,7 @@ private:
   std::function<Value*(Value*)> rn_fn = [this](Value* v) { return rn_env.at(v); };
 
 private:
-  std::shared_ptr<Graph> getBatchOperator(std::string name, int64_t input_num = -1);
+  std::shared_ptr<Graph> getBatchOperator(const std::string& name, int64_t input_num = -1);
   void visitAten(Node* n, Block* block, Block* res_block);
   void visitConstant(Node* n, Block* block, Block* res_block);
   void visitNumToTensor(Node* n, Block* block, Block* res_block);

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
@@ -185,7 +185,7 @@ c10::optional<IValue> toIValueProp(const Value* v) {
 } // namespace
 
 void checkAliasAnnotation(
-    std::shared_ptr<Graph> graph,
+    const std::shared_ptr<Graph>& graph,
     std::vector<IValue> pythonInputs,
     const std::string& unqualifiedOpName) {
   // Find the node that corresponds to our op name

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
@@ -73,9 +73,9 @@ bool deepEquals(const IValue& lhs, const IValue& rhs) {
 
 struct AliasAndIValue {
   AliasAndIValue(
-      const c10::optional<at::AliasInfo>& aliasInfo,
-      const IValue& iValue)
-      : aliasInfo(aliasInfo), iValue(iValue) {}
+      c10::optional<at::AliasInfo> aliasInfo,
+      IValue iValue)
+      : aliasInfo(std::move(aliasInfo)), iValue(std::move(iValue)) {}
 
   const c10::optional<at::AliasInfo> aliasInfo;
   const IValue iValue;

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.h
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.h
@@ -13,7 +13,7 @@ namespace jit {
 // This function expects a graph with a single op with `unqualifiedOpName`, plus
 // the inputs that you would otherwise have passed to the graph executor.
 TORCH_API void checkAliasAnnotation(
-    std::shared_ptr<Graph> graph,
+    const std::shared_ptr<Graph>& graph,
     std::vector<IValue> pythonInputs,
     const std::string& unqualifiedOpName);
 } // namespace jit

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -321,8 +321,8 @@ private:
 
 inline Stack createStackForSchema(
     const FunctionSchema& schema,
-    tuple_slice args,
-    py::kwargs kwargs = py::kwargs()) {
+    const tuple_slice& args,
+    const py::kwargs& kwargs = py::kwargs()) {
   if(args.size() + kwargs.size() > schema.arguments().size()) {
     throw std::runtime_error(c10::str(
         schema.name(), "() expected at most ", schema.arguments().size(),

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -37,11 +37,11 @@ std::string getPythonInterpreterStackTrace() {
 }
 
 std::shared_ptr<torch::jit::Graph> createGraphByTracing(
-    py::function func,
+    const py::function& func,
     Stack trace_inputs,
-    py::function var_name_lookup_fn,
+    const py::function& var_name_lookup_fn,
     bool force_outplace,
-    c10::optional<size_t> num_real_inputs) {
+    const c10::optional<size_t>& num_real_inputs) {
   size_t num_func_inputs = num_real_inputs.value_or(trace_inputs.size());
   auto enter_info = tracer::enter(std::move(trace_inputs));
   getTracingState()->lookup_var_name_fn = [var_name_lookup_fn](const Variable& var) -> std::string {
@@ -76,7 +76,7 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
 }
 
 Node* preRecordPythonTrace(THPObjectPtr pyobj,
-                                  std::string arg_types,
+                                  const std::string& arg_types,
                                   at::ArrayRef<Variable> inputs,
                                   pyobj_list scalar_args) {
   THPObjectPtr apply(PyObject_GetAttrString(pyobj.get(), "apply"));

--- a/torch/csrc/jit/python_tracer.h
+++ b/torch/csrc/jit/python_tracer.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <torch/csrc/python_headers.h>
-#include <memory>
 #include <torch/csrc/jit/tracer.h>
 #include <torch/csrc/utils/pybind.h>
+
+#include <memory>
+#include <string>
 
 namespace torch { namespace jit { namespace tracer {
 void initPythonTracerBindings(PyObject *module);
@@ -11,15 +13,16 @@ void initPythonTracerBindings(PyObject *module);
 
 std::string getPythonInterpreterStackTrace();
 Node* preRecordPythonTrace(
-    THPObjectPtr pyobj, std::string arg_types, at::ArrayRef<autograd::Variable> inputs,
+    THPObjectPtr pyobj,
+    const std::string& arg_types,
+    at::ArrayRef<autograd::Variable> inputs,
     pyobj_list scalar_args);
 
 std::shared_ptr<Graph> createGraphByTracing(
-    py::function func,
+    const py::function& func,
     Stack inputs,
-    py::function var_name_lookup_fn,
+    const py::function& var_name_lookup_fn,
     bool force_outplace,
-    c10::optional<size_t> num_real_inputs = {});
+    const c10::optional<size_t>& num_real_inputs = c10::nullopt);
 } // namespace tracer
-
 }} // namespace torch::jit

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1163,7 +1163,7 @@ Operator(                                                                      \
 // checking one of size & scale_factor is set
 // if scale_factor is a double list check that it's len == dim
 // reference: _check_size_scale_factor in torch/nn/functional.py
-void _check_size_factor(size_t dim, const IValue& size, IValue scale_factor) {
+void _check_size_factor(size_t dim, const IValue& size, const IValue& scale_factor) {
   if (size.isNone() && scale_factor.isNone()) {
     throw std::runtime_error("either size or scale_factor should be defined");
   }
@@ -1184,7 +1184,7 @@ void _check_size_factor(size_t dim, const IValue& size, IValue scale_factor) {
 // reference: _output_size in torch/nn/functional.py
 // size can be none, int or intlist
 // scale_factors can be none, float, or floatlist
-std::vector<int64_t> _output_size(at::Tensor input, size_t dim, IValue size, IValue scale_factors) {
+std::vector<int64_t> _output_size(const at::Tensor& input, size_t dim, const IValue& size, const IValue& scale_factors) {
   if (!size.isNone()) {
     if (size.isInt()) {
       std::vector<int64_t> repeated(dim, size.toInt());
@@ -1209,8 +1209,12 @@ std::vector<int64_t> _output_size(at::Tensor input, size_t dim, IValue size, IVa
 // reference: interpolate in torch/nn/functional.py
 // size can be none, int or intlist
 // scale_factors can be none, float, or floatlist
-at::Tensor interpolate(at::Tensor input, IValue size, IValue scale_factors,
-    std::string mode, c10::optional<bool> align_corners) {
+at::Tensor interpolate(
+    const at::Tensor& input,
+    const IValue& size,
+    const IValue& scale_factors,
+    const std::string& mode,
+    c10::optional<bool> align_corners) {
   if ((mode == "nearest" || mode == "area")) {
     if (align_corners != c10::nullopt) {
       throw std::runtime_error("align_corners option can only be set with the "
@@ -1279,7 +1283,7 @@ Operation interpolate_op(const Node* n) {
 // interpolate takes in float & float[] for scale factor
 // upsample takes in int & int[], so convert the ints to floats before
 // passing on to the interpolate op
-IValue convert_scale_factor_to_double(IValue int_ivalue) {
+IValue convert_scale_factor_to_double(const IValue& int_ivalue) {
   IValue scale_factor_double;
   if (int_ivalue.isInt()) {
     scale_factor_double = static_cast<double>(int_ivalue.toInt());
@@ -1384,10 +1388,10 @@ RegisterOperators reg3({
 });
 
 
-at::Tensor leaky_relu(at::Tensor tensor, double scalar) {
+at::Tensor leaky_relu(const at::Tensor& tensor, double scalar) {
   return at::leaky_relu(tensor, scalar);
 }
-at::Tensor cat(std::vector<at::Tensor> tensors) {
+at::Tensor cat(const std::vector<at::Tensor>& tensors) {
   return at::cat(tensors);
 }
 

--- a/torch/csrc/jit/scope.h
+++ b/torch/csrc/jit/scope.h
@@ -36,7 +36,7 @@ public:
   }
   Scope(ScopePtr parent, Symbol name) {
     name_ = name;
-    parent_ = parent;
+    parent_ = std::move(parent);
   }
   ScopePtr push(Symbol name);
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -105,7 +105,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   }
 
   // call it like a function, e.g. `outputs = this(inputs)`
-  std::shared_ptr<SugaredValue> call(SourceRange loc, Method & m, at::ArrayRef<NamedValue> inputs_, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
+  std::shared_ptr<SugaredValue> call(const SourceRange& loc, Method & m, at::ArrayRef<NamedValue> inputs_, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
     auto inputs = toValues(*m.graph(), inputs_);
     auto schema = getSchema(inputs.size(), n_binders);
 
@@ -139,7 +139,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
 
 protected:
 
-  py::object getattr(SourceRange loc, const std::string& name) {
+  py::object getattr(const SourceRange& loc, const std::string& name) {
     try {
       return py::getattr(self, name.c_str());
     } catch (py::error_already_set& e) {
@@ -151,10 +151,10 @@ protected:
 };
 
 struct VISIBILITY_HIDDEN PythonModuleValue : public PythonValue {
-  explicit PythonModuleValue(py::object mod) : PythonValue(mod) {}
+  explicit PythonModuleValue(py::object mod) : PythonValue(std::move(mod)) {}
 
   std::shared_ptr<SugaredValue> attr(
-      SourceRange loc,
+      const SourceRange& loc,
       Method& m,
       const std::string& field) override {
     py::object member = getattr(loc, field);
@@ -166,11 +166,11 @@ struct VISIBILITY_HIDDEN PythonModuleValue : public PythonValue {
 };
 
 struct VISIBILITY_HIDDEN ConstantPythonTupleValue : public PythonValue {
-  explicit ConstantPythonTupleValue(py::object tup) : PythonValue(tup) {}
+  explicit ConstantPythonTupleValue(py::object tup) : PythonValue(std::move(tup)) {}
   std::vector<std::shared_ptr<SugaredValue>> asTuple(
-      SourceRange loc,
+      const SourceRange& loc,
       Method& m,
-      c10::optional<size_t> size_hint = {}) override {
+      const c10::optional<size_t>& size_hint = {}) override {
     py::tuple tup = self;
     std::vector<std::shared_ptr<SugaredValue>> result;
     result.reserve(tup.size());
@@ -182,7 +182,7 @@ struct VISIBILITY_HIDDEN ConstantPythonTupleValue : public PythonValue {
   }
 
   Value* asValue(
-      SourceRange loc,
+      const SourceRange& loc,
       Method& m) override {
     std::vector<Value*> values;
     for (auto sugared_item : asTuple(loc, m)) {
@@ -210,7 +210,7 @@ struct ModuleValue : public SugaredValue {
   }
 
   // select an attribute on it, e.g. `this.field`
-  std::shared_ptr<SugaredValue> attr(SourceRange loc, Method & m, const std::string& field) override {
+  std::shared_ptr<SugaredValue> attr(const SourceRange& loc, Method & m, const std::string& field) override {
     // workaround to make self.training work
     // it adds a buffer 'training' to the model if one doesn't exist
     // and then loads that parameter, casting it to bool
@@ -251,14 +251,14 @@ struct ModuleValue : public SugaredValue {
   }
 
   // call module.forward
-  std::shared_ptr<SugaredValue> call(SourceRange loc, Method & caller, at::ArrayRef<NamedValue> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
+  std::shared_ptr<SugaredValue> call(const SourceRange& loc, Method & caller, at::ArrayRef<NamedValue> inputs, at::ArrayRef<NamedValue> attributes, size_t n_binders) override {
     return attr(loc, caller, "forward")->call(loc, caller, inputs, attributes, n_binders);
   }
 
   std::vector<std::shared_ptr<SugaredValue>> asTuple(
-      SourceRange loc,
+      const SourceRange& loc,
       Method& m,
-      c10::optional<size_t> size_hint = {}) override {
+      const c10::optional<size_t>& size_hint = {}) override {
     py::object py_module = py::cast(module);
     if(!py::isinstance(py_module, py::module::import("torch.jit").attr("_ConstModuleList")))
       return SugaredValue::asTuple(loc, m, size_hint);
@@ -296,7 +296,7 @@ struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
   }
 
   std::shared_ptr<SugaredValue> call(
-      SourceRange loc,
+      const SourceRange& loc,
       Method& caller,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
@@ -450,7 +450,7 @@ static void gatherParametersAndBuffers(std::vector<at::Tensor*> & values, const 
 
 namespace {
 
-Resolver pythonResolver(ResolutionCallback rcb) {
+Resolver pythonResolver(const ResolutionCallback& rcb) {
   return [rcb](const std::string& name, Method& m, const SourceRange& loc)
              -> std::shared_ptr<SugaredValue> {
     AutoGIL ag;
@@ -466,8 +466,8 @@ Resolver pythonResolver(ResolutionCallback rcb) {
 
 FunctionSchema getSchemaWithNameAndDefaults(
     const SourceRange& range,
-    const FunctionSchema schema,
-    at::optional<std::string> new_name,
+    const FunctionSchema& schema,
+    const at::optional<std::string>& new_name,
     const FunctionDefaults& default_args) {
   std::vector<Argument> new_args;
   for (auto& arg : schema.arguments()) {

--- a/torch/csrc/jit/script/lexer.cpp
+++ b/torch/csrc/jit/script/lexer.cpp
@@ -59,7 +59,7 @@ bool SharedParserData::isBinary(int kind, int* prec) {
   return false;
 }
 
-int stringToKind(std::string str) {
+int stringToKind(const std::string& str) {
   static std::once_flag init_flag;
   static std::unordered_map<std::string, int> str_to_kind;
   std::call_once(init_flag, []() {

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -109,7 +109,7 @@ enum TokenKind {
 };
 
 std::string kindToString(int kind);
-int stringToKind(std::string str);
+int stringToKind(const std::string& str);
 
 // nested hash tables that indicate char-by-char what is a valid token.
 struct TokenTrie;

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -15,7 +15,7 @@ void placeholderCreator(Method&) {
 
 c10::optional<std::vector<Value*>> try_emit_call_to(
     Graph& graph,
-    SourceRange loc,
+    const SourceRange& loc,
     Method& callee,
     c10::optional<NamedValue> self,
     ArrayRef<NamedValue> args,
@@ -33,7 +33,7 @@ c10::optional<std::vector<Value*>> try_emit_call_to(
 
   auto matched_schema = tryMatchSchema(
     callee.getSchema(),
-    loc, graph, self, args, kwargs, failure_messages, conv_tensors_to_nums);
+    loc, graph, std::move(self), args, kwargs, failure_messages, conv_tensors_to_nums);
   if(!matched_schema)
     return c10::nullopt;
 
@@ -48,7 +48,7 @@ c10::optional<std::vector<Value*>> try_emit_call_to(
   return inlineCallTo(graph, *callee.graph(), matched_schema->inputs);
 }
 
-std::vector<Value*> Method::emit_call_to(SourceRange loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs) {
+std::vector<Value*> Method::emit_call_to(const SourceRange& loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs) {
   JIT_ASSERT(!executor);
   std::stringstream failure_messages;
   if (auto result = try_emit_call_to(
@@ -96,8 +96,8 @@ void Module::save(const std::string& filename) {
 }
 
 void Module::to_impl(
-    c10::optional<at::Device> device,
-    c10::optional<at::ScalarType> dtype,
+    const c10::optional<at::Device>& device,
+    const c10::optional<at::ScalarType>& dtype,
     bool non_blocking) {
   // First call `to()` on every child module.
   for (auto& child : modules) {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -92,7 +92,7 @@ struct Method {
   // adding any extra parameters necessary to do this call
 
   // defined here to keep details of member_input handling confined to this class
-  std::vector<Value*> emit_call_to(SourceRange loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs);
+  std::vector<Value*> emit_call_to(const SourceRange& loc, Method & callee, ArrayRef<NamedValue> args, ArrayRef<NamedValue> kwargs);
 
   // if this isn't yet defined, run its method_creator function
   TORCH_API void ensure_defined();
@@ -334,7 +334,7 @@ struct Module {
   }
 
   IValue forward(std::vector<IValue> inputs) {
-    return get_method("forward")(inputs);
+    return get_method("forward")(std::move(inputs));
   }
 
   void register_parameter(const std::string & name, autograd::Variable v, bool is_buffer) {
@@ -356,7 +356,7 @@ struct Module {
   }
 
   Method& create_method(const std::string & name, std::function<void(Method&)> creator) {
-    std::unique_ptr<Method> method(new Method(this, name, optimize, std::make_shared<Graph>(), {}, creator));
+    std::unique_ptr<Method> method(new Method(this, name, optimize, std::make_shared<Graph>(), {}, std::move(creator)));
     return *methods.insert(name, std::move(method));
   }
 
@@ -462,8 +462,8 @@ struct Module {
 
  private:
   void to_impl(
-      c10::optional<at::Device> device,
-      c10::optional<at::ScalarType> dtype,
+      const c10::optional<at::Device>& device,
+      const c10::optional<at::ScalarType>& dtype,
       bool non_blocking);
 
   // invariant: to ensure member_inputs of Methods stay valid,
@@ -480,7 +480,7 @@ struct Module {
 // match the functions schema
 c10::optional<std::vector<Value*>> try_emit_call_to(
     Graph& graph,
-    SourceRange loc,
+    const SourceRange& loc,
     Method& callee,
     c10::optional<NamedValue> self,
     ArrayRef<NamedValue> args,

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -10,7 +10,7 @@ namespace jit {
 namespace script {
 
 
-inline Decl mergeTypesFromTypeComment(Decl decl, Decl type_annotation_decl, bool is_method) {
+inline Decl mergeTypesFromTypeComment(const Decl& decl, const Decl& type_annotation_decl, bool is_method) {
   auto expected_num_annotations = decl.params().size();
   if (is_method) {
     // `self` argument
@@ -48,7 +48,7 @@ struct Parser {
     // of the Compound tree are in the same place.
     return Ident::create(t.range, t.text());
   }
-  TreeRef createApply(Expr expr) {
+  TreeRef createApply(const Expr& expr) {
     TreeList attributes;
     auto range = L.cur().range;
     TreeList inputs;
@@ -165,7 +165,7 @@ struct Parser {
     auto cond = parseExp();
     L.expect(TK_ELSE);
     auto false_branch = parseExp(binary_prec);
-    return c(TK_IF_EXPR, range, {cond, true_branch, false_branch});
+    return c(TK_IF_EXPR, range, {cond, std::move(true_branch), false_branch});
   }
   // parse the longest expression whose binary operators have
   // precedence strictly greater than 'precedence'
@@ -287,7 +287,7 @@ struct Parser {
     }
   }
 
-  TreeRef parseSubscript(TreeRef value) {
+  TreeRef parseSubscript(const TreeRef& value) {
     const auto range = L.cur().range;
 
     auto subscript_exprs = parseList('[', ',', ']', &Parser::parseSubscriptExp);
@@ -337,7 +337,7 @@ struct Parser {
   // 'first' has already been parsed since expressions can exist
   // alone on a line:
   // first[,other,lhs] = rhs
-  TreeRef parseAssign(Expr lhs) {
+  TreeRef parseAssign(const Expr& lhs) {
     auto op = parseAssignmentOp();
     auto rhs = parseExpOrExpTuple();
     L.expect(TK_NEWLINE);

--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -52,7 +52,8 @@ struct Tree : std::enable_shared_from_this<Tree> {
   const TreeRef& tree(size_t i) const {
     return trees().at(i);
   }
-  virtual TreeRef map(std::function<TreeRef(TreeRef)> fn) {
+  virtual TreeRef map(const std::function<TreeRef(TreeRef)>& fn) {
+    (void)fn;
     return shared_from_this();
   }
   template <typename... Args>
@@ -136,7 +137,7 @@ struct Compound : public Tree {
   bool isAtom() const override {
     return false;
   }
-  TreeRef map(std::function<TreeRef(TreeRef)> fn) override {
+  TreeRef map(const std::function<TreeRef(TreeRef)>& fn) override {
     TreeList trees_;
     for (auto& t : trees()) {
       trees_.push_back(fn(t));
@@ -200,7 +201,7 @@ static inline std::ostream& operator<<(std::ostream& out, pretty_tree t_) {
   return out << std::endl;
 }
 
-static inline std::ostream& operator<<(std::ostream& out, TreeRef t) {
+static inline std::ostream& operator<<(std::ostream& out, const TreeRef& t) {
   return out << pretty_tree(t);
 }
 

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -151,7 +151,7 @@ struct List : public TreeView {
   T operator[](size_t i) const {
     return T(subtree(i));
   }
-  TreeRef map(std::function<TreeRef(const T&)> fn) {
+  TreeRef map(const std::function<TreeRef(const T&)>& fn) {
     return tree_->map([&](TreeRef v) { return fn(T(v)); });
   }
   static List create(const SourceRange& range, const std::vector<T>& subtrees) {
@@ -177,7 +177,7 @@ struct Maybe : public TreeView {
   T get() const {
     return T(tree_->trees().at(0));
   }
-  TreeRef map(std::function<TreeRef(const T&)> fn) {
+  TreeRef map(const std::function<TreeRef(const T&)>& fn) {
     return tree_->map([&](TreeRef v) { return fn(T(v)); });
   }
   static Maybe<T> create(const SourceRange& range) {
@@ -297,7 +297,7 @@ struct Param : public TreeView {
   explicit Param(const TreeRef& tree) : TreeView(tree) {
     tree_->match(TK_PARAM);
   }
-  static Param create(const SourceRange& range, const Ident& ident, const Expr& type, Maybe<Expr> def) {
+  static Param create(const SourceRange& range, const Ident& ident, const Expr& type, const Maybe<Expr>& def) {
     return Param(Compound::create(TK_PARAM, range, {ident, type, def}));
   }
   Ident ident() const {
@@ -309,7 +309,7 @@ struct Param : public TreeView {
   Maybe<Expr> defaultValue() const {
     return Maybe<Expr>(subtree(2));
   }
-  Param withType(Expr typ) const {
+  Param withType(const Expr& typ) const {
     return Param::create(range(), ident(), typ, defaultValue());
   }
 };
@@ -328,7 +328,7 @@ struct Decl : public TreeView {
   Maybe<Expr> return_type() const {
     return Maybe<Expr>(subtree(1));
   }
-  static Decl create(const SourceRange& range, const List<Param>& params, Maybe<Expr> return_type) {
+  static Decl create(const SourceRange& range, const List<Param>& params, const Maybe<Expr>& return_type) {
     return Decl(Compound::create(TK_DECL, range, {params, return_type}));
   }
 };
@@ -338,7 +338,7 @@ struct Def : public TreeView {
     tree->match(TK_DEF);
   }
   Def withName(std::string new_name) const {
-    auto new_ident = Ident::create(name().range(), new_name);
+    auto new_ident = Ident::create(name().range(), std::move(new_name));
     return create(range(), new_ident, decl(), statements());
   }
   Ident name() const {
@@ -553,7 +553,7 @@ struct ExprStmt : public Stmt {
   Expr expr() {
     return Expr(subtree(0));
   }
-  static ExprStmt create(const SourceRange& range, const Expr list) {
+  static ExprStmt create(const SourceRange& range, const Expr& list) {
     return ExprStmt(Compound::create(TK_EXPR_STMT, range, {list}));
   }
 };

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -14,7 +14,7 @@ struct SymbolicVariable {
     return v;
   }
   static SymbolicVariable asNewInput(Graph & g, std::string name = "") {
-    return g.addInput(name);
+    return g.addInput(std::move(name));
   }
   static SymbolicVariable asNewInput(Graph & g, TypePtr type) {
     return g.addInput()->setType(std::move(type));
@@ -239,13 +239,13 @@ struct SymbolicVariable {
     return create(aten::view, {*this, sizes})[0];
   }
   SymbolicVariable view(std::vector<std::int64_t> sizes) const {
-    return view(insertConstant(sizes));
+    return view(insertConstant(std::move(sizes)));
   }
   SymbolicVariable reshape(Value* sizes) const {
     return create(aten::reshape, {*this, sizes})[0];
   }
   SymbolicVariable reshape(std::vector<std::int64_t> sizes) const {
-    return reshape(insertConstant(sizes));
+    return reshape(insertConstant(std::move(sizes)));
   }
   SymbolicVariable addmm(SymbolicVariable mat1, SymbolicVariable mat2) const {
     return create(aten::addmm, {*this, mat1, mat2, insertConstant(1), insertConstant(1)})[0];
@@ -255,7 +255,7 @@ struct SymbolicVariable {
   }
 private:
   Value * insertConstant(IValue value) const {
-    return v->owningGraph()->insertConstant(value);
+    return v->owningGraph()->insertConstant(std::move(value));
   }
   SymbolicVariable typeLike(SymbolicVariable other) const {
     if (auto other_type = other.v->type()->cast<CompleteTensorType>())

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -191,7 +191,7 @@ void ArgumentStash::stashIntListElem(const std::string& arg_name, size_t size, s
   list_trace[idx] = prim;
 }
 
-void ArgumentStash::stashValue(const std::string& arg_name, size_t idx, const Variable& var, TypePtr type) {
+void ArgumentStash::stashValue(const std::string& arg_name, size_t idx, const Variable& var, const TypePtr& type) {
   if (!isTracing()) return;
 
   Value* ten = getValueTrace(var);

--- a/torch/csrc/jit/tracing_state.h
+++ b/torch/csrc/jit/tracing_state.h
@@ -91,7 +91,7 @@ struct ArgumentStash {
   TORCH_API static void stashValue(const std::string& arg_name,
                                    size_t idx,
                                    const Variable& var,
-                                   TypePtr type=nullptr);
+                                   const TypePtr& type=nullptr);
 
   static bool hasValue(const std::string& arg_name) {
     return stash.values.count(arg_name) > 0;
@@ -123,7 +123,7 @@ TORCH_API extern const char * WARN_CONSTRUCTOR;
 TORCH_API extern const char * WARN_RESIZE;
 TORCH_API void _do_warn(const char * _reason, const char * _kind);
 inline void warn(const char * _reason, const char * _kind=nullptr) {
-  if (auto state = getTracingState()) {
+  if (const auto& state = getTracingState()) {
     if (!state->warn) return;
     _do_warn(_reason, _kind);
   }

--- a/torch/csrc/utils/invalid_arguments.cpp
+++ b/torch/csrc/utils/invalid_arguments.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<Type> _buildType(std::string type_name, bool is_nullable) {
 }
 
 std::pair<Option, std::string> _parseOption(const std::string& _option_str,
-    const std::unordered_map<std::string, PyObject*> kwargs)
+    const std::unordered_map<std::string, PyObject*>& kwargs)
 {
   if (_option_str == "no arguments")
     return std::pair<Option, std::string>(Option(false, false), _option_str);

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -12,6 +12,7 @@
 #include <torch/csrc/utils/python_numbers.h>
 
 #include <stdexcept>
+#include <utility>
 
 namespace py = pybind11;
 
@@ -33,7 +34,7 @@ struct type_caster<at::Tensor> {
   }
 
   static handle
-  cast(at::Tensor src, return_value_policy /* policy */, handle /* parent */) {
+  cast(const at::Tensor& src, return_value_policy /* policy */, handle /* parent */) {
     if (!src.is_variable()) {
       throw std::runtime_error(
           "Expected tensor's dynamic type to be Variable, not Tensor");
@@ -55,7 +56,7 @@ public:
     }
   }
   static handle cast(torch::autograd::Variable src, return_value_policy /* policy */, handle /* parent */) {
-    return handle(THPVariable_Wrap(src));
+    return handle(THPVariable_Wrap(std::move(src)));
   }
 };
 

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -56,34 +56,34 @@ void maybe_initialize_cuda(const Device device) {
 Tensor dispatch_zeros(const Type& type, optional<Device> device, IntList sizes) {
   maybe_initialize_cuda(type);
   AutoNoGIL no_gil;
-  return torch::zeros(sizes, type.options(device));
+  return torch::zeros(sizes, type.options(std::move(device)));
 }
 
 Tensor dispatch_ones(const Type& type, optional<Device> device, IntList sizes) {
   maybe_initialize_cuda(type);
   AutoNoGIL no_gil;
-  return torch::ones(sizes, type.options(device));
+  return torch::ones(sizes, type.options(std::move(device)));
 }
 
 Tensor dispatch_full(const Type& type, Scalar fill_value, optional<Device> device, IntList sizes) {
   maybe_initialize_cuda(type);
   AutoNoGIL no_gil;
-  return torch::full(sizes, fill_value, type.options(device));
+  return torch::full(sizes, fill_value, type.options(std::move(device)));
 }
 
 Tensor new_with_sizes(const Type& type, optional<Device> device, IntList sizes) {
   maybe_initialize_cuda(type);
   AutoNoGIL no_gil;
-  return torch::empty(sizes, type.options(device));
+  return torch::empty(sizes, type.options(std::move(device)));
 }
 
 Tensor new_with_storage(const Type& type, Storage storage) {
   auto tensor = at::empty({}, type.options());
-  tensor.set_(storage);
+  tensor.set_(std::move(storage));
   return tensor;
 }
 
-Tensor new_with_tensor(const Type& type, Tensor other) {
+Tensor new_with_tensor(const Type& type, const Tensor& other) {
   if (other.type() != type) {
     throw TypeError("expected %s (got %s)", type.toString(), other.type().toString());
   }
@@ -239,7 +239,7 @@ Tensor new_from_data_copy(
     const Type& type,
     c10::optional<Device> device,
     PyObject* data) {
-  return internal_new_from_data(type, device, data, true, true, false);
+  return internal_new_from_data(type, std::move(device), data, true, true, false);
 }
 
 Tensor legacy_new_from_sequence(
@@ -249,7 +249,7 @@ Tensor legacy_new_from_sequence(
   if (!PySequence_Check(data)) {
     throw TypeError("new(): data must be a sequence (got %s)", Py_TYPE(data)->tp_name);
   }
-  return legacy_new_from_data(type, device, data);
+  return legacy_new_from_data(type, std::move(device), data);
 }
 
 void check_legacy_ctor_device(const Type& type, c10::optional<Device> device) {
@@ -453,7 +453,7 @@ Tensor legacy_new_from_data(
     const Type& type,
     c10::optional<Device> device,
     PyObject* data) {
-  return internal_new_from_data(type, device, data, false, false, false);
+  return internal_new_from_data(type, std::move(device), data, false, false, false);
 }
 
 Tensor sparse_coo_tensor_ctor(const Type& default_type, PyObject* args, PyObject* kwargs) {


### PR DESCRIPTION
This PR fixes around 250 places in the codebase where we were making unnecessary copies of objects (some large, some small).

@ezyang 