### PR TITLE
Add module and name to func created with _jit_internal.boolean_dispatch

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -111,7 +111,7 @@ def weak_script_method(fn):
     return fn
 
 
-def boolean_dispatch(arg_name, arg_index, default, if_true, if_false):
+def boolean_dispatch(arg_name, arg_index, default, if_true, if_false, module_name=None, func_name=None):
     """
     Dispatches to either of 2 weak script functions based on a boolean argument.
     In TorchScript, the boolean argument must be constant so that the correct
@@ -144,6 +144,11 @@ def boolean_dispatch(arg_name, arg_index, default, if_true, if_false):
     else:
         raise RuntimeError("only one function can have a docstring")
     fn.__doc__ = doc
+
+    if module_name is not None:
+        fn.__module__ = module_name
+    if func_name is not None:
+        fn.__name__ = func_name
 
     boolean_dispatched[fn] = {
         "if_true": if_true,

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -111,7 +111,7 @@ def weak_script_method(fn):
     return fn
 
 
-def boolean_dispatch(arg_name, arg_index, default, if_true, if_false, module_name=None, func_name=None):
+def boolean_dispatch(arg_name, arg_index, default, if_true, if_false, module_name, func_name):
     """
     Dispatches to either of 2 weak script functions based on a boolean argument.
     In TorchScript, the boolean argument must be constant so that the correct

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -361,7 +361,9 @@ fractional_max_pool2d = torch._jit_internal.boolean_dispatch(
     arg_index=4,
     default=False,
     if_true=fractional_max_pool2d_with_indices,
-    if_false=_fractional_max_pool2d)
+    if_false=_fractional_max_pool2d,
+    module_name=__name__,
+    func_name='fractional_max_pool2d')
 
 
 @weak_script
@@ -427,7 +429,9 @@ fractional_max_pool3d = torch._jit_internal.boolean_dispatch(
     arg_index=4,
     default=False,
     if_true=fractional_max_pool3d_with_indices,
-    if_false=_fractional_max_pool3d)
+    if_false=_fractional_max_pool3d,
+    module_name=__name__,
+    func_name='fractional_max_pool3d')
 
 
 @weak_script
@@ -457,7 +461,9 @@ max_pool1d = torch._jit_internal.boolean_dispatch(
     arg_index=6,
     default=False,
     if_true=max_pool1d_with_indices,
-    if_false=_max_pool1d)
+    if_false=_max_pool1d,
+    module_name=__name__,
+    func_name='max_pool1d')
 
 
 @weak_script
@@ -486,7 +492,9 @@ max_pool2d = torch._jit_internal.boolean_dispatch(
     arg_index=6,
     default=False,
     if_true=max_pool2d_with_indices,
-    if_false=_max_pool2d)
+    if_false=_max_pool2d,
+    module_name=__name__,
+    func_name='max_pool2d')
 
 
 @weak_script
@@ -516,7 +524,9 @@ max_pool3d = torch._jit_internal.boolean_dispatch(
     arg_index=6,
     default=False,
     if_true=max_pool3d_with_indices,
-    if_false=_max_pool3d)
+    if_false=_max_pool3d,
+    module_name=__name__,
+    func_name='max_pool3d')
 
 
 @weak_script
@@ -672,7 +682,9 @@ adaptive_max_pool1d = torch._jit_internal.boolean_dispatch(
     arg_index=2,
     default=False,
     if_true=adaptive_max_pool1d_with_indices,
-    if_false=_adaptive_max_pool1d)
+    if_false=_adaptive_max_pool1d,
+    module_name=__name__,
+    func_name='adaptive_max_pool1d')
 
 
 @weak_script
@@ -702,7 +714,9 @@ adaptive_max_pool2d = torch._jit_internal.boolean_dispatch(
     arg_index=2,
     default=False,
     if_true=adaptive_max_pool2d_with_indices,
-    if_false=_adaptive_max_pool2d)
+    if_false=_adaptive_max_pool2d,
+    module_name=__name__,
+    func_name='adaptive_max_pool2d')
 
 
 @weak_script
@@ -732,7 +746,9 @@ adaptive_max_pool3d = torch._jit_internal.boolean_dispatch(
     arg_index=2,
     default=False,
     if_true=adaptive_max_pool3d_with_indices,
-    if_false=_adaptive_max_pool3d)
+    if_false=_adaptive_max_pool3d,
+    module_name=__name__,
+    func_name='adaptive_max_pool3d')
 
 
 adaptive_avg_pool1d = _add_docstr(torch.adaptive_avg_pool1d, r"""


### PR DESCRIPTION
The use case for making this PR is the following bug : 
(with F = torch.nn.functional)
`F.max_pool2d.__module__` is `torch._jit_internal`
`F.max_pool2d.__name__` is `fn`

With this PR you get:
`F.max_pool2d.__module__` is `torch.nn.functional`
`F.max_pool2d.__name__` is `max_pool2d`