### PR TITLE
Disable binary_linux_conda_3.6_cu90_build on PRs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3088,9 +3088,10 @@ workflows:
       - binary_linux_conda_2.7_cpu_test:
           requires:
             - binary_linux_conda_2.7_cpu_build
-      - binary_linux_conda_3.6_cu90_test:
-          requires:
-            - binary_linux_conda_3.6_cu90_build
+      # This binary build is currently broken, see https://github.com/pytorch/pytorch/issues/16710
+      # - binary_linux_conda_3.6_cu90_test:
+      #     requires:
+      #       - binary_linux_conda_3.6_cu90_build
 
 ##############################################################################
 # Daily smoke test trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3072,7 +3072,8 @@ workflows:
       - binary_linux_manywheel_2.7mu_cpu_build
       - binary_linux_manywheel_3.7m_cu100_build
       - binary_linux_conda_2.7_cpu_build
-      - binary_linux_conda_3.6_cu90_build
+      # This binary build is currently broken, see https://github.com/pytorch/pytorch/issues/16710
+      # - binary_linux_conda_3.6_cu90_build
       - binary_linux_libtorch_2.7m_cu80_build
       - binary_macos_wheel_3.6_cpu_build
       - binary_macos_conda_2.7_cpu_build


### PR DESCRIPTION
Issue tracked at https://github.com/pytorch/pytorch/issues/16710

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

