### PR TITLE
flake8 hook fix

### DIFF
--- a/tools/flake8_hook.py
+++ b/tools/flake8_hook.py
@@ -5,7 +5,7 @@ from flake8.main import git
 if __name__ == '__main__':
     sys.exit(
         git.hook(
-            strict=git.config_for('strict'),
+            strict=True,
             lazy=git.config_for('lazy'),
         )
     )

--- a/tools/git-pre-commit
+++ b/tools/git-pre-commit
@@ -1,13 +1,7 @@
 #!/bin/bash
 set -e
 echo "Running pre-commit flake8"
-FLAKE8_OUT=$(python tools/flake8_hook.py)
-if [[ ${FLAKE8_OUT} ]]
-then
-  echo "${FLAKE8_OUT}"
-  exit 1
-fi
-
+python tools/flake8_hook.py
 
 if [ $(which clang-tidy) ]
 then


### PR DESCRIPTION
#15675 broke things if you had the git config variable `flake8.hook` set to true.

This PR bypasses checking the user's configuration entirely and always use strict, since the CI considers it a hard failure if you can't pass flake8.