### PR TITLE
Remove usage of deprecated "min_satisfying_examples" hypothesis setting

### DIFF
--- a/caffe2/python/hypothesis_test_util.py
+++ b/caffe2/python/hypothesis_test_util.py
@@ -65,32 +65,58 @@ def is_travis():
     return 'TRAVIS' in os.environ
 
 
-hypothesis.settings.register_profile(
-    "sandcastle",
-    hypothesis.settings(
-        derandomize=True,
-        suppress_health_check=[hypothesis.HealthCheck.too_slow],
-        database=None,
-        min_satisfying_examples=1,
-        max_examples=100,
-        verbosity=hypothesis.Verbosity.verbose))
+#  "min_satisfying_examples" setting has been deprecated in hypythesis
+#  3.56.0 and removed in hypothesis 4.x
+if hypothesis.version.__version_info__ >= (3, 56, 0):
+    hypothesis.settings.register_profile(
+        "sandcastle",
+        hypothesis.settings(
+            derandomize=True,
+            suppress_health_check=[hypothesis.HealthCheck.too_slow],
+            database=None,
+            max_examples=100,
+            verbosity=hypothesis.Verbosity.verbose))
+    hypothesis.settings.register_profile(
+        "dev",
+        hypothesis.settings(
+            suppress_health_check=[hypothesis.HealthCheck.too_slow],
+            database=None,
+            max_examples=10,
+            verbosity=hypothesis.Verbosity.verbose))
+    hypothesis.settings.register_profile(
+        "debug",
+        hypothesis.settings(
+            suppress_health_check=[hypothesis.HealthCheck.too_slow],
+            database=None,
+            max_examples=1000,
+            verbosity=hypothesis.Verbosity.verbose))
+else:
+    hypothesis.settings.register_profile(
+        "sandcastle",
+        hypothesis.settings(
+            derandomize=True,
+            suppress_health_check=[hypothesis.HealthCheck.too_slow],
+            database=None,
+            max_examples=100,
+            min_satisfying_examples=1,
+            verbosity=hypothesis.Verbosity.verbose))
+    hypothesis.settings.register_profile(
+        "dev",
+        hypothesis.settings(
+            suppress_health_check=[hypothesis.HealthCheck.too_slow],
+            database=None,
+            max_examples=10,
+            min_satisfying_examples=1,
+            verbosity=hypothesis.Verbosity.verbose))
+    hypothesis.settings.register_profile(
+        "debug",
+        hypothesis.settings(
+            suppress_health_check=[hypothesis.HealthCheck.too_slow],
+            database=None,
+            max_examples=1000,
+            min_satisfying_examples=1,
+            verbosity=hypothesis.Verbosity.verbose))
 
-hypothesis.settings.register_profile(
-    "dev",
-    hypothesis.settings(
-        suppress_health_check=[hypothesis.HealthCheck.too_slow],
-        database=None,
-        max_examples=10,
-        min_satisfying_examples=1,
-        verbosity=hypothesis.Verbosity.verbose))
-hypothesis.settings.register_profile(
-    "debug",
-    hypothesis.settings(
-        suppress_health_check=[hypothesis.HealthCheck.too_slow],
-        database=None,
-        max_examples=1000,
-        min_satisfying_examples=1,
-        verbosity=hypothesis.Verbosity.verbose))
 hypothesis.settings.load_profile(
     'sandcastle' if is_sandcastle() else os.getenv('CAFFE2_HYPOTHESIS_PROFILE',
                                                    'dev')


### PR DESCRIPTION
This setting has been deprecated in [hypythesis 3.56.0](https://github.com/HypothesisWorks/hypothesis/blob/d1b0df5b91051de7d3f9cea6550ce31e9f0ee2c8/hypothesis-python/docs/changes.rst#3560---2018-04-17) and recently has been removed in [hypothesis 4.x](https://github.com/HypothesisWorks/hypothesis/blob/d1b0df5b91051de7d3f9cea6550ce31e9f0ee2c8/hypothesis-python/docs/changes.rst#400---2019-01-14).