### PR TITLE
Back out "Delete duplicate copy of THCCachingAllocator."

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -56,46 +56,6 @@ class DataPtr {
   DeleterFnPtr get_deleter() const {
     return ptr_.get_deleter();
   }
-  /**
-   * Compare the deleter in a DataPtr to expected_deleter.
-   * If it matches, replace the deleter with new_deleter
-   * and return true; otherwise, does nothing and returns
-   * false.
-   *
-   * In general, it is not safe to unconditionally set the
-   * deleter on a DataPtr, because you don't know what
-   * the deleter is, and thus will have a hard time properly
-   * disposing of the deleter without storing the original
-   * deleter (this is difficult to do, because DeleterFnPtr
-   * is not a closure, and because the context on DataPtr is
-   * only a single word, you generally don't have enough
-   * space to store both the original deleter and its context).
-   * However, in some cases, you know /exactly/ what the deleter
-   * is, and you have a new deleter that manually wraps
-   * the old one.  In this case, you can safely swap the deleter
-   * after asserting that the deleters line up.
-   *
-   * What are the requirements on new_deleter?  It must still
-   * properly dispose of the void* pointer passed in as its argument,
-   * where void* is whatever the context of the original deleter
-   * is.  So in general, you expect the new deleter to look something
-   * like this:
-   *
-   *      [](void* ptr) {
-   *        some_new_stuff(ptr);
-   *        get_orig_allocator()->raw_deleter(ptr);
-   *      }
-   *
-   * Note that it won't work to close over the original
-   * allocator; you don't have enough space to do that!  Also,
-   * it's unsafe to assume that the passed in pointer in
-   * question is the memory pointer in question; it might not
-   * be; be sure to read the source code of the Allocator
-   * in question to confirm this.
-   */
-  C10_NODISCARD bool compare_exchange_deleter(DeleterFnPtr expected_deleter, DeleterFnPtr new_deleter) {
-    return ptr_.compare_exchange_deleter(expected_deleter, new_deleter);
-  }
   Device device() const {
     return device_;
   }

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -514,7 +514,7 @@ struct THCCachingAllocator
 
 THCCachingAllocator caching_allocator;
 
-void raw_delete(void* ptr) {
+static void CudaCachingDeleter(void* ptr) {
   caching_allocator.free(ptr);
 }
 
@@ -529,10 +529,10 @@ struct CudaCachingAllocator : public Allocator {
     if (size != 0) {
       caching_allocator.malloc(&r, size, cuda::getCurrentCUDAStream(device));
     }
-    return {r, r, &raw_delete, Device(DeviceType::CUDA, device)};
+    return {r, r, &CudaCachingDeleter, Device(DeviceType::CUDA, device)};
   }
   DeleterFnPtr raw_deleter() const override {
-    return &raw_delete;
+    return &CudaCachingDeleter;
   }
 };
 

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -26,8 +26,6 @@ namespace cuda {
 namespace CUDACachingAllocator {
 
 C10_CUDA_API Allocator* get();
-// Invariant: &raw_delete == get()->raw_deleter()
-C10_CUDA_API void raw_delete(void* ptr);
 C10_CUDA_API void emptyCache();
 C10_CUDA_API void cacheInfo(int dev_id, size_t* cachedAndFree, size_t* largestBlock);
 C10_CUDA_API void* getBaseAllocation(void *ptr, size_t *size);

--- a/c10/util/UniqueVoidPtr.h
+++ b/c10/util/UniqueVoidPtr.h
@@ -67,12 +67,6 @@ class UniqueVoidPtr {
     return std::move(ctx_);
   }
 
-  C10_NODISCARD bool compare_exchange_deleter(DeleterFnPtr expected_deleter, DeleterFnPtr new_deleter) {
-    if (get_deleter() != expected_deleter) return false;
-    ctx_ = std::unique_ptr<void, DeleterFnPtr>(ctx_.release(), new_deleter);
-    return true;
-  }
-
   template <typename T>
   T* cast_context(DeleterFnPtr expected_deleter) const {
     if (get_deleter() != expected_deleter)

--- a/caffe2/core/THCCachingAllocator.cu
+++ b/caffe2/core/THCCachingAllocator.cu
@@ -1,0 +1,309 @@
+#include "caffe2/core/THCCachingAllocator_gpu.h"
+
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <unordered_map>
+
+#include <cuda_runtime_api.h>
+
+#include "caffe2/core/context_gpu.h"
+
+//
+// Yet another caching allocator for CUDA device allocations.
+//
+// - The allocator attempts to find the smallest cached block that will fit the
+//   requested size. If the block is larger than the requested size, it may be
+//   split. If no block is found, the allocator will delegate to cudaMalloc.
+// - If the cudaMalloc fails, the allocator will free all cached blocks that
+//   are not split and retry the allocation.
+// - Large (>1MB) and small allocation requests are handled separately. Large
+//   allocation requests can be filled by a cudaMalloc call of the exact size.
+//   Small requests will allocate and split a 1MB buffer, if necessary.
+//
+// With this allocator, allocations and frees should logically be considered
+// "usages" of the memory segment associated with streams, just like kernel
+// launches. The programmer must insert the proper synchronization if memory
+// segments are used from multiple streams.
+//
+// Thread Safety: the allocator is NOT thread safe. Calls to { Alloc, Free }
+// must be synchronized by the programmer.
+//
+
+namespace {
+
+const size_t kRoundSmall = 512; // round up small allocs to 512 bytes
+const size_t kRoundLarge = 131072; // round up large allocs to 128 KiB
+const size_t kSmallAlloc = 1048576; // largest "small" allocation is 1 MiB
+
+struct Block {
+  int device; // gpu
+  cudaStream_t stream; // allocation stream
+  size_t size; // block size in bytes
+  char* ptr; // memory address
+  bool allocated; // in-use flag
+  Block* prev; // prev block if split from a larger allocation
+  Block* next; // next block if split from a larger allocation
+  int event_count; // number of outstanding CUDA events
+
+  Block(int device, cudaStream_t stream, size_t size, char* ptr = nullptr)
+      : device(device),
+        stream(stream),
+        size(size),
+        ptr(ptr),
+        allocated(0),
+        prev(nullptr),
+        next(nullptr),
+        event_count(0) {}
+};
+
+static bool BlockComparator(const Block* a, const Block* b) {
+  if (a->device != b->device) {
+    return a->device < b->device;
+  }
+  if (a->stream != b->stream) {
+    return (uintptr_t)a->stream < (uintptr_t)b->stream;
+  }
+  if (a->size != b->size) {
+    return a->size < b->size;
+  }
+  return (uintptr_t)a->ptr < (uintptr_t)b->ptr;
+}
+
+static size_t roundSize(size_t size) {
+  if (size < kRoundSmall) {
+    size = kRoundSmall;
+  } else if (size < kSmallAlloc) {
+    size += kRoundSmall - 1 - (size - 1) % kRoundSmall;
+  } else {
+    size += kRoundLarge - 1 - (size - 1) % kRoundLarge;
+  }
+  return size;
+}
+
+} // namespace
+
+namespace caffe2 {
+
+struct THCCachingAllocatorImpl {
+  typedef bool (*Comparison)(const Block*, const Block*);
+  typedef std::set<Block*, Comparison> FreeBlocks;
+
+  // lock around all operations
+  std::mutex mutex;
+
+  // cached blocks larger than 1 MB
+  FreeBlocks largeBlocks_;
+
+  // cached blocks 1 MB or smaller
+  FreeBlocks smallBlocks_;
+
+  // allocated blocks by device pointer
+  std::unordered_map<void*, Block*> allocatedBlocks_;
+
+  THCCachingAllocatorImpl()
+      : largeBlocks_(BlockComparator), smallBlocks_(BlockComparator) {}
+
+  ~THCCachingAllocatorImpl() {
+    emptyCache();
+  }
+
+  /** allocates a block which is safe to use from the provided stream */
+  cudaError_t Alloc(void** devPtr, size_t size, cudaStream_t stream) {
+    int device;
+    cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) {
+      return err;
+    }
+
+    size = roundSize(size);
+    bool small = size <= kSmallAlloc;
+
+    Block search_key(device, stream, size);
+    auto& free_blocks = small ? smallBlocks_ : largeBlocks_;
+
+    Block* block = nullptr;
+    Block* remaining = nullptr;
+
+    auto it = free_blocks.lower_bound(&search_key);
+    if (it != free_blocks.end() && (*it)->device == device &&
+        (*it)->stream == stream) {
+      block = *it;
+      free_blocks.erase(it);
+    } else {
+      void* ptr;
+      size_t alloc_size = small ? kSmallAlloc : size;
+      err = cudaMallocRetry(device, &ptr, alloc_size);
+      if (err != cudaSuccess) {
+        return err;
+      }
+      block = new Block(device, stream, alloc_size, (char*)ptr);
+    }
+
+    if (block->size - size >= (small ? kRoundSmall : kSmallAlloc + 1)) {
+      remaining = block;
+
+      block = new Block(device, stream, size, block->ptr);
+      block->prev = remaining->prev;
+      if (block->prev) {
+        block->prev->next = block;
+      }
+      block->next = remaining;
+
+      remaining->prev = block;
+      remaining->ptr += size;
+      remaining->size -= size;
+      free_blocks.insert(remaining);
+    }
+
+    block->allocated = true;
+    allocatedBlocks_[block->ptr] = block;
+
+    *devPtr = (void*)block->ptr;
+    return cudaSuccess;
+  }
+
+  cudaError_t Free(void* ptr) {
+    if (!ptr) {
+      return cudaSuccess;
+    }
+
+    auto it = allocatedBlocks_.find(ptr);
+    if (it == allocatedBlocks_.end()) {
+      return cudaErrorInvalidDevicePointer;
+    }
+
+    Block* block = it->second;
+    allocatedBlocks_.erase(it);
+    block->allocated = false;
+
+    freeBlock(block);
+    return cudaSuccess;
+  }
+
+  /** returns cached blocks to the system allocator */
+  cudaError_t emptyCache() {
+    cudaError_t err =
+        freeBlocks(largeBlocks_, largeBlocks_.begin(), largeBlocks_.end());
+    if (err != cudaSuccess) {
+      return err;
+    }
+    err = freeBlocks(smallBlocks_, smallBlocks_.begin(), smallBlocks_.end());
+    if (err != cudaSuccess) {
+      return err;
+    }
+    return cudaSuccess;
+  }
+
+  /** moves a block into the free block list */
+  void freeBlock(Block* block) {
+    CAFFE_ENFORCE(!block->allocated && block->event_count == 0);
+    bool small = block->size <= kSmallAlloc;
+    auto& free_blocks = small ? smallBlocks_ : largeBlocks_;
+    tryMergeBlocks(block, block->prev, free_blocks);
+    tryMergeBlocks(block, block->next, free_blocks);
+    free_blocks.insert(block);
+  }
+
+  /** combine previously split blocks */
+  void tryMergeBlocks(Block* dst, Block* src, FreeBlocks& free_blocks) {
+    if (!src || src->allocated || src->event_count > 0) {
+      return;
+    }
+    if (dst->prev == src) {
+      dst->ptr = src->ptr;
+      dst->prev = src->prev;
+      if (dst->prev) {
+        dst->prev->next = dst;
+      }
+    } else {
+      dst->next = src->next;
+      if (dst->next) {
+        dst->next->prev = dst;
+      }
+    }
+    dst->size += src->size;
+    free_blocks.erase(src);
+    delete src;
+  }
+
+  cudaError_t cudaMallocRetry(int device, void** devPtr, size_t size) {
+    // Try cudaMalloc. If cudaMalloc fails, frees all non-split cached blocks
+    // and retries.
+    cudaError_t err = cudaMalloc(devPtr, size);
+    if (err != cudaSuccess) {
+      cudaGetLastError();
+      err = freeCachedBlocks(device);
+      if (err != cudaSuccess) {
+        return err;
+      }
+      err = cudaMalloc(devPtr, size);
+      if (err != cudaSuccess) {
+        return err;
+      }
+    }
+    return cudaSuccess;
+  }
+
+  cudaError_t freeCachedBlocks(int device) {
+    // Free all non-split cached blocks on device
+    Block lower_bound(device, nullptr, 0);
+    Block upper_bound(device + 1, nullptr, 0);
+
+    cudaError_t err = freeBlocks(
+        largeBlocks_,
+        largeBlocks_.lower_bound(&lower_bound),
+        largeBlocks_.lower_bound(&upper_bound));
+    if (err != cudaSuccess) {
+      return err;
+    }
+    err = freeBlocks(
+        smallBlocks_,
+        smallBlocks_.lower_bound(&lower_bound),
+        smallBlocks_.lower_bound(&upper_bound));
+    return err;
+  }
+
+  cudaError_t freeBlocks(
+      FreeBlocks& blocks,
+      FreeBlocks::iterator it,
+      FreeBlocks::iterator end) {
+    // Frees all non-split blocks between `it` and `end`
+    while (it != end) {
+      Block* block = *it;
+      if (!block->prev && !block->next) {
+        cudaError_t err = cudaFree((void*)block->ptr);
+        if (err != cudaSuccess) {
+          return err;
+        }
+        auto cur = it;
+        ++it;
+        blocks.erase(cur);
+        delete block;
+      } else {
+        ++it;
+      }
+    }
+    return cudaSuccess;
+  }
+};
+
+THCCachingAllocator::THCCachingAllocator()
+    : _impl(new THCCachingAllocatorImpl()) {}
+
+THCCachingAllocator::~THCCachingAllocator() {
+  delete _impl;
+}
+
+cudaError_t
+THCCachingAllocator::Alloc(void** refPtr, size_t nbytes, cudaStream_t stream) {
+  return _impl->Alloc(refPtr, nbytes, stream);
+}
+
+cudaError_t THCCachingAllocator::Free(void* ptr) {
+  return _impl->Free(ptr);
+}
+
+} // namespace caffe2

--- a/caffe2/core/THCCachingAllocator_gpu.h
+++ b/caffe2/core/THCCachingAllocator_gpu.h
@@ -1,0 +1,24 @@
+#ifndef THC_CACHING_ALLOCATOR_H
+#define THC_CACHING_ALLOCATOR_H
+
+#include <cuda_runtime.h>
+
+namespace caffe2 {
+
+struct THCCachingAllocatorImpl;
+
+class THCCachingAllocator {
+ public:
+  THCCachingAllocator();
+  ~THCCachingAllocator();
+
+  cudaError_t Alloc(void** refPtr, size_t nbytes, cudaStream_t stream);
+  cudaError_t Free(void* ptr);
+
+ private:
+  THCCachingAllocatorImpl* _impl;
+};
+
+} // namespace caffe2
+
+#endif

--- a/caffe2/core/context_gpu.cu
+++ b/caffe2/core/context_gpu.cu
@@ -4,8 +4,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <c10/cuda/CUDACachingAllocator.h>
-
+#include "caffe2/core/THCCachingAllocator_gpu.h"
 #include "cub/util_allocator.cuh"
 
 // Needed to be included first to check the CAFFE2_USE_CUDNN macros.
@@ -160,6 +159,8 @@ CudaMemoryPoolType g_cuda_memory_pool_type;
 
 std::unique_ptr<cub::CachingDeviceAllocator> g_cub_allocator;
 
+std::unique_ptr<THCCachingAllocator> g_thc_allocator;
+
 // an unordered map that holds the map from the cuda memory pointer to the
 // device id that it is allocated from. This is used in the cuda memory pool
 // cases, where we need the device id to carry out the deletion.
@@ -273,6 +274,7 @@ static void Caffe2SetCUDAMemoryPool() {
     SetUpCub();
   } else if (FLAGS_caffe2_cuda_memory_pool == "thc") {
     g_cuda_memory_pool_type = CudaMemoryPoolType::THC;
+    g_thc_allocator.reset(new THCCachingAllocator());
   } else {
     CAFFE_THROW(
         "Unrecognized cuda memory pool type: ", FLAGS_caffe2_cuda_memory_pool);
@@ -403,121 +405,94 @@ struct DefaultCUDAAllocator final : public at::Allocator {
     std::lock_guard<std::mutex> lock(CUDAContext::mutex());
     // A one-time caffe2 cuda initializer.
     static Caffe2CudaInitializerHelper g_cuda_initializer_;
-    at::DataPtr r;
+    void* ptr = nullptr;
 
     if (FLAGS_caffe2_gpu_memory_tracking) {
       TrackMemoryAlloc(nbytes);
     }
-    void* ptr = nullptr;  // scrap space
-
-    // WARNING: If you update this switch statement, you must
-    // also update the switch statement in raw_deleter.
     switch (g_cuda_memory_pool_type) {
       case CudaMemoryPoolType::NONE:
         CUDA_ENFORCE(cudaMalloc(&ptr, nbytes));
-        r = {ptr, ptr, &DeleteNONE, at::Device(CUDA, CaffeCudaGetDevice())};
         if (FLAGS_caffe2_gpu_memory_tracking) {
-          g_cuda_device_affiliation[r.get()] = CaffeCudaGetDevice();
+          g_size_map[ptr] = nbytes;
+          g_cuda_device_affiliation[ptr] = CaffeCudaGetDevice();
         }
-        break;
+        return {ptr, ptr, &Delete, at::Device(CUDA, CaffeCudaGetDevice())};
       case CudaMemoryPoolType::CUB:
         CUDA_ENFORCE(g_cub_allocator->DeviceAllocate(&ptr, nbytes));
-        r = {ptr, ptr, &DeleteCUB, at::Device(CUDA, CaffeCudaGetDevice())};
-        // NB: device affiliation tracking is mandatory for CUB, as
-        // deleter must know what device a pointer lives on to free it.
-        g_cuda_device_affiliation[r.get()] = CaffeCudaGetDevice();
-        VLOG(2) << "CUB allocating pointer " << r.get() << " on device "
+        g_cuda_device_affiliation[ptr] = CaffeCudaGetDevice();
+        VLOG(2) << "CUB allocating pointer " << ptr << " on device "
                 << CaffeCudaGetDevice();
-        break;
-      case CudaMemoryPoolType::THC:
-        r = c10::cuda::CUDACachingAllocator::get()->allocate(nbytes);
         if (FLAGS_caffe2_gpu_memory_tracking) {
-          g_cuda_device_affiliation[r.get()] = CaffeCudaGetDevice();
-          auto b = r.compare_exchange_deleter(
-            &c10::cuda::CUDACachingAllocator::raw_delete,
-            &DeleteTHCWithTracking
-          );
-          AT_ASSERT(b);
+          g_size_map[ptr] = nbytes;
         }
-        break;
+        return {ptr, ptr, &Delete, at::Device(CUDA, CaffeCudaGetDevice())};
+      case CudaMemoryPoolType::THC:
+        CUDA_ENFORCE(g_thc_allocator->Alloc(&ptr, nbytes, 0 /* stream */));
+        if (FLAGS_caffe2_gpu_memory_tracking) {
+          g_size_map[ptr] = nbytes;
+          g_cuda_device_affiliation[ptr] = CaffeCudaGetDevice();
+        }
+        return {ptr, ptr, &Delete, at::Device(CUDA, CaffeCudaGetDevice())};
     }
-    if (FLAGS_caffe2_gpu_memory_tracking) {
-      g_size_map[r.get()] = nbytes;
-    }
-    return r;
+    return {nullptr, nullptr, &Delete, at::Device(CUDA, CaffeCudaGetDevice())};
   }
 
   at::DeleterFnPtr raw_deleter() const override {
-    // WARNING: This must be kept up-to-date the switch statement in allocate
-    switch (g_cuda_memory_pool_type) {
-      case CudaMemoryPoolType::NONE:
-        return &DeleteNONE;
-      case CudaMemoryPoolType::CUB:
-        return &DeleteCUB;
-      case CudaMemoryPoolType::THC:
-        if (FLAGS_caffe2_gpu_memory_tracking) {
-          return &DeleteTHCWithTracking;
-        } else {
-          return &c10::cuda::CUDACachingAllocator::raw_delete;
-        }
-    }
-    return nullptr;
+    return &Delete;
   }
 
  private:
-  // WARNING: You MUST take CUDAContext::mutex() before calling this function.
-  // NB: This should only be called when FLAGS_caffe2_gpu_memory_tracking is
-  // true.
-  static void UpdateSizeMapOnDelete(void* ptr) {
-    auto sz_it = g_size_map.find(ptr);
-    DCHECK(sz_it != g_size_map.end());
-    auto aff_it = g_cuda_device_affiliation.find(ptr);
-    DCHECK(aff_it != g_cuda_device_affiliation.end());
-    g_total_mem -= sz_it->second;
-    g_total_by_gpu_map[aff_it->second] -= sz_it->second;
-    g_size_map.erase(sz_it);
-  }
-
-  static void DeleteTHCWithTracking(void* ptr) {
-    std::lock_guard<std::mutex> lock(CUDAContext::mutex());
-    AT_ASSERT(FLAGS_caffe2_gpu_memory_tracking);
-    UpdateSizeMapOnDelete(ptr);
-    c10::cuda::CUDACachingAllocator::raw_delete(ptr);
-    g_cuda_device_affiliation.erase(g_cuda_device_affiliation.find(ptr));
-  }
-
-  static void DeleteNONE(void* ptr) {
+  static void Delete(void* ptr) {
+    // lock the mutex
     std::lock_guard<std::mutex> lock(CUDAContext::mutex());
     if (FLAGS_caffe2_gpu_memory_tracking) {
-      UpdateSizeMapOnDelete(ptr);
+      auto sz_it = g_size_map.find(ptr);
+      DCHECK(sz_it != g_size_map.end());
+      auto aff_it = g_cuda_device_affiliation.find(ptr);
+      DCHECK(aff_it != g_cuda_device_affiliation.end());
+      g_total_mem -= sz_it->second;
+      g_total_by_gpu_map[aff_it->second] -= sz_it->second;
+      g_size_map.erase(sz_it);
     }
-    // If memory pool is not set up, use simple cudaFree.
-    cudaError_t error = cudaFree(ptr);
-    // For some reason, in Python runtime we sometimes delete a data pointer
-    // after the cuda runtime exits - this is odd but is probably caused by
-    // a static workspace that pycaffe2 uses, and the destruction got
-    // entangled in some race condition. Anyway, since cuda runtime is
-    // exiting anyway, we will not need to worry about memory leak, so we
-    // basically ignore it. This is definitely not ideal but works for now.
-    if (error != cudaSuccess && error != cudaErrorCudartUnloading) {
-      LOG(FATAL) << "Error at: " << __FILE__ << ":" << __LINE__ << ": "
-                 << cudaGetErrorString(error);
-    }
-    if (FLAGS_caffe2_gpu_memory_tracking) {
-      g_cuda_device_affiliation.erase(g_cuda_device_affiliation.find(ptr));
-    }
-  }
 
-  static void DeleteCUB(void* ptr) {
-    std::lock_guard<std::mutex> lock(CUDAContext::mutex());
-    if (FLAGS_caffe2_gpu_memory_tracking) {
-      UpdateSizeMapOnDelete(ptr);
+    switch (g_cuda_memory_pool_type) {
+      case CudaMemoryPoolType::NONE: {
+        // If memory pool is not set up, use simple cudaFree.
+        cudaError_t error = cudaFree(ptr);
+        // For some reason, in Python runtime we sometimes delete a data pointer
+        // after the cuda runtime exits - this is odd but is probably caused by
+        // a static workspace that pycaffe2 uses, and the destruction got
+        // entangled in some race condition. Anyway, since cuda runtime is
+        // exiting anyway, we will not need to worry about memory leak, so we
+        // basically ignore it. This is definitely not ideal but works for now.
+        if (error != cudaSuccess && error != cudaErrorCudartUnloading) {
+          LOG(FATAL) << "Error at: " << __FILE__ << ":" << __LINE__ << ": "
+                     << cudaGetErrorString(error);
+        }
+
+        if (FLAGS_caffe2_gpu_memory_tracking) {
+          g_cuda_device_affiliation.erase(g_cuda_device_affiliation.find(ptr));
+        }
+
+        break;
+      }
+      case CudaMemoryPoolType::CUB: {
+        auto it = g_cuda_device_affiliation.find(ptr);
+        DCHECK(it != g_cuda_device_affiliation.end());
+        VLOG(2) << "CUB freeing pointer " << ptr << " on device " << it->second;
+        CUDA_ENFORCE(g_cub_allocator->DeviceFree(it->second, ptr));
+        g_cuda_device_affiliation.erase(it);
+        break;
+      }
+      case CudaMemoryPoolType::THC: {
+        CUDA_ENFORCE(g_thc_allocator->Free(ptr));
+        if (FLAGS_caffe2_gpu_memory_tracking) {
+          g_cuda_device_affiliation.erase(g_cuda_device_affiliation.find(ptr));
+        }
+        break;
+      }
     }
-    auto it = g_cuda_device_affiliation.find(ptr);
-    DCHECK(it != g_cuda_device_affiliation.end());
-    VLOG(2) << "CUB freeing pointer " << ptr << " on device " << it->second;
-    CUDA_ENFORCE(g_cub_allocator->DeviceFree(it->second, ptr));
-    g_cuda_device_affiliation.erase(it);
   }
 };
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16510 Back out "Delete duplicate copy of THCCachingAllocator."**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13863610/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16513 Add compare_exchange_deleter to DataPtr/UniqueVoidPtr&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13864245/)

This diff was supposed to be memory usage neutral, but based on
some internal flows involving cuDNN, it was not. Reverting pending
further investigation.

Original commit changeset: 03f1ebf7f11c

Differential Revision: [D13863610](https://our.internmc.facebook.com/intern/diff/D13863610/)