### PR TITLE
[C++ Frontend] Better tests/support for Python/C++ inter-op

### DIFF
--- a/test/cpp_extensions/cpp_frontend_extension.cpp
+++ b/test/cpp_extensions/cpp_frontend_extension.cpp
@@ -3,9 +3,13 @@
 #include <cstddef>
 #include <string>
 
-struct Net : torch::nn::Module {
-  Net(int64_t in, int64_t out) : fc(in, out) {
-    register_module("fc", fc);
+struct Net : torch::nn::Cloneable<Net> {
+  Net(int64_t in, int64_t out) : in_(in), out_(out) {
+    reset();
+  }
+
+  void reset() override {
+    fc = register_module("fc", torch::nn::Linear(in_, out_));
     buffer = register_buffer("buf", torch::eye(5));
   }
 
@@ -34,7 +38,8 @@ struct Net : torch::nn::Module {
     register_module(name, torch::nn::Linear(fc->options));
   }
 
-  torch::nn::Linear fc;
+  int64_t in_, out_;
+  torch::nn::Linear fc{nullptr};
   torch::Tensor buffer;
 };
 

--- a/torch/csrc/api/include/torch/python.h
+++ b/torch/csrc/api/include/torch/python.h
@@ -139,7 +139,7 @@ py::class_<ModuleType, Extra...> add_module_bindings(
           },
           py::arg("recurse") = true)
       .def_property_readonly(
-          "_modules", [](ModuleType& module) { return module.named_children(); })
+        "_modules", [](ModuleType& module) { return module.named_children(); })
       .def("modules", [](ModuleType& module) { return module.modules(); })
       .def("named_modules",
           [](ModuleType& module, py::object /* unused */, std::string prefix) {
@@ -166,10 +166,16 @@ py::class_<ModuleType, Extra...> add_module_bindings(
              py::object device,
              py::object dtype,
              bool non_blocking) {
-            module.to(
-                detail::py_object_to_device(device),
-                detail::py_object_to_dtype(dtype),
-                non_blocking);
+              if (device.is_none()) {
+                module.to(detail::py_object_to_dtype(dtype), non_blocking);
+              } else if (dtype.is_none()) {
+                module.to(detail::py_object_to_device(device), non_blocking);
+              } else {
+                module.to(
+                    detail::py_object_to_device(device),
+                    detail::py_object_to_dtype(dtype),
+                    non_blocking);
+              }
           },
           py::arg("device"),
           py::arg("dtype"),

--- a/torch/csrc/api/src/python/init.cpp
+++ b/torch/csrc/api/src/python/init.cpp
@@ -1,4 +1,5 @@
 #include <torch/python/init.h>
+#include <torch/python.h>
 
 #include <torch/nn/module.h>
 #include <torch/ordered_dict.h>
@@ -35,6 +36,7 @@ ITEM_TYPE_CASTER(std::shared_ptr<torch::nn::Module>, Module);
 
 namespace torch {
 namespace python {
+namespace {
 template <typename T>
 void bind_ordered_dict(py::module module, const char* dict_name) {
   using ODict = OrderedDict<std::string, T>;
@@ -56,6 +58,7 @@ void bind_ordered_dict(py::module module, const char* dict_name) {
       });
   // clang-format on
 }
+} // namespace
 
 void init_bindings(PyObject* module) {
   py::module m = py::handle(module).cast<py::module>();
@@ -65,7 +68,8 @@ void init_bindings(PyObject* module) {
   bind_ordered_dict<std::shared_ptr<nn::Module>>(cpp, "OrderedModuleDict");
 
   py::module nn = cpp.def_submodule("nn");
-  py::class_<nn::Module, std::shared_ptr<nn::Module>>(nn, "Module");
+  add_module_bindings(
+      py::class_<nn::Module, std::shared_ptr<nn::Module>>(nn, "Module"));
 }
 } // namespace python
 } // namespace torch


### PR DESCRIPTION
Methods like `module.named_modules()` returns a container of `shared_ptr<nn::Module>`. Currently the `nn::Module` base class does  not have Python bindings. This PR fixes this, and adds more unit tests.