### PR TITLE
Change SetOutputSize in ConvTransposeUnpoolBaseOp

### DIFF
--- a/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
+++ b/caffe2/mobile/contrib/ios/mpscnn/mpscnn.mm
@@ -257,11 +257,10 @@ void computeOutputHW(
     int* OH,
     int* OW) {
   Tensor input = caffe2::empty({1, 1, H, W}, at::dtype<float>().device(CPU));
-  Tensor output(CPU);
-  op->SetOutputSize(input, &output, 1);
-  CAFFE_ENFORCE_EQ(output.dim(), 4);
-  *OH = output.size(2);
-  *OW = output.size(3);
+  auto sizes = GetOutputSize(input, 1);
+  CAFFE_ENFORCE_EQ(sizes.size(), 4);
+  *OH = sizes[2];
+  *OW = sizes[3];
 }
 
 constexpr int computeMPSAlignOffset(int kernel, int pad) {

--- a/caffe2/operators/conv_transpose_op_cudnn.cc
+++ b/caffe2/operators/conv_transpose_op_cudnn.cc
@@ -135,7 +135,6 @@ template <typename T>
 bool CudnnConvTransposeOp<T>::RunOnDevice() {
   auto& X = Input(INPUT);
   auto& filter = Input(FILTER);
-  auto* Y = Output(0);
   int C = 0;
   switch (order_) {
     case StorageOrder::NHWC:
@@ -147,7 +146,8 @@ bool CudnnConvTransposeOp<T>::RunOnDevice() {
     default:
       LOG(FATAL) << "Unknown storage order: " << order_;
   }
-  ConvTransposeUnpoolBase<CUDAContext>::SetOutputSize(X, Y, C);
+  auto sizes = ConvTransposeUnpoolBase<CUDAContext>::GetOutputSize(X, C);
+  auto* Y = Output(0, sizes, at::dtype<T>());
 
   int N = 0, M = 0, H = 0, W = 0, H_out = 0, W_out = 0;
   switch (order_) {

--- a/caffe2/operators/conv_transpose_op_impl.h
+++ b/caffe2/operators/conv_transpose_op_impl.h
@@ -19,7 +19,6 @@ template <typename T, class Context>
 bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const Tensor& X = Input(INPUT);
   auto& filter = Input(FILTER);
-  Tensor* Y = Output(0);
   const int N = X.dim32(0), M = X.dim32(1), H = X.dim32(2), W = X.dim32(3);
   CAFFE_ENFORCE(filter.dim() == 4, "filter must be 4D tensor");
   CAFFE_ENFORCE(
@@ -32,7 +31,8 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   CAFFE_ENFORCE(
       filter.dim32(3) == this->kernel_w(),
       "filter width must be equal to kernel width");
-  ConvTransposeUnpoolBase<Context>::SetOutputSize(X, Y, C);
+  auto sizes = ConvTransposeUnpoolBase<Context>::GetOutputSize(X, C);
+  Tensor* Y = Output(0, sizes, at::dtype<T>());
 
   const int kernel_dim = C * this->kernel_h() * this->kernel_w();
   const int input_image_size = H * W;
@@ -141,7 +141,6 @@ template <typename T, class Context>
 bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   const Tensor& X = Input(INPUT);
   auto& filter = Input(FILTER);
-  Tensor* Y = Output(0);
   const auto N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), M = X.dim32(3);
   CAFFE_ENFORCE(filter.dim() == 4, "filter must be 4D tensor");
   CAFFE_ENFORCE(
@@ -154,7 +153,8 @@ bool ConvTransposeOp<T, Context>::RunOnDeviceWithOrderNHWC() {
       filter.dim32(2) == this->kernel_w(),
       "filter width must be equal to kernel width");
   const int C = filter.dim32(3);
-  ConvTransposeUnpoolBase<Context>::SetOutputSize(X, Y, C);
+  auto sizes = ConvTransposeUnpoolBase<Context>::GetOutputSize(X, C);
+  Tensor* Y = Output(0, sizes, at::dtype<T>());
 
   const auto kernel_dim = C * this->kernel_h() * this->kernel_w();
   const auto input_image_size = H * W;

--- a/caffe2/operators/conv_transpose_op_mobile_impl.h
+++ b/caffe2/operators/conv_transpose_op_mobile_impl.h
@@ -532,7 +532,6 @@ template <typename T, class Context>
 bool ConvTransposeMobileOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const Tensor& X = Input(INPUT);
   auto& filter = Input(FILTER);
-  Tensor* Y = Output(0);
   const int N = X.dim32(0), M = X.dim32(1), H = X.dim32(2), W = X.dim32(3);
   CAFFE_ENFORCE(filter.ndim() == 4, "filter must be 4D tensor");
   CAFFE_ENFORCE(
@@ -553,7 +552,8 @@ bool ConvTransposeMobileOp<T, Context>::RunOnDeviceWithOrderNCHW() {
         "bias dimension must be equal to output channel number");
   }
 
-  ConvTransposeUnpoolBase<Context>::SetOutputSize(X, Y, C);
+  auto sizes = ConvTransposeUnpoolBase<Context>::GetOutputSize(X, C);
+  Tensor* Y = Output(0, sizes, at::dtype<T>());
 
   const int outputH = Y->dim32(2);
   const int outputW = Y->dim32(3);

--- a/caffe2/operators/conv_transpose_unpool_op_base.h
+++ b/caffe2/operators/conv_transpose_unpool_op_base.h
@@ -130,8 +130,8 @@ class ConvTransposeUnpoolBase : public Operator<Context> {
       createSharedBuffer<Context>(ws_);
     }
   }
-  // Sets the output size. The output channel is manually specified.
-  void SetOutputSize(const Tensor& input, Tensor* output, int output_channel) {
+  // Gets the output size. The output channel is manually specified.
+  std::vector<int64_t> GetOutputSize(const Tensor& input, int output_channel) {
     CAFFE_ENFORCE(4 == input.dim());
     CAFFE_ENFORCE(input.numel() > 0);
     int N = input.dim32(0);
@@ -171,14 +171,16 @@ class ConvTransposeUnpoolBase : public Operator<Context> {
         &pads_[1],
         &pads_[3],
         &output_width);
+    std::vector<int64_t> sizes;
     if (channel_first) {
-      output->Resize(N, output_channel, output_height, output_width);
+      sizes = {N, output_channel, output_height, output_width};
     } else {
-      output->Resize(N, output_height, output_width, output_channel);
+      sizes = {N, output_height, output_width, output_channel};
     }
     VLOG(2) << "In: N " << N << " M " << M << " H " << H << " W " << W;
     VLOG(2) << "Out: output_channel " << output_channel << " H "
             << output_height << " W " << output_width;
+    return sizes;
   }
 
   bool RunOnDevice() override {

--- a/caffe2/operators/hip/conv_transpose_op_miopen.hip
+++ b/caffe2/operators/hip/conv_transpose_op_miopen.hip
@@ -157,7 +157,6 @@ template <typename T>
 bool MIOPENConvTransposeOp<T>::RunOnDevice() {
   auto& X = Input(INPUT);
   auto& Weight = Input(FILTER);
-  auto* Y = Output(0);
 
   // Figure out the output shape
   CAFFE_ENFORCE(X.ndim() >= 3 && X.ndim() <= 5);
@@ -166,7 +165,8 @@ bool MIOPENConvTransposeOp<T>::RunOnDevice() {
       "ConvTranspose op with MIOpen engine is supported only for 2D convolutions");
 
   const int C_in = Weight.dim32(1);
-  ConvTransposeUnpoolBase<HIPContext>::SetOutputSize(X, Y, C_in);
+  auto sizes = ConvTransposeUnpoolBase<HIPContext>::GetOutputSize(X, C_in);
+  auto* Y = Output(0, sizes, at::dtype<T>());
 
   int N = X.dim32(0);
   int C = X.dim32(1);

--- a/caffe2/operators/quantized/int8_conv_transpose_op.h
+++ b/caffe2/operators/quantized/int8_conv_transpose_op.h
@@ -56,7 +56,8 @@ class Int8ConvTransposeOp final : public ConvTransposeUnpoolBase<CPUContext> {
     const auto KW = W.t.size(2);
     const auto OC = W.t.size(3);
 
-    ConvTransposeUnpoolBase<CPUContext>::SetOutputSize(X.t, &(Y->t), OC);
+    auto sizes = ConvTransposeUnpoolBase<CPUContext>::GetOutputSize(X.t, OC);
+    ReinitializeTensor(&(Y->t), sizes, at::dtype<uint8_t>().device(CPU));
     CHECK_EQ(OC, Y->t.size(3));
 
     runWithSharedBuffer<CPUContext>(ws_, [&](Tensor* buffer) {


### PR DESCRIPTION
Summary: to avoid passing partially initialized Tensor around.

Differential Revision: D13744009
