### PR TITLE
Mark IntList as deprecated; robustify C10_DEPRECATED macro

### DIFF
--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -18,6 +18,7 @@
 #include <c10/util/SmallVector.h>
 #include <c10/util/C++17.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Deprecated.h>
 
 #include <array>
 #include <iterator>
@@ -269,6 +270,6 @@ using IntArrayRef = ArrayRef<int64_t>;
 
 // This alias is deprecated because it doesn't make ownership
 // semantics obvious.  Use IntArrayRef instead!
-using IntList = ArrayRef<int64_t>;
+using IntList C10_DEPRECATED = ArrayRef<int64_t>;
 
 } // namespace c10

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -4,7 +4,7 @@
 
 #if defined(_MSC_VER)
 // [[deprecated]] doesn't work on Windows, so try declspec first
-# define C10_DEPRECATED __declspec(deprecated)
+# define C10_DEPRECATED
 #elif (defined(__cplusplus) && __cplusplus > 201402L) || defined(__CUDACC__) || defined(__HIPCC__)
 // NB: We preferentially use [[deprecated]] for nvcc because
 // nvcc doesn't understand __attribute__((deprecated)) syntax

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -2,7 +2,10 @@
 
 // Largely from https://stackoverflow.com/questions/295120/c-mark-as-deprecated
 
-#if defined(__cplusplus) && __cplusplus > 201402L
+#if (defined(__cplusplus) && __cplusplus > 201402L) || defined(__CUDACC__) || defined(__HIPCC__)
+// NB: We preferentially use [[deprecated]] for nvcc because
+// nvcc doesn't understand __attribute__((deprecated)) syntax
+// for 'using' declarations (even though the host compiler does.)
 #define C10_DEPRECATED [[deprecated]]
 #else
 #if defined(__GNUC__)

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -2,18 +2,17 @@
 
 // Largely from https://stackoverflow.com/questions/295120/c-mark-as-deprecated
 
-#if (defined(__cplusplus) && __cplusplus > 201402L) || defined(__CUDACC__) || defined(__HIPCC__)
+#if defined(_MSC_VER)
+// [[deprecated]] doesn't work on Windows, so try declspec first
+# define C10_DEPRECATED __declspec(deprecated)
+#elif (defined(__cplusplus) && __cplusplus > 201402L) || defined(__CUDACC__) || defined(__HIPCC__)
 // NB: We preferentially use [[deprecated]] for nvcc because
 // nvcc doesn't understand __attribute__((deprecated)) syntax
 // for 'using' declarations (even though the host compiler does.)
-#define C10_DEPRECATED [[deprecated]]
+# define C10_DEPRECATED [[deprecated]]
+#elif defined(__GNUC__)
+# define C10_DEPRECATED __attribute__((deprecated))
 #else
-#if defined(__GNUC__)
-#define C10_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define C10_DEPRECATED __declspec(deprecated)
-#else
-#warning "You need to implement C10_DEPRECATED for this compiler"
-#define C10_DEPRECATED
-#endif // defined(__GNUC__)
-#endif // defined(__cplusplus) && __cplusplus > 201402L
+# warning "You need to implement C10_DEPRECATED for this compiler"
+# define C10_DEPRECATED
+#endif


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16802 Make C10_DEPRECATED a nullary macro.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13972298/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16803 Mark IntList as deprecated; robustify C10_DEPRECATED macro**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13972297/)

The reason I wasn't able to previously get this to work,
is that __attribute__((deprecated)) doesn't work in nvcc
(even though the host compiler ought to support it).  I
noticed that [[deprecated]] *does* work, so we preferentially
use that instead.

Differential Revision: [D13972297](https://our.internmc.facebook.com/intern/diff/D13972297/)