### PR TITLE
Add the support for stable ONNX opsets in exporter

### DIFF
--- a/test/onnx/expect/TestOperators.test_stable_opset.expect
+++ b/test/onnx/expect/TestOperators.test_stable_opset.expect
@@ -1,0 +1,63 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "0.4"
+graph {
+  node {
+    input: "0"
+    input: "1"
+    output: "2"
+    op_type: "Add"
+  }
+  name: "torch-jit-export"
+  input {
+    name: "0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -534,6 +534,12 @@ class TestOperators(TestCase):
         x = torch.tensor([[[2., 2.], [1., 0.]], [[0., 0.], [1., 1.]]], requires_grad=True)
         self.assertONNX(lambda x: torch.nonzero(x), x)
 
+    def test_stable_opset(self):
+        x = torch.randn(2, 3).float()
+        y = torch.randn(2, 3).float()
+        self.assertONNX(lambda x, y: x + y, (x, y), opset_version=9)
+
+
 if __name__ == '__main__':
     no_onnx_dep_flag = '--no-onnx'
     _onnx_dep = no_onnx_dep_flag not in common.UNITTEST_ARGS

--- a/test/onnx/test_pytorch_helper.py
+++ b/test/onnx/test_pytorch_helper.py
@@ -64,5 +64,6 @@ class TestCaffe2Backend(unittest.TestCase):
 
         np.testing.assert_almost_equal(torch_out.data.cpu().numpy(), c2_out, decimal=3)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -175,7 +175,7 @@ def _try_get_scalar_type(*args):
 # ONNX operator version
 # ---------------------------------------------------------------------
 
-# READ ME BEFORE EDITING _onnx_opset_version:
+# READ ME BEFORE EDITING _default_onnx_opset_version:
 #
 # The variable below controls which ONNX operator set version we are
 # targeting.   THIS VARIABLE HAS SEMANTIC EFFECT!  Say a breaking
@@ -192,7 +192,19 @@ def _try_get_scalar_type(*args):
 # increasing this number.  This includes symbolic definitions NOT in this
 # file, so grep for "OpName" (with quotes)
 
-_onnx_opset_version = 9
+_default_onnx_opset_version = 9
+_export_onnx_opset_version = _default_onnx_opset_version
+_onnx_stable_opsets = [9]
+
+
+def _set_opset_version(opset_version):
+    global _export_onnx_opset_version
+    if opset_version == _export_onnx_opset_version:
+        return
+    if opset_version in _onnx_stable_opsets:
+        _export_onnx_opset_version = opset_version
+        return
+    raise ValueError("Unsupported ONNX opset version: " + str(opset_version))
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Since ONNX 1.4 has been released, the stable opset will be 9. And I will bump up the default opset to 10 in a different PR. The _export_onnx_opset_version will be used to determine the opset in symbolics, and users can set it as parameter in export() and export_to_pretty_string().