### PR TITLE
Rename away uses of THAllocator and THCDeviceAllocator

### DIFF
--- a/aten/src/ATen/CPUFixedAllocator.h
+++ b/aten/src/ATen/CPUFixedAllocator.h
@@ -25,7 +25,7 @@ static cpu_fixed_free(void * state, void * allocation) {
     delete on_release;
 }
 
-static THAllocator CPU_fixed_allocator =
+static Allocator CPU_fixed_allocator =
   { cpu_fixed_malloc, cpu_fixed_realloc, cpu_fixed_free };
 
 }

--- a/aten/src/TH/THAllocator.h
+++ b/aten/src/TH/THAllocator.h
@@ -12,12 +12,10 @@
 #define TH_ALLOCATOR_MAPPED_FROMFD 32
 #define TH_ALLOCATOR_MAPPED_UNLINK 64
 
-using THAllocator = at::Allocator;
-
 /* default malloc/free allocator. malloc and realloc raise an error (using
  * THError) on allocation failure.
  */
-TH_API THAllocator* getTHDefaultAllocator(void);
+TH_API c10::Allocator* getTHDefaultAllocator(void);
 
 // Sentinel value/type to help distinguish the file descriptor constructor from
 // the non-file descriptor constructor

--- a/aten/src/TH/generic/THStorage.h
+++ b/aten/src/TH/generic/THStorage.h
@@ -51,7 +51,7 @@ TH_API THStorage* THStorage_(newWithSize4)(scalar_t, scalar_t, scalar_t, scalar_
 TH_API THStorage* THStorage_(newWithMapping)(const char *filename, ptrdiff_t size, int flags);
 
 TH_API THStorage* THStorage_(newWithAllocator)(ptrdiff_t size,
-                                               THAllocator* allocator);
+                                               c10::Allocator* allocator);
 TH_API THStorage* THStorage_(newWithDataAndAllocator)(
     at::DataPtr&& data, ptrdiff_t size, at::Allocator* allocator);
 

--- a/aten/src/THC/THCCachingAllocator.h
+++ b/aten/src/THC/THCCachingAllocator.h
@@ -8,7 +8,7 @@
 
 #include <THC/THCGeneral.h>
 
-THC_API THCDeviceAllocator* THCCachingAllocator_get(void);
+THC_API c10::Allocator* THCCachingAllocator_get(void);
 THC_API void THCCachingAllocator_emptyCache(void);
 THC_API void THCCachingAllocator_cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
 THC_API void* THCCachingAllocator_getBaseAllocation(void *ptr, size_t *size);

--- a/aten/src/THC/THCCachingHostAllocator.h
+++ b/aten/src/THC/THCCachingHostAllocator.h
@@ -21,7 +21,7 @@
 // Note that this allocator does not split larger allocations into smaller
 // blocks, unlike the caching device allocator.
 //
-THC_API THAllocator* getTHCCachingHostAllocator(void);
+THC_API c10::Allocator* getTHCCachingHostAllocator(void);
 
 // Records an event in the specified stream. The allocation 'ptr' will not be
 // re-used until the event has occurred.

--- a/aten/src/THC/THCGeneral.cpp
+++ b/aten/src/THC/THCGeneral.cpp
@@ -178,7 +178,7 @@ struct THCRNGState* THCState_getRngState(THCState *state)
   return state->rngState;
 }
 
-THAllocator* THCState_getCudaHostAllocator(THCState* state)
+c10::Allocator* THCState_getCudaHostAllocator(THCState* state)
 {
   return state->cudaHostAllocator;
 }
@@ -381,7 +381,7 @@ void __THCusparseCheck(cusparseStatus_t status, const char *file, const int line
 void* THCudaMalloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
-  THCDeviceAllocator* allocator = state->cudaDeviceAllocator;
+  c10::Allocator* allocator = state->cudaDeviceAllocator;
   return allocator->raw_allocate(size);
 }
 
@@ -392,7 +392,7 @@ void THCudaFree(THCState *state, void* ptr) {
 at::DataPtr THCudaHostAlloc(THCState *state, size_t size)
 {
   THCudaCheck(cudaGetLastError());
-  THAllocator* allocator = state->cudaHostAllocator;
+  c10::Allocator* allocator = state->cudaHostAllocator;
   return allocator->allocate(size);
 }
 
@@ -405,7 +405,7 @@ void THCudaHostRecord(THCState *state, void *ptr) {
 cudaError_t THCudaMemGetInfo(THCState *state,  size_t* freeBytes, size_t* totalBytes, size_t* largestBlock)
 {
   size_t cachedBytes = 0;
-  THCDeviceAllocator* allocator = state->cudaDeviceAllocator;
+  c10::Allocator* allocator = state->cudaDeviceAllocator;
 
   *largestBlock = 0;
   /* get info from CUDA first */

--- a/aten/src/THC/THCGeneral.h.in
+++ b/aten/src/THC/THCGeneral.h.in
@@ -46,8 +46,6 @@ struct THCRNGState;  /* Random number generator state. */
 typedef struct THCState THCState;
 struct THCState;
 
-typedef THAllocator THCDeviceAllocator;
-
 typedef struct _THCCudaResourcesPerDevice {
   /* cuBLAS handle is lazily initialized */
   cublasHandle_t blasHandle;
@@ -68,7 +66,7 @@ THC_API void THCudaShutdown(THCState* state);
 THC_API int THCState_getPeerToPeerAccess(THCState* state, int dev, int devToAccess);
 
 THC_API struct THCRNGState* THCState_getRngState(THCState* state);
-THC_API THAllocator* THCState_getCudaHostAllocator(THCState* state);
+THC_API c10::Allocator* THCState_getCudaHostAllocator(THCState* state);
 
 THC_API void THCMagma_init(THCState *state);
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -183,7 +183,7 @@ PyObject * THCPModule_initialSeed(PyObject *_unused)
 PyObject * THCPModule_cudaHostAllocator(PyObject *_unused)
 {
   HANDLE_TH_ERRORS
-  THAllocator* allocator = THCState_getCudaHostAllocator(state);
+  c10::Allocator* allocator = THCState_getCudaHostAllocator(state);
   return PyLong_FromVoidPtr(allocator);
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/generic/Storage.cpp
+++ b/torch/csrc/generic/Storage.cpp
@@ -40,14 +40,14 @@ static PyObject * THPStorage_(pynew)(PyTypeObject *type, PyObject *args, PyObjec
 
   THPStoragePtr self((THPStorage *)type->tp_alloc(type, 0));
   THPUtils_assert(self, "failed to allocate a " THPStorageStr " object");
-  THAllocator* allocator = nullptr;
+  c10::Allocator* allocator = nullptr;
 
   // Internally we allow constructing with a keywoard only argument cdata
   if (kwargs != nullptr) {
     PyObject *allocator_ptr = PyDict_GetItemString(kwargs, "allocator");
     if (allocator_ptr) {
       THPUtils_assert(THPUtils_checkLong(allocator_ptr), "invalid allocator");
-      allocator = (THAllocator*) PyLong_AsVoidPtr(allocator_ptr);
+      allocator = static_cast<c10::Allocator*>(PyLong_AsVoidPtr(allocator_ptr));
       PyDict_DelItemString(kwargs, "allocator");
     }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16059 Stop pretending that TH headers are both C++ and C compatible.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13686580/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16061 Rename away uses of THAllocator and THCDeviceAllocator**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13686869/)

I discovered I needed to delete these names in preparation of moving
THCCachingAllocator to c10_cuda; might as well also fix all the other
sites too.

Differential Revision: [D13686869](https://our.internmc.facebook.com/intern/diff/D13686869/)