### PR TITLE
In README.md CMAKE_PREFIX_PATH should be CONDA_PREFIX when using an conda virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,27 +152,17 @@ The details of the patch can be found out [here](https://support.microsoft.com/e
 
 #### Install Optional Dependencies
 
+Common
+```
+conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
+```
+
 On Linux
 ```bash
-export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
-
-# Install basic dependencies
-conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
-
 # Add LAPACK support for the GPU
 conda install -c pytorch magma-cuda92 # or [magma-cuda80 | magma-cuda91] depending on your cuda version
 ```
 
-On macOS
-```bash
-export CMAKE_PREFIX_PATH=[anaconda root directory]
-conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
-```
-
-On Windows
-```cmd
-conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
-```
 #### Get the PyTorch Source
 ```bash
 git clone --recursive https://github.com/pytorch/pytorch
@@ -182,11 +172,13 @@ cd pytorch
 #### Install PyTorch
 On Linux
 ```bash
+export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 python setup.py install
 ```
 
 On macOS
 ```bash
+export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ python setup.py install
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you want to build on Windows, Visual Studio 2017 14.11 toolset and NVTX are a
 Especially, for CUDA 8 build on Windows, there will be an additional requirement for VS 2015 Update 3 and a patch for it.
 The details of the patch can be found out [here](https://support.microsoft.com/en-gb/help/4020481/fix-link-exe-crashes-with-a-fatal-lnk1000-error-when-you-use-wholearch).
 
-#### Install Optional Dependencies
+#### Install Dependencies
 
 Common
 ```
@@ -159,7 +159,7 @@ conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
 
 On Linux
 ```bash
-# Add LAPACK support for the GPU
+# Add LAPACK support for the GPU if needed
 conda install -c pytorch magma-cuda92 # or [magma-cuda80 | magma-cuda91] depending on your cuda version
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The details of the patch can be found out [here](https://support.microsoft.com/e
 
 On Linux
 ```bash
-export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root directory]
+export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 # Install basic dependencies
 conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing


### PR DESCRIPTION
In current README.md, `CMAKE_PREFIX_PATH` is set to conda root even when you have activated an virtual environment. When an conda virtualenv is activated, packages are installed in `CONDA_PREFIX`, not conda root. I think `CMAKE_PREFIX_PATH` should also be set to `CONDA_PREFIX` in this case. I think some build issues can be solved with the new instruction. Maybe something like #14954.

@soumith,
When I made PR #15335 I was confused and made a wrong point. I think this PR could be the real solution.