### PR TITLE
Add compare_exchange_deleter to DataPtr/UniqueVoidPtr

### DIFF
--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -56,6 +56,46 @@ class DataPtr {
   DeleterFnPtr get_deleter() const {
     return ptr_.get_deleter();
   }
+  /**
+   * Compare the deleter in a DataPtr to expected_deleter.
+   * If it matches, replace the deleter with new_deleter
+   * and return true; otherwise, does nothing and returns
+   * false.
+   *
+   * In general, it is not safe to unconditionally set the
+   * deleter on a DataPtr, because you don't know what
+   * the deleter is, and thus will have a hard time properly
+   * disposing of the deleter without storing the original
+   * deleter (this is difficult to do, because DeleterFnPtr
+   * is not a closure, and because the context on DataPtr is
+   * only a single word, you generally don't have enough
+   * space to store both the original deleter and its context).
+   * However, in some cases, you know /exactly/ what the deleter
+   * is, and you have a new deleter that manually wraps
+   * the old one.  In this case, you can safely swap the deleter
+   * after asserting that the deleters line up.
+   *
+   * What are the requirements on new_deleter?  It must still
+   * properly dispose of the void* pointer passed in as its argument,
+   * where void* is whatever the context of the original deleter
+   * is.  So in general, you expect the new deleter to look something
+   * like this:
+   *
+   *      [](void* ptr) {
+   *        some_new_stuff(ptr);
+   *        get_orig_allocator()->raw_deleter(ptr);
+   *      }
+   *
+   * Note that it won't work to close over the original
+   * allocator; you don't have enough space to do that!  Also,
+   * it's unsafe to assume that the passed in pointer in
+   * question is the memory pointer in question; it might not
+   * be; be sure to read the source code of the Allocator
+   * in question to confirm this.
+   */
+  C10_NODISCARD bool compare_exchange_deleter(DeleterFnPtr expected_deleter, DeleterFnPtr new_deleter) {
+    return ptr_.compare_exchange_deleter(expected_deleter, new_deleter);
+  }
   Device device() const {
     return device_;
   }

--- a/c10/util/UniqueVoidPtr.h
+++ b/c10/util/UniqueVoidPtr.h
@@ -66,6 +66,11 @@ class UniqueVoidPtr {
   std::unique_ptr<void, DeleterFnPtr>&& move_context() {
     return std::move(ctx_);
   }
+  C10_NODISCARD bool compare_exchange_deleter(DeleterFnPtr expected_deleter, DeleterFnPtr new_deleter) {
+    if (get_deleter() != expected_deleter) return false;
+    ctx_ = std::unique_ptr<void, DeleterFnPtr>(ctx_.release(), new_deleter);
+    return true;
+  }
 
   template <typename T>
   T* cast_context(DeleterFnPtr expected_deleter) const {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16510 Back out "Delete duplicate copy of THCCachingAllocator."&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13863610/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16513 Add compare_exchange_deleter to DataPtr/UniqueVoidPtr**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13864245/)

compare_exchange_deleter makes it easier to replace a
deleter on a DataPtr with a new one, without requiring
allocating another closure to hold the old deleter.
See comment for details.

This diff was originally landed as part of D13762540
(#16226) but we are reverting that diff D13863610 (#16510)

Differential Revision: [D13864245](https://our.internmc.facebook.com/intern/diff/D13864245/)