### PR TITLE
Fold col offsets into bias; optimize FC for symmetric quantization

### DIFF
--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -154,41 +154,78 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
       t_begin = chrono::system_clock::now();
     }
     if (!dequantize_output_) {
-      row_offsets_.resize(PackAWithRowOffset<uint8_t>::rowOffsetBufferSize());
-      X_pack_buf_.resize(PackAWithRowOffset<uint8_t>::packedBufferSize());
-      PackAWithRowOffset<uint8_t> packA(
-          matrix_op_t::NoTranspose,
-          M,
-          K,
-          reinterpret_cast<const uint8_t*>(Xdata),
-          K,
-          X_pack_buf_.data(), // buffer for packed matrix
-          1, // group
-          row_offsets_.data());
-
-      DoNothing<> doNothingObj{};
-      ReQuantizeOutput<false /* FUSE_RELU */> outputProcObj(
-          doNothingObj,
-          &requantization_params_.real_multiplier,
-          out_qparams_.zero_point,
-          in_qparams_[0].zero_point,
-          &in_qparams_[1].zero_point,
-          packA.getRowOffsetBuffer(),
-          column_offsets_->data(),
-          b_quantized_data_,
-          N); // ncols per quant group
-
       Y_int32_.resize(Y->size());
-      fbgemmPacked(
-          packA,
-          *Wq_packed_,
-          reinterpret_cast<uint8_t*>(
-              OutputTensorCPU_(0)->template mutable_data<T>()),
-          Y_int32_.data(),
-          N,
-          outputProcObj,
-          0, // thread_id
-          1); // num_threads
+      DoNothing<> doNothingObj{};
+
+      if (in_qparams_[1].zero_point) {
+        row_offsets_.resize(PackAWithRowOffset<uint8_t>::rowOffsetBufferSize());
+        X_pack_buf_.resize(PackAWithRowOffset<uint8_t>::packedBufferSize());
+
+        PackAWithRowOffset<uint8_t> packA(
+            matrix_op_t::NoTranspose,
+            M,
+            K,
+            reinterpret_cast<const uint8_t*>(Xdata),
+            K,
+            X_pack_buf_.data(), // buffer for packed matrix
+            1, // group
+            row_offsets_.data());
+
+        ReQuantizeOutput<false /* FUSE_RELU */> outputProcObj(
+            doNothingObj,
+            &requantization_params_.real_multiplier,
+            out_qparams_.zero_point,
+            column_offsets_->empty() ? 0 : in_qparams_[0].zero_point,
+            &in_qparams_[1].zero_point,
+            packA.getRowOffsetBuffer(),
+            column_offsets_->empty() ? nullptr : column_offsets_->data(),
+            b_quantized_data_,
+            N); // ncols per quant group
+
+        fbgemmPacked(
+            packA,
+            *Wq_packed_,
+            reinterpret_cast<uint8_t*>(
+                OutputTensorCPU_(0)->template mutable_data<T>()),
+            Y_int32_.data(),
+            N,
+            outputProcObj,
+            0, // thread_id
+            1); // num_threads
+      } else {
+        X_pack_buf_.resize(PackAMatrix<uint8_t>::packedBufferSize());
+
+        PackAMatrix<uint8_t> packA(
+            matrix_op_t::NoTranspose,
+            M,
+            K,
+            reinterpret_cast<const uint8_t*>(Xdata),
+            K,
+            X_pack_buf_.data(), // buffer for packed matrix
+            1); // group
+
+        ReQuantizeOutput<false /* FUSE_RELU */> outputProcObj(
+            doNothingObj,
+            &requantization_params_.real_multiplier,
+            out_qparams_.zero_point,
+            column_offsets_->empty() ? 0 : in_qparams_[0].zero_point,
+            &in_qparams_[1].zero_point,
+            nullptr,
+            column_offsets_->empty() ? nullptr : column_offsets_->data(),
+            b_quantized_data_,
+            N); // ncols per quant group
+
+        fbgemmPacked(
+            packA,
+            *Wq_packed_,
+            reinterpret_cast<uint8_t*>(
+                OutputTensorCPU_(0)->template mutable_data<T>()),
+            Y_int32_.data(),
+            N,
+            outputProcObj,
+            0, // thread_id
+            1); // num_threads
+      }
     } else {
       // dequantize_output
       float* Y_data = OutputTensorCPU_(0)->template mutable_data<float>();
@@ -216,10 +253,10 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
             doNothingObj,
             in_qparams_[0].scale,
             &in_qparams_[1].scale,
-            in_qparams_[0].zero_point,
+            column_offsets_->empty() ? 0 : in_qparams_[0].zero_point,
             &in_qparams_[1].zero_point,
             packA.getRowOffsetBuffer(),
-            column_offsets_->data(),
+            column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_dequantized_data_, // bias
             N); // ncols per quant group
 
@@ -251,10 +288,10 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
             doNothingObj,
             in_qparams_[0].scale,
             &in_qparams_[1].scale,
-            in_qparams_[0].zero_point,
+            column_offsets_->empty() ? 0 : in_qparams_[0].zero_point,
             &in_qparams_[1].zero_point,
             packA.getRowOffsetBuffer(),
