### PR TITLE
Adding torch/lib64 in .gitignore for ppc64le CI build to pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ torch/lib/tmp_install
 torch/lib/torch_shm_manager
 torch/lib/site-packages/
 torch/lib/python*
+torch/lib64
 torch/include/
 torch/share/
 torch/test/


### PR DESCRIPTION
Adding torch/lib64 in .gitignore so that a git status --porcelain
check during CI build and test passes for ppc64le. During build
torch/lib64 is created and contains third-party libraries. This
should be ignored by the porcelain check

