### PR TITLE
Fix vec256 inversion

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -13,7 +13,7 @@ struct Vec256i {
 protected:
   __m256i values;
 
-  static inline __m256i invert(__m256i v) {
+  static inline __m256i invert(const __m256i& v) {
     const auto ones = _mm256_set1_epi64x(-1);
     return _mm256_xor_si256(ones, v);
   }

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -12,6 +12,11 @@ namespace {
 struct Vec256i {
 protected:
   __m256i values;
+
+  static inline __m256i invert(__m256i v) {
+    const auto ones = _mm256_set1_epi64x(-1);
+    return _mm256_xor_si256(ones, v);
+  }
 public:
   Vec256i() {}
   Vec256i(__m256i v) : values(v) {}
@@ -92,33 +97,22 @@ struct Vec256<int64_t> : public Vec256i {
     return _mm256_sub_epi64(inverse, is_larger);
   }
   Vec256<int64_t> operator==(const Vec256<int64_t>& other) const {
-    // _mm256_cmpeq_epi64 would set all bits in a int64_t to 1 if two values
-    // equal. Hence, we need to mask it to 0/1 instead of returning 0/-1.
-    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
-    return _mm256_and_si256(one, _mm256_cmpeq_epi64(values, other.values));
+    return _mm256_cmpeq_epi64(values, other.values);
   }
   Vec256<int64_t> operator!=(const Vec256<int64_t>& other) const {
-    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
-    auto eq = _mm256_cmpeq_epi64(values, other.values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, eq));  // invert
+    return invert(_mm256_cmpeq_epi64(values, other.values));
   }
   Vec256<int64_t> operator<(const Vec256<int64_t>& other) const {
-    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
-    return _mm256_and_si256(one, _mm256_cmpgt_epi64(other.values, values));
+    return _mm256_cmpgt_epi64(other.values, values);
   }
   Vec256<int64_t> operator<=(const Vec256<int64_t>& other) const {
-    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
-    auto gt = _mm256_cmpgt_epi64(values, other.values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, gt));  // invert
+    return invert(_mm256_cmpgt_epi64(values, other.values));
   }
   Vec256<int64_t> operator>(const Vec256<int64_t>& other) const {
-    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
-    return _mm256_and_si256(one, _mm256_cmpgt_epi64(values, other.values));
+    return _mm256_cmpgt_epi64(values, other.values);
   }
   Vec256<int64_t> operator>=(const Vec256<int64_t>& other) const {
-    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
-    auto lt = _mm256_cmpgt_epi64(other.values, values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, lt));  // invert
+    return invert(_mm256_cmpgt_epi64(other.values, values));
   }
 };
 
@@ -192,33 +186,22 @@ struct Vec256<int32_t> : public Vec256i {
     return _mm256_abs_epi32(values);
   }
   Vec256<int32_t> operator==(const Vec256<int32_t>& other) const {
-    // _mm256_cmpeq_epi32 would set all bits in a int16_t to 1 if two values
-    // equal. Hence, we need to mask it with 1 to return 0/1 instead of 0/-1
-    static const auto one = _mm256_set1_epi32(1);
-    return _mm256_and_si256(one, _mm256_cmpeq_epi32(values, other.values));
+    return _mm256_cmpeq_epi32(values, other.values);
   }
   Vec256<int32_t> operator!=(const Vec256<int32_t>& other) const {
-    static const auto one = _mm256_set1_epi32(1);
-    auto eq = _mm256_cmpeq_epi32(values, other.values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, eq));  // invert
+    return invert(_mm256_cmpeq_epi32(values, other.values));
   }
   Vec256<int32_t> operator<(const Vec256<int32_t>& other) const {
-    static const auto one = _mm256_set1_epi32(1);
-    return _mm256_and_si256(one, _mm256_cmpgt_epi32(other.values, values));
+    return _mm256_cmpgt_epi32(other.values, values);
   }
   Vec256<int32_t> operator<=(const Vec256<int32_t>& other) const {
-    static const auto one = _mm256_set1_epi32(1);
-    auto gt = _mm256_cmpgt_epi32(values, other.values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, gt));  // invert
+    return invert(_mm256_cmpgt_epi32(values, other.values));
   }
   Vec256<int32_t> operator>(const Vec256<int32_t>& other) const {
-    static const auto one = _mm256_set1_epi32(1);
-    return _mm256_and_si256(one, _mm256_cmpgt_epi32(values, other.values));
+    return _mm256_cmpgt_epi32(values, other.values);
   }
   Vec256<int32_t> operator>=(const Vec256<int32_t>& other) const {
-    static const auto one = _mm256_set1_epi32(1);
-    auto lt = _mm256_cmpgt_epi32(other.values, values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, lt));  // invert
+    return invert(_mm256_cmpgt_epi32(other.values, values));
   }
 };
 
