### PR TITLE
codemod #ifdef DEBUG to #ifndef NDEBUG

### DIFF
--- a/aten/src/TH/THLogAdd.cpp
+++ b/aten/src/TH/THLogAdd.cpp
@@ -24,7 +24,7 @@ double THLogAdd(double log_a, double log_b)
   }
 
   minusdif = log_b - log_a;
-#ifdef DEBUG
+#ifndef NDEBUG
   if (isnan(minusdif))
     THError("THLogAdd: minusdif (%f) log_b (%f) or log_a (%f) is nan", minusdif, log_b, log_a);
 #endif
@@ -42,7 +42,7 @@ double THLogSub(double log_a, double log_b)
     THError("LogSub: log_a (%f) should be greater than log_b (%f)", log_a, log_b);
 
   minusdif = log_b - log_a;
-#ifdef DEBUG
+#ifndef NDEBUG
   if (isnan(minusdif))
     THError("LogSub: minusdif (%f) log_b (%f) or log_a (%f) is nan", minusdif, log_b, log_a);
 #endif

--- a/aten/src/TH/THTensor.cpp
+++ b/aten/src/TH/THTensor.cpp
@@ -22,7 +22,7 @@ void THTensor_setStorage(THTensor *self, THStorage *storage_, ptrdiff_t storageO
     THArgCheck(size_.size() == stride_.size(), 5, "inconsistent size/stride sizes");
   }
 
-#ifdef DEBUG
+#ifndef NDEBUG
   THAssert(size_.size() <= INT_MAX);
 #endif
   THTensor_setStorageNd(self,
@@ -67,7 +67,7 @@ void THTensor_resize(THTensor *self, at::IntList size, at::IntList stride)
     THArgCheck(stride.size() == size.size(), 3, "invalid stride");
   }
 
-#ifdef DEBUG
+#ifndef NDEBUG
   THAssert(size.size() <= INT_MAX);
 #endif
   THTensor_resizeNd(self, size.size(), size.data(), stride.data());

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -95,7 +95,7 @@ void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask
   ptrdiff_t numel = THByteTensor_sumall(mask);
   scalar_t *tensor_data;
 
-#ifdef DEBUG
+#ifndef NDEBUG
   THAssert(numel <= LONG_MAX);
 #endif
   THTensor_(resize1d)(tensor,numel);
@@ -131,7 +131,7 @@ void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
                   if IS_NONZERO(*tensor_data) {
                     ++numel;
                   });
-#ifdef DEBUG
+#ifndef NDEBUG
   THAssert(numel <= LONG_MAX);
 #endif
   THLongTensor_resize2d(subscript, numel, tensor->dim());
@@ -190,7 +190,7 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
   numel = THLongTensor_nElement(index);
 
   std::vector<int64_t> newSize = THTensor_sizesLegacyNoScalars(src);
-#ifdef DEBUG
+#ifndef NDEBUG
   THAssert(numel <= LONG_MAX);
 #endif
   newSize[dim] = numel;

--- a/aten/src/THC/THCTensor.cpp
+++ b/aten/src/THC/THCTensor.cpp
@@ -71,7 +71,7 @@ void THCTensor_resize(THCState *state, THCTensor *self, at::IntList size, at::In
     THArgCheck(stride.size() == size.size(), 3, "invalid stride");
   }
 
-#ifdef DEBUG
+#ifndef NDEBUG
   THAssert(size.size() <= INT_MAX);
 #endif
   THCTensor_resizeNd(state, self, size.size(), size.data(), stride.data());

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -310,7 +310,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * of sizes of a tensor.
    */
   virtual int64_t numel() const {
-#ifdef DEBUG
+#ifndef NDEBUG
     AT_ASSERT(compute_numel() == numel_);
 #endif
     return numel_;
@@ -324,7 +324,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * a tensor is contiguous or not.
    */
   virtual bool is_contiguous() const {
-#ifdef DEBUG
+#ifndef NDEBUG
     AT_ASSERT(compute_contiguous() == is_contiguous_);
 #endif
     return is_contiguous_;


### PR DESCRIPTION
Currently we pass `NDEBUG` instead of `DEBUG` from cmake, and we should use the right flag instead.