### PR TITLE
Error when torch.load-ing a JIT model

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2070,6 +2070,7 @@ class TestJit(JitTestCase):
         warns = [str(w.message) for w in warns]
         self.assertEqual(len(warns), 0)
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: need to fix this test case for Windows")
     def test_torch_load_error(self):
         class J(torch.jit.ScriptModule):
             def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2070,6 +2070,21 @@ class TestJit(JitTestCase):
         warns = [str(w.message) for w in warns]
         self.assertEqual(len(warns), 0)
 
+    def test_torch_load_error(self):
+        class J(torch.jit.ScriptModule):
+            def __init__(self):
+                super(J, self).__init__()
+
+            @torch.jit.script_method
+            def forward(self, input):
+                return input + 100
+
+        j = J()
+        with tempfile.NamedTemporaryFile() as f:
+            j.save(f.name)
+            with self.assertRaisesRegex(RuntimeError, "is a zip"):
+                torch.load(f.name)
+
 
 class TestBatched(TestCase):
     # generate random examples and create an batchtensor with them

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -7,6 +7,7 @@ import struct
 import sys
 import torch
 import tarfile
+import zipfile
 import tempfile
 import warnings
 from contextlib import closing, contextmanager
@@ -546,6 +547,9 @@ def _load(f, map_location, pickle_module, **pickle_load_args):
         try:
             return legacy_load(f)
         except tarfile.TarError:
+            if zipfile.is_zipfile(f):
+                # .zip is used for torch.jit.save and will throw an un-pickling error here
+                raise RuntimeError("{} is a zip archive (did you mean to use torch.jit.load()?)".format(f.name))
             # if not a tarfile, reset file offset and proceed
             f.seek(0)
 


### PR DESCRIPTION
Throw a warning when calling `torch.load` on a zip file

Fixes #15570