### PR TITLE
Fix gather_op to handle various input data types

### DIFF
--- a/caffe2/operators/batch_gather_ops.cu
+++ b/caffe2/operators/batch_gather_ops.cu
@@ -17,7 +17,7 @@ template <>
 template <typename TInd>
 bool BatchGatherOp<CUDAContext>::DoRunWithType() {
     return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,
-           long,float,double,GenericTensorImplementation>,
+           uint8_t,at::Half,long,float,double,GenericTensorImplementation>,
            TInd>::call(this, Input(DATA));
 }
 

--- a/caffe2/operators/batch_gather_ops.cu
+++ b/caffe2/operators/batch_gather_ops.cu
@@ -16,8 +16,16 @@ bool BatchGatherOp<CUDAContext>::RunOnDevice() {
 template <>
 template <typename TInd>
 bool BatchGatherOp<CUDAContext>::DoRunWithType() {
+    return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,
+           long,float,double,GenericTensorImplementation>,
+           TInd>::call(this, Input(DATA));
+}
+
+template <>
+template <typename TInd, typename TData>
+bool BatchGatherOp<CUDAContext>::DoRunWithType2() {
   // BatchGather is a special-case of Gather with Axis = 1, wrap = false.
-  return gather_helper::gather_impl_cuda<TInd>(
+  return gather_helper::gather_impl_cuda<TInd,TData>(
       this, DATA, INDICES, 0, 1, false);
 }
 

--- a/caffe2/operators/batch_gather_ops.h
+++ b/caffe2/operators/batch_gather_ops.h
@@ -21,11 +21,28 @@ class BatchGatherOp final : public Operator<Context> {
   }
 
   template <typename TInd>
-  bool DoRunWithType() {
-    // BatchGather is a special-case of Gather with Axis = 1.
-    return gather_helper::gather_impl<TInd, Context>(
-        this, DATA, INDICES, 0, 1, false);
-  }
+      bool DoRunWithType() {
+          return DispatchHelper<
+              TensorTypes2<int8_t,int16_t,int32_t,int64_t,long,float,double,
+              GenericTensorImplementation>,TInd>::call(this, Input(DATA));
+      }
+
+  template <typename TInd, typename TData>
+      bool DoRunWithType2() {
+          // BatchGather is a special-case of Gather with Axis = 1.
+          return gather_helper::gather_impl<TInd, Context>(
+                  this, DATA, INDICES, 0, 1, false);
+      }
+
+  template <typename TInd>
+      bool DoRunWithOtherType2() {
+          CAFFE_THROW(
+                  "Gather is not implemented on tensor of type ",
+                  Input(DATA).meta().name(),
+                  " Consider adding it a type in the list DispatchHelper or implementing "
+                  "a generic version (which won't work for duplicated indices though)");
+      }
+
   INPUT_TAGS(DATA, INDICES);
 };
 

--- a/caffe2/operators/batch_gather_ops.h
+++ b/caffe2/operators/batch_gather_ops.h
@@ -23,8 +23,9 @@ class BatchGatherOp final : public Operator<Context> {
   template <typename TInd>
       bool DoRunWithType() {
           return DispatchHelper<
-              TensorTypes2<int8_t,int16_t,int32_t,int64_t,long,float,double,
-              GenericTensorImplementation>,TInd>::call(this, Input(DATA));
+              TensorTypes2<int8_t,int16_t,int32_t,int64_t,long,
+              uint8_t,at::Half,float,double,GenericTensorImplementation>,
+              TInd>::call(this, Input(DATA));
       }
 
   template <typename TInd, typename TData>

--- a/caffe2/operators/gather_op.cu
+++ b/caffe2/operators/gather_op.cu
@@ -13,8 +13,15 @@ bool GatherOp<CUDAContext>::RunOnDevice() {
 template <>
 template <typename Index>
 bool GatherOp<CUDAContext>::DoRunWithType() {
+    return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,long,float,double,
+           GenericTensorImplementation>,Index>::call(this, Input(DATA));
+}
+
+template <>
+template <typename Index, typename TData>
+bool GatherOp<CUDAContext>::DoRunWithType2() {
   // Use shared implementation with BatchGather
-  return gather_helper::gather_impl_cuda<Index>(
+  return gather_helper::gather_impl_cuda<Index,TData>(
       this, DATA, INDICES, 0, axis_, wrap_indices_);
 }
 

--- a/caffe2/operators/gather_op.cu
+++ b/caffe2/operators/gather_op.cu
@@ -13,8 +13,9 @@ bool GatherOp<CUDAContext>::RunOnDevice() {
 template <>
 template <typename Index>
 bool GatherOp<CUDAContext>::DoRunWithType() {
-    return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,long,float,double,
-           GenericTensorImplementation>,Index>::call(this, Input(DATA));
+    return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,
+           uint8_t,at::Half,long,float,double,GenericTensorImplementation>,
+           Index>::call(this, Input(DATA));
 }
 
 template <>

--- a/caffe2/operators/gather_op.h
+++ b/caffe2/operators/gather_op.h
@@ -177,7 +177,7 @@ class GatherOp : public Operator<Context> {
   template <typename Index>
       bool DoRunWithType() {
           return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,
-                 long,float,double,GenericTensorImplementation>,
+                 uint8_t,at::Half,long,float,double,GenericTensorImplementation>,
                  Index>::call(this, Input(DATA));
       }
 

--- a/caffe2/operators/gather_op.h
+++ b/caffe2/operators/gather_op.h
@@ -53,7 +53,7 @@ static void check_indexarray_range(
 }
 
 // Actual gather implementation - resizes output and copies indexed data.
-template <typename Index, typename Context>
+template <typename Index, typename TData, typename Context>
 static bool gather_impl(
     Operator<Context>* op,
     int dataIdx,
@@ -175,10 +175,26 @@ class GatherOp : public Operator<Context> {
   }
 
   template <typename Index>
-  bool DoRunWithType() {
-    return gather_helper::gather_impl<Index, Context>(
+      bool DoRunWithType() {
+          return DispatchHelper<TensorTypes2<int8_t,int16_t,int32_t,int64_t,
+                 long,float,double,GenericTensorImplementation>,
+                 Index>::call(this, Input(DATA));
+      }
+
+  template <typename Index, typename TData>
+      bool DoRunWithType2() {
+          return gather_helper::gather_impl<Index,Context>(
         this, DATA, INDICES, 0, axis_, wrap_indices_);
-  }
+      }
+
+  template <typename TIndex>
+      bool DoRunWithOtherType2() {
+          CAFFE_THROW(
+                  "Gather is not implemented on tensor of type ",
+                  Input(DATA).meta().name(),
+                  " Consider adding it a type in the list DispatchHelper or implementing "
+                  "a generic version (which won't work for duplicated indices though)");
+      }
 
   INPUT_TAGS(DATA, INDICES);
 

--- a/caffe2/python/operator_test/gather_test.py
+++ b/caffe2/python/operator_test/gather_test.py
@@ -15,7 +15,7 @@ import unittest
 device_opts = caffe2_pb2.DeviceOption()
 
 class TestGatherOpCPU(serial.SerializedTestCase):
-    device_type = caffe2_pb2.CPU
+    device_type = caffe2_pb2.PROTO_CPU
 
     def setUp(self):
            device_opts.device_type = self.device_type
@@ -74,7 +74,7 @@ if(workspace.has_gpu_support):
     TestGatherOpGPU = type(str("TestTestGatherOpGPU"),
                               (unittest.TestCase,),
                               dict(TestGatherOpCPU.__dict__,
-                                  device_type = caffe2_pb2.CUDA))
+                                  device_type = workspace.GpuDeviceType))
 
 
 if __name__ == "__main__":

--- a/caffe2/python/operator_test/gather_test.py
+++ b/caffe2/python/operator_test/gather_test.py
@@ -30,8 +30,8 @@ class TestGatherOpCPU(serial.SerializedTestCase):
             device_option=device_opts
             )
         workspace.ResetWorkspace()
-        workspace.FeedBlob("DATA", data.astype(dtype))
-        workspace.FeedBlob("INDICES", inds.astype(np.int32))
+        workspace.FeedBlob("DATA", data.astype(dtype),device_opts)
+        workspace.FeedBlob("INDICES", inds.astype(np.int32),device_opts)
         workspace.RunOperatorOnce(op)
         expected = np.take(data,inds);
         np.testing.assert_array_equal(expected,workspace.FetchBlob("OUTPUT"))

--- a/caffe2/python/operator_test/gather_test.py
+++ b/caffe2/python/operator_test/gather_test.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import numpy as np
+
+from caffe2.python import core, workspace
+from caffe2.proto import caffe2_pb2
+
+from hypothesis import given
+import caffe2.python.hypothesis_test_util as hu
+import caffe2.python.serialized_test.serialized_test_util as serial
+import unittest
+
+device_opts = caffe2_pb2.DeviceOption()
+
+class TestGatherOpCPU(serial.SerializedTestCase):
+    device_type = caffe2_pb2.CPU
+
+    def setUp(self):
+           device_opts.device_type = self.device_type
+
+    def run_gather(self, data, inds, dtype):
+        op = core.CreateOperator(
+            "Gather",
+            ["DATA", "INDICES"],
+            ["OUTPUT"],
+            "test gather operation",
+            control_input = None,
+            device_option=device_opts
+            )
+        workspace.ResetWorkspace()
+        workspace.FeedBlob("DATA", data.astype(dtype))
+        workspace.FeedBlob("INDICES", inds.astype(np.int32))
+        workspace.RunOperatorOnce(op)
+        expected = np.take(data,inds);
+        np.testing.assert_array_equal(expected,workspace.FetchBlob("OUTPUT"))
+
+    def test_gather_int8(self):
+        data = np.array([1, 2, 3, 4],dtype=np.int8)
+        inds = np.array([3,2,1,0])
+        self.run_gather(data,inds,np.int8)
+
+    def test_gather_float64(self):
+        data = np.array([1.3482698511467371e+308, -1.3482698511467371e+308,
+                         0.9999999999999999, 5e-324],dtype=np.float64)
+        inds = np.array([3,0,1,2])
+        self.run_gather(data,inds,np.float64)
+
+    def test_gather_double(self):
+        data = np.array([1.3482698511467371e+308, -1.3482698511467371e+308,
+                         0.9999999999999999, 5e-324],dtype=np.double)
+        inds = np.array([3,0,1,2])
+        self.run_gather(data,inds,np.double)
+
+    def test_gather_fp16(self):
+        data = np.array([1.01,0.99951,65504,0.000061035],dtype=np.float16)
+        inds = np.array([3,0,1,2])
+        self.run_gather(data,inds,np.float16)
+
+    def test_gather_long(self):
+        data = np.array([1.01,0.99951,65504,0.000061035],dtype=np.long)
+        inds = np.array([3,0,1,2])
+        self.run_gather(data,inds,np.long)
+
+    def test_gather_float(self):
+        data = np.array([1.4012984645e-45,3.4028234664e+38,
+                         0.9999999404,1.0000001192],dtype=np.float)
+        inds = np.array([3,0,1,2])
+        self.run_gather(data,inds,np.float)
+
+# run same tests on GPU if available
+if(workspace.has_gpu_support):
+    TestGatherOpGPU = type(str("TestTestGatherOpGPU"),
+                              (unittest.TestCase,),
+                              dict(TestGatherOpCPU.__dict__,
+                                  device_type = caffe2_pb2.CUDA))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
-GPU based gather operations return incorrect results if
 the input data type is not int32t. Attempts to use other
 data types in the input tensor results in incorrect or
 inconsistent results. This commit modifies the gather
 operation to handle the following data types:
    - int8_t
    - int16_t
    - int32_t
    - int64_t
    - long
    - float
    - double

