### PR TITLE
[ci] Set up stable docs push for v1.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -750,6 +750,31 @@ jobs:
           fi
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
+  pytorch_doc_push_stable:
+    environment:
+      JOB_BASE_NAME: pytorch-doc-push-stable
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:282"
+    resource_class: large
+    machine:
+      image: default
+    steps:
+    - run:
+        <<: *setup_ci_environment
+    - run:
+        <<: *install_doc_push_script
+    - run:
+        name: Doc Build and Push
+        no_output_timeout: "1h"
+        command: |
+          set -e
+          export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
+          echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
+          docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
+          export id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
+          docker cp /home/circleci/project/doc_push_script.sh $id:/var/lib/jenkins/workspace/doc_push_script.sh
+          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/stable 1.0.0 dry_run") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+
   pytorch_macos_10_13_py3_build:
     macos:
       xcode: "9.0"
@@ -1152,3 +1177,18 @@ workflows:
 
       - caffe2_py2_ios_macos10_13_build
       - caffe2_py2_system_macos10_13_build
+
+  stable_docs:
+    jobs:
+      - pytorch_linux_xenial_cuda8_cudnn7_py3_build:
+          filters:
+            branches:
+              only:
+                - v1.0.1
+      - pytorch_doc_push_stable:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn7_py3_build
+          filters:
+            branches:
+              only:
+                - v1.0.1


### PR DESCRIPTION
Adds a new CI workflow that is filtered to trigger only on merges to
v1.0.1.

Test Plan
- This PR sets up a doc push in dry_run mode. If it works, it won't
  actually push to stable docs; I am planning on scp-ing the docs build
  from the docker image and checking that everything looks fine before
  removing the dry_run option.
