### PR TITLE
Fixes selection of cuDNN algorithm

### DIFF
--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -155,9 +155,6 @@ struct AT_CUDA_API ConvolutionDescriptor
     AT_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale,
                                           CUDNN_CROSS_CORRELATION, mathType));
     AT_CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
-    AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_DEFAULT_MATH));
-    if(dataType == CUDNN_DATA_HALF)
-      AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_TENSOR_OP_MATH));
   }
 };
 

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -149,12 +149,18 @@ struct AT_CUDA_API ConvolutionDescriptor
                       &cudnnCreateConvolutionDescriptor,
                       &cudnnDestroyConvolutionDescriptor>
 {
-  void set(cudnnDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups) {
+  void set(cudnnDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups, cudnnMathType_t* convMathType) {
     cudnnDataType_t mathType = dataType;
     if (dataType == CUDNN_DATA_HALF) mathType = CUDNN_DATA_FLOAT;
     AT_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale,
                                           CUDNN_CROSS_CORRELATION, mathType));
     AT_CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
+    // Note that we are asumming the cdesc->mathType to be the same as the dataType
+    // by default. You will be using these default paths if torch.backends.cudnn.benchmark = False
+    // and torch.backends.cudnn.deterministic = True.
+    *convMathType = CUDNN_DEFAULT_MATH;
+    if(dataType == CUDNN_DATA_HALF)
+      *convMathType = CUDNN_TENSOR_OP_MATH;
   }
 };
 

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -155,6 +155,11 @@ struct AT_CUDA_API ConvolutionDescriptor
     AT_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale,
                                           CUDNN_CROSS_CORRELATION, mathType));
     AT_CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
+    // See Note [behavior of cudnnFind and cudnnGet]
+    AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_DEFAULT_MATH));
+    if(dataType == CUDNN_DATA_HALF)
+      AT_CUDNN_CHECK(cudnnSetConvolutionMathType(mut_desc(), CUDNN_TENSOR_OP_MATH));
+
   }
 };
 

--- a/aten/src/ATen/cudnn/Descriptors.h
+++ b/aten/src/ATen/cudnn/Descriptors.h
@@ -149,18 +149,12 @@ struct AT_CUDA_API ConvolutionDescriptor
                       &cudnnCreateConvolutionDescriptor,
                       &cudnnDestroyConvolutionDescriptor>
 {
-  void set(cudnnDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups, cudnnMathType_t* convMathType) {
+  void set(cudnnDataType_t dataType, int dim, int* pad, int* stride, int * upscale /* aka dilation */, int groups) {
     cudnnDataType_t mathType = dataType;
     if (dataType == CUDNN_DATA_HALF) mathType = CUDNN_DATA_FLOAT;
     AT_CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(mut_desc(), dim, pad, stride, upscale,
                                           CUDNN_CROSS_CORRELATION, mathType));
     AT_CUDNN_CHECK(cudnnSetConvolutionGroupCount(mut_desc(), groups));
-    // Note that we are asumming the cdesc->mathType to be the same as the dataType
-    // by default. You will be using these default paths if torch.backends.cudnn.benchmark = False
-    // and torch.backends.cudnn.deterministic = True.
-    *convMathType = CUDNN_DEFAULT_MATH;
-    if(dataType == CUDNN_DATA_HALF)
-      *convMathType = CUDNN_TENSOR_OP_MATH;
   }
 };
 

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -95,8 +95,8 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> cudnn_convolution_transpose_backwar
 #include <unordered_map>
 
 // Note [chooseAlgorithm doesn't respect mathType]
-// You might be wondering, why are we calling cudnnSetConvolutionMathType after
-// calling chooseAlgorithm...
+// You might be wondering, why not call cudnnSetConvolutionMathType in the 
+// convolution descriptor (cdesc) setter, before calling chooseAlgorithm...
 // Turns out, the mathType returned by the chooseAlgorithm can be different 
 // from what we set in the descriptor and hence, we have to explicitly update it 
 // after the chooseAlgorithm has found the best pair of algorithm+mathType. 
