### PR TITLE
Exclude pyi from flake8 checks.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
 ignore = E203,E305,E402,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504
-exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install
+exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install,*.pyi


### PR DESCRIPTION
Idiomatic pyi files will fail with Python 2 flake8 even
though they would work with mypy.  This is because pyi
files generally use Python 3 only syntax.  No point
in linting them.

There are currently no pyi files checked in, this is purely
a prophylactic measure.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

