### PR TITLE
[DEMO] demonstrate implementing get_jit_ast with script parser

### DIFF
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -930,6 +930,10 @@ void initJitScriptBindings(PyObject* module) {
       });
   m.def("_jit_import_methods", import_methods);
   m.def("_jit_set_emit_module_hook", setEmitModuleHook);
+  m.def("_jit_parse_function", [](const std::string& str, bool is_method) {
+    Parser p(str);
+    return Def(p.parseFunction(is_method));
+  });
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -200,6 +200,11 @@ struct SharedParserData {
   // if enclosed with 3 quotes newlines are valid
   // as elsewhere, backslash and new line should be ignored
   bool isString(const std::string& str, size_t start, size_t* len) {
+    if (str[start] == 'r' && start + 1 < str.size()) {
+      bool r = isString(str, start + 1, len);
+      *len += 1;
+      return r;
+    }
     char quote = str[start];
     if (quote != '\"' && quote != '\'')
       return false;

--- a/torch/csrc/jit/script/parse_string_literal.h
+++ b/torch/csrc/jit/script/parse_string_literal.h
@@ -36,8 +36,15 @@ inline c10::optional<char> parseOctal(const std::string& str, size_t pos) {
 inline std::string parseStringLiteral(
     const SourceRange& range,
     const std::string& str) {
-  int quote_len = isCharCount(str[0], str, 0, 3) ? 3 : 1;
-  auto ret_str = str.substr(quote_len, str.size() - quote_len * 2);
+  size_t offset = 0;
+  if (str[0] == 'r') {
+    offset = 1;
+  }
+  int quote_len = isCharCount(str[offset], str, offset, 3) ? 3 : 1;
+  auto ret_str = str.substr(offset + quote_len, str.size() - (quote_len * 2 + offset));
+  if (offset == 1) {
+    return ret_str;
+  }
   size_t pos = ret_str.find('\\');
   while (pos != std::string::npos) {
     // invariant: pos has to escape a character because it is a valid string

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -139,12 +139,16 @@ def _uses_true_division(fn):
 
 def get_jit_ast(fn, is_method):
     source = dedent(inspect.getsource(fn))
-    py_ast = ast.parse(source)
-    if len(py_ast.body) != 1 or not isinstance(py_ast.body[0], ast.FunctionDef):
-        raise RuntimeError("expected a single top-level function")
-    type_line = torch.jit.annotations.get_type_line(source)
-    ctx = SourceContext(source, _uses_true_division(fn))
-    return build_def(ctx, py_ast.body[0], type_line, is_method)
+    lines = source.split('\n')
+    if '@' in lines[0]:
+        source = '\n'.join(lines[1:])
+    return torch._C._jit_parse_function(source, is_method)
+    # py_ast = ast.parse(source)
+    # if len(py_ast.body) != 1 or not isinstance(py_ast.body[0], ast.FunctionDef):
+    #     raise RuntimeError("expected a single top-level function")
+    # type_line = torch.jit.annotations.get_type_line(source)
+    # ctx = SourceContext(source, _uses_true_division(fn))
+    # return build_def(ctx, py_ast.body[0], type_line, is_method)
 
 
 # Thin wrapper around SourceRangeFactory to store extra metadata


### PR DESCRIPTION
If we add support for raw strings (hacked in here, needs a better implementation), then we only fail 3 JIT tests by using the script parser rather than the python ast frontend. The failures are simple things to fix (missing handling or BroadcastingList1 in script frontend), other failures are just expect test differences.

+ easy way to parse python 2 style '# type:' annotations on a per-statement level.
+ less manual management of source ranges for tokens
+ less overall code to maintain

- the script frontend is likely buggy in subtle ways that our testing harnesses have not handled. For instance  `if x > 3: print 4` on a single line is valid python but not something our script frontend does yet
- the script frontend syntax is python 3 specific so there will be some issues with weird python syntax (for instance, forgetting parens in a python 2 TorchScript function).