### PR TITLE
[jit] points-to graph simplification

### DIFF
--- a/test/cpp/jit/gtest.cpp
+++ b/test/cpp/jit/gtest.cpp
@@ -32,6 +32,7 @@ JIT_TEST(TopologicalIndex)
 JIT_TEST(TopologicalMove)
 JIT_TEST(SubgraphUtils)
 JIT_TEST(AliasAnalysis)
+JIT_TEST(AliasTracker)
 
 JIT_TEST(THNNConv)
 JIT_TEST(ATenNativeBatchNorm)

--- a/test/cpp/jit/no-gtest.cpp
+++ b/test/cpp/jit/no-gtest.cpp
@@ -32,11 +32,11 @@ std::string runJITCPPTests() {
   testTopologicalIndex();
   testTopologicalMove();
   testSubgraphUtils();
-  testAliasAnalysis();
   testTHNNConv();
   testATenNativeBatchNorm();
   testRegisterFusionCachesKernel();
   testAliasAnalysis();
+  testAliasTracker();
   return out.str();
 }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -139,6 +139,7 @@ template <typename T>
 using ArrayRef = at::ArrayRef<T>;
 using NodeKind = Symbol;
 using topo_position_t = int64_t;
+using ValueSet = std::unordered_set<const Value*>;
 
 struct Value {
   TH_DISALLOW_COPY_AND_ASSIGN(Value);

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -10,8 +10,7 @@ bool shouldAnnotate(const TypePtr& type) {
   return type->isSubtypeOf(DynamicType::get()) ||
       type->kind() == TypeKind::ListType ||
       type->kind() == TypeKind::TupleType ||
-      type->kind() == TypeKind::DictType ||
-      type->kind() == TypeKind::VarType ||
+      type->kind() == TypeKind::DictType || type->kind() == TypeKind::VarType ||
       (type->kind() == TypeKind::OptionalType &&
        shouldAnnotate(type->cast<OptionalType>()->getElementType()));
 }
@@ -107,16 +106,11 @@ bool AliasDb::writesToInputAlias(Node* n) const {
   });
 }
 
