### PR TITLE
Unify the shape notation for all of the pytorch modules

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -432,9 +432,9 @@ class GLU(Module):
         dim (int): the dimension on which to split the input. Default: -1
 
     Shape:
-        - Input: :math:`(*, N, *)` where `*` means, any number of additional
+        - Input: :math:`(*_1, N, *_2)` where `*` means, any number of additional
           dimensions
-        - Output: :math:`(*, N / 2, *)`
+        - Output: :math:`(*_1, M, *_2)` where M = N / 2
 
     Examples::
 
@@ -787,8 +787,9 @@ class Softmin(Module):
         \text{Softmin}(x_{i}) = \frac{\exp(-x_i)}{\sum_j \exp(-x_j)}
 
     Shape:
-        - Input: any shape
-        - Output: same as input
+        - Input: :math:`(*)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(*)`, same shape as the input
 
     Arguments:
         dim (int): A dimension along which Softmin will be computed (so every slice
@@ -827,8 +828,9 @@ class Softmax(Module):
         \text{Softmax}(x_{i}) = \frac{\exp(x_i)}{\sum_j \exp(x_j)}
 
     Shape:
-        - Input: any shape
-        - Output: same as input
+        - Input: :math:`(*)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(*)`, same shape as the input
 
     Returns:
         a Tensor of the same dimension and shape as the input with
@@ -903,8 +905,9 @@ class LogSoftmax(Module):
         \text{LogSoftmax}(x_{i}) = \log\left(\frac{\exp(x_i) }{ \sum_j \exp(x_j)} \right)
 
     Shape:
-        - Input: any shape
-        - Output: same as input
+        - Input: :math:`(*)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(*)`, same shape as the input
 
     Arguments:
         dim (int): A dimension along which Softmax will be computed (so every slice

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -432,9 +432,9 @@ class GLU(Module):
         dim (int): the dimension on which to split the input. Default: -1
 
     Shape:
-        - Input: :math:`(*_1, N, *_2)` where `*` means, any number of additional
+        - Input: :math:`(\ast_1, N, \ast_2)` where `*` means, any number of additional
           dimensions
-        - Output: :math:`(*_1, M, *_2)` where M = N / 2
+        - Output: :math:`(\ast_1, M, \ast_2)` where :math:`M=N/2`
 
     Examples::
 

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -89,8 +89,8 @@ class AdaptiveLogSoftmaxWithLoss(Module):
     Shape:
         - input: :math:`(N, in\_features)`
         - target: :math:`(N)` where each value satisfies :math:`0 <= target[i] <= n\_classes`
-        - output: :math:`(N)`
-        - loss: ``Scalar``
+        - output1: :math:`(N)`
+        - output2: ``Scalar``
 
 
     .. _Efficient softmax approximation for GPUs:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -41,6 +41,11 @@ class Sequential(Module):
                   ('conv2', nn.Conv2d(20,64,5)),
                   ('relu2', nn.ReLU())
                 ]))
