### PR TITLE
[sparse] sparse.add and sparse.sub

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2275,7 +2275,8 @@
 
 # NOTE [Masked SparseTensor APIs]
 #
-# This includes all sparse APIs under 'torch.sparse.*'
+# Masked SparseTensor APIs treats SparseTensor inputs as masked tensor, such that only nnz locations
+# will engage in computations performed by an operator. All maked SparseTensor APIs are under 'torch.sparse.*'.
 
 - func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -2299,6 +2300,11 @@
   dispatch:
     SparseCPU: _sparse_add_cpu
     SparseCUDA: _sparse_add_cuda
+
+- func: _sparse_add(Tensor self, Scalar other, *, Scalar alpha=1) -> Tensor
+  dispatch:
+    SparseCPU: _sparse_add_scalar
+    SparseCUDA: _sparse_add_scalar
 
 - func: numel(Tensor self) -> int64_t
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1193,8 +1193,6 @@
 
 - func: mm_out(Tensor result, Tensor self, Tensor mat2) -> Tensor
 
-- func: _sparse_mm(Tensor sparse, Tensor dense) -> Tensor
-
 - func: mode(Tensor self, int64_t dim=-1, bool keepdim=false) -> (Tensor, Tensor)
   variants: function, method
 
@@ -1870,20 +1868,6 @@
     SparseCPU: norm_sparse
     SparseCUDA: norm_sparse
 
-# TODO: reduce signatures down to one when optional args is available
-- func: _sparse_sum(Tensor self) -> Tensor
-
-- func: _sparse_sum(Tensor self, *, ScalarType dtype) -> Tensor
-
-- func: _sparse_sum(Tensor self, IntList[1] dim) -> Tensor
-
-- func: _sparse_sum(Tensor self, IntList[1] dim, *, ScalarType dtype) -> Tensor
-
-- func: _sparse_sum_backward(Tensor grad, Tensor self, IntList dim) -> Tensor
-  dispatch:
-      SparseCPU: _sparse_sum_backward_cpu
-      SparseCUDA: _sparse_sum_backward_cuda
-
 - func: norm(Tensor self, Scalar p=2) -> Tensor
   variants: function, method
 
@@ -1987,8 +1971,6 @@
   dispatch:
     CPU: s_addmm_sparse_dense_cpu_
     CUDA: s_addmm_sparse_dense_cuda_
-
-- func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -2290,6 +2272,33 @@
     SparseCPU: copy_sparse_
     SparseCUDA: copy_sparse_
   requires_tensor: True
