### PR TITLE
Ignore flake8 warning about whitespace before ':'

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E305,E402,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504
+ignore = E203,E305,E402,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504
 exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install


### PR DESCRIPTION
Summary:
Ignore sometimes incorrect flake8 warning about whitespace before ':'

See https://github.com/ambv/black/issues/315

Differential Revision: D13565818
