### PR TITLE
caffe2 - make DataRandomFiller usable in unit tests

### DIFF
--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -1,0 +1,22 @@
+#include "caffe2/core/tensor.h"
+#include "caffe2/core/workspace.h"
+
+#include "test_utils.h"
+
+namespace caffe2 {
+namespace testing {
+
+const caffe2::Tensor& getTensor(
+    const caffe2::Workspace& workspace,
+    const std::string& name) {
+  return workspace.GetBlob(name)->Get<caffe2::Tensor>();
+}
+
+caffe2::Tensor* createTensor(
+    const std::string& name,
+    caffe2::Workspace* workspace) {
+  return BlobGetMutableTensor(workspace->CreateBlob(name), caffe2::CPU);
+}
+
+} // namespace testing
+} // namespace caffe2

--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -86,7 +86,7 @@ NetMutator& NetMutator::newOp(
     const std::string& type,
     const std::vector<string>& inputs,
     const std::vector<string>& outputs) {
-  createOperator(type, inputs, outputs, net_);
+  lastCreatedOp_ = createOperator(type, inputs, outputs, net_);
   return *this;
 }
 

--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -18,6 +18,13 @@ void assertTensorEqualsWithType(
 namespace caffe2 {
 namespace testing {
 
+// Asserts that two float values are close within epsilon.
+void assertNear(float value1, float value2, float epsilon) {
+  // These two enforces will give good debug messages.
+  CAFFE_ENFORCE_LE(value1, value2 + epsilon);
+  CAFFE_ENFORCE_GE(value1, value2 - epsilon);
+}
+
 void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2) {
   CAFFE_ENFORCE_EQ(tensor1.sizes(), tensor2.sizes());
   if (tensor1.IsType<float>()) {
@@ -49,6 +56,7 @@ void assertTensorListEquals(
 const caffe2::Tensor& getTensor(
     const caffe2::Workspace& workspace,
     const std::string& name) {
+  CAFFE_ENFORCE(workspace.HasBlob(name));
   return workspace.GetBlob(name)->Get<caffe2::Tensor>();
 }
 

--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -18,5 +18,29 @@ caffe2::Tensor* createTensor(
   return BlobGetMutableTensor(workspace->CreateBlob(name), caffe2::CPU);
 }
 
+caffe2::OperatorDef* createOperator(
+    const std::string& type,
+    const std::vector<string>& inputs,
+    const std::vector<string>& outputs,
+    caffe2::NetDef* net) {
+  auto* op = net->add_op();
+  op->set_type(type);
+  for (const auto& in : inputs) {
+    op->add_input(in);
+  }
+  for (const auto& out : outputs) {
+    op->add_output(out);
+  }
+  return op;
+}
+
+NetMutator& NetMutator::newOp(
+    const std::string& type,
+    const std::vector<string>& inputs,
+    const std::vector<string>& outputs) {
+  createOperator(type, inputs, outputs, net_);
+  return *this;
+}
+
 } // namespace testing
 } // namespace caffe2

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -29,6 +29,27 @@ caffe2::Tensor* createTensor(
     const std::string& name,
     caffe2::Workspace* workspace);
 
+// Create a new operator in the net.
+caffe2::OperatorDef* createOperator(
+    const std::string& type,
+    const std::vector<string>& inputs,
+    const std::vector<string>& outputs,
+    caffe2::NetDef* net);
+
+// Coincise util class to mutate a net in a chaining fashion.
+class NetMutator {
+ public:
+  explicit NetMutator(caffe2::NetDef* net) : net_(net) {}
+
+  NetMutator& newOp(
+      const std::string& type,
+      const std::vector<string>& inputs,
+      const std::vector<string>& outputs);
+
+ private:
+  caffe2::NetDef* net_;
+};
+
 } // namespace testing
 } // namespace caffe2
 

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/tensor.h"
 #include "caffe2/core/workspace.h"
+#include "caffe2/utils/proto_utils.h"
 
 #include <cmath>
 #include <vector>
@@ -121,7 +122,7 @@ caffe2::Tensor* createTensorAndConstantFill(
   return tensor;
 }
 
-// Coincise util class to mutate a net in a chaining fashion.
+// Concise util class to mutate a net in a chaining fashion.
 class NetMutator {
  public:
   explicit NetMutator(caffe2::NetDef* net) : net_(net) {}
@@ -131,11 +132,20 @@ class NetMutator {
       const std::vector<string>& inputs,
       const std::vector<string>& outputs);
 
+  // Add argument to the last created op.
+  template <typename T>
+  NetMutator& addArgument(const string& name, const T& value) {
+    CAFFE_ENFORCE(lastCreatedOp_ != nullptr);
+    AddArgument(name, value, lastCreatedOp_);
+    return *this;
+  }
+
  private:
   caffe2::NetDef* net_;
+  caffe2::OperatorDef* lastCreatedOp_;
 };
 
-// Coincise util class to mutate a workspace in a chaining fashion.
+// Concise util class to mutate a workspace in a chaining fashion.
 class WorkspaceMutator {
  public:
   explicit WorkspaceMutator(caffe2::Workspace* workspace)

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -10,14 +10,14 @@
 namespace caffe2 {
 namespace testing {
 
-// Asserts that the numeric values of two tensors are the same.
-template <typename T>
-void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2) {
-  CAFFE_ENFORCE_EQ(tensor1.sizes(), tensor2.sizes());
-  for (auto idx = 0; idx < tensor1.numel(); ++idx) {
-    CAFFE_ENFORCE_EQ(tensor1.data<T>()[idx], tensor2.data<T>()[idx]);
-  }
-}
+// Asserts that the values of two tensors are the same.
+void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2);
+
+// Asserts a list of tensors presented in two workspaces are equal.
+void assertTensorListEquals(
+    const std::vector<std::string>& tensorNames,
+    const Workspace& workspace1,
+    const Workspace& workspace2);
 
 // Read a tensor from the workspace.
 const caffe2::Tensor& getTensor(

--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -1,0 +1,35 @@
+#ifndef CAFFE2_UTILS_TEST_UTILS_H_
+#define CAFFE2_UTILS_TEST_UTILS_H_
+
+#include "caffe2/core/tensor.h"
+#include "caffe2/core/workspace.h"
+
+// Utilities that make it easier to write caffe2 C++ unit tests.
+// These utils are designed to be concise and easy to use. They may sacrifice
+// performance and should only be used in tests/non production code.
+namespace caffe2 {
+namespace testing {
+
+// Asserts that the numeric values of two tensors are the same.
+template <typename T>
+void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2) {
+  CAFFE_ENFORCE_EQ(tensor1.sizes(), tensor2.sizes());
+  for (auto idx = 0; idx < tensor1.numel(); ++idx) {
+    CAFFE_ENFORCE_EQ(tensor1.data<T>()[idx], tensor2.data<T>()[idx]);
+  }
+}
+
+// Read a tensor from the workspace.
+const caffe2::Tensor& getTensor(
+    const caffe2::Workspace& workspace,
+    const std::string& name);
+
+// Create a new tensor in the workspace.
+caffe2::Tensor* createTensor(
+    const std::string& name,
+    caffe2::Workspace* workspace);
+
+} // namespace testing
+} // namespace caffe2
+
+#endif // CAFFE2_UTILS_TEST_UTILS_H_

--- a/caffe2/predictor/emulator/data_filler.cc
+++ b/caffe2/predictor/emulator/data_filler.cc
@@ -159,5 +159,91 @@ void DataRandomFiller::fill_input_internal(TensorList_t* input_data) const {
   }
 }
 
+TestDataRandomFiller::TestDataRandomFiller(
+    const NetDef& net,
+    const std::vector<std::vector<std::vector<int64_t>>>& inputDims,
+    const std::vector<std::vector<std::string>>& inputTypes)
+    : DataRandomFiller() {
+  std::unordered_set<std::string> outputNames;
+  // Determine blobs that are outputs of some ops (intermediate blobs).
+  for (auto opIdx = 0; opIdx < net.op_size(); ++opIdx) {
+    const auto& op = net.op(opIdx);
+    for (auto outputIdx = 0; outputIdx < op.output_size(); ++outputIdx) {
+      outputNames.emplace(op.output(outputIdx));
+    }
+  }
+  // Determine ops that have non-intermediate inputs.
+  std::unordered_set<size_t> opWithRequiredInputs;
+  for (auto opIdx = 0; opIdx < net.op_size(); ++opIdx) {
+    const auto& op = net.op(opIdx);
+    for (auto inputIdx = 0; inputIdx < op.input_size(); ++inputIdx) {
+      if (!outputNames.count(op.input(inputIdx))) {
+        opWithRequiredInputs.emplace(opIdx);
+        break;
+      }
+    }
+  }
+
+  CAFFE_ENFORCE_EQ(inputDims.size(), opWithRequiredInputs.size());
+  CAFFE_ENFORCE_EQ(inputTypes.size(), opWithRequiredInputs.size());
+
+  int counter = 0;
+  for (auto opIdx = 0; opIdx < net.op_size(); ++opIdx) {
+    if (!opWithRequiredInputs.count(opIdx)) {
+      // Skip intermediate ops.
+      continue;
+    }
+    const auto& op = net.op(opIdx);
+    const auto& op_dims = inputDims[counter];
+    const auto& op_types = inputTypes[counter];
+    ++counter;
+
+    int countRequiredInputs = 0;
+    for (auto inputIdx = 0; inputIdx < op.input_size(); ++inputIdx) {
+      if (!outputNames.count(op.input(inputIdx))) {
+        ++countRequiredInputs;
+      }
+    }
+
+    CAFFE_ENFORCE(
+        op_dims.size() == countRequiredInputs,
+        op.name() + " has " + c10::to_string(op.input_size()) +
+            " (required) inputs; while the input dimension size is " +
+            c10::to_string(op_dims.size()));
+    CAFFE_ENFORCE(
+        op_types.size() == countRequiredInputs,
+        op.name() + " has " + c10::to_string(op.input_size()) +
+            " (required) inputs; while the input type size is " +
+            c10::to_string(op_types.size()));
+
+    int dimCounter = 0;
+    for (auto inputIdx = 0; inputIdx < op.input_size(); ++inputIdx) {
+      auto inputName = op.input(inputIdx);
+      if (outputNames.count(inputName)) {
+        // Skip intermediate inputs.
+        continue;
+      }
+      inputs_[inputName] = std::make_pair(
+          get_tensor_filler(op, dimCounter, op_dims), op_types[dimCounter]);
+      ++dimCounter;
+    }
+  }
+  CAFFE_ENFORCE(inputs_.size() > 0, "Empty input for run net");
+  // generate input names
+  for (const auto& input : inputs_) {
+    input_names_.push_back(input.first);
+  }
+}
+
+void TestDataRandomFiller::fillInputToWorkspace(Workspace* workspace) const {
+  for (auto& name : input_names_) {
+    const auto& it = inputs_.find(name);
+    CAFFE_ENFORCE(it != inputs_.end());
+    auto* tensor =
+        BlobGetMutableTensor(workspace->CreateBlob(name), caffe2::CPU);
+    fill_with_type(it->second.first, it->second.second, tensor);
+  }
+}
+
 } // namespace emulator
 } // namespace caffe2

