### PR TITLE
[wip] Add owningNode to graph interface

### DIFF
--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -989,21 +989,24 @@ void testSubgraphUtils() {
 
   // Merge everything into a single subgraph
   bool first = true;
-  Node* subgraph;
+  Node* subgraphNode;
   for (auto it = graph->nodes().rbegin(); it != graph->nodes().rend();) {
     if (first) {
-      subgraph = SubgraphUtils::createSingletonSubgraph(
+      subgraphNode = SubgraphUtils::createSingletonSubgraph(
           *it, prim::DifferentiableGraph);
-      it = ++subgraph->reverseIterator();
+      it = ++subgraphNode->reverseIterator();
       first = false;
     }
 
-    SubgraphUtils::mergeNodeIntoSubgraph(*it, subgraph);
-    it = ++subgraph->reverseIterator();
+    SubgraphUtils::mergeNodeIntoSubgraph(*it, subgraphNode);
+    it = ++subgraphNode->reverseIterator();
   }
 
+  auto subgraph = SubgraphUtils::getSubgraph(subgraphNode);
+  JIT_ASSERT(subgraph->owningNode() == subgraphNode);
+
   // Unmerge and compare with original node listing
-  SubgraphUtils::unmergeSubgraph(subgraph);
+  SubgraphUtils::unmergeSubgraph(subgraphNode);
   EliminateCommonSubexpression(graph);
 
   std::vector<Node*> newNodes(graph->nodes().begin(), graph->nodes().end());

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -257,6 +257,7 @@ struct DifferentiableGraphOp {
 
 void packGradient(Gradient gradient, Node* dnode) {
   JIT_ASSERT(dnode->kind() == prim::DifferentiableGraph);
+  JIT_ASSERT(gradient.f->owningNode() == dnode);
   dnode->g_(attr::Subgraph, gradient.f)
       ->g_(attr::ReverseSubgraph, gradient.df)
       ->i_(attr::f_real_outputs, gradient.f_real_outputs)

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -154,7 +154,9 @@ Node* createSingletonSubgraph(Node* n, Symbol subgraphKind) {
   JIT_ASSERT(isSubgraphNodeKind(subgraphKind));
   auto graph = n->owningGraph();
   auto subgraph = graph->create(subgraphKind, 0);
-  subgraph->g_(attr::Subgraph, std::make_shared<Graph>(graph->current_scope()));
+  subgraph->g_(
+      attr::Subgraph,
+      std::make_shared<Graph>(graph->current_scope(), subgraph));
   subgraph->insertBefore(n);
   mergeNodeIntoSubgraph(n, subgraph);
   return subgraph;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -707,7 +707,7 @@ struct to_ir {
                   // never create a Method for the closure
       popFrame(/*ends_def=*/true);
     }
-    std::shared_ptr<Graph> subgraph;
+    auto subgraph = std::make_shared<Graph>(closure_node);
     Value* context;
     std::tie(subgraph, context) = lambdaLift(block);
     runCleanupPasses(subgraph);
@@ -1917,7 +1917,7 @@ struct to_ir {
     }
 
     // Fork a new graph from its orignal owning graph
-    auto forked_graph = std::make_shared<Graph>();
+    auto forked_graph = std::make_shared<Graph>(fork_node);
 
     // Make sure we capture everything in the new graph.
     // The uncaptured values will be added to the fork signature.


### PR DESCRIPTION
This PR gives subgraphs a handle to their owner. I want to do this because I need `isBefore/After` to work across subgraphs.