### PR TITLE
Batched pdist

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -4,41 +4,83 @@
 
 #include <ATen/native/Distance.h>
 
-namespace at { namespace native {
+namespace at {
+namespace native {
 
 DEFINE_DISPATCH(pdist_forward_stub);
 DEFINE_DISPATCH(pdist_backward_stub);
 DEFINE_DISPATCH(cdist_stub);
 DEFINE_DISPATCH(cdist_backward_stub);
 
-Tensor pairwise_distance(const Tensor& x1, const Tensor& x2, double p, double eps, bool keepdim) {
+Tensor pairwise_distance(
+    const Tensor& x1,
+    const Tensor& x2,
+    double p,
+    double eps,
+    bool keepdim) {
   return at::norm(x1 - x2 + eps, p, 1, keepdim);
 }
 
-// This is to guarantee that the contiguous memory is passed to the backward pass
+// This is to guarantee that the contiguous memory is passed to the backward
+// pass
 Tensor pdist(const Tensor& self, const double p) {
-  AT_CHECK(self.dim() == 2,
-      "pdist only supports 2D tensors, got: ", self.dim(), "D");
-  AT_CHECK(at::isFloatingType(self.scalar_type()), "pdist only supports floating-point dtypes");
+  AT_CHECK(
+      self.dim() >= 2,
+      "pdist only supports at least 2D tensors, got: ",
+      self.dim(),
+      "D");
+  AT_CHECK(
+      at::isFloatingType(self.type().scalarType()),
+      "pdist only supports floating-point dtypes");
   AT_CHECK(p >= 0, "pdist only supports non-negative p values");
   return at::_pdist_forward(self.contiguous(), p);
 }
 
 Tensor cdist(const Tensor& x1, const Tensor& x2, const double p) {
-  AT_CHECK(x1.dim() == 2, "cdist only supports 2D tensors, X1 got: ", x1.dim(), "D");
-  AT_CHECK(at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X1 got: ", x1.scalar_type());
+  AT_CHECK(
+      x1.dim() == 2, "cdist only supports 2D tensors, X1 got: ", x1.dim(), "D");
+  AT_CHECK(
+      at::isFloatingType(x1.scalar_type()),
+      "cdist only supports floating-point dtypes, X1 got: ",
+      x1.scalar_type());
   auto device1 = x1.type().device_type();
-  AT_CHECK(device1 == kCPU || device1 == kCUDA, "cdist only supports CPU and CUDA devices, X1 got: ", device1);
-  AT_CHECK(x2.dim() == 2, "cdist only supports 2D tensors, X2 got: ", x2.dim(), "D");
-  AT_CHECK(at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X2 got: ", x2.scalar_type());
+  AT_CHECK(
+      device1 == kCPU || device1 == kCUDA,
+      "cdist only supports CPU and CUDA devices, X1 got: ",
+      device1);
+  AT_CHECK(
+      x2.dim() == 2, "cdist only supports 2D tensors, X2 got: ", x2.dim(), "D");
+  AT_CHECK(
+      at::isFloatingType(x1.scalar_type()),
+      "cdist only supports floating-point dtypes, X2 got: ",
+      x2.scalar_type());
   auto device2 = x2.type().device_type();
-  AT_CHECK(device2 == kCPU || device2 == kCUDA, "cdist only supports CPU and CUDA devices, X2 got: ", device2);
+  AT_CHECK(
+      device2 == kCPU || device2 == kCUDA,
+      "cdist only supports CPU and CUDA devices, X2 got: ",
+      device2);
   AT_CHECK(p >= 0, "cdist only supports non-negative p values");
-  AT_CHECK(device1 == device2, "X1 and X2 must have the same device type. X1: ", device1, " X2: ", device2);
-  AT_CHECK(!x1.is_cuda() || x1.get_device() == x2.get_device(), "device of X1 (", x1.get_device(), ") must match device of X2 (", x2.get_device(), ")");
+  AT_CHECK(
+      device1 == device2,
+      "X1 and X2 must have the same device type. X1: ",
+      device1,
+      " X2: ",
+      device2);
+  AT_CHECK(
+      !x1.is_cuda() || x1.get_device() == x2.get_device(),
+      "device of X1 (",
+      x1.get_device(),
+      ") must match device of X2 (",
+      x2.get_device(),
+      ")");
   int64_t c1 = x1.size(-1);
   int64_t c2 = x2.size(-1);
-  AT_CHECK(c1 == c2, "X1 and X2 must have the same number of columns. X1: ", c1, " X2: ", c2);
+  AT_CHECK(
+      c1 == c2,
+      "X1 and X2 must have the same number of columns. X1: ",
+      c1,
+      " X2: ",
+      c2);
 
   int64_t r1 = x1.size(-2);
   int64_t r2 = x2.size(-2);
@@ -53,16 +95,28 @@ Tensor cdist(const Tensor& x1, const Tensor& x2, const double p) {
   return result;
 }
 
-Tensor _cdist_backward(const Tensor& grad, const Tensor& x1, const Tensor& x2, const double p, const Tensor& cdist) {
+Tensor _cdist_backward(
+    const Tensor& grad,
+    const Tensor& x1,
+    const Tensor& x2,
+    const double p,
+    const Tensor& cdist) {
   AT_CHECK(x1.is_contiguous(), "_cdist_backward requires X1 to be contiguous");
   AT_CHECK(x2.is_contiguous(), "_cdist_backward requires X2 to be contiguous");
-  AT_CHECK(cdist.is_contiguous(), "_cdist_backward requires dist to be contiguous");
+  AT_CHECK(
+      cdist.is_contiguous(), "_cdist_backward requires dist to be contiguous");
   int64_t n = x1.size(-2);
   int64_t m = x1.size(-1);
   auto device1 = x1.type().device_type();
-  AT_CHECK(device1 == kCPU || device1 == kCUDA, "_cdist_backward only supports CPU and CUDA devices, X1 got: ", device1);
+  AT_CHECK(
+      device1 == kCPU || device1 == kCUDA,
+      "_cdist_backward only supports CPU and CUDA devices, X1 got: ",
+      device1);
   auto device2 = x2.type().device_type();
-  AT_CHECK(device2 == kCPU || device2 == kCUDA, "_cdist_backward only supports CPU and CUDA devices, X2 got: ", device2);
+  AT_CHECK(
+      device2 == kCPU || device2 == kCUDA,
+      "_cdist_backward only supports CPU and CUDA devices, X2 got: ",
+      device2);
   Tensor grad_x1 = at::empty({n, m}, x1.options());
   cdist_backward_stub(device1, grad_x1, grad, x1, x2, p, cdist);
   return grad_x1;
@@ -71,34 +125,73 @@ Tensor _cdist_backward(const Tensor& grad, const Tensor& x1, const Tensor& x2, c
 Tensor _pdist_forward(const Tensor& self, const double p) {
   AT_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.type().device_type();
-  AT_CHECK(device == kCPU || device == kCUDA, "_pdist_forward only supports CPU and CUDA devices, got: ", device);
-  Tensor result = at::empty({0}, self.options());
-  if (self.size(0) <= 1) {
-    result.resize_({0});
+  AT_CHECK(
+      device == kCPU || device == kCUDA,
+      "_pdist_forward only supports CPU and CUDA devices, got: ",
+      device);
+
+  const auto batches = self.sizes().slice(0, self.dim() - 2);
+  int64_t b = 1;
+  for (const auto& s : batches) {
+    b *= s;
+  }
+  int64_t n = self.size(-2);
+  int64_t d = self.size(-1);
+  int64_t r = n * (n - 1) / 2;
+
+  std::vector<int64_t> result_sizes(batches.begin(), batches.end());
+  result_sizes.push_back(r);
+  Tensor result = at::empty(result_sizes, self.options());
+
+  if (r == 0 || d == 0) {
+    result.fill_(0);
   } else {
-    int64_t n = self.size(0);
-    int64_t c = n * (n - 1) / 2;
-    result.resize_({c});
-    if (self.size(1) == 0) {
-      result.fill_(0);
-    } else {
-      pdist_forward_stub(device, result, self, p);
-    }
+    Tensor result_view = result.view({b, r});
+    pdist_forward_stub(device, result_view, self.view({b, n, d}), p);
   }
   return result;
 }
 
-Tensor _pdist_backward(const Tensor& grad, const Tensor& self, const double p, const Tensor& pdist) {
-  AT_CHECK(self.is_contiguous(), "_pdist_backward requires self to be contiguous");
-  AT_CHECK(pdist.is_contiguous(), "_pdist_backward requires pdist to be contiguous");
+Tensor _pdist_backward(
+    const Tensor& grad,
+    const Tensor& self,
+    const double p,
+    const Tensor& pdist) {
+  AT_CHECK(
+      self.is_contiguous(), "_pdist_backward requires self to be contiguous");
+  AT_CHECK(
+      pdist.is_contiguous(), "_pdist_backward requires pdist to be contiguous");
   auto device = self.type().device_type();
-  AT_CHECK(device == kCPU || device == kCUDA, "_pdist_backward only supports CPU and CUDA devices, got: ", device);
+  AT_CHECK(
+      device == kCPU || device == kCUDA,
+      "_pdist_backward only supports CPU and CUDA devices, got: ",
+      device);
   Tensor result = at::empty_like(self);
-  pdist_backward_stub(device, result, grad, self, p, pdist);
+
+  int64_t b = 1;
+  for (const auto& s : self.sizes().slice(0, self.dim() - 2)) {
+    b *= s;
+  }
+  int64_t n = self.size(-2);
+  int64_t d = self.size(-1);
+  int64_t r = pdist.size(-1);
+
+  Tensor result_view = result.view({b, n, d});
+  pdist_backward_stub(
+      device,
+      result_view,
+      grad.reshape({b, r}),
+      self.view({b, n, d}),
+      p,
+      pdist.view({b, r}));
   return result;
 }
 
-Tensor cosine_similarity(const Tensor& x1, const Tensor& x2, int64_t dim, double eps) {
+Tensor cosine_similarity(
+    const Tensor& x1,
+    const Tensor& x2,
+    int64_t dim,
+    double eps) {
   // Follow scipy impl to improve numerical precision
   // Use x / sqrt(x * x) instead of x / (sqrt(x) * sqrt(x))
   Tensor w12 = at::sum(x1 * x2, dim);
@@ -108,4 +201,5 @@ Tensor cosine_similarity(const Tensor& x1, const Tensor& x2, int64_t dim, double
   return w12.div_(n12);
 }
 
-}}  // namespace at::native
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/Distance.h
+++ b/aten/src/ATen/native/Distance.h
@@ -3,16 +3,30 @@
 #include <ATen/ATen.h>
 #include <ATen/native/DispatchStub.h>
 
-namespace at { namespace native {
+namespace at {
+namespace native {
 
-using pdist_forward_fn = void(*)(Tensor&, const Tensor&, const double p);
-using pdist_backward_fn = void(*)(Tensor&, const Tensor&, const Tensor&, const double p, const Tensor&);
-using cdist_fn = void(*)(Tensor&, const Tensor&, const Tensor&, const double p);
-using cdist_backward_fn = void(*)(Tensor&, const Tensor&, const Tensor&, const Tensor&, const double p, const Tensor&);
+using pdist_forward_fn = void (*)(Tensor&, const Tensor&, const double p);
+using pdist_backward_fn = void (*)(
+    Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const double p,
+    const Tensor&);
+using cdist_fn =
+    void (*)(Tensor&, const Tensor&, const Tensor&, const double p);
+using cdist_backward_fn = void (*)(
+    Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const double p,
+    const Tensor&);
 
 DECLARE_DISPATCH(pdist_forward_fn, pdist_forward_stub);
 DECLARE_DISPATCH(pdist_backward_fn, pdist_backward_stub);
 DECLARE_DISPATCH(cdist_fn, cdist_stub);
 DECLARE_DISPATCH(cdist_backward_fn, cdist_backward_stub);
 
-}} // namespace at::native
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -1,16 +1,18 @@
 #include <ATen/native/Distance.h>
 
-#include <numeric>
-#include <iterator>
 #include <algorithm>
+#include <iterator>
+#include <numeric>
 
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vml.h>
 
-namespace at { namespace native { namespace {
+namespace at {
+namespace native {
+namespace {
 
-template<typename scalar_t>
+template <typename scalar_t>
 struct Dist {
   using Vec = vec256::Vec256<scalar_t>;
 
@@ -38,103 +40,192 @@ struct Dist {
   // implementation of the general backward pass when p is less than two, so
   // there's a struct with only a backward pass for this case.
 
-  // TODO This is an inefficient way to compite sign, and can be much faster
+  // TODO This is an inefficient way to compute sign, and can be much faster
   // using native SSE instructions that should be added to Vec256.
   static inline Vec sign(Vec val) {
     return vec256::minimum(vec256::maximum(Vec(0), val.ceil()), Vec(1)) +
-      vec256::minimum(vec256::maximum(Vec(-1), val.floor()), Vec(0));
+        vec256::minimum(vec256::maximum(Vec(-1), val.floor()), Vec(0));
   }
 
   // Zero norm
   struct zdist_calc {
-    static inline Vec map(const Vec& diff, const Vec& p) { return vec256::minimum(diff.abs().ceil(), Vec(1)); }
-    static inline Vec red(const Vec& agg, const Vec& up) { return agg + up; }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
+    static inline Vec map(const Vec& diff, const scalar_t p) {
+      return vec256::minimum(diff.abs().ceil(), Vec(1));
+    }
+    static inline Vec red(const Vec& agg, const Vec& up) {
+      return agg + up;
+    }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t p) {
+      return agg;
+    }
   };
 
   // One norm
   struct odist_calc {
-    static inline Vec map(const Vec& diff, const Vec& p) { return diff; }
-    static inline Vec red(const Vec& agg, const Vec& up) { return agg + up; }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
-    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t dist, const Vec& p) { return Vec(grad) * sign(diff); }
+    static inline Vec map(const Vec& diff, const scalar_t p) {
+      return diff;
+    }
+    static inline Vec red(const Vec& agg, const Vec& up) {
+      return agg + up;
+    }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t p) {
+      return agg;
+    }
+    static inline Vec backward(
+        const Vec& diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const Vec& p) {
+      return Vec(grad) * sign(diff);
+    }
   };
 
   // Special general pnorm derivative if p is less than two
   struct lttdist_calc {
-    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t dist, const Vec& p) { return dist == 0.0 ? Vec(0) : sign(diff) * diff.abs().pow(p - Vec(1)) * Vec(grad) / Vec(dist).pow(p - Vec(1)); }
+    static inline Vec backward(
+        const Vec& diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const Vec& p) {
+      return dist == 0.0 ? Vec(0)
+                         : sign(diff) * diff.abs().pow(p - Vec(1)) * Vec(grad) /
+              Vec(dist).pow(p - Vec(1));
+    }
   };
 
   // Two norm
   struct tdist_calc {
     // TODO This can probably use fused add multiply to get better perf
-    static inline Vec map(const Vec& diff, const Vec& p) { return diff * diff; }
-    static inline Vec red(const Vec& agg, const Vec& up) { return agg + up; }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return std::sqrt(agg); }
-    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t dist, const Vec& p) { return dist == 0.0 ? Vec(0) : Vec(grad) * diff / Vec(dist); }
+    static inline Vec map(const Vec& diff, const scalar_t p) {
+      return diff * diff;
+    }
+    static inline Vec red(const Vec& agg, const Vec& up) {
+      return agg + up;
+    }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t p) {
+      return std::sqrt(agg);
+    }
+    static inline Vec backward(
+        const Vec& diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const Vec& p) {
+      return dist == 0.0 ? Vec(0) : Vec(grad) * diff / Vec(dist);
+    }
   };
 
   // General p norm
   struct pdist_calc {
-    static inline Vec map(const Vec& diff, const Vec& p) { return diff.pow(p); }
-    static inline Vec red(const Vec& agg, const Vec& up) { return agg + up; }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return std::pow(agg, 1.0 / p); }
-    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t dist, const Vec& p) { return dist == 0.0 ? Vec(0) : diff * diff.abs().pow(p - Vec(2)) * Vec(grad) / Vec(dist).pow(p - Vec(1)); }
+    static inline Vec map(const Vec& diff, const scalar_t p) {
+      return diff.pow(Vec(p));
+    }
+    static inline Vec red(const Vec& agg, const Vec& up) {
+      return agg + up;
+    }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t p) {
+      return std::pow(agg, 1.0 / p);
+    }
+    static inline Vec backward(
+        const Vec& diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const Vec& p) {
+      return dist == 0.0 ? Vec(0)
+                         : diff * diff.abs().pow(p - Vec(2)) * Vec(grad) /
+              Vec(dist).pow(p - Vec(1));
+    }
   };
 
-  // Info norm
+  // Inf norm
   struct idist_calc {
-    static inline Vec map(const Vec& diff, const Vec& p) { return diff; }
-    static inline Vec red(const Vec& agg, const Vec& up) { return vec256::maximum(agg, up); }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
+    static inline Vec map(const Vec& diff, const scalar_t p) {
+      return diff;
+    }
+    static inline Vec red(const Vec& agg, const Vec& up) {
+      return vec256::maximum(agg, up);
+    }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t p) {
+      return agg;
+    }
     // TODO This backward pass uses a very complext expression to compute (diff
     // == dist) that could be much faster if using SSE instructions.
-    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t dist, const Vec& p) { return Vec(grad) * sign(diff) * (Vec(1) - vec256::minimum(Vec(1), (diff.abs() - Vec(dist)).abs().ceil())); }
+    static inline Vec backward(
+        const Vec& diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const Vec& p) {
+      return Vec(grad) * sign(diff) *
+          (Vec(1) -
+           vec256::minimum(Vec(1), (diff.abs() - Vec(dist)).abs().ceil()));
+    }
   };
 
   template <typename F>
-  static void run_parallel_pdist(Tensor& result, const Tensor& self, const scalar_t p) {
-    const scalar_t * const self_start = self.data<scalar_t>();
-    const scalar_t * const self_end = self_start + self.numel();
-    int64_t n = self.size(0);
-    int64_t m = self.size(1);
+  static void run_parallel_pdist(
+      Tensor& result,
+      const Tensor& self,
+      const scalar_t p) {
+    const scalar_t* const self_start = self.data<scalar_t>();
+    scalar_t* const res_start = result.data<scalar_t>();
 
-    scalar_t * const res_start = result.data<scalar_t>();
-    int64_t combs = result.numel(); // n * (n - 1) / 2
+    int64_t b = self.size(0);
+    int64_t n = self.size(1);
+    int64_t d = self.size(2);
+    int64_t r = result.size(1); // n * (n - 1) / 2
+
+    double n2 = n - .5;
 
     // We conceptually iterate over tuples of (i, j, k) where i is the first
     // vector from the input, j is the second, and k is the result index. This
     // parallelizes over the range of k and infers what i and j are from the
     // value of k.
-    parallel_for(0, combs, internal::GRAIN_SIZE / (16 * m), [p, self_start, self_end, n, m, res_start](int64_t k, int64_t end) {
-      const Vec pvec(p);
-      double n2 = n - .5;
-      // The -1 accounts for floating point truncation issues
-      int64_t i = static_cast<int64_t>((n2 - std::sqrt(n2 * n2 - 2 * k - 1)));
-      int64_t j = k - n * i + i * (i + 1) / 2 + i + 1;
+    parallel_for(
+        0,
+        b * r,
+        internal::GRAIN_SIZE / (16 * d),
+        [p, self_start, res_start, b, n, d, r, n2](int64_t start, int64_t end) {
+          int64_t r_k = start % r;
+          int64_t b_l = start / r;
+          // The -1 accounts for floating point truncation issues
+          int64_t n_i =
+              static_cast<int64_t>((n2 - std::sqrt(n2 * n2 - 2 * r_k - 1)));
+          int64_t n_j = r_k - n * n_i + n_i * (n_i + 1) / 2 + n_i + 1;
 
-      const scalar_t * self_i = self_start + i * m;
-      const scalar_t * self_j = self_start + j * m;
-      scalar_t * res = res_start + k;
-      const scalar_t * const res_end = res_start + end;
+          const scalar_t* self_i = self_start + (b_l * n + n_i) * d;
+          const scalar_t* self_j = self_start + (b_l * n + n_j) * d;
+          const scalar_t* self_end = self_start + (b_l + 1) * n * d;
+          scalar_t* res = res_start + start;
 
-      while (res != res_end) {
-        *res = F::finish(vec256::map2_reduce_all<scalar_t>(
-          [&pvec](Vec a, Vec b) { return F::map((a - b).abs(), pvec); },
-          F::red, self_i, self_j, m), p);
+          while (start != end) {
+            *res = F::finish(
+                vec256::map2_reduce_all<scalar_t>(
+                    [p](Vec a, Vec b) { return F::map((a - b).abs(), p); },
+                    F::red,
+                    self_i,
+                    self_j,
+                    d),
+                p);
 
-        res += 1;
-        self_j += m;
-        if (self_j == self_end) {
-          self_i += m;
-          self_j = self_i + m;
-        }
-      }
-    });
+            start += 1;
+            res += 1;
+            self_j += d;
+            if (self_j == self_end) {
+              self_i += d;
+              if (self_i + d == self_end) {
+                self_i += d;
+                self_end += n * d;
+              }
+              self_j = self_i + d;
+            }
+          }
+        });
   }
 
   // Assumes self is nonempty, contiguous, and 2D
-  static void apply_pdist(Tensor& result, const Tensor& self, const scalar_t p) {
+  static void apply_pdist(
+      Tensor& result,
+      const Tensor& self,
+      const scalar_t p) {
     if (p == 0.0) {
       run_parallel_pdist<zdist_calc>(result, self, p);
     } else if (p == 1.0) {
@@ -149,39 +240,52 @@ struct Dist {
   }
 
   template <typename F>
-  static void run_parallel_cdist(Tensor& result, const Tensor& t1, const Tensor& t2, const scalar_t p) {
-    const scalar_t * const t1_start = t1.data<scalar_t>();
-    const scalar_t * const t2_start = t2.data<scalar_t>();
+  static void run_parallel_cdist(
+      Tensor& result,
+      const Tensor& t1,
+      const Tensor& t2,
+      const scalar_t p) {
+    const scalar_t* const t1_start = t1.data<scalar_t>();
+    const scalar_t* const t2_start = t2.data<scalar_t>();
     int64_t r1 = t1.size(-2);
     int64_t r2 = t2.size(-2);
     int64_t m = t1.size(-1);
 
-    scalar_t * const res_start = result.data<scalar_t>();
+    scalar_t* const res_start = result.data<scalar_t>();
     int64_t total = r1 * r2;
 
-    parallel_for(0, total, internal::GRAIN_SIZE / (16 * m), [=](int64_t start, int64_t end) {
-      const Vec pvec(p);
-      scalar_t * res = res_start + start;
-      const scalar_t * const res_end = res_start + end;
+    parallel_for(
+        0,
+        total,
+        internal::GRAIN_SIZE / (16 * m),
+        [p, t1_start, t2_start, r2, m, res_start](int64_t start, int64_t end) {
+          scalar_t* res = res_start + start;
 
-      int64_t k = start;
-      while (res != res_end) {
-        int64_t i = k / r2;
-        int64_t j = k % r2;
-        const scalar_t * self_i = t1_start + i * m;
-        const scalar_t * self_j = t2_start + j * m;
+          for (int64_t k = start; k != end; ++k) {
+            int64_t i = k / r2;
+            int64_t j = k % r2;
+            const scalar_t* self_i = t1_start + i * m;
+            const scalar_t* self_j = t2_start + j * m;
 
-        *res = F::finish(vec256::map2_reduce_all<scalar_t>(
-                [&pvec](Vec a, Vec b) { return F::map((a - b).abs(), pvec); },
-                F::red, self_i, self_j, m), p);
+            *res = F::finish(
+                vec256::map2_reduce_all<scalar_t>(
+                    [p](Vec a, Vec b) { return F::map((a - b).abs(), p); },
+                    F::red,
+                    self_i,
+                    self_j,
+                    m),
+                p);
 
-        res += 1;
-        k++;
-      }
-    });
+            res += 1;
+          }
+        });
   }
 
-  static void apply_cdist(Tensor& result, const Tensor& x1, const Tensor& x2, const scalar_t p) {
+  static void apply_cdist(
+      Tensor& result,
+      const Tensor& x1,
+      const Tensor& x2,
+      const scalar_t p) {
     if (p == 0.0) {
       run_parallel_cdist<zdist_calc>(result, x1, x2, p);
     } else if (p == 1.0) {
@@ -197,15 +301,26 @@ struct Dist {
 
   // This does a backward pass down a Vec column of the input
   template <typename F>
-  inline static void backward_down_column_pdist(const scalar_t * self_i, scalar_t * res_i, const scalar_t * grad_k, const scalar_t * dist_k, const Vec& pvec, int64_t n, int64_t m, int64_t gs, int64_t count = Vec::size()) {
-    for (const scalar_t * const self_end = self_i + m * n; self_i != self_end - m; self_i += m, res_i += m) {
-
+  inline static void backward_down_column_pdist(
+      const scalar_t* self_i,
+      scalar_t* res_i,
+      const scalar_t* grad_k,
+      const scalar_t* dist_k,
+      const Vec& pvec,
+      int64_t n,
+      int64_t d,
+      int64_t gs,
+      int64_t count = Vec::size()) {
+    for (const scalar_t* const self_end = self_i + n * d;
+         self_i != self_end - d;
+         self_i += d, res_i += d) {
       const Vec self_vec_i = Vec::loadu(self_i, count);
       Vec res_vec_i = Vec::loadu(res_i, count);
 
-      const scalar_t * self_j = self_i + m;
-      scalar_t * res_j = res_i + m;
-      for (; self_j != self_end; self_j += m, res_j += m, grad_k += gs, dist_k += 1) {
+      const scalar_t* self_j = self_i + d;
+      scalar_t* res_j = res_i + d;
+      for (; self_j != self_end;
+           self_j += d, res_j += d, grad_k += gs, dist_k += 1) {
         const Vec self_vec_j = Vec::loadu(self_j, count);
         Vec res_vec_j = Vec::loadu(res_j, count);
 
@@ -221,37 +336,91 @@ struct Dist {
   }
 
   template <typename F>
-  static void run_backward_parallel_pdist(Tensor& result, const Tensor & grad, const Tensor & self, const scalar_t p, const Tensor& dist) {
-    const int64_t n = self.size(0);
-    const int64_t m = self.size(1);
-    const int64_t gs = grad.stride(0);
+  static void run_backward_parallel_pdist(
+      Tensor& result,
+      const Tensor& grad,
+      const Tensor& self,
+      const scalar_t p,
+      const Tensor& dist) {
+    const int64_t b = self.size(0);
+    const int64_t n = self.size(1);
+    const int64_t d = self.size(2);
+    const int64_t r = dist.size(1);
 
-    const scalar_t * const grad_start = grad.data<scalar_t>();
-    const scalar_t * const dist_start = dist.data<scalar_t>();
-    const scalar_t * const self_start = self.data<scalar_t>();
-    scalar_t * const res_start = result.data<scalar_t>();
+    const int64_t gs_l = grad.stride(0);
+    const int64_t gs_k = grad.stride(1);
+
+    const scalar_t* const grad_start = grad.data<scalar_t>();
+    const scalar_t* const dist_start = dist.data<scalar_t>();
+    const scalar_t* const self_start = self.data<scalar_t>();
+    scalar_t* const res_start = result.data<scalar_t>();
 
     // The only way to parallelize and avoid locking requires parallelizing
     // over the columns of the input, i.e. we compute the gradient for the
     // first section of each vector independentaly of the second section, etc.
-    at::parallel_for(0, m / Vec::size(), internal::GRAIN_SIZE / (8 * n * n), [p, n, m, gs, grad_start, dist_start, self_start, res_start](int64_t l, int64_t end) {
-      const Vec pvec(p);
+    const int64_t dv = (d + Vec::size() - 1) /
+        Vec::size(); // number of Vecs in a row rounded up
+    at::parallel_for(
+        0,
+        b * dv,
+        internal::GRAIN_SIZE / (8 * n * n),
+        [p,
+         b,
+         n,
+         d,
+         r,
+         gs_l,
+         gs_k,
+         grad_start,
+         dist_start,
+         self_start,
+         res_start,
+         dv](int64_t start, int64_t end) {
+          const Vec pvec(p);
 
-      const scalar_t * self_l = self_start + l * Vec::size();
-      scalar_t * res_l = res_start + l * Vec::size();
+          const int64_t b_l = start / dv;
+          const int64_t d_v = start % dv;
 
-      for (const scalar_t * const res_end = res_start + end * Vec::size(); res_l != res_end; self_l += Vec::size(), res_l += Vec::size()) {
-        backward_down_column_pdist<F>(self_l, res_l, grad_start, dist_start, pvec, n, m, gs);
-      }
-    });
-    const int64_t remainder = m % Vec::size();
-    if (remainder) {
-      backward_down_column_pdist<F>(self_start + (m - remainder), res_start + (m - remainder), grad_start, dist_start, Vec(p), n, m, gs, remainder);
-    }
+          const scalar_t* self_l = self_start + b_l * n * d;
+          const scalar_t* self_v = self_l + d_v * Vec::size();
+
+          scalar_t* res_l = res_start + b_l * n * d;
+          scalar_t* res_v = res_l + d_v * Vec::size();
+
+          const scalar_t* dist_l = dist_start + b_l * r;
+          const scalar_t* grad_l = grad_start + b_l * gs_l;
+
+          while (start != end) {
+            const int64_t count =
+                std::min(d - (self_v - self_l), int64_t(Vec::size()));
+            backward_down_column_pdist<F>(
+                self_v, res_v, grad_l, dist_l, pvec, n, d, gs_k, count);
+
+            start += 1;
+            self_v += Vec::size();
+            res_v += Vec::size();
+            if (self_v == self_l + dv * Vec::size()) {
+              // Reached the end of the row
+              self_l += n * d;
+              self_v = self_l;
+
+              res_l += n * d;
+              res_v = res_l;
+
+              dist_l += r;
+              grad_l += gs_l;
+            }
+          }
+        });
   }
 
   // Assumes self is nonempty, contiguous, and 2D and dist is also contiguous
-  static void apply_backward_pdist(Tensor& result, const Tensor& grad, const Tensor& self, const double p, const Tensor& dist) {
+  static void apply_backward_pdist(
+      Tensor& result,
+      const Tensor& grad,
+      const Tensor& self,
+      const double p,
+      const Tensor& dist) {
     result.fill_(0);
     if (p == 0.0) {
     } else if (p == 1.0) {
@@ -267,7 +436,13 @@ struct Dist {
     }
   }
 
-  static void apply_backward_cdist(Tensor& result, const Tensor& grad, const Tensor& x1, const Tensor& x2, const double p, const Tensor& dist) {
+  static void apply_backward_cdist(
+      Tensor& result,
+      const Tensor& grad,
+      const Tensor& x1,
+      const Tensor& x2,
+      const double p,
+      const Tensor& dist) {
     result.fill_(0);
     if (p == 0.0) {
     } else if (p == 1.0) {
@@ -283,47 +458,82 @@ struct Dist {
     }
   }
 
-
   template <typename F>
-  static void run_backward_parallel_cdist(Tensor& result, const Tensor & grad, const Tensor & t1, const Tensor & t2, const scalar_t p, const Tensor& dist) {
+  static void run_backward_parallel_cdist(
+      Tensor& result,
+      const Tensor& grad,
+      const Tensor& t1,
+      const Tensor& t2,
+      const scalar_t p,
+      const Tensor& dist) {
     const int64_t r1 = t1.size(-2);
     const int64_t r2 = t2.size(-2);
     const int64_t m = t1.size(-1);
     const int64_t gs = grad.stride(1);
 
-    const scalar_t * const grad_start = grad.data<scalar_t>();
-    const scalar_t * const dist_start = dist.data<scalar_t>();
-    const scalar_t * const t1_start = t1.data<scalar_t>();
-    const scalar_t * const t2_start = t2.data<scalar_t>();
-    scalar_t * const res_start = result.data<scalar_t>();
+    const scalar_t* const grad_start = grad.data<scalar_t>();
+    const scalar_t* const dist_start = dist.data<scalar_t>();
+    const scalar_t* const t1_start = t1.data<scalar_t>();
+    const scalar_t* const t2_start = t2.data<scalar_t>();
+    scalar_t* const res_start = result.data<scalar_t>();
 
-    at::parallel_for(0, m / Vec::size(), internal::GRAIN_SIZE / (16 * r1), [=](int64_t l, int64_t end) {
-      const Vec pvec(p);
+    at::parallel_for(
+        0,
+        m / Vec::size(),
+        internal::GRAIN_SIZE / (16 * r1),
+        [=](int64_t l, int64_t end) {
+          const Vec pvec(p);
 
-      const scalar_t * i = t1_start + l * Vec::size();
-      const scalar_t * j = t2_start + l * Vec::size();
-      scalar_t * res_l = res_start + l * Vec::size();
+          const scalar_t* i = t1_start + l * Vec::size();
+          const scalar_t* j = t2_start + l * Vec::size();
+          scalar_t* res_l = res_start + l * Vec::size();
 
-      for (const scalar_t * const res_end = res_start + end * Vec::size(); res_l != res_end; i += Vec::size(), j += Vec::size(), res_l += Vec::size()) {
-        backward_down_column_cdist<F>(i, j, res_l, grad_start, dist_start, pvec, r1, r2, m, gs);
-      }
-    });
+          for (const scalar_t* const res_end = res_start + end * Vec::size();
+               res_l != res_end;
+               i += Vec::size(), j += Vec::size(), res_l += Vec::size()) {
+            backward_down_column_cdist<F>(
+                i, j, res_l, grad_start, dist_start, pvec, r1, r2, m, gs);
+          }
+        });
     const int64_t remainder = m % Vec::size();
     if (remainder) {
-      backward_down_column_cdist<F>(t1_start + (m - remainder), t2_start + (m - remainder), res_start + (m - remainder), grad_start, dist_start, Vec(p), r1, r2, m, gs, remainder);
+      backward_down_column_cdist<F>(
+          t1_start + (m - remainder),
+          t2_start + (m - remainder),
+          res_start + (m - remainder),
+          grad_start,
+          dist_start,
+          Vec(p),
+          r1,
+          r2,
+          m,
+          gs,
+          remainder);
     }
   }
 
   template <typename F>
-  inline static void backward_down_column_cdist(const scalar_t * t1, const scalar_t * t2, scalar_t * res, const scalar_t * grad_k, const scalar_t * dist_k, const Vec& pvec, int64_t r1, int64_t r2, int64_t m, int64_t gs, int64_t count = Vec::size()) {
-    const scalar_t * const t1_end = t1 + m * r1;
-    const scalar_t * const t2_end = t2 + m * r2;
+  inline static void backward_down_column_cdist(
+      const scalar_t* t1,
+      const scalar_t* t2,
+      scalar_t* res,
+      const scalar_t* grad_k,
+      const scalar_t* dist_k,
+      const Vec& pvec,
+      int64_t r1,
+      int64_t r2,
+      int64_t m,
+      int64_t gs,
+      int64_t count = Vec::size()) {
+    const scalar_t* const t1_end = t1 + m * r1;
+    const scalar_t* const t2_end = t2 + m * r2;
 
     for (; t1 != t1_end; t1 += m, res += m) {
       const Vec vec_t1 = Vec::loadu(t1, count);
       Vec res_vec = Vec::loadu(res, count);
 
-      for (const scalar_t * t2_curr = t2; t2_curr != t2_end; t2_curr += m, grad_k += gs, dist_k += 1) {
+      for (const scalar_t* t2_curr = t2; t2_curr != t2_end;
+           t2_curr += m, grad_k += gs, dist_k += 1) {
         const Vec vec_t2 = Vec::loadu(t2_curr, count);
         Vec res = F::backward(vec_t1 - vec_t2, *grad_k, *dist_k, pvec);
         res_vec = res_vec + res;
@@ -332,39 +542,56 @@ struct Dist {
       res_vec.store(res, count);
     }
   }
-
 };
 
-void pdist_forward_kernel_impl(Tensor& result, const Tensor& self, const double p) {
+void pdist_forward_kernel_impl(
+    Tensor& result,
+    const Tensor& self,
+    const double p) {
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist", [&] {
     Dist<scalar_t>::apply_pdist(result, self, p);
   });
 }
 
-static void pdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor& self, const double p, const Tensor& dist) {
+static void pdist_backward_kernel_impl(
+    Tensor& result,
+    const Tensor& grad,
+    const Tensor& self,
+    const double p,
+    const Tensor& dist) {
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist_backward", [&] {
     Dist<scalar_t>::apply_backward_pdist(result, grad, self, p, dist);
   });
 }
 
-static void cdist_kernel_impl(Tensor& result, const Tensor& x1, const Tensor& x2, const double p) {
+static void cdist_kernel_impl(
+    Tensor& result,
+    const Tensor& x1,
+    const Tensor& x2,
+    const double p) {
   AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "cdist", [&] {
     Dist<scalar_t>::apply_cdist(result, x1, x2, p);
   });
 }
 
-static void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor& x1, const Tensor& x2, const double p, const Tensor& dist) {
+static void cdist_backward_kernel_impl(
+    Tensor& result,
+    const Tensor& grad,
+    const Tensor& x1,
+    const Tensor& x2,
+    const double p,
+    const Tensor& dist) {
   AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "cdist_backward", [&] {
     Dist<scalar_t>::apply_backward_cdist(result, grad, x1, x2, p, dist);
   });
 }
 
-
-}  // anonymous namespace
+} // anonymous namespace
 
 REGISTER_DISPATCH(pdist_forward_stub, &pdist_forward_kernel_impl);
 REGISTER_DISPATCH(pdist_backward_stub, &pdist_backward_kernel_impl);
 REGISTER_DISPATCH(cdist_stub, &cdist_kernel_impl);
 REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_impl);
 
-}}  // namespace at::native
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -1,12 +1,12 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/Exceptions.h>
-#include <THC/THCTensorMathReduce.cuh>
 #include <math.h>
+#include <THC/THCTensorMathReduce.cuh>
 
 #include <ATen/native/Distance.h>
 
-
-namespace at { namespace native {
+namespace at {
+namespace native {
 
 namespace {
 
@@ -27,55 +27,151 @@ __forceinline__ __device__ double device_sqrt(double val) {
 
 template <typename scalar_t>
 struct dists {
-
   static __forceinline__ __device__ scalar_t sign(scalar_t val) {
     return (0 < val) - (val < 0);
   }
 
   // Zero norm
   struct zero {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) { agg += diff != 0.0; }
-    static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
-    static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
+    static __forceinline__ __device__ void inc(
+        scalar_t& agg,
+        const scalar_t diff,
+        const scalar_t p) {
+      agg += diff != 0.0;
+    }
+    static __forceinline__ __device__ scalar_t
+    finish(const scalar_t agg, const scalar_t p) {
+      return agg;
+    }
+    static __forceinline__ __device__ void agg(
+        scalar_t& update,
+        const scalar_t other) {
+      update += other;
+    }
   };
 
   // One norm
   struct one {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) { agg += diff; }
-    static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
-    static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
-    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return grad * sign(diff); }
+    static __forceinline__ __device__ void inc(
+        scalar_t& agg,
+        const scalar_t diff,
+        const scalar_t p) {
+      agg += diff;
+    }
+    static __forceinline__ __device__ scalar_t
+    finish(const scalar_t agg, const scalar_t p) {
+      return agg;
+    }
+    static __forceinline__ __device__ void agg(
+        scalar_t& update,
+        const scalar_t other) {
+      update += other;
+    }
+    static __forceinline__ __device__ scalar_t backward(
+        const scalar_t diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const scalar_t p) {
+      return grad * sign(diff);
+    }
   };
 
   // Special case backward when p is less than two
   struct lt_two {
-    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return dist == 0.0 ? 0 : sign(diff) * std::pow(std::abs(diff), p - 1) * grad / std::pow(dist, p - 1); }
+    static __forceinline__ __device__ scalar_t backward(
+        const scalar_t diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const scalar_t p) {
+      return dist == 0.0 ? 0
+                         : sign(diff) * std::pow(std::abs(diff), p - 1) * grad /
+              std::pow(dist, p - 1);
+    }
   };
 
   // Two norm
   struct two {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) { agg += diff * diff; }
-    static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t p) { return device_sqrt<scalar_t>(agg); }
-    static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
-    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return dist == 0.0 ? 0 : grad * diff / dist; }
+    static __forceinline__ __device__ void inc(
+        scalar_t& agg,
+        const scalar_t diff,
+        const scalar_t p) {
+      agg += diff * diff;
+    }
+    static __forceinline__ __device__ scalar_t
+    finish(const scalar_t agg, const scalar_t p) {
+      return device_sqrt<scalar_t>(agg);
+    }
+    static __forceinline__ __device__ void agg(
+        scalar_t& update,
+        const scalar_t other) {
+      update += other;
+    }
+    static __forceinline__ __device__ scalar_t backward(
+        const scalar_t diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const scalar_t p) {
+      return dist == 0.0 ? 0 : grad * diff / dist;
+    }
   };
 
   // General p norm
   struct p {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) { agg += std::pow(diff, p); }
-    static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t p) { return std::pow(agg, static_cast<scalar_t>(1) / p); }
-    static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { update += other; }
-    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return dist == 0.0 ? 0 : diff * std::pow(std::abs(diff), p - 2) * grad / std::pow(dist, p - 1); }
+    static __forceinline__ __device__ void inc(
+        scalar_t& agg,
+        const scalar_t diff,
+        const scalar_t p) {
+      agg += std::pow(diff, p);
+    }
+    static __forceinline__ __device__ scalar_t
+    finish(const scalar_t agg, const scalar_t p) {
+      return std::pow(agg, static_cast<scalar_t>(1) / p);
+    }
+    static __forceinline__ __device__ void agg(
+        scalar_t& update,
+        const scalar_t other) {
+      update += other;
+    }
+    static __forceinline__ __device__ scalar_t backward(
+        const scalar_t diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const scalar_t p) {
+      return dist == 0.0 ? 0
+                         : diff * std::pow(std::abs(diff), p - 2) * grad /
+              std::pow(dist, p - 1);
+    }
   };
 
   // Inf norm
   struct inf {
-    static __forceinline__ __device__ void inc(scalar_t& agg, const scalar_t diff, const scalar_t p) { if (diff > agg) { agg = diff; } }
-    static __forceinline__ __device__ scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
-    static __forceinline__ __device__ void agg(scalar_t& update, const scalar_t other) { if (other > update) { update = other; } }
-    static __forceinline__ __device__ scalar_t backward(const scalar_t diff, const scalar_t grad, const scalar_t dist, const scalar_t p) { return grad * sign(diff) * (std::abs(diff) == dist); }
+    static __forceinline__ __device__ void inc(
+        scalar_t& agg,
+        const scalar_t diff,
+        const scalar_t p) {
+      if (diff > agg) {
+        agg = diff;
+      }
+    }
+    static __forceinline__ __device__ scalar_t
+    finish(const scalar_t agg, const scalar_t p) {
+      return agg;
+    }
+    static __forceinline__ __device__ void agg(
+        scalar_t& update,
+        const scalar_t other) {
+      if (other > update) {
+        update = other;
+      }
+    }
+    static __forceinline__ __device__ scalar_t backward(
+        const scalar_t diff,
+        const scalar_t grad,
+        const scalar_t dist,
+        const scalar_t p) {
+      return grad * sign(diff) * (std::abs(diff) == dist);
+    }
   };
-
 };
 
 template <typename scalar_t, typename F>
@@ -102,19 +198,28 @@ __device__ static inline scalar_t reduce_agg(scalar_t agg) {
 }
 
 template <typename scalar_t, typename F>
-__global__ static void pdist_kernel_cuda_impl(scalar_t * result, const scalar_t * self, const int64_t n, const int64_t m, const scalar_t p,
-                                              const double n2, const double n2_squared_minus_1) {
-  const int k = blockIdx.x;
-  const int stride = blockDim.x;
+__global__ static void pdist_kernel_cuda_impl(
+    scalar_t* result,
+    const scalar_t* self,
+    const int64_t n,
+    const int64_t d,
+    const scalar_t p,
+    const double n2,
+    const double n2_squared_minus_1) {
+  const int64_t r_k = blockIdx.x;
+  const int64_t b_l = blockIdx.y;
+  const int64_t stride = blockDim.x;
 
   // The -1 accounts for floating point truncation issues
-  int64_t i = static_cast<int64_t>((n2 - device_sqrt<double>(n2_squared_minus_1 - 2 * k)));
-  int64_t j = k - n * i + i * (i + 1) / 2 + i + 1;
+  int64_t n_i = static_cast<int64_t>(
+      (n2 - device_sqrt<double>(n2_squared_minus_1 - 2 * r_k)));
+  int64_t n_j = r_k - n * n_i + n_i * (n_i + 1) / 2 + n_i + 1;
 
-  const scalar_t * const start = self + i * m;
-  const scalar_t * const end = start + m;
-  const scalar_t * a = start + threadIdx.x;
-  const scalar_t * b = self + j * m + threadIdx.x;
+  const scalar_t* const start = self + (b_l * n + n_i) * d;
+  const scalar_t* const end = start + d;
+  const scalar_t* a = start + threadIdx.x;
+  const scalar_t* b = self + (b_l * n + n_j) * d + threadIdx.x;
+
   scalar_t agg = 0.0;
   for (; a < end; a += stride, b += stride) {
     F::inc(agg, std::abs(*a - *b), p);
@@ -122,13 +227,24 @@ __global__ static void pdist_kernel_cuda_impl(scalar_t * result, const scalar_t 
 
   agg = reduce_agg<scalar_t, F>(agg);
   if (threadIdx.x == 0) {
-    result[k] = F::finish(agg, p);
+    const int64_t r = n * (n - 1) / 2;
+    result[b_l * r + r_k] = F::finish(agg, p);
   }
 }
 
 template <typename scalar_t, typename F>
-__global__ static void cdist_backward_kernel_cuda_impl(scalar_t * buffer, const scalar_t * grad, const scalar_t * x1, const scalar_t * x2, const scalar_t * dist, int64_t gs,
-                                                       const scalar_t p, const int64_t r1, const int64_t r2, const int64_t m, const int64_t count) {
+__global__ static void cdist_backward_kernel_cuda_impl(
+    scalar_t* buffer,
+    const scalar_t* grad,
+    const scalar_t* x1,
+    const scalar_t* x2,
+    const scalar_t* dist,
+    int64_t gs,
+    const scalar_t p,
+    const int64_t r1,
+    const int64_t r2,
+    const int64_t m,
+    const int64_t count) {
   const int k = blockIdx.y * blockDim.y + threadIdx.y;
   const int init = blockIdx.x * blockDim.x + threadIdx.x;
   const int stride = blockDim.x * gridDim.x;
@@ -143,12 +259,12 @@ __global__ static void cdist_backward_kernel_cuda_impl(scalar_t * buffer, const 
   const scalar_t grad_k = grad[k * gs];
   const scalar_t dist_k = dist[k];
 
-  const scalar_t * const start = x1 + i * m;
-  const scalar_t * const end = start + m;
-  const scalar_t * self_i = start + init;
-  const scalar_t * self_j = x2 + j * m + init;
+  const scalar_t* const start = x1 + i * m;
+  const scalar_t* const end = start + m;
+  const scalar_t* self_i = start + init;
+  const scalar_t* self_j = x2 + j * m + init;
 
-  scalar_t * buff_i = buffer + (r1 * j + i) * m + init;
+  scalar_t* buff_i = buffer + (r1 * j + i) * m + init;
 
   for (; self_i < end; self_i += stride, self_j += stride, buff_i += stride) {
     const scalar_t res = F::backward(*self_i - *self_j, grad_k, dist_k, p);
@@ -157,49 +273,72 @@ __global__ static void cdist_backward_kernel_cuda_impl(scalar_t * buffer, const 
 }
 
 template <typename scalar_t, typename F>
-__global__ static void pdist_backward_kernel_cuda_impl(scalar_t * buffer, const scalar_t * grad, const scalar_t * self, const scalar_t * dist, int64_t gs, const int64_t n, const int64_t m, const int64_t combs, const scalar_t p,
-                                                       const double n2, const double n2_squared_minus_1) {
-  const int k = blockIdx.y * blockDim.y + threadIdx.y;
-  const int init = blockIdx.x * blockDim.x + threadIdx.x;
-  const int stride = blockDim.x * gridDim.x;
+__global__ static void pdist_backward_kernel_cuda_impl(
+    scalar_t* result,
+    const scalar_t* grad,
+    const scalar_t* self,
+    const scalar_t* dist,
+    int64_t gs_l,
+    int64_t gs_k,
+    const int64_t n,
+    const int64_t d,
+    const int64_t r,
+    const scalar_t p,
+    const double n2,
+    const double n2_squared_minus_1) {
+  const int64_t b_l = blockIdx.z;
+  const int64_t r_k = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t init = blockIdx.y * blockDim.y + threadIdx.y;
+  const int64_t stride = blockDim.x * gridDim.x;
 
-  if (k >= combs) {
+  if (r_k >= r) {
     return;
   }
 
   // The -1 accounts for floating point truncation issues
-  int64_t i = static_cast<int64_t>((n2 - device_sqrt<double>(n2_squared_minus_1 - 2 * k)));
-  int64_t j = k - n * i + i * (i + 1) / 2 + i + 1;
-  int64_t ib = j - i - 1;
-  int64_t jb = n - 2 - i;
+  int64_t n_i = static_cast<int64_t>(
+      (n2 - device_sqrt<double>(n2_squared_minus_1 - 2 * r_k)));
+  int64_t n_j = r_k - n * n_i + n_i * (n_i + 1) / 2 + n_i + 1;
+  int64_t n_ir = n_j - n_i - 1;
+  int64_t n_jr = n - 2 - n_i;
 
-  const scalar_t grad_k = grad[k * gs];
-  const scalar_t dist_k = dist[k];
+  const scalar_t grad_lk = grad[b_l * gs_l + r_k * gs_k];
+  const scalar_t dist_lk = dist[b_l * r + r_k];
 
-  const scalar_t * const start = self + i * m;
-  const scalar_t * const end = start + m;
-  const scalar_t * self_i = start + init;
-  const scalar_t * self_j = self + j * m + init;
-  scalar_t * buff_i = buffer + (ib * n + i) * m + init;
-  scalar_t * buff_j = buffer + (jb * n + j) * m + init;
-  for (; self_i < end; self_i += stride, self_j += stride, buff_i += stride, buff_j += stride) {
-    const scalar_t res = F::backward(*self_i - *self_j, grad_k, dist_k, p);
-    *buff_i = res;
-    *buff_j = -res;
+  const scalar_t* const start = self + (b_l * n + n_i) * d;
+  const scalar_t* const end = start + d;
+  const scalar_t* self_i = start + init;
+  const scalar_t* self_j = self_i + (n_j - n_i) * d;
+  scalar_t* result_i = result + ((b_l * (n - 1) + n_ir) * n + n_i) * d + init;
+  scalar_t* result_j = result_i + ((n_jr - n_ir) * n + n_j - n_i) * d;
+  for (; self_i < end; self_i += stride,
+                       self_j += stride,
+                       result_i += stride,
+                       result_j += stride) {
+    const scalar_t res = F::backward(*self_i - *self_j, grad_lk, dist_lk, p);
+    *result_i = res;
+    *result_j = -res;
   }
 }
 
 template <typename scalar_t, typename F>
-__global__ static void cdist_kernel_cuda_impl(scalar_t * result, const scalar_t * x1, const scalar_t * x2, const scalar_t p, const int64_t r1, const int64_t r2, const int64_t m) {
+__global__ static void cdist_kernel_cuda_impl(
+    scalar_t* result,
+    const scalar_t* x1,
+    const scalar_t* x2,
+    const scalar_t p,
+    const int64_t r1,
+    const int64_t r2,
+    const int64_t m) {
   const int k = blockIdx.x;
   const int64_t i = k / r2;
   const int64_t j = k % r2;
   const int stride = blockDim.x;
 
-  const scalar_t * const start = x1 + i * m;
-  const scalar_t * const end = start + m;
-  const scalar_t * a = start + threadIdx.x;
-  const scalar_t * b = x2 + j * m + threadIdx.x;
+  const scalar_t* const start = x1 + i * m;
+  const scalar_t* const end = start + m;
+  const scalar_t* a = start + threadIdx.x;
+  const scalar_t* b = x2 + j * m + threadIdx.x;
 
   scalar_t agg = 0.0;
   for (; a < end; a += stride, b += stride) {
@@ -211,97 +350,289 @@ __global__ static void cdist_kernel_cuda_impl(scalar_t * result, const scalar_t 
   }
 }
 
-void cdist_kernel_impl(Tensor& result, const Tensor& x1, const Tensor& x2, double p) {
+void cdist_kernel_impl(
+    Tensor& result,
+    const Tensor& x1,
+    const Tensor& x2,
+    double p) {
   int64_t r1 = x1.size(-2);
   int64_t r2 = x2.size(-2);
   int64_t m = x1.size(-1);
-  const dim3 grid(r1*r2);
+  const dim3 grid(r1 * r2);
   const dim3 block(forward_threads);
 
   AT_DISPATCH_FLOATING_TYPES(x1.scalar_type(), "cdist_cuda", [&] {
     if (p == 0.0) {
-      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::zero><<<grid, block>>>(result.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), p, r1, r2, m);
+      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::zero><<<grid, block>>>(
+          result.data<scalar_t>(),
+          x1.data<scalar_t>(),
+          x2.data<scalar_t>(),
+          p,
+          r1,
+          r2,
+          m);
     } else if (p == 1.0) {
-      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(result.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), p, r1, r2, m);
+      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(
+          result.data<scalar_t>(),
+          x1.data<scalar_t>(),
+          x2.data<scalar_t>(),
+          p,
+          r1,
+          r2,
+          m);
     } else if (p == 2.0) {
-      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::two><<<grid, block>>>(result.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), p, r1, r2, m);
+      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::two><<<grid, block>>>(
+          result.data<scalar_t>(),
+          x1.data<scalar_t>(),
+          x2.data<scalar_t>(),
+          p,
+          r1,
+          r2,
+          m);
     } else if (std::isinf(p)) {
-      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf><<<grid, block>>>(result.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), p, r1, r2, m);
+      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf><<<grid, block>>>(
+          result.data<scalar_t>(),
+          x1.data<scalar_t>(),
+          x2.data<scalar_t>(),
+          p,
+          r1,
+          r2,
+          m);
     } else {
-      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::p><<<grid, block>>>(result.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), p, r1, r2, m);
+      cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::p><<<grid, block>>>(
+          result.data<scalar_t>(),
+          x1.data<scalar_t>(),
+          x2.data<scalar_t>(),
+          p,
+          r1,
+          r2,
+          m);
     }
   });
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
 void pdist_forward_kernel_impl(Tensor& result, const Tensor& self, double p) {
-  const dim3 grid(result.numel());
+  int64_t b = self.size(0);
+  int64_t n = self.size(1);
+  int64_t d = self.size(2);
+  int64_t r = result.size(1);
+
+  AT_CHECK(
+      b < (int32_t(1) << 16),
+      "The number of batches can't exceed ",
+      (int32_t(1) << 16) - 1,
+      " but was ",
+      b);
+  AT_CHECK(
+      r < (int64_t(1) << 32),
+      "The number of combinations can't exceed ",
+      (int64_t(1) << 32) - 1,
+      " but was ",
+      r);
+
+  const dim3 grid(r, b);
   const dim3 block(forward_threads);
-  int64_t n = self.size(0);
-  int64_t m = self.size(1);
+
   // https://github.com/pytorch/pytorch/issues/15511 demonstrated we need to do
-  // some math in fp64 -- this is just minimizing the amount of fp64 math we do on the device.
+  // some math in fp64 -- this is just minimizing the amount of fp64 math we do
+  // on the device.
   const double n2 = n - .5;
   const double n2_squared_minus_1 = n2 * n2 - 1;
 
   AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist_cuda", [&] {
     if (p == 0.0) {
-      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::zero><<<grid, block>>>(result.data<scalar_t>(), self.data<scalar_t>(), n, m, p, n2, n2_squared_minus_1);
+      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::zero><<<grid, block>>>(
+          result.data<scalar_t>(),
+          self.data<scalar_t>(),
+          n,
+          d,
+          p,
+          n2,
+          n2_squared_minus_1);
     } else if (p == 1.0) {
-      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(result.data<scalar_t>(), self.data<scalar_t>(), n, m, p, n2, n2_squared_minus_1);
+      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(
+          result.data<scalar_t>(),
+          self.data<scalar_t>(),
+          n,
+          d,
+          p,
+          n2,
+          n2_squared_minus_1);
     } else if (p == 2.0) {
-      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::two><<<grid, block>>>(result.data<scalar_t>(), self.data<scalar_t>(), n, m, p, n2, n2_squared_minus_1);
+      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::two><<<grid, block>>>(
+          result.data<scalar_t>(),
+          self.data<scalar_t>(),
+          n,
+          d,
+          p,
+          n2,
+          n2_squared_minus_1);
     } else if (std::isinf(p)) {
-      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf><<<grid, block>>>(result.data<scalar_t>(), self.data<scalar_t>(), n, m, p, n2, n2_squared_minus_1);
+      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf><<<grid, block>>>(
+          result.data<scalar_t>(),
+          self.data<scalar_t>(),
+          n,
+          d,
+          p,
+          n2,
+          n2_squared_minus_1);
     } else {
-      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::p><<<grid, block>>>(result.data<scalar_t>(), self.data<scalar_t>(), n, m, p, n2, n2_squared_minus_1);
+      pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::p><<<grid, block>>>(
+          result.data<scalar_t>(),
+          self.data<scalar_t>(),
+          n,
+          d,
+          p,
+          n2,
+          n2_squared_minus_1);
     }
   });
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-void pdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor& self, const double p, const Tensor& dist) {
+void pdist_backward_kernel_impl(
+    Tensor& result,
+    const Tensor& grad,
+    const Tensor& self,
+    const double p,
+    const Tensor& dist) {
   if (p == 0.0 || grad.numel() == 0 || self.numel() == 0) {
     result.fill_(0);
     return;
   }
+  // Be careful with changing these as they affect the maximum dimensions that
+  // backward can run on, however these are currently more permissive than the
+  // forward pass
+  const int block_x = 16;
+  const int block_y = 64;
 
-  const int64_t n = result.size(0);
-  int64_t m = self.size(1);
-  const int block_x = 64;
-  // NB: be careful with changing block_y; as it's currently written, grid_y is limited to be 2^16.
-  // From binary search, block_y of 16 gives us max pdist dim0 of 1449,
-  //                     block_y of  4 gives us max pdist dim0 of  725.
-  const int block_y = 16;
-  const int grid_x = (m + block_x * 8 - 1) / (block_x * 8);
-  const int grid_y = (dist.numel() + block_y - 1) / block_y;
-  const dim3 grid(grid_x, grid_y);
+  const int64_t b = self.size(0);
+  const int64_t n = self.size(1);
+  const int64_t d = self.size(2);
+  const int64_t r = dist.size(1);
+
+  AT_CHECK(
+      b < (int32_t(1) << 16),
+      "The number of batches can't exceed ",
+      (int32_t(1) << 16) - 1,
+      " but was ",
+      b);
+  AT_CHECK(
+      r < (int64_t(1) << 32) * block_x,
+      "The number of combinations can't exceed ",
+      (int64_t(1) << 32) * block_x - 1,
+      " but was ",
+      r);
+  AT_CHECK(
+      d < (int32_t(1) << 16) * block_y * 8,
+      "The number of dimensions can't exceed ",
+      (int32_t(1) << 16) * block_y * 8 - 1,
+      " but was ",
+      d);
+
+  const int grid_x = (r + block_x - 1) / block_x;
+  const int grid_y = (d + block_y * 8 - 1) / (block_y * 8);
+  const dim3 grid(grid_x, grid_y, b);
   const dim3 block(block_x, block_y);
+
   // https://github.com/pytorch/pytorch/issues/15511 demonstrated we need to do
-  // some math in fp64 -- this is just minimizing the amount of fp64 math we do on the device.
+  // some math in fp64 -- this is just minimizing the amount of fp64 math we do
+  // on the device.
   const double n2 = n - .5;
   const double n2_squared_minus_1 = n2 * n2 - 1;
 
-  Tensor buffer = at::empty({n - 1, result.size(0), result.size(1)}, result.options());
-  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist_cuda_backward", [&] {
+  Tensor buffer = at::empty({b, n - 1, n, d}, result.options());
+  AT_DISPATCH_FLOATING_TYPES(self.type(), "pdist_cuda_backward", [&] {
     if (p == 1.0) {
-      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), self.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(0), n, m, dist.numel(), p, n2, n2_squared_minus_1);
+      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::one>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              self.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(0),
+              grad.stride(1),
+              n,
+              d,
+              r,
+              p,
+              n2,
+              n2_squared_minus_1);
     } else if (p < 2.0) {
-      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::lt_two><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), self.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(0), n, m, dist.numel(), p, n2, n2_squared_minus_1);
+      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::lt_two>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              self.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(0),
+              grad.stride(1),
+              n,
+              d,
+              r,
+              p,
+              n2,
+              n2_squared_minus_1);
     } else if (p == 2.0) {
-      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::two><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), self.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(0), n, m, dist.numel(), p, n2, n2_squared_minus_1);
+      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::two>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              self.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(0),
+              grad.stride(1),
+              n,
+              d,
+              r,
+              p,
+              n2,
+              n2_squared_minus_1);
     } else if (std::isinf(p)) {
-      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), self.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(0), n, m, dist.numel(), p, n2, n2_squared_minus_1);
+      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              self.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(0),
+              grad.stride(1),
+              n,
+              d,
+              r,
+              p,
+              n2,
+              n2_squared_minus_1);
     } else {
-      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::p><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), self.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(0), n, m, dist.numel(), p, n2, n2_squared_minus_1);
+      pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::p>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              self.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(0),
+              grad.stride(1),
+              n,
+              d,
+              r,
+              p,
+              n2,
+              n2_squared_minus_1);
     }
   });
   AT_CUDA_CHECK(cudaGetLastError());
 
-  at::sum_out(result, buffer, 0);
+  at::sum_out(result, buffer, 1);
 }
 
-void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor& x1, const Tensor& x2, const double p, const Tensor& dist) {
+void cdist_backward_kernel_impl(
+    Tensor& result,
+    const Tensor& grad,
+    const Tensor& x1,
+    const Tensor& x2,
+    const double p,
+    const Tensor& dist) {
   if (p == 0.0 || grad.numel() == 0 || x1.numel() == 0 || x2.numel() == 0) {
     result.fill_(0);
     return;
@@ -323,22 +654,81 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   Tensor buffer = at::empty({r2, r1, m}, result.options());
   AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "cdist_cuda_backward", [&] {
     if (p == 1.0) {
-      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(1), p, r1, r2, m, count);
+      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::one>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              x1.data<scalar_t>(),
+              x2.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(1),
+              p,
+              r1,
+              r2,
+              m,
+              count);
     } else if (p < 2.0) {
-      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::lt_two><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(1), p, r1, r2, m, count);
+      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::lt_two>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              x1.data<scalar_t>(),
+              x2.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(1),
+              p,
+              r1,
+              r2,
+              m,
+              count);
     } else if (p == 2.0) {
-      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::two><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(1), p, r1, r2, m, count);
+      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::two>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              x1.data<scalar_t>(),
+              x2.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(1),
+              p,
+              r1,
+              r2,
+              m,
+              count);
     } else if (std::isinf(p)) {
-      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(1), p, r1, r2, m, count);
+      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::inf>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              x1.data<scalar_t>(),
+              x2.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(1),
+              p,
+              r1,
+              r2,
+              m,
+              count);
     } else {
-      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::p><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(1), p, r1, r2, m, count);
+      cdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::p>
+          <<<grid, block>>>(
+              buffer.data<scalar_t>(),
+              grad.data<scalar_t>(),
+              x1.data<scalar_t>(),
+              x2.data<scalar_t>(),
+              dist.data<scalar_t>(),
+              grad.stride(1),
+              p,
+              r1,
+              r2,
+              m,
+              count);
     }
   });
   AT_CUDA_CHECK(cudaGetLastError());
 
   at::sum_out(result, buffer, 0);
 }
-
 
 } // anonymous namespace
 
@@ -347,4 +737,5 @@ REGISTER_DISPATCH(pdist_backward_stub, &pdist_backward_kernel_impl);
 REGISTER_DISPATCH(cdist_stub, &cdist_kernel_impl);
 REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_impl);
 
-}} // at::native
+} // namespace native
+} // namespace at

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6192,10 +6192,10 @@ class TestNN(NNTestCase):
 
     @skipIfRocm
     def test_pdist(self):
