### PR TITLE
3x3x3 depthwise convolution with per channel quantization

### DIFF
--- a/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
@@ -29,6 +29,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         share_col_buffer=st.booleans(),
         preserve_activation_sparsity=st.booleans(),
         preserve_weight_sparsity=st.booleans(),
+        quantize_groupwise=st.booleans(),
         relu=st.booleans(),
         **hu.gcs_cpu_only
     )
@@ -42,6 +43,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         share_col_buffer,
         preserve_activation_sparsity,
         preserve_weight_sparsity,
+        quantize_groupwise,
         relu,
         gc,
         dc,
@@ -64,6 +66,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
             output_channels_per_group,
             batch_size,
             order,
+            groupwise_quantization=quantize_groupwise,
             preserve_activation_sparsity=preserve_activation_sparsity,
             preserve_weight_sparsity=preserve_weight_sparsity,
         )
@@ -115,6 +118,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                     inputs,
                     ["W_packed"],
                     group=group,
+                    quantize_groupwise=quantize_groupwise,
                     preserve_weight_sparsity=preserve_weight_sparsity,
                     in_scale=x_q_param.scale,
                     engine=engine,
@@ -135,6 +139,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                 preserve_weight_sparsity=preserve_weight_sparsity,
                 engine=engine,
                 group=group,
+                quantize_groupwise=quantize_groupwise,
                 device_option=gc,
             )
             if do_dequantize or do_prepack_weight:
@@ -166,7 +171,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
 
     @given(
         stride=st.integers(1, 2),
-        size=st.integers(4, 12),
+        size=st.integers(5, 12),
         # depthwise 3x3x3 fast path only works for a multiple of 8
         group=st.sampled_from([8, 24, 32]),
         batch_size=st.integers(1, 2),
@@ -175,6 +180,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         share_col_buffer=st.booleans(),
         preserve_activation_sparsity=st.booleans(),
         preserve_weight_sparsity=st.booleans(),
+        quantize_groupwise=st.just(True),
         **hu.gcs_cpu_only
     )
     def test_dnnlowp_depthwise_3x3x3_conv(
@@ -188,6 +194,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         share_col_buffer,
         preserve_activation_sparsity,
         preserve_weight_sparsity,
+        quantize_groupwise,
         gc,
         dc,
     ):
@@ -209,6 +216,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
             output_channels_per_group,
             batch_size,
             order,
+            groupwise_quantization=quantize_groupwise,
             preserve_activation_sparsity=preserve_activation_sparsity,
             preserve_weight_sparsity=preserve_weight_sparsity,
         )
@@ -250,6 +258,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                     inputs,
                     ["W_packed"],
                     group=group,
+                    quantize_groupwise=quantize_groupwise,
                     preserve_weight_sparsity=preserve_weight_sparsity,
                     in_scale=x_q_param.scale,
                     engine=engine,
@@ -270,6 +279,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                 preserve_weight_sparsity=preserve_weight_sparsity,
                 engine=engine,
                 group=group,
+                quantize_groupwise=quantize_groupwise,
                 device_option=gc,
             )
             if do_dequantize or do_prepack_weight:

--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -75,6 +75,8 @@ ConvDNNLowPOp<T, ReluFused>::RequantizationParams(int group_id) {
   return requantization_params_[quantize_groupwise_ ? group_id : 0];
 }
 
