### PR TITLE
Add Tensor?[] and Tensor[] to aten native schema

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -945,6 +945,7 @@ def create_generic(top_env, declarations):
                     'IndexTensor': 'const Tensor &' if const else 'Tensor &',
                     'Type': 'const Type &' if const else 'Type &',
                     'TensorOptions': 'const TensorOptions &' if const else 'TensorOptions &',
+                    'TensorList': 'TensorList',
                 }
 
             if argument.get('is_nullable') and argument['type'] not in translate_map(False).keys():

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -886,7 +886,7 @@
 - func: _cufft_clear_plan_cache() -> void
   device_guard: false
 
-- func: index(Tensor self, TensorList indices) -> Tensor
+- func: index(Tensor self, Tensor?[] indices) -> Tensor
   variants: function, method
   # NB: This function is special-cased in tools/autograd/gen_variable_type.py
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -886,7 +886,7 @@
 - func: _cufft_clear_plan_cache() -> void
   device_guard: false
 
-- func: index(Tensor self, Tensor?[] indices) -> Tensor
+- func: index(Tensor self, Tensor[] indices) -> Tensor
   variants: function, method
   # NB: This function is special-cased in tools/autograd/gen_variable_type.py
 

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -36,6 +36,10 @@ def parse_default(s):
 def sanitize_type(typ):
     if typ == 'Generator*':
         return 'Generator *'
+    elif typ == 'Tensor[]' or typ == 'Tensor?[]':
+        # list of optional tensor type is also default to TensorList
+        # TODO: remove this when undefined tensor semantic is removed
+        return 'TensorList'
     return typ
 
 
@@ -77,7 +81,7 @@ def parse_arguments(args, func_decl, func_name, func_return):
 
         typ = sanitize_types(t)
         assert len(typ) == 1
-        argument_dict = {'type': typ[0].rstrip('?'), 'name': name, 'is_nullable': typ[0].endswith('?')}
+        argument_dict = {'type': typ[0].rstrip('?'), 'name': name, 'is_nullable': '?' in t}
         match = re.match(r'IntList\[(\d+)\]', argument_dict['type'])
         if match:
             argument_dict['type'] = 'IntList'

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -696,7 +696,7 @@ def unpack_args(env, declaration):
         if 'TensorOptions' not in dynamic_type:
             is_nullable = arg.get('is_nullable', False)
             ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensorRef']
-            suffix = '_opt' if is_nullable and ref else ''
+            suffix = '_opt' if is_nullable and dynamic_type != 'TensorList' else ''
 
             body.append(UNPACK_TENSOR.substitute(
                 arg_name=arg['name'],

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -696,7 +696,7 @@ def unpack_args(env, declaration):
         if 'TensorOptions' not in dynamic_type:
             is_nullable = arg.get('is_nullable', False)
             ref = (not is_nullable) and dynamic_type not in ['TensorList', 'SparseTensorRef']
-            suffix = '_opt' if is_nullable else ''
+            suffix = '_opt' if is_nullable and ref else ''
 
             body.append(UNPACK_TENSOR.substitute(
                 arg_name=arg['name'],

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -73,7 +73,10 @@ def jit_type_of(arg):
         typ = 'int[{}]'.format(arg['size'])
 
     if arg.get('is_nullable') and '?' not in typ:
-        typ = '{}?'.format(typ)
+        if typ == 'Tensor[]':
+            typ = 'Tensor?[]'
+        else:
+            typ = '{}?'.format(typ)
     return typ
 
 


### PR DESCRIPTION
This PR is the first step to bridge the gap between ATen schema and JIT shema. basically we want to add list syntax `[]` in native_functions.yaml to enable the cases like `Tensor?[]` which serve the use case of #14902 . Tensor?[] will still sanitize to TensorList in ATen C++ type, but will have is_nullable=True for this argument to represent a list that contains optional tensor. 

For more details on the background see [here](https://gist.github.com/wanchaol/3d2545fcf72fb01750a00cdbb080e59e): 