### PR TITLE
Added correct isinf handling for Integral tensors

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -938,6 +938,9 @@ class TestCuda(TestCase):
     def test_neg(self):
         _TestTorchMixin._test_neg(self, lambda t: t.cuda())
 
+    def test_isinf(self):
+        _TestTorchMixin._test_isinf(self, lambda t: t.cuda())
+
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     def test_arithmetic_large_tensor(self):
         x = torch.empty(2**30, device='cuda')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5316,19 +5316,23 @@ class _TestTorchMixin(object):
         x = torch.tensor([1, 2, 3])
         self.assertEqual(torch.isfinite(x), torch.ByteTensor([1, 1, 1]))
 
+    @staticmethod
+    def _test_isinf(self, cast):
+        t1 = cast(torch.Tensor([1, inf, 2, -inf, nan]))
+        t2 = cast(torch.ByteTensor([1, 2, 3]))
+        t3 = cast(torch.CharTensor([1, 2, 3]))
+        t4 = cast(torch.ShortTensor([1, 2, 3]))
+        t5 = cast(torch.IntTensor([1, 2, 3]))
+        t6 = cast(torch.LongTensor([1, 2, 3]))
+        self.assertEqual(torch.isinf(t1), cast(torch.ByteTensor([0, 1, 0, 1, 0])))
+        self.assertEqual(torch.isinf(t2), cast(torch.ByteTensor([0, 0, 0])))
+        self.assertEqual(torch.isinf(t3), cast(torch.ByteTensor([0, 0, 0])))
+        self.assertEqual(torch.isinf(t4), cast(torch.ByteTensor([0, 0, 0])))
+        self.assertEqual(torch.isinf(t5), cast(torch.ByteTensor([0, 0, 0])))
+        self.assertEqual(torch.isinf(t6), cast(torch.ByteTensor([0, 0, 0])))
+
     def test_isinf(self):
-        t1 = torch.Tensor([1, inf, 2, -inf, nan])
-        t2 = torch.ByteTensor([1, 2, 3])
-        t3 = torch.CharTensor([1, 2, 3])
-        t4 = torch.ShortTensor([1, 2, 3])
-        t5 = torch.IntTensor([1, 2, 3])
-        t6 = torch.LongTensor([1, 2, 3])
-        self.assertEqual(torch.isinf(t1), torch.ByteTensor([0, 1, 0, 1, 0]))
-        self.assertEqual(torch.isinf(t2), torch.ByteTensor([0, 0, 0]))
-        self.assertEqual(torch.isinf(t3), torch.ByteTensor([0, 0, 0]))
-        self.assertEqual(torch.isinf(t4), torch.ByteTensor([0, 0, 0]))
-        self.assertEqual(torch.isinf(t5), torch.ByteTensor([0, 0, 0]))
-        self.assertEqual(torch.isinf(t6), torch.ByteTensor([0, 0, 0]))
+        self._test_isinf(self, lambda t: t)
 
     def test_isnan(self):
         x = torch.Tensor([1, nan, 2])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5317,8 +5317,18 @@ class _TestTorchMixin(object):
         self.assertEqual(torch.isfinite(x), torch.ByteTensor([1, 1, 1]))
 
     def test_isinf(self):
-        x = torch.Tensor([1, inf, 2, -inf, nan])
-        self.assertEqual(torch.isinf(x), torch.ByteTensor([0, 1, 0, 1, 0]))
+        t1 = torch.Tensor([1, inf, 2, -inf, nan])
+        t2 = torch.ByteTensor([1, 2, 3])
+        t3 = torch.CharTensor([1, 2, 3])
+        t4 = torch.ShortTensor([1, 2, 3])
+        t5 = torch.IntTensor([1, 2, 3])
+        t6 = torch.LongTensor([1, 2, 3])
+        self.assertEqual(torch.isinf(t1), torch.ByteTensor([0, 1, 0, 1, 0]))
+        self.assertEqual(torch.isinf(t2), torch.ByteTensor([0, 0, 0]))
+        self.assertEqual(torch.isinf(t3), torch.ByteTensor([0, 0, 0]))
+        self.assertEqual(torch.isinf(t4), torch.ByteTensor([0, 0, 0]))
+        self.assertEqual(torch.isinf(t5), torch.ByteTensor([0, 0, 0]))
+        self.assertEqual(torch.isinf(t6), torch.ByteTensor([0, 0, 0]))
 
     def test_isnan(self):
         x = torch.Tensor([1, nan, 2])

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -241,7 +241,7 @@ def isinf(tensor):
     if not isinstance(tensor, torch.Tensor):
         raise ValueError("The argument is not a tensor", str(tensor))
     if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
-        return torch.zeros_like(tensor, dtype = torch.uint8)
+        return torch.zeros_like(tensor, dtype=torch.uint8)
     return tensor.abs() == inf
 
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -240,6 +240,8 @@ def isinf(tensor):
     """
     if not isinstance(tensor, torch.Tensor):
         raise ValueError("The argument is not a tensor", str(tensor))
+    if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
+        return torch.zeros_like(tensor, dtype = torch.uint8)
     return tensor.abs() == inf
 
 


### PR DESCRIPTION
Currently torch.isinf on integral tensor will raise RuntimeError: value cannot be converted to type int16_t without overflow: inf. This pr will suppress the error and return false(0) for all integral tensors. The behavior will also be consistent with np.isinf