### PR TITLE
[ROCm] Document hip-clang and its __HIP__ macro

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -133,6 +133,17 @@ static inline  __device__  void atomicAdd(double *address, double val) {
 } while (assumed != old);
 }
 #elif !defined(__CUDA_ARCH__) && (CUDA_VERSION < 8000) || defined(__HIP_PLATFORM_HCC__)
+
+/* Note [hip-clang differences to hcc]
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * The upcoming hip-clang compiler for ROCm differs from hcc in a few details.
+ * It exports the __HIP__ macro, we can hence differentiate between hcc and
+ * hip-clang. In the below, hcc only received support for atomicAdd with double
+ * typing after work week 18312. hip-clang had support from the first version.
+ * In general, the code-visible differences between hip-clang and hcc will be
+ * minimal.
+ */
+
 #if defined(__HIP_PLATFORM_HCC__) && __hcc_workweek__ < 18312 && !__HIP__
   // This needs to be defined for the host side pass
   static inline  __device__  void atomicAdd(double *address, double val) { }

--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -11,6 +11,8 @@
 #include <caffe2/core/hip/common_gpu.h>
 #endif
 
+// See Note [hip-clang differences to hcc]
+
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__HIP__)
 #define CONVERSIONS_DECL __host__ __device__ inline
 #else

--- a/caffe2/utils/fixed_divisor.h
+++ b/caffe2/utils/fixed_divisor.h
@@ -5,6 +5,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+// See Note [hip-clang differences to hcc]
+
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__) || defined(__HIP__)
 #define FIXED_DIVISOR_DECL inline __host__ __device__
 #else

--- a/caffe2/utils/math_utils.h
+++ b/caffe2/utils/math_utils.h
@@ -3,6 +3,8 @@
 
 #include "caffe2/core/common.h"
 
+// See Note [hip-clang differences to hcc]
+
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__HIP__)
 #define MATH_UTILS_DECL inline __host__ __device__
 #else


### PR DESCRIPTION
In #16085 , we introduced initial hip-clang bring-up code. Document the use of the __HIP__ macro now.