### PR TITLE
Fix ReservoirSampling zero-initialization reliance

### DIFF
--- a/caffe2/operators/reservoir_sampling.cc
+++ b/caffe2/operators/reservoir_sampling.cc
@@ -106,6 +106,13 @@ class ReservoirSamplingOp final : public Operator<Context> {
     output->ExtendTo(output_num, 50);
     if (pos_to_object) {
       pos_to_object->ExtendTo(output_num, 50);
+      // ExtendTo doesn't zero-initialize tensors any more, explicitly clear
+      // the memory
+      memset(
+          pos_to_object->template mutable_data<int64_t>() +
+              output_batch_size * sizeof(int64_t),
+          0,
+          (output_num - output_batch_size) * sizeof(int64_t));
     }
 
     auto* output_data =


### PR DESCRIPTION
The op was implicitly relying on pos_to_output to be zero-initialized after extending. We're removing this functionality from allocator, thus fixing here. For some reason it wasn't spotted by junk-initialization but was reliably reproducible with standard malloc() if both junk_fill and zero_fill flags are turned off.

cc @kittipatv jerryzh168