-            column_offsets_->data(),
+            column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_dequantized_data_, // bias
             N); // ncols per quant group
 
@@ -327,8 +364,11 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
         row_offset *= in_qparams_[1].zero_point;
 
         for (int j = 0; j < N; ++j) {
-          Y_int32_[i * N + j] -=
-              in_qparams_[0].zero_point * (*column_offsets_)[j] + row_offset;
+          if (!column_offsets_->empty()) {
+            Y_int32_[i * N + j] -=
+                in_qparams_[0].zero_point * (*column_offsets_)[j];
+          }
+          Y_int32_[i * N + j] -= row_offset;
           Ydata[i * N + j] = Y_int32_[i * N + j] * in_qparams_[0].scale *
                   in_qparams_[1].scale +
               b_dequantized_data_[j];
@@ -346,8 +386,12 @@ bool FullyConnectedDNNLowPOp<T>::RunOnDevice() {
         row_offset *= in_qparams_[1].zero_point;
 
         for (int j = 0; j < N; ++j) {
-          Y_int32_[i * N + j] -=
-              in_qparams_[0].zero_point * (*column_offsets_)[j] + row_offset;
+          if (!column_offsets_->empty()) {
+            // empty column offset means it's folded into bias
+            Y_int32_[i * N + j] -=
+                in_qparams_[0].zero_point * (*column_offsets_)[j];
+          }
+          Y_int32_[i * N + j] -= row_offset;
           Y_int32_[i * N + j] += b_quantized_data_[j];
 
           Ydata[i * N + j] = fbgemm::Requantize<T>(
@@ -479,7 +523,13 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
     t_begin = chrono::system_clock::now();
   }
   // Pre-compute column_offset
-  if (!is_weight_constant_ || column_offsets_->empty()) {
+  // If input tensor doesn't use dynamic quantization, we fold column_offsets_
+  // into bias.
+  bool first_invocation = !b_quantized_data_ && !b_dequantized_data_;
+  bool fold_col_offset_into_bias =
+      this->template InputIsType<int8::Int8TensorCPU>(0) && !dequantize_output_;
+  if (!is_weight_constant_ ||
+      (first_invocation && !fold_col_offset_into_bias)) {
     if (this->template InputIsType<Int8FCDNNLowPPackedWeightBlob>(1)) {
       const auto& packed_filter =
           this->template Input<Int8FCDNNLowPPackedWeightBlob>(1);
@@ -498,14 +548,11 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
             << " ms";
     t_begin = chrono::system_clock::now();
   }
-  if (Wq_packed_ && !FLAGS_caffe2_dnnlowp_dump_tensors) {
-    // From here, W_quantized_ is not used anymore when we have Wq_packed_
-    vector<T_signed>().swap(W_quantized_);
-  }
 
   // Quantize bias
   if (!is_weight_constant_ || (!b_quantized_data_ && !b_dequantized_data_) ||
-      in_qparams_[0].scale != in_qparams0_scale_old_) {
+      in_qparams_[0].scale != in_qparams0_scale_old_ ||
+      in_qparams_[0].zero_point != in_qparams0_zero_point_old_) {
     if (this->template InputIsType<Int8FCDNNLowPPackedWeightBlob>(2) &&
         this->template Input<Int8FCDNNLowPPackedWeightBlob>(2).bias.get()) {
       const auto& packed_filter =
@@ -549,12 +596,46 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
           b_quantized_data_ = b_quantized_->data();
         }
       }
-      in_qparams0_scale_old_ = in_qparams_[0].scale;
+    }
+    in_qparams0_scale_old_ = in_qparams_[0].scale;
+    in_qparams0_zero_point_old_ = in_qparams_[0].zero_point;
+
+    // If column_offsets_ is empty even when we need column_offsets (asymmetric
+    // quantization in input), it means we need to fuse column_offsets to bias.
+    if (in_qparams_[0].zero_point && column_offsets_->empty() &&
+        b_quantized_data_) {
+      if (b_quantized_->empty()) {
+        b_quantized_->assign(b_quantized_data_, b_quantized_data_ + N);
+        b_quantized_data_ = b_quantized_->data();
+      }
+      vector<int32_t>* column_offset_ptr;
+      vector<int32_t> column_offset_temp;
+      if (this->template InputIsType<Int8FCDNNLowPPackedWeightBlob>(1)) {
+        const auto& packed_filter =
+            this->template Input<Int8FCDNNLowPPackedWeightBlob>(1);
+        column_offset_ptr = packed_filter.column_offsets.get();
+      } else {
+        vector<TensorQuantizationParams> temp_qparams;
+        temp_qparams.push_back(in_qparams_[1]);
+        column_offset_temp.resize(N);
+        ComputeColumnOffsets<T_signed>(
+            K, N, W_quantized_.data(), temp_qparams, column_offset_temp);
+        column_offset_ptr = &column_offset_temp;
+      }
+      for (int i = 0; i < N; ++i) {
+        (*b_quantized_)[i] -=
+            in_qparams_[0].zero_point * (*column_offset_ptr)[i];
+      }
     }
 
     CAFFE_ENFORCE(
         (dequantize_output_ && b_dequantized_data_) ||
         (!dequantize_output_ && b_quantized_data_));
+  }
+
+  if (Wq_packed_ && !FLAGS_caffe2_dnnlowp_dump_tensors) {
+    // From here, W_quantized_ is not used anymore when we have Wq_packed_
+    vector<T_signed>().swap(W_quantized_);
   }
 
   if (VLOG_IS_ON(3)) {

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.h
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.h
@@ -53,6 +53,7 @@ class FullyConnectedDNNLowPOp
   bool is_weight_constant_{true};
 
   float in_qparams0_scale_old_ = 0;
+  std::int32_t in_qparams0_zero_point_old_ = 0;
 }; // class FullyConnectedDNNLowPOp
 
 } // namespace caffe2

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
@@ -28,6 +28,8 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         out_quantized=st.booleans(),
         weight_quantized=st.booleans(),
         prepack_weight=st.booleans(),
+        preserve_activation_sparsity=st.booleans(),
+        preserve_weight_sparsity=st.booleans(),
         **hu.gcs_cpu_only
     )
     def test_dnnlowp_fully_connected_int(
@@ -39,11 +41,13 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         out_quantized,
         weight_quantized,
         prepack_weight,
+        preserve_activation_sparsity,
+        preserve_weight_sparsity,
         gc,
         dc,
     ):
         # X and W have scale 1, so exactly represented after quantization
-        X_min = -77
+        X_min = 0 if preserve_activation_sparsity else -77
         X_max = X_min + 255
         X = np.round(
             np.random.rand(batch_size, input_channels) * (X_max - X_min) + X_min
@@ -54,8 +58,12 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         X[:, 0] = X_min
         X[0, 1] = X_max
 
-        W_min = -100
-        W_max = W_min + 255
+        if preserve_weight_sparsity:
+            W_min = -128
+            W_max = 100
+        else:
+            W_min = -100
+            W_max = W_min + 255
         W = np.round(
             np.random.rand(output_channels, input_channels) * (W_max - W_min) + W_min
         )
@@ -102,14 +110,21 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
 
             if do_quantize:
                 quantize = core.CreateOperator(
-                    "Quantize", ["X"], ["X_q"], engine=engine, device_option=gc
+                    "Quantize",
+                    ["X"],
+                    ["X_q"],
+                    preserve_activation_sparsity=preserve_activation_sparsity,
+                    engine=engine,
+                    device_option=gc,
                 )
                 net.Proto().op.extend([quantize])
 
-            x_q_param = dnnlowp_utils.choose_quantization_params(X.min(), X.max())
+            x_q_param = dnnlowp_utils.choose_quantization_params(
+                X.min(), X.max(), preserve_activation_sparsity
+            )
             if do_quantize_weight:
                 int8_given_tensor_fill, w_q_param = dnnlowp_utils.create_int8_given_tensor_fill(
-                    W, "W_q"
+                    W, "W_q", preserve_weight_sparsity
                 )
                 init_net.Proto().op.extend([int8_given_tensor_fill])
 
@@ -127,6 +142,7 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                     "Int8FCPackWeight",
                     inputs,
                     ["W_packed"],
+                    preserve_weight_sparsity=preserve_weight_sparsity,
                     in_scale=x_q_param.scale,
                     engine=engine,
                 )
@@ -143,6 +159,8 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                 ],
                 ["Y_q" if do_dequantize else "Y"],
                 dequantize_output=not do_dequantize,
