### PR TITLE
[JIT] Move tracer impls into cpp file

### DIFF
--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -40,7 +40,7 @@ thread_local std::shared_ptr<TracingState> tracing_state;
 } // namespace detail
 
 TORCH_API std::function<void()> pauseTracing() {
-  std::shared_ptr<tracer::TracingState> state = getTracingState();
+  const std::shared_ptr<tracer::TracingState>& state = getTracingState();
   tracer::setTracingState(nullptr);
 
   return [state]() { tracer::setTracingState(state); };

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -39,11 +39,24 @@ thread_local std::shared_ptr<TracingState> tracing_state;
 
 } // namespace detail
 
+// Hack to emulate a lambda with move capture on non-c++11 targets
+// This is to make clang-tidy happy about copying the TracingState shared
+// ptr.
+struct ResumeTracingFunctor {
+  ResumeTracingFunctor(std::shared_ptr<tracer::TracingState> &&state) : state_(state) {}
+  void operator() () {
+    tracer::setTracingState(state_);
+  }
+
+ private:
+   std::shared_ptr<tracer::TracingState> state_;
+};
+
 TORCH_API std::function<void()> pauseTracing() {
-  const std::shared_ptr<tracer::TracingState>& state = getTracingState();
+  std::shared_ptr<tracer::TracingState> state = getTracingState();
   tracer::setTracingState(nullptr);
 
-  return [state]() { tracer::setTracingState(state); };
+  return ResumeTracingFunctor(std::move(state));
 }
 
  void delValueTrace(const Variable& var) {

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -39,6 +39,13 @@ thread_local std::shared_ptr<TracingState> tracing_state;
 
 } // namespace detail
 
