### PR TITLE
Enhance the documentation for torch.nn.DataParallel

### DIFF
--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -58,7 +58,7 @@ class DataParallel(Module):
 
     .. warning::
         In each forward, :attr:`module` is **replicated** on each device, so any
-        updates to the runing module in ``forward`` will be lost. For example,
+        updates to the running module in ``forward`` will be lost. For example,
         if :attr:`module` has a counter attribute that is incremented in each
         ``forward``, it will always stay at the initial value becasue the update
         is done on the replicas which are destroyed after ``forward``. However,

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -47,7 +47,7 @@ class DataParallel(Module):
     See also: :ref:`cuda-nn-dataparallel-instead`
 
     Arbitrary positional and keyword inputs are allowed to be passed into
-    DataParallel EXCEPT Tensors. All tensors will be scattered on dim
+    DataParallel but tensors are specially handled. All tensors will be scattered on dim
     specified (default 0). Primitive types will be broadcasted, but all
     other types will be a shallow copy and can be corrupted if written to in
     the model's forward pass.

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -47,9 +47,9 @@ class DataParallel(Module):
     See also: :ref:`cuda-nn-dataparallel-instead`
 
     Arbitrary positional and keyword inputs are allowed to be passed into
-    DataParallel but some types are specially handled. All tensors will be 
+    DataParallel but some types are specially handled. tensors will be
     **scattered** on dim specified (default 0). tuple, list and dict types will
-    be shallow copied, but other types will be shared among different threads
+    be shallow copied. The other types will be shared among different threads
     and can be corrupted if written to in the model's forward pass.
 
     The parallelized :attr:`module` must have its parameters and buffers on

--- a/torch/nn/parallel/data_parallel.py
+++ b/torch/nn/parallel/data_parallel.py
@@ -47,10 +47,10 @@ class DataParallel(Module):
     See also: :ref:`cuda-nn-dataparallel-instead`
 
     Arbitrary positional and keyword inputs are allowed to be passed into
-    DataParallel but tensors are specially handled. All tensors will be scattered on dim
-    specified (default 0). Primitive types will be broadcasted, but all
-    other types will be a shallow copy and can be corrupted if written to in
-    the model's forward pass.
+    DataParallel but some types are specially handled. All tensors will be 
+    **scattered** on dim specified (default 0). tuple, list and dict types will
+    be shallow copied, but other types will be shared among different threads
+    and can be corrupted if written to in the model's forward pass.
 
     The parallelized :attr:`module` must have its parameters and buffers on
     ``device_ids[0]`` before running this :class:`~torch.nn.DataParallel`


### PR DESCRIPTION
I found a few sentences in DataParallel docstring confusing, so I suggest this enhancement.

- Arbitrary arguments are allowed to be passed .... *INCLUDING* tensors (Not *EXCLUDING*)
- The original author said that "other types" are shallow-copied but I think actually only some builtin types are (effectively) shallow-copied.  And "other types" are shared. Here is an example.

```python
import torch
from torch.nn import Module, DataParallel
from collections import deque

class MyModel(Module):
    def forward(self, x):
        x.append(None)

model = MyModel(); model.cuda()
model = DataParallel(model)

d = deque()
model.forward(d)
print(d)
# deque([None, None, None, None])  # If num available gpus == 4
```

Below is a side note.

As far as I know, copying objects is not a specially frequent operation in python unlike some other languages. Notably, no copying is involved in assignment or function parameter passing. They are only name bindings and it is the whole point of "everything is object" python philosophy, I guess. If one keep this in mind, it may help you dealing with things like multithreading.