### PR TITLE
add NCHW2NHWC and NHWC2NCHW in utils.py

### DIFF
--- a/caffe2/python/operator_test/channel_shuffle_test.py
+++ b/caffe2/python/operator_test/channel_shuffle_test.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.python import core
+from caffe2.python import core, utils
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 from hypothesis import given

--- a/caffe2/python/operator_test/conv_transpose_test.py
+++ b/caffe2/python/operator_test/conv_transpose_test.py
@@ -6,7 +6,7 @@ import numpy as np
 from hypothesis import assume, given, settings
 import hypothesis.strategies as st
 
-from caffe2.python import core
+from caffe2.python import core, utils
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.hip_test_util as hiputl
 
@@ -57,8 +57,8 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
                 device_option=gc,
             )
             if order == "NCHW":
-                X_f = X.transpose((0, 3, 1, 2))
-                w_f = w.transpose((0, 3, 1, 2))
+                X_f = utils.NHWC2NCHW(X)
+                w_f = utils.NHWC2NCHW(w)
             else:
                 X_f = X
                 w_f = w
@@ -78,7 +78,7 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
             (batch_size, output_channels, output_size, output_size))
         np.testing.assert_allclose(
             outputs["NCHW"],
-            outputs["NHWC"].transpose((0, 3, 1, 2)),
+            utils.NHWC2NCHW(outputs["NHWC"]),
             atol=1e-4,
             rtol=1e-4)
 
@@ -127,8 +127,8 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
                 device_option=gc,
             )
             if order == "NCHW":
-                X_f = X.transpose((0, 3, 1, 2))
-                w_f = w.transpose((0, 3, 1, 2))
+                X_f = utils.NHWC2NCHW(X)
+                w_f = utils.NHWC2NCHW(w)
             else:
                 X_f = X
                 w_f = w
@@ -148,7 +148,7 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
             (batch_size, output_channels, output_size, output_size))
         np.testing.assert_allclose(
             outputs["NCHW"],
-            outputs["NHWC"].transpose((0, 3, 1, 2)),
+            utils.NHWC2NCHW(outputs["NHWC"]),
             atol=1e-4,
             rtol=1e-4)
 
@@ -201,8 +201,8 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
                 device_option=gc,
             )
             if order == "NCHW":
-                X_f = X.transpose((0, 3, 1, 2))
-                w_f = w.transpose((0, 3, 1, 2))
+                X_f = utils.NHWC2NCHW(X)
+                w_f = utils.NHWC2NCHW(w)
             else:
                 X_f = X
                 w_f = w
@@ -223,7 +223,7 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
             (batch_size, output_channels, output_h, output_w))
         np.testing.assert_allclose(
             outputs["NCHW"],
-            outputs["NHWC"].transpose((0, 3, 1, 2)),
+            utils.NHWC2NCHW(outputs["NHWC"]),
             atol=1e-4,
             rtol=1e-4)
 
@@ -268,8 +268,8 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
             no_gradient_to_input=not compute_dX,
         )
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, w, b] if use_bias else [X, w]
         self.assertDeviceChecks(dc, op, inputs, [0])
@@ -339,8 +339,8 @@ class TestConvolutionTranspose(hu.HypothesisTestCase):
             no_gradient_to_input=not compute_dX,
         )
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, w, b] if use_bias else [X, w]
         self.assertDeviceChecks(dc, op, inputs, [0])

--- a/caffe2/python/operator_test/deform_conv_test.py
+++ b/caffe2/python/operator_test/deform_conv_test.py
@@ -7,12 +7,10 @@ from hypothesis import assume, given
 import hypothesis.strategies as st
 
 from caffe2.proto import caffe2_pb2
-from caffe2.python import core, workspace
+from caffe2.python import core, utils, workspace
 import caffe2.python.hypothesis_test_util as hu
 import unittest
 import os
