### PR TITLE
Raise CalledProcessError when torch.distributed launch process not return 0

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -213,6 +213,9 @@ def main():
 
     for process in processes:
         process.wait()
+        if process.returncode != 0:
+            raise subprocess.CalledProcessError(returncode=process.returncode,
+                                                cmd=process.args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`torch.distributed.launch.py` will not raise error when `subprocess.Popen` is not return 0.
For better debugging it should always raise an error if processes launched have unusual behavior