### PR TITLE
Fix numerical stability in binomial.log_prob

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -954,6 +954,19 @@ class TestDistributions(TestCase):
             self._check_log_prob(Binomial(total_count, logits=logits), ref_log_prob)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_binomial_log_prob_float(self):
+        probs = torch.tensor([1e-5, 0.99999], dtype=torch.float)
+        total_count = 1000000.
+        x = torch.tensor([10, 9999], dtype=torch.float)
+        expected = scipy.stats.binom(total_count, probs.numpy()).logpmf(x.numpy())
+        log_prob = Binomial(total_count, probs).log_prob(x)
+        # Comparison is again scipy distributions which use float64.
+        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05))
+        logits = probs_to_logits(probs, is_binary=True)
+        log_prob = Binomial(total_count, logits=logits).log_prob(x)
+        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05))
+
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_binomial_log_prob_vectorized_count(self):
         probs = torch.tensor([0.2, 0.7, 0.9])
         for total_count, sample in [(torch.tensor([10]), torch.tensor([7., 3., 9.])),

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -954,23 +954,6 @@ class TestDistributions(TestCase):
             self._check_log_prob(Binomial(total_count, logits=logits), ref_log_prob)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_binomial_log_prob_float(self):
-        probs = torch.tensor([1e-5, 0.99999], dtype=torch.float)
-        total_count = 1000000.
-        x = torch.tensor([10, 9999], dtype=torch.float)
-        expected = scipy.stats.binom(total_count, probs.numpy()).logpmf(x.numpy())
-        log_prob = Binomial(total_count, probs).log_prob(x).numpy()
-        # Comparison is again scipy distributions which use float64.
-        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05),
-                        msg="Values not equal within the desired tolerance: \n"
-                            "actual={} \nexpected={}".format(log_prob, expected))
-        logits = probs_to_logits(probs, is_binary=True)
-        log_prob = Binomial(total_count, logits=logits).log_prob(x).numpy()
-        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05),
-                        msg="Values not equal within the desired tolerance: \n"
-                            "actual={} \nexpected={}".format(log_prob, expected))
-
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_binomial_log_prob_vectorized_count(self):
         probs = torch.tensor([0.2, 0.7, 0.9])
         for total_count, sample in [(torch.tensor([10]), torch.tensor([7., 3., 9.])),

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -959,12 +959,16 @@ class TestDistributions(TestCase):
         total_count = 1000000.
         x = torch.tensor([10, 9999], dtype=torch.float)
         expected = scipy.stats.binom(total_count, probs.numpy()).logpmf(x.numpy())
-        log_prob = Binomial(total_count, probs).log_prob(x)
+        log_prob = Binomial(total_count, probs).log_prob(x).numpy()
         # Comparison is again scipy distributions which use float64.
-        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05))
+        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05),
+                        msg="Values not equal within the desired tolerance: \n"
+                            "actual={} \nexpected={}".format(log_prob, expected))
         logits = probs_to_logits(probs, is_binary=True)
-        log_prob = Binomial(total_count, logits=logits).log_prob(x)
-        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05))
+        log_prob = Binomial(total_count, logits=logits).log_prob(x).numpy()
+        self.assertTrue(np.allclose(log_prob, expected, rtol=0.05),
+                        msg="Values not equal within the desired tolerance: \n"
+                            "actual={} \nexpected={}".format(log_prob, expected))
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_binomial_log_prob_vectorized_count(self):

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -113,11 +113,9 @@ class Binomial(Distribution):
         log_factorial_n = torch.lgamma(self.total_count + 1)
         log_factorial_k = torch.lgamma(value + 1)
         log_factorial_nmk = torch.lgamma(self.total_count - value + 1)
-        max_val = (-self.logits).clamp(min=0.0)
-        # Note that: torch.log1p(-self.probs)) = max_val - torch.log1p((self.logits + 2 * max_val).exp()))
+        # Note that: torch.log1p(-self.probs)) = - torch.log1p(self.logits.exp()))
         return (log_factorial_n - log_factorial_k - log_factorial_nmk +
-                value * self.logits + self.total_count * max_val -
-                self.total_count * torch.log1p((self.logits + 2 * max_val).exp()))
+                value * self.logits - self.total_count * torch.log1p(self.logits.exp()))
 
     def enumerate_support(self, expand=True):
         total_count = int(self.total_count.max())


### PR DESCRIPTION
This issue was discovered by @fehiepsi in https://github.com/uber/pyro/issues/1706 with the `log_prob` computation for Binomial, ~and can be seen with `torch.float32` when we have a combination of low probability value and high `total_count` - a test is added to capture this (since scipy only uses float64, the comparison is done using relative tolerance).~ 

The problem is in the code that tries to pull out the minimum values amongst the logits (written by me earlier, presumably to avoid numerical instability issues), but it is not needed.

EDIT: After a few attempts, I have been unable to reliably show that the change is more numerically stable, and have removed my previous test which fails on linux. The reason is that the issue manifests itself when `total_count` is high and `probs` is very low. However, the precision of `lgamma` when `total_count` is high is bad enough to wash away any benefits. The justification for this still stands though - (a) simplifies code (removes the unnecessary bit), (b) is no worse than the previous implementation, (c) has better continuity behavior as observed by @fehiepsi in the issue above.



cc. @fehiepsi, @alicanb, @fritzo 