### PR TITLE
Fix lint errors introduced in pytorch/pytorch@ceece5d

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -745,6 +745,7 @@ def brute_pdist(inp, p=2):
     inds[torch.arange(n - 1, 1, -1, dtype=torch.int).cumsum(0)] += torch.arange(2, n, dtype=torch.int)
     return unroll[..., inds.cumsum(0)]
 
+
 def brute_cdist(x, y, p=2):
     r1 = x.shape[-2]
     r2 = y.shape[-2]

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1231,7 +1231,6 @@ class _TestTorchMixin(object):
             for dtype in [torch.float32, torch.float64]:
                 test_pdist_single((1000, 2), device, 2, dtype, False)
 
-
     def test_cdist_empty(self):
         devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
         for device in devices:


### PR DESCRIPTION
@ifedan 

```
./test/common_utils.py:748:1: E302 expected 2 blank lines, found 1
./test/test_torch.py:1235:5: E303 too many blank lines (2)
```