### PR TITLE
Support fusion of mutable operators

### DIFF
--- a/torch/csrc/jit/fuser/codegen.cpp
+++ b/torch/csrc/jit/fuser/codegen.cpp
@@ -139,7 +139,7 @@ static std::string encodeRHS(const Node* n) {
       {aten::_cast_Float, "static_cast<float>(${0})"},
       {aten::abs, "fabs(${0})"},
       {aten::sigmoid, "1.f / (1.f + expf(-${0}))"},
-      {aten::relu, "${0} < 0 ? 0.f : ${0} "},
+      {aten::relu, "${0} <= 0 ? 0.f : ${0} "},
       {aten::log, "logf(${0})"},
       {aten::log10, "log10f(${0})"},
       {aten::log1p, "log1pf(${0})"},


### PR DESCRIPTION
This is a next step in making fusions in ResNets possible. The only piece
we're missing apart from my open PRs is the ability to differentiate convolutions, which I'm hoping to implement soon (using a method similar to the one I used for BN).

Note that while the method is valid, the fusions usually will only
happen in traced graphs. That is because while tracing, no matter
how the expression looks like, we will always assign the `Value*` of
the mutable _output_ to the tensor. On the other hand, the code
usually contains expressions like `x.relu_()`, which when scripted
does not overwrite the value of `x` with the return from that call
(which is exactly the same at run-time, but a different `Value*`).
This means that in this case there are no data dependencies that
our fuser could follow, and it will never even consider such a node
for fusion, even though it would result in a nice group.

**tl;dr** The following function is currently perfectly fusable when
traced, but not when scripted:

```python
def f(x):
    y = x * 2
    y.relu_()
    return y * 2
```

cc @suo @zdevito @mruberry 

