### PR TITLE
[wip] Separate targets for c10 modules

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -22,62 +22,24 @@ configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/macros/cmake_macros.h.in
     ${CMAKE_BINARY_DIR}/c10/macros/cmake_macros.h)
 
+function(c10_setup_visibility TARGET)
+  # If building shared library, set dllimport/dllexport proper.
+  target_compile_options(${TARGET} PRIVATE "-DC10_BUILD_MAIN_LIB")
+  # Enable hidden visibility if compiler supports it.
+  if (${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})
+    target_compile_options(${TARGET} PRIVATE "-fvisibility=hidden")
+  endif()
+endfunction()
+
+add_subdirectory(util)
+add_subdirectory(core)
+add_subdirectory(test)
+
 # Note: if you want to add ANY dependency to the c10 library, make sure you
 # check with the core PyTorch developers as the dependendency will be
 # transitively passed on to all libraries dependent on PyTorch.
-file(GLOB C10_SRCS
-        *.cpp
-        core/*.cpp
-        core/dispatch/*.cpp
-        core/opschema/*.cpp
-        core/impl/*.cpp
-        macros/*.cpp
-        util/*.cpp
-        )
-file(GLOB_RECURSE C10_ALL_TEST_FILES test/*.cpp)
-file(GLOB_RECURSE C10_HEADERS *.h)
-add_library(c10 ${C10_SRCS} ${C10_HEADERS})
-# If building shared library, set dllimport/dllexport proper.
-target_compile_options(c10 PRIVATE "-DC10_BUILD_MAIN_LIB")
-# Enable hidden visibility if compiler supports it.
-if (${COMPILER_SUPPORTS_HIDDEN_VISIBILITY})
-  target_compile_options(c10 PRIVATE "-fvisibility=hidden")
-endif()
-
-# ---[ Dependency of c10
-if (${USE_GFLAGS})
-   target_link_libraries(c10 PUBLIC gflags)
-endif()
-
-if (${USE_GLOG})
-    target_link_libraries(c10 PUBLIC glog::glog)
-endif()
-
-if (USE_NUMA)
-  if (NOT CAFFE2_DISABLE_NUMA)
-    message(STATUS "NUMA paths:")
-    message(STATUS ${Numa_INCLUDE_DIR})
-    message(STATUS ${Numa_LIBRARIES})
-    include_directories(SYSTEM ${Numa_INCLUDE_DIR})
-    target_link_libraries(c10 PRIVATE ${Numa_LIBRARIES})
-  else()
-    message(STATUS "NUMA is disabled")
-  endif()
-else()
-  message(STATUS "don't use NUMA")
-endif()
-
-if (ANDROID)
-    target_link_libraries(c10 PRIVATE log)
-endif()
-
-target_include_directories(
-    c10 PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>)
-
-add_subdirectory(test)
+add_library(c10 c10.h) # just use c10.h because we need at least one file in a library target
+target_link_libraries(c10 PUBLIC c10_util c10_core)
 
 if(USE_CUDA)
   add_subdirectory(cuda)

--- a/c10/core/CMakeLists.txt
+++ b/c10/core/CMakeLists.txt
@@ -1,0 +1,77 @@
+set(HEADERS
+  dispatch/DeviceId.h
+  dispatch/Dispatcher.h
+  dispatch/DispatchKey.h
+  dispatch/DispatchTable.h
+  dispatch/KernelRegistration.h
+  dispatch/LayoutId.h
+  dispatch/OpSchema.h
+  dispatch/OpSchemaRegistration.h
+  impl/DeviceGuardImplInterface.h
+  impl/FakeGuardImpl.h
+  impl/InlineDeviceGuard.h
+  impl/InlineStreamGuard.h
+  impl/VirtualGuardImpl.h
+  opschema/layer_norm.h
+  Allocator.h
+  Backend.h
+  CopyBytes.h
+  DefaultDtype.h
+  DefaultTensorOptions.h
+  Device.h
+  DeviceGuard.h
+  DeviceType.h
+  Layout.h
+  Scalar.h
+  ScalarType.h
+  ScalarTypeUtils.h
+  Storage.h
+  StorageImpl.h
+  Stream.h
+  StreamGuard.h
+  Tensor.h
+  TensorImpl.h
+  TensorOptions.h
+  TensorTypeId.h
+  TensorTypeIdRegistration.h
+  UndefinedTensorImpl.h
+  WrapDimMinimal.h
+)
+
+set(SOURCES
+  dispatch/DeviceId.cpp
+  dispatch/Dispatcher.cpp
+  dispatch/DispatchKey.cpp
+  dispatch/DispatchTable.cpp
+  dispatch/KernelRegistration.cpp
+  dispatch/LayoutId.cpp
+  dispatch/OpSchema.cpp
+  dispatch/OpSchemaRegistration.cpp
+  impl/DeviceGuardImplInterface.cpp
+  opschema/layer_norm.cpp
+  Allocator.cpp
+  CopyBytes.cpp
+  DefaultDtype.cpp
+  Device.cpp
+  DeviceType.cpp
+  Scalar.cpp
+  Storage.cpp
+  StorageImpl.cpp
+  Stream.cpp
+  TensorImpl.cpp
+  TensorOptions.cpp
+  TensorTypeId.cpp
+  TensorTypeIdRegistration.cpp
+  UndefinedTensorImpl.cpp
+)
+
+add_library(c10_core STATIC
+  ${HEADERS}
+  ${SOURCES}
+)
+
+c10_setup_visibility(c10_core)
+
+target_link_libraries(c10_core PUBLIC c10_util)
+
+install(TARGETS c10_core EXPORT Caffe2Targets DESTINATION lib)

--- a/c10/util/CMakeLists.txt
+++ b/c10/util/CMakeLists.txt
@@ -1,0 +1,93 @@
+set(HEADERS
+  AlignOf.h
+  ArrayRef.h
+  Backtrace.h
+  C++17.h
+  Exception.h
+  Flags.h
+  flat_hash_map.h
+  Half.h
+  IdWrapper.h
+  intrusive_ptr.h
+  LeftRight.h
+  logging_is_google_glog.h
+  logging_is_not_google_glog.h
+  Logging.h
+  Metaprogramming.h
+  numa.h
+  Optional.h
+  Registry.h
+  SmallVector.h
+  string_utils.h
+  StringUtil.h
+  Type.h
+  typeid.h
+  TypeList.h
+  TypeTraits.h
+  UniqueVoidPtr.h
+)
+
+set(SOURCES
+  Array.cpp
+  Backtrace.cpp
+  C++17.cpp
+  Exception.cpp
+  flags_use_gflags.cpp
+  flags_use_no_gflags.cpp
+  Half.cpp
+  intrusive_ptr.cpp
+  LeftRight.cpp
+  Logging.cpp
+  Metaprogramming.cpp
+  numa.cpp
+  Optional.cpp
+  SmallVector.cpp
+  StringUtil.cpp
+  Type.cpp
+  typeid.cpp
+  TypeList.cpp
+  TypeTraits.cpp
+  UniqueVoidPtr.cpp
+)
+
+add_library(c10_util STATIC
+  ${HEADERS}
+  ${SOURCES}
+)
+
+c10_setup_visibility(c10_util)
+
+target_include_directories(
+    c10_util PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>)
+
+# ---[ Dependency of c10
+if (${USE_GFLAGS})
+   target_link_libraries(c10_util PUBLIC gflags)
+endif()
+
+if (${USE_GLOG})
+    target_link_libraries(c10_util PUBLIC glog::glog)
+endif()
+
+if (ANDROID)
+    target_link_libraries(c10_util PRIVATE log)
+endif()
+
+if (USE_NUMA)
+  if (NOT CAFFE2_DISABLE_NUMA)
+    message(STATUS "NUMA paths:")
+    message(STATUS ${Numa_INCLUDE_DIR})
+    message(STATUS ${Numa_LIBRARIES})
+    include_directories(SYSTEM ${Numa_INCLUDE_DIR})
+    target_link_libraries(c10_util PRIVATE ${Numa_LIBRARIES})
+  else()
+    message(STATUS "NUMA is disabled")
+  endif()
+else()
+  message(STATUS "don't use NUMA")
+endif()
+
+install(TARGETS c10_util EXPORT Caffe2Targets DESTINATION lib)


### PR DESCRIPTION
- Split the c10 build target into c10/util and c10/core.
- Don't glob anymore