### PR TITLE
Specify broadcast=1 for Pow in onnx->caffe2 converter

### DIFF
--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -830,6 +830,12 @@ class Caffe2Backend(Backend):
                         already_broadcast = True
                 if not already_broadcast:
                     c2_op.arg.extend([caffe2.python.utils.MakeArgument('broadcast', 1)])
+        else:
+            # TODO: Caffe2's Pow does not support onnx broadcast semantics by
+            # default yet
+            if c2_op.type == 'Pow':
+                c2_op.arg.extend([caffe2.python.utils.MakeArgument('broadcast', 1)])
+
 
         return c2_op
 


### PR DESCRIPTION
Summary:
From onnx opset 7, Pow supports broadcast by default; unfortunately this
isn't the case for Pow in caffe2 yet. An onnx model that relies on Pow
broadcasting will not run when converted to caffe2 ("Dimension mismatch - did
you forget to set broadcast=1?").

This is a band-aid fix to simply add broadcast=1 to the caffe2 Pow operator
during the conversion. The proper fix is to have Pow support broadcast in
caffe2, and there is an old diff to do so - D8528654.

Differential Revision: D13830604