-
-import unittest
 
 
 def _cudnn_supports(
@@ -108,7 +106,7 @@ def _conv_2d_shuffle_offsets(
     w0 = [[w0] * input_channels] * output_channels
     return (
         np.array([e] * batch_size).astype(np.float32),
-        np.array(w0).astype(np.float32).transpose((0, 2, 3, 1))
+        utils.NCHW2NHWC(np.array(w0).astype(np.float32))
     )
 
 
@@ -163,8 +161,8 @@ class TestConvolution(hu.HypothesisTestCase):
             - 0.5
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, o, w, b] if use_bias else [X, o, w]
 
@@ -247,8 +245,8 @@ class TestConvolution(hu.HypothesisTestCase):
         w = np.ones((output_channels, kernel, kernel, input_channels), np.float32) - 0.5
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, o, w, b] if use_bias else [X, o, w]
 
@@ -334,9 +332,9 @@ class TestConvolution(hu.HypothesisTestCase):
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
 
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
-            w0 = w0.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
+            w0 = utils.NHWC2NCHW(w0)
 
         inputs = [X, o, w, b] if use_bias else [X, o, w]
 
@@ -425,8 +423,8 @@ class TestConvolution(hu.HypothesisTestCase):
             - 0.5
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, o, w, b] if use_bias else [X, o, w]
 
@@ -495,8 +493,8 @@ class TestConvolution(hu.HypothesisTestCase):
             - 0.5
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, o, w, b] if use_bias else [X, o, w]
         # Error handling path.

--- a/caffe2/python/operator_test/depthwise_3x3_conv_test.py
+++ b/caffe2/python/operator_test/depthwise_3x3_conv_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 import caffe2.python.hypothesis_test_util as hu
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from hypothesis import given
 import hypothesis.strategies as st
 
@@ -40,8 +40,8 @@ class Depthwise3x3ConvOpsTest(hu.HypothesisTestCase):
             - 0.5
         b = np.random.rand(channels).astype(np.float32) - 0.5
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, w, b] if use_bias else [X, w]
         # Error handling path.

--- a/caffe2/python/operator_test/group_conv_test.py
+++ b/caffe2/python/operator_test/group_conv_test.py
@@ -7,7 +7,7 @@ from hypothesis import assume, given, settings
 import hypothesis.strategies as st
 
 from caffe2.proto import caffe2_pb2
-from caffe2.python import core
+from caffe2.python import core, utils
 import caffe2.python.hip_test_util as hiputl
 import caffe2.python.hypothesis_test_util as hu
 
@@ -65,8 +65,8 @@ class TestGroupConvolution(hu.HypothesisTestCase):
             - 0.5
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
-            w = w.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
+            w = utils.NHWC2NCHW(w)
 
         inputs = [X, w, b] if use_bias else [X, w]
 

--- a/caffe2/python/operator_test/leaky_relu_test.py
+++ b/caffe2/python/operator_test/leaky_relu_test.py
@@ -6,7 +6,7 @@ import numpy as np
 from hypothesis import given, assume
 import hypothesis.strategies as st
 
-from caffe2.python import core, model_helper
+from caffe2.python import core, model_helper, utils
 import caffe2.python.hypothesis_test_util as hu
 
 
@@ -22,7 +22,7 @@ class TestLeakyRelu(hu.HypothesisTestCase):
             input_data <= 0, input_data >= -0.051)] = -0.051
 
         if order == 'NHWC':
-            input_data = np.transpose(input_data, axes=(0, 2, 3, 1))
+            input_data = utils.NCHW2NHWC(input_data)
 
         return input_data,
 
@@ -84,7 +84,7 @@ class TestLeakyRelu(hu.HypothesisTestCase):
             outputs[order] = self.ws.blobs['output'].fetch()
         np.testing.assert_allclose(
             outputs['NCHW'],
-            outputs['NHWC'].transpose((0, 3, 1, 2)),
+            utils.NHWC2NCHW(outputs["NHWC"]),
             atol=1e-4,
             rtol=1e-4)
 
@@ -158,7 +158,7 @@ class TestLeakyRelu(hu.HypothesisTestCase):
 
         input_blob = np.random.rand(N, C, H, W).astype(np.float32)
         if order == 'NHWC':
-            input_blob = np.transpose(input_blob, axes=(0, 2, 3, 1))
+            input_blob = utils.NCHW2NHWC(input_blob)
 
         self.ws.create_blob('input').feed(input_blob)
 
@@ -167,7 +167,7 @@ class TestLeakyRelu(hu.HypothesisTestCase):
 
         output_blob = self.ws.blobs['output'].fetch()
         if order == 'NHWC':
