### PR TITLE
Typos and broken RSTs fixed in torch.distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -257,6 +257,15 @@ Probability distributions - torch.distributions
     :undoc-members:
     :show-inheritance:
 
+:hidden:`LogitRelaxedBernoulli`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.relaxed_bernoulli
+.. autoclass:: LogitRelaxedBernoulli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :hidden:`RelaxedOneHotCategorical`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -9,7 +9,8 @@ from torch.nn.functional import binary_cross_entropy_with_logits
 
 class Bernoulli(ExponentialFamily):
     r"""
-    Creates a Bernoulli distribution parameterized by :attr:`probs` or :attr:`logits` (but not both).
+    Creates a Bernoulli distribution parameterized by :attr:`probs`
+    or :attr:`logits` (but not both).
 
     Samples are binary (0 or 1). They take the value `1` with probability `p`
     and `0` with probability `1 - p`.

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -21,7 +21,7 @@ class Bernoulli(ExponentialFamily):
         tensor([ 0.])
 
     Args:
-        probs (Number, Tensor): the probabilty of sampling `1`
+        probs (Number, Tensor): the probability of sampling `1`
         logits (Number, Tensor): the log-odds of sampling `1`
     """
     arg_constraints = {'probs': constraints.unit_interval,

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -22,7 +22,7 @@ class Geometric(Distribution):
         tensor([ 2.])
 
     Args:
-        probs (Number, Tensor): the probabilty of sampling `1`. Must be in range (0, 1]
+        probs (Number, Tensor): the probability of sampling `1`. Must be in range (0, 1]
         logits (Number, Tensor): the log-odds of sampling `1`.
     """
     arg_constraints = {'probs': constraints.unit_interval,

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -9,8 +9,9 @@ from torch.nn.functional import binary_cross_entropy_with_logits
 
 class Geometric(Distribution):
     r"""
-    Creates a Geometric distribution parameterized by :attr:`probs`, where :attr:`probs` is the probability of
-    success of Bernoulli trials. It represents the probability that in :math:`k + 1` Bernoulli trials, the
+    Creates a Geometric distribution parameterized by :attr:`probs`,
+    where :attr:`probs` is the probability of success of Bernoulli trials.
+    It represents the probability that in :math:`k + 1` Bernoulli trials, the
     first :math:`k` trials failed, before seeing a success.
 
     Samples are non-negative integers [0, :math:`\inf`).

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -16,7 +16,7 @@ class LogitRelaxedBernoulli(Distribution):
 
     Args:
         temperature (Tensor): relaxation temperature
-        probs (Number, Tensor): the probabilty of sampling `1`
+        probs (Number, Tensor): the probability of sampling `1`
         logits (Number, Tensor): the log-odds of sampling `1`
 
     [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random Variables
@@ -104,7 +104,7 @@ class RelaxedBernoulli(TransformedDistribution):
 
     Args:
         temperature (Tensor): relaxation temperature
-        probs (Number, Tensor): the probabilty of sampling `1`
+        probs (Number, Tensor): the probability of sampling `1`
         logits (Number, Tensor): the log-odds of sampling `1`
     """
     arg_constraints = {'probs': constraints.unit_interval,

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -9,8 +9,9 @@ from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_
 
 class LogitRelaxedBernoulli(Distribution):
     r"""
-    Creates a LogitRelaxedBernoulli distribution parameterized by :attr:`probs` or :attr:`logits`
-    (but not both), which is the logit of a RelaxedBernoulli distribution.
+    Creates a LogitRelaxedBernoulli distribution parameterized by :attr:`probs`
+    or :attr:`logits` (but not both), which is the logit of a RelaxedBernoulli
+    distribution.
 
     Samples are logits of values in (0, 1). See [1] for more details.
 
@@ -19,8 +20,8 @@ class LogitRelaxedBernoulli(Distribution):
         probs (Number, Tensor): the probability of sampling `1`
         logits (Number, Tensor): the log-odds of sampling `1`
 
-    [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random Variables
-    (Maddison et al, 2017)
+    [1] The Concrete Distribution: A Continuous Relaxation of Discrete Random
+    Variables (Maddison et al, 2017)
 
     [2] Categorical Reparametrization with Gumbel-Softmax
     (Jang et al, 2017)
@@ -91,9 +92,10 @@ class LogitRelaxedBernoulli(Distribution):
 
 class RelaxedBernoulli(TransformedDistribution):
     r"""
-    Creates a RelaxedBernoulli distribution, parametrized by :attr:`temperature`, and either
-    :attr:`probs` or :attr:`logits` (but not both). This is a relaxed version of the `Bernoulli`
-    distribution, so the values are in (0, 1), and has reparametrizable samples.
+    Creates a RelaxedBernoulli distribution, parametrized by
+    :attr:`temperature`, and either :attr:`probs` or :attr:`logits`
+    (but not both). This is a relaxed version of the `Bernoulli` distribution,
+    so the values are in (0, 1), and has reparametrizable samples.
 
     Example::
 


### PR DESCRIPTION
- probabilty -> probability
- make long lines break
- Add LogitRelaxedBernoulli in distribution.rst