### PR TITLE
Parse the command line and check the arguments before build_deps()

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -121,6 +121,13 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   ./xla/scripts/apply_patches.sh
 fi
 
+
+# check that setup.py would fail with bad arguments
+echo "The next three invocations are expected to fail with invalid command error messages."
+( ! get_exit_code python setup.py bad_argument )
+( ! get_exit_code python setup.py clean] )
+( ! get_exit_code python setup.py clean bad_argument )
+
 # ppc64le build fails when WERROR=1
 # set only when building other architectures
 # only use for "python setup.py install" line

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -157,3 +157,11 @@ if [[ "$BUILD_ENVIRONMENT" == *pytorch-linux-xenial-cuda* ]]; then
     fi
   fi
 fi
+
+function get_exit_code() {
+  set +e
+  "$@"
+  retcode=$?
+  set -e
+  return $retcode
+}

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -64,13 +64,6 @@ if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
     # Increase stack size, because ASAN red zones use more stack
     ulimit -s 81920
 
-    function get_exit_code() {
-      set +e
-      "$@"
-      retcode=$?
-      set -e
-      return $retcode
-    }
     (cd test && python -c "import torch")
     echo "The next three invocations are expected to crash; if they don't that means ASAN/UBSAN is misconfigured"
     (cd test && ! get_exit_code python -c "import torch; torch._C._crash_if_csrc_asan(3)")

--- a/setup.py
+++ b/setup.py
@@ -727,7 +727,7 @@ if __name__ == '__main__':
         ok = dist.parse_command_line()
     except DistutilsArgError as msg:
         raise SystemExit(core.gen_usage(dist.script_name) + "\nerror: %s" % msg)
-    if ok != True:
+    if not ok:
         sys.exit()
 
     if RUN_BUILD_DEPS:

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,9 @@
 
 from __future__ import print_function
 from setuptools import setup, Extension, distutils, Command, find_packages
-from distutils import dir_util
+from distutils import core, dir_util
+from distutils.core import Distribution
+from distutils.errors import DistutilsArgError
 import setuptools.command.build_ext
 import setuptools.command.install
 import distutils.command.clean
@@ -716,6 +718,18 @@ def print_box(msg):
     print('-' * (size + 2))
 
 if __name__ == '__main__':
+    # Parse the command line and check the arguments
+    # before we proceed with building deps and setup
+    dist = Distribution()
+    dist.script_name = sys.argv[0]
+    dist.script_args = sys.argv[1:]
+    try:
+        ok = dist.parse_command_line()
+    except DistutilsArgError as msg:
+        raise SystemExit(core.gen_usage(dist.script_name) + "\nerror: %s" % msg)
+    if ok != True:
+        sys.exit()
+
     if RUN_BUILD_DEPS:
         build_deps()
     setup(


### PR DESCRIPTION
This is needed to check for wrong arguments or --help options
before `build_deps()` is executed. Otherwise command line arguments
are not parsed and checked until `setup()` is run.

Fixes: #16707 
