### PR TITLE
[JIT] Preserve module hierarchy on traced modules

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7149,6 +7149,8 @@ a")
 
         traced = torch.jit.trace(TraceMe(), (torch.rand(4, 3, dtype=torch.float),))
         assert(traced.ssm._has_method('foo'))
+        imported = self.getExportImportCopy(traced)
+        assert(imported.ssm._has_method('foo'))
 
     def test_call_traced_module_from_traced_module(self):
         class TracedModule1(torch.nn.Module):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7131,6 +7131,10 @@ a")
         # submodule during tracing
 
         class AnotherScriptMod(torch.jit.ScriptModule):
+            def __init__(self):
+                super(AnotherScriptMod, self).__init__()
+                self.param = torch.nn.Parameter(torch.rand(1, 2, 3))
+
             @torch.jit.script_method
             def bar(self):
                 return torch.zeros(4, 5)
@@ -7161,6 +7165,7 @@ a")
         imported = self.getExportImportCopy(traced)
         assert(imported.ssm._has_method('foo'))
         assert(imported.ssm.asm._has_method('bar'))
+        assert(imported.ssm.asm._has_parameter('param'))
 
     def test_call_traced_module_from_traced_module(self):
         class TracedModule1(torch.nn.Module):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7165,19 +7165,19 @@ a")
         # for each of these checks, check that *BOTH* the underlying
         # _C.ScriptModule object has the expected method/param, as well as the
         # Python object that wraps it.
-        assert(traced.ssm._has_method('foo'))
-        assert(hasattr(traced.ssm, 'foo'))
+        self.assertTrue(traced.ssm._has_method('foo'))
+        self.assertTrue(hasattr(traced.ssm, 'foo'))
 
         imported = self.getExportImportCopy(traced)
 
-        assert(imported.ssm._has_method('foo'))
-        assert(hasattr(imported.ssm, 'foo'))
+        self.assertTrue(imported.ssm._has_method('foo'))
+        self.assertTrue(hasattr(imported.ssm, 'foo'))
 
-        assert(imported.ssm.asm._has_method('bar'))
-        assert(hasattr(imported.ssm.asm, 'bar'))
+        self.assertTrue(imported.ssm.asm._has_method('bar'))
+        self.assertTrue(hasattr(imported.ssm.asm, 'bar'))
 
-        assert(imported.ssm.asm._has_parameter('param'))
-        assert(hasattr(imported.ssm.asm, 'param'))
+        self.assertTrue(imported.ssm.asm._has_parameter('param'))
+        self.assertTrue(hasattr(imported.ssm.asm, 'param'))
 
     def test_call_traced_module_from_traced_module(self):
         class TracedModule1(torch.nn.Module):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7130,7 +7130,16 @@ a")
         # Test that we preserve the module hierarchy for a ScriptModule
         # submodule during tracing
 
+        class AnotherScriptMod(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def bar(self):
+                return torch.zeros(4, 5)
+
         class SomeScriptMod(torch.jit.ScriptModule):
+            def __init__(self):
+                super(SomeScriptMod, self).__init__()
+                self.asm = AnotherScriptMod()
+
             @torch.jit.script_method
             def foo(self):
                 return torch.zeros(3, 4)
@@ -7151,6 +7160,7 @@ a")
         assert(traced.ssm._has_method('foo'))
         imported = self.getExportImportCopy(traced)
         assert(imported.ssm._has_method('foo'))
+        assert(imported.ssm.asm._has_method('bar'))
 
     def test_call_traced_module_from_traced_module(self):
         class TracedModule1(torch.nn.Module):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7160,12 +7160,24 @@ a")
             def forward(self, x):
                 return self.ssm.bar() + x
 
-        traced = torch.jit.trace(TraceMe(), (torch.rand(4, 3, dtype=torch.float),))
+        orig = TraceMe()
+        traced = torch.jit.trace(orig, (torch.rand(4, 3, dtype=torch.float),))
+        # for each of these checks, check that *BOTH* the underlying
+        # _C.ScriptModule object has the expected method/param, as well as the
+        # Python object that wraps it.
         assert(traced.ssm._has_method('foo'))
+        assert(hasattr(traced.ssm, 'foo'))
+
         imported = self.getExportImportCopy(traced)
+
         assert(imported.ssm._has_method('foo'))
+        assert(hasattr(imported.ssm, 'foo'))
+
         assert(imported.ssm.asm._has_method('bar'))
+        assert(hasattr(imported.ssm.asm, 'bar'))
+
         assert(imported.ssm.asm._has_parameter('param'))
+        assert(hasattr(imported.ssm.asm, 'param'))
 
     def test_call_traced_module_from_traced_module(self):
         class TracedModule1(torch.nn.Module):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -686,7 +686,8 @@ void initJitScriptBindings(PyObject* module) {
         PythonPrint(ss, self, tensors, false);
         return ss.str();
       })
-      .def("apply", &Module::apply);
+      .def("apply", &Module::apply)
+      .def("copy", &Module::copy);
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
     .def("graph", [&](Method& self) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -687,7 +687,7 @@ void initJitScriptBindings(PyObject* module) {
         return ss.str();
       })
       .def("apply", &Module::apply)
-      .def("copy", &Module::copy);
+      .def("_copy", &Module::copy);
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
     .def("graph", [&](Method& self) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -687,7 +687,7 @@ void initJitScriptBindings(PyObject* module) {
         return ss.str();
       })
       .def("apply", &Module::apply)
