### PR TITLE
DOC: correct docstring for torch and torch.Tensor package

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -198,14 +198,14 @@ In-place version of :meth:`~Tensor.add`
 
 add_docstr_all('addbmm',
                r"""
-addbmm(beta=1, mat, alpha=1, batch1, batch2) -> Tensor
+addbmm(beta=1, alpha=1, batch1, batch2) -> Tensor
 
 See :func:`torch.addbmm`
 """)
 
 add_docstr_all('addbmm_',
                r"""
-addbmm_(beta=1, mat, alpha=1, batch1, batch2) -> Tensor
+addbmm_(beta=1, alpha=1, batch1, batch2) -> Tensor
 
 In-place version of :meth:`~Tensor.addbmm`
 """)
@@ -240,28 +240,28 @@ In-place version of :meth:`~Tensor.addcmul`
 
 add_docstr_all('addmm',
                r"""
-addmm(beta=1, mat, alpha=1, mat1, mat2) -> Tensor
+addmm(beta=1, alpha=1, mat1, mat2) -> Tensor
 
 See :func:`torch.addmm`
 """)
 
 add_docstr_all('addmm_',
                r"""
-addmm_(beta=1, mat, alpha=1, mat1, mat2) -> Tensor
+addmm_(beta=1, alpha=1, mat1, mat2) -> Tensor
 
 In-place version of :meth:`~Tensor.addmm`
 """)
 
 add_docstr_all('addmv',
                r"""
-addmv(beta=1, tensor, alpha=1, mat, vec) -> Tensor
+addmv(beta=1, alpha=1, mat, vec) -> Tensor
 
 See :func:`torch.addmv`
 """)
 
 add_docstr_all('addmv_',
                r"""
-addmv_(beta=1, tensor, alpha=1, mat, vec) -> Tensor
+addmv_(beta=1, alpha=1, mat, vec) -> Tensor
 
 In-place version of :meth:`~Tensor.addmv`
 """)
@@ -2541,9 +2541,12 @@ add_docstr_all('to_sparse',
 to_sparse(sparseDims) -> Tensor
 Returns a sparse copy of the tensor.  PyTorch supports sparse tensors in
 :ref:`coordinate format <sparse-docs>`.
+
 Args:
     sparseDims (int, optional): the number of sparse dimensions to include in the new sparse tensor
+
 Example::
+
     >>> d = torch.tensor([[0, 0, 0], [9, 0, 10], [0, 0, 0]])
     >>> d
     tensor([[ 0,  0,  0],
@@ -2656,11 +2659,9 @@ type_as(tensor) -> Tensor
 Returns this tensor cast to the type of the given tensor.
 
 This is a no-op if the tensor is already of the correct type. This is
-equivalent to::
+equivalent to ``self.type(tensor.type())``
 
-    self.type(tensor.type())
-
-Params:
+Args:
     tensor (Tensor): the tensor which has the desired type
 """)
 
@@ -2673,11 +2674,11 @@ Returns a tensor which contains all slices of size :attr:`size` from
 
 Step between two slices is given by :attr:`step`.
 
-If `sizedim` is the size of dimension dim for :attr:`self`, the size of
+If `sizedim` is the size of dimension :attr:`dim` for :attr:`self`, the size of
 dimension :attr:`dim` in the returned tensor will be
 `(sizedim - size) / step + 1`.
 
-An additional dimension of size size is appended in the returned tensor.
+An additional dimension of size :attr:`size` is appended in the returned tensor.
 
 Args:
     dim (int): dimension in which unfolding happens

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -219,7 +219,7 @@ If :attr:`batch1` is a :math:`(b \times n \times m)` tensor, :attr:`batch2` is a
 and :attr:`out` will be a :math:`(n \times p)` tensor.
 
 .. math::
-    out = \beta\ \text{mat} + \alpha\ (\sum_{i=0}^{b} \text{batch1}_i \mathbin{@} \text{batch2}_i)
+    out = \beta\ \text{mat} + \alpha\ (\sum_{i=0}^{b-1} \text{batch1}_i \mathbin{@} \text{batch2}_i)
 
 For inputs of type `FloatTensor` or `DoubleTensor`, arguments :attr:`beta` and :attr:`alpha`
 must be real numbers, otherwise they should be integers.
@@ -5736,7 +5736,7 @@ Ignoring the batch dimensions, it computes the following expression:
 
 .. math::
     X[\omega_1, \dots, \omega_d] =
-        \sum_{n_1=0}^{N_1} \dots \sum_{n_d=0}^{N_d} x[n_1, \dots, n_d]
+        \sum_{n_1=0}^{N_1-1} \dots \sum_{n_d=0}^{N_d-1} x[n_1, \dots, n_d]
          e^{-j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
 
 where :math:`d` = :attr:`signal_ndim` is number of dimensions for the
@@ -5839,7 +5839,7 @@ expression:
 
 .. math::
     X[\omega_1, \dots, \omega_d] =
-        \frac{1}{\prod_{i=1}^d N_i} \sum_{n_1=0}^{N_1} \dots \sum_{n_d=0}^{N_d} x[n_1, \dots, n_d]
+        \frac{1}{\prod_{i=1}^d N_i} \sum_{n_1=0}^{N_1-1} \dots \sum_{n_d=0}^{N_d-1} x[n_1, \dots, n_d]
          e^{\ j\ 2 \pi \sum_{i=0}^d \frac{\omega_i n_i}{N_i}},
 
 where :math:`d` = :attr:`signal_ndim` is number of dimensions for the

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -289,7 +289,7 @@ def stft(input, n_fft, hop_length=None, win_length=None, window=None,
     expression:
 
     .. math::
-        X[m, \omega] = \sum_{k = 0}^{\text{win\_length}}%
+        X[m, \omega] = \sum_{k = 0}^{\text{win\_length-1}}%
                             \text{window}[k]\ \text{input}[m \times \text{hop\_length} + k]\ %
                             \exp\left(- j \frac{2 \pi \cdot \omega k}{\text{win\_length}}\right),
 
@@ -680,7 +680,7 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):
         >>> torch.norm(a, float('inf'))
         tensor(4.)
         >>> torch.norm(b, float('inf'))
-        tensor([4., 3., 4.])
+        tensor(4.)
         >>> c = torch.tensor([[ 1, 2, 3],[-1, 1, 4]] , dtype= torch.float)
         >>> torch.norm(c, dim=0)
         tensor([1.4142, 2.2361, 5.0000])


### PR DESCRIPTION
This PR is a simple fix for the mistake in the  "tensor"  and "torch.Tensor"doc.