### PR TITLE
Move OrderedDict to c10

### DIFF
--- a/c10/util/OrderedDict.h
+++ b/c10/util/OrderedDict.h
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-namespace torch {
+namespace c10 {
 /// An ordered dictionary implementation, akin to Python's `OrderedDict`.
 template <typename Key, typename Value>
 class OrderedDict {
@@ -473,4 +473,4 @@ void OrderedDict<Key, Value>::reserve(size_t requested_capacity) {
   items_.reserve(requested_capacity);
 }
 
-} // namespace torch
+} // namespace c10

--- a/setup.py
+++ b/setup.py
@@ -793,7 +793,6 @@ if __name__ == '__main__':
                 'lib/include/torch/csrc/api/include/torch/data/samplers/*.h',
                 'lib/include/torch/csrc/api/include/torch/data/transforms/*.h',
                 'lib/include/torch/csrc/api/include/torch/detail/*.h',
-                'lib/include/torch/csrc/api/include/torch/detail/ordered_dict.h',
                 'lib/include/torch/csrc/api/include/torch/nn/*.h',
                 'lib/include/torch/csrc/api/include/torch/nn/modules/*.h',
                 'lib/include/torch/csrc/api/include/torch/nn/parallel/*.h',

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <torch/nn/pimpl.h>
-#include <torch/ordered_dict.h>
 #include <torch/serialize/archive.h>
 #include <torch/types.h>
 
 #include <ATen/ATen.h>
+#include <c10/util/OrderedDict.h>
 
 #include <functional>
 #include <iosfwd>

--- a/torch/csrc/api/include/torch/python.h
+++ b/torch/csrc/api/include/torch/python.h
@@ -2,7 +2,6 @@
 
 #include <torch/detail/static.h>
 #include <torch/nn/module.h>
-#include <torch/ordered_dict.h>
 #include <torch/types.h>
 
 #include <torch/csrc/Device.h>
@@ -10,6 +9,8 @@
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
+
+#include <c10/util/OrderedDict.h>
 
 #include <iterator>
 #include <string>

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -1,10 +1,9 @@
 #include <torch/nn/module.h>
 
-#include <torch/ordered_dict.h>
-
 #include <torch/csrc/autograd/generated/VariableType.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/OrderedDict.h>
 
 #include <algorithm>
 #include <functional>

--- a/torch/csrc/api/src/optim/optimizer.cpp
+++ b/torch/csrc/api/src/optim/optimizer.cpp
@@ -1,9 +1,9 @@
 #include <torch/optim/optimizer.h>
-
 #include <torch/csrc/autograd/generated/variable_factories.h>
-#include <torch/ordered_dict.h>
 #include <torch/serialize/archive.h>
 #include <torch/types.h>
+
+#include <c10/util/OrderedDict.h>
 
 #include <string>
 #include <utility>

--- a/torch/csrc/api/src/python/init.cpp
+++ b/torch/csrc/api/src/python/init.cpp
@@ -1,10 +1,9 @@
 #include <torch/python/init.h>
 #include <torch/python.h>
-
 #include <torch/nn/module.h>
-#include <torch/ordered_dict.h>
-
 #include <torch/csrc/utils/pybind.h>
+
+#include <c10/util/OrderedDict.h>
 
 #include <string>
 #include <vector>
@@ -15,9 +14,9 @@ namespace pybind11 {
 namespace detail {
 #define ITEM_TYPE_CASTER(T, Name)                                             \
   template <>                                                                 \
-  struct type_caster<typename torch::OrderedDict<std::string, T>::Item> {     \
+  struct type_caster<typename c10::OrderedDict<std::string, T>::Item> {       \
    public:                                                                    \
-    using Item = typename torch::OrderedDict<std::string, T>::Item;           \
+    using Item = typename c10::OrderedDict<std::string, T>::Item;             \
     using PairCaster = make_caster<std::pair<std::string, T>>;                \
     PYBIND11_TYPE_CASTER(Item, _("Ordered" #Name "DictItem"));                \
     bool load(handle src, bool convert) {                                     \

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -17,7 +17,7 @@
 #include <torch/csrc/jit/python_tracer.h>
 #include <torch/csrc/jit/script/parser.h>
 
-#include <torch/csrc/api/include/torch/ordered_dict.h>
+#include <c10/util/OrderedDict.h>
 
 #include <ATen/ATen.h>
 
@@ -654,7 +654,7 @@ void initJitScriptBindings(PyObject* module) {
           "_method_names",
           [](Module& self) {
             using Item =
-                torch::OrderedDict<std::string, std::unique_ptr<Method>>::Item;
+                c10::OrderedDict<std::string, std::unique_ptr<Method>>::Item;
             return fmap(self.get_methods(), [](const Item& item) {
               return (*item)->name();
             });

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -10,11 +10,11 @@
 #include <torch/csrc/jit/source_range.h>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#include <torch/csrc/api/include/torch/ordered_dict.h>
 #include <torch/csrc/utils/memory.h>
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
+#include <c10/util/OrderedDict.h>
 
 #include <functional>
 #include <memory>
@@ -451,14 +451,14 @@ struct Module {
     return modules[name].module;
   }
 
-  const torch::OrderedDict<std::string, NamedModule>& get_modules() const {
+  const c10::OrderedDict<std::string, NamedModule>& get_modules() const {
     return modules;
   }
-  const torch::OrderedDict<std::string, NamedParameter>& get_parameters()
+  const c10::OrderedDict<std::string, NamedParameter>& get_parameters()
       const {
     return parameters;
   }
-  const torch::OrderedDict<std::string, std::unique_ptr<Method>>& get_methods()
+  const c10::OrderedDict<std::string, std::unique_ptr<Method>>& get_methods()
       const {
     return methods;
   }
@@ -570,9 +570,9 @@ struct Module {
   // it is only legal to _add_ new modules and parameters.
   // removing them will allow member_inputs to point to invalid parameters
   // no such restriction exists for methods
-  torch::OrderedDict<std::string, NamedModule> modules;
-  torch::OrderedDict<std::string, NamedParameter> parameters;
-  torch::OrderedDict<std::string, std::unique_ptr<Method>> methods;
+  c10::OrderedDict<std::string, NamedModule> modules;
+  c10::OrderedDict<std::string, NamedParameter> parameters;
+  c10::OrderedDict<std::string, std::unique_ptr<Method>> methods;
   bool optimize;
 };
 


### PR DESCRIPTION
Makes a little more sense since it was used in a few places outside the C++ API, and is necessary to use it for ordered dictionaries in #16208