### PR TITLE
Fixing missing cpp tests for Caffe2 setup.py builds

### DIFF
--- a/.jenkins/caffe2/bench.sh
+++ b/.jenkins/caffe2/bench.sh
@@ -2,7 +2,8 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-# Anywhere except $ROOT_DIR should work
+# Anywhere except $ROOT_DIR should work. This is so the python import doesn't
+# get confused by any 'caffe2' directory in cwd
 cd "$INSTALL_PREFIX"
 
 if [[ $BUILD_ENVIRONMENT == *-cuda* ]]; then
@@ -13,7 +14,7 @@ else
     num_gpus=0
 fi
 
-caffe2_pypath="$(python -c 'import os; import caffe2; print(os.path.dirname(os.path.realpath(caffe2.__file__)))')"
+caffe2_pypath="$(cd /usr && python -c 'import os; import caffe2; print(os.path.dirname(os.path.realpath(caffe2.__file__)))')"
 cmd="$PYTHON $caffe2_pypath/python/examples/resnet50_trainer.py --train_data null --batch_size 64 --epoch_size 6400 --num_epochs 2"
 if (( $num_gpus == 0 )); then
     cmd="$cmd --use_cpu"

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -234,7 +234,7 @@ if [[ "$BUILD_ENVIRONMENT" == *cmake* ]]; then
   # This is to save test binaries for testing
   mv "$INSTALL_PREFIX/test/" "$INSTALL_PREFIX/cpp_test/"
 
-  ls $INSTALL_PREFIX
+  ls -lah $INSTALL_PREFIX
 
 else
   # Python build. Uses setup.py to install into site-packages
@@ -249,6 +249,9 @@ else
   build_args+=("USE_FBGEMM=OFF")
   build_args+=("USE_MKLDNN=OFF")
   build_args+=("USE_DISTRIBUTED=ON")
+  for build_arg in "${build_args[@]}"; do
+    export $build_arg
+  done
 
   # sccache will be stuck if  all cores are used for compiling
   # see https://github.com/pytorch/pytorch/pull/7361
@@ -256,20 +259,7 @@ else
     export MAX_JOBS=`expr $(nproc) - 1`
   fi
 
-  for build_arg in "${build_args[@]}"; do
-    export $build_arg
-  done
   $PYTHON setup.py install --user
-
-  # This is to save test binaries for testing. Copying caffe2/test to
-  # INSTALL_PREFIX, which is /usr/local/caffe2/, enables these setup.py builds
-  # to share cpp-tests test-code with the cmake-only build above. In test.sh
-  # the cpp tests are run in install_prefix
-  cp -r torch/lib/tmp_install $INSTALL_PREFIX
-  mkdir -p "$INSTALL_PREFIX/cpp_test/"
-  cp -r caffe2/test/* "$INSTALL_PREFIX/cpp_test/"
-
-  ls $INSTALL_PREFIX
 
   report_compile_cache_stats
 fi

--- a/.jenkins/caffe2/common.sh
+++ b/.jenkins/caffe2/common.sh
@@ -16,3 +16,7 @@ fi
 # builds. In +python builds the cpp tests are copied to /usr/local/caffe2 so
 # that the test code in .jenkins/test.sh is the same
 INSTALL_PREFIX="/usr/local/caffe2"
+
+mkdir -p "$gtest_reports_dir" || true
+mkdir -p "$pytest_reports_dir" || true
+mkdir -p "$INSTALL_PREFIX" || true


### PR DESCRIPTION
These were broken (always skipped in setup.py builds) by https://github.com/pytorch/pytorch/pull/15917