### PR TITLE
Make test_proper_exit more robust

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -755,11 +755,11 @@ class TestDataLoader(TestCase):
                 # workers.
                 loader_setup_event.wait(timeout=JOIN_TIMEOUT)
                 if not loader_setup_event.is_set():
-                    fail_msg = desc + ': loader process failed to setup with given time'
+                    fail_msg = desc + ': loader process failed to setup within given time'
                     if loader_p.exception is not None:
                         self.fail(fail_msg + ', and had exception {}'.format(loader_p.exception))
                     elif not loader_p.is_alive():
-                        self.fail(fail_msg + ', and exited with code {} but no exception'.format(loader_p.exitcode))
+                        self.fail(fail_msg + ', and exited with code {} but had no exception'.format(loader_p.exitcode))
                     else:
                         self.fail(fail_msg + ', and is still alive.')
 
@@ -769,10 +769,15 @@ class TestDataLoader(TestCase):
 
                 try:
                     loader_p.join(JOIN_TIMEOUT + MP_STATUS_CHECK_INTERVAL)
-                    self.assertFalse(loader_p.is_alive(), desc + ': loader process not terminated')
+                    if loader_p.is_alive():
+                        fail_msg = desc + ': loader process did not terminate'
+                        if loader_p.exception is not None:
+                            self.fail(fail_msg + ', and had exception {}'.format(loader_p.exception))
+                        else:
+                            self.fail(fail_msg + ', and had no exception')
                     _, alive = psutil.wait_procs(worker_psutil_p, timeout=(MP_STATUS_CHECK_INTERVAL + JOIN_TIMEOUT))
                     if len(alive) > 0:
-                        self.fail(desc + ': worker process (pid(s) {}) not terminated'.format(
+                        self.fail(desc + ': worker process (pid(s) {}) did not terminate'.format(
                             ', '.join(str(p.pid) for p in alive)))
                     if exit_method is None:
                         self.assertEqual(loader_p.exitcode, 0)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -49,7 +49,7 @@ if not NO_MULTIPROCESSING_SPAWN:
     mp = mp.get_context(method='spawn')
 
 
-JOIN_TIMEOUT = 17.0 if (IS_WINDOWS or IS_PPC) else 11.0
+JOIN_TIMEOUT = 17.0 if (IS_WINDOWS or IS_PPC) else 13.0
 
 
 class TestDatasetRandomSplit(TestCase):


### PR DESCRIPTION
1. Improve error message for better debugging info
2. Increase timeout
3. Also apply the windows worker failure detection mechanism on non-Windows platforms, for better robustness

Attempt to fix #14501 

cc @ezyang 