### PR TITLE
Support communicating with C2 protobuf in Onnxifi flow

### DIFF
--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -18,6 +18,7 @@ namespace caffe2 {
 namespace {
 
 const std::string kNetPos("net_pos");
+constexpr size_t kBufferSize = 64;
 
 // TODO: We probably don't want use protobuf as annotation in the future.
 void AnnotateOpIndex(NetDef* net) {
@@ -25,6 +26,19 @@ void AnnotateOpIndex(NetDef* net) {
   for (auto& op : *(net->mutable_op())) {
     AddArgument(kNetPos, i++, &op);
   }
+}
+
+// Wrap TensorShape into TensorProto
+TensorProto WrapShapeIntoTensorProto(
+    const std::string& name,
+    const TensorShape& shape) {
+  TensorProto t;
+  t.set_name(name);
+  t.set_data_type(shape.data_type());
+  for (const auto i : shape.dims()) {
+    t.add_dims(i);
+  }
+  return t;
 }
 
 uint64_t OnnxifiDataType(caffe2::TensorProto::DataType t) {
@@ -86,14 +100,6 @@ std::unordered_map<std::string, TensorShape> InferShapes(
   return shape_hints;
 }
 
-void DumpModel(
-    const ::ONNX_NAMESPACE::ModelProto& model,
-    const std::string& fname) {
-  std::ofstream ff(fname);
-  ff << ::ONNX_NAMESPACE::ProtoDebugString(model) << std::endl;
-  ff.close();
-}
-
 std::vector<::ONNX_NAMESPACE::ValueInfoProto> ConvertToValueInfo(
     const std::vector<std::string>& names,
     const std::unordered_map<std::string, TensorShape>& shape_hints,
@@ -123,6 +129,58 @@ std::vector<::ONNX_NAMESPACE::ValueInfoProto> ConvertToValueInfo(
     }
   }
   return r;
+}
+
+// Given a net, with primiary inputs and outputs defined in its
+// external_inputs/outputs, and given the set of weights and extra weights
+// (created during conversion to ONNX if exists), we check whether some of the
+// weights are used in the net, and if so, we put it in the initialize_list and
+// add it to the external_inputs too.
+// \param net [in] c2 net (cutoff from a bigger net)
+// \param weights_in_ws [in] all the weights in the workspace
+// \param extra_weights [in] extra weights possibly generated during ONNX
+// conversion \param initialization_list [out] weights that needs to be offload
+// to backend \param total_inputs_vec [out] total #inputs of the net that
+// doesn't have a producer
+void GetWeightsAndInputs(
+    const NetDef& net,
+    const std::unordered_set<std::string>& weights_in_ws,
+    const std::vector<std::string>& extra_weights,
+    std::unordered_set<std::string>* initialization_list,
+    std::vector<std::string>* total_inputs_vec) {
+  std::unordered_set<std::string> total_inputs;
+
+  // extra weights is definitely extra weights/inputs
+  for (const auto& extra_weight : extra_weights) {
+    if (total_inputs.emplace(extra_weight).second) {
+      total_inputs_vec->emplace_back(extra_weight);
+    }
+    initialization_list->emplace(extra_weight);
+  }
+
+  // Boundary inputs that should not be weights
+  std::unordered_set<std::string> boundary_inputs;
+  for (const auto& i : net.external_input()) {
+    boundary_inputs.emplace(i);
+  }
+
+  for (const auto& op : net.op()) {
+    for (const auto& input : op.input()) {
+      bool not_seen = total_inputs.emplace(input).second;
+      if (!not_seen) {
+        continue;
+      }
+      if (weights_in_ws.count(input)) {
+        // We add weights as inputs too
+        total_inputs_vec->emplace_back(input);
+        initialization_list->emplace(input);
+        VLOG(2) << "Add weights: " << input;
+      } else if (boundary_inputs.count(input)) {
+        VLOG(2) << "Adding boundary input: " << input;
+        total_inputs_vec->emplace_back(input);
+      }
+    }
+  }
 }
 
 void FillModelInfo(::ONNX_NAMESPACE::ModelProto* model) {
@@ -209,10 +267,96 @@ OperatorDef OnnxifiTransformer::BuildOnnxifiOp(
       VLOG(2) << "Adding output hint: " << o;
     }
   }
+
+  // Tell Onnxifi op that the model is in onnx or c2 proto format
+  AddArgument("use_onnx", opts_.use_onnx ? 1 : 0, &op);
+
+  // Tell Onnxifi op which backend id to use
+  AddArgument("backend_id", idx_, &op);
+
   return op;
 }
 
-NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
+NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaC2(
+    const caffe2::NetDef& net,
+    const std::unordered_set<std::string>& weights_in_ws,
+    const std::unordered_map<std::string, TensorShape>& shape_hints) {
+  // We already have all the ops and external inputs and outputs!
+  NetDef wrapper_net(net);
+
+  // Compute output shape hints
+  std::unordered_map<std::string, TensorShape> output_shape_hints;
+  for (const auto& o : wrapper_net.external_output()) {
+    const auto it = shape_hints.find(o);
+    CAFFE_ENFORCE(
+        it != shape_hints.end(), "Cannot find shape info for output ", o);
+    const auto& shape = it->second;
+    output_shape_hints.emplace(o, shape);
+  }
+
+  // Remove the second output of Concat from external_output. In addition, we
+  // remove those outputs from the Onnxifi op too.
+  // TODO: This approach is a bit hacky as we assume that the second output is
+  // never used. A more appropriate approach can be learned from the ONNX path,
+  // where we statically computes the split_info given input shape and insert a
+  // GivenTensorIntFill op
+  std::unordered_set<std::string> split_infos;
+  NetDef net_copy(net);
+  for (auto& op : *wrapper_net.mutable_op()) {
+    if (op.type() == "Concat" && op.output_size() == 2) {
+      split_infos.emplace(op.output(1));
+    }
+  }
+  wrapper_net.clear_external_output();
+  net_copy.clear_external_output();
+  for (const auto& o : net.external_output()) {
+    if (!split_infos.count(o)) {
+      wrapper_net.add_external_output(o);
+      net_copy.add_external_output(o);
+    }
+  }
+
+  // Figure out weights and add it to external_inputs too
+  std::vector<std::string> extra_weights;
+  std::unordered_set<std::string> initialization_list;
+  std::vector<std::string> total_inputs_vec;
+  GetWeightsAndInputs(
+      net,
+      weights_in_ws,
+      extra_weights,
+      &initialization_list,
+      &total_inputs_vec);
+  auto* shape_arg = wrapper_net.add_arg();
+  shape_arg->set_name("input_shape_info");
+  wrapper_net.clear_external_input();
+  for (const auto& i : total_inputs_vec) {
+    wrapper_net.add_external_input(i);
+    shape_arg->mutable_tensors()->Add()->CopyFrom(
+        WrapShapeIntoTensorProto(i, shape_hints.at(i)));
+  }
+
+  // Debugging stuff
+  if (opts_.debug) {
+    WriteProtoToTextFile(wrapper_net, "debug.pb_txt");
+  }
+
+  // C2 model is ready. Build ONNXIFI Op
+  std::string model_str;
+  wrapper_net.SerializeToString(&model_str);
+  NetDef net_opt;
+  auto* op = net_opt.add_op();
+  *op = BuildOnnxifiOp(
+      model_str, output_shape_hints, initialization_list, net_copy);
+  for (const auto& i : op->input()) {
+    net_opt.add_external_input(i);
+  }
+  for (const auto& o : op->output()) {
+    net_opt.add_external_output(o);
+  }
+  return net_opt;
+}
+
+NetDef OnnxifiTransformer::SubnetToOnnxifiOpViaOnnx(
     const caffe2::NetDef& net,
     const std::unordered_set<std::string>& weights_in_ws,
     Workspace* ws,
@@ -291,40 +435,14 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
   }
 
   // Convert inputs and figure out weights
-  std::unordered_set<std::string> total_inputs;
   std::unordered_set<std::string> initialization_list;
   std::vector<std::string> total_inputs_vec;
-
-  // Extra intermediate weights created during conversion
-  for (const auto& extra_weight : extra_weights) {
-    if (total_inputs.emplace(extra_weight).second) {
-      total_inputs_vec.emplace_back(extra_weight);
-    }
-    initialization_list.emplace(extra_weight);
-  }
-  // Boundary inputs, should not be weights
-  std::unordered_set<std::string> boundary_inputs;
-  for (const auto& i : net.external_input()) {
-    boundary_inputs.emplace(i);
-  }
-
-  for (const auto& op : net.op()) {
-    for (const auto& input : op.input()) {
-      bool not_seen = total_inputs.emplace(input).second;
-      if (!not_seen) {
-        continue;
-      }
-      if (weights_in_ws.count(input)) {
-        // We add weights as inputs too
-        total_inputs_vec.emplace_back(input);
-        initialization_list.emplace(input);
-        VLOG(2) << "Add weights: " << input;
-      } else if (boundary_inputs.count(input)) {
-        VLOG(2) << "Adding boundary input: " << input;
-        total_inputs_vec.emplace_back(input);
-      }
-    }
-  }
+  GetWeightsAndInputs(
+      net,
+      weights_in_ws,
+      extra_weights,
+      &initialization_list,
+      &total_inputs_vec);
   io_vec = ConvertToValueInfo(
       total_inputs_vec,
       *shape_hints,
@@ -335,7 +453,7 @@ NetDef OnnxifiTransformer::SubnetToOnnxifiOp(
 
   // Debugging stuff
   if (opts_.debug) {
-    DumpModel(onnx_model, "debug.onnxtxt");
+    WriteProtoToTextFile(onnx_model, "debug.onnx_txt");
   }
 
   // Onnx model is ready. Build ONNXIFI Op
@@ -381,6 +499,92 @@ CaffeMap<std::string, TensorShape> OnnxifiTransformer::SsaRewriteAndMapNames(
     }
   }
   return shape_hints_ordered;
+}
+
+NetDef OnnxifiTransformer::TransformViaC2(
+    NetDef* pred_net,
+    const std::unordered_set<std::string>& weights,
+    const std::unordered_set<int>& blacklisted_ops,
+    const std::unordered_map<std::string, TensorShape>& shape_hints) {
+  onnxifi_library* backend = lib_;
+  idx_ = 0;
+  // Try to find a backend that support Caffe2 proto. Note that this is quite
+  // opportunistic as we don't offcially support Caffe2 proto.
+  if (!opts_.use_onnx) {
+    char buf[kBufferSize];
+    for (int i = 0; i < backend_ids_.size(); ++i) {
+      size_t len = kBufferSize;
+      auto ret = backend->onnxGetBackendInfo(
+          backend_ids_[i], ONNXIFI_BACKEND_DEVICE, buf, &len);
+      if (ret == ONNXIFI_STATUS_SUCCESS && strstr(buf, "Caffe2")) {
+        LOG(INFO) << "Using backend with Caffe2 Proto, ID: " << i;
+        idx_ = i;
+        break;
+      }
+    }
+  }
+  onnxBackendID backend_id = backend_ids_[idx_];
+
+  auto c2_supports = [&shape_hints, &blacklisted_ops, backend, backend_id](
+                         const caffe2::OperatorDef& op) {
+    try {
+      int pos =
+          ArgumentHelper::GetSingleArgument<OperatorDef, int>(op, kNetPos, -1);
+      if (blacklisted_ops.count(pos)) {
+        return false;
+      }
+
+      // Build a c2 net with one op
+      NetDef net;
+      net.add_op()->CopyFrom(op);
+      for (const auto& i : op.input()) {
+        net.add_external_input(i);
+      }
+      for (const auto& o : op.output()) {
+        net.add_external_output(o);
+      }
+      // Remove the second output of Concat from the external_output
+      if (op.type() == "Concat" && op.output_size() == 2) {
+        net.mutable_external_output()->RemoveLast();
+      }
+
+      // Encode the input/output shapes to an argument
+      auto* shape_arg = net.add_arg();
+      shape_arg->set_name("input_shape_info");
+      for (const auto& i : op.input()) {
+        shape_arg->mutable_tensors()->Add()->CopyFrom(
+            WrapShapeIntoTensorProto(i, shape_hints.at(i)));
+      }
+      shape_arg = net.add_arg();
+      shape_arg->set_name("output_shape_info");
+      for (const auto& i : op.output()) {
+        shape_arg->mutable_tensors()->Add()->CopyFrom(
+            WrapShapeIntoTensorProto(i, shape_hints.at(i)));
+      }
+
+      std::string c2_model_str;
+      net.SerializeToString(&c2_model_str);
+      auto ret = backend->onnxGetBackendCompatibility(
+          backend_id, c2_model_str.size(), c2_model_str.c_str());
+      if (ret != ONNXIFI_STATUS_SUCCESS) {
+        LOG(INFO) << "Don't support c2 op " << op.type() << " (" << ret << ")";
+        return false;
+      } else {
+        return true;
+      }
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "Caught exception when converting op " << op.type()
+                 << ", what: " << ex.what();
+      return false;
+    }
+  };
+
+  auto c2_converter =
+      [this, &weights, &shape_hints](const caffe2::NetDef& net) {
+        return SubnetToOnnxifiOpViaC2(net, weights, shape_hints);
+      };
+
+  return opt::OptimizeForBackend(*pred_net, c2_supports, c2_converter);
 }
 
 NetDef OnnxifiTransformer::TransformViaOnnx(
@@ -498,7 +702,7 @@ NetDef OnnxifiTransformer::TransformViaOnnx(
   onnx::OnnxExporter exporter2(nullptr);
   auto onnx_converter = [this, ws, &weights, shape_hints, &exporter2](
                             const caffe2::NetDef& net) mutable {
-    return SubnetToOnnxifiOp(net, weights, ws, &exporter2, shape_hints);
+    return SubnetToOnnxifiOpViaOnnx(net, weights, ws, &exporter2, shape_hints);
   };
 
   return opt::OptimizeForBackend(*pred_net, onnx_supports, onnx_converter);
@@ -541,8 +745,9 @@ void OnnxifiTransformer::Transform(
   }
 
   // Transform the net
-  NetDef net_opt =
-      TransformViaOnnx(ws, pred_net, weights, blacklisted_ops, &shape_hints);
+  NetDef net_opt = opts_.use_onnx
+      ? TransformViaOnnx(ws, pred_net, weights, blacklisted_ops, &shape_hints)
+      : TransformViaC2(pred_net, weights, blacklisted_ops, shape_hints);
 
   // Need to figure out a proper place to handle device option
   net_opt.mutable_device_option()->CopyFrom(pred_net->device_option());

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -51,13 +51,20 @@ class CAFFE2_API OnnxifiTransformer final {
  private:
   // Since we create new tensors during the conversion process, we actually need
   // into inject them into the original workspace
-  caffe2::NetDef SubnetToOnnxifiOp(
+  caffe2::NetDef SubnetToOnnxifiOpViaOnnx(
       const caffe2::NetDef& net,
       const std::unordered_set<std::string>& weights_in_ws,
       Workspace* ws,
       onnx::OnnxExporter* exporter,
       std::unordered_map<std::string, TensorShape>* shape_hints);
 
+  // Convert a cutoff subgraph net to an Onnxifi op
+  caffe2::NetDef SubnetToOnnxifiOpViaC2(
+      const caffe2::NetDef& net,
+      const std::unordered_set<std::string>& weights_in_ws,
+      const std::unordered_map<std::string, TensorShape>& shape_hints);
+
+  // We already have all the ops and external inputs and outputs!
   OperatorDef BuildOnnxifiOp(
       const std::string& onnx_model_str,
       const std::unordered_map<std::string, TensorShape>& output_size_hints,
@@ -68,6 +75,13 @@ class CAFFE2_API OnnxifiTransformer final {
       Workspace* ws,
       NetDef* pred_net,
       const std::unordered_map<std::string, TensorShape>& input_shape_hints);
+
+  // Transform by passing C2 proto to backend
+  NetDef TransformViaC2(
+      NetDef* pred_net,
+      const std::unordered_set<std::string>& weights,
+      const std::unordered_set<int>& blacklisted_ops,
+      const std::unordered_map<std::string, TensorShape>& shape_hints);
 
   // Transform by passing ONNX proto to backend
   NetDef TransformViaOnnx(
@@ -85,6 +99,9 @@ class CAFFE2_API OnnxifiTransformer final {
 
   // Number of backends
   size_t num_backends_{0};
+
+  // backend idx
+  int idx_{0};
 
   // Backned IDs
   std::vector<onnxBackendID> backend_ids_;

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -20,7 +20,8 @@ def onnxifi_caffe2_net(
         pred_net,
         input_shapes,
         infer_shapes=False,
-        debug=False):
+        debug=False,
+        use_onnx=True):
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
@@ -45,7 +46,8 @@ def onnxifi_caffe2_net(
                              external_inputs,
                              shape_hints,
                              infer_shapes,
-                             debug)
+                             debug,
+                             use_onnx)
     pred_net_cut = caffe2_pb2.NetDef()
     pred_net_cut.ParseFromString(pred_net_str)
     return pred_net_cut

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1607,7 +1607,8 @@ void addGlobalMethods(py::module& m) {
          const std::vector<std::string>& external_inputs,
          const std::unordered_map<std::string, std::vector<int>>& shapes,
          bool infer_shapes,
-         bool debug_builder) -> py::bytes {
+         bool debug_builder,
+         bool use_onnx) -> py::bytes {
         caffe2::NetDef pred_net;
         CAFFE_ENFORCE(
             ParseProtoFromLargeString(
@@ -1621,6 +1622,7 @@ void addGlobalMethods(py::module& m) {
         OnnxifiTransformerOptions opts;
         opts.infer_shapes = infer_shapes;
         opts.debug = debug_builder;
+        opts.use_onnx = use_onnx;
         OnnxifiTransformer ts(opts);
         ts.Transform(
             GetCurrentWorkspace(),


### PR DESCRIPTION
Summary: Create a path to pass serialized C2 protobuf instead of ONNX during ONNXIFI flow

Differential Revision: D13536603
