### PR TITLE
disable testing group conv with EIGEN engine

### DIFF
--- a/caffe2/python/operator_test/conv_test.py
+++ b/caffe2/python/operator_test/conv_test.py
@@ -97,6 +97,8 @@ class TestConvolution(serial.SerializedTestCase):
         assume(group == 1 or order == "NCHW" or gc.device_type == caffe2_pb2.CPU)
         if group != 1 and order == "NHWC":
             dc = [d for d in dc if d.device_type == caffe2_pb2.CPU]
+        # Group conv not implemented with EIGEN engine.
+        assume(group == 1 or engine != "EIGEN")
 
         input_channels *= group
         output_channels *= group

--- a/caffe2/python/operator_test/group_conv_test.py
+++ b/caffe2/python/operator_test/group_conv_test.py
@@ -43,6 +43,9 @@ class TestGroupConvolution(hu.HypothesisTestCase):
         else:
             # TODO: Group conv in NHWC not implemented for GPU yet.
             assume(group == 1 or order == "NCHW" or gc.device_type != caffe2_pb2.CUDA)
+        # Group conv not implemented with EIGEN engine.
+        assume(group == 1 or engine != "EIGEN")
+
         input_channels = input_channels_per_group * group
         output_channels = output_channels_per_group * group
 


### PR DESCRIPTION
Summary: group conv is not implemented with EIGEN engine so this diff disables related tests

Reviewed By: jamesr66a

Differential Revision: D13807204
