### PR TITLE
Merge job-spec env variables of Pytorch/Caffe2 CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ setup_ci_environment: &setup_ci_environment
       nvidia-smi
     fi
 
-    if [[ "${JOB_BASE_NAME}" == *-build ]]; then
+    if [[ "${BUILD_ENVIRONMENT}" == *-build ]]; then
       echo "declare -x IN_CIRCLECI=1" > /home/circleci/project/env
       echo "declare -x COMMIT_SOURCE=${CIRCLE_BRANCH}" >> /home/circleci/project/env
       echo "declare -x PYTHON_VERSION=${PYTHON_VERSION}" >> /home/circleci/project/env
@@ -167,7 +167,7 @@ setup_ci_environment: &setup_ci_environment
       export MAX_JOBS=$(( ${SCCACHE_MAX_JOBS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${SCCACHE_MAX_JOBS} ))
       echo "declare -x MAX_JOBS=${MAX_JOBS}" >> /home/circleci/project/env
 
-      if [[ "${JOB_BASE_NAME}" == *xla* ]]; then
+      if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
         # This IAM user allows write access to S3 bucket for sccache & bazels3cache
         echo "declare -x AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_SCCACHE_AND_XLA_BAZEL_S3_BUCKET_V1}" >> /home/circleci/project/env
         echo "declare -x AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_SCCACHE_AND_XLA_BAZEL_S3_BUCKET_V1}" >> /home/circleci/project/env
@@ -228,7 +228,7 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
 
         docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-        export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+        export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
         # Push intermediate Docker image for next phase to use
@@ -258,9 +258,9 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
           export id=$(docker run -t -d -w /var/lib/jenkins ${COMMIT_DOCKER_IMAGE})
         fi
         if [ -n "${MULTI_GPU}" ]; then
-          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/multigpu-test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/multigpu-test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         else
-          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/test.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         fi
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -501,8 +501,8 @@ binary_populate_env: &binary_populate_env
     touch "$envfile"
     chmod +x "$envfile"
 
-    # Parse the JOB_BASE_NAME to package type, python, and cuda
-    configs=($JOB_BASE_NAME)
+    # Parse the BUILD_ENVIRONMENT to package type, python, and cuda
+    configs=($BUILD_ENVIRONMENT)
     export PACKAGE_TYPE="${configs[0]}"
     export DESIRED_PYTHON="${configs[1]}"
     export DESIRED_CUDA="${configs[2]}"
@@ -1000,118 +1000,118 @@ version: 2
 jobs:
   pytorch_linux_trusty_py2_7_9_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py2.7.9-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py2.7.9-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py2.7.9:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_py2_7_9_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py2.7.9-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py2.7.9-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py2.7.9:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_py2_7_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py2.7-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py2.7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py2.7:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_py2_7_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py2.7-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py2.7-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py2.7:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_py3_5_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.5-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.5-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_py3_5_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.5-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.5-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_py3_6_gcc4_8_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc4.8-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.6-gcc4.8-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc4.8:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_py3_6_gcc4_8_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc4.8-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.6-gcc4.8-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc4.8:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_py3_6_gcc5_4_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc5.4-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.6-gcc5.4-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_py3_6_gcc5_4_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc5.4-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.6-gcc5.4-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_xla_linux_trusty_py3_6_gcc5_4_build:
     environment:
-      JOB_BASE_NAME: pytorch-xla-linux-trusty-py3.6-gcc5.4-build
+      BUILD_ENVIRONMENT: pytorch-xla-linux-trusty-py3.6-gcc5.4-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:278"
     <<: *pytorch_linux_build_defaults
 
   pytorch_xla_linux_trusty_py3_6_gcc5_4_test:
     environment:
-      JOB_BASE_NAME: pytorch-xla-linux-trusty-py3.6-gcc5.4-test
+      BUILD_ENVIRONMENT: pytorch-xla-linux-trusty-py3.6-gcc5.4-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc5.4:278"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_py3_6_gcc7_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc7-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.6-gcc7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc7:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_py3_6_gcc7_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-py3.6-gcc7-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.6-gcc7-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.6-gcc7:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_pynightly_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-pynightly-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-pynightly-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-pynightly:285"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_trusty_pynightly_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-trusty-pynightly-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-pynightly-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-pynightly:285"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py3_clang5_asan_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-asan-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-asan-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:285"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py3_clang5_asan_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-asan-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-asan-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:285"
       PYTHON_VERSION: "3.6"
     resource_class: large
@@ -1119,15 +1119,14 @@ jobs:
 
   pytorch_linux_xenial_cuda8_cudnn7_py3_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda8-cudnn7-py3-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
-      BUILD_ENVIRONMENT: "pytorch-linux-xenial-cuda8-cudnn7-py3"
+      BUILD_ENVIRONMENT: "pytorch-linux-xenial-cuda8-cudnn7-py3-build"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda8_cudnn7_py3_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda8-cudnn7-py3-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda8-cudnn7-py3-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1136,7 +1135,7 @@ jobs:
 
   pytorch_linux_xenial_cuda8_cudnn7_py3_multigpu_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda8-cudnn7-py3-multigpu-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda8-cudnn7-py3-multigpu-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1146,7 +1145,7 @@ jobs:
 
   pytorch_linux_xenial_cuda8_cudnn7_py3_NO_AVX2_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX2-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX2-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1155,7 +1154,7 @@ jobs:
 
   pytorch_linux_xenial_cuda8_cudnn7_py3_NO_AVX_NO_AVX2_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX-NO_AVX2-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX-NO_AVX2-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1164,14 +1163,14 @@ jobs:
 
   pytorch_linux_xenial_cuda9_cudnn7_py2_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py2-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:285"
       PYTHON_VERSION: "2.7"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py2_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py2-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:285"
       PYTHON_VERSION: "2.7"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1180,14 +1179,14 @@ jobs:
 
   pytorch_linux_xenial_cuda9_cudnn7_py3_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py3-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py3_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9-cudnn7-py3-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1196,14 +1195,14 @@ jobs:
 
   pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:285"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1212,14 +1211,14 @@ jobs:
 
   pytorch_linux_xenial_cuda10_cudnn7_py3_gcc7_build:
     environment:
-      JOB_BASE_NAME: pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7:285"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_short_perf_test_gpu:
     environment:
-      JOB_BASE_NAME: pytorch-short-perf-test-gpu
+      BUILD_ENVIRONMENT: pytorch-short-perf-test-gpu
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -1245,12 +1244,12 @@ jobs:
           echo "declare -x AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_PERF_TEST_S3_BUCKET_V3}" >> /home/circleci/project/env
           docker cp /home/circleci/project/env $id:/var/lib/jenkins/workspace/env
 
-          export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/short-perf-test-gpu.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/short-perf-test-gpu.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
   pytorch_doc_push:
     environment:
-      JOB_BASE_NAME: pytorch-doc-push
+      BUILD_ENVIRONMENT: pytorch-doc-push
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:285"
     resource_class: large
     machine:
@@ -1274,9 +1273,9 @@ jobs:
 
           if [[ "${CIRCLE_BRANCH}" != "master" ]]; then
             # Do a dry_run of the docs build. This will build the docs but not push them.
-            export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/master master dry_run") | docker exec -u jenkins -i "$id" bash) 2>&1'
+            export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/master master dry_run") | docker exec -u jenkins -i "$id" bash) 2>&1'
           else
-            export COMMAND='((echo "export JOB_BASE_NAME=${JOB_BASE_NAME}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/master master") | docker exec -u jenkins -i "$id" bash) 2>&1'
+            export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./doc_push_script.sh docs/master master") | docker exec -u jenkins -i "$id" bash) 2>&1'
           fi
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -1290,8 +1289,7 @@ jobs:
       - run:
           name: Build
           environment:
-            JOB_BASE_NAME: pytorch-macos-10.13-py3-build
-            BUILD_ENVIRONMENT: pytorch-macos-10.13-py3
+            BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-build
           no_output_timeout: "1h"
           command: |
             set -e
@@ -1335,8 +1333,7 @@ jobs:
       - run:
           name: Test
           environment:
-            JOB_BASE_NAME: pytorch-macos-10.13-py3-test
-            BUILD_ENVIRONMENT: pytorch-macos-10.13-py3
+            BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
           no_output_timeout: "1h"
           command: |
             set -e
@@ -1358,8 +1355,7 @@ jobs:
       - run:
           name: Build
           environment:
-            JOB_BASE_NAME: pytorch-macos-10.13-cuda9.2-cudnn7-py3-build
-            BUILD_ENVIRONMENT: pytorch-macos-10.13-cuda9.2-cudnn7-py3
+            BUILD_ENVIRONMENT: pytorch-macos-10.13-cuda9.2-cudnn7-py3-build
           no_output_timeout: "1h"
           command: |
             set -e
@@ -1396,172 +1392,151 @@ jobs:
 
   caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda9.0-cudnn7-ubuntu16.04-build
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.0-cudnn7-ubuntu16.04-build"
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-cuda9.0-cudnn7-ubuntu16.04"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda9.0-cudnn7-ubuntu16.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-ubuntu16.04:238"
       USE_CUDA_DOCKER_RUNTIME: "1"
-      BUILD_ENVIRONMENT: "py2-cuda9.0-cudnn7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.0-cudnn7-ubuntu16.04-test"
     resource_class: gpu.medium
     <<: *caffe2_linux_test_defaults
 
   caffe2_cmake_cuda9_0_cudnn7_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "cmake-cuda9.0-cudnn7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04-build"
     <<: *caffe2_linux_build_defaults
 
   caffe2_cmake_cuda9_0_cudnn7_ubuntu16_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-ubuntu16.04:238"
       USE_CUDA_DOCKER_RUNTIME: "1"
-      BUILD_ENVIRONMENT: "cmake-cuda9.0-cudnn7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04-test"
     resource_class: gpu.medium
     <<: *caffe2_linux_test_defaults
 
   caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda9.1-cudnn7-ubuntu16.04-build
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.1-cudnn7-ubuntu16.04-build"
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.1-cudnn7-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-cuda9.1-cudnn7-ubuntu16.04"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_cuda9_1_cudnn7_ubuntu16_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda9.1-cudnn7-ubuntu16.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.1-cudnn7-ubuntu16.04:238"
       USE_CUDA_DOCKER_RUNTIME: "1"
-      BUILD_ENVIRONMENT: "py2-cuda9.1-cudnn7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.1-cudnn7-ubuntu16.04-test"
     resource_class: gpu.medium
     <<: *caffe2_linux_test_defaults
 
   caffe2_py2_mkl_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-mkl-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-mkl-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-mkl-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-mkl-ubuntu16.04-build"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_mkl_ubuntu16_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-py2-mkl-ubuntu16.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-mkl-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-mkl-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-mkl-ubuntu16.04-test"
     resource_class: large
     <<: *caffe2_linux_test_defaults
 
   caffe2_py2_gcc4_8_ubuntu14_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-gcc4.8-ubuntu14.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc4.8-ubuntu14.04:238"
-      BUILD_ENVIRONMENT: "py2-gcc4.8-ubuntu14.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-gcc4.8-ubuntu14.04-build"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_gcc4_8_ubuntu14_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-py2-gcc4.8-ubuntu14.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc4.8-ubuntu14.04:238"
-      BUILD_ENVIRONMENT: "py2-gcc4.8-ubuntu14.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-gcc4.8-ubuntu14.04-test"
     resource_class: large
     <<: *caffe2_linux_test_defaults
 
   caffe2_onnx_py2_gcc5_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-onnx-py2-gcc5-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc5-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "onnx-py2-gcc5-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-onnx-py2-gcc5-ubuntu16.04-build"
     <<: *caffe2_linux_build_defaults
 
   caffe2_onnx_py2_gcc5_ubuntu16_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-onnx-py2-gcc5-ubuntu16.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc5-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "onnx-py2-gcc5-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-onnx-py2-gcc5-ubuntu16.04-test"
     resource_class: large
     <<: *caffe2_linux_test_defaults
 
   caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda8.0-cudnn7-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda8.0-cudnn7-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-cuda8.0-cudnn7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda8.0-cudnn7-ubuntu16.04-build"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_cuda8_0_cudnn7_ubuntu16_04_test:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda8.0-cudnn7-ubuntu16.04-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda8.0-cudnn7-ubuntu16.04:238"
       USE_CUDA_DOCKER_RUNTIME: "1"
-      BUILD_ENVIRONMENT: "py2-cuda8.0-cudnn7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda8.0-cudnn7-ubuntu16.04-test"
     resource_class: gpu.medium
     <<: *caffe2_linux_test_defaults
 
   caffe2_py2_gcc4_9_ubuntu14_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-gcc4.9-ubuntu14.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc4.9-ubuntu14.04:238"
-      BUILD_ENVIRONMENT: "py2-gcc4.9-ubuntu14.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-gcc4.9-ubuntu14.04-build"
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_clang3_8_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-clang3.8-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang3.8-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-clang3.8-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-clang3.8-ubuntu16.04-build"
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_clang3_9_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-clang3.9-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang3.9-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-clang3.9-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-clang3.9-ubuntu16.04-build"
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_clang7_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-clang7-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang7-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-clang7-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-clang7-ubuntu16.04-build"
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_android_ubuntu16_04_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-android-ubuntu16.04-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-android-ubuntu16.04:238"
-      BUILD_ENVIRONMENT: "py2-android-ubuntu16.04"
+      BUILD_ENVIRONMENT: "caffe2-py2-android-ubuntu16.04-build"
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_cuda9_0_cudnn7_centos7_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda9.0-cudnn7-centos7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-centos7:238"
-      BUILD_ENVIRONMENT: "py2-cuda9.0-cudnn7-centos7"
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.0-cudnn7-centos7-build"
     <<: *caffe2_linux_build_defaults
 
   caffe2_py2_cuda9_0_cudnn7_centos7_test:
     environment:
-      JOB_BASE_NAME: caffe2-py2-cuda9.0-cudnn7-centos7-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-centos7:238"
       USE_CUDA_DOCKER_RUNTIME: "1"
-      BUILD_ENVIRONMENT: "py2-cuda9.0-cudnn7-centos7"
+      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.0-cudnn7-centos7-test"
     resource_class: gpu.medium
     <<: *caffe2_linux_test_defaults
 
   caffe2_py2_ios_macos10_13_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-ios-macos10.13-build
+      BUILD_ENVIRONMENT: caffe2-py2-ios-macos10.13-build
       BUILD_IOS: "1"
       PYTHON_INSTALLATION: "system"
       PYTHON_VERSION: "2"
@@ -1569,7 +1544,7 @@ jobs:
 
   caffe2_py2_system_macos10_13_build:
     environment:
-      JOB_BASE_NAME: caffe2-py2-system-macos10.13-build
+      BUILD_ENVIRONMENT: caffe2-py2-system-macos10.13-build
       PYTHON_INSTALLATION: "system"
       PYTHON_VERSION: "2"
     <<: *caffe2_macos_build_defaults
@@ -1594,334 +1569,334 @@ jobs:
           retry pip install awscli==1.6
           "$BUILDER_ROOT/cron/update_s3_htmls.sh"
 
-      
+
 
 ##############################################################################
 # Binary build specs individual job specifications
 ##############################################################################
   binary_linux_manywheel_2.7m_cpu_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cpu"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7mu_cpu_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cpu"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.5m_cpu_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cpu"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.6m_cpu_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cpu"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.7m_cpu_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cpu"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7m_cu80_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu80"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7mu_cu80_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu80"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.5m_cu80_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu80"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.6m_cu80_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu80"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.7m_cu80_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu80"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7m_cu90_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu90"
     docker:
       - image: "soumith/manylinux-cuda90"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7mu_cu90_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu90"
     docker:
       - image: "soumith/manylinux-cuda90"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.5m_cu90_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu90"
     docker:
       - image: "soumith/manylinux-cuda90"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.6m_cu90_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu90"
     docker:
       - image: "soumith/manylinux-cuda90"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.7m_cu90_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu90"
     docker:
       - image: "soumith/manylinux-cuda90"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7m_cu100_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu100"
     docker:
       - image: "soumith/manylinux-cuda100"
     <<: *binary_linux_build
 
   binary_linux_manywheel_2.7mu_cu100_build:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu100"
     docker:
       - image: "soumith/manylinux-cuda100"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.5m_cu100_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu100"
     docker:
       - image: "soumith/manylinux-cuda100"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.6m_cu100_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu100"
     docker:
       - image: "soumith/manylinux-cuda100"
     <<: *binary_linux_build
 
   binary_linux_manywheel_3.7m_cu100_build:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu100"
     docker:
       - image: "soumith/manylinux-cuda100"
     <<: *binary_linux_build
 
   binary_linux_conda_2.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.5_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.6_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_2.7_cu80_build:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu80"
+      BUILD_ENVIRONMENT: "conda 2.7 cu80"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.5_cu80_build:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu80"
+      BUILD_ENVIRONMENT: "conda 3.5 cu80"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.6_cu80_build:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu80"
+      BUILD_ENVIRONMENT: "conda 3.6 cu80"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.7_cu80_build:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu80"
+      BUILD_ENVIRONMENT: "conda 3.7 cu80"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_2.7_cu90_build:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu90"
+      BUILD_ENVIRONMENT: "conda 2.7 cu90"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.5_cu90_build:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu90"
+      BUILD_ENVIRONMENT: "conda 3.5 cu90"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.6_cu90_build:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu90"
+      BUILD_ENVIRONMENT: "conda 3.6 cu90"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.7_cu90_build:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu90"
+      BUILD_ENVIRONMENT: "conda 3.7 cu90"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_2.7_cu100_build:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu100"
+      BUILD_ENVIRONMENT: "conda 2.7 cu100"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.5_cu100_build:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu100"
+      BUILD_ENVIRONMENT: "conda 3.5 cu100"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.6_cu100_build:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu100"
+      BUILD_ENVIRONMENT: "conda 3.6 cu100"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_conda_3.7_cu100_build:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu100"
+      BUILD_ENVIRONMENT: "conda 3.7 cu100"
     docker:
       - image: "soumith/conda-cuda"
     <<: *binary_linux_build
 
   binary_linux_libtorch_2.7m_cpu_build:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_libtorch_2.7m_cu80_build:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu80"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
     docker:
       - image: "soumith/manylinux-cuda80"
     <<: *binary_linux_build
 
   binary_linux_libtorch_2.7m_cu90_build:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu90"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
     docker:
       - image: "soumith/manylinux-cuda90"
     <<: *binary_linux_build
 
   binary_linux_libtorch_2.7m_cu100_build:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu100"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
     docker:
       - image: "soumith/manylinux-cuda100"
     <<: *binary_linux_build
 
   binary_macos_wheel_2.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "wheel 2.7 cpu"
+      BUILD_ENVIRONMENT: "wheel 2.7 cpu"
     <<: *binary_mac_build
 
   binary_macos_wheel_3.5_cpu_build:
     environment:
-      JOB_BASE_NAME: "wheel 3.5 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.5 cpu"
     <<: *binary_mac_build
 
   binary_macos_wheel_3.6_cpu_build:
     environment:
-      JOB_BASE_NAME: "wheel 3.6 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.6 cpu"
     <<: *binary_mac_build
 
   binary_macos_wheel_3.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "wheel 3.7 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.7 cpu"
     <<: *binary_mac_build
 
   binary_macos_conda_2.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
     <<: *binary_mac_build
 
   binary_macos_conda_3.5_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
     <<: *binary_mac_build
 
   binary_macos_conda_3.6_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
     <<: *binary_mac_build
 
   binary_macos_conda_3.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
     <<: *binary_mac_build
 
   binary_macos_libtorch_2.7_cpu_build:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7 cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7 cpu"
     <<: *binary_mac_build
 
   # Binary build tests
@@ -1930,37 +1905,37 @@ jobs:
   #############################################################################
   binary_linux_manywheel_2.7m_cpu_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *binary_linux_test
 
   binary_linux_manywheel_2.7mu_cpu_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *binary_linux_test
 
   binary_linux_manywheel_3.5m_cpu_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *binary_linux_test
 
   binary_linux_manywheel_3.6m_cpu_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *binary_linux_test
 
   binary_linux_manywheel_3.7m_cpu_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *binary_linux_test
 
   binary_linux_manywheel_2.7m_cu80_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     resource_class: gpu.medium
@@ -1968,7 +1943,7 @@ jobs:
 
   binary_linux_manywheel_2.7mu_cu80_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     resource_class: gpu.medium
@@ -1976,7 +1951,7 @@ jobs:
 
   binary_linux_manywheel_3.5m_cu80_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     resource_class: gpu.medium
@@ -1984,7 +1959,7 @@ jobs:
 
   binary_linux_manywheel_3.6m_cu80_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     resource_class: gpu.medium
@@ -1992,7 +1967,7 @@ jobs:
 
   binary_linux_manywheel_3.7m_cu80_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     resource_class: gpu.medium
@@ -2000,7 +1975,7 @@ jobs:
 
   binary_linux_manywheel_2.7m_cu90_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
     resource_class: gpu.medium
@@ -2008,7 +1983,7 @@ jobs:
 
   binary_linux_manywheel_2.7mu_cu90_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
     resource_class: gpu.medium
@@ -2016,7 +1991,7 @@ jobs:
 
   binary_linux_manywheel_3.5m_cu90_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
     resource_class: gpu.medium
@@ -2024,7 +1999,7 @@ jobs:
 
   binary_linux_manywheel_3.6m_cu90_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
     resource_class: gpu.medium
@@ -2032,7 +2007,7 @@ jobs:
 
   binary_linux_manywheel_3.7m_cu90_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
     resource_class: gpu.medium
@@ -2040,7 +2015,7 @@ jobs:
 
   binary_linux_manywheel_2.7m_cu100_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
     resource_class: gpu.medium
@@ -2048,7 +2023,7 @@ jobs:
 
   binary_linux_manywheel_2.7mu_cu100_test:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
     resource_class: gpu.medium
@@ -2056,7 +2031,7 @@ jobs:
 
   binary_linux_manywheel_3.5m_cu100_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
     resource_class: gpu.medium
@@ -2064,7 +2039,7 @@ jobs:
 
   binary_linux_manywheel_3.6m_cu100_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
     resource_class: gpu.medium
@@ -2072,7 +2047,7 @@ jobs:
 
   binary_linux_manywheel_3.7m_cu100_test:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
     resource_class: gpu.medium
@@ -2080,31 +2055,31 @@ jobs:
 
   binary_linux_conda_2.7_cpu_test:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *binary_linux_test
 
   binary_linux_conda_3.5_cpu_test:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *binary_linux_test
 
   binary_linux_conda_3.6_cpu_test:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *binary_linux_test
 
   binary_linux_conda_3.7_cpu_test:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *binary_linux_test
 
   binary_linux_conda_2.7_cu80_test:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu80"
+      BUILD_ENVIRONMENT: "conda 2.7 cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2112,7 +2087,7 @@ jobs:
 
   binary_linux_conda_3.5_cu80_test:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu80"
+      BUILD_ENVIRONMENT: "conda 3.5 cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2120,7 +2095,7 @@ jobs:
 
   binary_linux_conda_3.6_cu80_test:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu80"
+      BUILD_ENVIRONMENT: "conda 3.6 cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2128,7 +2103,7 @@ jobs:
 
   binary_linux_conda_3.7_cu80_test:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu80"
+      BUILD_ENVIRONMENT: "conda 3.7 cu80"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2136,7 +2111,7 @@ jobs:
 
   binary_linux_conda_2.7_cu90_test:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu90"
+      BUILD_ENVIRONMENT: "conda 2.7 cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2144,7 +2119,7 @@ jobs:
 
   binary_linux_conda_3.5_cu90_test:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu90"
+      BUILD_ENVIRONMENT: "conda 3.5 cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2152,7 +2127,7 @@ jobs:
 
   binary_linux_conda_3.6_cu90_test:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu90"
+      BUILD_ENVIRONMENT: "conda 3.6 cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2160,7 +2135,7 @@ jobs:
 
   binary_linux_conda_3.7_cu90_test:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu90"
+      BUILD_ENVIRONMENT: "conda 3.7 cu90"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2168,7 +2143,7 @@ jobs:
 
   binary_linux_conda_2.7_cu100_test:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu100"
+      BUILD_ENVIRONMENT: "conda 2.7 cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2176,7 +2151,7 @@ jobs:
 
   binary_linux_conda_3.5_cu100_test:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu100"
+      BUILD_ENVIRONMENT: "conda 3.5 cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2184,7 +2159,7 @@ jobs:
 
   binary_linux_conda_3.6_cu100_test:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu100"
+      BUILD_ENVIRONMENT: "conda 3.6 cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2192,7 +2167,7 @@ jobs:
 
   binary_linux_conda_3.7_cu100_test:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu100"
+      BUILD_ENVIRONMENT: "conda 3.7 cu100"
       USE_CUDA_DOCKER_RUNTIME: "1"
       DOCKER_IMAGE: "soumith/conda-cuda"
     resource_class: gpu.medium
@@ -2201,25 +2176,25 @@ jobs:
 # There is currently no testing for libtorch TODO
 #  binary_linux_libtorch_2.7m_cpu_test:
 #    environment:
-#      JOB_BASE_NAME: "libtorch 2.7m cpu"
+#      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #
 #  binary_linux_libtorch_2.7m_cu80_test:
 #    environment:
-#      JOB_BASE_NAME: "libtorch 2.7m cu80"
+#      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #
 #  binary_linux_libtorch_2.7m_cu90_test:
 #    environment:
-#      JOB_BASE_NAME: "libtorch 2.7m cu90"
+#      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 #
 #  binary_linux_libtorch_2.7m_cu100_test:
 #    environment:
-#      JOB_BASE_NAME: "libtorch 2.7m cu100"
+#      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
 #    resource_class: gpu.medium
 #    <<: *binary_linux_test
 
@@ -2227,247 +2202,247 @@ jobs:
   #############################################################################
   binary_linux_manywheel_2.7m_cpu_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cpu"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7mu_cpu_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cpu"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.5m_cpu_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cpu"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.6m_cpu_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cpu"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.7m_cpu_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cpu"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7m_cu80_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu80"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7mu_cu80_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu80"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.5m_cu80_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu80"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.6m_cu80_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu80"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.7m_cu80_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu80"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7m_cu90_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu90"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7mu_cu90_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu90"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.5m_cu90_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu90"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.6m_cu90_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu90"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.7m_cu90_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu90"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7m_cu100_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu100"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_2.7mu_cu100_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu100"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.5m_cu100_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu100"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.6m_cu100_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu100"
     <<: *binary_linux_upload
 
   binary_linux_manywheel_3.7m_cu100_upload:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu100"
     <<: *binary_linux_upload
 
   binary_linux_conda_2.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.5_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.6_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
     <<: *binary_linux_upload
 
   binary_linux_conda_2.7_cu80_upload:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu80"
+      BUILD_ENVIRONMENT: "conda 2.7 cu80"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.5_cu80_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu80"
+      BUILD_ENVIRONMENT: "conda 3.5 cu80"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.6_cu80_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu80"
+      BUILD_ENVIRONMENT: "conda 3.6 cu80"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.7_cu80_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu80"
+      BUILD_ENVIRONMENT: "conda 3.7 cu80"
     <<: *binary_linux_upload
 
   binary_linux_conda_2.7_cu90_upload:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu90"
+      BUILD_ENVIRONMENT: "conda 2.7 cu90"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.5_cu90_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu90"
+      BUILD_ENVIRONMENT: "conda 3.5 cu90"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.6_cu90_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu90"
+      BUILD_ENVIRONMENT: "conda 3.6 cu90"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.7_cu90_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu90"
+      BUILD_ENVIRONMENT: "conda 3.7 cu90"
     <<: *binary_linux_upload
 
   binary_linux_conda_2.7_cu100_upload:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu100"
+      BUILD_ENVIRONMENT: "conda 2.7 cu100"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.5_cu100_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu100"
+      BUILD_ENVIRONMENT: "conda 3.5 cu100"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.6_cu100_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu100"
+      BUILD_ENVIRONMENT: "conda 3.6 cu100"
     <<: *binary_linux_upload
 
   binary_linux_conda_3.7_cu100_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu100"
+      BUILD_ENVIRONMENT: "conda 3.7 cu100"
     <<: *binary_linux_upload
 
   binary_linux_libtorch_2.7m_cpu_upload:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
     <<: *binary_linux_upload
 
   binary_linux_libtorch_2.7m_cu80_upload:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu80"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
     <<: *binary_linux_upload
 
   binary_linux_libtorch_2.7m_cu90_upload:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu90"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
     <<: *binary_linux_upload
 
   binary_linux_libtorch_2.7m_cu100_upload:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu100"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
     <<: *binary_linux_upload
 
   binary_macos_wheel_2.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "wheel 2.7 cpu"
+      BUILD_ENVIRONMENT: "wheel 2.7 cpu"
     <<: *binary_mac_upload
 
   binary_macos_wheel_3.5_cpu_upload:
     environment:
-      JOB_BASE_NAME: "wheel 3.5 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.5 cpu"
     <<: *binary_mac_upload
 
   binary_macos_wheel_3.6_cpu_upload:
     environment:
-      JOB_BASE_NAME: "wheel 3.6 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.6 cpu"
     <<: *binary_mac_upload
 
   binary_macos_wheel_3.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "wheel 3.7 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.7 cpu"
     <<: *binary_mac_upload
 
   binary_macos_conda_2.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
     <<: *binary_mac_upload
 
   binary_macos_conda_3.5_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
     <<: *binary_mac_upload
 
   binary_macos_conda_3.6_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
     <<: *binary_mac_upload
 
   binary_macos_conda_3.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
     <<: *binary_mac_upload
 
   binary_macos_libtorch_2.7_cpu_upload:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7 cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7 cpu"
     <<: *binary_mac_upload
 
 
@@ -2476,37 +2451,37 @@ jobs:
 ##############################################################################
   smoke_linux_manywheel_2.7m_cpu:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_manywheel_2.7mu_cpu:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cpu"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_manywheel_3.5m_cpu:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_manywheel_3.6m_cpu:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_manywheel_3.7m_cpu:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cpu"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cpu"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_manywheel_2.7m_cu80:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu80"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2514,7 +2489,7 @@ jobs:
 
   smoke_linux_manywheel_2.7mu_cu80:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu80"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu80"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2522,7 +2497,7 @@ jobs:
 
   smoke_linux_manywheel_3.5m_cu80:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu80"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2530,7 +2505,7 @@ jobs:
 
   smoke_linux_manywheel_3.6m_cu80:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu80"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2538,7 +2513,7 @@ jobs:
 
   smoke_linux_manywheel_3.7m_cu80:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu80"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu80"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2546,7 +2521,7 @@ jobs:
 
   smoke_linux_manywheel_2.7m_cu90:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu90"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2554,7 +2529,7 @@ jobs:
 
   smoke_linux_manywheel_2.7mu_cu90:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu90"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu90"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2562,7 +2537,7 @@ jobs:
 
   smoke_linux_manywheel_3.5m_cu90:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu90"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2570,7 +2545,7 @@ jobs:
 
   smoke_linux_manywheel_3.6m_cu90:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu90"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2578,7 +2553,7 @@ jobs:
 
   smoke_linux_manywheel_3.7m_cu90:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu90"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu90"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2586,7 +2561,7 @@ jobs:
 
   smoke_linux_manywheel_2.7m_cu100:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7m cu100"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2594,7 +2569,7 @@ jobs:
 
   smoke_linux_manywheel_2.7mu_cu100:
     environment:
-      JOB_BASE_NAME: "manywheel 2.7mu cu100"
+      BUILD_ENVIRONMENT: "manywheel 2.7mu cu100"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2602,7 +2577,7 @@ jobs:
 
   smoke_linux_manywheel_3.5m_cu100:
     environment:
-      JOB_BASE_NAME: "manywheel 3.5m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.5m cu100"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2610,7 +2585,7 @@ jobs:
 
   smoke_linux_manywheel_3.6m_cu100:
     environment:
-      JOB_BASE_NAME: "manywheel 3.6m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.6m cu100"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2618,7 +2593,7 @@ jobs:
 
   smoke_linux_manywheel_3.7m_cu100:
     environment:
-      JOB_BASE_NAME: "manywheel 3.7m cu100"
+      BUILD_ENVIRONMENT: "manywheel 3.7m cu100"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2626,31 +2601,31 @@ jobs:
 
   smoke_linux_conda_2.7_cpu:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *smoke_linux_test
 
   smoke_linux_conda_3.5_cpu:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *smoke_linux_test
 
   smoke_linux_conda_3.6_cpu:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *smoke_linux_test
 
   smoke_linux_conda_3.7_cpu:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
       DOCKER_IMAGE: "soumith/conda-cuda"
     <<: *smoke_linux_test
 
   smoke_linux_conda_2.7_cu80:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu80"
+      BUILD_ENVIRONMENT: "conda 2.7 cu80"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2658,7 +2633,7 @@ jobs:
 
   smoke_linux_conda_3.5_cu80:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu80"
+      BUILD_ENVIRONMENT: "conda 3.5 cu80"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2666,7 +2641,7 @@ jobs:
 
   smoke_linux_conda_3.6_cu80:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu80"
+      BUILD_ENVIRONMENT: "conda 3.6 cu80"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2674,7 +2649,7 @@ jobs:
 
   smoke_linux_conda_3.7_cu80:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu80"
+      BUILD_ENVIRONMENT: "conda 3.7 cu80"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2682,7 +2657,7 @@ jobs:
 
   smoke_linux_conda_2.7_cu90:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu90"
+      BUILD_ENVIRONMENT: "conda 2.7 cu90"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2690,7 +2665,7 @@ jobs:
 
   smoke_linux_conda_3.5_cu90:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu90"
+      BUILD_ENVIRONMENT: "conda 3.5 cu90"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2698,7 +2673,7 @@ jobs:
 
   smoke_linux_conda_3.6_cu90:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu90"
+      BUILD_ENVIRONMENT: "conda 3.6 cu90"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2706,7 +2681,7 @@ jobs:
 
   smoke_linux_conda_3.7_cu90:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu90"
+      BUILD_ENVIRONMENT: "conda 3.7 cu90"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2714,7 +2689,7 @@ jobs:
 
   smoke_linux_conda_2.7_cu100:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cu100"
+      BUILD_ENVIRONMENT: "conda 2.7 cu100"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2722,7 +2697,7 @@ jobs:
 
   smoke_linux_conda_3.5_cu100:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cu100"
+      BUILD_ENVIRONMENT: "conda 3.5 cu100"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2730,7 +2705,7 @@ jobs:
 
   smoke_linux_conda_3.6_cu100:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cu100"
+      BUILD_ENVIRONMENT: "conda 3.6 cu100"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2738,7 +2713,7 @@ jobs:
 
   smoke_linux_conda_3.7_cu100:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cu100"
+      BUILD_ENVIRONMENT: "conda 3.7 cu100"
       DOCKER_IMAGE: "soumith/conda-cuda"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -2746,35 +2721,35 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cpu_shared-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
       LIBTORCH_VARIANT: "shared-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_libtorch_2.7m_cpu_shared-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
       LIBTORCH_VARIANT: "shared-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_libtorch_2.7m_cpu_static-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
       LIBTORCH_VARIANT: "static-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_libtorch_2.7m_cpu_static-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
       LIBTORCH_VARIANT: "static-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
     <<: *smoke_linux_test
 
   smoke_linux_libtorch_2.7m_cu80_shared-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu80"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
       LIBTORCH_VARIANT: "shared-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2783,7 +2758,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu80_shared-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu80"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
       LIBTORCH_VARIANT: "shared-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2792,7 +2767,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu80_static-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu80"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
       LIBTORCH_VARIANT: "static-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2801,7 +2776,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu80_static-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu80"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu80"
       LIBTORCH_VARIANT: "static-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda80"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2810,7 +2785,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu90_shared-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu90"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
       LIBTORCH_VARIANT: "shared-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2819,7 +2794,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu90_shared-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu90"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
       LIBTORCH_VARIANT: "shared-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2828,7 +2803,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu90_static-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu90"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
       LIBTORCH_VARIANT: "static-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2837,7 +2812,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu90_static-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu90"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu90"
       LIBTORCH_VARIANT: "static-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda90"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2846,7 +2821,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu100_shared-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu100"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
       LIBTORCH_VARIANT: "shared-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2855,7 +2830,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu100_shared-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu100"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
       LIBTORCH_VARIANT: "shared-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2864,7 +2839,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu100_static-with-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu100"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
       LIBTORCH_VARIANT: "static-with-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2873,7 +2848,7 @@ jobs:
 
   smoke_linux_libtorch_2.7m_cu100_static-without-deps:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cu100"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cu100"
       LIBTORCH_VARIANT: "static-without-deps"
       DOCKER_IMAGE: "soumith/manylinux-cuda100"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2882,47 +2857,47 @@ jobs:
 
   smoke_macos_wheel_2.7_cpu:
     environment:
-      JOB_BASE_NAME: "wheel 2.7 cpu"
+      BUILD_ENVIRONMENT: "wheel 2.7 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_wheel_3.5_cpu:
     environment:
-      JOB_BASE_NAME: "wheel 3.5 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.5 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_wheel_3.6_cpu:
     environment:
-      JOB_BASE_NAME: "wheel 3.6 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.6 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_wheel_3.7_cpu:
     environment:
-      JOB_BASE_NAME: "wheel 3.7 cpu"
+      BUILD_ENVIRONMENT: "wheel 3.7 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_conda_2.7_cpu:
     environment:
-      JOB_BASE_NAME: "conda 2.7 cpu"
+      BUILD_ENVIRONMENT: "conda 2.7 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_conda_3.5_cpu:
     environment:
-      JOB_BASE_NAME: "conda 3.5 cpu"
+      BUILD_ENVIRONMENT: "conda 3.5 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_conda_3.6_cpu:
     environment:
-      JOB_BASE_NAME: "conda 3.6 cpu"
+      BUILD_ENVIRONMENT: "conda 3.6 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_conda_3.7_cpu:
     environment:
-      JOB_BASE_NAME: "conda 3.7 cpu"
+      BUILD_ENVIRONMENT: "conda 3.7 cpu"
     <<: *smoke_mac_test
 
   smoke_macos_libtorch_2.7_cpu:
     environment:
-      JOB_BASE_NAME: "libtorch 2.7m cpu"
+      BUILD_ENVIRONMENT: "libtorch 2.7m cpu"
     <<: *smoke_mac_test
 
 

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -5,7 +5,7 @@ set -ex
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # TODO: Migrate all centos jobs to use proper devtoolset
-if [[ "$BUILD_ENVIRONMENT" == "py2-cuda9.0-cudnn7-centos7" ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *py2-cuda9.0-cudnn7-centos7* ]]; then
   # There is a bug in pango packge on Centos7 that causes undefined
   # symbols, upgrading glib2 to >=2.56.1 solves the issue. See
   # https://bugs.centos.org/view.php?id=15495
@@ -134,7 +134,7 @@ build_args+=("BUILD_TEST=ON")
 build_args+=("INSTALL_TEST=ON")
 build_args+=("USE_ZSTD=ON")
 
-if [[ $BUILD_ENVIRONMENT == py2-cuda9.0-cudnn7-ubuntu16.04 ]]; then
+if [[ $BUILD_ENVIRONMENT == *py2-cuda9.0-cudnn7-ubuntu16.04* ]]; then
   # removing http:// duplicate in favor of nvidia-ml.list
   # which is https:// version of the same repo
   sudo rm -f /etc/apt/sources.list.d/nvidia-machine-learning.list

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -4,7 +4,7 @@
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-build"
+COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Clang version:"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -4,7 +4,7 @@
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-build"
+COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # For distributed, four environmental configs:
@@ -30,7 +30,7 @@ if [[ "$BUILD_ENVIRONMENT" == *-xenial-cuda9*gcc7* ]] || [[ "$BUILD_ENVIRONMENT"
   sudo mkdir -p /var/run/sshd
 fi
 
-if [[ "$BUILD_ENVIRONMENT" == "pytorch-linux-xenial-py3-clang5-asan" ]]; then
+if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-py3-clang5-asan* ]]; then
   exec "$(dirname "${BASH_SOURCE[0]}")/build-asan.sh" $*
 fi
 
@@ -116,7 +116,7 @@ if [[ "$BUILD_ENVIRONMENT" == *trusty-py3.6-gcc5.4* ]]; then
 fi
 
 # Patch required to build xla
-if [[ "${JOB_BASE_NAME}" == *xla* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   git clone --recursive https://github.com/pytorch/xla.git
   patch -p1 < xla/pytorch.patch
 fi
@@ -176,7 +176,7 @@ if [[ "$BUILD_TEST_LIBTORCH" == "1" ]]; then
 fi
 
 # Test XLA build
-if [[ "${JOB_BASE_NAME}" == *xla* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   # TODO: Move this to Dockerfile.
   # Bazel doesn't work with sccache gcc. https://github.com/bazelbuild/bazel/issues/3642
   sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"

--- a/.jenkins/pytorch/enabled-configs.txt
+++ b/.jenkins/pytorch/enabled-configs.txt
@@ -42,11 +42,11 @@ pytorch-macos-10.13-cuda9.2-cudnn7-py3-build
 pytorch-docker-build-test
 short-perf-test-cpu
 short-perf-test-gpu
-py2-clang7-rocmdeb-ubuntu16.04-build
-py2-clang7-rocmdeb-ubuntu16.04-test
-py2-devtoolset7-rocmrpm-centos7.5-build
-py2-devtoolset7-rocmrpm-centos7.5-test
+py2-clang7-rocmdeb-ubuntu16.04
+py2-devtoolset7-rocmrpm-centos7.5
 pytorch-ppc64le-cuda9.2-cudnn7-py3-build
 pytorch-ppc64le-cuda9.2-cudnn7-py3-test
 pytorch-ppc64le-cuda9.1-cudnn7-py3-build
 pytorch-ppc64le-cuda9.1-cudnn7-py3-test
+pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX2-test
+pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX-NO_AVX2-test

--- a/.jenkins/pytorch/macos-build-test.sh
+++ b/.jenkins/pytorch/macos-build-test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-build* ]]; then
+if [ -z "${BUILD_ENVIRONMENT}" ] || [[ "${BUILD_ENVIRONMENT}" == *-build* ]]; then
   source "$(dirname "${BASH_SOURCE[0]}")/macos-build.sh"
 fi
 
-if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test* ]]; then
+if [ -z "${BUILD_ENVIRONMENT}" ] || [[ "${BUILD_ENVIRONMENT}" == *-test* ]]; then
   source "$(dirname "${BASH_SOURCE[0]}")/macos-test.sh"
 fi

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-build"
+COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 export PATH="/usr/local/bin:$PATH"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
@@ -22,7 +22,7 @@ git submodule update --init --recursive
 export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 
 # Build PyTorch
-if [[ "${JOB_BASE_NAME}" == *cuda9.2* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *cuda9.2* ]]; then
   export CUDA_VERSION=9.2
   export TORCH_CUDA_ARCH_LIST=5.2
   export PATH=/Developer/NVIDIA/CUDA-${CUDA_VERSION}/bin${PATH:+:${PATH}}
@@ -51,7 +51,7 @@ if which sccache > /dev/null; then
   printf "#!/bin/sh\nexec sccache $(which clang) \$*" > "${PYTORCH_ENV_DIR}/clang"
   chmod a+x "${PYTORCH_ENV_DIR}/clang"
 
-  if [[ "${JOB_BASE_NAME}" == *cuda* ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
     printf "#!/bin/sh\nexec sccache $(which nvcc) \$*" > "${PYTORCH_ENV_DIR}/nvcc"
     chmod a+x "${PYTORCH_ENV_DIR}/nvcc"
     export CUDA_NVCC_EXECUTABLE="${PYTORCH_ENV_DIR}/nvcc"

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-test"
+COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 export PATH="/usr/local/bin:$PATH"
@@ -27,7 +27,7 @@ export CMAKE_PREFIX_PATH=${PYTORCH_ENV_DIR}/miniconda3/
 
 # Test PyTorch
 if [ -z "${IN_CIRCLECI}" ]; then
-  if [[ "${JOB_BASE_NAME}" == *cuda9.2* ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda9.2* ]]; then
     # Eigen gives "explicit specialization of class must precede its first use" error
     # when compiling with Xcode 9.1 toolchain, so we have to use Xcode 8.2 toolchain instead.
     export DEVELOPER_DIR=/Library/Developer/CommandLineTools
@@ -108,14 +108,14 @@ test_custom_script_ops() {
 }
 
 
-if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
+if [ -z "${BUILD_ENVIRONMENT}" ] || [[ "${BUILD_ENVIRONMENT}" == *-test ]]; then
   test_python_all
   test_libtorch
   test_custom_script_ops
 else
-  if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *-test1 ]]; then
     test_python_all
-  elif [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
+  elif [[ "${BUILD_ENVIRONMENT}" == *-test2 ]]; then
     test_libtorch
     test_custom_script_ops
   fi

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -4,7 +4,7 @@
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-multigpu-test"
+COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch (distributed only)"

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -4,7 +4,7 @@
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-test"
+COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 echo "Testing pytorch"
@@ -85,9 +85,9 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   pip install -q psutil "librosa>=0.6.2" --user
 fi
 
-if [[ "${JOB_BASE_NAME}" == *-NO_AVX-* ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == *-NO_AVX-* ]]; then
   export ATEN_CPU_CAPABILITY=default
-elif [[ "${JOB_BASE_NAME}" == *-NO_AVX2-* ]]; then
+elif [[ "${BUILD_ENVIRONMENT}" == *-NO_AVX2-* ]]; then
   export ATEN_CPU_CAPABILITY=avx
 fi
 
@@ -186,8 +186,8 @@ test_xla() {
   assert_git_not_dirty
 }
 
-if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
-  if [[ "${JOB_BASE_NAME}" == *xla* ]]; then
+if [ -z "${BUILD_ENVIRONMENT}" ] || [[ "${BUILD_ENVIRONMENT}" == *-test ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
     test_torchvision
     test_xla
   else
@@ -199,10 +199,10 @@ if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
     test_custom_script_ops
   fi
 else
-  if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
+  if [[ "${BUILD_ENVIRONMENT}" == *-test1 ]]; then
     test_torchvision
     test_python_nn
-  elif [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
+  elif [[ "${BUILD_ENVIRONMENT}" == *-test2 ]]; then
     test_torchvision
     test_python_all_except_nn
     test_aten

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -148,15 +148,15 @@ test_api.exe --gtest_filter="-IntegrationTest.MNIST*"
 EOL
 
 run_tests() {
-    if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
+    if [ -z "${BUILD_ENVIRONMENT}" ] || [[ "${BUILD_ENVIRONMENT}" == *-test ]]; then
         $TMP_DIR/ci_scripts/test_python_nn.bat && \
         $TMP_DIR/ci_scripts/test_python_all_except_nn.bat && \
         $TMP_DIR/ci_scripts/test_custom_script_ops.bat && \
         $TMP_DIR/ci_scripts/test_libtorch.bat
     else
-        if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
+        if [[ "${BUILD_ENVIRONMENT}" == *-test1 ]]; then
             $TMP_DIR/ci_scripts/test_python_nn.bat
-        elif [[ "${JOB_BASE_NAME}" == *-test2 ]]; then
+        elif [[ "${BUILD_ENVIRONMENT}" == *-test2 ]]; then
             $TMP_DIR/ci_scripts/test_python_all_except_nn.bat && \
             $TMP_DIR/ci_scripts/test_custom_script_ops.bat && \
             $TMP_DIR/ci_scripts/test_libtorch.bat


### PR DESCRIPTION
The idea is to unify the environment variables `JOB_BASE_NAME` and `BUILD_ENVIRONMENT` which controlled the Pytorch and Caffe2 jobs respectively. In this commit, we have converted all the `JOB_BASE_NAME` references in _.jenkins/pytorch/*_ files to `BUILD_ENVIRONMENT`. Then, did the same thing in ._circleci/config.yml_. One thing that we needed to be careful was when both `BUILD_ENVIRONMENT `and `JOB_BASE_NAME` were present under same declaration in _config.yml_ file (e.g., for "caffe2-" stuffs). To ensure that all "==" checks work as expected, we also had to add "*" in some if conditions in _.jenkins/caffe2/build.sh_ file. Finally, removed "-build", "-test", etc. suffixes from `COMPACT_JOB_NAME` variable assignment in the bash script files in _.jenkins/pytorch_ folder, e.g., modify `COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}-build"` to `COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"`.