### PR TITLE
Precommit hook: just warn if no clang-tidy

### DIFF
--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -2,13 +2,21 @@
 set -e
 echo "Running pre-commit flake8"
 python tools/flake8_hook.py
-echo "Running pre-commit clang-tidy"
-python tools/clang_tidy.py \
-  --paths torch/csrc \
-  --diff HEAD \
-  -g"-torch/csrc/distributed/Module.cpp" \
-  -g"-torch/csrc/jit/export.cpp" \
-  -g"-torch/csrc/jit/import.cpp" \
-  -j
+
+if [ $(which clang-tidy) ]
+then
+  echo "Running pre-commit clang-tidy"
+  python tools/clang_tidy.py \
+    --paths torch/csrc \
+    --diff HEAD \
+    -g"-torch/csrc/distributed/Module.cpp" \
+    -g"-torch/csrc/jit/export.cpp" \
+    -g"-torch/csrc/jit/import.cpp" \
+    -j
+else
+  echo "WARNING: Couldn't find clang-tidy executable."
+  echo "  Please install it if you want local clang-tidy checks."
+fi
+
 echo "Running pre-commit clang-format"
 python tools/clang_format.py


### PR DESCRIPTION
The precommit hook shouldn't hard fail if there's no `clang-tidy`, just warn and omit the check.