### PR TITLE
Support Tensor alias annotations for native_functions.yaml

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -210,9 +210,9 @@ def postprocess_output_declarations(output_declarations):
                 if decl.inplace:
                     ret['name'] = 'self'
                 elif len(decl.returns) == 1:
-                    ret['name'] = 'result'
+                    ret['name'] = 'out'
                 else:
-                    ret['name'] = 'result' + str(n)
+                    ret['name'] = 'out' + str(n)
             else:
                 has_named_ret = True
 

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -203,13 +203,13 @@ In order to provide implementations for these Python functions the legacy schema
 requires C++ implementations for three situations `abs(Tensor self)  -> Tensor`, 
 `abs_(Tensor self) -> Tensor` and `abs_out(Tensor out, Tensor self) -> Tensor`.
 
-Now, as we move towards the unification, we use different syntax to represent some of
-this using annotations and translate to the legacy schema for the downstream consumers
-such as the C++ code generation.
+Now, as we move towards the unification, we start to use a different syntax to represent
+this by using annotations. In the end we still translate to the legacy schema for the downstream
+consumers such as the C++ code generation, but this will soon change.
 
-For this schema we restrict ourselves to `Tensor(a)` and `Tensor(a!)`. If two Tensors
-carry the same annotation, they both *may* represent the same memory. A write annotation,
-as indicated by an exclamation mark, indicates that they both *may* also be written to.
+If two Tensors carry the same annotation, they both *may* represent the same memory.
+A write annotation, as indicated by an exclamation mark, indicates that they both *may*
+also be written to.
 
 Let's revisit the previous three situtations
   - `abs(Tensor self) -> Tensor` stays the same as it will always allocate new memory.
@@ -224,6 +224,9 @@ Let's revisit the previous three situtations
     document the intended usage. This maps to the legacy `abs_out(Tensor out, Tensor self) -> Tensor`.
     As with the legacy `_out` function you must call the argument `Tensor out` or `Tensor out0`,
     `Tensor out1` in the context of multiple arguments.
+
+We check that the user uses these annotations and throw asserts if she doesn't. If this causes
+a lot of confusion please add @cpuhrsch to your PR.
 
 ### `dispatch`
 

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -225,6 +225,10 @@ Let's revisit the previous three situtations
     As with the legacy `_out` function you must call the argument `Tensor out` or `Tensor out0`,
     `Tensor out1` in the context of multiple arguments.
 
+There is also another situtation in which we use annotations, namely views.
+  - `transpose(Tensor(a) self, int dim0, int dim1) -> Tensor(a)`
+    An alias to the memory represented by self may be also returned, however it is not mutated.
+
 We check that the user uses these annotations and throw asserts if she doesn't. If this causes
 a lot of confusion please add @cpuhrsch to your PR.
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -80,28 +80,33 @@
 - func: dropout(Tensor input, float p, bool train) -> Tensor
   matches_jit_signature: True
 
-- func: dropout_(Tensor self, float p, bool train) -> Tensor
+- func: dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: feature_dropout(Tensor input, float p, bool train) -> Tensor
   matches_jit_signature: True
 
-- func: feature_dropout_(Tensor self, float p, bool train) -> Tensor
+- func: feature_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: alpha_dropout(Tensor input, float p, bool train) -> Tensor
   matches_jit_signature: True
 
-- func: alpha_dropout_(Tensor self, float p, bool train) -> Tensor
+- func: alpha_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: feature_alpha_dropout(Tensor input, float p, bool train) -> Tensor
   matches_jit_signature: True
 
