### PR TITLE
Fix build with cuda but no cudnn in caffe2

### DIFF
--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -44,6 +44,11 @@ void addCUDAGlobalMethods(py::module& m) {
   m.attr("cudnn_convolution_fwd_algo_count") = py::int_((int) CUDNN_CONVOLUTION_FWD_ALGO_COUNT);
   m.attr("cudnn_convolution_bwd_data_algo_count") = py::int_((int) CUDNN_CONVOLUTION_BWD_DATA_ALGO_COUNT);
   m.attr("cudnn_convolution_bwd_filter_algo_count") = py::int_((int) CUDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT);
+#else
+  m.def("get_cudnn_version", [](){ return static_cast<size_t>(0);});
+  m.attr("cudnn_convolution_fwd_algo_count") = py::int_(0);
+  m.attr("cudnn_convolution_bwd_data_algo_count") = py::int_(0);
+  m.attr("cudnn_convolution_bwd_filter_algo_count") = py::int_(0);
 #endif
   m.def("get_cuda_peer_access_pattern", []() {
     std::vector<std::vector<bool>> pattern;


### PR DESCRIPTION
Just noticed while building on a machine without cudnn present - it was building but the runtime failed since some methods weren't bound