### PR TITLE
Allow the variable type association to depend on backend+scalar_type,…

### DIFF
--- a/aten/src/ATen/templates/TypeExtension.cpp
+++ b/aten/src/ATen/templates/TypeExtension.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<Generator> ${Type}::generator() const {
 }
 
 ScalarType ${Type}::scalarType() const {
-  AT_ERROR("scalarType is not implemented for ${Type}");
+  return ScalarType::Float;
 }
 
 caffe2::TypeMeta ${Type}::typeMeta() const {

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -40,8 +40,6 @@ using namespace torch::autograd::generated;
 
 namespace torch { namespace autograd {
 
-extern std::vector<std::unique_ptr<Type>> type_to_variable_type;
-
 inline void check_inplace(const Tensor& tensor) {
   auto& var = static_cast<const Variable&>(tensor);
   if (var.requires_grad() && var.is_leaf() && GradMode::is_enabled()) {


### PR DESCRIPTION
When an XLA tensor registration happen, the mapping between typed ID and variable type does not allow