### PR TITLE
Remove redundant wrappers in torch.distributions

### DIFF
--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -20,13 +20,6 @@ def _batch_mv(bmat, bvec):
     return torch.matmul(bmat, bvec.unsqueeze(-1)).squeeze(-1)
 
 
-def _batch_diag(bmat):
-    r"""
-    Returns the diagonals of a batch of square matrices.
-    """
-    return torch.diagonal(bmat, dim1=-2, dim2=-1)
-
-
 def _batch_trtrs_lower(bb, bA):
     """
     Applies `torch.trtrs` for batches of matrices. `bb` and `bA` should have
@@ -186,11 +179,11 @@ class MultivariateNormal(Distribution):
             self._validate_sample(value)
         diff = value - self.loc
         M = _batch_mahalanobis(self._unbroadcasted_scale_tril, diff)
-        half_log_det = _batch_diag(self._unbroadcasted_scale_tril).log().sum(-1)
+        half_log_det = self._unbroadcasted_scale_tril.diagonal(dim1=-2, dim2=-1).log().sum(-1)
         return -0.5 * (self._event_shape[0] * math.log(2 * math.pi) + M) - half_log_det
 
     def entropy(self):
-        half_log_det = _batch_diag(self._unbroadcasted_scale_tril).log().sum(-1)
+        half_log_det = self._unbroadcasted_scale_tril.diagonal(dim1=-2, dim2=-1).log().sum(-1)
         H = 0.5 * self._event_shape[0] * (1.0 + math.log(2 * math.pi)) + half_log_det
         if len(self._batch_shape) == 0:
             return H


### PR DESCRIPTION
Changelog:
- Remove torch.distributions.multivariate_normal._batch_diag : same functionality is provided by torch.diagonal
- Remove torch.distributions.lowrank_multivariate_normal._batch_vector_diag : same functionality is provided by torch.diag_embed

Test plan:
- All existing tests should pass

