### PR TITLE
Android oss fixes

### DIFF
--- a/caffe2/perfkernels/CMakeLists.txt
+++ b/caffe2/perfkernels/CMakeLists.txt
@@ -16,7 +16,9 @@ set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} ${common_srcs})
 # Currently MSVC seems to have a symbol not found error while linking (related
 # to source file order?). As a result we will currently disable the perfkernel
 # in msvc.
-if (NOT MSVC AND CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
+# Additionally, android seems to have incomplete AVX2 intrinsics in the headers that it ships,
+# so we are seeing compiler errors in android X86 mode. Hence, disabling for now.
+if (NOT MSVC AND NOT ANDROID AND CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
   add_library(Caffe2_perfkernels_avx OBJECT ${avx_srcs})
   add_library(Caffe2_perfkernels_avx2 OBJECT ${avx2_srcs})
   add_dependencies(Caffe2_perfkernels_avx Caffe2_PROTO c10)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1192,7 +1192,11 @@ if (NOT BUILD_ATEN_MOBILE)
     add_compile_options(-DUSE_GCC_GET_CPUID)
   ENDIF()
 
-  FIND_PACKAGE(AVX) # checks AVX and AVX2
+  if (NOT ANDROID)
+    # android seems to have incomplete AVX2 intrinsics in the headers that it ships,
+    # so we are seeing compiler errors in android X86 mode. Hence, disabling for now.
+    FIND_PACKAGE(AVX) # checks AVX and AVX2
+  endif(NOT ANDROID)
 
   # we don't set -mavx and -mavx2 flags globally, but only for specific files
   # however, we want to enable the AVX codepaths, so we still need to

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -174,8 +174,10 @@ if (CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
   # Currently MSVC seems to have a symbol not found error while linking (related
   # to source file order?). As a result we will currently disable the perfkernel
   # in msvc.
+  # Additionally, android seems to have incomplete AVX2 intrinsics in the headers that it ships,
+  # so we are seeing compiler errors in android X86 mode. Hence, disabling for now.
   # Also see CMakeLists.txt under caffe2/perfkernels.
-  if (NOT MSVC)
+  if (NOT MSVC AND NOT ANDROID)
     set(CAFFE2_PERF_WITH_AVX 1)
     set(CAFFE2_PERF_WITH_AVX2 1)
   endif()

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -65,7 +65,7 @@ CMAKE_ARGS+=("-DBUILD_TEST=OFF")
 CMAKE_ARGS+=("-DBUILD_BINARY=OFF")
 CMAKE_ARGS+=("-DBUILD_PYTHON=OFF")
 CMAKE_ARGS+=("-DBUILD_SHARED_LIBS=OFF")
-CMAKE_ARGS+=("-DANDROID_TOOLCHAIN=gcc")
+CMAKE_ARGS+=("-DANDROID_TOOLCHAIN=clang")
 # Disable unused dependencies
 CMAKE_ARGS+=("-DUSE_CUDA=OFF")
 CMAKE_ARGS+=("-DUSE_GFLAGS=OFF")
@@ -106,3 +106,7 @@ if [ -z "$MAX_JOBS" ]; then
   fi
 fi
 cmake --build . -- "-j${MAX_JOBS}"
+
+touch $BUILD_ROOT/lib/libprotoc.a
+touch $BUILD_ROOT/bin/protoc
+cmake --build . -- "-j${MAX_JOBS}" install


### PR DESCRIPTION
Two main fixes were needed to build with latest Android NDK:

- AVX needed to be disabled on Android x86 configuration, because it looks like the compiler shipped with Android NDK didn't have all of the intrinsics defined that we use
- Latest NDK prefers `clang`, so switched to that
- `make install` wasn't working because of cmake's insistence on finding `protoc`, but we built host `protoc`. So I faked it for the script

Somewhat addresses the following issues:

- https://github.com/pytorch/pytorch/issues/14354
- https://github.com/pytorch/pytorch/issues/15427
- https://github.com/pytorch/pytorch/issues/14280
- https://github.com/pytorch/pytorch/issues/14258
- https://github.com/pytorch/pytorch/issues/13116
- https://github.com/pytorch/pytorch/issues/9752
- https://github.com/pytorch/pytorch/issues/7589

The only work I did was to test the whole thing, add some cmake fixes and send a PR.
Pretty much all the hard work was done by @t-vi as part of his heroic effort to get AICamera working again on PyTorch master.

Updated the README of https://github.com/soumith/AICamera to make it clear what exactly has to be done to make it work. Sent a PR to https://github.com/t-vi/AICamera/pull/2

cc: @bwasti @dreiss @t-vi @Suhail 