### PR TITLE
Stop pretending that TH headers are both C++ and C compatible.

### DIFF
--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -2,9 +2,7 @@
 
 #include <TH/THGeneral.h>
 
-#ifdef __cplusplus
 #include <ATen/Allocator.h>
-#endif
 
 #define TH_ALLOCATOR_MAPPED_SHARED 1
 #define TH_ALLOCATOR_MAPPED_SHAREDMEM 2
@@ -14,20 +12,13 @@
 #define TH_ALLOCATOR_MAPPED_FROMFD 32
 #define TH_ALLOCATOR_MAPPED_UNLINK 64
 
-#ifdef __cplusplus
 using THAllocator = at::Allocator;
-#else
-// struct at_THAllocator doesn't and will never exist, but we cannot name
-// the actual struct because it's a namespaced C++ thing
-typedef struct at_THAllocator THAllocator;
-#endif
 
 /* default malloc/free allocator. malloc and realloc raise an error (using
  * THError) on allocation failure.
  */
 TH_API THAllocator* getTHDefaultAllocator(void);
 
-#ifdef __cplusplus
 // Sentinel value/type to help distinguish the file descriptor constructor from
 // the non-file descriptor constructor
 enum WithFd { WITH_FD };
@@ -109,5 +100,3 @@ protected:
   void checkFlags();
   void initializeAlloc();
 };
-
-#endif // __cplusplus

--- a/aten/src/TH/THGeneral.h.in
+++ b/aten/src/TH/THGeneral.h.in
@@ -26,11 +26,7 @@
 #cmakedefine BLAS_F2C
 #cmakedefine BLAS_USE_CBLAS_DOT
 
-#ifdef __cplusplus
 # define TH_EXTERNC extern "C"
-#else
-# define TH_EXTERNC extern
-#endif
 
 // Note(jiayq): copied from ATen/core/Macros.h. Because internal build of TH
 // and ATen are not unified yet, we need to duplicate code for now. Long term

--- a/aten/src/TH/THHalf.h
+++ b/aten/src/TH/THHalf.h
@@ -1,15 +1,8 @@
 #ifndef TH_HALF_H
 #define TH_HALF_H
 
-#ifdef __cplusplus
 #include <ATen/core/Half.h>
-#endif
 
-#ifdef __cplusplus
 #define THHalf at::Half
-#else
-typedef struct at_Half at_Half;
-#define THHalf at_Half
-#endif
 
 #endif

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -2,10 +2,8 @@
 #define TH_GENERIC_FILE "TH/generic/THStorage.h"
 #else
 
-#ifdef __cplusplus
 #include <ATen/Allocator.h>
 #include <c10/core/StorageImpl.h>
-#endif
 
 /* on pourrait avoir un liste chainee
    qui initialise math, lab structures (or more).
@@ -23,12 +21,7 @@
 
 // Struct definition is moved to THStorage.hpp (so this file stays C compatible)
 
-#ifdef __cplusplus
 #define THStorage at::StorageImpl
-#else
-typedef struct at_Storage_Impl at_Storage_Impl;
-#define THStorage at_Storage_Impl
-#endif
 
 // These used to be distinct types; for some measure of backwards compatibility and documentation
 // alias these to the single THStorage type.
@@ -59,10 +52,8 @@ TH_API THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t siz
 
 TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
                                                THAllocator* allocator);
-#ifdef __cplusplus
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
     at::DataPtr&& data, ptrdiff_t size, at::Allocator* allocator);
-#endif
 
 /* should not differ with API */
 TH_API void THStorage_(setFlag)(THStorage *storage, const char flag);

--- a/aten/src/TH/generic/THTensor.h
+++ b/aten/src/TH/generic/THTensor.h
@@ -4,16 +4,9 @@
 
 /* a la lua? dim, storageoffset, ...  et les methodes ? */
 
-#ifdef __cplusplus
 #include <c10/core/TensorImpl.h>
-#endif
 
-#ifdef __cplusplus
 #define THTensor at::TensorImpl
-#else
-typedef struct at_Tensor_Impl at_Tensor_Impl;
-#define THTensor at_Tensor_Impl
-#endif
 
 // These used to be distinct types; for some measure of backwards compatibility and documentation
 // alias these to the single THTensor type.

--- a/aten/src/THC/THCAllocator.h
+++ b/aten/src/THC/THCAllocator.h
@@ -5,7 +5,6 @@
 
 // IPC doesn't support (re)allocation
 
-#ifdef __cplusplus
 class CAFFE2_API THCIpcDeleter {
  public:
   THCIpcDeleter(std::shared_ptr<void> basePtr);
@@ -14,6 +13,5 @@ class CAFFE2_API THCIpcDeleter {
 private:
   std::shared_ptr<void> basePtr_;
 };
-#endif
 
 #endif

--- a/aten/src/THC/THCCachingAllocator.h
+++ b/aten/src/THC/THCCachingAllocator.h
@@ -1,14 +1,10 @@
 #ifndef THC_DEVICE_ALLOCATOR_INC
 #define THC_DEVICE_ALLOCATOR_INC
 
-#ifdef __cplusplus
 #include <c10/cuda/CUDAStream.h>
 #include <ATen/cuda/ATenCUDAGeneral.h>
-#endif
 
-#if (__cplusplus >= 201103L) || (defined(_MSC_VER) && defined(__cplusplus))
 #include <mutex>
-#endif
 
 #include <THC/THCGeneral.h>
 
@@ -16,9 +12,7 @@ THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
 THC_API void THCCachingAllocator_emptyCache(void);
 THC_API void THCCachingAllocator_cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);
