### PR TITLE
Fix compare_exchange_weak usage in weak_intrusive_ptr

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -576,7 +576,7 @@ class weak_intrusive_ptr final {
         // Return nullptr.
         return intrusive_ptr<TTarget, NullType>(NullType::singleton());
       }
-    } while (target_->refcount_.compare_exchange_weak(refcount, refcount + 1));
+    } while (!target_->refcount_.compare_exchange_weak(refcount, refcount + 1));
     return intrusive_ptr<TTarget, NullType>(target_);
   }
 


### PR DESCRIPTION
In the case of spurious failure, refcount is not incremented -- which leads to underflow once all references are released.

This was discovered when exercising multiprocessing on ppc64le.