### PR TITLE
Don't automatically handle context parameter

### DIFF
--- a/caffe2/core/c10_operator.h
+++ b/caffe2/core/c10_operator.h
@@ -85,7 +85,7 @@ inline c10::FunctionSchema make_function_schema_for_c10(const char* OperatorName
   /* Store the c10 operator handle so call_caffe2_op_from_c10 can access it */                    \
   namespace detail {                                                                              \
   template<>                                                                                      \
-  const c10::OperatorHandle& c10_op_handle_for_c2_op<OperatorClass<caffe2::CPUContext>>() {       \
+  const c10::OperatorHandle& c10_op_handle_for_c2_op<OperatorClass>() {                           \
     return caffe2::_c10_ops::OperatorName();                                                      \
   }                                                                                               \
   }}                                                                                              \
@@ -93,6 +93,6 @@ inline c10::FunctionSchema make_function_schema_for_c10(const char* OperatorName
   namespace c10 {                                                                                 \
   C10_REGISTER_KERNEL(caffe2::_c10_ops::OperatorName)                                             \
       /*.withCache<Cache>()*/                                                                     \
-      .kernel<&caffe2::detail::call_caffe2_op_from_c10<OperatorClass<caffe2::CPUContext>>>()      \
+      .kernel<&caffe2::detail::call_caffe2_op_from_c10<OperatorClass>>()                          \
       .dispatchKey(CPUTensorId());                                                                \
   }

--- a/caffe2/operators/bbox_transform_op.h
+++ b/caffe2/operators/bbox_transform_op.h
@@ -8,13 +8,16 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
 
+C10_DECLARE_CAFFE2_OPERATOR(BBoxTransformOp)
+
 namespace caffe2 {
 
 template <typename T, class Context>
 class BBoxTransformOp final : public Operator<Context> {
  public:
-  BBoxTransformOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<Context>(operator_def, ws),
+  template<class... Args>
+  explicit BBoxTransformOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
         weights_(this->template GetRepeatedArgument<T>(
             "weights",
             vector<T>{1.0f, 1.0f, 1.0f, 1.0f})),

--- a/caffe2/operators/bbox_transform_op.h
+++ b/caffe2/operators/bbox_transform_op.h
@@ -8,16 +8,13 @@
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
 
-C10_DECLARE_CAFFE2_OPERATOR(BBoxTransformOp)
-
 namespace caffe2 {
 
 template <typename T, class Context>
 class BBoxTransformOp final : public Operator<Context> {
  public:
-  template<class... Args>
-  explicit BBoxTransformOp(Args&&... args)
-      : Operator<Context>(std::forward<Args>(args)...),
+  BBoxTransformOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
         weights_(this->template GetRepeatedArgument<T>(
             "weights",
             vector<T>{1.0f, 1.0f, 1.0f, 1.0f})),

--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -195,5 +195,5 @@ C10_REGISTER_CAFFE2_OPERATOR_CPU(
     c10::Argument("mean"),
     c10::Argument("stdev")
   }),
-  caffe2::LayerNormOp
+  caffe2::LayerNormOp<caffe2::CPUContext>
 )


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16867 Don't automatically handle context parameter**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13995696/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16878 Also register op schema when no kernels are registered&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13997959/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16883 [wip] Ensure there's only one dispatcher&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14000153/)

Some caffe2 operators (example: BBoxTransform) have not just one template parameter which is the context, but might have multiple template parameters.
Because of this, we can't handle the context parameter inside the macro.

Differential Revision: [D13995696](https://our.internmc.facebook.com/intern/diff/D13995696/)