@@ -387,33 +370,22 @@ struct Vec256<int16_t> : public Vec256i {
     return _mm256_abs_epi16(values);
   }
   Vec256<int16_t> operator==(const Vec256<int16_t>& other) const {
-    // _mm256_cmpeq_epi16 would set all bits in a int16_t to 1 if two values
-    // equal. Hence, we need to mask it with 1 to return 0/1 instead of 0/-1
-    static const auto one = _mm256_set1_epi16(1);
-    return _mm256_and_si256(one, _mm256_cmpeq_epi16(values, other.values));
+    return _mm256_cmpeq_epi16(values, other.values);
   }
   Vec256<int16_t> operator!=(const Vec256<int16_t>& other) const {
-    static const auto one = _mm256_set1_epi16(1);
-    auto eq = _mm256_cmpeq_epi16(values, other.values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, eq));  // invert
+    return invert(_mm256_cmpeq_epi16(values, other.values));
   }
   Vec256<int16_t> operator<(const Vec256<int16_t>& other) const {
-    static const auto one = _mm256_set1_epi16(1);
-    return _mm256_and_si256(one, _mm256_cmpgt_epi16(other.values, values));
+    return _mm256_cmpgt_epi16(other.values, values);
   }
   Vec256<int16_t> operator<=(const Vec256<int16_t>& other) const {
-    static const auto one = _mm256_set1_epi16(1);
-    auto gt = _mm256_cmpgt_epi16(values, other.values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, gt));  // invert
+    return invert(_mm256_cmpgt_epi16(values, other.values));
   }
   Vec256<int16_t> operator>(const Vec256<int16_t>& other) const {
-    static const auto one = _mm256_set1_epi16(1);
-    return _mm256_and_si256(one, _mm256_cmpgt_epi16(values, other.values));
+    return _mm256_cmpgt_epi16(values, other.values);
   }
   Vec256<int16_t> operator>=(const Vec256<int16_t>& other) const {
-    static const auto one = _mm256_set1_epi16(1);
-    auto lt = _mm256_cmpgt_epi16(other.values, values);
-    return _mm256_and_si256(one, _mm256_xor_si256(one, lt));  // invert
+    return invert(_mm256_cmpgt_epi16(other.values, values));
   }
 };
 

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -92,28 +92,33 @@ struct Vec256<int64_t> : public Vec256i {
     return _mm256_sub_epi64(inverse, is_larger);
   }
   Vec256<int64_t> operator==(const Vec256<int64_t>& other) const {
-    return _mm256_cmpeq_epi64(values, other.values);
+    // _mm256_cmpeq_epi64 would set all bits in a int64_t to 1 if two values
+    // equal. Hence, we need to mask it to 0/1 instead of returning 0/-1.
+    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
+    return _mm256_and_si256(one, _mm256_cmpeq_epi64(values, other.values));
   }
   Vec256<int64_t> operator!=(const Vec256<int64_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
     auto eq = _mm256_cmpeq_epi64(values, other.values);
-    return _mm256_xor_si256(zero, eq);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, eq));  // invert
   }
   Vec256<int64_t> operator<(const Vec256<int64_t>& other) const {
-    return _mm256_cmpgt_epi64(other.values, values);
+    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
+    return _mm256_and_si256(one, _mm256_cmpgt_epi64(other.values, values));
   }
   Vec256<int64_t> operator<=(const Vec256<int64_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
     auto gt = _mm256_cmpgt_epi64(values, other.values);
-    return _mm256_xor_si256(zero, gt);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, gt));  // invert
   }
   Vec256<int64_t> operator>(const Vec256<int64_t>& other) const {
-    return _mm256_cmpgt_epi64(values, other.values);
+    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
+    return _mm256_and_si256(one, _mm256_cmpgt_epi64(values, other.values));
   }
   Vec256<int64_t> operator>=(const Vec256<int64_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_setr_epi64x(1, 1, 1, 1);
     auto lt = _mm256_cmpgt_epi64(other.values, values);
-    return _mm256_xor_si256(zero, lt);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, lt));  // invert
   }
 };
 
