### PR TITLE
[ROCm] tune elementwise for AMD uarch

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -41,7 +41,7 @@ void gpu_index_kernel(TensorIterator& iter, IntList index_size, IntList index_st
   char* in_ptr = (char*)iter.data_ptr(1);
 
   auto offset_calc = index_make_offset_calculator<3>(iter);
-  launch_kernel<128, 4>(iter.numel(), [=]__device__(int idx) {
+  launch_kernel<launch_size_nd, launch_bound2>(iter.numel(), [=]__device__(int idx) {
     auto offsets = offset_calc.get(idx);
     char* out_data = out_ptr + offsets[0];
     char* in_data = in_ptr + offsets[1];

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -24,21 +24,19 @@
 
 #ifdef __HIP_PLATFORM_HCC__
 static constexpr int launch_size_1d = 1024;
-static constexpr int launch_size_nd = 128;
-static constexpr int launch_bound2_1d = 16;
-static constexpr int launch_bound2_nd = 4;
+static constexpr int launch_size_nd = 1024;
+static constexpr int launch_bound2 = 16;
 #else
 static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;
-static constexpr int launch_bound2_1d = 4;
-static constexpr int laucnh_bound2_nd = 4;
+static constexpr int launch_bound2 = 4;
 #endif
 
 
 namespace at { namespace native {
 
-template<int nt, int nt_2, int vt, typename func_t>
-C10_LAUNCH_BOUNDS(nt, nt_2)
+template<int nt, int vt, typename func_t>
+C10_LAUNCH_BOUNDS(nt, launch_bound2)
 __global__ void elementwise_kernel(int N, func_t f) {
   int tid = threadIdx.x;
   int nv = nt * vt;
@@ -97,13 +95,13 @@ void gpu_nullary_kernel(TensorIterator& iter, const func_t& f) {
   if (iter.is_trivial_1d()) {
     auto strides = iter.get_inner_strides();
     int stride0 = strides[0];
-    launch_kernel<launch_size_1d, launch_bound2_1d, 1>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_1d, 1>(numel, [=]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       *out = f();
     });
   } else {
     auto offset_calc = make_offset_calculator<1>(iter);
-    launch_kernel<launch_size_nd, launch_bound2_nd, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, launch_bound2>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       *out = f();
@@ -143,14 +141,14 @@ void gpu_unary_kernel(TensorIterator& iter, const func_t& f) {
     auto strides = iter.get_inner_strides();
     int stride0 = strides[0];
     int stride1 = strides[1];
-    launch_kernel<launch_size_1d, launch_bound2_1d, 1>(numel, [out_data, stride0, stride1, in1_data, f]__device__(int idx) {
+    launch_kernel<launch_size_1d, 1>(numel, [out_data, stride0, stride1, in1_data, f]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       arg1_t* in1 = (arg1_t*)&in1_data[stride1 * idx];
       *out = f(*in1);
     });
   } else {
     auto offset_calc = make_offset_calculator<2>(iter);
-    launch_kernel<launch_size_nd, launch_bound2_nd, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, launch_bound2>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       arg1_t* in1 = (arg1_t*)&in1_data[offsets[1]];
@@ -200,7 +198,7 @@ void gpu_binary_kernel(TensorIterator& iter, const func_t& f) {
     int stride0 = strides[0];
     int stride1 = strides[1];
     int stride2 = strides[2];
-    launch_kernel<launch_size_1d, launch_bound2_1d, 1>(numel, [stride0, stride1, out_data, in1_data, f, stride2, in2_data]__device__(int idx) {
+    launch_kernel<launch_size_1d, 1>(numel, [stride0, stride1, out_data, in1_data, f, stride2, in2_data]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       arg1_t* in1 = (arg1_t*)&in1_data[stride1 * idx];
       arg2_t* in2 = (arg2_t*)&in2_data[stride2 * idx];
@@ -208,7 +206,7 @@ void gpu_binary_kernel(TensorIterator& iter, const func_t& f) {
     });
   } else {
     auto offset_calc = make_offset_calculator<3>(iter);
-    launch_kernel<launch_size_nd, launch_bound2_nd,4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, launch_bound2>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       arg1_t* in1 = (arg1_t*)&in1_data[offsets[1]];

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -22,11 +22,21 @@
 #define ASSERT_HOST_DEVICE_LAMBDA(type)
 #endif
 
+#ifdef __HIP_PLATFORM_HCC__
+static constexpr int launch_size_1d = 1024;
+static constexpr int launch_size_nd = 256;
+static constexpr int launch_bounds_2 = 16;
+#else
+static constexpr int launch_size_1d = 512;
+static constexpr int launch_size_nd = 128;
+static constexpr int launch_bounds_2 = 4;
+#endif
+
 
 namespace at { namespace native {
 
 template<int nt, int vt, typename func_t>
-C10_LAUNCH_BOUNDS(nt, 4)
+C10_LAUNCH_BOUNDS(nt, launch_bounds_2)
 __global__ void elementwise_kernel(int N, func_t f) {
   int tid = threadIdx.x;
   int nv = nt * vt;
@@ -85,13 +95,13 @@ void gpu_nullary_kernel(TensorIterator& iter, const func_t& f) {
   if (iter.is_trivial_1d()) {
     auto strides = iter.get_inner_strides();
     int stride0 = strides[0];
-    launch_kernel<512, 1>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_1d, 1>(numel, [=]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       *out = f();
     });
   } else {
     auto offset_calc = make_offset_calculator<1>(iter);
-    launch_kernel<128, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, 4>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       *out = f();
@@ -131,14 +141,14 @@ void gpu_unary_kernel(TensorIterator& iter, const func_t& f) {
     auto strides = iter.get_inner_strides();
     int stride0 = strides[0];
     int stride1 = strides[1];
-    launch_kernel<512, 1>(numel, [out_data, stride0, stride1, in1_data, f]__device__(int idx) {
+    launch_kernel<launch_size_1d, 1>(numel, [out_data, stride0, stride1, in1_data, f]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       arg1_t* in1 = (arg1_t*)&in1_data[stride1 * idx];
       *out = f(*in1);
     });
   } else {
     auto offset_calc = make_offset_calculator<2>(iter);
-    launch_kernel<128, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, 4>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       arg1_t* in1 = (arg1_t*)&in1_data[offsets[1]];
@@ -188,7 +198,7 @@ void gpu_binary_kernel(TensorIterator& iter, const func_t& f) {
     int stride0 = strides[0];
     int stride1 = strides[1];
     int stride2 = strides[2];
-    launch_kernel<512, 1>(numel, [stride0, stride1, out_data, in1_data, f, stride2, in2_data]__device__(int idx) {
+    launch_kernel<launch_size_1d, 1>(numel, [stride0, stride1, out_data, in1_data, f, stride2, in2_data]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       arg1_t* in1 = (arg1_t*)&in1_data[stride1 * idx];
       arg2_t* in2 = (arg2_t*)&in2_data[stride2 * idx];
@@ -196,7 +206,7 @@ void gpu_binary_kernel(TensorIterator& iter, const func_t& f) {
     });
   } else {
     auto offset_calc = make_offset_calculator<3>(iter);
-    launch_kernel<128, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, 4>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       arg1_t* in1 = (arg1_t*)&in1_data[offsets[1]];

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -60,7 +60,7 @@ static OffsetCalculator<N> make_offset_calculator(const TensorIterator& iter) {
   return OffsetCalculator<N>(iter.ndim(), iter.shape().data(), strides.data());
 }
 
-template<int nt, int nt_2, int vt, typename func_t>
+template<int nt, int vt, typename func_t>
 static void launch_kernel(int64_t N, const func_t& f) {
   if (N == 0) {
     return;

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -24,7 +24,7 @@
 
 #ifdef __HIP_PLATFORM_HCC__
 static constexpr int launch_size_1d = 1024;
-static constexpr int launch_size_nd = 256;
+static constexpr int launch_size_nd = 128;
 static constexpr int launch_bounds_2 = 16;
 #else
 static constexpr int launch_size_1d = 512;

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -68,7 +68,7 @@ static void launch_kernel(int64_t N, const func_t& f) {
   dim3 block(nt);
   dim3 grid((N + block.x * vt - 1) / (block.x * vt));
   auto stream = at::cuda::getCurrentCUDAStream();
-  elementwise_kernel<nt, nt_2, vt, func_t><<<grid, block, 0, stream>>>(N, f);
+  elementwise_kernel<nt, vt, func_t><<<grid, block, 0, stream>>>(N, f);
   AT_CUDA_CHECK(cudaGetLastError());
 }
 

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -25,18 +25,20 @@
 #ifdef __HIP_PLATFORM_HCC__
 static constexpr int launch_size_1d = 1024;
 static constexpr int launch_size_nd = 128;
-static constexpr int launch_bounds_2 = 16;
+static constexpr int launch_bound2_1d = 16;
+static constexpr int launch_bound2_nd = 4;
 #else
 static constexpr int launch_size_1d = 512;
 static constexpr int launch_size_nd = 128;
-static constexpr int launch_bounds_2 = 4;
+static constexpr int launch_bound2_1d = 4;
+static constexpr int laucnh_bound2_nd = 4;
 #endif
 
 
 namespace at { namespace native {
 
-template<int nt, int vt, typename func_t>
-C10_LAUNCH_BOUNDS(nt, launch_bounds_2)
+template<int nt, int nt_2, int vt, typename func_t>
+C10_LAUNCH_BOUNDS(nt, nt_2)
 __global__ void elementwise_kernel(int N, func_t f) {
   int tid = threadIdx.x;
   int nv = nt * vt;
@@ -60,7 +62,7 @@ static OffsetCalculator<N> make_offset_calculator(const TensorIterator& iter) {
   return OffsetCalculator<N>(iter.ndim(), iter.shape().data(), strides.data());
 }
 
-template<int nt, int vt, typename func_t>
+template<int nt, int nt_2, int vt, typename func_t>
 static void launch_kernel(int64_t N, const func_t& f) {
   if (N == 0) {
     return;
@@ -68,7 +70,7 @@ static void launch_kernel(int64_t N, const func_t& f) {
   dim3 block(nt);
   dim3 grid((N + block.x * vt - 1) / (block.x * vt));
   auto stream = at::cuda::getCurrentCUDAStream();
-  elementwise_kernel<nt, vt, func_t><<<grid, block, 0, stream>>>(N, f);
+  elementwise_kernel<nt, nt_2, vt, func_t><<<grid, block, 0, stream>>>(N, f);
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -95,13 +97,13 @@ void gpu_nullary_kernel(TensorIterator& iter, const func_t& f) {
   if (iter.is_trivial_1d()) {
     auto strides = iter.get_inner_strides();
     int stride0 = strides[0];
-    launch_kernel<launch_size_1d, 1>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_1d, launch_bound2_1d, 1>(numel, [=]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       *out = f();
     });
   } else {
     auto offset_calc = make_offset_calculator<1>(iter);
-    launch_kernel<launch_size_nd, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, launch_bound2_nd, 4>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       *out = f();
@@ -141,14 +143,14 @@ void gpu_unary_kernel(TensorIterator& iter, const func_t& f) {
     auto strides = iter.get_inner_strides();
     int stride0 = strides[0];
     int stride1 = strides[1];
-    launch_kernel<launch_size_1d, 1>(numel, [out_data, stride0, stride1, in1_data, f]__device__(int idx) {
+    launch_kernel<launch_size_1d, launch_bound2_1d, 1>(numel, [out_data, stride0, stride1, in1_data, f]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       arg1_t* in1 = (arg1_t*)&in1_data[stride1 * idx];
       *out = f(*in1);
     });
   } else {
     auto offset_calc = make_offset_calculator<2>(iter);
-    launch_kernel<launch_size_nd, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, launch_bound2_nd, 4>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       arg1_t* in1 = (arg1_t*)&in1_data[offsets[1]];
@@ -198,7 +200,7 @@ void gpu_binary_kernel(TensorIterator& iter, const func_t& f) {
     int stride0 = strides[0];
     int stride1 = strides[1];
     int stride2 = strides[2];
-    launch_kernel<launch_size_1d, 1>(numel, [stride0, stride1, out_data, in1_data, f, stride2, in2_data]__device__(int idx) {
+    launch_kernel<launch_size_1d, launch_bound2_1d, 1>(numel, [stride0, stride1, out_data, in1_data, f, stride2, in2_data]__device__(int idx) {
       arg0_t* out = (arg0_t*)&out_data[stride0 * idx];
       arg1_t* in1 = (arg1_t*)&in1_data[stride1 * idx];
       arg2_t* in2 = (arg2_t*)&in2_data[stride2 * idx];
@@ -206,7 +208,7 @@ void gpu_binary_kernel(TensorIterator& iter, const func_t& f) {
     });
   } else {
     auto offset_calc = make_offset_calculator<3>(iter);
-    launch_kernel<launch_size_nd, 4>(numel, [=]__device__(int idx) {
+    launch_kernel<launch_size_nd, launch_bound2_nd,4>(numel, [=]__device__(int idx) {
       auto offsets = offset_calc.get(idx);
       arg0_t* out = (arg0_t*)&out_data[offsets[0]];
       arg1_t* in1 = (arg1_t*)&in1_data[offsets[1]];


### PR DESCRIPTION
Tune elementwise kernel for AMD architectures by increasing the work group sizes and launch bounds. This change improves training throughput for torchvision models by up to 11% in our tests while exhibiting no significant performance regression.

No functional/performance change for CUDA - just shifting numbers into constrexpr.
