### PR TITLE
Robust determination of cudnn library and relevant conda packages.

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -130,7 +130,7 @@ def get_cudnn_version(run_lambda):
         return None
     # Alphabetize the result because the order is non-deterministic otherwise
     files = list(sorted(files))
-    if len(files)==1:
+    if len(files) == 1:
         return files[0]
     result = '\n'.join(files)
     return 'Probably one of the following:\n{}'.format(result)

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -73,7 +73,8 @@ def get_conda_packages(run_lambda):
         grep_cmd = r'findstr /R "torch soumith mkl magma"'
     else:
         grep_cmd = r'grep "torch\|soumith\|mkl\|magma"'
-    out = run_and_read_all(run_lambda, 'conda list | ' + grep_cmd)
+    conda = os.environ.get('CONDA_EXE', 'conda')
+    out = run_and_read_all(run_lambda, conda + ' list | ' + grep_cmd)
     if out is None:
         return out
     # Comment starting at beginning of line


### PR DESCRIPTION

This PR implements:
1. a fix to issue #12174 - determine the location of cudnn library using `ldconfig`
2. a fix to determine the installed conda packages (in recent versions of conda, the command `conda` is a Bash function that cannot be called within a python script, so using CONDA_EXE environment variable instead)