### PR TITLE
[ROCm] Use parallel thrust execution policy on ROCm

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -18,7 +18,7 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/unique.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 

--- a/aten/src/THC/THCTensorMasked.cuh
+++ b/aten/src/THC/THCTensorMasked.cuh
@@ -9,7 +9,7 @@
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 

--- a/aten/src/THC/THCTensorMath.cu
+++ b/aten/src/THC/THCTensorMath.cu
@@ -17,7 +17,7 @@
 #include <thrust/sequence.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 #include <cfloat>

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -12,7 +12,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/inner_product.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 

--- a/aten/src/THC/THCTensorTopK.cu
+++ b/aten/src/THC/THCTensorTopK.cu
@@ -8,7 +8,7 @@
 #include <THC/THCTensorMathReduce.cuh>
 #include <algorithm> // for std::min
 
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 

--- a/aten/src/THC/generic/THCStorage.cu
+++ b/aten/src/THC/generic/THCStorage.cu
@@ -7,7 +7,7 @@ void THCStorage_(fill)(THCState *state, THCStorage *self, scalar_t value)
   THCThrustAllocator thrustAlloc(state);
   thrust::device_ptr<scalar_t> self_data(THCStorage_(data)(state, self));
   thrust::fill(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     self_data, self_data+self->numel(), value);

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -69,7 +69,7 @@ void THCTensor_(maskedCopy)(THCState* state,
     maskPrefixSumData(THCudaLongTensor_data(state, maskPrefixSum));
 
   thrust::exclusive_scan(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     maskData,
@@ -139,7 +139,7 @@ void THCTensor_(maskedSelect)(THCState* state,
     maskPrefixSumData(THCudaLongTensor_data(state, maskPrefixSum));
 
   thrust::exclusive_scan(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     maskData,

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -280,12 +280,12 @@ void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor,
   strided_range<Iter> strided_tensor(tensor_data,
                                      tensor_data+N*num_dim, num_dim);
 
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
   cudaStream_t stream = THCState_getCurrentStream(state);
 #endif
 
   strided_range<Iter>::iterator dend = thrust::copy_if(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(stream),
 #endif
     idxfirst,

--- a/aten/src/THC/generic/THCTensorMath.cu
+++ b/aten/src/THC/generic/THCTensorMath.cu
@@ -302,7 +302,7 @@ void THCTensor_(nonzero)(THCState* state, THCudaLongTensor *tensor,
     strided_range<Iter> stride_dim(tensor_data+dim,
                                    tensor_data+N*num_dim, num_dim);
     thrust::transform(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(stream),
 #endif
       strided_tensor.begin(),

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -270,7 +270,7 @@ accreal THCTensor_(dist)(THCState *state, THCTensor *self,
 
   if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(INFINITY))) {
     result = thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       self_data, self_data+size, src_data, scalar_cast<accreal>(0),
@@ -278,7 +278,7 @@ accreal THCTensor_(dist)(THCState *state, THCTensor *self,
       ThrustTensorDistOp<scalar_t, accreal>(scalar_cast<scalar_t>(1)));
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(-INFINITY))) {
     result = thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       self_data, self_data+size, src_data, scalar_cast<accreal>(INFINITY),
@@ -286,7 +286,7 @@ accreal THCTensor_(dist)(THCState *state, THCTensor *self,
       ThrustTensorDistOp<scalar_t, accreal>(scalar_cast<scalar_t>(1)));
   } else if (THCNumerics<accreal>::eq(value, scalar_cast<accreal>(0))) {
     result = thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       self_data, self_data+size, src_data, scalar_cast<accreal>(0),
@@ -294,7 +294,7 @@ accreal THCTensor_(dist)(THCState *state, THCTensor *self,
       ThrustTensorDistOp<scalar_t, accreal>(scalar_cast<scalar_t>(0)));
   } else {
     result = thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       self_data, self_data+size, src_data, scalar_cast<accreal>(0),

--- a/aten/src/THC/generic/THCTensorMathScan.cu
+++ b/aten/src/THC/generic/THCTensorMathScan.cu
@@ -15,7 +15,7 @@ __host__ void THCTensor_(scanThrust)(
   thrust::device_ptr<scalar_t> dst_data(THCTensor_(data)(state, dst));
   ptrdiff_t size = THCTensor_(nElement)(state, src);
   thrust::inclusive_scan(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       src_data, src_data + size, dst_data,

--- a/aten/src/THC/generic/THCTensorMode.cu
+++ b/aten/src/THC/generic/THCTensorMode.cu
@@ -31,7 +31,7 @@ void THCTensor_(calculateMode)(THCState *state,
 
   // Fill sortBuffer with [0, 1, 2, ... nElement - 1]
   thrust::sequence(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,
@@ -40,7 +40,7 @@ void THCTensor_(calculateMode)(THCState *state,
 
   // Sort the input data. The original indices of the data are stored in seq
   thrust::sort_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,
@@ -54,7 +54,7 @@ void THCTensor_(calculateMode)(THCState *state,
   // Count # of unique elements via an inner product between adjacent elements.
   // Add 1 if two neighboring element are not equal.
   int unique = 1 + thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,
@@ -71,7 +71,7 @@ void THCTensor_(calculateMode)(THCState *state,
   thrust::device_vector<scalar_t> keys(unique);
   thrust::device_vector<int> counts(unique);
   thrust::reduce_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,
@@ -85,7 +85,7 @@ void THCTensor_(calculateMode)(THCState *state,
 
   // Find index of maximum count
   thrust::device_vector<int>::iterator it = thrust::max_element(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,
@@ -96,7 +96,7 @@ void THCTensor_(calculateMode)(THCState *state,
   // Find first index within which it occurs
 #if defined(THC_REAL_IS_HALF)
   thrust::device_vector<scalar_t>::iterator positionIter = thrust::find_if(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,
@@ -104,7 +104,7 @@ void THCTensor_(calculateMode)(THCState *state,
     iter.begin(), iter.end(), ThrustHalfEqualToPredicate(mode));
 #else
   thrust::device_vector<scalar_t>::iterator positionIter = thrust::find(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #else
     thrust::device,

--- a/aten/src/THC/generic/THCTensorSort.cu
+++ b/aten/src/THC/generic/THCTensorSort.cu
@@ -222,7 +222,7 @@ void THCTensor_(sortViaThrust)(THCState* state,
   thrust::counting_iterator<int64_t> countIter(0);
 
   thrust::copy(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     countIter, countIter + totalElements, indexIter);
@@ -231,13 +231,13 @@ void THCTensor_(sortViaThrust)(THCState* state,
   // (the values we're sorting)
   if (dir) {
     thrust::stable_sort_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       keyIter, keyIter + totalElements, indexIter, ThrustGTOp<scalar_t>());
   } else {
     thrust::stable_sort_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       keyIter, keyIter + totalElements, indexIter, ThrustLTOp<scalar_t>());
@@ -248,7 +248,7 @@ void THCTensor_(sortViaThrust)(THCState* state,
   // stably sorting here, preserving the relative order of values
   // per each slice
   thrust::stable_sort_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     indexIter, indexIter + totalElements, keyIter,
@@ -257,7 +257,7 @@ void THCTensor_(sortViaThrust)(THCState* state,
   // Translate the global integer 0-based index to a per-slice real
   // Lua index
   thrust::for_each(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     indexIter, indexIter + totalElements,

--- a/aten/src/THCUNN/LookupTableBag.cu
+++ b/aten/src/THCUNN/LookupTableBag.cu
@@ -7,7 +7,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/transform_reduce.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 #include <thrust/unique.h>

--- a/aten/src/THCUNN/MSECriterion.cu
+++ b/aten/src/THCUNN/MSECriterion.cu
@@ -10,7 +10,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/reduce.h>
 #include <thrust/inner_product.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 

--- a/aten/src/THCUNN/SmoothL1Criterion.cu
+++ b/aten/src/THCUNN/SmoothL1Criterion.cu
@@ -10,7 +10,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/reduce.h>
 #include <thrust/inner_product.h>
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
 #include <thrust/system/cuda/execution_policy.h>
 #endif
 

--- a/aten/src/THCUNN/generic/LookupTable.cu
+++ b/aten/src/THCUNN/generic/LookupTable.cu
@@ -76,14 +76,14 @@ void THNN_(LookupTable_accGradParameters)(
     thrust::counting_iterator<THCIndex_t> countIter(TH_INDEX_BASE);
 
     thrust::copy(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       countIter, countIter + numel, origIndicesIter);
 
     // Sort; a stable sort is not required
     thrust::sort_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       sortedIndicesIter, sortedIndicesIter + numel,
@@ -106,7 +106,7 @@ void THNN_(LookupTable_accGradParameters)(
     // sorted: 2 5 5 5 7 7 8 9 9
     //  count: 1 1 2 3 1 2 1 1 2
     thrust::inclusive_scan_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       sortedIndices_ptr,
@@ -119,7 +119,7 @@ void THNN_(LookupTable_accGradParameters)(
     // sorted: 2 5 5 5 7 7 8 9 9
     //  count: 1 3 3 3 2 2 1 2 2
     thrust::inclusive_scan_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       thrust::make_reverse_iterator(sortedIndices_ptr + numel),

--- a/aten/src/THCUNN/generic/LookupTableBag.cu
+++ b/aten/src/THCUNN/generic/LookupTableBag.cu
@@ -114,14 +114,14 @@ void THNN_(LookupTableBag_accGradParameters)(
     thrust::counting_iterator<THCIndex_t> countIter(TH_INDEX_BASE);
 
     thrust::copy(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       countIter, countIter + numel, origIndicesIter);
 
     // Sort; a stable sort is not required
     thrust::sort_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       sortedIndicesIter, sortedIndicesIter + numel,
@@ -145,7 +145,7 @@ void THNN_(LookupTableBag_accGradParameters)(
     // sorted: 2 5 5 5 7 7 8 9 9
     //  count: 1 1 2 3 1 2 1 1 2
     thrust::inclusive_scan_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       sortedIndices_ptr,
@@ -158,7 +158,7 @@ void THNN_(LookupTableBag_accGradParameters)(
     // sorted: 2 5 5 5 7 7 8 9 9
     //  count: 1 3 3 3 2 2 1 2 2
     thrust::inclusive_scan_by_key(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       thrust::make_reverse_iterator(sortedIndices_ptr + numel),

--- a/aten/src/THCUNN/generic/MSECriterion.cu
+++ b/aten/src/THCUNN/generic/MSECriterion.cu
@@ -24,7 +24,7 @@ void THNN_(MSECriterion_updateOutput)(
     thrust::device_ptr<scalar_t> input_data(THCTensor_(data)(state, input));
     thrust::device_ptr<scalar_t> target_data(THCTensor_(data)(state, target));
     accreal sum = thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       input_data, input_data+size, target_data, (accreal) 0,
@@ -78,7 +78,7 @@ void THNN_(MSECriterion_updateGradInput)(
     thrust::device_ptr<scalar_t> gradInput_data(THCTensor_(data)(state, gradInput));
 
     thrust::transform(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
       thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
       input_data, input_data+size, target_data, gradInput_data,
@@ -105,14 +105,14 @@ void THNN_(MSECriterion_updateGradInput)(
   thrust::device_ptr<scalar_t> gradInput_data(THCTensor_(data)(state, gradInput));
 
   thrust::transform(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     input_data, input_data+size, target_data, gradInput_data,
     mse_updateGradInput_functor<scalar_t, accreal>(2));
 
   thrust::transform(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     gradInput_data, gradInput_data+size, gradOutput_data, gradInput_data,

--- a/aten/src/THCUNN/generic/SmoothL1Criterion.cu
+++ b/aten/src/THCUNN/generic/SmoothL1Criterion.cu
@@ -34,7 +34,7 @@ void THNN_(SmoothL1Criterion_updateOutput)(
   thrust::device_ptr<scalar_t> input_data(THCTensor_(data)(state, input));
   thrust::device_ptr<scalar_t> target_data(THCTensor_(data)(state, target));
   accreal sum = thrust::inner_product(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     input_data, input_data+size, target_data, (accreal) 0,
@@ -89,7 +89,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
   thrust::device_ptr<scalar_t> gradInput_data(THCTensor_(data)(state, gradInput));
 
   thrust::transform(
-#if CUDA_VERSION >= 7000
+#if CUDA_VERSION >= 7000 || defined __HIP_PLATFORM_HCC__
     thrust::cuda::par(thrustAlloc).on(THCState_getCurrentStream(state)),
 #endif
     input_data, input_data+size, target_data, gradInput_data,


### PR DESCRIPTION
The Thrust shipped with ROCm  is recent enough to support this API. Minimize divergence between CUDA/ROCm by changing idef guards.