### PR TITLE
Replace getargspec with getfullargspec

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -178,7 +178,10 @@ def to_gpu(obj, type_map={}):
 
 
 def get_function_arglist(func):
-    return inspect.getfullargspec(func).args
+    if sys.version_info > (3,):
+        return inspect.getfullargspec(func).args
+    else:
+        return inspect.getargspec(func).args
 
 
 def set_rng_seed(seed):

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -178,7 +178,7 @@ def to_gpu(obj, type_map={}):
 
 
 def get_function_arglist(func):
-    return inspect.getargspec(func).args
+    return inspect.getfullargspec(func).args
 
 
 def set_rng_seed(seed):


### PR DESCRIPTION
Replace `getargspec` with `getfullargspec` to resolve test warnings. Fixes #15344 .