### PR TITLE
Revert unneeded fixes in flat_hash_map

### DIFF
--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -1,11 +1,9 @@
 // Taken from https://github.com/skarupke/flat_hash_map/blob/2c4687431f978f02a3780e24b8b701d22aa32d9c/flat_hash_map.hpp
 // with fixes applied:
-// - https://github.com/skarupke/flat_hash_map/pull/8
 // - https://github.com/skarupke/flat_hash_map/pull/25
 // - https://github.com/skarupke/flat_hash_map/pull/26
 // - replace size_t with uint64_t to fix it for 32bit
 // - add "GCC diagnostic" pragma to ignore -Wshadow
-// - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems to have issues with it otherwise
 
 //          Copyright Malte Skarupke 2017.
 // Distributed under the Boost Software License, Version 1.0.
@@ -294,9 +292,9 @@ class sherwood_v3_table : private EntryAlloc, private Hasher, private Equal
     using Entry = detailv3::sherwood_v3_entry<T>;
     using AllocatorTraits = std::allocator_traits<EntryAlloc>;
     using EntryPointer = typename AllocatorTraits::pointer;
+    struct convertible_to_iterator;
 
 public:
-    struct convertible_to_iterator;
 
     using value_type = T;
     using size_type = uint64_t;
@@ -522,7 +520,6 @@ public:
             if (it->has_value())
                 return { it };
         }
-        return end();
     }
     const_iterator begin() const
     {
@@ -531,7 +528,6 @@ public:
             if (it->has_value())
                 return { it };
         }
-        return end();
     }
     const_iterator cbegin() const
     {
@@ -925,7 +921,6 @@ private:
         return static_cast<Equal &>(*this)(lhs, rhs);
     }
 
-public:
     struct convertible_to_iterator
     {
         EntryPointer it;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16867 Don't automatically handle context parameter&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13995696/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16878 Also register op schema when no kernels are registered&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13997959/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16691 Register CUDA kernels for caffe2 operators&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13901619/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16864 Revert unneeded fixes in flat_hash_map**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13985779/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16881 Fix constexpr in KernelRegistrationBuilder&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D13998486/)

The begin()/end() fix actually doesn't make sense, see my comment on https://github.com/skarupke/flat_hash_map/pull/8
This diff removes it and also removes the public/private fix introduced previously for gcc5.
That public/private fix was introduced because it caused a compiler error on sandcastle for some reason, but I now think that this wasn't the actual reason.
Whatever the actual reason was, it seems fixed since it builds now and if this passes sandcastle, we can land it.

Differential Revision: [D13985779](https://our.internmc.facebook.com/intern/diff/D13985779/)