### PR TITLE
Allow list and tuples to be passed as output_size to max_unpool1d

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7129,6 +7129,12 @@ class TestNNInit(TestCase):
         output, indices = F.max_pool1d(torch.randn([1, 1, 4]), 2, stride=2, return_indices=True)
         self.assertEqual(F.max_unpool1d(output, indices, 2), F.max_unpool1d(output, indices, 2, stride=2))
 
+        # Test list / tuple passed as argument to max_unpool1d
+        input = torch.randn([1, 1, 5])
+        output, indices = F.max_pool1d(input, 2, stride=2, return_indices=True)
+        self.assertEqual(F.max_unpool1d(output, indices, 2, stride=2, output_size=input.shape),
+                         F.max_unpool1d(output, indices, 2, stride=2, output_size=input.size()))
+
         # Test 2D
         output, indices = F.max_pool2d(torch.randn([1, 1, 4, 4]), 2, stride=2, return_indices=True)
         self.assertEqual(F.max_unpool2d(output, indices, 2), F.max_unpool2d(output, indices, 2, stride=2))

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -565,8 +565,12 @@ def max_unpool1d(input, indices, kernel_size, stride=None, padding=0,
     padding = _single(padding)
     output_size = _unpool_output_size(input, kernel_size, _stride, padding,
                                       output_size)
+    if isinstance(output_size, list):
+        output_size = output_size + [1]
+    else:
+        output_size = output_size + (1,)
     return torch._C._nn.max_unpool2d(input.unsqueeze(3), indices.unsqueeze(3),
-                                     output_size + type(output_size)([1])).squeeze(3)
+                                     output_size).squeeze(3)
 
 
 @weak_script

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -565,7 +565,8 @@ def max_unpool1d(input, indices, kernel_size, stride=None, padding=0,
     padding = _single(padding)
     output_size = _unpool_output_size(input, kernel_size, _stride, padding,
                                       output_size)
-    return torch._C._nn.max_unpool2d(input.unsqueeze(3), indices.unsqueeze(3), output_size + [1]).squeeze(3)
+    return torch._C._nn.max_unpool2d(input.unsqueeze(3), indices.unsqueeze(3),
+                                     output_size + type(output_size)([1])).squeeze(3)
 
 
 @weak_script


### PR DESCRIPTION
Changelog:
- Modify concantenation of [1] to a tuple by using cases for list and non-list types.

Test plan:
- Added a test case to compare the results between `list` and `tuple` (here `torch.Size()`)

Fixes https://github.com/pytorch/pytorch/issues/16486
