### PR TITLE
Chunk dataset implementation

### DIFF
--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -60,6 +60,70 @@ TEST(DataTest, TransformCallsGetApplyCorrectly) {
   ASSERT_EQ(batch, expected);
 }
 
+// dummy chunk data reader with 3 chunks and 35 examples in total. Each chunk
+// contains 10, 5, 20 examples respectively.
+struct DummyChunkDataReader
+    : public datasets::ChunkDataReader<DummyChunkDataReader, std::vector<int>> {
+ public:
+  using BatchType = std::vector<int>;
+
+  /// Read an entire chunk.
+  BatchType read_chunk(size_t chunk_index) override {
+    BatchType batch_data;
+    int start_index = chunk_index == 0
+        ? 0
+        : std::accumulate(chunk_sizes, chunk_sizes + chunk_index, 0);
+
+    batch_data.resize(chunk_sizes[chunk_index]);
+
+    std::iota(batch_data.begin(), batch_data.end(), start_index);
+
+    return batch_data;
+  }
+
+  size_t get_chunk_count() override {
+    return chunk_count_;
+  };
+
+  void reset() override{};
+
+  const static size_t chunk_count_ = 3;
+  size_t chunk_sizes[chunk_count_] = {10, 5, 20};
+};
+
+TEST(DataTest, ChunkDataSetWithInvalidInitParameter) {
+  DummyChunkDataReader data_reader;
+  samplers::SequentialSampler sampler(0);
+
+  auto initialization_function = [&](size_t preloader_count, size_t batch_size, size_t cache_size){
+    datasets::SharedBatchDataset<datasets::ChunkDataSet<
+          DummyChunkDataReader,
+          samplers::SequentialSampler,
+          samplers::SequentialSampler>> dataset =
+          datasets::make_shared_dataset<datasets::ChunkDataSet<
+              DummyChunkDataReader,
+              samplers::SequentialSampler,
+              samplers::SequentialSampler>>(
+              data_reader, sampler, sampler, preloader_count, batch_size, false, cache_size);
+  };
+
+  ASSERT_THROWS_WITH(
+      initialization_function(0, 1, 1),
+      "Preloader count is 0. At least one preloader needs to be specified.");
+
+  ASSERT_THROWS_WITH(
+      initialization_function(1, 0, 1),
+      "Batch size is 0. A positive batch size needs to be specified.");
+
+  ASSERT_THROWS_WITH(
+      initialization_function(1, 1, 0),
+      "Cache size is 0. A positive cache size needs to be specified.");
+
+  ASSERT_THROWS_WITH(
+      initialization_function(1, 10, 5),
+      "Cache size is less than batch size. Cache needs to be large enough to hold at least one batch.");
+}
+
 struct InfiniteStreamDataset
     : datasets::StreamDataset<InfiniteStreamDataset, std::vector<int>> {
   std::vector<int> get_batch(size_t batch_size) override {
@@ -99,6 +163,7 @@ TEST(DataTest, InfiniteStreamDataset) {
   }
   ASSERT_EQ(batch_index, 3);
 }
+
 TEST(DataTest, NoSequencerIsIdentity) {
   using namespace torch::data::detail::sequencers; // NOLINT
   NoSequencer<int> no_sequencer;
@@ -1350,105 +1415,211 @@ TEST(DataLoaderTest, StatefulDatasetWithCollate) {
   ASSERT_TRUE(batch->target[0].allclose(torch::zeros(kBatchSize - 1)));
 }
 
-class DummyChunkReader
-    : public datasets::ChunkDataReader<DummyChunkReader, std::vector<int>> {
+// This test tests the core function for iterate through a chunk dataset. It
+// contains test cases with different parameter combination. (For example,
+// different prefetch count, batch size and data loader worker count). It
+// verifies the return batches size and content when the order is deterministic.
+TEST(DataLoaderTest, ChunkDataSetGetBatch) {
+  // different prefetch count for testing.
+  const size_t prefetch_counts[] = {1, 2, 3, 4};
+
+  // different batch size for testing.
+  const size_t batch_sizes[] = {5, 7};
+
+  // test with/without worker threads
+  const size_t dataloader_worker_counts[] = {0, 2};
+
+  const size_t total_example_count = 35;
+  DummyChunkDataReader data_reader;
+  samplers::SequentialSampler sampler(0);
+
+  // test functionality across epoch boundary
+  const int epoch_count = 2;
+
+  for (auto prefetch_count : prefetch_counts) {
+    for (auto batch_size : batch_sizes) {
+      for (auto dataloader_worker_count : dataloader_worker_counts) {
+        datasets::SharedBatchDataset<datasets::ChunkDataSet<
+            DummyChunkDataReader,
+            samplers::SequentialSampler,
+            samplers::SequentialSampler>>
+            dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+                DummyChunkDataReader,
+                samplers::SequentialSampler,
+                samplers::SequentialSampler>>(
+                data_reader, sampler, sampler, prefetch_count, batch_size);
+
+        auto data_loader = torch::data::make_data_loader(
+            dataset,
+            DataLoaderOptions(batch_size)
+                .workers(dataloader_worker_count));
+
+        for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+          std::vector<bool> result(total_example_count, false);
+          int iteration_count = 0;
+          for (auto iterator = data_loader->begin();
+               iterator != data_loader->end();
+               ++iterator, ++iteration_count) {
+            std::vector<int>& batch = *iterator;
+            ASSERT_EQ(batch.size(), batch_size);
+
+            // When prefetch_count is equal to 1 and no worker thread, the batch
+            // order is deterministic. So we can verify elements in each batch.
+            if (prefetch_count == 1 && dataloader_worker_count == 0) {
+              for (size_t j = 0; j < batch_size; ++j) {
+                ASSERT_EQ(batch[j], iteration_count * batch_size + j);
+              }
+            }
+            for (size_t j = 0; j < batch_size; ++j) {
+              result[batch[j]] = true;
+            }
+          }
+
+          for (auto data : result) {
+            ASSERT_EQ(data, true);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DataLoaderTest, ChunkDataSetWithBatchSizeMismatch) {
+  const size_t prefetch_count = 1;
+  const size_t batch_size = 5;
+  const size_t requested_batch_size = 6;
+
+  DummyChunkDataReader data_reader;
+  samplers::SequentialSampler sampler(0);
+
+  datasets::SharedBatchDataset<datasets::ChunkDataSet<
+      DummyChunkDataReader,
+      samplers::SequentialSampler,
+      samplers::SequentialSampler>>
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+          DummyChunkDataReader,
+          samplers::SequentialSampler,
+          samplers::SequentialSampler>>(
+          data_reader, sampler, sampler, prefetch_count, batch_size);
+
+  auto data_loader = torch::data::make_data_loader(
+      dataset,
+      DataLoaderOptions(requested_batch_size).workers(0));
+
+  std::string exception_msg =
+      "The requested batch size does not match with the initialized batch size.\n"
+      " The requested batch size is 6, while the data set is created with batch size equal to 5";
+
+  ASSERT_THROWS_WITH(*(data_loader->begin()), exception_msg);
+}
+
+struct DummyEmptyChunkDataReader
+    : public datasets::
+          ChunkDataReader<DummyEmptyChunkDataReader, std::vector<int>> {
  public:
   using BatchType = std::vector<int>;
-  using BatchRequestType = size_t;
 
-  DummyChunkReader(size_t num_chunks, size_t chunk_size)
-      : datasets::ChunkDataReader<DummyChunkReader, std::vector<int>>(),
-        num_chunks_(num_chunks),
-        chunk_size_(chunk_size) {}
-
-  DummyChunkReader(DummyChunkReader&& other) {
-    num_chunks_ = other.num_chunks_;
-    chunk_size_ = other.chunk_size_;
-    chunk_index_ = other.chunk_index_.load();
-  }
-
-  std::vector<int> read_chunk(size_t chunk_index) override {
-    std::vector<int> batch(chunk_size_);
-    size_t counter = chunk_index * chunk_size_;
-    for (auto& i : batch) {
-      i = counter++;
-    }
-    return batch;
+  BatchType read_chunk(size_t chunk_index) override {
+    return {};
   }
 
   size_t get_chunk_count() override {
-    return num_chunks_;
-  }
+    return chunk_count_;
+  };
 
-  void reset() override {}
+  void reset() override{};
 
- private:
-  std::atomic<int> chunk_index_{0};
-  size_t num_chunks_;
-  size_t chunk_size_;
+  const static size_t chunk_count_ = 3;
 };
 
-TEST(DataTest, DataLoaderWithChunkSupportSingleWorker) {
-  const size_t kBatchSize = 13;
-  const size_t kNumChunks = 10;
+TEST(DataLoaderTest, ChunkDataSetWithEmptyBatchThrowException) {
+  const size_t prefetch_count = 1;
+  const size_t batch_size = 5;
+  DummyEmptyChunkDataReader data_reader;
+  samplers::SequentialSampler sampler(0);
 
-  auto dataset =
-      torch::data::datasets::make_shared_dataset<datasets::ChunkDataSet<
-          DummyChunkReader,
+  datasets::SharedBatchDataset<datasets::ChunkDataSet<
+      DummyEmptyChunkDataReader,
+      samplers::SequentialSampler,
+      samplers::SequentialSampler>>
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+          DummyEmptyChunkDataReader,
           samplers::SequentialSampler,
           samplers::SequentialSampler>>(
-          DummyChunkReader(kNumChunks, kBatchSize),
-          samplers::SequentialSampler(kNumChunks),
-          samplers::SequentialSampler(kBatchSize),
-          kBatchSize)
-          .map(transforms::BatchLambda<std::vector<int>, int>(
-              [](const std::vector<int>& x) {
-                return std::accumulate(x.begin(), x.end(), 0);
-              }));
-  auto data_loader =
-      torch::data::make_data_loader(dataset, DataLoaderOptions(kBatchSize));
+          data_reader, sampler, sampler, prefetch_count, batch_size);
 
-  int count = 0;
-  for (int sum : *data_loader) {
-    int res = 0;
-    for (int i = 0; i < kBatchSize; ++i) {
-      res += count * kBatchSize + i;
-    }
-    ASSERT_EQ(sum, res);
-    count++;
-  }
-  ASSERT_EQ(count, 10);
+  auto data_loader = torch::data::make_data_loader(
+      dataset, DataLoaderOptions(batch_size).workers(0));
+
+  ASSERT_THROWS_WITH(*(data_loader->begin()), "Chunk with index 0 is empty");
 }
 
-TEST(DataTest, DataLoaderWithChunkSupportMultiWorker) {
-  const size_t kBatchSize = 13;
-  const size_t kNumChunks = 10;
+TEST(DataLoaderTest, ChunkDataSetWithEmptyBatchIgnoreEmptyChunk) {
+  const size_t prefetch_count = 1;
+  const size_t batch_size = 5;
+  DummyEmptyChunkDataReader data_reader;
+  samplers::SequentialSampler sampler(0);
 
-  auto dataset =
-      torch::data::datasets::make_shared_dataset<datasets::ChunkDataSet<
-          DummyChunkReader,
+  datasets::SharedBatchDataset<datasets::ChunkDataSet<
+      DummyEmptyChunkDataReader,
+      samplers::SequentialSampler,
+      samplers::SequentialSampler>>
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+          DummyEmptyChunkDataReader,
           samplers::SequentialSampler,
           samplers::SequentialSampler>>(
-          DummyChunkReader(kNumChunks, kBatchSize),
-          samplers::SequentialSampler(kNumChunks),
-          samplers::SequentialSampler(kBatchSize),
-          kBatchSize)
-          .map(transforms::BatchLambda<std::vector<int>, int>(
-              [](const std::vector<int>& x) {
-                return std::accumulate(x.begin(), x.end(), 0);
-              }));
-  auto data_loader =
-      torch::data::make_data_loader(dataset, DataLoaderOptions(kBatchSize));
+          data_reader, sampler, sampler, prefetch_count, batch_size, true);
 
-  int count = 0;
-  int result_sum = 0;
-  int expected_sum = 0;
-  for (int sum : *data_loader) {
-    result_sum += sum;
-    for (int i = 0; i < kBatchSize; ++i) {
-      expected_sum += count * kBatchSize + i;
-    }
-    count++;
+  auto data_loader = torch::data::make_data_loader(
+      dataset, DataLoaderOptions(batch_size).workers(0));
+
+  for (auto iterator = data_loader->begin(); iterator!= data_loader->end();  ++iterator) {
+    ASSERT_EQ(iterator->size(), 0);
   }
-  ASSERT_EQ(result_sum, expected_sum);
+}
+
+TEST(DataLoaderTest, ChunkDataSetGetBatchWithUnevenBatchSize) {
+  struct D : public datasets::ChunkDataReader<D, std::vector<int>> {
+   public:
+    using BatchType = std::vector<int>;
+
+    BatchType read_chunk(size_t chunk_index) override {
+      BatchType batch_data(10, 0);
+      return batch_data;
+    }
+
+    size_t get_chunk_count() override { return 2; };
+
+    void reset() override{};
+  };
+
+  const size_t batch_sizes[] = { 17, 30 };
+  D data_reader;
+  samplers::SequentialSampler sampler(0);
+
+  for (auto batch_size : batch_sizes) {
+    datasets::SharedBatchDataset<datasets::ChunkDataSet<
+        D,
+        samplers::SequentialSampler,
+        samplers::SequentialSampler>>
+        dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+            D,
+            samplers::SequentialSampler,
+            samplers::SequentialSampler>>(
+            data_reader, sampler, sampler, 1, batch_size, true);
+
+    auto data_loader = torch::data::make_data_loader(
+        dataset, DataLoaderOptions(batch_size).workers(0));
+
+    for (auto iterator = data_loader->begin(); iterator != data_loader->end(); ++iterator) {
+      std::vector<int> batch = *iterator;
+      auto batch_size = batch.size();
+      if (batch_size == 17){
+        ASSERT_TRUE(batch.size() == 17 || batch.size() == 3);
+      }
+      if (batch_size == 30){
+        ASSERT_TRUE(batch.size() == 20);
+      }
+    }
+  }
 }

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -1350,73 +1350,61 @@ TEST(DataLoaderTest, StatefulDatasetWithCollate) {
   ASSERT_TRUE(batch->target[0].allclose(torch::zeros(kBatchSize - 1)));
 }
 
-class DummyChunkDataSet : public datasets::ChunkDataSet<
-                         DummyChunkDataSet,
-                         std::vector<int>,
-                         samplers::SequentialSampler,
-                         samplers::SequentialSampler> {
+class DummyChunkReader
+    : public datasets::ChunkDataReader<DummyChunkReader, std::vector<int>> {
  public:
-  using BatchType = torch::optional<std::vector<int>>;
+  using BatchType = std::vector<int>;
   using BatchRequestType = size_t;
-  DummyChunkDataSet(size_t num_chunks, size_t batch_size)
-      : datasets::ChunkDataSet<
-            DummyChunkDataSet,
-            std::vector<int>,
-            samplers::SequentialSampler,
-            samplers::SequentialSampler>(),
+
+  DummyChunkReader(size_t num_chunks, size_t chunk_size)
+      : datasets::ChunkDataReader<DummyChunkReader, std::vector<int>>(),
         num_chunks_(num_chunks),
-        batch_size_(batch_size),
-        chunk_sampler_(std::move(samplers::SequentialSampler(num_chunks))),
-        example_sampler_(std::move(samplers::SequentialSampler(batch_size))) {}
+        chunk_size_(chunk_size) {}
+
+  DummyChunkReader(DummyChunkReader&& other) {
+    num_chunks_ = other.num_chunks_;
+    chunk_size_ = other.chunk_size_;
+    chunk_index_ = other.chunk_index_.load();
+  }
 
   std::vector<int> read_chunk(size_t chunk_index) override {
-    std::vector<int> batch(batch_size_);
-    size_t counter = chunk_index * batch_size_;
+    std::vector<int> batch(chunk_size_);
+    size_t counter = chunk_index * chunk_size_;
     for (auto& i : batch) {
       i = counter++;
     }
     return batch;
   }
 
-  /// Simply returns an entire chunk to test the API for now.
-  torch::optional<std::vector<int>> get_batch(size_t batch_size) override {
-    int index = chunk_index_.fetch_add(1);
-    if (index < num_chunks_) {
-      return read_chunk(index);
-    }
-    return torch::nullopt;
-  }
-
-  samplers::SequentialSampler get_chunk_sampler() override {
-    return chunk_sampler_;
-  }
-
-  samplers::SequentialSampler get_example_sampler() override {
-    return example_sampler_;
-  }
-
   size_t get_chunk_count() override {
     return num_chunks_;
   }
 
+  void reset() override {}
+
  private:
   std::atomic<int> chunk_index_{0};
   size_t num_chunks_;
-  size_t batch_size_;
-  samplers::SequentialSampler chunk_sampler_;
-  samplers::SequentialSampler example_sampler_;
+  size_t chunk_size_;
 };
 
 TEST(DataTest, DataLoaderWithChunkSupportSingleWorker) {
   const size_t kBatchSize = 13;
   const size_t kNumChunks = 10;
 
-  auto dataset = torch::data::datasets::make_shared_dataset<DummyChunkDataSet>(
-                     kNumChunks, kBatchSize)
-                     .map(transforms::BatchLambda<std::vector<int>, int>(
-                         [](const std::vector<int>& x) {
-                           return std::accumulate(x.begin(), x.end(), 0);
-                         }));
+  auto dataset =
+      torch::data::datasets::make_shared_dataset<datasets::ChunkDataSet<
+          DummyChunkReader,
+          samplers::SequentialSampler,
+          samplers::SequentialSampler>>(
+          DummyChunkReader(kNumChunks, kBatchSize),
+          samplers::SequentialSampler(kNumChunks),
+          samplers::SequentialSampler(kBatchSize),
+          kBatchSize)
+          .map(transforms::BatchLambda<std::vector<int>, int>(
+              [](const std::vector<int>& x) {
+                return std::accumulate(x.begin(), x.end(), 0);
+              }));
   auto data_loader =
       torch::data::make_data_loader(dataset, DataLoaderOptions(kBatchSize));
 
@@ -1436,12 +1424,19 @@ TEST(DataTest, DataLoaderWithChunkSupportMultiWorker) {
   const size_t kBatchSize = 13;
   const size_t kNumChunks = 10;
 
-  auto dataset = torch::data::datasets::make_shared_dataset<DummyChunkDataSet>(
-                     kNumChunks, kBatchSize)
-                     .map(transforms::BatchLambda<std::vector<int>, int>(
-                         [](const std::vector<int>& x) {
-                           return std::accumulate(x.begin(), x.end(), 0);
-                         }));
+  auto dataset =
+      torch::data::datasets::make_shared_dataset<datasets::ChunkDataSet<
+          DummyChunkReader,
+          samplers::SequentialSampler,
+          samplers::SequentialSampler>>(
+          DummyChunkReader(kNumChunks, kBatchSize),
+          samplers::SequentialSampler(kNumChunks),
+          samplers::SequentialSampler(kBatchSize),
+          kBatchSize)
+          .map(transforms::BatchLambda<std::vector<int>, int>(
+              [](const std::vector<int>& x) {
+                return std::accumulate(x.begin(), x.end(), 0);
+              }));
   auto data_loader =
       torch::data::make_data_loader(dataset, DataLoaderOptions(kBatchSize));
 

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -63,7 +63,7 @@ TEST(DataTest, TransformCallsGetApplyCorrectly) {
 // dummy chunk data reader with 3 chunks and 35 examples in total. Each chunk
 // contains 10, 5, 20 examples respectively.
 struct DummyChunkDataReader
-    : public datasets::ChunkDataReader<DummyChunkDataReader, std::vector<int>> {
+    : public datasets::ChunkDataReader<std::vector<int>> {
  public:
   using BatchType = std::vector<int>;
 
@@ -81,7 +81,7 @@ struct DummyChunkDataReader
     return batch_data;
   }
 
-  size_t get_chunk_count() override {
+  size_t chunk_count() override {
     return chunk_count_;
   };
 
@@ -96,15 +96,15 @@ TEST(DataTest, ChunkDataSetWithInvalidInitParameter) {
   samplers::SequentialSampler sampler(0);
 
   auto initialization_function = [&](size_t preloader_count, size_t batch_size, size_t cache_size){
-    datasets::SharedBatchDataset<datasets::ChunkDataSet<
+    datasets::SharedBatchDataset<datasets::ChunkDataset<
           DummyChunkDataReader,
           samplers::SequentialSampler,
           samplers::SequentialSampler>> dataset =
-          datasets::make_shared_dataset<datasets::ChunkDataSet<
+          datasets::make_shared_dataset<datasets::ChunkDataset<
               DummyChunkDataReader,
               samplers::SequentialSampler,
               samplers::SequentialSampler>>(
-              data_reader, sampler, sampler, preloader_count, batch_size, false, cache_size);
+              data_reader, sampler, sampler, datasets::ChunkDatasetOptions(preloader_count, batch_size, false, cache_size));
   };
 
   ASSERT_THROWS_WITH(
@@ -1439,15 +1439,15 @@ TEST(DataLoaderTest, ChunkDataSetGetBatch) {
   for (auto prefetch_count : prefetch_counts) {
     for (auto batch_size : batch_sizes) {
       for (auto dataloader_worker_count : dataloader_worker_counts) {
-        datasets::SharedBatchDataset<datasets::ChunkDataSet<
+        datasets::SharedBatchDataset<datasets::ChunkDataset<
             DummyChunkDataReader,
             samplers::SequentialSampler,
             samplers::SequentialSampler>>
-            dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+            dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
                 DummyChunkDataReader,
                 samplers::SequentialSampler,
                 samplers::SequentialSampler>>(
-                data_reader, sampler, sampler, prefetch_count, batch_size);
+                data_reader, sampler, sampler, datasets::ChunkDatasetOptions(prefetch_count, batch_size));
 
         auto data_loader = torch::data::make_data_loader(
             dataset,
@@ -1492,15 +1492,15 @@ TEST(DataLoaderTest, ChunkDataSetWithBatchSizeMismatch) {
   DummyChunkDataReader data_reader;
   samplers::SequentialSampler sampler(0);
 
-  datasets::SharedBatchDataset<datasets::ChunkDataSet<
+  datasets::SharedBatchDataset<datasets::ChunkDataset<
       DummyChunkDataReader,
       samplers::SequentialSampler,
       samplers::SequentialSampler>>
-      dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
           DummyChunkDataReader,
           samplers::SequentialSampler,
           samplers::SequentialSampler>>(
-          data_reader, sampler, sampler, prefetch_count, batch_size);
+          data_reader, sampler, sampler, datasets::ChunkDatasetOptions(prefetch_count, batch_size));
 
   auto data_loader = torch::data::make_data_loader(
       dataset,
@@ -1508,14 +1508,13 @@ TEST(DataLoaderTest, ChunkDataSetWithBatchSizeMismatch) {
 
   std::string exception_msg =
       "The requested batch size does not match with the initialized batch size.\n"
-      " The requested batch size is 6, while the data set is created with batch size equal to 5";
+      " The requested batch size is 6, while the dataset is created with batch size equal to 5";
 
   ASSERT_THROWS_WITH(*(data_loader->begin()), exception_msg);
 }
 
 struct DummyEmptyChunkDataReader
-    : public datasets::
-          ChunkDataReader<DummyEmptyChunkDataReader, std::vector<int>> {
+    : public datasets:: ChunkDataReader<std::vector<int>> {
  public:
   using BatchType = std::vector<int>;
 
@@ -1523,7 +1522,7 @@ struct DummyEmptyChunkDataReader
     return {};
   }
 
-  size_t get_chunk_count() override {
+  size_t chunk_count() override {
     return chunk_count_;
   };
 
@@ -1538,15 +1537,15 @@ TEST(DataLoaderTest, ChunkDataSetWithEmptyBatchThrowException) {
   DummyEmptyChunkDataReader data_reader;
   samplers::SequentialSampler sampler(0);
 
-  datasets::SharedBatchDataset<datasets::ChunkDataSet<
+  datasets::SharedBatchDataset<datasets::ChunkDataset<
       DummyEmptyChunkDataReader,
       samplers::SequentialSampler,
       samplers::SequentialSampler>>
-      dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
           DummyEmptyChunkDataReader,
           samplers::SequentialSampler,
           samplers::SequentialSampler>>(
-          data_reader, sampler, sampler, prefetch_count, batch_size);
+          data_reader, sampler, sampler, datasets::ChunkDatasetOptions(prefetch_count, batch_size));
 
   auto data_loader = torch::data::make_data_loader(
       dataset, DataLoaderOptions(batch_size).workers(0));
@@ -1560,15 +1559,15 @@ TEST(DataLoaderTest, ChunkDataSetWithEmptyBatchIgnoreEmptyChunk) {
   DummyEmptyChunkDataReader data_reader;
   samplers::SequentialSampler sampler(0);
 
-  datasets::SharedBatchDataset<datasets::ChunkDataSet<
+  datasets::SharedBatchDataset<datasets::ChunkDataset<
       DummyEmptyChunkDataReader,
       samplers::SequentialSampler,
       samplers::SequentialSampler>>
-      dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
           DummyEmptyChunkDataReader,
           samplers::SequentialSampler,
           samplers::SequentialSampler>>(
-          data_reader, sampler, sampler, prefetch_count, batch_size, true);
+          data_reader, sampler, sampler, datasets::ChunkDatasetOptions(prefetch_count, batch_size, true));
 
   auto data_loader = torch::data::make_data_loader(
       dataset, DataLoaderOptions(batch_size).workers(0));
@@ -1579,7 +1578,7 @@ TEST(DataLoaderTest, ChunkDataSetWithEmptyBatchIgnoreEmptyChunk) {
 }
 
 TEST(DataLoaderTest, ChunkDataSetGetBatchWithUnevenBatchSize) {
-  struct D : public datasets::ChunkDataReader<D, std::vector<int>> {
+  struct D : public datasets::ChunkDataReader<std::vector<int>> {
    public:
     using BatchType = std::vector<int>;
 
@@ -1588,7 +1587,7 @@ TEST(DataLoaderTest, ChunkDataSetGetBatchWithUnevenBatchSize) {
       return batch_data;
     }
 
-    size_t get_chunk_count() override { return 2; };
+    size_t chunk_count() override { return 2; };
 
     void reset() override{};
   };
@@ -1598,15 +1597,15 @@ TEST(DataLoaderTest, ChunkDataSetGetBatchWithUnevenBatchSize) {
   samplers::SequentialSampler sampler(0);
 
   for (auto batch_size : batch_sizes) {
-    datasets::SharedBatchDataset<datasets::ChunkDataSet<
+    datasets::SharedBatchDataset<datasets::ChunkDataset<
         D,
         samplers::SequentialSampler,
         samplers::SequentialSampler>>
-        dataset = datasets::make_shared_dataset<datasets::ChunkDataSet<
+        dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
             D,
             samplers::SequentialSampler,
             samplers::SequentialSampler>>(
-            data_reader, sampler, sampler, 1, batch_size, true);
+            data_reader, sampler, sampler, datasets::ChunkDatasetOptions(1, batch_size, true));
 
     auto data_loader = torch::data::make_data_loader(
         dataset, DataLoaderOptions(batch_size).workers(0));

--- a/torch/csrc/api/include/torch/data/datasets.h
+++ b/torch/csrc/api/include/torch/data/datasets.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/data/datasets/base.h>
+#include <torch/data/datasets/chunk.h>
 #include <torch/data/datasets/map.h>
 #include <torch/data/datasets/mnist.h>
 #include <torch/data/datasets/shared.h>

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -22,13 +22,213 @@ class ChunkDataReader {
   using BatchType = Batch;
 
   /// Read an entire chunk.
-  virtual Batch read_chunk(size_t chunk_index) = 0;
+  virtual BatchType read_chunk(size_t chunk_index) = 0;
 
   /// Returns the number of chunks available in this reader.
   virtual size_t get_chunk_count() = 0;
 
   /// This will clear any internal state associate with this reader.
   virtual void reset() = 0;
+};
+
+/// A class that contains a raw unwrapped batch unit. An unwrapped batch unit is
+/// the raw data without 'optional' wrapper. It can be a collection of images,
+/// utterances, e.t.c.
+template <typename UnwrappedBatch = std::vector<Example<>>>
+struct UnwrappedBatchData {
+ public:
+  using UnwrappedBatchType = UnwrappedBatch;
+
+  UnwrappedBatchData(UnwrappedBatchType data) : batch_data(std::move(data)) {}
+
+  UnwrappedBatchData(std::exception_ptr e) : exception(e) {}
+
+  /// batch data to return
+  UnwrappedBatchType batch_data;
+
+  /// exception pointer which captures any abnormal exceptions while creating the
+  /// batch.
+  std::exception_ptr exception;
+};
+
+/// BatchDataBuffer manages a queue of UnwrappedBatchData. After a new chunk is
+/// loaded, BatchDataBuffer splits it into small batches and push them into the
+/// queue. When get_batch is called from data loader, it pops cached batches and
+/// return. If the cache is empty, it either waits to load more chunks or return
+/// null if all chunks are loaded.
+template <
+    typename UnwrappedBatch = std::vector<Example<>>,
+    typename ExampleSampler = samplers::RandomSampler>
+class BatchDataBuffer {
+ public:
+  using UnwrappedBatchType = UnwrappedBatch;
+  using BatchType = torch::optional<UnwrappedBatchType>;
+  using BatchRequestType = typename ExampleSampler::BatchRequestType;
+
+  BatchDataBuffer(
+      size_t num_chunks,
+      size_t batch_size,
+      ExampleSampler example_sampler,
+      bool ignore_empty_chunk,
+      size_t cache_size)
+      : remaining_chunk_count_(num_chunks),
+        batch_size_(batch_size),
+        example_sampler_(std::move(example_sampler)),
+        ignore_empty_chunk_(ignore_empty_chunk),
+        queue_depth_(cache_size) {}
+
+  /// Return batch data from the queue. Called from the ChunkDataSet main
+  /// thread.
+  BatchType get_batch(size_t batch_size) {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    cvr_.wait(lock, [this] {
+      // wait till there is available data in the queue or if all chunks are
+      // loaded (i.e. the data set is exhausted for this epoch)
+      return (
+          this->total_example_count_in_queue_ >= batch_size_ ||
+          remaining_chunk_count_ == 0);
+    });
+    if (batch_queue_.empty()) {
+      lock.unlock();
+      AT_ASSERT(remaining_chunk_count_ == 0);
+
+      // All batches have been retrieved. Return an empty batch.
+      return nullopt;
+    }
+
+    auto batch_data = batch_queue_.front();
+    batch_queue_.pop();
+    if (batch_data.exception) {
+      throw WorkerException(batch_data.exception);
+    }
+
+    this->total_example_count_in_queue_ -= batch_data.batch_data.size();
+    lock.unlock();
+    cvw_.notify_all(); // notify all writers.
+
+    return batch_data.batch_data;
+  }
+
+  // skip one chunk
+  void skip_chunk() {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    AT_ASSERT(remaining_chunk_count_ > 0);
+    remaining_chunk_count_--;
+    lock.unlock();
+    cvr_.notify_all();
+  }
+
+  /// Push preloaded chunks to batch queue. Called from the ChunkDataSet worker
+  /// threads.
+  void add_chunk_data(size_t index, UnwrappedBatchType data) {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    cvw_.wait(lock, [this] {
+      // stop loading if we have preloaded enough data.
+      return this->total_example_count_in_queue_ < queue_depth_;
+    });
+
+    auto data_size = data.size();
+    auto remaining_size = data_size;
+    example_sampler_.reset(data_size);
+
+    if (!batch_queue_.empty()) {
+      // if the queue has exiting data, and the last batch doesn't have enough
+      // examples to fill a batch_size batch, add more example to this batch first.
+      auto& batch_data = batch_queue_.back();
+      size_t current_count = batch_data.batch_data.size();
+      if (current_count < batch_size_) {
+        auto example_count =
+            std::min(remaining_size, batch_size_ - current_count);
+        auto batch_example_indices = example_sampler_.next(example_count);
+        AT_ASSERT(
+            batch_example_indices &&
+            batch_example_indices.value().size() == example_count)
+        BatchRequestType indices = batch_example_indices.value();
+        for (size_t i : indices) {
+          batch_data.batch_data.emplace_back(std::move(data[i]));
+        }
+        remaining_size -= example_count;
+      }
+    }
+
+    // If we still have data remaining after filling the last pushed batch, add
+    // them to the queue too.
+    while (remaining_size > 0) {
+      UnwrappedBatchType current_batch;
+
+      // Allocate the batch memory ahead of time.
+      current_batch.reserve(batch_size_);
+
+      auto example_count = std::min(remaining_size, batch_size_);
+      auto batch_example_indices = example_sampler_.next(example_count);
+      AT_ASSERT(
+          batch_example_indices &&
+          batch_example_indices.value().size() == example_count)
+      BatchRequestType indices = batch_example_indices.value();
+      for (size_t i : indices) {
+        current_batch.emplace_back(std::move(data[i]));
+      }
+      remaining_size -= example_count;
+      UnwrappedBatchData<UnwrappedBatchType> batch_data(
+          std::move(current_batch));
+      batch_queue_.push(std::move(batch_data));
+    }
+    this->total_example_count_in_queue_ += data_size;
+
+    AT_ASSERT(remaining_chunk_count_ > 0);
+    this->remaining_chunk_count_--;
+
+    lock.unlock();
+    cvr_.notify_all();
+  }
+
+  /// Push exceptions throwed during preloading into batch queue. Called from
+  /// the ChunkDataSet worker threads.
+  void add_chunk_data(size_t index, std::exception_ptr e_ptr) {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    cvw_.wait(lock, [this] {
+      // stop loading if we have preloaded enough data.
+      return this->total_example_count_in_queue_ < queue_depth_;
+    });
+    UnwrappedBatchData<UnwrappedBatchType> batch_data(e_ptr);
+    batch_queue_.push(std::move(batch_data));
+
+    AT_ASSERT(remaining_chunk_count_ > 0);
+    remaining_chunk_count_--;
+    lock.unlock();
+    cvr_.notify_all(); // notify all readers.
+  }
+
+  /// count of remaining chunk to be loaded. It is initialized with the total
+  /// chunk count and it decreases when a chunk data is retrieved. When this reaches
+  /// to 0, no more chunk needs to be loaded.
+  size_t remaining_chunk_count_ = 0;
+
+  /// The batch size is needed to create batches from the chunk data. Similar to
+  /// regular dataloader where the batches are created with prefetches,
+  /// BatchDataBuffer perform the batch creation using the provided batch size.
+  size_t batch_size_ = 0;
+
+  /// count of total example stored in the queue
+  size_t total_example_count_in_queue_ = 0;
+
+  /// local cache to store example batches from loaded chunk
+  std::queue<UnwrappedBatchData<UnwrappedBatchType>> batch_queue_;
+
+  // sync batch_queue_ update.
+  std::mutex queue_mutex_;
+
+  std::condition_variable cvr_;
+  std::condition_variable cvw_;
+
+  ExampleSampler example_sampler_;
+
+  // indicator for whether an empty chunk should be ignored. When it is true, an
+  // example will throw, otherwise, this empty chunk is skipped.
+  bool ignore_empty_chunk_ = false;
+
+  // configurable queue depth for batch_queue_
+  size_t queue_depth_;
 };
 
 /// A stateful dataset that support hierarchical sampling and prefetching of
@@ -50,6 +250,7 @@ class ChunkDataSet final
           size_t> {
  public:
   using BatchType = torch::optional<typename ChunkReader::BatchType>;
+  using UnwrappedBatchType = typename ChunkReader::BatchType;
   using BatchRequestType = size_t;
   using ChunkSamplerType = ChunkSampler;
   using ExampleSamplerType = ExampleSampler;
@@ -58,29 +259,94 @@ class ChunkDataSet final
       ChunkReader chunk_reader,
       ChunkSampler chunk_sampler,
       ExampleSampler example_sampler,
-      size_t batch_size)
+      size_t preloader_count,
+      size_t batch_size,
+      bool ignore_empty_chunk = false,
+      size_t cache_size = 500)
       : chunk_reader_(std::move(chunk_reader)),
         chunk_sampler_(std::move(chunk_sampler)),
         example_sampler_(std::move(example_sampler)),
-        batch_size_(batch_size) {}
+        preloader_count_(preloader_count),
+        batch_size_(batch_size),
+        ignore_empty_chunk_(ignore_empty_chunk),
+        cache_size_(cache_size) {
+    if (preloader_count_ == 0) {
+      throw std::runtime_error(
+          "Preloader count is 0. At least one preloader needs to be specified.");
+    }
+
+    if (batch_size == 0) {
+      throw std::runtime_error(
+          "Batch size is 0. A positive batch size needs to be specified.");
+    }
+
+    if (cache_size_ == 0) {
+      throw std::runtime_error(
+          "Cache size is 0. A positive cache size needs to be specified.");
+    }
+
+    if (cache_size < batch_size){
+      throw std::runtime_error(
+          "Cache size is less than batch size. Cache needs to be large enough to hold at least one batch.");
+    }
+    // chunk_sampler_ =
+    //     std::make_unique<samplers::ThreadSafeSampler<ChunkSamplerType>>(
+    //         std::move(chunk_sampler));
+  }
+
+  virtual ~ChunkDataSet() {
+    free_workers();
+  }
 
   /// Default get_batch method of BatchDataSet. This method returns
   /// Example batches created from the preloaded chunks. The implemenation
   /// is dataset agnostic and does not need overriding in different chunk
   /// data sets.
   BatchType get_batch(size_t batch_size) override {
-    // Temporary: for API only testing.
-    int index = chunk_index_.fetch_add(1);
-    if (index < chunk_reader_.get_chunk_count()) {
-      return chunk_reader_.read_chunk(index);
+    if (chunk_buffer_ == nullptr) {
+      throw std::runtime_error(
+          "Dataset needs to call reset() before calling get_batch().");
     }
-    return torch::nullopt;
+    if (batch_size != batch_size_) {
+      std::string error =
+          "The requested batch size does not match with the initialized batch size.\n"
+          " The requested batch size is " + std::to_string(batch_size) +
+          ", while the data set is created with batch size equal to " +
+          std::to_string(batch_size_);
+
+      throw std::runtime_error(error);
+    }
+    return chunk_buffer_->get_batch(batch_size);
   }
 
   /// This will clear any internal state and starts the internal prefetching
   /// mechanism for the chunk dataset.
   virtual void reset() {
+    // free workers from previous reset if there is any.
+    free_workers();
+    preload_threads_.clear();
+
     chunk_reader_.reset();
+
+    size_t chunks_to_load = chunk_reader_.get_chunk_count();
+    chunk_sampler_.reset(chunks_to_load);
+
+    // Creates a new chunk buffer each time we reset the dataset.
+    chunk_buffer_ = torch::make_unique<
+        BatchDataBuffer<UnwrappedBatchType, ExampleSamplerType>>(
+        chunks_to_load,
+        batch_size_,
+        example_sampler_,
+        ignore_empty_chunk_,
+        cache_size_);
+
+    // create new workers for this new epoch.
+    quit_worker_ = false;
+
+    for (size_t i = 0; i < preloader_count_; ++i) {
+      preload_threads_.emplace_back(
+          [this, i]() { this->preloader(i); });
+    }
   }
 
   /// size is not used for chunk dataset.
@@ -89,12 +355,77 @@ class ChunkDataSet final
   }
 
  private:
+  /// running on worker thread to preload chunk data.
+  void preloader(size_t id) {
+    while (!quit_worker_) {
+      size_t chunk_id;
+      try {
+        auto chunk_sampler_result = chunk_sampler_.next(1);
+        if (chunk_sampler_result.has_value()) {
+          chunk_id = chunk_sampler_result.value()[0];
+        } else {
+          break;
+        }
+        UnwrappedBatchType data = chunk_reader_.read_chunk(chunk_id);
+        if (data.empty()) {
+          if (!ignore_empty_chunk_) {
+            std::string error =
+                "Chunk with index " + std::to_string(chunk_id) + " is empty";
+            throw std::runtime_error(error);
+          } else {
+            // skip adding the current chunk data and move to the next.
+            chunk_buffer_->skip_chunk();
+          }
+        }
+        else {
+          chunk_buffer_->add_chunk_data(chunk_id, std::move(data));
+        }
+      } catch (...) {
+        chunk_buffer_->add_chunk_data(chunk_id, std::current_exception());
+      }
+    }
+  }
+
+  /// Block the current thread until the workers finish execution and exit.
+  void free_workers() {
+    if (!quit_worker_) {
+      quit_worker_ = true;
+      for (auto& worker_thread : preload_threads_) {
+        worker_thread.join();
+      }
+    }
+  }
+
+ private:
+  // chunk reader is responsible for reading chunk data
   ChunkReader chunk_reader_;
-  ChunkSampler chunk_sampler_;
-  ExampleSampler example_sampler_;
-  size_t batch_size_;
-  // Temporary: for API only testing.
-  std::atomic<int> chunk_index_{0};
+
+  // chunk sampler to shuffle different chunks
+  samplers::ThreadSafeSampler<ChunkSamplerType> chunk_sampler_;
+
+  // example sampler to shuffle examples in a specific chunk
+  ExampleSamplerType example_sampler_;
+
+  // chunk data buffer which holds chunk data from preloading thread.
+  std::shared_ptr<BatchDataBuffer<UnwrappedBatchType, ExampleSamplerType>>
+      chunk_buffer_;
+
+  // worker thread pool
+  std::vector<std::thread> preload_threads_;
+
+  // worker thread count
+  size_t preloader_count_ = 0;
+
+  size_t batch_size_ = 0;
+
+  // if it is set to true, the dataset will quietly move to the next chunk when
+  // the current one is empty. Otherwise, an exception is thrown on the empty
+  // batch.
+  bool ignore_empty_chunk_ = false;
+
+  bool quit_worker_;
+
+  size_t cache_size_;
 };
 } // namespace datasets
 } // namespace data

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <torch/csrc/utils/memory.h>
 #include <torch/data/datasets/stateful.h>
-#include <torch/data/example.h>
-#include <torch/data/samplers.h>
 
 namespace torch {
 namespace data {
@@ -15,42 +12,22 @@ namespace datasets {
 /// A chunk could be an entire file, such as an audio data file or an image,
 /// or part of a file in the case of a large text-file split based on seek
 /// positions.
-template <typename Self, typename Batch = std::vector<Example<>>>
+template <typename Chunk = std::vector<Example<>>>
 class ChunkDataReader {
  public:
-  using SelfType = Self;
-  using BatchType = Batch;
+  using ChunkType = Chunk;
 
   /// Read an entire chunk.
-  virtual BatchType read_chunk(size_t chunk_index) = 0;
+  virtual ChunkType read_chunk(size_t chunk_index) = 0;
 
   /// Returns the number of chunks available in this reader.
-  virtual size_t get_chunk_count() = 0;
+  virtual size_t chunk_count() = 0;
 
   /// This will clear any internal state associate with this reader.
   virtual void reset() = 0;
 };
 
-/// A class that contains a raw unwrapped batch unit. An unwrapped batch unit is
-/// the raw data without 'optional' wrapper. It can be a collection of images,
-/// utterances, e.t.c.
-template <typename UnwrappedBatch = std::vector<Example<>>>
-struct UnwrappedBatchData {
- public:
-  using UnwrappedBatchType = UnwrappedBatch;
-
-  UnwrappedBatchData(UnwrappedBatchType data) : batch_data(std::move(data)) {}
-
-  UnwrappedBatchData(std::exception_ptr e) : exception(e) {}
-
-  /// batch data to return
-  UnwrappedBatchType batch_data;
-
-  /// exception pointer which captures any abnormal exceptions while creating the
-  /// batch.
-  std::exception_ptr exception;
-};
-
+namespace detail {
 /// BatchDataBuffer manages a queue of UnwrappedBatchData. After a new chunk is
 /// loaded, BatchDataBuffer splits it into small batches and push them into the
 /// queue. When get_batch is called from data loader, it pops cached batches and
@@ -70,23 +47,23 @@ class BatchDataBuffer {
       size_t batch_size,
       ExampleSampler example_sampler,
       bool ignore_empty_chunk,
-      size_t cache_size)
+      size_t queue_capacity)
       : remaining_chunk_count_(num_chunks),
         batch_size_(batch_size),
         example_sampler_(std::move(example_sampler)),
         ignore_empty_chunk_(ignore_empty_chunk),
-        queue_depth_(cache_size) {}
+        queue_capacity_(queue_capacity) {}
 
-  /// Return batch data from the queue. Called from the ChunkDataSet main
+  /// Return batch data from the queue. Called from the ChunkDataset main
   /// thread.
-  BatchType get_batch(size_t batch_size) {
+  BatchType get_batch() {
     std::unique_lock<std::mutex> lock(queue_mutex_);
-    cvr_.wait(lock, [this] {
+    cv_read_.wait(lock, [this] {
       // wait till there is available data in the queue or if all chunks are
-      // loaded (i.e. the data set is exhausted for this epoch)
+      // loaded (i.e. the dataset is exhausted for this epoch)
       return (
           this->total_example_count_in_queue_ >= batch_size_ ||
-          remaining_chunk_count_ == 0);
+          this->remaining_chunk_count_ == 0);
     });
     if (batch_queue_.empty()) {
       lock.unlock();
@@ -96,17 +73,17 @@ class BatchDataBuffer {
       return nullopt;
     }
 
-    auto batch_data = batch_queue_.front();
+    auto batch = batch_queue_.front();
     batch_queue_.pop();
-    if (batch_data.exception) {
-      throw WorkerException(batch_data.exception);
+    if (batch.exception) {
+      throw WorkerException(batch.exception);
     }
 
-    this->total_example_count_in_queue_ -= batch_data.batch_data.size();
+    total_example_count_in_queue_ -= batch.batch_data.size();
     lock.unlock();
-    cvw_.notify_all(); // notify all writers.
+    cv_write_.notify_all();
 
-    return batch_data.batch_data;
+    return batch.batch_data;
   }
 
   // skip one chunk
@@ -115,39 +92,49 @@ class BatchDataBuffer {
     AT_ASSERT(remaining_chunk_count_ > 0);
     remaining_chunk_count_--;
     lock.unlock();
-    cvr_.notify_all();
+    cv_read_.notify_all();
   }
 
-  /// Push preloaded chunks to batch queue. Called from the ChunkDataSet worker
+  /// Push preloaded chunks to batch queue. Called from the ChunkDataset worker
   /// threads.
-  void add_chunk_data(size_t index, UnwrappedBatchType data) {
+  void add_chunk_data(UnwrappedBatchType data) {
     std::unique_lock<std::mutex> lock(queue_mutex_);
-    cvw_.wait(lock, [this] {
+    cv_write_.wait(lock, [this] {
       // stop loading if we have preloaded enough data.
-      return this->total_example_count_in_queue_ < queue_depth_;
+      return this->total_example_count_in_queue_ < this->queue_capacity_ || stop_;
     });
+
+    if (stop_){
+      // When stop_ is true, it means this current thread needs to be tore down.
+      // Return without any further processing.
+      return;
+    }
 
     auto data_size = data.size();
     auto remaining_size = data_size;
     example_sampler_.reset(data_size);
 
+    auto fill_batch = [&](size_t example_count, UnwrappedBatchType& batch) {
+      auto batch_example_indices = this->example_sampler_.next(example_count);
+      AT_ASSERT(
+          batch_example_indices &&
+          batch_example_indices.value().size() == example_count)
+      BatchRequestType indices = batch_example_indices.value();
+      for (size_t i : indices) {
+        batch.emplace_back(std::move(data[i]));
+      }
+      remaining_size -= example_count;
+    };
+
     if (!batch_queue_.empty()) {
-      // if the queue has exiting data, and the last batch doesn't have enough
+      // if the queue has existing data, and the last batch doesn't have enough
       // examples to fill a batch_size batch, add more example to this batch first.
-      auto& batch_data = batch_queue_.back();
-      size_t current_count = batch_data.batch_data.size();
+      auto& batch = batch_queue_.back();
+      size_t current_count = batch.batch_data.size();
       if (current_count < batch_size_) {
         auto example_count =
             std::min(remaining_size, batch_size_ - current_count);
-        auto batch_example_indices = example_sampler_.next(example_count);
-        AT_ASSERT(
-            batch_example_indices &&
-            batch_example_indices.value().size() == example_count)
-        BatchRequestType indices = batch_example_indices.value();
-        for (size_t i : indices) {
-          batch_data.batch_data.emplace_back(std::move(data[i]));
-        }
-        remaining_size -= example_count;
+        fill_batch(example_count, batch.batch_data);
       }
     }
 
@@ -160,43 +147,47 @@ class BatchDataBuffer {
       current_batch.reserve(batch_size_);
 
       auto example_count = std::min(remaining_size, batch_size_);
-      auto batch_example_indices = example_sampler_.next(example_count);
-      AT_ASSERT(
-          batch_example_indices &&
-          batch_example_indices.value().size() == example_count)
-      BatchRequestType indices = batch_example_indices.value();
-      for (size_t i : indices) {
-        current_batch.emplace_back(std::move(data[i]));
-      }
-      remaining_size -= example_count;
-      UnwrappedBatchData<UnwrappedBatchType> batch_data(
-          std::move(current_batch));
-      batch_queue_.push(std::move(batch_data));
+      fill_batch(example_count, current_batch);
+      batch_queue_.emplace(std::move(current_batch));
     }
-    this->total_example_count_in_queue_ += data_size;
+    total_example_count_in_queue_ += data_size;
 
     AT_ASSERT(remaining_chunk_count_ > 0);
-    this->remaining_chunk_count_--;
+    remaining_chunk_count_--;
 
     lock.unlock();
-    cvr_.notify_all();
+    cv_read_.notify_all();
   }
 
-  /// Push exceptions throwed during preloading into batch queue. Called from
-  /// the ChunkDataSet worker threads.
-  void add_chunk_data(size_t index, std::exception_ptr e_ptr) {
+  /// Push exceptions thrown during preloading into batch queue. Called from
+  /// the ChunkDataset worker threads.
+  void add_chunk_data(std::exception_ptr e_ptr) {
     std::unique_lock<std::mutex> lock(queue_mutex_);
-    cvw_.wait(lock, [this] {
+    cv_write_.wait(lock, [this] {
       // stop loading if we have preloaded enough data.
-      return this->total_example_count_in_queue_ < queue_depth_;
+      return this->total_example_count_in_queue_ < this->queue_capacity_ || stop_;
     });
-    UnwrappedBatchData<UnwrappedBatchType> batch_data(e_ptr);
-    batch_queue_.push(std::move(batch_data));
+
+    if (stop_){
+      // When stop_ is true, it means this current thread needs to be tore down,
+      // the batch buffer will be discarded, so no need to enqueue any new
+      // exceptions.
+      return;
+    }
+
+    batch_queue_.emplace(e_ptr);
 
     AT_ASSERT(remaining_chunk_count_ > 0);
     remaining_chunk_count_--;
     lock.unlock();
-    cvr_.notify_all(); // notify all readers.
+    cv_read_.notify_all();
+  }
+
+  void stop(){
+    stop_ = true;
+
+    // notify all writers, wake them from wait to exit current method.
+    cv_write_.notify_all();
   }
 
   /// count of remaining chunk to be loaded. It is initialized with the total
@@ -212,23 +203,90 @@ class BatchDataBuffer {
   /// count of total example stored in the queue
   size_t total_example_count_in_queue_ = 0;
 
+  /// struct that contains a raw unwrapped batch unit. An unwrapped batch unit is
+  /// the raw data without 'optional' wrapper. It can be a collection of images,
+  /// utterances, e.t.c.
+  struct UnwrappedBatchData {
+    explicit UnwrappedBatchData(UnwrappedBatchType data) : batch_data(std::move(data)) {}
+
+    explicit UnwrappedBatchData(std::exception_ptr e) : exception(e) {}
+
+    /// batch data to return
+    UnwrappedBatchType batch_data;
+
+    /// exception pointer which captures any abnormal exceptions while creating the
+    /// batch.
+    std::exception_ptr exception;
+  };
+
   /// local cache to store example batches from loaded chunk
-  std::queue<UnwrappedBatchData<UnwrappedBatchType>> batch_queue_;
+  std::queue<UnwrappedBatchData> batch_queue_;
 
   // sync batch_queue_ update.
   std::mutex queue_mutex_;
 
-  std::condition_variable cvr_;
-  std::condition_variable cvw_;
+  std::condition_variable cv_read_;
+  std::condition_variable cv_write_;
 
   ExampleSampler example_sampler_;
 
-  // indicator for whether an empty chunk should be ignored. When it is true, an
-  // example will throw, otherwise, this empty chunk is skipped.
+  // indicator for whether an empty chunk should be ignored. When it is false, an
+  // empty chunk will throw, otherwise,it is skipped.
   bool ignore_empty_chunk_ = false;
 
-  // configurable queue depth for batch_queue_
-  size_t queue_depth_;
+  // configurable maximun number of elements the queue can hold at one time.
+  size_t queue_capacity_;
+
+  // When set to true, it wakes the writer threads from the wait and exit current
+  // function call. This is needed when ChunkDataSet.Reset is called while the
+  // previous epoch is not exhausted yet. When ChunkDataset is waiting its
+  // preloader to finish previous work before tearing down the thread, the
+  // preloader could be still waiting for the conditional variable, thus cause
+  // the program to hang. This boolean is used to break this waiting condition.
+  bool stop_ = false;
+};
+} // namespace detail
+
+/// Options to configure a `ChunkDataset`.
+struct ChunkDatasetOptions {
+  ChunkDatasetOptions() = delete;
+  ChunkDatasetOptions(
+      size_t preloader_count,
+      size_t batch_size,
+      bool ignore_empty_chunk = false,
+      size_t cache_size = 2048)
+      : preloader_count_(preloader_count),
+        batch_size_(batch_size),
+        ignore_empty_chunk_(ignore_empty_chunk),
+        cache_size_(cache_size) {
+    AT_CHECK(
+        preloader_count_ > 0,
+        "Preloader count is 0. At least one preloader needs to be specified.");
+    AT_CHECK(
+        batch_size_ > 0,
+        "Batch size is 0. A positive batch size needs to be specified.");
+    AT_CHECK(
+        cache_size_ > 0,
+        "Cache size is 0. A positive cache size needs to be specified.");
+    AT_CHECK(
+        cache_size_ >= batch_size_,
+        "Cache size is less than batch size. Cache needs to be large enough to "
+        "hold at least one batch.");
+  }
+
+  /// The number of worker thread to preload chunk data.
+  TORCH_ARG(size_t, preloader_count);
+
+  /// The size of each batch.
+  TORCH_ARG(size_t, batch_size);
+
+  /// If it is set to true, the dataset will quietly move to the next chunk when
+  /// the current one is empty. Otherwise, an exception is thrown on the empty
+  /// batch.
+  TORCH_ARG(bool, ignore_empty_chunk) = false;
+
+  // the capacity of the queue for batch caching.
+  TORCH_ARG(size_t, cache_size) = 2048;
 };
 
 /// A stateful dataset that support hierarchical sampling and prefetching of
@@ -243,9 +301,9 @@ template <
     typename ChunkReader,
     typename ChunkSampler = samplers::RandomSampler,
     typename ExampleSampler = samplers::RandomSampler>
-class ChunkDataSet final
+class ChunkDataset final
     : public StatefulDataset<
-          ChunkDataSet<ChunkReader, ChunkSampler, ExampleSampler>,
+          ChunkDataset<ChunkReader, ChunkSampler, ExampleSampler>,
           typename ChunkReader::BatchType,
           size_t> {
  public:
@@ -255,95 +313,65 @@ class ChunkDataSet final
   using ChunkSamplerType = ChunkSampler;
   using ExampleSamplerType = ExampleSampler;
 
-  ChunkDataSet(
+  ChunkDataset(
       ChunkReader chunk_reader,
       ChunkSampler chunk_sampler,
       ExampleSampler example_sampler,
-      size_t preloader_count,
-      size_t batch_size,
-      bool ignore_empty_chunk = false,
-      size_t cache_size = 500)
+      ChunkDatasetOptions options)
       : chunk_reader_(std::move(chunk_reader)),
         chunk_sampler_(std::move(chunk_sampler)),
         example_sampler_(std::move(example_sampler)),
-        preloader_count_(preloader_count),
-        batch_size_(batch_size),
-        ignore_empty_chunk_(ignore_empty_chunk),
-        cache_size_(cache_size) {
-    if (preloader_count_ == 0) {
-      throw std::runtime_error(
-          "Preloader count is 0. At least one preloader needs to be specified.");
-    }
-
-    if (batch_size == 0) {
-      throw std::runtime_error(
-          "Batch size is 0. A positive batch size needs to be specified.");
-    }
-
-    if (cache_size_ == 0) {
-      throw std::runtime_error(
-          "Cache size is 0. A positive cache size needs to be specified.");
-    }
-
-    if (cache_size < batch_size){
-      throw std::runtime_error(
-          "Cache size is less than batch size. Cache needs to be large enough to hold at least one batch.");
-    }
-    // chunk_sampler_ =
-    //     std::make_unique<samplers::ThreadSafeSampler<ChunkSamplerType>>(
-    //         std::move(chunk_sampler));
+        options_(std::move(options)) {
   }
 
-  virtual ~ChunkDataSet() {
+  virtual ~ChunkDataset() {
     free_workers();
   }
 
-  /// Default get_batch method of BatchDataSet. This method returns
+  /// Default get_batch method of BatchDataset. This method returns
   /// Example batches created from the preloaded chunks. The implemenation
   /// is dataset agnostic and does not need overriding in different chunk
-  /// data sets.
+  /// datasets.
   BatchType get_batch(size_t batch_size) override {
-    if (chunk_buffer_ == nullptr) {
-      throw std::runtime_error(
-          "Dataset needs to call reset() before calling get_batch().");
-    }
-    if (batch_size != batch_size_) {
-      std::string error =
-          "The requested batch size does not match with the initialized batch size.\n"
-          " The requested batch size is " + std::to_string(batch_size) +
-          ", while the data set is created with batch size equal to " +
-          std::to_string(batch_size_);
+    AT_CHECK(
+      batch_buffer_ != nullptr,
+      "Dataset needs to call reset() before calling get_batch().");
 
-      throw std::runtime_error(error);
-    }
-    return chunk_buffer_->get_batch(batch_size);
+    AT_CHECK(
+      batch_size == options_.batch_size_,
+      "The requested batch size does not match with the initialized batch size.\n"
+      " The requested batch size is ", batch_size,
+      ", while the dataset is created with batch size equal to ", options_.batch_size_);
+
+    return batch_buffer_->get_batch();
   }
 
   /// This will clear any internal state and starts the internal prefetching
   /// mechanism for the chunk dataset.
-  virtual void reset() {
+  void reset() override {
     // free workers from previous reset if there is any.
     free_workers();
     preload_threads_.clear();
 
     chunk_reader_.reset();
 
-    size_t chunks_to_load = chunk_reader_.get_chunk_count();
+    size_t chunks_to_load = chunk_reader_.chunk_count();
     chunk_sampler_.reset(chunks_to_load);
 
-    // Creates a new chunk buffer each time we reset the dataset.
-    chunk_buffer_ = torch::make_unique<
-        BatchDataBuffer<UnwrappedBatchType, ExampleSamplerType>>(
+    // Throw out any existing cached batch in the buffer and re-creates a new
+    // chunk buffer.
+    batch_buffer_ = torch::make_unique<
+        detail::BatchDataBuffer<UnwrappedBatchType, ExampleSamplerType>>(
         chunks_to_load,
-        batch_size_,
+        options_.batch_size_,
         example_sampler_,
-        ignore_empty_chunk_,
-        cache_size_);
+        options_.ignore_empty_chunk_,
+        options_.cache_size_);
 
     // create new workers for this new epoch.
     quit_worker_ = false;
 
-    for (size_t i = 0; i < preloader_count_; ++i) {
+    for (size_t i = 0; i < options_.preloader_count_; ++i) {
       preload_threads_.emplace_back(
           [this, i]() { this->preloader(i); });
     }
@@ -358,30 +386,26 @@ class ChunkDataSet final
   /// running on worker thread to preload chunk data.
   void preloader(size_t id) {
     while (!quit_worker_) {
-      size_t chunk_id;
       try {
-        auto chunk_sampler_result = chunk_sampler_.next(1);
-        if (chunk_sampler_result.has_value()) {
+        size_t chunk_id = 0;
+        if (auto chunk_sampler_result = chunk_sampler_.next(1)) {
           chunk_id = chunk_sampler_result.value()[0];
         } else {
           break;
         }
         UnwrappedBatchType data = chunk_reader_.read_chunk(chunk_id);
+        AT_CHECK(options_.ignore_empty_chunk_ || !data.empty(),
+                 "Chunk with index " + std::to_string(chunk_id) + " is empty");
+
         if (data.empty()) {
-          if (!ignore_empty_chunk_) {
-            std::string error =
-                "Chunk with index " + std::to_string(chunk_id) + " is empty";
-            throw std::runtime_error(error);
-          } else {
-            // skip adding the current chunk data and move to the next.
-            chunk_buffer_->skip_chunk();
-          }
+          // skip adding the current chunk data and move to the next.
+          batch_buffer_->skip_chunk();
         }
         else {
-          chunk_buffer_->add_chunk_data(chunk_id, std::move(data));
+          batch_buffer_->add_chunk_data(std::move(data));
         }
       } catch (...) {
-        chunk_buffer_->add_chunk_data(chunk_id, std::current_exception());
+        batch_buffer_->add_chunk_data(std::current_exception());
       }
     }
   }
@@ -390,6 +414,9 @@ class ChunkDataSet final
   void free_workers() {
     if (!quit_worker_) {
       quit_worker_ = true;
+      if(batch_buffer_){
+        batch_buffer_->stop();
+      }
       for (auto& worker_thread : preload_threads_) {
         worker_thread.join();
       }
@@ -397,7 +424,9 @@ class ChunkDataSet final
   }
 
  private:
-  // chunk reader is responsible for reading chunk data
+  // Templated class that defines what is a chunk and how to read chunk data.
+  // When a chunk is returned by chunk_reader_, ChunkDtatset split it into
+  // batches and caches them in batch_buffer_.
   ChunkReader chunk_reader_;
 
   // chunk sampler to shuffle different chunks
@@ -406,26 +435,18 @@ class ChunkDataSet final
   // example sampler to shuffle examples in a specific chunk
   ExampleSamplerType example_sampler_;
 
-  // chunk data buffer which holds chunk data from preloading thread.
-  std::shared_ptr<BatchDataBuffer<UnwrappedBatchType, ExampleSamplerType>>
-      chunk_buffer_;
+  // batch data buffer which holds chunk data from preloading thread.
+  std::shared_ptr<detail::BatchDataBuffer<UnwrappedBatchType, ExampleSamplerType>>
+      batch_buffer_;
 
   // worker thread pool
   std::vector<std::thread> preload_threads_;
 
-  // worker thread count
-  size_t preloader_count_ = 0;
+  /// The options the Dataset was configured with.
+  const ChunkDatasetOptions options_;
 
-  size_t batch_size_ = 0;
-
-  // if it is set to true, the dataset will quietly move to the next chunk when
-  // the current one is empty. Otherwise, an exception is thrown on the empty
-  // batch.
-  bool ignore_empty_chunk_ = false;
-
-  bool quit_worker_;
-
-  size_t cache_size_;
+  // indicate whether the worker thread can be teared down
+  bool quit_worker_ = false;
 };
 } // namespace datasets
 } // namespace data

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -107,6 +107,7 @@ class BatchDataBuffer {
     if (stop_){
       // When stop_ is true, it means this current thread needs to be tore down.
       // Return without any further processing.
+      lock.unlock();
       return;
     }
 
@@ -172,6 +173,7 @@ class BatchDataBuffer {
       // When stop_ is true, it means this current thread needs to be tore down,
       // the batch buffer will be discarded, so no need to enqueue any new
       // exceptions.
+      lock.unlock();
       return;
     }
 

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <torch/csrc/utils/memory.h>
+#include <torch/data/datasets/stateful.h>
+#include <torch/data/example.h>
+#include <torch/data/samplers.h>
+
+namespace torch {
+namespace data {
+namespace datasets {
+
+/// A stateful dataset that support hierarchical sampling and prefetching of
+/// entre chunks.
+///
+/// A chunk could be an entire file, such as an audio data file or an image,
+/// or part of a file in the case of a large text-file split based on seek
+/// positions.
+///
+/// Unlike regular dataset, chunk dataset require two samplers to operate and
+/// keeps an internal state. `ChunkSampler` selects, which chunk to load next,
+/// while the `ExampleSampler` determins the order of Examples that are returned
+/// in each `get_batch` call. The hierarchical sampling approach used here is
+/// inspired by this paper http://martin.zinkevich.org/publications/nips2010.pdf
+template <
+    typename Self,
+    typename Batch = std::vector<Example<>>,
+    typename ChunkSampler = samplers::RandomSampler,
+    typename ExampleSampler = samplers::RandomSampler>
+class ChunkDataSet : public StatefulDataset<Self, Batch, size_t> {
+ public:
+  using SelfType = Self;
+  using BatchType = Batch;
+  using ChunkSamplerType = ChunkSampler;
+  using ExampleSamplerType = ExampleSampler;
+
+  /// Read an entire chunk. A derived class needs to override this method.
+  virtual Batch read_chunk(size_t chunk_index) = 0;
+
+  /// Returns the chunk sampler for this dataset.
+  virtual ChunkSampler get_chunk_sampler() = 0;
+
+  /// Returns the example sampler for this dataset.
+  virtual ExampleSampler get_example_sampler() = 0;
+
+  /// returns the number of chunks available in this dataset.
+  virtual size_t get_chunk_count() = 0;
+
+  /// Default get_batch method of BatchDataSet. This method returns Example
+  /// batches created from the preloaded chunks. The implemenation is dataset
+  /// agnostic and does not need overriding in different chunk data sets.
+  optional<Batch> get_batch(size_t batch_size) override {
+    // Temporary: tests will have a simple implemenation.
+    return torch::nullopt;
+  }
+
+  /// This will clear any internal state and starts the internal prefetching
+  /// mechanism for the chunk dataset.
+  virtual void reset() {}
+
+  /// size is not used for chunk dataset.
+  optional<size_t> size() const override {
+    return torch::nullopt;
+  }
+};
+} // namespace datasets
+} // namespace data
+} // namespace torch

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -383,10 +383,8 @@ class ChunkDataset final
         }
         UnwrappedBatchType data = chunk_reader_.read_chunk(chunk_id);
         if (data.empty()) {
-          AT_WARN("Chunk with index ", std::to_string(chunk_id),
-          " is empty. Skip and move to the next chunk.");
-
-          // skip the current chunk data and move to the next.
+          // if the chunk is empty, skip the current chunk data and move on to
+          // the next.
           batch_buffer_->skip_chunk();
         }
         else {

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -9,12 +9,30 @@ namespace torch {
 namespace data {
 namespace datasets {
 
-/// A stateful dataset that support hierarchical sampling and prefetching of
-/// entre chunks.
+/// Interface for chunk reader, which performs data chunking and reading of
+/// entire chunks.
 ///
 /// A chunk could be an entire file, such as an audio data file or an image,
 /// or part of a file in the case of a large text-file split based on seek
 /// positions.
+template <typename Self, typename Batch = std::vector<Example<>>>
+class ChunkDataReader {
+ public:
+  using SelfType = Self;
+  using BatchType = Batch;
+
+  /// Read an entire chunk.
+  virtual Batch read_chunk(size_t chunk_index) = 0;
+
+  /// Returns the number of chunks available in this reader.
+  virtual size_t get_chunk_count() = 0;
+
+  /// This will clear any internal state associate with this reader.
+  virtual void reset() = 0;
+};
+
+/// A stateful dataset that support hierarchical sampling and prefetching of
+/// entre chunks.
 ///
 /// Unlike regular dataset, chunk dataset require two samplers to operate and
 /// keeps an internal state. `ChunkSampler` selects, which chunk to load next,
@@ -22,45 +40,61 @@ namespace datasets {
 /// in each `get_batch` call. The hierarchical sampling approach used here is
 /// inspired by this paper http://martin.zinkevich.org/publications/nips2010.pdf
 template <
-    typename Self,
-    typename Batch = std::vector<Example<>>,
+    typename ChunkReader,
     typename ChunkSampler = samplers::RandomSampler,
     typename ExampleSampler = samplers::RandomSampler>
-class ChunkDataSet : public StatefulDataset<Self, Batch, size_t> {
+class ChunkDataSet final
+    : public StatefulDataset<
+          ChunkDataSet<ChunkReader, ChunkSampler, ExampleSampler>,
+          typename ChunkReader::BatchType,
+          size_t> {
  public:
-  using SelfType = Self;
-  using BatchType = Batch;
+  using BatchType = torch::optional<typename ChunkReader::BatchType>;
+  using BatchRequestType = size_t;
   using ChunkSamplerType = ChunkSampler;
   using ExampleSamplerType = ExampleSampler;
 
-  /// Read an entire chunk. A derived class needs to override this method.
-  virtual Batch read_chunk(size_t chunk_index) = 0;
+  ChunkDataSet(
+      ChunkReader chunk_reader,
+      ChunkSampler chunk_sampler,
+      ExampleSampler example_sampler,
+      size_t batch_size)
+      : chunk_reader_(std::move(chunk_reader)),
+        chunk_sampler_(std::move(chunk_sampler)),
+        example_sampler_(std::move(example_sampler)),
+        batch_size_(batch_size) {}
 
-  /// Returns the chunk sampler for this dataset.
-  virtual ChunkSampler get_chunk_sampler() = 0;
-
-  /// Returns the example sampler for this dataset.
-  virtual ExampleSampler get_example_sampler() = 0;
-
-  /// returns the number of chunks available in this dataset.
-  virtual size_t get_chunk_count() = 0;
-
-  /// Default get_batch method of BatchDataSet. This method returns Example
-  /// batches created from the preloaded chunks. The implemenation is dataset
-  /// agnostic and does not need overriding in different chunk data sets.
-  optional<Batch> get_batch(size_t batch_size) override {
-    // Temporary: tests will have a simple implemenation.
+  /// Default get_batch method of BatchDataSet. This method returns
+  /// Example batches created from the preloaded chunks. The implemenation
+  /// is dataset agnostic and does not need overriding in different chunk
+  /// data sets.
+  BatchType get_batch(size_t batch_size) override {
+    // Temporary: for API only testing.
+    int index = chunk_index_.fetch_add(1);
+    if (index < chunk_reader_.get_chunk_count()) {
+      return chunk_reader_.read_chunk(index);
+    }
     return torch::nullopt;
   }
 
   /// This will clear any internal state and starts the internal prefetching
   /// mechanism for the chunk dataset.
-  virtual void reset() {}
+  virtual void reset() {
+    chunk_reader_.reset();
+  }
 
   /// size is not used for chunk dataset.
   optional<size_t> size() const override {
     return torch::nullopt;
   }
+
+ private:
+  ChunkReader chunk_reader_;
+  ChunkSampler chunk_sampler_;
+  ExampleSampler example_sampler_;
+  size_t batch_size_;
+  // Temporary: for API only testing.
+  std::atomic<int> chunk_index_{0};
 };
 } // namespace datasets
 } // namespace data

--- a/torch/csrc/api/include/torch/data/samplers/base.h
+++ b/torch/csrc/api/include/torch/data/samplers/base.h
@@ -49,7 +49,7 @@ class ThreadSafeSampler
  public:
   using BatchRequestType = typename OriginalSampler::BatchRequestType;
 
-  ThreadSafeSampler(OriginalSampler sampler) : sampler_(std::move(sampler)) {}
+  explicit ThreadSafeSampler(OriginalSampler sampler) : sampler_(std::move(sampler)) {}
 
   void reset(optional<size_t> new_size) override {
     std::lock_guard<std::mutex> lock(this->mutex_);
@@ -72,6 +72,8 @@ class ThreadSafeSampler
   }
 
  private:
+  // member variable for multi-threading lock.
+  // declare it to be mutable for locking in const member function.
   mutable std::mutex mutex_;
   OriginalSampler sampler_;
 };

--- a/torch/csrc/api/include/torch/data/samplers/base.h
+++ b/torch/csrc/api/include/torch/data/samplers/base.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <vector>
+#include <mutex>
 
 namespace torch {
 namespace serialize {
@@ -27,7 +28,6 @@ class Sampler {
 
   /// Resets the `Sampler`'s internal state.
   /// Typically called before a new epoch.
-
   /// Optionally, accepts a new size when reseting the sampler.
   TORCH_API virtual void reset(optional<size_t> new_size) = 0;
 
@@ -40,6 +40,40 @@ class Sampler {
 
   /// Deserializes the `Sampler` from the `archive`.
   TORCH_API virtual void load(serialize::InputArchive& archive) = 0;
+};
+
+/// Wraps a provided sampler to make it thread safe.
+template <typename OriginalSampler>
+class ThreadSafeSampler
+    : public Sampler<typename OriginalSampler::BatchRequestType> {
+ public:
+  using BatchRequestType = typename OriginalSampler::BatchRequestType;
+
+  ThreadSafeSampler(OriginalSampler sampler) : sampler_(std::move(sampler)) {}
+
+  void reset(optional<size_t> new_size) override {
+    std::lock_guard<std::mutex> lock(this->mutex_);
+    sampler_.reset(new_size);
+  }
+
+  optional<BatchRequestType> next(size_t batch_size) override {
+    std::lock_guard<std::mutex> lock(this->mutex_);
+    return sampler_.next(batch_size);
+  }
+
+  void save(serialize::OutputArchive& archive) const override {
+    std::lock_guard<std::mutex> lock(this->mutex_);
+    sampler_.save(archive);
+  }
+
+  void load(serialize::InputArchive& archive) override {
+    std::lock_guard<std::mutex> lock(this->mutex_);
+    sampler_.load(archive);
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  OriginalSampler sampler_;
 };
 } // namespace samplers
 } // namespace data

--- a/torch/csrc/api/include/torch/data/samplers/base.h
+++ b/torch/csrc/api/include/torch/data/samplers/base.h
@@ -44,12 +44,12 @@ class Sampler {
 
 /// Wraps a provided sampler to make it thread safe.
 template <typename OriginalSampler>
-class ThreadSafeSampler
+class LockedSampler
     : public Sampler<typename OriginalSampler::BatchRequestType> {
  public:
   using BatchRequestType = typename OriginalSampler::BatchRequestType;
 
-  explicit ThreadSafeSampler(OriginalSampler sampler) : sampler_(std::move(sampler)) {}
+  explicit LockedSampler(OriginalSampler sampler) : sampler_(std::move(sampler)) {}
 
   void reset(optional<size_t> new_size) override {
     std::lock_guard<std::mutex> lock(this->mutex_);


### PR DESCRIPTION
This PR contains the implementation of chunk dataset, with the API proposed in PR https://github.com/pytorch/pytorch/pull/15562

A chunk dataset is derived from StatefulDataset. It utilizes worker threads to prefetches chunk data, splits it into batches and caches them into a queue. When get_batch is called from dataloader, batch data is retrieved from the queue, and data in new chunks will be pushed for later following batches. 

Chunk dataset uses two samplers (chunk_sampler and example_sampler) to perform sampling. The chunk_sampler decides which chunk to load, and example_sampler shuffles the examples inside a specific chunk. More detail of this sampling approach can be found here: http://martin.zinkevich.org/publications/nips2010.pdf
