### PR TITLE
Fix init_omp when MKL_NUM_THREADS is not set

### DIFF
--- a/caffe2/core/init_omp.cc
+++ b/caffe2/core/init_omp.cc
@@ -49,8 +49,8 @@ REGISTER_CAFFE2_INIT_FUNCTION(Caffe2SetOpenMPThreads,
 
 #ifdef CAFFE2_USE_MKL
 bool Caffe2SetMKLThreads(int*, char***) {
-  if (!getenv("MKL_NUM_THREADS")) {
-    VLOG(1) << "MKL_NUM_THREADS not passed, defaulting to 1 thread";
+  if (!getenv("MKL_NUM_THREADS") && !getenv("OMP_NUM_THREADS")) {
+    VLOG(1) << "MKL_NUM_THREADS and OMP_NUM_THREADS not passed, defaulting to 1 thread";
     mkl_set_num_threads(1);
   }
 


### PR DESCRIPTION
According to the MKL user guide, when call mkl_set_num_threads(), it will force Intel MKL to use a given number of OpenMP threads and this call will prevent it from reacting to the environment variables MKL_NUM_THREADS, MKL_DOMAIN_NUM_THREADS, and OMP_NUM_THREADS.

In caffe2 function caffe2/core/init_omp.cc , when doing Caffe2SetMKLThreads, it will just test whether MKL_NUM_THREADS is set, if not set, it will call mkl_set_num_threads(1) to make MKL run with 1 thread which will make it's not reacting to the environment variables  OMP_NUM_THREADS. 

To make OMP_NUM_THREADS can also work on the MKL threading, suggest to modify the if condition as below:
  if (!getenv("MKL_NUM_THREADS") && !getenv("OMP_NUM_THREADS")) {
     VLOG(1) << "MKL_NUM_THREADS and OMP_NUM_THREADS not passed, defaulting to 1
     mkl_set_num_threads(1);
  }

that is, when MKL_NUM_THREADS and OMP_NUM_THREADS both are not set, then call mkl_set_num_threads(1) as default.


 