### PR TITLE
Fix and add testing for nullptr allocator in c2->pt conversion

### DIFF
--- a/aten/src/TH/generic/THStorage.cpp
+++ b/aten/src/TH/generic/THStorage.cpp
@@ -120,7 +120,7 @@ THStorage* THStorage_(newWithDataAndAllocator)(at::DataPtr&& data, ptrdiff_t siz
       size,
       std::move(data),
       allocator,
-      true).release();
+      allocator != nullptr).release();
   return storage;
 }
 

--- a/aten/src/THC/generic/THCStorage.cpp
+++ b/aten/src/THC/generic/THCStorage.cpp
@@ -122,7 +122,7 @@ THCStorage* THCStorage_(newWithDataAndAllocator)(
       size,
       std::move(data),
       allocator,
-      true).release();
+      allocator != nullptr).release();
   return storage;
 }
 

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -183,6 +183,7 @@ struct C10_API InefficientStdFunctionContext {
 
 } // namespace c10
 
+// TODO: move to c10
 namespace caffe2 {
 
 /** Set the allocator for DeviceType `t`. The passed in allocator pointer is

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -21,6 +21,10 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
         numel_(numel),
         resizable_(resizable),
         allocator_(allocator) {
+    if (resizable) {
+      AT_ASSERTM(
+          allocator_, "For resizable storage, allocator must be provided");
+    }
     if (numel > 0) {
       if (data_type_.id() == caffe2::TypeIdentifier::uninitialized()) {
         AT_ERROR(
@@ -45,8 +49,12 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
       : StorageImpl(device, caffe2::TypeMeta()) {}
 
   StorageImpl(at::Device device, caffe2::TypeMeta data_type)
-      : StorageImpl(data_type, 0, at::DataPtr(nullptr, device), nullptr, true) {
-  }
+      : StorageImpl(
+            data_type,
+            0,
+            at::DataPtr(nullptr, device),
+            caffe2::GetAllocator(device.type()),
+            true) {}
 
   StorageImpl& operator=(StorageImpl&& other) = default;
   StorageImpl& operator=(const StorageImpl&) = delete;
@@ -171,6 +179,10 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
   }
 
   void set_resizable(bool resizable) {
+    if (resizable) {
+      // We need an allocator to be resizable
+      AT_ASSERT(allocator_);
+    }
     resizable_ = resizable;
   }
 
@@ -208,6 +220,8 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
     // capacity() might not return the value that was set here, if itemsize does
     // not evenly divide it.
     numel_ = capacity / data_type_.itemsize();
+    allocator_ = nullptr;
+    resizable_ = false;
   }
 
  private:

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1135,7 +1135,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     } else {
       int64_t numel = capacity / data_type.itemsize();
       // Create a new Storage
-      storage_ = Storage(data_type, numel, std::move(data_ptr), nullptr, true);
+      storage_ = Storage(
+          data_type,
+          numel,
+          std::move(data_ptr),
+          /*allocator=*/nullptr,
+          /*resizable=*/false);
       data_type_ = data_type;
       storage_offset_ = 0;
     }
@@ -1178,7 +1183,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         return storage_.data();
       }
       const Allocator* allocator = storage_.allocator();
-      // TODO: Get rid of StaticContext
+      // Storage might have nullptr allocator in rare cases, for example, if
+      // an external memory segment has been wrapped with Tensor and we don't
+      // know how to reallocate it. However, in order to preserve legacy C2
+      // behavior, we allow reallocating the memory using default allocator.
       if (allocator == nullptr) {
         allocator = caffe2::GetAllocator(storage_.device_type());
       }


### PR DESCRIPTION
Fixes the bug for when tensor is created on Caffe2 side, then passed to PT and resized. Now we just initialize allocator correctly.

Note that the code in raw_mutable_data() is still necessary because of non-resizable tensors.
