### PR TITLE
Removed obsolete argument correct_transform_coords in bbox_transform op.

### DIFF
--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -22,12 +22,6 @@ Transform proposal bounding boxes to target bounding box using bounding box
         "Set to false to match the detectron code, set to true for keypoint"
         " models and for backward compatibility")
     .Arg(
-        "correct_transform_coords",
-        "bool (default false), Correct bounding box transform coordates,"
-        " see bbox_transform() in boxes.py "
-        "Set to true to match the detectron code, set to false for backward"
-        " compatibility")
-    .Arg(
         "rotated",
         "bool (default false). If true, then boxes (rois and deltas) include "
         "angle info to handle rotation. The format will be "
@@ -160,7 +154,6 @@ bool BBoxTransformOp<float, CPUContext>::RunOnDevice() {
           cur_deltas,
           weights_,
           utils::BBOX_XFORM_CLIP_DEFAULT,
-          correct_transform_coords_,
           angle_bound_on_,
           angle_bound_lo_,
           angle_bound_hi_);
@@ -188,7 +181,8 @@ bool BBoxTransformOp<float, CPUContext>::RunOnDevice() {
 
 } // namespace caffe2
 
-using BBoxTransformOpFloatCPU = caffe2::BBoxTransformOp<float, caffe2::CPUContext>;
+using BBoxTransformOpFloatCPU =
+    caffe2::BBoxTransformOp<float, caffe2::CPUContext>;
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     BBoxTransform,
@@ -198,7 +192,6 @@ C10_REGISTER_CAFFE2_OPERATOR_CPU(
         c10::Argument("im_info"),
         c10::Argument("weights", ListType::create(FloatType::get())),
         c10::Argument("apply_scale", BoolType::get()),
-        c10::Argument("correct_transform_coords", BoolType::get()),
         c10::Argument("rotated", BoolType::get()),
         c10::Argument("angle_bound_on", BoolType::get()),
         c10::Argument("angle_bound_lo", IntType::get()),
@@ -209,5 +202,4 @@ C10_REGISTER_CAFFE2_OPERATOR_CPU(
         c10::Argument("output_0"),
         c10::Argument("output_1"),
     }),
-    BBoxTransformOpFloatCPU
-);
+    BBoxTransformOpFloatCPU);

--- a/caffe2/operators/bbox_transform_op.h
+++ b/caffe2/operators/bbox_transform_op.h
@@ -23,9 +23,6 @@ class BBoxTransformOp final : public Operator<Context> {
             vector<T>{1.0f, 1.0f, 1.0f, 1.0f})),
         apply_scale_(
             this->template GetSingleArgument<bool>("apply_scale", true)),
-        correct_transform_coords_(this->template GetSingleArgument<bool>(
-            "correct_transform_coords",
-            false)),
         rotated_(this->template GetSingleArgument<bool>("rotated", false)),
         angle_bound_on_(
             this->template GetSingleArgument<bool>("angle_bound_on", true)),
@@ -52,10 +49,6 @@ class BBoxTransformOp final : public Operator<Context> {
   // Set to false to match the detectron code, set to true for the keypoint
   //   model and for backward compatibility
   bool apply_scale_{true};
-  // Correct bounding box transform coordates, see bbox_transform() in boxes.py
-  // Set to true to match the detectron code, set to false for backward
-  //   compatibility
-  bool correct_transform_coords_{false};
   // Set for RRPN case to handle rotated boxes. Inputs should be in format
   // [ctr_x, ctr_y, width, height, angle (in degrees)].
   bool rotated_{false};

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -228,7 +228,6 @@ void GenerateProposalsOp<CPUContext>::ProposalsForOneImage(
       bbox_deltas_sorted,
       bbox_weights,
       utils::BBOX_XFORM_CLIP_DEFAULT,
-      correct_transform_coords_,
       angle_bound_on_,
       angle_bound_lo_,
       angle_bound_hi_);
@@ -364,12 +363,6 @@ non-maximum suppression is applied to generate the final bounding boxes.
     .Arg("nms_thresh", "(float) RPN_NMS_THRESH")
     .Arg("min_size", "(float) RPN_MIN_SIZE")
     .Arg(
-        "correct_transform_coords",
-        "bool (default false), Correct bounding box transform coordates,"
-        " see bbox_transform() in boxes.py "
-        "Set to true to match the detectron code, set to false for backward"
-        " compatibility")
-    .Arg(
         "angle_bound_on",
         "bool (default true). If set, for rotated boxes, angle is "
         "normalized to be within [angle_bound_lo, angle_bound_hi].")
@@ -425,7 +418,6 @@ C10_REGISTER_CAFFE2_OPERATOR_CPU(
         c10::Argument("post_nms_topN", IntType::get()),
         c10::Argument("nms_thresh", FloatType::get()),
         c10::Argument("min_size", FloatType::get()),
-        c10::Argument("correct_transform_coords", BoolType::get()),
         c10::Argument("angle_bound_on", BoolType::get()),
         c10::Argument("angle_bound_lo", IntType::get()),
         c10::Argument("angle_bound_hi", IntType::get()),
@@ -435,5 +427,4 @@ C10_REGISTER_CAFFE2_OPERATOR_CPU(
         c10::Argument("output_0"),
         c10::Argument("output_1"),
     }),
-    caffe2::GenerateProposalsOp<caffe2::CPUContext>
-);
+    caffe2::GenerateProposalsOp<caffe2::CPUContext>);

