### PR TITLE
Add missing namespace to use macro in non-nom namespaces

### DIFF
--- a/caffe2/opt/converter.h
+++ b/caffe2/opt/converter.h
@@ -62,7 +62,7 @@ C10_DECLARE_REGISTRY(ConverterRegistry, Converter);
   class opName##Converter : public Converter {                                \
     std::unique_ptr<nom::repr::NeuralNetOperator> convertToNeuralNetOperator( \
         const OperatorDef& op) override {                                     \
-      return util::make_unique<repr::opName>();                               \
+      return nom::util::make_unique<nom::repr::opName>();                     \
     }                                                                         \
     virtual ~opName##Converter() {}                                           \
   };


### PR DESCRIPTION
Fix typo

Differential Revision: D10153233
