### PR TITLE
Added deviceCount() virtual method to DeviceGuardImplInterface

### DIFF
--- a/aten/src/ATen/detail/CPUGuardImpl.h
+++ b/aten/src/ATen/detail/CPUGuardImpl.h
@@ -34,6 +34,9 @@ struct CPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     // no-op
     return Stream(Stream::DEFAULT, Device(DeviceType::CPU, -1));
   }
+  DeviceIndex deviceCount() const override {
+    return 1;
+  }
 };
 
 }} // namespace at::detail

--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -67,6 +67,11 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
     setCurrentHIPStream(cs);
     return old_stream.unwrap();
   }
+  DeviceIndex deviceCount() const override {
+    int deviceCnt;
+    C10_HIP_CHECK(hipGetDeviceCount(&deviceCnt));
+    return deviceCnt;
+  }
 };
 
 // All of the guards which have HIPGuardImpl burned in need to also have

--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -51,6 +51,11 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     setCurrentCUDAStream(cs);
     return old_stream.unwrap();
   }
+  DeviceIndex deviceCount() const override {
+    int deviceCnt;
+    C10_CUDA_CHECK(cudaGetDeviceCount(&deviceCnt));
+    return deviceCnt;
+  }
 };
 
 }}} // namespace c10::cuda::impl

--- a/c10/impl/DeviceGuardImplInterface.h
+++ b/c10/impl/DeviceGuardImplInterface.h
@@ -81,6 +81,11 @@ struct C10_API DeviceGuardImplInterface {
   virtual Stream exchangeStream(Stream) const noexcept = 0;
 
   /**
+   * Get the number of devices.
+   */
+  virtual DeviceIndex deviceCount() const = 0;
+
+  /**
    * Intended use of this class is to leak the DeviceGuardImpl at program end.
    * So you better not call the destructor, buster!
    */

--- a/c10/impl/FakeGuardImpl.h
+++ b/c10/impl/FakeGuardImpl.h
@@ -54,6 +54,9 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
     current_streams_[s.device_index()] = s.id();
     return Stream(Stream::UNSAFE, s.device(), old_id);
   }
+  DeviceIndex deviceCount() const override {
+    return 1;
+  }
   // Convenience methods for testing
   static DeviceIndex getDeviceIndex() {
     return current_device_;

--- a/c10/impl/VirtualGuardImpl.h
+++ b/c10/impl/VirtualGuardImpl.h
@@ -40,6 +40,9 @@ public:
   Stream exchangeStream(Stream s) const noexcept override {
     return impl_->exchangeStream(s);
   }
+  DeviceIndex deviceCount() const override {
+    return impl_->deviceCount();
+  }
 private:
   const DeviceGuardImplInterface* impl_ = nullptr;
 };


### PR DESCRIPTION
Summary: Added deviceCount() virtual method to DeviceGuardImplInterface, also added correspondent implementation for CPUGuardImpl, CUDAGuardImpl, FakeGuardImpl, VirtualGuardImpl, HIPGuardImplMasqueradingAsCUDA

Differential Revision: D13554609
