### PR TITLE
Switch to CUDA implementation if batch size >= 65536 for affine_grid

### DIFF
--- a/torch/nn/_functions/vision.py
+++ b/torch/nn/_functions/vision.py
@@ -6,7 +6,7 @@ from ..._jit_internal import weak_script
 @weak_script
 def affine_grid_generator(theta, size):
     # type: (Tensor, List[int]) -> Tensor
-    if theta.is_cuda and cudnn.enabled and cudnn.is_acceptable(theta) and len(size) == 4:
+    if theta.is_cuda and cudnn.enabled and cudnn.is_acceptable(theta) and len(size) == 4 and size[0] < 65536:
         N, C, H, W = size
         ret = torch.cudnn_affine_grid_generator(theta, N, C, H, W)
     else:


### PR DESCRIPTION
Changelog:

- Append a condition that switches to the native CUDA implementation for affine_grid

Fixes #16365 

cc: @fmassa 

