### PR TITLE
Determinism breaks when the number of workers of a DataLoader

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -118,7 +118,7 @@ def _worker_loop(dataset, index_queue, data_queue, done_event,
 
         # Intialize C side signal handlers for SIGBUS and SIGSEGV. Python signal
         # module's handlers are executed after Python returns from C low-level
-        # handlers, likely when the same fatal signal happened again already.
+        # handlers, likely when the same fatal signal had already happened.
         # https://docs.python.org/3/library/signal.html Sec. 18.8.1.1
         _set_worker_signal_handlers()
 


### PR DESCRIPTION
### Related PR
Fixed non-determinate preprocessing on DataLoader #4640

### Content
I read the PR above and has always expected that determinism is ensured if I do `manual_seed` before making a data loader. Recently I encountered a situation where the determinism seemed broken. It took me a while to figure out what went wrong, and I learned that the random number generation was conditioned on `worker_id`, hence the number of workers of a loader. I thought it was implicit and hard to expect, so I fixed it.

### An example

```python
import random
from datetime import datetime
import torch
from torch.utils.data import Dataset, DataLoader


class RandomDataset(Dataset):
    def __getitem__(self, item):
        # return torch.LongTensor([random.randint(0, 9999)])
        return torch.LongTensor(1).random_() % 10000

    def __len__(self):
        return 11


def train_load(dset, num_workers):
    # Simulate train loading
    torch.manual_seed(0)  # Fix seed
    loader = DataLoader(dset, num_workers=num_workers)
    print([data.item() for data in loader])


dset = RandomDataset()

for i in range(3):
    train_load(dset, 1)
    
train_load(dset, 2)
train_load(dset, 3)
train_load(dset, 4)

```

```python
# previous (torch 1.0.0)
[8378, 3997, 9259, 9542, 4167, 9875, 2475, 4502, 2503, 2990, 5795]
[8378, 3997, 9259, 9542, 4167, 9875, 2475, 4502, 2503, 2990, 5795]
[8378, 3997, 9259, 9542, 4167, 9875, 2475, 4502, 2503, 2990, 5795]
[8378, 9306, 3997, 4917, 9259, 9434, 9542, 3405, 4167, 2219, 9875]
[8378, 9306, 2250, 3997, 4917, 3659, 9259, 9434, 716, 9542, 3405]
[8378, 9306, 2250, 5787, 3997, 4917, 3659, 2776, 9259, 9434, 716]
```

```python
# this PR
[8378, 9306, 2250, 5787, 5415, 2162, 2645, 4624, 1128, 9602, 7094]
[8378, 9306, 2250, 5787, 5415, 2162, 2645, 4624, 1128, 9602, 7094]
[8378, 9306, 2250, 5787, 5415, 2162, 2645, 4624, 1128, 9602, 7094]
[8378, 9306, 2250, 5787, 5415, 2162, 2645, 4624, 1128, 9602, 7094]
[8378, 9306, 2250, 5787, 5415, 2162, 2645, 4624, 1128, 9602, 7094]
[8378, 9306, 2250, 5787, 5415, 2162, 2645, 4624, 1128, 9602, 7094]
```

@SsnL Please have a look at this PR