### PR TITLE
Export ReduceMean/ReduceFrontMean/ReduceBackMean (Caffe2) to ReduceMean (ONNX).

### DIFF
--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -89,6 +89,10 @@ class CAFFE2_API OnnxExporter {
       const caffe2::OperatorDef& def,
       const std::unordered_map<std::string, caffe2::TensorShape>& shapes);
 
+  ConvertedResult CreateReduceMeanNodes(
+      const caffe2::OperatorDef& def,
+      const std::unordered_map<std::string, caffe2::TensorShape>& shapes);
+
   ConvertedResult CreateConcatNodes(
       const caffe2::OperatorDef& def,
       const std::unordered_map<std::string, caffe2::TensorShape>& shapes);

--- a/caffe2/operators/reduce_front_back_mean_ops.cc
+++ b/caffe2/operators/reduce_front_back_mean_ops.cc
@@ -193,7 +193,8 @@ Y: [4.3333335    2.1666667     6.]
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(true)
-    });
+    })
+    .InheritOnnxSchema("ReduceMean");
 OPERATOR_SCHEMA(ReduceFrontMeanGradient).NumInputs(2, 3).NumOutputs(1);
 
 REGISTER_CPU_OPERATOR(ReduceBackMean, SumReduceDimsOp<CPUContext, false, true>);
@@ -285,7 +286,8 @@ Y: [[3.7777777 4.888889 ]]
     .TensorInferenceFunction([](const OperatorDef& def,
                                 const vector<TensorShape>& in) {
       REDUCTION_OP_SHAPE_INFERENCE(false)
-    });
+    })
+    .InheritOnnxSchema("ReduceMean");
 OPERATOR_SCHEMA(ReduceBackMeanGradient).NumInputs(2, 3).NumOutputs(1);
 
 #undef REDUCTION_OP_SHAPE_INFERENCE

--- a/caffe2/operators/reduce_ops.cc
+++ b/caffe2/operators/reduce_ops.cc
@@ -506,7 +506,8 @@ Y:
         "keepdims",
         "(*int*): set to 1 to keep the reduced dimension(s) (default=1), else set to 0 to not keep the reduced dimension(s)")
     .Input(0, "X", "(*Tensor`<float>`*): input tensor")
-    .Output(0, "Y", "(*Tensor`<float>`*): reduced tensor");
+    .Output(0, "Y", "(*Tensor`<float>`*): reduced tensor")
+    .InheritOnnxSchema("ReduceMean");
 
 OPERATOR_SCHEMA(ReduceL2Gradient).NumInputs(3).NumOutputs(1);
 


### PR DESCRIPTION
The second input (`lengths`) is not supported.