### PR TITLE
add a constexpr in c10::Half

### DIFF
--- a/c10/util/Half.cpp
+++ b/c10/util/Half.cpp
@@ -4,6 +4,8 @@
 
 namespace c10 {
 
+constexpr Half::from_bits_t Half::from_bits;
+
 static_assert(
     std::is_standard_layout<Half>::value,
     "c10::Half must be standard layout.");


### PR DESCRIPTION
Debug build generates references which are not resolved otherwise

as recognized by @dlibenzi