### PR TITLE
Removing Slice+Concat pattern from ONNX export of LSTM and GRU ops

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1307,11 +1307,6 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         return g.op('Concat', *slices, axis_i=0)
 
     def transform_weights(layer_index):
-        # if variant == 'RNN':
-        #     weight_ih, weight_hh, bias_ih, bias_hh = layer_weights[layer_index]
-        # elif variant == 'GRU' or variant == 'LSTM':
-        #     weight_ih, weight_hh, bias_ih, bias_hh = \
-        #         [reform_weights(g, w, hidden_size, reform_permutation) for w in layer_weights[layer_index]]
         weight_ih, weight_hh, bias_ih, bias_hh = layer_weights[layer_index]
         bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
 

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1307,11 +1307,12 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
         return g.op('Concat', *slices, axis_i=0)
 
     def transform_weights(layer_index):
-        if variant == 'RNN':
-            weight_ih, weight_hh, bias_ih, bias_hh = layer_weights[layer_index]
-        elif variant == 'GRU' or variant == 'LSTM':
-            weight_ih, weight_hh, bias_ih, bias_hh = \
-                [reform_weights(g, w, hidden_size, reform_permutation) for w in layer_weights[layer_index]]
+        # if variant == 'RNN':
+        #     weight_ih, weight_hh, bias_ih, bias_hh = layer_weights[layer_index]
+        # elif variant == 'GRU' or variant == 'LSTM':
+        #     weight_ih, weight_hh, bias_ih, bias_hh = \
+        #         [reform_weights(g, w, hidden_size, reform_permutation) for w in layer_weights[layer_index]]
+        weight_ih, weight_hh, bias_ih, bias_hh = layer_weights[layer_index]
         bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
 
         return tuple(g.op('Unsqueeze', x, axes_i=[0]) for x in (weight_ih, weight_hh, bias_concat))

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -267,7 +267,7 @@ def _model_to_graph(model, args, f, verbose=False, training=False,
             raise RuntimeError('\'forward\' method must be a script method')
     else:
         graph, torch_out = _trace_and_get_graph_from_model(model, args, training)
-        params = list(_unique_state_dict(model).values())
+        params = list(_unique_state_dict(model).values()).copy()
 
         all_names = list(_unique_state_dict(model).keys())
         if (operator_export_type == OperatorExportTypes.ONNX):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -215,7 +215,7 @@ def _weight_transformation(param, name, type):
         raise RuntimeError("Parameter type must be either 'lstm' or 'gru'.")
 
     param_size = param.size()
-    if ((param_size[0] & (num_gates - 1) != 0 )):
+    if (param_size[0] & (num_gates - 1) != 0 ):
         raise RuntimeError("Weight matrix size must be a multiple of number of gates for the RNN node.")
     hidden_size = param_size[0] // num_gates
     start_indices = [x * hidden_size for x in gate_permutation]
@@ -273,8 +273,8 @@ def _model_to_graph(model, args, f, verbose=False, training=False,
         all_names = list(_unique_state_dict(model).keys())
         if (operator_export_type == OperatorExportTypes.ONNX):
             rnn_param_dict = _rnn_unique_param_name_dict(model)
-            params = [_weight_transformation(param, name, rnn_param_dict[name]) 
-            if name in rnn_param_dict.keys() else param for (param, name) in zip(params, all_names)]
+            params = [_weight_transformation(param, name, rnn_param_dict[name])
+                if name in rnn_param_dict.keys() else param for (param, name) in zip(params, all_names)]
 
     graph = _optimize_graph(graph, operator_export_type)
 


### PR DESCRIPTION
Currently, the export of RNN nodes creates several Slice+Concat nodes in the exported ONNX graph. This increases the graph size and can be a performance bottleneck. The root cause of this issue is the difference in format for the parameter weight and bias tensors of LSTM/GRU nodes between PyTorch and ONNX. In this change we transform the weight format directly in the parameter tensors and not through symbolic manipulation. This removes the Slice+Concat node pattern in the exported ONNX graph.

