### PR TITLE
Unify the usage of Dequantize

### DIFF
--- a/caffe2/quantization/server/conv_pool_dnnlowp_op_base.h
+++ b/caffe2/quantization/server/conv_pool_dnnlowp_op_base.h
@@ -82,7 +82,7 @@ class ConvPoolDNNLowPOpBase : public ConvPoolOpBase<CPUContext> {
       actual = OutputTensorCPU_(0)->template data<float>();
     } else {
       actual_temp.resize(OutputTensorCPU_(0)->numel());
-      Dequantize(
+      fbgemm::Dequantize<T>(
           OutputTensorCPU_(0)->template data<T>(),
           actual_temp.data(),
           OutputTensorCPU_(0)->numel(),
@@ -105,7 +105,7 @@ class ConvPoolDNNLowPOpBase : public ConvPoolOpBase<CPUContext> {
 
   void RunOnDeviceEpilogue_() {
     if (dequantize_output_) {
-      Dequantize(
+      fbgemm::Dequantize<T>(
           out_temp_.data(),
           OutputTensorCPU_(0)->template mutable_data<float>(),
           OutputTensorCPU_(0)->size(),

--- a/caffe2/quantization/server/dequantize_dnnlowp_op.cc
+++ b/caffe2/quantization/server/dequantize_dnnlowp_op.cc
@@ -24,7 +24,7 @@ bool DequantizeDNNLowPOp<T>::RunOnDevice() {
 
   CAFFE_ENFORCE(input.template IsType<T>());
   Output(0)->ResizeLike(input);
-  Dequantize(
+  fbgemm::Dequantize<T>(
       input.template data<T>(),
       Output(0)->template mutable_data<float>(),
       input.numel(),

--- a/caffe2/quantization/server/dnnlowp_op.h
+++ b/caffe2/quantization/server/dnnlowp_op.h
@@ -130,7 +130,7 @@ class DNNLowPOp : public Operator<CPUContext> {
       actual = OutputTensorCPU_(0)->template data<float>();
     } else {
       actual_temp.resize(OutputTensorCPU_(0)->numel());
-      Dequantize(
+      fbgemm::Dequantize<float>(
           OutputTensorCPU_(0)->template data<float>(),
           actual_temp.data(),
           OutputTensorCPU_(0)->numel(),
@@ -151,7 +151,7 @@ class DNNLowPOp : public Operator<CPUContext> {
 
   void RunOnDeviceEpilogue_() {
     if (dequantize_output_) {
-      Dequantize(
+      fbgemm::Dequantize<T>(
           out_temp_.data(),
           OutputTensorCPU_(0)->template mutable_data<float>(),
           OutputTensorCPU_(0)->numel(),

--- a/caffe2/quantization/server/op_wrapper.h
+++ b/caffe2/quantization/server/op_wrapper.h
@@ -41,7 +41,7 @@ class OpWrapper {
         // model loading when we're running a shadow operator in fp32 for
         // example for measuring quantization error.
         float_tensor->ResizeLike(qtensor);
-        Dequantize(
+        fbgemm::Dequantize<T>(
             qtensor.data<T>(),
             float_tensor->template mutable_data<float>(),
             qtensor.numel(),

--- a/caffe2/quantization/server/relu_dnnlowp_op.cc
+++ b/caffe2/quantization/server/relu_dnnlowp_op.cc
@@ -65,7 +65,7 @@ bool ReluDNNLowPOp<T>::RunOnDevice() {
   // If input was not quantized, output should be dequantized because ReLU
   // can be inplace.
   if (!X.template IsType<T>()) {
-    Dequantize(
+    fbgemm::Dequantize<T>(
         Y_data, Y->template mutable_data<float>(), Y->numel(), in_qparams);
   }
 

--- a/caffe2/quantization/server/sigmoid_test.cc
+++ b/caffe2/quantization/server/sigmoid_test.cc
@@ -23,8 +23,8 @@ TEST(Sigmoid, SigmoidUnitTest) {
       uint8_t x_q = fbgemm::Quantize<uint8_t>(
           x, sigmoid_approx.GetInputQuantizationParams());
       uint8_t y_q = sigmoid_approx.Compute(x_q);
-      float y =
-          fbgemm::Dequantize(y_q, sigmoid_approx.GetOutputQuantizationParams());
+      float y = fbgemm::Dequantize<uint8_t>(
+          y_q, sigmoid_approx.GetOutputQuantizationParams());
       float sigmoid = exp(x) / (exp(x) + 1);
       float err = fabs(sigmoid - y);
       sq_err_sum += err * err;

--- a/caffe2/quantization/server/tanh_test.cc
+++ b/caffe2/quantization/server/tanh_test.cc
@@ -27,8 +27,8 @@ TEST(Tanh, TanhUnitTest) {
       uint8_t x_q = fbgemm::Quantize<uint8_t>(
           x, tanh_approx.GetInputQuantizationParams());
       uint8_t y_q = tanh_approx.Compute(x_q);
-      float y =
-          fbgemm::Dequantize(y_q, tanh_approx.GetOutputQuantizationParams());
+      float y = fbgemm::Dequantize<uint8_t>(
+          y_q, tanh_approx.GetOutputQuantizationParams());
       float err = fabs(tanh(x) - y);
       sq_err_sum += err * err;
       max_err = std::max(err, max_err);


### PR DESCRIPTION
Summary:
The declaration of "Dequantize" is in "fbsource/fbcode/deeplearning/fbgemm2/QuantUtils.h", so it requires the "namespace fbgemm".

<T> is actually optional, since the type can de deduced from the first argument.

In some places we have "Dequantize<T>(...)", while in other places we have "Dequantize(...)". We'd better unify them. As a reference, all occurrences of "Quantize" are using "fbgemm::Quantize<T>(...)".

Differential Revision: D13570847
