### PR TITLE
Fix type-o in unsupported data type error message

### DIFF
--- a/caffe2/operators/batch_gather_ops.cu
+++ b/caffe2/operators/batch_gather_ops.cu
@@ -128,8 +128,8 @@ bool BatchGatherGradientOp<CUDAContext>::DoRunWithOtherType2() {
   CAFFE_THROW(
       "BatchGatherGradient is not implemented on tensor of type ",
       Input(DATA).meta().name(),
-      "Consider adding it a type in the list DispatchHelper or implementing "
-      "a generic version (which won't work for duplicated indices though)");
+      "consider adding it as a type in the DispatchHelper list or implementing"
+      " a generic version (which won't work for duplicated indices though)");
 }
 
 REGISTER_CUDA_OPERATOR(BatchGather, BatchGatherOp<CUDAContext>);

--- a/caffe2/operators/batch_gather_ops.h
+++ b/caffe2/operators/batch_gather_ops.h
@@ -128,8 +128,9 @@ class BatchGatherGradientOp final : public Operator<Context> {
     CAFFE_THROW(
         "BatchGatherGradient is not implemented on tensor of type ",
         Input(DATA).meta().name(),
-        "Consider adding it a type in the list DispatchHelper or implementing "
-        "a generic version (which won't work for duplicated indices though)");
+        "consider adding it as a type in the DispatchHelper list or "
+        "implementing a generic version (which won't work for "
+        "duplicated indices though)");
   }
 
   INPUT_TAGS(DATA, INDICES, GRAD);

--- a/caffe2/operators/map_ops.h
+++ b/caffe2/operators/map_ops.h
@@ -89,7 +89,7 @@ class CreateMapOp final : public Operator<Context> {
     CAFFE_THROW(
         "CreateMap is not implemented on value tensor of type ",
         DataTypeToTypeMeta(value_dtype).name(),
-        "Consider adding it a type in the list DispatchHelper");
+        "consider adding it as a type in the DispatchHelper list");
   }
 
   OUTPUT_TAGS(MAP);
@@ -140,7 +140,7 @@ class KeyValueToMapOp final : public Operator<Context> {
     CAFFE_THROW(
         "KeyValueToMap is not implemented on value tensor of type ",
         Input(VALUES).dtype().name(),
-        "Consider adding it a type in the list DispatchHelper");
+        "consider adding it as a type in the DispatchHelper list");
   }
 
   INPUT_TAGS(KEYS, VALUES);

--- a/caffe2/operators/sparse_to_dense_op.h
+++ b/caffe2/operators/sparse_to_dense_op.h
@@ -107,8 +107,9 @@ class SparseToDenseOp final : public Operator<Context> {
     CAFFE_THROW(
         "SparseToDense is not implemented on tensor of type ",
         Input(VALUES).dtype().name(),
-        "Consider adding it a type in the list DispatchHelper or implementing "
-        "a generic version (which won't work for duplicated indices though)");
+        "consider adding it as a type in the DispatchHelper list or "
+        "implementing a generic version (which won't work for "
+        "duplicated indices though)");
   }
 
  private:


### PR DESCRIPTION
-In the case where an operator does not support a given data type
 an error message is emitted to alert the user, this message is
incorrectly structured. This commit adds to and rearranges the
error message to make it a little clearer.

