### PR TITLE
Integrate PyTorch quantization APIs into ensemble export modules

### DIFF
--- a/aten/src/ATen/core/thread_pool.h
+++ b/aten/src/ATen/core/thread_pool.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <utility>
 
+#include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
 
 namespace c10 {
@@ -62,7 +63,9 @@ class CAFFE2_API ThreadPool : public c10::TaskThreadPoolBase {
  public:
   ThreadPool() = delete;
 
-  explicit ThreadPool(std::size_t pool_size, int numa_node_id = -1);
+  explicit ThreadPool(
+      std::size_t pool_size,
+      int numa_node_id = -1);
 
   ~ThreadPool();
 
@@ -96,6 +99,8 @@ class CAFFE2_API ThreadPool : public c10::TaskThreadPoolBase {
   // @brief Entry point for pool threads.
   void main_loop(std::size_t index);
 };
+
+CAFFE2_API void setNumThreads(size_t v);
 
 CAFFE2_API ThreadPool& global_work_queue();
 

--- a/caffe2/utils/thread_pool.h
+++ b/caffe2/utils/thread_pool.h
@@ -9,7 +9,9 @@ namespace caffe2 {
 
 class CAFFE2_API TaskThreadPool : public c10::ThreadPool {
  public:
-  explicit TaskThreadPool(std::size_t pool_size, int numa_node_id = -1)
+  explicit TaskThreadPool(
+      std::size_t pool_size,
+      int numa_node_id = -1)
       : ThreadPool(pool_size, numa_node_id) {}
 
   // TODO move this to ATen/core/thread_pool.h

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -493,7 +493,6 @@ std::vector<Symbol> findSimilarOperators(Symbol input_op) {
   return getRegistry().findSimilarOperators(input_op);
 }
 
-
 Operator& sig(const char* signature) {
   return *getRegistry().lookupByLiteral(signature);
 }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -75,6 +75,10 @@ struct Method {
     get_executor().run(stack);
   }
 
+  void run(Stack&& stack) {
+    run(stack);
+  }
+
   IValue operator()(std::vector<IValue> stack) {
     checkInputsAgainstSchema(stack);
     run(stack);


### PR DESCRIPTION
Summary: This gives us a boolean flag `quantize` on the `BeamSearch` module that allows us to apply FBGEMM quantization to a pretrained PyTorch model and export this to PyTorch native runtime.

Differential Revision: D13514776
