### PR TITLE
Fix SIOF in torch using caffe2 registry

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -58,11 +58,11 @@ OperatorBase::OperatorBase(const OperatorDef& operator_def, Workspace* ws)
 
 OperatorBase::OperatorBase(
     const c10::FunctionSchema& fn_schema,
-    const std::vector<c10::IValue>& inputs,
-    const std::vector<c10::IValue*>& outputs)
+    std::vector<c10::IValue> inputs,
+    std::vector<c10::IValue*> outputs)
     : fn_schema_(make_unique<c10::FunctionSchema>(std::move(fn_schema))),
-      ivalue_inputs_(inputs),
-      ivalue_outputs_(outputs) {
+      ivalue_inputs_(std::move(inputs)),
+      ivalue_outputs_(std::move(outputs)) {
   input_tensors_.resize(ivalue_inputs_.size());
   output_tensors_.resize(ivalue_outputs_.size());
 }
@@ -325,8 +325,8 @@ unique_ptr<OperatorBase> CreateOperator(
 
 void RunOperator(
     c10::Symbol name,
-    std::vector<c10::IValue>& inputs,
-    std::vector<c10::IValue*>& outputs) {
+    const std::vector<c10::IValue>& inputs,
+    const std::vector<c10::IValue*>& outputs) {
   auto fn_wrap =
       caffe2::FunctionSchemaRegistry()->Create(name.toUnqualString());
   CAFFE_ENFORCE(
@@ -376,8 +376,8 @@ C10_DEFINE_REGISTRY(
     FunctionSchemaOperatorRegistry,
     OperatorBase,
     const c10::FunctionSchema,
-    const std::vector<c10::IValue>&,
-    const std::vector<c10::IValue*>&);
+    std::vector<c10::IValue>,
+    std::vector<c10::IValue*>);
 
 C10_DEFINE_REGISTRY(FunctionSchemaRegistry, FunctionSchemaStorageBase);
 

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -37,8 +37,8 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   explicit OperatorBase(const OperatorDef& operator_def, Workspace* ws);
   explicit OperatorBase(
       const c10::FunctionSchema&,
-      const std::vector<c10::IValue>&,
-      const std::vector<c10::IValue*>&);
+      std::vector<c10::IValue>,
+      std::vector<c10::IValue*>);
 
   virtual ~OperatorBase() noexcept {}
 
@@ -593,8 +593,8 @@ class Operator : public OperatorBase {
   }
   explicit Operator(
       const c10::FunctionSchema& fn_schema,
-      const std::vector<c10::IValue>& inputs,
-      const std::vector<c10::IValue*>& outputs)
+      std::vector<c10::IValue> inputs,
+      std::vector<c10::IValue*> outputs)
       : OperatorBase(fn_schema, inputs, outputs) {
     // In the constructor, we switch to the device so that the child class
     // constructors will run on that device.
@@ -1144,8 +1144,8 @@ C10_DECLARE_REGISTRY(
     FunctionSchemaOperatorRegistry,
     OperatorBase,
     const c10::FunctionSchema,
-    const std::vector<c10::IValue>&,
-    const std::vector<c10::IValue*>&);
+    std::vector<c10::IValue>,
+    std::vector<c10::IValue*>);
 
 struct FunctionSchemaStorageBase {
   FunctionSchemaStorageBase() {}
@@ -1229,8 +1229,8 @@ CAFFE2_API unique_ptr<OperatorBase> CreateOperator(
 // instantiate and run the operator.
 CAFFE2_API void RunOperator(
     c10::Symbol name,
-    std::vector<c10::IValue>& inputs,
-    std::vector<c10::IValue*>& outputs);
+    const std::vector<c10::IValue>& inputs,
+    const std::vector<c10::IValue*>& outputs);
 
 CAFFE2_API const std::string OpRegistryKey(
     const std::string& op_type,

--- a/torch/csrc/jit/caffe2_operator.cpp
+++ b/torch/csrc/jit/caffe2_operator.cpp
@@ -9,7 +9,7 @@ Operator createOperatorFromCaffe2(const std::string& name) {
   auto fn_wrap = caffe2::FunctionSchemaRegistry()->Create(symbolic_name.toUnqualString());
   CAFFE_ENFORCE(
       fn_wrap,
-      "Operator not registered with FunctionSchema constructor.",
+      "Operator not registered with FunctionSchema constructor:",
       name);
   auto fn = fn_wrap->getSchema();
 

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -282,10 +282,10 @@ struct TORCH_API RegisterOperators {
 
   /// Requires declaration of the FunctionSchema with
   /// REGISTER_FUNCTION_SCHEMA_OPERATOR(name, ...)
-  static RegisterOperators&& Caffe2Operator(const std::string& name) {
+  static RegisterOperators Caffe2Operator(const std::string& name) {
     auto r = RegisterOperators();
     registerOperator(createOperatorFromCaffe2(name));
-    return std::move(r);
+    return r;
   }
 
   /// Creates a new operator from a name and implementation function (function

--- a/torch/csrc/jit/register_caffe2_ops.cpp
+++ b/torch/csrc/jit/register_caffe2_ops.cpp
@@ -1,0 +1,5 @@
+#include <jit/custom_operator.h>
+
+#define REGISTER_CAFFE2_OP(name) \
+  static caffe2::CAFFE2_STRUCT_OP_REGISTRATION_##name CAFFE2_STRUCT_OP_REGISTRATION_DEFN_TORCH_##name; \
+  static auto CAFFE2_OP_EXPORT_##name = torch::jit::RegisterOperators::Caffe2Operator(#name);


### PR DESCRIPTION
Summary:
This resolves the issues associated with caffe2 initialization (specifically the REGISTER_FUNCTION_SCHEMA_OPERATOR calls) being run after Torch's static op registration calls.

The fix employs a meyer's singleton wrapped by the constructor of a type.  Everything is placed inside a macro to make it easier for users to use.

Differential Revision: D13854306
