### PR TITLE
Use __getattribute__ instead of __getattr__ in nn.Module

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1124,6 +1124,19 @@ class TestNN(NNTestCase):
         with self.assertRaises(KeyError):
             m.add_module('attribute_name', nn.Module())
 
+    def test_property_attribute_error_message(self):
+        class CustomModule(nn.Module):
+            @property
+            def property_a(self):
+                return self.property_b
+
+        # The message should reference property_b, not property_a (issue #13981)
+        self.assertRaisesRegex(
+            AttributeError,
+            "'CustomModule' object has no attribute 'property_b'",
+            lambda: CustomModule().property_a,
+        )
+
     def test_Sequential_getitem(self):
         l1 = nn.Linear(10, 20)
         l2 = nn.Linear(20, 30)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -525,7 +525,7 @@ class Module(object):
             # object is used here instead of super() for performance
             return object.__getattribute__(self, name)
         except AttributeError:
-            __dict__ = super().__getattribute__('__dict__')
+            __dict__ = object.__getattribute__('__dict__')
             if '_parameters' in __dict__:
                 _parameters = __dict__['_parameters']
                 if name in _parameters:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -525,7 +525,7 @@ class Module(object):
             # object is used here instead of super() for performance
             return object.__getattribute__(self, name)
         except AttributeError:
-            __dict__ = object.__getattribute__('__dict__')
+            __dict__ = object.__getattribute__(self, '__dict__')
             if '_parameters' in __dict__:
                 _parameters = __dict__['_parameters']
                 if name in _parameters:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -520,21 +520,25 @@ class Module(object):
         if '_load_state_dict_pre_hooks' not in self.__dict__:
             self._load_state_dict_pre_hooks = OrderedDict()
 
-    def __getattr__(self, name):
-        if '_parameters' in self.__dict__:
-            _parameters = self.__dict__['_parameters']
-            if name in _parameters:
-                return _parameters[name]
-        if '_buffers' in self.__dict__:
-            _buffers = self.__dict__['_buffers']
-            if name in _buffers:
-                return _buffers[name]
-        if '_modules' in self.__dict__:
-            modules = self.__dict__['_modules']
-            if name in modules:
-                return modules[name]
-        raise AttributeError("'{}' object has no attribute '{}'".format(
-            type(self).__name__, name))
+    def __getattribute__(self, name):
+        try:
+            # object is used here instead of super() for performance
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            __dict__ = super().__getattribute__('__dict__')
+            if '_parameters' in __dict__:
+                _parameters = __dict__['_parameters']
+                if name in _parameters:
+                    return _parameters[name]
+            if '_buffers' in __dict__:
+                _buffers = __dict__['_buffers']
+                if name in _buffers:
+                    return _buffers[name]
+            if '_modules' in __dict__:
+                modules = __dict__['_modules']
+                if name in modules:
+                    return modules[name]
+            raise
 
     def __setattr__(self, name, value):
         def remove_from(*dicts):


### PR DESCRIPTION
This allows for more informative error messages when `@property` methods raise
`AttributeError`. This is because the default behavior is to assume an
`AttributeError` means the property does not exist, and to fall back to
`__getattr__`. Hence something like

```py
    @property
    def property_a(self):
        return self.property_b # does not exist
```

on `nn.Module` or a subclass of `nn.Module` will raise an error stating that
`property_a` does not exist, because `'property_a'` is what gets passed as the
`name` to `__getattr__`. By using `__getattribute__`, we can control this behavior
(by falling back to `object.__getattribute__`), and get a more informative error
message stating that `property_b` does not exist.

The downside of this change is a performance degradation for normal attribute
lookups (by about 3x) and dynamic attribute lookups (by about 2x). Failing
attribute lookups are about the same speed. It is also possible to optimize
for dynamic attribute lookups by moving the call to `object.__getattribute__` to
the end, making them as fast as they are with `__getattr__`, but this makes
normal attribute lookups about 10x slower than with `__getattr__`. I do not know
which should be optimized for, or if the performance of attribute lookups on
`nn.Module` and its subclasses is more important than this improved error
reporting.

Fixes #13981.

I would love to get some confirmation on the performance benchmarks, and an idea if this is acceptable or not (I don't actually know how important nn.Module attribute lookups would be for performance). As far as I know, if this is not acceptable, then issue #13981 is not fixable, unless there is some other way to make my `__getattribute__` faster. 