### PR TITLE
Fix issues under caffe round 1

### DIFF
--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -168,7 +168,7 @@ class C10_API EnforceFailMessage {
   }
 
  private:
-  std::string* msg_;
+  std::string* msg_{};
 };
 
 #define BINARY_COMP_HELPER(name, op)                         \

--- a/caffe2/core/db.h
+++ b/caffe2/core/db.h
@@ -282,8 +282,8 @@ class CAFFE2_API DBReader {
   unique_ptr<DB> db_;
   unique_ptr<Cursor> cursor_;
   mutable std::mutex reader_mutex_;
-  uint32_t num_shards_;
-  uint32_t shard_id_;
+  uint32_t num_shards_{};
+  uint32_t shard_id_{};
 
   C10_DISABLE_COPY_AND_ASSIGN(DBReader);
 };

--- a/caffe2/core/event.h
+++ b/caffe2/core/event.h
@@ -229,7 +229,7 @@ class CAFFE2_API Event {
 
 #ifdef CAFFE2_USE_EXCEPTION_PTR
   std::exception_ptr caught_exception_;
-  int64_t exception_timestamp_;
+  int64_t exception_timestamp_{};
 #endif // CAFFE2_USE_EXCEPTION_PTR
 
   static EventCreateFunction event_creator_[MaxDeviceTypes];

--- a/caffe2/core/workspace.h
+++ b/caffe2/core/workspace.h
@@ -308,7 +308,7 @@ class CAFFE2_API Workspace {
   }
 
  public:
-  std::atomic<int> last_failed_op_net_position;
+  std::atomic<int> last_failed_op_net_position{};
 
  private:
   struct Bookkeeper {

--- a/caffe2/utils/simple_queue.h
+++ b/caffe2/utils/simple_queue.h
@@ -69,7 +69,7 @@ class SimpleQueue {
   std::mutex mutex_;
   std::condition_variable cv_;
   std::queue<T> queue_;
-  bool no_more_jobs_;
+  bool no_more_jobs_{};
   // We do not allow copy constructors.
   SimpleQueue(const SimpleQueue& /*src*/) {}
 };


### PR DESCRIPTION
Summary: Previously the ads code ran into some issues where we would not properly initialize member fields, and the member functions started using these fields without in their raw uninitialized states. This was exploited by Thin-TLO last week and caused issues, so I wanted to fix this class of issue altogether. This diff is generated by clang-tidy to automatically fix this class of issue, separating out the caffe specific changes so that we would not have any issues down the road.

Differential Revision: D13776185