@@ -187,28 +192,33 @@ struct Vec256<int32_t> : public Vec256i {
     return _mm256_abs_epi32(values);
   }
   Vec256<int32_t> operator==(const Vec256<int32_t>& other) const {
-    return _mm256_cmpeq_epi32(values, other.values);
+    // _mm256_cmpeq_epi32 would set all bits in a int16_t to 1 if two values
+    // equal. Hence, we need to mask it with 1 to return 0/1 instead of 0/-1
+    static const auto one = _mm256_set1_epi32(1);
+    return _mm256_and_si256(one, _mm256_cmpeq_epi32(values, other.values));
   }
   Vec256<int32_t> operator!=(const Vec256<int32_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_set1_epi32(1);
     auto eq = _mm256_cmpeq_epi32(values, other.values);
-    return _mm256_xor_si256(zero, eq);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, eq));  // invert
   }
   Vec256<int32_t> operator<(const Vec256<int32_t>& other) const {
-    return _mm256_cmpgt_epi32(other.values, values);
+    static const auto one = _mm256_set1_epi32(1);
+    return _mm256_and_si256(one, _mm256_cmpgt_epi32(other.values, values));
   }
   Vec256<int32_t> operator<=(const Vec256<int32_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_set1_epi32(1);
     auto gt = _mm256_cmpgt_epi32(values, other.values);
-    return _mm256_xor_si256(zero, gt);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, gt));  // invert
   }
   Vec256<int32_t> operator>(const Vec256<int32_t>& other) const {
-    return _mm256_cmpgt_epi32(values, other.values);
+    static const auto one = _mm256_set1_epi32(1);
+    return _mm256_and_si256(one, _mm256_cmpgt_epi32(values, other.values));
   }
   Vec256<int32_t> operator>=(const Vec256<int32_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_set1_epi32(1);
     auto lt = _mm256_cmpgt_epi32(other.values, values);
-    return _mm256_xor_si256(zero, lt);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, lt));  // invert
   }
 };
 
