### PR TITLE
Fix static build on Windows

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -258,8 +258,8 @@ endif()
 
 
 if (TORCH_STATIC)
-  target_compile_definitions(torch PUBLIC TORCH_BUILD_STATIC_LIBS)
   add_library(torch STATIC ${TORCH_SRCS})
+  target_compile_definitions(torch PUBLIC TORCH_BUILD_STATIC_LIBS)
 else()
   add_library(torch SHARED ${TORCH_SRCS})
 endif()


### PR DESCRIPTION
Tested locally. It could be now be started by running `set EXTRA_CAFFE2_CMAKE_FLAGS= -DTORCH_STATIC=1` before build. If we want to make sure it works, then maybe we should add it into CI.