### PR TITLE
Implement torch.squareform

### DIFF
--- a/aten/src/ATen/native/SquareForm.cpp
+++ b/aten/src/ATen/native/SquareForm.cpp
@@ -1,0 +1,154 @@
+#include <ATen/ATen.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/native/SquareForm.h>
+
+namespace at
+{
+namespace native
+{
+template <typename scalar_t>
+static void squareform_frame(
+    scalar_t *input_p, scalar_t *output_p, int64_t square_size,
+    int64_t input_dim, bool checks)
+{
+  int64_t idx = 0;
+  if (input_dim == 1)
+  {
+    // from 1D to 2D
+    for (int64_t i = 0; i < square_size; i++)
+    {
+      scalar_t *dest_ii = output_p + i * square_size + i;
+      *dest_ii = 0;
+      for (int64_t j = i + 1; j < square_size; j++)
+      {
+        scalar_t *dest_ij = output_p + i * square_size + j;
+        scalar_t *dest_ji = output_p + j * square_size + i;
+        *dest_ij = input_p[idx];
+        *dest_ji = input_p[idx];
+        idx++;
+      }
+    }
+  }
+  else
+  {
+    // from 2D to 1D
+    for (int64_t i = 0; i < square_size; i++)
+    {
+      if (checks)
+      {
+        AT_CHECK(*(input_p + i * square_size + i) == 0,
+            "input has non-zero in diagnoal");
+      }
+      for (int64_t j = i + 1; j < square_size; j++)
+      {
+        output_p[idx] = *(input_p + i * square_size + j);
+        idx++;
+        if (checks)
+        {
+          AT_CHECK(*(input_p + i * square_size + j) == *(input_p + j * square_size + i),
+              "input is not symmetirc");
+        }
+      }
+    }
+  }
+}
+
+template <typename scalar_t>
+static void squareform_backward_frame(
+    scalar_t *grad_input, scalar_t *grad_output, int64_t square_size,
+    int64_t input_dim)
+{
+  int64_t idx = 0;
+  if (input_dim == 1)
+  {
+    /// backward for 2D to 1D
+    for (int64_t i = 0; i < square_size; i++)
+    {
+      for (int64_t j = i + 1; j < square_size; j++)
+      {
+        scalar_t *dest_ij = grad_output + i * square_size + j;
+        scalar_t *dest_ji = grad_output + j * square_size + i;
+        *dest_ij = grad_input[idx] / 2.0;
+        *dest_ji = grad_input[idx] / 2.0;
+        idx++;
+      }
+    }
+  }
+  else
+  {
+    /// backward for 1D to 2D
+    for (int64_t i = 0; i < square_size; i++)
+    {
+      for (int64_t j = i + 1; j < square_size; j++)
+      {
+        grad_output[idx] = *(grad_input + i * square_size + j);
+        grad_output[idx] += *(grad_input + j * square_size + i);
+        idx++;
+      }
+    }
+  }
+}
+
+Tensor squareform_cpu(const Tensor& self, bool checks)
+{
+  AT_CHECK((self.dim() == 1 || self.dim() == 2),
+      "Expected vector-form distance or square-form distance as input",
+      " but the dimension of input is ", self.dim());
+  auto input = self.contiguous();
+  Tensor out_tensor;
+  int64_t vector_size = 0;
+  int64_t d = 0;
+  if (input.dim() == 1)
+  {
+    vector_size = input.size(0);
+    d = getSquareSize(vector_size);
+    out_tensor = at::empty({d, d}, input.options());
+  }
+  else
+  {
+    AT_CHECK(input.size(0) == input.size(1),
+        "Expected square matrix as input, size(0) ",
+        input.size(0), " != size(1) ", input.size(1));
+    d = input.size(0);
+    vector_size = d * (d - 1) / 2;
+    out_tensor = at::empty({vector_size}, input.options());
+  }
+  AT_DISPATCH_ALL_TYPES(input.type(), "squareform", [&] {
+    squareform_frame<scalar_t> (input.data<scalar_t>(),
+      out_tensor.data<scalar_t>(), d, input.dim(), checks);
+  });
+  return out_tensor;
+}
+
+Tensor squareform_backward_cpu(const Tensor& grad, const Tensor& self)
+{
+  AT_CHECK((grad.dim() == 1 || grad.dim() == 2),
+      "Expected the input dim is 1 or 2, but got ", grad.dim());
+  auto input = grad.contiguous();
+  Tensor out_tensor;
+  int64_t vector_size = 0;
+  int64_t d = 0;
+  if (input.dim() == 1)
+  {
+    vector_size = input.size(0);
+    d = getSquareSize(vector_size);
+    out_tensor = at::zeros({d, d}, input.options());
+  }
+  else
+  {
+    AT_CHECK(input.size(0) == input.size(1),
+        "expected square-form distance as input, size(0) ",
+        input.size(0), " != size(1) ", input.size(1));
+    d = input.size(0);
+    vector_size = d * (d - 1) / 2;
+    out_tensor = at::empty({vector_size}, input.options());
+  }
+  AT_DISPATCH_ALL_TYPES(input.type(), "squareform", [&] {
+    squareform_backward_frame<scalar_t> (input.data<scalar_t>(),
+      out_tensor.data<scalar_t>(), d, input.dim());
+  });
+  return out_tensor;
+}
+
+}  // at::native
+}  // at

