### PR TITLE
Make tuple checks faster

### DIFF
--- a/torch/csrc/utils/six.h
+++ b/torch/csrc/utils/six.h
@@ -13,7 +13,7 @@ inline bool isTuple(pybind11::handle input) {
   if (PyTuple_Check(input.ptr())) {
     return true;
   }
-  return pybind11::str(input.get_type().attr("__module__")) == "torch.return_types";
+  return pybind11::cast<std::string>(input.get_type().attr("__module__")) == "torch.return_types";
 }
 
 inline bool isTuple(PyObject* obj) {

--- a/torch/csrc/utils/six.h
+++ b/torch/csrc/utils/six.h
@@ -10,8 +10,10 @@ namespace six {
 // by a pytorch operator.
 
 inline bool isTuple(pybind11::handle input) {
-  std::string m = pybind11::str(input.get_type().attr("__module__"));
-  return pybind11::isinstance<pybind11::tuple>(input) || m == "torch.return_types";
+  if (PyTuple_Check(input.ptr())) {
+    return true;
+  }
+  return pybind11::str(input.get_type().attr("__module__")) == "torch.return_types";
 }
 
 inline bool isTuple(PyObject* obj) {

--- a/torch/csrc/utils/six.h
+++ b/torch/csrc/utils/six.h
@@ -13,7 +13,11 @@ inline bool isTuple(pybind11::handle input) {
   if (PyTuple_Check(input.ptr())) {
     return true;
   }
+#if PY_MAJOR_VERSION == 2
   return pybind11::cast<std::string>(input.get_type().attr("__module__")) == "torch.return_types";
+#else
+  return false;
+#endif
 }
 
 inline bool isTuple(PyObject* obj) {


### PR DESCRIPTION
As the comment indicates, the issue is only present in some versions of
Python 2, so we should be able to use heavily optimized PyTuple_Check in
most cases, and skip allocation of the strings, and unnecessary lookups
on object's type.

cc @ezyang @zasdfgbnm 