### PR TITLE
[ci] Enable stable docs build for v1.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,7 +749,7 @@ jobs:
           # stable release docs push. We keep an eternal PR open for merging
           # v1.0.1 -> master; everytime v1.0.1 is updated the following is run.
           elif [[ "${CIRCLE_BRANCH}" == "v1.0.1" ]]; then
-            export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/stable 1.0.0 dry_run") | docker exec -u jenkins -i "$id" bash) 2>&1'
+            export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/stable 1.0.0") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           # For open PRs: Do a dry_run of the docs build, don't push build
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,7 +749,7 @@ jobs:
           # stable release docs push. We keep an eternal PR open for merging
           # v1.0.1 -> master; everytime v1.0.1 is updated the following is run.
           elif [[ "${CIRCLE_BRANCH}" == "v1.0.1" ]]; then
-            export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/stable 1.0.0") | docker exec -u jenkins -i "$id" bash) 2>&1'
+            export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/stable 1.0.1") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           # For open PRs: Do a dry_run of the docs build, don't push build
           else


### PR DESCRIPTION
Test Plan:
- Already tested with dry_run mode using #16452. I pulled the docker image of the dry
  run and verified that the html of the docs looks fine.

Future:
- Backport all changes to master so someone reading master
  pytorch/pytorch .circleci/config.yml knows what is going on.

