### PR TITLE
Add back c2 string_utils include header to benchmark_helper

### DIFF
--- a/binaries/benchmark_helper.h
+++ b/binaries/benchmark_helper.h
@@ -22,6 +22,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/net.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/utils/string_utils.h"
 #include "c10/util/string_utils.h"
 
 using std::map;


### PR DESCRIPTION
Differential Revision: D13439694
