### PR TITLE
Fix type annotation error.

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -570,7 +570,7 @@ class RNNCellBase(Module):
 
     @weak_script_method
     def check_forward_hidden(self, input, hx, hidden_label=''):
-        # type: (Tensor, Tensor, str)
+        # type: (Tensor, Tensor, str) -> None
         if input.size(0) != hx.size(0):
             raise RuntimeError(
                 "Input batch size {} doesn't match hidden{} batch size {}".format(


### PR DESCRIPTION
According to mypy, the trailing -> None is mandatory.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

