### PR TITLE
Reset grad attribute when called using del

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1140,6 +1140,21 @@ class TestAutograd(TestCase):
                             self.assertIs(dtype, output.dtype)
                             self.assertEqual(1, output.get_device())
 
+    def test_attribute_deletion(self):
+        x = torch.randn((5, 5), requires_grad=True)
+        del x.grad
+        self.assertIsNone(x.grad)
+        with self.assertRaises(RuntimeError):
+            del x.data
+        with self.assertRaises(TypeError):
+            x.data = None
+        with self.assertRaises(RuntimeError):
+            del x.requires_grad
+        with self.assertRaises(RuntimeError):
+            del x._grad_fn
+        with self.assertRaises(RuntimeError):
+            del x._backward_hooks
+
     def test_grad_assignment(self):
         x = torch.randn(5, 5)
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -184,6 +184,7 @@ PyObject *THPVariable_get_grad_fn(THPVariable *self)
 static int THPVariable_set_grad_fn(THPVariable *self, PyObject *obj)
 {
   HANDLE_TH_ERRORS
+  THPUtils_assertRet(-1, obj, "Deletion of _grad_fn not allowed. Detach tensor instead!");
   THPUtils_assertRet(-1, obj == Py_None, "_grad_fn can be only set to None");
   self->cdata.detach_();
   return 0;
@@ -216,9 +217,11 @@ static PyObject * THPVariable_get_data(THPVariable *self)
 int THPVariable_set_data(THPVariable *self, PyObject *data)
 {
   HANDLE_TH_ERRORS
+  THPUtils_assertRet(-1, data, "Deleting tensor data is not allowed. Delete tensor instead!");
   if (!THPVariable_Check(data)) {
     throw torch::TypeError("Variable data has to be a tensor, but got %s", Py_TYPE(data)->tp_name);
   }
+
   self->cdata.set_data(THPVariable_UnpackData(data));
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
@@ -235,7 +238,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad)
 {
   HANDLE_TH_ERRORS
   auto& var = self->cdata;
-  if (py_grad == Py_None) {
+  if (!py_grad || py_grad == Py_None) {
     var.grad().reset();
     return 0;
   }
@@ -299,7 +302,7 @@ PyObject *THPVariable_get_requires_grad(THPVariable *self)
 int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj)
 {
   HANDLE_TH_ERRORS
-  THPUtils_assertRet(-1, PyBool_Check(obj), "requires_grad must be a bool");
+  THPUtils_assertRet(-1, obj && PyBool_Check(obj), "requires_grad must be a bool");
   auto& var = self->cdata;
   auto requires_grad = (obj == Py_True);
   if (!var.is_leaf()) {
@@ -336,6 +339,7 @@ PyObject *THPVariable_get_backwards_hooks(THPVariable *self)
 int THPVariable_set_backwards_hooks(THPVariable *self, PyObject *obj)
 {
   HANDLE_TH_ERRORS
+  THPUtils_assertRet(-1, obj, "Deletion of _backwards_hooks not allowed!");
   if (obj == Py_None) {
     obj = nullptr;
   }


### PR DESCRIPTION
del Tensor.grad set PyObject to nullptr
and Tensor.grad = None set PyObject to Py_None
Handling both the cases now
fixes ##16471
