### PR TITLE
Fix ODR violation in UndefinedTensorImpl

### DIFF
--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -3,6 +3,12 @@
 
 namespace c10 {
 
+// This *must* be in a .cpp file to not get ODR violations
+C10_EXPORT TensorImpl* UndefinedTensorImpl::singleton() {
+  static UndefinedTensorImpl _singleton;
+  return &_singleton;
+}
+
 // should this use the globalContext?  Can it get a context passed in somehow?
 UndefinedTensorImpl::UndefinedTensorImpl()
 : TensorImpl(UndefinedTensorId(), caffe2::TypeMeta(), nullptr, /* is variable */ false) {
@@ -35,6 +41,5 @@ int64_t UndefinedTensorImpl::storage_offset() const {
 IntList UndefinedTensorImpl::strides() const {
   AT_ERROR("strides() called on undefined Tensor");
 }
-UndefinedTensorImpl UndefinedTensorImpl::_singleton;
 
 }

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -6,17 +6,7 @@ namespace c10 {
 
 struct C10_API UndefinedTensorImpl final : public TensorImpl {
  public:
-  // Without this, we get:
-  //  error: identifier "at::UndefinedTensorImpl::_singleton" is undefined in device code
-  // (ostensibly because the constexpr tricks MSVC into trying to compile this
-  // function for device as well).
-#ifdef _WIN32
-  static inline TensorImpl * singleton() {
-#else
-  static constexpr inline TensorImpl * singleton() {
-#endif
-    return &_singleton;
-  }
+  static C10_API TensorImpl * singleton();
   IntList sizes() const override;
   IntList strides() const override;
   int64_t size(int64_t d) const override;
@@ -26,7 +16,6 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
   int64_t storage_offset() const override;
 private:
   UndefinedTensorImpl();
-  static UndefinedTensorImpl _singleton;
 public:
   friend struct UndefinedType;
 };

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -73,14 +73,14 @@ class C10_API intrusive_ptr_target {
 // some other compilers don't know about -Wterminate or -Wexceptions and
 // will show a warning about unknown warning options otherwise.
 #ifdef _MSC_VER
-#  pragma warning(push)  
-#  pragma warning(disable: 4297) // function assumed not to throw an exception but does  
-#else  
-#  pragma GCC diagnostic push  
-#  pragma GCC diagnostic ignored "-Wpragmas"  
-#  pragma GCC diagnostic ignored "-Wunknown-warning-option"  
-#  pragma GCC diagnostic ignored "-Wterminate"  
-#  pragma GCC diagnostic ignored "-Wexceptions"  
+#  pragma warning(push)
+#  pragma warning(disable: 4297) // function assumed not to throw an exception but does
+#else
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpragmas"
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#  pragma GCC diagnostic ignored "-Wterminate"
+#  pragma GCC diagnostic ignored "-Wexceptions"
 #endif
     AT_ASSERTM(
         refcount_.load() == 0,
@@ -89,9 +89,9 @@ class C10_API intrusive_ptr_target {
         weakcount_.load() == 0,
         "Tried to destruct an intrusive_ptr_target that still has weak_intrusive_ptr to it");
 #ifdef _MSC_VER
-#  pragma warning(pop)  
-#else  
-#  pragma GCC diagnostic pop  
+#  pragma warning(pop)
+#else
+#  pragma GCC diagnostic pop
 #endif
   }
 
@@ -154,13 +154,6 @@ class intrusive_ptr final {
 //  static_assert(
 //      std::is_base_of<intrusive_ptr_target, TTarget>::value,
 //      "intrusive_ptr can only be used for classes that inherit from intrusive_ptr_target.");
-#ifndef _WIN32
-  // This static_assert triggers on MSVC
-  //  error C2131: expression did not evaluate to a constant
-  static_assert(
-      NullType::singleton() == NullType::singleton(),
-      "NullType must have a constexpr singleton() method");
-#endif
   static_assert(
       std::is_same<TTarget*, decltype(NullType::singleton())>::value,
       "NullType::singleton() must return a element_type* pointer");
@@ -409,13 +402,7 @@ class weak_intrusive_ptr final {
   static_assert(
       std::is_base_of<intrusive_ptr_target, TTarget>::value,
       "intrusive_ptr can only be used for classes that inherit from intrusive_ptr_target.");
-#ifndef _WIN32
-  // This static_assert triggers on MSVC
-  //  error C2131: expression did not evaluate to a constant
-  static_assert(
-      NullType::singleton() == NullType::singleton(),
-      "NullType must have a constexpr singleton() method");
-#endif
+
   static_assert(
       std::is_same<TTarget*, decltype(NullType::singleton())>::value,
       "NullType::singleton() must return a element_type* pointer");


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#15369 Fix ODR violation in UndefinedTensorImpl**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13511379/)

This allows UndefinedTensorImpl to be used across library boundaries.
Without this, each library gets their own singleton instance causing memory corruption because undefined tensors aren't recognized correctly.

Note that this comes with a small performance penalty because the singleton pointer can't be accessed at compile time anymore.

Differential Revision: [D13511379](https://our.internmc.facebook.com/intern/diff/D13511379/)