### PR TITLE
Fix the iterator category for torch::data::Iterator

### DIFF
--- a/torch/csrc/api/include/torch/data/iterator.h
+++ b/torch/csrc/api/include/torch/data/iterator.h
@@ -136,7 +136,7 @@ class Iterator {
   using value_type = Batch;
   using pointer = Batch*;
   using reference = Batch&;
-  using iterator_category = std::output_iterator_tag;
+  using iterator_category = std::input_iterator_tag;
 
   explicit Iterator(std::unique_ptr<detail::IteratorImpl<Batch>> impl)
       : impl_(std::move(impl)) {}


### PR DESCRIPTION
Try to fix https://github.com/pytorch/pytorch/issues/14410.
Additional info: From this [page](https://stackoverflow.com/questions/14062297/canonical-way-to-define-forward-output-iterator), If we change it into `input_iterator_tag`, it doesn't mean the `output_iterator_tag` is lost.