### PR TITLE
Support FC (Caffe2) -> Gemm (ONNX) with variable input shape.

### DIFF
--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -792,7 +792,6 @@ ConvertedResult OnnxExporter::CreateUpsampleNodes(
         MakeTensor("resolved scale tensor", tmp_vector, TensorProto::FLOAT);
 
     auto node = MakeNode("Constant", {}, {resolved_scale});
-    MakeAttribute("value", resolved_scale_tensor);
     node.add_attribute()->CopyFrom(
         MakeAttribute("value", resolved_scale_tensor));
     nodes.emplace_back(node);
@@ -932,16 +931,18 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
   if (has_axis) {
     axis = it->second->i();
   }
+
+  auto gemm_x_input = x;
   if (x_shape.dims().size() > 2) {
     // we need to reshape only when dimension is higher than 2
-    auto outer = DimProd(x_shape, 0, axis);
-    auto inner = DimProd(x_shape, axis, x_shape.dims().size());
-    std::vector<int64_t> dims = {outer, inner};
-    auto reshaped_x = dummy_->NewDummyName();
-    const_tensors.emplace_back(CreateOnnxShapeTensor(dummy_, dims));
-    nodes.emplace_back(
-        MakeNode("Reshape", {x, const_tensors.back().name()}, {reshaped_x}));
-    x = reshaped_x;
+    const auto inner = DimProd(x_shape, axis, x_shape.dims().size());
+
+    gemm_x_input = dummy_->NewDummyName();
+    const_tensors.emplace_back(CreateOnnxShapeTensor(dummy_,
+                std::vector<int64_t>{ -1, inner }));
+    nodes.emplace_back(MakeNode("Reshape",
+                { x, const_tensors.back().name() },
+                { gemm_x_input }));
   }
 
   it = args.find("axis_w");
@@ -953,32 +954,48 @@ ConvertedResult OnnxExporter::CreateGemmNodes(
     // we need to reshape only when dimension is higher than 2
     auto outer = DimProd(w_shape, 0, axis_w);
     auto inner = DimProd(w_shape, axis_w, w_shape.dims().size());
-    std::vector<int64_t> dims = {outer, inner};
     auto reshaped_w = dummy_->NewDummyName();
-    const_tensors.emplace_back(CreateOnnxShapeTensor(dummy_, dims));
-    nodes.emplace_back(
-        MakeNode("Reshape", {w, const_tensors.back().name()}, {reshaped_w}));
+    const_tensors.emplace_back(CreateOnnxShapeTensor(dummy_,
+                std::vector<int64_t>{ outer, inner }));
+    nodes.emplace_back(MakeNode("Reshape",
+                { w, const_tensors.back().name() },
+                { reshaped_w }));
     w = reshaped_w;
   }
 
-  auto gemm_y_output = (has_axis) ? dummy_->NewDummyName() : y;
-  std::vector<AttributeProto> attrs = {MakeAttribute("transB", 1L)};
-  nodes.emplace_back(MakeNode(
-      "Gemm",
-      {x, w, b},
-      {gemm_y_output},
-      attrs,
-      def.name()));
+  auto gemm_y_output = axis > 1 ? dummy_->NewDummyName() : y;
+  nodes.emplace_back(MakeNode("Gemm",
+              { gemm_x_input, w, b },
+              { gemm_y_output },
+              { MakeAttribute("transB", 1L) },
+              def.name()));
 
-  if (has_axis) {
-    std::vector<int64_t> dims;
-    for (int i = 0; i < axis; ++i) {
-      dims.push_back(x_shape.dims(i));
-    }
-    dims.push_back(-1);
-    const_tensors.emplace_back(CreateOnnxShapeTensor(dummy_, dims));
-    nodes.emplace_back(
-        MakeNode("Reshape", {gemm_y_output, const_tensors.back().name()}, {y}));
+  // capture the outer shape if needed.
+  if (axis > 1) {
+    const auto x_shape = dummy_->NewDummyName();
+    nodes.emplace_back(MakeNode("Shape", {x}, {x_shape}));
+
+    const auto x_shape_outer = dummy_->NewDummyName();
+    nodes.emplace_back(MakeNode("Slice",
+                { x_shape },
+                { x_shape_outer },
+                std::vector<AttributeProto>{
+                    MakeAttribute("starts", std::vector<int64_t>{ 0 }),
+                    MakeAttribute("ends", std::vector<int64_t>{ axis }),
+                }));
+
+    const auto y_shape = dummy_->NewDummyName();
+    const_tensors.emplace_back(CreateOnnxShapeTensor(dummy_, { -1 }));
+    nodes.emplace_back(MakeNode("Concat",
+                { x_shape_outer, const_tensors.back().name() },
+                { y_shape },
+                std::vector<AttributeProto>{
+                    MakeAttribute("axis", static_cast<int64_t>(0)),
+                }));
+ 
+    nodes.emplace_back(MakeNode("Reshape",
+                { gemm_y_output, y_shape },
+                { y }));
   }
 
   return result;

--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -133,6 +133,39 @@ class TestCaffe2Basic(DownloadingTestCase):
         onnx_outputs = c2.run_model(onnx_model, inputs=[X])
         self.assertSameOutputs(c2_outputs, onnx_outputs)
 
+    def test_fc(self):
+        X_fake = np.zeros((3, 1, 3, 1, 7), dtype=np.float32)
+        X = np.random.randn(5, 2, 3, 1, 7).astype(np.float32)
+        W = np.random.randn(11, 21).astype(np.float32)
+        B = np.random.randn(11).astype(np.float32)
+
+        predict_net = caffe2_pb2.NetDef()
+        predict_net.name = 'test-fc-net'
+        predict_net.external_input[:] = ['X', 'W', 'B']
+        predict_net.external_output[:] = ['Y']
+        predict_net.op.extend([
+            core.CreateOperator(
+                'FC',
+                inputs=['X', 'W', 'B'],
+                outputs=['Y'],
+                axis=2,
+            ),
+        ])
+        ws, c2_outputs = c2_native_run_net(
+            init_net=None,
+            predict_net=predict_net,
+            inputs=[X, W, B])
+
+        onnx_model = c2_onnx.caffe2_net_to_onnx_model(
+            predict_net=predict_net,
+            value_info={
+                'X': (onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[X.dtype], X_fake.shape),
+                'W': (onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[W.dtype], W.shape),
+                'B': (onnx.mapping.NP_TYPE_TO_TENSOR_TYPE[B.dtype], B.shape),
+            })
+        onnx_outputs = c2.run_model(onnx_model, inputs=[X, W, B])
+        self.assertSameOutputs(c2_outputs, onnx_outputs)
+
     def test_gemm(self):
         # simple
         A = np.random.randn(3, 2).astype(np.float32)


### PR DESCRIPTION
For >2D input, previously the code uses static shape captured during tracing and reshape before/after `Gemm`.
Now we add `-1` to the first `Reshape`, and uses `Shape(X) => Slice(outer) => Concat(with -1 for inner) => Reshape` for the second.

