### PR TITLE
Fix macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,6 +307,7 @@ caffe2_macos_build_defaults: &caffe2_macos_build_defaults
 
           export IN_CIRCLECI=1
 
+          brew update
           # moreutils installs a `parallel` executable by default, which conflicts with the executable from the GNU `parallel`
           # so we must unlink GNU `parallel` first, and relink it afterwards
           brew unlink parallel
@@ -459,6 +460,8 @@ smoke_mac_build: &smoke_mac_build
           set -ex
           export DATE=today
           export NIGHTLIES_DATE_PREAMBLE=1.0.0.dev
+
+          brew update
           # moreutils installs a `parallel` executable by default, which conflicts with the executable from the GNU `parallel`
           # so we must unlink GNU `parallel` first, and relink it afterwards
           brew unlink parallel
@@ -814,6 +817,8 @@ jobs:
             set -e
 
             export IN_CIRCLECI=1
+
+            brew update
             # moreutils installs a `parallel` executable by default, which conflicts with the executable from the GNU `parallel`
             # so we must unlink GNU `parallel` first, and relink it afterwards
             brew unlink parallel
@@ -861,6 +866,8 @@ jobs:
           command: |
             set -e
             export IN_CIRCLECI=1
+
+            brew update
             # moreutils installs a `parallel` executable by default, which conflicts with the executable from the GNU `parallel`
             # so we must unlink GNU `parallel` first, and relink it afterwards
             brew unlink parallel
@@ -889,6 +896,7 @@ jobs:
 
             export IN_CIRCLECI=1
 
+            brew update
             # moreutils installs a `parallel` executable by default, which conflicts with the executable from the GNU `parallel`
             # so we must unlink GNU `parallel` first, and relink it afterwards
             brew unlink parallel


### PR DESCRIPTION
macos builds are broken now with the following error:
```
/usr/local/Homebrew/Library/Homebrew/config.rb:39:in `initialize': no implicit conversion of nil into String (TypeError)
	from /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `new'
	from /usr/local/Homebrew/Library/Homebrew/config.rb:39:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/Homebrew/Library/Homebrew/global.rb:25:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:13:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:13:in `<main>'
Exited with code 1
```

No recent commits look suspicious, and I can even reproduce locally on my macbook, so it might be related to some new `brew` updates. Empirically, calling `brew update` first seems to fix this.


Example error build: https://circleci.com/gh/pytorch/pytorch/534392?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link