### PR TITLE
Enable conv+add fusion, same as conv+sum

### DIFF
--- a/caffe2/python/ideep/convfusion_op_test.py
+++ b/caffe2/python/ideep/convfusion_op_test.py
@@ -125,10 +125,11 @@ class ConvFusionTest(hu.HypothesisTestCase):
            batch_size=st.integers(1, 3),
            use_bias=st.booleans(),
            group=st.integers(1, 1),
+           sum_add=st.sampled_from(["Sum", "Add"]),
            **mu.gcs)
     def test_convolution_sum_fusion(self, stride, pad, kernel, size,
                              input_channels, output_channels,
-                             batch_size, use_bias, group, gc, dc):
+                             batch_size, use_bias, group, sum_add, gc, dc):
         conv_S0 = core.CreateOperator(
             "Conv",
             ["SX0", "Sw0", "Sb0"] if use_bias else ["SX0", "Sw0"],
@@ -150,7 +151,7 @@ class ConvFusionTest(hu.HypothesisTestCase):
             device_option=dc[0]
         )
         sum = core.CreateOperator(
-            "Sum",
+            sum_add,
             ["S0", "Y0"],
             ["S0"],
             device_option=dc[0]
@@ -264,10 +265,11 @@ class ConvFusionTest(hu.HypothesisTestCase):
            batch_size=st.integers(1, 3),
            use_bias=st.booleans(),
            group=st.integers(1, 1),
+           sum_add=st.sampled_from(["Sum", "Add"]),
            **mu.gcs)
     def test_convolution_sum_relu_fusion(self, stride, pad, kernel, size,
                              input_channels, output_channels,
-                             batch_size, use_bias, group, gc, dc):
+                             batch_size, use_bias, group, sum_add, gc, dc):
         conv_S0 = core.CreateOperator(
             "Conv",
             ["SX0", "Sw0", "Sb0"] if use_bias else ["SX0", "Sw0"],
@@ -289,7 +291,7 @@ class ConvFusionTest(hu.HypothesisTestCase):
             device_option=dc[0]
         )
         sum = core.CreateOperator(
-            "Sum",
+            sum_add,
             ["S0", "Y0"],
             ["S0"],
             device_option=dc[0]


### PR DESCRIPTION
Enable conv+add fusion, same as conv+sum

Caution: only element-wise add is supported on IDEEP without scalar
broadcast. Otherwise, the fusion is illegal.

