### PR TITLE
Add support for NHWC cuDNN convolutions

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -132,4 +132,33 @@ void FilterDescriptor::set(const at::Tensor &t, int64_t pad) {
   set(getDataType(t), (int) dim, size);
 }
 
+std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d) {
+  out << "FilterDescriptor " << static_cast<void*>(d.desc()) << "\n";
+  int nbDims;
+  int dimA[CUDNN_DIM_MAX];
+  cudnnTensorFormat_t format;
+  cudnnDataType_t dtype;
+  cudnnGetFilterNdDescriptor(d.desc(), CUDNN_DIM_MAX, &dtype, &format, &nbDims, dimA);
+  out << "    type = " << cudnnTypeToString(dtype) << "\n";
+  out << "    nbDims = " << nbDims << "\n";
+  // Read out only nbDims of the array!
+  out << "    dimA = ";
+  for (auto i : ArrayRef<int>{dimA, static_cast<size_t>(nbDims)}) {
+    out << i << ", ";
+  }
+  out << "\n";
+  out << "    format = ";
+  if (format == CUDNN_TENSOR_NCHW) {
+    out << "NCHW";
+  } else if (format == CUDNN_TENSOR_NHWC) {
+    out << "NHWC";
+  } else {
+    out << "<unrecognized>";
+  }
+  out << "\n";
+  return out;
+}
+
+void FilterDescriptor::print() { std::cout << *this; }
+
 }}

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -177,11 +177,15 @@ class FilterDescriptor
 public:
   void set(const at::Tensor &t, int64_t pad = 0);
 
+  void print();
+
 private:
   void set(cudnnDataType_t dataType, int dim, int* size) {
     AT_CUDNN_CHECK(cudnnSetFilterNdDescriptor(mut_desc(), dataType, CUDNN_TENSOR_NCHW, dim, size));
   }
 };
+
+std::ostream& operator<<(std::ostream & out, const FilterDescriptor& d);
 
 struct AT_CUDA_API ConvolutionDescriptor
   : public Descriptor<cudnnConvolutionStruct,

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -4,6 +4,7 @@
 #include <ATen/cuda/Exceptions.h>
 
 #include <ATen/cudnn/cudnn-wrapper.h>
+#include <ATen/cudnn/Layout.h>
 #include <ATen/ATen.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/cuda/ATenCUDAGeneral.h>