+
+    Shape:
+        - Input: :math:`(*)` where `*` means, any number of additional
+          dimensions
+        - Output: :math:`(*)`, same shape as the input
     """
 
     def __init__(self, *args):

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -40,8 +40,8 @@ class Dropout(_DropoutNd):
         inplace: If set to ``True``, will do this operation in-place. Default: ``False``
 
     Shape:
-        - Input: `Any`. Input can be of any shape
-        - Output: `Same`. Output is of the same shape as input
+        - Input: :math:`(*)`. Input can be of any shape
+        - Output: :math:`(*)`. Output is of the same shape as input
 
     Examples::
 
@@ -173,8 +173,8 @@ class AlphaDropout(_DropoutNd):
             in-place
 
     Shape:
-        - Input: `Any`. Input can be of any shape
-        - Output: `Same`. Output is of the same shape as input
+        - Input: :math:`(*)`. Input can be of any shape
+        - Output: :math:`(*)`. Output is of the same shape as input
 
     Examples::
 

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -20,9 +20,9 @@ class Linear(Module):
 
     Shape:
         - Input: :math:`(N, *, H_{in})` where :math:`*` means any number of
-          additional dimensions and H_{in} = \text{in\_features}
+          additional dimensions and :math:`H_{in} = \text{in\_features}`
         - Output: :math:`(N, *, H_{out})` where all but the last dimension
-          are the same shape as the input and H_{out} = \text{out\_features}
+          are the same shape as the input and :math:`H_{out} = \text{out\_features}`.
 
     Attributes:
         weight: the learnable weights of the module of shape

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -85,12 +85,12 @@ class Bilinear(Module):
             Default: ``True``
 
     Shape:
-        - Input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}` = \text{in1\_features} and
+        - Input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}=\text{in1\_features}` and
           :math:`*` means any number of additional dimensions. All but the last dimension
           of the inputs should be the same.
-        - Input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}` = \text{in2\_features}.
-        - Output: :math:`(N, *, H_{out})` where :math:`H_{out}` = \text{out\_features} and all but the last dimension
-          are the same shape as the input.
+        - Input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}=\text{in2\_features}`.
+        - Output: :math:`(N, *, H_{out})` where :math:`H_{out}=\text{out\_features}`
+          and all but the last dimension are the same shape as the input.
 
     Attributes:
         weight: the learnable weights of the module of shape

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -19,10 +19,10 @@ class Linear(Module):
             Default: ``True``
 
     Shape:
-        - Input: :math:`(N, *, \text{in\_features})` where :math:`*` means any number of
-          additional dimensions
-        - Output: :math:`(N, *, \text{out\_features})` where all but the last dimension
-          are the same shape as the input.
+        - Input: :math:`(N, *, H_{in})` where :math:`*` means any number of
+          additional dimensions and H_{in} = \text{in\_features}
+        - Output: :math:`(N, *, H_{out})` where all but the last dimension
+          are the same shape as the input and H_{out} = \text{out\_features}
 
     Attributes:
         weight: the learnable weights of the module of shape
@@ -85,10 +85,11 @@ class Bilinear(Module):
             Default: ``True``
 
     Shape:
-        - Input: :math:`(N, *, \text{in1\_features})`, :math:`(N, *, \text{in2\_features})`
-          where :math:`*` means any number of additional dimensions. All but the last
-          dimension of the inputs should be the same.
-        - Output: :math:`(N, *, \text{out\_features})` where all but the last dimension
+        - Input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}` = \text{in1\_features} and
+          :math:`*` means any number of additional dimensions. All but the last dimension
+          of the inputs should be the same.
+        - Input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}` = \text{in2\_features}.
+        - Output: :math:`(N, *, H_{out})` where :math:`H_{out}` = \text{out\_features} and all but the last dimension
           are the same shape as the input.
 
     Attributes:

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -270,6 +270,13 @@ class PoissonNLLLoss(_Loss):
         >>> target = torch.randn(5, 2)
         >>> output = loss(log_input, target)
         >>> output.backward()
+
+    Shape:
+        - Input: :math:`(N, *)` where `*` means, any number of additional
+          dimensions
+        - Target: :math:`(N, *)`, same shape as the input
+        - Output: scalar by default. If `reduce` is ``False``, then :math:`(N, *)`,
+          the same shape as the input
     """
     __constants__ = ['log_input', 'full', 'eps', 'reduction']
 
@@ -350,10 +357,10 @@ class KLDivLoss(_Loss):
 
 
     Shape:
-        - input: :math:`(N, *)` where `*` means, any number of additional
+        - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
-        - target: :math:`(N, *)`, same shape as the input
-        - output: scalar by default. If `reduce` is ``False``, then :math:`(N, *)`,
+        - Target: :math:`(N, *)`, same shape as the input
+        - Output: scalar by default. If `reduce` is ``False``, then :math:`(N, *)`,
           the same shape as the input
 
     """
@@ -571,6 +578,8 @@ class BCEWithLogitsLoss(_Loss):
          - Input: :math:`(N, *)` where `*` means, any number of additional
            dimensions
          - Target: :math:`(N, *)`, same shape as the input
+         - Output: scalar. If `reduce` is False, then :math:`(N, *)`, same
+           shape as input.
 
      Examples::
 
@@ -640,8 +649,9 @@ class HingeEmbeddingLoss(_Loss):
             specifying either of those two args will override :attr:`reduction`. Default: 'mean'
 
     Shape:
-        - Input: Tensor of arbitrary shape. The sum operation operates over all the elements.
-        - Target: Same shape as input.
+        - Input: :math:`(*)` where `*` means, any number of dimensions. The sum operation
+          operates over all the elements.
+        - Target: :math:`(*)`, same shape as the input
         - Output: scalar. If reduce is ``False``, then same shape as the input
     """
     __constants__ = ['margin', 'reduction']
@@ -797,8 +807,9 @@ class SoftMarginLoss(_Loss):
             specifying either of those two args will override :attr:`reduction`. Default: 'mean'
 
     Shape:
