### PR TITLE
Fix (#2) ppc64le build break on git status --porcelain check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docs/src/**/*
 docs/cpp/build
 docs/cpp/source/api
 test/.coverage
+test/.hypothesis/
 test/cpp/api/mnist
 test/custom_operator/model.pt
 test/data/gpu_tensors.pt


### PR DESCRIPTION
Add test/.hypothesis/ to .gitignore to pass git status --porcelain check in CI build

