### PR TITLE
Relax lower bound for nogil timing test to avoid false alarm

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1692,7 +1692,7 @@ class TestCuda(TestCase):
         self.assertTrue(s.query())
 
         # not necessary to check e_tik and e_tok, as elapsed_time would throw
-        # exception is otherwise.
+        # exception if otherwise.
         return e_tik.elapsed_time(e_tok)
 
     @staticmethod
@@ -1711,7 +1711,7 @@ class TestCuda(TestCase):
         self.assertTrue(s.query())
 
         # not necessary to check e_tik and e_tok, as elapsed_time would throw
-        # exception is otherwise.
+        # exception if otherwise.
         return e_tik.elapsed_time(e_tok)
 
     @staticmethod
@@ -1738,7 +1738,7 @@ class TestCuda(TestCase):
         self.assertTrue(e_sync.query())
 
         # not necessary to check e_tik and e_tok, as elapsed_time would throw
-        # exception is otherwise.
+        # exception if otherwise.
         return e_tik.elapsed_time(e_tok)
 
     @staticmethod
@@ -1780,7 +1780,6 @@ class TestCuda(TestCase):
                 e_tok.synchronize()
                 total_time = e_tik.elapsed_time(e_tok)
 
-            print (parent_time, child_time, total_time)
             # Without GIL, the two 50ms synchronization can overlap, and hence
             # the expected execution time should be only a little bit higher
             # than 50ms and well below 100ms. However, the real spin time of

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1782,12 +1782,12 @@ class TestCuda(TestCase):
 
             # Without GIL, the two 50ms synchronization can overlap, and hence
             # the expected execution time should be only a little bit higher
-            # than 50ms and well below 100ms. However, the real spin time of
-            # torch.cuda._sleep(50 ms) varies (I have seen 45ms). Hence, using
-            # absolute wall clock time is not reliable. This test uses relative
-            # comparisons, checking if the sum of synchronization time in parent
-            # and child is greater than the real execution time by least 20ms
-            self.assertGreater(parent_time + child_time, total_time + 20)
+            # than 50ms and well below 100ms (assuming 1 cycle is 1 nano sec).
+            # However, relying on absolute execution time is not reliable as it
+            # may vary. Therefore, this test uses relative comparisons, checking
+            # if the sum of synchronization time in parent and child is greater
+            # than the real execution time by least 40%.
+            self.assertGreater(parent_time + child_time, total_time * 1.4)
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     @skipIfRocm

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -657,6 +657,7 @@ def compare_cpu_gpu(tensor_constructor, arg_constructor, fn, t, precision=1e-5):
 
 class TestCuda(TestCase):
     _do_cuda_memory_leak_check = True
+    FIFTY_MIL_CYCLES = 50000000
 
     @staticmethod
     def _test_memory_stats_generator(self, device=None, N=35):
@@ -1580,7 +1581,8 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
-            torch.cuda._sleep(50000000)  # spin for about 50 ms on device1
+            # spin for about 50 ms on device1
+            torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
 
         self.assertTrue(s0.query())
         self.assertFalse(s1.query())
@@ -1677,7 +1679,7 @@ class TestCuda(TestCase):
         self.assertGreater(start_event.elapsed_time(event), 0)
 
     @staticmethod
-    def _stream_synchronize(self, spin_time_cycles=50000000):
+    def _stream_synchronize(self, spin_time_cycles):
         s = torch.cuda.current_stream()
         e_tik = torch.cuda.Event(enable_timing=True)
         e_tok = torch.cuda.Event(enable_timing=True)
@@ -1694,7 +1696,7 @@ class TestCuda(TestCase):
         return e_tik.elapsed_time(e_tok)
 
     @staticmethod
-    def _event_synchronize(self, spin_time_cycles=50000000):
+    def _event_synchronize(self, spin_time_cycles):
         s = torch.cuda.current_stream()
         e_tik = torch.cuda.Event(enable_timing=True)
         e_tok = torch.cuda.Event(enable_timing=True)
@@ -1711,7 +1713,7 @@ class TestCuda(TestCase):
         return e_tik.elapsed_time(e_tok)
 
     @staticmethod
-    def _event_wait(self, spin_time_cycles=50000000):
+    def _event_wait(self, spin_time_cycles):
         s0 = torch.cuda.current_stream()
         s1 = torch.cuda.Stream()
         e_tik = torch.cuda.Event(blocking=True, enable_timing=True)
@@ -1740,7 +1742,7 @@ class TestCuda(TestCase):
         with torch.cuda.device('cuda:1'):
             c2p.put(0)
             p2c.get()
-            c2p.put(sync_func(self, 50000000))
+            c2p.put(sync_func(self, TestCuda.FIFTY_MIL_CYCLES))
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     @skipIfRocm
@@ -1763,7 +1765,7 @@ class TestCuda(TestCase):
             with torch.cuda.device('cuda:0'):
                 e_tik.record()
                 p2c.put(0)