-            output_blob = np.transpose(output_blob, axes=(0, 3, 1, 2))
+            output_blob = utils.NHWC2NCHW(output_blob)
 
         assert output_blob.shape == (N, C, H, W)
 

--- a/caffe2/python/operator_test/locally_connected_op_test.py
+++ b/caffe2/python/operator_test/locally_connected_op_test.py
@@ -6,7 +6,7 @@ import numpy as np
 from hypothesis import given
 import hypothesis.strategies as st
 
-from caffe2.python import core
+from caffe2.python import core, utils
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
@@ -74,10 +74,10 @@ class TestLocallyConnectedOp(serial.SerializedTestCase):
             return [output]
 
         def lc_2d_nhwc(X, W, b=None):
-            XT = np.transpose(X, [0, 3, 1, 2])
+            XT = utils.NHWC2NCHW(X)
             WT = np.transpose(W, [0, 1, 2, 5, 3, 4])
             output = lc_2d_nchw(XT, WT, b)
-            return [np.transpose(output[0], [0, 2, 3, 1])]
+            return [utils.NCHW2NHWC(output[0])]
 
         ref_op = lc_2d_nchw if order == "NCHW" else lc_2d_nhwc
 

--- a/caffe2/python/operator_test/order_switch_test.py
+++ b/caffe2/python/operator_test/order_switch_test.py
@@ -2,34 +2,36 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
-
-from caffe2.python import core
+from caffe2.python import core, utils
 from hypothesis import given
 
 
 class OrderSwitchOpsTest(hu.HypothesisTestCase):
-    @given(X=hu.tensor(min_dim=3, max_dim=5, min_value=1, max_value=5),
-           engine=st.sampled_from(["", "CUDNN"]), **hu.gcs)
+    @given(
+        X=hu.tensor(min_dim=3, max_dim=5, min_value=1, max_value=5),
+        engine=st.sampled_from(["", "CUDNN"]),
+        **hu.gcs
+    )
     def test_nchw2nhwc(self, X, engine, gc, dc):
         op = core.CreateOperator("NCHW2NHWC", ["X"], ["Y"], engine=engine)
 
         def nchw2nhwc_ref(X):
-            X_reshaped = X.transpose((0,) + tuple(range(2, X.ndim)) + (1,))
-            return (X_reshaped,)
+            return (utils.NCHW2NHWC(X),)
 
         self.assertReferenceChecks(gc, op, [X], nchw2nhwc_ref)
         self.assertGradientChecks(gc, op, [X], 0, [0])
         self.assertDeviceChecks(dc, op, [X], [0])
 
-    @given(X=hu.tensor(min_dim=3, max_dim=5, min_value=1, max_value=5),
-           engine=st.sampled_from(["", "CUDNN"]), **hu.gcs)
+    @given(
+        X=hu.tensor(min_dim=3, max_dim=5, min_value=1, max_value=5),
+        engine=st.sampled_from(["", "CUDNN"]),
+        **hu.gcs
+    )
     def test_nhwc2nchw(self, X, engine, gc, dc):
         op = core.CreateOperator("NHWC2NCHW", ["X"], ["Y"], engine=engine)
 
         def nhwc2nchw_ref(X):
-            X_reshaped = X.transpose(
-                (0, X.ndim - 1) + tuple(range(1, X.ndim - 1)))
-            return (X_reshaped,)
+            return (utils.NHWC2NCHW(X),)
 
         self.assertReferenceChecks(gc, op, [X], nhwc2nchw_ref)
         self.assertGradientChecks(gc, op, [X], 0, [0])

--- a/caffe2/python/operator_test/pooling_test.py
+++ b/caffe2/python/operator_test/pooling_test.py
@@ -8,7 +8,7 @@ import hypothesis.strategies as st
 import os
 import unittest
 
-from caffe2.python import core, workspace
+from caffe2.python import core, utils, workspace
 import caffe2.python.hip_test_util as hiputl
 import caffe2.python.hypothesis_test_util as hu
 
@@ -54,7 +54,7 @@ class TestPooling(hu.HypothesisTestCase):
             batch_size, size, size, input_channels).astype(np.float32)
 
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
         self.assertDeviceChecks(dc, op, [X], [0])
         if 'MaxPool' not in op_type:
             self.assertGradientChecks(gc, op, [X], 0, [0])
