### PR TITLE
Install Thrust package and stop patching

### DIFF
--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -76,13 +76,8 @@ install_centos() {
                    rocsparse \
                    hipsparse \
                    rocrand \
-                   rccl
-
-  # Needed for now, will be replaced once hip-thrust is packaged for CentOS
-  git clone --recursive https://github.com/ROCmSoftwarePlatform/Thrust.git /data/Thrust
-  rm -rf /data/Thrust/thrust/system/cuda/detail/cub-hip
-  git clone --recursive https://github.com/ROCmSoftwarePlatform/cub-hip.git /data/Thrust/thrust/system/cuda/detail/cub-hip
-  ln -s /data/Thrust/thrust /opt/rocm/include/thrust
+                   rccl \
+                   Thrust
 }
  
 # Install Python packages depending on the base OS


### PR DESCRIPTION
Summary: I think the Thrust package has want we want for /opt/rocm/include/thrust. We probably can stop patching it now.

Differential Revision: D14015177
