### PR TITLE
Fix slogdet sign requiring grad when input requires grad

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -729,7 +729,8 @@
   self: slice_backward(grad, self.sizes(), dim, start, end, step)
 
 - name: slogdet(Tensor self)
-  self: slogdet_backward(grads, self, result0, result1)
+  self: slogdet_backward(grad, self, result0, result1)
+  output_differentiability: [false, true]
 
 - name: sort(Tensor self, int64_t dim, bool descending)
   self: index_select_backward(grad, dim, result1, self.sizes(), true)


### PR DESCRIPTION
The real fix for https://github.com/pytorch/pytorch/issues/15605.

This is sort of BC breaking because now
```py
In [1]: import torch

In [2]: a = torch.randn(3, 3, requires_grad=True)

In [3]: a.slogdet()
Out[3]: (tensor(1.), tensor(0.1356, grad_fn=<SlogdetBackward>))

In [4]: a.slogdet()[0].requires_grad
Out[4]: False
```
while before this patch ` a.slogdet()[0]` requires grad with `grad_fn=<SlogdetBackward>`. But any use of backproping through this value will meet the error in #15605 so I don't think this is a problem.