### PR TITLE
Add support for exporting onnx split

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -115,6 +115,7 @@ namespace c10 {
   _(onnx, Less)                    \
   _(onnx, Not)                     \
   _(onnx, ATen)                    \
+  _(onnx, Split)                   \
   FORALL_ATTR_BASE_SYMBOLS(_)      \
   _(attr, Subgraph)                \
   _(attr, ReverseSubgraph)         \
@@ -140,7 +141,8 @@ namespace c10 {
   _(attr, a)                       \
   _(attr, b)                       \
   _(attr, beg)                     \
-  _(attr, idx)
+  _(attr, idx)                     \
+  _(attr, split)
 #else
 #define FORALL_NS_SYMBOLS(_) \
   _(namespaces, prim)              \

--- a/test/onnx/expect/TestOperators.test_split.expect
+++ b/test/onnx/expect/TestOperators.test_split.expect
@@ -1,0 +1,92 @@
+ir_version: 3
+producer_name: "pytorch"
+producer_version: "0.4"
+graph {
+  node {
+    input: "tensor"
+    output: "1"
+    output: "2"
+    output: "3"
+    op_type: "Split"
+    attribute {
+      name: "axis"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "split"
+      ints: 2
+      ints: 1
+      ints: 3
+      type: INTS
+    }
+  }
+  name: "torch-jit-export"
+  input {
+    name: "tensor"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "3"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/expect/TestOperators.test_split_with_sizes.expect
+++ b/test/onnx/expect/TestOperators.test_split_with_sizes.expect
@@ -16,8 +16,8 @@ graph {
     attribute {
       name: "split"
       ints: 2
-      ints: 2
-      ints: 2
+      ints: 1
+      ints: 3
       type: INTS
     }
   }
@@ -64,7 +64,7 @@ graph {
             dim_value: 2
           }
           dim {
-            dim_value: 2
+            dim_value: 1
           }
         }
       }
@@ -80,7 +80,7 @@ graph {
             dim_value: 2
           }
           dim {
-            dim_value: 2
+            dim_value: 3
           }
         }
       }

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -179,6 +179,10 @@ class TestOperators(TestCase):
         x = torch.tensor([0.0, 1.0, 2.0], requires_grad=True)
         self.assertONNX(lambda x: x.chunk(2), x)
 
+    def test_split(self):
+        x = torch.tensor([[0.0, 1.0, 1.0, 0.0, 2.0, 2.0], [2.0, 3.0, 3.0, 2.0, 1.0, 1.0]])
+        self.assertONNX(lambda x: torch.split(x, [2,1,3], 1), x)
+
     def test_concat2(self):
         x = torch.randn(2, 3)
         y = torch.randn(2, 3)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -181,7 +181,7 @@ class TestOperators(TestCase):
 
     def test_split(self):
         x = torch.tensor([[0.0, 1.0, 1.0, 0.0, 2.0, 2.0], [2.0, 3.0, 3.0, 2.0, 1.0, 1.0]])
-        self.assertONNX(lambda x: torch.split(x, [2,1,3], 1), x)
+        self.assertONNX(lambda x: torch.split(x, [2, 1, 3], 1), x)
 
     def test_concat2(self):
         x = torch.randn(2, 3)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -181,6 +181,10 @@ class TestOperators(TestCase):
 
     def test_split(self):
         x = torch.tensor([[0.0, 1.0, 1.0, 0.0, 2.0, 2.0], [2.0, 3.0, 3.0, 2.0, 1.0, 1.0]])
+        self.assertONNX(lambda x: torch.split(x, 2, 1), x)
+
+    def test_split_with_sizes(self):
+        x = torch.tensor([[0.0, 1.0, 1.0, 0.0, 2.0, 2.0], [2.0, 3.0, 3.0, 2.0, 1.0, 1.0]])
         self.assertONNX(lambda x: torch.split(x, [2, 1, 3], 1), x)
 
     def test_concat2(self):

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -423,7 +423,7 @@ def prim_ConstantSplit(g, self, split_size, dim):
     leftover = size % split_size
     if leftover:
         splits.append(leftover)
-    return g.op("Split", self, split_i=splits, axis_i=dim, outputs=len(splits))
+    return g.op("Split", self, split_i=splits, axis_i=dim, outputs=1)
 
 
 # TODO: It would be better to export this as a chunk directly, as this is
@@ -433,6 +433,18 @@ def prim_ConstantSplit(g, self, split_size, dim):
 def prim_ConstantChunk(g, self, chunks, dim):
     split_size = (self.type().sizes()[dim] + chunks - 1) // chunks
     return prim_ConstantSplit(g, self, split_size, dim)
+
+
+@parse_args('v', 'i', 'i')
+def split(g, self, split_size, dim):
+    print('symbolic::split: self: ' + str(self))
+    return prim_ConstantSplit(g, self, split_size, dim)
+
+
+@parse_args('v', 'is', 'i')
+def split_with_sizes(g, self, split_sizes, dim):
+    print('symbolic::split: self: ' + str(self))
+    return g.op("Split", self, split_i=split_sizes, axis_i=dim, outputs=1)
 
 
 @parse_args('v', 'i', 'v')

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -423,7 +423,7 @@ def prim_ConstantSplit(g, self, split_size, dim):
     leftover = size % split_size
     if leftover:
         splits.append(leftover)
-    return g.op("Split", self, split_i=splits, axis_i=dim, outputs=1)
+    return g.op("Split", self, split_i=splits, axis_i=dim, outputs=len(splits))
 
 
 # TODO: It would be better to export this as a chunk directly, as this is
@@ -437,13 +437,16 @@ def prim_ConstantChunk(g, self, chunks, dim):
 
 @parse_args('v', 'i', 'i')
 def split(g, self, split_size, dim):
-    print('symbolic::split: self: ' + str(self))
-    return prim_ConstantSplit(g, self, split_size, dim)
+    size = self.type().sizes()[dim]
+    splits = [split_size] * (size // split_size)
+    leftover = size % split_size
+    if leftover:
+        splits.append(leftover)
+    return g.op("Split", self, split_i=splits, axis_i=dim, outputs=1)
 
 
 @parse_args('v', 'is', 'i')
 def split_with_sizes(g, self, split_sizes, dim):
-    print('symbolic::split: self: ' + str(self))
     return g.op("Split", self, split_i=split_sizes, axis_i=dim, outputs=1)
 
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -515,11 +515,11 @@ def _run_symbolic_function(g, n, inputs, env, operator_export_type=OperatorExpor
                 else:
                     raise RuntimeError("Unsupported prim::Constant kind: `{}`. Send a bug report.".format(
                         n.kindOf("value")))
-            elif op_name == "Undefined" or op_name == "None" or op_name == "ListConstruct":
+            elif op_name == "Undefined" or op_name == "None" or op_name == "ListConstruct" or op_name == "ListUnpack":
                 # Undefined/None is not an ONNX operator; keep it as prim::Undefined/
                 # prim::None and let the exporter handle finally eliminating these
 
-                # For ListConstruct, it will be erased in the ONNX peephole pass
+                # For ListConstruct/ListUnpack, it will be erased in the ONNX peephole pass
                 return None
             elif op_name == 'Loop' or op_name == 'If':
                 new_op_outputs = g.op(op_name, *inputs, outputs=n.outputsSize())


### PR DESCRIPTION
* With the update of split output to dynamic list it breaks the export to onnx.
 Now split ir becomes two ops: 1. Dynamic[] <= Split(), and 2. out1, out2, out3
 <= Prim::ListUnpack. In this fix these two consecutive ops get fused when being
 exported to onnx.