### PR TITLE
Make C10_DEPRECATED a nullary macro.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -63,8 +63,8 @@ PURE_VIRTUAL_TYPE_METHOD_DECLARATION = CodeTemplate("""\
 virtual ${return_type} ${method_prefix_derived}${api_name}(${type_method_formals}) const = 0;
 """)
 DEPRECATED_PURE_VIRTUAL_TYPE_METHOD_DECLARATION = CodeTemplate("""\
-C10_DEPRECATED(virtual ${return_type} \
-${method_prefix_derived}${api_name}(${type_method_formals}) const = 0);
+C10_DEPRECATED virtual ${return_type} \
+${method_prefix_derived}${api_name}(${type_method_formals}) const = 0;
 """)
 PURE_VIRTUAL_TYPE_METHOD_DECLARATION_BROADCAST = CodeTemplate("""\
 virtual ${return_type} ${api_name}(${type_method_formals}) const = 0;
@@ -139,7 +139,7 @@ static inline ${return_type} ${api_name}(${formals_with_defaults});
 """)
 # add a method declaration in Functions.h
 DEPRECATED_FUNCTION_DECLARATION = CodeTemplate("""\
-C10_DEPRECATED(static inline ${return_type} ${api_name}(${formals_with_defaults}));
+C10_DEPRECATED static inline ${return_type} ${api_name}(${formals_with_defaults});
 """)
 # add method definition in Functions.h
 FUNCTION_DEFINITION = CodeTemplate("""\

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -3,14 +3,14 @@
 // Largely from https://stackoverflow.com/questions/295120/c-mark-as-deprecated
 
 #if defined(__cplusplus) && __cplusplus > 201402L
-#define C10_DEPRECATED(function) [[deprecated]] function
+#define C10_DEPRECATED [[deprecated]]
 #else
 #if defined(__GNUC__)
-#define C10_DEPRECATED(function) __attribute__((deprecated)) function
+#define C10_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
-#define C10_DEPRECATED(function) __declspec(deprecated) function
+#define C10_DEPRECATED __declspec(deprecated)
 #else
 #warning "You need to implement C10_DEPRECATED for this compiler"
-#define C10_DEPRECATED(function) function
+#define C10_DEPRECATED
 #endif // defined(__GNUC__)
 #endif // defined(__cplusplus) && __cplusplus > 201402L


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16802 Make C10_DEPRECATED a nullary macro.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13972298/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16803 Mark IntList as deprecated; robustify C10_DEPRECATED macro&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13972297/)

It turned out we always inserted the relevant pragma at the
same location.  So it's much clearer and easier to use if
we just don't force the user to pass in a function token
(previously, users of this macro were doing very strange things
to get the macro usage in the correct place).

Differential Revision: [D13972298](https://our.internmc.facebook.com/intern/diff/D13972298/)