### PR TITLE
Disable layernorm_c10 test for now

### DIFF
--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -118,6 +118,7 @@ class TestLayerNormOp(serial.SerializedTestCase):
         )
 
     @given(X=hu.tensors(n=1), **hu.gcs_cpu_only)
+    @unittest.skip("Tensor interop enforcement needs fixing")
     def test_layer_norm_op_c10(self, X, gc, dc):
         X = X[0]
         if len(X.shape) == 1:


### PR DESCRIPTION
Summary: two PRs landed concurrently - enforcing tensor constraints and refactoring c10. Since it's not a prod code - disable test and I'll let Sebastian to fix it properly.

Reviewed By: ezyang

Differential Revision: D13908117
