### PR TITLE
Allow converting char tensor to numpy; add [fi]info.min

### DIFF
--- a/docs/source/type_info.rst
+++ b/docs/source/type_info.rst
@@ -15,7 +15,7 @@ torch.finfo
 .. class:: torch.finfo
 
 A :class:`torch.finfo` is an object that represents the numerical properties of a floating point
-:class:`torch.dtype`, (i.e. `torch.float32`, `torch.float64`, and `torch.float16`). This is similar to `numpy.finfo <https://docs.scipy.org/doc/numpy/reference/generated/numpy.finfo.html>`_.
+:class:`torch.dtype`, (i.e. ``torch.float32``, ``torch.float64``, and ``torch.float16``). This is similar to `numpy.finfo <https://docs.scipy.org/doc/numpy/reference/generated/numpy.finfo.html>`_.
 
 A :class:`torch.finfo` provides the following attributes:
 
@@ -23,13 +23,14 @@ A :class:`torch.finfo` provides the following attributes:
 Name        Type    Description
 =========   =====   ========================================
 bits        int     The number of bits occupied by the type.
-eps         float   The smallest representable number such that 1.0 + eps != 1.0.
+eps         float   The smallest representable number such that ``1.0 + eps != 1.0``.
 max         float   The largest representable number.
+min         float   The smallest representable number (typically ``-max``).
 tiny        float   The smallest positive representable number.
 =========   =====   ========================================
 
 .. note::
-  The constructor of :class:`torch.finfo` can be called without argument, in which case the class is created for the pytorch default dtype (as returned by ``torch.get_default_dtype()``).   
+  The constructor of :class:`torch.finfo` can be called without argument, in which case the class is created for the pytorch default dtype (as returned by :func:`torch.get_default_dtype`).
 
 
 .. _iinfo-doc:
@@ -41,7 +42,7 @@ torch.iinfo
 
 
 A :class:`torch.iinfo` is an object that represents the numerical properties of a integer
-:class:`torch.dtype` (i.e. `torch.uint8`, `torch.int8`, `torch.int16`, `torch.int32`, and `torch.int64`). This is similar to `numpy.iinfo <https://docs.scipy.org/doc/numpy/reference/generated/numpy.iinfo.html>`_.
+:class:`torch.dtype` (i.e. ``torch.uint8``, ``torch.int8``, ``torch.int16``, ``torch.int32``, and ``torch.int64``). This is similar to `numpy.iinfo <https://docs.scipy.org/doc/numpy/reference/generated/numpy.iinfo.html>`_.
 
 A :class:`torch.iinfo` provides the following attributes:
 
@@ -50,4 +51,5 @@ Name        Type    Description
 =========   =====   ========================================
 bits        int     The number of bits occupied by the type.
 max         int     The largest representable number.
+min         int     The smallest representable number.
 =========   =====   ========================================

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8760,25 +8760,46 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             w.resize((10, 10))
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_toNumpy(self):
+    def test_to_numpy(self):
+        def get_castable_tensor(shape, tp):
+            dtype = tp.dtype
+            if dtype.is_floating_point:
+                dtype_info = torch.finfo(dtype)
+                # can't directly use min and max, because for double, max - min
+                # is greater than double range and sampling always gives inf.
+                low = max(dtype_info.min, -1e10)
+                high = min(dtype_info.max, 1e10)
+                t = torch.empty(shape, dtype=torch.float64).uniform_(low, high)
+            else:
+                # can't directly use min and max, because for int64_t, max - min
+                # is greater than int64_t range and triggers UB.
+                dtype_info = torch.iinfo(dtype)
+                low = max(dtype_info.min, int(-1e10))
+                high = min(dtype_info.max, int(1e10))
+                dtype_info = torch.iinfo(dtype)
+                t = torch.empty(shape, dtype=torch.int64).random_(low, high)
+            return t.to(dtype)
+
         types = [
-            'torch.ByteTensor',
-            'torch.IntTensor',
-            'torch.HalfTensor',
-            'torch.FloatTensor',
-            'torch.DoubleTensor',
-            'torch.LongTensor',
+            torch.ByteTensor,
+            torch.CharTensor,
+            torch.ShortTensor,
+            torch.IntTensor,
+            torch.HalfTensor,
+            torch.FloatTensor,
+            torch.DoubleTensor,
+            torch.LongTensor,
         ]
         for tp in types:
             # 1D
             sz = 10
-            x = torch.randn(sz).mul(255).type(tp)
+            x = get_castable_tensor(sz, tp)
             y = x.numpy()
             for i in range(sz):
                 self.assertEqual(x[i], y[i])
 
             # 1D > 0 storage offset
-            xm = torch.randn(sz * 2).mul(255).type(tp)
+            xm = get_castable_tensor(sz * 2, tp)
             x = xm.narrow(0, sz - 1, sz)
             self.assertTrue(x.storage_offset() > 0)
             y = x.numpy()
@@ -8798,13 +8819,13 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             # contiguous 2D
             sz1 = 3
             sz2 = 5
-            x = torch.randn(sz1, sz2).mul(255).type(tp)
+            x = get_castable_tensor((sz1, sz2), tp)
             y = x.numpy()
             check2d(x, y)
             self.assertTrue(y.flags['C_CONTIGUOUS'])
 
             # with storage offset
