### PR TITLE
Enable undefined at::Tensor to be passed as Output

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -33,6 +33,9 @@ inline Tensor GetSizedTensorWithOptions(
     at::IntList dims,
     at::TensorOptions options) {
   Tensor tensor = std::move(previous_tensor);
+  if (!tensor.defined()) {
+    return caffe2::empty(dims, options);
+  }
   if (tensor.GetDevice() == options.device() ||
       (!tensor.GetDevice().has_index() &&
        tensor.GetDeviceType() == options.device().type())) {

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -185,7 +185,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
         ival->isTensor(),
         "Output(int, DeviceType) is only available for IValues that store Tensors");
     Tensor tensor = caffe2::Tensor(ival->toTensor());
-    if (tensor.GetDeviceType() != type) {
+    if (!tensor.defined() || tensor.GetDeviceType() != type) {
       // Fix tensor type
       tensor = Tensor(type);
       auto at_tensor = at::Tensor(std::move(tensor.getIntrusivePtr()));

--- a/torch/csrc/jit/caffe2_operator.cpp
+++ b/torch/csrc/jit/caffe2_operator.cpp
@@ -31,9 +31,7 @@ Operator createOperatorFromCaffe2(const std::string& name) {
       std::vector<c10::IValue*> outputs;
       for (size_t i = 0; i < output_size; ++i) {
         if (TensorType::get() == fn.returns()[i].type()) {
-          caffe2::Tensor tensor(caffe2::CPU);
-          auto at_tensor = at::Tensor(c10::C10Tensor(std::move(tensor)));
-          outputs_real.emplace_back(c10::IValue(at_tensor));
+          outputs_real.emplace_back(c10::IValue(at::Tensor()));
         } else {
           outputs_real.emplace_back(c10::IValue());
         }


### PR DESCRIPTION
Summary: with Jerry's new updates Tensor must be defined -- as a result I've needed to update the shim for caffe2 ops being used in PyTorch

Reviewed By: smessmer

Differential Revision: D13946950
