### PR TITLE
Improve deduction of blob names in onnxifi transform.

### DIFF
--- a/caffe2/core/net_utils.cc
+++ b/caffe2/core/net_utils.cc
@@ -1,0 +1,33 @@
+#include "caffe2/core/net_utils.h"
+
+namespace caffe2 {
+
+std::unordered_set<std::string> DeriveWeightNames(const NetDef& net, const std::vector<std::string>& primary_input_names) {
+  std::unordered_set<std::string> input_names;
+  // Add inputs of all the operators of the net to the set.
+  for (const auto& op : net.op()) {
+    for (const auto& input : op.input()) {
+      input_names.emplace(input);
+    }
+  }
+  // Then remove those inputs that have a producer.
+  for (const auto& op : net.op()) {
+    for (const auto& output : op.output()) {
+      const auto it = input_names.find(output);
+      if (it != input_names.end()) {
+        input_names.erase(it);
+      }
+    }
+  }
+  // Check if the input is one of the primary inputs.
+  for (const auto& input : primary_input_names) {
+    const auto it = input_names.find(input);
+    if (it != input_names.end()) {
+      input_names.erase(it);
+    }
+  }
+  // These should be weights for a C2 net.
+  return input_names;
+}
+
+}

--- a/caffe2/core/net_utils.h
+++ b/caffe2/core/net_utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "caffe2/core/net.h"
+
+namespace caffe2 {
+std::unordered_set<std::string> DeriveWeightNames(const NetDef& net, const std::vector<std::string>& primary_input_names);
+}

--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -28,7 +28,9 @@ using ConvertedResult =
 // output names for predict net.
 CAFFE2_API std::unordered_map<std::string, std::string> SsaRewrite(
     caffe2::NetDef* init_net,
-    caffe2::NetDef* pred_net);
+    caffe2::NetDef* pred_net,
+    const std::unordered_set<std::string>& exceptions =
+        std::unordered_set<std::string>());
 
 ::ONNX_NAMESPACE::TensorProto::DataType Caffe2TypeToOnnxType(
     caffe2::TensorProto::DataType t);

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -977,8 +977,7 @@ NetDef OnnxifiTransformer::TransformViaOnnx(
 void OnnxifiTransformer::Transform(
     Workspace* ws,
     NetDef* pred_net,
-    const std::vector<std::string>& external_inputs,
-    const std::vector<std::string>& weight_names,
+    const std::unordered_set<std::string>& weight_names,
     const std::unordered_map<std::string, TensorShape>& input_shape_hints,
     const std::unordered_set<int>& blacklisted_ops) {
   CAFFE_ENFORCE(ws);

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -42,6 +42,7 @@ class CAFFE2_API OnnxifiTransformer final {
       Workspace* ws,
       NetDef* pred_net,
       const std::vector<std::string>& external_inputs,
+      const std::vector<std::string>& weight_names,
       const std::unordered_map<std::string, TensorShape>& shape_hints,
       const std::unordered_set<int>& blacklisted_ops);
 
@@ -85,6 +86,7 @@ class CAFFE2_API OnnxifiTransformer final {
   CaffeMap<std::string, TensorShape> SsaRewriteAndMapNames(
       Workspace* ws,
       NetDef* pred_net,
+      const std::unordered_set<std::string>& weights,
       const std::unordered_map<std::string, TensorShape>& input_shape_hints);
 
   // Transform by passing C2 proto to backend

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -41,8 +41,7 @@ class CAFFE2_API OnnxifiTransformer final {
   void Transform(
       Workspace* ws,
       NetDef* pred_net,
-      const std::vector<std::string>& external_inputs,
-      const std::vector<std::string>& weight_names,
+      const std::unordered_set<std::string>& weight_names,
       const std::unordered_map<std::string, TensorShape>& shape_hints,
       const std::unordered_set<int>& blacklisted_ops);
 

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -40,10 +40,10 @@ def onnxifi_caffe2_net(
                     need_input_tensor = False
             if need_input_tensor:
                 workspace.FeedBlob(k, np.random.randn(*v).astype(np.float32))
-                external_inputs.append(k)
 
     for k, v in input_shapes.items():
         shape_hints[k] = v
+        external_inputs.append(k)
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
                              external_inputs,
                              shape_hints,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1628,10 +1628,13 @@ void addGlobalMethods(py::module& m) {
         opts.debug = debug_builder;
         opts.use_onnx = use_onnx;
         OnnxifiTransformer ts(opts);
+        Workspace* curr_ws = GetCurrentWorkspace();
+        auto weight_names = curr_ws->Blobs();
         ts.Transform(
-            GetCurrentWorkspace(),
+            curr_ws,
             &pred_net,
             external_inputs,
+            weight_names,
             tensor_shapes,
             std::unordered_set<int>());
         std::string pred_net_str2;

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -9,6 +9,7 @@
 #include "caffe2/core/asan.h"
 #include "caffe2/core/blob_stats.h"
 #include "caffe2/core/db.h"
+#include "caffe2/core/net_utils.h"
 #include "caffe2/core/numa.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/core/stats.h"
@@ -1629,11 +1630,10 @@ void addGlobalMethods(py::module& m) {
         opts.use_onnx = use_onnx;
         OnnxifiTransformer ts(opts);
         Workspace* curr_ws = GetCurrentWorkspace();
-        auto weight_names = curr_ws->Blobs();
+        auto weight_names = DeriveWeightNames(pred_net, external_inputs);
         ts.Transform(
             curr_ws,
             &pred_net,
-            external_inputs,
             weight_names,
             tensor_shapes,
             std::unordered_set<int>());


### PR DESCRIPTION
Summary:
Currently the weight name derivation requires the assumption that workspace has
blobs with weight names only. A polluted workspace will probably not work and
my produce unexpected results. This diff is the first part of some of the
cleanup.

Differential Revision: D14026002
