### PR TITLE
Expose RoIAlign to torch

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -33,6 +33,9 @@ inline Tensor GetSizedTensorWithOptions(
     at::IntList dims,
     at::TensorOptions options) {
   Tensor tensor = std::move(previous_tensor);
+  if (!tensor.defined()) {
+    return caffe2::empty(dims, options);
+  }
   if (tensor.GetDevice() == options.device() ||
       (!tensor.GetDevice().has_index() &&
        tensor.GetDeviceType() == options.device().type())) {

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -185,7 +185,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
         ival->isTensor(),
         "Output(int, DeviceType) is only available for IValues that store Tensors");
     Tensor tensor = caffe2::Tensor(ival->toTensor());
-    if (tensor.GetDeviceType() != type) {
+    if (!tensor.defined() || tensor.GetDeviceType() != type) {
       // Fix tensor type
       tensor = Tensor(type);
       auto at_tensor = at::Tensor(std::move(tensor.getIntrusivePtr()));

--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -181,8 +181,17 @@ to the end.)
     .Output(1, "mean", "Mean values for each feature vector")
     .Output(2, "stddev", "Standard deviations for each feature vector");
 
-} // namespace caffe2
+DEFINE_FUNCTION_SCHEMA_OPERATOR(
+    LayerNorm,
+    (std::vector<c10::Argument>{c10::Argument("input_0"),
+                                c10::Argument("axis", IntType::get()),
+                                c10::Argument("epsilon", FloatType::get())}),
+    (std::vector<c10::Argument>{c10::Argument("output_0"),
+                                c10::Argument("output_1"),
+                                c10::Argument("output_2")}),
+    LayerNormOp<CPUContext>);
 
+} // namespace caffe2
 
 // Register layer norm with c10
 namespace {

--- a/caffe2/operators/layer_norm_op.h
+++ b/caffe2/operators/layer_norm_op.h
@@ -11,13 +11,16 @@
 
 namespace caffe2 {
 
+DECLARE_FUNCTION_SCHEMA_OPERATOR(LayerNorm);
+
 template <class Context>
 class LayerNormOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  LayerNormOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<Context>(operator_def, ws),
+  template <class... Args>
+  LayerNormOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
         OP_SINGLE_ARG(int, "axis", axis_, 1),
         OP_SINGLE_ARG(float, "epsilon", epsilon_, 1e-5f) {}
 

--- a/caffe2/operators/roi_align_op.cc
+++ b/caffe2/operators/roi_align_op.cc
@@ -336,6 +336,20 @@ bool RoIAlignOp<float, CPUContext>::RunOnDevice() {
 
 REGISTER_CPU_OPERATOR(RoIAlign, RoIAlignOp<float, CPUContext>);
 
+using RoIAlignCPUFloatImpl = RoIAlignOp<float, CPUContext>;
+DEFINE_FUNCTION_SCHEMA_OPERATOR(
+    RoIAlign,
+    (std::vector<c10::Argument>{
+        c10::Argument("input_0"),
+        c10::Argument("input_1"),
+        c10::Argument("order", StringType::get()),
+        c10::Argument("spatial_scale", FloatType::get()),
+        c10::Argument("pooled_h", IntType::get()),
+        c10::Argument("pooled_w", IntType::get()),
+        c10::Argument("sampling_ratio", IntType::get())}),
+    (std::vector<c10::Argument>{c10::Argument("output_0")}),
+    RoIAlignCPUFloatImpl);
+
 // Input: X, rois; Output: Y
 OPERATOR_SCHEMA(RoIAlign)
     .NumInputs(2)

--- a/caffe2/operators/roi_align_op.h
+++ b/caffe2/operators/roi_align_op.h
@@ -9,11 +9,14 @@
 
 namespace caffe2 {
 
+DECLARE_FUNCTION_SCHEMA_OPERATOR(RoIAlign);
+
 template <typename T, class Context>
 class RoIAlignOp final : public Operator<Context> {
  public:
-  RoIAlignOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<Context>(operator_def, ws),
+  template <class... Args>
+  RoIAlignOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
         order_(StringToStorageOrder(
             this->template GetSingleArgument<string>("order", "NCHW"))),
         spatial_scale_(

--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -167,6 +167,21 @@ class TestLayerNormOp(serial.SerializedTestCase):
         torch.testing.assert_allclose(expected_mean, actual_mean)
         torch.testing.assert_allclose(expected_stdev, actual_stdev)
 
+    @given(X=hu.tensors(n=1), **hu.gcs)
+    def test_layer_norm_op_pytorch_2(self, X, gc, dc):
+        X = X[0]
+        if len(X.shape) == 1:
+            X = np.expand_dims(X, axis=0)
+        axis = np.random.randint(0, len(X.shape))
+        epsilon = 1e-4
+
+        expected_norm, expected_mean, expected_stdev = _layer_norm_ref(axis, epsilon, X)
+        actual_norm, actual_mean, actual_stdev = torch.ops._caffe2.LayerNorm(torch.tensor(X), axis, epsilon)
+
+        torch.testing.assert_allclose(expected_norm, actual_norm)
+        torch.testing.assert_allclose(expected_mean, actual_mean)
+        torch.testing.assert_allclose(expected_stdev, actual_stdev)
+
     @given(X=hu.tensor(min_dim=2), **hu.gcs)
     def test_layer_norm_brew_wrapper(self, X, gc, dc):
         axis = np.random.randint(0, len(X.shape))

--- a/caffe2/python/operator_test/torch_integration_test.py
+++ b/caffe2/python/operator_test/torch_integration_test.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import core, workspace
+import torch
+from hypothesis import given
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+
+class TorchIntegration(hu.HypothesisTestCase):
+    @given(
+        H=st.integers(min_value=50, max_value=100),
+        W=st.integers(min_value=50, max_value=100),
+        C=st.integers(min_value=1, max_value=3),
+        num_rois=st.integers(min_value=1, max_value=10),
+        pooled_size=st.sampled_from([7, 14])
+        )
+    def test_roi_align(self, H, W, C, num_rois, pooled_size):
+        X = np.random.randn(1, C, H, W).astype(np.float32)
+        R = np.zeros((num_rois, 5)).astype(np.float32)
+        for i in range(num_rois):
+            x = np.random.uniform(1, W - 1)
+            y = np.random.uniform(1, H - 1)
+            w = np.random.uniform(1, min(x, W - x))
+            h = np.random.uniform(1, min(y, H - y))
+            R[i] = [0, x, y, w, h]
+
+        def roialign_ref(X, R):
+            ref_op = core.CreateOperator(
+                "RoIAlign",
+                ["X_ref", "R_ref"],
+                ["Y_ref"],
+                order="NCHW",
+                spatial_scale=1.0,
+                pooled_h=pooled_size,
+                pooled_w=pooled_size,
+                sampling_ratio=0,
+            )
+            workspace.FeedBlob("X_ref", X)
+            workspace.FeedBlob("R_ref", R)
+            workspace.RunOperatorOnce(ref_op)
+            return workspace.FetchBlob("Y_ref")
+        Y_ref = torch.tensor(roialign_ref(X, R))
+        Y = torch.ops._caffe2.RoIAlign(
+                torch.tensor(X), torch.tensor(R),
+                "NCHW", 1., pooled_size, pooled_size, 0)
+        torch.testing.assert_allclose(Y, Y_ref)
+

--- a/torch/csrc/jit/caffe2_operator.cpp
+++ b/torch/csrc/jit/caffe2_operator.cpp
@@ -31,9 +31,7 @@ Operator createOperatorFromCaffe2(const std::string& name) {
       std::vector<c10::IValue*> outputs;
       for (size_t i = 0; i < output_size; ++i) {
         if (TensorType::get() == fn.returns()[i].type()) {
-          caffe2::Tensor tensor(caffe2::CPU);
-          auto at_tensor = at::Tensor(c10::C10Tensor(std::move(tensor)));
-          outputs_real.emplace_back(c10::IValue(at_tensor));
+          outputs_real.emplace_back(c10::IValue(at::Tensor()));
         } else {
           outputs_real.emplace_back(c10::IValue());
         }

--- a/torch/csrc/jit/register_caffe2_ops.cpp
+++ b/torch/csrc/jit/register_caffe2_ops.cpp
@@ -1,5 +1,8 @@
 #include <jit/custom_operator.h>
+#include "caffe2/operators/layer_norm_op.h"
 
 #define REGISTER_CAFFE2_OP(name) \
   static caffe2::CAFFE2_STRUCT_OP_REGISTRATION_##name CAFFE2_STRUCT_OP_REGISTRATION_DEFN_TORCH_##name; \
   static auto CAFFE2_OP_EXPORT_##name = torch::jit::RegisterOperators::Caffe2Operator(#name);
+
+REGISTER_CAFFE2_OP(LayerNorm);

--- a/torch/csrc/jit/register_caffe2_ops.cpp
+++ b/torch/csrc/jit/register_caffe2_ops.cpp
@@ -1,8 +1,10 @@
 #include <jit/custom_operator.h>
 #include "caffe2/operators/layer_norm_op.h"
+#include "caffe2/operators/roi_align_op.h"
 
 #define REGISTER_CAFFE2_OP(name) \
   static caffe2::CAFFE2_STRUCT_OP_REGISTRATION_##name CAFFE2_STRUCT_OP_REGISTRATION_DEFN_TORCH_##name; \
   static auto CAFFE2_OP_EXPORT_##name = torch::jit::RegisterOperators::Caffe2Operator(#name);
 
 REGISTER_CAFFE2_OP(LayerNorm);
+REGISTER_CAFFE2_OP(RoIAlign);


### PR DESCRIPTION
Summary: enable calling roialign (caffe2) from torch frontend

Differential Revision: D13855525
