### PR TITLE
Support multiple inheritance in torch.distributions

### DIFF
--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -82,6 +82,7 @@ class ConstraintRegistry(object):
     """
     def __init__(self):
         self._registry = {}
+        super(ConstraintRegistry, self).__init__()
 
     def register(self, constraint, factory=None):
         """

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -34,6 +34,7 @@ class Distribution(object):
                     continue  # skip checking lazily-constructed args
                 if not constraint.check(getattr(self, param)).all():
                     raise ValueError("The parameter {} has invalid values".format(param))
+        super(Distribution, self).__init__()
 
     def expand(self, batch_shape, _instance=None):
         """

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -83,6 +83,7 @@ class Transform(object):
             self._cached_x_y = None, None
         else:
             raise ValueError('cache_size must be 0 or 1')
+        super(Transform, self).__init__()
 
     @property
     def inv(self):


### PR DESCRIPTION
This adds calls to `super().__init__()` in three classes in torch.distributions.

This is needed when `Distribution` and `Transform` objects are used with multiple inheritance, as e.g. combined with `torch.nn.Module`s. For example
```py
class MyModule(torch.distributions.Transform, torch.nn.Module):
    ...
```
cc  @martinjankowiak @esling who have wanted to use this pattern, e.g. in #16756