### PR TITLE
Stop op observer on async completion

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -820,7 +820,11 @@ class Operator : public OperatorBase {
         this->RecordLastFailedOpNetPosition();
       }
 
-      StopAllObservers();
+      if (HasAsyncPart() && !IsEventDisabled() && event().SupportsCallback()) {
+        event().SetCallback([this] { StopAllObservers(); });
+      } else {
+        StopAllObservers();
+      }
 
       return result;
     } catch (EnforceNotMet& err) {


### PR DESCRIPTION
Summary:
For async CPU operators, only stop the observer when the underlying
event is finished.

Differential Revision: D13928190
