### PR TITLE
To affect the conda install process, CONDA_PREFIX should be set, not CMAKE_PREFIX_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The details of the patch can be found out [here](https://support.microsoft.com/e
 
 On Linux
 ```bash
-export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root directory]
+export CONDA_PREFIX="$(dirname $(which conda))/../"  # anaconda root directory
 
 # Install basic dependencies
 conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
@@ -165,7 +165,7 @@ conda install -c pytorch magma-cuda92 # or [magma-cuda80 | magma-cuda91] dependi
 
 On macOS
 ```bash
-export CMAKE_PREFIX_PATH=[anaconda root directory]
+export CONDA_PREFIX="$(dirname $(which conda))/../"  # anaconda root directory
 conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
 ```
 
@@ -182,11 +182,13 @@ cd pytorch
 #### Install PyTorch
 On Linux
 ```bash
+export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"  # anaconda root directory
 python setup.py install
 ```
 
 On macOS
 ```bash
+export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"  # anaconda root directory
 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 


### PR DESCRIPTION
This PR is about README.md

I was trying to build pytorch in a conda env and I had trouble setting some include paths correctly for cmake. After hours of inspection, it turned out that `CMAKE_PREFIX_PATH` doesn't affect the conda install process as opposed to my expectation; And I guess the original author(@soumith) expected the same as me. According to the [conda docs](https://conda.io/docs/user-guide/tasks/build-packages/environment-variables.html), `CONDA_PREFIX` is the one in charge. So I added  `CONDA_PREFIX`'s and moved `CMAKE_PREFIX_PATH`'s to proper places.

I think some build issues can be solved with the new instruction. Maybe #14954, as an example.