### PR TITLE
Fix pip list format in collect_env

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -198,7 +198,7 @@ def get_pip_packages(run_lambda):
             grep_cmd = r'findstr /R "numpy torch"'
         else:
             grep_cmd = r'grep "torch\|numpy"'
-        return run_and_read_all(run_lambda, pip + ' list --format=legacy | ' + grep_cmd)
+        return run_and_read_all(run_lambda, pip + ' list --format=freeze | ' + grep_cmd)
 
     if not PY3:
         return 'pip', run_with_pip('pip')


### PR DESCRIPTION
Since pip 18.0 (2018-07-22), `legacy` is no longer a valid choice for `pip list --format` as can be seen in the [Release Notes](https://pip.pypa.io/en/stable/news/#id62). Therefore, the options now are: `columns`, `freeze` and `json`. With `legacy`, this is how it looked like:

```
[...]
Versions of relevant libraries:
[pip3] numpy (1.16.1)
[pip3] torch (1.0.1)
[pip3] torchvision (0.2.1)
[...]
```

Changing to `freeze`, this is how it looks like:

```
[...]
Versions of relevant libraries:
[pip3] numpy==1.16.1
[pip3] torch==1.0.1
[pip3] torchvision==0.2.1
[...]
```

Currently, this is what happens:

```
[...]
Versions of relevant libraries:
[pip] Could not collect
[...]
```
The `freeze` option is also available in old pip, so this change is backwards compatible. Also, if we would like to keep the old style, which I think it is not necessary, I could easily change that.

---

In case anyone wants to know how `columns` looks like (I prefer `freeze`):

```
[...]
Versions of relevant libraries:
[pip3] numpy               1.16.1    
[pip3] torch               1.0.1     
[pip3] torchvision         0.2.1
[...]
```