### PR TITLE
Tensor reinitialization codemod - 2/5

### DIFF
--- a/caffe2/operators/boolean_mask_ops.cu
+++ b/caffe2/operators/boolean_mask_ops.cu
@@ -39,7 +39,8 @@ class BooleanMaskOp<CUDAContext> final : public Operator<CUDAContext> {
 
     const auto* maskData = mask.data<bool>();
     const auto outerSize = mask.size(0);
-    indices_.Resize(outerSize);
+    ReinitializeTensor(
+        &indices_, {outerSize}, at::dtype<int64_t>().device(CUDA));
     auto* indicesData = indices_.mutable_data<int64_t>();
 
     size_t numBytes = 0;
@@ -57,7 +58,8 @@ class BooleanMaskOp<CUDAContext> final : public Operator<CUDAContext> {
     auto numint64_t =
         static_cast<int64_t>((numBytes + sizeof(int64_t) - 1) / sizeof(int64_t));
     // allocate one more int64_t at the end of scratch for storing numOfOutput
-    scratch_.Resize(numint64_t + 1);
+    ReinitializeTensor(
+        &scratch_, {numint64_t + 1}, at::dtype<int64_t>().device(CUDA));
     auto* scratchData = scratch_.mutable_data<int64_t>();
     auto* numOfOutputData = scratchData + numint64_t;
 
@@ -108,8 +110,8 @@ class BooleanMaskOp<CUDAContext> final : public Operator<CUDAContext> {
   }
 
  private:
-  Tensor indices_{CUDA};
-  Tensor scratch_{CUDA};
+  Tensor indices_;
+  Tensor scratch_;
 };
 
 REGISTER_CUDA_OPERATOR(BooleanMask, BooleanMaskOp<CUDAContext>);

--- a/caffe2/operators/channel_backprop_stats_op.cu
+++ b/caffe2/operators/channel_backprop_stats_op.cu
@@ -161,9 +161,6 @@ bool ChannelBackpropStatsOp<CUDAContext>::RunOnDevice() {
   const int W = X.ndim() > 3 ? X.dim32(3) : 1;
   const int D = X.ndim() > 4 ? X.dim32(4) : 1;
 
-  
-  
-
   const auto Xarr = X.data<float>();
   const auto dYarr = dY.data<float>();
   const auto meanArr = mean.data<float>();
@@ -177,8 +174,10 @@ bool ChannelBackpropStatsOp<CUDAContext>::RunOnDevice() {
   const auto numBlocksPerChannel = CAFFE_GET_BLOCKS(valsPerChannel);
   const auto numBlocksTotal = numBlocksPerChannel * N * C;
 
-  dBiasScratch_.Resize(numBlocksTotal);
-  dScaleScratch_.Resize(numBlocksTotal);
+  ReinitializeTensor(
+      &dBiasScratch_, {numBlocksTotal}, at::dtype<float>().device(CUDA));
+  ReinitializeTensor(
+      &dScaleScratch_, {numBlocksTotal}, at::dtype<float>().device(CUDA));
 
   ChannelBackpropStatsBlockKernel<CAFFE_CUDA_NUM_THREADS>
       <<<numBlocksTotal, CAFFE_CUDA_NUM_THREADS, 0, context_.cuda_stream()>>>(

--- a/caffe2/operators/channel_backprop_stats_op.h
+++ b/caffe2/operators/channel_backprop_stats_op.h
@@ -23,8 +23,8 @@ class ChannelBackpropStatsOp : public Operator<Context> {
   INPUT_TAGS(INPUT, SAVED_MEAN, SAVED_INV_STDDEV, OUTPUT_GRAD);
   OUTPUT_TAGS(SCALE_GRAD, BIAS_GRAD);
 
-  Tensor dBiasScratch_{Context::GetDeviceType()};
-  Tensor dScaleScratch_{Context::GetDeviceType()};
+  Tensor dBiasScratch_;
+  Tensor dScaleScratch_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/channel_stats_op.cu
+++ b/caffe2/operators/channel_stats_op.cu
@@ -154,17 +154,16 @@ bool ChannelStatsOp<CUDAContext>::RunOnDevice() {
   const int W = X.ndim() > 3 ? X.dim32(3) : 1;
   const int D = X.ndim() > 4 ? X.dim32(4) : 1;
 
-  
-  
-
   const auto X_arr = X.data<float>();
   const auto valsPerChannel = H * W * D;
 
   const auto numBlocksPerChannel = CAFFE_GET_BLOCKS(valsPerChannel);
   const auto numBlocksTotal = numBlocksPerChannel * N * C;
 
-  sumScratch_.Resize(numBlocksTotal);
-  sumsqScratch_.Resize(numBlocksTotal);
+  ReinitializeTensor(
+      &sumScratch_, {numBlocksTotal}, at::dtype<float>().device(CUDA));
+  ReinitializeTensor(
+      &sumsqScratch_, {numBlocksTotal}, at::dtype<float>().device(CUDA));
 
   auto sum = Output(SUM, {C}, at::dtype<float>());
   auto sumsq = Output(SUMSQ, {C}, at::dtype<float>());

--- a/caffe2/operators/channel_stats_op.h
+++ b/caffe2/operators/channel_stats_op.h
@@ -23,8 +23,8 @@ class ChannelStatsOp : public Operator<Context> {
   INPUT_TAGS(INPUT);
   OUTPUT_TAGS(SUM, SUMSQ);
 
-  Tensor sumScratch_{Context::GetDeviceType()};
-  Tensor sumsqScratch_{Context::GetDeviceType()};
+  Tensor sumScratch_;
+  Tensor sumsqScratch_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/conv_op.h
+++ b/caffe2/operators/conv_op.h
@@ -85,8 +85,8 @@ class ConvGradientOp final : public ConvPoolOpBase<Context> {
   bool RunOnDeviceWithOrderNHWC() override;
 
  private:
-  Tensor col_buffer_{Context::GetDeviceType()};
-  Tensor bias_multiplier_{Context::GetDeviceType()};
+  Tensor col_buffer_;
+  Tensor bias_multiplier_;
   Tensor img_shape_device_{Context::GetDeviceType()};
   Tensor col_buffer_shape_device_{Context::GetDeviceType()};
   bool no_bias_;

--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -521,9 +521,18 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   col_buffer_shape.push_back(C / group_ * kernel_dims_size);
   col_buffer_shape.insert(
       col_buffer_shape.end(), output_dims.begin(), output_dims.end());
-  col_buffer_.Resize(col_buffer_shape);
+  vector<int64_t> col_buffer_shape_64;
+  std::copy(
+      col_buffer_shape.cbegin(),
+      col_buffer_shape.cend(),
+      std::back_inserter(col_buffer_shape_64));
+  ReinitializeTensor(
+      &col_buffer_,
+      col_buffer_shape_64,
+      at::dtype<T>().device(Context::GetDeviceType()));
 
   if (kernel_.size() != 2) {
+    // TODO: SetDeviceTensor accept vector<int64_t>
     SetDeviceTensor(img_shape, &img_shape_device_);
     SetDeviceTensor(col_buffer_shape, &col_buffer_shape_device_);
   }
@@ -542,15 +551,16 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   T* dbias_data = nullptr;
   if (!no_bias_) {
     auto* dbias = Output(BIAS_OR_INPUT_GRAD, {M}, at::dtype<T>());
-    if (bias_multiplier_.numel() != output_image_size) {
-      // If the helper bias multiplier is not M, reshape and fill it with one.
-      bias_multiplier_.Resize(vector<int64_t>(1, output_image_size));
-      math::Set<T, Context>(
-          output_image_size,
-          static_cast<T>(1),
-          bias_multiplier_.template mutable_data<T>(),
-          &context_);
-    }
+    // Removed the check for whether bias_multiplier_ has correct size or not
+    ReinitializeTensor(
+        &bias_multiplier_,
+        vector<int64_t>(1, output_image_size),
+        at::dtype<T>().device(Context::GetDeviceType()));
+    math::Set<T, Context>(
+        output_image_size,
+        static_cast<T>(1),
+        bias_multiplier_.template mutable_data<T>(),
+        &context_);
     dbias_data = dbias->template mutable_data<T>();
     math::Set<T, Context>(dbias->numel(), 0, dbias_data, &context_);
   }
@@ -726,7 +736,15 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   vector<int> col_buffer_shape(output_dims.size() + 1);
   std::copy(output_dims.cbegin(), output_dims.cend(), col_buffer_shape.begin());
   col_buffer_shape.back() = C * kernel_dims_size;
-  col_buffer_.Resize(col_buffer_shape);
+  vector<int64_t> col_buffer_shape_64;
+  std::copy(
+      col_buffer_shape.cbegin(),
+      col_buffer_shape.cend(),
+      std::back_inserter(col_buffer_shape_64));
+  ReinitializeTensor(
+      &col_buffer_,
+      col_buffer_shape_64,
+      at::dtype<T>().device(Context::GetDeviceType()));
 
   if (kernel_.size() != 2) {
     SetDeviceTensor(img_shape, &img_shape_device_);
@@ -748,15 +766,16 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
     auto* dbias = Output(BIAS_OR_INPUT_GRAD, {M}, at::dtype<T>());
     dbias_data = dbias->template mutable_data<T>();
     math::Set<T, Context>(dbias->numel(), 0, dbias_data, &context_);
-    if (bias_multiplier_.numel() != output_image_size) {
-      // If the helper bias multiplier is not M, reshape and fill it with one.
-      bias_multiplier_.Resize(vector<int64_t>(1, output_image_size));
-      math::Set<T, Context>(
-          output_image_size,
-          static_cast<T>(1),
-          bias_multiplier_.template mutable_data<T>(),
-          &context_);
-    }
+    // Removed the check for whether bias_multiplier_ has correct size or not
+    ReinitializeTensor(
+        &bias_multiplier_,
+        vector<int64_t>(1, output_image_size),
+        at::dtype<T>().device(Context::GetDeviceType()));
+    math::Set<T, Context>(
+        output_image_size,
+        static_cast<T>(1),
+        bias_multiplier_.template mutable_data<T>(),
+        &context_);
   }
 
   for (int image_id = 0; image_id < N; ++image_id) {

--- a/caffe2/operators/conv_transpose_op.h
+++ b/caffe2/operators/conv_transpose_op.h
@@ -18,8 +18,8 @@ class ConvTransposeOp final : public ConvTransposeUnpoolBase<Context> {
   bool RunOnDeviceWithOrderNHWC() override;
 
  private:
-  Tensor col_buffer_{Context::GetDeviceType()};
-  Tensor bias_multiplier_{Context::GetDeviceType()};
+  Tensor col_buffer_;
+  Tensor bias_multiplier_;
   // Input: X, W, b
   // Output: Y
   INPUT_TAGS(INPUT, FILTER, BIAS);
@@ -41,8 +41,8 @@ class ConvTransposeGradientOp final : public ConvTransposeUnpoolBase<Context> {
   bool RunOnDeviceWithOrderNHWC() override;
 
  private:
-  Tensor col_buffer_{Context::GetDeviceType()};
-  Tensor bias_multiplier_{Context::GetDeviceType()};
+  Tensor col_buffer_;
+  Tensor bias_multiplier_;
   const bool no_bias_;
   // input: X, W, dY
   // output: dW, optionally db and dX

--- a/caffe2/operators/deform_conv_op.h
+++ b/caffe2/operators/deform_conv_op.h
@@ -71,7 +71,7 @@ class DeformConvOp final : public DeformConvOpBase<T, Context> {
 
  private:
   Tensor col_buffer_{Context::GetDeviceType()};
-  Tensor bias_multiplier_{Context::GetDeviceType()};
+  Tensor bias_multiplier_;
   Tensor img_shape_device_{Context::GetDeviceType()};
   Tensor col_buffer_shape_device_{Context::GetDeviceType()};
   // Input: X, o, W, b
@@ -96,8 +96,8 @@ class DeformConvGradientOp final : public DeformConvOpBase<T, Context> {
   bool RunOnDeviceWithOrderNCHW() override;
 
  private:
-  Tensor col_buffer_{Context::GetDeviceType()};
-  Tensor bias_multiplier_{Context::GetDeviceType()};
+  Tensor col_buffer_;
+  Tensor bias_multiplier_;
   Tensor img_shape_device_{Context::GetDeviceType()};
   Tensor col_buffer_shape_device_{Context::GetDeviceType()};
   bool no_bias_;

--- a/caffe2/operators/deform_conv_op_impl.h
+++ b/caffe2/operators/deform_conv_op_impl.h
@@ -119,7 +119,10 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       // If the helper bias multiplier is not image size, reshape and fill it
       // with
       // one.
-      bias_multiplier_.Resize(vector<int64_t>(1, output_image_size));
+      ReinitializeTensor(
+          &bias_multiplier_,
+          vector<int64_t>(1, output_image_size),
+          at::dtype<T>().device(Context::GetDeviceType()));
       math::Set<T, Context>(
           output_image_size,
           static_cast<T>(1),
@@ -280,7 +283,10 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   col_buffer_shape.push_back(C * kernel_dims_size);
   col_buffer_shape.insert(
       col_buffer_shape.end(), output_dims.begin(), output_dims.end());
-  col_buffer_.Resize(col_buffer_shape);
+  ReinitializeTensor(
+      &col_buffer_,
+      col_buffer_shape,
+      at::dtype<T>().device(Context::GetDeviceType()));
 
   const int col_buffer_offset = col_buffer_.size() / group_;
 
@@ -301,7 +307,10 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     auto* dbias = Output(BIAS_OR_INPUT_GRAD, {M}, at::dtype<T>());
     if (bias_multiplier_.size() != output_image_size) {
       // If the helper bias multiplier is not M, reshape and fill it with one.
-      bias_multiplier_.Resize(vector<int64_t>(1, output_image_size));
+      ReinitializeTensor(
+          &bias_multiplier_,
+          vector<int64_t>(1, output_image_size),
+          at::dtype<T>().device(Context::GetDeviceType()));
       math::Set<T, Context>(
           output_image_size,
           static_cast<T>(1),


### PR DESCRIPTION
Summary:
Codemod generated with clangr shard mode, 25 files per diff,
To eliminiate partially initialized Tensor, we split the initialization of local Tensor variables into two steps, first declare un uninitialized Tensor, and
call `ReinitializeTensor` to initialize it.
motivation: https://github.com/pytorch/pytorch/pull/12407

Differential Revision: D13586732
