### PR TITLE
Make btriunpack work for high dimensional batches and faster than before

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1814,6 +1814,10 @@ class TestCuda(TestCase):
         _TestTorchMixin._test_btrisolve(self, lambda t: t.cuda())
 
     @skipIfRocm
+    def test_btriunpack(self):
+        _TestTorchMixin._test_btriunpack(self, lambda t: t.cuda())
+
+    @skipIfRocm
     def test_dim_reduction(self):
         _TestTorchMixin._test_dim_reduction(self, lambda t: t.cuda())
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1603,6 +1603,24 @@ class _TestTorchMixin(object):
     def test_btrisolve(self):
         self._test_btrisolve(self, lambda t: t)
 
+    @staticmethod
+    def _test_btriunpack(self, cast):
+        def run_test(shape, cast):
+            a = cast(torch.randn(*shape))
+            a_lu, p = torch.btrifact(a.reshape(-1, shape[-1], shape[-1]))
+            a_lu = a_lu.reshape_as(a)
+            p = p.reshape(a.shape[:-1])
+            p_ref, l_ref, u_ref = torch.btriunpack(a_lu, p)
+            self.assertEqual(p_ref.matmul(l_ref.matmul(u_ref)), a)
+
+        run_test((5, 3, 3), cast)
+        run_test((7, 3, 5, 5), cast)
+        run_test((7, 5, 3, 3, 3), cast)
+
+    @skipIfNoLapack
+    def test_btriunpack(self):
+        self._test_btriunpack(self, lambda t: t)
+
     def test_bmm(self):
         num_batches = 10
         M, N, O = 23, 8, 12

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -3,6 +3,7 @@ import torch.nn.functional as F
 from torch._six import inf
 from operator import mul
 from functools import reduce
+from itertools import product
 import math
 import warnings
 
@@ -95,28 +96,26 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
         >>> A_ = torch.bmm(P, torch.bmm(A_L, A_U))
     """
 
-    nBatch, sz, _ = LU_data.size()
+    sz = LU_data.size(-1)
 
     if unpack_data:
-        I_U = torch.triu(torch.ones(sz, sz)).type_as(LU_data).byte().unsqueeze(0).expand(nBatch, sz, sz)
-        I_L = 1 - I_U
-        L = LU_data.new(LU_data.size()).zero_()
-        U = LU_data.new(LU_data.size()).zero_()
-        I_diag = torch.eye(sz).type_as(LU_data).byte().unsqueeze(0).expand(nBatch, sz, sz)
-        L[I_diag] = 1.0
-        L[I_L] = LU_data[I_L]
-        U[I_U] = LU_data[I_U]
+        I_U = torch.ones(sz, sz, device=LU_data.device, dtype=torch.uint8).triu_().expand_as(LU_data)
+        zero = torch.tensor(0.).type_as(LU_data)
+        U = torch.where(I_U, LU_data, zero)
+        L = torch.where(I_U, zero, LU_data)
+        L.diagonal(dim1=-2, dim2=-1).fill_(1)
     else:
         L = U = None
 
     if unpack_pivots:
-        P = torch.eye(sz).type_as(LU_data).unsqueeze(0).repeat(nBatch, 1, 1)
-        for i in range(nBatch):
-            for j in range(sz):
-                k = int(LU_pivots[i, j] - 1)
-                t = P[i, :, j].clone()
-                P[i, :, j] = P[i, :, k]
-                P[i, :, k] = t
+        P = torch.eye(sz, device=LU_data.device, dtype=LU_data.dtype).expand_as(LU_data).clone()
+        LU_pivots = LU_pivots - 1
+        for idx in product(*map(lambda x: list(range(x)), LU_data.shape[:-2])):
+            final_order = list(range(sz))
+            for k, j in enumerate(LU_pivots[idx]):
+              final_order[k], final_order[j] = final_order[j], final_order[k]
+            P[idx] = P[idx][final_order]
+        P = P.transpose(-2, -1)  # This is because we permuted the rows in the previous operation
     else:
         P = None
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -113,7 +113,7 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
         for idx in product(*map(lambda x: list(range(x)), LU_data.shape[:-2])):
             final_order = list(range(sz))
             for k, j in enumerate(LU_pivots[idx]):
-              final_order[k], final_order[j] = final_order[j], final_order[k]
+                final_order[k], final_order[j] = final_order[j], final_order[k]
             P[idx] = P[idx][final_order]
         P = P.transpose(-2, -1)  # This is because we permuted the rows in the previous operation
     else:

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -114,8 +114,7 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
             final_order = list(range(sz))
             for k, j in enumerate(LU_pivots[idx]):
                 final_order[k], final_order[j] = final_order[j], final_order[k]
-            P[idx] = P[idx][final_order]
-        P = P.transpose(-2, -1)  # This is because we permuted the rows in the previous operation
+            P[idx] = P[idx].index_select(1, torch.tensor(final_order))
     else:
         P = None
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -114,7 +114,7 @@ def btriunpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
             final_order = list(range(sz))
             for k, j in enumerate(LU_pivots[idx]):
                 final_order[k], final_order[j] = final_order[j], final_order[k]
-            P[idx] = P[idx].index_select(1, torch.tensor(final_order))
+            P[idx] = P[idx].index_select(1, torch.as_tensor(final_order, device=LU_pivots.device))
     else:
         P = None
 


### PR DESCRIPTION
Changelog:
- Optimize btriunpack by using `torch.where` instead of indexing, inplace operations instead of out place operations and avoiding costly permutations by computing the final permutation over a list.

Test plan:
- Added tests for btriunpack in test_torch.py (and a port to test_cuda.py)

This should help unblock testing in #14964 . I created a separate PR so that reviewing can be done efficiently.
