### PR TITLE
Remove ATen/Half.h and ATen/core/Half.h forwarding headers.

### DIFF
--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <ATen/Config.h>
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 
 // Defines the accumulation type for a scalar type.
 // Example:

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/Type.h>
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <c10/util/Exception.h>
 
 #define AT_PRIVATE_CASE_TYPE(enum_type, type, ...) \

--- a/aten/src/ATen/Half.h
+++ b/aten/src/ATen/Half.h
@@ -1,2 +1,0 @@
-#pragma once
-#include <ATen/core/Half.h>

--- a/aten/src/ATen/core/Half.h
+++ b/aten/src/ATen/core/Half.h
@@ -1,2 +1,0 @@
-#pragma once
-#include <c10/util/Half.h>

--- a/aten/src/ATen/cuda/CUDATensorMethods.cuh
+++ b/aten/src/ATen/cuda/CUDATensorMethods.cuh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/Tensor.h>
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/aten/src/ATen/templates/SparseTypeDerived.cpp
+++ b/aten/src/ATen/templates/SparseTypeDerived.cpp
@@ -13,7 +13,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/Utils.h>
 #include <ATen/WrapDimUtils.h>
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/Optional.h>
 

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -15,7 +15,7 @@ $storage_tensor_headers
 #include <ATen/NativeFunctions.h>
 #include <ATen/Utils.h>
 #include <ATen/WrapDimUtils.h>
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/Optional.h>

--- a/aten/src/TH/THHalf.h
+++ b/aten/src/TH/THHalf.h
@@ -1,7 +1,7 @@
 #ifndef TH_HALF_H
 #define TH_HALF_H
 
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 
 #define THHalf at::Half
 

--- a/caffe2/core/types.h
+++ b/caffe2/core/types.h
@@ -9,7 +9,7 @@
 #include "caffe2/core/logging.h"
 #include <c10/util/typeid.h>
 #include "caffe2/proto/caffe2_pb.h"
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 
 namespace caffe2 {
 
@@ -42,7 +42,7 @@ CAFFE2_API const TypeMeta& DataTypeToTypeMeta(const TensorProto::DataType& dt);
 }  // namespace caffe2
 
 ///////////////////////////////////////////////////////////////////////////////
-// at::Half is defined in ATen/core/Half.h. Currently half float operators are
+// at::Half is defined in c10/util/Half.h. Currently half float operators are
 // mainly on CUDA gpus.
 // The reason we do not directly use the cuda __half data type is because that
 // requires compilation with nvcc. The float16 data type should be compatible

--- a/caffe2/perfkernels/adagrad.h
+++ b/caffe2/perfkernels/adagrad.h
@@ -5,7 +5,7 @@
 #define CAFFE2_PERFKERNELS_ADAGRAD_H_USE_INTRINSIC
 #include <immintrin.h>
 #endif
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <c10/util/Logging.h>
 
 namespace caffe2 {

--- a/caffe2/perfkernels/embedding_lookup_avx2.cc
+++ b/caffe2/perfkernels/embedding_lookup_avx2.cc
@@ -5,7 +5,7 @@
 //// DO NOT MODIFY!!!
 //// --------------------------
 
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <c10/util/Logging.h>
 #include <immintrin.h>
 #include <cassert>

--- a/caffe2/perfkernels/embedding_lookup_fused_8bit_rowwise_avx2.cc
+++ b/caffe2/perfkernels/embedding_lookup_fused_8bit_rowwise_avx2.cc
@@ -5,7 +5,7 @@
 //// DO NOT MODIFY!!!
 //// --------------------------
 
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <c10/util/Logging.h>
 #include <immintrin.h>
 #include <cassert>

--- a/caffe2/perfkernels/hp_emblookup_codegen.py
+++ b/caffe2/perfkernels/hp_emblookup_codegen.py
@@ -335,7 +335,7 @@ code.append("//// BY {}".format(sys.argv[0]))
 code.append("//// DO NOT MODIFY!!!")
 code.append("//// --------------------------\n")
 
-code.append("#include <ATen/core/Half.h>")
+code.append("#include <c10/util/Half.h>")
 code.append("#include <c10/util/Logging.h>")
 code.append("#include <immintrin.h>")
 code.append("#include <cassert>\n")

--- a/caffe2/perfkernels/typed_axpy_avx2.cc
+++ b/caffe2/perfkernels/typed_axpy_avx2.cc
@@ -1,6 +1,6 @@
 #include "caffe2/perfkernels/cvtsh_ss_bugfix.h"
 
-#include <ATen/core/Half.h>
+#include <c10/util/Half.h>
 #include <emmintrin.h>
 #include <immintrin.h>
 

--- a/docs/cpp/source/Doxyfile
+++ b/docs/cpp/source/Doxyfile
@@ -31,7 +31,6 @@ STRIP_FROM_PATH        = ../../..
 # What folders / files Doxygen should process.
 INPUT                  = ../../../aten/src/ATen/ATen.h \
                          ../../../aten/src/ATen/Backend.h \
-                         ../../../aten/src/ATen/core/Half.h \
                          ../../../aten/src/ATen/core/ScalarType.h \
                          ../../../aten/src/ATen/core/Tensor.h \
                          ../../../aten/src/ATen/cuda/CUDAContext.h \
@@ -47,6 +46,7 @@ INPUT                  = ../../../aten/src/ATen/ATen.h \
                          ../../../build/aten/src/ATen/Functions.h \
                          ../../../c10/core/Device.h \
                          ../../../c10/core/DeviceType.h \
+                         ../../../c10/util/Half.h \
                          ../../../c10/util/ArrayRef.h \
                          ../../../c10/util/Exception.h \
                          ../../../c10/util/Optional.h \

--- a/test/cpp_extensions/complex_registration_extension.cpp
+++ b/test/cpp_extensions/complex_registration_extension.cpp
@@ -11,7 +11,7 @@
 #include "ATen/NativeFunctions.h"
 #include "ATen/Utils.h"
 #include "ATen/WrapDimUtils.h"
-#include "ATen/core/Half.h"
+#include "c10/util/Half.h"
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/Optional.h>


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16115 Remove ATen/Half.h and ATen/core/Half.h forwarding headers.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13717049/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16121 Remove ATen/Allocator.h forwarding header.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13717899/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16122 complex_registration_extension.cpp includes to angled brackets&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13717900/)



Differential Revision: [D13717049](https://our.internmc.facebook.com/intern/diff/D13717049/)