### PR TITLE
Remove dependency on ResourceGuard from IR.h.

### DIFF
--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -7,6 +7,7 @@
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/interpreter.h>
 #include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/resource_guard.h>
 #include <ATen/core/ivalue.h>
 #include <torch/csrc/jit/passes/batch_mm.h>
 #include <torch/csrc/jit/passes/canonicalize_ops.h>

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -4,7 +4,6 @@
 #include <torch/csrc/jit/generic_if.h>
 #include <torch/csrc/jit/graph_node_list.h>
 #include <torch/csrc/jit/named_value.h>
-#include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/scope.h>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
@@ -1145,27 +1144,43 @@ struct Graph {
   TORCH_API void freeBlock(Block* b);
 };
 
-struct WithInsertPoint : public ResourceGuard {
-  WithInsertPoint(Node* n)
-      : ResourceGuard([this] { prev->owningGraph()->setInsertPoint(prev); }),
-        prev(n->owningGraph()->insertPoint()) {
+/** \brief An utility class for setting temporary insertion points.
+ *
+ * When an object of this class is created, it stores the current insertion
+ * point, sets the new one, and restores the original insertion point  when the
+ * object is destroyed.
+ */
+struct WithInsertPoint {
+  WithInsertPoint(Node* n) : prev_(n->owningGraph()->insertPoint()) {
     n->owningGraph()->setInsertPoint(n);
   }
   WithInsertPoint(Block* b) : WithInsertPoint(b->return_node()) {}
 
- private:
-  Node* prev;
-};
-
-struct WithCurrentScope : public ResourceGuard {
-  WithCurrentScope(Graph& g, ScopePtr scope)
-      : ResourceGuard([&g, this]() { g.set_current_scope(prev_scope); }),
-        prev_scope(g.current_scope()) {
-    g.set_current_scope(std::move(scope));
+  ~WithInsertPoint() {
+    prev_->owningGraph()->setInsertPoint(prev_);
   }
 
  private:
-  ScopePtr prev_scope;
+  Node* prev_;
+};
+
+/** \brief An utility class for setting temporary scopes.
+ *
+ * When an object of this class is created, it stores the current scope, sets
+ * the new one, and restores the original scope when the object is destroyed.
+ */
+struct WithCurrentScope {
+  WithCurrentScope(Graph& g, ScopePtr scope)
+      : graph_(&g), prev_scope_(g.current_scope()) {
+    g.set_current_scope(std::move(scope));
+  }
+  ~WithCurrentScope() {
+    graph_->set_current_scope(prev_scope_);
+  }
+
+ private:
+  Graph* graph_;
+  ScopePtr prev_scope_;
 };
 
 inline Value::Value(Node* node_, size_t offset_)


### PR DESCRIPTION
It looks like `WithInsertionPoint` and `WithCurrentScope` can be easily implemented without 
`ResourceGuard` - that helps readability and removes one more dependency. Is there anything I'm missing?