+
+# NOTE [Masked SparseTensor APIs]
+#
+# This includes all sparse APIs under 'torch.sparse.*'
+
+- func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+
+- func: _sparse_mm(Tensor sparse, Tensor dense) -> Tensor
+
+# TODO: reduce signatures down to one when optional args is available
+- func: _sparse_sum(Tensor self) -> Tensor
+
+- func: _sparse_sum(Tensor self, *, ScalarType dtype) -> Tensor
+
+- func: _sparse_sum(Tensor self, IntList[1] dim) -> Tensor
+
+- func: _sparse_sum(Tensor self, IntList[1] dim, *, ScalarType dtype) -> Tensor
+
+- func: _sparse_sum_backward(Tensor grad, Tensor self, IntList dim) -> Tensor
+  dispatch:
+      SparseCPU: _sparse_sum_backward_cpu
+      SparseCUDA: _sparse_sum_backward_cuda
+
+- func: _sparse_add(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+  dispatch:
+    SparseCPU: _sparse_add_cpu
+    SparseCUDA: _sparse_add_cuda
 
 - func: numel(Tensor self) -> int64_t
   variants: function, method

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -310,6 +310,10 @@ SparseTensor _sparse_add_cpu(const SparseTensor& t_, const SparseTensor& src_, S
   // TODO: handle type promotion
   AT_CHECK(t_.type() == src_.type(), "input SparseTensor 't' and 'src' must share the same type, but got t.type = ", t_.type(), " and src.type = ", src_.type());
 
+  if (t_._nnz() == 0 || src_._nnz() == 0) {
+    return t_.clone();
+  }
+
   auto t = t_.coalesce();
   auto src = src_.coalesce();
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -302,6 +302,22 @@ SparseTensor& add_out_sparse_cpu(SparseTensor& r, const SparseTensor& t, const S
 // which will coalesce input tensors. However, all these rely on other components
 // to work for model training on masked SparsesTenors, such as 'optimizer'.
 // --------------------------------------------------------------------
+SparseTensor _sparse_add_scalar(const SparseTensor& t_, Scalar src, Scalar alpha) {
+  AT_ASSERT(t_.is_sparse());
+
+  if (t_._nnz() == 0) {
+    return t_.clone();
+  }
+
+  auto t = t_.coalesce();
+
+  Tensor r_values = at::add(t._values(), src, alpha);
+  SparseTensor r = at::_sparse_coo_tensor_with_dims_and_tensors(t.sparse_dim(), t.dense_dim(), t.sizes(), t._indices().clone(), r_values, t.options());
+  r._coalesced_(true);
+  return r;
+}
+
+
 SparseTensor _sparse_add_cpu(const SparseTensor& t_, const SparseTensor& src_, Scalar alpha) {
   AT_ASSERT(t_.is_sparse());
   AT_ASSERT(src_.is_sparse());

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -306,7 +306,7 @@ SparseTensor _sparse_add_scalar(const SparseTensor& t_, Scalar src, Scalar alpha
   AT_ASSERT(t_.is_sparse());
 
   if (t_._nnz() == 0) {
-    return t_.clone();
+    return t_;
   }
 
   auto t = t_.coalesce();
@@ -327,7 +327,7 @@ SparseTensor _sparse_add_cpu(const SparseTensor& t_, const SparseTensor& src_, S
   AT_CHECK(t_.type() == src_.type(), "input SparseTensor 't' and 'src' must share the same type, but got t.type = ", t_.type(), " and src.type = ", src_.type());
 
   if (t_._nnz() == 0 || src_._nnz() == 0) {
-    return t_.clone();
+    return t_;
   }
 
   auto t = t_.coalesce();

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -345,7 +345,7 @@ SparseTensor _sparse_add_cpu(const SparseTensor& t_, const SparseTensor& src_, S
   auto dims_to_flatten = std::vector<int64_t>();
 
   // check all dense dims have same size between t and src
-  for (int64_t i = t_sizes_v.size()-1; i > t_sparse_dim; i--) {
+  for (int64_t i = t_sizes_v.size()-1; i >= t_sparse_dim; i--) {
     if (t_sizes_v[i] != src_sizes_v[i]) {
       AT_ERROR("add: expected dense dims to have same size between t and src SparseTensors");
     }

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -534,7 +534,7 @@ SparseTensor _sparse_add_cuda(const SparseTensor& t_, const SparseTensor& src_, 
   auto t_indices_ti = getTensorInfo<int64_t, int64_t>(t_indices_1D);
   auto t_indices_pos_ti = getTensorInfo<int64_t, int64_t>(t_indices_pos);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(t_values.type(), "_sparse_add_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(t_values.type(), "_sparse_add_cuda", [&] {
     auto src_values_ti = getTensorInfo<scalar_t, int64_t>(src_values);
     auto t_values_ti = getTensorInfo<scalar_t, int64_t>(t_values);
     auto r_values_ti = getTensorInfo<scalar_t, int64_t>(r_values);

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -452,6 +452,10 @@ SparseTensor _sparse_add_cuda(const SparseTensor& t_, const SparseTensor& src_, 
   // TODO: handle type promotion
   AT_CHECK(t_.type() == src_.type(), "add: input SparseTensor 't' and 'src' must share the same type, but got t.type = ", t_.type(), " and src.type = ", src_.type());
 
+  if (t_._nnz() == 0 || src_._nnz() == 0) {
+    return t_.clone();
+  }
+
   auto t = t_.coalesce();
   auto src = src_.coalesce();
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -471,7 +471,7 @@ SparseTensor _sparse_add_cuda(const SparseTensor& t_, const SparseTensor& src_, 
   auto dims_to_flatten = std::vector<int64_t>();
 
   // check all dense dims have same size between t and src
-  for (int64_t i = t_sizes_v.size()-1; i > t_sparse_dim; i--) {
+  for (int64_t i = t_sizes_v.size()-1; i >= t_sparse_dim; i--) {
     if (t_sizes_v[i] != src_sizes_v[i]) {
       AT_ERROR("add: expected dense dims to have same size between t and src SparseTensors");
     }
@@ -492,8 +492,8 @@ SparseTensor _sparse_add_cuda(const SparseTensor& t_, const SparseTensor& src_, 
 
   LongTensor t_indices = t._indices();
   LongTensor src_indices = src._indices();
-  Tensor t_values = t._values();
-  Tensor src_values = src._values();
+  Tensor t_values = t._values().contiguous();
+  Tensor src_values = src._values().contiguous();
   int64_t t_nnz = t._nnz();
   int64_t src_nnz = src._nnz();
   Tensor r_values = at::empty_like(t_values);

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -510,9 +510,6 @@ SparseTensor _sparse_add_cuda(const SparseTensor& t_, const SparseTensor& src_, 
   LongTensor src_indices_1D = flatten_indices_by_dims(src_indices, src_sizes, dims_to_flatten);  // already sorted since only dims with size = 1 are not flattened
   LongTensor t_indices_pos = at::empty_like(t_indices_1D); // store lower_bound of input indices at grad indices
 
-  // std::cout << "t_indices_1D: " << t_indices_1D << std::endl;
-  // std::cout << "src_indices_1D: " << src_indices_1D << std::endl;
-
   thrust_ptr t_indices_iter(t_indices_1D.data<int64_t>());
   thrust_ptr src_indices_iter(src_indices_1D.data<int64_t>());
   thrust_ptr t_indices_pos_iter(t_indices_pos.data<int64_t>());
@@ -521,8 +518,6 @@ SparseTensor _sparse_add_cuda(const SparseTensor& t_, const SparseTensor& src_, 
                       src_indices_iter, src_indices_iter + src_nnz,
                       t_indices_iter, t_indices_iter + t_nnz,
                       t_indices_pos_iter);
-
-  // std::cout << "t_indices_pos: " << t_indices_pos << std::endl;
 
   // config to run cuda kernel
   int64_t total_threads = t_nnz;

--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -139,7 +139,16 @@ Therefore, representation of a SparseTensor of sparse_dim = 0 is simply a dense 
 
 Functions
 ----------------------------------
+Here shows function APIs for Masked SparseTensor, where operations will only be
+applied to nnz locations of SparseTensor inputs. This implies some operations
+will be mathematically inconsistent with dense counterpart. For instance, given
+a tensor of ``a = torch.tensor([1, 0, 2])``, ``torch.add(a, 1)`` outputs
+``torch.tensor([2, 1, 3])``, while a Masked SparseTensor op ``torch.sparse.add(a.to_sparse(), 1).to_dense()``
+outputs ``torch.tensor([2, 0, 3])``. These APIs will be very useful for Graph Network
+models and applications.
 
+.. autofunction:: torch.sparse.add
 .. autofunction:: torch.sparse.addmm
 .. autofunction:: torch.sparse.mm
 .. autofunction:: torch.sparse.sum
+.. autofunction:: torch.sparse.sub

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -957,6 +957,7 @@ class TestSparse(TestCase):
 
         test_add(10, 2, [2, 3, 4], [2, 3, 4])
         test_add(10, 2, [2, 3, 4], [2, 1, 4])
+        test_add(10, 2, [2, 3, 4], [1, 3, 4])
 
         def test_sub(nnz, sparse_dim, sizes1, sizes2):
             S1 = self._gen_sparse(sparse_dim, nnz, sizes1)[0]
@@ -977,6 +978,15 @@ class TestSparse(TestCase):
 
         test_sub(10, 2, [2, 3, 4], [2, 3, 4])
         test_sub(10, 2, [2, 3, 4], [2, 1, 4])
+        test_sub(10, 2, [2, 3, 4], [1, 3, 4])
+
+        # TODO:
+        # 1. test empty inputs
+        # 2. test inputs with shapes that are not broadcastable
+        #    1) len(S1.sizes()) < len(S2.sizes())
+        #    2) (2,3,4) vs (2,2,4)
+        #    3) (2,3,4) vs (3,4)  -> unsqueeze is needed
+        # 3. test differed dtypes
 
     def test_norm(self):
         def test_shape(sparse_dims, nnz, with_size):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -951,6 +951,10 @@ class TestSparse(TestCase):
             D3.masked_fill_(mask, 0)
             self.assertEqual(S3.to_dense(), D3)
 
+            def f(S1, S2):
+                return torch.sparse.add(S1, S2).to_dense()
+            gradcheck(f, (S1.requires_grad_(True), S2), check_sparse_nnz=True)
+
         test_add(10, 2, [2, 3, 4], [2, 3, 4])
         test_add(10, 2, [2, 3, 4], [2, 1, 4])
 
@@ -966,6 +970,10 @@ class TestSparse(TestCase):
             D3 = D1 - D2
             D3.masked_fill_(mask, 0)
             self.assertEqual(S3.to_dense(), D3)
+
+            def f(S1, S2):
+                return torch.sparse.sub(S1, S2).to_dense()
+            gradcheck(f, (S1.requires_grad_(True), S2), check_sparse_nnz=True)
 
         test_sub(10, 2, [2, 3, 4], [2, 3, 4])
         test_sub(10, 2, [2, 3, 4], [2, 1, 4])

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -935,6 +935,41 @@ class TestSparse(TestCase):
         self._test_spadd_shape(0, [50, 30, 0], [2, 0])
         self._test_spadd_shape(10, [50, 30, 20], [2, 0])
 
+    @skipIfRocm
+    def test_sparse_add_sub(self):
+
+        def test_add(nnz, sparse_dim, sizes1, sizes2):
+            S1 = self._gen_sparse(sparse_dim, nnz, sizes1)[0]
+            S2 = self._gen_sparse(sparse_dim, nnz, sizes2)[0]
+            S3 = torch.sparse.add(S1, S2)
+
+            D1 = S1.to_dense()
+            D2 = S2.to_dense()
+            mask = (D1 == 0)
+
+            D3 = D1 + D2
+            D3.masked_fill_(mask, 0)
+            self.assertEqual(S3.to_dense(), D3)
+
+        test_add(10, 2, [2, 3, 4], [2, 3, 4])
+        test_add(10, 2, [2, 3, 4], [2, 1, 4])
+
+        def test_sub(nnz, sparse_dim, sizes1, sizes2):
+            S1 = self._gen_sparse(sparse_dim, nnz, sizes1)[0]
+            S2 = self._gen_sparse(sparse_dim, nnz, sizes2)[0]
+            S3 = torch.sparse.sub(S1, S2)
+
+            D1 = S1.to_dense()
+            D2 = S2.to_dense()
+            mask = (D1 == 0)
+
+            D3 = D1 - D2
+            D3.masked_fill_(mask, 0)
+            self.assertEqual(S3.to_dense(), D3)
+
+        test_sub(10, 2, [2, 3, 4], [2, 3, 4])
+        test_sub(10, 2, [2, 3, 4], [2, 1, 4])
+
     def test_norm(self):
         def test_shape(sparse_dims, nnz, with_size):
             x, _, _ = self._gen_sparse(sparse_dims, nnz, with_size)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -996,6 +996,12 @@ class TestSparse(TestCase):
         S2 = S2.to(dtype=torch.double)
         self.assertRaises(RuntimeError, lambda: torch.sparse.add(S1, S2))
 
+        # raise at dense size mismatch
+        S1 = self._gen_sparse(2, 5, [3, 4, 5])[0]
+        S2 = self._gen_sparse(2, 5, [3, 1, 1])[0]
+        self.assertRaises(RuntimeError, lambda: torch.sparse.add(S1, S2))
+        self.assertRaises(RuntimeError, lambda: torch.sparse.sub(S1, S2))
+
     def test_norm(self):
         def test_shape(sparse_dims, nnz, with_size):
             x, _, _ = self._gen_sparse(sparse_dims, nnz, with_size)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -867,7 +867,10 @@
   dense: mm_mat2_backward(grad, sparse, dense.sizes(), dense.strides(), alpha)
 
 - name: _sparse_add(Tensor self, Tensor other, *, Scalar alpha)
-  self: grad
+  self: _sparse_add_backward(grad, self)
+
+- name: _sparse_add(Tensor self, Scalar other, *, Scalar alpha)
+  self: _sparse_add_backward(grad, self)
 
 - name: _standard_gamma(Tensor self, Generator generator)
   self: grad * _standard_gamma_grad(self, result)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -117,11 +117,6 @@
   mat1: mm_mat1_backward(grad, mat2, mat1, alpha)
   mat2: mm_mat2_backward(grad, mat1, mat2.sizes(), mat2.strides(), alpha)
 
-- name: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta, Scalar alpha)
-  self: maybe_multiply(grad, beta)
-  sparse: _sparse_addmm_sparse_backward(grad, sparse, dense, alpha)
-  dense: mm_mat2_backward(grad, sparse, dense.sizes(), dense.strides(), alpha)
-
 - name: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta, Scalar alpha)
   self: maybe_multiply(grad, beta)
   mat: grad.ger(vec) * alpha
@@ -861,8 +856,18 @@
 - name: _sparse_coo_tensor_with_dims_and_tensors(int64_t sparse_dim, int64_t dense_dim, IntList size, Tensor indices, Tensor values, TensorOptions options)
   values: sparse_constructor_values_backward(grad, indices, values.sizes())
 
+# masked SparseTensor APIs backward
+
 - name: _sparse_sum(Tensor self, IntList dim)
   self: at::_sparse_sum_backward(grad, self, dim)
+
+- name: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta, Scalar alpha)
+  self: maybe_multiply(grad, beta)
+  sparse: _sparse_addmm_sparse_backward(grad, sparse, dense, alpha)
+  dense: mm_mat2_backward(grad, sparse, dense.sizes(), dense.strides(), alpha)
+
+- name: _sparse_add(Tensor self, Tensor other, *, Scalar alpha)
+  self: grad
 
 - name: _standard_gamma(Tensor self, Generator generator)
   self: grad * _standard_gamma_grad(self, result)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -523,6 +523,11 @@ Tensor _sparse_addmm_sparse_backward(const Tensor& grad, const Tensor& sparse_, 
   return grad_sparse.sparse_mask(at::SparseTensorRef(sparse));
 }
 
+Tensor _sparse_add_backward(const Tensor& grad, const Tensor& t) {
+  AT_ASSERT(grad.is_sparse());
+  return grad.coalesce();
+}
+
 Tensor renorm_backward(const Tensor & grad, const Tensor & self, Scalar p, int64_t dim, Scalar maxnorm) {
   auto transposed_sizes = self.transpose(dim, 0).sizes().vec();
   auto flatten = [&](const Tensor & t) {

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -525,7 +525,8 @@ Tensor _sparse_addmm_sparse_backward(const Tensor& grad, const Tensor& sparse_, 
 
 Tensor _sparse_add_backward(const Tensor& grad, const Tensor& t) {
   AT_ASSERT(grad.is_sparse());
-  return grad.coalesce();
+  AT_ASSERT(grad.is_coalesced());
+  return grad;
 }
 
 Tensor renorm_backward(const Tensor & grad, const Tensor & self, Scalar p, int64_t dim, Scalar maxnorm) {

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -145,6 +145,9 @@ def add(input, other):
     For a sparse dim ``i``, if ``sizes(i)`` differs, then ``input.sizes(i) > 1``
     and ``other.sizes(i) == 1``.
 
+    Backward supports for :attr:`input` but not :attr:`other`. Note that
+    the gradients of :attr:`input` is coalesced.
+
     Args:
         input (SparseTensor): the first input SparseTensor
         other (SparseTensor): the second input SparseTensor
@@ -163,6 +166,9 @@ def sub(input, other):
     on sparse dims, and requires dense dims to be the same between two inputs.
     For a sparse dim ``i``, if ``sizes(i)`` differs, then ``input.sizes(i) > 1``
     and ``other.sizes(i) == 1``.
+
+    Backward supports for :attr:`input` but not :attr:`other`. Note that
+    the gradients of :attr:`input` is coalesced.
 
     Args:
         input (SparseTensor): the first input SparseTensor

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -5,6 +5,8 @@ __all__ = [
     'addmm',
     'mm',
     'sum',
+    'add',
+    'sub',
 ]
 
 
@@ -132,3 +134,41 @@ def sum(input, dim=None, dtype=None):
             return torch._sparse_sum(input, dim, dtype=dtype)
         else:
             return torch._sparse_sum(input, dtype=dtype)
+
+
+def add(input, other):
+    r"""
+    Element of the SparseTensor :attr:`other` is added to corresponding
+    locations of SparseTensor :attr:`input`. The number of dims must be
+    the same between two inputs tensors. This operation supports broadcasting
+    on sparse dims, and requires dense dims to be the same between two inputs.
+    For a sparse dim ``i``, if ``sizes(i)`` differs, then ``input.sizes(i) > 1``
+    and ``other.sizes(i) == 1``.
+
+    Args:
+        input (SparseTensor): the first input SparseTensor
+        other (SparseTensor): the second input SparseTensor
+
+    Example::
+
+    """
+    return torch._sparse_add(input, other, alpha=1)
+
+
+def sub(input, other):
+    r"""
+    Element of the SparseTensor :attr:`other` is subtracted from corresponding
+    locations of SparseTensor :attr:`input`. The number of dims must be
+    the same between two inputs tensors. This operation supports broadcasting
+    on sparse dims, and requires dense dims to be the same between two inputs.
+    For a sparse dim ``i``, if ``sizes(i)`` differs, then ``input.sizes(i) > 1``
+    and ``other.sizes(i) == 1``.
+
+    Args:
+        input (SparseTensor): the first input SparseTensor
+        other (SparseTensor): the second input SparseTensor
+
+    Example::
+
+    """
+    return torch._sparse_add(input, other, alpha=-1)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -150,7 +150,7 @@ def add(input, other):
 
     Args:
         input (SparseTensor): the first input SparseTensor
-        other (SparseTensor): the second input SparseTensor
+        other (SparseTensor or a scalar): the value to add to input
 
     Example::
 
@@ -172,7 +172,7 @@ def sub(input, other):
 
     Args:
         input (SparseTensor): the first input SparseTensor
-        other (SparseTensor): the second input SparseTensor
+        other (SparseTensor or a scalar): the value to add to input
 
     Example::
 

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -153,7 +153,52 @@ def add(input, other):
         other (SparseTensor or a scalar): the value to add to input
 
     Example::
+        >>> nnz = 4
+        >>> dims1 = [2, 2]
+        >>> I = torch.cat([torch.randint(0, dims1[0], size=(nnz,)),
+                           torch.randint(0, dims1[1], size=(nnz,)),], 0).reshape(2, nnz)
+        >>> V = torch.rand(nnz)
+        >>> S1 = torch.sparse_coo_tensor(I, V, dims1)
+        >>> S1
+        tensor(indices=tensor([[0, 0, 0, 1],
+                               [0, 1, 0, 0]]),
+               values=tensor([0.7437, 0.2626, 0.9034, 0.0787]),
+               size=(2, 2), nnz=4, layout=torch.sparse_coo)
 
+        >>> dims2 = [2, 1]
+        >>> I = torch.cat([torch.randint(0, dims2[0], size=(nnz,)),
+                           torch.randint(0, dims2[1], size=(nnz,)),], 0).reshape(2, nnz)
+        >>> V = torch.rand(nnz)
+        >>> S2 = torch.sparse_coo_tensor(I, V, dims2)
+        >>> S2
+        tensor(indices=tensor([[1, 0, 1, 1],
+                               [0, 0, 0, 0]]),
+               values=tensor([0.8652, 0.6640, 0.2394, 0.8972]),
+               size=(2, 1), nnz=4, layout=torch.sparse_coo)
+
+        >>> S3 = torch.sparse.add(S1, S2)
+        >>> S3
+        tensor(indices=tensor([[0, 0, 1],
+                               [0, 1, 0]]),
+               values=tensor([2.3111, 0.9266, 2.0804]),
+               size=(2, 2), nnz=3, layout=torch.sparse_coo)
+
+        # add a scalar
+        >>> I = torch.cat([torch.randint(0, dims1[0], size=(nnz,)),
+                           torch.randint(0, dims1[1], size=(nnz,)),], 0).reshape(2, nnz)
+        >>> V = torch.rand(nnz)
+        >>> S4 = torch.sparse_coo_tensor(I, V, dims1)
+        >>> S4
+        tensor(indices=tensor([[0, 1, 1, 1],
+                               [1, 1, 0, 0]]),
+               values=tensor([0.0945, 0.3280, 0.7648, 0.8265]),
+               size=(2, 2), nnz=4, layout=torch.sparse_coo)
+
+        >>> torch.sparse.add(S1, 1)
+            tensor(indices=tensor([[0, 1, 1],
+                                   [1, 0, 1]]),
+                   values=tensor([1.0945, 2.5913, 1.3280]),
+                   size=(2, 2), nnz=3, layout=torch.sparse_coo)
     """
     return torch._sparse_add(input, other, alpha=1)
 
@@ -173,8 +218,5 @@ def sub(input, other):
     Args:
         input (SparseTensor): the first input SparseTensor
         other (SparseTensor or a scalar): the value to add to input
-
-    Example::
-
     """
     return torch._sparse_add(input, other, alpha=-1)


### PR DESCRIPTION
- add `sparse.add(S1, S2)` and `sparse.sub(S1, S2)` with broadcasting on sparse dims
- support autograd and has backward for S1
- currently only support inputs with the same number of dims
- sparse sizes of S1 and S2 are broadcasting when either of them is true at any sparse dim `i`:
    - `S1.sizes(i) == S2.sizes(i)`
    -  `S1.sizes(i) > 1 &&  S2.sizes(i) == 1`