### PR TITLE
no EIGEN engine for DeformConv

### DIFF
--- a/caffe2/python/operator_test/deform_conv_test.py
+++ b/caffe2/python/operator_test/deform_conv_test.py
@@ -1,22 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import numpy as np
-from hypothesis import assume, given
+import os
+import unittest
+
+import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
-
+import numpy as np
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, utils, workspace
-import caffe2.python.hypothesis_test_util as hu
-import unittest
-import os
+from hypothesis import assume, given
 
 
-def _cudnn_supports(
-        dilation=False,
-        nhwc=False,
-):
+def _cudnn_supports(dilation=False, nhwc=False):
     """Return True if cuDNN supports this configuration."""
     v = workspace.GetCuDNNVersion()
     if dilation and v < 6000:
@@ -29,43 +24,35 @@ def _cudnn_supports(
 
 
 def _conv_1d_output_size(size, kernel, pad, dilation, stride):
-    return max(
-        1,
-        int((size + pad * 2 - (dilation * (kernel - 1) + 1)) / stride) + 1
-    )
+    return max(1, int((size + pad * 2 - (dilation * (kernel - 1) + 1)) / stride) + 1)
 
 
-def _conv_2d_output_size(size, kernel, pad_h, pad_w, dilation,
-                         stride_h, stride_w):
+def _conv_2d_output_size(size, kernel, pad_h, pad_w, dilation, stride_h, stride_w):
     return [
         _conv_1d_output_size(size, kernel, pad_h, dilation, stride_h),
-        _conv_1d_output_size(size, kernel, pad_w, dilation, stride_w)
+        _conv_1d_output_size(size, kernel, pad_w, dilation, stride_w),
     ]
 
 
 def _conv_2d_offsets_dims(
-        batch_size,
-        size,
-        kernel,
-        pad_h,
-        pad_w,
-        dilation,
-        stride_h,
-        stride_w,
-        deformable_group
+    batch_size,
+    size,
+    kernel,
+    pad_h,
+    pad_w,
+    dilation,
+    stride_h,
+    stride_w,
+    deformable_group,
 ):
     dims = [batch_size, 2 * kernel * kernel * deformable_group]
-    dims.extend(_conv_2d_output_size(size, kernel, pad_h, pad_w,
-                                     dilation, stride_h, stride_w))
+    dims.extend(
+        _conv_2d_output_size(size, kernel, pad_h, pad_w, dilation, stride_h, stride_w)
+    )
     return dims
 
 
-def _conv_2d_random_offsets(
-    batch_size,
-    kernel,
-    dims,
-    num_deformable_group
-):
+def _conv_2d_random_offsets(batch_size, kernel, dims, num_deformable_group):
     o = []
     for y0 in range(0, kernel):
         for x0 in range(0, kernel):
@@ -83,12 +70,7 @@ def _conv_2d_random_offsets(
 
 
 def _conv_2d_shuffle_offsets(
-    batch_size,
-    kernel,
-    dims,
-    num_deformable_group,
-    input_channels,
-    output_channels
+    batch_size, kernel, dims, num_deformable_group, input_channels, output_channels
 ):
     o = []
     w0 = [[0 for x in range(kernel)] for y in range(kernel)]
@@ -106,35 +88,48 @@ def _conv_2d_shuffle_offsets(
     w0 = [[w0] * input_channels] * output_channels
     return (
         np.array([e] * batch_size).astype(np.float32),
-        utils.NCHW2NHWC(np.array(w0).astype(np.float32))
+        utils.NCHW2NHWC(np.array(w0).astype(np.float32)),
     )
 
 
 class TestConvolution(hu.HypothesisTestCase):
-
     @unittest.skipIf(not workspace.has_gpu_support, "No gpu support")
-    @given(stride=st.integers(1, 3),
-           pad=st.integers(0, 3),
-           kernel=st.integers(1, 5),
-           dilation=st.integers(1, 3),
-           size=st.integers(7, 10),
-           input_channels=st.integers(1, 8),
-           output_channels=st.integers(1, 8),
-           batch_size=st.integers(1, 3),
-           order=st.sampled_from(["NCHW"]),
-           engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
-           use_bias=st.booleans(),
-           deformable_group=st.integers(1, 3),
-           **hu.gcs_gpu_only)
-    def test_null_offset_convolution(self, stride, pad, kernel, dilation, size,
-                                     input_channels, output_channels, batch_size,
-                                     order, engine, use_bias, deformable_group,
-                                     gc, dc):
+    @given(
+        stride=st.integers(1, 3),
+        pad=st.integers(0, 3),
+        kernel=st.integers(1, 5),
+        dilation=st.integers(1, 3),
+        size=st.integers(7, 10),
+        input_channels=st.integers(1, 8),
+        output_channels=st.integers(1, 8),
+        batch_size=st.integers(1, 3),
+        order=st.sampled_from(["NCHW"]),
+        engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
+        use_bias=st.booleans(),
+        deformable_group=st.integers(1, 3),
+        **hu.gcs_gpu_only
+    )
+    def test_null_offset_convolution(
+        self,
+        stride,
+        pad,
+        kernel,
+        dilation,
+        size,
+        input_channels,
+        output_channels,
+        batch_size,
+        order,
+        engine,
+        use_bias,
+        deformable_group,
+        gc,
+        dc,
+    ):
         dkernel = dilation * (kernel - 1) + 1
 
-        if gc.device_type == caffe2_pb2.CUDA and engine == 'CUDNN':
-            assume(_cudnn_supports(dilation=(dilation > 1),
-                                   nhwc=(order == 'NHWC')))
+        if gc.device_type == caffe2_pb2.CUDA and engine == "CUDNN":
+            assume(_cudnn_supports(dilation=(dilation > 1), nhwc=(order == "NHWC")))
 
         assume(engine != "MKLDNN" or use_bias is True)
 
@@ -150,15 +145,28 @@ class TestConvolution(hu.HypothesisTestCase):
             engine=engine,
             deformable_group=deformable_group,
         )
-        offset_dims = _conv_2d_offsets_dims(batch_size, size, kernel, pad, pad,
-                                            dilation, stride, stride,
-                                            deformable_group)
-        X = np.random.rand(
-            batch_size, size, size, input_channels).astype(np.float32) - 0.5
-        o = np.zeros(tuple(offset_dims), np.float32)
-        w = np.random.rand(
-            output_channels, kernel, kernel, input_channels).astype(np.float32)\
+        offset_dims = _conv_2d_offsets_dims(
+            batch_size,
+            size,
+            kernel,
+            pad,
+            pad,
+            dilation,
+            stride,
+            stride,
+            deformable_group,
+        )
+        X = (
+            np.random.rand(batch_size, size, size, input_channels).astype(np.float32)
             - 0.5
+        )
+        o = np.zeros(tuple(offset_dims), np.float32)
+        w = (
+            np.random.rand(output_channels, kernel, kernel, input_channels).astype(
+                np.float32
+            )
+            - 0.5
+        )
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
             X = utils.NHWC2NCHW(X)
@@ -191,7 +199,7 @@ class TestConvolution(hu.HypothesisTestCase):
                 pad=pad,
                 order=order,
                 engine=engine,
-                device_option=gc
+                device_option=gc,
             )
             workspace.RunOperatorOnce(reference_op)
             reference_blob = workspace.FetchBlob("Y0")
@@ -200,28 +208,42 @@ class TestConvolution(hu.HypothesisTestCase):
         self.assertReferenceChecks(gc, op, inputs, reference_conv_op)
 
     @unittest.skipIf(not workspace.has_gpu_support, "No gpu support")
-    @given(stride=st.integers(1, 3),
-           pad=st.integers(0, 0),
-           kernel=st.integers(1, 5),
-           dilation=st.integers(1, 3),
-           size=st.integers(7, 10),
-           input_channels=st.integers(1, 8),
-           output_channels=st.integers(1, 8),
-           batch_size=st.integers(1, 3),
-           order=st.sampled_from(["NCHW"]),
-           engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
-           use_bias=st.booleans(),
-           deformable_group=st.integers(1, 4),
-           **hu.gcs_gpu_only)
-    def test_flat_input_convolution(self, stride, pad, kernel, dilation, size,
-                                    input_channels, output_channels, batch_size,
-                                    order, engine, use_bias,
-                                    deformable_group, gc, dc):
+    @given(
+        stride=st.integers(1, 3),
+        pad=st.integers(0, 0),
+        kernel=st.integers(1, 5),
+        dilation=st.integers(1, 3),
+        size=st.integers(7, 10),
+        input_channels=st.integers(1, 8),
+        output_channels=st.integers(1, 8),
+        batch_size=st.integers(1, 3),
+        order=st.sampled_from(["NCHW"]),
+        engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
+        use_bias=st.booleans(),
+        deformable_group=st.integers(1, 4),
+        **hu.gcs_gpu_only
+    )
+    def test_flat_input_convolution(
+        self,
+        stride,
+        pad,
+        kernel,
+        dilation,
+        size,
+        input_channels,
+        output_channels,
+        batch_size,
+        order,
+        engine,
+        use_bias,
+        deformable_group,
+        gc,
+        dc,
+    ):
         dkernel = dilation * (kernel - 1) + 1
 
-        if gc.device_type == caffe2_pb2.CUDA and engine == 'CUDNN':
-            assume(_cudnn_supports(dilation=(dilation > 1),
-                                   nhwc=(order == 'NHWC')))
+        if gc.device_type == caffe2_pb2.CUDA and engine == "CUDNN":
+            assume(_cudnn_supports(dilation=(dilation > 1), nhwc=(order == "NHWC")))
 
         assume(engine != "MKLDNN" or use_bias is True)
 
@@ -238,10 +260,10 @@ class TestConvolution(hu.HypothesisTestCase):
             deformable_group=deformable_group,
         )
         X = np.ones((batch_size, size, size, input_channels), np.float32) - 0.5
