### PR TITLE
Fix commit races on binary CI on master PR-merges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -590,6 +590,10 @@ binary_checkout: &binary_checkout
       git reset --hard "$CIRCLE_SHA1"
       git checkout -q -B "$CIRCLE_BRANCH"
       git reset --hard "$CIRCLE_SHA1"
+    elif [[ -n "$CIRCLE_SHA1" ]]; then
+      # "smoke" binary build on master on PR merges
+      git reset --hard "$CIRCLE_SHA1"
+      git checkout -q -B master
     fi
     git submodule update --init --recursive
     echo "Using Pytorch from "
@@ -599,6 +603,8 @@ binary_checkout: &binary_checkout
     # Clone the Builder master repo
     git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
     pushd "$BUILDER_ROOT"
+    git fetch origin
+    git reset origin/master --hard
     echo "Using builder from "
     git log --max-count 1
     popd


### PR DESCRIPTION
There is no way to test this until it is merged.

On master jobs that run after a PR is merged, there is no CIRCLE_PR_NUMBER so the binary builds clone pytorch/pytorch/master, which races.

Based off of https://circleci.com/docs/2.0/env-vars/ and the circleci checkout code
```
# use git+ssh instead of https
git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
git config --global gc.auto 0 || true

if [ -e /home/circleci/project/.git ]
then
  cd /home/circleci/project
  git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
else
  mkdir -p /home/circleci/project
  cd /home/circleci/project
  git clone "$CIRCLE_REPOSITORY_URL" .
fi

if [ -n "$CIRCLE_TAG" ]
then
  git fetch --force origin "refs/tags/${CIRCLE_TAG}"
else
  git fetch --force origin "master:remotes/origin/master"
fi


if [ -n "$CIRCLE_TAG" ]
then
  git reset --hard "$CIRCLE_SHA1"
  git checkout -q "$CIRCLE_TAG"
elif [ -n "$CIRCLE_BRANCH" ]
then
  git reset --hard "$CIRCLE_SHA1"
  git checkout -q -B "$CIRCLE_BRANCH"
fi

git reset --hard "$CIRCLE_SHA1"
```
I believe we do no use git tags