### PR TITLE
[c10d] Make Store::setTimeout take milliseconds

### DIFF
--- a/torch/lib/c10d/Store.cpp
+++ b/torch/lib/c10d/Store.cpp
@@ -9,11 +9,11 @@ constexpr std::chrono::milliseconds Store::kNoTimeout;
 Store::~Store() {}
 
 // Set timeout function
-void Store::setTimeout(const std::chrono::seconds& timeoutSec) {
-  if (timeoutSec.count() == 0) {
+void Store::setTimeout(const std::chrono::milliseconds& timeout) {
+  if (timeout.count() == 0) {
     timeout_ = kNoTimeout;
   }
-  timeout_ = timeoutSec;
+  timeout_ = timeout;
 }
 
 } // namespace c10d

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -35,7 +35,7 @@ class Store {
       const std::vector<std::string>& keys,
       const std::chrono::milliseconds& timeout) = 0;
 
-  void setTimeout(const std::chrono::seconds& timeoutSec);
+  void setTimeout(const std::chrono::milliseconds& timeout);
 
  protected:
   std::chrono::milliseconds timeout_;


### PR DESCRIPTION
This is particularly useful when using a c10d::Store from tests.

cc @jgehring

