### PR TITLE
Fix cudnn dropout

### DIFF
--- a/caffe2/core/workspace.cc
+++ b/caffe2/core/workspace.cc
@@ -176,6 +176,13 @@ const Blob* Workspace::GetBlob(const string& name) const {
   return nullptr;
 }
 
+const Blob* Workspace::GetLocalBlob(const string& name) const {
+  if (blob_map_.count(name)) {
+    return blob_map_.at(name).get();
+  }
+  return nullptr;
+}
+
 void Workspace::AddBlobMapping(
     const Workspace* parent,
     const std::unordered_map<string, string>& forwarded_blobs,
@@ -209,6 +216,11 @@ void Workspace::AddBlobMapping(
 
 Blob* Workspace::GetBlob(const string& name) {
   return const_cast<Blob*>(static_cast<const Workspace*>(this)->GetBlob(name));
+}
+
+Blob* Workspace::GetLocalBlob(const string& name) {
+  return const_cast<Blob*>(
+      static_cast<const Workspace*>(this)->GetLocalBlob(name));
 }
 
 NetBase* Workspace::CreateNet(const NetDef& net_def, bool overwrite) {

--- a/caffe2/core/workspace.h
+++ b/caffe2/core/workspace.h
@@ -223,6 +223,14 @@ class CAFFE2_API Workspace {
    * not exist, a nullptr is returned.
    */
   Blob* GetBlob(const string& name);
+  /**
+   * Like GetBlob but doesn't lookup the parent workspace.
+   */
+  const Blob* GetLocalBlob(const string& name) const;
+  /**
+   * Like GetBlob but doesn't lookup the parent workspace.
+   */
+  Blob* GetLocalBlob(const string& name);
 
   /**
    * Renames a local workspace blob. If blob is not found in the local blob list

--- a/caffe2/operators/dropout_op_cudnn.cc
+++ b/caffe2/operators/dropout_op_cudnn.cc
@@ -55,7 +55,7 @@ class CuDNNDropoutOp final : public Operator<CUDAContext> {
   cudnnTensorDescriptor_t data_desc_;
   cudnnDropoutDescriptor_t dropout_desc_;
 
-  at::IntList cudnn_input_dims_;
+  vector<int64_t> cudnn_input_dims_;
 
   float ratio_;
   bool is_test_;
@@ -113,7 +113,7 @@ class CuDNNDropoutGradientOp final : public Operator<CUDAContext> {
   cudnnTensorDescriptor_t data_desc_;
   cudnnDropoutDescriptor_t dropout_desc_;
 
-  at::IntList cudnn_input_dims_;
+  vector<int64_t> cudnn_input_dims_;
 
   Blob* scratch_blob_;
 
@@ -150,7 +150,7 @@ bool CuDNNDropoutOp::DoRunWithType() {
     if (X.sizes() != cudnn_input_dims_) {
       CAFFE_ENFORCE(scratch_blob_);
       Tensor* states = BlobGetMutableTensor(scratch_blob_, CUDA);
-      cudnn_input_dims_ = X.sizes();
+      cudnn_input_dims_ = X.sizes().vec();
       CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
           data_desc_,
           GetCudnnTensorFormat(StorageOrder::NCHW),
@@ -246,7 +246,7 @@ bool CuDNNDropoutGradientOp::DoRunWithType() {
   }
 
   if (dY.sizes() != cudnn_input_dims_) {
-    cudnn_input_dims_ = dY.sizes();
+    cudnn_input_dims_ = dY.sizes().vec();
     CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
         data_desc_,
         GetCudnnTensorFormat(StorageOrder::NCHW),


### PR DESCRIPTION
Summary:
Revert accidental changes introduced in D13335176

IntList is a range and copying it just copies pointers. Thus pointers would point either on deallocated memory or on the same memory causing equality always pass.

Differential Revision: D13537131
