### PR TITLE
Add device='cpu' to pack_padded_sequence #16542

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4463,6 +4463,7 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'You can pass `enforce_sorted=False`'):
             packed = rnn_utils.pack_padded_sequence(torch.randn(3, 3), [1, 3, 2])
 
+    @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_pack_padded_sequence_default_cuda_tensor(self):
         # Set default tensor type to cuda.FloatTensor, as this has triggered the error
         torch.set_default_tensor_type(torch.cuda.FloatTensor)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4467,10 +4467,12 @@ class TestNN(NNTestCase):
         # Set default tensor type to cuda.FloatTensor, as this has triggered the error
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
         # Run all tests
-        self.test_pack_sequence()
-        self.test_pack_padded_sequence()
+        try:
+            self.test_pack_sequence()
+            self.test_pack_padded_sequence()
         # Reset default tensor type to FloatTensor
-        torch.set_default_tensor_type(torch.FloatTensor)
+        finally:
+            torch.set_default_tensor_type(torch.FloatTensor)
 
     def _test_variable_sequence(self, device="cpu", dtype=torch.float):
         def pad(var, length):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4463,6 +4463,15 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'You can pass `enforce_sorted=False`'):
             packed = rnn_utils.pack_padded_sequence(torch.randn(3, 3), [1, 3, 2])
 
+    def test_pack_padded_sequence_default_cuda_tensor(self):
+        # Set default tensor type to cuda.FloatTensor, as this has triggered the error
+        torch.set_default_tensor_type(torch.cuda.FloatTensor)
+        # Run all tests
+        self.test_pack_sequence()
+        self.test_pack_padded_sequence()
+        # Reset default tensor type to FloatTensor
+        torch.set_default_tensor_type(torch.FloatTensor)
+
     def _test_variable_sequence(self, device="cpu", dtype=torch.float):
         def pad(var, length):
             if var.size(0) == length:

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -192,7 +192,7 @@ def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)
                       'values, and it will treat them as constants, likely rendering '
                       'the trace incorrect for any other combination of lengths.',
                       category=torch.jit.TracerWarning, stacklevel=2)
-    lengths = torch.as_tensor(lengths, dtype=torch.int64)
+    lengths = torch.as_tensor(lengths, dtype=torch.int64, device='cpu')
     if enforce_sorted:
         sorted_indices = None
     else:


### PR DESCRIPTION
Add the `device='cpu'` argument to the `lengths` tensor, which could otherwise throw an error if the default tensor type was set to a CUDA type as discussed in #16542

CC @zou3519 
