### PR TITLE
[caffe2] Add Winograd Conv method for CPU

### DIFF
--- a/caffe2/ideep/ideep_utils.h
+++ b/caffe2/ideep/ideep_utils.h
@@ -18,4 +18,7 @@ namespace caffe2 {
   using iattr = ideep::descriptor_group::attr_t;                               \
   using ibn_flag = ideep::batch_normalization_flag;
 
+const int CONV_ALGORITHM_AUTO = 0;
+const int CONV_ALGORITHM_WINOGRAD = 1;
+
 } // namespace caffe2

--- a/caffe2/ideep/operators/conv_fusion_op.cc
+++ b/caffe2/ideep/operators/conv_fusion_op.cc
@@ -20,7 +20,9 @@ class IDEEPConvFusionOp final : public IDEEPConvPoolOpBase {
         fusion_type_(static_cast<FusionType>(
             OperatorBase::GetSingleArgument<int>("fusion_type", 0))),
         training_mode_(
-            OperatorBase::GetSingleArgument<int>("training_mode", 0)) {
+            OperatorBase::GetSingleArgument<int>("training_mode", 0)),
+        conv_algorithm_(
+            OperatorBase::GetSingleArgument<int>("conv_algorithm", CONV_ALGORITHM_AUTO)) {
     OPERATOR_NEEDS_FEATURE(
         pad_l() == pad_r() && pad_t() == pad_b(),
         "Uneven padding not supported.");
@@ -75,6 +77,11 @@ class IDEEPConvFusionOp final : public IDEEPConvPoolOpBase {
         "*",
         group_);
 
+    ideep::algorithm aalgorithm = ideep::algorithm::convolution_direct;
+    if (conv_algorithm_ == CONV_ALGORITHM_WINOGRAD) {
+      aalgorithm = ideep::algorithm::convolution_winograd;
+    }
+
     bool weights_changed =
         (cached_weights_descriptor_ != filter.get_descriptor());
     if (weights_changed && !training_mode_) {
@@ -102,7 +109,8 @@ class IDEEPConvFusionOp final : public IDEEPConvPoolOpBase {
           pad_tl(),
           pad_br(),
           group_,
-          attr());
+          attr(),
+          aalgorithm);
     } else {
       ideep::convolution_forward::compute(
           X,
@@ -114,7 +122,8 @@ class IDEEPConvFusionOp final : public IDEEPConvPoolOpBase {
           pad_tl(),
           pad_br(),
           group_,
-          attr());
+          attr(),
+          aalgorithm);
     }
 
     if (fusion_type_ != FUSION_CONV_RELU) {
@@ -130,6 +139,7 @@ class IDEEPConvFusionOp final : public IDEEPConvPoolOpBase {
   FusionType fusion_type_;
 
   bool training_mode_;
+  int conv_algorithm_;
   ideep::tensor filter_;
   ideep::tensor::descriptor cached_weights_descriptor_;
 

--- a/caffe2/ideep/operators/conv_fusion_op.cc
+++ b/caffe2/ideep/operators/conv_fusion_op.cc
@@ -137,7 +137,6 @@ class IDEEPConvFusionOp final : public IDEEPConvPoolOpBase {
 
  private:
   FusionType fusion_type_;
-
   bool training_mode_;
   int conv_algorithm_;
   ideep::tensor filter_;

--- a/caffe2/ideep/operators/conv_op.cc
+++ b/caffe2/ideep/operators/conv_op.cc
@@ -10,7 +10,9 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
   IDEEPConvOp(const OperatorDef& operator_def, Workspace* ws)
       : IDEEPConvPoolOpBase(operator_def, ws),
         training_mode_(
-            OperatorBase::GetSingleArgument<int>("training_mode", 0)) {
+            OperatorBase::GetSingleArgument<int>("training_mode", 0)),
+        conv_algorithm_(
+            OperatorBase::GetSingleArgument<int>("conv_algorithm", CONV_ALGORITHM_AUTO)) {
     OPERATOR_NEEDS_FEATURE(
         pad_l() == pad_r() && pad_t() == pad_b(),
         "Uneven padding not supported.");
@@ -36,6 +38,11 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
         "*",
         group_);
 
+    ideep::algorithm aalgorithm = ideep::algorithm::convolution_direct;
+    if (conv_algorithm_ == CONV_ALGORITHM_WINOGRAD) {
+      aalgorithm = ideep::algorithm::convolution_winograd;
+    }
+
     bool weights_changed =
         (cached_weights_descriptor_ != filter.get_descriptor());
     if (weights_changed && !training_mode_) {
@@ -50,7 +57,8 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
               pad_tl(),
               pad_br(),
               dilation_,
-              group_);
+              group_,
+              aalgorithm);
       filter_.init<ideep::utils::allocator, ideep::convolution_forward>(
           expected_descriptor);
       ideep::reorder::compute(filter_in, filter_);
@@ -73,7 +81,9 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
           dilation_,
           pad_tl(),
           pad_br(),
-          group_);
+          group_,
+          ideep::descriptor_group::attr_t(),
+          aalgorithm);
     } else {
       ideep::convolution_forward::compute(
           X,
@@ -84,7 +94,9 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
           dilation_,
           pad_tl(),
           pad_br(),
-          group_);
+          group_,
+          ideep::descriptor_group::attr_t(),
+          aalgorithm);
     }
 
     return true;
