### PR TITLE
Enable single graph sharing between multiple threads for onnxifiop

### DIFF
--- a/caffe2/onnx/onnxifi_graph_info.cc
+++ b/caffe2/onnx/onnxifi_graph_info.cc
@@ -1,0 +1,52 @@
+#include "caffe2/onnx/onnxifi_graph_info.h"
+
+namespace caffe2 {
+namespace onnx {
+
+SharedPtrBackendGraphInfo OnnxBackendGraphMap::lookup(const std::string& key) {
+  std::lock_guard<std::mutex> guard(backend_graph_map_lock_);
+  auto it = backend_graph_map_.find(key);
+  if (it != backend_graph_map_.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+SharedPtrBackendGraphInfo OnnxBackendGraphMap::insert(
+    const std::string& key,
+    BackendGraphInfo backend_graph_info) {
+  // First acquire lock.
+  std::lock_guard<std::mutex> guard(backend_graph_map_lock_);
+  // Then check if the backend_graph_info already exists in the map.
+  if (backend_graph_map_.find(key) != backend_graph_map_.end()) {
+    // If it already exists, return it.
+    // The onus is on the caller to release onnxGraph pointed by
+    // backend_graph_info
+    return backend_graph_map_[key];
+  }
+  const auto& ret_pair = backend_graph_map_.emplace(
+      key, std::make_shared<BackendGraphInfo>(std::move(backend_graph_info)));
+  return ret_pair.first->second;
+}
+
+void OnnxBackendGraphMap::remove(const std::string& key) {
+  SharedPtrBackendGraphInfo tmp;
+  {
+    std::lock_guard<std::mutex> guard(backend_graph_map_lock_);
+    auto it = backend_graph_map_.find(key);
+    if (it != backend_graph_map_.end()) {
+      if (it->second.unique()) {
+        tmp = it->second;
+        backend_graph_map_.erase(it);
+      }
+    }
+  }
+}
+
+OnnxBackendGraphMap* getOnnxBackendGraphMap() {
+  static OnnxBackendGraphMap onnx_backend_graph_map;
+  return &onnx_backend_graph_map;
+}
+
+} // namespace onnx
+} // namespace caffe2

--- a/caffe2/onnx/onnxifi_graph_info.h
+++ b/caffe2/onnx/onnxifi_graph_info.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include "caffe2/core/logging.h"
+#include "onnx/onnxifi_loader.h"
+
+namespace caffe2 {
+namespace onnx {
+
+struct BackendGraphInfo {
+  onnxBackendID backend_id;
+  onnxBackend backend;
+  onnxGraph graph;
+  onnxifi_library* lib{nullptr};
+  BackendGraphInfo(
+      onnxBackendID backend_id,
+      onnxBackend backend,
+      onnxGraph graph,
+      onnxifi_library* lib)
+      : backend_id(backend_id), backend(backend), graph(graph), lib(lib) {}
+  BackendGraphInfo(const BackendGraphInfo& other) = delete;
+  BackendGraphInfo& operator=(const BackendGraphInfo& other) = delete;
+  BackendGraphInfo(BackendGraphInfo&& other) noexcept {
+    backend_id = other.backend_id;
+    backend = other.backend;
+    graph = other.graph;
+    lib = other.lib;
+    other.backend_id = other.backend = other.graph = other.lib = nullptr;
+  }
+  BackendGraphInfo& operator=(BackendGraphInfo&& other) {
+    backend_id = other.backend_id;
+    backend = other.backend;
+    graph = other.graph;
+    lib = other.lib;
+    other.backend_id = other.backend = other.graph = other.lib = nullptr;
+    return *this;
+  }
+  ~BackendGraphInfo() {
+    if (lib) {
+      onnxStatus err;
+      if (graph) {
+        err = lib->onnxReleaseGraph(graph);
+        if (err != ONNXIFI_STATUS_SUCCESS) {
+          LOG(ERROR) << "Error when calling onnxReleaseGraph";
+        }
+      }
+      if (backend) {
+        err = lib->onnxReleaseBackend(backend);
+        if (err != ONNXIFI_STATUS_SUCCESS) {
+          LOG(ERROR) << "Error when calling onnxReleaseBackend";
+        }
+      }
+      if (backend_id) {
+        err = lib->onnxReleaseBackendID(backend_id);
+        if (err != ONNXIFI_STATUS_SUCCESS) {
+          LOG(ERROR) << "Error when calling onnxReleaseBackendID";
+        }
+      }
+    }
+  }
+};
+using SharedPtrBackendGraphInfo = std::shared_ptr<BackendGraphInfo>;
+
+// This class maintains a map of already created graph for nets+ops
+class OnnxBackendGraphMap {
+ public:
+  OnnxBackendGraphMap() {}
+  // Make class noncopyable and nomovable.
+  OnnxBackendGraphMap(const OnnxBackendGraphMap&) = delete;
+  OnnxBackendGraphMap(OnnxBackendGraphMap&&) = delete;
+  OnnxBackendGraphMap operator=(const OnnxBackendGraphMap&) = delete;
+  OnnxBackendGraphMap operator=(OnnxBackendGraphMap&&) = delete;
+  SharedPtrBackendGraphInfo lookup(const std::string& key);
+  // If acquisition of graph_ptr fails then graph already exists. And the
+  // corresponding SharedPtrBackendGraphInfo is returned. Otherwise graph_ptr is
+  // inserted in the map and the wrapper SharedPtrBackendGraphInfo is
+  // returned.teebfhlbnheuk
+  SharedPtrBackendGraphInfo insert(
+      const std::string& key,
+      BackendGraphInfo graph);
+  void remove(const std::string& key);
+
+ private:
+  std::mutex backend_graph_map_lock_;
+  std::unordered_map<std::string, SharedPtrBackendGraphInfo> backend_graph_map_;
+};
+
+OnnxBackendGraphMap* getOnnxBackendGraphMap();
+} // namespace onnx
+} // namespace caffe2

--- a/caffe2/onnx/onnxifi_init.cc
+++ b/caffe2/onnx/onnxifi_init.cc
@@ -6,12 +6,12 @@
 
 namespace caffe2 {
 namespace onnx {
+
 onnxifi_library* initOnnxifiLibrary() {
   static std::once_flag once;
   static onnxifi_library core{};
   std::call_once(once, []() {
-    auto ret =
-        onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, nullptr, &core);
+    auto ret = onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, nullptr, &core);
     if (!ret) {
       CAFFE_THROW("Cannot load onnxifi lib");
     }

--- a/caffe2/onnx/onnxifi_init.h
+++ b/caffe2/onnx/onnxifi_init.h
@@ -4,6 +4,7 @@
 
 namespace caffe2 {
 namespace onnx {
+
 onnxifi_library* initOnnxifiLibrary();
-}
+} // namespace onnx
 } // namespace caffe2

--- a/caffe2/operators/onnxifi_op.h
+++ b/caffe2/operators/onnxifi_op.h
@@ -7,6 +7,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/onnx/onnxifi_graph_info.h"
 #include "caffe2/onnx/onnxifi_init.h"
 #include "caffe2/utils/string_utils.h"
 
@@ -27,6 +28,7 @@ class OnnxifiOp final : public Operator<Context> {
   OnnxifiOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws) {
     lib_ = onnx::initOnnxifiLibrary();
+    backend_graph_map_ptr_ = onnx::getOnnxBackendGraphMap();
     CAFFE_ENFORCE(lib_, "Cannot initialize ONNXIFI library");
     auto onnx_model_str =
         this->template GetSingleArgument<std::string>("onnx_model", "");
@@ -88,59 +90,13 @@ class OnnxifiOp final : public Operator<Context> {
     auto weight_descs = BuildInitializationList(
         &mapped_ws, &initializer_set, &weight_names, &weight_shapes);
 
-    // Build the Onnxifi engine
-    int idx = this->template GetSingleArgument<int>("backend_id", 0);
-    CAFFE_ENFORCE_EQ(
-        lib_->onnxGetBackendIDs(nullptr, &num_backends_),
-        ONNXIFI_STATUS_FALLBACK);
-    CAFFE_ENFORCE_GT(
-        num_backends_, 0, "At least 1 onnxifi backend should be available");
-    CAFFE_ENFORCE_LT(
-        idx,
-        num_backends_,
-        "Backend idx out of bound: ",
-        idx,
-        ", #backends: ",
-        num_backends_);
-    backend_ids_.resize(num_backends_);
-    CAFFE_ENFORCE_EQ(
-        lib_->onnxGetBackendIDs(backend_ids_.data(), &num_backends_),
-        ONNXIFI_STATUS_SUCCESS);
-
-    CAFFE_ENFORCE_EQ(
-        lib_->onnxInitBackend(
-            backend_ids_[idx], property_pointers.data(), &backend_),
-        ONNXIFI_STATUS_SUCCESS);
-    CAFFE_ENFORCE_EQ(
-        lib_->onnxInitGraph(
-            backend_,
-            nullptr,
-            onnx_model_str.size(),
-            (void*)(onnx_model_str.c_str()),
-            weight_descs.size(),
-            weight_descs.data(),
-            &graph_),
-        ONNXIFI_STATUS_SUCCESS);
+    BuildBackendAndGraph(property_pointers, onnx_model_str, weight_descs);
   }
 
   ~OnnxifiOp() {
-    if (graph_) {
-      if (lib_->onnxReleaseGraph(graph_) != ONNXIFI_STATUS_SUCCESS) {
-        LOG(ERROR) << "Error when calling onnxReleaseGraph";
-      }
-      graph_ = nullptr;
-    }
-    if (backend_) {
-      if (lib_->onnxReleaseBackend(backend_) != ONNXIFI_STATUS_SUCCESS) {
-        LOG(ERROR) << "Error when calling onnxReleaseBackend";
-      }
-      backend_ = nullptr;
-    }
-    for (unsigned i = 0; i < num_backends_; ++i) {
-      if (lib_->onnxReleaseBackendID(backend_ids_[i]) != ONNXIFI_STATUS_SUCCESS) {
-        LOG(ERROR) << "Error when calling onnxReleaseBackendID";
-      }
-    }
+    backend_graph_shared_ptr_.reset();
+
+    backend_graph_map_ptr_->remove(op_id_string_);
   }
 
   bool RunOnDevice() override;
@@ -167,6 +123,82 @@ class OnnxifiOp final : public Operator<Context> {
     property_list->push_back(ONNXIFI_BACKEND_PROPERTY_NONE);
   }
 
+  void BuildBackendAndGraph(
+      const std::vector<uint64_t>& property_pointers,
+      const std::string& onnx_model_str,
+      const std::vector<onnxTensorDescriptorV1>& weight_descs) {
+    op_id_string_ =
+        this->template GetSingleArgument<std::string>("net_pos", "");
+    auto net_id_string =
+        this->template GetSingleArgument<std::string>("model_id", "");
+    op_id_string_ += net_id_string;
+
+    backend_graph_shared_ptr_ = backend_graph_map_ptr_->lookup(op_id_string_);
+
+    if (backend_graph_shared_ptr_ == nullptr) {
+      // Build the Onnxifi engine
+      std::vector<onnxBackendID> backend_ids;
+      auto backend_index =
+          this->template GetSingleArgument<int>("backend_id", 0);
+      CAFFE_ENFORCE_EQ(
+          lib_->onnxGetBackendIDs(nullptr, &num_backends_),
+          ONNXIFI_STATUS_FALLBACK);
+      CAFFE_ENFORCE_GT(
+          num_backends_, 0, "At least 1 onnxifi backend should be available");
+      CAFFE_ENFORCE_LT(
+          backend_index,
+          num_backends_,
+          "Backend idx out of bound: ",
+          backend_index,
+          ", #backends: ",
+          num_backends_);
+      backend_ids.resize(num_backends_);
+      CAFFE_ENFORCE_EQ(
+          lib_->onnxGetBackendIDs(backend_ids.data(), &num_backends_),
+          ONNXIFI_STATUS_SUCCESS);
+
+      backend_id_ = backend_ids[backend_index];
+
+      CAFFE_ENFORCE_EQ(
+          lib_->onnxInitBackend(
+              backend_id_, property_pointers.data(), &backend_),
+          ONNXIFI_STATUS_SUCCESS);
+
+      // Release unused backend ids.
+      for (auto i = 0; i < num_backends_; ++i) {
+        if (i == backend_index) {
+          continue;
+        }
+        lib_->onnxReleaseBackendID(backend_ids[i]);
+      }
+      CAFFE_ENFORCE_EQ(
+          lib_->onnxInitGraph(
+              backend_,
+              nullptr,
+              onnx_model_str.size(),
+              (const void*)(onnx_model_str.c_str()),
+              weight_descs.size(),
+              weight_descs.data(),
+              &graph_),
+          ONNXIFI_STATUS_SUCCESS);
+      backend_graph_shared_ptr_ = backend_graph_map_ptr_->insert(
+          op_id_string_,
+          onnx::BackendGraphInfo(backend_id_, backend_, graph_, lib_));
+      // This checks if our insertion was successful or some other thread did
+      // the insert in the meantime.
+      if (backend_graph_shared_ptr_->backend_id != backend_id_ ||
+          backend_graph_shared_ptr_->backend != backend_ ||
+          backend_graph_shared_ptr_->graph != graph_) {
+        lib_->onnxReleaseBackendID(backend_id_);
+        lib_->onnxReleaseBackend(backend_);
+        lib_->onnxReleaseGraph(graph_);
+      }
+    }
+    backend_id_ = backend_graph_shared_ptr_->backend_id;
+    backend_ = backend_graph_shared_ptr_->backend;
+    graph_ = backend_graph_shared_ptr_->graph;
+  }
+
   std::vector<onnxTensorDescriptorV1> BuildInitializationList(
       Workspace* ws,
       std::unordered_set<std::string>* initialization_list,
@@ -175,10 +207,13 @@ class OnnxifiOp final : public Operator<Context> {
 
   // pointer to loaded onnxifi library
   onnxifi_library* lib_{nullptr};
+  onnx::OnnxBackendGraphMap* backend_graph_map_ptr_;
+  std::string op_id_string_;
 
-  std::vector<onnxBackendID> backend_ids_;
+  onnxBackendID backend_id_{nullptr};
   onnxBackend backend_{nullptr};
   onnxGraph graph_{nullptr};
+  onnx::SharedPtrBackendGraphInfo backend_graph_shared_ptr_;
   size_t num_backends_{0};
 
   // input/output descriptors

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -18,13 +18,17 @@ namespace caffe2 {
 namespace {
 
 const std::string kNetPos("net_pos");
+const std::string kNetId("model_id");
 constexpr size_t kBufferSize = 64;
 
 // TODO: We probably don't want use protobuf as annotation in the future.
 void AnnotateOpIndex(NetDef* net) {
   int i = 0;
+  auto net_id =
+      ArgumentHelper(*net).GetSingleArgument<std::string>("model_id", "");
   for (auto& op : *(net->mutable_op())) {
     AddArgument(kNetPos, i++, &op);
+    AddArgument(kNetId, net_id, &op);
   }
 }
 


### PR DESCRIPTION
Summary:
Implements single thead safe map enabling sharing of generated graph between
different ops.
Added model_id to every onnxified op to help create a unique id in the map.
Some formatting fix.

Differential Revision: D13663927