--- a/caffe2/operators/generate_proposals_op.h
+++ b/caffe2/operators/generate_proposals_op.h
@@ -91,9 +91,6 @@ class GenerateProposalsOp final : public Operator<Context> {
         rpn_nms_thresh_(
             this->template GetSingleArgument<float>("nms_thresh", 0.7f)),
         rpn_min_size_(this->template GetSingleArgument<float>("min_size", 16)),
-        correct_transform_coords_(this->template GetSingleArgument<bool>(
-            "correct_transform_coords",
-            false)),
         angle_bound_on_(
             this->template GetSingleArgument<bool>("angle_bound_on", true)),
         angle_bound_lo_(
@@ -135,10 +132,6 @@ class GenerateProposalsOp final : public Operator<Context> {
   float rpn_nms_thresh_{0.7};
   // RPN_MIN_SIZE
   float rpn_min_size_{16};
-  // Correct bounding box transform coordates, see bbox_transform() in boxes.py
-  // Set to true to match the detectron code, set to false for backward
-  // compatibility
-  bool correct_transform_coords_{false};
   // If set, for rotated boxes in RRPN, output angles are normalized to be
   // within [angle_bound_lo, angle_bound_hi].
   bool angle_bound_on_{true};

--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -39,8 +39,7 @@ EArrXXt<typename Derived1::Scalar> bbox_transform_upright(
     const Eigen::ArrayBase<Derived2>& deltas,
     const std::vector<typename Derived2::Scalar>& weights =
         std::vector<typename Derived2::Scalar>{1.0, 1.0, 1.0, 1.0},
-    const float bbox_xform_clip = BBOX_XFORM_CLIP_DEFAULT,
-    const bool correct_transform_coords = false) {
+    const float bbox_xform_clip = BBOX_XFORM_CLIP_DEFAULT) {
   using T = typename Derived1::Scalar;
   using EArrXX = EArrXXt<T>;
   using EArrX = EArrXt<T>;
@@ -70,17 +69,15 @@ EArrXXt<typename Derived1::Scalar> bbox_transform_upright(
   EArrX pred_w = dw.exp() * widths;
   EArrX pred_h = dh.exp() * heights;
 
-  T offset(correct_transform_coords ? 1.0 : 0.0);
-
   EArrXX pred_boxes = EArrXX::Zero(deltas.rows(), deltas.cols());
   // x1
   pred_boxes.col(0) = pred_ctr_x - T(0.5) * pred_w;
   // y1
   pred_boxes.col(1) = pred_ctr_y - T(0.5) * pred_h;
   // x2
-  pred_boxes.col(2) = pred_ctr_x + T(0.5) * pred_w - offset;
+  pred_boxes.col(2) = pred_ctr_x + T(0.5) * pred_w - T(1.0);
   // y2
-  pred_boxes.col(3) = pred_ctr_y + T(0.5) * pred_h - offset;
+  pred_boxes.col(3) = pred_ctr_y + T(0.5) * pred_h - T(1.0);
 
   return pred_boxes;
 }
@@ -169,15 +166,13 @@ EArrXXt<typename Derived1::Scalar> bbox_transform(
     const std::vector<typename Derived2::Scalar>& weights =
         std::vector<typename Derived2::Scalar>{1.0, 1.0, 1.0, 1.0},
     const float bbox_xform_clip = BBOX_XFORM_CLIP_DEFAULT,
-    const bool correct_transform_coords = false,
     const bool angle_bound_on = true,
     const int angle_bound_lo = -90,
     const int angle_bound_hi = 90) {
   CAFFE_ENFORCE(boxes.cols() == 4 || boxes.cols() == 5);
   if (boxes.cols() == 4) {
     // Upright boxes
-    return bbox_transform_upright(
-        boxes, deltas, weights, bbox_xform_clip, correct_transform_coords);
+    return bbox_transform_upright(boxes, deltas, weights, bbox_xform_clip);
   } else {
     // Rotated boxes with angle info
     return bbox_transform_rotated(

--- a/caffe2/operators/generate_proposals_op_util_boxes_test.cc
+++ b/caffe2/operators/generate_proposals_op_util_boxes_test.cc
@@ -31,8 +31,7 @@ TEST(UtilsBoxesTest, TestBboxTransformRandom) {
       bbox.array(),
       deltas.array(),
       std::vector<float>{1.0, 1.0, 1.0, 1.0},
-      BBOX_XFORM_CLIP,
-      true);
+      BBOX_XFORM_CLIP);
   EXPECT_NEAR((result.matrix() - result_gt).norm(), 0.0, 1e-4);
 }
 
@@ -65,7 +64,6 @@ TEST(UtilsBoxesTest, TestBboxTransformRotated) {
       deltas.array(),
       std::vector<float>{1.0, 1.0, 1.0, 1.0},
       BBOX_XFORM_CLIP,
-      true, /* correct_transform_coords */
       false /* angle_bound_on */);
   EXPECT_NEAR((result.matrix() - result_gt).norm(), 0.0, 1e-2);
 }
@@ -98,7 +96,6 @@ TEST(UtilsBoxesTest, TestBboxTransformRotatedNormalized) {
       deltas.array(),
       std::vector<float>{1.0, 1.0, 1.0, 1.0},
       BBOX_XFORM_CLIP,
-      true, /* correct_transform_coords */
       true, /* angle_bound_on */
       -90, /* angle_bound_lo */
       90 /* angle_bound_hi */);


### PR DESCRIPTION
Summary:
Removed obsolete argument correct_transform_coords in bbox_transform op.
* It was only for backward compatibility. We should not have models using it now.

Differential Revision: D13937430
