### PR TITLE
[wip] Ensure there's only one dispatcher

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -90,7 +90,7 @@ public:
   // dispatch tables.  This could be easily adjusted to have a single global hash
   // table.
 
-  static Dispatcher& singleton();
+  static CAFFE2_API Dispatcher& singleton();
 
   /**
    * Register a new operator schema. The handle returned can be used to register


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16867 Don't automatically handle context parameter&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13995696/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #16878 Also register op schema when no kernels are registered&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D13997959/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#16883 [wip] Ensure there's only one dispatcher**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14000153/)

Just to be sure, this singleton should probably have a CAFFE2_API macro.

Differential Revision: [D14000153](https://our.internmc.facebook.com/intern/diff/D14000153/)