### PR TITLE
Activation histogram net observer with multiple histogram files as output

### DIFF
--- a/caffe2/quantization/server/activation_distribution_observer.cc
+++ b/caffe2/quantization/server/activation_distribution_observer.cc
@@ -285,10 +285,12 @@ HistogramNetObserver::HistogramNetObserver(
     NetBase* subject,
     const string& out_file_name,
     int nbins,
-    int dump_freq)
+    int dump_freq,
+    bool mul_nets)
     : NetObserver(subject),
       dump_freq_(dump_freq),
       cnt_(0),
+      mul_nets_(mul_nets),
       out_file_name_(out_file_name) {
   hist_infos_.resize(subject->GetOperators().size());
 
@@ -313,9 +315,15 @@ HistogramNetObserver::HistogramNetObserver(
 void HistogramNetObserver::DumpAndReset_(
     const string& out_file_name,
     bool print_total_min_max) {
-  ofstream f(out_file_name);
+  stringstream file_name;
+  file_name << out_file_name;
+  if (mul_nets_) {
+    file_name << ".";
+    file_name << this;
+  }
+  ofstream f(file_name.str());
   if (!f) {
-    LOG(WARNING) << this << ": can't open " << out_file_name;
+    LOG(WARNING) << this << ": can't open " << file_name.str();
   }
 
   for (int op_index = 0; op_index < hist_infos_.size(); ++op_index) {

--- a/caffe2/quantization/server/activation_distribution_observer.h
+++ b/caffe2/quantization/server/activation_distribution_observer.h
@@ -104,7 +104,8 @@ class HistogramNetObserver final : public NetObserver {
       NetBase* subject,
       const std::string& out_file_name,
       int nbins,
-      int dump_freq = -1);
+      int dump_freq = -1,
+      bool mul_nets = false);
   ~HistogramNetObserver();
 
  private:
@@ -114,6 +115,11 @@ class HistogramNetObserver final : public NetObserver {
       bool print_total_min_max = false);
 
   int dump_freq_, cnt_;
+
+  /** If multiple nets exist and are attached with the observers, the histogram
+   * files for the nets will be appended with netbase addresses.
+   */
+  bool mul_nets_;
   const std::string out_file_name_;
   std::vector<std::shared_ptr<HistogramObserver::Info>> hist_infos_;
 };


### PR DESCRIPTION
Summary: Save the histogram of each net to a separate file

Differential Revision: D13991610
