### PR TITLE
[jit] allow non-final returns

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8841,6 +8841,84 @@ a")
         with self.capture_stdout() as captured:
             print(fn(x, scale, shift))
 
+    def test_non_final_return(self):
+
+        def simple(x):
+            if bool(x > 3):
+                return x + 1
+            else:
+                return x + 2
+            raise RuntimeError("nope")
+
+        def nest(x):
+            x = x + 1
+            if bool(x > 3):
+                if bool(x > 4):
+                    x += 1
+                return x + 1
+            else:
+                return x + 2
+
+        def early_ret(x):
+            x = x + 1
+            if bool(x > 3):
+                return x + 1
+            x = x + 1
+            return x + 2
+
+        def nest_early_ret(x):
+            x = x + 1
+            if bool(x > 3):
+                if bool(x > 4):
+                    return x + 2
+                return x + 1
+            x = x + 1
+            return x + 2
+
+        self.checkScript(simple, torch.rand(1))
+        self.checkScript(nest, torch.rand(1))
+        self.checkScript(early_ret, torch.rand(1))
+        self.checkScript(nest_early_ret, torch.rand(1))
+
+        with self.assertRaisesRegex(RuntimeError, "early"):
+            @torch.jit.script
+            def not_early_ret(x):
+                if bool(x > 3):
+                    if bool(x > 4):
+                        return 1
+                    print("foo")
+                else:
+                    print("5")
+                return 7
+
+        with self.assertRaisesRegex(RuntimeError, "some paths"):
+            @torch.jit.script
+            def not_total_ret(x):
+                if bool(x > 3):
+                    if bool(x > 4):
+                        return 1
+                    else:
+                        return 2
+                else:
+                    print("5")
+                return 7
+
+        with self.assertRaisesRegex(RuntimeError, "from a loop"):
+            @torch.jit.script
+            def nest_while_ret(x):
+                while bool(x > 4):
+                    if bool(x < 3):
+                        return 4
+                return 5
+
+        with self.assertRaisesRegex(RuntimeError, "from a loop"):
+            @torch.jit.script
+            def nest_for_ret(x):
+                for i in range(3):
+                    if bool(x < 3):
+                        return 4
+                return 5
+
 
 class MnistNet(nn.Module):
     def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6824,13 +6824,12 @@ a")
             MethodNoSelf()
 
     def test_return_stmt_not_at_end(self):