@@ -94,6 +106,7 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
   INPUT_TAGS(INPUT, FILTER, BIAS);
   OUTPUT_TAGS(OUTPUT);
 
+  int conv_algorithm_;
   bool training_mode_;
   ideep::tensor filter_;
   ideep::tensor::descriptor cached_weights_descriptor_;

--- a/caffe2/ideep/operators/conv_op.cc
+++ b/caffe2/ideep/operators/conv_op.cc
@@ -106,8 +106,8 @@ class IDEEPConvOp final : public IDEEPConvPoolOpBase {
   INPUT_TAGS(INPUT, FILTER, BIAS);
   OUTPUT_TAGS(OUTPUT);
 
-  int conv_algorithm_;
   bool training_mode_;
+  int conv_algorithm_;
   ideep::tensor filter_;
   ideep::tensor::descriptor cached_weights_descriptor_;
 };

--- a/caffe2/python/ideep/conv_op_test.py
+++ b/caffe2/python/ideep/conv_op_test.py
@@ -13,7 +13,6 @@ from caffe2.python.transformations import optimizeForIDEEP
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.ideep_test_util as mu
 
-
 @unittest.skipIf(not workspace.C.use_mkldnn, "No MKLDNN support.")
 class ConvTest(hu.HypothesisTestCase):
     @given(stride=st.integers(1, 3),
@@ -47,6 +46,44 @@ class ConvTest(hu.HypothesisTestCase):
                 output_channels * group, input_channels, kernel, kernel) \
             .astype(np.float32) - 0.5
         b = np.random.rand(output_channels * group).astype(np.float32) - 0.5
+
+        inputs = [X, w, b] if use_bias else [X, w]
+        self.assertDeviceChecks(dc, op, inputs, [0])
+
+        if training_mode:
+            for i in range(len(inputs)):
+                self.assertGradientChecks(gc, op, inputs, i, [0], threshold=0.01)
+    @given(stride=st.integers(1, 3),
+           pad=st.integers(0, 3),
+           size=st.integers(8, 10),
+           input_channels=st.integers(16, 32),
+           output_channels=st.integers(16, 32),
+           batch_size=st.integers(1, 3),
+           use_bias=st.booleans(),
+           training_mode=st.booleans(),
+           **mu.gcs)
+    def test_winograd_convolution(self, stride, pad, size,
+                             input_channels, output_channels,
+                             batch_size, use_bias, training_mode, gc, dc):
+        training = 1 if training_mode else 0
+        conv3x3_winograd_algorithm = 1
+        kernel = 3
+        op = core.CreateOperator(
+            "Conv",
+            ["X", "w", "b"] if use_bias else ["X", "w"],
+            ["Y"],
+            stride=stride,
+            pad=pad,
+            kernel=kernel,
+            training_mode=training,
+            algorithm=conv3x3_winograd_algorithm
+        )
+        X = np.random.rand(
+            batch_size, input_channels, size, size).astype(np.float32) - 0.5
+        w = np.random.rand(
+                output_channels, input_channels, kernel, kernel) \
+            .astype(np.float32) - 0.5
+        b = np.random.rand(output_channels).astype(np.float32) - 0.5
 
         inputs = [X, w, b] if use_bias else [X, w]
         self.assertDeviceChecks(dc, op, inputs, [0])


### PR DESCRIPTION
Add winograd conv method. Users can select the direct conv or winograd conv in the model file.
We close the origin pr https://github.com/pytorch/pytorch/pull/12154 and create this new one for better rebasing.