### PR TITLE
[JIT] Support tracing GenericList

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6392,7 +6392,7 @@ a")
             return list_stuff[0][0], list_stuff[1][1]
 
         traced = torch.jit.trace(bar, torch.rand(3, 4))
-        x = torch.rand(3, 4)
+        x = torch.rand(5, 6)
         self.assertEqual(bar(x), traced(x))
 
     @suppress_warnings

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6382,6 +6382,19 @@ a")
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
+    def test_trace_nested_datatypes(self):
+        @torch.jit.script
+        def foo(x):
+            return [[x + 1, x - 1], [x + 2, x - 2]]
+
+        def bar(x):
+            list_stuff = foo(x)
+            return list_stuff[0][0], list_stuff[1][1]
+
+        traced = torch.jit.trace(bar, torch.rand(3, 4))
+        x = torch.rand(3, 4)
+        self.assertEqual(bar(x), traced(x))
+
     @suppress_warnings
     def test_onnx_export_func_with_warnings(self):
         @torch.jit.script

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -737,7 +737,18 @@ RegisterOperators reg({
               return 0;
             };
           } else {
-            AT_ERROR("Unsupported list type: ", lt->getElementType()->str());
+            return [=](Stack& stack) {
+              auto glist = pop(stack);
+              const auto& list = glist.toGenericList()->elements();
+              AT_CHECK(
+                  list.size() == num_outputs,
+                  "Expected ",
+                  num_outputs,
+                  " elements in a list but found ",
+                  list.size());
+              stack.insert(stack.end(), list.begin(), list.end());
+              return 0;
+            };
           }
         }),
     Operator(

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -47,23 +47,24 @@ void setValueTrace(const IValue& v, Value* value) {
   } else if (v.isTensorList()) {
     auto& outputs = v.toTensorList()->elements();
     auto graph = getTracingState()->graph;
-    Node* unpack_node = graph->appendNode(
-        graph->create(prim::ListUnpack, {value}, outputs.size()));
+    Node* unpack_node = graph->insertNode(
+      graph->createListUnpack(value, outputs.size()));
     for (size_t i = 0; i < outputs.size(); ++i) {
       setValueTrace(outputs[i], unpack_node->outputs()[i]);
     }
   } else if (v.isTuple()) {
     auto& outputs = v.toTuple()->elements();
     auto graph = getTracingState()->graph;
-    Node* unpack_node = graph->appendNode(
-        graph->create(prim::TupleUnpack, {value}, outputs.size()));
+    Node* unpack_node = graph->insertNode(
+      graph->createTupleUnpack(value));
     for (size_t i = 0; i < outputs.size(); ++i) {
       setValueTrace(outputs[i], unpack_node->outputs()[i]);
     }
   } else if (v.isGenericList()) {
     auto elements = v.toGenericListRef();
     auto graph = getTracingState()->graph;
-    Node* unpack_node = graph->appendNode(graph->createListUnpack(value, elements.size()));
+    Node* unpack_node = graph->insertNode(
+      graph->createListUnpack(value, elements.size()));
     for (size_t i = 0; i < elements.size(); ++i) {
       setValueTrace(elements[i], unpack_node->outputs()[i]);
     }

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -60,6 +60,13 @@ void setValueTrace(const IValue& v, Value* value) {
     for (size_t i = 0; i < outputs.size(); ++i) {
       setValueTrace(outputs[i], unpack_node->outputs()[i]);
     }
+  } else if (v.isGenericList()) {
+    auto elements = v.toGenericListRef();
+    auto graph = getTracingState()->graph;
+    Node* unpack_node = graph->appendNode(graph->createListUnpack(value, elements.size()));
+    for (size_t i = 0; i < elements.size(); ++i) {
+      setValueTrace(elements[i], unpack_node->outputs()[i]);
+    }
   } else {
     std::ostringstream os;
     os << "Tracer cannot set value trace for type " << v.tagKind() << ". "


### PR DESCRIPTION
Treat GenericList similarly to tuples and TensorList: recursively unpack them and assignValueTrace accordingly. Also add interpreter support for ListUnpack on GenericList