### PR TITLE
Remove redundant includes from ir.{h,cpp}.

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1,10 +1,8 @@
 #include <torch/csrc/jit/ir.h>
 
-#include <torch/csrc/autograd/function.h>
 #include <torch/csrc/jit/assertions.h>
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/operator.h>
-#include <torch/csrc/jit/passes/alias_analysis.h>
 #include <torch/csrc/jit/passes/python_print.h>
 #include <torch/csrc/jit/script/schema_matching.h>
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -11,15 +11,12 @@
 #include <torch/csrc/jit/named_value.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/scope.h>
-#include <torch/csrc/jit/source_location.h>
-#include <torch/csrc/jit/source_range.h>
 #include <torch/csrc/jit/type.h>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/utils/disallow_copy.h>
 #include <torch/csrc/utils/functional.h>
 #include <torch/csrc/utils/object_ptr.h>
-#include <torch/csrc/utils/python_stub.h>
 
 #include <ATen/ATen.h>
 #include <c10/util/ArrayRef.h>


### PR DESCRIPTION
Test Plan:
test_jit.py

