### PR TITLE
added example to clear ambiguity in torch.Tensor.view

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -8,7 +8,6 @@ from ._torch_docs import parse_kwargs
 def add_docstr_all(method, docstr):
     add_docstr(getattr(torch._C._TensorBase, method), docstr)
 
-
 new_common_args = parse_kwargs("""
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.
@@ -2772,16 +2771,16 @@ Example::
     >>> z.size()
     torch.Size([2, 8])
 
-    >>> a=torch.randn((1,2,3,4))
-    >>> a.shape
+    >>> a = torch.randn(1, 2, 3, 4)
+    >>> a.size()
     torch.Size([1, 2, 3, 4])
-    >>> b = a.transpose(1,2)  # Swaps 2nd and 3rd dimension
-    >>> b.shape
+    >>> b = a.transpose(1, 2)  # Swaps 2nd and 3rd dimension
+    >>> b.size()
     torch.Size([1, 3, 2, 4])
-    >>> c = a.view((1, 3, 2, 4))  # Does not change tensor layout in memory
-    >>> c.shape
+    >>> c = a.view(1, 3, 2, 4)  # Does not change tensor layout in memory
+    >>> c.size()
     torch.Size([1, 3, 2, 4])
-    >>> bool((b == c).all())
+    >>> torch.equal(b, c)
     False
 
 """)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -8,6 +8,7 @@ from ._torch_docs import parse_kwargs
 def add_docstr_all(method, docstr):
     add_docstr(getattr(torch._C._TensorBase, method), docstr)
 
+
 new_common_args = parse_kwargs("""
     size (int...): a list, tuple, or :class:`torch.Size` of integers defining the
         shape of the output tensor.
@@ -2770,6 +2771,18 @@ Example::
     >>> z = x.view(-1, 8)  # the size -1 is inferred from other dimensions
     >>> z.size()
     torch.Size([2, 8])
+
+    >>> a=torch.randn((1,2,3,4))
+    >>> a.shape
+    torch.Size([1, 2, 3, 4])
+    >>> b = a.transpose(1,2)  # Swaps 2nd and 3rd dimension
+    >>> b.shape
+    torch.Size([1, 3, 2, 4])
+    >>> c = a.view((1, 3, 2, 4))  # Does not change tensor layout in memory
+    >>> c.shape
+    torch.Size([1, 3, 2, 4])
+    >>> bool((b == c).all())
+    False
 
 """)
 


### PR DESCRIPTION
Added example to the documentation of [torch.Tensor.view](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.view) to avoid the misunderstanding referenced in issue [#16560](https://github.com/pytorch/pytorch/issues/16560)