### PR TITLE
Prevent VS2017 from emitting ambiguous symbol errors

### DIFF
--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -114,16 +114,20 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
   }
 
   /// Forwards to the call operator of the contained module.
+  /// NOTE: std::forward is qualified to prevent VS2017 emitting
+  ///       error C2872: 'std': ambiguous symbol
   template <typename... Args>
   auto operator()(Args&&... args)
-      -> decltype((*impl_)(std::forward<Args>(args)...)) {
-    return (*impl_)(std::forward<Args>(args)...);
+      -> decltype((*impl_)(::std::forward<Args>(args)...)) {
+    return (*impl_)(::std::forward<Args>(args)...);
   }
 
   /// Forwards to the subscript operator of the contained module.
+  /// NOTE: std::forward is qualified to prevent VS2017 emitting
+  ///       error C2872: 'std': ambiguous symbol
   template <typename Arg>
-  auto operator[](Arg&& arg) -> decltype((*impl_)[std::forward<Arg>(arg)]) {
-    return (*impl_)[std::forward<Arg>(arg)];
+  auto operator[](Arg&& arg) -> decltype((*impl_)[::std::forward<Arg>(arg)]) {
+    return (*impl_)[::std::forward<Arg>(arg)];
   }
 
   /// Returns true if the `ModuleHolder` does not contain a module.


### PR DESCRIPTION
These `std::forward` calls cause VS2017 to emit:

    error C2872: 'std': ambiguous symbol

This fix prevents the ambiguity by specifying that `::std` is intended.