@@ -105,7 +105,7 @@ class TestPooling(hu.HypothesisTestCase):
         X = np.random.rand(
             batch_size, size, input_channels).astype(np.float32)
         if order == "NCHW":
-            X = X.transpose((0, 2, 1))
+            X = utils.NHWC2NCHW(X)
 
         self.assertDeviceChecks(dc, op, [X], [0])
         if 'MaxPool' not in op_type:
@@ -145,7 +145,7 @@ class TestPooling(hu.HypothesisTestCase):
         X = np.random.rand(
             batch_size, size, size, size, input_channels).astype(np.float32)
         if order == "NCHW":
-            X = X.transpose((0, 4, 1, 2, 3))
+            X = utils.NHWC2NCHW(X)
 
         self.assertDeviceChecks(dc, op, [X], [0], threshold=0.001)
         if 'MaxPool' not in op_type:
@@ -178,7 +178,7 @@ class TestPooling(hu.HypothesisTestCase):
         X = np.random.rand(
             batch_size, size, size, size, input_channels).astype(np.float32)
         if order == "NCHW":
-            X = X.transpose((0, 4, 1, 2, 3))
+            X = utils.NHWC2NCHW(X)
 
         self.assertDeviceChecks(dc, op, [X], [0], threshold=0.001)
         if 'MaxPool' not in op_type:
@@ -209,7 +209,7 @@ class TestPooling(hu.HypothesisTestCase):
             batch_size, size, size, input_channels).astype(np.float32)
 
         # transpose due to order = NCHW
-        X = X.transpose((0, 3, 1, 2))
+        X = utils.NHWC2NCHW(X)
 
         self.assertDeviceChecks(dc, op, [X], [0])
 
@@ -298,7 +298,7 @@ class TestPooling(hu.HypothesisTestCase):
         X = np.random.rand(
             batch_size, size, size, input_channels).astype(np.float32)
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
 
         self.assertDeviceChecks(dc, op, [X], [0])
         if 'MaxPool' not in op_type:
@@ -329,7 +329,7 @@ class TestPooling(hu.HypothesisTestCase):
         X = np.random.rand(
             batch_size, size, size, input_channels).astype(np.float32)
         if order == "NCHW":
-            X = X.transpose((0, 3, 1, 2))
+            X = utils.NHWC2NCHW(X)
 
         self.assertDeviceChecks(dc, op, [X], [0])
         if 'MaxPool' not in op_type:

--- a/caffe2/python/operator_test/spatial_bn_op_test.py
+++ b/caffe2/python/operator_test/spatial_bn_op_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.proto import caffe2_pb2
-from caffe2.python import brew, core, workspace
+from caffe2.python import brew, core, utils, workspace
 import caffe2.python.hip_test_util as hiputl
 import caffe2.python.hypothesis_test_util as hu
 from caffe2.python.model_helper import ModelHelper
@@ -62,7 +62,7 @@ class TestSpatialBN(serial.SerializedTestCase):
             .astype(np.float32) - 0.5
 
         if order == "NHWC":
-            X = X.transpose(0, 2, 3, 4, 1)
+            X = utils.NCHW2NHWC(X)
         self.assertReferenceChecks(gc, op, [X, scale, bias, mean, var],
                                    reference_spatialbn_test)
         self.assertDeviceChecks(dc, op, [X, scale, bias, mean, var], [0])

--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -407,3 +407,13 @@ def ArgsToDict(args):
         else:
             ans[arg.name] = None
     return ans
+
+
+def NHWC2NCHW(tensor):
+    assert tensor.ndim >= 1
+    return tensor.transpose((0, tensor.ndim - 1) + tuple(range(1, tensor.ndim - 1)))
+
+
+def NCHW2NHWC(tensor):
+    assert tensor.ndim >= 2
+    return tensor.transpose((0,) + tuple(range(2, tensor.ndim)) + (1,))

--- a/caffe2/quantization/server/channel_shuffle_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/channel_shuffle_dnnlowp_op_test.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from hypothesis import given
 
 
@@ -26,8 +26,7 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
         X[0, 0, 0, 0] = 0
         X[0, 0, 0, 1] = 255
         if order == "NHWC":