-        output_size = _conv_2d_output_size(size, kernel, pad, pad,
-                                           dilation, stride, stride)
-        o = _conv_2d_random_offsets(batch_size, kernel, output_size,
-                                    deformable_group)
+        output_size = _conv_2d_output_size(
+            size, kernel, pad, pad, dilation, stride, stride
+        )
+        o = _conv_2d_random_offsets(batch_size, kernel, output_size, deformable_group)
         w = np.ones((output_channels, kernel, kernel, input_channels), np.float32) - 0.5
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
@@ -275,7 +297,7 @@ class TestConvolution(hu.HypothesisTestCase):
                 pad=pad,
                 order=order,
                 engine=engine,
-                device_option=gc
+                device_option=gc,
             )
             workspace.RunOperatorOnce(reference_op)
             reference_blob = workspace.FetchBlob("Y0")
@@ -284,28 +306,42 @@ class TestConvolution(hu.HypothesisTestCase):
         self.assertReferenceChecks(gc, op, inputs, reference_conv_op)
 
     @unittest.skipIf(not workspace.has_gpu_support, "No gpu support")
-    @given(stride=st.integers(1, 1),
-           pad=st.integers(0, 0),
-           kernel=st.integers(1, 5),
-           dilation=st.integers(1, 1),
-           size=st.integers(7, 10),
-           input_channels=st.integers(1, 8),
-           output_channels=st.integers(1, 8),
-           batch_size=st.integers(1, 3),
-           order=st.sampled_from(["NCHW"]),
-           engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
-           use_bias=st.booleans(),
-           deformable_group=st.integers(1, 4),
-           **hu.gcs_gpu_only)
-    def test_shuffle_input_convolution(self, stride, pad, kernel, dilation, size,
-                                       input_channels, output_channels, batch_size,
-                                       order, engine, use_bias,
-                                       deformable_group, gc, dc):
+    @given(
+        stride=st.integers(1, 1),
+        pad=st.integers(0, 0),
+        kernel=st.integers(1, 5),
+        dilation=st.integers(1, 1),
+        size=st.integers(7, 10),
+        input_channels=st.integers(1, 8),
+        output_channels=st.integers(1, 8),
+        batch_size=st.integers(1, 3),
+        order=st.sampled_from(["NCHW"]),
+        engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
+        use_bias=st.booleans(),
+        deformable_group=st.integers(1, 4),
+        **hu.gcs_gpu_only
+    )
+    def test_shuffle_input_convolution(
+        self,
+        stride,
+        pad,
+        kernel,
+        dilation,
+        size,
+        input_channels,
+        output_channels,
+        batch_size,
+        order,
+        engine,
+        use_bias,
+        deformable_group,
+        gc,
+        dc,
+    ):
         dkernel = dilation * (kernel - 1) + 1
 
