### PR TITLE
A quick fix for Stream operation errors on non-current device

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1427,7 +1427,7 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
-            torch.cuda._sleep(5000000000)  # spin for about 5 sec on device1
+            torch.cuda._sleep(50000000)  # spin for about 50 ms on device1
 
         self.assertTrue(s0.query())
         self.assertFalse(s1.query())
@@ -1442,6 +1442,17 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d1):
             s1.synchronize()
+
+        self.assertTrue(s0.query())
+        self.assertTrue(s1.query())
+
+        with torch.cuda.device(d0):
+            self.assertTrue(s0.query())
+            self.assertTrue(s1.query())
+
+        with torch.cuda.device(d1):
+            self.assertTrue(s0.query())
+            self.assertTrue(s1.query())
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_tensor_device(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1418,6 +1418,7 @@ class TestCuda(TestCase):
             self.assertNotEqual(torch.cuda.current_stream(), default_stream)
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipIfRocm
     def test_streams_multi_gpu_query(self):
         d0 = torch.device('cuda:0')
         d1 = torch.device('cuda:1')

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1417,6 +1417,29 @@ class TestCuda(TestCase):
             self.assertEqual(torch.cuda.current_stream().device, 1)
             self.assertNotEqual(torch.cuda.current_stream(), default_stream)
 
+    @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    def test_streams_multi_gpu_query(self):
+        d0 = torch.device('cuda:0')
+        d1 = torch.device('cuda:1')
+
+        with torch.cuda.device(d0):
+            s0 = torch.cuda.current_stream()
+
+        with torch.cuda.device(d1):
+            s1 = torch.cuda.current_stream()
+            torch.cuda._sleep(5000000000)  # spin for about 5 sec on device1
+
+        self.assertTrue(s0.query())
+        self.assertFalse(s1.query())
+
+        with torch.cuda.device(d0):
+            self.assertTrue(s0.query())
+            self.assertFalse(s1.query())
+
+        with torch.cuda.device(d1):
+            self.assertTrue(s0.query())
+            self.assertFalse(s1.query())
+
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_tensor_device(self):
         self.assertEqual(torch.cuda.FloatTensor(1).get_device(), 0)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1440,6 +1440,9 @@ class TestCuda(TestCase):
             self.assertTrue(s0.query())
             self.assertFalse(s1.query())
 
+        with torch.cuda.device(d1):
+            s1.synchronize()
+
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_tensor_device(self):
         self.assertEqual(torch.cuda.FloatTensor(1).get_device(), 0)

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -75,11 +75,13 @@ class Stream(torch._C._CudaStreamBase):
         Returns:
             A boolean indicating if all kernels in this stream are completed.
         """
-        res = cudart().cudaStreamQuery(self)
-        if res == cudaStatus.ERROR_NOT_READY:
-            return False
-        check_error(res)
-        return True
+        with torch.cuda.device(self.device):
+            res = cudart().cudaStreamQuery(self)
+            if res == cudaStatus.ERROR_NOT_READY:
+                return False
+            check_error(res)
+            return True
+        return False
 
     def synchronize(self):
         r"""Wait for all the kernels in this stream to complete.


### PR DESCRIPTION
see #15682

This is a quick fix by implementing the simpler solution as suggested by @colesbury. As benchmark result shows, it slows down `Stream.query()` by ~20%, I would be happy to further pursue a more complex solution by implementing this in C++/ATen. But I would still vote for merge this quick fix first just to get rid of the bug sooner.

~Test TBA~ Added

FYI @jeffreyksmithjr 

#### Benchmark

now

```python
In [1]: def f():
   ...:     d0 = torch.device('cuda:0')
   ...:     d1 = torch.device('cuda:1')
   ...:     with torch.cuda.device(d0):
   ...:         s0 = torch.cuda.current_stream()
   ...:     with torch.cuda.device(d1):
   ...:         s1 = torch.cuda.current_stream()
   ...:     s0.query()
   ...:     s1.query()

In [4]: %timeit f()
38.1 µs ± 4.2 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit f()
37.6 µs ± 2.7 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

before

```python
In [4]: %timeit f()
28.5 µs ± 1.74 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit f()
35.3 µs ± 2.91 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```