-#ifdef __cplusplus
 THC_API void THCCachingAllocator_recordStream(void *ptr, at::cuda::CUDAStream stream);
-#endif
 THC_API uint64_t THCCachingAllocator_currentMemoryAllocated(int device);
 THC_API uint64_t THCCachingAllocator_maxMemoryAllocated(int device);
 THC_API void     THCCachingAllocator_resetMaxMemoryAllocated(int device);
@@ -26,9 +20,7 @@ THC_API uint64_t THCCachingAllocator_currentMemoryCached(int device);
 THC_API uint64_t THCCachingAllocator_maxMemoryCached(int device);
 THC_API void     THCCachingAllocator_resetMaxMemoryCached(int device);
 
-#if (__cplusplus >= 201103L) || (defined(_MSC_VER) && defined(__cplusplus))
 THC_API std::mutex* THCCachingAllocator_getCudaFreeMutex();
-#endif
 
 AT_CUDA_API std::shared_ptr<void> THCCaching_CUDAIpcDevptr(std::string handle);
 #endif

--- a/aten/src/THC/THCCachingHostAllocator.h
+++ b/aten/src/THC/THCCachingHostAllocator.h
@@ -4,9 +4,7 @@
 #include <THC/THCGeneral.h>
 
 
-#ifdef __cplusplus
 #include <c10/cuda/CUDAStream.h>
-#endif
 
 //
 // A caching allocator for CUDA host allocations (pinned memory).
@@ -27,9 +25,7 @@ THC_API THAllocator* getTHCCachingHostAllocator(void);
 
 // Records an event in the specified stream. The allocation 'ptr' will not be
 // re-used until the event has occurred.
-#ifdef __cplusplus
 THC_API cudaError_t THCCachingHostAllocator_recordEvent(void *ptr, at::cuda::CUDAStream stream);
-#endif
 
 // Releases cached pinned memory allocations via cudaHostFree
 THC_API void THCCachingHostAllocator_emptyCache(void);

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -8,9 +8,7 @@
 #undef log2
 #undef expm1
 
-#ifdef __cplusplus
 #include <c10/cuda/CUDAStream.h>
-#endif
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -20,11 +18,7 @@
 
 #cmakedefine USE_MAGMA
 
-#ifdef __cplusplus
 # define THC_EXTERNC extern "C"
-#else
-# define THC_EXTERNC extern
-#endif
 
 #ifdef _WIN32
 # if defined(ATen_cuda_EXPORTS) || defined(caffe2_gpu_EXPORTS) || defined(CAFFE2_CUDA_BUILD_MAIN_LIB)
@@ -105,9 +99,7 @@ THC_API void __THCusparseCheck(cusparseStatus_t status, const char *file, const 
 THC_API void* THCudaMalloc(THCState *state, size_t size);
 THC_API void THCudaFree(THCState *state, void* ptr);
 
-#ifdef __cplusplus
 at::DataPtr THCudaHostAlloc(THCState *state, size_t size);
-#endif
 
 THC_API void THCudaHostRecord(THCState *state, void *ptr);
 

--- a/aten/src/THC/generic/THCStorage.h
+++ b/aten/src/THC/generic/THCStorage.h
@@ -31,14 +31,12 @@ THC_API THCStorage* THCStorage_(newWithSize3)(THCState *state, scalar_t, scalar_
 THC_API THCStorage* THCStorage_(newWithSize4)(THCState *state, scalar_t, scalar_t, scalar_t, scalar_t);
 THC_API THCStorage* THCStorage_(newWithMapping)(THCState *state, const char *filename, ptrdiff_t size, int shared);
 
-#ifdef __cplusplus
 THC_API THCStorage* THCStorage_(newWithAllocator)(
   THCState *state, ptrdiff_t size,
   at::Allocator* allocator);
 THC_API THCStorage* THCStorage_(newWithDataAndAllocator)(
   THCState *state, at::DataPtr&& data, ptrdiff_t size,
   at::Allocator* allocator);
-#endif
 
 THC_API void THCStorage_(setFlag)(THCState *state, THCStorage *storage, const char flag);
 THC_API void THCStorage_(clearFlag)(THCState *state, THCStorage *storage, const char flag);

--- a/aten/src/THC/generic/THCTensorSort.h
+++ b/aten/src/THC/generic/THCTensorSort.h
@@ -4,17 +4,10 @@
 
 /* Performs an in-place sort of (keys, values). Only works for slice sizes
    <= 2048 at the moment (slice size == size of keys/values dim `dim`) */
-#ifdef __cplusplus
 THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
                                              THCTensor* keys,
                                              THCudaLongTensor* values,
                                              int dim, bool dir);
-#else
-THC_API void THCTensor_(sortKeyValueInplace)(THCState* state,
-                                             THCTensor* keys,
-                                             THCudaLongTensor* values,
-                                             int dim, int order);
-#endif
 
 /* Performs an out-of-place sort of `input`, returning the per-slice indices
    in `indices` and the sorted values in `sorted` */


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16059 Stop pretending that TH headers are both C++ and C compatible.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13686580/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16061 Rename away uses of THAllocator and THCDeviceAllocator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13686869/)

Just deleted all __cplusplus ifdef guards; we only ever use
these headers in C++ contexts.

Differential Revision: [D13686580](https://our.internmc.facebook.com/intern/diff/D13686580/)