### PR TITLE
Implement SparseAdagrad + SparseLengthsSumGradient in FP16

### DIFF
--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -159,6 +159,9 @@ inline void rowwise_adagrad_update_inlined(
   }
 }
 
+
+
+
 } // namespace internal
 
 // version with prefetching


### PR DESCRIPTION
Summary:
Implement fusion operator
SparseAdagradFusedWithSparseLengthsSumGradient for fp16

Templetize this code to support float as well as at::Half

adagrad_compute_prefetch was different from it's fp16 counterpart by one argument for the random number generator, this does not need to be exposed and can be abstracted into adagrad_compute_prefetch <float or Half>

Changed the template to take structs instead of inline functions, this should not have a performance impact because the compiler inlines it.

Changed the transformer to account for the engine
Implemented an FP16 version of this operator which uses stochastic quantization

WIP: commonizing the tests

Differential Revision: D13620665
