### PR TITLE
reduce parameter space of test_1x1_conv to avoid timeout

### DIFF
--- a/caffe2/python/operator_test/conv_test.py
+++ b/caffe2/python/operator_test/conv_test.py
@@ -884,12 +884,12 @@ class TestConvolution(serial.SerializedTestCase):
 
     @serial.given(
         op_type=st.sampled_from(["Conv", "Conv2D"]),
-        N=st.integers(1, 4),
-        G=st.integers(1, 4),
-        DX=st.integers(1, 4),
-        DY=st.integers(1, 4),
-        H=st.integers(1, 4),
-        W=st.integers(1, 4),
+        N=st.integers(1, 3),
+        G=st.integers(1, 3),
+        DX=st.integers(1, 3),
+        DY=st.integers(1, 3),
+        H=st.integers(1, 3),
+        W=st.integers(1, 3),
         use_bias=st.booleans(),
         order=st.sampled_from(["NCHW", "NHWC"]),
         force_algo_fwd=_cudnn_convolution_algo_count("fwd"),


### PR DESCRIPTION
Summary: As title says

Differential Revision: D13758202
