### PR TITLE
Tag model_id and onnxifi index in OnnxifiOp

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -103,6 +103,12 @@ class CAFFE2_API OnnxifiTransformer final {
   // backend idx
   int idx_{0};
 
+  // Number of Onnxifi Ops we build so far
+  int onnxifi_op_id_{0};
+
+  // Model id
+  std::string model_id_;
+
   // Backned IDs
   std::vector<onnxBackendID> backend_ids_;
 


### PR DESCRIPTION
Summary: We added onnxGraph sharing keyed on model id and net seq number but we forgot to supply these info to the Onnxifi. Therefore, we will only create ONE onnxGraph whatsoever... This diff adds necessary info to the OnnxifiOp to prevent this from happening.

Differential Revision: D13912356
