### PR TITLE
[precommit-hook] make flake8 failure blocking

### DIFF
--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -e
 echo "Running pre-commit flake8"
-python tools/flake8_hook.py
+FLAKE8_OUT=$(python tools/flake8_hook.py)
+if [[ ${FLAKE8_OUT} ]]
+then
+  echo "${FLAKE8_OUT}"
+  exit 1
+fi
+
 
 if [ $(which clang-tidy) ]
 then


### PR DESCRIPTION
Right now it just prints whatever flake8 errors and moves forward with the commit. This is too easy to miss.

It should block the commit so that the user can fix the issue