### PR TITLE
Don't setup x86_64-linux-gnu-gcc as an sccache wrapper.

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -65,7 +65,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     fi
 
     # Setup wrapper scripts
-    for compiler in cc c++ gcc g++ x86_64-linux-gnu-gcc; do
+    for compiler in cc c++ gcc g++; do
       (
         echo "#!/bin/sh"
         echo "exec $SCCACHE $(which $compiler) \"\$@\""


### PR DESCRIPTION
When I do this setup in a local Docker development environment,
I get the following error:

    x86_64-linux-gnu-gcc: error trying to exec 'cc1plus': execvp: No such file or directory

Somehow, gcc seems to get confused when it gets run from the wrong
directory.  Best not to do it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

