### PR TITLE
Potential fix for model inference crash on Win10 (#15919)

### DIFF
--- a/torch/csrc/jit/stack.h
+++ b/torch/csrc/jit/stack.h
@@ -65,9 +65,7 @@ static inline void pop(Stack& stack, Types&... args) {
 }
 template <typename... Types>
 static inline void push(Stack& stack, Types&&... args) {
-  constexpr size_t N = sizeof...(args);
-  int result[N] = {(stack.emplace_back(std::forward<Types>(args)), 0)...};
-  (void)result;
+	std::initializer_list<int>{(stack.emplace_back(std::forward<Types>(args)), 0)...};
 }
 
 // The packer here is carefully written not to make any unnecessary


### PR DESCRIPTION
Please refer to issue #15919