-                parent_time = sync_func(self, 50000000)
+                parent_time = sync_func(self, TestCuda.FIFTY_MIL_CYCLES)
                 child_time = c2p.get()
                 e_tok.record()
                 e_tok.synchronize()
@@ -1786,7 +1788,8 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d0):
             s0 = torch.cuda.current_stream()
-            torch.cuda._sleep(50000000)  # spin for about 50 ms on device1
+            # spin for about 50 ms on device1
+            torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             e0 = torch.cuda.Event()
             s0.record_event(e0)
 
@@ -1815,7 +1818,8 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
-            torch.cuda._sleep(50000000)  # spin for about 50 ms on device1
+            # spin for about 50 ms on device1
+            torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             e1 = s1.record_event()
 
         self.assertTrue(e0.query())
@@ -1853,13 +1857,14 @@ class TestCuda(TestCase):
         with torch.cuda.device(d0):
             s0 = torch.cuda.current_stream()
             e0 = torch.cuda.Event(enable_timing=True)
-            torch.cuda._sleep(10)  # spin for about 50 ms on device1
+            torch.cuda._sleep(10)
             s0.record_event(e0)
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
             e1 = torch.cuda.Event(enable_timing=True)
-            torch.cuda._sleep(30000000)  # spin for about 50 ms on device1
+            # spin for about 50 ms on device1
+            torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             s1.record_event(e1)
 
         e0.synchronize()
@@ -1875,7 +1880,8 @@ class TestCuda(TestCase):
         with torch.cuda.device(d0):
             s0 = torch.cuda.current_stream()
             e2 = torch.cuda.Event(enable_timing=True)
-            torch.cuda._sleep(30000000)  # spin for about 50 ms on device1
+            # spin for about 50 ms on device1
+            torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             s0.record_event(e2)
             s0.synchronize()
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1743,9 +1743,9 @@ class TestCuda(TestCase):
             self.assertGreater(tok - tik, 0.045)
             # If GIL is enforced, the execution time should be a little higher
             # than 100ms in theory. But, again due to the timing inaccuracy, it
-            # may go below 100ms. Therefore, we set upper bound to 80ms to avoid
+            # may go below 100ms. Therefore, we set upper bound to 95ms to avoid
             # false negative.
-            self.assertLess(tok - tik, 0.08)
+            self.assertLess(tok - tik, 0.095)
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     @skipIfRocm

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1581,7 +1581,6 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
-            # spin for about 50 ms on device1
             torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
 
         self.assertTrue(s0.query())
@@ -1789,7 +1788,6 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d0):
             s0 = torch.cuda.current_stream()
-            # spin for about 50 ms on device1
             torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             e0 = torch.cuda.Event()
             s0.record_event(e0)
@@ -1819,7 +1817,6 @@ class TestCuda(TestCase):
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
-            # spin for about 50 ms on device1
             torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             e1 = s1.record_event()
 
@@ -1864,7 +1861,6 @@ class TestCuda(TestCase):
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()
             e1 = torch.cuda.Event(enable_timing=True)
-            # spin for about 50 ms on device1
             torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             s1.record_event(e1)
 
@@ -1881,7 +1877,6 @@ class TestCuda(TestCase):
         with torch.cuda.device(d0):
             s0 = torch.cuda.current_stream()
             e2 = torch.cuda.Event(enable_timing=True)
-            # spin for about 50 ms on device1
             torch.cuda._sleep(TestCuda.FIFTY_MIL_CYCLES)
             s0.record_event(e2)
             s0.synchronize()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1771,13 +1771,14 @@ class TestCuda(TestCase):
                 e_tok.synchronize()
                 total_time = e_tik.elapsed_time(e_tok)
 
-            # Without GIL, the two 50ms synchronization can overlap, and hence
-            # the expected execution time should be only a little bit higher
-            # than 50ms and well below 100ms (assuming 1 cycle is 1 nano sec).
-            # However, relying on absolute execution time is not reliable as it
-            # may vary. Therefore, this test uses relative comparisons, checking
-            # if the sum of synchronization time in parent and child is greater
-            # than the real execution time by least 40%.
+            # Without GIL, synchronizations in parent and child threads can
+            # overlap. The total execution time should be a little bit longer
+            # than spinning fifty million cycles and much shorter than twice of
+            # that. However, testing absolute execution time is not reliable as
+            # it may vary on different hardware in different environments.
+            # Therefore, this test uses relative comparisons, checking if the
+            # sum of parent and child threads execution time is greater than the
+            # real execution time by least 40%.
             self.assertGreater(parent_time + child_time, total_time * 1.4)
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1733,8 +1733,9 @@ class TestCuda(TestCase):
             t.join()
             tok = time.time()
 
-            self.assertGreater(tok - tik, 0.05)
-            self.assertLess(tok - tik, 0.1)
+            # the 5 ms room helps to avoid false alarm due to timing inaccuracy
+            self.assertGreater(tok - tik, 0.045)
+            self.assertLess(tok - tik, 0.095)
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     @skipIfRocm


### PR DESCRIPTION
fixes #16250, #16271 