### PR TITLE
Change default Caffe2 CUDA memory pool to "thc".

### DIFF
--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -24,7 +24,7 @@
 
 C10_DEFINE_string(
     caffe2_cuda_memory_pool,
-    "",
+    "thc",
     "Sets the memory pool used by caffe2. Possible values are "
     "none, cnmem, thc and cub.");
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16117 Remove unnecessary includes and headers from THCCachingAllocator, move to at::cuda:: namespace&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13717836/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16119 Move THCCachingAllocator to c10_cuda.&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13718768/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16226 Delete duplicate copy of THCCachingAllocator.&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13762540/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16332 Change default Caffe2 CUDA memory pool to "thc".**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13805475/)



Differential Revision: [D13805475](https://our.internmc.facebook.com/intern/diff/D13805475/)