-        if gc.device_type == caffe2_pb2.CUDA and engine == 'CUDNN':
-            assume(_cudnn_supports(dilation=(dilation > 1),
-                                   nhwc=(order == 'NHWC')))
+        if gc.device_type == caffe2_pb2.CUDA and engine == "CUDNN":
+            assume(_cudnn_supports(dilation=(dilation > 1), nhwc=(order == "NHWC")))
 
         assume(engine != "MKLDNN" or use_bias is True)
 
@@ -321,13 +357,21 @@ class TestConvolution(hu.HypothesisTestCase):
             engine=engine,
             deformable_group=deformable_group,
         )
-        X = np.random.rand(
-            batch_size, size, size, input_channels).astype(np.float32) - 0.5
-        output_size = _conv_2d_output_size(size, kernel, pad, pad,
-                                           dilation, stride, stride)
-        o, w0 = _conv_2d_shuffle_offsets(batch_size, kernel, output_size,
-                                         deformable_group, input_channels,
-                                         output_channels)
+        X = (
+            np.random.rand(batch_size, size, size, input_channels).astype(np.float32)
+            - 0.5
+        )
+        output_size = _conv_2d_output_size(
+            size, kernel, pad, pad, dilation, stride, stride
+        )
+        o, w0 = _conv_2d_shuffle_offsets(
+            batch_size,
+            kernel,
+            output_size,
+            deformable_group,
+            input_channels,
+            output_channels,
+        )
         w = np.ones((output_channels, kernel, kernel, input_channels), np.float32)
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
 