-        for device, trans in itertools.product(device_(), [False, True]):
-            inp = torch.randn(4, 5, dtype=torch.double, device=device, requires_grad=True)
+        for device, trans, size in itertools.product(device_(), [False, True], [(3, 4, 5), (17, 37)]):
+            inp = torch.randn(size, dtype=torch.double, device=device, requires_grad=True)
             if trans:
-                inp = inp.transpose(0, 1)
+                inp = inp.transpose(-2, -1)
             for p in [0, 1, 2, 0.5, 1.5, 2.5, float('inf')]:
                 self.assertTrue(gradcheck(lambda x: F.pdist(x, p), (inp,)))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1209,7 +1209,7 @@ class _TestTorchMixin(object):
             self.assertTrue(torch.allclose(expected, actual))
 
         for device in torch.testing.get_all_device_types():
-            for shape in [(4, 5), (3, 2), (2, 1)]:
+            for shape in [(3, 4, 5), (17, 19), (4, 5), (3, 2), (2, 1)]:
                 for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
                     for trans in [False, True]:
                         for dtype in [torch.float32, torch.float64]:
@@ -1218,7 +1218,9 @@ class _TestTorchMixin(object):
             # do a simplified comparison with big inputs, see:
             # https://github.com/pytorch/pytorch/issues/15511
             for dtype in [torch.float32, torch.float64]:
