### PR TITLE
Fix sum_to behavior with zero dimensions

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -147,7 +147,7 @@ static inline Tensor sum_to(Tensor tensor, const IntList shape) {
     reduce_dims.push_back(i);
   }
   for (int64_t i = leading_dims; i < static_cast<int64_t>(sizes.size()); ++i) {
-    if (shape[i - leading_dims] == 1 && sizes[i] > 1) {
+    if (shape[i - leading_dims] == 1 && sizes[i] != 1) {
       reduce_dims.push_back(i);
     }
   }

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -202,6 +202,15 @@ class TestAutograd(TestCase):
         x_grad, x_grad_clone = compute_grad(create_graph=True)
         self.assertEqual(x_grad, x_grad_clone)
 
+    def test_sum_to_with_empty_dim_grad(self):
+        a = torch.rand(4, 0)
+        b = torch.rand(4, 1, requires_grad=True)
+        c = a + b
+        assert c.shape == (4, 0)
+        c.sum().backward()
+
+        self.assertEqual(b.grad, torch.zeros(4, 1))
+
     def test_hessian_vector(self):
         x = torch.randn(2, 2, requires_grad=True)
         y = torch.randn(2, 2, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -203,13 +203,14 @@ class TestAutograd(TestCase):
         self.assertEqual(x_grad, x_grad_clone)
 
     def test_sum_to_with_empty_dim_grad(self):
-        a = torch.rand(4, 0)
+        a = torch.rand(4, 0, requires_grad=True)
         b = torch.rand(4, 1, requires_grad=True)
         c = a + b
         assert c.shape == (4, 0)
         c.sum().backward()
 
         self.assertEqual(b.grad, torch.zeros(4, 1))
+        self.assertEqual(a.grad, torch.zeros(4, 0))
 
     def test_hessian_vector(self):
         x = torch.randn(2, 2, requires_grad=True)


### PR DESCRIPTION
Fixes #15223.

This fixes an autograd bug where backprop either fails or produces
gradients of incorrect sizes when tensors with zero-sized dimensions are
involved.

Previously, we were reducing along dimensions that had size greater than 1
when summing to a size in autograd. This is incorrect because we should also reduce
along dimensions with size 0 to produce a tensor of size 1 in that
dimension that then gets viewed to the correct shape.

Test Plan:
- Added a test for this case.

cc @gchanan @soumith 