@@ -365,7 +409,7 @@ class TestConvolution(hu.HypothesisTestCase):
                 pad=pad,
                 order=order,
                 engine=engine,
-                device_option=gc
+                device_option=gc,
             )
             workspace.RunOperatorOnce(reference_op)
             reference_blob = workspace.FetchBlob("Y0")
@@ -375,27 +419,42 @@ class TestConvolution(hu.HypothesisTestCase):
 
     # CUDNN does NOT support different padding values and we skip it
     @unittest.skipIf(not workspace.has_gpu_support, "No gpu support")
-    @given(stride_h=st.integers(1, 3),
-           stride_w=st.integers(1, 3),
-           pad_h=st.integers(0, 3),
-           pad_w=st.integers(0, 3),
-           kernel=st.integers(2, 5),
-           size=st.integers(1, 8),
-           input_channels=st.integers(1, 3),
-           output_channels=st.integers(1, 3),
-           batch_size=st.integers(1, 3),
-           order=st.sampled_from(["NCHW"]),
-           engine=st.sampled_from(["", "EIGEN"]),
-           shared_buffer=st.booleans(),
-           use_bias=st.booleans(),
-           deformable_group=st.integers(1, 3),
-           **hu.gcs_gpu_only)
-    def test_conv_separate_stride_pad_gradients(self, stride_h, stride_w,
-                                                pad_h, pad_w, kernel, size,
-                                                input_channels, output_channels,
-                                                batch_size, order, engine,
-                                                shared_buffer, use_bias,
-                                                deformable_group, gc, dc):
+    @given(
+        stride_h=st.integers(1, 3),
+        stride_w=st.integers(1, 3),
+        pad_h=st.integers(0, 3),
+        pad_w=st.integers(0, 3),
+        kernel=st.integers(2, 5),
+        size=st.integers(1, 8),
+        input_channels=st.integers(1, 3),
+        output_channels=st.integers(1, 3),
+        batch_size=st.integers(1, 3),
+        order=st.sampled_from(["NCHW"]),
+        engine=st.sampled_from(["", "EIGEN"]),
+        shared_buffer=st.booleans(),
+        use_bias=st.booleans(),
+        deformable_group=st.integers(1, 3),
+        **hu.gcs_gpu_only
+    )
+    def test_conv_separate_stride_pad_gradients(
+        self,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        kernel,
+        size,
+        input_channels,
+        output_channels,
+        batch_size,
+        order,
+        engine,
+        shared_buffer,
+        use_bias,
+        deformable_group,
+        gc,
+        dc,
+    ):
         op = core.CreateOperator(
             "DeformConv",
             ["X", "o", "w", "b"] if use_bias else ["X", "o", "w"],
@@ -412,15 +471,20 @@ class TestConvolution(hu.HypothesisTestCase):
             shared_buffer=int(shared_buffer),
             deformable_group=deformable_group,
         )
