### PR TITLE
Enhance the documentation for DistributedDataParallel from torch.nn.parallel.distributed 

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -59,7 +59,7 @@ class DistributedDataParallel(Module):
     parallel training.
 
     Here is how to use it: on each host with N GPUs, you should spawn up N
-    processes, while ensuring that each process invidually works on a single GPU
+    processes, while ensuring that each process individually works on a single GPU
     from 0 to N-1. Therefore, it is your job to ensure that your training script
     operates on a single given GPU by calling:
 

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -26,9 +26,7 @@ class DistributedDataParallel(Module):
     each such replica handles a portion of the input. During the backwards
     pass, gradients from each node are averaged.
 
-    The batch size should be larger than the number of GPUs used locally. It
-    should also be an integer multiple of the number of GPUs so that each chunk
-    is the same size (so that each GPU processes the same number of samples).
+    The batch size should be larger than the number of GPUs used locally.
 
     See also: :ref:`distributed-basics` and :ref:`cuda-nn-dataparallel-instead`.
     The same constraints on input as in :class:`torch.nn.DataParallel` apply.


### PR DESCRIPTION
- a typo fixed
- made the docs consistent with #5108

And maybe one more change is needed. According to the current docs 
> The batch size should be larger than the number of GPUs used **locally**.

But shouldn't the batch size be larger than the number of GPUs used **either locally or remotely**? Sadly, I couldn't experiment this with my single GPU.