### PR TITLE
nomnigraph - easy - use new test utils in converter_nomnigraph_test

### DIFF
--- a/caffe2/core/test_utils.cc
+++ b/caffe2/core/test_utils.cc
@@ -44,7 +44,7 @@ void assertTensorListEquals(
     const std::vector<std::string>& tensorNames,
     const Workspace& workspace1,
     const Workspace& workspace2) {
-  for (const string& tensorName : tensorNames) {
+  for (const std::string& tensorName : tensorNames) {
     CAFFE_ENFORCE(workspace1.HasBlob(tensorName));
     CAFFE_ENFORCE(workspace2.HasBlob(tensorName));
     auto& tensor1 = getTensor(workspace1, tensorName);
@@ -68,8 +68,8 @@ caffe2::Tensor* createTensor(
 
 caffe2::OperatorDef* createOperator(
     const std::string& type,
-    const std::vector<string>& inputs,
-    const std::vector<string>& outputs,
+    const std::vector<std::string>& inputs,
+    const std::vector<std::string>& outputs,
     caffe2::NetDef* net) {
   auto* op = net->add_op();
   op->set_type(type);
@@ -84,9 +84,31 @@ caffe2::OperatorDef* createOperator(
 
 NetMutator& NetMutator::newOp(
     const std::string& type,
-    const std::vector<string>& inputs,
-    const std::vector<string>& outputs) {
+    const std::vector<std::string>& inputs,
+    const std::vector<std::string>& outputs) {
   lastCreatedOp_ = createOperator(type, inputs, outputs, net_);
+  return *this;
+}
+
+NetMutator& NetMutator::externalInputs(
+    const std::vector<std::string>& externalInputs) {
+  for (auto& blob : externalInputs) {
+    net_->add_external_input(blob);
+  }
+  return *this;
+}
+
+NetMutator& NetMutator::externalOutputs(
+    const std::vector<std::string>& externalOutputs) {
+  for (auto& blob : externalOutputs) {
+    net_->add_external_output(blob);
+  }
+  return *this;
+}
+
+NetMutator& NetMutator::setDeviceOptionName(const std::string& name) {
+  CAFFE_ENFORCE(lastCreatedOp_ != nullptr);
+  lastCreatedOp_->mutable_device_option()->set_node_name(name);
   return *this;
 }
 


### PR DESCRIPTION
Summary: Use new test utils in converter_nomnigraph_test , and add utils to set device option name, external inputs, outputs.

Differential Revision: D13586228
