### PR TITLE
Make it consistent for OperatorBase usage

### DIFF
--- a/caffe2/quantization/server/concat_dnnlowp_op.cc
+++ b/caffe2/quantization/server/concat_dnnlowp_op.cc
@@ -16,11 +16,11 @@ ConcatDNNLowPOp<T>::ConcatDNNLowPOp(
     Workspace* ws)
     : BaseType(operator_def, ws) {
   if (HasArgument("axis")) {
-    axis_ = OperatorBase::GetSingleArgument<int>("axis", -1);
-    add_axis_ = OperatorBase::GetSingleArgument<int>("add_axis", 0);
+    axis_ = this->template GetSingleArgument<int>("axis", -1);
+    add_axis_ = this->template GetSingleArgument<int>("add_axis", 0);
   } else {
     axis_ = GetDimFromOrderString(
-        OperatorBase::GetSingleArgument<string>("order", "NCHW"));
+        this->template GetSingleArgument<string>("order", "NCHW"));
     add_axis_ = 0;
   }
   CAFFE_ENFORCE_GE(axis_, 0);
@@ -35,7 +35,7 @@ bool ConcatDNNLowPOp<T>::RunOnDevice() {
   Tensor* split = nullptr;
   int* axis_data = nullptr;
   if (OutputSize() >= 2) {
-    split = OperatorBase::Output<Tensor>(1, CPU);
+    split = this->template Output<Tensor>(1, CPU);
     split->Resize(vector<int64_t>(1, InputSize()));
     axis_data = split->template mutable_data<int>();
   }

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
@@ -46,10 +46,10 @@ ConvDNNLowPAcc16Op<ReluFused>::ConvDNNLowPAcc16Op(
     const OperatorDef& operator_def,
     Workspace* ws)
     : ConvDNNLowPOp<uint8_t, ReluFused>(operator_def, ws),
-      nbits_in_non_outlier_(OperatorBase::GetSingleArgument<int>(
+      nbits_in_non_outlier_(this->template GetSingleArgument<int>(
           "nbits_in_non_outlier",
           FLAGS_caffe2_dnnlowp_nbits_in_non_outlier)),
-      copy_to_32bit_frequency_(OperatorBase::GetSingleArgument<int>(
+      copy_to_32bit_frequency_(this->template GetSingleArgument<int>(
           "copy_to_32bit_frequency",
           FLAGS_caffe2_dnnlowp_copy_to_32bit_frequency)) {
   if (nbits_in_non_outlier_ == 0) {
@@ -181,8 +181,7 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
         static int log_occurences = 0;
         if (log_occurences < 32) {
           ++log_occurences;
-          LOG(WARNING) << "Conv with weight "
-                       << OperatorBase::debug_def().input(FILTER)
+          LOG(WARNING) << "Conv with weight " << this->debug_def().input(FILTER)
                        << " falls back to slow path because " << reason;
         }
       }
@@ -772,8 +771,8 @@ bool ConvDNNLowPAcc16Op<ReluFused>::RunOnDeviceWithOrderNHWC() {
   dt = chrono::duration<double>(t_end - t_very_begin).count();
   double ops = 2. * N * output_image_size * M * kernel_dim;
   double gops = ops / dt / 1e9;
-  LOG(INFO) << "this=" << this << " " << OperatorBase::debug_def().type()
-            << " output=" << OperatorBase::debug_def().output(0) << " "
+  LOG(INFO) << "this=" << this << " " << this->debug_def().type()
+            << " output=" << this->debug_def().output(0) << " "
             << N * output_image_size << "x" << M << "x" << kernel_dim
             << " G=" << group_ << " C/G=" << C / group_ << " K/G=" << M / group_
             << " R=" << kernel_h() << " S=" << kernel_w() << " : " << dt * 1e3

--- a/caffe2/quantization/server/conv_relu_op.cc
+++ b/caffe2/quantization/server/conv_relu_op.cc
@@ -5,10 +5,10 @@ namespace caffe2 {
 template <typename T, class Context>
 bool ConvReluOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   // Delegate to local conv operator
-  for (int i = 0; i < OperatorBase::InputSize(); ++i) {
+  for (int i = 0; i < this->InputSize(); ++i) {
     local_input_blobs_[i]->ShareExternal(
-        const_cast<void*>(OperatorBase::Inputs()[i]->GetRaw()),
-        OperatorBase::Inputs()[i]->meta());
+        const_cast<void*>(this->Inputs()[i]->GetRaw()),
+        this->Inputs()[i]->meta());
   }
 
   if (!local_op_->RunOnDeviceWithOrderNCHW()) {
@@ -36,10 +36,10 @@ bool ConvReluOp<T, Context>::RunOnDeviceWithOrderNCHW() {
 template <typename T, class Context>
 bool ConvReluOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   // Delegate to local conv operator
-  for (int i = 0; i < OperatorBase::InputSize(); ++i) {
+  for (int i = 0; i < this->InputSize(); ++i) {
     local_input_blobs_[i]->ShareExternal(
-        const_cast<void*>(OperatorBase::Inputs()[i]->GetRaw()),
-        OperatorBase::Inputs()[i]->meta());
+        const_cast<void*>(this->Inputs()[i]->GetRaw()),
+        this->Inputs()[i]->meta());
   }
 
   if (!local_op_->RunOnDeviceWithOrderNHWC()) {

--- a/caffe2/quantization/server/dequantize_dnnlowp_op.cc
+++ b/caffe2/quantization/server/dequantize_dnnlowp_op.cc
@@ -19,7 +19,7 @@ bool DequantizeDNNLowPOp<T>::RunOnDevice() {
       GetInputTensorQuantizationParamsOf(this, 0, qfactory_.get());
 
   const TensorCPU& input = InputIsType<int8::Int8TensorCPU>(0)
-      ? OperatorBase::Input<int8::Int8TensorCPU>(0).t
+      ? this->template Input<int8::Int8TensorCPU>(0).t
       : Input(0);
 
   CAFFE_ENFORCE(input.template IsType<T>());

--- a/caffe2/quantization/server/elementwise_dnnlowp_op.h
+++ b/caffe2/quantization/server/elementwise_dnnlowp_op.h
@@ -25,7 +25,7 @@ class UnaryElementwiseWithArgsDNNLowPOp : public Operator<CPUContext> {
       arguments_parsed_ = true;
     }
 
-    auto& input = OperatorBase::Input<int8::Int8TensorCPU>(0).t;
+    auto& input = this->template Input<int8::Int8TensorCPU>(0).t;
     auto& output = Outputs()[0]->template GetMutable<int8::Int8TensorCPU>()->t;
     output.ResizeLike(input);
     functor_(

--- a/caffe2/quantization/server/elementwise_linear_dnnlowp_op.cc
+++ b/caffe2/quantization/server/elementwise_linear_dnnlowp_op.cc
@@ -25,7 +25,7 @@ ElementwiseLinearDNNLowPOp<T>::ElementwiseLinearDNNLowPOp(
     const OperatorDef& operator_def,
     Workspace* ws)
     : BaseType(operator_def, ws),
-      axis_(OperatorBase::GetSingleArgument<int>("axis", 1)) {}
+      axis_(this->template GetSingleArgument<int>("axis", 1)) {}
 
 template <typename T>
 bool ElementwiseLinearDNNLowPOp<T>::RunOnDevice() {

--- a/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_acc16_op.cc
@@ -13,10 +13,10 @@ FullyConnectedDNNLowPAcc16Op::FullyConnectedDNNLowPAcc16Op(
     const OperatorDef& operator_def,
     Workspace* ws)
     : FullyConnectedDNNLowPOp<uint8_t>(operator_def, ws),
-      nbits_in_non_outlier_(OperatorBase::GetSingleArgument<int>(
+      nbits_in_non_outlier_(this->template GetSingleArgument<int>(
           "nbits_in_non_outlier",
           FLAGS_caffe2_dnnlowp_nbits_in_non_outlier)),
-      copy_to_32bit_frequency_(OperatorBase::GetSingleArgument<int>(
+      copy_to_32bit_frequency_(this->template GetSingleArgument<int>(
           "copy_to_32bit_frequency",
           FLAGS_caffe2_dnnlowp_copy_to_32bit_frequency)) {}
 
@@ -77,7 +77,7 @@ bool FullyConnectedDNNLowPAcc16Op::RunOnDevice() {
         int outlier_cnt = Wq_outlier_->ColPtr()[N];
 
         LOG(INFO) << "Proportion of outlier for FC layer with weight blob "
-                  << OperatorBase::debug_def().input(1) << " is "
+                  << this->debug_def().input(1) << " is "
                   << (float)outlier_cnt / W_quantized_.size();
 
         LOG(INFO) << "copy_to_32bit_frequency " << copy_to_32bit_frequency_;

--- a/caffe2/quantization/server/fully_connected_fake_lowp_op.h
+++ b/caffe2/quantization/server/fully_connected_fake_lowp_op.h
@@ -52,10 +52,10 @@ class FullyConnectedFakeLowpFPOp final : public Operator<Context> {
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   FullyConnectedFakeLowpFPOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)),
-        axis_w_(OperatorBase::GetSingleArgument<int32_t>("axis_w", 1)),
+        axis_(this->template GetSingleArgument<int32_t>("axis", 1)),
+        axis_w_(this->template GetSingleArgument<int32_t>("axis_w", 1)),
         float16_compute_(
-            OperatorBase::GetSingleArgument<bool>("float16_compute", false)) {}
+            this->template GetSingleArgument<bool>("float16_compute", false)) {}
   ~FullyConnectedFakeLowpFPOp() {}
 
   template <
@@ -98,10 +98,10 @@ class FullyConnectedGradientFakeLowpFPOp : public Operator<Context> {
       const OperatorDef& operator_def,
       Workspace* ws)
       : Operator<Context>(operator_def, ws),
-        axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)),
-        axis_w_(OperatorBase::GetSingleArgument<int32_t>("axis_w", 1)),
+        axis_(this->template GetSingleArgument<int32_t>("axis", 1)),
+        axis_w_(this->template GetSingleArgument<int32_t>("axis_w", 1)),
         float16_compute_(
-            OperatorBase::GetSingleArgument<bool>("float16_compute", false)) {}
+            this->template GetSingleArgument<bool>("float16_compute", false)) {}
   ~FullyConnectedGradientFakeLowpFPOp() {}
 
   template <

--- a/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op.cc
@@ -14,12 +14,12 @@ FullyConnectedRowWiseDNNLowPOp<T>::FullyConnectedRowWiseDNNLowPOp(
     const OperatorDef& operator_def,
     Workspace* ws)
     : BaseType(operator_def, ws),
-      axis_(OperatorBase::GetSingleArgument<int32_t>("axis", 1)),
-      axis_w_(OperatorBase::GetSingleArgument<int32_t>("axis_w", 1)),
+      axis_(this->template GetSingleArgument<int32_t>("axis", 1)),
+      axis_w_(this->template GetSingleArgument<int32_t>("axis_w", 1)),
       b_quantized_(make_shared<vector<int32_t>>()),
       column_offsets_(make_shared<vector<int32_t>>()),
       is_weight_constant_(
-          OperatorBase::GetSingleArgument<bool>("constant_weight", true)) {
+          this->template GetSingleArgument<bool>("constant_weight", true)) {
   using namespace dnnlowp;
   LOG(INFO) << "Using Rowwise Quantization!";
   if (!is_weight_constant_) {
@@ -232,9 +232,8 @@ bool FullyConnectedRowWiseDNNLowPOp<T>::RunOnDevice() {
     dt = chrono::duration<double>(t_end - t_very_begin).count();
     double gops = ops / dt / 1e9;
     VLOG(3) << "@PERF this=" << this
-            << " output=" << OperatorBase::debug_def().output(0) << " " << M
-            << "x" << N << "x" << K << ": " << dt * 1e3 << " ms " << gops
-            << " gops";
+            << " output=" << this->debug_def().output(0) << " " << M << "x" << N
+            << "x" << K << ": " << dt * 1e3 << " ms " << gops << " gops";
   }
 
   return true;

--- a/caffe2/quantization/server/group_norm_dnnlowp_op.cc
+++ b/caffe2/quantization/server/group_norm_dnnlowp_op.cc
@@ -56,9 +56,9 @@ void GroupNormDNNLowPOp<T>::QuantizeGamma() {
       const int C = gamma.size();
       gamma_quantized_.resize(C);
       gamma_quantized_data_ = gamma_quantized_.data();
-      if (OperatorBase::InputIsType<int8::Int8TensorCPU>(GAMMA)) {
+      if (this->template InputIsType<int8::Int8TensorCPU>(GAMMA)) {
         const auto& gamma_int8 =
-            OperatorBase::Input<int8::Int8TensorCPU>(GAMMA);
+            this->template Input<int8::Int8TensorCPU>(GAMMA);
         auto& gamma_qparams = in_qparams_[GAMMA];
         gamma_qparams.scale = gamma_int8.scale;
         const T* gamma_data = gamma.template data<T>();
@@ -118,8 +118,8 @@ void GroupNormDNNLowPOp<T>::QuantizeBeta() {
     const auto& X_qparams = in_qparams_[INPUT];
     const auto& gamma_qparams = in_qparams_[GAMMA];
     auto& beta_qparams = in_qparams_[BETA];
-    if (OperatorBase::InputIsType<int8::Int8TensorCPU>(BETA)) {
-      const auto& beta_int8 = OperatorBase::Input<int8::Int8TensorCPU>(BETA);
+    if (this->template InputIsType<int8::Int8TensorCPU>(BETA)) {
+      const auto& beta_int8 = this->template Input<int8::Int8TensorCPU>(BETA);
       beta_qparams.scale = beta_int8.scale;
       beta_qparams.zero_point = beta_int8.zero_point;
       CAFFE_ENFORCE_LE(

--- a/caffe2/quantization/server/lstm_unit_dnnlowp_op.cc
+++ b/caffe2/quantization/server/lstm_unit_dnnlowp_op.cc
@@ -16,7 +16,7 @@ LSTMUnitDNNLowPOp<T>::LSTMUnitDNNLowPOp(
     Workspace* ws)
     : LSTMUnitOp<CPUContext>(operator_def, ws),
       drop_states_(
-          OperatorBase::template GetSingleArgument<bool>("drop_states", false)),
+          this->template GetSingleArgument<bool>("drop_states", false)),
       qfactory_(GetQuantizationFactoryOf(this)) {}
 
 template <typename T>
@@ -39,7 +39,7 @@ OpWrapper<LSTMUnitOp<CPUContext>, T>* LSTMUnitDNNLowPOp<T>::Fp32Op_() {
 template <typename T>
 const TensorCPU& LSTMUnitDNNLowPOp<T>::InputTensorCPU_(int idx) {
   return InputIsType<int8::Int8TensorCPU>(idx)
-      ? OperatorBase::Input<int8::Int8TensorCPU>(idx).t
+      ? this->template Input<int8::Int8TensorCPU>(idx).t
       : Input(idx);
 }
 

--- a/caffe2/quantization/server/relu_dnnlowp_op.cc
+++ b/caffe2/quantization/server/relu_dnnlowp_op.cc
@@ -7,7 +7,7 @@ namespace caffe2 {
 template <typename T>
 bool ReluDNNLowPOp<T>::RunOnDevice() {
   auto& X = InputIsType<int8::Int8TensorCPU>(0)
-      ? OperatorBase::Input<int8::Int8TensorCPU>(0).t
+      ? (this->template Input<int8::Int8TensorCPU>(0)).t
       : Input(0);
 
   TensorCPU* Y = nullptr;

--- a/caffe2/quantization/server/relu_dnnlowp_op.h
+++ b/caffe2/quantization/server/relu_dnnlowp_op.h
@@ -10,6 +10,7 @@ namespace caffe2 {
 template <typename T>
 class ReluDNNLowPOp final : public Operator<CPUContext> {
  public:
+  USE_OPERATOR_FUNCTIONS(CPUContext);
   ReluDNNLowPOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<CPUContext>(operator_def, ws),
         qfactory_(dnnlowp::GetQuantizationFactoryOf(this)) {}

--- a/caffe2/quantization/server/utility_dnnlowp_ops.h
+++ b/caffe2/quantization/server/utility_dnnlowp_ops.h
@@ -37,7 +37,7 @@ class GatherDNNLowPOp final : public GatherOp<CPUContext> {
   bool DoRunWithType() {
     // If we endup using it on GPU doing O(N) memcpy is probably not best :)
     // TODO: implement prefetching if it starts mattering (TF does it)
-    auto& data = OperatorBase::Input<int8::Int8TensorCPU>(DATA).t;
+    auto& data = (this->template Input<int8::Int8TensorCPU>(DATA)).t;
     auto& indices = Input(INDICES);
     auto* output = &Outputs()[0]->template GetMutable<int8::Int8TensorCPU>()->t;
 


### PR DESCRIPTION
Summary:
"OperatorBase::" is changed to "this->template ".

For example,

  # This no longer works
  OperatorBase::GetSingleArgument<>()
  # Should change to:
  this->template GetSingleArgument<>()

https://fb.workplace.com/groups/101100140348621/permalink/576804082778222/

Follow up of D13574832.

Sample Diff:
D9319742, D10045844.

Differential Revision: D13613574
