### PR TITLE
[WIP] Fixes selection of cuDNN algorithm 

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -195,9 +195,6 @@ struct AT_CUDA_API ConvolutionDescriptor
                                           CUDNN_CROSS_CORRELATION, mathType));
 #if CUDNN_VERSION >= 7000
     AT_CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
-    AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_DEFAULT_MATH));
-    if(dataType == CUDNN_DATA_HALF)
-      AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_TENSOR_OP_MATH));
 #endif
   }
 };

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -505,6 +505,18 @@ struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
         pref,
         0,
         algo));
+    
+    // cudnnConvolutionFwdAlgoPerf_t perfResults;
+    // int returnedAlgoCount;
+    // AT_CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm_v7(
+    //     args.handle,
+    //     args.idesc.desc(),
+    //     args.wdesc.desc(),
+    //     args.cdesc.desc(),
+    //     args.odesc.desc(),
+    //     2,
+    //     returnedAlgoCount,
+    //     perfResults));
   }
 
   static void getWorkspaceSize(


### PR DESCRIPTION
Work in progress. Will soon update!

Summary from different conversations:

```
Everywhere where just algo is now used, algo+math type will have to be. cdesc will also have to be modified according to the returned math type. cudnnGet* does not return math type, so there are 2 options: 1) keep cudnnGet and assume math type based on data type 2) use cudnnGet*_v7, which will require more code changes.
```
```
So the behavior of `cudnnFindConvolutionForwardAlgorithmEx`  is that it will try all algo's and all math type.  The fastest math type can be different from the input `convDesc->mathType`.

The output value in `perfResults[0]` contains the fastest algo and mathType combination. User needs to update `convDesc->mathType` to reflect this finding.

So, since we are also observing that algo1 with default math actually has quite a bit of speed up in v7.4, the find algo is now correctly returning algo1 instead of 0 with mathtype=0 combination.  But if the user does not update the mathType of convDesc, they will end up with the slowest choice of algo1 + tensor_op.

In the API logs of both versions of pytorch, the last `cudnnConvolutionForward` call is done with `val=CUDNN_TENSOR_OP_MATH`.  This suggests that in both versions, pytorch is doing suboptimal calls.
```

#### Nvprof:
- Before: ![before](https://user-images.githubusercontent.com/8906225/50870515-313daf80-136d-11e9-8f1e-b7c3f90c16bc.png)
- After: ![after](https://user-images.githubusercontent.com/8906225/50870534-3f8bcb80-136d-11e9-83ac-80f9aa05a38a.png)

#### Timing:
- Current pytorch nightly container: 0.006510331630706787
- With this patch: 0.004045917987823487
- Speedup: ~37x

#### Code used in analysis:
```
import torch
import time
import torch.nn as nn
print("cudnn version", torch.backends.cudnn.version())

conv = nn.Conv2d(16,256,(3,3),dilation=(2,2), padding=(1,1)).cuda().half()
torch.backends.cudnn.benchmark=True

input = torch.randn(64,16,56,56, device="cuda").half()
out=conv(input)
gO=torch.rand_like(out)
torch.cuda.synchronize()

s = time.time()
for i in range(100):
   out = conv(input.detach())
   out.backward(gO)
torch.cuda.synchronize()
e = time.time()
print((e-s)/100)
```