--- a/aten/src/ATen/native/SquareForm.h
+++ b/aten/src/ATen/native/SquareForm.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <cmath>
+namespace at
+{
+namespace native
+{
+static inline int64_t getSquareSize(int64_t vector_size)
+{
+  // solve the equation of d * (d - 1) / 2 == vector_size
+  // d = (std::sqrt(8 * size + 1) + 1) / 2;
+  // d is 1 if vector_size is 0, otherwise
+  // grab the closest value to the square root of the number
+  // of elements times 2 to see if the number of elements
+  // is indeed a binomial coefficient.
+  int64_t d = 1;
+  if (vector_size > 0)
+  {
+    d = std::ceil(std::sqrt(vector_size * 2));
+  }
+  AT_CHECK(d * (d - 1) / 2 == vector_size,
+    "Incompatible vector size [", vector_size,
+    "]. It must be a binomial coefficient n choose 2 for some integer");
+  return d;
+}
+
+}  // at::native
+}  // at

--- a/aten/src/ATen/native/cuda/SquareForm.cu
+++ b/aten/src/ATen/native/cuda/SquareForm.cu
@@ -1,0 +1,217 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/Utils.h>
+#include <c10/util/Exception.h>
+#include <THC/THCDeviceUtils.cuh>
+#include <ATen/native/SquareForm.h>
+
+
+namespace at {
+namespace native {
+namespace {
+void getSquareformCudaConfig(dim3& block, dim3& grid, int64_t totalElements)
+{
+  int curDevice = -1;
+  cudaGetDevice(&curDevice);
+  block = cuda::getApplyBlock();
+  AT_CHECK(cuda::getApplyGrid(totalElements, grid, curDevice),
+      "Could not get squareform cuda config");
+}
+} // anonymous namespace
+
+__host__ __device__ __forceinline__ int64_t getVectorIndex(int64_t n,
+    int64_t i, int64_t j)
+{
+  // by definition of squareform, element of (i, j) square matrix with size n
+  // is mapped to vector element at (n choose 2)-((n-i) choose 2)+(j-i- 1)
+  return n * (n - 1) / 2 - (n - i) * (n - i - 1) / 2 + j - i - 1;
+}
+
+template <typename scalar_t>
+__global__ void squareform_kernel(
+    const scalar_t* input_data,
+    scalar_t* output_data,
+    int64_t square_size,
+    int64_t input_dim,
+    bool checks,
+    scalar_t* check_data)
+{
+  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (input_dim == 1)
+  {
+    // from 1D to 2D
+    for (; idx < square_size * square_size; idx += blockDim.x * gridDim.x)
+    {
+      int64_t i = idx / square_size, j = idx % square_size;
+      scalar_t v(0);
+      if (j > i)
+      {
+        int64_t vidx = getVectorIndex(square_size, i, j);
+        v = input_data[vidx];
+      }
+      else if (j < i)
+      {
+        int64_t vidx = getVectorIndex(square_size, j, i);
+        v = input_data[vidx];
+      }
+      *(output_data + square_size * i + j) = v;
+    }
+  }
+  else
+  {
+    // from 2D to 1D
+    for (; idx < square_size * square_size; idx += blockDim.x * gridDim.x)
+    {
+      int64_t i = idx / square_size, j = idx % square_size;
+      if (j > i)
+      {
+        int64_t vidx = getVectorIndex(square_size, i, j);
+        output_data[vidx] = *(input_data + square_size * i + j);
+        if (checks)
+        {
+          if (*(input_data + square_size * i + j) != 
+              *(input_data + square_size * j + i))
+          {
+            *check_data = 1;
+          }
+        }
+      }
+      else if (j == i)
+      {
+        if (checks)
+        {
+          if (*(input_data + square_size * i + j) != 0)
+          {
+            *check_data = 1;
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename scalar_t>
+__global__ void squareform_backward_kernel(
+    const scalar_t* grad_input,
+    scalar_t* grad_output,
+    int64_t square_size,
+    int64_t input_dim)
+{
+  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (input_dim == 1)
+  {
+    /// backward for 2D to 1D
+    for (; idx < square_size * square_size; idx += blockDim.x * gridDim.x)
+    {
+      int64_t i = idx / square_size, j = idx % square_size;
+      if (j > i)
+      {
+        int64_t vidx = getVectorIndex(square_size, i, j);
+        *(grad_output + square_size * i + j) = grad_input[vidx] / 2.0;
+        *(grad_output + square_size * j + i) = grad_input[vidx] / 2.0;
+      }
+    }
+  }
+  else
+  {
+    /// backward for 1D to 2D
+    for (; idx < square_size * square_size; idx += blockDim.x * gridDim.x)
+    {
+      int64_t i = idx / square_size, j = idx % square_size;
+      if (j > i)
+      {
+        int64_t vidx = getVectorIndex(square_size, i, j);
+        auto v = *(grad_input + square_size * i + j);
+        atomicAdd(&grad_output[vidx], v);
+      }
+      else if (i > j)
+      {
+        int64_t vidx = getVectorIndex(square_size, j, i);
+        auto v = *(grad_input + square_size * i + j);
+        atomicAdd(&grad_output[vidx], v);
+      }
+    }
+  }
+}
+
+Tensor squareform_cuda(const Tensor& self, bool checks)
+{
+  AT_CHECK((self.dim() == 1 || self.dim() == 2),
+      "Expected vector-form distance or square-form distance as input",
+      " but the dimension of input is ", self.dim());
+  auto input = self.contiguous();
+  Tensor out_tensor;
+  int64_t vector_size = 0;
+  int64_t d = 0;
+  if (input.dim() == 1)
+  {
+    vector_size = input.size(0);
+    d = getSquareSize(vector_size);
+    out_tensor = at::empty({d, d}, input.options());
+  }
+  else
+  {
+    AT_CHECK(input.size(0) == input.size(1),
+        "Expected square matrix as input, size(0) ",
+        input.size(0), " != size(1) ", input.size(1));
+    d = input.size(0);
+    vector_size = d * (d - 1) / 2;
+    out_tensor = at::empty({vector_size}, input.options());
+  }
+  dim3 gridSize, blockSize;
+  getSquareformCudaConfig(blockSize, gridSize, d);
+  Tensor check_tensor = at::zeros({1}, input.options());
+  AT_DISPATCH_ALL_TYPES_AND_HALF(input.type(), "squareform", [&] {
+    squareform_kernel<scalar_t>
+    <<<gridSize, blockSize, 0, at::cuda::getCurrentCUDAStream()>>>(
+      input.data<scalar_t>(), out_tensor.data<scalar_t>(), d, input.dim(),
+      checks, check_tensor.data<scalar_t>());
+  });
+  if (checks)
+  {
+    int64_t r = check_tensor[0].item<int64_t>();
+    AT_CHECK(r == 0, " Input is not symmetric or has non-zero diagonal");
+  }
+  AT_CUDA_CHECK(cudaGetLastError());
+  return out_tensor;
+}
+
+Tensor squareform_backward_cuda(const Tensor& grad, const Tensor& self)
+{
+  AT_CHECK((grad.dim() == 1 || grad.dim() == 2),
+      "Expected the input dim is 1 or 2, but got ", grad.dim());
+  auto input = grad.contiguous();
+  Tensor out_tensor;
+  int64_t vector_size = 0;
+  int64_t d = 0;
+  if (input.dim() == 1)
+  {
+    vector_size = input.size(0);
+    d = getSquareSize(vector_size);
+    out_tensor = at::zeros({d, d}, input.options());
+  }
+  else
+  {
+    AT_CHECK(input.size(0) == input.size(1),
+        "expected square-form distance as input, size(0) ",
+        input.size(0), " != size(1) ", input.size(1));
+    d = input.size(0);
+    vector_size = d * (d - 1) / 2;
+    out_tensor = at::zeros({vector_size}, input.options());
+  }
+  dim3 gridSize, blockSize;
+  getSquareformCudaConfig(blockSize, gridSize, d);
+  AT_DISPATCH_ALL_TYPES_AND_HALF(input.type(), "squareform", [&] {
+    squareform_backward_kernel<scalar_t>
+    <<<gridSize, blockSize, 0, at::cuda::getCurrentCUDAStream()>>>(
+      input.data<scalar_t>(), out_tensor.data<scalar_t>(), d, input.dim());
+  });
+  AT_CUDA_CHECK(cudaGetLastError());
+  return out_tensor;
+}
+
+} // at::native
+} // at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1266,6 +1266,16 @@
 - func: cosine_similarity(Tensor x1, Tensor x2, int64_t dim=1, double eps=1e-8) -> Tensor
   variants: function
 
+- func: squareform(Tensor self, bool checks=true) -> Tensor
+  dispatch:
+    CPU: squareform_cpu
+    CUDA: squareform_cuda
+
+- func: squareform_backward(Tensor grad_out, Tensor self) -> Tensor
+  dispatch:
+    CPU: squareform_backward_cpu
+    CUDA: squareform_backward_cuda
+
 - func: permute(Tensor self, IntList dims) -> Tensor
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 

--- a/test/common_methods_invocations.py
+++ b/test/common_methods_invocations.py
@@ -804,6 +804,13 @@ def method_tests():
 # TODO: clamp with min/max
 
 
+def torch_function_tests():
+    return [
+        ('squareform', (1,), NO_ARGS, '1d'),
+        ('squareform', (45,), NO_ARGS, '1d_large'),
+    ]
+
+
 def create_input(call_args, requires_grad=True, non_contiguous=False, call_kwargs=None):
     if not isinstance(call_args, tuple):
         call_args = (call_args,)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -572,6 +572,13 @@
   self: not_implemented("_pdist_backward")
   pdist: not_implemented("_pdist_backward")
 
+- name: squareform(Tensor self, bool checks)
+  self: squareform_backward(grad, self)
+
+- name: squareform_backward(Tensor grad_out, Tensor self)
+  grad_out: squareform(grad, false)
+  self: zeros_like(self)
+
 - name: normal_(Tensor self, double mean, double std, Generator generator)
   self: zeros_like(grad)
 


### PR DESCRIPTION
Summary:
implement the equivalent of
https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.squareform.html#scipy.spatial.distance.squareform
as torch.squareform.

Differential Revision: D13568360

Test Plan:
# Basic functional test
python test/test_torch.py TestTorch.test_squareform 
# Autograd
python test/test_autograd.py  TestAutograd.test_squareform_1d TestAutograd.test_squareform_2d TestAutograd.test_squareform_1d_large TestAutograd.test_squareform_2d_large




# Benchmark in ipython
import torch
from scipy.spatial.distance import squareform, pdist
cuda = torch.device('cuda')
#1024x1024
v523776 = torch.arange(1, 523777, dtype=torch.double)
#2048x2048
v2096128 = torch.arange(1, 2096129, dtype=torch.double)
#10000x10000
v49995000 = torch.arange(1, 49995001, dtype=torch.double)

c523776 = torch.arange(1, 523777, dtype=torch.double, device = cuda)
c2096128 = torch.arange(1, 2096129, dtype=torch.double, device = cuda)
c49995000 = torch.arange(1, 49995001, dtype=torch.double, device = cuda)
lst = [v523776, v2096128, v49995000]
clst = [c523776, c2096128, c49995000]

def foo(lst, f):
  for vec in lst:
    ysq = f(vec)
    yvec = f(ysq)


timeit foo(lst, squareform)

timeit foo(lst, torch.squareform)

timeit foo(clst, torch.squareform)

# scipy
In [5]: timeit foo(lst, squareform)
3.62 s ± 28.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# torch cpu
In [6]: timeit foo(lst, torch.squareform)
2.11 s ± 49.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# torch cuda
In [7]: timeit foo(clst, torch.squareform)
41.6 ms ± 11.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)