+// FIXME : code duplication with
+// ConvDNNLowPPackWeightOp::TakeDepthWise3x3FastPath_
 template <typename T, bool ReluFused>
 bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3FastPath_() {
   const Tensor& X = InputTensorCPU_(INPUT);
@@ -84,9 +86,11 @@ bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3FastPath_() {
       this->kernel_.size() == 2 && kernel_h() == 3 && kernel_w() == 3 &&
       stride_h() == stride_w() && (stride_h() == 1 || stride_h() == 2) &&
       dilation_h() == 1 && dilation_w() == 1 && pad_t() == 1 && pad_b() == 1 &&
-      pad_l() == 1 && pad_r() == 1 && GetCpuId().avx2() && !quantize_groupwise_;
+      pad_l() == 1 && pad_r() == 1 && GetCpuId().avx2();
 }
 
+// FIXME : code duplication with
+// ConvDNNLowPPackWeightOp::TakeDepthWise3x3x3FastPath_
 template <typename T, bool ReluFused>
 bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3x3FastPath_() {
   const Tensor& X = InputTensorCPU_(INPUT);
@@ -102,7 +106,7 @@ bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3x3FastPath_() {
       this->dilation_[2] == 1 &&
       accumulate(
           this->pads_.begin(), this->pads_.end(), 1, multiplies<int>()) == 1 &&
-      GetCpuId().avx2() && !quantize_groupwise_;
+      GetCpuId().avx2();
   return ret;
 }
 
@@ -1017,27 +1021,53 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    fbgemm::depthwise_3x3x3_pad_1(
-        N,
-        X.dim32(1),
-        X.dim32(2),
-        X.dim32(3),
-        C,
-        this->stride_[0],
-        this->stride_[1],
-        this->stride_[2],
-        in_qparams_[INPUT].zero_point,
-        reinterpret_cast<const uint8_t*>(Xdata),
-        FilterQuantizationParams(0).zero_point,
-        *Wq_depthwise_3x3x3_packed_,
-        requantization_params_[0].real_multiplier,
-        out_qparams_.zero_point,
-        Y_uint8_data,
-        column_offsets_->data(),
-        b_quantized_data_,
-        ReluFused,
-        dnnlowp_get_thread_num(),
-        dnnlowp_get_num_threads());
+    {
+      if (quantize_groupwise_) {
+        fbgemm::depthwise_3x3x3_per_channel_quantization_pad_1(
+            N,
+            X.dim32(1),
+            X.dim32(2),
+            X.dim32(3),
+            C,
+            this->stride_[0],
+            this->stride_[1],
+            this->stride_[2],
+            in_qparams_[INPUT].zero_point,
+            reinterpret_cast<const uint8_t*>(Xdata),
+            filter_zero_points_.data(),
+            *Wq_depthwise_3x3x3_packed_,
+            requantization_multipliers_.data(),
+            out_qparams_.zero_point,
+            Y_uint8_data,
+            column_offsets_->data(),
+            b_quantized_data_,
+            ReluFused,
+            dnnlowp_get_thread_num(),
+            dnnlowp_get_num_threads());
+      } else {
+        fbgemm::depthwise_3x3x3_pad_1(
+            N,
+            X.dim32(1),
+            X.dim32(2),
+            X.dim32(3),
+            C,
+            this->stride_[0],
+            this->stride_[1],
+            this->stride_[2],
+            in_qparams_[INPUT].zero_point,
+            reinterpret_cast<const uint8_t*>(Xdata),
+            FilterQuantizationParams(0).zero_point,
+            *Wq_depthwise_3x3x3_packed_,
+            requantization_params_[0].real_multiplier,
+            out_qparams_.zero_point,
+            Y_uint8_data,
+            column_offsets_->data(),
+            b_quantized_data_,
+            ReluFused,
+            dnnlowp_get_thread_num(),
+            dnnlowp_get_num_threads());
+      }
+    } // omp parallel
 
     return;
   } else if (TakeDepthWise3x3FastPath_()) {
@@ -1049,29 +1079,54 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
-    fbgemm::depthwise_3x3_pad_1(
-        N,
-        H,
-        W,
-        C,
-        stride_h(),
-        stride_w(),
-        in_qparams_[INPUT].zero_point,
-        reinterpret_cast<const uint8_t*>(Xdata),
-        FilterQuantizationParams(0).zero_point,
-        *Wq_depthwise_3x3_packed_,
-        requantization_params_[0].real_multiplier,
-        out_qparams_.zero_point,
-        Y_uint8_data,
-        column_offsets_->data(),
-        b_quantized_data_,
-        dnnlowp_get_thread_num(),
-        dnnlowp_get_num_threads(),
-        ReluFused);
+    {
+      if (quantize_groupwise_) {
+        fbgemm::depthwise_3x3_per_channel_quantization_pad_1(
+            N,
+            H,
+            W,
+            C,
+            stride_h(),
+            stride_w(),
+            in_qparams_[INPUT].zero_point,
+            reinterpret_cast<const uint8_t*>(Xdata),
+            filter_zero_points_.data(),
+            *Wq_depthwise_3x3_packed_,
+            requantization_multipliers_.data(),
+            out_qparams_.zero_point,
+            Y_uint8_data,
+            column_offsets_->data(),
+            b_quantized_data_,
+            ReluFused,
+            dnnlowp_get_thread_num(),
+            dnnlowp_get_num_threads());
+      } else {
+        fbgemm::depthwise_3x3_pad_1(
+            N,
+            H,
+            W,
+            C,
+            stride_h(),
+            stride_w(),
+            in_qparams_[INPUT].zero_point,
+            reinterpret_cast<const uint8_t*>(Xdata),
+            FilterQuantizationParams(0).zero_point,
+            *Wq_depthwise_3x3_packed_,
+            requantization_params_[0].real_multiplier,
+            out_qparams_.zero_point,
+            Y_uint8_data,
+            column_offsets_->data(),
+            b_quantized_data_,
+            ReluFused,
+            dnnlowp_get_thread_num(),
+            dnnlowp_get_num_threads());
+      }
+    } // omp parallel
 
     return;
   }
 
+  // Normal path for non-special (e.g., no depth-wise) convolutions.
   using namespace fbgemm;
   int row_offset_size_per_thread = -1;
   int x_pack_buf_size_per_thread = -1;

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -326,7 +326,7 @@ bool ConvDNNLowPPackWeightOp::TakeDepthWise3x3FastPath_() {
       kernel_h() == 3 && kernel_w() == 3 && stride_h() == stride_w() &&
       (stride_h() == 1 || stride_h() == 2) && dilation_h() == 1 &&
       dilation_w() == 1 && pad_t() == 1 && pad_b() == 1 && pad_l() == 1 &&
-      pad_r() == 1 && GetCpuId().avx2() && !quantize_groupwise_;
+      pad_r() == 1 && GetCpuId().avx2();
 }
 
 bool ConvDNNLowPPackWeightOp::TakeDepthWise3x3x3FastPath_() {
@@ -345,7 +345,7 @@ bool ConvDNNLowPPackWeightOp::TakeDepthWise3x3x3FastPath_() {
       this->dilation_[2] == 1 &&
       accumulate(
           this->pads_.begin(), this->pads_.end(), 1, multiplies<int>()) == 1 &&
-      GetCpuId().avx2() && !quantize_groupwise_;
+      GetCpuId().avx2();
   return ret;
 }
 


### PR DESCRIPTION
Summary: fbgemm didn't have per-channel quantization for 3x3x3 depth-wise convolution

Differential Revision: D13587438