-bool AliasDb::mayAlias(
-    const std::unordered_set<const Value*>& a,
-    const std::unordered_set<const Value*>& b) const {
+bool AliasDb::mayAlias(const ValueSet& a, const ValueSet& b) const {
   return aliasTracker_->mayAlias(a, b);
 }
 
-void AliasDb::getWritesImpl(
-    Node* n,
-    std::unordered_set<const Value*>& ret,
-    bool recurseBlocks) const {
+void AliasDb::getWritesImpl(Node* n, ValueSet& ret, bool recurseBlocks) const {
   for (const auto input : n->inputs()) {
     if (writesTo(n, input)) {
       ret.insert(input);
@@ -137,17 +131,13 @@ void AliasDb::getWritesImpl(
   }
 }
 
-std::unordered_set<const Value*> AliasDb::getWrites(Node* n, bool recurseBlocks)
-    const {
-  std::unordered_set<const Value*> writes;
+ValueSet AliasDb::getWrites(Node* n, bool recurseBlocks) const {
+  ValueSet writes;
   getWritesImpl(n, writes, recurseBlocks);
   return writes;
 }
 
-void AliasDb::getReadsImpl(
-    Node* n,
-    std::unordered_set<const Value*>& ret,
-    bool recurseBlocks) const {
+void AliasDb::getReadsImpl(Node* n, ValueSet& ret, bool recurseBlocks) const {
   for (const auto input : n->inputs()) {
     ret.insert(input);
   }
@@ -164,9 +154,8 @@ void AliasDb::getReadsImpl(
   }
 }
 
-std::unordered_set<const Value*> AliasDb::getReads(Node* n, bool recurseBlocks)
-    const {
-  std::unordered_set<const Value*> reads;
+ValueSet AliasDb::getReads(Node* n, bool recurseBlocks) const {
+  ValueSet reads;
   getReadsImpl(n, reads, recurseBlocks);
   return reads;
 }

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -30,9 +30,6 @@ class AliasDb {
   TORCH_API explicit AliasDb(std::shared_ptr<Graph> graph);
   TORCH_API ~AliasDb();
 
-  // Does `n` write to any alias sets?
-  bool hasWrites(Node* n) const;
-
   // There are limitations to what effects the alias analysis can track. Two
   // kinds of nodes may have untracked effects:
   // 1. Nodes that write to a value that may alias the graph inputs (since
@@ -44,16 +41,21 @@ class AliasDb {
   bool hasUntrackedEffects(Node* n) const;
 
   // Get all the values that `n` writes to.
-  std::unordered_set<const Value*> getWrites(Node* n) const;
+  // NOTE: this only returns values directly written to, not aliases thereof
+  //
+  // if `recurseBlocks` is true, gather writes on the nodes in `n`s sub-blocks
+  std::unordered_set<const Value*> getWrites(
+      Node* n,
+      bool recurseBlocks = false) const;
 
-  // Get all values that may alias to `v`.
-  std::unordered_set<const Value*> getAliases(const Value* v) const;
+  // Do any values in group `a` potentially share a memory location with any
+  // value in group `b`?
+  bool mayAlias(
+      const std::unordered_set<const Value*>& a,
+      const std::unordered_set<const Value*>& b) const;
 
   // Do any nodes write to an alias set inputed/outputed by `n`?
   bool hasWriters(const Node* n) const;
-
-  // Same as hasWriters() but ignores writes after `n`.
-  bool hasWritersBefore(const Node* n) const;
 
   // Move 'n' (already in the graph) after 'movePoint' in the topological order.
   //
@@ -81,13 +83,27 @@ class AliasDb {
   void move(Node* toMove, Node* movePoint, MoveSide moveSide);
   bool isBeforeOrAfter(const Node* n, MoveSide moveSide) const;
 
+  void getWritesImpl(
+      Node* n,
+      std::unordered_set<const Value*>& ret,
+      bool recurseBlocks = false) const;
+
+  // Get all the values that `n` reads from.
+  // if `recurseBlocks` is true, gather reads on the nodes in `n`s sub-blocks
+  std::unordered_set<const Value*> getReads(Node* n, bool recurseBlocks = false)
+      const;
+
+  void getReadsImpl(
+      Node* n,
+      std::unordered_set<const Value*>& ret,
+      bool recurseBlocks = false) const;
+  // Does `n` write to any alias sets?
+  bool hasWrites(Node* n) const;
+
   // Does `n` use or write to any wildcard aliases?
   bool hasWildcard(const Node* n) const;
   // Returns nullopt if there are no wildcard nodes
   c10::optional<const Node*> getLastWildcard() const;
-
-  // Get all nodes that write to any alias set inputed/outputed by `n`
-  std::unordered_set<Node*> getWriters(const Node* n) const;
 
   // Does `n` write to a value that may alias one of the graph inputs?
   bool writesToInputAlias(Node* n) const;

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -25,6 +25,7 @@ namespace jit {
  * we're not sure what this value may alias. To be conservative, we consider
  * the wildcard alias set as potentially aliasing any value.
  */
+
 class AliasDb {
  public:
   TORCH_API explicit AliasDb(std::shared_ptr<Graph> graph);
@@ -44,15 +45,11 @@ class AliasDb {
   // NOTE: this only returns values directly written to, not aliases thereof
   //
   // if `recurseBlocks` is true, gather writes on the nodes in `n`s sub-blocks
-  std::unordered_set<const Value*> getWrites(
-      Node* n,
-      bool recurseBlocks = false) const;
+  ValueSet getWrites(Node* n, bool recurseBlocks = false) const;
 
   // Do any values in group `a` potentially share a memory location with any
   // value in group `b`?
-  bool mayAlias(
-      const std::unordered_set<const Value*>& a,
-      const std::unordered_set<const Value*>& b) const;
+  bool mayAlias(const ValueSet& a, const ValueSet& b) const;
 
   // Do any nodes write to an alias set inputed/outputed by `n`?
   bool hasWriters(const Node* n) const;
@@ -83,20 +80,13 @@ class AliasDb {
   void move(Node* toMove, Node* movePoint, MoveSide moveSide);
   bool isBeforeOrAfter(const Node* n, MoveSide moveSide) const;
 
-  void getWritesImpl(
-      Node* n,
-      std::unordered_set<const Value*>& ret,
-      bool recurseBlocks = false) const;
+  void getWritesImpl(Node* n, ValueSet& ret, bool recurseBlocks = false) const;
 
   // Get all the values that `n` reads from.
   // if `recurseBlocks` is true, gather reads on the nodes in `n`s sub-blocks
-  std::unordered_set<const Value*> getReads(Node* n, bool recurseBlocks = false)
-      const;
+  ValueSet getReads(Node* n, bool recurseBlocks = false) const;
 
-  void getReadsImpl(
-      Node* n,
-      std::unordered_set<const Value*>& ret,
-      bool recurseBlocks = false) const;
+  void getReadsImpl(Node* n, ValueSet& ret, bool recurseBlocks = false) const;
   // Does `n` write to any alias sets?
   bool hasWrites(Node* n) const;
 

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1,7 +1,7 @@
 #include <torch/csrc/jit/passes/shape_analysis.h>
 
-#include <torch/csrc/jit/argument_spec.h>
 #include <c10/util/Exception.h>
+#include <torch/csrc/jit/argument_spec.h>
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/operator.h>
@@ -208,7 +208,7 @@ class ShapePropagator {
       return dependsOnMutationMemo_[node];
     }
 
-    if (aliasDb_.hasWritersBefore(node)) {
+    if (aliasDb_.hasWriters(node)) {
       // If something could have written to a value used by this node, we can't
       // guarantee the result is the same when running it in isolation.
       dependsOnMutationMemo_[node] = true;

--- a/torch/csrc/jit/passes/utils/alias_tracker.cpp
+++ b/torch/csrc/jit/passes/utils/alias_tracker.cpp
@@ -8,7 +8,35 @@ namespace jit {
 
 // Returns true iff `v` is present in the alias set tracker.
 bool AliasTracker::contains(const Value* v) const {
-  return map_.count(v);
+  return isWildcard(v) || map_.count(v);
+}
+
+bool AliasTracker::mayAlias(const Value* a, const Value* b) const {
+  if (isWildcard(a) || isWildcard(b)) {
+    return true;
+  }
+
+  if (!map_.count(a) || !map_.count(b)) {
+    return false;
+  }
+
+  const auto aEl = map_.at(a);
+  const auto bEl = map_.at(b);
+
+  const auto aMemLoc = aEl->getMemoryLocations();
+  const auto bMemLoc = bEl->getMemoryLocations();
+
+  // XXX: This could be more efficiently done as a bitwise AND on two bitfields
+  // that represent memory location membership. If these comparisons end up
+  // being a bottleneck, consider implementing it that way.
+  for (const auto aLoc : aMemLoc) {
+    for (const auto bLoc : bMemLoc) {
+      if (aLoc == bLoc) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 bool AliasTracker::writesTo(Node* n, const Value* v) const {
@@ -16,29 +44,18 @@ bool AliasTracker::writesTo(Node* n, const Value* v) const {
     return wildcardWriters_.count(n);
   }
 
-  if (!map_.count(v)) {
+  if (!map_.count(v) || !writeIndex_.count(n)) {
     return false;
   }
 
-  return map_.at(v)->writers.count(n);
-}
-
-// Whether `a` *may* point to `b`
-bool AliasTracker::pointsTo(const Value* a, const Value* b) const {
-  if (!map_.count(a)) {
-    return false;
-  }
-  if (isWildcard(a) || isWildcard(b)) {
+  // Can short-circuit if we know this node writes directly to `v`
+  if (writeIndex_.at(n).count(v)) {
     return true;
   }
 
-  // BFS the subtree where the root is `a`s element and the branches are the
-  // `pointsTo` relationships.
-  const auto root = map_.at(a);
-  return root->bfs(
-      [&](const Element* el) { return el->value == b; },
-      BfsDirection::POINTS_TO,
-      /*shortCircuit=*/true);
+  // Otherwise, check if `v` may alias any of written-to values in `n`
+  const auto vSet = std::unordered_set<const Value*>{v};
+  return mayAlias(vSet, writeIndex_.at(n));
 }
 
 // Make `v` point at `to`.
@@ -99,64 +116,9 @@ void AliasTracker::registerWrite(const Value* v, Node* n) {
   }
 
   AT_ASSERT(map_.count(v));
-  map_.at(v)->writers.insert(n);
+  writeIndex_[n].insert(v);
 }
 
-// Return all aliases of `v`. This is the full set of any other value that
-// *may* represent the same memory location.
-// NOTE: this does not consider wildcard values
-std::unordered_set<const Value*> AliasTracker::getAliases(
-    const Value* v) const {
-  std::unordered_set<const Value*> ret;
-  if (!map_.count(v)) {
-    return ret;
-  }
-
-  const auto root = map_.at(v);
-
-  root->bfs(
-      [&](const Element* el) {
-        ret.insert(el->value);
-        return false; // fn has to return bool but we don't use the result
-      },
-      BfsDirection::BOTH);
-  return ret;
-}
-
-// Get all nodes that write to `v` or a value that may alias `v`.
-std::unordered_set<Node*> AliasTracker::getWrites(const Value* v) const {
-  std::unordered_set<Node*> ret;
-  if (!map_.count(v)) {
-    return ret;
-  }
-
-  // Any write to a wilcard may write to `v`.
-  for (auto writer : wildcardWriters_) {
-    ret.insert(writer);
-  }
-
-  if (useCache_) {
-    for (auto writer : getWritersCached(v)) {
-      ret.insert(writer);
-    }
-    return ret;
-  }
-
-  const auto root = map_.at(v);
-  root->bfs(
-      [&](const Element* el) {
-        for (auto writer : el->writers) {
-          ret.insert(writer);
-        }
-        return false; // fn has to return bool but we don't use the result
-      },
-      BfsDirection::BOTH);
-
-  return ret;
-}
-
-// Functionally equivalent to getWrites().size() > 0, but with a
-// short-circuiting implementation to be faster.
 bool AliasTracker::hasWriters(const Value* v) const {
   if (!map_.count(v)) {
     return false;
@@ -174,15 +136,30 @@ bool AliasTracker::hasWriters(const Value* v) const {
     return true;
   }
 
-  if (useCache_) {
-    return hasWritersCached(v);
+  if (isWriteCacheStale_) {
+    rebuildWriteCache();
   }
 
-  const auto root = map_.at(v);
-  return root->bfs(
-      [&](const Element* el) { return el->writers.size() > 0; },
-      BfsDirection::BOTH,
-      /*shortCircuit=*/true);
+  for (const auto loc : map_.at(v)->getMemoryLocations()) {
+    if (writeCache_.count(loc)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void AliasTracker::rebuildWriteCache() const {
+  for (const auto& pr : writeIndex_) {
+    const auto& writtenValues = pr.second;
+
+    for (const auto value : writtenValues) {
+      for (const auto loc : map_.at(value)->getMemoryLocations()) {
+        writeCache_.insert(loc);
+      }
+    }
+  }
+  isWriteCacheStale_ = false;
 }
 
 void AliasTracker::dump() const {
@@ -205,15 +182,30 @@ void AliasTracker::dump() const {
   std::cout << "\n";
 }
 
+std::unordered_set<const AliasTracker::Element*> AliasTracker::Element::
+    getMemoryLocations() const {
+  if (!cachedMemoryLocations_.empty()) {
+    return cachedMemoryLocations_;
+  }
+
+  // Do a BFS in the `points-to` direction, collecting all memory locations
+  std::unordered_set<const Element*> ret;
+  this->bfs(
+      [&](const Element* el) {
+        if (el->pointsTo.empty()) {
+          ret.insert(el);
+        }
+      },
+      BfsDirection::POINTS_TO);
+
+  cachedMemoryLocations_ = ret;
+  return ret;
+}
+
 // Do a breadth-first search over the graph, starting at `this` and
 // traversing in the direction `dir`.`fn` will be run on each element.
-//
-// If `shortCircuit` is set, then if `fn` evaluates to true the search will
-// short-circuit and return true. You can use this to do existence checks
-// on the graph or whatever.
 template <typename Fn>
-bool AliasTracker::Element::bfs(Fn fn, BfsDirection dir, bool shortCircuit)
-    const {
+bool AliasTracker::Element::bfs(Fn fn, BfsDirection dir) const {
   std::queue<const Element*> queue;
   std::unordered_set<const Element*> seen;
 
@@ -223,9 +215,7 @@ bool AliasTracker::Element::bfs(Fn fn, BfsDirection dir, bool shortCircuit)
     queue.pop();
     seen.insert(el);
 
-    if (fn(el) && shortCircuit) {
-      return true;
-    }
+    fn(el);
 
     switch (dir) {
       case BfsDirection::POINTS_TO: {
@@ -243,76 +233,9 @@ bool AliasTracker::Element::bfs(Fn fn, BfsDirection dir, bool shortCircuit)
           }
         }
       } break;
-
-      case BfsDirection::BOTH: {
-        for (auto ptr : el->pointsTo) {
-          if (!seen.count(ptr)) {
-            queue.push(ptr);
-          }
-        }
-        for (auto ptr : el->pointedFrom) {
-          if (!seen.count(ptr)) {
-            queue.push(ptr);
-          }
-        }
-      } break;
     }
   }
   return false;
 }
-// Cache results in a way to make common queries constant time.
-void AliasTracker::cache() const {
-  if (!cacheStale_) {
-    return;
-  }
-
-  for (const auto& pr : elements_) {
-    const auto el = pr.first;
-    // For each value that does point to anything, assign a fresh set.
-    if (el->pointsTo.size() == 0) {
-      const auto id = getFreshId();
-      assignSet(el, id);
-
-      // Propagate this set to every element that points to `el`
-      el->bfs(
-          [&](const Element* pointerTo) { return assignSet(pointerTo, id); },
-          BfsDirection::POINTED_FROM);
-    }
-  }
-
-  cacheStale_ = false;
-}
-
-bool AliasTracker::hasWritersCached(const Value* v) const {
-  cache();
-  for (const auto& set : elementToSet_.at(map_.at(v))) {
-    if (setToWrites_.count(set) && setToWrites_.at(set).size() > 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
-std::unordered_set<Node*> AliasTracker::getWritersCached(const Value* v) const {
-  cache();
-  std::unordered_set<Node*> ret;
-  for (const auto& set : elementToSet_.at(map_.at(v))) {
-    if (setToWrites_.count(set) > 0) {
-      for (auto write : setToWrites_.at(set)) {
-        ret.insert(write);
-      }
-    }
-  }
-  return ret;
-}
-
-bool AliasTracker::assignSet(const Element* el, set_id_t id) const {
-  elementToSet_[el].insert(id);
-  for (auto write : el->writers) {
-    setToWrites_[id].insert(write);
-  }
-  return true;
-}
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/utils/alias_tracker.cpp
+++ b/torch/csrc/jit/passes/utils/alias_tracker.cpp
@@ -54,7 +54,7 @@ bool AliasTracker::writesTo(Node* n, const Value* v) const {
   }
 
   // Otherwise, check if `v` may alias any of written-to values in `n`
-  const auto vSet = std::unordered_set<const Value*>{v};
+  const auto vSet = ValueSet{v};
   return mayAlias(vSet, writeIndex_.at(n));
 }
 

--- a/torch/csrc/jit/passes/utils/alias_tracker.h
+++ b/torch/csrc/jit/passes/utils/alias_tracker.h
@@ -4,20 +4,29 @@
 
 namespace torch {
 namespace jit {
+
 // class AliasTracker
 //
 // This class tracks the "A points to B" graph for all values, as well as
 // wildcards and writes. It is used by AliasDb to provide a higher-level API.
+//
+// We maintain a DAG where:
+//   - Vertices (called "elements") represent values and
+//     other aliasing entities (e.g. like the stuff inside a list)
+//   - Edges represent a "points-to" relationship.
+//
+// Leaves in this DAG are entities that don't point to anything, and thus
+// correspond to unique "memory locations".
+//
+// So, by traversing the "points-to" graph to the leaves, you can determine
+// which memory locations an element may point to.
 class AliasTracker {
  public:
   // Returns true iff `v` is present in the alias set tracker.
   bool contains(const Value* v) const;
 
-  // Does `n` write to `v` directly? (Does not consider aliases)
+  // Does `n` write to a memory location that `v` may point to?
   bool writesTo(Node* n, const Value* v) const;
-
-  // Whether `a` *may* point to `b`
-  bool pointsTo(const Value* a, const Value* b) const;
 
   // Make `v` point at `to`.
   void makePointerTo(const Value* v, const Value* to);
@@ -34,21 +43,65 @@ class AliasTracker {
   // Register the fact that `n` writes to `v`.
   void registerWrite(const Value* v, Node* n);
 
-  // Return all aliases of `v`. This is the full set of any other value that
-  // *may* represent the same memory location.
-  // NOTE: this does not consider wildcard values
-  std::unordered_set<const Value*> getAliases(const Value* v) const;
-
-  // Get all nodes that write to `v` or a value that may alias `v`.
-  std::unordered_set<Node*> getWrites(const Value* v) const;
-
-  // Functionally equivalent to getWrites().size() > 0, but with a
-  // short-circuiting implementation to be faster.
+  // Does anything write to the memory locations that `v` may point to?
   bool hasWriters(const Value* v) const;
 
   // Get all nodes that write to a wildcard value.
   const std::unordered_set<Node*>& getWildcardWriters() const {
     return wildcardWriters_;
+  }
+
+  // Do `a` and `b` potentially share a memory location?
+  bool mayAlias(const Value* a, const Value* b) const;
+
+  // Do any values in group `a` potentially share a memory location with any
+  // value in group `b`?
+  //
+  // This is written so that either of the inputs could be a multiset
+  template <typename T, typename U>
+  bool mayAlias(const T& a, const U& b) const {
+    if (a.empty() || b.empty()) {
+      return false;
+    }
+
+    // Record all memory locations from group `a`
+    std::unordered_set<const Element*> memoryLocations;
+    for (auto it = a.cbegin(); it != a.cend();) {
+      const auto value = *it;
+      if (isWildcard(value)) {
+        return true;
+      }
+
+      if (map_.count(value)) {
+        for (const auto loc : map_.at(value)->getMemoryLocations()) {
+          memoryLocations.insert(loc);
+        }
+      }
+
+      const auto cnt = a.count(*it);
+      std::advance(it, cnt);
+    }
+
+    // If any of group `b`s memory locations overlap, return true.
+    for (auto it = b.cbegin(); it != b.cend();) {
+      const auto value = *it;
+      if (isWildcard(value)) {
+        return true;
+      }
+
+      if (map_.count(value)) {
+        for (const auto loc : map_.at(value)->getMemoryLocations()) {
+          if (memoryLocations.count(loc)) {
+            return true;
+          }
+        }
+      }
+
+      const auto cnt = b.count(*it);
+      std::advance(it, cnt);
+    }
+    // No overlap, so group `a` and `b` do not share a memory location
+    return false;
   }
 
   void dump() const;
@@ -57,30 +110,27 @@ class AliasTracker {
   enum class BfsDirection {
     POINTS_TO,
     POINTED_FROM,
-    // Consider both pointer directions. The closure obtained from this
-    // represents the whole "alias set" of a value.
-    BOTH
   };
   // `Element` represents the vertex in the points-to graph. It has a 1:1
   // relationship with IR `Value`s.
   struct Element {
     const Value* value = nullptr;
-    // All values that this value *may* point to. It's possible to have multiple
-    // values that you might point to due to control flow/complex ops
+    // All elements that this element *may* point to. It's possible to have
+    // multiple elements that you might point to due to control flow/complex ops
     std::unordered_set<Element*> pointsTo;
-    // Backreference to values that point to `this`
+    // Backreference for points-to.
     std::unordered_set<Element*> pointedFrom;
-    // Nodes that write to this specific value.
-    std::unordered_set<Node*> writers;
+
+    std::unordered_set<const Element*> getMemoryLocations() const;
+    // We do path compression to make repeated memory location queries faster.
+    // An empty cache means it is invalidated (it can never be empty otherwise,
+    // since every element must point to at least one memory location).
+    mutable std::unordered_set<const Element*> cachedMemoryLocations_;
 
     // Do a breadth-first search over the graph, starting at `this` and
     // traversing in the direction `dir`.`fn` will be run on each element.
-    //
-    // If `shortCircuit` is set, then if `fn` evaluates to true the search will
-    // short-circuit and return true. You can use this to do existence checks
-    // on the graph or whatever.
     template <typename Fn>
-    bool bfs(Fn fn, BfsDirection dir, bool shortCircuit = false) const;
+    bool bfs(Fn fn, BfsDirection dir) const;
   };
 
   // Structure that owns all the element pointers. It's a map of
@@ -94,25 +144,10 @@ class AliasTracker {
   std::unordered_set<Node*> wildcardWriters_;
   size_t numWrites_ = 0;
 
-  /**
-   * Caching layer.
-   */
-  using set_id_t = size_t;
-  bool useCache_ = true;
-  mutable std::unordered_map<const Element*, std::unordered_set<set_id_t>>
-      elementToSet_;
-  mutable std::unordered_map<set_id_t, std::unordered_set<Node*>> setToWrites_;
-  mutable bool cacheStale_ = true;
-  mutable set_id_t lastId = 0;
-
-  // Cache results in a way to make common queries constant time.
-  void cache() const;
-  bool hasWritersCached(const Value* v) const;
-  std::unordered_set<Node*> getWritersCached(const Value* v) const;
-  bool assignSet(const Element* el, set_id_t id) const;
-  set_id_t getFreshId() const {
-    return ++lastId;
-  };
+  std::unordered_map<Node*, std::unordered_set<const Value*>> writeIndex_;
+  mutable std::unordered_set<const Element*> writeCache_;
+  mutable bool isWriteCacheStale_ = true;
+  void rebuildWriteCache() const;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/passes/utils/alias_tracker.h
+++ b/torch/csrc/jit/passes/utils/alias_tracker.h
@@ -139,12 +139,12 @@ class AliasTracker {
   // Index to look up whatever element corresponds to that value.
   std::unordered_map<const Value*, Element*> map_;
   // All values that may point to a wildcard value.
-  std::unordered_set<const Value*> wildcards_;
+  ValueSet wildcards_;
   // All nodes that write to a wildcard
   std::unordered_set<Node*> wildcardWriters_;
   size_t numWrites_ = 0;
 
-  std::unordered_map<Node*, std::unordered_set<const Value*>> writeIndex_;
+  std::unordered_map<Node*, ValueSet> writeIndex_;
   mutable std::unordered_set<const Element*> writeCache_;
   mutable bool isWriteCacheStale_ = true;
   void rebuildWriteCache() const;


### PR DESCRIPTION
This PR reworks the mutability API to be simpler (updates passes to use "mayAlias" calls) and improves the caching logic.

The difference is that we now directly express the idea of a "memory location." Leaves in the alias trackers points-to graph are considered unique memory locations, and mayAlias questions can be boiled down whether two values share a leaf.

To speed up queries, some basic path compression has been added.