### PR TITLE
[ROCm] Remove __forceinline__ hipification step.

### DIFF
--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -505,15 +505,6 @@ def disable_asserts(input_string):
     return output_string
 
 
-def replace_forceinline(input_string):
-    """__forceinline__'d methods can cause 'symbol multiply defined' errors in HIP.
-    Adding 'static' to all such methods leads to compilation errors, so
-    replacing '__forceinline__' with 'inline' as a workaround
-    https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_faq.md#what-if-hip-generates-error-of-symbol-multiply-defined-only-on-amd-machine
-    """
-    return input_string.replace("__forceinline__", "inline")
-
-
 def replace_math_functions(input_string):
     """ FIXME: Temporarily replace std:: invocations of math functions with non-std:: versions to prevent linker errors
         NOTE: This can lead to correctness issues when running tests, since the correct version of the math function (exp/expf) might not get called.
@@ -936,9 +927,6 @@ def preprocessor(output_directory, filepath, stats):
         # Replace std:: with non-std:: versions
         if filepath.endswith(".cu") or filepath.endswith(".cuh"):
           output_source = replace_math_functions(output_source)
-
-        # Replace __forceinline__ with inline
-        output_source = replace_forceinline(output_source)
 
         # Include header if device code is contained.
         output_source = hip_header_magic(output_source)


### PR DESCRIPTION
The HIP definition now correctly contains the inline attribute.

