### PR TITLE
Pre-commit flake8/clang-tidy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,7 @@ On the initial build, you can also speed things up with the environment
 variables `DEBUG` and `NO_CUDA`.
 
 - `DEBUG=1` will enable debug builds (-g -O0)
+- `REL_WITH_DEB_INFO=1` will enable debug symbols with optimizations (-g -O3)
 - `NO_CUDA=1` will disable compiling CUDA (in case you are developing on something not CUDA related), to save compile time.
 
 For example:
@@ -462,6 +463,16 @@ be the path to where you built PyTorch from source, e.g. `build` in the PyTorch
 root folder if you used `setup.py build`. You can use `-c <clang-tidy-binary>`
 to change the clang-tidy this script uses. Make sure you have PyYaml installed,
 which is in PyTorch's `requirements.txt`.
+
+### Pre-commit Tidy/Linting Hook
+
+We use clang-tidy and flake8 to perform additional formatting and semantic checking
+of code. We provide a pre-commit git hook for performing these checks, before
+a commit is created:
+
+  ```sh
+  $ ln -s ../../tools/git-pre-commit .git/hooks/pre-commit
+  ```
 
 ## Caffe2 notes
 

--- a/tools/flake8_hook.py
+++ b/tools/flake8_hook.py
@@ -1,0 +1,11 @@
+import sys
+
+from flake8.main import git
+
+if __name__ == '__main__':
+    sys.exit(
+        git.hook(
+            strict=git.config_for('strict'),
+            lazy=git.config_for('lazy'),
+        )
+    )

--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+echo "Running pre-commit flake8"
+python tools/flake8_hook.py
+echo "Running pre-commit clang-tidy"
+python tools/clang_tidy.py \
+  --paths torch/csrc \
+  --diff HEAD \
+  -g"-torch/csrc/distributed/Module.cpp" \
+  -g"-torch/csrc/jit/export.cpp" \
+  -g"-torch/csrc/jit/import.cpp" \
+  -j


### PR DESCRIPTION
Provide a pre-commit hook that does flake8 and clang tidy checks. Enables the clang-tidy script to run in parallel to make it fast enough to be used in a pre-commit hook.