### PR TITLE
Use std::vector instead of alloca to work around hcc crash

### DIFF
--- a/aten/src/ATen/cuda/detail/IndexUtils.cu
+++ b/aten/src/ATen/cuda/detail/IndexUtils.cu
@@ -1,4 +1,5 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
+#include <vector>
 
 namespace at {
 namespace cuda {
@@ -35,7 +36,7 @@ within the next one.
 */
 bool maybeOverlappingIndices(const Tensor& t) {
   /* Extract size/stride arrays; only consider size >1 dims. */
-  SizeAndStride *info = (SizeAndStride *)alloca(sizeof(SizeAndStride) * t.dim());
+  std::vector<SizeAndStride> info(t.dim());
   int dims = t.dim();
   int nonSize1Dims = 0;
   for (int i = 0; i < dims; ++i) {
@@ -58,7 +59,7 @@ bool maybeOverlappingIndices(const Tensor& t) {
   }
 
   /* Ascending order (innermost dimension in sorted view is at [0]) */
-  qsort(info, nonSize1Dims, sizeof(SizeAndStride), compareSizeAndStride);
+  qsort(info.data(), nonSize1Dims, sizeof(SizeAndStride), compareSizeAndStride);
 
   for (int i = 0; i < (nonSize1Dims - 1); ++i) {
     if (((info[i].size - 1) * info[i].stride) >= info[i + 1].stride) {


### PR DESCRIPTION
#15121 