### PR TITLE
Remove deprecated caffe2::Tensor APIs

### DIFF
--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -59,7 +59,7 @@ private:
   }
   at::Tensor tensorWrapping(const Tensor& ten_) {
     auto& ten = const_cast<Tensor&>(ten_);
-    return typeFor(ten).tensorFromBlob(ten.raw_mutable_data(), ten.dims());
+    return typeFor(ten).tensorFromBlob(ten.raw_mutable_data(), ten.sizes());
   }
 
   at::Tensor peek(size_t i, size_t N) {

--- a/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_op_trt.cc
@@ -161,7 +161,7 @@ bool TensorRTOp::RunOnDevice() {
   size_t N = 0;
   for (int i = 0; i < InputSize(); ++i) {
     const auto& input_tensor = Input(i);
-    const auto tensor_dims = input_tensor.dims();
+    const auto tensor_dims = input_tensor.sizes();
     CAFFE_ENFORCE(!tensor_dims.empty(), "Input tensor cannot be empty");
     if (i == 0) {
       N = tensor_dims.front();
@@ -198,7 +198,7 @@ bool TensorRTOp::RunOnDevice() {
         // input, check input dimensions
         const auto& input_tensor = Input(input_idx++);
         const float* input_data = input_tensor.data<float>();
-        const auto tensor_dims = input_tensor.dims();
+        const auto tensor_dims = input_tensor.sizes();
         auto chw = CheckDims(dims, tensor_dims);
         bindings.push_back((void*)(input_data + offset * chw));
       } else {

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -439,11 +439,6 @@ class CAFFE2_API Tensor final {
     return impl_.get()->sizes();
   }
 
-  // To be deprecated
-  inline at::IntList dims() const {
-    return impl_.get()->sizes();
-  }
-
   inline int64_t size_from_dim(int k) const {
     return size_from_dim_(k, impl_->sizes());
   }

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -83,6 +83,7 @@ class CAFFE2_API Tensor final {
     Resize(dims);
   }
 
+  // TODO: remove?
   explicit Tensor(const vector<int>& dims, DeviceType type)
       : Tensor(type) {
     Resize(dims);

--- a/caffe2/mobile/contrib/ios/ios_caffe_predictor.cc
+++ b/caffe2/mobile/contrib/ios/ios_caffe_predictor.cc
@@ -50,8 +50,7 @@ Caffe2IOSPredictor::Caffe2IOSPredictor(const caffe2::NetDef& init_net,
 
 void Caffe2IOSPredictor::run(const Tensor& inData, Tensor& outData, std::string& errorMessage) {
   FLAGS_caffe2_force_shared_col_buffer = true;
-  caffe2::Tensor input(caffe2::CPU);
-  input.Resize(inData.dims);
+  caffe2::Tensor input = caffe2::empty(inData.dims, at::dtype<uint8_t>().device(caffe2::CPU));
   input.ShareExternalPointer(inData.data);
   caffe2::Predictor::TensorList input_vec;
   input_vec.emplace_back(std::move(input));
@@ -67,7 +66,7 @@ void Caffe2IOSPredictor::run(const Tensor& inData, Tensor& outData, std::string&
     errorMessage.swap(error);
     return;
   }
-  caffe2::TensorCPU* output = &output_vec.front();
+  caffe2::Tensor* output = &output_vec.front();
   outData.data = output->mutable_data<uint8_t>();
-  outData.dims = output->dims().vec();
+  outData.dims = output->sizes().vec();
 }

--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
@@ -256,12 +256,12 @@ void computeOutputHW(
     int W,
     int* OH,
     int* OW) {
-  Tensor input(CPU), output(CPU);
-  input.Resize(1, 1, H, W);
+  Tensor input = caffe2::empty({1, 1, H, W}, at::dtype<float>().device(CPU));
+  Tensor output(CPU);
   op->SetOutputSize(input, &output, 1);
-  CAFFE_ENFORCE_EQ(output.ndim(), 4);
-  *OH = output.dim(2);
-  *OW = output.dim(3);
+  CAFFE_ENFORCE_EQ(output.dim(), 4);
+  *OH = output.size(2);
+  *OW = output.size(3);
 }
 
 constexpr int computeMPSAlignOffset(int kernel, int pad) {
@@ -285,7 +285,7 @@ constexpr int computeMPSAlignOffset(int kernel, int pad) {
 size_t ComputeStartIndex(
     const TensorCPU& tensor,
     const std::vector<int>& index) {
-  DCHECK_EQ(index.size(), tensor.ndim());
+  DCHECK_EQ(index.size(), tensor.dim());
 
   size_t ret = 0;
   for (int i = 0; i < index.size(); i++) {
@@ -306,12 +306,12 @@ utils::ConstTensorView<T> GetSubTensorView(
     return utils::ConstTensorView<T>(nullptr, {});
   }
 
-  std::vector<int> start_dims(tensor.ndim(), 0);
+  std::vector<int> start_dims(tensor.dim(), 0);
   start_dims.at(0) = dim0_start_index;
   auto st_idx = ComputeStartIndex(tensor, start_dims);
   auto ptr = tensor.data<T>() + st_idx;
 
-  auto input_dims = tensor.dims();
+  auto input_dims = tensor.sizes();
   std::vector<int> ret_dims(input_dims.begin() + 1, input_dims.end());
 
   utils::ConstTensorView<T> ret(ptr, ret_dims);
@@ -328,9 +328,9 @@ class CopyToMPSCNNOp final : public Operator<CPUContext> {
     std::vector<MPSImageWrapper> wrappers(Inputs().size());
     for (auto i = 0; i < Inputs().size(); ++i) {
       const auto& X = Input(i);
-      CAFFE_ENFORCE(X.ndim() > 0 && X.ndim() <= 4);
+      CAFFE_ENFORCE(X.dim() > 0 && X.dim() <= 4);
       std::vector<int64_t> XDims = {1, 1, 1, 1};
-      XDims.assign(X.dims().begin(), X.dims().end());
+      XDims.assign(X.sizes().begin(), X.sizes().end());
 
       caffe2::Timer t;
       const auto n = XDims[0];
@@ -476,11 +476,11 @@ class MPSCNNPackedInt8BGRANHWCToNCHWCStylizerPreprocessOp final
     const auto& X = Input(0);
     const auto& mean = Input(1);
     CAFFE_ENFORCE_EQ(mean.size(), 3);
-    CAFFE_ENFORCE_EQ(X.ndim(), 4);
-    CAFFE_ENFORCE_EQ(X.dim(0), 1);
-    CAFFE_ENFORCE_EQ(X.dim(3), 4);
-    const auto H = X.dim(1);
-    const auto W = X.dim(2);
+    CAFFE_ENFORCE_EQ(X.dim(), 4);
+    CAFFE_ENFORCE_EQ(X.size(0), 1);
+    CAFFE_ENFORCE_EQ(X.size(3), 4);
+    const auto H = X.size(1);
+    const auto W = X.size(2);
 
     caffe2::Timer t;
 
@@ -749,7 +749,7 @@ class MPSCNNConvOp final : public ConvPoolOpBase<CPUContext> {
 
     auto& filter = Input(FILTER);
     auto& bias = Input(BIAS);
-    CAFFE_ENFORCE_EQ(filter.ndim(), 4);
+    CAFFE_ENFORCE_EQ(filter.dim(), 4);
     // For NCHW, X.dim32(1), inputChannels
     const int C = X.featureChannels;
     const int M = filter.dim32(0);
@@ -757,7 +757,7 @@ class MPSCNNConvOp final : public ConvPoolOpBase<CPUContext> {
 
     CAFFE_ENFORCE(filter.dim32(2) == kernel_h(), "");
     CAFFE_ENFORCE(filter.dim32(3) == kernel_w(), "");
-    CAFFE_ENFORCE(bias.ndim() == 1, "");
+    CAFFE_ENFORCE(bias.dim() == 1, "");
     CAFFE_ENFORCE(bias.dim32(0) == M, "");
 
     const auto kH = kernel_h();
@@ -986,9 +986,9 @@ class MPSCNNMulOp final : public Operator<CPUContext> {
 
     const auto& X1 = Input(1);
     CAFFE_ENFORCE_EQ(
-        X1.ndim(),
+        X1.dim(),
         1,
-        "MPSCNNMulOp: Only ndim == 1 for Input(1) is supported for now");
+        "MPSCNNMulOp: Only dim == 1 for Input(1) is supported for now");
 
     auto X1_ = [getMPSCNNContext().device
         newBufferWithBytes:X1.template data<float>()
@@ -1054,9 +1054,9 @@ class MPSCNNSubOp final : public Operator<CPUContext> {
 
     const auto& X1 = Input(1);
     CAFFE_ENFORCE_EQ(
-        X1.ndim(),
+        X1.dim(),
         1,
-        "MPSCNNSubOp: Only ndim == 1 for Input(1) is supported for now");
+        "MPSCNNSubOp: Only dim == 1 for Input(1) is supported for now");
 
     auto X1_ = [getMPSCNNContext().device
         newBufferWithBytes:X1.template data<float>()
@@ -1454,14 +1454,14 @@ class MPSCNNConvTransposeOp final : public ConvTransposeUnpoolBase<CPUContext> {
 
     auto& filter = Input(FILTER);
     auto& bias = Input(BIAS);
-    CAFFE_ENFORCE(filter.ndim(), 4);
+    CAFFE_ENFORCE(filter.dim(), 4);
     const int output_channels = filter.dim32(1);
     const int input_channels = filter.dim32(0);
 
     CAFFE_ENFORCE(X.featureChannels == input_channels, "");
     CAFFE_ENFORCE(filter.dim32(2) == kernel_h(), "");
     CAFFE_ENFORCE(filter.dim32(3) == kernel_w(), "");
-    CAFFE_ENFORCE(bias.ndim() == 1, "");
+    CAFFE_ENFORCE(bias.dim() == 1, "");
     CAFFE_ENFORCE(bias.dim32(0) == output_channels, "");
 
     const auto kH = kernel_h();
@@ -1964,7 +1964,7 @@ class MPSCNNRoIWarpOp final : public Operator<CPUContext> {
     auto X = inputWrapper.getImage();
     CAFFE_ENFORCE_EQ(X.numberOfImages, 1);
     const auto& R = Input(1);
-    CAFFE_ENFORCE_EQ(R.ndim(), 2);
+    CAFFE_ENFORCE_EQ(R.dim(), 2);
     CAFFE_ENFORCE(R.dim32(1) == 4 || R.dim32(1) == 5);
     const auto roiBytes = R.dim32(0) * 4 * sizeof(float16_t);
     if (!roiBuffer_ || roiBuffer_.length != roiBytes) {
@@ -2249,25 +2249,25 @@ class MPSCNNGenerateProposalsCPPOp final : public Operator<CPUContext> {
     auto* out_rois = Output(0);
     auto* out_rois_probs = Output(1);
 
-    CAFFE_ENFORCE_EQ(scores.ndim(), 4, scores.ndim());
+    CAFFE_ENFORCE_EQ(scores.dim(), 4, scores.dim());
     CAFFE_ENFORCE(scores.template IsType<float>(), scores.meta().name());
-    const auto num_images = scores.dim(0);
-    const auto A = scores.dim(1);
-    const auto height = scores.dim(2);
-    const auto width = scores.dim(3);
+    const auto num_images = scores.size(0);
+    const auto A = scores.size(1);
+    const auto height = scores.size(2);
+    const auto width = scores.size(3);
     const auto K = height * width;
 
     // bbox_deltas: (num_images, A * 4, H, W)
     CAFFE_ENFORCE_EQ(
-        bbox_deltas.dims(), (vector<int64_t>{num_images, 4 * A, height, width}));
+        bbox_deltas.sizes(), (vector<int64_t>{num_images, 4 * A, height, width}));
 
     // im_info_tensor: (num_images, 3), format [height, width, scale; ...]
-    CAFFE_ENFORCE_EQ(im_info_tensor.dims(), (vector<int64_t>{num_images, 3}));
+    CAFFE_ENFORCE_EQ(im_info_tensor.sizes(), (vector<int64_t>{num_images, 3}));
     CAFFE_ENFORCE(
         im_info_tensor.template IsType<float>(), im_info_tensor.meta().name());
 
     // anchors: (A, 4)
-    CAFFE_ENFORCE_EQ(anchors.dims(), (vector<int64_t>{A, 4}));
+    CAFFE_ENFORCE_EQ(anchors.sizes(), (vector<int64_t>{A, 4}));
     CAFFE_ENFORCE(anchors.template IsType<float>(), anchors.meta().name());
     // Broadcast the anchors to all pixels
     auto all_anchors_vec =
@@ -2276,8 +2276,8 @@ class MPSCNNGenerateProposalsCPPOp final : public Operator<CPUContext> {
 
     Eigen::Map<const ERArrXXf> im_info(
         im_info_tensor.data<float>(),
-        im_info_tensor.dim(0),
-        im_info_tensor.dim(1));
+        im_info_tensor.size(0),
+        im_info_tensor.size(1));
 
     const int roi_col_count = 5;
     out_rois->Resize(0, roi_col_count);
@@ -2300,7 +2300,7 @@ class MPSCNNGenerateProposalsCPPOp final : public Operator<CPUContext> {
           &im_i_probs);
 
       int csz = im_i_boxes.rows();
-      int cur_start_idx = out_rois->dim(0);
+      int cur_start_idx = out_rois->size(0);
 
       out_rois->Extend(csz, 50);
       out_rois_probs->Extend(csz, 50);

--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn_test.mm
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn_test.mm
@@ -123,7 +123,7 @@ void testMPSCNN() {
               for (auto i = 0; i < N; ++i) {
                 const auto& t1 = ws.GetBlob(cpu(i))->Get<TensorCPU>();
                 const auto& t2 = ws.GetBlob(y_cpu(i))->Get<TensorCPU>();
-                CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+                CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
                 for (auto i = 0; i < t1.size(); ++i) {
                   // FP16 <-> FP32 round trip.
                   CHECK_NEAR(t1.data<float>()[i], t2.data<float>()[i], 1e-2);
@@ -269,7 +269,7 @@ void testMPSCNN() {
         const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
         const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-        CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+        CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
         for (auto i = 0; i < t1.size(); ++i) {
           // FP16 <-> FP32 round trip, accumulation, etc.
           const float t1_i = t1.data<float>()[i];
@@ -385,7 +385,7 @@ void testMPSCNN() {
             const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
             const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-            CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+            CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
             for (auto i = 0; i < t1.size(); ++i) {
               // FP16 <-> FP32 round trip, accumulation, etc.
               const float t1_i = t1.data<float>()[i];
@@ -462,7 +462,7 @@ void testMPSCNN() {
           const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
           const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-          CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+          CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
           for (auto i = 0; i < t1.size(); ++i) {
             // FP16 <-> FP32 round trip, accumulation, etc.
             const float t1_i = t1.data<float>()[i];
@@ -555,7 +555,7 @@ void testMPSCNN() {
         const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
         const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-        CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+        CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
         for (auto i = 0; i < t1.size(); ++i) {
           // FP16 <-> FP32 round trip, accumulation, etc.
           const float t1_i = t1.data<float>()[i];
@@ -643,7 +643,7 @@ void testMPSCNN() {
                   std::vector<int64_t>{int64_t(batchSize), int64_t(COut)});
               // Note dims do not match, as Metal leaves a 1x1 spatial
               // dimension.
-              CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+              CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
 
               for (auto i = 0; i < t1.size(); ++i) {
                 // FP16 <-> FP32 round trip, accumulation, etc.
@@ -758,7 +758,7 @@ void testMPSCNN() {
                           const auto& t1 =
                               ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-                          CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+                          CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
                           for (auto i = 0; i < t1.size(); ++i) {
                             // FP16 <-> FP32 round trip, accumulation, etc.
                             const float t1_i = t1.data<float>()[i];
@@ -844,7 +844,7 @@ void testMPSCNN() {
       const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
       const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-      CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+      CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
       for (auto i = 0; i < t1.size(); ++i) {
         // FP16 <-> FP32 round trip, accumulation, etc.
         const float t1_i = t1.data<float>()[i];
@@ -927,7 +927,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -986,7 +986,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<uint8_t>()[i];
@@ -1045,7 +1045,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<uint8_t>()[i];
@@ -1161,7 +1161,7 @@ void testMPSCNN() {
                       const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
                       const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-                      CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+                      CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
                       for (auto i = 0; i < t1.size(); ++i) {
                         // FP16 <-> FP32 round trip, accumulation, etc.
                         const float t1_i = t1.data<float>()[i];
@@ -1259,7 +1259,7 @@ void testMPSCNN() {
             const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
             const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-            CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+            CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
             for (auto i = 0; i < t1.size(); ++i) {
               // FP16 <-> FP32 round trip, accumulation, etc.
               const float t1_i = t1.data<float>()[i];
@@ -1373,7 +1373,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -1476,7 +1476,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -1584,7 +1584,7 @@ void testMPSCNN() {
               const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
               const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-              CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+              CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
               for (auto i = 0; i < t1.size(); ++i) {
                 // FP16 <-> FP32 round trip, accumulation, etc.
                 const float t1_i = t1.data<float>()[i];
@@ -1708,7 +1708,7 @@ void testMPSCNN() {
                 const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
                 const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-                CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+                CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
                 for (auto i = 0; i < t1.size(); ++i) {
                   // FP16 <-> FP32 round trip, accumulation, etc.
                   const float t1_i = t1.data<float>()[i];
@@ -1779,7 +1779,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -1844,7 +1844,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -1909,7 +1909,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -1998,7 +1998,7 @@ void testMPSCNN() {
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -2052,7 +2052,7 @@ void testMPSCNN() {
       const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
       const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-      CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+      CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
       for (auto i = 0; i < t1.size(); ++i) {
         // FP16 <-> FP32 round trip, accumulation, etc.
         const float t1_i = t1.data<float>()[i];
@@ -2117,8 +2117,8 @@ void testMPSCNN() {
     ws.RunNetOnce(netdef);
     const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
     const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
-    CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-    LOG(INFO) << t1.dims();
+    CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+    LOG(INFO) << t1.sizes();
     for (auto i = 0; i < t1.size(); ++i) {
       // FP16 <-> FP32 round trip, accumulation, etc.
       const float t1_i = t1.data<float>()[i];
@@ -2231,8 +2231,8 @@ void testMPSCNN() {
             const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
             const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
 
-            CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-            LOG(INFO) << t1.dims();
+            CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+            LOG(INFO) << t1.sizes();
             for (auto i = 0; i < t1.size(); ++i) {
               // FP16 <-> FP32 round trip, accumulation, etc.
               const float t1_i = t1.data<float>()[i];
@@ -2343,8 +2343,8 @@ void testMPSCNN() {
         const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
         const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
 
-        CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-        LOG(INFO) << t1.dims();
+        CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+        LOG(INFO) << t1.sizes();
         for (auto i = 0; i < t1.size(); ++i) {
           // FP16 <-> FP32 round trip, accumulation, etc.
           const float t1_i = t1.data<float>()[i];
@@ -2422,8 +2422,8 @@ void testMPSCNN() {
             const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
             const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
 
-            CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-            LOG(INFO) << t1.dims();
+            CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+            LOG(INFO) << t1.sizes();
             for (auto i = 0; i < t1.size(); ++i) {
               // FP16 <-> FP32 round trip, accumulation, etc.
               const float t1_i = t1.data<float>()[i];
@@ -2628,8 +2628,8 @@ void testMPSCNN() {
       ws.RunNetOnce(netdef);
       const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
       const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
-      CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-      LOG(INFO) << t1.dims();
+      CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+      LOG(INFO) << t1.sizes();
       for (auto i = 0; i < t1.size(); ++i) {
         // FP16 <-> FP32 round trip, accumulation, etc.
         const float t1_i = t1.data<float>()[i];
@@ -2769,8 +2769,8 @@ void testMPSCNN() {
                                 ws.GetBlob("Y_cpu")->Get<TensorCPU>();
                             const auto& t1 =
                                 ws.GetBlob("Y_ref")->Get<TensorCPU>();
-                            CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-                            LOG(INFO) << t1.dims();
+                            CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+                            LOG(INFO) << t1.sizes();
                             for (auto i = 0; i < t1.size(); ++i) {
                               // FP16 <-> FP32 round trip, accumulation, etc.
                               const float t1_i = t1.data<float>()[i];
@@ -2869,8 +2869,8 @@ void testMPSCNN() {
           const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
           const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
-          CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-          LOG(INFO) << t1.dims();
+          CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+          LOG(INFO) << t1.sizes();
           for (auto i = 0; i < t1.size(); ++i) {
             // FP16 <-> FP32 round trip, accumulation, etc.
             const float t1_i = t1.data<float>()[i];
@@ -2938,7 +2938,7 @@ void testMPSCNN() {
           const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
           const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
-          CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
+          CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
           for (auto i = 0; i < t1.size(); ++i) {
             // FP16 <-> FP32 round trip, accumulation, etc.
             const float t1_i = t1.data<float>()[i];
@@ -3024,8 +3024,8 @@ void testMPSCNN() {
           const auto& t1 = ws.GetBlob("Y_ref")->Get<TensorCPU>();
 
           const auto& t2 = ws.GetBlob("Y_cpu")->Get<TensorCPU>();
-          CAFFE_ENFORCE_EQ(t1.dims(), t2.dims());
-          LOG(INFO) << t1.dims();
+          CAFFE_ENFORCE_EQ(t1.sizes(), t2.sizes());
+          LOG(INFO) << t1.sizes();
           for (auto i = 0; i < t1.size(); ++i) {
             // FP16 <-> FP32 round trip, accumulation, etc.
             const float t1_i = t1.data<float>()[i];
@@ -3365,7 +3365,7 @@ void compareModels(const NetDef& initNet, NetDef predictNet) {
     {
       const auto& mt = mws.GetBlob(name)->Get<TensorCPU>();
       const auto& ct = cws.GetBlob(name)->Get<TensorCPU>();
-      CHECK_EQ(mt.dims(), ct.dims());
+      CHECK_EQ(mt.sizes(), ct.sizes());
       for (auto j = 0; j < mt.size(); ++j) {
         if (mt.IsType<float>()) {
           if (j < 10) {
@@ -3422,13 +3422,13 @@ void verifyRewrite(
   for (auto i = 0; i < predictNet.external_output_size(); i++) {
     auto blobName = predictNet.external_output(i);
     LOG(INFO) << "Checking output blob:" << blobName;
-    const auto& mt = mws.GetBlob(blobName)->Get<TensorCPU>();
-    const auto& ct = cws.GetBlob(blobName)->Get<TensorCPU>();
+    const auto& mt = mws.GetBlob(blobName)->Get<Tensor>();
+    const auto& ct = cws.GetBlob(blobName)->Get<Tensor>();
     if (mt.size() == 0 || ct.size() == 0) {
       LOG(INFO) << "One of the operator failed.";
       return;
     }
-    // CHECK_EQ(mt.dims(), ct.dims());
+    // CHECK_EQ(mt.sizes(), ct.sizes());
     for (auto j = 0; j < fmin(mt.size(), ct.size()); ++j) {
       if (mt.IsType<float>()) {
         if (j < 10) {

--- a/caffe2/mobile/contrib/nnapi/nnapi.cc
+++ b/caffe2/mobile/contrib/nnapi/nnapi.cc
@@ -270,7 +270,7 @@ void NNApi::addConv(const OperatorDef& op, bool fuse_relu) {
   const std::string& weight_name = op.input(1);
   const auto& weight = ws_.GetBlob(weight_name)->Get<TensorCPU>();
   std::vector<uint32_t> weight_dims;
-  for (auto dim : weight.dims()) {
+  for (auto dim : weight.sizes()) {
     weight_dims.push_back(dim);
   }
   CAFFE_ENFORCE_EQ(weight_dims.size(), 4);
@@ -560,7 +560,7 @@ void NNApi::init(const TensorVector& inputs, TensorVector* outputs) {
       }
       const std::string& input_blob = run_net_.external_input(i);
       std::vector<uint32_t> dims;
-      for (auto dim : inputs[i]->dims()) {
+      for (auto dim : inputs[i]->sizes()) {
         dims.push_back(dim);
       }
       addTensorOperand(input_blob, tensor_type_, dims, scale, zero_point);

--- a/caffe2/mobile/contrib/nnapi/nnapi_test.cc
+++ b/caffe2/mobile/contrib/nnapi/nnapi_test.cc
@@ -16,8 +16,8 @@ namespace {
 // CPU: t1, NN-API: t2
 void checkError(const TensorCPU& t1, const TensorCPU& t2, float error) {
   CAFFE_ENFORCE_EQ(
-      t1.dims(),
-      t2.dims(),
+      t1.sizes(),
+      t2.sizes(),
       "t1.size() = ",
       t1.size(),
       ", t2.size() = ",

--- a/caffe2/mobile/contrib/ulp2/ulp.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp.cc
@@ -15,7 +15,7 @@ void uniformQuantize2b1b(const TensorCPU& X,
   const auto N = X.size_to_dim(X.ndim() - 1);
   auto C = X.size() / N;
   const auto QC = divRoundUp(C,  8);
-  auto XQs = X.dims().vec();
+  auto XQs = X.sizes().vec();
   XQs[X.ndim() - 1] = QC;
   CAFFE_ENFORCE_EQ(XQ.size(), k2b1bXBits);
   for (auto i = 0; i < k2b1bXBits; ++i) {
@@ -137,7 +137,7 @@ void signQuantize(const TensorCPU& X, TensorCPU* XQ) {
   const auto N = X.size_to_dim(X.ndim() - 1);
   auto C = X.size() / N;
   const auto QC = divRoundUp(C,  8);
-  auto XQs = X.dims().vec();
+  auto XQs = X.sizes().vec();
   XQs[X.ndim() - 1] = QC;
   XQ->Resize(XQs);
   const float* Xdata = X.data<float>();

--- a/caffe2/mobile/contrib/ulp2/ulp_neon.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp_neon.cc
@@ -98,7 +98,7 @@ void uniformQuantize2b1bNeon(QConvState* state,
   const size_t C = X.dim32(X.ndim() - 1);
   const size_t N = X.size() / C;
   const size_t QC = divRoundUp(C, 8);
-  auto XQs = X.dims().vec();
+  auto XQs = X.sizes().vec();
   XQs[X.ndim() - 1] = QC;
   CAFFE_ENFORCE_EQ(XQ.size(), k2b1bXBits);
   for (auto i = 0; i < k2b1bXBits; ++i) {

--- a/caffe2/mobile/contrib/ulp2/ulp_test.cc
+++ b/caffe2/mobile/contrib/ulp2/ulp_test.cc
@@ -185,7 +185,7 @@ void gemmTest(int64_t M, int64_t N, int64_t K) {
     Y.Resize(M, N);
     gemmNT(M, N, K, X.data<float>(), W.data<float>(), Y.mutable_data<float>());
   }
-  EXPECT_TRUE(Y.dims() == YQ.dims());
+  EXPECT_TRUE(Y.sizes() == YQ.sizes());
   for (auto i = 0; i < Y.size(); ++i) {
     EXPECT_NEAR(Y.data<float>()[i], YQ.data<float>()[i], 1e-3);
   }
@@ -214,7 +214,7 @@ TEST(QConv, ConvTest) {
     qconv(ConvArgs{}, XQ, WQ, nullptr, &YQ);
   }
   { conv(ConvArgs{}, X, W, nullptr, &Y); }
-  EXPECT_TRUE(Y.dims() == YQ.dims());
+  EXPECT_TRUE(Y.sizes() == YQ.sizes());
   for (auto i = 0; i < Y.size(); ++i) {
     EXPECT_NEAR(Y.data<float>()[i], YQ.data<float>()[i], 1e-3);
   }
@@ -304,9 +304,9 @@ void ConvTest2b1b(int IC, int KH, int KW, int H, int W, int OC, int N, ConvArgs 
 
   { conv(args, X, W_, &bias, &Y); }
 
-  EXPECT_TRUE(Y.dims() == YQ.dims());
-  EXPECT_TRUE(Y.dims() == Y2b1b.dims());
-  EXPECT_TRUE(Y.dims() == YOP.dims());
+  EXPECT_TRUE(Y.sizes() == YQ.sizes());
+  EXPECT_TRUE(Y.sizes() == Y2b1b.sizes());
+  EXPECT_TRUE(Y.sizes() == YOP.sizes());
 
   // for (auto i = 0; i < Y.size(); ++i) {
   //   LOG(INFO) << "i: " << i << ", y[i]: " << Y.data<float>()[i]

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -215,6 +215,7 @@ class ConvPoolOpBase : public Operator<Context> {
   // implementations that do not use first-class Tensor objects, such as the
   // MKL operator. One can still call this function with dummy
   // Tensor objects in order to obtain the sizes.
+  // TODO: passing sizes directly rather than Tensor
   void SetOutputSize(const Tensor& input, Tensor* output, int output_channel) {
     CAFFE_ENFORCE(input.numel() > 0);
     vector<int> output_dims;

--- a/caffe2/operators/elementwise_div_op.cu
+++ b/caffe2/operators/elementwise_div_op.cu
@@ -396,9 +396,9 @@ class BinaryElementwiseWithArgsGradientOp<
         }
       } else {
         std::copy(
-            C.dims().cbegin(), C.dims().cend(), std::back_inserter(A_dims));
+            C.sizes().cbegin(), C.sizes().cend(), std::back_inserter(A_dims));
         std::copy(
-            B.dims().cbegin(), B.dims().cend(), std::back_inserter(B_dims));
+            B.sizes().cbegin(), B.sizes().cend(), std::back_inserter(B_dims));
       }
       B_data = B.template data<T>();
       C_data = C.template data<T>();
@@ -425,9 +425,9 @@ class BinaryElementwiseWithArgsGradientOp<
         }
       } else {
         std::copy(
-            A.dims().cbegin(), A.dims().cend(), std::back_inserter(A_dims));
+            A.sizes().cbegin(), A.sizes().cend(), std::back_inserter(A_dims));
         std::copy(
-            B.dims().cbegin(), B.dims().cend(), std::back_inserter(B_dims));
+            B.sizes().cbegin(), B.sizes().cend(), std::back_inserter(B_dims));
       }
       dC_data = dC.template data<T>();
       A_data = A.template data<T>();

--- a/caffe2/operators/generate_proposals_op.h
+++ b/caffe2/operators/generate_proposals_op.h
@@ -11,6 +11,7 @@ namespace caffe2 {
 namespace utils {
 
 // A sub tensor view
+// TODO: Remove???
 template <class T>
 class ConstTensorView {
  public:

--- a/caffe2/operators/generate_proposals_op_gpu_test.cc
+++ b/caffe2/operators/generate_proposals_op_gpu_test.cc
@@ -215,7 +215,7 @@ TEST(GenerateProposalsTest, TestRealDownSampledGPU) {
   Tensor rois{CPU};
   rois.CopyFrom(rois_gpu);
 
-  EXPECT_EQ(rois.dims(), (vector<int64_t>{rois_gt.rows(), rois_gt.cols()}));
+  EXPECT_EQ(rois.sizes(), (vector<int64_t>{rois_gt.rows(), rois_gt.cols()}));
   auto rois_data =
       Eigen::Map<const ERMatXf>(rois.data<float>(), rois.dim(0), rois.dim(1));
   EXPECT_NEAR((rois_data.matrix() - rois_gt).cwiseAbs().maxCoeff(), 0, 1e-4);
@@ -227,7 +227,7 @@ TEST(GenerateProposalsTest, TestRealDownSampledGPU) {
   Tensor rois_probs{CPU};
   rois_probs.CopyFrom(rois_probs_gpu);
   EXPECT_EQ(
-      rois_probs.dims(), (vector<int64_t>{int64_t(rois_probs_gt.size())}));
+      rois_probs.sizes(), (vector<int64_t>{int64_t(rois_probs_gt.size())}));
   auto rois_probs_data =
       ConstEigenVectorArrayMap<float>(rois_probs.data<float>(), rois.dim(0));
   EXPECT_NEAR(
@@ -414,7 +414,7 @@ TEST(GenerateProposalsTest, TestRealDownSampledRotatedAngle0GPU) {
   Tensor rois{CPU};
   rois.CopyFrom(rois_gpu);
 
-  EXPECT_EQ(rois.dims(), (vector<int64_t>{rois_gt.rows(), rois_gt.cols()}));
+  EXPECT_EQ(rois.sizes(), (vector<int64_t>{rois_gt.rows(), rois_gt.cols()}));
   auto rois_data =
       Eigen::Map<const ERMatXf>(rois.data<float>(), rois.dim(0), rois.dim(1));
   EXPECT_NEAR((rois_data.matrix() - rois_gt).cwiseAbs().maxCoeff(), 0, 1e-4);
@@ -426,7 +426,7 @@ TEST(GenerateProposalsTest, TestRealDownSampledRotatedAngle0GPU) {
   Tensor rois_probs{CPU};
   rois_probs.CopyFrom(rois_probs_gpu);
   EXPECT_EQ(
-      rois_probs.dims(), (vector<int64_t>{int64_t(rois_probs_gt.size())}));
+      rois_probs.sizes(), (vector<int64_t>{int64_t(rois_probs_gt.size())}));
   auto rois_probs_data =
       ConstEigenVectorArrayMap<float>(rois_probs.data<float>(), rois.dim(0));
   EXPECT_NEAR(
@@ -619,7 +619,7 @@ TEST(GenerateProposalsTest, TestRealDownSampledRotatedGPU) {
   auto& rois_gpu = rois_blob->Get<TensorCUDA>();
   Tensor rois{CPU};
   rois.CopyFrom(rois_gpu);
-  EXPECT_EQ(rois.dims(), (vector<int64_t>{26, 6}));
+  EXPECT_EQ(rois.sizes(), (vector<int64_t>{26, 6}));
   auto rois_data =
       Eigen::Map<const ERMatXf>(rois.data<float>(), rois.size(0), rois.size(1));
   EXPECT_NEAR((rois_data.matrix() - rois_gt).cwiseAbs().maxCoeff(), 0, 1e-3);
@@ -631,7 +631,7 @@ TEST(GenerateProposalsTest, TestRealDownSampledRotatedGPU) {
   Tensor rois_probs{CPU};
   rois_probs.CopyFrom(rois_probs_gpu);
   EXPECT_EQ(
-      rois_probs.dims(), (vector<int64_t>{int64_t(rois_probs_gt.size())}));
+      rois_probs.sizes(), (vector<int64_t>{int64_t(rois_probs_gt.size())}));
   auto rois_probs_data =
       ConstEigenVectorArrayMap<float>(rois_probs.data<float>(), rois.size(0));
   EXPECT_NEAR(

--- a/caffe2/operators/hip/activation_ops_miopen.h
+++ b/caffe2/operators/hip/activation_ops_miopen.h
@@ -58,9 +58,9 @@ class MIOPENActivationOp final : public MIOPENActivationOpBase {
       return true;
     }
     // See if we need to reshape.
-    if (X.dims() != mio_dims_) {
+    if (X.sizes() != mio_dims_) {
       VLOG(1) << "Setting descriptors.";
-      mio_dims_ = X.dims().vec();
+      mio_dims_ = X.sizes().vec();
       int C = 1, H = 1, W = 1;
       if (X.ndim() == 4) {
         // Normal 4-dimensional tensors for images.
@@ -114,9 +114,9 @@ class MIOPENActivationGradientOp final : public MIOPENActivationOpBase {
       return true;
     }
     // See if we need to reshape.
-    if (Y.dims() != mio_dims_) {
+    if (Y.sizes() != mio_dims_) {
       VLOG(1) << "Setting descriptors.";
-      mio_dims_ = Y.dims().vec();
+      mio_dims_ = Y.sizes().vec();
       int C = 1, H = 1, W = 1;
       if (Y.ndim() == 4) {
         // Normal 4-dimensional tensors for images.

--- a/caffe2/operators/hip/conv_op_miopen.hip
+++ b/caffe2/operators/hip/conv_op_miopen.hip
@@ -238,19 +238,19 @@ bool MIOPENConvOp::DoRunWithType() {
       "If you set group, the number of output channels should be divisible "
       "by group.");
 
-  bool input_changed = (X.dims() != mio_input_dims_);
-  bool weight_changed = (Weight.dims() != mio_weight_dims_);
+  bool input_changed = (X.sizes() != mio_input_dims_);
+  bool weight_changed = (Weight.sizes() != mio_weight_dims_);
 
   if (input_changed || weight_changed) {
     VLOG(1) << "Changing MIOpen descriptor configurations.";
     if (input_changed) {
-      mio_input_dims_ = X.dims().vec();
+      mio_input_dims_ = X.sizes().vec();
       MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
           bottom_desc_, miopenTypeWrapper<T_X>::type, N, C, H, W));
     }
 
     if (weight_changed) {
-      mio_weight_dims_ = Weight.dims().vec();
+      mio_weight_dims_ = Weight.sizes().vec();
       MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
           conv_desc_,
           mode_,
@@ -436,19 +436,19 @@ bool MIOPENConvGradientOp::DoRunWithType() {
       "by group.");
 
   bool doBwdDataComputation = (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2)));
-  bool input_changed = (X.dims() != mio_input_dims_);
-  bool weight_changed = (Weight.dims() != mio_weight_dims_);
+  bool input_changed = (X.sizes() != mio_input_dims_);
+  bool weight_changed = (Weight.sizes() != mio_weight_dims_);
 
   if (input_changed || weight_changed) {
     VLOG(1) << "Changing MIOpen descriptor configurations.";
     if (input_changed) {
-      mio_input_dims_ = X.dims().vec();
+      mio_input_dims_ = X.sizes().vec();
       MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
           bottom_desc_, miopenTypeWrapper<T_X>::type, N, C, H, W));
     }
 
     if (weight_changed) {
-      mio_weight_dims_ = Weight.dims().vec();
+      mio_weight_dims_ = Weight.sizes().vec();
       MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
           conv_desc_,
           mode_,

--- a/caffe2/operators/hip/conv_transpose_op_miopen.hip
+++ b/caffe2/operators/hip/conv_transpose_op_miopen.hip
@@ -180,19 +180,19 @@ bool MIOPENConvTransposeOp<T>::RunOnDevice() {
   int W_out = Y->ndim() > 3 ? Y->dim32(3) : 1;
   int D_out = Y->ndim() > 4 ? Y->dim32(4) : 1;
 
-  bool input_changed = (X.dims() != mio_input_dims_);
-  bool weight_changed = (Weight.dims() != mio_weight_dims_);
+  bool input_changed = (X.sizes() != mio_input_dims_);
+  bool weight_changed = (Weight.sizes() != mio_weight_dims_);
 
   if (input_changed || weight_changed) {
     VLOG(1) << "Changing MIOpen descriptor configurations.";
     if (input_changed) {
-      mio_input_dims_ = X.dims().vec();
+      mio_input_dims_ = X.sizes().vec();
       MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
           bottom_desc_, miopenTypeWrapper<T>::type, N, C, H, W));
     }
 
     if (weight_changed) {
-      mio_weight_dims_ = Weight.dims().vec();
+      mio_weight_dims_ = Weight.sizes().vec();
       MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
           conv_desc_,
           miopenTranspose,
@@ -324,19 +324,19 @@ bool MIOPENConvTransposeGradientOp<T>::RunOnDevice() {
   D_out = dY.ndim() > 4 ? dY.dim32(4) : 1;
 
   bool doBwdDataComputation = (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2)));
-  bool input_changed = (X.dims() != mio_input_dims_);
-  bool weight_changed = (Weight.dims() != mio_weight_dims_);
+  bool input_changed = (X.sizes() != mio_input_dims_);
+  bool weight_changed = (Weight.sizes() != mio_weight_dims_);
 
   if (input_changed || weight_changed) {
     VLOG(1) << "Changing MIOpen descriptor configurations.";
     if (input_changed) {
-      mio_input_dims_ = X.dims().vec();
+      mio_input_dims_ = X.sizes().vec();
       MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
           bottom_desc_, miopenTypeWrapper<T>::type, N, C, H, W));
     }
 
     if (weight_changed) {
-      mio_weight_dims_ = Weight.dims().vec();
+      mio_weight_dims_ = Weight.sizes().vec();
       MIOPEN_ENFORCE(miopenInitConvolutionDescriptor(
           conv_desc_,
           miopenTranspose,

--- a/caffe2/operators/hip/elu_op_miopen.hip
+++ b/caffe2/operators/hip/elu_op_miopen.hip
@@ -34,9 +34,9 @@ class MIOPENActivationOp<miopenActivationELU> final
       Y->template mutable_data<T>();
       return true;
     }
-    if (X.dims() != mio_dims_) {
+    if (X.sizes() != mio_dims_) {
       VLOG(1) << "Setting descriptors.";
-      mio_dims_ = X.dims().vec();
+      mio_dims_ = X.sizes().vec();
       int C = 1, H = 1, W = 1;
       if (X.ndim() == 4) {
         // Normal 4-dimensional tensors for images.
@@ -98,9 +98,9 @@ class MIOPENActivationGradientOp<miopenActivationELU> final
       dX->template mutable_data<T>();
       return true;
     }
-    if (Y.dims() != mio_dims_) {
+    if (Y.sizes() != mio_dims_) {
       VLOG(1) << "Setting descriptors.";
-      mio_dims_ = Y.dims().vec();
+      mio_dims_ = Y.sizes().vec();
       int C = 1, H = 1, W = 1;
       if (Y.ndim() == 4) {
         // Normal 4-dimensional tensors for images.

--- a/caffe2/operators/hip/local_response_normalization_op_miopen.hip
+++ b/caffe2/operators/hip/local_response_normalization_op_miopen.hip
@@ -122,9 +122,9 @@ bool MIOPEN_LRNOP::DoRunWithType() {
   auto* Y = Output(0);
 
   // Reshape tensor descriptors if necessary
-  if (X.dims() != miopen_input_dims_) {
+  if (X.sizes() != miopen_input_dims_) {
     VLOG(1) << "Setting descriptors";
-    miopen_input_dims_ = X.dims().vec();
+    miopen_input_dims_ = X.sizes().vec();
     int C = 1, H = 1, W = 1;
     // Normal 4-dimensional tensors for images.
     C = X.dim32(1);
@@ -173,9 +173,9 @@ bool MIOPENLRNGradientOp::DoRunWithType() {
   const auto& dY = Input(2);
   auto* dX = Output(0);
 
-  if (dY.dims() != miopen_input_dims_) {
+  if (dY.sizes() != miopen_input_dims_) {
     VLOG(1) << "Setting descriptors";
-    miopen_input_dims_ = dY.dims().vec();
+    miopen_input_dims_ = dY.sizes().vec();
     int C = 1, H = 1, W = 1;
     // Normal 4-dimensional tensors for images.
     C = dY.dim32(1);

--- a/caffe2/operators/hip/spatial_batch_norm_op_miopen.hip
+++ b/caffe2/operators/hip/spatial_batch_norm_op_miopen.hip
@@ -136,9 +136,9 @@ bool MIOpenSpatialBNOp::DoRunWithType() {
   T* Y_data = Y->template mutable_data<T>();
 
   // See if we need to reshape.
-  if (N > 0 && X.dims() != miopen_input_dims_) {
+  if (N > 0 && X.sizes() != miopen_input_dims_) {
     VLOG(1) << "Setting descriptors.";
-    miopen_input_dims_ = X.dims().vec();
+    miopen_input_dims_ = X.sizes().vec();
     MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
         data_desc_, miopenTypeWrapper<T>::type, N, C, H, W));
 
@@ -277,8 +277,8 @@ bool MIOpenSpatialBNGradientOp::DoRunWithType() {
   CAFFE_ENFORCE_EQ(scale.ndim(), 1);
   CAFFE_ENFORCE_EQ(scale.dim32(0), C);
   // See if we need to reshape.
-  if (N > 0 && X.dims() != miopen_input_dims_) {
-    miopen_input_dims_ = X.dims().vec();
+  if (N > 0 && X.sizes() != miopen_input_dims_) {
+    miopen_input_dims_ = X.sizes().vec();
     MIOPEN_ENFORCE(miopenSet4dTensorDescriptor(
         data_desc_, miopenTypeWrapper<T>::type, N, C, H, W));
 

--- a/caffe2/operators/mean_op.h
+++ b/caffe2/operators/mean_op.h
@@ -32,7 +32,7 @@ class MeanOp final : public Operator<Context> {
     for (int i = 1; i < InputSize(); ++i) {
       if (output->sizes() != Input(i).sizes()) {
         CAFFE_THROW(
-            "Check failed: output->dims() == Input(i).dims().",
+            "Check failed: output->sizes() == Input(i).sizes().",
             "Description: Input #",
             i,
             ", input dimension:",

--- a/caffe2/operators/rnn/hip/recurrent_op_miopen.hip
+++ b/caffe2/operators/rnn/hip/recurrent_op_miopen.hip
@@ -97,7 +97,7 @@ void RecurrentBaseOp<T>::initialize(
         rnnInput,
         rnnDirection,
         rnnMode,
-        miopenRNNwithBias, 
+        miopenRNNwithBias,
         miopenRNNdefault,
         miopenTypeWrapper<T>::type));
   }
@@ -154,7 +154,7 @@ void RecurrentBaseOp<T>::initialize(
         miopen_wrapper_.inline_miopen_handle(),
         rnnDesc_,
         xDesc_->descs()[0],
-        wDesc_, 
+        wDesc_,
         miopenTypeWrapper<T>::type));
   }
 
@@ -172,13 +172,13 @@ void RecurrentBaseOp<T>::initialize(
 template <typename T>
 bool RecurrentOp<T>::RunOnDevice() {
   const int seqLength = Input(INPUT).dim32(0);
-  if (Input(INPUT).dims() != cachedInputDims_) {
+  if (Input(INPUT).sizes() != cachedInputDims_) {
     initialize(
         Input(INPUT),
         Output(OUTPUT),
         Output(HIDDEN_OUTPUT),
         Output(CELL_OUTPUT));
-    cachedInputDims_ = Input(INPUT).dims().vec();
+    cachedInputDims_ = Input(INPUT).sizes().vec();
   }
 
   // Validation checks
@@ -189,7 +189,7 @@ bool RecurrentOp<T>::RunOnDevice() {
       xDesc_->descs()[0],
       &weightsSize,
       miopenTypeWrapper<T>::type));
-  
+
   CAFFE_ENFORCE_EQ(Input(WEIGHT).nbytes(), weightsSize);
 
   // Training reserve size
@@ -264,9 +264,9 @@ bool RecurrentOp<T>::RunOnDevice() {
 template <typename T>
 bool RecurrentGradientOp<T>::RunOnDevice() {
   const int seqLength = Input(INPUT).dim32(0);
-  if (Input(INPUT).dims() != cachedInputDims_) {
+  if (Input(INPUT).sizes() != cachedInputDims_) {
     initialize(Input(INPUT));
-    cachedInputDims_ = Input(INPUT).dims().vec();
+    cachedInputDims_ = Input(INPUT).sizes().vec();
   }
   MIOPEN_ENFORCE(miopenGetRNNTrainingReserveSize(
       miopen_wrapper_.inline_miopen_handle(),
@@ -386,7 +386,7 @@ bool RecurrentParamAccessOp<T, mode>::RunOnDevice() {
         rnnDesc_,
         layer,
         param_id,
-        &bias_size)); 
+        &bias_size));
 
     void* bias;
     miopen_wrapper_.with_miopen_state(0, [&](MIOPENState* state) {
@@ -399,7 +399,7 @@ bool RecurrentParamAccessOp<T, mode>::RunOnDevice() {
         xDesc_->descs()[0],
         wDesc_,
         Input(1).template data<T>(),
-        param_id, 
+        param_id,
         biasDesc,
         bias));
     std::array<int,3> biasDims {1,1,1};
@@ -438,7 +438,7 @@ bool RecurrentParamAccessOp<T, mode>::RunOnDevice() {
         xDesc_->descs()[0],
         param_id,
         &param_size));
-    
+
     void* pmatrix;
     miopen_wrapper_.with_miopen_state(0, [&](MIOPENState* state) {
         pmatrix = state->workspace().get(param_size);
@@ -450,7 +450,7 @@ bool RecurrentParamAccessOp<T, mode>::RunOnDevice() {
         xDesc_->descs()[0],
         wDesc_,
         Input(1).template data<T>(),
-        param_id, 
+        param_id,
         matrixParamDesc,
         pmatrix));
     std::array<int,3> matDims {1,1,1};
@@ -503,7 +503,7 @@ REGISTER_MIOPEN_OPERATOR(
 OPERATOR_SCHEMA(RecurrentParamGet)
     .NumInputs(2)
     .NumOutputs(1);
-    
+
 struct GetRecurrentGradient : public GradientMakerBase {
   using GradientMakerBase::GradientMakerBase;
   vector<OperatorDef> GetGradientDefs() override {

--- a/caffe2/operators/segment_reduction_op_gpu.cu
+++ b/caffe2/operators/segment_reduction_op_gpu.cu
@@ -438,7 +438,7 @@ class CUDASparseLengthsSumOp : public Operator<CUDAContext> {
     const int64_t outputSize = lengthsInput.dim(0);
     const int len_length = outputSize;
 
-    auto shape = dataInput.dims().vec();
+    auto shape = dataInput.sizes().vec();
     shape[0] = outputSize;
     auto* output = Output(0, shape, at::dtype<T>());
     T* out_data = output->template mutable_data<T>();
@@ -558,7 +558,7 @@ class CUDASparseLengthsMeanOp : public Operator<CUDAContext> {
     const int64_t outputSize = lengthsInput.dim(0);
     const int len_length = outputSize;
 
-    auto shape = dataInput.dims().vec();
+    auto shape = dataInput.sizes().vec();
     shape[0] = outputSize;
     auto* output = Output(0, shape, at::dtype<T>());
     T* out_data = output->template mutable_data<T>();
@@ -679,7 +679,7 @@ class CUDASparseLengthsMaxOp : public Operator<CUDAContext> {
     const int64_t outputSize = lengthsInput.dim(0);
     int len_length = outputSize;
 
-    auto shape = dataInput.dims().vec();
+    auto shape = dataInput.sizes().vec();
     shape[0] = outputSize;
     auto* output = Output(0, shape, at::dtype<T>());
 
@@ -812,7 +812,7 @@ class CUDASparseLengthsWeightedSumOp : public Operator<CUDAContext> {
     const int64_t outputSize = lengthsInput.dim(0);
     const int len_length = outputSize;
 
-    auto shape = dataInput.dims().vec();
+    auto shape = dataInput.sizes().vec();
     shape[0] = outputSize;
     auto* output = Output(0, shape, at::dtype<T>());
     T* out_data = output->template mutable_data<T>();
@@ -939,7 +939,7 @@ class CUDAUnsortedSegmentSumOp : public Operator<CUDAContext> {
 
     if (segment_ids.size() == 0 || data.size() == 0) {
       // Special handling for empty input
-      auto dims = data.dims().vec();
+      auto dims = data.sizes().vec();
       if (dims.size() > 0) {
         dims[0] = 0;
       }
@@ -987,7 +987,7 @@ class CUDAUnsortedSegmentSumOp : public Operator<CUDAContext> {
         sizeof(SIndex), K_tensor_.template data<SIndex>(), &K);
     context_.FinishDeviceComputation();
 
-    auto dims = data.dims().vec();
+    auto dims = data.sizes().vec();
     dims[0] = K + 1;
     auto* output = Output(0, dims, at::dtype<T>());
 
@@ -1090,7 +1090,7 @@ class SortedSegmentRangeMeanOp : public Operator<Context> {
     int M = input.dim32(0);
     int N = input.size_from_dim(1);
     auto* output = Output(0);
-    auto dims = input.dims().vec();
+    auto dims = input.sizes().vec();
     SIndex K = 0;
     context_.CopyBytesToCPU(
         sizeof(SIndex),
@@ -1301,7 +1301,7 @@ class CUDASparseLengthsSumGradientWithIndicesOp : public Operator<CUDAContext> {
     CAFFE_ENFORCE(segmentGradsInput.ndim() > 0);
     CAFFE_ENFORCE(len_length == segmentGradsInput.dim(0));
 
-    auto shape = segmentGradsInput.dims().vec();
+    auto shape = segmentGradsInput.sizes().vec();
     int output_0dim = indicesInput.dim(0);
     shape[0] = output_0dim;
     auto* dataGradsOutput = Output(0, shape, at::dtype<T>());
@@ -1380,7 +1380,7 @@ class CUDASparseLengthsMeanGradientWithIndicesOp
     CAFFE_ENFORCE(segmentGradsInput.ndim() > 0);
     CAFFE_ENFORCE(len_length == segmentGradsInput.dim(0));
 
-    auto shape = segmentGradsInput.dims().vec();
+    auto shape = segmentGradsInput.sizes().vec();
     int output_0dim = indicesInput.dim(0);
     shape[0] = output_0dim;
     auto* dataGradsOutput = Output(0, shape, at::dtype<T>());
@@ -1461,7 +1461,7 @@ class CUDASparseLengthsWeightedSumGradientWithIndicesOp
     CAFFE_ENFORCE(segmentGradsInput.ndim() > 0);
     CAFFE_ENFORCE(len_length == segmentGradsInput.dim(0));
 
-    auto shape = segmentGradsInput.dims().vec();
+    auto shape = segmentGradsInput.sizes().vec();
     int output_0dim = indicesInput.dim(0);
     shape[0] = output_0dim;
     auto* dataGradsOutput = Output(0, shape, at::dtype<T>());
@@ -1609,7 +1609,7 @@ class CUDALengthsMaxWithMainInputAndForwardOutputGradientOp
     auto* prefix_sum_length_data =
         inclusive_scan_length_buffer_.template data<int>();
 
-    auto shape = dataInput.dims().vec();
+    auto shape = dataInput.sizes().vec();
     auto* dataGradsOutput = Output(0, shape, at::dtype<T>());
 
     const T* in_data = segmentGradsInput.template data<T>();
@@ -1694,7 +1694,7 @@ class CUDASparseLengthsIndicesInGradientWeightedSumWithMainInputGradientOp
     CAFFE_ENFORCE(segmentGradsInput.ndim() > 0);
     CAFFE_ENFORCE(len_length == segmentGradsInput.dim(0));
 
-    auto shape = segmentGradsInput.dims().vec();
+    auto shape = segmentGradsInput.sizes().vec();
     int output_0dim = indicesInput.dim(0);
     shape[0] = output_0dim;
     auto* dataGradsOutput = Output(0, shape, at::dtype<T>());

--- a/caffe2/operators/spatial_batch_norm_op_cudnn.cu
+++ b/caffe2/operators/spatial_batch_norm_op_cudnn.cu
@@ -118,7 +118,7 @@ class CuDNNSpatialBNOp final : public SpatialBNOp<CUDAContext> {
     T* Y_data = Y->mutable_data<T>();
 
     if (N > 0) {
-      const std::vector<int> input_dims(X.dims().cbegin(), X.dims().cend());
+      const std::vector<int> input_dims(X.sizes().cbegin(), X.sizes().cend());
       if (input_dims != data_dims_) {
         data_dims_ = input_dims;
         SetTensorDescriptor(
@@ -303,7 +303,7 @@ class CuDNNSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
       return true;
     }
 
-    const std::vector<int> input_dims(X.dims().cbegin(), X.dims().cend());
+    const std::vector<int> input_dims(X.sizes().cbegin(), X.sizes().cend());
     if (input_dims != data_dims_) {
       data_dims_ = input_dims;
       SetTensorDescriptor(
@@ -344,6 +344,7 @@ class CuDNNSpatialBNGradientOp final : public SpatialBNGradientOp<CUDAContext> {
   cudnnTensorDescriptor_t param_desc_;
   cudnnBatchNormMode_t mode_;
 
+  // TODO: int -> int64_t
   std::vector<int> data_dims_;
 };
 

--- a/caffe2/operators/top_k.cu
+++ b/caffe2/operators/top_k.cu
@@ -321,8 +321,8 @@ bool TopKGradientCudaOp<T, Context>::RunOnDevice() {
   const auto& indices = Input(1);
   const auto& original_input = Input(2);
   auto* output = Output(0);
-  at::IntList values_dims = values.dims();
-  at::IntList origin_dims = original_input.dims();
+  at::IntList values_dims = values.sizes();
+  at::IntList origin_dims = original_input.sizes();
   CAFFE_ENFORCE_EQ(values_dims.size(), origin_dims.size());
   output->Resize(origin_dims);
   T* output_data = output->template mutable_data<T>();

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -273,7 +273,7 @@ class SumOp : public Operator<Context> {
     for (int i = 1; i < InputSize(); ++i) {
       if (output->sizes() != Input(i).sizes()) {
         CAFFE_THROW(
-            "Check failed: output->dims() == Input(i).dims().",
+            "Check failed: output->sizes() == Input(i).sizes().",
             "Description: Input #",
             i,
             ", input dimension:",

--- a/caffe2/python/pybind_state_hip.cc
+++ b/caffe2/python/pybind_state_hip.cc
@@ -69,7 +69,7 @@ void addHIPObjectMethods(py::module& m) {
           "Copy data from given DLPack tensor into this tensor.")
       .def_property_readonly(
           "_shape",
-          [](const DLPackWrapper<HIPContext>& t) { return t.tensor->dims(); })
+          [](const DLPackWrapper<HIPContext>& t) { return t.tensor->sizes(); })
       .def(
           "_reshape",
           [](DLPackWrapper<HIPContext>* t, std::vector<int64_t> dims) {

--- a/caffe2/queue/rebatching_queue.cc
+++ b/caffe2/queue/rebatching_queue.cc
@@ -21,7 +21,7 @@ void concat(
 
   for (int i = 0; i < numTensors; ++i) {
     SmartTensorPrinter::PrintTensor(inputZero.at(i));
-    outputDims[i] = inputZero.at(i).dims().vec();
+    outputDims[i] = inputZero.at(i).sizes().vec();
     outputDims[i].insert(outputDims[i].begin(), numRows);
   }
 
@@ -42,7 +42,7 @@ void concat(
       CAFFE_ENFORCE_EQ(inputZero[j].itemsize(), input.itemsize());
       CAFFE_ENFORCE_EQ(inputZero[j].ndim(), input.dim());
       for (int k = 0; k < input.dim(); ++k) {
-        CAFFE_ENFORCE_EQ(input.sizes()[k], inputZero[j].dims()[k]);
+        CAFFE_ENFORCE_EQ(input.sizes()[k], inputZero[j].size(k));
       }
 
       // Skip empty tensors

--- a/modules/detectron/ps_roi_pool_op.cu
+++ b/modules/detectron/ps_roi_pool_op.cu
@@ -246,7 +246,7 @@ bool PSRoIPoolOp<float, CUDAContext>::RunOnDevice() {
 
   auto* Y = Output(0, {R.dim32(0), output_dim_, pooled_height_, pooled_width_}, at::dtype<float>()); // PSRoI pooled data
   auto* A = Output(1, Y->sizes(), at::dtype<int>()); // mapping_channel
-  int output_size = Y->size();
+  int output_size = Y->numel();
   PSRoIPoolForward<float><<<CAFFE_GET_BLOCKS(output_size),
                             CAFFE_CUDA_NUM_THREADS,
                             0, context_.cuda_stream()>>>(


### PR DESCRIPTION
Summary: Plan is to remove the APIs we want to deprecate one by one and make sure it still builds in sandcastle and ossci

Reviewed By: ezyang

Differential Revision: D12812029
