### PR TITLE
Fix broken rst of torch.nn.utils.spectral_norm and others

### DIFF
--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -196,7 +196,7 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=No
         \sigma(\mathbf{W}) = \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
     Spectral normalization stabilizes the training of discriminators (critics)
-    in Generaive Adversarial Networks (GANs) by rescaling the weight tensor
+    in Generative Adversarial Networks (GANs) by rescaling the weight tensor
     with spectral norm :math:`\sigma` of the weight matrix calculated using
     power iteration method. If the dimension of the weight tensor is greater
     than 2, it is reshaped to 2D in power iteration method to get spectral
@@ -211,7 +211,7 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=No
         module (nn.Module): containing module
         name (str, optional): name of weight parameter
         n_power_iterations (int, optional): number of power iterations to
-            calculate spectal norm
+            calculate spectral norm
         eps (float, optional): epsilon for numerical stability in
             calculating norms
         dim (int, optional): dimension corresponding to number of outputs,
@@ -219,7 +219,7 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=No
             ConvTranspose1/2/3d, when it is 1
 
     Returns:
-        The original module with the spectal norm hook
+        The original module with the spectral norm hook
 
     Example::
 

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -192,7 +192,7 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=No
     r"""Applies spectral normalization to a parameter in the given module.
 
     .. math::
-        \mathbf{W} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})},
+        \mathbf{W}_{SN} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})},
         \sigma(\mathbf{W}) = \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
     Spectral normalization stabilizes the training of discriminators (critics)

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -192,8 +192,8 @@ def spectral_norm(module, name='weight', n_power_iterations=1, eps=1e-12, dim=No
     r"""Applies spectral normalization to a parameter in the given module.
 
     .. math::
-         \mathbf{W} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})} \\
-         \sigma(\mathbf{W}) = \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
+        \mathbf{W} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})},
+        \sigma(\mathbf{W}) = \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
 
     Spectral normalization stabilizes the training of discriminators (critics)
     in Generaive Adversarial Networks (GANs) by rescaling the weight tensor


### PR DESCRIPTION
- Currently, the [rst](https://pytorch.org/docs/stable/nn.html#torch.nn.utils.spectral_norm) looks broken, at least in my browser. So I fixed it.
- I thought a subscript may be needed to the left W in the definition.
- A few typos fixed.

@crcrpar 