### PR TITLE
Add test/example for symbolic override in onnx/test_operators.py

### DIFF
--- a/test/onnx/expect/TestOperators.test_symbolic_override.expect
+++ b/test/onnx/expect/TestOperators.test_symbolic_override.expect
@@ -1,0 +1,84 @@
+ir_version: 3
+producer_name: "pytorch"
+producer_version: "0.4"
+graph {
+  node {
+    input: "x"
+    input: "x"
+    output: "2"
+    op_type: "Add"
+  }
+  node {
+    input: "2"
+    input: "1"
+    output: "3"
+    op_type: "Add"
+  }
+  name: "torch-jit-export"
+  initializer {
+    dims: 1
+    data_type: 1
+    name: "1"
+    raw_data: "\000\000\200?"
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "3"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}


### PR DESCRIPTION
Server for both test and example purpose.