### PR TITLE
append caffe2 prefix to dnnlowp cmd line options

### DIFF
--- a/caffe2/quantization/server/caffe2_dnnlowp_utils.cc
+++ b/caffe2/quantization/server/caffe2_dnnlowp_utils.cc
@@ -8,15 +8,15 @@
 #include <omp.h>
 #endif
 
-C10_DECLARE_int32(dnnlowp_activation_quantization_precision);
-C10_DECLARE_int32(dnnlowp_weight_quantization_precision);
-C10_DECLARE_int32(dnnlowp_requantization_multiplier_precision);
-C10_DECLARE_int32(dnnlowp_eltwise_quantization_precision);
-C10_DECLARE_bool(dnnlowp_force_scale_power_of_two);
-C10_DECLARE_bool(dnnlowp_preserve_activation_sparsity);
-C10_DECLARE_bool(dnnlowp_preserve_weight_sparsity);
-C10_DECLARE_string(dnnlowp_activation_quantization_kind);
-C10_DECLARE_string(dnnlowp_weight_quantization_kind);
+C10_DECLARE_int32(caffe2_dnnlowp_activation_quantization_precision);
+C10_DECLARE_int32(caffe2_dnnlowp_weight_quantization_precision);
+C10_DECLARE_int32(caffe2_dnnlowp_requantization_multiplier_precision);
+C10_DECLARE_int32(caffe2_dnnlowp_eltwise_quantization_precision);
+C10_DECLARE_bool(caffe2_dnnlowp_force_scale_power_of_two);
+C10_DECLARE_bool(caffe2_dnnlowp_preserve_activation_sparsity);
+C10_DECLARE_bool(caffe2_dnnlowp_preserve_weight_sparsity);
+C10_DECLARE_string(caffe2_dnnlowp_activation_quantization_kind);
+C10_DECLARE_string(caffe2_dnnlowp_weight_quantization_kind);
 
 namespace dnnlowp {
 
@@ -264,44 +264,46 @@ static unique_ptr<QuantizationFactory> GetQuantizationFactoryOf_(
       ArgumentHelper::GetSingleArgument<OperatorDef, int>(
           op_def,
           "activation_precision",
-          FLAGS_dnnlowp_activation_quantization_precision);
+          FLAGS_caffe2_dnnlowp_activation_quantization_precision);
   int weight_precision = ArgumentHelper::GetSingleArgument<OperatorDef, int>(
-      op_def, "weight_precision", FLAGS_dnnlowp_weight_quantization_precision);
+      op_def,
+      "weight_precision",
+      FLAGS_caffe2_dnnlowp_weight_quantization_precision);
   int requantization_multiplier_precision =
       ArgumentHelper::GetSingleArgument<OperatorDef, int>(
           op_def,
           "requantization_multiplier_precision",
-          FLAGS_dnnlowp_requantization_multiplier_precision);
+          FLAGS_caffe2_dnnlowp_requantization_multiplier_precision);
   int eltwise_quantization_precision =
       ArgumentHelper::GetSingleArgument<OperatorDef, int>(
           op_def,
           "eltwise_quantization_precision",
-          FLAGS_dnnlowp_eltwise_quantization_precision);
+          FLAGS_caffe2_dnnlowp_eltwise_quantization_precision);
   bool preserve_activation_sparsity =
       ArgumentHelper::GetSingleArgument<OperatorDef, bool>(
           op_def,
           "preserve_activation_sparsity",
-          FLAGS_dnnlowp_preserve_activation_sparsity);
+          FLAGS_caffe2_dnnlowp_preserve_activation_sparsity);
   bool preserve_weight_sparsity =
       ArgumentHelper::GetSingleArgument<OperatorDef, bool>(
           op_def,
           "preserve_weight_sparsity",
-          FLAGS_dnnlowp_preserve_weight_sparsity);
+          FLAGS_caffe2_dnnlowp_preserve_weight_sparsity);
   bool force_scale_power_of_two =
       ArgumentHelper::GetSingleArgument<OperatorDef, bool>(
           op_def,
           "force_scale_power_of_two",
-          FLAGS_dnnlowp_force_scale_power_of_two);
+          FLAGS_caffe2_dnnlowp_force_scale_power_of_two);
   string activation_quantization_kind =
       ArgumentHelper::GetSingleArgument<OperatorDef, string>(
           op_def,
           "activation_quantization_kind",
-          FLAGS_dnnlowp_activation_quantization_kind);
+          FLAGS_caffe2_dnnlowp_activation_quantization_kind);
   string weight_quantization_kind =
       ArgumentHelper::GetSingleArgument<OperatorDef, string>(
           op_def,
           "weight_quantization_kind",
-          FLAGS_dnnlowp_weight_quantization_kind);
+          FLAGS_caffe2_dnnlowp_weight_quantization_kind);
 
   VLOG(2) << "Quantization method for op with output " << op_def.output(0)
           << " activation_precision " << activation_precision

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
@@ -14,8 +14,8 @@
 #include "fbgemm_pack_op.h"
 #include "im2col_dnnlowp.h"
 
