### PR TITLE
call istringstream clear after str

### DIFF
--- a/caffe2/quantization/server/activation_distribution_observer.cc
+++ b/caffe2/quantization/server/activation_distribution_observer.cc
@@ -498,6 +498,7 @@ RegisterQuantizationParamsWithHistogramNetObserver::
   }
 
   ist.str(first_line);
+  ist.clear();
 
   bool new_format = true;
   int op_index, i, nbins;
@@ -506,6 +507,7 @@ RegisterQuantizationParamsWithHistogramNetObserver::
   ist >> op_index >> op_type >> i >> tensor_name >> min >> max >> nbins;
   if (nwords_first_line != nbins + 7) {
     ist.str(first_line);
+    ist.clear();
     ist >> op_index >> i >> tensor_name >> min >> max >> nbins;
     if (nwords_first_line == nbins + 6) {
       new_format = false;

--- a/caffe2/quantization/server/caffe2_dnnlowp_utils.cc
+++ b/caffe2/quantization/server/caffe2_dnnlowp_utils.cc
@@ -438,6 +438,7 @@ NetDef AddScaleZeroOffsetArgumentsWithHistogram(
   }
 
   ist.str(first_line);
+  ist.clear();
 
   bool new_format = true;
   int op_index, i, nbins;
@@ -446,6 +447,7 @@ NetDef AddScaleZeroOffsetArgumentsWithHistogram(
   ist >> op_index >> op_type >> i >> tensor_name >> min >> max >> nbins;
   if (nwords_first_line != nbins + 7) {
     ist.str(first_line);
+    ist.clear();
     ist >> op_index >> i >> tensor_name >> min >> max >> nbins;
     if (nwords_first_line == nbins + 6) {
       new_format = false;


### PR DESCRIPTION
Summary:
Sometimes parsing histogram was not working correctly due to changes in D13633256
We need to call istringstream clear after str

Differential Revision: D13977509