@@ -216,16 +226,16 @@ template <>
 void convert(const int32_t *src, float *dst, int64_t n) {
   int64_t i;
   // int32_t and float have same size
-#ifndef _MSC_VER  
-# pragma unroll  
+#ifndef _MSC_VER
+# pragma unroll
 #endif
   for (i = 0; i <= (n - Vec256<int32_t>::size()); i += Vec256<int32_t>::size()) {
     auto input_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
     auto output_vec = _mm256_cvtepi32_ps(input_vec);
     _mm256_storeu_ps(reinterpret_cast<float*>(dst + i), output_vec);
   }
-#ifndef _MSC_VER  
-# pragma unroll  
+#ifndef _MSC_VER
+# pragma unroll
 #endif
   for (; i < n; i++) {
     dst[i] = static_cast<float>(src[i]);
@@ -236,16 +246,16 @@ template <>
 void convert(const int32_t *src, double *dst, int64_t n) {
   int64_t i;
   // int32_t has half the size of double
-#ifndef _MSC_VER  
-# pragma unroll  
+#ifndef _MSC_VER
+# pragma unroll
 #endif
   for (i = 0; i <= (n - Vec256<double>::size()); i += Vec256<double>::size()) {
     auto input_128_vec = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i));
     auto output_vec = _mm256_cvtepi32_pd(input_128_vec);
     _mm256_storeu_pd(reinterpret_cast<double*>(dst + i), output_vec);
   }
-#ifndef _MSC_VER  
-# pragma unroll  
+#ifndef _MSC_VER
+# pragma unroll
 #endif
   for (; i < n; i++) {
     dst[i] = static_cast<double>(src[i]);
@@ -377,28 +387,33 @@ struct Vec256<int16_t> : public Vec256i {
     return _mm256_abs_epi16(values);
   }
   Vec256<int16_t> operator==(const Vec256<int16_t>& other) const {
-    return _mm256_cmpeq_epi16(values, other.values);
+    // _mm256_cmpeq_epi16 would set all bits in a int16_t to 1 if two values
+    // equal. Hence, we need to mask it with 1 to return 0/1 instead of 0/-1
+    static const auto one = _mm256_set1_epi16(1);
+    return _mm256_and_si256(one, _mm256_cmpeq_epi16(values, other.values));
   }
   Vec256<int16_t> operator!=(const Vec256<int16_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_set1_epi16(1);
     auto eq = _mm256_cmpeq_epi16(values, other.values);
-    return _mm256_xor_si256(zero, eq);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, eq));  // invert
   }
   Vec256<int16_t> operator<(const Vec256<int16_t>& other) const {
-    return _mm256_cmpgt_epi16(other.values, values);
+    static const auto one = _mm256_set1_epi16(1);
+    return _mm256_and_si256(one, _mm256_cmpgt_epi16(other.values, values));
   }
   Vec256<int16_t> operator<=(const Vec256<int16_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_set1_epi16(1);
     auto gt = _mm256_cmpgt_epi16(values, other.values);
-    return _mm256_xor_si256(zero, gt);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, gt));  // invert
   }
   Vec256<int16_t> operator>(const Vec256<int16_t>& other) const {
-    return _mm256_cmpgt_epi16(values, other.values);
+    static const auto one = _mm256_set1_epi16(1);
+    return _mm256_and_si256(one, _mm256_cmpgt_epi16(values, other.values));
   }
   Vec256<int16_t> operator>=(const Vec256<int16_t>& other) const {
-    auto zero = _mm256_set1_epi64x(0);
+    static const auto one = _mm256_set1_epi16(1);
     auto lt = _mm256_cmpgt_epi16(other.values, values);
-    return _mm256_xor_si256(zero, lt);  // invert
+    return _mm256_and_si256(one, _mm256_xor_si256(one, lt));  // invert
   }
 };
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1388,6 +1388,14 @@ class _TestTorchMixin(object):
     def test_neg(self):
         self._test_neg(self, lambda t: t)
 
+    def test_threshold(self):
+        for dtype in torch.testing.get_all_dtypes():
+            if dtype != torch.uint8 and dtype != torch.float16:
+                # 100 is wide enough to use AVX2 instructions for all types
+                x = torch.randn(100).sign().to(dtype=dtype)
+                y = torch.threshold(x, 0, 0)
+                self.assertTrue(y.le(0).any())
+
     def test_reciprocal(self):
         a = torch.randn(100, 89)
         res_div = 1 / a


### PR DESCRIPTION
@soumith @zou3519 

I was browsing the code, and think `vec256_int.h` might need a minor revision, but not 100% sure.

1. It currently invert the result by `XOR` with 0. Should it `XOR` with 1 instead?
~2. AVX2 logical operations would set all bits in a byte/word/... to `1` if the condition holds. So functions, such as `_mm256_cmpeq_epi64 ` would return `0/-1` instead of `0/1`. Should it be masked with `1` to make sure it returns 0/1?~

~Would I be correct if I assume that the code revised below is not yet activated, but will be after we port legacy code to ATen?~