-      .def("_copy", &Module::copy);
+      .def("_copy_into", &Module::copy_into);
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
     .def("graph", [&](Method& self) {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -468,13 +468,14 @@ struct Module {
       parameter_remap[kv.value().slot()] = retval->parameter_slot(kv.key());
     }
     for (auto &kv : modules) {
-      NamedModule nm;
-      nm.name = kv.key();
-      nm.module = kv.value().module->copy();
-      retval->modules[kv.key()] = nm;
+      retval->register_module(kv.key(), kv.value().module->copy());
     }
     for (auto &kv : methods) {
-      retval->create_method(kv.key(), kv.value()->graph()->copy(), {});
+      std::vector<at::Tensor*> params;
+      for (auto &p : kv.value()->params()) {
+        params.push_back(parameter_remap[p]);
+      }
+      retval->create_method(kv.key(), kv.value()->graph()->copy(), params);
     }
     return retval;
   }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -460,16 +460,16 @@ struct Module {
 
   void save(const std::string& filename);
 
-  std::shared_ptr<Module> copy(std::shared_ptr<Module> retval, std::function<std::shared_ptr<Module>(std::vector<std::string>)> module_lookup, std::vector<std::string> names = {}) const {
+  void copy_into(std::function<std::shared_ptr<Module>(std::vector<std::string>)> module_lookup, std::vector<std::string> names = {}) const {
     std::unordered_map<at::Tensor*, at::Tensor*> parameter_remap;
+    auto curr = module_lookup(names);
     for (auto &kv : parameters) {
-      retval->register_parameter(kv.key(), *kv.value().slot(), kv.value().is_buffer);
-      parameter_remap[kv.value().slot()] = retval->parameter_slot(kv.key());
+      curr->register_parameter(kv.key(), *kv.value().slot(), kv.value().is_buffer);
+      parameter_remap[kv.value().slot()] = curr->parameter_slot(kv.key());
     }
     for (auto &kv : modules) {
       names.push_back(kv.key());
-      auto new_mod = module_lookup(names);
-      kv.value().module->copy(new_mod, module_lookup, names);
+      kv.value().module->copy_into(module_lookup, names);
       names.pop_back();
     }
     for (auto &kv : methods) {
@@ -477,9 +477,8 @@ struct Module {
       for (auto &p : kv.value()->params()) {
         params.push_back(parameter_remap[p]);
       }
-      retval->create_method(kv.key(), kv.value()->graph()->copy(), params);
+      curr->create_method(kv.key(), kv.value()->graph()->copy(), params);
     }
-    return retval;
   }
 
  private:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1306,10 +1306,7 @@ class TracedModule(ScriptModule):
         for name, submodule in orig._modules.items():
             if isinstance(submodule, ScriptModule) and not isinstance(submodule, TracedModule):
                 self._modules[name] = submodule.copy()
-                p = self._modules[name]._get_parameters()
-                for i in range(len(p)):
-                    self._parameters[p[i][0]] = p[i][1]
-                    check_unique(p[i][1])
+                self._register_module(name, self._modules[name])
             else:
                 self._modules[name] = TracedModule(submodule, id_set, optimize=optimize)
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1142,6 +1142,7 @@ if _enabled:
 
         def copy(self):
             m = ScriptModule()
+
             def module_lookup(names):
                 curr = m
                 for name in names:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1304,7 +1304,14 @@ class TracedModule(ScriptModule):
             raise ValueError("Modules that have hooks assigned can't be compiled")
 
         for name, submodule in orig._modules.items():
-            self._modules[name] = TracedModule(submodule, id_set, optimize=optimize)
+            if isinstance(submodule, ScriptModule) and not isinstance(submodule, TracedModule):
+                self._modules[name] = submodule.copy()
+                p = self._modules[name]._get_parameters()
+                for i in range(len(p)):
+                    self._parameters[p[i][0]] = p[i][1]
+                    check_unique(p[i][1])
+            else:
+                self._modules[name] = TracedModule(submodule, id_set, optimize=optimize)
 
         self._freeze()
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1140,6 +1140,18 @@ if _enabled:
             rcb = createResolutionCallback(frames_up=1)
             self._define(lang, rcb, True)
 
+        def copy(self):
+            m = ScriptModule()
+            def module_lookup(names):
+                curr = m
+                for name in names:
+                    if not hasattr(curr, name):
+                        setattr(curr, name, ScriptModule())
+                    curr = getattr(curr, name)
+                return curr
+            self._copy(m, module_lookup, [])
+            return m
+
     class WeakScriptModuleProxy(ScriptModule):
         def __init__(self, original, stubs):
             # Guards behavior of __setattr__ and __getattr__ so ScriptModule
@@ -1306,7 +1318,6 @@ class TracedModule(ScriptModule):
         for name, submodule in orig._modules.items():
             if isinstance(submodule, ScriptModule) and not isinstance(submodule, TracedModule):
                 self._modules[name] = submodule.copy()
-                self._register_module(name, self._modules[name])
             else:
                 self._modules[name] = TracedModule(submodule, id_set, optimize=optimize)
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1150,7 +1150,7 @@ if _enabled:
                         setattr(curr, name, ScriptModule())
                     curr = getattr(curr, name)
                 return curr
-            self._copy(m, module_lookup, [])
+            self._copy_into(module_lookup, [])
             return m
 
     class WeakScriptModuleProxy(ScriptModule):


### PR DESCRIPTION
We need this, for example, to properly call `_unpack` when we have a traced module in the hierarchy