-                test_pdist_single((1000, 2), device, 2, dtype, False)
+                test_pdist_single((1000, 4, 2), device, 2, dtype, False)
+                test_pdist_single((2, 1000, 2), device, 2, dtype, False)
+                test_pdist_single((2, 4, 1000), device, 2, dtype, False)
 
     def test_cdist_empty(self):
         for device in torch.testing.get_all_device_types():


### PR DESCRIPTION
This is a refactor of the old batched pdist but using the new tests and using double point floating math for computing indices.
I also added some checks for size when computing cuda batches.
Currently CUDA can't handle a batch size larger than 2 ^ 16 - 1, which seems large enough to be useful.

I also ran clang-format, so the diff might be a little messy, but the only changes are in the bodies of the loops for computing pdist and the gradient.

Speed seems to be the same as before adding batched support.
In addition to the tests I double checked that this worked / ran for large inputs:

size | device | dtype | tests
----|---------|-------|-----
(2^16, 7) | cpu | float | brute equality
(2^12, 7) | cuda | float | brute equality
(2^16 - 1, 16, 7) | cuda, cpu | float | brute equality
(512, 7) | cuda, cpu | double | gradcheck
(512, 8, 7) | cuda, cpu | double | gradcheck
(2^12, 7) | cuda, cpu | double | brute grad equality
(2^14, 16, 7) | cuda, cpu | double | brute grad equality

Where *brute equality* means it `torch.allclose` was true between the value computed by `pdist` and `common_utils.brute_pdist`, *gradcheck* means `torch.autograd.gradcheck` passed, and *brute grad equality* means `torch.allclose` was true between the gradient vectors of the sum of pdist outputs.
Most of the sizes were chosen because memory ran out, or computation time got exceedingly long.