### PR TITLE
Fix log_prob for Gumbel distribution

### DIFF
--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -45,6 +45,13 @@ class Gumbel(TransformedDistribution):
         new.scale = self.scale.expand(batch_shape)
         return super(Gumbel, self).expand(batch_shape, _instance=new)
 
+    # Explicitly defining the log probability function for Gumbel due to precision issues
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        y = (self.loc - value) / self.scale
+        return (y - y.exp()) - self.scale.log()
+
     @property
     def mean(self):
         return self.loc + self.scale * euler_constant


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/15681

Changelog:
- Add hard-coded implementation of log_prob

Test plan:
- Existing tests should pass

cc: @fritzo 
There seems to be a precision issue (reported above) in the Gumbel `log_prob` function computed using the transforms, which is why I have hard-coded it.