### PR TITLE
Fix _apply in nn.Module

### DIFF
--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -449,7 +449,7 @@ class TestCppExtension(common.TestCase):
         sequential.to(old_dtype)
         self.assertEqual(sequential[2].parameters()[0].dtype, old_dtype)
 
-        # Make sure we can access these method recursively.
+        # Make sure we can access these methods recursively.
         self.assertEqual(len(list(sequential.parameters())), len(net.parameters()) * 2 + 1)
         self.assertEqual(len(list(sequential.named_parameters())), len(net.named_parameters()) * 2 + 1)
         self.assertEqual(len(list(sequential.buffers())), len(net.buffers()) * 2)
@@ -551,6 +551,22 @@ class TestCppExtension(common.TestCase):
             self.assertTrue(p.device.type == "cuda")
             self.assertTrue(p.device.index == 0)
             self.assertEqual(cpu_parameters[i], p)
+
+        net.cpu()
+        net.add_new_parameter("a", torch.eye(5))
+        net.add_new_parameter("b", torch.eye(5))
+        net.add_new_buffer("c", torch.eye(5))
+        net.add_new_buffer("d", torch.eye(5))
+        net.add_new_submodule("fc2")
+        net.add_new_submodule("fc3")
+
+        for p in net.parameters():
+            self.assertTrue(p.device.type == "cpu")
+
+        net.cuda()
+
+        for p in net.parameters():
+            self.assertTrue(p.device.type == "cuda")
 
     def test_returns_shared_library_path_when_is_python_module_is_true(self):
         source = """


### PR DESCRIPTION
Fixes an issue that arose from https://github.com/pytorch/pytorch/pull/13481 where `.shared_memory()` couldn't be called. Effectively undoes all changes to `nn.Module` from that PR and solve the relevant problem in a different way (the goal was to be able to call `._apply()` on the Python wrapper for a C++ module).

@soumith 