### PR TITLE
LayerNorm Registration Example

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -33,6 +33,9 @@ inline Tensor GetSizedTensorWithOptions(
     at::IntList dims,
     at::TensorOptions options) {
   Tensor tensor = std::move(previous_tensor);
+  if (!tensor.defined()) {
+    return caffe2::empty(dims, options);
+  }
   if (tensor.GetDevice() == options.device() ||
       (!tensor.GetDevice().has_index() &&
        tensor.GetDeviceType() == options.device().type())) {

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -185,7 +185,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
         ival->isTensor(),
         "Output(int, DeviceType) is only available for IValues that store Tensors");
     Tensor tensor = caffe2::Tensor(ival->toTensor());
-    if (tensor.GetDeviceType() != type) {
+    if (!tensor.defined() || tensor.GetDeviceType() != type) {
       // Fix tensor type
       tensor = Tensor(type);
       auto at_tensor = at::Tensor(std::move(tensor.getIntrusivePtr()));

--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -181,8 +181,17 @@ to the end.)
     .Output(1, "mean", "Mean values for each feature vector")
     .Output(2, "stddev", "Standard deviations for each feature vector");
 
-} // namespace caffe2
+DEFINE_FUNCTION_SCHEMA_OPERATOR(
+    LayerNorm,
+    (std::vector<c10::Argument>{c10::Argument("input_0"),
+                                c10::Argument("axis", IntType::get()),
+                                c10::Argument("epsilon", FloatType::get())}),
+    (std::vector<c10::Argument>{c10::Argument("output_0"),
+                                c10::Argument("output_1"),
+                                c10::Argument("output_2")}),
+    LayerNormOp<CPUContext>);
 
+} // namespace caffe2
 
 // Register layer norm with c10
 namespace {

--- a/caffe2/operators/layer_norm_op.h
+++ b/caffe2/operators/layer_norm_op.h
@@ -11,13 +11,16 @@
 
 namespace caffe2 {
 
+DECLARE_FUNCTION_SCHEMA_OPERATOR(LayerNorm);
+
 template <class Context>
 class LayerNormOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  LayerNormOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<Context>(operator_def, ws),
+  template <class... Args>
+  LayerNormOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
         OP_SINGLE_ARG(int, "axis", axis_, 1),
         OP_SINGLE_ARG(float, "epsilon", epsilon_, 1e-5f) {}
 

--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -167,6 +167,21 @@ class TestLayerNormOp(serial.SerializedTestCase):
         torch.testing.assert_allclose(expected_mean, actual_mean)
         torch.testing.assert_allclose(expected_stdev, actual_stdev)
 
+    @given(X=hu.tensors(n=1), **hu.gcs)
+    def test_layer_norm_op_pytorch_2(self, X, gc, dc):
+        X = X[0]
+        if len(X.shape) == 1:
+            X = np.expand_dims(X, axis=0)
+        axis = np.random.randint(0, len(X.shape))
+        epsilon = 1e-4
+
+        expected_norm, expected_mean, expected_stdev = _layer_norm_ref(axis, epsilon, X)
+        actual_norm, actual_mean, actual_stdev = torch.ops._caffe2.LayerNorm(torch.tensor(X), axis, epsilon)
+
+        torch.testing.assert_allclose(expected_norm, actual_norm)
+        torch.testing.assert_allclose(expected_mean, actual_mean)
+        torch.testing.assert_allclose(expected_stdev, actual_stdev)
+
     @given(X=hu.tensor(min_dim=2), **hu.gcs)
     def test_layer_norm_brew_wrapper(self, X, gc, dc):
         axis = np.random.randint(0, len(X.shape))

--- a/torch/csrc/jit/caffe2_operator.cpp
+++ b/torch/csrc/jit/caffe2_operator.cpp
@@ -31,9 +31,7 @@ Operator createOperatorFromCaffe2(const std::string& name) {
       std::vector<c10::IValue*> outputs;
       for (size_t i = 0; i < output_size; ++i) {
         if (TensorType::get() == fn.returns()[i].type()) {
-          caffe2::Tensor tensor(caffe2::CPU);
-          auto at_tensor = at::Tensor(c10::C10Tensor(std::move(tensor)));
-          outputs_real.emplace_back(c10::IValue(at_tensor));
+          outputs_real.emplace_back(c10::IValue(at::Tensor()));
         } else {
           outputs_real.emplace_back(c10::IValue());
         }

--- a/torch/csrc/jit/register_caffe2_ops.cpp
+++ b/torch/csrc/jit/register_caffe2_ops.cpp
@@ -1,5 +1,8 @@
 #include <jit/custom_operator.h>
+#include "caffe2/operators/layer_norm_op.h"
 
 #define REGISTER_CAFFE2_OP(name) \
   static caffe2::CAFFE2_STRUCT_OP_REGISTRATION_##name CAFFE2_STRUCT_OP_REGISTRATION_DEFN_TORCH_##name; \
   static auto CAFFE2_OP_EXPORT_##name = torch::jit::RegisterOperators::Caffe2Operator(#name);
+
+REGISTER_CAFFE2_OP(LayerNorm);


### PR DESCRIPTION
Summary: This diff includes an example registration of a caffe2 op in torch.  A previous attempt ran into a static initialization order bug.

Differential Revision: D13854304