-            xm = torch.randn(sz1 * 2, sz2).mul(255).type(tp)
+            xm = get_castable_tensor((sz1 * 2, sz2), tp)
             x = xm.narrow(0, sz1 - 1, sz1)
             y = x.numpy()
             self.assertTrue(x.storage_offset() > 0)
@@ -8812,28 +8833,28 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertTrue(y.flags['C_CONTIGUOUS'])
 
             # non-contiguous 2D
-            x = torch.randn(sz2, sz1).mul(255).type(tp).t()
+            x = get_castable_tensor((sz2, sz1), tp).t()
             y = x.numpy()
             check2d(x, y)
             self.assertFalse(y.flags['C_CONTIGUOUS'])
 
             # with storage offset
-            xm = torch.randn(sz2 * 2, sz1).mul(255).type(tp)
+            xm = get_castable_tensor((sz2 * 2, sz1), tp)
             x = xm.narrow(0, sz2 - 1, sz2).t()
             y = x.numpy()
             self.assertTrue(x.storage_offset() > 0)
             check2d(x, y)
 
             # non-contiguous 2D with holes
-            xm = torch.randn(sz2 * 2, sz1 * 2).mul(255).type(tp)
+            xm = get_castable_tensor((sz2 * 2, sz1 * 2), tp)
             x = xm.narrow(0, sz2 - 1, sz2).narrow(1, sz1 - 1, sz1).t()
             y = x.numpy()
             self.assertTrue(x.storage_offset() > 0)
             check2d(x, y)
 
-            if tp != 'torch.HalfTensor':
+            if tp != torch.HalfTensor:
                 # check writeable
-                x = torch.randn(3, 4).mul(255).type(tp)
+                x = get_castable_tensor((3, 4), tp)
                 y = x.numpy()
                 self.assertTrue(y.flags.writeable)
                 y[0][1] = 3

--- a/test/test_type_info.py
+++ b/test/test_type_info.py
@@ -31,6 +31,7 @@ class TestDTypeInfo(TestCase):
             xninfo = np.iinfo(xn.dtype)
             self.assertEqual(xinfo.bits, xninfo.bits)
             self.assertEqual(xinfo.max, xninfo.max)
+            self.assertEqual(xinfo.min, xninfo.min)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_finfo(self):
@@ -42,6 +43,7 @@ class TestDTypeInfo(TestCase):
             xninfo = np.finfo(xn.dtype)
             self.assertEqual(xinfo.bits, xninfo.bits)
             self.assertEqual(xinfo.max, xninfo.max)
+            self.assertEqual(xinfo.min, xninfo.min)
             self.assertEqual(xinfo.eps, xninfo.eps)
             self.assertEqual(xinfo.tiny, xninfo.tiny)
             torch.set_default_dtype(dtype)

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -133,9 +133,22 @@ static PyObject* THPFInfo_max(THPFInfo* self, void*) {
   });
 }
 
+static PyObject* THPFInfo_min(THPFInfo* self, void*) {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(at::CPU(self->type), "min", [] {
+    return PyFloat_FromDouble(
+        std::numeric_limits<at::scalar_value_type<scalar_t>::type>::lowest());
+  });
+}
+
 static PyObject* THPIInfo_max(THPFInfo* self, void*) {
   return AT_DISPATCH_INTEGRAL_TYPES(at::CPU(self->type), "max", [] {
     return THPUtils_packInt64(std::numeric_limits<scalar_t>::max());
+  });
+}
+
+static PyObject* THPIInfo_min(THPFInfo* self, void*) {
+  return AT_DISPATCH_INTEGRAL_TYPES(at::CPU(self->type), "min", [] {
+    return THPUtils_packInt64(std::numeric_limits<scalar_t>::lowest());
   });
 }
 
@@ -150,6 +163,7 @@ static struct PyGetSetDef THPFInfo_properties[] = {
     {"bits", (getter)THPDTypeInfo_bits, nullptr, nullptr, nullptr},
     {"eps", (getter)THPFInfo_eps, nullptr, nullptr, nullptr},
     {"max", (getter)THPFInfo_max, nullptr, nullptr, nullptr},
+    {"min", (getter)THPFInfo_min, nullptr, nullptr, nullptr},
     {"tiny", (getter)THPFInfo_tiny, nullptr, nullptr, nullptr},
     {nullptr}};
 
@@ -200,6 +214,7 @@ PyTypeObject THPFInfoType = {
 static struct PyGetSetDef THPIInfo_properties[] = {
     {"bits", (getter)THPDTypeInfo_bits, nullptr, nullptr, nullptr},
     {"max", (getter)THPIInfo_max, nullptr, nullptr, nullptr},
+    {"min", (getter)THPIInfo_min, nullptr, nullptr, nullptr},
     {nullptr}};
 
 static PyMethodDef THPIInfo_methods[] = {

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -152,6 +152,7 @@ static int aten_to_dtype(const at::Type& type) {
       case kLong: return NPY_INT64;
       case kInt: return NPY_INT32;
       case kShort: return NPY_INT16;
+      case kChar: return NPY_INT8;
       case kByte: return NPY_UINT8;
       case kChar: return NPY_INT8;
       default: break;

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -154,7 +154,6 @@ static int aten_to_dtype(const at::Type& type) {
       case kShort: return NPY_INT16;
       case kChar: return NPY_INT8;
       case kByte: return NPY_UINT8;
-      case kChar: return NPY_INT8;
       default: break;
     }
   }


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/14710 with test fixed.

Also added `finfo.min` and `iinfo.min` to get castable tensors.

cc @soumith 