-        X = np.random.rand(
-            batch_size, size, size, input_channels).astype(np.float32) - 0.5
-        output_size = _conv_2d_output_size(size, kernel, pad_h, pad_w, 1,
-                                           stride_h, stride_w)
-        o = _conv_2d_random_offsets(batch_size, kernel, output_size,
-                                    deformable_group)
-        w = np.random.rand(
-            output_channels, kernel, kernel, input_channels).astype(np.float32)\
+        X = (
+            np.random.rand(batch_size, size, size, input_channels).astype(np.float32)
             - 0.5
+        )
+        output_size = _conv_2d_output_size(
+            size, kernel, pad_h, pad_w, 1, stride_h, stride_w
+        )
+        o = _conv_2d_random_offsets(batch_size, kernel, output_size, deformable_group)
+        w = (
+            np.random.rand(output_channels, kernel, kernel, input_channels).astype(
+                np.float32
+            )
+            - 0.5
+        )
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
             X = utils.NHWC2NCHW(X)
@@ -447,27 +511,42 @@ class TestConvolution(hu.HypothesisTestCase):
             self.assertGradientChecks(gc, op, inputs, i, [0])
 
     @unittest.skipIf(not workspace.has_gpu_support, "No gpu support")
-    @given(stride=st.integers(1, 3),
-           pad=st.integers(0, 3),
-           kernel=st.integers(1, 5),
-           dilation=st.integers(1, 3),
-           size=st.integers(7, 10),
-           input_channels=st.integers(1, 8),
-           output_channels=st.integers(1, 8),
-           batch_size=st.integers(1, 3),
-           order=st.sampled_from(["NCHW"]),
-           engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
-           use_bias=st.booleans(),
-           deformable_group=st.integers(1, 3),
-           **hu.gcs_gpu_only)
-    def test_conv_gradients(self, stride, pad, kernel, dilation, size,
-                            input_channels, output_channels, batch_size, order,
-                            engine, use_bias, deformable_group, gc, dc):
+    @given(
+        stride=st.integers(1, 3),
+        pad=st.integers(0, 3),
+        kernel=st.integers(1, 5),
+        dilation=st.integers(1, 3),
+        size=st.integers(7, 10),
+        input_channels=st.integers(1, 8),
+        output_channels=st.integers(1, 8),
+        batch_size=st.integers(1, 3),
+        order=st.sampled_from(["NCHW"]),
+        engine=st.sampled_from(["", "CUDNN", "MKLDNN"]),
+        use_bias=st.booleans(),
+        deformable_group=st.integers(1, 3),
+        **hu.gcs_gpu_only
+    )
+    def test_conv_gradients(
+        self,
+        stride,
+        pad,
+        kernel,
+        dilation,
+        size,
+        input_channels,
+        output_channels,
+        batch_size,
+        order,
+        engine,
+        use_bias,
+        deformable_group,
+        gc,
+        dc,
+    ):
         dkernel = dilation * (kernel - 1) + 1
 