-            # NCHW -> NHWC
-            X = X.transpose((0, 2, 3, 1))
+            X = utils.NCHW2NHWC(X)
 
         net = core.Net("test_net")
 
@@ -52,16 +51,14 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
 
         def channel_shuffle_ref(X):
             if order == "NHWC":
-                # NHWC -> NCHW
-                X = X.transpose((0, 3, 1, 2))
+                X = utils.NHWC2NCHW(X)
             Y_r = X.reshape(
                 X.shape[0], groups, X.shape[1] // groups, X.shape[2], X.shape[3]
             )
             Y_trns = Y_r.transpose((0, 2, 1, 3, 4))
             Y_reshaped = Y_trns.reshape(X.shape)
             if order == "NHWC":
-                # NCHW -> NHWC
-                Y_reshaped = Y_reshaped.transpose((0, 2, 3, 1))
+                Y_reshaped = utils.NCHW2NHWC(Y_reshaped)
             return Y_reshaped
 
         Y_ref = channel_shuffle_ref(X)
@@ -80,8 +77,7 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
         )
         X[0, 0, 0, 0] = 0
         X[0, 0, 0, 1] = 255
-        # NCHW -> NHWC
-        X = X.transpose((0, 2, 3, 1))
+        X = utils.NCHW2NHWC(X)
 
         net = core.Net("test_net")
 
@@ -106,16 +102,14 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
 
         def channel_shuffle_ref(X):
             if order == "NHWC":
-                # NHWC -> NCHW
-                X = X.transpose((0, 3, 1, 2))
+                X = utils.NHWC2NCHW(X)
             Y_r = X.reshape(
                 X.shape[0], groups, X.shape[1] // groups, X.shape[2], X.shape[3]
             )
             Y_trns = Y_r.transpose((0, 2, 1, 3, 4))
             Y_reshaped = Y_trns.reshape(X.shape)
             if order == "NHWC":
-                # NCHW -> NHWC
-                Y_reshaped = Y_reshaped.transpose((0, 2, 3, 1))
+                Y_reshaped = utils.NCHW2NHWC(Y_reshaped)
             return Y_reshaped
 
         Y_ref = channel_shuffle_ref(X)

--- a/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
@@ -4,14 +4,12 @@ import collections
 
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import (
     check_quantized_results_close,
     generate_conv_inputs,
     generate_convnd_inputs,
-    nchw2nhwc,
-    nhwc2nchw,
 )
 from hypothesis import given
 
@@ -229,8 +227,8 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
             fall_back_to_NCHW = "DNNLOWP" not in engine
 
             if fall_back_to_NCHW:
-                X_nchw = nhwc2nchw(X)
-                W_nchw = nhwc2nchw(W)
+                X_nchw = utils.NHWC2NCHW(X)
+                W_nchw = utils.NHWC2NCHW(W)
             do_quantize = "DNNLOWP" in engine
             do_dequantize = "DNNLOWP" in engine
             do_prepack_weight = engine == "DNNLOWP" and prepack_weight
@@ -303,7 +301,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
             self.ws.run(net)
             Y = self.ws.blobs["Y"].fetch()
             if fall_back_to_NCHW:
-                Y = nchw2nhwc(Y)
+                Y = utils.NCHW2NHWC(Y)
             outputs.append(Output(Y=Y, op_type=op_type, engine=engine, order=order))
 
         check_quantized_results_close(outputs, symmetric=preserve_activation_sparsity)

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
@@ -5,12 +5,11 @@ import collections
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import (
     check_quantized_results_close,
     generate_conv_inputs,
-    nhwc2nchw,
 )
 from hypothesis import assume, given
 
@@ -104,8 +103,8 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         W[..., 1] = W_min + 128  # "zeros"
 
         if order == "NCHW":
-            X = nhwc2nchw(X)
-            W = nhwc2nchw(W)
+            X = utils.NHWC2NCHW(X)
+            W = utils.NHWC2NCHW(W)
 
         # No input quantization error in bias
         b = np.round(np.random.randn(output_channels)).astype(np.float32)