-        with self.assertRaisesRegex(RuntimeError, 'return statements can appear only at the end of the function body'):
-            @torch.jit.script
-            def return_stmt_wrong(x):
-                if bool(x > 3):
-                    return 3
-                else:
-                    return x
+        def return_stmt(x):
+            if bool(x > 3):
+                return x + 3
+            else:
+                return x
+        self.checkScript(return_stmt, (torch.rand(1),))
 
     def test_for_range_no_arg(self):
         with self.assertRaisesRegex(RuntimeError, r'range\(\) expects 1 argument but got 0'):

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -85,6 +85,7 @@ torch_sources_no_python_default = [
     "torch/csrc/jit/register_special_ops.cpp",
     "torch/csrc/jit/scope.cpp",
     "torch/csrc/jit/script/compiler.cpp",
+    "torch/csrc/jit/script/final_returns.cpp",
     "torch/csrc/jit/script/type_parser.cpp",
     "torch/csrc/jit/script/sugared_value.cpp",
     "torch/csrc/jit/script/schema_matching.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -189,6 +189,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/register_special_ops.cpp
   ${TORCH_SRC_DIR}/csrc/jit/scope.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/compiler.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/final_returns.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/schema_matching.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/type_parser.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/sugared_value.cpp

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -439,12 +439,7 @@ private:
 
 
     // body
-    std::vector<TreeRef> stmts = def.statements().get()->trees();
-    // make sure everthing always returns.
-    // if an earlier statement returns moveAllReturnsToEnd will just delete this one
-    stmts.emplace_back(Return::create(
-        def.range(), Expr(Compound::create(TK_NONE, def.range(), {}))));
-    auto stmts_list = moveAllReturnsToEnd(List<Stmt>::unsafeCreate(def.statements().range(), std::move(stmts)));
+    auto stmts_list = moveAllReturnsToEnd(def.statements());
     emitStatements(stmts_list.begin(), stmts_list.end());
     std::vector<Argument> returns = {emitOutput(def.range(), schema, block)};
     return {def.name().name(), std::move(arguments), std::move(returns)};

--- a/torch/csrc/jit/script/final_returns.cpp
+++ b/torch/csrc/jit/script/final_returns.cpp
@@ -5,20 +5,9 @@ namespace torch {
 namespace jit {
 namespace script {
 
-struct ReturnsInfo {
-  enum Status {
-    AllReturn, OneNoReturn, NoReturn
-  };
-  ReturnsInfo(Status status, List<Stmt> stmts, std::vector<bool> path = {})
-  : status_(status), stmts_(std::move(stmts)), path_(std::move(path)) {}
-  ReturnsInfo(Status status, const SourceRange& range, std::vector<TreeRef> trees, std::vector<bool> path = {})
-  : ReturnsInfo(status, List<Stmt>::unsafeCreate(range, std::move(trees)), std::move(path)) {}
-
-  Status status_;
+struct ReturnInfo {
+  bool returns_;
   List<Stmt> stmts_;
-  // if OneNoReturn, the path through the final if statements to find
-  // the block that does not return.
-  std::vector<bool> path_;
 };
 
 void checkNoReturn(const TreeRef& ref) {
@@ -29,35 +18,18 @@ void checkNoReturn(const TreeRef& ref) {
   }
 }
 
-TreeRef spliceToEnd(const std::vector<bool>& path, size_t idx, const If& if_stmt, const List<Stmt>& rest);
-List<Stmt> spliceToEnd(const std::vector<bool>& path, size_t idx, const List<Stmt>& branch, const List<Stmt>& rest) {
-  std::vector<TreeRef> stmts = branch.get()->trees();
-  if (idx == path.size()) {
-    stmts.insert(stmts.end(), rest.get()->trees().begin(), rest.get()->trees().end());
-  } else {
-    auto last = If(stmts.back());
-    stmts.back() = spliceToEnd(path, idx, last, rest);
-  }
-  return List<Stmt>::unsafeCreate(branch.range(), std::move(stmts));
-}
-TreeRef spliceToEnd(const std::vector<bool>& path, size_t idx, const If& if_stmt, const List<Stmt>& rest) {
-  if (path[idx]) {
-    auto branch = spliceToEnd(path, idx + 1, if_stmt.trueBranch(), rest);
-    return if_stmt.withNewBranches(branch, if_stmt.falseBranch());
-  } else {
-    auto branch = spliceToEnd(path, idx + 1, if_stmt.falseBranch(), rest);
-    return if_stmt.withNewBranches(if_stmt.trueBranch(), branch);
-  }
+void failReturns(const If& if_stmt, const char * what) {
+  throw ErrorReport(if_stmt)
+        << what << " contains some paths that return and some paths that do not. "
+        << "If statements must either entirely return or never return.";
 }
 
-void checkAlwaysReturns(const If& if_stmt, ReturnsInfo::Status status) {
-  if (status != ReturnsInfo::AllReturn) {
-    throw ErrorReport(if_stmt)
-        << "when returning from a (possibly nested) if statement there must be at most one branch that does not return. Here there are multiple branches that do not return";
-  }
-}
 
-ReturnsInfo makeReturnsFinal(const List<Stmt>& stmts) {
+ReturnInfo makeReturnsFinal(const SourceRange& range, at::ArrayRef<TreeRef> stmts, bool return_none);
+ReturnInfo makeReturnsFinal(const List<Stmt>& stmts, bool return_none) {
+  return makeReturnsFinal(stmts.range(), stmts.get()->trees(), return_none);
+}
+ReturnInfo makeReturnsFinal(const SourceRange& range, at::ArrayRef<TreeRef> stmts, bool return_none) {
   std::vector<TreeRef> changed;
   changed.reserve(stmts.size());
   for(size_t i = 0; i < stmts.size(); ++i) {
@@ -65,43 +37,27 @@ ReturnsInfo makeReturnsFinal(const List<Stmt>& stmts) {
     switch(stmt->kind()) {
       case TK_IF: {
         auto if_stmt = If(stmt);
-        auto true_final = makeReturnsFinal(if_stmt.trueBranch());
-        auto false_final = makeReturnsFinal(if_stmt.falseBranch());
-        if (true_final.status_ == ReturnsInfo::AllReturn &&
-            false_final.status_ == ReturnsInfo::AllReturn) {
-          changed.emplace_back(if_stmt.withNewBranches(true_final.stmts_, false_final.stmts_));
-          return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
-        } else if (true_final.status_ == ReturnsInfo::NoReturn &&
-            false_final.status_ == ReturnsInfo::NoReturn) {
-          changed.emplace_back(stmt);
-        } else {
-          std::vector<bool> path;
-          if (false_final.status_ != ReturnsInfo::AllReturn) {
-            checkAlwaysReturns(if_stmt, true_final.status_);
-            path.push_back(false);
-            path.insert(path.end(), false_final.path_.begin(), false_final.path_.end());
-          } else {
-            AT_CHECK(true_final.status_ != ReturnsInfo::AllReturn);
-            checkAlwaysReturns(if_stmt, false_final.status_);
-            path.push_back(true);
-            path.insert(path.end(), true_final.path_.begin(), true_final.path_.end());
+        auto true_final = makeReturnsFinal(if_stmt.trueBranch(), false);
+        // early return an if statement without an else block:
+        if (true_final.returns_ && if_stmt.falseBranch().size() == 0) {
+          auto rest_final = makeReturnsFinal(range, stmts.slice(i + 1), return_none);
+          if (!rest_final.returns_) {
+            failReturns(if_stmt, "The enclosing if statement");
           }
-          at::ArrayRef<TreeRef> stmts_view = stmts.get()->trees();
-          auto rest_final = makeReturnsFinal(List<Stmt>::unsafeCreate(
-              stmts.range(), stmts_view.slice(i + 1).vec()));
-          path.insert(
-              path.end(), rest_final.path_.begin(), rest_final.path_.end());
-          auto new_if =
-              if_stmt.withNewBranches(true_final.stmts_, false_final.stmts_);
-          TreeRef spliced = spliceToEnd(path, 0, new_if, rest_final.stmts_);
-          changed.emplace_back(spliced);
-          if (rest_final.status_ == ReturnsInfo::AllReturn) {
-            return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
-          } else {
-            path.insert(path.end(), rest_final.path_.begin(), rest_final.path_.end());
-            return ReturnsInfo(ReturnsInfo::OneNoReturn, stmts.range(), std::move(changed), std::move(path));
-          }
+          changed.emplace_back(if_stmt.withNewBranches(true_final.stmts_, rest_final.stmts_));
+          return {true, List<Stmt>::unsafeCreate(range, std::move(changed))};
         }
+
+        auto false_final = makeReturnsFinal(if_stmt.falseBranch(), false);
+        if (!true_final.returns_ && !false_final.returns_) {
+          changed.emplace_back(if_stmt);
+          break;
+        }
+        if (true_final.returns_ && false_final.returns_) {
+          changed.emplace_back(if_stmt.withNewBranches(true_final.stmts_, false_final.stmts_));
+          return {true, List<Stmt>::unsafeCreate(range, std::move(changed))};
+        }
+        failReturns(if_stmt, "This if statement");
       } break;
       case TK_WHILE:
         changed.emplace_back(stmt);
@@ -110,18 +66,22 @@ ReturnsInfo makeReturnsFinal(const List<Stmt>& stmts) {
       case TK_RETURN:
         changed.emplace_back(stmt);
         // ignore the rest the the block, all paths return
-        return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
+        return {true, List<Stmt>::unsafeCreate(range, std::move(changed))};
       default:
         changed.emplace_back(stmt);
         break;
     }
   }
-  // we reach the end of the block, no returns have happened, so NoReturn
-  return ReturnsInfo(ReturnsInfo::NoReturn, stmts.range(), std::move(changed));
+  if (return_none) {
+    // add an implicit return none node
+    changed.emplace_back(Return::create(range, Expr(Compound::create(TK_NONE, range, {}))));
+  }
+  // we reach the end of the block, no returns have happened
+  return {return_none, List<Stmt>::unsafeCreate(range, std::move(changed))};
 }
 
 List<Stmt> moveAllReturnsToEnd(const List<Stmt>& stmts) {
-  return makeReturnsFinal(stmts).stmts_;
+  return makeReturnsFinal(stmts, true).stmts_;
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/final_returns.cpp
+++ b/torch/csrc/jit/script/final_returns.cpp
@@ -53,7 +53,7 @@ TreeRef spliceToEnd(const std::vector<bool>& path, size_t idx, const If& if_stmt
 void checkAlwaysReturns(const If& if_stmt, ReturnsInfo::Status status) {
   if (status != ReturnsInfo::AllReturn) {
     throw ErrorReport(if_stmt)
-        << "when returning from a (possibly nested) if statement there must be at most one branch that does not return. Here there are multiple returning branches";
+        << "when returning from a (possibly nested) if statement there must be at most one branch that does not return. Here there are multiple branches that do not return";
   }
 }
 
@@ -94,6 +94,7 @@ ReturnsInfo makeReturnsFinal(const List<Stmt>& stmts) {
           auto new_if =
               if_stmt.withNewBranches(true_final.stmts_, false_final.stmts_);
           TreeRef spliced = spliceToEnd(path, 0, new_if, rest_final.stmts_);
+          changed.emplace_back(spliced);
           if (rest_final.status_ == ReturnsInfo::AllReturn) {
             return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
           } else {

--- a/torch/csrc/jit/script/final_returns.cpp
+++ b/torch/csrc/jit/script/final_returns.cpp
@@ -1,0 +1,128 @@
+#include <torch/csrc/jit/script/final_returns.h>
+#include <torch/csrc/jit/ir.h>
+
+namespace torch {
+namespace jit {
+namespace script {
+
+struct ReturnsInfo {
+  enum Status {
+    AllReturn, OneNoReturn, NoReturn
+  };
+  ReturnsInfo(Status status, List<Stmt> stmts, std::vector<bool> path = {})
+  : status_(status), stmts_(std::move(stmts)), path_(std::move(path)) {}
+  ReturnsInfo(Status status, const SourceRange& range, std::vector<TreeRef> trees, std::vector<bool> path = {})
+  : ReturnsInfo(status, List<Stmt>::unsafeCreate(range, std::move(trees)), std::move(path)) {}
+
+  Status status_;
+  List<Stmt> stmts_;
+  // if OneNoReturn, the path through the final if statements to find
+  // the block that does not return.
+  std::vector<bool> path_;
+};
+
+void checkNoReturn(const TreeRef& ref) {
+  if (ref->kind() == TK_RETURN)
+    throw ErrorReport(ref) << "return is not allowed from a loop.";
+  for(const TreeRef& child : ref->trees()) {
+    checkNoReturn(child);
+  }
+}
+
+TreeRef spliceToEnd(const std::vector<bool>& path, size_t idx, const If& if_stmt, const List<Stmt>& rest);
+List<Stmt> spliceToEnd(const std::vector<bool>& path, size_t idx, const List<Stmt>& branch, const List<Stmt>& rest) {
+  std::vector<TreeRef> stmts = branch.get()->trees();
+  if (idx == path.size()) {
+    stmts.insert(stmts.end(), rest.get()->trees().begin(), rest.get()->trees().end());
+  } else {
+    auto last = If(stmts.back());
+    stmts.back() = spliceToEnd(path, idx, last, rest);
+  }
+  return List<Stmt>::unsafeCreate(branch.range(), std::move(stmts));
+}
+TreeRef spliceToEnd(const std::vector<bool>& path, size_t idx, const If& if_stmt, const List<Stmt>& rest) {
+  if (path[idx]) {
+    auto branch = spliceToEnd(path, idx + 1, if_stmt.trueBranch(), rest);
+    return if_stmt.withNewBranches(branch, if_stmt.falseBranch());
+  } else {
+    auto branch = spliceToEnd(path, idx + 1, if_stmt.falseBranch(), rest);
+    return if_stmt.withNewBranches(if_stmt.trueBranch(), branch);
+  }
+}
+
+void checkAlwaysReturns(const If& if_stmt, ReturnsInfo::Status status) {
+  if (status != ReturnsInfo::AllReturn) {
+    throw ErrorReport(if_stmt)
+        << "when returning from a (possibly nested) if statement there must be at most one branch that does not return. Here there are multiple returning branches";
+  }
+}
+
+ReturnsInfo makeReturnsFinal(const List<Stmt>& stmts) {
+  std::vector<TreeRef> changed;
+  changed.reserve(stmts.size());
+  for(size_t i = 0; i < stmts.size(); ++i) {
+    const TreeRef& stmt = stmts[i];
+    switch(stmt->kind()) {
+      case TK_IF: {
+        auto if_stmt = If(stmt);
+        auto true_final = makeReturnsFinal(if_stmt.trueBranch());
+        auto false_final = makeReturnsFinal(if_stmt.falseBranch());
+        if (true_final.status_ == ReturnsInfo::AllReturn &&
+            false_final.status_ == ReturnsInfo::AllReturn) {
+          changed.emplace_back(if_stmt.withNewBranches(true_final.stmts_, false_final.stmts_));
+          return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
+        } else if (true_final.status_ == ReturnsInfo::NoReturn &&
+            false_final.status_ == ReturnsInfo::NoReturn) {
+          changed.emplace_back(stmt);
+        } else {
+          std::vector<bool> path;
+          if (false_final.status_ != ReturnsInfo::AllReturn) {
+            checkAlwaysReturns(if_stmt, true_final.status_);
+            path.push_back(false);
+            path.insert(path.end(), false_final.path_.begin(), false_final.path_.end());
+          } else {
+            AT_CHECK(true_final.status_ != ReturnsInfo::AllReturn);
+            checkAlwaysReturns(if_stmt, false_final.status_);
+            path.push_back(true);
+            path.insert(path.end(), true_final.path_.begin(), true_final.path_.end());
+          }
+          at::ArrayRef<TreeRef> stmts_view = stmts.get()->trees();
+          auto rest_final = makeReturnsFinal(List<Stmt>::unsafeCreate(
+              stmts.range(), stmts_view.slice(i + 1).vec()));
+          path.insert(
+              path.end(), rest_final.path_.begin(), rest_final.path_.end());
+          auto new_if =
+              if_stmt.withNewBranches(true_final.stmts_, false_final.stmts_);
+          TreeRef spliced = spliceToEnd(path, 0, new_if, rest_final.stmts_);
+          if (rest_final.status_ == ReturnsInfo::AllReturn) {
+            return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
+          } else {
+            path.insert(path.end(), rest_final.path_.begin(), rest_final.path_.end());
+            return ReturnsInfo(ReturnsInfo::OneNoReturn, stmts.range(), std::move(changed), std::move(path));
+          }
+        }
+      } break;
+      case TK_WHILE:
+        changed.emplace_back(stmt);
+        checkNoReturn(stmt);
+        break;
+      case TK_RETURN:
+        changed.emplace_back(stmt);
+        // ignore the rest the the block, all paths return
+        return ReturnsInfo(ReturnsInfo::AllReturn, stmts.range(), std::move(changed));
+      default:
+        changed.emplace_back(stmt);
+        break;
+    }
+  }
+  // we reach the end of the block, no returns have happened, so NoReturn
+  return ReturnsInfo(ReturnsInfo::NoReturn, stmts.range(), std::move(changed));
+}
+
+List<Stmt> moveAllReturnsToEnd(const List<Stmt>& stmts) {
+  return makeReturnsFinal(stmts).stmts_;
+}
+
+} // namespace script
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/final_returns.h
+++ b/torch/csrc/jit/script/final_returns.h
@@ -10,6 +10,48 @@ namespace torch {
 namespace jit {
 namespace script {
 
+// This is an AST-to-AST transform that ensures that all return statements
+// are at the end of the natural control-flow of the program.
+//
+// Since the return is at the end of the function, it is equivalent
+// to simply assigning the returned value to to a special `$return` variable
+// that is universally set to be the output of the function.
+//
+// This transform is only intended to support a subset of control-flow
+// structures to make the transformation both easy to do _and_ easy to
+// explain to users of TorchScript. The second constraint is important: if
+// it is unclear what is allowed users will get the impression that the
+// subset is difficult to use.
+//
+//   if <cond>:
+//     <true>
+//   else:
+//     <false>
+//   <rest>
+//
+// In particular we allow:
+// 1. If statements where neither <true> nor <false> branch returns.
+// 2. If statements where both <true> and <false> always return.
+// 3. An 'early return' if statement where <true> always returns <false> is empty, and <rest>
+// always returns.
+//
+// We do not allow returns from loops in any case.
+//
+// This pass handles the following cases as follows:
+//
+// 1. Neither branch returns so we can just leave the branches as is
+// 2. Both branches return, so we recursively transform the program such that
+// <true> and <false>'s final action is to return. We then delete <rest>
+// because the code is dead. The remaining program preserves the inductive
+// property that its last action is to return since both branches end in a return.
+// 3. In this case we know that <true> and <rest> always returns, and <false> is empty.
+//    We transform the graph to:
+//    if <cond>:
+//       <true>
+//     else:
+//       <rest>
+//    Now it is another instance of case (2).
+
 List<Stmt> moveAllReturnsToEnd(const List<Stmt>& stmts);
 
 }

--- a/torch/csrc/jit/script/final_returns.h
+++ b/torch/csrc/jit/script/final_returns.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <torch/csrc/jit/script/error_report.h>
+#include <torch/csrc/jit/script/tree_views.h>
+
+namespace torch {
+namespace jit {
+namespace script {
+
+List<Stmt> moveAllReturnsToEnd(const List<Stmt>& stmts);
+
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/final_returns.h
+++ b/torch/csrc/jit/script/final_returns.h
@@ -5,6 +5,7 @@
 
 #include <torch/csrc/jit/script/error_report.h>
 #include <torch/csrc/jit/script/tree_views.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
 
 namespace torch {
 namespace jit {
@@ -52,7 +53,7 @@ namespace script {
 //       <rest>
 //    Now it is another instance of case (2).
 
-List<Stmt> moveAllReturnsToEnd(const List<Stmt>& stmts);
+TORCH_API List<Stmt> moveAllReturnsToEnd(const List<Stmt>& stmts);
 
 }
 } // namespace jit

--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -144,6 +144,7 @@ struct Compound : public Tree {
     }
     return Compound::create(kind(), range(), std::move(trees_));
   }
+
   const SourceRange& range() const override {
     return range_;
   }

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -159,6 +159,9 @@ struct List : public TreeView {
     TreeList type_erased_sub {subtrees.begin(), subtrees.end()};
     return List(Compound::create(TK_LIST, range, std::move(type_erased_sub)));
   }
+  static List unsafeCreate(const SourceRange& range, TreeList&& subtrees) {
+    return List(Compound::create(TK_LIST, range, std::move(subtrees)));
+  }
   size_t size() const {
     return tree_->trees().size();
   }
@@ -379,6 +382,9 @@ struct If : public Stmt {
   }
   List<Stmt> falseBranch() const {
     return List<Stmt>(subtree(2));
+  }
+  If withNewBranches(const List<Stmt>& true_branch, const List<Stmt>& false_branch) const {
+    return create(range(), cond(), true_branch, false_branch);
   }
   static If create(
       const SourceRange& range,

--- a/torch/csrc/jit/script/type_parser.cpp
+++ b/torch/csrc/jit/script/type_parser.cpp
@@ -62,7 +62,7 @@ bool isTorch(const Expr& expr) {
 
 
 
-c10::optional<std::pair<TypePtr, int32_t>> handleBroadcastList(const Expr& expr) {
+c10::optional<std::pair<TypePtr, int32_t>> parseBroadcastList(const Expr& expr) {
   if (expr.kind() != TK_SUBSCRIPT)
     return c10::nullopt;
   auto subscript = Subscript(expr);
@@ -73,7 +73,7 @@ c10::optional<std::pair<TypePtr, int32_t>> handleBroadcastList(const Expr& expr)
 
   // handle the case where the BroadcastingList is wrapped in a Optional type
   if(var.name().name() == "Optional") {
-    auto broadcast_list = handleBroadcastList(subscript_exprs[0]);
+    auto broadcast_list = parseBroadcastList(subscript_exprs[0]);
     if (broadcast_list) {
       TypePtr opt_type = OptionalType::create(broadcast_list->first);
       return std::pair<TypePtr, int32_t>(opt_type, broadcast_list->second);

--- a/torch/csrc/jit/script/type_parser.h
+++ b/torch/csrc/jit/script/type_parser.h
@@ -7,6 +7,7 @@ namespace script {
 struct Expr;
 TORCH_API c10::optional<std::string> parseBaseTypeName(const Expr& expr);
 TORCH_API c10::TypePtr parseTypeFromExpr(const Expr& expr);
+TORCH_API c10::optional<std::pair<c10::TypePtr, int32_t>> parseBroadcastList(const Expr& expr);
 }
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This PR allows a subclass of programs that have return statements that are not final in the graph.

`final_returns.h` contains the a comment describing how this is accomplished.
To minimize complexity in `compiler.cpp`, this pass is done as an AST-to-AST rewrite before the compiler runs.