-C10_DECLARE_int32(dnnlowp_nbits_in_non_outlier);
-C10_DECLARE_int32(dnnlowp_copy_to_32bit_frequency);
+C10_DECLARE_int32(caffe2_dnnlowp_nbits_in_non_outlier);
+C10_DECLARE_int32(caffe2_dnnlowp_copy_to_32bit_frequency);
 C10_DECLARE_bool(caffe2_dnnlowp_shared_int32_buffer);
 
 namespace caffe2 {
@@ -29,10 +29,10 @@ ConvDNNLowPAcc16Op<ReluFused>::ConvDNNLowPAcc16Op(
     : ConvDNNLowPOp<uint8_t, ReluFused>(operator_def, ws),
       nbits_in_non_outlier_(OperatorBase::GetSingleArgument<int>(
           "nbits_in_non_outlier",
-          FLAGS_dnnlowp_nbits_in_non_outlier)),
+          FLAGS_caffe2_dnnlowp_nbits_in_non_outlier)),
       copy_to_32bit_frequency_(OperatorBase::GetSingleArgument<int>(
           "copy_to_32bit_frequency",
-          FLAGS_dnnlowp_copy_to_32bit_frequency)) {}
+          FLAGS_caffe2_dnnlowp_copy_to_32bit_frequency)) {}
 
 template <bool ReluFused>
 bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNCHW() {

--- a/caffe2/quantization/server/dnnlowp.cc
+++ b/caffe2/quantization/server/dnnlowp.cc
@@ -11,53 +11,53 @@
 #endif
 
 C10_DEFINE_int32(
-    dnnlowp_activation_quantization_precision,
+    caffe2_dnnlowp_activation_quantization_precision,
     8,
     "Precision used for activation tensors");
 C10_DEFINE_int32(
-    dnnlowp_weight_quantization_precision,
+    caffe2_dnnlowp_weight_quantization_precision,
     8,
     "Precision used for weight tensors");
 C10_DEFINE_int32(
-    dnnlowp_requantization_multiplier_precision,
+    caffe2_dnnlowp_requantization_multiplier_precision,
     32,
     "Precision of integer multipliers used for rescaling quantized numbers");
 C10_DEFINE_int32(
-    dnnlowp_eltwise_quantization_precision,
+    caffe2_dnnlowp_eltwise_quantization_precision,
     16,
     "Precision used for intermediate numbers during elementwise operations");
 C10_DEFINE_bool(
-    dnnlowp_force_scale_power_of_two,
+    caffe2_dnnlowp_force_scale_power_of_two,
     false,
     "When true, force quantization scales to a power of two");
 C10_DEFINE_bool(
-    dnnlowp_preserve_activation_sparsity,
+    caffe2_dnnlowp_preserve_activation_sparsity,
     false,
     "When true, 0 is mapped to 0 after quantization: "
     "i.e., symmetric quantization");
 C10_DEFINE_bool(
-    dnnlowp_preserve_weight_sparsity,
+    caffe2_dnnlowp_preserve_weight_sparsity,
     false,
     "When true, 0 is mapped to 0 after quantization: "
     "i.e., symmetric quantization");
 C10_DEFINE_string(
-    dnnlowp_activation_quantization_kind,
+    caffe2_dnnlowp_activation_quantization_kind,
     "min_max",
     "Quantization method for activation tensors. "
     "Allowed values: min_max, l2, l2_approx, kl, l1, p99");
 C10_DEFINE_string(
-    dnnlowp_weight_quantization_kind,
+    caffe2_dnnlowp_weight_quantization_kind,
     "min_max",
     "Quantization method for weight tensors. "
     "Allowed values: min_max, l2, l2_approx, kl, l1, p99");
 C10_DEFINE_int32(
-    dnnlowp_nbits_in_non_outlier,
+    caffe2_dnnlowp_nbits_in_non_outlier,
     8,
     "When outlier-aware quantization is used, if a quantized number can be "
     "represented by this number of bits, it is considered not an outlier so "
     "handled with 16-bit accumulation");
 C10_DEFINE_int32(
-    dnnlowp_copy_to_32bit_frequency,
+    caffe2_dnnlowp_copy_to_32bit_frequency,
     32,
     "When outlier-aware quantization is used, this option specifies how often "
     "we spill 16-bit accumulated numbers to 32-bit during the first pass");
@@ -81,8 +81,8 @@ QuantizationFactory::QuantizationKind StringToKind(const string& s) {
   } else if (s_lower == "l2") {
     return QuantizationFactory::L2_MIN_QUANTIZATION;
   } else if (s_lower == "l2_approx") {
-    if (FLAGS_dnnlowp_preserve_weight_sparsity ||
-        FLAGS_dnnlowp_preserve_activation_sparsity) {
+    if (FLAGS_caffe2_dnnlowp_preserve_weight_sparsity ||
+        FLAGS_caffe2_dnnlowp_preserve_activation_sparsity) {
       return QuantizationFactory::L2_MIN_QUANTIZATION;
     } else {
       return QuantizationFactory::L2_MIN_QUANTIZATION_APPROX;
@@ -99,39 +99,40 @@ QuantizationFactory::QuantizationKind StringToKind(const string& s) {
 
 QuantizationFactory* QuantizationFactory::GetDefaultInstance() {
   static QuantizationFactory singleton(
-      FLAGS_dnnlowp_activation_quantization_precision,
-      FLAGS_dnnlowp_weight_quantization_precision,
-      FLAGS_dnnlowp_requantization_multiplier_precision,
-      FLAGS_dnnlowp_eltwise_quantization_precision,
-      FLAGS_dnnlowp_preserve_activation_sparsity,
-      FLAGS_dnnlowp_preserve_weight_sparsity,
-      FLAGS_dnnlowp_force_scale_power_of_two,
-      StringToKind(FLAGS_dnnlowp_activation_quantization_kind),
-      StringToKind(FLAGS_dnnlowp_weight_quantization_kind));
+      FLAGS_caffe2_dnnlowp_activation_quantization_precision,
+      FLAGS_caffe2_dnnlowp_weight_quantization_precision,
+      FLAGS_caffe2_dnnlowp_requantization_multiplier_precision,
+      FLAGS_caffe2_dnnlowp_eltwise_quantization_precision,
+      FLAGS_caffe2_dnnlowp_preserve_activation_sparsity,
+      FLAGS_caffe2_dnnlowp_preserve_weight_sparsity,
+      FLAGS_caffe2_dnnlowp_force_scale_power_of_two,
+      StringToKind(FLAGS_caffe2_dnnlowp_activation_quantization_kind),
+      StringToKind(FLAGS_caffe2_dnnlowp_weight_quantization_kind));
 
   static bool log_printed = false;
   if (!log_printed) {
     LOG(INFO) << "activation_precision "
-              << FLAGS_dnnlowp_activation_quantization_precision;
+              << FLAGS_caffe2_dnnlowp_activation_quantization_precision;
     LOG(INFO) << "weight_precision "
-              << FLAGS_dnnlowp_weight_quantization_precision;
+              << FLAGS_caffe2_dnnlowp_weight_quantization_precision;
     LOG(INFO) << "requantization_multiplier_precision "
-              << FLAGS_dnnlowp_requantization_multiplier_precision;
+              << FLAGS_caffe2_dnnlowp_requantization_multiplier_precision;
     LOG(INFO) << "eltwise_quantize_precision "
-              << FLAGS_dnnlowp_eltwise_quantization_precision;
+              << FLAGS_caffe2_dnnlowp_eltwise_quantization_precision;
     LOG(INFO) << "preserve_activation_sparsity "
-              << FLAGS_dnnlowp_preserve_activation_sparsity;
+              << FLAGS_caffe2_dnnlowp_preserve_activation_sparsity;
     LOG(INFO) << "preserve_weight_sparsity "
-              << FLAGS_dnnlowp_preserve_weight_sparsity;
+              << FLAGS_caffe2_dnnlowp_preserve_weight_sparsity;
     LOG(INFO) << "force_scale_power_of_two "
-              << FLAGS_dnnlowp_force_scale_power_of_two;
+              << FLAGS_caffe2_dnnlowp_force_scale_power_of_two;
     LOG(INFO) << "activation_quantization_kind "
-              << FLAGS_dnnlowp_activation_quantization_kind;
+              << FLAGS_caffe2_dnnlowp_activation_quantization_kind;
     LOG(INFO) << "weight_quantization_kind "
-              << FLAGS_dnnlowp_weight_quantization_kind;
-    LOG(INFO) << "nbits_in_non_outlier " << FLAGS_dnnlowp_nbits_in_non_outlier;
+              << FLAGS_caffe2_dnnlowp_weight_quantization_kind;
+    LOG(INFO) << "nbits_in_non_outlier "
+              << FLAGS_caffe2_dnnlowp_nbits_in_non_outlier;
     LOG(INFO) << "copy_to_32bit_frequency "
-              << FLAGS_dnnlowp_copy_to_32bit_frequency;
+              << FLAGS_caffe2_dnnlowp_copy_to_32bit_frequency;
     LOG(INFO) << "omp_get_max_threads() " << caffe2::dnnlowp_get_max_threads();
 
     log_printed = true;

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -4,7 +4,7 @@
 
 #include "caffe2_dnnlowp_utils.h"
 
-C10_DECLARE_int32(dnnlowp_nbits_in_non_outlier);
+C10_DECLARE_int32(caffe2_dnnlowp_nbits_in_non_outlier);
 
 namespace caffe2 {
 
@@ -214,7 +214,7 @@ FullyConnectedDNNLowPPackWeightOp::FullyConnectedDNNLowPPackWeightOp(
       axis_w_(this->GetSingleArgument<int32_t>("axis_w", 1)) {
   if (this->debug_def().engine() == "DNNLOWP_ACC16") {
     nbits_in_non_outlier_ = this->GetSingleArgument<int>(
-        "nbits_in_non_outlier", FLAGS_dnnlowp_nbits_in_non_outlier);
+        "nbits_in_non_outlier", FLAGS_caffe2_dnnlowp_nbits_in_non_outlier);
   }
 }
 
@@ -311,7 +311,7 @@ ConvDNNLowPPackWeightOp::ConvDNNLowPPackWeightOp(
           this->GetSingleArgument<bool>("quantize_groupwise", false)) {
   if (this->debug_def().engine() == "DNNLOWP_ACC16") {
     nbits_in_non_outlier_ = this->GetSingleArgument<int>(
-        "nbits_in_non_outlier", FLAGS_dnnlowp_nbits_in_non_outlier);
+        "nbits_in_non_outlier", FLAGS_caffe2_dnnlowp_nbits_in_non_outlier);
   }
 }
 

--- a/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.cc
@@ -4,8 +4,8 @@
 
 #include "fbgemm_pack_op.h"
 
-C10_DECLARE_int32(dnnlowp_nbits_in_non_outlier);
-C10_DECLARE_int32(dnnlowp_copy_to_32bit_frequency);
+C10_DECLARE_int32(caffe2_dnnlowp_nbits_in_non_outlier);
+C10_DECLARE_int32(caffe2_dnnlowp_copy_to_32bit_frequency);
 
 namespace caffe2 {
 
@@ -15,10 +15,10 @@ FullyConnectedDNNLowPAcc16Op::FullyConnectedDNNLowPAcc16Op(
     : FullyConnectedDNNLowPOp<uint8_t>(operator_def, ws),
       nbits_in_non_outlier_(OperatorBase::GetSingleArgument<int>(
           "nbits_in_non_outlier",
-          FLAGS_dnnlowp_nbits_in_non_outlier)),
+          FLAGS_caffe2_dnnlowp_nbits_in_non_outlier)),
       copy_to_32bit_frequency_(OperatorBase::GetSingleArgument<int>(
           "copy_to_32bit_frequency",
-          FLAGS_dnnlowp_copy_to_32bit_frequency)) {}
+          FLAGS_caffe2_dnnlowp_copy_to_32bit_frequency)) {}
 
 bool FullyConnectedDNNLowPAcc16Op::RunOnDevice() {
   using namespace std;

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -10,7 +10,7 @@
 #include "mmio.h"
 
 C10_DEFINE_bool(
-    dnnlowp_enforce_default_caffe2_operators,
+    caffe2_dnnlowp_enforce_default_operators,
     false,
     "When true, enforce to use the default Caffe2 operators inside DNNLOWP"
     "instead of using its own implementation that uses AVX2 instructions"
@@ -48,7 +48,7 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
 
   this->ParseDNNLowPOperatorArguments_();
 
-  if ((!GetCpuId().avx2() || FLAGS_dnnlowp_enforce_default_caffe2_operators) &&
+  if ((!GetCpuId().avx2() || FLAGS_caffe2_dnnlowp_enforce_default_operators) &&
       dequantize_output_) {
     if (!GetCpuId().avx2()) {
       static int log_occurences = 0;


### PR DESCRIPTION
Summary: Following convention of having caffe2_ prefix in command line options

Differential Revision: D13252055
