### PR TITLE
[wip] Test calling c10 ops from pytorch

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9782,6 +9782,15 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         do_test(torch.tensor([[1, 2]]).data)
         do_test(torch.tensor([[1, 2]]).detach())
 
+    def test_c10_layer_norm(self):
+        # test that we can call c10 ops and they return a reasonable result
+        X = torch.rand(5, 5, dtype=torch.float)
+        epsilon = 1e-4
+
+        expected_norm = torch.nn.functional.layer_norm(X, X.size()[1:], eps=epsilon)
+        actual_norm, actual_mean, actual_stdev = torch.ops.caffe2.layer_norm_dont_use_this_op_yet(torch.tensor(X), 0, epsilon)
+        torch.testing.assert_allclose(expected_norm, actual_norm)
+
 # Functions to test negative dimension wrapping
 METHOD = 1
 INPLACE_METHOD = 2

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -309,3 +309,6 @@ def compiled_with_cxx11_abi():
 
 # Import the ops "namespace"
 from torch._ops import ops
+
+# Import caffe2 ops
+import caffe2.python._import_c_extension


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#15936 [wip] Test calling c10 ops from pytorch**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13628955/)

This adds a simple test case that calls a c10 op from pytorch.

Differential Revision: [D13628955](https://our.internmc.facebook.com/intern/diff/D13628955/)