### PR TITLE
keep extra_info of each op in ProfDagStats

### DIFF
--- a/caffe2/core/prof_dag_counters.h
+++ b/caffe2/core/prof_dag_counters.h
@@ -64,10 +64,13 @@ class ProfDAGReport {
   void PrintStats();
 
  private:
-  ProfDAGProto statsProto(const std::string& name, const ProfDAGStats& stats)
-      const;
+  ProfDAGProto statsProto(
+      const std::string& name,
+      const ProfDAGStats& stats,
+      const std::vector<std::string>& op_extra_info) const;
 
   std::vector<std::string> op_types_;
+  std::vector<std::vector<std::string>> op_extra_info_;
 
   std::string net_name_;
 

--- a/caffe2/proto/prof_dag.proto
+++ b/caffe2/proto/prof_dag.proto
@@ -42,6 +42,10 @@ message ProfDAGProto {
 
   // Blob profiles that this node outputs.
   repeated BlobProfile output_profile = 5;
+
+  // The extra_info from the operator device option.
+  repeated string extra_info = 7;
+
 }
 
 // Operator profiling information.


### PR DESCRIPTION
Summary:
Net transform attaches a global_op_id which is defined as a tuple of (orig_net_name, original_op_index) to each operator,
The global_op_id is encoded as extra_info in each operator.

This DIFF keeps track of the extra_info information. When getPerOpStas() is called, it attaches the extra_info to the result ProfDagStats protobuf.

Differential Revision: D13016289
