### PR TITLE
Print out operator suggestions for unknown builtin op

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8199,7 +8199,7 @@ a")
             def close_match(x):
                 return x.masked_fill(True)
 
-        with self.assertRaisesRegex(RuntimeError, "This op may not exist or may not be currently"
+        with self.assertRaisesRegex(RuntimeError, "This op may not exist or may not be currently "
                                     "supported in TorchScript"):
             @torch.jit.script
             def unknown_op(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8191,6 +8191,21 @@ a")
         with self.assertRaisesRegex(RuntimeError, "Expected 4-dimensional input for 4-dimensional weight"):
             foo(torch.ones([123]))  # wrong size
 
+    def test_builtin_error_messsage(self):
+        from torch.nn.modules.utils import _single, _pair, _triple, _quadruple
+
+        with self.assertRaisesRegex(RuntimeError, "aten::masked_fill_"):
+            @torch.jit.script
+            def close_match(x):
+                return x.masked_fill(True)
+
+        with self.assertRaisesRegex(RuntimeError, "This op may not exist or may not be currently"
+                                    "supported in TorchScript"):
+            @torch.jit.script
+            def unknown_op(x):
+                torch.set_grad_enabled(True)
+                return x
+
     def test_exceptions(self):
         cu = torch.jit.CompilationUnit('''
             def foo(cond):

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -85,6 +85,7 @@ torch_sources_no_python_default = [
     "torch/csrc/jit/register_special_ops.cpp",
     "torch/csrc/jit/scope.cpp",
     "torch/csrc/jit/script/compiler.cpp",
+    "torch/csrc/jit/script/edit_distance.cpp",
     "torch/csrc/jit/script/final_returns.cpp",
     "torch/csrc/jit/script/type_parser.cpp",
     "torch/csrc/jit/script/sugared_value.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -195,6 +195,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/script/sugared_value.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/parser.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/builtin_functions.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/edit_distance.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
   ${TORCH_SRC_DIR}/csrc/jit/tracer.cpp

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -431,6 +431,13 @@ struct OperatorRegistry {
       return it->second;
     return empty;
   }
+
+  const OperatorMap getAllOperators() {
+    std::lock_guard<std::mutex> guard(lock);
+    registerPendingOperators();
+    return operators;
+  }
+
 };
 
 OperatorRegistry& getRegistry() {
@@ -458,7 +465,11 @@ const std::vector<std::shared_ptr<Operator>>& getAllOperatorsFor(Symbol name) {
   return getRegistry().getOperators(name);
 }
 
-Operator& sig(const char* signature) {
+const OperatorMap getAllOperators() {
+  return getRegistry().getAllOperators();
+}
+
+Operator& sig(const char *signature) {
   return *getRegistry().lookupByLiteral(signature);
 }
 

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -94,6 +94,10 @@ TORCH_API std::string canonicalSchemaString(const FunctionSchema& schema);
 
 TORCH_API const std::vector<std::shared_ptr<Operator>>& getAllOperatorsFor(
     Symbol name);
+
+// returns a copy of the operator map
+TORCH_API const std::unordered_map<Symbol, std::vector<std::shared_ptr<Operator>>> getAllOperators();
+
 std::shared_ptr<Operator> findOperatorFor(const Node* node);
 const Operator& getOperatorFor(const Node* node);
 

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -95,9 +95,6 @@ TORCH_API std::string canonicalSchemaString(const FunctionSchema& schema);
 TORCH_API const std::vector<std::shared_ptr<Operator>>& getAllOperatorsFor(
     Symbol name);
 
-// returns a copy of the operator map
-TORCH_API const std::unordered_map<Symbol, std::vector<std::shared_ptr<Operator>>> getAllOperators();
-
 std::shared_ptr<Operator> findOperatorFor(const Node* node);
 const Operator& getOperatorFor(const Node* node);
 

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -108,9 +108,7 @@ inline Operation getOperation(const Node* node) {
 }
 
 
-// return nullopt if it's not a match, otherwise it's score
-using OperatorEntry = std::pair<Symbol, std::vector<std::shared_ptr<Operator>>>;
-TORCH_API std::multimap<int64_t, OperatorEntry> findSimilarOperators(Symbol input_op);
+TORCH_API std::vector<Symbol> findSimilarOperators(Symbol input_op);
 
 TORCH_API void registerOperator(Operator&& op);
 

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -107,6 +107,14 @@ inline Operation getOperation(const Node* node) {
   return getOperatorFor(node).getOperation(node);
 }
 
+
+// return nullopt if it's not a match, otherwise it's score
+using OperatorScore = c10::optional<int64_t>;
+using OperatorEntry = std::pair<Symbol, std::vector<std::shared_ptr<Operator>>>;
+
+TORCH_API std::multimap<int64_t, OperatorEntry> fuzzyFindOperators(std::function<OperatorScore(OperatorEntry)>
+    rankingFunc);
+
 TORCH_API void registerOperator(Operator&& op);
 
 // XXX: this function is meant to be used with string literals only!

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -112,8 +112,7 @@ inline Operation getOperation(const Node* node) {
 using OperatorScore = c10::optional<int64_t>;
 using OperatorEntry = std::pair<Symbol, std::vector<std::shared_ptr<Operator>>>;
 
-TORCH_API std::multimap<int64_t, OperatorEntry> fuzzyFindOperators(std::function<OperatorScore(OperatorEntry)>
-    rankingFunc);
+TORCH_API std::multimap<int64_t, OperatorEntry> findSimilarOperators(Symbol input_op);
 
 TORCH_API void registerOperator(Operator&& op);
 

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -109,9 +109,7 @@ inline Operation getOperation(const Node* node) {
 
 
 // return nullopt if it's not a match, otherwise it's score
-using OperatorScore = c10::optional<int64_t>;
 using OperatorEntry = std::pair<Symbol, std::vector<std::shared_ptr<Operator>>>;
-
 TORCH_API std::multimap<int64_t, OperatorEntry> findSimilarOperators(Symbol input_op);
 
 TORCH_API void registerOperator(Operator&& op);

--- a/torch/csrc/jit/script/edit_distance.cpp
+++ b/torch/csrc/jit/script/edit_distance.cpp
@@ -1,6 +1,6 @@
 #include <torch/csrc/jit/script/edit_distance.h>
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 #include <memory>
 
 namespace torch {

--- a/torch/csrc/jit/script/edit_distance.cpp
+++ b/torch/csrc/jit/script/edit_distance.cpp
@@ -1,17 +1,18 @@
 #include <torch/csrc/jit/script/edit_distance.h>
 #include <algorithm>
 #include <memory>
+#include <string.h>
 
 namespace torch { namespace jit { namespace script {
 
 // computes levenshtein edit distance between two words
 // returns maxEditDistance + 1 if the edit distance exceeds MaxEditDistance
 // reference: http://llvm.org/doxygen/edit__distance_8h_source.html
-size_t ComputeEditDistance(const std::string& word1, const std::string& word2,
+size_t ComputeEditDistance(const char * word1, const char * word2,
     size_t maxEditDistance) {
 
-  size_t m = word1.size();;
-  size_t n = word2.size();
+  size_t m = strlen(word1);;
+  size_t n = strlen(word2);
 
   const unsigned small_buffer_size = 64;
   unsigned small_buffer[small_buffer_size];

--- a/torch/csrc/jit/script/edit_distance.cpp
+++ b/torch/csrc/jit/script/edit_distance.cpp
@@ -1,23 +1,27 @@
 #include <torch/csrc/jit/script/edit_distance.h>
+#include <string.h>
 #include <algorithm>
 #include <memory>
-#include <string.h>
 
-namespace torch { namespace jit { namespace script {
+namespace torch {
+namespace jit {
+namespace script {
 
 // computes levenshtein edit distance between two words
 // returns maxEditDistance + 1 if the edit distance exceeds MaxEditDistance
 // reference: http://llvm.org/doxygen/edit__distance_8h_source.html
-size_t ComputeEditDistance(const char * word1, const char * word2,
+size_t ComputeEditDistance(
+    const char* word1,
+    const char* word2,
     size_t maxEditDistance) {
 
-  size_t m = strlen(word1);;
+  size_t m = strlen(word1);
   size_t n = strlen(word2);
 
   const unsigned small_buffer_size = 64;
   unsigned small_buffer[small_buffer_size];
   std::unique_ptr<unsigned[]> allocated;
-  unsigned *row = small_buffer;
+  unsigned* row = small_buffer;
   if (n + 1 > small_buffer_size) {
     row = new unsigned[n + 1];
     allocated.reset(row);
@@ -34,8 +38,8 @@ size_t ComputeEditDistance(const char * word1, const char * word2,
     for (size_t x = 1; x <= n; ++x) {
       int old_row = row[x];
       row[x] = std::min(
-          previous + (word1[y-1] == word2[x-1] ? 0u : 1u),
-          std::min(row[x-1], row[x])+1);
+          previous + (word1[y - 1] == word2[x - 1] ? 0u : 1u),
+          std::min(row[x - 1], row[x]) + 1);
       previous = old_row;
       best_this_row = std::min(best_this_row, row[x]);
     }
@@ -48,5 +52,6 @@ size_t ComputeEditDistance(const char * word1, const char * word2,
   return result;
 }
 
-
-}}}
+} // namespace script
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/edit_distance.cpp
+++ b/torch/csrc/jit/script/edit_distance.cpp
@@ -1,0 +1,51 @@
+#include <torch/csrc/jit/script/edit_distance.h>
+#include <algorithm>
+#include <memory>
+
+namespace torch { namespace jit { namespace script {
+
+// computes levenshtein edit distance between two words
+// returns maxEditDistance + 1 if the edit distance exceeds MaxEditDistance
+// reference: http://llvm.org/doxygen/edit__distance_8h_source.html
+size_t ComputeEditDistance(const std::string& word1, const std::string& word2,
+    size_t maxEditDistance) {
+
+  size_t m = word1.size();;
+  size_t n = word2.size();
+
+  const unsigned small_buffer_size = 64;
+  unsigned small_buffer[small_buffer_size];
+  std::unique_ptr<unsigned[]> allocated;
+  unsigned *row = small_buffer;
+  if (n + 1 > small_buffer_size) {
+    row = new unsigned[n + 1];
+    allocated.reset(row);
+  }
+
+  for (unsigned i = 1; i <= n; ++i)
+    row[i] = i;
+
+  for (size_t y = 1; y <= m; ++y) {
+    row[0] = y;
+    unsigned best_this_row = row[0];
+
+    unsigned previous = y - 1;
+    for (size_t x = 1; x <= n; ++x) {
+      int old_row = row[x];
+      row[x] = std::min(
+          previous + (word1[y-1] == word2[x-1] ? 0u : 1u),
+          std::min(row[x-1], row[x])+1);
+      previous = old_row;
+      best_this_row = std::min(best_this_row, row[x]);
+    }
+
+    if (maxEditDistance && best_this_row > maxEditDistance)
+      return maxEditDistance + 1;
+  }
+
+  unsigned result = row[n];
+  return result;
+}
+
+
+}}}

--- a/torch/csrc/jit/script/edit_distance.h
+++ b/torch/csrc/jit/script/edit_distance.h
@@ -4,10 +4,15 @@
 #include <cstddef>
 #include <string>
 
-namespace torch { namespace jit { namespace script {
+namespace torch {
+namespace jit {
+namespace script {
 
-
-TORCH_API size_t ComputeEditDistance(const char * word1, const char * word2,
+TORCH_API size_t ComputeEditDistance(
+    const char* word1,
+    const char* word2,
     size_t maxEditDistance);
 
-}}}
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/edit_distance.h
+++ b/torch/csrc/jit/script/edit_distance.h
@@ -7,7 +7,7 @@
 namespace torch { namespace jit { namespace script {
 
 
-TORCH_API size_t ComputeEditDistance(const std::string& word1, const std::string& word2,
+TORCH_API size_t ComputeEditDistance(const char * word1, const char * word2,
     size_t maxEditDistance);
 
 }}}

--- a/torch/csrc/jit/script/edit_distance.h
+++ b/torch/csrc/jit/script/edit_distance.h
@@ -1,0 +1,50 @@
+#include <algorithm>
+#include <memory>
+
+namespace torch { namespace jit { namespace script {
+
+// computes levenshtein edit distance between two words
+// returns maxEditDistance + 1 if the edit distance exceeds MaxEditDistance
+// reference: http://llvm.org/doxygen/edit__distance_8h_source.html
+size_t computeEditDistance(const std::string& word1, const std::string& word2,
+    size_t maxEditDistance) {
+
+  size_t m = word1.size();
+  size_t n = word2.size();
+
+  const unsigned small_buffer_size = 64;
+  unsigned small_buffer[small_buffer_size];
+  std::unique_ptr<unsigned[]> allocated;
+  unsigned *row = small_buffer;
+  if (n + 1 > small_buffer_size) {
+    row = new unsigned[n + 1];
+    allocated.reset(row);
+  }
+
+  for (unsigned i = 1; i <= n; ++i)
+    row[i] = i;
+
+  for (size_t y = 1; y <= m; ++y) {
+    row[0] = y;
+    unsigned best_this_row = row[0];
+
+    unsigned previous = y - 1;
+    for (size_t x = 1; x <= n; ++x) {
+      int old_row = row[x];
+      row[x] = std::min(
+          previous + (word1[y-1] == word2[x-1] ? 0u : 1u),
+          std::min(row[x-1], row[x])+1);
+      previous = old_row;
+      best_this_row = std::min(best_this_row, row[x]);
+    }
+
+    if (maxEditDistance && best_this_row > maxEditDistance)
+      return maxEditDistance + 1;
+  }
+
+  unsigned result = row[n];
+  return result;
+}
+
+
+}}}

--- a/torch/csrc/jit/script/edit_distance.h
+++ b/torch/csrc/jit/script/edit_distance.h
@@ -1,50 +1,13 @@
-#include <algorithm>
-#include <memory>
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <cstddef>
+#include <string>
 
 namespace torch { namespace jit { namespace script {
 
-// computes levenshtein edit distance between two words
-// returns maxEditDistance + 1 if the edit distance exceeds MaxEditDistance
-// reference: http://llvm.org/doxygen/edit__distance_8h_source.html
-size_t computeEditDistance(const std::string& word1, const std::string& word2,
-    size_t maxEditDistance) {
 
-  size_t m = word1.size();
-  size_t n = word2.size();
-
-  const unsigned small_buffer_size = 64;
-  unsigned small_buffer[small_buffer_size];
-  std::unique_ptr<unsigned[]> allocated;
-  unsigned *row = small_buffer;
-  if (n + 1 > small_buffer_size) {
-    row = new unsigned[n + 1];
-    allocated.reset(row);
-  }
-
-  for (unsigned i = 1; i <= n; ++i)
-    row[i] = i;
-
-  for (size_t y = 1; y <= m; ++y) {
-    row[0] = y;
-    unsigned best_this_row = row[0];
-
-    unsigned previous = y - 1;
-    for (size_t x = 1; x <= n; ++x) {
-      int old_row = row[x];
-      row[x] = std::min(
-          previous + (word1[y-1] == word2[x-1] ? 0u : 1u),
-          std::min(row[x-1], row[x])+1);
-      previous = old_row;
-      best_this_row = std::min(best_this_row, row[x]);
-    }
-
-    if (maxEditDistance && best_this_row > maxEditDistance)
-      return maxEditDistance + 1;
-  }
-
-  unsigned result = row[n];
-  return result;
-}
-
+TORCH_API size_t ComputeEditDistance(const std::string& word1, const std::string& word2,
+    size_t maxEditDistance);
 
 }}}

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -212,9 +212,10 @@ c10::optional<MatchedSchema> tryMatchSchema(
       self = c10::nullopt;
     } else if (!arg.kwarg_only() && used_args < args.size()) {
       // allow zeros(IntList sizes) to work with zeros(1, 2) or zeros(1)
-      if (allow_conversions && arg.type()->kind() == TypeKind::ListType && // the formal must be a list
-          !arg.N() && // it must not be a broadcasting list like int[3], otherwise
-                    // a single int is a valid input
+      if (arg.type()->kind() ==
+              TypeKind::ListType && // the formal must be a list
+          !arg.N() && // it must not be a broadcasting list like int[3],
+                      // otherwise a single int is a valid input
           (schema_i + 1 == schema.arguments().size() ||
            schema.arguments()[schema_i + 1]
                .kwarg_only())) { // must be the last position argument

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -212,10 +212,9 @@ c10::optional<MatchedSchema> tryMatchSchema(
       self = c10::nullopt;
     } else if (!arg.kwarg_only() && used_args < args.size()) {
       // allow zeros(IntList sizes) to work with zeros(1, 2) or zeros(1)
-      if (arg.type()->kind() ==
-              TypeKind::ListType && // the formal must be a list
-          !arg.N() && // it must not be a broadcasting list like int[3],
-                      // otherwise a single int is a valid input
+      if (allow_conversions && arg.type()->kind() == TypeKind::ListType && // the formal must be a list
+          !arg.N() && // it must not be a broadcasting list like int[3], otherwise
+                    // a single int is a valid input
           (schema_i + 1 == schema.arguments().size() ||
            schema.arguments()[schema_i + 1]
                .kwarg_only())) { // must be the last position argument
@@ -349,6 +348,7 @@ static std::string prefixLine(
   return ss.str();
 }
 
+
 // Search for operators matching the provided symbol name and input types.
 // If one is found, emit a node to the graph for that operator.
 Value* emitBuiltinCall(
@@ -404,9 +404,24 @@ Value* emitBuiltinCall(
   if (!required) {
     return nullptr;
   }
+  // no operators found with the same name, print out similarly named operators
   if (variants.size() == 0) {
-    throw ErrorReport(loc) << "unknown builtin op";
+    auto close_operators = findSimilarOperators(name);
+    auto error = ErrorReport(loc);
+    auto user_function_name = name.toQualString();
+    error << "unknown builtin op: " << user_function_name << "\n";
+    if (close_operators.size() == 0) {
+      error << "Could not find any similar ops to " << user_function_name
+        << ". This op may not exist or may not be currently supported in TorchScript\n";
+    } else {
+      error << "Here are some suggestions: \n";
+      for (auto op: close_operators) {
+        error << "\t" << op.second.first.toQualString() << "\n";
+      }
+    }
+    throw error;
   }
+
   throw ErrorReport(loc) << "arguments for call are not valid:\n"
                          << prefixLine(failure_messages.str(), "  ")
                          << "for call at";

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -406,17 +406,17 @@ Value* emitBuiltinCall(
   }
   // no operators found with the same name, print out similarly named operators
   if (variants.size() == 0) {
-    auto close_operators = findSimilarOperators(name);
+    const auto close_symbols = findSimilarOperators(name);
     auto error = ErrorReport(loc);
-    auto user_function_name = name.toQualString();
+    const auto& user_function_name = name.toQualString();
     error << "unknown builtin op: " << user_function_name << "\n";
-    if (close_operators.size() == 0) {
+    if (close_symbols.size() == 0) {
       error << "Could not find any similar ops to " << user_function_name
         << ". This op may not exist or may not be currently supported in TorchScript\n";
     } else {
       error << "Here are some suggestions: \n";
-      for (auto op: close_operators) {
-        error << "\t" << op.second.first.toQualString() << "\n";
+      for (const auto& sym : close_symbols) {
+        error << "\t" << sym.toQualString() << "\n";
       }
     }
     throw error;


### PR DESCRIPTION
This improves the error message for "unknown builtin op" to suggest similarly named ops. 

Currently it prints out all operators with a name within two edits. 

Related issue: https://github.com/pytorch/pytorch/issues/13409