### PR TITLE
fix silent failure on Windows builds

### DIFF
--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 COMPACT_JOB_NAME=pytorch-win-ws2016-cuda9-cudnn7-py3-test
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
@@ -75,7 +75,7 @@ set PYTHONPATH=%TMP_DIR_WIN%\\build;%PYTHONPATH%
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     cd %TMP_DIR_WIN%\\build
     python %TMP_DIR_WIN%\\ci_scripts\\download_image.py %TMP_DIR_WIN%\\%IMAGE_COMMIT_TAG%.7z
-    :: 7z: `-aos` skips if exists because this .bat can be called multiple times
+    :: 7z: -aos skips if exists because this .bat can be called multiple times
     7z x %TMP_DIR_WIN%\\%IMAGE_COMMIT_TAG%.7z -aos
     cd %WORKING_DIR%
 ) else (


### PR DESCRIPTION
Closes #16983

Remove backticks that are being interpreted by the shell. Add -e option to bash script to avoid future such failures

