### PR TITLE
[sparse] sparse.squeeze and sparse.unsqueeze

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -687,6 +687,10 @@ Tensor squeeze(const Tensor& self, int64_t dim) {
   int64_t dims = self.dim();
   dim = maybe_wrap_dim(dim, dims);
 
+  if (self.is_sparse()) {
+    return at::_sparse_squeeze(self, dim);
+  }
+
   if (dims == 0 || self.sizes()[dim] != 1) {
     return self.as_strided(self.sizes(), self.strides());
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1790,6 +1790,10 @@
   variants: method
   device_guard: false
 
+- func: _sparse_unsqueeze(Tensor self, int64_t dim) -> Tensor
+
+- func: _sparse_squeeze(Tensor self, int64_t dim) -> Tensor
+
 - func: var(Tensor self, bool unbiased=true) -> Tensor
   variants: function, method
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1795,8 +1795,14 @@
 - func: _sparse_unsqueeze_backward(Tensor grad, Tensor self, int64_t dim) -> Tensor
 
 - func: _sparse_squeeze(Tensor self, int64_t dim) -> Tensor
+  dispatch:
+    SparseCPU: _sparse_squeeze
+    SparseCUDA: _sparse_squeeze
 
 - func: _sparse_squeeze_backward(Tensor grad, Tensor self, int64_t dim) -> Tensor
+  dispatch:
+    SparseCPU: _sparse_squeeze_backward
+    SparseCUDA: _sparse_squeeze_backward
 
 - func: var(Tensor self, bool unbiased=true) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1792,7 +1792,11 @@
 
 - func: _sparse_unsqueeze(Tensor self, int64_t dim) -> Tensor
 
+- func: _sparse_unsqueeze_backward(Tensor grad, Tensor self, int64_t dim) -> Tensor
+
 - func: _sparse_squeeze(Tensor self, int64_t dim) -> Tensor
+
+- func: _sparse_squeeze_backward(Tensor grad, Tensor self, int64_t dim) -> Tensor
 
 - func: var(Tensor self, bool unbiased=true) -> Tensor
   variants: function, method

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -501,10 +501,20 @@ SparseTensor _sparse_squeeze(const SparseTensor& self, int64_t dim) {
   AT_ASSERT(self.is_sparse());
   dim = maybe_wrap_dim(dim, self.dim());
   auto sizes = self.sizes();
+
   if (sizes[dim] != 1) { // if dim is not squeezable, return a clone of input SparseTensor directly
     return self.clone();
   }
+
   int64_t sparse_dim = self.sparse_dim();
+
+  if (sparse_dim == 1 && dim == 0) {
+    // this should return a the values of a sparse, but we prefer to
+    // use SparseTensor.values() directly instead of SparseTensor.squeeze(0)
+    AT_ERROR("Cannot squeeze sparse_dim of a SparseTensor with sparse_dim = 1 and its size = 1, ",
+             "from which a dense tensor values() should be returned. Please use SparseTensor._values() directly");
+  }
+
   int64_t dense_dim = self.dense_dim();
   auto indices = self._indices();
   auto new_sizes = sizes.vec();

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -502,8 +502,8 @@ SparseTensor _sparse_squeeze(const SparseTensor& self, int64_t dim) {
   dim = maybe_wrap_dim(dim, self.dim());
   auto sizes = self.sizes();
 
-  if (sizes[dim] != 1) { // if dim is not squeezable, return a clone of input SparseTensor directly
-    return self.clone();
+  if (sizes[dim] != 1) { // if dim is not squeezable, return input SparseTensor directly
+    return self;
   }
 
   int64_t sparse_dim = self.sparse_dim();

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -726,10 +726,10 @@
   self: unsqueeze_to(grad, dim, self.sizes())
 
 - name: _sparse_squeeze(Tensor self, int64_t dim)
-  self: _sparse_squeeze_backward(grad, dim)
+  self: at::_sparse_squeeze_backward(grad, self, dim)
 
 - name: _sparse_unsqueeze(Tensor self, int64_t dim)
-  self: _sparse_unsqueeze_backward(grad, dim)
+  self: at::_sparse_unsqueeze_backward(grad, self, dim)
 
 - name: std(Tensor self, bool unbiased)
   self: var_backward(grad / (result * 2), self, unbiased)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -717,7 +717,7 @@
   self: unsqueeze_to(grad, self.sizes());
 
 - name: squeeze(Tensor self, int64_t dim)
-  self: unsqueeze_to(grad, dim, self.sizes())
+  self: squeeze_backward(grad, self, dim)
 
 - name: squeeze_(Tensor self)
   self: unsqueeze_to(grad, self.sizes());
@@ -833,7 +833,7 @@
   self: grad.reshape(self.sizes())
 
 - name: unsqueeze(Tensor self, int64_t dim)
-  self: grad.squeeze(dim)
+  self: unsqueeze_backward(grad, self, dim)
 
 - name: unsqueeze_(Tensor self, int64_t dim)
   self: grad.squeeze(dim)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -725,6 +725,12 @@
 - name: squeeze_(Tensor self, int64_t dim)
   self: unsqueeze_to(grad, dim, self.sizes())
 
+- name: _sparse_squeeze(Tensor self, int64_t dim)
+  self: _sparse_squeeze_backward(grad, dim)
+
+- name: _sparse_unsqueeze(Tensor self, int64_t dim)
+  self: _sparse_unsqueeze_backward(grad, dim)
+
 - name: std(Tensor self, bool unbiased)
   self: var_backward(grad / (result * 2), self, unbiased)
 

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -457,6 +457,28 @@ Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
   return self;
 }
 
+Tensor squeeze_backward(const Tensor& grad, const Tensor& t, int64_t dim) {
+  if (t.is_sparse()) {
+    return at::_sparse_squeeze_backward(grad, t, dim);
+  }
+  IntList t_sizes = t.sizes();
+  dim = at::maybe_wrap_dim(dim, t_sizes.size());
+  // in NumPy it's not an error to unsqueeze a scalar, but we still need to avoided
+  // unsqueezing in the backward.
+  if (t_sizes.size() > 0 && t_sizes[dim] == 1) {
+    return grad.unsqueeze(dim);
+  }
+  return grad;
+}
+
+Tensor unsqueeze_backward(const Tensor& grad, const Tensor& t, int64_t dim) {
+  if (t.is_sparse()) {
+    return at::_sparse_unsqueeze_backward(grad, t, dim);
+  }
+  return grad.squeeze(dim);
+}
+
+
 std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim) {
   dim = at::legacy_cat_wrap_dim(dim, sizes);
   std::vector<Tensor> grad_inputs(sizes.size());

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -457,18 +457,6 @@ Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
   return self;
 }
 
-Tensor _sparse_squeeze_backward(const Tensor& grad, int64_t dim) {
-  AT_ASSERT(grad.is_sparse());
-  auto r = at::_sparse_unsqueeze(grad, dim).coalesce();
-  return r;
-}
-
-Tensor _sparse_unsqueeze_backward(const Tensor& grad, int64_t dim) {
-  AT_ASSERT(grad.is_sparse());
-  auto r = at::_sparse_squeeze(grad, dim).coalesce();
-  return r;
-}
-
 std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim) {
   dim = at::legacy_cat_wrap_dim(dim, sizes);
   std::vector<Tensor> grad_inputs(sizes.size());

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -457,6 +457,18 @@ Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntList sizes) {
   return self;
 }
 
+Tensor _sparse_squeeze_backward(const Tensor& grad, int64_t dim) {
+  AT_ASSERT(grad.is_sparse());
+  auto r = at::_sparse_unsqueeze(grad, dim).coalesce();
+  return r;
+}
+
+Tensor _sparse_unsqueeze_backward(const Tensor& grad, int64_t dim) {
+  AT_ASSERT(grad.is_sparse());
+  auto r = at::_sparse_squeeze(grad, dim).coalesce();
+  return r;
+}
+
 std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim) {
   dim = at::legacy_cat_wrap_dim(dim, sizes);
   std::vector<Tensor> grad_inputs(sizes.size());

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4396,6 +4396,8 @@ will squeeze the tensor to the shape :math:`(A \times B)`.
 .. note:: The returned tensor shares the storage with the input tensor,
           so changing the contents of one will change the contents of the other.
 
+.. note:: When :attr:`dim` is given, SparseTensor input is also supported.
+
 Args:
     input (Tensor): the input tensor
     dim (int, optional): if given, the input will be squeezed only in
@@ -5129,6 +5131,8 @@ The returned tensor shares the same underlying data with this tensor.
 A :attr:`dim` value within the range ``[-input.dim() - 1, input.dim() + 1)``
 can be used. Negative :attr:`dim` will correspond to :meth:`unsqueeze`
 applied at :attr:`dim` = ``dim + input.dim() + 1``.
+
+.. note:: When :attr:`dim` is given, SparseTensor input is also supported.
 
 Args:
     input (Tensor): the input tensor

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -5,6 +5,8 @@ __all__ = [
     'addmm',
     'mm',
     'sum',
+    'squeeze',
+    'unsqueeze',
 ]
 
 
@@ -132,3 +134,11 @@ def sum(input, dim=None, dtype=None):
             return torch._sparse_sum(input, dim, dtype=dtype)
         else:
             return torch._sparse_sum(input, dtype=dtype)
+
+
+def squeeze(input, dim):
+    return torch._sparse_squeeze(input, dim)
+
+
+def unsqueeze(input, dim):
+    return torch._sparse_unsqueeze(input, dim)

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -137,8 +137,50 @@ def sum(input, dim=None, dtype=None):
 
 
 def squeeze(input, dim):
+    r"""
+    Squeeze a given :attr:`dim` at a SparseTensor. Autograd is supported,
+    and gradients of :attr:`input` is coalesced. Note that squeeze a
+    ``sparse_dim`` of a SparseTensor input with ``sparse_dim = 1`` and
+    ``sizes(0) == 1`` is not allowed, because this should return the
+    ``values()`` of input, in that case please use ``SparseTensor.values()``
+    instead.
+
+    See :func:`torch.squeeze` for more details.
+
+    Args:
+        input (Tensor): the input SparseTensor
+        dim (int): the dim to squeeze
+
+    Example::
+
+      >>> S = torch.randn(2, 1, 3).to_sparse(2)
+      >>> torch.sparse.squeeze(S, 1)
+      tensor(indices=tensor([[0, 1]]),
+             values=tensor([[ 0.2486, -1.0453, -0.6903],
+                            [-0.0133,  1.1690, -1.6560]]),
+             size=(2, 3), nnz=2, layout=torch.sparse_coo)
+    """
     return torch._sparse_squeeze(input, dim)
 
 
 def unsqueeze(input, dim):
+    r"""
+    Unsqueeze a given :attr:`dim` at a SparseTensor. Autograd is supported,
+    and gradients of :attr:`input` is coalesced. See :func:`torch.unsqueeze`
+    for more details.
+
+    Args:
+        input (Tensor): the input SparseTensor
+        dim (int): the dim to unsqueeze
+
+    Example::
+
+      >>> S = torch.randn(2, 3).to_sparse(1)
+      >>> torch.sparse.unsqueeze(S, 1)
+      tensor(indices=tensor([[0, 1],
+                             [0, 0]]),
+             values=tensor([[-0.5497, -0.2158,  1.1104],
+                            [-0.2841,  0.3221, -0.3292]]),
+             size=(2, 1, 3), nnz=2, layout=torch.sparse_coo)
+    """
     return torch._sparse_unsqueeze(input, dim)


### PR DESCRIPTION
- squeeze and unsqueeze are useful to reshape SparseTensors in order to support broadcasting
- keeping both APIs: `torch.sparse.squeeze(S)` and `torch.squeeze(S)`, as well as `torch.sparse.unsqueeze(S)` and `torch.unsqueeze(S)`. The reason is it is more natural / easier for user to find an API under `torch.sparse.*` than to search for both of `torch.*` and `torch.sparse.*`. This is temporally, when SparseTensor is supported as a type, we should merge the two sets of APIs.
- support autograd
- update docs