### PR TITLE
Fix the tensor deserialization problem of jit script module on CUDA

### DIFF
--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -157,7 +157,7 @@ at::Tensor ScriptModuleDeserializer::loadTensor(
     } else if (device.type() == at::DeviceType::CUDA) {
       at::Tensor cpu_tensor =
           at::empty({0}, at::CPU(type).options())
-              .set_(cpu_storage, tensor_proto.offset(), dims, strides);
+              .set_(cpu_storage);
       at::Storage cuda_storage =
           cpu_tensor.to(device, cpu_tensor.scalar_type()).storage();
       storage_it =


### PR DESCRIPTION
Now we create a temporary tensor for the whole record.

Fix https://github.com/pytorch/pytorch/issues/15271