--- a/caffe2/predictor/emulator/data_filler.h
+++ b/caffe2/predictor/emulator/data_filler.h
@@ -93,7 +93,9 @@ class DataRandomFiller : public Filler {
 
   void fill_parameter(Workspace* ws) const override;
 
- private:
+ protected:
+  DataRandomFiller() {}
+
   TensorFiller get_tensor_filler(
       const OperatorDef& op_def,
       int input_index,
@@ -116,6 +118,22 @@ class DataRandomFiller : public Filler {
   using filler_type_pair_t = std::pair<TensorFiller, std::string>;
   std::unordered_map<std::string, filler_type_pair_t> parameters_;
   std::unordered_map<std::string, filler_type_pair_t> inputs_;
+};
+
+// A DataRandomFiller that is more convenient to use in unit tests.
+// Callers just need to supply input dimensions and types for non-intermediate
+// blobs.
+// It also treats parameters the same way as non-intermediate inputs (no
+// handling of parameters separately).
+class TestDataRandomFiller : public DataRandomFiller {
+ public:
+  TestDataRandomFiller(
+      const NetDef& net,
+      const std::vector<std::vector<std::vector<int64_t>>>& inputDims,
+      const std::vector<std::vector<std::string>>& inputTypes);
+
+  // Fill input directly to the workspace.
+  void fillInputToWorkspace(Workspace* workspace) const;
 };
 
 } // namespace emulator


### PR DESCRIPTION
Summary: - Make DataRandomFiller able to accept input_dims and input_types for only non intermediate inputs. Add a helper to fill input directly to a workspace

Differential Revision: D13408345
