### PR TITLE
add SingleLoadedNetSupplier

### DIFF
--- a/caffe2/predictor/emulator/net_supplier.h
+++ b/caffe2/predictor/emulator/net_supplier.h
@@ -44,9 +44,30 @@ class SingleNetSupplier : public NetSupplier {
     return RunnableNet(netdef_, filler_.get());
   }
 
- private:
+ protected:
   const unique_ptr<Filler> filler_;
   const caffe2::NetDef netdef_;
+};
+
+/*
+ * A simple net supplier that always return the same net and filler pair.
+ * The SingleLoadedNetSupplier contains a shared ptr to a workspace with
+ * parameters already loaded by net loader.
+ */
+class SingleLoadedNetSupplier : public SingleNetSupplier {
+ public:
+  SingleLoadedNetSupplier(
+      std::unique_ptr<Filler> filler,
+      caffe2::NetDef netdef,
+      std::shared_ptr<Workspace> ws)
+      : SingleNetSupplier(std::move(filler), netdef), ws_(ws) {}
+
+  std::shared_ptr<Workspace> get_loaded_workspace() {
+    return ws_;
+  }
+
+ private:
+  const std::shared_ptr<Workspace> ws_;
 };
 
 class MutatingNetSupplier : public NetSupplier {


### PR DESCRIPTION
Summary:
LogfiledbNetLoader loads all external input blobs into a workspace instance, we pack a shared pointer to this loaded workspace into the SingleLoadedNetSupplier.
SingleLoadedNetSupplier will pass this workspace to BlackBoxPredictor to be executed. (D13891759 is a WIP of how it all comes together)

Reviewed By: yinghai

Differential Revision: D13901467
