### PR TITLE
Start unittesting our main observer

### DIFF
--- a/caffe2/python/test_util.py
+++ b/caffe2/python/test_util.py
@@ -42,15 +42,19 @@ def str_compare(a, b, encoding="utf8"):
     return a == b
 
 
+def get_default_test_flags():
+    return [
+        'caffe2',
+        '--caffe2_log_level=0',
+        '--caffe2_cpu_allocator_do_zero_fill=0',
+        '--caffe2_cpu_allocator_do_junk_fill=1',
+    ]
+
+
 class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        workspace.GlobalInit([
-            'caffe2',
-            '--caffe2_log_level=0',
-            '--caffe2_cpu_allocator_do_zero_fill=0',
-            '--caffe2_cpu_allocator_do_junk_fill=1',
-        ])
+        workspace.GlobalInit(get_default_test_flags())
         # clear the default engines settings to separate out its
         # affect from the ops tests
         core.SetEnginePref({}, {})


### PR DESCRIPTION
Summary:
OSS:

just splitting out basic flags from a unit test. So I can extend them in another test where I need to add additional flags.

Reviewed By: yinghai

Differential Revision: D13159184