+                preserve_activation_sparsity=preserve_activation_sparsity,
+                preserve_weight_sparsity=preserve_weight_sparsity,
                 engine=engine,
                 device_option=gc,
             )
@@ -151,7 +169,9 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                 # output dynamically by looking at the range of output of each
                 # batch, so here we provide the range of output observed from
                 # fp32 reference implementation
-                dnnlowp_utils.add_quantization_param_args(fc, outputs[0][0])
+                dnnlowp_utils.add_quantization_param_args(
+                    fc, outputs[0][0], preserve_activation_sparsity
+                )
             net.Proto().op.extend([fc])
 
             if do_dequantize:
@@ -169,4 +189,4 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                 Output(Y=self.ws.blobs["Y"].fetch(), op_type=op_type, engine=engine)
             )
 
-        check_quantized_results_close(outputs)
+        check_quantized_results_close(outputs, symmetric=preserve_activation_sparsity)


### PR DESCRIPTION
Summary:
We can fold col offsets into bias if zero point of activation is constant.
fbgemm still needs to provide an option to pass col offsets in case zero point of activation keep changes (e.g., dynamic quantization).
A trick to optimize static quantization case is setting A zero point to 0 after folding into bias.

This diff also optimizes when weights use symmetric quantization. When B zero point is 0, we use PackAMatrix instead of PackAWithRowOffset .

TODO:
Ideally, PackAWithRowOffset should perform as fast as PackAMatrix when B_zero_point is 0
Same in PackAWithIm2Col and depthwise/groupwise convolution

Differential Revision: D14013931