+TORCH_API std::function<void()> pauseTracing() {
+  std::shared_ptr<tracer::TracingState> state = getTracingState();
+  tracer::setTracingState(nullptr);
+
+  return [state]() { tracer::setTracingState(state); };
+}
+
  void delValueTrace(const Variable& var) {
   AT_ASSERT(var.defined());
   auto& env_stack = getTracingState()->env_stack;
@@ -119,6 +126,134 @@ Value* getValueTrace(const IValue& var) {
     oss << "Unknown type used in value trace lookup!";
     throw std::runtime_error(oss.str());
   }
+}
+
+// allow tracing of tuples passed to List[Tensor] or Tuple[Tensor...] arguments
+// One might merge getValueTrace and getNestedValueTrace after checking that
+// casting to IValue instead  of Variable is OK
+Value* getNestedValueTrace(const IValue& v) {
+  auto& state = getTracingState();
+  if (v.isTensorList()) {
+    return state->graph
+        ->insertNode(state->graph->createList(
+            DynamicType::get(),
+            fmap(
+                v.toTensorListRef(),
+                [](const IValue& val) { return getNestedValueTrace(val); })))
+        ->output();
+  } else if (v.isTuple()) {
+    return state->graph
+        ->insertNode(state->graph->createTuple(fmap(
+            v.toTuple()->elements(),
+            [](const IValue& val) { return getNestedValueTrace(val); })))
+        ->output();
+  }
+  return getValueTrace(v.toTensor());
+}
+
+Value* getOutputTrace(
+    const std::shared_ptr<TracingState>& state,
+    const Variable& var) {
+  if (!var.defined()) {
+    Node* n = state->graph->createUndefined();
+    return state->graph->insertNode(n)->output();
+  }
+
+  auto& value_map = getTracingState()->env_stack.back().value_map;
+  auto it = value_map.find(var);
+  if (it == value_map.end()) {
+    std::ostringstream os;
+    os << "output of traced region did not have observable "
+       << "data dependence with trace inputs; this probably indicates your program "
+       << "cannot be understood by the tracer.";
+    throw std::runtime_error(os.str());
+  }
+  return it->second;
+}
+
+Value* getNestedOutputTrace(
+    const std::shared_ptr<TracingState>& state,
+    const IValue& iv) {
+  if (iv.isTensor()) {
+    return getOutputTrace(state, iv.toTensor());
+  } else if (iv.isTuple()) {
+    const auto& elems = iv.toTuple()->elements();
+    auto tuple_node = state->graph->createTuple(
+        fmap(elems, [&state](const IValue& iv) {
+          return getNestedOutputTrace(state, iv);
+        }));
+    state->graph->insertNode(tuple_node);
+    return tuple_node->output();
+  } else {
+    AT_ERROR(
+        "Only tensors or tuples of tensors can be output from traced functions");
+  }
+}
+
+// Start tracing, treating 'inputs' as inputs to the trace, which can be
+// varied on subsequent invocations of the trace.  Any other variables
+// will be treated as constants.
+std::pair<std::shared_ptr<TracingState>, Stack> enter(Stack inputs) {
+  if (isTracing()) {
+    AT_ERROR("Tracing can't be nested");
+  }
+  auto state = std::make_shared<TracingState>();
+  setTracingState(state);
+  // XXX: this function mutates input
+  const std::function<IValue(IValue, TypePtr, Value*)> add_input =
+      [&](IValue input, TypePtr type, Value* value) -> IValue {
+    value->setType(type);
+    if (type->isSubtypeOf(DynamicType::get())) {
+      auto input_tensor = input.toTensor();
+      auto name = Variable(input_tensor).name();
+      auto& value_map = state->env_stack.back().value_map;
+      if (value_map.find(input_tensor) != value_map.end()) {
+        input_tensor = input_tensor.view(input_tensor.sizes());
+      }
+      value->setUniqueName(name);
+      value_map[input_tensor] = value;
+      return input_tensor;
+    } else if (auto tuple_type = type->cast<TupleType>()) {
+      auto unpack_node =
+          state->graph->insertNode(state->graph->createTupleUnpack(value));
+      auto elem_values = unpack_node->outputs();
+      auto elem_types = tuple_type->elements();
+      Stack elems = input.toTuple()->elements();
+      size_t num_elems = elems.size();
+      AT_ASSERT(
+          elem_values.size() == num_elems && elem_types.size() == num_elems);
+      for (size_t i = 0; i < num_elems; ++i) {
+        elems[i] = add_input(elems[i], elem_types[i], elem_values[i]);
+      }
+      return Tuple::create(std::move(elems));
+    } else {
+      AT_ERROR(
+          "Only tensors or tuples of tensors can be inputs to traced functions");
+    }
+  };
+  for (IValue& input : inputs) {
+    input = add_input(
+        input, incompleteInferTypeFrom(input), state->graph->addInput());
+  }
+  return std::make_pair(state, inputs);
+}
+
+// Exit a trace, treating 'outputs' as the outputs of the trace.  These
+// are the variables whose values will be computed upon subsequent
+// invocations of the trace.
+void exit(const Stack& outputs) {
+  auto& state = getTracingState();
+  size_t i = 0;
+  for (auto& output : outputs) {
+    state->graph->registerOutput(getNestedOutputTrace(state, output));
+    i++;
+  }
+  setTracingState(nullptr);
+}
+
+// Abort tracing. Used to reset the state in case of errors.
+void abandon() {
+  setTracingState(nullptr);
 }
 
 void setValueTrace(const IValue& v, Value* value) {
@@ -336,6 +471,29 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
       graph->insertNode(graph->createNumToTensor(node->output()))->output();
   setValueTrace(size_var, ten);
   return size_var;
+}
+
+void ensureUniqueIfOutOfPlaced(
+    const char* name,
+    const at::Tensor& tensor) {
+  auto& state = getTracingState();
+  if (state && state->force_outplace == false) {
+    // If we're not converting in-place ops to out-of-place, this check is
+    // unnecessary
+    return;
+  }
+  auto aliases = tensor.storage().use_count();
+  if (isTracing() && aliases > 1) {
+    std::stringstream ss;
+    ss << "There are " << aliases
+       << " live references to the data region being modified when tracing in-place operator "
+       << name
+       << ". This might cause the trace to be incorrect, because all other views "
+       << "that also reference this data will not not reflect this change in the trace! "
+       << "On the other hand, if all other views use the same memory chunk, but are disjoint (e.g. "
+       << "are outputs of torch.split), this might still be safe.";
+    warn(ss.str().c_str());
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -51,142 +51,25 @@ TORCH_API void setValueTrace(const IValue& v, Value* value);
 
 TORCH_API void delValueTrace(const Variable& var);
 
-inline std::function<void()> pauseTracing() {
-  std::shared_ptr<tracer::TracingState> state = getTracingState();
-  tracer::setTracingState(nullptr);
-
-  return [state]() { tracer::setTracingState(state); };
-}
+TORCH_API std::function<void()> pauseTracing();
 
 TORCH_API Value* getValueTrace(const IValue& var);
 
-// allow tracing of tuples passed to List[Tensor] or Tuple[Tensor...] arguments
-// One might merge getValueTrace and getNestedValueTrace after checking that
-// casting to IValue instead  of Variable is OK
-inline Value* getNestedValueTrace(const IValue& v) {
-  auto& state = getTracingState();
-  if (v.isTensorList()) {
-    return state->graph
-        ->insertNode(state->graph->createList(
-            DynamicType::get(),
-            fmap(
-                v.toTensorListRef(),
-                [](const IValue& val) { return getNestedValueTrace(val); })))
-        ->output();
-  } else if (v.isTuple()) {
-    return state->graph
-        ->insertNode(state->graph->createTuple(fmap(
-            v.toTuple()->elements(),
-            [](const IValue& val) { return getNestedValueTrace(val); })))
-        ->output();
-  }
-  return getValueTrace(v.toTensor());
-}
+TORCH_API Value* getNestedValueTrace(const IValue& v);
 
-inline Value* getOutputTrace(
+TORCH_API Value* getOutputTrace(
     const std::shared_ptr<TracingState>& state,
-    const Variable& var) {
-  if (!var.defined()) {
-    Node* n = state->graph->createUndefined();
-    return state->graph->insertNode(n)->output();
-  }
+    const Variable& var);
 
-  auto& value_map = getTracingState()->env_stack.back().value_map;
-  auto it = value_map.find(var);
-  if (it == value_map.end()) {
-    std::ostringstream os;
-    os << "output of traced region did not have observable "
-       << "data dependence with trace inputs; this probably indicates your program "
-       << "cannot be understood by the tracer.";
-    throw std::runtime_error(os.str());
-  }
-  return it->second;
-}
-
-inline Value* getNestedOutputTrace(
+TORCH_API Value* getNestedOutputTrace(
     const std::shared_ptr<TracingState>& state,
-    const IValue& iv) {
-  if (iv.isTensor()) {
-    return getOutputTrace(state, iv.toTensor());
-  } else if (iv.isTuple()) {
-    const auto& elems = iv.toTuple()->elements();
-    auto tuple_node = state->graph->createTuple(
-        fmap(elems, [&state](const IValue& iv) {
-          return getNestedOutputTrace(state, iv);
-        }));
-    state->graph->insertNode(tuple_node);
-    return tuple_node->output();
-  } else {
-    AT_ERROR(
-        "Only tensors or tuples of tensors can be output from traced functions");
-  }
-}
+    const IValue& iv);
 
-// Start tracing, treating 'inputs' as inputs to the trace, which can be
-// varied on subsequent invocations of the trace.  Any other variables
-// will be treated as constants.
-inline std::pair<std::shared_ptr<TracingState>, Stack> enter(Stack inputs) {
-  if (isTracing()) {
-    AT_ERROR("Tracing can't be nested");
-  }
-  auto state = std::make_shared<TracingState>();
-  setTracingState(state);
-  // XXX: this function mutates input
-  const std::function<IValue(IValue, TypePtr, Value*)> add_input =
-      [&](IValue input, TypePtr type, Value* value) -> IValue {
-    value->setType(type);
-    if (type->isSubtypeOf(DynamicType::get())) {
-      auto input_tensor = input.toTensor();
-      auto name = Variable(input_tensor).name();
-      auto& value_map = state->env_stack.back().value_map;
-      if (value_map.find(input_tensor) != value_map.end()) {
-        input_tensor = input_tensor.view(input_tensor.sizes());
-      }
-      value->setUniqueName(name);
-      value_map[input_tensor] = value;
-      return input_tensor;
-    } else if (auto tuple_type = type->cast<TupleType>()) {
-      auto unpack_node =
-          state->graph->insertNode(state->graph->createTupleUnpack(value));
-      auto elem_values = unpack_node->outputs();
-      auto elem_types = tuple_type->elements();
-      Stack elems = input.toTuple()->elements();
-      size_t num_elems = elems.size();
-      AT_ASSERT(
-          elem_values.size() == num_elems && elem_types.size() == num_elems);
-      for (size_t i = 0; i < num_elems; ++i) {
-        elems[i] = add_input(elems[i], elem_types[i], elem_values[i]);
-      }
-      return Tuple::create(std::move(elems));
-    } else {
-      AT_ERROR(
-          "Only tensors or tuples of tensors can be inputs to traced functions");
-    }
-  };
-  for (IValue& input : inputs) {
-    input = add_input(
-        input, incompleteInferTypeFrom(input), state->graph->addInput());
-  }
-  return std::make_pair(state, inputs);
-}
+TORCH_API std::pair<std::shared_ptr<TracingState>, Stack> enter(Stack inputs);
 
-// Exit a trace, treating 'outputs' as the outputs of the trace.  These
-// are the variables whose values will be computed upon subsequent
-// invocations of the trace.
-inline void exit(const Stack& outputs) {
-  auto& state = getTracingState();
-  size_t i = 0;
-  for (auto& output : outputs) {
-    state->graph->registerOutput(getNestedOutputTrace(state, output));
-    i++;
-  }
-  setTracingState(nullptr);
-}
+TORCH_API void exit(const Stack& outputs);
 
-// Abort tracing. Used to reset the state in case of errors.
-inline void abandon() {
-  setTracingState(nullptr);
-}
+TORCH_API void abandon();
 
 // NB: those serve both as an intermediate steps in addInputs below,
 // as well as the overloads that terminate template recursion
@@ -233,28 +116,9 @@ void addInputs(Node* n, const char* name, std::array<bool, N> value) {
       "Found an unsupported argument type in the JIT tracer. File a bug report.");
 }
 
-inline void ensureUniqueIfOutOfPlaced(
+TORCH_API void ensureUniqueIfOutOfPlaced(
     const char* name,
-    const at::Tensor& tensor) {
-  auto& state = getTracingState();
-  if (state && state->force_outplace == false) {
-    // If we're not converting in-place ops to out-of-place, this check is
-    // unnecessary
-    return;
-  }
-  auto aliases = tensor.storage().use_count();
-  if (isTracing() && aliases > 1) {
-    std::stringstream ss;
-    ss << "There are " << aliases
-       << " live references to the data region being modified when tracing in-place operator "
-       << name
-       << ". This might cause the trace to be incorrect, because all other views "
-       << "that also reference this data will not not reflect this change in the trace! "
-       << "On the other hand, if all other views use the same memory chunk, but are disjoint (e.g. "
-       << "are outputs of torch.split), this might still be safe.";
-    warn(ss.str().c_str());
-  }
-}
+    const at::Tensor& tensor);
 
 template <
     typename T,


### PR DESCRIPTION
Working on the tracer was really annoying because a lot of the implementations were in `tracer.h` and editing that file caused us to rebuild almost the whole world. So this moves all the implementations into tracer.cpp