### PR TITLE
Fix operator initialization order

### DIFF
--- a/caffe2/core/net_parallel.cc
+++ b/caffe2/core/net_parallel.cc
@@ -20,8 +20,6 @@ ParallelNet::ParallelNet(
       num_workers_, 0, "Expected positive number of worker threads");
 
   helper_ = caffe2::make_unique<ParallelNetExecutorHelper>(this);
-  task_graph_ = TaskGraphRegistry()->Create(
-      FLAGS_caffe2_task_graph_engine, helper_.get(), options_);
 
   // initialize operators
   operator_nodes_ = dag_utils::prepareOperatorNodes(net_def, ws);
@@ -31,6 +29,10 @@ ParallelNet::ParallelNet(
     op->SetExecutorHelper(helper_.get());
     operators_.push_back(op);
   }
+
+  task_graph_ = TaskGraphRegistry()->Create(
+      FLAGS_caffe2_task_graph_engine, helper_.get(), options_);
+  CAFFE_ENFORCE(task_graph_, "Couldn't initialize task graph");
 
   // compute chains
   // TODO: inference mode for chaining


### PR DESCRIPTION
Summary: Initilize task graph after operators (task graph uses ops)

Differential Revision: D13530864
