### PR TITLE
Report the slowest 10 tests when using pytest

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -335,7 +335,7 @@ def get_executable_command(options):
     else:
         executable = [sys.executable]
     if options.pytest:
-        executable += ['-m', 'pytest']
+        executable += ['-m', 'pytest', '--durations=10']
     return executable
 
 


### PR DESCRIPTION
This flag is useful in identifying if a test is taking way too long like the ones in the following snippet when running the test suite with pytest. https://github.com/pytorch/pytorch/blob/9757ad35b0b56cf955f294e751de9b437f9bb4ff/test/common_utils.py#L814-L835