### PR TITLE
Keep weights name unchanged during SsaRewrite

### DIFF
--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -28,7 +28,9 @@ using ConvertedResult =
 // output names for predict net.
 CAFFE2_API std::unordered_map<std::string, std::string> SsaRewrite(
     caffe2::NetDef* init_net,
-    caffe2::NetDef* pred_net);
+    caffe2::NetDef* pred_net,
+    const std::unordered_set<std::string>& exceptions =
+        std::unordered_set<std::string>());
 
 ::ONNX_NAMESPACE::TensorProto::DataType Caffe2TypeToOnnxType(
     caffe2::TensorProto::DataType t);

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -42,6 +42,7 @@ class CAFFE2_API OnnxifiTransformer final {
       Workspace* ws,
       NetDef* pred_net,
       const std::vector<std::string>& external_inputs,
+      const std::vector<std::string>& weight_names,
       const std::unordered_map<std::string, TensorShape>& shape_hints,
       const std::unordered_set<int>& blacklisted_ops);
 
@@ -85,6 +86,7 @@ class CAFFE2_API OnnxifiTransformer final {
   CaffeMap<std::string, TensorShape> SsaRewriteAndMapNames(
       Workspace* ws,
       NetDef* pred_net,
+      const std::unordered_set<std::string>& weights,
       const std::unordered_map<std::string, TensorShape>& input_shape_hints);
 
   // Transform by passing C2 proto to backend

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1628,10 +1628,13 @@ void addGlobalMethods(py::module& m) {
         opts.debug = debug_builder;
         opts.use_onnx = use_onnx;
         OnnxifiTransformer ts(opts);
+        Workspace* curr_ws = GetCurrentWorkspace();
+        auto weight_names = curr_ws->Blobs();
         ts.Transform(
-            GetCurrentWorkspace(),
+            curr_ws,
             &pred_net,
             external_inputs,
+            weight_names,
             tensor_shapes,
             std::unordered_set<int>());
         std::string pred_net_str2;


### PR DESCRIPTION
Summary:
During onnxifi transformation net ssa is rewritten. At the last step the weight
names are changed back to what they were before. The diff keeps the weight
names unchanged thru the process.

Differential Revision: D13972597
