### PR TITLE
Replace resize_dim() with set_sizes_and_strides() in

### DIFF
--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -43,7 +43,7 @@ inline THStorage* THTensor_getStoragePtr(const THTensor* tensor) {
 inline void THTensor_maybe_zero_dim(THTensor *tensor, bool condition_when_zero_dim) {
   bool set_zero_dim = condition_when_zero_dim && tensor->sizes().size() == 1 && tensor->size(0) == 1;
   if (set_zero_dim) {
-    tensor->resize_dim(0);
+    tensor->set_sizes_and_strides({}, {});
   }
 }
 


### PR DESCRIPTION
Summary:
We have a function resize_dim() on TensorImpl in c10/core/TensorImpl.h which lets you change the dimensionality of a tensor, resizing both sizes and strides. Unfortunately, this API is fairly easy to misuse, because it fills in the new entries with garbage when you size it larger. We want to refactor the call sites to use set_sizes_and_strides() instead, so that there is never an intermediate tensor state where the sizes/strides don't make sense. In this diff, resize_dim() is
replaced with set_sizes_and_strides() in aten/src/TH/THTensor.hpp.

Differential Revision: D13505512