-        - Input: Tensor of arbitrary shape.
-        - Target: Same shape as input.
+        - Input: :math:`(*)` where `*` means, any number of additional
+          dimensions
+        - Target: :math:`(*)`, same shape as the input
         - Output: scalar. If reduce is ``False``, then same shape as the input
 
     """

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -25,8 +25,8 @@ class LocalResponseNorm(Module):
         k: additive factor. Default: 1
 
     Shape:
-        - Input: :math:`(N, C, ...)`
-        - Output: :math:`(N, C, ...)` (same shape as input)
+        - Input: :math:`(N, C, *)`
+        - Output: :math:`(N, C, *)` (same shape as input)
 
     Examples::
 
@@ -188,8 +188,8 @@ class GroupNorm(Module):
             and zeros (for biases). Default: ``True``.
 
     Shape:
-        - Input: :math:`(N, num\_channels, *)`
-        - Output: :math:`(N, num\_channels, *)` (same shape as input)
+        - Input: :math:`(N, C, *)` where C=num\_channels
+        - Output: :math:`(N, C, *)` (same shape as input)
 
     Examples::
 

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -188,7 +188,7 @@ class GroupNorm(Module):
             and zeros (for biases). Default: ``True``.
 
     Shape:
-        - Input: :math:`(N, C, *)` where C=num\_channels
+        - Input: :math:`(N, C, *)` where :math:`C=\text{num\_channels}`
         - Output: :math:`(N, C, *)` (same shape as input)
 
     Examples::

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -19,9 +19,9 @@ class PixelShuffle(Module):
         upscale_factor (int): factor to increase spatial resolution by
 
     Shape:
-        - Input: :math:`(N, L, H_{in}, W_{in})` where :math:`L=C \times \text{upscale_factor}^2`
-        - Output: :math:`(N, C, H_{out}, W_{out})` where :math:`H \times \text{upscale_factor}`
-          and :math:`W \times \text{upscale_factor}`
+        - Input: :math:`(N, L, H_{in}, W_{in})` where :math:`L=C \times \text{upscale\_factor}^2`
+        - Output: :math:`(N, C, H_{out}, W_{out})` where :math:`H \times \text{upscale\_factor}`
+          and :math:`W \times \text{upscale\_factor}`
 
     Examples::
 

--- a/torch/nn/modules/pixelshuffle.py
+++ b/torch/nn/modules/pixelshuffle.py
@@ -19,8 +19,9 @@ class PixelShuffle(Module):
         upscale_factor (int): factor to increase spatial resolution by
 
     Shape:
-        - Input: :math:`(N, C \times \text{upscale_factor}^2, H, W)`
-        - Output: :math:`(N, C, H \times \text{upscale_factor}, W \times \text{upscale_factor})`
+        - Input: :math:`(N, L, H_{in}, W_{in})` where :math:`L=C \times \text{upscale_factor}^2`
+        - Output: :math:`(N, C, H_{out}, W_{out})` where :math:`H \times \text{upscale_factor}`
+          and :math:`W \times \text{upscale_factor}`
 
     Examples::
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -310,15 +310,15 @@ class RNN(RNNBase):
 
     Shape:
         - Input1: :math:`(L, N, H_{in})` tensor containing input features where
-          :math:`H_{in}` = `input_size` and `L` represents a sequence length.
+          :math:`H_{in}=\text{input\_size}` and `L` represents a sequence length.
         - Input2: :math:`(S, N, H_{out})` tensor
           containing the initial hidden state for each element in the batch.
-          Defaults to zero if not provided. where S=num_layers * num_directions
+          :math:`H_{out}=\text{hidden\_size}`
+          Defaults to zero if not provided. where :math:`S=\text{num\_layers} * \text{num\_directions}`
           If the RNN is bidirectional, num_directions should be 2, else it should be 1.
-        - Output1: :math:`(L, N, H_{all})` where :math:`H_all`=num_directions * hidden_size
+        - Output1: :math:`(L, N, H_{all})` where :math:`H_all=\text{num\_directions} * \text{hidden\_size}`
         - Output2: :math:`(S, N, H_{out})` tensor containing the next hidden state
           for each element in the batch
-
 
     Attributes:
         weight_ih_l[k]: the learnable input-hidden weights of the k-th layer,
@@ -539,12 +539,13 @@ class GRU(RNNBase):
 
     Shape:
         - Input1: :math:`(L, N, H_{in})` tensor containing input features where
-          :math:`H_{in}` = `input_size` and `L` represents a sequence length.
+          :math:`H_{in}=\text{input\_size}` and `L` represents a sequence length.
         - Input2: :math:`(S, N, H_{out})` tensor
           containing the initial hidden state for each element in the batch.
-          Defaults to zero if not provided. where S=num_layers * num_directions
+          :math:`H_{out}=\text{hidden\_size}`
+          Defaults to zero if not provided. where :math:`S=\text{num\_layers} * \text{num\_directions}`
           If the RNN is bidirectional, num_directions should be 2, else it should be 1.
-        - Output1: :math:`(L, N, H_{all})` where :math:`H_all`=num_directions * hidden_size
+        - Output1: :math:`(L, N, H_{all})` where :math:`H_all=\text{num\_directions} * \text{hidden\_size}`
         - Output2: :math:`(S, N, H_{out})` tensor containing the next hidden state
           for each element in the batch
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -308,6 +308,18 @@ class RNN(RNNBase):
           Like *output*, the layers can be separated using
           ``h_n.view(num_layers, num_directions, batch, hidden_size)``.
 
+    Shape:
+        - Input1: :math:`(L, N, H_{in})` tensor containing input features where
+          :math:`H_{in}` = `input_size` and `L` represents a sequence length.
+        - Input2: :math:`(S, N, H_{out})` tensor
+          containing the initial hidden state for each element in the batch.
+          Defaults to zero if not provided. where S=num_layers * num_directions
+          If the RNN is bidirectional, num_directions should be 2, else it should be 1.
+        - Output1: :math:`(L, N, H_{all})` where :math:`H_all`=num_directions * hidden_size
+        - Output2: :math:`(S, N, H_{out})` tensor containing the next hidden state
+          for each element in the batch
+
+
     Attributes:
         weight_ih_l[k]: the learnable input-hidden weights of the k-th layer,
             of shape `(hidden_size * input_size)` for `k = 0`. Otherwise, the shape is
@@ -525,6 +537,17 @@ class GRU(RNNBase):
           Like *output*, the layers can be separated using
           ``h_n.view(num_layers, num_directions, batch, hidden_size)``.
 
+    Shape:
+        - Input1: :math:`(L, N, H_{in})` tensor containing input features where
+          :math:`H_{in}` = `input_size` and `L` represents a sequence length.
+        - Input2: :math:`(S, N, H_{out})` tensor
+          containing the initial hidden state for each element in the batch.
+          Defaults to zero if not provided. where S=num_layers * num_directions
+          If the RNN is bidirectional, num_directions should be 2, else it should be 1.
+        - Output1: :math:`(L, N, H_{all})` where :math:`H_all`=num_directions * hidden_size
+        - Output2: :math:`(S, N, H_{out})` tensor containing the next hidden state
+          for each element in the batch
+
     Attributes:
         weight_ih_l[k] : the learnable input-hidden weights of the :math:`\text{k}^{th}` layer
             (W_ir|W_iz|W_in), of shape `(3*hidden_size x input_size)`
@@ -630,6 +653,15 @@ class RNNCell(RNNCellBase):
 
     Outputs: h'
         - **h'** of shape `(batch, hidden_size)`: tensor containing the next hidden state
+          for each element in the batch
+
+    Shape:
+        - Input1: :math:`(N, H_{in})` tensor containing input features where
+          :math:`H_{in}` = `input_size`
+        - Input2: :math:`(N, H_{out})` tensor containing the initial hidden
+          state for each element in the batch where :math:`H_{out}` = `hidden_size`
+          Defaults to zero if not provided.
+        - Output: :math:`(N, H_{out})` tensor containing the next hidden state
           for each element in the batch
 
     Attributes:
@@ -800,6 +832,15 @@ class GRUCell(RNNCellBase):
 
     Outputs: h'
         - **h'** of shape `(batch, hidden_size)`: tensor containing the next hidden state
+          for each element in the batch
+
+    Shape:
+        - Input1: :math:`(N, H_{in})` tensor containing input features where
+          :math:`H_{in}` = `input_size`
+        - Input2: :math:`(N, H_{out})` tensor containing the initial hidden
+          state for each element in the batch where :math:`H_{out}` = `hidden_size`
+          Defaults to zero if not provided.
+        - Output: :math:`(N, H_{out})` tensor containing the next hidden state
           for each element in the batch
 
     Attributes:

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -33,9 +33,8 @@ class Embedding(Module):
                          initialized from :math:`\mathcal{N}(0, 1)`
 
     Shape:
-
-        - Input: LongTensor of arbitrary shape containing the indices to extract
-        - Output: `(*, embedding_dim)`, where `*` is the input shape
+        - Input: :math:`(*)`, LongTensor of arbitrary shape containing the indices to extract
+        - Output: :math:`(*, embedding_dim)`, where `*` is the input shape
 
     .. note::
         Keep in mind that only a limited number of optimizers support

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -34,7 +34,7 @@ class Embedding(Module):
 
     Shape:
         - Input: :math:`(*)`, LongTensor of arbitrary shape containing the indices to extract
-        - Output: :math:`(*, embedding_dim)`, where `*` is the input shape
+        - Output: :math:`(*, H)`, where `*` is the input shape and :math:`H=\text{embedding\_dim}`
 
     .. note::
         Keep in mind that only a limited number of optimizers support


### PR DESCRIPTION
PR to update the shape notation for all of the torch.nn modules to take a unified form. The goal is to make these definitions machine-readable and those checkable by unifying the style across all of the different modules.