-        if gc.device_type == caffe2_pb2.CUDA and engine == 'CUDNN':
-            assume(_cudnn_supports(dilation=(dilation > 1),
-                                   nhwc=(order == 'NHWC')))
+        if gc.device_type == caffe2_pb2.CUDA and engine == "CUDNN":
+            assume(_cudnn_supports(dilation=(dilation > 1), nhwc=(order == "NHWC")))
 
         assume(engine != "MKLDNN" or use_bias is True)
 
@@ -483,14 +562,20 @@ class TestConvolution(hu.HypothesisTestCase):
             engine=engine,
             deformable_group=deformable_group,
         )
-        X = np.random.rand(
-            batch_size, size, size, input_channels).astype(np.float32) - 0.5
-        output_size = _conv_2d_output_size(size, kernel, pad, pad,
-                                           dilation, stride, stride)
-        o = _conv_2d_random_offsets(batch_size, kernel, output_size, deformable_group)
-        w = np.random.rand(
-            output_channels, kernel, kernel, input_channels).astype(np.float32)\
+        X = (
+            np.random.rand(batch_size, size, size, input_channels).astype(np.float32)
             - 0.5
+        )
+        output_size = _conv_2d_output_size(
+            size, kernel, pad, pad, dilation, stride, stride
+        )
+        o = _conv_2d_random_offsets(batch_size, kernel, output_size, deformable_group)
+        w = (
+            np.random.rand(output_channels, kernel, kernel, input_channels).astype(
+                np.float32
+            )
+            - 0.5
+        )
         b = np.random.rand(output_channels).astype(np.float32) - 0.5
         if order == "NCHW":
             X = utils.NHWC2NCHW(X)
@@ -518,4 +603,5 @@ class TestConvolution(hu.HypothesisTestCase):
 
 if __name__ == "__main__":
     import unittest
+
     unittest.main()

--- a/caffe2/python/operator_test/deform_conv_test.py
+++ b/caffe2/python/operator_test/deform_conv_test.py
@@ -430,7 +430,6 @@ class TestConvolution(hu.HypothesisTestCase):
         output_channels=st.integers(1, 3),
         batch_size=st.integers(1, 3),
         order=st.sampled_from(["NCHW"]),
-        engine=st.sampled_from(["", "EIGEN"]),
         shared_buffer=st.booleans(),
         use_bias=st.booleans(),
         deformable_group=st.integers(1, 3),
@@ -448,7 +447,6 @@ class TestConvolution(hu.HypothesisTestCase):
         output_channels,
         batch_size,
         order,
-        engine,
         shared_buffer,
         use_bias,
         deformable_group,
@@ -467,7 +465,6 @@ class TestConvolution(hu.HypothesisTestCase):
             pad_r=pad_w,
             kernel=kernel,
             order=order,
-            engine=engine,
             shared_buffer=int(shared_buffer),
             deformable_group=deformable_group,
         )


### PR DESCRIPTION
Summary: There's no EIGEN engine implemented for DeformConv but unit test was checking it.

Differential Revision: D13967306
