### PR TITLE
Relax check on outputs

### DIFF
--- a/caffe2/opt/converter.cc
+++ b/caffe2/opt/converter.cc
@@ -384,10 +384,13 @@ repr::NNModule convertToNNModule(
 
   for (const auto& outputName : net.external_output()) {
     CAFFE_ENFORCE(
-        blobMap.count(outputName),
-        "NetDef has ill-formed external_output: \"",
-        outputName,
-        "\"");
+        !strict || blobMap.count(outputName),
+        "NetDef has ill-formed external_output:",
+        outputName);
+    if (!blobMap.count(outputName)) {
+      LOG(ERROR) << "NetDef has ill-formed external_output: " << outputName;
+      continue;
+    }
     module.outputs.insert(blobMap[outputName]);
   }
 

--- a/caffe2/python/transformations_test.py
+++ b/caffe2/python/transformations_test.py
@@ -328,16 +328,15 @@ class TestTransformations(tu.TestCase):
             atol=1e-04
         )
 
-    def test_converterEnforceUnusedInputs(self):
+    def test_converterDontEnforceUnusedInputs(self):
         net = core.Net("net")
         net.Relu(["X"], ["Y"])
         net.Proto().external_input.extend(["fake"])
         # This should now work
         transformer.AddNNPACK(net)  # just testing the converter
 
-    def test_converterEnforceUnusedOutputs(self):
+    def test_converterDontEnforceUnusedOutputs(self):
         net = core.Net("net")
         net.Relu(["X"], ["Y"])
         net.Proto().external_output.extend(["fake"])
-        with self.assertRaises(Exception):
-            transformer.AddNNPACK(net)  # just testing the converter
+        transformer.AddNNPACK(net)  # just testing the converter


### PR DESCRIPTION
Summary: many nets in the wild seem to have outputs that are never produced by the net.

Reviewed By: ZolotukhinM

Differential Revision: D13534185
