### PR TITLE
Fix issue with scalars and __rpow__

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2325,6 +2325,9 @@ class TestCuda(TestCase):
     def test_min_with_inf(self):
         _TestTorchMixin._test_min_with_inf(self, (torch.half, torch.float, torch.double), 'cuda')
 
+    def test_rpow(self):
+        _TestTorchMixin._test_rpow(self, lambda x: x.cuda())
+
     def test_int_pow(self):
         _TestTorchMixin._test_int_pow(self, lambda x: x.cuda())
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1974,9 +1974,18 @@ class _TestTorchMixin(object):
             res2[i] = math.pow(3, m1[i][4])
         self.assertEqual(res1, res2)
 
-    def test_rpow(self):
-        m = torch.randn(10, 10)
+    @staticmethod
+    def _test_rpow(self, cast):
+        m = cast(torch.randn(10, 10))
         self.assertEqual(torch.pow(2, m), 2**m)
+
+        # test with scalar
+        m = cast(torch.randn(1).squeeze())
+        assert m.dim() == 0, "m is intentionally a scalar"
+        self.assertEqual(torch.pow(2, m), 2**m)
+
+    def test_rpow(self):
+        self._test_rpow(self, lambda x: x)
 
     @staticmethod
     def _test_int_pow(self, cast):

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -388,7 +388,7 @@ class Tensor(torch._C._TensorBase):
         raise NotImplementedError("in-place pow not implemented")
 
     def __rpow__(self, other):
-        return self.new([other]) ** self
+        return self.new_tensor(other) ** self
 
     def __floordiv__(self, other):
         result = self / other


### PR DESCRIPTION
Changelog:

- Modify __rpow__ function in tensor.py to adapt to scalars

Test plan:

- Add scalar entry in test_rpow
- Add CUDA port

Fixes #16685 