--- a/caffe2/quantization/server/conv_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_op_test.py
@@ -4,14 +4,12 @@ import collections
 
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import (
     check_quantized_results_close,
     generate_conv_inputs,
     generate_convnd_inputs,
-    nchw2nhwc,
-    nhwc2nchw,
 )
 from hypothesis import assume, given
 
@@ -356,8 +354,8 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
             fall_back_to_NCHW = "DNNLOWP" not in engine and order == "NHWC"
 
             if fall_back_to_NCHW:
-                X_nchw = nhwc2nchw(X)
-                W_nchw = nhwc2nchw(W)
+                X_nchw = utils.NHWC2NCHW(X)
+                W_nchw = utils.NHWC2NCHW(W)
 
             do_quantize = "DNNLOWP" in engine
             do_dequantize = "DNNLOWP" in engine
@@ -446,7 +444,7 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
             self.ws.run(net)
             Y = self.ws.blobs["Y"].fetch()
             if fall_back_to_NCHW:
-                Y = nchw2nhwc(Y)
+                Y = utils.NCHW2NHWC(Y)
             outputs.append(Output(Y=Y, op_type=op_type, engine=engine, order=order))
 
         check_quantized_results_close(outputs)

--- a/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
@@ -5,12 +5,11 @@ import collections
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import (
     check_quantized_results_close,
     generate_conv_inputs,
-    nhwc2nchw,
 )
 from hypothesis import assume, given
 
@@ -107,8 +106,8 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
                 ] += g
 
         if order == "NCHW":
-            X = nhwc2nchw(X)
-            W = nhwc2nchw(W)
+            X = utils.NHWC2NCHW(X)
+            W = utils.NHWC2NCHW(W)
 
         # No input quantization error in bias
         b = np.round(np.random.randn(output_channels)).astype(np.float32)
@@ -267,8 +266,8 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
                 ] += g
 
             if order == "NCHW":
-                X = nhwc2nchw(X)
-                W = nhwc2nchw(W)
+                X = utils.NHWC2NCHW(X)
+                W = utils.NHWC2NCHW(W)
 
             # No input quantization error in bias
             b = np.round(np.random.randn(output_channels)).astype(np.float32)

--- a/caffe2/quantization/server/dnnlowp_test_utils.py
+++ b/caffe2/quantization/server/dnnlowp_test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
+from caffe2.python import utils
 from hypothesis import assume
 
 
@@ -31,14 +32,6 @@ def pairwise(iterable):
     a, b = tee(iterable)
     next(b, None)
     return zip(a, b)
-
-
-def nhwc2nchw(tensor):
-    return tensor.transpose((0, tensor.ndim - 1) + tuple(range(1, tensor.ndim - 1)))
-
-
-def nchw2nhwc(tensor):
-    return tensor.transpose((0,) + tuple(range(2, tensor.ndim)) + (1,))
 
 
 # Make sure we won't have overflows from vpmaddubsw instruction used in fbgemm)
@@ -271,8 +264,8 @@ def generate_convnd_inputs(
         )
 
     if order == "NCHW":
-        X = nhwc2nchw(X)
-        W = nhwc2nchw(W)
+        X = utils.NHWC2NCHW(X)
+        W = utils.NHWC2NCHW(W)
 
     b = np.random.randn(output_channels).astype(np.float32)
 

--- a/caffe2/quantization/server/group_norm_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/group_norm_dnnlowp_op_test.py
@@ -5,7 +5,7 @@ import collections
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 import numpy as np
-from caffe2.python import core, dyndep, workspace
+from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import check_quantized_results_close
 from hypothesis import given
@@ -46,7 +46,7 @@ class DNNLowPOpGroupNormTest(hu.HypothesisTestCase):
 
         X = np.random.rand(N, C, H, W).astype(np.float32) * 5.0 - 1.0
         if order == "NHWC":
-            X = np.transpose(X, [0, 2, 3, 1])
+            X = utils.NCHW2NHWC(X)
         gamma = np.random.rand(C).astype(np.float32) * 2.0 - 1.0
         beta = np.random.randn(C).astype(np.float32) - 0.5
 


### PR DESCRIPTION
Summary: Use NHWC2NCHW or NCHW2NHWC functions which is easier to understand compared to code using transpose and generalizable to non-2D convolutions.

Differential Revision: D13557674
