### PR TITLE
Allow generic containers as module inputs

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -917,6 +917,8 @@ template<> inline TypePtr getTypePtr<std::vector<double>>() { return ListType::o
 template<> inline TypePtr getTypePtr<std::vector<int64_t>>() { return ListType::ofInts(); }
 
 CAFFE2_API TypePtr incompleteInferTypeFrom(const IValue& value);
+CAFFE2_API TypePtr attemptToRecoverType(const IValue& input_ivalue);
+CAFFE2_API bool isSubvalueOf(const IValue& input_ivalue, TypePtr type);
 
 using TypeEnv = std::unordered_map<std::string, TypePtr>;
 struct MatchTypeReturn {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -149,6 +149,42 @@ TypePtr incompleteInferTypeFrom(const IValue& value) {
   AT_ERROR("Type cannot be accurately recovered from this IValue.");
 }
 
+// This attempts to recover the type from an IValue, including nested Generic
+// Lists. It only examines the first element of each generic container,
+// and if a generic container is empty returns typevar as the base element.
+// XXX: only used for better error messages, should not be used elsewhere
+TypePtr attemptToRecoverType(const IValue& input_ivalue) {
+  if (input_ivalue.isGenericList()) {
+    auto& ivalue_list = input_ivalue.toGenericListRef();
+    if (ivalue_list.size() == 0) {
+      return ListType::create(VarType::create("t"));
+    }
+    return ListType::create(attemptToRecoverType(ivalue_list[0]));
+  }
+  return incompleteInferTypeFrom(input_ivalue);
+}
+
+// Checks if input_ivalue is a subvalue of type.
+// Only examines the first element of generic containers
+bool isSubvalueOf(const IValue& input_ivalue, TypePtr type) {
+  auto ivalue = input_ivalue;
+  while (ivalue.isGenericList()) {
+    auto list_type = type->cast<ListType>();
+    if (!list_type) {
+      return false;
+    }
+    auto& ivalue_list = ivalue.toGenericListRef();
+    if (ivalue_list.size() == 0) {
+      return true;
+    }
+    type = list_type->getElementType();
+    ivalue = ivalue_list[0];
+  }
+  const TypePtr base_type = incompleteInferTypeFrom(ivalue);
+  return base_type->isSubtypeOf(type);
+}
+
+
 c10::optional<TypePtr> unifyTypes(const TypePtr& t1, const TypePtr& t2) {
   //cases that t1 == t2, or t1 is a type refinement of t2 and vice versa
   if (t1->isSubtypeOf(t2)) {

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -165,8 +165,7 @@ TypePtr attemptToRecoverType(const IValue& input_ivalue) {
 }
 
 // Checks if input_ivalue is a subvalue of type.
-bool isSubvalueOf(const IValue& input_ivalue, TypePtr type) {
-  auto ivalue = input_ivalue;
+bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
   if (ivalue.isGenericList()) {
     auto list_type = type->cast<ListType>();
     if (!list_type) {

--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -66,4 +66,26 @@ TEST(TorchScriptTest, TestNestedIValueModuleArgMatching) {
                   "position 0, but instead got value of type t[][][]") == 0);
 
   };
+
+  std::vector<torch::jit::IValue> gen_list;
+  std::vector<int64_t> int_list = {1, 2, 3};
+
+  gen_list.emplace_back(list);
+  gen_list.emplace_back(int_list);
+
+  try {
+    module->run_method("nested_loop", gen_list, b);
+    AT_ASSERT(false);
+  } catch (const c10::Error& error) {
+    //TODO: currently does not unify types across encounted generic lists,
+    //so the error message is not helpful here.
+    AT_ASSERT(
+        std::string(error.what_without_backtrace())
+            .find("Expected value of type Tensor[][] for argument 'a' in "
+                  "position 0, but instead got value of type Tensor[][]") == 0);
+
+  };
+
+
+
 }


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/16326

Previously we didn't handle module inputs which included Generic Lists. When checking whether a generic list if a subvalue of the input arg type, I currently recurse on every element of the list. This shouldn't be too slow since the innermost list will be specialized and we won't have to check it's elements. 

E.g. Tensor[][] -> GenericList [TensorList ]. 

The error message could be improved, but extracting the complete type of nested lists would have to deal with unifying types across lists / empty lists & typevars so I'm going to save that for a follow up PR. 





