### PR TITLE
respect grad guard for torch.jit._fork and torch.jit._wait

### DIFF
--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/autograd/edge.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
+#include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/assertions.h>
@@ -729,7 +730,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         // the current thread will continue running before it suspends.
         InterpreterState state(intrusive_from_this());
         e.future->addCallback([state]() {
-          c10::global_work_queue().run(InterpreterContinuation(state, Stack()));
+          c10::global_work_queue().run(InterpreterContinuation(state, Stack(),
+              autograd::GradMode::is_enabled()));
         });
 
         return true;
@@ -880,5 +882,10 @@ c10::intrusive_ptr<Future> InterpreterState::getFuture() {
 InterpreterState::InterpreterState(
     c10::intrusive_ptr<c10::intrusive_ptr_target> pImpl_)
     : pImpl(std::move(pImpl_)) {}
+
+void InterpreterContinuation::operator()() {
+  autograd::AutoGradMode grad_mode(grad_mode_enabled);
+  state.runAsync(stack);
+}
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -73,16 +73,15 @@ struct Suspend : public std::exception {
 };
 
 struct InterpreterContinuation {
-  InterpreterContinuation(InterpreterState state_, Stack stack_)
-      : state(state_), stack(std::move(stack_)) {}
+  InterpreterContinuation(InterpreterState state_, Stack stack_, bool grad_mode_enabled_)
+      : state(state_), stack(std::move(stack_)), grad_mode_enabled(grad_mode_enabled_) {}
 
-  void operator()() {
-    state.runAsync(stack);
-  }
+  void operator()();
 
  private:
   InterpreterState state;
   Stack stack;
+  bool grad_mode_enabled;
 };
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -810,7 +810,8 @@ RegisterOperators reg({
             InterpreterState forked_interprester(code);
             InterpreterContinuation continuation(
                 forked_interprester,
-                Stack(stack.end() - n_inputs, stack.end()));
+                Stack(stack.end() - n_inputs, stack.end()),
+                autograd::GradMode::is_enabled());
             drop(stack, n_inputs);
 
             push(stack, forked_interprester.getFuture());


### PR DESCRIPTION
Summary:
respect grad guard for torch.jit._fork and torch.jit._wait.

Verified that the test failed without the fix, and pass with the fix.

Ideally I would like to enable and disable grad inside the forked function.
It doesn't seems like it's supported at this moment. This code handles that
as well. 

D13708374
