### PR TITLE
Correct type annotation for torch.nn.functional.pad

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2653,7 +2653,7 @@ def affine_grid(theta, size):
 
 @weak_script
 def pad(input, pad, mode='constant', value=0):
-    # type: (Tensor, List[int], str, float) -> Tensor
+    # type: (Tensor, Tuple[int], str, float) -> Tensor
     r"""Pads tensor.
 
     Padding size:


### PR DESCRIPTION
The type annotation for F.pad is set as List[int] for the pad parameter. However, the docstring suggests it should be a Tuple[int]. This inconsistency results in a warning to be generated by static analysis tools like Pycharm when using a tuple as suggested by the docstring example. This commit changes the type annotation to match the docstring.

However, since it looks like a list will work as well, perhaps Sequence[int] or Union[List[int], Tuple[int]] is actually preferred? At first glance it looks like the use Sequence or Union may have some risk of interfering with Jit though. Review welcome.

