### PR TITLE
add clang-format check to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,12 @@ matrix:
               - llvm-toolchain-trusty
             packages: clang-tidy
         script: tools/run-clang-tidy-in-ci.sh
-
+      - env: CLANG_FORMAT
+        python: "3.6"
+        addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+              - llvm-toolchain-trusty
+            packages: clang-format
+        script: tools/run-clang-format-in-ci.sh

--- a/tools/run-clang-format-in-ci.sh
+++ b/tools/run-clang-format-in-ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Run clang-format on whitelisted files and return non-zero if it
+# introduced a diff
+
+DIFF_AGAINST=HEAD
+# From https://docs.travis-ci.com/user/environment-variables
+if [[ $TRAVIS ]]; then
+  git remote add upstream https://github.com/pytorch/pytorch
+  git fetch upstream "$TRAVIS_BRANCH"
+  DIFF_AGAINST="upstream/$TRAVIS_BRANCH"
+fi
+
+CLANG_FORMAT_DIFF=$(python tools/clang_format.py --diff "$DIFF_AGAINST")
+if [[ ${CLANG_FORMAT_DIFF} ]]
+then
+  echo "${CLANG_FORMAT_DIFF}"
+  exit 1
+fi
+


### PR DESCRIPTION
Simple check that runs against your PR's changes and complains if running clang-format would have created a change. Does nothing when run against master, so it's "safe" to accept changes that fail this check and it won't break the build.