### PR TITLE
Adding CUDA event IPC test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1523,9 +1523,9 @@ class TestCuda(TestCase):
         e0 = torch.cuda.Event(enable_timing=False, interprocess=True)
         self.assertTrue(e0.query())
 
-        mp.set_start_method('spawn')
-        p = mp.Process(target=TestCuda._test_event_handle_consumer,
-                       args=(e0.ipc_handle(),))
+        ctx = mp.get_context('spawn')
+        p = ctx.Process(target=TestCuda._test_event_handle_consumer,
+                        args=(e0.ipc_handle(),))
         p.start()
 
         torch.cuda._sleep(int(50 * get_cycles_per_ms()))  # spin for about 50 ms

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1511,7 +1511,7 @@ class TestCuda(TestCase):
 
     def _test_event_handle_consumer(handle):
         e1 = torch.cuda.Event(_handle=handle)
-        # synchronization here is not really necessary, as the torch.cuda.Event
+        # synchronization here is not really necessary, as the subprocess spawn
         # invocation above will block until the current device wakes up. This is
         # testing if event can be successfully created from a handle.
         e1.synchronize()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1518,6 +1518,7 @@ class TestCuda(TestCase):
 
     @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
                      don't support multiprocessing with spawn start method")
+    @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
     @skipIfRocm
     def test_events_handle(self):
         e0 = torch.cuda.Event(enable_timing=False, interprocess=True)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1509,32 +1509,6 @@ class TestCuda(TestCase):
         self.assertTrue(event.query())
         self.assertGreater(start_event.elapsed_time(event), 0)
 
-    def _test_event_handle_consumer(handle):
-        e1 = torch.cuda.Event(_handle=handle)
-        # synchronization here is not really necessary, as the subprocess spawn
-        # invocation above will block until the current device wakes up. This is
-        # testing if event can be successfully created from a handle.
-        e1.synchronize()
-
-    @unittest.skipIf(NO_MULTIPROCESSING_SPAWN, "Disabled for environments that \
-                     don't support multiprocessing with spawn start method")
-    @unittest.skipIf(not TEST_CUDA_IPC, 'CUDA IPC not available')
-    @skipIfRocm
-    def test_events_handle(self):
-        e0 = torch.cuda.Event(enable_timing=False, interprocess=True)
-        self.assertTrue(e0.query())
-
-        ctx = mp.get_context('spawn')
-        p = ctx.Process(target=TestCuda._test_event_handle_consumer,
-                        args=(e0.ipc_handle(),))
-        p.start()
-
-        torch.cuda._sleep(int(50 * get_cycles_per_ms()))  # spin for about 50 ms
-        e0.record()
-        self.assertFalse(e0.query())
-        p.join()
-        self.assertTrue(e0.query())
-
     @skipIfRocm
     def test_record_stream(self):
         cycles_per_ms = get_cycles_per_ms()


### PR DESCRIPTION
Hi @colesbury, is the added test valid? Current `Event.ipc_handle()` implementation fails the test at line 1522 with the following message, and I got the same message when trying to bind it with `CUDAEvent.h`. 

```python
    def check_error(res):
        if res != cudaStatus.SUCCESS:
>           raise CudaError(res)
E           torch.cuda.CudaError: invalid device ordinal (10)
```

### update

1. It confirms that an event can be reconstructed from a handle on a different device. I think this makes sense, otherwise multi-gpu event synchronization would require frequent context switching.
2. `record()` and `synchronize` work correctly as long as both original and reconstructed events are not destructed. More specifically, when calling `synchronize`, the event (either original or reconstructed) that last called `record` must not be destructed. Otherwise, `synchronize` could block forever.