@@ -175,13 +176,14 @@ class FilterDescriptor
                       &cudnnDestroyFilterDescriptor>
 {
 public:
-  void set(const at::Tensor &t, int64_t pad = 0);
+  // NB: layout cannot be inferred from t, because some tensors are both valid NCHW and NHWC filters
+  void set(const at::Tensor &t, Layout layout, int64_t pad = 0);
 
   void print();
 
 private:
-  void set(cudnnDataType_t dataType, int dim, int* size) {
-    AT_CUDNN_CHECK(cudnnSetFilterNdDescriptor(mut_desc(), dataType, CUDNN_TENSOR_NCHW, dim, size));
+  void set(cudnnDataType_t dataType, int dim, int* size, cudnnTensorFormat_t format) {
+    AT_CUDNN_CHECK(cudnnSetFilterNdDescriptor(mut_desc(), dataType, format, dim, size));
   }
 };
 

--- a/aten/src/ATen/cudnn/Layout.h
+++ b/aten/src/ATen/cudnn/Layout.h
@@ -1,13 +1,7 @@
 #pragma once
 
-#include <ATen/cuda/CUDAContext.h>
-#include <ATen/cuda/Exceptions.h>
-
 #include <ATen/cudnn/cudnn-wrapper.h>
 #include <ATen/ATen.h>
-#include <ATen/TensorUtils.h>
-#include <ATen/cuda/ATenCUDAGeneral.h>
-#include <cuda.h>
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/cudnn/Layout.h
+++ b/aten/src/ATen/cudnn/Layout.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+
+#include <ATen/cudnn/cudnn-wrapper.h>
+#include <ATen/ATen.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/cuda/ATenCUDAGeneral.h>
+#include <cuda.h>
+
+namespace at { namespace native {
+
+enum class Layout {
+  // N = batch dimension, C = channels, F = feature dimension(s)
+  NCF,
+  NFC
+};
+
+struct LayoutPermutation {
+  static constexpr size_t max_dims = 5;
+
+  LayoutPermutation(Layout from, Layout to, int64_t ndim)
+    : perm_(make_perm(from, to, ndim)), ndim_(ndim) {}
+
+  static std::array<int64_t, max_dims> make_perm(Layout from, Layout to, int64_t ndim) {
+    AT_ASSERT(ndim <= max_dims);
+    // XXX: Note that only the first ndim entries will be used, so the rest can be
+    // out of bound or even garbage.
+    if (from == Layout::NCF && to == Layout::NFC) {
+      std::array<int64_t, max_dims> r = {0, 2, 3, 4};
+      r[ndim - 1] = 1;
+      return r;
+    } else if (from == Layout::NFC && to == Layout::NCF) {
+      return {0, ndim - 1, 1, 2, 3};
+    } else {
+      AT_ASSERT(from == to);
+      return {0, 1, 2, 3, 4};
+    }
+  }
+
+  operator ArrayRef<int64_t>() const {
+    return ArrayRef<int64_t>(perm_).slice(0, ndim_);
+  }
+
+  const std::array<int64_t, max_dims> perm_;
+  const int64_t ndim_;
+};
+
+inline c10::optional<Layout> getLayout(const Tensor& t) {
+  auto strides = t.strides();
+  AT_ASSERT(strides.size() >= 3);
+  if (strides[strides.size() - 1] == 1 && t.is_contiguous()) {
+    return {Layout::NCF};
+  }
+  if (strides[1] == 1 &&
+      t.permute(LayoutPermutation{Layout::NCF, Layout::NFC, t.dim()}).is_contiguous()) {
+    return {Layout::NFC};
+  }
+  return {};
+}
+
+inline cudnnTensorFormat_t getCudnnTensorFormat(Layout l) {
+  switch (l) {
+    case Layout::NCF:
+      return CUDNN_TENSOR_NCHW;
+    case Layout::NFC:
+      return CUDNN_TENSOR_NHWC;
+  }
+  AT_ASSERTM(false, "Unhandled layout in getCudnnTensorFormat");
+}
+
+inline Tensor contiguousIn(Tensor t, Layout layout) {
+  switch (layout) {
+    case Layout::NCF:
+      return t.contiguous();
+    case Layout::NFC:
+      return t.permute(LayoutPermutation{Layout::NCF, Layout::NFC, t.dim()})
+              .contiguous()
+              .permute(LayoutPermutation{Layout::NFC, Layout::NCF, t.dim()});
+  }
+  AT_ASSERTM(false, "Unhandled layout in contiguous_in");
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -846,7 +846,7 @@ Tensor allocate_output(at::IntList sizes, Layout layout, const TensorOptions& op
       auto output = at::empty(ArrayRef<int64_t>(transposed_sizes).slice(0, sizes.size()), options);
 
       // Permute the dimensions to fix sizes to NCF
-      return output.permute(LayoutPermutation{Layout::NFC, Layout::NCF, sizes.size()});
+      return output.permute(LayoutPermutation{Layout::NFC, Layout::NCF, static_cast<int64_t>(sizes.size())});
     }
   }
   AT_ASSERTM(false, "Unhandled layout in allocate_output");

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -490,7 +490,7 @@ namespace {
         const Tensor& weight_buf, cudnnHandle_t handle, const RNNDescriptorParams& rnn,
         const RNNDescriptor& rnn_desc, const TensorDescriptor& x_desc, cudnnDataType_t datatype) {
     FilterDescriptor w_desc;
-    w_desc.set(weight_buf, 3);
+    w_desc.set(weight_buf, Layout::NCF, 3);
 
     int64_t num_linear_layers = _num_linear_layers(rnn.mode);
     int64_t num_dir_layers = rnn.num_directions() * rnn.num_layers;
@@ -633,7 +633,7 @@ Tensor _cudnn_rnn_flatten_weight(
   auto weight_buf = at::zeros(num_weights, any_param.options());
 
   FilterDescriptor w_desc;
-  w_desc.set(weight_buf, 3);
+  w_desc.set(weight_buf, Layout::NCF, 3);
 
   // Slice off views into weight_buf
   std::vector<Tensor> params_arr;
@@ -724,7 +724,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   if (!weight_buf.defined()) {
     auto num_weights = get_num_weights(handle, descs.rnn_desc, descs.x_descs[0], fn.rnn.datatype);
     weight_buf = at::empty(num_weights, x.options());
-    w_desc.set(weight_buf, 3);
+    w_desc.set(weight_buf, Layout::NCF, 3);
     weight_buf.zero_();
     std::vector<Tensor> params;
     size_t params_stride0;
@@ -732,7 +732,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
     _copyParams(MatrixRef<Tensor>{weight, static_cast<size_t>(weight_stride0)},
                 MatrixRef<Tensor>{params, params_stride0});
   } else {
-    w_desc.set(weight_buf, 3);
+    w_desc.set(weight_buf, Layout::NCF, 3);
   }
 
   AT_CHECK(!cx.defined() || cx.sizes().equals(hidden_size),
@@ -882,7 +882,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_rnn_backward_input(
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
   FilterDescriptor w_desc;
-  w_desc.set(weight_buf, 3);
+  w_desc.set(weight_buf, Layout::NCF, 3);
 
   size_t workspace_size;
   auto x_descs_arr = descs.get_x_descs();
@@ -986,7 +986,7 @@ std::vector<Tensor> _cudnn_rnn_backward_weight(
   RNNDescriptors descs(fn, handle, x, y, hx, cx);
 
   FilterDescriptor w_desc;
-  w_desc.set(weight_buf, 3);
+  w_desc.set(weight_buf, Layout::NCF, 3);
 
   size_t workspace_size;
   auto x_descs_arr = descs.get_x_descs();


### PR DESCRIPTION
At a cost of relaxing the constraint that our convolution ops always return contiguous inputs. Basically we attempt to infer that the input is in NHWC format, and in that case we return an output in NHWC as well. NHWC is 10-20% faster than NCHW in fp16.