### PR TITLE
Ensure there aren't variables in checked_tensor_unwrap, checked_tenso…

### DIFF
--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -94,7 +94,8 @@ static inline std::vector<TensorImpl*> checked_tensor_list_unwrap(ArrayRef<Tenso
                " for sequence element ", i , " in sequence argument at position #", pos, " '", name, "'");
     }
     if (expr.is_variable()) {
-      AT_ERROR("Expected Tensor (not Variable) for argument #", pos, " '", name, "'");
+      AT_ERROR("Expected Tensor (not Variable) for sequence element ",
+               i , " in sequence argument at position #", pos, " '", name, "'");
     }
     unwrapped.emplace_back(expr.unsafeGetTensorImpl());
   }

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -73,6 +73,9 @@ static inline TensorImpl* checked_tensor_unwrap(const Tensor& expr, const char *
     AT_ERROR("Expected object of scalar type ", scalar_type, " but got scalar type ", expr.scalar_type(),
              " for argument #", pos, " '", name, "'");
   }
+  if (expr.is_variable()) {
+    AT_ERROR("Expected Tensor (not Variable) for argument #", pos, " '", name, "'");
+  }
   return expr.unsafeGetTensorImpl();
 }
 
@@ -88,7 +91,10 @@ static inline std::vector<TensorImpl*> checked_tensor_list_unwrap(ArrayRef<Tenso
     }
     if (expr.scalar_type() != scalar_type) {
       AT_ERROR("Expected object of scalar type ", scalar_type, " but got scalar type ", expr.scalar_type(),
-               " for sequence elment ", i , " in sequence argument at position #", pos, " '", name, "'");
+               " for sequence element ", i , " in sequence argument at position #", pos, " '", name, "'");
+    }
+    if (expr.is_variable()) {
+      AT_ERROR("Expected Tensor (not Variable) for argument #", pos, " '", name, "'");
     }
     unwrapped.emplace_back(expr.unsafeGetTensorImpl());
   }


### PR DESCRIPTION
…r_list_unwrap.

These functions use unsafeGetTensorImpl(), which doesn't work with Variables (in a silent way that may blow up later).
So let's do early checking.