@@ -669,6 +669,11 @@ void findAlgorithm(const cudnnDataType_t dataType, const ConvolutionArgs& args, 
 
   if (args.params.deterministic && !benchmark) {
     algoPerf->algo = search::DEFAULT_ALGO;
+    if (dataType == CUDNN_DATA_HALF) {
+      algoPerf->mathType = CUDNN_TENSOR_OP_MATH;
+    } else {
+      algoPerf->mathType = CUDNN_DEFAULT_MATH;
+    }
     search::getWorkspaceSize(args, algoPerf->algo, &(algoPerf->memory));
     return;
   }
@@ -699,6 +704,11 @@ void findAlgorithm(const cudnnDataType_t dataType, const ConvolutionArgs& args, 
       *algoPerf = perfResults;
   } else {
       algoPerf->algo = search::DEFAULT_ALGO;
+      if (dataType == CUDNN_DATA_HALF) {
+        algoPerf->mathType = CUDNN_TENSOR_OP_MATH;
+      } else {
+        algoPerf->mathType = CUDNN_DEFAULT_MATH;
+      }
       search::getWorkspaceSize(args, algoPerf->algo, &(algoPerf->memory));
   }
 }
@@ -721,6 +731,11 @@ Workspace chooseAlgorithm(
     // switch to default algorithm and record it in the cache to prevent
     // further OOM errors
     algoPerf->algo = search::DEFAULT_ALGO;
+    if (dataType == CUDNN_DATA_HALF) {
+      algoPerf->mathType = CUDNN_TENSOR_OP_MATH;
+    } else {
+      algoPerf->mathType = CUDNN_DEFAULT_MATH;
+    }
     search::getWorkspaceSize(args, algoPerf->algo, &(algoPerf->memory));
     search::cache().insert(args.params, *algoPerf);
     return Workspace(algoPerf->memory);
@@ -805,19 +820,19 @@ void raw_cudnn_convolution_forward_out(
   auto dataType = getCudnnDataType(input);
 
   ConvolutionArgs args{ input, output, weight };
-  cudnnConvolutionFwdAlgoPerf_t fwdAlgPerf;
   args.handle = getCudnnHandle();
   setConvolutionParams(&args.params, input, weight, padding, stride, dilation, groups, deterministic);
   args.idesc.set(input);
   args.wdesc.set(weight);
   args.odesc.set(output);
-  args.cdesc.set(dataType, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, &(fwdAlgPerf.mathType));
+  args.cdesc.set(dataType, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups);
 
   // TODO: when we do legacy group convolution support, we'll repeatedly
   // reinitialize the workspace for each convolution we do.  This is
   // wasteful; we'd rather reuse the workspace.  OTOH, legacy group
   // convolution support is already pretty slow, so this might not
   // matter.  (This applies to raw_cudnn_convolution_backward_input as well.)
+  cudnnConvolutionFwdAlgoPerf_t fwdAlgPerf;
   Workspace workspace = chooseAlgorithm(dataType, args, benchmark, &fwdAlgPerf);
 
   // update convDesc mathType since cudnn now requires both algo + mathType to figure out
@@ -934,14 +949,14 @@ void raw_cudnn_convolution_backward_input_out(
   auto dataType = getCudnnDataType(grad_output);
 
   ConvolutionArgs args{ grad_input, grad_output, weight };
-  cudnnConvolutionBwdDataAlgoPerf_t bwdDataAlgPerf;
   args.handle = getCudnnHandle();
   setConvolutionParams(&args.params, grad_input, weight, padding, stride, dilation, groups, deterministic);
   args.idesc.set(grad_input);
   args.wdesc.set(weight);
   args.odesc.set(grad_output);
-  args.cdesc.set(dataType, grad_output.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, &(bwdDataAlgPerf.mathType));
+  args.cdesc.set(dataType, grad_output.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups);
 
+  cudnnConvolutionBwdDataAlgoPerf_t bwdDataAlgPerf;
   Workspace workspace = chooseAlgorithm(dataType, args, benchmark, &bwdDataAlgPerf);
 
   // update convDesc mathType since cudnn now requires both algo + mathType to figure out
@@ -1075,14 +1090,14 @@ void raw_cudnn_convolution_backward_weight_out(
   auto dataType = getCudnnDataType(input);
 
   ConvolutionArgs args{ input, grad_output, grad_weight };
-  cudnnConvolutionBwdFilterAlgoPerf_t bwdFilterAlgPerf;
   args.handle = getCudnnHandle();
   setConvolutionParams(&args.params, input, grad_weight, padding, stride, dilation, groups, deterministic);
   args.idesc.set(input);
   args.wdesc.set(grad_weight);
   args.odesc.set(grad_output);
-  args.cdesc.set(dataType, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups, &(bwdFilterAlgPerf.mathType));
+  args.cdesc.set(dataType, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups);
 
+  cudnnConvolutionBwdFilterAlgoPerf_t bwdFilterAlgPerf;
   Workspace workspace = chooseAlgorithm(dataType, args, benchmark, &bwdFilterAlgPerf);
 
   // update convDesc mathType since cudnn now requires both algo + mathType to figure out

--- a/aten/src/ATen/native/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/cudnn/Conv.cpp
@@ -340,9 +340,9 @@ struct BenchmarkCache {
   }
 };
 
-BenchmarkCache<cudnnConvolutionFwdAlgo_t> fwd_algos;
-BenchmarkCache<cudnnConvolutionBwdDataAlgo_t> bwd_data_algos;
-BenchmarkCache<cudnnConvolutionBwdFilterAlgo_t> bwd_filter_algos;
+BenchmarkCache<cudnnConvolutionFwdAlgoPerf_t> fwd_algos;
+BenchmarkCache<cudnnConvolutionBwdDataAlgoPerf_t> bwd_data_algos;
+BenchmarkCache<cudnnConvolutionBwdFilterAlgoPerf_t> bwd_filter_algos;
 
 // TODO: Stop manually allocating CUDA memory; allocate an ATen byte
 // tensor instead.
@@ -363,7 +363,7 @@ struct Workspace {
   void* data;
 };
 
-template<typename algo_t>
+template<typename perf_t>
 struct algorithm_search {
 };
 
@@ -452,14 +452,14 @@ perf_t getBestAlgorithm(perf_t *perfResults, bool deterministic, int n_algo) {
 }
 
 template<>
-struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
+struct algorithm_search<cudnnConvolutionFwdAlgoPerf_t> {
   using perf_t = cudnnConvolutionFwdAlgoPerf_t;
   using algo_t = cudnnConvolutionFwdAlgo_t;
 
   static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
-  static BenchmarkCache<algo_t>& cache() { return fwd_algos; }
+  static BenchmarkCache<perf_t>& cache() { return fwd_algos; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args) {
+  static perf_t findAlgorithm(const cudnnDataType_t dataType, const ConvolutionArgs& args, bool benchmark) {
     static const algo_t algos[] = {
          CUDNN_CONVOLUTION_FWD_ALGO_GEMM,
          CUDNN_CONVOLUTION_FWD_ALGO_FFT,
@@ -475,36 +475,32 @@ struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
                   "Missing cuDNN convolution forward algorithms");
     int perf_count;
     std::unique_ptr<perf_t[]> perf_results(new perf_t[num_algos]);
-    size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
-    Workspace ws(max_ws_size);
-    AT_CUDNN_CHECK(cudnnFindConvolutionForwardAlgorithmEx(
-        args.handle,
-        args.idesc.desc(), args.input.data_ptr(),
-        args.wdesc.desc(), args.weight.data_ptr(),
-        args.cdesc.desc(),
-        args.odesc.desc(), args.output.data_ptr(),
-        num_algos,
-        &perf_count,
-        perf_results.get(),
-        ws.data,
-        ws.size));
-    return getBestAlgorithm(perf_results.get(), args.params.deterministic, perf_count);
-  }
-
-  static void getAlgorithm(
-    const ConvolutionArgs& args,
-    algo_t* algo)
-  {
-    cudnnConvolutionFwdPreference_t pref = CUDNN_CONVOLUTION_FWD_PREFER_FASTEST;
-    AT_CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(
-        args.handle,
-        args.idesc.desc(),
-        args.wdesc.desc(),
-        args.cdesc.desc(),
-        args.odesc.desc(),
-        pref,
-        0,
-        algo));
+    if (!benchmark) {
+      AT_CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm_v7(
+          args.handle,
+          args.idesc.desc(),
+          args.wdesc.desc(),
+          args.cdesc.desc(),
+          args.odesc.desc(),
+          num_algos,
+          &perf_count,
+          perf_results.get()));
+    } else {
+      size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
+      Workspace ws(max_ws_size);
+      AT_CUDNN_CHECK(cudnnFindConvolutionForwardAlgorithmEx(
+          args.handle,
+          args.idesc.desc(), args.input.data_ptr(),
+          args.wdesc.desc(), args.weight.data_ptr(),
+          args.cdesc.desc(),
+          args.odesc.desc(), args.output.data_ptr(),
+          num_algos,
+          &perf_count,
+          perf_results.get(),
+          ws.data,
+          ws.size));
+    }
+    return getBestAlgorithm<perf_t>(perf_results.get(), args.params.deterministic, perf_count);
   }
 
   static void getWorkspaceSize(
@@ -523,14 +519,14 @@ struct algorithm_search<cudnnConvolutionFwdAlgo_t> {
 };
 
 template<>
-struct algorithm_search<cudnnConvolutionBwdDataAlgo_t> {
+struct algorithm_search<cudnnConvolutionBwdDataAlgoPerf_t> {
   using perf_t = cudnnConvolutionBwdDataAlgoPerf_t;
   using algo_t = cudnnConvolutionBwdDataAlgo_t;
 
   static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
-  static BenchmarkCache<algo_t>& cache() { return bwd_data_algos; }
+  static BenchmarkCache<perf_t>& cache() { return bwd_data_algos; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args) {
+  static perf_t findAlgorithm(const cudnnDataType_t dataType, const ConvolutionArgs& args, bool benchmark) {
     static const algo_t algos[] = {
         CUDNN_CONVOLUTION_BWD_DATA_ALGO_0,
         CUDNN_CONVOLUTION_BWD_DATA_ALGO_1,
@@ -544,32 +540,32 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgo_t> {
                   "Missing cuDNN convolution backward data algorithms.");
     int perf_count;
     std::unique_ptr<perf_t[]> perf_results(new perf_t[num_algos]);
-    size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
-    Workspace ws(max_ws_size);
-    AT_CUDNN_CHECK(cudnnFindConvolutionBackwardDataAlgorithmEx(
-        args.handle,
-        args.wdesc.desc(), args.weight.data_ptr(),
-        args.odesc.desc(), args.output.data_ptr(),
-        args.cdesc.desc(),
-        args.idesc.desc(), args.input.data_ptr(),
-        num_algos,
-        &perf_count,
-        perf_results.get(),
-        ws.data,
-        ws.size));
-    return getBestAlgorithm(perf_results.get(), args.params.deterministic, perf_count);
-  }
-
-  static void getAlgorithm(const ConvolutionArgs& args, algo_t* algo) {
-    AT_CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(
-        args.handle,
-        args.wdesc.desc(),
-        args.odesc.desc(),
-        args.cdesc.desc(),
-        args.idesc.desc(),
-        CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST,
-        0,
-        algo));
+    if (!benchmark) {
+      AT_CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm_v7(
+          args.handle,
+          args.wdesc.desc(),
+          args.odesc.desc(),
+          args.cdesc.desc(),
+          args.idesc.desc(),
+          num_algos,
+          &perf_count,
+          perf_results.get()));
+    } else {
+      size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
+      Workspace ws(max_ws_size);
+      AT_CUDNN_CHECK(cudnnFindConvolutionBackwardDataAlgorithmEx(
+          args.handle,
+          args.wdesc.desc(), args.weight.data_ptr(),
+          args.odesc.desc(), args.output.data_ptr(),
+          args.cdesc.desc(),
+          args.idesc.desc(), args.input.data_ptr(),
+          num_algos,
+          &perf_count,
+          perf_results.get(),
+          ws.data,
+          ws.size));
+    }
+    return getBestAlgorithm<perf_t>(perf_results.get(), args.params.deterministic, perf_count);
   }
 
   static void getWorkspaceSize(
@@ -588,15 +584,15 @@ struct algorithm_search<cudnnConvolutionBwdDataAlgo_t> {
 };
 
 template<>
-struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
+struct algorithm_search<cudnnConvolutionBwdFilterAlgoPerf_t> {
   using perf_t = cudnnConvolutionBwdFilterAlgoPerf_t;
   using algo_t = cudnnConvolutionBwdFilterAlgo_t;
 
   static constexpr auto DEFAULT_ALGO = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
 
-  static BenchmarkCache<algo_t>& cache() { return bwd_filter_algos; }
+  static BenchmarkCache<perf_t>& cache() { return bwd_filter_algos; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args) {
+  static perf_t findAlgorithm(const cudnnDataType_t dataType, const ConvolutionArgs& args, bool benchmark) {
     static const algo_t algos[] = {
         CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0,
         CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1,
@@ -610,35 +606,33 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
     static_assert(sizeof(algos) / sizeof(algos[0]) == num_algos,
                   "Missing cuDNN convolution backward filter algorithms.");
     std::unique_ptr<perf_t[]> perf_results(new perf_t[num_algos]);
-    size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
     int perf_count;
-    Workspace ws(max_ws_size);
-
-    AT_CUDNN_CHECK(cudnnFindConvolutionBackwardFilterAlgorithmEx(
-        args.handle,
-        args.idesc.desc(), args.input.data_ptr(),
-        args.odesc.desc(), args.output.data_ptr(),
-        args.cdesc.desc(),
-        args.wdesc.desc(), args.weight.data_ptr(),
-        num_algos,
-        &perf_count,
-        perf_results.get(),
-        ws.data,
-        ws.size));
+    if (!benchmark) {
+      AT_CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm_v7(
+          args.handle,
+          args.idesc.desc(),
+          args.odesc.desc(),
+          args.cdesc.desc(),
+          args.wdesc.desc(),
+          num_algos,
+          &perf_count,
+          perf_results.get()));
+    } else {
+      size_t max_ws_size = getMaxWorkspaceSize(args, algos, num_algos);
+      Workspace ws(max_ws_size);
+      AT_CUDNN_CHECK(cudnnFindConvolutionBackwardFilterAlgorithmEx(
+          args.handle,
+          args.idesc.desc(), args.input.data_ptr(),
+          args.odesc.desc(), args.output.data_ptr(),
+          args.cdesc.desc(),
+          args.wdesc.desc(), args.weight.data_ptr(),
+          num_algos,
+          &perf_count,
+          perf_results.get(),
+          ws.data,
+          ws.size));
+    }
     return getBestAlgorithm<perf_t>(perf_results.get(), args.params.deterministic, perf_count);
-  }
-
-  static void getAlgorithm(const ConvolutionArgs& args, algo_t* algo) {
-    AT_CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
-        args.handle,
-        args.idesc.desc(),
-        args.odesc.desc(),
-        args.cdesc.desc(),
-        args.wdesc.desc(),
-        CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST,
-        0,
-        algo)
-    );
   }
 
   static void getWorkspaceSize(const ConvolutionArgs& args, algo_t algo, size_t* workspaceSize)
@@ -654,70 +648,87 @@ struct algorithm_search<cudnnConvolutionBwdFilterAlgo_t> {
   }
 };
 
-template<typename algo_t>
-void findAlgorithm(const ConvolutionArgs& args, bool benchmark, algo_t* algo) {
-  using search = algorithm_search<algo_t>;
+template<typename perf_t>
+void findAlgorithm(const cudnnDataType_t dataType, const ConvolutionArgs& args, bool benchmark, perf_t* algoPerf) {
+  using search = algorithm_search<perf_t>;
   auto& cache = search::cache();
 
-  if (cache.find(args.params, algo)) {
+  if (cache.find(args.params, algoPerf)) {
     return;
   }
 
   if (args.params.deterministic && !benchmark) {
-    *algo = search::DEFAULT_ALGO;
+    algoPerf->algo = search::DEFAULT_ALGO;
+    if (dataType == CUDNN_DATA_HALF) {
+      algoPerf->mathType = CUDNN_TENSOR_OP_MATH;
+    } else {
+      algoPerf->mathType = CUDNN_DEFAULT_MATH;
+    }
+    search::getWorkspaceSize(args, algoPerf->algo, &(algoPerf->memory));
     return;
   }
 
-  if (!benchmark) {
-    search::getAlgorithm(args, algo);
-    return;
-  }
+  if (benchmark) {
+    if (cache.find(args.params, algoPerf)) {
+      // re-check cache since another thread may have benchmarked the algorithm
+      return;
+    }
+  } 
 
-  if (cache.find(args.params, algo)) {
-    // re-check cache since another thread may have benchmarked the algorithm
-    return;
-  }
-
-  auto perfResults = search::findAlgorithm(args);
+  auto perfResults = search::findAlgorithm(dataType, args, benchmark);
   // for deterministic algo, look at all the perf results and return the best
   // deterministic algo
   if (perfResults.status == CUDNN_STATUS_SUCCESS &&
       !(args.params.deterministic && perfResults.determinism != CUDNN_DETERMINISTIC)) {
-      *algo = perfResults.algo;
-  } else {
-      *algo = search::DEFAULT_ALGO;
-  }
-  cache.insert(args.params, *algo);
+      
+      // if benchmarking, map the original params with the found algo+math type for re-use
+      if (benchmark) {
+        cache.insert(args.params, perfResults);
 
-  // Free the cached blocks in our caching allocator. They are
-  // needed here because the above benchmarking uses a huge amount of memory,
-  // e.g. a few GBs.
-  c10::cuda::CUDACachingAllocator::emptyCache();
+        // Free the cached blocks in our caching allocator. They are
+        // needed here because the above benchmarking uses a huge amount of memory,
+        // e.g. a few GBs.
+        c10::cuda::CUDACachingAllocator::emptyCache();
+      }
+
+      *algoPerf = perfResults;
+  } else {
+      algoPerf->algo = search::DEFAULT_ALGO;
+      if (dataType == CUDNN_DATA_HALF) {
+        algoPerf->mathType = CUDNN_TENSOR_OP_MATH;
+      } else {
+        algoPerf->mathType = CUDNN_DEFAULT_MATH;
+      }
+      search::getWorkspaceSize(args, algoPerf->algo, &(algoPerf->memory));
+  }
 }
 
-template<typename algo_t>
+template<typename perf_t>
 Workspace chooseAlgorithm(
+    const cudnnDataType_t dataType,
     const ConvolutionArgs& args,
     bool benchmark,
-    algo_t* algo)
+    perf_t* algoPerf)
 {
-  findAlgorithm(args, benchmark, algo);
+  findAlgorithm(dataType, args, benchmark, algoPerf);
 
-  using search = algorithm_search<algo_t>;
-  size_t workspace_size;
-  search::getWorkspaceSize(args, *algo, &workspace_size);
+  using search = algorithm_search<perf_t>;
   try {
-    return Workspace(workspace_size);
+    return Workspace(algoPerf->memory);
   } catch (const std::exception& e) {
     cudaGetLastError(); // clear OOM error
 
     // switch to default algorithm and record it in the cache to prevent
     // further OOM errors
-    *algo = search::DEFAULT_ALGO;
-    search::cache().insert(args.params, *algo);
-
-    search::getWorkspaceSize(args, *algo, &workspace_size);
-    return Workspace(workspace_size);
+    algoPerf->algo = search::DEFAULT_ALGO;
+    if (dataType == CUDNN_DATA_HALF) {
+      algoPerf->mathType = CUDNN_TENSOR_OP_MATH;
+    } else {
+      algoPerf->mathType = CUDNN_DEFAULT_MATH;
+    }
+    search::getWorkspaceSize(args, algoPerf->algo, &(algoPerf->memory));
+    search::cache().insert(args.params, *algoPerf);
+    return Workspace(algoPerf->memory);
   }
 }
 
@@ -811,8 +822,12 @@ void raw_cudnn_convolution_forward_out(
   // wasteful; we'd rather reuse the workspace.  OTOH, legacy group
   // convolution support is already pretty slow, so this might not
   // matter.  (This applies to raw_cudnn_convolution_backward_input as well.)
-  cudnnConvolutionFwdAlgo_t fwdAlg;
-  Workspace workspace = chooseAlgorithm(args, benchmark, &fwdAlg);
+  cudnnConvolutionFwdAlgoPerf_t fwdAlgPerf;
+  Workspace workspace = chooseAlgorithm(dataType, args, benchmark, &fwdAlgPerf);
+
+  // update convDesc mathType since cudnn now requires both algo + mathType to figure out
+  // whether to use Tensor cores or not
+  AT_CUDNN_CHECK(cudnnSetConvolutionMathType(args.cdesc.mut_desc(), fwdAlgPerf.mathType));
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
@@ -821,7 +836,7 @@ void raw_cudnn_convolution_forward_out(
     args.handle,
     &one, args.idesc.desc(), input.data_ptr(),
     args.wdesc.desc(), weight.data_ptr(),
-    args.cdesc.desc(), fwdAlg, workspace.data, workspace.size,
+    args.cdesc.desc(), fwdAlgPerf.algo, workspace.data, workspace.size,
     &zero, args.odesc.desc(), output.data_ptr()));
 }
 
@@ -930,8 +945,12 @@ void raw_cudnn_convolution_backward_input_out(
   args.odesc.set(grad_output);
   args.cdesc.set(dataType, grad_output.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups);
 
-  cudnnConvolutionBwdDataAlgo_t bwdDataAlg;
-  Workspace workspace = chooseAlgorithm(args, benchmark, &bwdDataAlg);
+  cudnnConvolutionBwdDataAlgoPerf_t bwdDataAlgPerf;
+  Workspace workspace = chooseAlgorithm(dataType, args, benchmark, &bwdDataAlgPerf);
+
+  // update convDesc mathType since cudnn now requires both algo + mathType to figure out
+  // whether to use Tensor cores or not
+  AT_CUDNN_CHECK(cudnnSetConvolutionMathType(args.cdesc.mut_desc(), bwdDataAlgPerf.mathType));
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
@@ -940,7 +959,7 @@ void raw_cudnn_convolution_backward_input_out(
       args.handle,
       &one, args.wdesc.desc(), weight.data_ptr(),
       args.odesc.desc(), grad_output.data_ptr(),
-      args.cdesc.desc(), bwdDataAlg, workspace.data, workspace.size,
+      args.cdesc.desc(), bwdDataAlgPerf.algo, workspace.data, workspace.size,
       &zero, args.idesc.desc(), grad_input.data_ptr()));
 }
 
@@ -1066,8 +1085,12 @@ void raw_cudnn_convolution_backward_weight_out(
   args.odesc.set(grad_output);
   args.cdesc.set(dataType, input.dim() - 2, args.params.padding, args.params.stride, args.params.dilation, args.params.groups);
 
-  cudnnConvolutionBwdFilterAlgo_t bwdFilterAlg;
-  Workspace workspace = chooseAlgorithm(args, benchmark, &bwdFilterAlg);
+  cudnnConvolutionBwdFilterAlgoPerf_t bwdFilterAlgPerf;
+  Workspace workspace = chooseAlgorithm(dataType, args, benchmark, &bwdFilterAlgPerf);
+
+  // update convDesc mathType since cudnn now requires both algo + mathType to figure out
+  // whether to use Tensor cores or not
+  AT_CUDNN_CHECK(cudnnSetConvolutionMathType(args.cdesc.mut_desc(), bwdFilterAlgPerf.mathType));
 
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
@@ -1076,7 +1099,7 @@ void raw_cudnn_convolution_backward_weight_out(
       args.handle,
       &one, args.idesc.desc(), input.data_ptr(),
       args.odesc.desc(), grad_output.data_ptr(),
-      args.cdesc.desc(), bwdFilterAlg, workspace.data, workspace.size,
+      args.cdesc.desc(), bwdFilterAlgPerf.algo, workspace.data, workspace.size,
       &zero, args.wdesc.desc(), grad_weight.data_ptr()));
 }
 


### PR DESCRIPTION
#### Summary:
This PR updates the logic for using cudnnGet* and cudnnFind*. Current version of cudnn find and get (v7) returns a pair of best algorithm and the convDesc mathType. While we were using the returned algorithm, we didn't update the mathType. As a result, we ended up with a slow choice of algorithm and math type. Without this patch, we are seeing a 10x regression in group convolutions.

Changelist:
- Changed the template arguments to be `perf_t` instead of `algo_t` to unify cudnnFind and cudnnGet. Both cudnnFind and cudnnGet have the same purpose and hence, it made sense to unify them and get rid of `getAlgorithm`.
- Used cudnnGet*_v7 everywhere cudnnGet* was being used.
- Removed all cudnn6 paths (This PR depends on https://github.com/pytorch/pytorch/pull/15851)

CC: @ngimel @csarofeen for review

#### Nvprof:
- Before: On the left is the timeline for cudnnFind and on the right it is for cudnnGet. In the cudnnFind timeline, the first few kernel calls are for the find algorithm. It is seen here that the algo chosen is not the fastest one (because chosen algo1 is run with mathType 1). ![before](https://user-images.githubusercontent.com/8906225/50870515-313daf80-136d-11e9-8f1e-b7c3f90c16bc.png)
- After: Compared to the timeline above, when the mathType is updated, we see that the fastest algo is chosen indeed. (In 7.4 algo1+mathType 0 is giving better perf) ![after](https://user-images.githubusercontent.com/8906225/50870534-3f8bcb80-136d-11e9-83ac-80f9aa05a38a.png)

#### Timing:
- Current pytorch nightly container: 0.006510331630706787
- With this patch: 0.004045917987823487
- Speedup: ~1.5x

#### Code used in analysis:
```
import torch
import time
import torch.nn as nn
print("cudnn version", torch.backends.cudnn.version())

conv = nn.Conv2d(16,256,(3,3),dilation=(2,2), padding=(1,1)).cuda().half()
torch.backends.cudnn.benchmark=True

input = torch.randn(64,16,56,56, device="cuda").half()
out=conv(input)
gO=torch.rand_like(out)
torch.cuda.synchronize()

s = time.time()
for i in range(100):
   out = conv(input.detach())
   out.backward(gO)
torch.cuda.synchronize()
e = time.time()
print((e-s)/100)
```