### PR TITLE
[C++ Frontend] Fix serialization

### DIFF
--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -495,6 +495,16 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   bool is_training_{true};
 };
 
+/// Serialize a `Module` pointer into an `OutputArchive`.
+serialize::OutputArchive& operator<<(
+    serialize::OutputArchive& archive,
+    const std::shared_ptr<nn::Module>& module);
+
+/// Deserializes a `Module` from an `InputArchive`.
+serialize::InputArchive& operator>>(
+    serialize::InputArchive& archive,
+    const std::shared_ptr<nn::Module>& module);
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ nn::Module ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename ModuleType>

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -496,12 +496,12 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
 };
 
 /// Serialize a `Module` pointer into an `OutputArchive`.
-serialize::OutputArchive& operator<<(
+TORCH_API serialize::OutputArchive& operator<<(
     serialize::OutputArchive& archive,
     const std::shared_ptr<nn::Module>& module);
 
 /// Deserializes a `Module` from an `InputArchive`.
-serialize::InputArchive& operator>>(
+TORCH_API serialize::InputArchive& operator>>(
     serialize::InputArchive& archive,
     const std::shared_ptr<nn::Module>& module);
 

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -57,12 +57,8 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
       typename Head,
       typename... Tail,
       typename = typename std::enable_if<
-      !(
-          torch::detail::is_module_holder_of<Head, ContainedType>::value
-          && (sizeof...(Tail) == 0)
-       )
-      >::type
-          >
+          !(torch::detail::is_module_holder_of<Head, ContainedType>::value &&
+            (sizeof...(Tail) == 0))>::type>
   explicit ModuleHolder(Head&& head, Tail&&... tail)
       : impl_(new Contained(
             std::forward<Head>(head),
@@ -160,22 +156,20 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   }
 };
 
-/// Serializes an `OptimizerBase` into an `OutputArchive`.
+/// Serializes a `ModuleHolder` into an `OutputArchive`.
 template <typename ModuleType>
 serialize::OutputArchive& operator<<(
     serialize::OutputArchive& archive,
     const nn::ModuleHolder<ModuleType>& module) {
-  module->save(archive);
-  return archive;
+  return archive << module.ptr();
 }
 
-/// Deserializes a `Tensor` from an `InputArchive`.
+/// Deserializes a `ModuleHolder` from an `InputArchive`.
 template <typename ModuleType>
 serialize::InputArchive& operator>>(
     serialize::InputArchive& archive,
     nn::ModuleHolder<ModuleType>& module) {
-  module->load(archive);
-  return archive;
+  return archive >> module.ptr();
 }
 
 } // namespace nn


### PR DESCRIPTION
Fixes a bug where (de-)/serializing a hierarchy of submodules where one submodule doesn't have any parameters, but its submodules do, doesn't get properly loaded. This had to do with the fact that the old protobuf format couldn't store empty parameters.

Fixes https://github.com/pytorch/pytorch/issues/14891

@soumith @ezyang @ebetica 