### PR TITLE
Add timers to test_jit.py.

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -304,7 +304,7 @@ class TestCase(expecttest.TestCase):
         t = time.time() - self.startTime
         needToPrintTime = os.environ.get('PYTORCH_TEST_TIMING')
         if needToPrintTime:
-            print "%s: %.3f" % (self.id(), t)
+            print("%s: %.3f" % (self.id(), t))
 
     def assertTensorsSlowEqual(self, x, y, prec=None, message=''):
         max_err = 0

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -298,6 +298,13 @@ class TestCase(expecttest.TestCase):
 
     def setUp(self):
         set_rng_seed(SEED)
+        self.startTime = time.time()
+
+    def tearDown(self):
+        t = time.time() - self.startTime
+        needToPrintTime = os.environ.get('PYTORCH_TEST_TIMING')
+        if needToPrintTime:
+            print "%s: %.3f" % (self.id(), t)
 
     def assertTensorsSlowEqual(self, x, y, prec=None, message=''):
         max_err = 0

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1,4 +1,5 @@
 from __future__ import division
+import time
 import torch
 import torch.jit
 import torch.nn as nn
@@ -254,11 +255,16 @@ class JitTestCase(TestCase):
             torch.jit.TracerWarning.ignore_lib_warnings()
             JitTestCase._restored_warnings = True
         torch._C._jit_set_emit_module_hook(self.emitModuleHook)
+        self.startTime = time.time()
 
     def tearDown(self):
         # needs to be cleared because python might be unloaded before
         # the callback gets destucted
         torch._C._jit_set_emit_module_hook(None)
+        t = time.time() - self.startTime
+        needToPrintTime = os.environ.get('PYTORCH_TEST_TIMING')
+        if needToPrintTime:
+            print "%s: %.3f" % (self.id(), t)
 
     @contextmanager
     def disableModuleHook(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -264,7 +264,7 @@ class JitTestCase(TestCase):
         t = time.time() - self.startTime
         needToPrintTime = os.environ.get('PYTORCH_TEST_TIMING')
         if needToPrintTime:
-            print "%s: %.3f" % (self.id(), t)
+            print("%s: %.3f" % (self.id(), t))
 
     @contextmanager
     def disableModuleHook(self):


### PR DESCRIPTION
To use it one needs to set PYTORCH_TEST_TIMING environment variable: when it's
set, the test outputs time spent on each unit test, like this:
```
.__main__.TestBatched.test_batch_argmax: 0.257
.__main__.TestBatched.test_batch_cat: 0.004
.__main__.TestBatched.test_batch_elementwise_binary: 0.004
.__main__.TestBatched.test_batch_elementwise_unary: 0.002
.__main__.TestBatched.test_batch_index_select: 0.070
.__main__.TestBatched.test_batch_matmul: 0.064
.__main__.TestBatched.test_batch_mm: 0.006
.__main__.TestBatched.test_batch_select: 0.004
.__main__.TestBatched.test_batch_softmax: 0.325
.__main__.TestBatched.test_batch_sum: 0.005
```
Otherwise, the behavior should not change.

