### PR TITLE
fixed LogSigmoid math string that wasn't rendering in documentation

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -559,7 +559,8 @@ class LeakyReLU(Module):
 class LogSigmoid(Module):
     r"""Applies the element-wise function:
 
-    .. math:`\text{LogSigmoid}(x) = \log\left(\frac{ 1 }{ 1 + \exp(-x)}\right)`
+    .. math::
+        \text{LogSigmoid}(x) = \log\left(\frac{ 1 }{ 1 + \exp(-x)}\right)
 
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional


### PR DESCRIPTION
The documentation for LogSigmoid says:

> Applies the element-wise function:
> \<blank\>

Now the documentation properly displays the math string.