### PR TITLE
Make the exception raised from "numpy.dtype(numpy.void, (INT,))" less cryptic

### DIFF
--- a/caffe2/python/schema.py
+++ b/caffe2/python/schema.py
@@ -731,6 +731,13 @@ class Scalar(Field):
         if dtype is not None and isinstance(dtype, tuple) and dtype[1] == 1:
             dtype = (dtype[0], (1,))
         if dtype is not None:
+            if isinstance(dtype, tuple) and dtype[0] == np.void:
+                raise TypeError(
+                    "Cannot set the Scalar with type {} for blob {}."
+                    "If this blob is the output of some operation, "
+                    "please verify the input of that operation has "
+                    "proper type.".format(dtype, blob)
+                )
             dtype = np.dtype(dtype)
         # If blob is not None and it is not a BlobReference, we assume that
         # it is actual tensor data, so we will try to cast it to a numpy array.

--- a/caffe2/python/schema_test.py
+++ b/caffe2/python/schema_test.py
@@ -389,6 +389,15 @@ class TestDB(unittest.TestCase):
         assert t.get('field_1', None) == s2
         assert t.get('field_2', None) is None
 
+    def testScalarForVoidType(self):
+        s0_good = schema.Scalar((None, (2, )))
+        with self.assertRaises(TypeError):
+            s0_bad = schema.Scalar((np.void, (2, )))
+
+        s1_good = schema.Scalar(np.void)
+        s2_good = schema.Scalar(None)
+        assert s1_good == s2_good
+
     def testScalarShape(self):
         s0 = schema.Scalar(np.int32)
         self.assertEqual(s0.field_type().shape, ())


### PR DESCRIPTION
Summary:
https://fb.facebook.com/groups/582508038765902/permalink/736710343345670/?comment_id=824042307945806&reply_comment_id=824318864584817

numpy.dtype(numpy.void, (<INT>, )) raises a cryptic message "invalid itemsize in generic type tuple" that is hard to debug.

This diff adds the message to ask the user to investigate the error causing blob.

Differential Revision: D13973359
