### PR TITLE
[ROCm] Update CI to recently released ROCm 2.1 release

### DIFF
--- a/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
@@ -33,6 +33,19 @@ void std_var_kernel_impl<at::Half>(TensorIterator& iter, bool unbiased, bool tak
   gpu_reduce_kernel<at::Half, at::Half>(iter, WelfordOps<at::Half, float> { unbiased, take_sqrt }, WelfordData<float> {});
 }
 
+#ifdef __HIPCC__
+template <>
+void sum_kernel_impl<int16_t, int16_t>(TensorIterator& iter) {
+  // There is a Register Coalescing bug in LLVM causing the hcc
+  // compiler segfaults:
+  // https://bugs.llvm.org/show_bug.cgi?id=39602
+  // To work around it, use int32 as the accumulate type.
+  gpu_reduce_kernel<int16_t, int16_t>(iter, func_wrapper<int16_t> ([]GPU_LAMBDA(int32_t a, int32_t b) -> int32_t {
+    return a + b;
+  }));
+}
+#endif
+
 template <typename scalar_t, typename acc_t=scalar_t>
 void prod_kernel_impl(TensorIterator& iter) {
   gpu_reduce_kernel<scalar_t, scalar_t>(iter, func_wrapper<scalar_t> ([]GPU_LAMBDA(acc_t a, acc_t b) -> acc_t {
@@ -51,6 +64,18 @@ void mean_kernel_impl(TensorIterator& iter) {
   float factor = float(iter.num_output_elements()) / iter.numel();
   gpu_reduce_kernel<scalar_t, out_t>(iter, MeanOps<acc_t, float> {factor});
 }
+
+#ifdef __HIPCC__
+template <>
+void mean_kernel_impl<int16_t, int16_t, int16_t>(TensorIterator& iter) {
+  // There is a Register Coalescing bug in LLVM causing the hcc
+  // compiler segfaults:
+  // https://bugs.llvm.org/show_bug.cgi?id=39602
+  // To work around it, use int32 as the accumulate type.
+  float factor = float(iter.num_output_elements()) / iter.numel();
+  gpu_reduce_kernel<int16_t, int16_t>(iter, MeanOps<int32_t, float> {factor});
+}
+#endif // __HIPCC__
 
 template <typename scalar_t, typename acc_t=scalar_t, typename out_t=scalar_t>
 void norm_kernel_cuda_impl(TensorIterator& iter, Scalar val) {

--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -30,16 +30,8 @@ install_ubuntu() {
                    rocsparse \
                    hipsparse \
                    rocrand \
-                   hip-thrust
-
-    pushd /tmp
-    wget https://github.com/RadeonOpenCompute/hcc/releases/download/roc-1.9.2-pytorch-eap/hcc-1.2.18473-Linux.deb
-    wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_base-1.5.18462.deb
-    wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_doc-1.5.18462.deb
-    wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_hcc-1.5.18462.deb
-    wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_samples-1.5.18462.deb
-    apt install -y ./hcc-1.2.18473-Linux.deb ./hip_base-1.5.18462.deb ./hip_hcc-1.5.18462.deb ./hip_doc-1.5.18462.deb ./hip_samples-1.5.18462.deb
-    popd
+                   hip-thrust \
+                   rccl
 
     # HIP has a bug that drops DEBUG symbols in generated MakeFiles.
     # https://github.com/ROCm-Developer-Tools/HIP/pull/588
@@ -86,15 +78,6 @@ install_centos() {
                    rocrand \
                    rccl
 
-  pushd /tmp
-  wget https://github.com/RadeonOpenCompute/hcc/releases/download/roc-1.9.2-pytorch-eap/hcc-1.2.18473-Linux.rpm
-  wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_base-1.5.18462.rpm
-  wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_doc-1.5.18462.rpm
-  wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_hcc-1.5.18462.rpm
-  wget https://github.com/ROCm-Developer-Tools/HIP/releases/download/roc-1.9.2-pytorch-eap/hip_samples-1.5.18462.rpm
-  rpm -i --replacefiles ./hcc-1.2.18473-Linux.rpm ./hip_base-1.5.18462.rpm ./hip_hcc-1.5.18462.rpm ./hip_doc-1.5.18462.rpm ./hip_samples-1.5.18462.rpm
-  popd
-  
   # Cleanup
   yum clean all
   rm -rf /var/cache/yum

--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -78,12 +78,6 @@ install_centos() {
                    rocrand \
                    rccl
 
-  # Cleanup
-  yum clean all
-  rm -rf /var/cache/yum
-  rm -rf /var/lib/yum/yumdb
-  rm -rf /var/lib/yum/history
-
   # Needed for now, will be replaced once hip-thrust is packaged for CentOS
   git clone --recursive https://github.com/ROCmSoftwarePlatform/Thrust.git /data/Thrust
   rm -rf /data/Thrust/thrust/system/cuda/detail/cub-hip

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1975,6 +1975,7 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    @skipIfRocm
     def test_gamma_gpu_sample(self):
         set_rng_seed(0)
         for alpha, beta in product([0.1, 1.0, 5.0], [0.1, 1.0, 10.0]):


### PR DESCRIPTION
* we do not need EAP packages any longer as the antistatic feature is now in the release
* consistently install the rccl package
* Skip one unit test that has regressed with 2.1
* Follow-up PRs will use 2.1 features once deployed on CI