-- func: feature_alpha_dropout_(Tensor self, float p, bool train) -> Tensor
+- func: feature_alpha_dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: abs(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: function, method
 
-- func: abs_(Tensor self) -> Tensor
+- func: abs_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _abs__cpu
@@ -116,7 +121,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: acos_(Tensor self) -> Tensor
+- func: acos_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _acos__cpu
@@ -141,7 +147,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: add_(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: add_(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: add_out(Tensor result, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
@@ -151,14 +158,16 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: add_(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
+- func: add_(Tensor(a!) self, Scalar other, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
   variants: function, method
 
-- func: addmv_(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addmv_(Tensor(a!) self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
 - func: addmv_out(Tensor result, Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
@@ -167,7 +176,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: addr_(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addr_(Tensor(a!) self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: addr_out(Tensor result, Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
@@ -250,7 +260,8 @@
   variants: function, method
   device_guard: False
 
-- func: as_strided_(Tensor self, int[] size, int[] stride, int? storage_offset=None) -> Tensor
+- func: as_strided_(Tensor(a!) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -258,7 +269,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: asin_(Tensor self) -> Tensor
+- func: asin_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _asin__cpu
@@ -273,7 +285,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: atan_(Tensor self) -> Tensor
+- func: atan_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _atan__cpu
@@ -291,13 +304,15 @@
     CPU: baddbmm_cpu
     CUDA: baddbmm_cuda
 
-- func: baddbmm_(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: baddbmm_(Tensor(a!) self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     CPU: baddbmm__cpu
     CUDA: baddbmm__cuda
 
-- func: _baddbmm_mkl_(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: _baddbmm_mkl_(Tensor(a!) self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
 
 - func: baddbmm_out(Tensor result, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
@@ -321,13 +336,15 @@
 - func: bernoulli_out(Tensor result, Tensor self, *, Generator? generator=None) -> Tensor
   variants: function
 
-- func: bernoulli_(Tensor self, Tensor p, *, Generator? generator=None) -> Tensor
+- func: bernoulli_(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     CPU: bernoulli_tensor_cpu_
     CUDA: bernoulli_tensor_cuda_
 
-- func: bernoulli_(Tensor self, float p=0.5, *, Generator? generator=None) -> Tensor
+- func: bernoulli_(Tensor(a!) self, float p=0.5, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     CPU: bernoulli_scalar_cpu_
@@ -388,7 +405,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: ceil_(Tensor self) -> Tensor
+- func: ceil_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _ceil__cpu
@@ -411,7 +429,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: clamp_(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
+- func: clamp_(Tensor(a!) self, Scalar? min=None, Scalar? max=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _clamp__cpu
@@ -426,7 +445,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: clamp_max_(Tensor self, Scalar max) -> Tensor
+- func: clamp_max_(Tensor(a!) self, Scalar max) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _clamp_max__cpu
@@ -441,7 +461,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: clamp_min_(Tensor self, Scalar min) -> Tensor
+- func: clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _clamp_min__cpu
@@ -500,7 +521,8 @@
 - func: conv_transpose3d(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int groups=1, int[3] dilation=1) -> Tensor
   matches_jit_signature: True
 
-- func: s_copy_(Tensor self, Tensor src, bool non_blocking=False) -> Tensor
+- func: s_copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)
+  matches_jit_signature: True
   cpu_half: True
   dispatch:
     CPU: _s_copy__cpu
@@ -512,7 +534,7 @@
   dispatch:
     CUDA: _s_copy_from_cuda
 
-- func: _copy_same_type_(Tensor self, Tensor src) -> void
+- func: _copy_same_type_(Tensor(a!) self, Tensor src) -> void
   cpu_half: True
   dispatch:
     CPU: _copy_same_type__cpu
@@ -521,7 +543,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: cos_(Tensor self) -> Tensor
+- func: cos_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _cos__cpu
@@ -536,7 +559,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: cosh_(Tensor self) -> Tensor
+- func: cosh_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _cosh__cpu
@@ -693,7 +717,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: div_(Tensor self, Tensor other) -> Tensor
+- func: div_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: div_out(Tensor result, Tensor self, Tensor other) -> Tensor
@@ -703,7 +728,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: div_(Tensor self, Scalar other) -> Tensor
+- func: div_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: dot(Tensor self, Tensor tensor) -> Tensor
@@ -723,7 +749,7 @@
     CPU: embedding_dense_backward_cpu
     CUDA: embedding_dense_backward_cuda
 
-- func: embedding_renorm_(Tensor self, IndexTensor indices, float max_norm, float norm_type) -> Tensor
+- func: embedding_renorm_(Tensor(a!) self, IndexTensor indices, float max_norm, float norm_type) -> Tensor(a!)
   dispatch:
     CPU: embedding_renorm_cpu_
     CUDA: embedding_renorm_cuda_
@@ -763,7 +789,8 @@
     SparseCPU: empty_sparse
     SparseCUDA: empty_sparse
 
-- func: resize_(Tensor self, int[] size) -> Tensor
+- func: resize_(Tensor(a!) self, int[] size) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   cpu_half: True
   device_guard: False
@@ -790,7 +817,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: erf_(Tensor self) -> Tensor
+- func: erf_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _erf__cpu
@@ -805,7 +833,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: erfc_(Tensor self) -> Tensor
+- func: erfc_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _erfc__cpu
@@ -820,7 +849,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: exp_(Tensor self) -> Tensor
+- func: exp_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _exp__cpu
@@ -835,7 +865,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: expm1_(Tensor self) -> Tensor
+- func: expm1_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _expm1__cpu
@@ -873,17 +904,20 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: fill_(Tensor self, Scalar value) -> Tensor
+- func: fill_(Tensor(a!) self, Scalar value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
-- func: fill_(Tensor self, Tensor value) -> Tensor
+- func: fill_(Tensor(a!) self, Tensor value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
 - func: floor(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: function, method
 
-- func: floor_(Tensor self) -> Tensor
+- func: floor_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _floor__cpu
@@ -1021,14 +1055,15 @@
   variants: function, method
   # NB: This function is special-cased in tools/autograd/gen_variable_type.py
 
-- func: index_copy_(Tensor self, int dim, IndexTensor index, Tensor source) -> Tensor
+- func: index_copy_(Tensor(a!) self, int dim, IndexTensor index, Tensor source) -> Tensor(a!)
   variants: method
 
 - func: index_put(Tensor self, Tensor[] indices, Tensor values, bool accumulate=False) -> Tensor
   matches_jit_signature: True
   variants: function, method
 
-- func: index_put_(Tensor self, Tensor[] indices, Tensor values, bool accumulate=False) -> Tensor
+- func: index_put_(Tensor(a!) self, Tensor[] indices, Tensor values, bool accumulate=False) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
 - func: instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> Tensor
@@ -1131,7 +1166,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: log_(Tensor self) -> Tensor
+- func: log_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _log__cpu
@@ -1146,7 +1182,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: log10_(Tensor self) -> Tensor
+- func: log10_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _log10__cpu
@@ -1161,7 +1198,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: log1p_(Tensor self) -> Tensor
+- func: log1p_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _log1p__cpu
@@ -1180,7 +1218,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: log2_(Tensor self) -> Tensor
+- func: log2_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _log2__cpu
@@ -1398,7 +1437,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mul_(Tensor self, Tensor other) -> Tensor
+- func: mul_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: mul_out(Tensor result, Tensor self, Tensor other) -> Tensor
@@ -1408,7 +1448,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mul_(Tensor self, Scalar other) -> Tensor
+- func: mul_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: mv(Tensor self, Tensor vec) -> Tensor
@@ -1421,7 +1462,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mvlgamma_(Tensor self, int p) -> Tensor
+- func: mvlgamma_(Tensor(a!) self, int p) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: narrow_copy(Tensor self, int dim, int start, int length) -> Tensor
@@ -1617,7 +1659,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: round_(Tensor self) -> Tensor
+- func: round_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _round__cpu
@@ -1631,13 +1674,15 @@
 - func: rrelu(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
-- func: rrelu_(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
+- func: rrelu_(Tensor(a!) self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: relu(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: function, method
 
-- func: relu_(Tensor self) -> Tensor
+- func: relu_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
 - func: prelu(Tensor self, Tensor weight) -> Tensor
@@ -1672,7 +1717,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: rsqrt_(Tensor self) -> Tensor
+- func: rsqrt_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _rsqrt__cpu
@@ -1690,18 +1736,21 @@
 - func: selu(Tensor self) -> Tensor
   matches_jit_signature: True
 
-- func: selu_(Tensor self) -> Tensor
+- func: selu_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: celu(Tensor self, Scalar alpha=1.0) -> Tensor
   matches_jit_signature: True
 
-- func: celu_(Tensor self, Scalar alpha=1.0) -> Tensor
+- func: celu_(Tensor(a!) self, Scalar alpha=1.0) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: sigmoid(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: function, method
 
-- func: sigmoid_(Tensor self) -> Tensor
+- func: sigmoid_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _sigmoid__cpu
@@ -1716,7 +1765,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sin_(Tensor self) -> Tensor
+- func: sin_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _sin__cpu
@@ -1731,7 +1781,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sinh_(Tensor self) -> Tensor
+- func: sinh_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _sinh__cpu
@@ -1746,7 +1797,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: detach_(Tensor self) -> Tensor
+- func: detach_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
 - func: size(Tensor self, int dim) -> int
@@ -1839,11 +1891,13 @@
   variants: function, method
   device_guard: False
 
-- func: squeeze_(Tensor self) -> Tensor
+- func: squeeze_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
-- func: squeeze_(Tensor self, int dim) -> Tensor
+- func: squeeze_(Tensor(a!) self, int dim) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
@@ -1912,7 +1966,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sqrt_(Tensor self) -> Tensor
+- func: sqrt_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _sqrt__cpu
@@ -1964,7 +2019,8 @@
   device_guard: False
   variants: function, method
 
-- func: t_(Tensor self) -> Tensor
+- func: t_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   device_guard: False
   variants: method
 
@@ -1972,7 +2028,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: tan_(Tensor self) -> Tensor
+- func: tan_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _tan__cpu
@@ -1987,7 +2044,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: tanh_(Tensor self) -> Tensor
+- func: tanh_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _tanh__cpu
@@ -2007,7 +2065,8 @@
   matches_jit_signature: True
   variants: function
 
-- func: threshold_(Tensor self, Scalar threshold, Scalar value) -> Tensor
+- func: threshold_(Tensor(a!) self, Scalar threshold, Scalar value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
 
 - func: threshold_out(Tensor result, Tensor self, Scalar threshold, Scalar value) -> Tensor
@@ -2020,7 +2079,8 @@
   variants: function, method
   device_guard: False
 
-- func: transpose_(Tensor self, int dim0, int dim1) -> Tensor
+- func: transpose_(Tensor(a!) self, int dim0, int dim1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
@@ -2057,7 +2117,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: trunc_(Tensor self) -> Tensor
+- func: trunc_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
   dispatch:
     CPU: _trunc__cpu
@@ -2092,7 +2153,8 @@
   variants: function, method
   device_guard: False
 
-- func: unsqueeze_(Tensor self, int dim) -> Tensor
+- func: unsqueeze_(Tensor(a!) self, int dim) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
@@ -2254,12 +2316,14 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: native_resize_as_(Tensor self, Tensor the_template) -> Tensor
+- func: native_resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: resize_as_sparse_
     SparseCUDA: resize_as_sparse_
 
-- func: resize_as_(Tensor self, Tensor the_template) -> Tensor
+- func: resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function, method
 
 - func: native_pow_out(Tensor result, Tensor self, Scalar exponent) -> Tensor
@@ -2280,12 +2344,14 @@
   variants: function, method
   variants: method, function
 
-- func: native_zero_(Tensor self) -> Tensor
+- func: native_zero_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: zero_sparse_
     SparseCUDA: zero_sparse_
 
-- func: zero_(Tensor self) -> Tensor
+- func: zero_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method, function
 
 - func: sub_out(Tensor result, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
@@ -2294,7 +2360,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sub_(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: sub_(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
@@ -2302,7 +2369,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sub_(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
+- func: sub_(Tensor(a!) self, Scalar other, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: rsub(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
@@ -2325,7 +2393,8 @@
     CPU: s_addmm_sparse_dense_cpu
     CUDA: s_addmm_sparse_dense_cuda
 
-- func: s_native_addmm_(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: s_native_addmm_(Tensor(a!) self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: s_addmm_sparse_dense_cpu_
     CUDA: s_addmm_sparse_dense_cuda_
@@ -2339,7 +2408,8 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: addmm_(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addmm_(Tensor(a!) self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 
@@ -2483,14 +2553,16 @@
   requires_tensor: True
 
 
-- func: sparse_resize_(Tensor self, int[] size, int sparse_dim, int dense_dim) -> Tensor
+- func: sparse_resize_(Tensor(a!) self, int[] size, int sparse_dim, int dense_dim) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: sparse_resize_
     SparseCUDA: sparse_resize_
   requires_tensor: True
 
-- func: sparse_resize_and_clear_(Tensor self, int[] size, int sparse_dim, int dense_dim) -> Tensor
+- func: sparse_resize_and_clear_(Tensor(a!) self, int[] size, int sparse_dim, int dense_dim) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: sparse_resize_and_clear_
@@ -2599,7 +2671,8 @@
 # This method doesn't do any check but only directly sets the flag. So it can be
 # a bit unsafe. Similar to _indices and _values, this is useful for implementing
 # custom sparse operations in Python/C++ extension.
-- func: _coalesced_(Tensor self, bool coalesced) -> Tensor
+- func: _coalesced_(Tensor(a!) self, bool coalesced) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: _coalesced_sparse_
@@ -2637,7 +2710,8 @@
     SparseCUDA: hspmm_sparse_cuda
   requires_tensor: True
 
-- func: copy_sparse_to_sparse_(Tensor self, Tensor src, bool non_blocking=False) -> Tensor
+- func: copy_sparse_to_sparse_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
   dispatch:
     SparseCPU: copy_sparse_
@@ -2805,19 +2879,21 @@
   variants: method
   device_guard: False
 
-- func: set_(Tensor self, Storage source) -> Tensor
+- func: set_(Tensor(a!) self, Storage source) -> Tensor(a!)
   variants: method
   device_guard: False
 
-- func: set_(Tensor self, Storage source, int storage_offset, int[] size, int[] stride=[]) -> Tensor
+- func: set_(Tensor(a!) self, Storage source, int storage_offset, int[] size, int[] stride=[]) -> Tensor(a!)
   variants: method
   device_guard: False
 
-- func: set_(Tensor self, Tensor source) -> Tensor
+- func: set_(Tensor(a!) self, Tensor source) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
-- func: set_(Tensor self) -> Tensor
+- func: set_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
@@ -2826,74 +2902,96 @@
   variants: method
   device_guard: False
 
-- func: masked_fill_(Tensor self, Tensor mask, Scalar value) -> Tensor
+- func: masked_fill_(Tensor(a!) self, Tensor mask, Scalar value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: masked_fill_(Tensor self, Tensor mask, Tensor value) -> Tensor
+- func: masked_fill_(Tensor(a!) self, Tensor mask, Tensor value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: masked_scatter_(Tensor self, Tensor mask, Tensor source) -> Tensor
+- func: masked_scatter_(Tensor(a!) self, Tensor mask, Tensor source) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: view(Tensor self, int[] size) -> Tensor
   variants: method
   device_guard: False
 
-- func: put_(Tensor self, Tensor index, Tensor source, bool accumulate=False) -> Tensor
+- func: put_(Tensor(a!) self, Tensor index, Tensor source, bool accumulate=False) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: index_add_(Tensor self, int dim, Tensor index, Tensor source) -> Tensor
+- func: index_add_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: index_fill_(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
+- func: index_fill_(Tensor(a!) self, int dim, Tensor index, Scalar value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: index_fill_(Tensor self, int dim, Tensor index, Tensor value) -> Tensor
+- func: index_fill_(Tensor(a!) self, int dim, Tensor index, Tensor value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: scatter_(Tensor self, int dim, Tensor index, Tensor src) -> Tensor
+- func: scatter_(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: scatter_(Tensor self, int dim, Tensor index, Scalar value) -> Tensor
+- func: scatter_(Tensor(a!) self, int dim, Tensor index, Scalar value) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: scatter_add_(Tensor self, int dim, Tensor index, Tensor src) -> Tensor
+- func: scatter_add_(Tensor(a!) self, int dim, Tensor index, Tensor src) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: lt_(Tensor self, Scalar other) -> Tensor
+- func: lt_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: lt_(Tensor self, Tensor other) -> Tensor
+- func: lt_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: gt_(Tensor self, Scalar other) -> Tensor
+- func: gt_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: gt_(Tensor self, Tensor other) -> Tensor
+- func: gt_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: le_(Tensor self, Scalar other) -> Tensor
+- func: le_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: le_(Tensor self, Tensor other) -> Tensor
+- func: le_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: ge_(Tensor self, Scalar other) -> Tensor
+- func: ge_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: ge_(Tensor self, Tensor other) -> Tensor
+- func: ge_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: eq_(Tensor self, Scalar other) -> Tensor
+- func: eq_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: eq_(Tensor self, Tensor other) -> Tensor
+- func: eq_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: ne_(Tensor self, Scalar other) -> Tensor
+- func: ne_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: ne_(Tensor self, Tensor other) -> Tensor
+- func: ne_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: __and__(Tensor self, Scalar other) -> Tensor
@@ -2904,10 +3002,12 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: __iand__(Tensor self, Scalar other) -> Tensor
+- func: __iand__(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: __iand__(Tensor self, Tensor other) -> Tensor
+- func: __iand__(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: __or__(Tensor self, Scalar other) -> Tensor
@@ -2918,10 +3018,12 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: __ior__(Tensor self, Scalar other) -> Tensor
+- func: __ior__(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: __ior__(Tensor self, Tensor other) -> Tensor
+- func: __ior__(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: __xor__(Tensor self, Scalar other) -> Tensor
@@ -2932,10 +3034,12 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: __ixor__(Tensor self, Scalar other) -> Tensor
+- func: __ixor__(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: __ixor__(Tensor self, Tensor other) -> Tensor
+- func: __ixor__(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: __lshift__(Tensor self, Scalar other) -> Tensor
@@ -2946,10 +3050,12 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: __ilshift__(Tensor self, Scalar other) -> Tensor
+- func: __ilshift__(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: __ilshift__(Tensor self, Tensor other) -> Tensor
+- func: __ilshift__(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: __rshift__(Tensor self, Scalar other) -> Tensor
@@ -2960,76 +3066,97 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: __irshift__(Tensor self, Scalar other) -> Tensor
+- func: __irshift__(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: __irshift__(Tensor self, Tensor other) -> Tensor
+- func: __irshift__(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: lgamma_(Tensor self) -> Tensor
+- func: lgamma_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: atan2_(Tensor self, Tensor other) -> Tensor
+- func: atan2_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: tril_(Tensor self, int diagonal=0) -> Tensor
+- func: tril_(Tensor(a!) self, int diagonal=0) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     CPU: tril_cpu_
     CUDA: tril_cuda_
 
-- func: triu_(Tensor self,  int diagonal=0) -> Tensor
+- func: triu_(Tensor(a!) self,  int diagonal=0) -> Tensor(a!)
   variants: method
   dispatch:
     CPU: triu_cpu_
     CUDA: triu_cuda_
 
-- func: digamma_(Tensor self) -> Tensor
+- func: digamma_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: polygamma_(Tensor self, int n) -> Tensor
+- func: polygamma_(Tensor(a!) self, int n) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: erfinv_(Tensor self) -> Tensor
+- func: erfinv_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: frac_(Tensor self) -> Tensor
+- func: frac_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: renorm_(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
+- func: renorm_(Tensor(a!) self, Scalar p, int dim, Scalar maxnorm) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: reciprocal_(Tensor self) -> Tensor
+- func: reciprocal_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: neg_(Tensor self) -> Tensor
+- func: neg_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: pow_(Tensor self, Scalar exponent) -> Tensor
+- func: pow_(Tensor(a!) self, Scalar exponent) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: pow_(Tensor self, Tensor exponent) -> Tensor
+- func: pow_(Tensor(a!) self, Tensor exponent) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: lerp_(Tensor self, Tensor end, Scalar weight) -> Tensor
+- func: lerp_(Tensor(a!) self, Tensor end, Scalar weight) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: sign_(Tensor self) -> Tensor
+- func: sign_(Tensor(a!) self) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: fmod_(Tensor self, Scalar other) -> Tensor
+- func: fmod_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: fmod_(Tensor self, Tensor other) -> Tensor
+- func: fmod_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: remainder_(Tensor self, Scalar other) -> Tensor
+- func: remainder_(Tensor(a!) self, Scalar other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: remainder_(Tensor self, Tensor other) -> Tensor
+- func: remainder_(Tensor(a!) self, Tensor other) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: addbmm_(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addbmm_(Tensor(a!) self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 - func: addbmm_out(Tensor result, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
@@ -3038,37 +3165,48 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: addcmul_(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+- func: addcmul_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: addcdiv_(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+- func: addcdiv_(Tensor(a!) self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: random_(Tensor self, int from, int to, *, Generator? generator=None) -> Tensor
+- func: random_(Tensor(a!) self, int from, int to, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: random_(Tensor self, int to, *, Generator? generator=None) -> Tensor
+- func: random_(Tensor(a!) self, int to, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: random_(Tensor self, *, Generator? generator=None) -> Tensor
+- func: random_(Tensor(a!) self, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: uniform_(Tensor self, float from=0, float to=1, *, Generator? generator=None) -> Tensor
+- func: uniform_(Tensor(a!) self, float from=0, float to=1, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: normal_(Tensor self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor
+- func: normal_(Tensor(a!) self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: cauchy_(Tensor self, float median=0, float sigma=1, *, Generator? generator=None) -> Tensor
+- func: cauchy_(Tensor(a!) self, float median=0, float sigma=1, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: log_normal_(Tensor self, float mean=1, float std=2, *, Generator? generator=None) -> Tensor
+- func: log_normal_(Tensor(a!) self, float mean=1, float std=2, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: exponential_(Tensor self, float lambd=1, *, Generator? generator=None) -> Tensor
+- func: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
-- func: geometric_(Tensor self, float p, *, Generator? generator=None) -> Tensor
+- func: geometric_(Tensor(a!) self, float p, *, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
 
 # wrappers for TH functions
@@ -3691,7 +3829,8 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: elu_(Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor
+- func: elu_(Tensor(a!) self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor(a!)
+  matches_jit_signature: True
   python_module: nn
 
 - func: glu_out(Tensor output, Tensor self, int dim=-1) -> Tensor
@@ -3722,7 +3861,8 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: hardtanh_(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
+- func: hardtanh_(Tensor(a!) self, Scalar min_val=-1, Scalar max_val=1) -> Tensor(a!)
+  matches_jit_signature: True
   python_module: nn
 
 - func: leaky_relu_out(Tensor output, Tensor self, Scalar negative_slope=0.01) -> Tensor
@@ -3739,7 +3879,8 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: leaky_relu_(Tensor self, Scalar negative_slope=0.01) -> Tensor
+- func: leaky_relu_(Tensor(a!) self, Scalar negative_slope=0.01) -> Tensor(a!)
+  matches_jit_signature: True
   python_module: nn
 
 - func: log_sigmoid_out(Tensor output, Tensor self) -> Tensor
@@ -3776,7 +3917,8 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: rrelu_with_noise_(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
+- func: rrelu_with_noise_(Tensor(a!) self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   python_module: nn
 
 - func: softplus_out(Tensor output, Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -51,7 +51,7 @@
   dispatch:
     CUDA: _cudnn_rnn
 
-- func: _cudnn_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, BoolTensor? dropout_state, Tensor reserve, std::array<bool,4> output_mask) -> (Tensor, Tensor, Tensor, Tensor[])
+- func: _cudnn_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, BoolTensor? dropout_state, Tensor reserve, bool[4] output_mask) -> (Tensor, Tensor, Tensor, Tensor[])
   dispatch:
     CUDA: _cudnn_rnn_backward
 
@@ -513,7 +513,7 @@
 - func: _convolution_nogroup(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding) -> Tensor
   matches_jit_signature: True
 
-- func: _convolution_double_backward(Tensor? ggI, Tensor? ggW, Tensor? ggb, Tensor gO, Tensor weight, Tensor self, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: _convolution_double_backward(Tensor? ggI, Tensor? ggW, Tensor? ggb, Tensor gO, Tensor weight, Tensor self, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
 
 - func: conv1d(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, int[1] padding=0, int[1] dilation=1, int groups=1) -> Tensor
   matches_jit_signature: True
@@ -625,7 +625,7 @@
   dispatch:
     CUDA: cudnn_convolution_backward_input
 
-- func: cudnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: cudnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: cudnn_convolution_backward
 
@@ -646,7 +646,7 @@
 
 # NB: output_padding not strictly needed here, but it's helpful for the float
 # backwards
-- func: cudnn_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: cudnn_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: cudnn_convolution_transpose_backward
 
@@ -1410,7 +1410,7 @@
 - func: mkldnn_convolution_backward_weights(int[] weight_size, Tensor grad_output, Tensor self, int[] padding, int[] stride, int[] dilation, int groups, bool bias_defined) -> (Tensor, Tensor)
   matches_jit_signature: True
 
-- func: mkldnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: mkldnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
 
 - func: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
   matches_jit_signature: True
@@ -1432,7 +1432,7 @@
   dispatch:
     CUDA: miopen_convolution_backward_input
 
-- func: miopen_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: miopen_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: miopen_convolution_backward
 
@@ -1453,7 +1453,7 @@
 
 # NB: output_padding not strictly needed here, but it's helpful for the float
 # backwards
-- func: miopen_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: miopen_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: miopen_convolution_transpose_backward
 
@@ -1537,7 +1537,7 @@
     CPU: batch_norm_cpu
     CUDA: batch_norm_cuda
 
-- func: native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
     CPU: batch_norm_backward_cpu
     CUDA: batch_norm_backward_cuda
@@ -1555,7 +1555,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: _nnpack_spatial_convolution_backward(Tensor input, Tensor grad_output, Tensor weight, int[2] padding, std::array<bool,3> output_mask) -> (Tensor, Tensor, Tensor)
+- func: _nnpack_spatial_convolution_backward(Tensor input, Tensor grad_output, Tensor weight, int[2] padding, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   variants: function
 
 - func: _nnpack_spatial_convolution_backward_input(Tensor input, Tensor grad_output, Tensor weight, int[2] padding) -> Tensor
@@ -4569,7 +4569,7 @@
 - func: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
-- func: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+- func: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
 - func: thnn_conv_transpose3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int[3] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
@@ -4588,7 +4588,7 @@
 - func: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
-- func: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+- func: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
 - func: thnn_conv2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, *, Tensor(a!) output) -> Tensor(a!)
@@ -4607,7 +4607,7 @@
 - func: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
-- func: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+- func: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
 - func: thnn_conv_depthwise2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
@@ -4627,7 +4627,7 @@
 - func: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
-- func: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, std::array<bool,2> output_mask) -> (Tensor grad_input, Tensor grad_weight)
+- func: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool[2] output_mask) -> (Tensor grad_input, Tensor grad_weight)
   python_module: nn
 
 - func: thnn_conv3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, *, Tensor(a!) output) -> Tensor(a!)
@@ -4646,7 +4646,7 @@
 - func: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, Tensor finput, Tensor fgrad_input, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
-- func: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+- func: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, Tensor finput, Tensor fgrad_input, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
 - func: thnn_conv_dilated2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
@@ -4665,7 +4665,7 @@
 - func: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, Tensor columns, Tensor ones, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
-- func: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+- func: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, Tensor columns, Tensor ones, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
 - func: thnn_conv_dilated3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
@@ -4684,7 +4684,7 @@
 - func: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[] dilation, Tensor columns, Tensor ones, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
-- func: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
+- func: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, Tensor columns, Tensor ones, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
 - func: thnn_col2im(Tensor self, int[2] output_size, int[2] kernel_size, int[2] dilation, int[2] padding, int[2] stride) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -112,7 +112,7 @@
     CPU: _abs__cpu
     CUDA: _abs__cuda
 
-- func: abs_out(Tensor out, Tensor self) -> Tensor
+- func: abs(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _abs_out_cpu
     CUDA: _abs_out_cuda
@@ -128,7 +128,7 @@
     CPU: _acos__cpu
     CUDA: _acos__cuda
 
-- func: acos_out(Tensor out, Tensor self) -> Tensor
+- func: acos(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _acos_out_cpu
     CUDA: _acos_out_cuda
@@ -151,7 +151,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: add_out(Tensor out, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: add(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: add(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
@@ -170,7 +170,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: addmv_out(Tensor out, Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -180,7 +180,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: addr_out(Tensor out, Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: affine_grid_generator(Tensor theta, int[] size) -> Tensor
   matches_jit_signature: True
@@ -194,7 +194,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: all_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: all(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: allclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> bool
   matches_jit_signature: True
@@ -204,7 +204,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: any_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: any(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: arange(Scalar end, TensorOptions options=[]) -> Tensor
 
@@ -212,9 +212,9 @@
 
 - func: arange(Scalar start, Scalar end, Scalar step, TensorOptions options=[]) -> Tensor
 
-- func: arange_out(Tensor out, Scalar end) -> Tensor
+- func: arange(Scalar end, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: arange_out(Tensor out, Scalar start, Scalar end, Scalar step=1) -> Tensor
+- func: arange(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: arange_cpu_out
     CUDA: arange_cuda_out
@@ -276,7 +276,7 @@
     CPU: _asin__cpu
     CUDA: _asin__cuda
 
-- func: asin_out(Tensor out, Tensor self) -> Tensor
+- func: asin(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _asin_out_cpu
     CUDA: _asin_out_cuda
@@ -292,7 +292,7 @@
     CPU: _atan__cpu
     CUDA: _atan__cuda
 
-- func: atan_out(Tensor out, Tensor self) -> Tensor
+- func: atan(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _atan_out_cpu
     CUDA: _atan_out_cuda
@@ -315,7 +315,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: baddbmm_out(Tensor out, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   variants: function
   dispatch:
     CPU: baddbmm_out_cpu
@@ -333,7 +333,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: bernoulli_out(Tensor out, Tensor self, *, Generator? generator=None) -> Tensor
+- func: bernoulli(Tensor self, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
   variants: function
 
 - func: bernoulli_(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
@@ -386,7 +386,7 @@
     CPU: bmm_cpu
     CUDA: bmm_cuda
 
-- func: bmm_out(Tensor out, Tensor self, Tensor mat2) -> Tensor
+- func: bmm(Tensor self, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   dispatch:
     CPU: bmm_out_cpu
@@ -399,7 +399,7 @@
 - func: cat(Tensor[] tensors, int dim=0) -> Tensor
   matches_jit_signature: True
 
-- func: cat_out(Tensor out, Tensor[] tensors, int dim=0) -> Tensor
+- func: cat(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ceil(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -412,7 +412,7 @@
     CPU: _ceil__cpu
     CUDA: _ceil__cuda
 
-- func: ceil_out(Tensor out, Tensor self) -> Tensor
+- func: ceil(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _ceil_out_cpu
     CUDA: _ceil_out_cuda
@@ -436,7 +436,7 @@
     CPU: _clamp__cpu
     CUDA: _clamp__cuda
 
-- func: clamp_out(Tensor out, Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
+- func: clamp(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _clamp_out_cpu
     CUDA: _clamp_out_cuda
@@ -452,7 +452,7 @@
     CPU: _clamp_max__cpu
     CUDA: _clamp_max__cuda
 
-- func: clamp_max_out(Tensor out, Tensor self, Scalar max) -> Tensor
+- func: clamp_max(Tensor self, Scalar max, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _clamp_max_out_cpu
     CUDA: _clamp_max_out_cuda
@@ -468,7 +468,7 @@
     CPU: _clamp_min__cpu
     CUDA: _clamp_min__cuda
 
-- func: clamp_min_out(Tensor out, Tensor self, Scalar min) -> Tensor
+- func: clamp_min(Tensor self, Scalar min, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _clamp_min_out_cpu
     CUDA: _clamp_min_out_cuda
@@ -550,7 +550,7 @@
     CPU: _cos__cpu
     CUDA: _cos__cuda
 
-- func: cos_out(Tensor out, Tensor self) -> Tensor
+- func: cos(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _cos_out_cpu
     CUDA: _cos_out_cuda
@@ -566,7 +566,7 @@
     CPU: _cosh__cpu
     CUDA: _cosh__cuda
 
-- func: cosh_out(Tensor out, Tensor self) -> Tensor
+- func: cosh(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _cosh_out_cpu
     CUDA: _cosh_out_cuda
@@ -662,9 +662,9 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: cumsum_out(Tensor out, Tensor self, int dim, *, ScalarType dtype) -> Tensor
+- func: cumsum(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
-- func: cumsum_out(Tensor out, Tensor self, int dim) -> Tensor
+- func: cumsum(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: cumprod(Tensor self, int dim, *, ScalarType dtype) -> Tensor
@@ -675,9 +675,9 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: cumprod_out(Tensor out, Tensor self, int dim, *, ScalarType dtype) -> Tensor
+- func: cumprod(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
-- func: cumprod_out(Tensor out, Tensor self, int dim) -> Tensor
+- func: cumprod(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank=0, int reduction=Mean) -> Tensor
   matches_jit_signature: True
@@ -721,7 +721,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: div_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: div(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: div(Tensor self, Scalar other) -> Tensor
@@ -736,7 +736,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: dot_out(Tensor out, Tensor self, Tensor tensor) -> Tensor
+- func: dot(Tensor self, Tensor tensor, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: einsum(std::string equation, Tensor[] tensors) -> Tensor
 
@@ -798,7 +798,7 @@
     CPU: resize_cpu_
     CUDA: resize_cuda_
 
-- func: empty_out(Tensor out, int[] size) -> Tensor
+- func: empty(int[] size, *, Tensor(a!) out) -> Tensor(a!)
   device_guard: False
 
 - func: empty_like(Tensor self) -> Tensor
@@ -824,7 +824,7 @@
     CPU: _erf__cpu
     CUDA: _erf__cuda
 
-- func: erf_out(Tensor out, Tensor self) -> Tensor
+- func: erf(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _erf_out_cpu
     CUDA: _erf_out_cuda
@@ -840,7 +840,7 @@
     CPU: _erfc__cpu
     CUDA: _erfc__cuda
 
-- func: erfc_out(Tensor out, Tensor self) -> Tensor
+- func: erfc(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _erfc_out_cpu
     CUDA: _erfc_out_cuda
@@ -856,7 +856,7 @@
     CPU: _exp__cpu
     CUDA: _exp__cuda
 
-- func: exp_out(Tensor out, Tensor self) -> Tensor
+- func: exp(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _exp_out_cpu
     CUDA: _exp_out_cuda
@@ -872,7 +872,7 @@
     CPU: _expm1__cpu
     CUDA: _expm1__cuda
 
-- func: expm1_out(Tensor out, Tensor self) -> Tensor
+- func: expm1(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _expm1_out_cpu
     CUDA: _expm1_out_cuda
@@ -890,12 +890,12 @@
 
 - func: eye(int n, int m, TensorOptions options=[]) -> Tensor
 
-- func: eye_out(Tensor out, int n) -> Tensor
+- func: eye(int n, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
 
-- func: eye_out(Tensor out, int n, int m) -> Tensor
+- func: eye(int n, int m, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
@@ -923,14 +923,14 @@
     CPU: _floor__cpu
     CUDA: _floor__cuda
 
-- func: floor_out(Tensor out, Tensor self) -> Tensor
+- func: floor(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _floor_out_cpu
     CUDA: _floor_out_cuda
 
 - func: full(int[] size, Scalar fill_value, TensorOptions options=[]) -> Tensor
 
-- func: full_out(Tensor out, int[] size, Scalar fill_value) -> Tensor
+- func: full(int[] size, Scalar fill_value, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: full_like(Tensor self, Scalar fill_value) -> Tensor
   matches_jit_signature: True
@@ -992,13 +992,13 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: ger_out(Tensor out, Tensor self, Tensor vec2) -> Tensor
+- func: ger(Tensor self, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: gesv(Tensor self, Tensor A) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: function, method
 
-- func: gesv_out(Tensor solution, Tensor lu, Tensor self, Tensor A) -> (Tensor, Tensor)
+- func: gesv(Tensor self, Tensor A, *, Tensor(a!) solution, Tensor(b!) lu) ->(Tensor(a!), Tensor(b!))
 
 # gesv handles broadcasting of arbitrary batch dims while _gesv_helper does not.
 - func: _gesv_helper(Tensor self, Tensor A) -> (Tensor, Tensor)
@@ -1074,7 +1074,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: inverse_out(Tensor out, Tensor self) -> Tensor
+- func: inverse(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: _inverse_helper(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1135,7 +1135,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: kthvalue_out(Tensor values, Tensor indices, Tensor self, int k, int dim=-1, bool keepdim=False) -> (Tensor, Tensor)
+- func: kthvalue(Tensor self, int k, int dim=-1, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
 
 - func: layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> Tensor
   matches_jit_signature: True
@@ -1157,7 +1157,7 @@
 
 - func: linspace(Scalar start, Scalar end, int steps=100, TensorOptions options=[]) -> Tensor
 
-- func: linspace_out(Tensor out, Scalar start, Scalar end, int steps=100) -> Tensor
+- func: linspace(Scalar start, Scalar end, int steps=100, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: linspace_cpu_out
     CUDA: linspace_cuda_out
@@ -1173,7 +1173,7 @@
     CPU: _log__cpu
     CUDA: _log__cuda
 
-- func: log_out(Tensor out, Tensor self) -> Tensor
+- func: log(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _log_out_cpu
     CUDA: _log_out_cuda
@@ -1189,7 +1189,7 @@
     CPU: _log10__cpu
     CUDA: _log10__cuda
 
-- func: log10_out(Tensor out, Tensor self) -> Tensor
+- func: log10(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _log10_out_cpu
     CUDA: _log10_out_cuda
@@ -1207,7 +1207,7 @@
     SparseCPU: log1p_sparse_
     SparseCUDA: log1p_sparse_
 
-- func: log1p_out(Tensor out, Tensor self) -> Tensor
+- func: log1p(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _log1p_out_cpu
     CUDA: _log1p_out_cuda
@@ -1225,7 +1225,7 @@
     CPU: _log2__cpu
     CUDA: _log2__cuda
 
-- func: log2_out(Tensor out, Tensor self) -> Tensor
+- func: log2(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _log2_out_cpu
     CUDA: _log2_out_cuda
@@ -1236,7 +1236,7 @@
 
 - func: logspace(Scalar start, Scalar end, int steps=100, TensorOptions options=[]) -> Tensor
 
-- func: logspace_out(Tensor out, Scalar start, Scalar end, int steps=100) -> Tensor
+- func: logspace(Scalar start, Scalar end, int steps=100, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: logspace_cpu_out
     CUDA: logspace_cuda_out
@@ -1266,7 +1266,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: logsumexp_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: logsumexp(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor
   matches_jit_signature: True
@@ -1275,7 +1275,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: matmul_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: matmul(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: matrix_rank(Tensor self, float tol, bool symmetric=False) -> Tensor
   matches_jit_signature: True
@@ -1290,7 +1290,7 @@
 - func: max(Tensor self, int64_t dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
 
-- func: max_out(Tensor max, Tensor max_values, Tensor self, int64_t dim, bool keepdim=False) -> (Tensor values, Tensor indices)
+- func: max(Tensor self, int64_t dim, bool keepdim=False, *, Tensor(a!) max, Tensor(b!) max_values) ->(Tensor(a!) values, Tensor(b!) indices)
 
 - func: max_values(Tensor self, int dim, bool keepdim=False) -> Tensor
   matches_jit_signature: True
@@ -1330,23 +1330,23 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mean_out(Tensor out, Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: mean(Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
-- func: mean_out(Tensor out, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: mean(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: mean_out(Tensor out, Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
+- func: mean(Tensor self, int[1] dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
 - func: median(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: function, method
 
-- func: median_out(Tensor values, Tensor indices, Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
+- func: median(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
 
 - func: min(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: function, method
 
-- func: min_out(Tensor min, Tensor min_indices, Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
+- func: min(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) min, Tensor(b!) min_indices) ->(Tensor(a!), Tensor(b!))
 
 - func: min_values(Tensor self, int dim, bool keepdim=False) -> Tensor
   matches_jit_signature: True
@@ -1422,7 +1422,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mm_out(Tensor out, Tensor self, Tensor mat2) -> Tensor
+- func: mm(Tensor self, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: _sparse_mm(Tensor sparse, Tensor dense) -> Tensor
   matches_jit_signature: True
@@ -1431,7 +1431,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mode_out(Tensor values, Tensor indices, Tensor self, int dim=-1, bool keepdim=False) -> (Tensor, Tensor)
+- func: mode(Tensor self, int dim=-1, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
 
 - func: mul(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -1441,7 +1441,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: mul_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: mul(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
   # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: mul(Tensor self, Scalar other) -> Tensor
@@ -1456,7 +1456,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mv_out(Tensor out, Tensor self, Tensor vec) -> Tensor
+- func: mv(Tensor self, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: mvlgamma(Tensor self, int p) -> Tensor
   matches_jit_signature: True
@@ -1516,7 +1516,7 @@
 
 - func: ones(int[] size, TensorOptions options=[]) -> Tensor
 
-- func: ones_out(Tensor out, int[] size) -> Tensor
+- func: ones(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ones_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1561,9 +1561,9 @@
 
 - func: rand(int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: rand_out(Tensor out, int[] size, *) -> Tensor
+- func: rand(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: rand_out(Tensor out, int[] size, *, Generator? generator) -> Tensor
+- func: rand(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
 - func: rand_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1578,13 +1578,13 @@
 
 - func: randint(int low, int high, int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: randint_out(Tensor out, int high, int[] size, *) -> Tensor
+- func: randint(int high, int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: randint_out(Tensor out, int high, int[] size, *, Generator? generator) -> Tensor
+- func: randint(int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
-- func: randint_out(Tensor out, int low, int high, int[] size, *) -> Tensor
+- func: randint(int low, int high, int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: randint_out(Tensor out, int low, int high, int[] size, *, Generator? generator) -> Tensor
+- func: randint(int low, int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
 - func: randint_like(Tensor self, int high) -> Tensor
   matches_jit_signature: True
@@ -1600,9 +1600,9 @@
 
 - func: randn(int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: randn_out(Tensor out, int[] size, *) -> Tensor
+- func: randn(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: randn_out(Tensor out, int[] size, *, Generator? generator) -> Tensor
+- func: randn(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
 - func: randn_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1613,9 +1613,9 @@
 
 - func: randperm(int n, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: randperm_out(Tensor out, int n, *) -> Tensor
+- func: randperm(int n, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: randperm_out(Tensor out, int n, *, Generator? generator) -> Tensor
+- func: randperm(int n, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: randperm_out_cpu
     CUDA: randperm_out_cuda
@@ -1624,7 +1624,7 @@
 
 - func: range(Scalar start, Scalar end, TensorOptions options=[]) -> Tensor
 
-- func: range_out(Tensor out, Scalar start, Scalar end, Scalar step=1) -> Tensor
+- func: range(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: range_cpu_out
     CUDA: range_cuda_out
@@ -1666,7 +1666,7 @@
     CPU: _round__cpu
     CUDA: _round__cuda
 
-- func: round_out(Tensor out, Tensor self) -> Tensor
+- func: round(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _round_out_cpu
     CUDA: _round_out_cuda
@@ -1724,7 +1724,7 @@
     CPU: _rsqrt__cpu
     CUDA: _rsqrt__cuda
 
-- func: rsqrt_out(Tensor out, Tensor self) -> Tensor
+- func: rsqrt(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _rsqrt_out_cpu
     CUDA: _rsqrt_out_cuda
@@ -1756,7 +1756,7 @@
     CPU: _sigmoid__cpu
     CUDA: _sigmoid__cuda
 
-- func: sigmoid_out(Tensor out, Tensor self) -> Tensor
+- func: sigmoid(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _sigmoid_out_cpu
     CUDA: _sigmoid_out_cuda
@@ -1772,7 +1772,7 @@
     CPU: _sin__cpu
     CUDA: _sin__cuda
 
-- func: sin_out(Tensor out, Tensor self) -> Tensor
+- func: sin(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _sin_out_cpu
     CUDA: _sin_out_cuda
@@ -1788,7 +1788,7 @@
     CPU: _sinh__cpu
     CUDA: _sinh__cuda
 
-- func: sinh_out(Tensor out, Tensor self) -> Tensor
+- func: sinh(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _sinh_out_cpu
     CUDA: _sinh_out_cuda
@@ -1839,37 +1839,37 @@
     CPU: softmax_backward_cpu
     CUDA: softmax_backward_cuda
 
-- func: _sparse_add_out(Tensor out, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: _sparse_add(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: add_out_sparse_cpu
     SparseCUDA: add_out_sparse_cuda
 
-- func: _sparse_dense_add_out(Tensor out, Tensor self, SparseTensorRef other, *, Scalar alpha=1) -> Tensor
+- func: _sparse_dense_add(Tensor self, SparseTensorRef other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: add_out_dense_sparse_cpu
     CUDA: add_out_dense_sparse_cuda
 
-- func: _sparse_div_zerodim_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: _sparse_div_zerodim(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: div_out_sparse_zerodim
     SparseCUDA: div_out_sparse_zerodim
 
-- func: _sparse_div_scalar_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: _sparse_div_scalar(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: div_out_sparse_scalar
     SparseCUDA: div_out_sparse_scalar
 
-- func: _sparse_mul_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: _sparse_mul(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: mul_out_sparse_cpu
     SparseCUDA: mul_out_sparse_cuda
 
-- func: _sparse_mul_zerodim_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: _sparse_mul_zerodim(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: mul_out_sparse_zerodim
     SparseCUDA: mul_out_sparse_zerodim
 
-- func: _sparse_mul_scalar_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: _sparse_mul_scalar(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: mul_out_sparse_scalar
     SparseCUDA: mul_out_sparse_scalar
@@ -1905,7 +1905,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sspaddmm_out(Tensor out, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _sspaddmm_out_only_sparse
     CUDA: _sspaddmm_out_only_sparse_cuda
@@ -1915,7 +1915,7 @@
 - func: stack(Tensor[] tensors, int dim=0) -> Tensor
   matches_jit_signature: True
 
-- func: stack_out(Tensor out, Tensor[] tensors, int dim=0) -> Tensor
+- func: stack(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
 
 # The signature is designed to be consistent with librosa except that it is
 # missing the `pad_mode` and `center` arguments, which are taken care of at
@@ -1951,11 +1951,11 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sum_out(Tensor out, Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: sum(Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
-- func: sum_out(Tensor out, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: sum(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: sum_out(Tensor out, Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
+- func: sum(Tensor self, int[1] dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
 - func: sum_to_size(Tensor self, int[] size) -> Tensor
   matches_jit_signature: True
@@ -1973,7 +1973,7 @@
     CPU: _sqrt__cpu
     CUDA: _sqrt__cuda
 
-- func: sqrt_out(Tensor out, Tensor self) -> Tensor
+- func: sqrt(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _sqrt_out_cpu
     CUDA: _sqrt_out_cuda
@@ -1986,7 +1986,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: std_out(Tensor out, Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
+- func: std(Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: prod(Tensor self, *, ScalarType dtype) -> Tensor
@@ -2009,11 +2009,11 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: prod_out(Tensor out, Tensor self, int dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: prod(Tensor self, int dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
-- func: prod_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: prod(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: prod_out(Tensor out, Tensor self, int dim, *, ScalarType dtype) -> Tensor
+- func: prod(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
 - func: t(Tensor self) -> Tensor
   device_guard: False
@@ -2035,7 +2035,7 @@
     CPU: _tan__cpu
     CUDA: _tan__cuda
 
-- func: tan_out(Tensor out, Tensor self) -> Tensor
+- func: tan(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _tan_out_cpu
     CUDA: _tan_out_cuda
@@ -2051,7 +2051,7 @@
     CPU: _tanh__cpu
     CUDA: _tanh__cuda
 
-- func: tanh_out(Tensor out, Tensor self) -> Tensor
+- func: tanh(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _tanh_out_cpu
     CUDA: _tanh_out_cuda
@@ -2069,7 +2069,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: threshold_out(Tensor out, Tensor self, Scalar threshold, Scalar value) -> Tensor
+- func: threshold(Tensor self, Scalar threshold, Scalar value, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor
   matches_jit_signature: True
@@ -2124,7 +2124,7 @@
     CPU: _trunc__cpu
     CUDA: _trunc__cuda
 
-- func: trunc_out(Tensor out, Tensor self) -> Tensor
+- func: trunc(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: _trunc_out_cpu
     CUDA: _trunc_out_cuda
@@ -2166,7 +2166,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: var_out(Tensor out, Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
+- func: var(Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: view_as(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -2213,7 +2213,7 @@
 
 - func: zeros(int[] size, TensorOptions options=[]) -> Tensor
 
-- func: zeros_out(Tensor out, int[] size) -> Tensor
+- func: zeros(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: zeros_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -2284,9 +2284,9 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: norm_out(Tensor out, Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: norm(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
 
-- func: norm_out(Tensor out, Tensor self, Scalar? p, int[1] dim, bool keepdim=False) -> Tensor
+- func: norm(Tensor self, Scalar? p, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: frobenius_norm(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -2296,14 +2296,14 @@
   matches_jit_signature: True
   variants: function
 
-- func: frobenius_norm_out(Tensor out, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: frobenius_norm(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
 
 - func: nuclear_norm(Tensor self, bool keepdim=False) -> Tensor
   matches_jit_signature: True
   variants: function
 
-- func: nuclear_norm_out(Tensor out, Tensor self, bool keepdim=False) -> Tensor
+- func: nuclear_norm(Tensor self, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
 
 - func: native_clone(Tensor self) -> Tensor
@@ -2326,7 +2326,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: native_pow_out(Tensor out, Tensor self, Scalar exponent) -> Tensor
+- func: native_pow(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: pow_out_sparse_scalar
     SparseCUDA: pow_out_sparse_scalar
@@ -2337,7 +2337,7 @@
     SparseCPU: pow_sparse_scalar
     SparseCUDA: pow_sparse_scalar
 
-- func: pow_out(Tensor out, Tensor self, Scalar exponent) -> Tensor
+- func: pow(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: pow(Tensor self, Scalar exponent) -> Tensor
   matches_jit_signature: True
@@ -2354,7 +2354,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: sub_out(Tensor out, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: sub(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: sub(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -2382,7 +2382,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: s_native_addmm_out(Tensor out, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: s_native_addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: s_addmm_out_sparse_dense_cpu
     CUDA: s_addmm_out_sparse_dense_cuda
@@ -2402,7 +2402,7 @@
 - func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
 
-- func: addmm_out(Tensor out, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -2697,7 +2697,7 @@
   device_guard: False
 
 
-- func: hspmm_out(Tensor out, Tensor mat1, Tensor mat2) -> Tensor
+- func: hspmm(Tensor mat1, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     SparseCPU: hspmm_out_sparse_cpu
     SparseCUDA: hspmm_out_sparse_cuda
@@ -3159,7 +3159,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: addbmm_out(Tensor out, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -3211,19 +3211,19 @@
 
 # wrappers for TH functions
 
-- func: diag_out(Tensor out, Tensor self, int diagonal=0) -> Tensor
+- func: diag(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: diag(Tensor self, int diagonal=0) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: cross_out(Tensor out, Tensor self, Tensor other, int dim=-1) -> Tensor
+- func: cross(Tensor self, Tensor other, int dim=-1, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: cross(Tensor self, Tensor other, int dim=-1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: triu_out(Tensor out, Tensor self, int diagonal=0) -> Tensor
+- func: triu(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: triu_cpu_out
     CUDA: triu_cuda_out
@@ -3232,7 +3232,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: tril_out(Tensor out, Tensor self, int diagonal=0) -> Tensor
+- func: tril(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: tril_cpu_out
     CUDA: tril_cuda_out
@@ -3255,150 +3255,150 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: ne_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: ne(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ne(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ne_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: ne(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ne(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: eq_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: eq(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: eq(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: eq_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: eq(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: eq(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ge_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: ge(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ge(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ge_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: ge(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ge(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: le_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: le(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: le(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: le_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: le(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: le(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gt_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: gt(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: gt(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gt_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: gt(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: gt(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lt_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: lt(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: lt(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lt_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: lt(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: lt(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: take_out(Tensor out, Tensor self, Tensor index) -> Tensor
+- func: take(Tensor self, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: take(Tensor self, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: index_select_out(Tensor out, Tensor self, int dim, Tensor index) -> Tensor
+- func: index_select(Tensor self, int dim, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: index_select(Tensor self, int dim, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: masked_select_out(Tensor out, Tensor self, Tensor mask) -> Tensor
+- func: masked_select(Tensor self, Tensor mask, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: masked_select(Tensor self, Tensor mask) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: nonzero_out(Tensor out, Tensor self) -> Tensor
+- func: nonzero(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: nonzero(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gather_out(Tensor out, Tensor self, int dim, Tensor index) -> Tensor
+- func: gather(Tensor self, int dim, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: gather(Tensor self, int dim, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: addcmul_out(Tensor out, Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+- func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: addcdiv_out(Tensor out, Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+- func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gels_out(Tensor X, Tensor qr, Tensor self, Tensor A) -> (Tensor, Tensor)
+- func: gels(Tensor self, Tensor A, *, Tensor(a!) X, Tensor(b!) qr) ->(Tensor(a!), Tensor(b!))
 
 - func: gels(Tensor self, Tensor A) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: trtrs_out(Tensor X, Tensor M, Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False) -> (Tensor, Tensor)
+- func: trtrs(Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False, *, Tensor(a!) X, Tensor(b!) M) ->(Tensor(a!), Tensor(b!))
 
 - func: trtrs(Tensor self, Tensor A, bool upper=True, bool transpose=False, bool unitriangular=False) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: symeig_out(Tensor e, Tensor V, Tensor self, bool eigenvectors=False, bool upper=True) -> (Tensor, Tensor)
+- func: symeig(Tensor self, bool eigenvectors=False, bool upper=True, *, Tensor(a!) e, Tensor(b!) V) ->(Tensor(a!), Tensor(b!))
 
 - func: symeig(Tensor self, bool eigenvectors=False, bool upper=True) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: eig_out(Tensor e, Tensor v, Tensor self, bool eigenvectors=False) -> (Tensor, Tensor)
+- func: eig(Tensor self, bool eigenvectors=False, *, Tensor(a!) e, Tensor(b!) v) ->(Tensor(a!), Tensor(b!))
 
 - func: eig(Tensor self, bool eigenvectors=False) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: svd_out(Tensor U, Tensor S, Tensor V, Tensor self, bool some=True, bool compute_uv=True) -> (Tensor U, Tensor S, Tensor V)
+- func: svd(Tensor self, bool some=True, bool compute_uv=True, *, Tensor(a!) U, Tensor(b!) S, Tensor(c!) V) ->(Tensor(a!) U, Tensor(b!) S, Tensor(c!) V)
 
 - func: svd(Tensor self, bool some=True, bool compute_uv=True) -> (Tensor U, Tensor S, Tensor V)
   variants: method, function
 
-- func: cholesky_out(Tensor out, Tensor self, bool upper=False) -> Tensor
+- func: cholesky(Tensor self, bool upper=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: cholesky(Tensor self, bool upper=False) -> Tensor
   matches_jit_signature: True
@@ -3411,7 +3411,7 @@
     CPU: _cholesky_helper_cpu
     CUDA: _cholesky_helper_cuda
 
-- func: cholesky_solve_out(Tensor out, Tensor self, Tensor input2, bool upper=False) -> Tensor
+- func: cholesky_solve(Tensor self, Tensor input2, bool upper=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
   matches_jit_signature: True
@@ -3424,91 +3424,91 @@
     CPU: _cholesky_solve_helper_cpu
     CUDA: _cholesky_solve_helper_cuda
 
-- func: potri_out(Tensor out, Tensor self, bool upper=True) -> Tensor
+- func: potri(Tensor self, bool upper=True, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: potri(Tensor self, bool upper=True) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: pstrf_out(Tensor u, Tensor piv, Tensor self, bool upper=True, Scalar tol=-1) -> (Tensor, Tensor)
+- func: pstrf(Tensor self, bool upper=True, Scalar tol=-1, *, Tensor(a!) u, Tensor(b!) piv) ->(Tensor(a!), Tensor(b!))
 
 - func: pstrf(Tensor self, bool upper=True, Scalar tol=-1) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: qr_out(Tensor Q, Tensor R, Tensor self) -> (Tensor, Tensor)
+- func: qr(Tensor self, *, Tensor(a!) Q, Tensor(b!) R) ->(Tensor(a!), Tensor(b!))
 
 - func: qr(Tensor self) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: geqrf_out(Tensor out0, Tensor out1, Tensor self) -> (Tensor, Tensor)
+- func: geqrf(Tensor self, *, Tensor(a!) out0, Tensor(b!) out1) ->(Tensor(a!), Tensor(b!))
 
 - func: geqrf(Tensor self) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: orgqr_out(Tensor out, Tensor self, Tensor input2) -> Tensor
+- func: orgqr(Tensor self, Tensor input2, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: orgqr(Tensor self, Tensor input2) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ormqr_out(Tensor out, Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor
+- func: ormqr(Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: ormqr(Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: btrifact_out(Tensor A_LU, Tensor pivots, Tensor self, *, bool pivot=True) -> (Tensor, Tensor)
+- func: btrifact(Tensor self, *, bool pivot=True, Tensor(a!) A_LU, Tensor(b!) pivots) ->(Tensor(a!), Tensor(b!))
 
 - func: btrifact(Tensor self, *, bool pivot=True) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: btrifact_with_info_out(Tensor A_LU, Tensor pivots, Tensor info, Tensor self, *, bool pivot=True) -> (Tensor, Tensor, Tensor)
+- func: btrifact_with_info(Tensor self, *, bool pivot=True, Tensor(a!) A_LU, Tensor(b!) pivots, Tensor(c!) info) ->(Tensor(a!), Tensor(b!), Tensor(c!))
 
 - func: btrifact_with_info(Tensor self, *, bool pivot=True) -> (Tensor, Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: btrisolve_out(Tensor out, Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor
+- func: btrisolve(Tensor self, Tensor LU_data, Tensor LU_pivots, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: btrisolve(Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: multinomial_out(Tensor out, Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
+- func: multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
 
 - func: multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lgamma_out(Tensor out, Tensor self) -> Tensor
+- func: lgamma(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: lgamma(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: digamma_out(Tensor out, Tensor self) -> Tensor
+- func: digamma(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: digamma(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: polygamma_out(Tensor out, int n, Tensor self) -> Tensor
+- func: polygamma(int n, Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: polygamma(int n, Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: erfinv_out(Tensor out, Tensor self) -> Tensor
+- func: erfinv(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: erfinv(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: frac_out(Tensor out, Tensor self) -> Tensor
+- func: frac(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: frac(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -3518,67 +3518,67 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: reciprocal_out(Tensor out, Tensor self) -> Tensor
+- func: reciprocal(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: reciprocal(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: neg_out(Tensor out, Tensor self) -> Tensor
+- func: neg(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: neg(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: atan2_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: atan2(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: atan2(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lerp_out(Tensor out, Tensor self, Tensor end, Scalar weight) -> Tensor
+- func: lerp(Tensor self, Tensor end, Scalar weight, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: lerp(Tensor self, Tensor end, Scalar weight) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: histc_out(Tensor out, Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
+- func: histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: sign_out(Tensor out, Tensor self) -> Tensor
+- func: sign(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: sign(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: fmod_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: fmod(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: fmod(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: fmod_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: fmod(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: fmod(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: remainder_out(Tensor out, Tensor self, Scalar other) -> Tensor
+- func: remainder(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: remainder(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: remainder_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: remainder(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: remainder(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: min_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: min(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: min(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -3588,7 +3588,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: max_out(Tensor out, Tensor self, Tensor other) -> Tensor
+- func: max(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: max(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -3602,13 +3602,13 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: sort_out(Tensor values, Tensor indices, Tensor self, int dim=-1, bool descending=False) -> (Tensor, Tensor)
+- func: sort(Tensor self, int dim=-1, bool descending=False, *, Tensor(a!) values, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
 
 - func: sort(Tensor self, int dim=-1, bool descending=False) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: topk_out(Tensor values, Tensor indices, Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor, Tensor)
+- func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, *, Tensor(a!) values, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
 
 - func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor, Tensor)
   matches_jit_signature: True
@@ -3622,7 +3622,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: renorm_out(Tensor out, Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
+- func: renorm(Tensor self, Scalar p, int dim, Scalar maxnorm, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: renorm(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
   matches_jit_signature: True
@@ -3636,27 +3636,27 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: pow_out(Tensor out, Tensor self, Tensor exponent) -> Tensor
+- func: pow(Tensor self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: pow(Tensor self, Tensor exponent) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: pow_out(Tensor out, Scalar self, Tensor exponent) -> Tensor
+- func: pow(Scalar self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
 
 - func: pow(Scalar self, Tensor exponent) -> Tensor
   matches_jit_signature: True
 
-- func: normal_out(Tensor output, Tensor mean, float std=1, *, Generator? generator=None) -> Tensor
+- func: normal(Tensor mean, float std=1, *, Generator? generator=None, Tensor(a!) output) -> Tensor(a!)
 
 - func: normal(Tensor mean, float std=1, *, Generator? generator=None) -> Tensor
   matches_jit_signature: True
 
-- func: normal_out(Tensor output, float mean, Tensor std, *, Generator? generator=None) -> Tensor
+- func: normal(float mean, Tensor std, *, Generator? generator=None, Tensor(a!) output) -> Tensor(a!)
 
 - func: normal(double mean, Tensor std, *, Generator? generator=None) -> Tensor
 
-- func: normal_out(Tensor output, Tensor mean, Tensor std, *, Generator? generator=None) -> Tensor
+- func: normal(Tensor mean, Tensor std, *, Generator? generator=None, Tensor(a!) output) -> Tensor(a!)
 
 - func: normal(Tensor mean, Tensor std, *, Generator? generator=None) -> Tensor
   matches_jit_signature: True
@@ -3664,165 +3664,165 @@
 - func: alias(Tensor self) -> Tensor
   variants: method, function
 
-- func: _dirichlet_grad_out(Tensor output, Tensor x, Tensor alpha, Tensor total) -> Tensor
+- func: _dirichlet_grad(Tensor x, Tensor alpha, Tensor total, *, Tensor(a!) output) -> Tensor(a!)
 
 - func: _dirichlet_grad(Tensor x, Tensor alpha, Tensor total) -> Tensor
   matches_jit_signature: True
 
 ## NN wrappers
 
-- func: binary_cross_entropy_out(Tensor output, Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean) -> Tensor
+- func: binary_cross_entropy(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: binary_cross_entropy(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: binary_cross_entropy_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, Tensor weight, int reduction) -> Tensor
+- func: binary_cross_entropy_backward(Tensor grad_output, Tensor self, Tensor target, Tensor weight, int reduction, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: binary_cross_entropy_backward(Tensor grad_output, Tensor self, Tensor target, Tensor weight, int reduction) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: mse_loss_out(Tensor output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
+- func: mse_loss(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: mse_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: mse_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
+- func: mse_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: mse_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: l1_loss_out(Tensor output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
+- func: l1_loss(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: l1_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: l1_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
+- func: l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: multi_margin_loss_out(Tensor output, Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor
+- func: multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: multi_margin_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, int reduction) -> Tensor
+- func: multi_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, int reduction, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: multi_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor weight, int reduction) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: multilabel_margin_loss_out(Tensor output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
+- func: multilabel_margin_loss(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: multilabel_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: multilabel_margin_loss_forward_out(Tensor output, Tensor is_target, Tensor self, Tensor target, int reduction) -> (Tensor, Tensor)
+- func: multilabel_margin_loss_forward(Tensor self, Tensor target, int reduction, *, Tensor(a!) output, Tensor(b!) is_target) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 - func: multilabel_margin_loss_forward(Tensor self, Tensor target, int reduction) -> (Tensor output, Tensor is_target)
   python_module: nn
 
-- func: multilabel_margin_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, int reduction, Tensor is_target) -> Tensor
+- func: multilabel_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, Tensor is_target, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: multilabel_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, Tensor is_target) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: nll_loss_out(Tensor output, Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
+- func: nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: nll_loss_forward_out(Tensor output, Tensor total_weight, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor, Tensor)
+- func: nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, *, Tensor(a!) output, Tensor(b!) total_weight) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 - func: nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor output, Tensor total_weight)
   python_module: nn
 
-- func: nll_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
+- func: nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: nll_loss2d_out(Tensor output, Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
+- func: nll_loss2d(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: nll_loss2d(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: nll_loss2d_forward_out(Tensor output, Tensor total_weight, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor, Tensor)
+- func: nll_loss2d_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, *, Tensor(a!) output, Tensor(b!) total_weight) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 - func: nll_loss2d_forward(Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index) -> (Tensor output, Tensor total_weight)
   python_module: nn
 
-- func: nll_loss2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
+- func: nll_loss2d_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: nll_loss2d_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: smooth_l1_loss_out(Tensor output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
+- func: smooth_l1_loss(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: smooth_l1_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: smooth_l1_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
+- func: smooth_l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: smooth_l1_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: soft_margin_loss_out(Tensor output, Tensor self, Tensor target, int reduction=Mean) -> Tensor
+- func: soft_margin_loss(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: soft_margin_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: soft_margin_loss_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
+- func: soft_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: soft_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: elu_out(Tensor output, Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor
+- func: elu(Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: elu(Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: elu_backward_out(Tensor grad_input, Tensor grad_output, Scalar alpha, Scalar scale, Scalar input_scale, Tensor output) -> Tensor
+- func: elu_backward(Tensor grad_output, Scalar alpha, Scalar scale, Scalar input_scale, Tensor output, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: elu_backward(Tensor grad_output, Scalar alpha, Scalar scale, Scalar input_scale, Tensor output) -> Tensor
@@ -3833,28 +3833,28 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: glu_out(Tensor output, Tensor self, int dim=-1) -> Tensor
+- func: glu(Tensor self, int dim=-1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: glu(Tensor self, int dim=-1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: glu_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int dim) -> Tensor
+- func: glu_backward(Tensor grad_output, Tensor self, int dim, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: glu_backward(Tensor grad_output, Tensor self, int dim) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: hardtanh_out(Tensor output, Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
+- func: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: hardtanh_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val) -> Tensor
+- func: hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: hardtanh_backward(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val) -> Tensor
@@ -3865,14 +3865,14 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: leaky_relu_out(Tensor output, Tensor self, Scalar negative_slope=0.01) -> Tensor
+- func: leaky_relu(Tensor self, Scalar negative_slope=0.01, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: leaky_relu(Tensor self, Scalar negative_slope=0.01) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: leaky_relu_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Scalar negative_slope) -> Tensor
+- func: leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope) -> Tensor
@@ -3883,34 +3883,34 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: log_sigmoid_out(Tensor output, Tensor self) -> Tensor
+- func: log_sigmoid(Tensor self, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: log_sigmoid(Tensor self) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: log_sigmoid_forward_out(Tensor output, Tensor buffer, Tensor self) -> (Tensor, Tensor)
+- func: log_sigmoid_forward(Tensor self, *, Tensor(a!) output, Tensor(b!) buffer) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 - func: log_sigmoid_forward(Tensor self) -> (Tensor output, Tensor buffer)
   python_module: nn
 
-- func: log_sigmoid_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor buffer) -> Tensor
+- func: log_sigmoid_backward(Tensor grad_output, Tensor self, Tensor buffer, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: log_sigmoid_backward(Tensor grad_output, Tensor self, Tensor buffer) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: rrelu_with_noise_out(Tensor output, Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
+- func: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 
-- func: rrelu_with_noise_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training) -> Tensor
+- func: rrelu_with_noise_backward(Tensor grad_output, Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: rrelu_with_noise_backward(Tensor grad_output, Tensor self, Tensor noise, Scalar lower, Scalar upper, bool training) -> Tensor
@@ -3921,35 +3921,35 @@
   matches_jit_signature: True
   python_module: nn
 
-- func: softplus_out(Tensor output, Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor
+- func: softplus(Tensor self, Scalar beta=1, Scalar threshold=20, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: softplus(Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: softplus_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Scalar beta, Scalar threshold, Tensor output) -> Tensor
+- func: softplus_backward(Tensor grad_output, Tensor self, Scalar beta, Scalar threshold, Tensor output, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: softplus_backward(Tensor grad_output, Tensor self, Scalar beta, Scalar threshold, Tensor output) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: softshrink_out(Tensor output, Tensor self, Scalar lambd=0.5) -> Tensor
+- func: softshrink(Tensor self, Scalar lambd=0.5, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: softshrink(Tensor self, Scalar lambd=0.5) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: softshrink_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Scalar lambd) -> Tensor
+- func: softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: adaptive_avg_pool2d_out(Tensor output, Tensor self, int[2] output_size) -> Tensor
+- func: adaptive_avg_pool2d(Tensor self, int[2] output_size, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: adaptive_avg_pool2d_out_cpu
@@ -3962,7 +3962,7 @@
     CPU: adaptive_avg_pool2d_cpu
     CUDA: adaptive_avg_pool2d_cuda
 
-- func: adaptive_avg_pool2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self) -> Tensor
+- func: adaptive_avg_pool2d_backward(Tensor grad_output, Tensor self, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: adaptive_avg_pool2d_backward_out_cpu
@@ -3975,14 +3975,14 @@
     CPU: adaptive_avg_pool2d_backward_cpu
     CUDA: adaptive_avg_pool2d_backward_cuda
 
-- func: adaptive_avg_pool3d_out(Tensor output, Tensor self, int[3] output_size) -> Tensor
+- func: adaptive_avg_pool3d(Tensor self, int[3] output_size, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: adaptive_avg_pool3d(Tensor self, int[3] output_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: adaptive_avg_pool3d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self) -> Tensor
+- func: adaptive_avg_pool3d_backward(Tensor grad_output, Tensor self, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: adaptive_avg_pool3d_backward(Tensor grad_output, Tensor self) -> Tensor
@@ -3990,14 +3990,14 @@
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
-- func: adaptive_max_pool2d_out(Tensor output, Tensor indices, Tensor self, int[2] output_size) -> (Tensor, Tensor)
+- func: adaptive_max_pool2d(Tensor self, int[2] output_size, *, Tensor(a!) output, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
 - func: adaptive_max_pool2d(Tensor self, int[2] output_size) -> (Tensor, Tensor)
   python_module: nn
 
-- func: adaptive_max_pool2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor indices) -> Tensor
+- func: adaptive_max_pool2d_backward(Tensor grad_output, Tensor self, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: adaptive_max_pool2d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor
@@ -4005,42 +4005,42 @@
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
-- func: adaptive_max_pool3d_out(Tensor output, Tensor indices, Tensor self, int[3] output_size) -> (Tensor, Tensor)
+- func: adaptive_max_pool3d(Tensor self, int[3] output_size, *, Tensor(a!) output, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
 - func: adaptive_max_pool3d(Tensor self, int[3] output_size) -> (Tensor, Tensor)
   python_module: nn
 
-- func: adaptive_max_pool3d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor indices) -> Tensor
+- func: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: avg_pool2d_out(Tensor output, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, bool ceil_mode=False, bool count_include_pad=True) -> Tensor
+- func: avg_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, bool ceil_mode=False, bool count_include_pad=True, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: avg_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, bool ceil_mode=False, bool count_include_pad=True) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: avg_pool2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, bool ceil_mode, bool count_include_pad) -> Tensor
+- func: avg_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, bool ceil_mode, bool count_include_pad, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: avg_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, bool ceil_mode, bool count_include_pad) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: avg_pool3d_out(Tensor output, Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, bool ceil_mode=False, bool count_include_pad=True) -> Tensor
+- func: avg_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, bool ceil_mode=False, bool count_include_pad=True, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: avg_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, bool ceil_mode=False, bool count_include_pad=True) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: avg_pool3d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, bool ceil_mode, bool count_include_pad) -> Tensor
+- func: avg_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, bool ceil_mode, bool count_include_pad, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: avg_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, bool ceil_mode, bool count_include_pad) -> Tensor
@@ -4048,7 +4048,7 @@
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
-- func: fractional_max_pool2d_out(Tensor output, Tensor indices, Tensor self, int[2] kernel_size, int[2] output_size, Tensor random_samples) -> (Tensor, Tensor)
+- func: fractional_max_pool2d(Tensor self, int[2] kernel_size, int[2] output_size, Tensor random_samples, *, Tensor(a!) output, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
   python_module: nn
   dispatch:
     CPU: fractional_max_pool2d_out_cpu
@@ -4061,7 +4061,7 @@
     CPU: fractional_max_pool2d_cpu
     CUDA: fractional_max_pool2d_cuda
 
-- func: fractional_max_pool2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices) -> Tensor
+- func: fractional_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: fractional_max_pool2d_backward_out_cpu
@@ -4074,7 +4074,7 @@
     CPU: fractional_max_pool2d_backward_cpu
     CUDA: fractional_max_pool2d_backward_cuda
 
-- func: fractional_max_pool3d_out(Tensor output, Tensor indices, Tensor self, int[3] kernel_size, int[3] output_size, Tensor random_samples) -> (Tensor output, Tensor indices)
+- func: fractional_max_pool3d(Tensor self, int[3] kernel_size, int[3] output_size, Tensor random_samples, *, Tensor(a!) output, Tensor(b!) indices) ->(Tensor(a!) output, Tensor(b!) indices)
   python_module: nn
   dispatch:
     CPU: fractional_max_pool3d_out_cpu
@@ -4086,7 +4086,7 @@
     CPU: fractional_max_pool3d_cpu
     CUDA: fractional_max_pool3d_cuda
 
-- func: fractional_max_pool3d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[3] kernel_size, int[3] output_size, Tensor indices) -> Tensor
+- func: fractional_max_pool3d_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] output_size, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: fractional_max_pool3d_backward_out_cpu
@@ -4099,14 +4099,14 @@
     CPU: fractional_max_pool3d_backward_cpu
     CUDA: fractional_max_pool3d_backward_cuda
 
-- func: max_pool2d_with_indices_out(Tensor output, Tensor indices, Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor output, Tensor indices)
+- func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False, *, Tensor(a!) output, Tensor(b!) indices) ->(Tensor(a!) output, Tensor(b!) indices)
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
   python_module: nn
 
-- func: max_pool2d_with_indices_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
+- func: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor
@@ -4114,49 +4114,49 @@
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
-- func: max_pool3d_with_indices_out(Tensor output, Tensor indices, Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
+- func: max_pool3d_with_indices(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False, *, Tensor(a!) output, Tensor(b!) indices) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool3d_with_indices(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
   python_module: nn
 
-- func: max_pool3d_with_indices_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool ceil_mode, Tensor indices) -> Tensor
+- func: max_pool3d_with_indices_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool ceil_mode, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: max_pool3d_with_indices_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool ceil_mode, Tensor indices) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: max_unpool2d_out(Tensor output, Tensor self, Tensor indices, int[2] output_size) -> Tensor
+- func: max_unpool2d(Tensor self, Tensor indices, int[2] output_size, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: max_unpool2d(Tensor self, Tensor indices, int[2] output_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: max_unpool2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor indices, int[2] output_size) -> Tensor
+- func: max_unpool2d_backward(Tensor grad_output, Tensor self, Tensor indices, int[2] output_size, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: max_unpool2d_backward(Tensor grad_output, Tensor self, Tensor indices, int[2] output_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: max_unpool3d_out(Tensor output, Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding) -> Tensor
+- func: max_unpool3d(Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: max_unpool3d(Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: max_unpool3d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding) -> Tensor
+- func: max_unpool3d_backward(Tensor grad_output, Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: max_unpool3d_backward(Tensor grad_output, Tensor self, Tensor indices, int[3] output_size, int[3] stride, int[3] padding) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: reflection_pad1d_out(Tensor output, Tensor self, int[2] padding) -> Tensor
+- func: reflection_pad1d(Tensor self, int[2] padding, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: reflection_pad1d_out_cpu
@@ -4169,7 +4169,7 @@
     CPU: reflection_pad1d_cpu
     CUDA: reflection_pad1d_cuda
 
-- func: reflection_pad1d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[2] padding) -> Tensor
+- func: reflection_pad1d_backward(Tensor grad_output, Tensor self, int[2] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: reflection_pad1d_backward_out_cpu
@@ -4182,7 +4182,7 @@
     CPU: reflection_pad1d_backward_cpu
     CUDA: reflection_pad1d_backward_cuda
 
-- func: reflection_pad2d_out(Tensor output, Tensor self, int[4] padding) -> Tensor
+- func: reflection_pad2d(Tensor self, int[4] padding, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: reflection_pad2d_out_cpu
@@ -4195,7 +4195,7 @@
     CPU: reflection_pad2d_cpu
     CUDA: reflection_pad2d_cuda
 
-- func: reflection_pad2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[4] padding) -> Tensor
+- func: reflection_pad2d_backward(Tensor grad_output, Tensor self, int[4] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: reflection_pad2d_backward_out_cpu
@@ -4208,7 +4208,7 @@
     CPU: reflection_pad2d_backward_cpu
     CUDA: reflection_pad2d_backward_cuda
 
-- func: replication_pad1d_out(Tensor output, Tensor self, int[2] padding) -> Tensor
+- func: replication_pad1d(Tensor self, int[2] padding, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: replication_pad1d_out_cpu
@@ -4221,7 +4221,7 @@
     CPU: replication_pad1d_cpu
     CUDA: replication_pad1d_cuda
 
-- func: replication_pad1d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[2] padding) -> Tensor
+- func: replication_pad1d_backward(Tensor grad_output, Tensor self, int[2] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: replication_pad1d_backward_out_cpu
@@ -4234,7 +4234,7 @@
     CPU: replication_pad1d_backward_cpu
     CUDA: replication_pad1d_backward_cuda
 
-- func: replication_pad2d_out(Tensor output, Tensor self, int[4] padding) -> Tensor
+- func: replication_pad2d(Tensor self, int[4] padding, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: replication_pad2d_out_cpu
@@ -4247,7 +4247,7 @@
     CPU: replication_pad2d_cpu
     CUDA: replication_pad2d_cuda
 
-- func: replication_pad2d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[4] padding) -> Tensor
+- func: replication_pad2d_backward(Tensor grad_output, Tensor self, int[4] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: replication_pad2d_backward_out_cpu
@@ -4260,7 +4260,7 @@
     CPU: replication_pad2d_backward_cpu
     CUDA: replication_pad2d_backward_cuda
 
-- func: replication_pad3d_out(Tensor output, Tensor self, int[6] padding) -> Tensor
+- func: replication_pad3d(Tensor self, int[6] padding, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: replication_pad3d_out_cpu
@@ -4273,7 +4273,7 @@
     CPU: replication_pad3d_cpu
     CUDA: replication_pad3d_cuda
 
-- func: replication_pad3d_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[6] padding) -> Tensor
+- func: replication_pad3d_backward(Tensor grad_output, Tensor self, int[6] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
   dispatch:
     CPU: replication_pad3d_backward_out_cpu
@@ -4286,247 +4286,247 @@
     CPU: replication_pad3d_backward_cpu
     CUDA: replication_pad3d_backward_cuda
 
-- func: upsample_linear1d_out(Tensor output, Tensor self, int[1] output_size, bool align_corners) -> Tensor
+- func: upsample_linear1d(Tensor self, int[1] output_size, bool align_corners, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_linear1d(Tensor self, int[1] output_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_linear1d_backward_out(Tensor grad_input, Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners) -> Tensor
+- func: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_linear1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_bilinear2d_out(Tensor output, Tensor self, int[2] output_size, bool align_corners) -> Tensor
+- func: upsample_bilinear2d(Tensor self, int[2] output_size, bool align_corners, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_bilinear2d(Tensor self, int[2] output_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_bilinear2d_backward_out(Tensor grad_input, Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners) -> Tensor
+- func: upsample_bilinear2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_bilinear2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_bicubic2d_out(Tensor output, Tensor self, int[2] output_size, bool align_corners) -> Tensor
+- func: upsample_bicubic2d(Tensor self, int[2] output_size, bool align_corners, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_bicubic2d(Tensor self, int[2] output_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_bicubic2d_backward_out(Tensor grad_input, Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners) -> Tensor
+- func: upsample_bicubic2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_bicubic2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_trilinear3d_out(Tensor output, Tensor self, int[3] output_size, bool align_corners) -> Tensor
+- func: upsample_trilinear3d(Tensor self, int[3] output_size, bool align_corners, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_trilinear3d(Tensor self, int[3] output_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_trilinear3d_backward_out(Tensor grad_input, Tensor grad_output, int[3] output_size, int[5] input_size, bool align_corners) -> Tensor
+- func: upsample_trilinear3d_backward(Tensor grad_output, int[3] output_size, int[5] input_size, bool align_corners, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_trilinear3d_backward(Tensor grad_output, int[3] output_size, int[5] input_size, bool align_corners) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_nearest1d_out(Tensor output, Tensor self, int[1] output_size) -> Tensor
+- func: upsample_nearest1d(Tensor self, int[1] output_size, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_nearest1d(Tensor self, int[1] output_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_nearest1d_backward_out(Tensor grad_input, Tensor grad_output, int[1] output_size, int[3] input_size) -> Tensor
+- func: upsample_nearest1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_nearest1d_backward(Tensor grad_output, int[1] output_size, int[3] input_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_nearest2d_out(Tensor output, Tensor self, int[2] output_size) -> Tensor
+- func: upsample_nearest2d(Tensor self, int[2] output_size, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_nearest2d(Tensor self, int[2] output_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_nearest2d_backward_out(Tensor grad_input, Tensor grad_output, int[2] output_size, int[4] input_size) -> Tensor
+- func: upsample_nearest2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_nearest2d_backward(Tensor grad_output, int[2] output_size, int[4] input_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_nearest3d_out(Tensor output, Tensor self, int[3] output_size) -> Tensor
+- func: upsample_nearest3d(Tensor self, int[3] output_size, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_nearest3d(Tensor self, int[3] output_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: upsample_nearest3d_backward_out(Tensor grad_input, Tensor grad_output, int[3] output_size, int[5] input_size) -> Tensor
+- func: upsample_nearest3d_backward(Tensor grad_output, int[3] output_size, int[5] input_size, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: upsample_nearest3d_backward(Tensor grad_output, int[3] output_size, int[5] input_size) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: sigmoid_backward_out(Tensor grad_input, Tensor grad_output, Tensor output) -> Tensor
+- func: sigmoid_backward(Tensor grad_output, Tensor output, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: sigmoid_backward(Tensor grad_output, Tensor output) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: tanh_backward_out(Tensor grad_input, Tensor grad_output, Tensor output) -> Tensor
+- func: tanh_backward(Tensor grad_output, Tensor output, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
 
 - func: tanh_backward(Tensor grad_output, Tensor output) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_transpose2d_out(Tensor output, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int[2] dilation=1) -> Tensor
+- func: thnn_conv_transpose2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int[2] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv_transpose2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] output_padding=0, int[2] dilation=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_transpose2d_forward_out(Tensor output, Tensor columns, Tensor ones, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_transpose2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, *, Tensor(a!) output, Tensor(b!) columns, Tensor(c!) ones) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_transpose2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation) -> (Tensor output, Tensor columns, Tensor ones)
   python_module: nn
 
-- func: thnn_conv_transpose2d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor? grad_bias, Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_transpose2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
-- func: thnn_conv_transpose3d_out(Tensor output, Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int[3] dilation=1) -> Tensor
+- func: thnn_conv_transpose3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int[3] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv_transpose3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int[3] dilation=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_transpose3d_forward_out(Tensor output, Tensor finput, Tensor fgrad_input, Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_transpose3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, *, Tensor(a!) output, Tensor(b!) finput, Tensor(c!) fgrad_input) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_transpose3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation) -> (Tensor output, Tensor finput, Tensor fgrad_input)
   python_module: nn
 
-- func: thnn_conv_transpose3d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor? grad_bias, Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_transpose3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] output_padding, int[3] dilation, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
-- func: thnn_conv2d_out(Tensor output, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0) -> Tensor
+- func: thnn_conv2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv2d_forward_out(Tensor output, Tensor finput, Tensor fgrad_input, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, *, Tensor(a!) output, Tensor(b!) finput, Tensor(c!) fgrad_input) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding) -> (Tensor output, Tensor finput, Tensor fgrad_input)
   python_module: nn
 
-- func: thnn_conv2d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor? grad_bias, Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
-- func: thnn_conv_depthwise2d_out(Tensor output, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1) -> Tensor
+- func: thnn_conv_depthwise2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv_depthwise2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_depthwise2d_forward_out(Tensor output, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] dilation) -> Tensor
+- func: thnn_conv_depthwise2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] dilation, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv_depthwise2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] dilation) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_depthwise2d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation) -> (Tensor, Tensor)
+- func: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight) ->(Tensor(a!), Tensor(b!))
   python_module: nn
 
 - func: thnn_conv_depthwise2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, std::array<bool,2> output_mask) -> (Tensor grad_input, Tensor grad_weight)
   python_module: nn
 
-- func: thnn_conv3d_out(Tensor output, Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0) -> Tensor
+- func: thnn_conv3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv3d_forward_out(Tensor output, Tensor finput, Tensor fgrad_input, Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, *, Tensor(a!) output, Tensor(b!) finput, Tensor(c!) fgrad_input) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding) -> (Tensor output, Tensor finput, Tensor fgrad_input)
   python_module: nn
 
-- func: thnn_conv3d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor? grad_bias, Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, Tensor finput, Tensor fgrad_input) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, Tensor finput, Tensor fgrad_input, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, Tensor finput, Tensor fgrad_input, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
-- func: thnn_conv_dilated2d_out(Tensor output, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1) -> Tensor
+- func: thnn_conv_dilated2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv_dilated2d(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_dilated2d_forward_out(Tensor output, Tensor columns, Tensor ones, Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] dilation) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_dilated2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] dilation, *, Tensor(a!) output, Tensor(b!) columns, Tensor(c!) ones) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_dilated2d_forward(Tensor self, Tensor weight, int[2] kernel_size, Tensor? bias, int[2] stride, int[2] padding, int[2] dilation) -> (Tensor output, Tensor columns, Tensor ones)
   python_module: nn
 
-- func: thnn_conv_dilated2d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor? grad_bias, Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, Tensor columns, Tensor ones) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, Tensor columns, Tensor ones, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_dilated2d_backward(Tensor grad_output, Tensor self, Tensor weight, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)
   python_module: nn
 
-- func: thnn_conv_dilated3d_out(Tensor output, Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1) -> Tensor
+- func: thnn_conv_dilated3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1, *, Tensor(a!) output) -> Tensor(a!)
   python_module: nn
 
 - func: thnn_conv_dilated3d(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] dilation=1) -> Tensor
   matches_jit_signature: True
   python_module: nn
 
-- func: thnn_conv_dilated3d_forward_out(Tensor output, Tensor columns, Tensor ones, Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] dilation) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_dilated3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] dilation, *, Tensor(a!) output, Tensor(b!) columns, Tensor(c!) ones) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_dilated3d_forward(Tensor self, Tensor weight, int[3] kernel_size, Tensor? bias, int[3] stride, int[3] padding, int[3] dilation) -> (Tensor output, Tensor columns, Tensor ones)
   python_module: nn
 
-- func: thnn_conv_dilated3d_backward_out(Tensor? grad_input, Tensor? grad_weight, Tensor? grad_bias, Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[] dilation, Tensor columns, Tensor ones) -> (Tensor, Tensor, Tensor)
+- func: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[] dilation, Tensor columns, Tensor ones, *, Tensor?(a!) grad_input, Tensor?(b!) grad_weight, Tensor?(c!) grad_bias) ->(Tensor(a!), Tensor(b!), Tensor(c!))
   python_module: nn
 
 - func: thnn_conv_dilated3d_backward(Tensor grad_output, Tensor self, Tensor weight, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, Tensor columns, Tensor ones, std::array<bool,3> output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -112,7 +112,7 @@
     CPU: _abs__cpu
     CUDA: _abs__cuda
 
-- func: abs_out(Tensor result, Tensor self) -> Tensor
+- func: abs_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _abs_out_cpu
     CUDA: _abs_out_cuda
@@ -128,7 +128,7 @@
     CPU: _acos__cpu
     CUDA: _acos__cuda
 
-- func: acos_out(Tensor result, Tensor self) -> Tensor
+- func: acos_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _acos_out_cpu
     CUDA: _acos_out_cuda
@@ -151,7 +151,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: add_out(Tensor result, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: add_out(Tensor out, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: add(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
@@ -170,7 +170,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: addmv_out(Tensor result, Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addmv_out(Tensor out, Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -180,7 +180,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: addr_out(Tensor result, Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addr_out(Tensor out, Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: affine_grid_generator(Tensor theta, int[] size) -> Tensor
   matches_jit_signature: True
@@ -194,7 +194,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: all_out(Tensor result, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: all_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
 
 - func: allclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> bool
   matches_jit_signature: True
@@ -204,7 +204,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: any_out(Tensor result, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: any_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
 
 - func: arange(Scalar end, TensorOptions options=[]) -> Tensor
 
@@ -212,9 +212,9 @@
 
 - func: arange(Scalar start, Scalar end, Scalar step, TensorOptions options=[]) -> Tensor
 
-- func: arange_out(Tensor result, Scalar end) -> Tensor
+- func: arange_out(Tensor out, Scalar end) -> Tensor
 
-- func: arange_out(Tensor result, Scalar start, Scalar end, Scalar step=1) -> Tensor
+- func: arange_out(Tensor out, Scalar start, Scalar end, Scalar step=1) -> Tensor
   dispatch:
     CPU: arange_cpu_out
     CUDA: arange_cuda_out
@@ -276,7 +276,7 @@
     CPU: _asin__cpu
     CUDA: _asin__cuda
 
-- func: asin_out(Tensor result, Tensor self) -> Tensor
+- func: asin_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _asin_out_cpu
     CUDA: _asin_out_cuda
@@ -292,7 +292,7 @@
     CPU: _atan__cpu
     CUDA: _atan__cuda
 
-- func: atan_out(Tensor result, Tensor self) -> Tensor
+- func: atan_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _atan_out_cpu
     CUDA: _atan_out_cuda
@@ -315,7 +315,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: baddbmm_out(Tensor result, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: baddbmm_out(Tensor out, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   variants: function
   dispatch:
     CPU: baddbmm_out_cpu
@@ -333,7 +333,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: bernoulli_out(Tensor result, Tensor self, *, Generator? generator=None) -> Tensor
+- func: bernoulli_out(Tensor out, Tensor self, *, Generator? generator=None) -> Tensor
   variants: function
 
 - func: bernoulli_(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
@@ -386,7 +386,7 @@
     CPU: bmm_cpu
     CUDA: bmm_cuda
 
-- func: bmm_out(Tensor result, Tensor self, Tensor mat2) -> Tensor
+- func: bmm_out(Tensor out, Tensor self, Tensor mat2) -> Tensor
   variants: function
   dispatch:
     CPU: bmm_out_cpu
@@ -399,7 +399,7 @@
 - func: cat(Tensor[] tensors, int dim=0) -> Tensor
   matches_jit_signature: True
 
-- func: cat_out(Tensor result, Tensor[] tensors, int dim=0) -> Tensor
+- func: cat_out(Tensor out, Tensor[] tensors, int dim=0) -> Tensor
 
 - func: ceil(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -412,7 +412,7 @@
     CPU: _ceil__cpu
     CUDA: _ceil__cuda
 
-- func: ceil_out(Tensor result, Tensor self) -> Tensor
+- func: ceil_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _ceil_out_cpu
     CUDA: _ceil_out_cuda
@@ -436,7 +436,7 @@
     CPU: _clamp__cpu
     CUDA: _clamp__cuda
 
-- func: clamp_out(Tensor result, Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
+- func: clamp_out(Tensor out, Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
   dispatch:
     CPU: _clamp_out_cpu
     CUDA: _clamp_out_cuda
@@ -452,7 +452,7 @@
     CPU: _clamp_max__cpu
     CUDA: _clamp_max__cuda
 
-- func: clamp_max_out(Tensor result, Tensor self, Scalar max) -> Tensor
+- func: clamp_max_out(Tensor out, Tensor self, Scalar max) -> Tensor
   dispatch:
     CPU: _clamp_max_out_cpu
     CUDA: _clamp_max_out_cuda
@@ -468,7 +468,7 @@
     CPU: _clamp_min__cpu
     CUDA: _clamp_min__cuda
 
-- func: clamp_min_out(Tensor result, Tensor self, Scalar min) -> Tensor
+- func: clamp_min_out(Tensor out, Tensor self, Scalar min) -> Tensor
   dispatch:
     CPU: _clamp_min_out_cpu
     CUDA: _clamp_min_out_cuda
@@ -550,7 +550,7 @@
     CPU: _cos__cpu
     CUDA: _cos__cuda
 
-- func: cos_out(Tensor result, Tensor self) -> Tensor
+- func: cos_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _cos_out_cpu
     CUDA: _cos_out_cuda
@@ -566,7 +566,7 @@
     CPU: _cosh__cpu
     CUDA: _cosh__cuda
 
-- func: cosh_out(Tensor result, Tensor self) -> Tensor
+- func: cosh_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _cosh_out_cpu
     CUDA: _cosh_out_cuda
@@ -662,9 +662,9 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: cumsum_out(Tensor result, Tensor self, int dim, *, ScalarType dtype) -> Tensor
+- func: cumsum_out(Tensor out, Tensor self, int dim, *, ScalarType dtype) -> Tensor
 
-- func: cumsum_out(Tensor result, Tensor self, int dim) -> Tensor
+- func: cumsum_out(Tensor out, Tensor self, int dim) -> Tensor
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: cumprod(Tensor self, int dim, *, ScalarType dtype) -> Tensor
@@ -675,9 +675,9 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: cumprod_out(Tensor result, Tensor self, int dim, *, ScalarType dtype) -> Tensor
+- func: cumprod_out(Tensor out, Tensor self, int dim, *, ScalarType dtype) -> Tensor
 
-- func: cumprod_out(Tensor result, Tensor self, int dim) -> Tensor
+- func: cumprod_out(Tensor out, Tensor self, int dim) -> Tensor
 
 - func: ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank=0, int reduction=Mean) -> Tensor
   matches_jit_signature: True
@@ -721,7 +721,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: div_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: div_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: div(Tensor self, Scalar other) -> Tensor
@@ -736,7 +736,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: dot_out(Tensor result, Tensor self, Tensor tensor) -> Tensor
+- func: dot_out(Tensor out, Tensor self, Tensor tensor) -> Tensor
 
 - func: einsum(std::string equation, Tensor[] tensors) -> Tensor
 
@@ -798,7 +798,7 @@
     CPU: resize_cpu_
     CUDA: resize_cuda_
 
-- func: empty_out(Tensor result, int[] size) -> Tensor
+- func: empty_out(Tensor out, int[] size) -> Tensor
   device_guard: False
 
 - func: empty_like(Tensor self) -> Tensor
@@ -824,7 +824,7 @@
     CPU: _erf__cpu
     CUDA: _erf__cuda
 
-- func: erf_out(Tensor result, Tensor self) -> Tensor
+- func: erf_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _erf_out_cpu
     CUDA: _erf_out_cuda
@@ -840,7 +840,7 @@
     CPU: _erfc__cpu
     CUDA: _erfc__cuda
 
-- func: erfc_out(Tensor result, Tensor self) -> Tensor
+- func: erfc_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _erfc_out_cpu
     CUDA: _erfc_out_cuda
@@ -856,7 +856,7 @@
     CPU: _exp__cpu
     CUDA: _exp__cuda
 
-- func: exp_out(Tensor result, Tensor self) -> Tensor
+- func: exp_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _exp_out_cpu
     CUDA: _exp_out_cuda
@@ -872,7 +872,7 @@
     CPU: _expm1__cpu
     CUDA: _expm1__cuda
 
-- func: expm1_out(Tensor result, Tensor self) -> Tensor
+- func: expm1_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _expm1_out_cpu
     CUDA: _expm1_out_cuda
@@ -890,12 +890,12 @@
 
 - func: eye(int n, int m, TensorOptions options=[]) -> Tensor
 
-- func: eye_out(Tensor result, int n) -> Tensor
+- func: eye_out(Tensor out, int n) -> Tensor
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
 
-- func: eye_out(Tensor result, int n, int m) -> Tensor
+- func: eye_out(Tensor out, int n, int m) -> Tensor
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
@@ -923,14 +923,14 @@
     CPU: _floor__cpu
     CUDA: _floor__cuda
 
-- func: floor_out(Tensor result, Tensor self) -> Tensor
+- func: floor_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _floor_out_cpu
     CUDA: _floor_out_cuda
 
 - func: full(int[] size, Scalar fill_value, TensorOptions options=[]) -> Tensor
 
-- func: full_out(Tensor result, int[] size, Scalar fill_value) -> Tensor
+- func: full_out(Tensor out, int[] size, Scalar fill_value) -> Tensor
 
 - func: full_like(Tensor self, Scalar fill_value) -> Tensor
   matches_jit_signature: True
@@ -992,7 +992,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: ger_out(Tensor result, Tensor self, Tensor vec2) -> Tensor
+- func: ger_out(Tensor out, Tensor self, Tensor vec2) -> Tensor
 
 - func: gesv(Tensor self, Tensor A) -> (Tensor, Tensor)
   matches_jit_signature: True
@@ -1074,7 +1074,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: inverse_out(Tensor result, Tensor self) -> Tensor
+- func: inverse_out(Tensor out, Tensor self) -> Tensor
 
 - func: _inverse_helper(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1157,7 +1157,7 @@
 
 - func: linspace(Scalar start, Scalar end, int steps=100, TensorOptions options=[]) -> Tensor
 
-- func: linspace_out(Tensor result, Scalar start, Scalar end, int steps=100) -> Tensor
+- func: linspace_out(Tensor out, Scalar start, Scalar end, int steps=100) -> Tensor
   dispatch:
     CPU: linspace_cpu_out
     CUDA: linspace_cuda_out
@@ -1173,7 +1173,7 @@
     CPU: _log__cpu
     CUDA: _log__cuda
 
-- func: log_out(Tensor result, Tensor self) -> Tensor
+- func: log_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _log_out_cpu
     CUDA: _log_out_cuda
@@ -1189,7 +1189,7 @@
     CPU: _log10__cpu
     CUDA: _log10__cuda
 
-- func: log10_out(Tensor result, Tensor self) -> Tensor
+- func: log10_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _log10_out_cpu
     CUDA: _log10_out_cuda
@@ -1207,7 +1207,7 @@
     SparseCPU: log1p_sparse_
     SparseCUDA: log1p_sparse_
 
-- func: log1p_out(Tensor result, Tensor self) -> Tensor
+- func: log1p_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _log1p_out_cpu
     CUDA: _log1p_out_cuda
@@ -1225,7 +1225,7 @@
     CPU: _log2__cpu
     CUDA: _log2__cuda
 
-- func: log2_out(Tensor result, Tensor self) -> Tensor
+- func: log2_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _log2_out_cpu
     CUDA: _log2_out_cuda
@@ -1236,7 +1236,7 @@
 
 - func: logspace(Scalar start, Scalar end, int steps=100, TensorOptions options=[]) -> Tensor
 
-- func: logspace_out(Tensor result, Scalar start, Scalar end, int steps=100) -> Tensor
+- func: logspace_out(Tensor out, Scalar start, Scalar end, int steps=100) -> Tensor
   dispatch:
     CPU: logspace_cpu_out
     CUDA: logspace_cuda_out
@@ -1266,7 +1266,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: logsumexp_out(Tensor result, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: logsumexp_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
 
 - func: margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor
   matches_jit_signature: True
@@ -1275,7 +1275,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: matmul_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: matmul_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: matrix_rank(Tensor self, float tol, bool symmetric=False) -> Tensor
   matches_jit_signature: True
@@ -1330,11 +1330,11 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mean_out(Tensor result, Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: mean_out(Tensor out, Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
 
-- func: mean_out(Tensor result, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: mean_out(Tensor out, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
 
-- func: mean_out(Tensor result, Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
+- func: mean_out(Tensor out, Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
 
 - func: median(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
   matches_jit_signature: True
@@ -1422,7 +1422,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mm_out(Tensor result, Tensor self, Tensor mat2) -> Tensor
+- func: mm_out(Tensor out, Tensor self, Tensor mat2) -> Tensor
 
 - func: _sparse_mm(Tensor sparse, Tensor dense) -> Tensor
   matches_jit_signature: True
@@ -1441,7 +1441,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: mul_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: mul_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
   # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: mul(Tensor self, Scalar other) -> Tensor
@@ -1456,7 +1456,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: mv_out(Tensor result, Tensor self, Tensor vec) -> Tensor
+- func: mv_out(Tensor out, Tensor self, Tensor vec) -> Tensor
 
 - func: mvlgamma(Tensor self, int p) -> Tensor
   matches_jit_signature: True
@@ -1516,7 +1516,7 @@
 
 - func: ones(int[] size, TensorOptions options=[]) -> Tensor
 
-- func: ones_out(Tensor result, int[] size) -> Tensor
+- func: ones_out(Tensor out, int[] size) -> Tensor
 
 - func: ones_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1561,9 +1561,9 @@
 
 - func: rand(int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: rand_out(Tensor result, int[] size, *) -> Tensor
+- func: rand_out(Tensor out, int[] size, *) -> Tensor
 
-- func: rand_out(Tensor result, int[] size, *, Generator? generator) -> Tensor
+- func: rand_out(Tensor out, int[] size, *, Generator? generator) -> Tensor
 
 - func: rand_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1578,13 +1578,13 @@
 
 - func: randint(int low, int high, int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: randint_out(Tensor result, int high, int[] size, *) -> Tensor
+- func: randint_out(Tensor out, int high, int[] size, *) -> Tensor
 
-- func: randint_out(Tensor result, int high, int[] size, *, Generator? generator) -> Tensor
+- func: randint_out(Tensor out, int high, int[] size, *, Generator? generator) -> Tensor
 
-- func: randint_out(Tensor result, int low, int high, int[] size, *) -> Tensor
+- func: randint_out(Tensor out, int low, int high, int[] size, *) -> Tensor
 
-- func: randint_out(Tensor result, int low, int high, int[] size, *, Generator? generator) -> Tensor
+- func: randint_out(Tensor out, int low, int high, int[] size, *, Generator? generator) -> Tensor
 
 - func: randint_like(Tensor self, int high) -> Tensor
   matches_jit_signature: True
@@ -1600,9 +1600,9 @@
 
 - func: randn(int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: randn_out(Tensor result, int[] size, *) -> Tensor
+- func: randn_out(Tensor out, int[] size, *) -> Tensor
 
-- func: randn_out(Tensor result, int[] size, *, Generator? generator) -> Tensor
+- func: randn_out(Tensor out, int[] size, *, Generator? generator) -> Tensor
 
 - func: randn_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1613,9 +1613,9 @@
 
 - func: randperm(int n, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
-- func: randperm_out(Tensor result, int n, *) -> Tensor
+- func: randperm_out(Tensor out, int n, *) -> Tensor
 
-- func: randperm_out(Tensor result, int n, *, Generator? generator) -> Tensor
+- func: randperm_out(Tensor out, int n, *, Generator? generator) -> Tensor
   dispatch:
     CPU: randperm_out_cpu
     CUDA: randperm_out_cuda
@@ -1624,7 +1624,7 @@
 
 - func: range(Scalar start, Scalar end, TensorOptions options=[]) -> Tensor
 
-- func: range_out(Tensor result, Scalar start, Scalar end, Scalar step=1) -> Tensor
+- func: range_out(Tensor out, Scalar start, Scalar end, Scalar step=1) -> Tensor
   dispatch:
     CPU: range_cpu_out
     CUDA: range_cuda_out
@@ -1666,7 +1666,7 @@
     CPU: _round__cpu
     CUDA: _round__cuda
 
-- func: round_out(Tensor result, Tensor self) -> Tensor
+- func: round_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _round_out_cpu
     CUDA: _round_out_cuda
@@ -1724,7 +1724,7 @@
     CPU: _rsqrt__cpu
     CUDA: _rsqrt__cuda
 
-- func: rsqrt_out(Tensor result, Tensor self) -> Tensor
+- func: rsqrt_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _rsqrt_out_cpu
     CUDA: _rsqrt_out_cuda
@@ -1756,7 +1756,7 @@
     CPU: _sigmoid__cpu
     CUDA: _sigmoid__cuda
 
-- func: sigmoid_out(Tensor result, Tensor self) -> Tensor
+- func: sigmoid_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _sigmoid_out_cpu
     CUDA: _sigmoid_out_cuda
@@ -1772,7 +1772,7 @@
     CPU: _sin__cpu
     CUDA: _sin__cuda
 
-- func: sin_out(Tensor result, Tensor self) -> Tensor
+- func: sin_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _sin_out_cpu
     CUDA: _sin_out_cuda
@@ -1788,7 +1788,7 @@
     CPU: _sinh__cpu
     CUDA: _sinh__cuda
 
-- func: sinh_out(Tensor result, Tensor self) -> Tensor
+- func: sinh_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _sinh_out_cpu
     CUDA: _sinh_out_cuda
@@ -1839,37 +1839,37 @@
     CPU: softmax_backward_cpu
     CUDA: softmax_backward_cuda
 
-- func: _sparse_add_out(Tensor result, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: _sparse_add_out(Tensor out, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
   dispatch:
     SparseCPU: add_out_sparse_cpu
     SparseCUDA: add_out_sparse_cuda
 
-- func: _sparse_dense_add_out(Tensor result, Tensor self, SparseTensorRef other, *, Scalar alpha=1) -> Tensor
+- func: _sparse_dense_add_out(Tensor out, Tensor self, SparseTensorRef other, *, Scalar alpha=1) -> Tensor
   dispatch:
     CPU: add_out_dense_sparse_cpu
     CUDA: add_out_dense_sparse_cuda
 
-- func: _sparse_div_zerodim_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: _sparse_div_zerodim_out(Tensor out, Tensor self, Tensor other) -> Tensor
   dispatch:
     SparseCPU: div_out_sparse_zerodim
     SparseCUDA: div_out_sparse_zerodim
 
-- func: _sparse_div_scalar_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: _sparse_div_scalar_out(Tensor out, Tensor self, Scalar other) -> Tensor
   dispatch:
     SparseCPU: div_out_sparse_scalar
     SparseCUDA: div_out_sparse_scalar
 
-- func: _sparse_mul_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: _sparse_mul_out(Tensor out, Tensor self, Tensor other) -> Tensor
   dispatch:
     SparseCPU: mul_out_sparse_cpu
     SparseCUDA: mul_out_sparse_cuda
 
-- func: _sparse_mul_zerodim_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: _sparse_mul_zerodim_out(Tensor out, Tensor self, Tensor other) -> Tensor
   dispatch:
     SparseCPU: mul_out_sparse_zerodim
     SparseCUDA: mul_out_sparse_zerodim
 
-- func: _sparse_mul_scalar_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: _sparse_mul_scalar_out(Tensor out, Tensor self, Scalar other) -> Tensor
   dispatch:
     SparseCPU: mul_out_sparse_scalar
     SparseCUDA: mul_out_sparse_scalar
@@ -1905,7 +1905,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sspaddmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: sspaddmm_out(Tensor out, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   dispatch:
     CPU: _sspaddmm_out_only_sparse
     CUDA: _sspaddmm_out_only_sparse_cuda
@@ -1915,7 +1915,7 @@
 - func: stack(Tensor[] tensors, int dim=0) -> Tensor
   matches_jit_signature: True
 
-- func: stack_out(Tensor result, Tensor[] tensors, int dim=0) -> Tensor
+- func: stack_out(Tensor out, Tensor[] tensors, int dim=0) -> Tensor
 
 # The signature is designed to be consistent with librosa except that it is
 # missing the `pad_mode` and `center` arguments, which are taken care of at
@@ -1951,11 +1951,11 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: sum_out(Tensor result, Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: sum_out(Tensor out, Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
 
-- func: sum_out(Tensor result, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: sum_out(Tensor out, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
 
-- func: sum_out(Tensor result, Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
+- func: sum_out(Tensor out, Tensor self, int[1] dim, *, ScalarType dtype) -> Tensor
 
 - func: sum_to_size(Tensor self, int[] size) -> Tensor
   matches_jit_signature: True
@@ -1973,7 +1973,7 @@
     CPU: _sqrt__cpu
     CUDA: _sqrt__cuda
 
-- func: sqrt_out(Tensor result, Tensor self) -> Tensor
+- func: sqrt_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _sqrt_out_cpu
     CUDA: _sqrt_out_cuda
@@ -1986,7 +1986,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: std_out(Tensor result, Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
+- func: std_out(Tensor out, Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: prod(Tensor self, *, ScalarType dtype) -> Tensor
@@ -2009,11 +2009,11 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: prod_out(Tensor result, Tensor self, int dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: prod_out(Tensor out, Tensor self, int dim, bool keepdim, *, ScalarType dtype) -> Tensor
 
-- func: prod_out(Tensor result, Tensor self, int dim, bool keepdim=False) -> Tensor
+- func: prod_out(Tensor out, Tensor self, int dim, bool keepdim=False) -> Tensor
 
-- func: prod_out(Tensor result, Tensor self, int dim, *, ScalarType dtype) -> Tensor
+- func: prod_out(Tensor out, Tensor self, int dim, *, ScalarType dtype) -> Tensor
 
 - func: t(Tensor self) -> Tensor
   device_guard: False
@@ -2035,7 +2035,7 @@
     CPU: _tan__cpu
     CUDA: _tan__cuda
 
-- func: tan_out(Tensor result, Tensor self) -> Tensor
+- func: tan_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _tan_out_cpu
     CUDA: _tan_out_cuda
@@ -2051,7 +2051,7 @@
     CPU: _tanh__cpu
     CUDA: _tanh__cuda
 
-- func: tanh_out(Tensor result, Tensor self) -> Tensor
+- func: tanh_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _tanh_out_cpu
     CUDA: _tanh_out_cuda
@@ -2069,7 +2069,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: threshold_out(Tensor result, Tensor self, Scalar threshold, Scalar value) -> Tensor
+- func: threshold_out(Tensor out, Tensor self, Scalar threshold, Scalar value) -> Tensor
 
 - func: threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor
   matches_jit_signature: True
@@ -2124,7 +2124,7 @@
     CPU: _trunc__cpu
     CUDA: _trunc__cuda
 
-- func: trunc_out(Tensor result, Tensor self) -> Tensor
+- func: trunc_out(Tensor out, Tensor self) -> Tensor
   dispatch:
     CPU: _trunc_out_cpu
     CUDA: _trunc_out_cuda
@@ -2166,7 +2166,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: var_out(Tensor result, Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
+- func: var_out(Tensor out, Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
 
 - func: view_as(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -2213,7 +2213,7 @@
 
 - func: zeros(int[] size, TensorOptions options=[]) -> Tensor
 
-- func: zeros_out(Tensor result, int[] size) -> Tensor
+- func: zeros_out(Tensor out, int[] size) -> Tensor
 
 - func: zeros_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -2284,9 +2284,9 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: norm_out(Tensor result, Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
+- func: norm_out(Tensor out, Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor
 
-- func: norm_out(Tensor result, Tensor self, Scalar? p, int[1] dim, bool keepdim=False) -> Tensor
+- func: norm_out(Tensor out, Tensor self, Scalar? p, int[1] dim, bool keepdim=False) -> Tensor
 
 - func: frobenius_norm(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -2296,14 +2296,14 @@
   matches_jit_signature: True
   variants: function
 
-- func: frobenius_norm_out(Tensor result, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
+- func: frobenius_norm_out(Tensor out, Tensor self, int[1] dim, bool keepdim=False) -> Tensor
   variants: function
 
 - func: nuclear_norm(Tensor self, bool keepdim=False) -> Tensor
   matches_jit_signature: True
   variants: function
 
-- func: nuclear_norm_out(Tensor result, Tensor self, bool keepdim=False) -> Tensor
+- func: nuclear_norm_out(Tensor out, Tensor self, bool keepdim=False) -> Tensor
   variants: function
 
 - func: native_clone(Tensor self) -> Tensor
@@ -2326,7 +2326,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: native_pow_out(Tensor result, Tensor self, Scalar exponent) -> Tensor
+- func: native_pow_out(Tensor out, Tensor self, Scalar exponent) -> Tensor
   dispatch:
     SparseCPU: pow_out_sparse_scalar
     SparseCUDA: pow_out_sparse_scalar
@@ -2337,7 +2337,7 @@
     SparseCPU: pow_sparse_scalar
     SparseCUDA: pow_sparse_scalar
 
-- func: pow_out(Tensor result, Tensor self, Scalar exponent) -> Tensor
+- func: pow_out(Tensor out, Tensor self, Scalar exponent) -> Tensor
 
 - func: pow(Tensor self, Scalar exponent) -> Tensor
   matches_jit_signature: True
@@ -2354,7 +2354,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: sub_out(Tensor result, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
+- func: sub_out(Tensor out, Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 
 - func: sub(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -2382,7 +2382,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: s_native_addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: s_native_addmm_out(Tensor out, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   dispatch:
     CPU: s_addmm_out_sparse_dense_cpu
     CUDA: s_addmm_out_sparse_dense_cuda
@@ -2402,7 +2402,7 @@
 - func: _sparse_addmm(Tensor self, Tensor sparse, Tensor dense, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
 
-- func: addmm_out(Tensor result, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addmm_out(Tensor out, Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -2446,7 +2446,7 @@
 #        2. ctor and member accessor with autograd support
 #
 # To achieve 1, we need to provide a set of *dangerous* APIs (dangerous in the
-# sense that misusing them will break sparse tensor invariant and may result in
+# sense that misusing them will break sparse tensor invariant and may out in
 # unexpected behavior, e.g., crash). These methods are all prefixed with
 # underscore "_" to indicate that they should be used with care. We provide:
 #
@@ -2697,7 +2697,7 @@
   device_guard: False
 
 
-- func: hspmm_out(Tensor result, Tensor mat1, Tensor mat2) -> Tensor
+- func: hspmm_out(Tensor out, Tensor mat1, Tensor mat2) -> Tensor
   dispatch:
     SparseCPU: hspmm_out_sparse_cpu
     SparseCUDA: hspmm_out_sparse_cuda
@@ -3089,7 +3089,7 @@
     CPU: tril_cpu_
     CUDA: tril_cuda_
 
-- func: triu_(Tensor(a!) self,  int diagonal=0) -> Tensor(a!)
+- func: triu_(Tensor(a!) self, int diagonal=0) -> Tensor(a!)
   variants: method
   dispatch:
     CPU: triu_cpu_
@@ -3159,7 +3159,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: addbmm_out(Tensor result, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+- func: addbmm_out(Tensor out, Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
 - func: addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -3211,19 +3211,19 @@
 
 # wrappers for TH functions
 
-- func: diag_out(Tensor result, Tensor self, int diagonal=0) -> Tensor
+- func: diag_out(Tensor out, Tensor self, int diagonal=0) -> Tensor
 
 - func: diag(Tensor self, int diagonal=0) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: cross_out(Tensor result, Tensor self, Tensor other, int dim=-1) -> Tensor
+- func: cross_out(Tensor out, Tensor self, Tensor other, int dim=-1) -> Tensor
 
 - func: cross(Tensor self, Tensor other, int dim=-1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: triu_out(Tensor result, Tensor self, int diagonal=0) -> Tensor
+- func: triu_out(Tensor out, Tensor self, int diagonal=0) -> Tensor
   dispatch:
     CPU: triu_cpu_out
     CUDA: triu_cuda_out
@@ -3232,7 +3232,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: tril_out(Tensor result, Tensor self, int diagonal=0) -> Tensor
+- func: tril_out(Tensor out, Tensor self, int diagonal=0) -> Tensor
   dispatch:
     CPU: tril_cpu_out
     CUDA: tril_cuda_out
@@ -3255,115 +3255,115 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: ne_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: ne_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: ne(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ne_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: ne_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: ne(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: eq_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: eq_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: eq(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: eq_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: eq_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: eq(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ge_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: ge_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: ge(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ge_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: ge_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: ge(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: le_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: le_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: le(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: le_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: le_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: le(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gt_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: gt_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: gt(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gt_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: gt_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: gt(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lt_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: lt_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: lt(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lt_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: lt_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: lt(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: take_out(Tensor result, Tensor self, Tensor index) -> Tensor
+- func: take_out(Tensor out, Tensor self, Tensor index) -> Tensor
 
 - func: take(Tensor self, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: index_select_out(Tensor result, Tensor self, int dim, Tensor index) -> Tensor
+- func: index_select_out(Tensor out, Tensor self, int dim, Tensor index) -> Tensor
 
 - func: index_select(Tensor self, int dim, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: masked_select_out(Tensor result, Tensor self, Tensor mask) -> Tensor
+- func: masked_select_out(Tensor out, Tensor self, Tensor mask) -> Tensor
 
 - func: masked_select(Tensor self, Tensor mask) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: nonzero_out(Tensor result, Tensor self) -> Tensor
+- func: nonzero_out(Tensor out, Tensor self) -> Tensor
 
 - func: nonzero(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: gather_out(Tensor result, Tensor self, int dim, Tensor index) -> Tensor
+- func: gather_out(Tensor out, Tensor self, int dim, Tensor index) -> Tensor
 
 - func: gather(Tensor self, int dim, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: addcmul_out(Tensor result, Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+- func: addcmul_out(Tensor out, Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: addcdiv_out(Tensor result, Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
+- func: addcdiv_out(Tensor out, Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   matches_jit_signature: True
@@ -3398,7 +3398,7 @@
 - func: svd(Tensor self, bool some=True, bool compute_uv=True) -> (Tensor U, Tensor S, Tensor V)
   variants: method, function
 
-- func: cholesky_out(Tensor result, Tensor self, bool upper=False) -> Tensor
+- func: cholesky_out(Tensor out, Tensor self, bool upper=False) -> Tensor
 
 - func: cholesky(Tensor self, bool upper=False) -> Tensor
   matches_jit_signature: True
@@ -3411,7 +3411,7 @@
     CPU: _cholesky_helper_cpu
     CUDA: _cholesky_helper_cuda
 
-- func: cholesky_solve_out(Tensor result, Tensor self, Tensor input2, bool upper=False) -> Tensor
+- func: cholesky_solve_out(Tensor out, Tensor self, Tensor input2, bool upper=False) -> Tensor
 
 - func: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
   matches_jit_signature: True
@@ -3424,7 +3424,7 @@
     CPU: _cholesky_solve_helper_cpu
     CUDA: _cholesky_solve_helper_cuda
 
-- func: potri_out(Tensor result, Tensor self, bool upper=True) -> Tensor
+- func: potri_out(Tensor out, Tensor self, bool upper=True) -> Tensor
 
 - func: potri(Tensor self, bool upper=True) -> Tensor
   matches_jit_signature: True
@@ -3442,19 +3442,19 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: geqrf_out(Tensor result0, Tensor result1, Tensor self) -> (Tensor, Tensor)
+- func: geqrf_out(Tensor out0, Tensor out1, Tensor self) -> (Tensor, Tensor)
 
 - func: geqrf(Tensor self) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: method, function
 
-- func: orgqr_out(Tensor result, Tensor self, Tensor input2) -> Tensor
+- func: orgqr_out(Tensor out, Tensor self, Tensor input2) -> Tensor
 
 - func: orgqr(Tensor self, Tensor input2) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: ormqr_out(Tensor result, Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor
+- func: ormqr_out(Tensor out, Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor
 
 - func: ormqr(Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor
   matches_jit_signature: True
@@ -3472,43 +3472,43 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: btrisolve_out(Tensor result, Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor
+- func: btrisolve_out(Tensor out, Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor
 
 - func: btrisolve(Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: multinomial_out(Tensor result, Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
+- func: multinomial_out(Tensor out, Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
 
 - func: multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lgamma_out(Tensor result, Tensor self) -> Tensor
+- func: lgamma_out(Tensor out, Tensor self) -> Tensor
 
 - func: lgamma(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: digamma_out(Tensor result, Tensor self) -> Tensor
+- func: digamma_out(Tensor out, Tensor self) -> Tensor
 
 - func: digamma(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: polygamma_out(Tensor result, int n, Tensor self) -> Tensor
+- func: polygamma_out(Tensor out, int n, Tensor self) -> Tensor
 
 - func: polygamma(int n, Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: erfinv_out(Tensor result, Tensor self) -> Tensor
+- func: erfinv_out(Tensor out, Tensor self) -> Tensor
 
 - func: erfinv(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: frac_out(Tensor result, Tensor self) -> Tensor
+- func: frac_out(Tensor out, Tensor self) -> Tensor
 
 - func: frac(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -3518,67 +3518,67 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: reciprocal_out(Tensor result, Tensor self) -> Tensor
+- func: reciprocal_out(Tensor out, Tensor self) -> Tensor
 
 - func: reciprocal(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: neg_out(Tensor result, Tensor self) -> Tensor
+- func: neg_out(Tensor out, Tensor self) -> Tensor
 
 - func: neg(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: atan2_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: atan2_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: atan2(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: lerp_out(Tensor result, Tensor self, Tensor end, Scalar weight) -> Tensor
+- func: lerp_out(Tensor out, Tensor self, Tensor end, Scalar weight) -> Tensor
 
 - func: lerp(Tensor self, Tensor end, Scalar weight) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: histc_out(Tensor result, Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
+- func: histc_out(Tensor out, Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
 
 - func: histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: sign_out(Tensor result, Tensor self) -> Tensor
+- func: sign_out(Tensor out, Tensor self) -> Tensor
 
 - func: sign(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: fmod_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: fmod_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: fmod(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: fmod_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: fmod_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: fmod(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: remainder_out(Tensor result, Tensor self, Scalar other) -> Tensor
+- func: remainder_out(Tensor out, Tensor self, Scalar other) -> Tensor
 
 - func: remainder(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: remainder_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: remainder_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: remainder(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: min_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: min_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: min(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -3588,7 +3588,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: max_out(Tensor result, Tensor self, Tensor other) -> Tensor
+- func: max_out(Tensor out, Tensor self, Tensor other) -> Tensor
 
 - func: max(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -3622,7 +3622,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: renorm_out(Tensor result, Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
+- func: renorm_out(Tensor out, Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
 
 - func: renorm(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
   matches_jit_signature: True
@@ -3636,13 +3636,13 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: pow_out(Tensor result, Tensor self, Tensor exponent) -> Tensor
+- func: pow_out(Tensor out, Tensor self, Tensor exponent) -> Tensor
 
 - func: pow(Tensor self, Tensor exponent) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
-- func: pow_out(Tensor result, Scalar self, Tensor exponent) -> Tensor
+- func: pow_out(Tensor out, Scalar self, Tensor exponent) -> Tensor
 
 - func: pow(Scalar self, Tensor exponent) -> Tensor
   matches_jit_signature: True

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -266,6 +266,7 @@
   variants: function
 
 - func: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -514,6 +515,7 @@
   matches_jit_signature: True
 
 - func: _convolution_double_backward(Tensor? ggI, Tensor? ggW, Tensor? ggb, Tensor gO, Tensor weight, Tensor self, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
 
 - func: conv1d(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, int[1] padding=0, int[1] dilation=1, int groups=1) -> Tensor
   matches_jit_signature: True
@@ -626,6 +628,7 @@
     CUDA: cudnn_convolution_backward_input
 
 - func: cudnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   dispatch:
     CUDA: cudnn_convolution_backward
 
@@ -647,6 +650,7 @@
 # NB: output_padding not strictly needed here, but it's helpful for the float
 # backwards
 - func: cudnn_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   dispatch:
     CUDA: cudnn_convolution_transpose_backward
 
@@ -736,6 +740,7 @@
   variants: function, method
 
 - func: diagonal(Tensor(a) self, int offset=0, int dim1=0, int dim2=1) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
 
 - func: div(Tensor self, Tensor other) -> Tensor
@@ -910,6 +915,7 @@
     CUDA: _expm1_out_cuda
 
 - func: expand(Tensor(a) self, int[] size, *, bool implicit=False) -> Tensor(a)
+  matches_jit_signature: True
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
   device_guard: False
 
@@ -1411,6 +1417,7 @@
   matches_jit_signature: True
 
 - func: mkldnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
 
 - func: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
   matches_jit_signature: True
@@ -1433,6 +1440,7 @@
     CUDA: miopen_convolution_backward_input
 
 - func: miopen_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   dispatch:
     CUDA: miopen_convolution_backward
 
@@ -1454,6 +1462,7 @@
 # NB: output_padding not strictly needed here, but it's helpful for the float
 # backwards
 - func: miopen_convolution_transpose_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] output_padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   dispatch:
     CUDA: miopen_convolution_transpose_backward
 
@@ -1528,6 +1537,7 @@
     SparseCUDA: narrow_copy_sparse
 
 - func: narrow(Tensor(a) self, int dim, int start, int length) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -1538,6 +1548,7 @@
     CUDA: batch_norm_cuda
 
 - func: native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   dispatch:
     CPU: batch_norm_backward_cpu
     CUDA: batch_norm_backward_cuda
@@ -1556,6 +1567,7 @@
   variants: function
 
 - func: _nnpack_spatial_convolution_backward(Tensor input, Tensor grad_output, Tensor weight, int[2] padding, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   variants: function
 
 - func: _nnpack_spatial_convolution_backward_input(Tensor input, Tensor grad_output, Tensor weight, int[2] padding) -> Tensor
@@ -1595,6 +1607,7 @@
   variants: function
 
 - func: permute(Tensor(a) self, int[] dims) -> Tensor(a)
+  matches_jit_signature: True
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 
 - func: pixel_shuffle(Tensor self, int upscale_factor) -> Tensor
@@ -1732,9 +1745,11 @@
     CUDA: _round_out_cuda
 
 - func: rrelu(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
+  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
 - func: rrelu_(Tensor(a!) self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
 - func: relu(Tensor self) -> Tensor
@@ -1791,6 +1806,7 @@
     CUDA: _rsqrt_out_cuda
 
 - func: select(Tensor(a) self, int dim, int index) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -1871,6 +1887,7 @@
   device_guard: False
 
 - func: slice(Tensor(a) self, int dim=0, int start=0, int end=9223372036854775807, int step=1) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -1954,10 +1971,12 @@
   device_guard: False
 
 - func: squeeze(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
 - func: squeeze(Tensor(a) self, int dim) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -2096,6 +2115,7 @@
   matches_jit_signature: True
 
 - func: t(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   device_guard: False
   variants: function, method
 
@@ -2159,6 +2179,7 @@
   variants: function
 
 - func: transpose(Tensor(a) self, int dim0, int dim1) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -2235,6 +2256,7 @@
   matches_jit_signature: True
 
 - func: unsqueeze(Tensor(a) self, int dim) -> Tensor(a)
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -2749,6 +2771,7 @@
 
 
 - func: _indices(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: _indices_sparse
@@ -2757,6 +2780,7 @@
   device_guard: False
 
 - func: _values(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: _values_sparse
@@ -2777,6 +2801,7 @@
   device_guard: False
 
 - func: indices(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: indices_sparse
@@ -2785,6 +2810,7 @@
   device_guard: False
 
 - func: values(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   variants: method
   dispatch:
     SparseCPU: values_sparse
@@ -3012,6 +3038,7 @@
   variants: method
 
 - func: view(Tensor(a) self, int[] size) -> Tensor(a)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
@@ -3776,6 +3803,7 @@
   variants: method, function
 
 - func: unfold(Tensor(a) self, int dimension, int size, int step) -> Tensor(a)
+  matches_jit_signature: True
   variants: method
   device_guard: False
 
@@ -3811,6 +3839,7 @@
   matches_jit_signature: True
 
 - func: alias(Tensor(a) self) -> Tensor(a)
+  matches_jit_signature: True
   variants: method, function
 
 - func: _dirichlet_grad(Tensor x, Tensor alpha, Tensor total, *, Tensor(a!) output) -> Tensor(a!)
@@ -4057,6 +4086,7 @@
   python_module: nn
 
 - func: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
+  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 
@@ -4068,6 +4098,7 @@
   python_module: nn
 
 - func: rrelu_with_noise_(Tensor(a!) self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
+  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -265,7 +265,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: as_strided(Tensor self, int[] size, int[] stride, int? storage_offset=None) -> Tensor
+- func: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -437,7 +437,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: chunk(Tensor self, int chunks, int dim=0) -> Tensor[]
+- func: chunk(Tensor(a) self, int chunks, int dim=0) -> Tensor[](a)
   variants: function, method
   device_guard: False
 
@@ -735,7 +735,7 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: diagonal(Tensor self, int offset=0, int dim1=0, int dim2=1) -> Tensor
+- func: diagonal(Tensor(a) self, int offset=0, int dim1=0, int dim2=1) -> Tensor(a)
   variants: function, method
 
 - func: div(Tensor self, Tensor other) -> Tensor
@@ -909,7 +909,7 @@
     CPU: _expm1_out_cpu
     CUDA: _expm1_out_cuda
 
-- func: expand(Tensor self, int[] size, *, bool implicit=False) -> Tensor
+- func: expand(Tensor(a) self, int[] size, *, bool implicit=False) -> Tensor(a)
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
   device_guard: False
 
@@ -1527,7 +1527,7 @@
     SparseCPU: narrow_copy_sparse
     SparseCUDA: narrow_copy_sparse
 
-- func: narrow(Tensor self, int dim, int start, int length) -> Tensor
+- func: narrow(Tensor(a) self, int dim, int start, int length) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -1594,7 +1594,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: permute(Tensor self, int[] dims) -> Tensor
+- func: permute(Tensor(a) self, int[] dims) -> Tensor(a)
   variants: method  # This is method-only to match the previous tensor API. In the future we could make this a function too.
 
 - func: pixel_shuffle(Tensor self, int upscale_factor) -> Tensor
@@ -1790,7 +1790,7 @@
     CPU: _rsqrt_out_cpu
     CUDA: _rsqrt_out_cuda
 
-- func: select(Tensor self, int dim, int index) -> Tensor
+- func: select(Tensor(a) self, int dim, int index) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -1870,7 +1870,7 @@
   variants: function, method
   device_guard: False
 
-- func: slice(Tensor self, int dim=0, int start=0, int end=9223372036854775807, int step=1) -> Tensor
+- func: slice(Tensor(a) self, int dim=0, int start=0, int end=9223372036854775807, int step=1) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -1944,7 +1944,7 @@
     SparseCPU: mul_out_sparse_scalar
     SparseCUDA: mul_out_sparse_scalar
 
-- func: split(Tensor self, int split_size, int dim=0) -> Tensor[]
+- func: split(Tensor(a) self, int split_size, int dim=0) -> Tensor[](a)
   variants: function, method
   device_guard: False
 
@@ -1953,11 +1953,11 @@
   variants: function, method
   device_guard: False
 
-- func: squeeze(Tensor self) -> Tensor
+- func: squeeze(Tensor(a) self) -> Tensor(a)
   variants: function, method
   device_guard: False
 
-- func: squeeze(Tensor self, int dim) -> Tensor
+- func: squeeze(Tensor(a) self, int dim) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -2095,7 +2095,7 @@
 - func: prod(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
   matches_jit_signature: True
 
-- func: t(Tensor self) -> Tensor
+- func: t(Tensor(a) self) -> Tensor(a)
   device_guard: False
   variants: function, method
 
@@ -2158,7 +2158,7 @@
   matches_jit_signature: True
   variants: function
 
-- func: transpose(Tensor self, int dim0, int dim1) -> Tensor
+- func: transpose(Tensor(a) self, int dim0, int dim1) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -2234,7 +2234,7 @@
 - func: _unsafe_view(Tensor self, int[] size) -> Tensor
   matches_jit_signature: True
 
-- func: unsqueeze(Tensor self, int dim) -> Tensor
+- func: unsqueeze(Tensor(a) self, int dim) -> Tensor(a)
   variants: function, method
   device_guard: False
 
@@ -2748,7 +2748,7 @@
   device_guard: False
 
 
-- func: _indices(Tensor self) -> Tensor
+- func: _indices(Tensor(a) self) -> Tensor(a)
   variants: method
   dispatch:
     SparseCPU: _indices_sparse
@@ -2756,7 +2756,7 @@
   requires_tensor: True
   device_guard: False
 
-- func: _values(Tensor self) -> Tensor
+- func: _values(Tensor(a) self) -> Tensor(a)
   variants: method
   dispatch:
     SparseCPU: _values_sparse
@@ -2776,7 +2776,7 @@
   requires_tensor: True
   device_guard: False
 
-- func: indices(Tensor self) -> Tensor
+- func: indices(Tensor(a) self) -> Tensor(a)
   variants: method
   dispatch:
     SparseCPU: indices_sparse
@@ -2784,7 +2784,7 @@
   requires_tensor: True
   device_guard: False
 
-- func: values(Tensor self) -> Tensor
+- func: values(Tensor(a) self) -> Tensor(a)
   variants: method
   dispatch:
     SparseCPU: values_sparse
@@ -2820,7 +2820,7 @@
   variants: function, method
   device_guard: False
 
-- func: unbind(Tensor self, int dim=0) -> Tensor[]
+- func: unbind(Tensor(a) self, int dim=0) -> Tensor[](a)
   variants: function, method
 
 - func: to_sparse(Tensor self, int sparse_dim) -> Tensor
@@ -3011,7 +3011,7 @@
   matches_jit_signature: True
   variants: method
 
-- func: view(Tensor self, int[] size) -> Tensor
+- func: view(Tensor(a) self, int[] size) -> Tensor(a)
   variants: method
   device_guard: False
 
@@ -3775,7 +3775,7 @@
   matches_jit_signature: True
   variants: method, function
 
-- func: unfold(Tensor self, int dimension, int size, int step) -> Tensor
+- func: unfold(Tensor(a) self, int dimension, int size, int step) -> Tensor(a)
   variants: method
   device_guard: False
 
@@ -3810,7 +3810,7 @@
 - func: normal(Tensor mean, Tensor std, *, Generator? generator=None) -> Tensor
   matches_jit_signature: True
 
-- func: alias(Tensor self) -> Tensor
+- func: alias(Tensor(a) self) -> Tensor(a)
   variants: method, function
 
 - func: _dirichlet_grad(Tensor x, Tensor alpha, Tensor total, *, Tensor(a!) output) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -113,6 +113,7 @@
     CUDA: _abs__cuda
 
 - func: abs(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _abs_out_cpu
     CUDA: _abs_out_cuda
@@ -129,6 +130,7 @@
     CUDA: _acos__cuda
 
 - func: acos(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _acos_out_cpu
     CUDA: _acos_out_cuda
@@ -152,6 +154,7 @@
   variants: method
 
 - func: add(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: add(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
@@ -171,6 +174,7 @@
   variants: function, method
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -181,6 +185,7 @@
   variants: method
 
 - func: addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: affine_grid_generator(Tensor theta, int[] size) -> Tensor
   matches_jit_signature: True
@@ -195,6 +200,7 @@
   variants: function, method
 
 - func: all(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: allclose(Tensor self, Tensor other, float rtol=1e-05, float atol=1e-08, bool equal_nan=False) -> bool
   matches_jit_signature: True
@@ -205,6 +211,7 @@
   variants: function, method
 
 - func: any(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: arange(Scalar end, TensorOptions options=[]) -> Tensor
 
@@ -213,8 +220,10 @@
 - func: arange(Scalar start, Scalar end, Scalar step, TensorOptions options=[]) -> Tensor
 
 - func: arange(Scalar end, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: arange(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: arange_cpu_out
     CUDA: arange_cuda_out
@@ -277,6 +286,7 @@
     CUDA: _asin__cuda
 
 - func: asin(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _asin_out_cpu
     CUDA: _asin_out_cuda
@@ -293,6 +303,7 @@
     CUDA: _atan__cuda
 
 - func: atan(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _atan_out_cpu
     CUDA: _atan_out_cuda
@@ -316,6 +327,7 @@
   variants: function
 
 - func: baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
   dispatch:
     CPU: baddbmm_out_cpu
@@ -334,6 +346,7 @@
   variants: function, method
 
 - func: bernoulli(Tensor self, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
 
 - func: bernoulli_(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
@@ -387,6 +400,7 @@
     CUDA: bmm_cuda
 
 - func: bmm(Tensor self, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
   dispatch:
     CPU: bmm_out_cpu
@@ -400,6 +414,7 @@
   matches_jit_signature: True
 
 - func: cat(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ceil(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -413,6 +428,7 @@
     CUDA: _ceil__cuda
 
 - func: ceil(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _ceil_out_cpu
     CUDA: _ceil_out_cuda
@@ -437,6 +453,7 @@
     CUDA: _clamp__cuda
 
 - func: clamp(Tensor self, Scalar? min=None, Scalar? max=None, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _clamp_out_cpu
     CUDA: _clamp_out_cuda
@@ -453,6 +470,7 @@
     CUDA: _clamp_max__cuda
 
 - func: clamp_max(Tensor self, Scalar max, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _clamp_max_out_cpu
     CUDA: _clamp_max_out_cuda
@@ -469,6 +487,7 @@
     CUDA: _clamp_min__cuda
 
 - func: clamp_min(Tensor self, Scalar min, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _clamp_min_out_cpu
     CUDA: _clamp_min_out_cuda
@@ -551,6 +570,7 @@
     CUDA: _cos__cuda
 
 - func: cos(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _cos_out_cpu
     CUDA: _cos_out_cuda
@@ -567,6 +587,7 @@
     CUDA: _cosh__cuda
 
 - func: cosh(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _cosh_out_cpu
     CUDA: _cosh_out_cuda
@@ -663,8 +684,10 @@
   variants: function, method
 
 - func: cumsum(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: cumsum(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: cumprod(Tensor self, int dim, *, ScalarType dtype) -> Tensor
@@ -676,8 +699,10 @@
   variants: function, method
 
 - func: cumprod(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: cumprod(Tensor self, int dim, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank=0, int reduction=Mean) -> Tensor
   matches_jit_signature: True
@@ -722,6 +747,7 @@
   variants: method
 
 - func: div(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: div(Tensor self, Scalar other) -> Tensor
@@ -737,6 +763,7 @@
   variants: function, method
 
 - func: dot(Tensor self, Tensor tensor, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: einsum(std::string equation, Tensor[] tensors) -> Tensor
 
@@ -799,6 +826,7 @@
     CUDA: resize_cuda_
 
 - func: empty(int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   device_guard: False
 
 - func: empty_like(Tensor self) -> Tensor
@@ -825,6 +853,7 @@
     CUDA: _erf__cuda
 
 - func: erf(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _erf_out_cpu
     CUDA: _erf_out_cuda
@@ -841,6 +870,7 @@
     CUDA: _erfc__cuda
 
 - func: erfc(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _erfc_out_cpu
     CUDA: _erfc_out_cuda
@@ -857,6 +887,7 @@
     CUDA: _exp__cuda
 
 - func: exp(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _exp_out_cpu
     CUDA: _exp_out_cuda
@@ -873,6 +904,7 @@
     CUDA: _expm1__cuda
 
 - func: expm1(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _expm1_out_cpu
     CUDA: _expm1_out_cuda
@@ -891,11 +923,13 @@
 - func: eye(int n, int m, TensorOptions options=[]) -> Tensor
 
 - func: eye(int n, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
 
 - func: eye(int n, int m, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: eye_out_cpu
     CUDA: eye_out_cuda
@@ -924,6 +958,7 @@
     CUDA: _floor__cuda
 
 - func: floor(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _floor_out_cpu
     CUDA: _floor_out_cuda
@@ -931,6 +966,7 @@
 - func: full(int[] size, Scalar fill_value, TensorOptions options=[]) -> Tensor
 
 - func: full(int[] size, Scalar fill_value, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: full_like(Tensor self, Scalar fill_value) -> Tensor
   matches_jit_signature: True
@@ -993,6 +1029,7 @@
   variants: function, method
 
 - func: ger(Tensor self, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: gesv(Tensor self, Tensor A) -> (Tensor, Tensor)
   matches_jit_signature: True
@@ -1075,6 +1112,7 @@
   variants: function, method
 
 - func: inverse(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: _inverse_helper(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1158,6 +1196,7 @@
 - func: linspace(Scalar start, Scalar end, int steps=100, TensorOptions options=[]) -> Tensor
 
 - func: linspace(Scalar start, Scalar end, int steps=100, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: linspace_cpu_out
     CUDA: linspace_cuda_out
@@ -1174,6 +1213,7 @@
     CUDA: _log__cuda
 
 - func: log(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _log_out_cpu
     CUDA: _log_out_cuda
@@ -1190,6 +1230,7 @@
     CUDA: _log10__cuda
 
 - func: log10(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _log10_out_cpu
     CUDA: _log10_out_cuda
@@ -1208,6 +1249,7 @@
     SparseCUDA: log1p_sparse_
 
 - func: log1p(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _log1p_out_cpu
     CUDA: _log1p_out_cuda
@@ -1226,6 +1268,7 @@
     CUDA: _log2__cuda
 
 - func: log2(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _log2_out_cpu
     CUDA: _log2_out_cuda
@@ -1237,6 +1280,7 @@
 - func: logspace(Scalar start, Scalar end, int steps=100, TensorOptions options=[]) -> Tensor
 
 - func: logspace(Scalar start, Scalar end, int steps=100, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: logspace_cpu_out
     CUDA: logspace_cuda_out
@@ -1267,6 +1311,7 @@
   variants: function, method
 
 - func: logsumexp(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: margin_ranking_loss(Tensor input1, Tensor input2, Tensor target, float margin=0.0, int reduction=Mean) -> Tensor
   matches_jit_signature: True
@@ -1276,6 +1321,7 @@
   variants: function, method
 
 - func: matmul(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: matrix_rank(Tensor self, float tol, bool symmetric=False) -> Tensor
   matches_jit_signature: True
@@ -1331,10 +1377,13 @@
   variants: function, method
 
 - func: mean(Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: mean(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: mean(Tensor self, int[1] dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: median(Tensor self, int dim, bool keepdim=False) -> (Tensor, Tensor)
   matches_jit_signature: True
@@ -1423,6 +1472,7 @@
   variants: function, method
 
 - func: mm(Tensor self, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: _sparse_mm(Tensor sparse, Tensor dense) -> Tensor
   matches_jit_signature: True
@@ -1442,6 +1492,7 @@
   variants: method
 
 - func: mul(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
   # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: mul(Tensor self, Scalar other) -> Tensor
@@ -1457,6 +1508,7 @@
   variants: function, method
 
 - func: mv(Tensor self, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: mvlgamma(Tensor self, int p) -> Tensor
   matches_jit_signature: True
@@ -1517,6 +1569,7 @@
 - func: ones(int[] size, TensorOptions options=[]) -> Tensor
 
 - func: ones(int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ones_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -1562,6 +1615,7 @@
 - func: rand(int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
 - func: rand(int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: rand(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
@@ -1579,10 +1633,12 @@
 - func: randint(int low, int high, int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
 - func: randint(int high, int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: randint(int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
 - func: randint(int low, int high, int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: randint(int low, int high, int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
@@ -1601,6 +1657,7 @@
 - func: randn(int[] size, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
 - func: randn(int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: randn(int[] size, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
 
@@ -1614,6 +1671,7 @@
 - func: randperm(int n, *, Generator? generator, TensorOptions options=[]) -> Tensor
 
 - func: randperm(int n, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: randperm(int n, *, Generator? generator, Tensor(a!) out) -> Tensor(a!)
   dispatch:
@@ -1625,6 +1683,7 @@
 - func: range(Scalar start, Scalar end, TensorOptions options=[]) -> Tensor
 
 - func: range(Scalar start, Scalar end, Scalar step=1, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: range_cpu_out
     CUDA: range_cuda_out
@@ -1667,6 +1726,7 @@
     CUDA: _round__cuda
 
 - func: round(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _round_out_cpu
     CUDA: _round_out_cuda
@@ -1725,6 +1785,7 @@
     CUDA: _rsqrt__cuda
 
 - func: rsqrt(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _rsqrt_out_cpu
     CUDA: _rsqrt_out_cuda
@@ -1757,6 +1818,7 @@
     CUDA: _sigmoid__cuda
 
 - func: sigmoid(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _sigmoid_out_cpu
     CUDA: _sigmoid_out_cuda
@@ -1773,6 +1835,7 @@
     CUDA: _sin__cuda
 
 - func: sin(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _sin_out_cpu
     CUDA: _sin_out_cuda
@@ -1789,6 +1852,7 @@
     CUDA: _sinh__cuda
 
 - func: sinh(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _sinh_out_cpu
     CUDA: _sinh_out_cuda
@@ -1840,6 +1904,7 @@
     CUDA: softmax_backward_cuda
 
 - func: _sparse_add(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: add_out_sparse_cpu
     SparseCUDA: add_out_sparse_cuda
@@ -1850,26 +1915,31 @@
     CUDA: add_out_dense_sparse_cuda
 
 - func: _sparse_div_zerodim(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: div_out_sparse_zerodim
     SparseCUDA: div_out_sparse_zerodim
 
 - func: _sparse_div_scalar(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: div_out_sparse_scalar
     SparseCUDA: div_out_sparse_scalar
 
 - func: _sparse_mul(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: mul_out_sparse_cpu
     SparseCUDA: mul_out_sparse_cuda
 
 - func: _sparse_mul_zerodim(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: mul_out_sparse_zerodim
     SparseCUDA: mul_out_sparse_zerodim
 
 - func: _sparse_mul_scalar(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: mul_out_sparse_scalar
     SparseCUDA: mul_out_sparse_scalar
@@ -1906,6 +1976,7 @@
   variants: function, method
 
 - func: sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _sspaddmm_out_only_sparse
     CUDA: _sspaddmm_out_only_sparse_cuda
@@ -1916,6 +1987,7 @@
   matches_jit_signature: True
 
 - func: stack(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 # The signature is designed to be consistent with librosa except that it is
 # missing the `pad_mode` and `center` arguments, which are taken care of at
@@ -1952,10 +2024,13 @@
   variants: function, method
 
 - func: sum(Tensor self, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: sum(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: sum(Tensor self, int[1] dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: sum_to_size(Tensor self, int[] size) -> Tensor
   matches_jit_signature: True
@@ -1974,6 +2049,7 @@
     CUDA: _sqrt__cuda
 
 - func: sqrt(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _sqrt_out_cpu
     CUDA: _sqrt_out_cuda
@@ -1987,6 +2063,7 @@
   variants: function, method
 
 - func: std(Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 # FIXME: These could be combined as optional<ScalarType> but for https://github.com/pytorch/pytorch/issues/6593.
 - func: prod(Tensor self, *, ScalarType dtype) -> Tensor
@@ -2010,10 +2087,13 @@
   variants: function, method
 
 - func: prod(Tensor self, int dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: prod(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: prod(Tensor self, int dim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: t(Tensor self) -> Tensor
   device_guard: False
@@ -2036,6 +2116,7 @@
     CUDA: _tan__cuda
 
 - func: tan(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _tan_out_cpu
     CUDA: _tan_out_cuda
@@ -2052,6 +2133,7 @@
     CUDA: _tanh__cuda
 
 - func: tanh(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _tanh_out_cpu
     CUDA: _tanh_out_cuda
@@ -2070,6 +2152,7 @@
   variants: function
 
 - func: threshold(Tensor self, Scalar threshold, Scalar value, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor
   matches_jit_signature: True
@@ -2125,6 +2208,7 @@
     CUDA: _trunc__cuda
 
 - func: trunc(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: _trunc_out_cpu
     CUDA: _trunc_out_cuda
@@ -2141,6 +2225,7 @@
     CUDA: _unique_cuda
 
 - func: _unique_dim(Tensor self, int dim, bool sorted=True, bool return_inverse=False) -> (Tensor, Tensor)
+  matches_jit_signature: True
   variants: function
   dispatch:
     CPU: _unique_dim_cpu
@@ -2167,6 +2252,7 @@
   variants: function, method
 
 - func: var(Tensor self, int[1] dim, bool unbiased=True, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: view_as(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -2214,6 +2300,7 @@
 - func: zeros(int[] size, TensorOptions options=[]) -> Tensor
 
 - func: zeros(int[] size, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: zeros_like(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -2285,8 +2372,10 @@
   variants: function, method
 
 - func: norm(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: norm(Tensor self, Scalar? p, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: frobenius_norm(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -2297,6 +2386,7 @@
   variants: function
 
 - func: frobenius_norm(Tensor self, int[1] dim, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
 
 - func: nuclear_norm(Tensor self, bool keepdim=False) -> Tensor
@@ -2304,6 +2394,7 @@
   variants: function
 
 - func: nuclear_norm(Tensor self, bool keepdim=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   variants: function
 
 - func: native_clone(Tensor self) -> Tensor
@@ -2327,6 +2418,7 @@
   variants: function, method
 
 - func: native_pow(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: pow_out_sparse_scalar
     SparseCUDA: pow_out_sparse_scalar
@@ -2338,6 +2430,7 @@
     SparseCUDA: pow_sparse_scalar
 
 - func: pow(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: pow(Tensor self, Scalar exponent) -> Tensor
   matches_jit_signature: True
@@ -2355,6 +2448,7 @@
   variants: method, function
 
 - func: sub(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: sub(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -2383,6 +2477,7 @@
   variants: function
 
 - func: s_native_addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: s_addmm_out_sparse_dense_cpu
     CUDA: s_addmm_out_sparse_dense_cuda
@@ -2403,6 +2498,7 @@
   matches_jit_signature: True
 
 - func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -2698,6 +2794,7 @@
 
 
 - func: hspmm(Tensor mat1, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     SparseCPU: hspmm_out_sparse_cpu
     SparseCUDA: hspmm_out_sparse_cuda
@@ -3090,6 +3187,7 @@
     CUDA: tril_cuda_
 
 - func: triu_(Tensor(a!) self, int diagonal=0) -> Tensor(a!)
+  matches_jit_signature: True
   variants: method
   dispatch:
     CPU: triu_cpu_
@@ -3160,6 +3258,7 @@
   variants: method
 
 - func: addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   matches_jit_signature: True
@@ -3212,18 +3311,21 @@
 # wrappers for TH functions
 
 - func: diag(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: diag(Tensor self, int diagonal=0) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: cross(Tensor self, Tensor other, int dim=-1, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: cross(Tensor self, Tensor other, int dim=-1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: triu(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: triu_cpu_out
     CUDA: triu_cuda_out
@@ -3233,6 +3335,7 @@
   variants: method, function
 
 - func: tril(Tensor self, int diagonal=0, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: tril_cpu_out
     CUDA: tril_cuda_out
@@ -3256,114 +3359,133 @@
   variants: method, function
 
 - func: ne(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ne(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: ne(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ne(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: eq(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: eq(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: eq(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: eq(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: ge(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ge(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: ge(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ge(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: le(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: le(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: le(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: le(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: gt(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: gt(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: gt(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: gt(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: lt(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: lt(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: lt(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: lt(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: take(Tensor self, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: take(Tensor self, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: index_select(Tensor self, int dim, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: index_select(Tensor self, int dim, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: masked_select(Tensor self, Tensor mask, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: masked_select(Tensor self, Tensor mask) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: nonzero(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: nonzero(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: gather(Tensor self, int dim, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: gather(Tensor self, int dim, Tensor index) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
   matches_jit_signature: True
@@ -3399,6 +3521,7 @@
   variants: method, function
 
 - func: cholesky(Tensor self, bool upper=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: cholesky(Tensor self, bool upper=False) -> Tensor
   matches_jit_signature: True
@@ -3412,6 +3535,7 @@
     CUDA: _cholesky_helper_cuda
 
 - func: cholesky_solve(Tensor self, Tensor input2, bool upper=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: cholesky_solve(Tensor self, Tensor input2, bool upper=False) -> Tensor
   matches_jit_signature: True
@@ -3425,6 +3549,7 @@
     CUDA: _cholesky_solve_helper_cuda
 
 - func: potri(Tensor self, bool upper=True, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: potri(Tensor self, bool upper=True) -> Tensor
   matches_jit_signature: True
@@ -3449,12 +3574,14 @@
   variants: method, function
 
 - func: orgqr(Tensor self, Tensor input2, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: orgqr(Tensor self, Tensor input2) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: ormqr(Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: ormqr(Tensor self, Tensor input2, Tensor input3, bool left=True, bool transpose=False) -> Tensor
   matches_jit_signature: True
@@ -3473,42 +3600,49 @@
   variants: method, function
 
 - func: btrisolve(Tensor self, Tensor LU_data, Tensor LU_pivots, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: btrisolve(Tensor self, Tensor LU_data, Tensor LU_pivots) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: lgamma(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: lgamma(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: digamma(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: digamma(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: polygamma(int n, Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: polygamma(int n, Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: erfinv(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: erfinv(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: frac(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: frac(Tensor self) -> Tensor
   matches_jit_signature: True
@@ -3519,66 +3653,77 @@
   variants: method, function
 
 - func: reciprocal(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: reciprocal(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: neg(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: neg(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: atan2(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: atan2(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: lerp(Tensor self, Tensor end, Scalar weight, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: lerp(Tensor self, Tensor end, Scalar weight) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: sign(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: sign(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: fmod(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: fmod(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: fmod(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: fmod(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: remainder(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: remainder(Tensor self, Scalar other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: remainder(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: remainder(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: min(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: min(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -3589,6 +3734,7 @@
   variants: method, function
 
 - func: max(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: max(Tensor self, Tensor other) -> Tensor
   matches_jit_signature: True
@@ -3623,6 +3769,7 @@
   variants: method, function
 
 - func: renorm(Tensor self, Scalar p, int dim, Scalar maxnorm, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: renorm(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor
   matches_jit_signature: True
@@ -3637,12 +3784,14 @@
   variants: method, function
 
 - func: pow(Tensor self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: pow(Tensor self, Tensor exponent) -> Tensor
   matches_jit_signature: True
   variants: method, function
 
 - func: pow(Scalar self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
+  matches_jit_signature: True
 
 - func: pow(Scalar self, Tensor exponent) -> Tensor
   matches_jit_signature: True
@@ -3995,6 +4144,7 @@
 
 # Return: (Tensor output, Tensor indices)
 - func: adaptive_max_pool2d(Tensor self, int[2] output_size) -> (Tensor, Tensor)
+  matches_jit_signature: True
   python_module: nn
 
 - func: adaptive_max_pool2d_backward(Tensor grad_output, Tensor self, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
@@ -4010,6 +4160,7 @@
 
 # Return: (Tensor output, Tensor indices)
 - func: adaptive_max_pool3d(Tensor self, int[3] output_size) -> (Tensor, Tensor)
+  matches_jit_signature: True
   python_module: nn
 
 - func: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
@@ -4056,6 +4207,7 @@
 
 # Return: (Tensor output, Tensor indices)
 - func: fractional_max_pool2d(Tensor self, int[2] kernel_size, int[2] output_size, Tensor random_samples) -> (Tensor, Tensor)
+  matches_jit_signature: True
   python_module: nn
   dispatch:
     CPU: fractional_max_pool2d_cpu
@@ -4104,6 +4256,7 @@
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
+  matches_jit_signature: True
   python_module: nn
 
 - func: max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
@@ -4119,6 +4272,7 @@
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool3d_with_indices(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
+  matches_jit_signature: True
   python_module: nn
 
 - func: max_pool3d_with_indices_backward(Tensor grad_output, Tensor self, int[3] kernel_size, int[3] stride, int[3] padding, int[3] dilation, bool ceil_mode, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4053,6 +4053,7 @@
   python_module: nn
 
 - func: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None, *, Tensor(a!) output) -> Tensor(a!)
+  matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 
 - func: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
@@ -4067,7 +4068,7 @@
   python_module: nn
 
 - func: rrelu_with_noise_(Tensor(a!) self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
-  matches_jit_signature: True
+  matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 
 - func: softplus(Tensor self, Scalar beta=1, Scalar threshold=20, *, Tensor(a!) output) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1287,10 +1287,10 @@
   matches_jit_signature: True
   variants: function, method
 
-- func: max(Tensor self, int64_t dim, bool keepdim=false) -> (Tensor values, Tensor indices)
+- func: max(Tensor self, int64_t dim, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
 
-- func: max_out(Tensor max, Tensor max_values, Tensor self, int64_t dim, bool keepdim=false) -> (Tensor values, Tensor indices)
+- func: max_out(Tensor max, Tensor max_values, Tensor self, int64_t dim, bool keepdim=False) -> (Tensor values, Tensor indices)
 
 - func: max_values(Tensor self, int dim, bool keepdim=False) -> Tensor
   matches_jit_signature: True
@@ -4103,7 +4103,7 @@
   python_module: nn
 
 # Return: (Tensor output, Tensor indices)
-- func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride={}, int[2] padding=0, int[2] dilation=1, bool ceil_mode=false) -> (Tensor, Tensor)
+- func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
   python_module: nn
 
 - func: max_pool2d_with_indices_backward_out(Tensor grad_input, Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -438,7 +438,8 @@
   matches_jit_signature: True
   variants: function
 
-- func: chunk(Tensor(a) self, int chunks, int dim=0) -> Tensor[](a)
+- func: chunk(Tensor(a) self, int chunks, int dim=0) -> Tensor(a)[]
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -1745,11 +1746,9 @@
     CUDA: _round_out_cuda
 
 - func: rrelu(Tensor self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
-  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
 - func: rrelu_(Tensor(a!) self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
-  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
 - func: relu(Tensor self) -> Tensor
@@ -1961,7 +1960,8 @@
     SparseCPU: mul_out_sparse_scalar
     SparseCUDA: mul_out_sparse_scalar
 
-- func: split(Tensor(a) self, int split_size, int dim=0) -> Tensor[](a)
+- func: split(Tensor(a) self, int split_size, int dim=0) -> Tensor(a)[]
+  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -2846,7 +2846,8 @@
   variants: function, method
   device_guard: False
 
-- func: unbind(Tensor(a) self, int dim=0) -> Tensor[](a)
+- func: unbind(Tensor(a) self, int dim=0) -> Tensor(a)[]
+  matches_jit_signature: True
   variants: function, method
 
 - func: to_sparse(Tensor self, int sparse_dim) -> Tensor
@@ -4086,7 +4087,6 @@
   python_module: nn
 
 - func: rrelu_with_noise(Tensor self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
-  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 
@@ -4098,7 +4098,6 @@
   python_module: nn
 
 - func: rrelu_with_noise_(Tensor(a!) self, Tensor noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
-  matches_jit_signature: True
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
   python_module: nn
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1735,7 +1735,7 @@
   matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
 - func: rrelu_(Tensor(a!) self, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor(a!)
-  matches_jit_signature: True
+  matches_jit_signature: False # TODO: The default value of upper and some Caffe2 builds will trigger the assert.
 
 - func: relu(Tensor self) -> Tensor
   matches_jit_signature: True

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -150,11 +150,13 @@ def parse_arguments(args, func_decl, func_name, func_return, inplace):
         arguments.append(argument_dict)
     if inplace:
         found_self = False
-        for argument in arguments:
+        for arg_idx, argument in enumerate(arguments):
             if argument['name'] == "self" and inplace:
                 assert argument['annotation'] and argument['annotation'].endswith("!"), \
                     "Inplace function \"{}\" needs to annotate Tensor argument named self as mutable.".format(func_decl['func'])
                 found_self = True
+                print("func_return[" + str(arg_idx) + "]")
+                print(func_return[arg_idx])
         assert found_self, "Inplace function \"{}\" needs Tensor argument named self.".format(func_decl['func'])
     return arguments
 
@@ -224,17 +226,9 @@ def run(paths):
                     func_decl, return_decl = [x.strip() for x in func['func'].split('->')]
                 else:
                     raise Exception('Expected return declaration')
-                # print("func_decl")
-                # print(func_decl)
                 fn_name, arguments = func_decl.split('(', 1)
-                # print("fn_name")
-                # print(fn_name)
-                # print("arguments")
-                # print(arguments)
                 assert arguments[-1] == ")", "Expecting closing ) for {}".format(func['func'])
                 arguments = arguments[:-1]  # Expect closing )
-                # print("arguments1")
-                # print(arguments)
                 declaration['name'] = func.get('name', fn_name)
                 declaration['inplace'] = re.search('(^__i|[^_]_$)', fn_name) is not None
                 return_arguments = parse_return_arguments(return_decl, declaration['inplace'], func)

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -85,18 +85,11 @@ def sanitize_types(types):
 
 
 def get_annotation(t):
-    found = False
-    if t == "Tensor?(a!)":
-        print(t)
-        found = True
     match = re.match(r'(Tensor.*)\((.+)\)', t)
     annotation = None
     if match:
         t = match.group(1)
         annotation = match.group(2)
-    if found:
-        print(t)
-        print(annotation)
     return t, annotation
 
 
@@ -160,10 +153,6 @@ def parse_arguments(args, func_decl, declaration, func_return):
     arguments_out = []
     arguments_other = []
     for argument in arguments:
-        # TODO: convention is that the ith-argument correspond to the i-th return, but it would
-        # be better if we just named everything and matched by name.
-        print(argument.get('annotation', ''))
-        print(argument.get('annotation', ''))
         if argument['type'] == "Tensor" and argument['annotation'] and re.match(r'^(.*!)$', argument['annotation']) and argument.get('kwarg_only'):
             argument['output'] = True
             argument['kwarg_only'] = False
@@ -172,6 +161,8 @@ def parse_arguments(args, func_decl, declaration, func_return):
         else:
             arguments_other.append(argument)
 
+    # TODO: convention is that the ith-argument correspond to the i-th return, but it would
+    # be better if we just named everything and matched by name.
     for arg_idx, argument in enumerate(arguments_out):
         assert argument['annotation'] == func_return[arg_idx]['annotation'], \
                 "For func {} writeable keyword Tensor arguments need to have a matching return Tensor. Further, the ith-argument needs to correspond to the i-th return.".format(func_decl['func'])

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -31,10 +31,10 @@ def type_argument_translations(arg):
         default = name[1]
     name = name[0]
 
-    match = re.match(r'(Tensor.*)\((.+)\)', t)
+    match = re.match(r'(Tensor.*)\((.+)\)(.*)', t)
     annotation = None
     if match:
-        t = match.group(1)
+        t = match.group(1) + match.group(3)
         annotation = match.group(2)
 
     # This enables "Generator? x = None and translates to legacy

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -177,7 +177,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
         "as can be passed as output.".format(name)
 
     if name.endswith('_out'):
-        raise RuntimeError("Native function {} may not be suffixed with _out as we transistion to a unified schema. "
+        raise RuntimeError("Native function {} may not be suffixed with _out as we transition to a unified schema. "
                            "Otherwise you will cause confusion amongst consumers of native functions.".format(name))
 
     if is_out_fn and func_variants not in [[], 'function', ['function']]:
@@ -189,7 +189,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
         assert len(arguments_out) == 0, "func {} is not marked as output yet contains output " \
             "keyword arguments".format(name)
 
-    # Explicit checking for void is a hack and should disappear after a more
+    # TODO: Explicit checking for void is a hack and should disappear after a more
     # functionally complete implementation of Tensor aliases.
     if declaration['inplace'] and len(func_return) > 0 and func_return[0]['type'] != "void":
         found_self = False

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -119,7 +119,6 @@ def type_argument_translations(arg):
 def parse_arguments(args, func_variants, declaration, func_return):
     arguments = []
     kwarg_only = False
-    inplace = declaration['inplace']
 
     if len(args.strip()) == 0:
         return arguments

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -31,6 +31,12 @@ def type_argument_translations(arg):
         default = name[1]
     name = name[0]
 
+    match = re.match(r'(Tensor.*)\((.+)\)', t)
+    annotation = None
+    if match:
+        t = match.group(1)
+        annotation = match.group(2)
+
     # This enables "Generator? x = None and translates to legacy
     # "Generator* x = nullptr". See [temp translations].
     if t == 'Generator?' and default == 'None':
@@ -58,6 +64,9 @@ def type_argument_translations(arg):
         match = re.match(r'int\[(\d+)\]', t)
         t = 'IntList'
         size = int(match.group(1))
+    elif re.match(r'bool\[(\d+)\]', t):
+        match = re.match(r'bool\[(\d+)\]', t)
+        t = 'std::array<bool,{}>'.format(match.group(1))
 
     # Legacy type sanitization. TODO: Do we really need this?
     if t == 'Generator*':
@@ -102,12 +111,6 @@ def type_argument_translations(arg):
                 default = float(default)
             except ValueError:
                 pass
-
-    match = re.match(r'(Tensor.*)\((.+)\)', t)
-    annotation = None
-    if match:
-        t = match.group(1)
-        annotation = match.group(2)
 
     return t, name, default, size, annotation
 

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -35,16 +35,24 @@ def temp_type_translations(typ):
 
 
 def parse_default(s):
-    if s.lower() == 'true':
+    if s == 'True':
         return True
-    elif s.lower() == 'false':
+    elif s == 'False':
         return False
+    elif s == 'true':
+        raise RuntimeError("Please use True and not true. "
+                    "See [temp translations] for details.")
+    elif s == 'false':
+        raise RuntimeError("Please use False and not false. "
+                    "See [temp translations] for details.")
     elif s == 'nullptr':
         return s
     # Enables default argument [] by translating to legacy {}.
     # See [temp translations]
     elif s == '[]':
         return '{}'
+    # Enables lists by translating to legacy {.*}.
+    # See [temp translations]
     elif re.match(r'\[.*\]', s):
         return "{" + s[1:-1] + "}"
     elif s == 'None':
@@ -152,7 +160,6 @@ def parse_arguments(args, func_decl, func_name, func_return, inplace):
     # Explicit check for void is a hack and should disappear after a more
     # functionally complete implementation of Tensor aliases.
     if inplace and len(func_return) > 0 and func_return[0]['type'] != "void":
-        print("ASF")
         found_self = False
         for arg_idx, argument in enumerate(arguments):
             if argument['name'] == "self" and inplace:
@@ -163,8 +170,6 @@ def parse_arguments(args, func_decl, func_name, func_return, inplace):
                         "Inplace function annotations of function {} need to match between input and correponding output.".format(func_decl['func'])
                 assert argument['name'] == func_return[arg_idx]['name']
                 assert argument['type'] == func_return[arg_idx]['type']
-                print("func_return[" + str(arg_idx) + "]")
-                print(func_return[arg_idx])
         assert found_self, "Inplace function \"{}\" needs Tensor argument named self.".format(func_decl['func'])
     return arguments
 

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -171,11 +171,11 @@ def parse_arguments(args, func_variants, declaration, func_return):
     # be better if we just named everything and matched by name.
     for arg_idx, argument in enumerate(arguments_out):
         assert argument['annotation'] == func_return[arg_idx]['annotation'], \
-                "For func {} writeable keyword Tensor arguments need to have a matching return Tensor. Further, " \
-                "the ith-argument needs to correspond to the i-th return.".format(name)
+            "For func {} writeable keyword Tensor arguments need to have a matching return Tensor. Further, " \
+            "the ith-argument needs to correspond to the i-th return.".format(name)
 
-    assert len(arguments_out) <= len(func_return), "func {} must return at least as many Tensors as can be passed " \
-            "as output.".format(name)
+    assert len(arguments_out) <= len(func_return), "func {} must return at least as many Tensors " \
+        "as can be passed as output.".format(name)
 
     if name.endswith('_out'):
         raise RuntimeError("Native function {} may not be suffixed with _out as we transistion to a unified schema. "
@@ -187,7 +187,8 @@ def parse_arguments(args, func_variants, declaration, func_return):
                            "(which usually manifests itself as the result variable being undefined.) "
                            "The culprit was: {}".format(name))
     if not is_out_fn:
-        assert len(arguments_out) == 0, "func {} is not marked as output yet contains output keyword arguments".format(name)
+        assert len(arguments_out) == 0, "func {} is not marked as output yet contains output " \
+            "keyword arguments".format(name)
 
     # Explicit checking for void is a hack and should disappear after a more
     # functionally complete implementation of Tensor aliases.
@@ -200,8 +201,8 @@ def parse_arguments(args, func_variants, declaration, func_return):
                     "as mutable.".format(name)
                 found_self = True
                 assert argument['annotation'] == func_return[arg_idx]['annotation'], \
-                        "Inplace function annotations of function {} need to match between " \
-                        "input and correponding output.".format(name)
+                    "Inplace function annotations of function {} need to match between " \
+                    "input and correponding output.".format(name)
                 assert argument['name'] == func_return[arg_idx]['name']
                 assert argument['type'] == func_return[arg_idx]['type']
         assert found_self, "Inplace function \"{}\" needs Tensor argument named self.".format(name)
@@ -226,8 +227,8 @@ def parse_return_arguments(return_decl, inplace, func_decl):
         else:
             if t == "Tensor" and inplace:
                 assert annotation and annotation.endswith("!"), \
-                        "Return Tensor of function \"{}\" flagged as inplace needs to be " \
-                        "annotated as mutable".format(func_decl['func'])
+                    "Return Tensor of function \"{}\" flagged as inplace needs to be " \
+                    "annotated as mutable".format(func_decl['func'])
                 argument_dict['name'] = 'self'
             else:
                 argument_dict['name'] = 'result' if not multiple_args else 'result' + str(arg_idx)

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -64,6 +64,7 @@ def type_argument_translations(arg):
         match = re.match(r'int\[(\d+)\]', t)
         t = 'IntList'
         size = int(match.group(1))
+    # Enables bool[x] by translating to legacy std::array<bool,x>. See [temp translations]
     elif re.match(r'bool\[(\d+)\]', t):
         match = re.match(r'bool\[(\d+)\]', t)
         t = 'std::array<bool,{}>'.format(match.group(1))

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -295,7 +295,7 @@ def format_trace_inputs(declaration):
         trace_name = uninplace_api_name(declaration['api_name'])
         has_factory_name = trace_name in FACTORY_FUNCTION_NAMES
         if has_factory_name:
-            outplace = ADD_TRACE_INPUT.substitute(name='result', input='result.options()')
+            outplace = ADD_TRACE_INPUT.substitute(name='out', input='out.options()')
         else:
             outplace = ''
 

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -357,16 +357,12 @@ def gen_jit_dispatch(declarations, out, template_path):
     num_shards = 3
     shards = [[] for _ in range(num_shards)]
 
-    foa = open("/tmp/aa", 'w')
-    fob = open("/tmp/bb", 'w')
     # ops are assigned arbitrarily but stably to a file based on hash
     for group in jit_decl_groups:
         x = sum(ord(c) for c in group[0]['name']) % num_shards
         for decl in group:
-            shards[x].append(OPERATOR.substitute(signature=signature(decl, foa, fob),
+            shards[x].append(OPERATOR.substitute(signature=signature(decl),
                                                  op=emit_decl_variant(decl)))
-    foa.close()
-    fob.close()
 
     for i, shard in enumerate(shards):
         env = {
@@ -410,7 +406,7 @@ def is_kwarg_only(a):
     return a.get('kwarg_only') or a.get('output')
 
 
-def signature(decl, foa, fob):
+def signature(decl):
     def format_arg(arg):
         name = arg['name'] if not arg.get('output') else 'out'
         typ = jit_type_of(arg)
@@ -458,13 +454,6 @@ def signature(decl, foa, fob):
             decl['schema_string'] + ' is flagged as JIT signature compliant' + \
             ', but does not match the signature ' + constructed_string
         return decl['schema_string']
-    else:
-        import Levenshtein
-        if 'schema_string' in decl and len(decl['schema_string']) > 0:
-            d = Levenshtein.distance(constructed_string, decl['schema_string'])
-            fob.write(str(d) + "\t" + constructed_string + "\t" + decl['schema_string'] + "\n")
-            if d == 0:
-                foa.write(decl['schema_string'] + "\n")
     return constructed_string
 
 


### PR DESCRIPTION
Adds Tensor alias annotations. 

This isn't a full implementation of alias annotations, but that isn't required to increase compliance with the JIT signature schema. There are some sanity checks within native_parse.py for their usage, which can also help overall correctness. Otherwise, this exists solely for further alignment between the JIT signature schema and the native_functions.yaml func schema.

This gets us to ~85% matches.