### PR TITLE
[wip] Allow calling pytorch ops from caffe2 test cases

### DIFF
--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -11,6 +11,7 @@ import caffe2.python.serialized_test.serialized_test_util as serial
 import numpy as np
 import os
 import unittest
+import torch
 
 
 class TestLayerNormOp(serial.SerializedTestCase):


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #15243 Enable calling caffe2 LayerNorm from PyTorch and JIT&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13473791/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#15890 [wip] Allow calling pytorch ops from caffe2 test cases**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13613704/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #15880 Remove code duplication&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13611232/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #15895 Test cases for calling caffe2 LayerNorm from PyTorch and JIT&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13615336/)

This sets up the build system so that PyTorch operations can be called from Caffe2 test cases.

A diff on top of this one will use this to call the caffe2_layer_norm op from caffe2 test cases but through pytorch.

Differential Revision: [D13613704](https://our.internmc.facebook.com/intern/diff/D13613704/)