### PR TITLE
fix DistributedDataParallel for VariableImpl to TensorImpl redesign

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -265,6 +265,7 @@ class _DistTestBase(object):
 
         self._barrier()
 
+    @skip_if_small_worldsize
     def test_get_backend(self):
         if dist.get_world_size() > 2:
             group = [1, 2]
@@ -296,6 +297,7 @@ class _DistTestBase(object):
             dist.Backend(["gloo"])
 
     # Test destroy
+    @skip_if_small_worldsize
     def test_destroy_group(self):
         if dist.get_world_size() > 2:
             group = [1, 2]
@@ -306,6 +308,7 @@ class _DistTestBase(object):
         dist.destroy_process_group(group_id)
 
     # Test get rank and size of group
+    @skip_if_small_worldsize
     def test_get_rank_size_group(self):
         if dist.get_world_size() > 2:
             group = [1, 2]

--- a/torch/lib/THD/base/init_methods/InitMethod.hpp
+++ b/torch/lib/THD/base/init_methods/InitMethod.hpp
@@ -44,8 +44,8 @@ struct InitMethod {
       if (rank >= world_size || rank == -1)
         throw std::logic_error("rank was not set in config");
 
-      if (public_address == "")
-        throw std::logic_error("public_address was not set in config");
+      if (public_address == "" && world_size > 1)
+        throw std::logic_error("public_address was not set in config and world_size is larger than 1");
 
       if (rank == 0) {
         if (master.listen_socket < 0)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -389,7 +389,7 @@ class DistributedDataParallel(Module):
                                          self.broadcast_bucket_size)
             for tensors, module_params_data in zip(result[1:], self.modules_params_data[1:]):
                 for tensor, param_data in zip(tensors, module_params_data):
-                    param_data.set_(tensor)
+                    param_data.copy_(tensor)
 
         # module buffer sync
         if self.broadcast_buffers:
@@ -437,7 +437,6 @@ class DistributedDataParallel(Module):
             # We can flush these and save memory for replicas
             if device_idx > 0:
                 param.grad = None
-                param.data.set_()
 
             # Current device's bucket is full
             if self.buckets_ready_size[bucket_idx][device_idx] == self.bucket_sizes[bucket_idx]:


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/13827 introduced a change where underlying storage could no longer be changed after calling tensor.data.  There are two places in the DistributedDataParallel class where this requirement is violated.  For now, fix up the DistributedDataParallel class by replacing the inplace storage update with a copy and removing one optimization meant to reduce the memory footprint on replicas.

Differential Revision: D13571669
