### PR TITLE
Tensor reinitialization codemod

### DIFF
--- a/caffe2/core/int8_serialization.cc
+++ b/caffe2/core/int8_serialization.cc
@@ -66,13 +66,14 @@ class Int8TensorCPUDeserializer : public TensorDeserializer {
     Int8TensorCPU* tensor = blob->template GetMutable<Int8TensorCPU>();
     tensor->scale = proto.scale();
     tensor->zero_point = proto.bias();
-    vector<int> dims;
+    vector<int64_t> dims;
     for (const int d : proto.dims()) {
       dims.push_back(d);
     }
-    tensor->t.Resize(dims);
     switch (proto.data_type()) {
       case TensorProto_DataType_INT32:
+        ReinitializeTensor(
+            &(tensor->t), dims, at::dtype<int32_t>().device(CPU));
         detail::CopyFromProtoAsIs(
             tensor->t.numel(),
             proto.data(),
@@ -80,6 +81,7 @@ class Int8TensorCPUDeserializer : public TensorDeserializer {
             &this->context_);
         break;
       case TensorProto_DataType_UINT8:
+        ReinitializeTensor(&(tensor->t), dims, at::dtype<uint8_t>().device(CPU));
         detail::CopyFromProtoWithCast(
             tensor->t.numel(),
             proto.data(),

--- a/caffe2/core/tensor_int8.h
+++ b/caffe2/core/tensor_int8.h
@@ -13,6 +13,7 @@ struct Int8TensorCPU {
   int32_t zero_point{0};
   // Generally stores uint8_t data, but sometimes int32_t (e.g. bias
   // parameters).
+  // TODO: remove CPU
   Tensor t{CPU};
 };
 } // namespace int8

--- a/caffe2/experiments/operators/fully_connected_op_sparse.h
+++ b/caffe2/experiments/operators/fully_connected_op_sparse.h
@@ -124,10 +124,14 @@ class FullyConnectedOp_SPARSE final : public Operator<Context> {
       Wcsr.template data<T>(), iw.template data<int>(),
       jw.template data<int>(), N, K, M, Xt.template data<T>(),
       Yt->template mutable_data<T>(), &context_);
-    // Add bias term
-    if (bias_multiplier_.numel() != M) {
-      // If the helper bias multiplier is not M, reshape and fill it with one.
-      bias_multiplier_.Resize(shape(M));
+
+    // If the helper bias multiplier is not defined or not M, reshape and fill
+    // it with one.
+    if (!bias_multiplier_.defined() || bias_multiplier_.numel() != M) {
+      ReinitializeTensor(
+          &bias_multiplier_,
+          shape(M),
+          at::dtype<T>().device(Context::GetDeviceType()));
       math::Set<T, Context>(
           M, static_cast<T>(1), bias_multiplier_.template mutable_data<T>(),
           &context_);
@@ -140,7 +144,7 @@ class FullyConnectedOp_SPARSE final : public Operator<Context> {
   }
 
  protected:
-  Tensor bias_multiplier_{Context::GetDeviceType()};
+  Tensor bias_multiplier_;
 };
 
 

--- a/caffe2/operators/conv_op_eigen.cc
+++ b/caffe2/operators/conv_op_eigen.cc
@@ -34,14 +34,14 @@ template <typename T>
 bool EigenConvOp<T>::RunOnDeviceWithOrderNCHW() {
   auto& X = Input(INPUT);
   auto& filter = Input(FILTER);
-  auto* Y = Output(0);
   const int N = X.dim32(0), C = X.dim32(1), H = X.dim32(2), W = X.dim32(3);
   CAFFE_ENFORCE(4 == filter.dim());
   const int M = filter.dim32(0);
   CAFFE_ENFORCE(filter.dim32(1) == C);
   CAFFE_ENFORCE(filter.dim32(2) == kernel_h());
   CAFFE_ENFORCE(filter.dim32(3) == kernel_w());
-  ConvPoolOpBase<CPUContext>::SetOutputSize(X, Y, filter.dim32(0));
+  auto sizes = ConvPoolOpBase<CPUContext>::GetOutputSize(X, filter.dim32(0));
+  auto* Y = Output(0, sizes, at::dtype<T>());
   Eigen::array<int64_t, 4> kernel_shuffles
       { {int64_t(2), int64_t(3), int64_t(1), int64_t(0)} };
   Eigen::array<int64_t, 4> input_shuffles
@@ -128,14 +128,14 @@ template <typename T>
 bool EigenConvOp<T>::RunOnDeviceWithOrderNHWC() {
   auto& X = Input(INPUT);
   auto& filter = Input(FILTER);
-  auto* Y = Output(0);
   const int N = X.dim32(0), H = X.dim32(1), W = X.dim32(2), C = X.dim32(3);
   CAFFE_ENFORCE(4 == filter.dim());
   const int M = filter.dim32(0);
   CAFFE_ENFORCE(filter.dim32(1) == kernel_h());
   CAFFE_ENFORCE(filter.dim32(2) == kernel_w());
   CAFFE_ENFORCE(filter.dim32(3) == C);
-  ConvPoolOpBase<CPUContext>::SetOutputSize(X, Y, filter.dim32(0));
+  auto sizes = ConvPoolOpBase<CPUContext>::GetOutputSize(X, filter.dim32(0));
+  auto* Y = Output(0, sizes, at::dtype<T>());
   // Eigen expects filter to be of shape (kernel_h, kernel_w, C, M) for
   // optimization purposes, so we will create a temp one.
   Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic> temp_filter(

--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -21,7 +21,6 @@ template <typename T, class Context>
 bool ConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const auto& X = Input(INPUT);
   const auto& filter = Input(FILTER);
-  auto* Y = Output(0);
   const int N = X.dim32(0);
   const int C = X.dim32(1);
   const int G = group_;
@@ -44,10 +43,11 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     CAFFE_ENFORCE_EQ(filter.dim32(i + 2), kernel_[i]);
     kernel_size *= kernel_[i];
   }
-  ConvPoolOpBase<Context>::SetOutputSize(X, Y, M);
+
+  auto output_sizes = ConvPoolOpBase<Context>::GetOutputSize(X, M);
+  auto* Y = Output(0, output_sizes, at::dtype<T>());
 
   if (N == 0) {
-    Y->template mutable_data<T>();
     return true;
   }
 
@@ -196,7 +196,6 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
       "Only 1-3d convolution is supported for NHWC storage type");
   const Tensor& X = Input(INPUT);
   const auto& filter = Input(FILTER);
-  Tensor* Y = Output(0);
   const int N = X.dim32(0), C = X.dim32(X.dim() - 1);
   const int G = group_;
   CAFFE_ENFORCE_EQ(X.dim(), filter.dim());
@@ -218,13 +217,13 @@ bool ConvOp<T, Context>::RunOnDeviceWithOrderNHWC() {
     CAFFE_ENFORCE_EQ(filter.dim32(i + 1), kernel_[i]);
     kernel_size *= kernel_[i];
   }
-  ConvPoolOpBase<Context>::SetOutputSize(X, Y, M);
+
+  auto output_sizes = ConvPoolOpBase<Context>::GetOutputSize(X, M);
+  auto* Y = Output(0, output_sizes, at::dtype<T>());
 
   if (N == 0) {
-    Y->template mutable_data<T>();
     return true;
   }
-
   const vector<int> Y_dims = GetDims(*Y);
   const int X_HxW = X.numel() / (N * C);
   const int Y_HxW = Y->numel() / (N * M);

--- a/caffe2/operators/deform_conv_op_impl.h
+++ b/caffe2/operators/deform_conv_op_impl.h
@@ -17,7 +17,6 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const Tensor& X = Input(INPUT);
   const Tensor& offset = Input(OFFSET);
   auto& filter = Input(FILTER);
-  Tensor* Y = Output(0);
   const int N = X.dim32(0), C = X.dim32(1);
   CAFFE_ENFORCE_EQ(X.dim(), filter.dim());
   const int M = filter.dim32(0);
@@ -82,7 +81,8 @@ bool DeformConvOp<T, Context>::RunOnDeviceWithOrderNCHW() {
     kernel_dims_size *= kernel_[i];
   }
 
-  ConvPoolOpBase<Context>::SetOutputSize(X, Y, filter.dim32(0));
+  auto output_sizes = ConvPoolOpBase<Context>::GetOutputSize(X, filter.dim32(0));
+  auto* Y = Output(0, output_sizes, at::dtype<T>());
 
   const vector<int> input_dims = GetDims(X);
   const vector<int> output_dims = GetDims(*Y);
@@ -196,8 +196,8 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   auto& offset = Input(OFFSET);
   auto& filter = Input(FILTER);
   auto& dY = Input(OUTPUT_GRAD);
-  
-  
+
+
   const int N = X.dim32(0), C = X.dim32(1);
 
   const vector<int> input_dims = this->GetDims(X);
@@ -303,7 +303,7 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
 
   T* dbias_data = nullptr;
   if (!no_bias_) {
-    
+
     auto* dbias = Output(BIAS_OR_INPUT_GRAD, {M}, at::dtype<T>());
     if (bias_multiplier_.numel() != output_image_size) {
       // If the helper bias multiplier is not M, reshape and fill it with one.
@@ -323,7 +323,7 @@ bool DeformConvGradientOp<T, Context>::RunOnDeviceWithOrderNCHW() {
 
   T* dXdata = nullptr;
   if (OutputSize() == 4 || (no_bias_ && (OutputSize() == 3))) {
-    
+
     auto* dX = Output(no_bias_ ? BIAS_OR_INPUT_GRAD : INPUT_GRAD, X.sizes(), at::dtype<T>());
     dXdata = dX->template mutable_data<T>();
     math::Set<T, Context>(dX->numel(), 0, dXdata, &context_);

--- a/caffe2/operators/locally_connected_op_impl.h
+++ b/caffe2/operators/locally_connected_op_impl.h
@@ -20,7 +20,6 @@ template <typename T, class Context>
 bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
   const auto& X = Input(INPUT);
   const auto& filter = Input(FILTER);
-  auto* Y = Output(0);
   const int image_ndim = X.dim() - 2;
   CAFFE_ENFORCE_EQ(X.dim() + image_ndim, filter.dim());
   lc_op_util::ShapeParams shape;
@@ -41,7 +40,8 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNCHW() {
       0,
       "The number of output channels is not divisible by group.");
 
-  ConvPoolOpBase<Context>::SetOutputSize(X, Y, shape.M);
+  auto output_sizes = ConvPoolOpBase<Context>::GetOutputSize(X, shape.M);
+  auto* Y = Output(0, output_sizes, at::dtype<T>());
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(*Y);
   const std::vector<int> output_image_dims = GetDims(*Y);
@@ -109,7 +109,6 @@ template <typename T, class Context>
 bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   const auto& X = Input(INPUT);
   const auto& filter = Input(FILTER);
-  auto* Y = Output(0);
   CAFFE_ENFORCE_EQ(
       kernel_.size(),
       2,
@@ -124,7 +123,8 @@ bool LocallyConnectedOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   CAFFE_ENFORCE_EQ(filter.dim32(image_ndim + 1), kernel_h());
   CAFFE_ENFORCE_EQ(filter.dim32(image_ndim + 2), kernel_w());
   CAFFE_ENFORCE_EQ(filter.dim32(image_ndim + 3), shape.C);
-  ConvPoolOpBase<Context>::SetOutputSize(X, Y, shape.M);
+  auto sizes = ConvPoolOpBase<Context>::GetOutputSize(X, shape.M);
+  auto* Y = Output(0, sizes, at::dtype<T>());
 
   shape.input_image_size = GetDimsSize(X);
   shape.output_image_size = GetDimsSize(*Y);

--- a/caffe2/operators/lp_pool_op.cc
+++ b/caffe2/operators/lp_pool_op.cc
@@ -13,8 +13,8 @@ struct LpPoolFunctor {
 template <>
 bool PoolOp<float, CPUContext, LpPoolFunctor>::RunOnDeviceWithOrderNCHW() {
   auto& X = Input(0);
-  auto* Y = Output(0);
-  ConvPoolOpBase::SetOutputSize(X, Y, X.dim32(1));
+  auto sizes = ConvPoolOpBase::GetOutputSize(X, X.dim32(1));
+  auto* Y = Output(0, sizes, at::dtype<float>());
   const auto p = OperatorBase::GetSingleArgument<float>("p", 2.0);
   const auto inv_p = 1.0 / p;
 
@@ -59,11 +59,11 @@ bool PoolOp<float, CPUContext, LpPoolFunctor>::RunOnDeviceWithOrderNCHW() {
 template <>
 bool PoolOp<float, CPUContext, LpPoolFunctor>::RunOnDeviceWithOrderNHWC() {
   auto& X = Input(0);
-  auto* Y = Output(0);
   int height = X.dim32(1);
   int width = X.dim32(2);
   int channels = X.dim32(3);
-  ConvPoolOpBase::SetOutputSize(X, Y, channels);
+  auto sizes = ConvPoolOpBase::GetOutputSize(X, channels);
+  auto* Y = Output(0, sizes, at::dtype<float>());
 
   const auto p = OperatorBase::GetSingleArgument<float>("p", 2.0);
   const auto inv_p = 1.0 / p;

--- a/caffe2/operators/lp_pool_op.cu
+++ b/caffe2/operators/lp_pool_op.cu
@@ -215,8 +215,9 @@ __global__ void LpPoolBackwardNHWC(
 template <>
 bool PoolOp<float, CUDAContext, LpPoolFunctor>::RunOnDeviceWithOrderNCHW() {
   auto& X = Input(0);
-  auto* Y = Output(0);
-  ConvPoolOpBase<CUDAContext>::SetOutputSize(X, Y, X.dim32(1));
+  auto sizes = ConvPoolOpBase<CUDAContext>::GetOutputSize(X, X.dim32(1));
+  auto* Y = Output(0, sizes, at::dtype<float>());
+
   int output_size = Y->numel();
   LpPoolForwardNCHW<float>
       <<<CAFFE_GET_BLOCKS(output_size),
@@ -245,8 +246,9 @@ bool PoolOp<float, CUDAContext, LpPoolFunctor>::RunOnDeviceWithOrderNCHW() {
 template <>
 bool PoolOp<float, CUDAContext, LpPoolFunctor>::RunOnDeviceWithOrderNHWC() {
   auto& X = Input(0);
-  auto* Y = Output(0);
-  ConvPoolOpBase<CUDAContext>::SetOutputSize(X, Y, X.dim32(3));
+  auto sizes = ConvPoolOpBase<CUDAContext>::GetOutputSize(X, X.dim32(3));
+  auto* Y = Output(0, sizes, at::dtype<float>());
+
   int output_size = Y->numel();
   LpPoolForwardNHWC<float>
       <<<CAFFE_GET_BLOCKS(output_size),

--- a/caffe2/operators/pad_op.cc
+++ b/caffe2/operators/pad_op.cc
@@ -22,11 +22,11 @@ using std::max;
 template <>
 bool PadImageOp<float, CPUContext>::RunOnDeviceWithOrderNCHW() {
   auto& X = Input(0);
-  auto* Y = Output(0);
   int channels = X.dim32(1);
   int height = X.dim32(2);
   int width = X.dim32(3);
-  ConvPoolOpBase::SetOutputSize(X, Y, channels);
+  auto sizes = ConvPoolOpBase::GetOutputSize(X, channels);
+  auto* Y = Output(0, sizes, at::dtype<float>());
 
   const float* Xdata = X.data<float>();
   float* Ydata = Y->template mutable_data<float>();
@@ -160,11 +160,11 @@ bool PadImageOp<float, CPUContext>::RunOnDeviceWithOrderNCHW() {
 template <>
 bool PadImageOp<float, CPUContext>::RunOnDeviceWithOrderNHWC() {
   auto& X = Input(0);
-  auto* Y = Output(0);
   int height = X.dim32(1);
   int width = X.dim32(2);
   int channels = X.dim32(3);
-  ConvPoolOpBase::SetOutputSize(X, Y, channels);
+  auto sizes = ConvPoolOpBase::GetOutputSize(X, channels);
+  auto* Y = Output(0, sizes, at::dtype<float>());
   const float* Xdata = X.data<float>();
   float* Ydata = Y->template mutable_data<float>();
 

--- a/caffe2/operators/pool_op.h
+++ b/caffe2/operators/pool_op.h
@@ -37,10 +37,10 @@ class PoolOp final : public ConvPoolOpBase<Context> {
 
   bool RunOnDeviceWithOrderNCHW() override {
     const auto& X = Input(0);
-    auto* Y = Output(0);
     const int N = X.dim32(0);
     const int C = X.dim32(1);
-    ConvPoolOpBase<Context>::SetOutputSize(X, Y, C);
+    auto sizes = ConvPoolOpBase<Context>::GetOutputSize(X, C);
+    auto* Y = Output(0, sizes, at::dtype<T>());
     const T* X_data = X.template data<T>();
     T* Y_data = Y->template mutable_data<T>();
     if (N == 0) {
@@ -69,11 +69,11 @@ class PoolOp final : public ConvPoolOpBase<Context> {
 
   bool RunOnDeviceWithOrderNHWC() override {
     const auto& X = Input(0);
-    auto* Y = Output(0);
     const int ndim = X.dim();
     const int N = X.dim32(0);
     const int C = X.dim32(ndim - 1);
-    ConvPoolOpBase<Context>::SetOutputSize(X, Y, C);
+    auto sizes = ConvPoolOpBase<Context>::GetOutputSize(X, C);
+    auto* Y = Output(0, sizes, at::dtype<T>());
     const T* X_data = X.template data<T>();
     T* Y_data = Y->template mutable_data<T>();
     if (N == 0) {

--- a/caffe2/operators/quantized/int8_add_op.h
+++ b/caffe2/operators/quantized/int8_add_op.h
@@ -50,7 +50,7 @@ class Int8AddOp final : public Operator<CPUContext> {
       this->template GetSingleArgument<int>("Y_zero_point", 0);
     const float Y_scale =
       this->template GetSingleArgument<float>("Y_scale", 1);
-    Y->t.ResizeLike(A.t);
+    ReinitializeTensor(&(Y->t), A.t.sizes(), at::dtype(A.t.dtype()).device(CPU));
     Y->zero_point = Y_zero_point;
     Y->scale = Y_scale;
 

--- a/caffe2/operators/quantized/int8_channel_shuffle_op.h
+++ b/caffe2/operators/quantized/int8_channel_shuffle_op.h
@@ -32,7 +32,7 @@ class Int8ChannelShuffleOp final : public ConvPoolOpBase<CPUContext> {
   bool RunOnDeviceWithOrderNHWC() override {
     const auto& X = Inputs()[0]->template Get<Int8TensorCPU>();
     auto* Y = Outputs()[0]->template GetMutable<Int8TensorCPU>();
-    Y->t.ResizeLike(X.t);
+    ReinitializeTensor(&(Y->t), X.t.sizes(), at::dtype(X.t.dtype()).device(CPU));
     Y->scale = X.scale;
     Y->zero_point = X.zero_point;
     const int32_t Y_offset = this->template GetSingleArgument<int>("Y_zero_point", 0);

--- a/caffe2/operators/quantized/int8_flatten_op.h
+++ b/caffe2/operators/quantized/int8_flatten_op.h
@@ -28,7 +28,10 @@ class Int8FlattenOp : public Operator<CPUContext> {
     Y->zero_point = Y_offset;
     CAFFE_ENFORCE_GE(
         X.t.sizes().size(), axis_, "The rank of the tensor must be >= axis.");
-    Y->t.Resize(X.t.size_to_dim(axis_), X.t.size_from_dim(axis_));
+    ReinitializeTensor(
+        &(Y->t),
+        {X.t.size_to_dim(axis_), X.t.size_from_dim(axis_)},
+        at::dtype(X.t.dtype()).device(CPU));
     context_.CopyItemsToCPU(
         X.t.dtype(),
         X.t.numel(),

--- a/caffe2/operators/quantized/int8_given_tensor_fill_op.h
+++ b/caffe2/operators/quantized/int8_given_tensor_fill_op.h
@@ -26,7 +26,7 @@ class Int8GivenTensorFillOp final : public Operator<CPUContext> {
 
   bool RunOnDevice() override {
     auto* output = Outputs()[0]->template GetMutable<Int8TensorCPU>();
-    ReinitializeTensor(&output->t, shape_, at::dtype<uint8_t>().device(CPU));
+    ReinitializeTensor(&(output->t), shape_, at::dtype<uint8_t>().device(CPU));
     output->scale = scale_;
     output->zero_point = zero_point_;
     return Fill(output);
@@ -76,7 +76,7 @@ class Int8GivenIntTensorFillOp final : public Operator<CPUContext> {
 
   bool RunOnDevice() override {
     auto* output = Outputs()[0]->template GetMutable<Int8TensorCPU>();
-    output->t.Resize(shape_);
+    ReinitializeTensor(&(output->t), shape_, at::dtype<uint8_t>().device(CPU));
     output->scale = scale_;
     output->zero_point = zero_point_;
     return Fill(output);

--- a/caffe2/operators/quantized/int8_leaky_relu_op.h
+++ b/caffe2/operators/quantized/int8_leaky_relu_op.h
@@ -49,7 +49,7 @@ class Int8LeakyReluOp final : public Operator<CPUContext> {
 
     Y->scale = Y_scale;
     Y->zero_point = Y_zero_point;
-    Y->t.ResizeLike(X.t);
+    ReinitializeTensor(&(Y->t), X.t.sizes(), at::dtype(X.t.dtype()).device(CPU));
 
     initQNNPACK();
 

--- a/caffe2/operators/quantized/int8_quantize_op.h
+++ b/caffe2/operators/quantized/int8_quantize_op.h
@@ -70,7 +70,7 @@ class Int8QuantizeOp final : public Operator<CPUContext> {
   bool RunOnDevice() override {
     const auto& X = Input(0);
     auto* Y = Outputs()[0]->template GetMutable<Int8TensorCPU>();
-    Y->t.ResizeLike(X);
+    ReinitializeTensor(&(Y->t), X.sizes(), at::dtype(X.dtype()).device(CPU));
     int32_t Y_offset = this->template GetSingleArgument<int>("Y_zero_point", 0);
     auto Y_scale = this->template GetSingleArgument<float>("Y_scale", 1);
     Y->scale = Y_scale;

--- a/caffe2/operators/quantized/int8_relu_op.h
+++ b/caffe2/operators/quantized/int8_relu_op.h
@@ -27,7 +27,7 @@ class Int8ReluOp final : public Operator<CPUContext> {
   bool RunOnDevice() override {
     const auto& X = Inputs()[0]->template Get<Int8TensorCPU>();
     auto* Y = Outputs()[0]->template GetMutable<Int8TensorCPU>();
-    Y->t.ResizeLike(X.t);
+    ReinitializeTensor(&(Y->t), X.t.sizes(), at::dtype(X.t.dtype()).device(CPU));
     Y->scale = X.scale;
     Y->zero_point = X.zero_point;
     CHECK_GE(X.zero_point, std::numeric_limits<uint8_t>::min());

--- a/caffe2/operators/quantized/int8_reshape_op.h
+++ b/caffe2/operators/quantized/int8_reshape_op.h
@@ -36,6 +36,7 @@ class Int8ReshapeOp final : public ReshapeOp<uint8_t, CPUContext> {
     CHECK_EQ(Y_scale, X.scale);
     Y->scale = Y_scale;
     Y->zero_point = Y_offset;
+    ReinitializeTensor(&Y->t, X.t.sizes(), at::dtype(X.t.dtype()).device(CPU));
     DoRunWithTypeImpl<T>(X.t, &Y->t);
     return true;
   }

--- a/caffe2/operators/quantized/int8_roi_align_op.h
+++ b/caffe2/operators/quantized/int8_roi_align_op.h
@@ -289,9 +289,10 @@ class Int8RoIAlignOp final : public Operator<CPUContext> {
 
     if (R.numel() == 0) {
       // Handle empty rois
-      Y->t.Resize(0, pooled_height_, pooled_width_, X.t.dim32(3));
-      // The following mutable_data calls are needed to allocate the tensors
-      Y->t.mutable_data<uint8_t>();
+      ReinitializeTensor(
+          &(Y->t),
+          {0, pooled_height_, pooled_width_, X.t.dim32(3)},
+          at::dtype(X.t.dtype()).device(CPU));
       return true;
     }
 

--- a/caffe2/operators/quantized/int8_sigmoid_op.h
+++ b/caffe2/operators/quantized/int8_sigmoid_op.h
@@ -43,7 +43,7 @@ class Int8SigmoidOp final : public Operator<CPUContext> {
 
     Y->scale = Y_scale;
     Y->zero_point = Y_zero_point;
-    Y->t.ResizeLike(X.t);
+    ReinitializeTensor(&(Y->t), X.t.sizes(), at::dtype(X.t.dtype()).device(CPU));
 
     initQNNPACK();
 

--- a/caffe2/operators/quantized/int8_softmax_op.h
+++ b/caffe2/operators/quantized/int8_softmax_op.h
@@ -45,7 +45,7 @@ class Int8SoftmaxOp final : public Operator<CPUContext> {
 
     Y->scale = Y_scale;
     Y->zero_point = Y_zero_point;
-    Y->t.ResizeLike(X.t);
+    ReinitializeTensor(&(Y->t), X.t.sizes(), at::dtype(X.t.dtype()).device(CPU));
 
     initQNNPACK();
 

--- a/caffe2/quantization/server/quantize_dnnlowp_op.cc
+++ b/caffe2/quantization/server/quantize_dnnlowp_op.cc
@@ -39,7 +39,8 @@ bool QuantizeDNNLowPOp<T>::RunOnDevice() {
   }
   int8::Int8TensorCPU* output =
       Outputs()[0]->template GetMutable<int8::Int8TensorCPU>();
-  output->t.ResizeLike(Input(0));
+  ReinitializeTensor(
+      &(output->t), Input(0).sizes(), at::dtype<T>().device(CPU));
 
   const float* in_data = Input(0).template data<float>();
   T* out_data = output->t.template mutable_data<T>();


### PR DESCRIPTION
Summary:
Codemod generated with clangr shard mode, 25 files per diff,
To eliminiate partially initialized Tensor, we split the initialization of local Tensor variables into two steps, first declare un uninitialized Tensor, and
call `ReinitializeTensor` to initialize it.
motivation: https://github.com/pytorch/pytorch/pull/12407

Differential Revision: D13717360
