### PR TITLE
caffe2_benchmark msvc build fix

### DIFF
--- a/binaries/benchmark_helper.h
+++ b/binaries/benchmark_helper.h
@@ -85,11 +85,12 @@ void writeTextOutput(
   str.pop_back();
   lines.push_back(str);
 
-  auto flags = std::ios::out;
+  // static casts are workaround for MSVC build
+  auto flags = static_cast<std::ios_base::openmode>(std::ios::out);
   if (index != 0) {
-    flags |= std::ios::app;
+    flags |= static_cast<std::ios_base::openmode>(std::ios::app);
   } else {
-    flags |= std::ios::trunc;
+    flags |= static_cast<std::ios_base::openmode>(std::ios::trunc);
   }
   std::ofstream output_file(output_name, flags);
   std::ostream_iterator<std::string> output_iterator(output_file, "\n");


### PR DESCRIPTION
Fixing error in caffe2_benchmark binary

```
2018-12-29T14:09:59.7867995Z   d:\a\1\s\caffe2_builders\v141\pytorch\binaries\benchmark_helper.h(90): error C2678: binary '|=': no operator found which takes a left-hand operand of type 'std::_Iosb<int>::_Openmode' (or there is no acceptable conversion) (compiling source file D:\a\1\s\caffe2_builders\v141\pytorch\binaries\benchmark_helper.cc) [D:\a\1\s\caffe2_builders\v141\pytorch\build\Release\binaries\caffe2_benchmark.vcxproj]
2018-12-29T14:09:59.7868252Z   d:\a\1\s\caffe2_builders\v141\pytorch\binaries\benchmark_helper.h(92): error C2678: binary '|=': no operator found which takes a left-hand operand of type 'std::_Iosb<int>::_Openmode' (or there is no acceptable conversion) (compiling source file D:\a\1\s\caffe2_builders\v141\pytorch\binaries\benchmark_helper.cc) [D:\a\1\s\caffe2_builders\v141\pytorch\build\Release\binaries\caffe2_benchmark.vcxproj]
```