### PR TITLE
Change IR graph print format to make it look more pythonic

### DIFF
--- a/test/expect/TestBatched.test_for.expect
+++ b/test/expect/TestBatched.test_for.expect
@@ -1,8 +1,8 @@
-graph(%x.1_data : Tensor
-      %x.1_mask : Tensor
-      %x.1_dims : Tensor
-      %y_data : Tensor
-      %y_mask : Tensor
+graph(%x.1_data : Tensor,
+      %x.1_mask : Tensor,
+      %x.1_dims : Tensor,
+      %y_data : Tensor,
+      %y_mask : Tensor,
       %y_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : bool = prim::Constant[value=1]()

--- a/test/expect/TestBatched.test_for.expect
+++ b/test/expect/TestBatched.test_for.expect
@@ -3,12 +3,12 @@ graph(%x.1_data : Tensor
       %x.1_dims : Tensor
       %y_data : Tensor
       %y_mask : Tensor
-      %y_dims : Tensor) {
+      %y_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : bool = prim::Constant[value=1]()
   %8 : int = prim::Constant[value=10]()
   %x : Tensor, %10 : Tensor, %11 : Tensor = prim::Loop(%8, %7, %x.1_data, %x.1_mask, %x.1_dims)
-    block0(%loop_num : int, %5_data : Tensor, %5_mask : Tensor, %5_dims : Tensor) {
+    block0(%loop_num : int, %5_data : Tensor, %5_mask : Tensor, %5_dims : Tensor):
       %16 : Long() = prim::NumToTensor(%6)
       %alpha : float = prim::Float(%16)
       %data.1 : Tensor = aten::add(%5_data, %y_data, %alpha)
@@ -16,7 +16,5 @@ graph(%x.1_data : Tensor
       %dims : Tensor = aten::__or__(%5_dims, %y_dims)
       %data : Tensor = aten::where(%mask, %data.1, %5_data)
       -> (%7, %data, %mask, %dims)
-    }
   %22 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%x, %10, %11)
-  return (%22);
-}
+  return (%22)

--- a/test/expect/TestBatched.test_if_else.expect
+++ b/test/expect/TestBatched.test_if_else.expect
@@ -3,7 +3,7 @@ graph(%a.1_data : Tensor
       %a.1_dims : Tensor
       %b_data : Tensor
       %b_mask : Tensor
-      %b_dims : Tensor) {
+      %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : Tensor = aten::gt(%a.1_data, %b_data)
   %8 : Tensor = aten::mul(%a.1_mask, %b_mask)
@@ -24,25 +24,21 @@ graph(%a.1_data : Tensor
   %23 : int = aten::dim(%data.2)
   %24 : bool = aten::eq(%23, %20)
   %cond_data : Tensor, %cond_mask : Tensor = prim::If(%24)
-    block0() {
+    block0():
       %27 : int = aten::dim(%data.1)
       %28 : int = aten::sub(%27, %20)
       %data.4 : Tensor = prim::Loop(%28, %19, %data.2)
-        block0(%30 : int, %31 : Tensor) {
+        block0(%30 : int, %31 : Tensor):
           %32 : int = aten::dim(%31)
           %data.3 : Tensor = aten::unsqueeze(%31, %32)
           -> (%19, %data.3)
-        }
       %cond_data.1 : Tensor = aten::expand_as(%data.4, %data.1)
       %cond_mask.1 : Tensor = aten::expand_as(%data.4, %mask.1)
       -> (%cond_data.1, %cond_mask.1)
-    }
-    block1() {
+    block1():
       -> (%data.2, %data.2)
-    }
   %res_data : Tensor = aten::where(%cond_data, %data.1, %data)
   %res_mask : Tensor = aten::where(%cond_mask, %mask.1, %mask)
   %res_dims : Tensor = aten::__or__(%dims.1, %dims)
   %39 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%res_data, %res_mask, %res_dims)
-  return (%39);
-}
+  return (%39)

--- a/test/expect/TestBatched.test_if_else.expect
+++ b/test/expect/TestBatched.test_if_else.expect
@@ -1,8 +1,8 @@
-graph(%a.1_data : Tensor
-      %a.1_mask : Tensor
-      %a.1_dims : Tensor
-      %b_data : Tensor
-      %b_mask : Tensor
+graph(%a.1_data : Tensor,
+      %a.1_mask : Tensor,
+      %a.1_dims : Tensor,
+      %b_data : Tensor,
+      %b_mask : Tensor,
       %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : Tensor = aten::gt(%a.1_data, %b_data)

--- a/test/expect/TestBatched.test_if_else_with_scalar.expect
+++ b/test/expect/TestBatched.test_if_else_with_scalar.expect
@@ -1,8 +1,8 @@
-graph(%a.1_data : Tensor
-      %a.1_mask : Tensor
-      %a.1_dims : Tensor
-      %b_data : Tensor
-      %b_mask : Tensor
+graph(%a.1_data : Tensor,
+      %a.1_mask : Tensor,
+      %a.1_dims : Tensor,
+      %b_data : Tensor,
+      %b_mask : Tensor,
       %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : float = prim::Constant[value=0.1]()

--- a/test/expect/TestBatched.test_if_else_with_scalar.expect
+++ b/test/expect/TestBatched.test_if_else_with_scalar.expect
@@ -3,7 +3,7 @@ graph(%a.1_data : Tensor
       %a.1_dims : Tensor
       %b_data : Tensor
       %b_mask : Tensor
-      %b_dims : Tensor) {
+      %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : float = prim::Constant[value=0.1]()
   %8 : Float() = prim::NumToTensor(%7)
@@ -26,25 +26,21 @@ graph(%a.1_data : Tensor
   %25 : int = aten::dim(%data.2)
   %26 : bool = aten::eq(%25, %22)
   %cond_data : Tensor, %cond_mask : Tensor = prim::If(%26)
-    block0() {
+    block0():
       %29 : int = aten::dim(%data.1)
       %30 : int = aten::sub(%29, %22)
       %data.4 : Tensor = prim::Loop(%30, %21, %data.2)
-        block0(%32 : int, %33 : Tensor) {
+        block0(%32 : int, %33 : Tensor):
           %34 : int = aten::dim(%33)
           %data.3 : Tensor = aten::unsqueeze(%33, %34)
           -> (%21, %data.3)
-        }
       %cond_data.1 : Tensor = aten::expand_as(%data.4, %data.1)
       %cond_mask.1 : Tensor = aten::expand_as(%data.4, %mask.1)
       -> (%cond_data.1, %cond_mask.1)
-    }
-    block1() {
+    block1():
       -> (%data.2, %data.2)
-    }
   %res_data : Tensor = aten::where(%cond_data, %data.1, %data)
   %res_mask : Tensor = aten::where(%cond_mask, %mask.1, %mask)
   %res_dims : Tensor = aten::__or__(%dims.1, %dims)
   %41 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%res_data, %res_mask, %res_dims)
-  return (%41);
-}
+  return (%41)

--- a/test/expect/TestBatched.test_if_noelse.expect
+++ b/test/expect/TestBatched.test_if_noelse.expect
@@ -3,7 +3,7 @@ graph(%a.1_data : Tensor
       %a.1_dims : Tensor
       %b_data : Tensor
       %b_mask : Tensor
-      %b_dims : Tensor) {
+      %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : Tensor = aten::gt(%a.1_data, %b_data)
   %8 : Tensor = aten::mul(%a.1_mask, %b_mask)
@@ -19,25 +19,21 @@ graph(%a.1_data : Tensor
   %18 : int = aten::dim(%data.2)
   %19 : bool = aten::eq(%18, %15)
   %cond_data : Tensor, %cond_mask : Tensor = prim::If(%19)
-    block0() {
+    block0():
       %22 : int = aten::dim(%data)
       %23 : int = aten::sub(%22, %15)
       %data.4 : Tensor = prim::Loop(%23, %14, %data.2)
-        block0(%25 : int, %26 : Tensor) {
+        block0(%25 : int, %26 : Tensor):
           %27 : int = aten::dim(%26)
           %data.3 : Tensor = aten::unsqueeze(%26, %27)
           -> (%14, %data.3)
-        }
       %cond_data.1 : Tensor = aten::expand_as(%data.4, %data)
       %cond_mask.1 : Tensor = aten::expand_as(%data.4, %mask)
       -> (%cond_data.1, %cond_mask.1)
-    }
-    block1() {
+    block1():
       -> (%data.2, %data.2)
-    }
   %res_data : Tensor = aten::where(%cond_data, %data, %a.1_data)
   %res_mask : Tensor = aten::where(%cond_mask, %mask, %a.1_mask)
   %res_dims : Tensor = aten::__or__(%dims, %a.1_dims)
   %34 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%res_data, %res_mask, %res_dims)
-  return (%34);
-}
+  return (%34)

--- a/test/expect/TestBatched.test_if_noelse.expect
+++ b/test/expect/TestBatched.test_if_noelse.expect
@@ -1,8 +1,8 @@
-graph(%a.1_data : Tensor
-      %a.1_mask : Tensor
-      %a.1_dims : Tensor
-      %b_data : Tensor
-      %b_mask : Tensor
+graph(%a.1_data : Tensor,
+      %a.1_mask : Tensor,
+      %a.1_dims : Tensor,
+      %b_data : Tensor,
+      %b_mask : Tensor,
       %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : Tensor = aten::gt(%a.1_data, %b_data)

--- a/test/expect/TestBatched.test_if_noelse_with_scalar.expect
+++ b/test/expect/TestBatched.test_if_noelse_with_scalar.expect
@@ -1,8 +1,8 @@
-graph(%a.1_data : Tensor
-      %a.1_mask : Tensor
-      %a.1_dims : Tensor
-      %b_data : Tensor
-      %b_mask : Tensor
+graph(%a.1_data : Tensor,
+      %a.1_mask : Tensor,
+      %a.1_dims : Tensor,
+      %b_data : Tensor,
+      %b_mask : Tensor,
       %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : float = prim::Constant[value=0.1]()

--- a/test/expect/TestBatched.test_if_noelse_with_scalar.expect
+++ b/test/expect/TestBatched.test_if_noelse_with_scalar.expect
@@ -3,7 +3,7 @@ graph(%a.1_data : Tensor
       %a.1_dims : Tensor
       %b_data : Tensor
       %b_mask : Tensor
-      %b_dims : Tensor) {
+      %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : float = prim::Constant[value=0.1]()
   %8 : Float() = prim::NumToTensor(%7)
@@ -21,25 +21,21 @@ graph(%a.1_data : Tensor
   %20 : int = aten::dim(%data.2)
   %21 : bool = aten::eq(%20, %17)
   %cond_data : Tensor, %cond_mask : Tensor = prim::If(%21)
-    block0() {
+    block0():
       %24 : int = aten::dim(%data)
       %25 : int = aten::sub(%24, %17)
       %data.4 : Tensor = prim::Loop(%25, %16, %data.2)
-        block0(%27 : int, %28 : Tensor) {
+        block0(%27 : int, %28 : Tensor):
           %29 : int = aten::dim(%28)
           %data.3 : Tensor = aten::unsqueeze(%28, %29)
           -> (%16, %data.3)
-        }
       %cond_data.1 : Tensor = aten::expand_as(%data.4, %data)
       %cond_mask.1 : Tensor = aten::expand_as(%data.4, %mask)
       -> (%cond_data.1, %cond_mask.1)
-    }
-    block1() {
+    block1():
       -> (%data.2, %data.2)
-    }
   %res_data : Tensor = aten::where(%cond_data, %data, %a.1_data)
   %res_mask : Tensor = aten::where(%cond_mask, %mask, %a.1_mask)
   %res_dims : Tensor = aten::__or__(%dims, %a.1_dims)
   %36 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%res_data, %res_mask, %res_dims)
-  return (%36);
-}
+  return (%36)

--- a/test/expect/TestBatched.test_while.expect
+++ b/test/expect/TestBatched.test_while.expect
@@ -3,7 +3,7 @@ graph(%a.1_data : Tensor
       %a.1_dims : Tensor
       %b_data : Tensor
       %b_mask : Tensor
-      %b_dims : Tensor) {
+      %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : int = prim::Constant[value=9223372036854775807]()
   %8 : Tensor = aten::gt(%a.1_data, %b_data)
@@ -15,7 +15,7 @@ graph(%a.1_data : Tensor
   %14 : Tensor = aten::gt(%13, %11)
   %15 : bool = prim::Bool(%14)
   %16 : Tensor, %17 : Tensor, %a : Tensor, %19 : Tensor, %20 : Tensor = prim::Loop(%7, %15, %8, %9, %a.1_data, %a.1_mask, %a.1_dims)
-    block0(%loop_num : int, %cond_data.2 : Tensor, %cond_mask.2 : Tensor, %6_data : Tensor, %6_mask : Tensor, %6_dims : Tensor) {
+    block0(%loop_num : int, %cond_data.2 : Tensor, %cond_mask.2 : Tensor, %6_data : Tensor, %6_mask : Tensor, %6_dims : Tensor):
       %27 : Long() = prim::NumToTensor(%6)
       %alpha : float = prim::Float(%27)
       %data : Tensor = aten::sub(%6_data, %b_data, %alpha)
@@ -30,22 +30,19 @@ graph(%a.1_data : Tensor
       %38 : int = aten::dim(%data.2)
       %39 : bool = aten::eq(%38, %35)
       %cond_data : Tensor, %cond_mask : Tensor = prim::If(%39)
-        block0() {
+        block0():
           %42 : int = aten::dim(%data)
           %43 : int = aten::sub(%42, %35)
           %data.4 : Tensor = prim::Loop(%43, %34, %data.2)
-            block0(%45 : int, %46 : Tensor) {
+            block0(%45 : int, %46 : Tensor):
               %47 : int = aten::dim(%46)
               %data.3 : Tensor = aten::unsqueeze(%46, %47)
               -> (%34, %data.3)
-            }
           %cond_data.1 : Tensor = aten::expand_as(%data.4, %data)
           %cond_mask.1 : Tensor = aten::expand_as(%data.4, %mask)
           -> (%cond_data.1, %cond_mask.1)
-        }
-        block1() {
+        block1():
           -> (%data.2, %data.2)
-        }
       %res_data : Tensor = aten::where(%cond_data, %data, %6_data)
       %res_mask : Tensor = aten::where(%cond_mask, %mask, %6_mask)
       %res_dims : Tensor = aten::__or__(%dims, %6_dims)
@@ -55,7 +52,5 @@ graph(%a.1_data : Tensor
       %57 : Tensor = aten::gt(%56, %54)
       %58 : bool = prim::Bool(%57)
       -> (%58, %32, %33, %res_data, %res_mask, %res_dims)
-    }
   %59 : (Tensor, Tensor, Tensor) = prim::TupleConstruct(%a, %19, %20)
-  return (%59);
-}
+  return (%59)

--- a/test/expect/TestBatched.test_while.expect
+++ b/test/expect/TestBatched.test_while.expect
@@ -1,8 +1,8 @@
-graph(%a.1_data : Tensor
-      %a.1_mask : Tensor
-      %a.1_dims : Tensor
-      %b_data : Tensor
-      %b_mask : Tensor
+graph(%a.1_data : Tensor,
+      %a.1_mask : Tensor,
+      %a.1_dims : Tensor,
+      %b_data : Tensor,
+      %b_mask : Tensor,
       %b_dims : Tensor):
   %6 : int = prim::Constant[value=1]()
   %7 : int = prim::Constant[value=9223372036854775807]()

--- a/test/expect/TestCustomOperators.test_script_graph_contains_custom_op.expect
+++ b/test/expect/TestCustomOperators.test_script_graph_contains_custom_op.expect
@@ -1,4 +1,3 @@
-graph(%x : Dynamic) {
+graph(%x : Dynamic):
   %1 : Dynamic = aten::relu(%x)
-  return (%1);
-}
+  return (%1)

--- a/test/expect/TestFuser.test_broadcast_cuda.expect
+++ b/test/expect/TestFuser.test_broadcast_cuda.expect
@@ -1,14 +1,12 @@
 graph(%x : Float(*, *)
       %scale : Float(*)
-      %shift : Float(*)) {
+      %shift : Float(*)):
   %3 : Float(*, *) = prim::FusionGroup_0(%shift, %x, %scale)
-  return (%3);
-}
+  return (%3)
 with prim::FusionGroup_0 = graph(%0 : Float(*)
       %1 : Float(*, *)
-      %2 : Float(*)) {
+      %2 : Float(*)):
   %3 : int = prim::Constant[value=1]()
   %4 : Float(*, *) = aten::mul(%1, %2)
   %5 : Float(*, *) = aten::add(%4, %0, %3)
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestFuser.test_broadcast_cuda.expect
+++ b/test/expect/TestFuser.test_broadcast_cuda.expect
@@ -1,10 +1,10 @@
-graph(%x : Float(*, *)
-      %scale : Float(*)
+graph(%x : Float(*, *),
+      %scale : Float(*),
       %shift : Float(*)):
   %3 : Float(*, *) = prim::FusionGroup_0(%shift, %x, %scale)
   return (%3)
-with prim::FusionGroup_0 = graph(%0 : Float(*)
-      %1 : Float(*, *)
+with prim::FusionGroup_0 = graph(%0 : Float(*),
+      %1 : Float(*, *),
       %2 : Float(*)):
   %3 : int = prim::Constant[value=1]()
   %4 : Float(*, *) = aten::mul(%1, %2)

--- a/test/expect/TestFuser.test_chunk_cuda.expect
+++ b/test/expect/TestFuser.test_chunk_cuda.expect
@@ -1,11 +1,9 @@
-graph(%x : Float(*, *)) {
+graph(%x : Float(*, *)):
   %1 : Float(*, *) = prim::FusionGroup_0(%x)
-  return (%1);
-}
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)) {
+  return (%1)
+with prim::FusionGroup_0 = graph(%0 : Float(*, *)):
   %1 : Float(*, *), %2 : Float(*, *), %3 : Float(*, *) = prim::ConstantChunk[chunks=3, dim=1](%0)
   %4 : int = prim::Constant[value=1]()
   %5 : Float(*, *) = aten::mul(%1, %2)
   %6 : Float(*, *) = aten::add(%5, %3, %4)
-  return (%6);
-}
+  return (%6)

--- a/test/expect/TestFuser.test_chunk_distributes_cuda.expect
+++ b/test/expect/TestFuser.test_chunk_distributes_cuda.expect
@@ -1,11 +1,11 @@
-graph(%x : Float(*, *)
+graph(%x : Float(*, *),
       %y : Float(*, *)):
   %2 : Tensor[] = prim::ListConstruct(%x, %y)
   %3 : Tensor[] = aten::broadcast_tensors(%2)
   %4 : Tensor, %5 : Tensor = prim::ListUnpack(%3)
   %6 : Float(*, *) = prim::FusionGroup_0(%5, %4)
   return (%6)
-with prim::FusionGroup_0 = graph(%0 : Tensor
+with prim::FusionGroup_0 = graph(%0 : Tensor,
       %1 : Tensor):
   %2 : Float(*, *), %3 : Float(*, *) = prim::ConstantChunk[chunks=2, dim=1](%1)
   %4 : Float(*, *), %5 : Float(*, *) = prim::ConstantChunk[chunks=2, dim=1](%0)

--- a/test/expect/TestFuser.test_chunk_distributes_cuda.expect
+++ b/test/expect/TestFuser.test_chunk_distributes_cuda.expect
@@ -1,18 +1,16 @@
 graph(%x : Float(*, *)
-      %y : Float(*, *)) {
+      %y : Float(*, *)):
   %2 : Tensor[] = prim::ListConstruct(%x, %y)
   %3 : Tensor[] = aten::broadcast_tensors(%2)
   %4 : Tensor, %5 : Tensor = prim::ListUnpack(%3)
   %6 : Float(*, *) = prim::FusionGroup_0(%5, %4)
-  return (%6);
-}
+  return (%6)
 with prim::FusionGroup_0 = graph(%0 : Tensor
-      %1 : Tensor) {
+      %1 : Tensor):
   %2 : Float(*, *), %3 : Float(*, *) = prim::ConstantChunk[chunks=2, dim=1](%1)
   %4 : Float(*, *), %5 : Float(*, *) = prim::ConstantChunk[chunks=2, dim=1](%0)
   %6 : int = prim::Constant[value=1]()
   %7 : Float(*, *) = aten::add(%2, %4, %6)
   %8 : Float(*, *) = aten::add(%3, %5, %6)
   %9 : Float(*, *) = aten::mul(%7, %8)
-  return (%9);
-}
+  return (%9)

--- a/test/expect/TestFuser.test_chunk_multiple_cuda.expect
+++ b/test/expect/TestFuser.test_chunk_multiple_cuda.expect
@@ -1,14 +1,13 @@
 graph(%s : Float(*, *, *)
       %x : Float(*, *, *)
       %y : Float(*, *, *)
-      %z : Float(*, *, *)) {
+      %z : Float(*, *, *)):
   %4 : Float(*, *, *) = prim::FusionGroup_0(%s, %y, %x, %z)
-  return (%4);
-}
+  return (%4)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *, *)
       %1 : Float(*, *, *)
       %2 : Float(*, *, *)
-      %3 : Float(*, *, *)) {
+      %3 : Float(*, *, *)):
   %4 : Float(*, *, *), %5 : Float(*, *, *) = prim::ConstantChunk[chunks=2, dim=2](%3)
   %6 : Float(*, *, *), %7 : Float(*, *, *), %8 : Float(*, *, *) = prim::ConstantChunk[chunks=3, dim=1](%2)
   %9 : Float(*, *, *), %10 : Float(*, *, *) = prim::ConstantChunk[chunks=2, dim=0](%1)
@@ -20,5 +19,4 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *, *)
   %16 : Float(*, *, *) = aten::add(%15, %10, %11)
   %17 : Float(*, *, *) = aten::add(%16, %4, %11)
   %18 : Float(*, *, *) = aten::add(%17, %5, %11)
-  return (%18);
-}
+  return (%18)

--- a/test/expect/TestFuser.test_chunk_multiple_cuda.expect
+++ b/test/expect/TestFuser.test_chunk_multiple_cuda.expect
@@ -1,12 +1,12 @@
-graph(%s : Float(*, *, *)
-      %x : Float(*, *, *)
-      %y : Float(*, *, *)
+graph(%s : Float(*, *, *),
+      %x : Float(*, *, *),
+      %y : Float(*, *, *),
       %z : Float(*, *, *)):
   %4 : Float(*, *, *) = prim::FusionGroup_0(%s, %y, %x, %z)
   return (%4)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *, *)
-      %1 : Float(*, *, *)
-      %2 : Float(*, *, *)
+with prim::FusionGroup_0 = graph(%0 : Float(*, *, *),
+      %1 : Float(*, *, *),
+      %2 : Float(*, *, *),
       %3 : Float(*, *, *)):
   %4 : Float(*, *, *), %5 : Float(*, *, *) = prim::ConstantChunk[chunks=2, dim=2](%3)
   %6 : Float(*, *, *), %7 : Float(*, *, *), %8 : Float(*, *, *) = prim::ConstantChunk[chunks=3, dim=1](%2)

--- a/test/expect/TestFuser.test_concat_cuda.expect
+++ b/test/expect/TestFuser.test_concat_cuda.expect
@@ -1,8 +1,8 @@
-graph(%hx : Float(*, *)
+graph(%hx : Float(*, *),
       %cx : Float(*, *)):
   %2 : Float(*, *) = prim::FusionGroup_0(%hx, %cx)
   return (%2)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
       %1 : Float(*, *)):
   %2 : int = prim::Constant[value=1]()
   %3 : Float(*, *) = aten::add(%0, %1, %2)

--- a/test/expect/TestFuser.test_concat_cuda.expect
+++ b/test/expect/TestFuser.test_concat_cuda.expect
@@ -1,13 +1,11 @@
 graph(%hx : Float(*, *)
-      %cx : Float(*, *)) {
+      %cx : Float(*, *)):
   %2 : Float(*, *) = prim::FusionGroup_0(%hx, %cx)
-  return (%2);
-}
+  return (%2)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Float(*, *)) {
+      %1 : Float(*, *)):
   %2 : int = prim::Constant[value=1]()
   %3 : Float(*, *) = aten::add(%0, %1, %2)
   %4 : Float(*, *) = aten::mul(%0, %1)
   %5 : Float(*, *) = prim::FusedConcat[dim=0](%3, %4)
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestFuser.test_concat_invariant_cuda.expect
+++ b/test/expect/TestFuser.test_concat_invariant_cuda.expect
@@ -1,16 +1,14 @@
 graph(%x : Float(*, *)
       %y : Float(*, *)
-      %z : Float(*, *)) {
+      %z : Float(*, *)):
   %3 : int = prim::Constant[value=1]()
   %w : Float(*, *) = prim::FusionGroup_0(%x, %y)
   %5 : Float(*, *) = aten::add(%w, %z, %3)
-  return (%5);
-}
+  return (%5)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Float(*, *)) {
+      %1 : Float(*, *)):
   %2 : int = prim::Constant[value=1]()
   %x1 : Float(*, *) = aten::add(%0, %1, %2)
   %y1 : Float(*, *) = aten::sub(%0, %1, %2)
   %w : Float(*, *) = prim::FusedConcat[dim=0](%x1, %y1)
-  return (%w);
-}
+  return (%w)

--- a/test/expect/TestFuser.test_concat_invariant_cuda.expect
+++ b/test/expect/TestFuser.test_concat_invariant_cuda.expect
@@ -1,11 +1,11 @@
-graph(%x : Float(*, *)
-      %y : Float(*, *)
+graph(%x : Float(*, *),
+      %y : Float(*, *),
       %z : Float(*, *)):
   %3 : int = prim::Constant[value=1]()
   %w : Float(*, *) = prim::FusionGroup_0(%x, %y)
   %5 : Float(*, *) = aten::add(%w, %z, %3)
   return (%5)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
       %1 : Float(*, *)):
   %2 : int = prim::Constant[value=1]()
   %x1 : Float(*, *) = aten::add(%0, %1, %2)

--- a/test/expect/TestFuser.test_lstm_concat_cuda.expect
+++ b/test/expect/TestFuser.test_lstm_concat_cuda.expect
@@ -1,9 +1,9 @@
-graph(%input : Float(*, *)
-      %input0 : Float(*, *)
-      %cx : Float(*, *)
-      %weight : Float(*, *)
-      %weight0 : Float(*, *)
-      %bias : Float(*)
+graph(%input : Float(*, *),
+      %input0 : Float(*, *),
+      %cx : Float(*, *),
+      %weight : Float(*, *),
+      %weight0 : Float(*, *),
+      %bias : Float(*),
       %bias0 : Float(*)):
   %7 : Float(*, *) = aten::t(%weight)
   %8 : Float(*, *) = aten::mm(%input, %7)
@@ -14,10 +14,10 @@ graph(%input : Float(*, *)
   %13 : Tensor, %14 : Tensor, %15 : Tensor, %16 : Tensor = prim::ListUnpack(%12)
   %17 : Float(*, *) = prim::FusionGroup_0(%cx, %16, %15, %14, %13)
   return (%17)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Tensor
-      %2 : Tensor
-      %3 : Tensor
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
+      %1 : Tensor,
+      %2 : Tensor,
+      %3 : Tensor,
       %4 : Tensor):
   %5 : Float(*, *), %6 : Float(*, *), %7 : Float(*, *), %8 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
   %9 : Float(*, *), %10 : Float(*, *), %11 : Float(*, *), %12 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%3)

--- a/test/expect/TestFuser.test_lstm_concat_cuda.expect
+++ b/test/expect/TestFuser.test_lstm_concat_cuda.expect
@@ -4,7 +4,7 @@ graph(%input : Float(*, *)
       %weight : Float(*, *)
       %weight0 : Float(*, *)
       %bias : Float(*)
-      %bias0 : Float(*)) {
+      %bias0 : Float(*)):
   %7 : Float(*, *) = aten::t(%weight)
   %8 : Float(*, *) = aten::mm(%input, %7)
   %9 : Float(*, *) = aten::t(%weight0)
@@ -13,13 +13,12 @@ graph(%input : Float(*, *)
   %12 : Tensor[] = aten::broadcast_tensors(%11)
   %13 : Tensor, %14 : Tensor, %15 : Tensor, %16 : Tensor = prim::ListUnpack(%12)
   %17 : Float(*, *) = prim::FusionGroup_0(%cx, %16, %15, %14, %13)
-  return (%17);
-}
+  return (%17)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Tensor
       %2 : Tensor
       %3 : Tensor
-      %4 : Tensor) {
+      %4 : Tensor):
   %5 : Float(*, *), %6 : Float(*, *), %7 : Float(*, *), %8 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
   %9 : Float(*, *), %10 : Float(*, *), %11 : Float(*, *), %12 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%3)
   %13 : Float(*, *), %14 : Float(*, *), %15 : Float(*, *), %16 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%2)
@@ -47,5 +46,4 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %41 : Float(*, *) = aten::tanh(%cy)
   %hy : Float(*, *) = aten::mul(%outgate0, %41)
   %43 : Float(*, *) = prim::FusedConcat[dim=0](%hy, %cy)
-  return (%43);
-}
+  return (%43)

--- a/test/expect/TestFuser.test_lstm_cuda-backward.expect
+++ b/test/expect/TestFuser.test_lstm_cuda-backward.expect
@@ -24,7 +24,7 @@ graph(%0 : Float(*, *)
       %outgate : Float(*, *)
       %24 : int[]
       %25 : int[]
-      %26 : Float(*, *)) {
+      %26 : Float(*, *)):
   %27 : int = prim::Constant[value=1]()
   %28 : int[] = aten::size(%outgate)
   %29 : int[] = aten::size(%26)
@@ -50,12 +50,11 @@ graph(%0 : Float(*, *)
   %52 : Float(*, *) = aten::t(%11)
   %53 : Float(*, *) = aten::mm(%52, %43)
   %54 : Float(*, *) = aten::t(%53)
-  return (%grad_other.5, %41, %42, %46, %49, %51, %54);
-}
+  return (%grad_other.5, %41, %42, %46, %49, %51, %54)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Float(*, *)
       %2 : Float(*, *)
-      %3 : int[]) {
+      %3 : int[]):
   %4 : int = prim::Constant[value=1]()
   %5 : Float(*, *) = aten::mul(%1, %2)
   %grad_self.1 : Tensor = aten::_grad_sum_to_size(%5, %3)
@@ -63,8 +62,7 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %8 : Float(*, *) = aten::add(%7, %4, %4)
   %9 : Float(*, *) = aten::mul(%8, %0)
   %10 : Tensor = aten::mul(%9, %grad_self.1)
-  return (%10);
-}
+  return (%10)
 with prim::FusionGroup_1 = graph(%0 : Float(*, *)
       %1 : Float(*, *)
       %2 : Float(*, *)
@@ -79,7 +77,7 @@ with prim::FusionGroup_1 = graph(%0 : Float(*, *)
       %11 : int[]
       %12 : int[]
       %13 : int[]
-      %14 : int[]) {
+      %14 : int[]):
   %15 : int = prim::Constant[value=1]()
   %16 : Float(*, *) = aten::neg(%0)
   %17 : Float(*, *) = aten::add(%16, %15, %15)
@@ -110,5 +108,4 @@ with prim::FusionGroup_1 = graph(%0 : Float(*, *)
   %42 : Tensor = aten::mul(%18, %grad_self.5)
   %43 : Tensor = aten::mul(%39, %0)
   %grad_other.5 : Tensor = aten::_grad_sum_to_size(%43, %8)
-  return (%grad_other.5, %42, %38, %35);
-}
+  return (%grad_other.5, %42, %38, %35)

--- a/test/expect/TestFuser.test_lstm_cuda-backward.expect
+++ b/test/expect/TestFuser.test_lstm_cuda-backward.expect
@@ -1,29 +1,29 @@
-graph(%0 : Float(*, *)
-      %1 : Float(*, *)
-      %2 : UndefinedTensor
-      %3 : UndefinedTensor
-      %4 : UndefinedTensor
-      %5 : UndefinedTensor
-      %6 : UndefinedTensor
-      %7 : UndefinedTensor
-      %8 : UndefinedTensor
-      %9 : Float(*, *)
-      %10 : Float(*, *)
-      %11 : Float(*, *)
-      %12 : Float(*, *)
-      %13 : Float(*, *)
-      %14 : int[]
-      %15 : int[]
-      %16 : int[]
-      %17 : int[]
-      %18 : int[]
-      %19 : int[]
-      %ingate : Float(*, *)
-      %forgetgate : Float(*, *)
-      %cellgate : Float(*, *)
-      %outgate : Float(*, *)
-      %24 : int[]
-      %25 : int[]
+graph(%0 : Float(*, *),
+      %1 : Float(*, *),
+      %2 : UndefinedTensor,
+      %3 : UndefinedTensor,
+      %4 : UndefinedTensor,
+      %5 : UndefinedTensor,
+      %6 : UndefinedTensor,
+      %7 : UndefinedTensor,
+      %8 : UndefinedTensor,
+      %9 : Float(*, *),
+      %10 : Float(*, *),
+      %11 : Float(*, *),
+      %12 : Float(*, *),
+      %13 : Float(*, *),
+      %14 : int[],
+      %15 : int[],
+      %16 : int[],
+      %17 : int[],
+      %18 : int[],
+      %19 : int[],
+      %ingate : Float(*, *),
+      %forgetgate : Float(*, *),
+      %cellgate : Float(*, *),
+      %outgate : Float(*, *),
+      %24 : int[],
+      %25 : int[],
       %26 : Float(*, *)):
   %27 : int = prim::Constant[value=1]()
   %28 : int[] = aten::size(%outgate)
@@ -51,9 +51,9 @@ graph(%0 : Float(*, *)
   %53 : Float(*, *) = aten::mm(%52, %43)
   %54 : Float(*, *) = aten::t(%53)
   return (%grad_other.5, %41, %42, %46, %49, %51, %54)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Float(*, *)
-      %2 : Float(*, *)
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
+      %1 : Float(*, *),
+      %2 : Float(*, *),
       %3 : int[]):
   %4 : int = prim::Constant[value=1]()
   %5 : Float(*, *) = aten::mul(%1, %2)
@@ -63,20 +63,20 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %9 : Float(*, *) = aten::mul(%8, %0)
   %10 : Tensor = aten::mul(%9, %grad_self.1)
   return (%10)
-with prim::FusionGroup_1 = graph(%0 : Float(*, *)
-      %1 : Float(*, *)
-      %2 : Float(*, *)
-      %3 : Float(*, *)
-      %4 : Float(*, *)
-      %5 : Float(*, *)
-      %6 : Float(*, *)
-      %7 : Float(*, *)
-      %8 : int[]
-      %9 : int[]
-      %10 : int[]
-      %11 : int[]
-      %12 : int[]
-      %13 : int[]
+with prim::FusionGroup_1 = graph(%0 : Float(*, *),
+      %1 : Float(*, *),
+      %2 : Float(*, *),
+      %3 : Float(*, *),
+      %4 : Float(*, *),
+      %5 : Float(*, *),
+      %6 : Float(*, *),
+      %7 : Float(*, *),
+      %8 : int[],
+      %9 : int[],
+      %10 : int[],
+      %11 : int[],
+      %12 : int[],
+      %13 : int[],
       %14 : int[]):
   %15 : int = prim::Constant[value=1]()
   %16 : Float(*, *) = aten::neg(%0)

--- a/test/expect/TestFuser.test_lstm_cuda-forward.expect
+++ b/test/expect/TestFuser.test_lstm_cuda-forward.expect
@@ -1,19 +1,19 @@
-graph(%x : Float(*, *)
-      %hx : Float(*, *)
-      %cx : Float(*, *)
-      %w_ih : Float(*, *)
-      %w_hh : Float(*, *)
-      %b_ih : Float(*)
+graph(%x : Float(*, *),
+      %hx : Float(*, *),
+      %cx : Float(*, *),
+      %w_ih : Float(*, *),
+      %w_hh : Float(*, *),
+      %b_ih : Float(*),
       %b_hh : Float(*)):
   %hy : Float(*, *), %cy : Float(*, *) = prim::DifferentiableGraph_0(%cx, %b_hh, %b_ih, %hx, %w_hh, %x, %w_ih)
   %9 : (Float(*, *), Float(*, *)) = prim::TupleConstruct(%hy, %cy)
   return (%9)
-with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
-      %1 : Float(*)
-      %2 : Float(*)
-      %3 : Float(*, *)
-      %4 : Float(*, *)
-      %5 : Float(*, *)
+with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *),
+      %1 : Float(*),
+      %2 : Float(*),
+      %3 : Float(*, *),
+      %4 : Float(*, *),
+      %5 : Float(*, *),
       %6 : Float(*, *)):
   %7 : Float(*, *) = aten::t(%6)
   %8 : Float(*, *) = aten::mm(%5, %7)
@@ -36,10 +36,10 @@ with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
   %34 : int[] = prim::BroadcastSizes(%32, %30)
   %35 : int[] = prim::BroadcastSizes(%33, %31)
   return (%hy, %cy, %7, %9, %11, %12, %21, %13, %22, %14, %ingate.1, %forgetgate.1, %cellgate.1, %outgate.1, %34, %35, %24)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Tensor
-      %2 : Tensor
-      %3 : Tensor
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
+      %1 : Tensor,
+      %2 : Tensor,
+      %3 : Tensor,
       %4 : Tensor):
   %5 : Float(*, *), %6 : Float(*, *), %7 : Float(*, *), %8 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
   %9 : Float(*, *), %10 : Float(*, *), %11 : Float(*, *), %12 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%3)

--- a/test/expect/TestFuser.test_lstm_cuda-forward.expect
+++ b/test/expect/TestFuser.test_lstm_cuda-forward.expect
@@ -4,18 +4,17 @@ graph(%x : Float(*, *)
       %w_ih : Float(*, *)
       %w_hh : Float(*, *)
       %b_ih : Float(*)
-      %b_hh : Float(*)) {
+      %b_hh : Float(*)):
   %hy : Float(*, *), %cy : Float(*, *) = prim::DifferentiableGraph_0(%cx, %b_hh, %b_ih, %hx, %w_hh, %x, %w_ih)
   %9 : (Float(*, *), Float(*, *)) = prim::TupleConstruct(%hy, %cy)
-  return (%9);
-}
+  return (%9)
 with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
       %1 : Float(*)
       %2 : Float(*)
       %3 : Float(*, *)
       %4 : Float(*, *)
       %5 : Float(*, *)
-      %6 : Float(*, *)) {
+      %6 : Float(*, *)):
   %7 : Float(*, *) = aten::t(%6)
   %8 : Float(*, *) = aten::mm(%5, %7)
   %9 : Float(*, *) = aten::t(%4)
@@ -36,13 +35,12 @@ with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
   %33 : int[] = aten::size(%ingate.1)
   %34 : int[] = prim::BroadcastSizes(%32, %30)
   %35 : int[] = prim::BroadcastSizes(%33, %31)
-  return (%hy, %cy, %7, %9, %11, %12, %21, %13, %22, %14, %ingate.1, %forgetgate.1, %cellgate.1, %outgate.1, %34, %35, %24);
-}
+  return (%hy, %cy, %7, %9, %11, %12, %21, %13, %22, %14, %ingate.1, %forgetgate.1, %cellgate.1, %outgate.1, %34, %35, %24)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Tensor
       %2 : Tensor
       %3 : Tensor
-      %4 : Tensor) {
+      %4 : Tensor):
   %5 : Float(*, *), %6 : Float(*, *), %7 : Float(*, *), %8 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
   %9 : Float(*, *), %10 : Float(*, *), %11 : Float(*, *), %12 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%3)
   %13 : Float(*, *), %14 : Float(*, *), %15 : Float(*, *), %16 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%2)
@@ -69,5 +67,4 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %cy : Float(*, *) = aten::add(%38, %39, %21)
   %41 : Float(*, *) = aten::tanh(%cy)
   %hy : Float(*, *) = aten::mul(%outgate.1, %41)
-  return (%hy, %41, %cy, %outgate.1, %cellgate.1, %forgetgate.1, %ingate.1);
-}
+  return (%hy, %41, %cy, %outgate.1, %cellgate.1, %forgetgate.1, %ingate.1)

--- a/test/expect/TestFuser.test_lstm_traced_cpu.expect
+++ b/test/expect/TestFuser.test_lstm_traced_cpu.expect
@@ -1,9 +1,9 @@
-graph(%0 : Float(3, 10)
-      %1 : Float(3, 20)
-      %2 : Float(3, 20)
-      %3 : Float(80, 10)
-      %4 : Float(80, 20)
-      %5 : Float(80)
+graph(%0 : Float(3, 10),
+      %1 : Float(3, 20),
+      %2 : Float(3, 20),
+      %3 : Float(80, 10),
+      %4 : Float(80, 20),
+      %5 : Float(80),
       %6 : Float(80)):
   %7 : Float(10!, 80!) = aten::t(%3)
   %8 : Float(3!, 80) = aten::expand[size=[3, 80], implicit=0](%5)
@@ -15,14 +15,14 @@ graph(%0 : Float(3, 10)
   %17 : Float(3!, 20), %18 : Float(3!, 20), %19 : Float(3!, 20), %20 : Float(3!, 20) = aten::chunk[chunks=4, dim=1](%12)
   %21 : Float(3, 20), %22 : Float(3, 20) = prim::FusionGroup_0[device=-1](%2, %16, %20, %15, %19, %14, %18, %13, %17)
   return (%21, %22)
-with prim::FusionGroup_0 = graph(%12 : Float(3, 20)
-      %22 : Float(3!, 20)
-      %23 : Float(3!, 20)
-      %25 : Float(3!, 20)
-      %26 : Float(3!, 20)
-      %28 : Float(3!, 20)
-      %29 : Float(3!, 20)
-      %31 : Float(3!, 20)
+with prim::FusionGroup_0 = graph(%12 : Float(3, 20),
+      %22 : Float(3!, 20),
+      %23 : Float(3!, 20),
+      %25 : Float(3!, 20),
+      %26 : Float(3!, 20),
+      %28 : Float(3!, 20),
+      %29 : Float(3!, 20),
+      %31 : Float(3!, 20),
       %32 : Float(3!, 20)):
   %33 : Float(3, 20) = aten::add[alpha={1}](%31, %32)
   %30 : Float(3, 20) = aten::add[alpha={1}](%28, %29)

--- a/test/expect/TestFuser.test_lstm_traced_cpu.expect
+++ b/test/expect/TestFuser.test_lstm_traced_cpu.expect
@@ -4,7 +4,7 @@ graph(%0 : Float(3, 10)
       %3 : Float(80, 10)
       %4 : Float(80, 20)
       %5 : Float(80)
-      %6 : Float(80)) {
+      %6 : Float(80)):
   %7 : Float(10!, 80!) = aten::t(%3)
   %8 : Float(3!, 80) = aten::expand[size=[3, 80], implicit=0](%5)
   %9 : Float(3, 80) = aten::addmm[alpha={1}, beta={1}](%8, %0, %7)
@@ -14,8 +14,7 @@ graph(%0 : Float(3, 10)
   %13 : Float(3!, 20), %14 : Float(3!, 20), %15 : Float(3!, 20), %16 : Float(3!, 20) = aten::chunk[chunks=4, dim=1](%9)
   %17 : Float(3!, 20), %18 : Float(3!, 20), %19 : Float(3!, 20), %20 : Float(3!, 20) = aten::chunk[chunks=4, dim=1](%12)
   %21 : Float(3, 20), %22 : Float(3, 20) = prim::FusionGroup_0[device=-1](%2, %16, %20, %15, %19, %14, %18, %13, %17)
-  return (%21, %22);
-}
+  return (%21, %22)
 with prim::FusionGroup_0 = graph(%12 : Float(3, 20)
       %22 : Float(3!, 20)
       %23 : Float(3!, 20)
@@ -24,7 +23,7 @@ with prim::FusionGroup_0 = graph(%12 : Float(3, 20)
       %28 : Float(3!, 20)
       %29 : Float(3!, 20)
       %31 : Float(3!, 20)
-      %32 : Float(3!, 20)) {
+      %32 : Float(3!, 20)):
   %33 : Float(3, 20) = aten::add[alpha={1}](%31, %32)
   %30 : Float(3, 20) = aten::add[alpha={1}](%28, %29)
   %27 : Float(3, 20) = aten::add[alpha={1}](%25, %26)
@@ -38,5 +37,4 @@ with prim::FusionGroup_0 = graph(%12 : Float(3, 20)
   %7 : Float(3, 20) = aten::add[alpha={1}](%13, %10)
   %4 : Float(3, 20) = aten::tanh(%7)
   %2 : Float(3, 20) = aten::mul(%15, %4)
-  return (%2, %7);
-}
+  return (%2, %7)

--- a/test/expect/TestFuser.test_lstm_traced_cuda.expect
+++ b/test/expect/TestFuser.test_lstm_traced_cuda.expect
@@ -4,7 +4,7 @@ graph(%input : Float(*, *)
       %weight : Float(*, *)
       %weight0 : Float(*, *)
       %bias : Float(*)
-      %bias0 : Float(*)) {
+      %bias0 : Float(*)):
   %7 : Float(*, *) = aten::t(%weight)
   %8 : Float(*, *) = aten::mm(%input, %7)
   %9 : Float(*, *) = aten::t(%weight0)
@@ -14,13 +14,12 @@ graph(%input : Float(*, *)
   %13 : Tensor, %14 : Tensor, %15 : Tensor, %16 : Tensor = prim::ListUnpack(%12)
   %17 : Float(*, *), %cy : Float(*, *) = prim::FusionGroup_0(%cx, %16, %15, %14, %13)
   %19 : (Float(*, *), Float(*, *)) = prim::TupleConstruct(%17, %cy)
-  return (%19);
-}
+  return (%19)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Tensor
       %2 : Tensor
       %3 : Tensor
-      %4 : Tensor) {
+      %4 : Tensor):
   %5 : Float(*, *), %6 : Float(*, *), %7 : Float(*, *), %8 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
   %9 : Float(*, *), %10 : Float(*, *), %11 : Float(*, *), %12 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%3)
   %13 : Float(*, *), %14 : Float(*, *), %15 : Float(*, *), %16 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%2)
@@ -47,5 +46,4 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %cy : Float(*, *) = aten::add(%38, %39, %21)
   %41 : Float(*, *) = aten::tanh(%cy)
   %42 : Float(*, *) = aten::mul(%outgate0, %41)
-  return (%42, %cy);
-}
+  return (%42, %cy)

--- a/test/expect/TestFuser.test_lstm_traced_cuda.expect
+++ b/test/expect/TestFuser.test_lstm_traced_cuda.expect
@@ -1,9 +1,9 @@
-graph(%input : Float(*, *)
-      %input0 : Float(*, *)
-      %cx : Float(*, *)
-      %weight : Float(*, *)
-      %weight0 : Float(*, *)
-      %bias : Float(*)
+graph(%input : Float(*, *),
+      %input0 : Float(*, *),
+      %cx : Float(*, *),
+      %weight : Float(*, *),
+      %weight0 : Float(*, *),
+      %bias : Float(*),
       %bias0 : Float(*)):
   %7 : Float(*, *) = aten::t(%weight)
   %8 : Float(*, *) = aten::mm(%input, %7)
@@ -15,10 +15,10 @@ graph(%input : Float(*, *)
   %17 : Float(*, *), %cy : Float(*, *) = prim::FusionGroup_0(%cx, %16, %15, %14, %13)
   %19 : (Float(*, *), Float(*, *)) = prim::TupleConstruct(%17, %cy)
   return (%19)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Tensor
-      %2 : Tensor
-      %3 : Tensor
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
+      %1 : Tensor,
+      %2 : Tensor,
+      %3 : Tensor,
       %4 : Tensor):
   %5 : Float(*, *), %6 : Float(*, *), %7 : Float(*, *), %8 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
   %9 : Float(*, *), %10 : Float(*, *), %11 : Float(*, *), %12 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%3)

--- a/test/expect/TestFuser.test_milstm_cuda-backward.expect
+++ b/test/expect/TestFuser.test_milstm_cuda-backward.expect
@@ -1,34 +1,34 @@
-graph(%0 : Float(*, *)
-      %1 : Float(*, *)
-      %2 : UndefinedTensor
-      %3 : UndefinedTensor
-      %4 : UndefinedTensor
-      %5 : UndefinedTensor
-      %6 : UndefinedTensor
-      %7 : UndefinedTensor
-      %8 : UndefinedTensor
-      %9 : UndefinedTensor
-      %10 : Float(*, *)
-      %11 : Float(*)
-      %12 : Float(*)
-      %13 : Float(*)
-      %14 : Float(*, *)
-      %15 : Float(*, *)
-      %Wx : Float(*, *)
-      %Uz : Float(*, *)
-      %18 : Float(*, *)
-      %19 : int[]
-      %20 : int[]
-      %21 : int[]
-      %22 : int[]
-      %23 : int[]
-      %24 : int[]
-      %ingate : Float(*, *)
-      %forgetgate : Float(*, *)
-      %cellgate : Float(*, *)
-      %outgate : Float(*, *)
-      %29 : int[]
-      %30 : int[]
+graph(%0 : Float(*, *),
+      %1 : Float(*, *),
+      %2 : UndefinedTensor,
+      %3 : UndefinedTensor,
+      %4 : UndefinedTensor,
+      %5 : UndefinedTensor,
+      %6 : UndefinedTensor,
+      %7 : UndefinedTensor,
+      %8 : UndefinedTensor,
+      %9 : UndefinedTensor,
+      %10 : Float(*, *),
+      %11 : Float(*),
+      %12 : Float(*),
+      %13 : Float(*),
+      %14 : Float(*, *),
+      %15 : Float(*, *),
+      %Wx : Float(*, *),
+      %Uz : Float(*, *),
+      %18 : Float(*, *),
+      %19 : int[],
+      %20 : int[],
+      %21 : int[],
+      %22 : int[],
+      %23 : int[],
+      %24 : int[],
+      %ingate : Float(*, *),
+      %forgetgate : Float(*, *),
+      %cellgate : Float(*, *),
+      %outgate : Float(*, *),
+      %29 : int[],
+      %30 : int[],
       %31 : Float(*, *)):
   %32 : int = prim::Constant[value=1]()
   %33 : int[] = aten::size(%outgate)
@@ -61,9 +61,9 @@ graph(%0 : Float(*, *)
   %63 : Float(*, *) = aten::mm(%62, %58)
   %64 : Float(*, *) = aten::t(%63)
   return (%44, %grad_self.7, %grad_self.9, %grad_self.13, %61, %64)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Float(*, *)
-      %2 : Float(*, *)
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
+      %1 : Float(*, *),
+      %2 : Float(*, *),
       %3 : int[]):
   %4 : int = prim::Constant[value=1]()
   %5 : Float(*, *) = aten::mul(%1, %2)
@@ -73,19 +73,19 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %9 : Float(*, *) = aten::mul(%8, %0)
   %10 : Tensor = aten::mul(%9, %grad_self.1)
   return (%10)
-with prim::FusionGroup_1 = graph(%0 : Float(*, *)
-      %1 : Float(*, *)
-      %2 : Float(*, *)
-      %3 : Float(*, *)
-      %4 : Float(*, *)
-      %5 : Float(*, *)
-      %6 : Float(*, *)
-      %7 : Float(*, *)
-      %8 : int[]
-      %9 : int[]
-      %10 : int[]
-      %11 : int[]
-      %12 : int[]
+with prim::FusionGroup_1 = graph(%0 : Float(*, *),
+      %1 : Float(*, *),
+      %2 : Float(*, *),
+      %3 : Float(*, *),
+      %4 : Float(*, *),
+      %5 : Float(*, *),
+      %6 : Float(*, *),
+      %7 : Float(*, *),
+      %8 : int[],
+      %9 : int[],
+      %10 : int[],
+      %11 : int[],
+      %12 : int[],
       %13 : int[]):
   %14 : int = prim::Constant[value=1]()
   %15 : Float(*, *) = aten::neg(%7)
@@ -116,22 +116,22 @@ with prim::FusionGroup_1 = graph(%0 : Float(*, *)
   %grad_self.5 : Tensor = aten::_grad_sum_to_size(%39, %8)
   %41 : Tensor = aten::mul(%17, %grad_self.5)
   return (%41, %37, %34)
-with prim::FusionGroup_2 = graph(%0 : Tensor
-      %1 : Float(*, *)
+with prim::FusionGroup_2 = graph(%0 : Tensor,
+      %1 : Float(*, *),
       %2 : int[]):
   %3 : Tensor = aten::mul(%0, %1)
   %grad_self.7 : Tensor = aten::_grad_sum_to_size(%3, %2)
   return (%grad_self.7)
-with prim::FusionGroup_3 = graph(%0 : Tensor
-      %1 : Float(*, *)
+with prim::FusionGroup_3 = graph(%0 : Tensor,
+      %1 : Float(*, *),
       %2 : int[]):
   %3 : Tensor = aten::mul(%0, %1)
   %grad_self.9 : Tensor = aten::_grad_sum_to_size(%3, %2)
   return (%grad_self.9)
-with prim::FusionGroup_4 = graph(%0 : Tensor
-      %1 : Float(*, *)
-      %2 : Tensor
-      %3 : Float(*)
+with prim::FusionGroup_4 = graph(%0 : Tensor,
+      %1 : Float(*, *),
+      %2 : Tensor,
+      %3 : Float(*),
       %4 : int[]):
   %5 : int = prim::Constant[value=1]()
   %6 : Tensor = aten::mul(%2, %3)
@@ -140,14 +140,14 @@ with prim::FusionGroup_4 = graph(%0 : Tensor
   %grad_other.11 : Tensor = aten::_grad_sum_to_size(%8, %4)
   %10 : Tensor = aten::add(%grad_other.7, %grad_other.11, %5)
   return (%10)
-with prim::FusionGroup_5 = graph(%0 : Float(*, *)
-      %1 : Float(*)
-      %2 : Tensor
-      %3 : Float(*, *)
-      %4 : Tensor
-      %5 : Float(*)
-      %6 : int[]
-      %7 : int[]
+with prim::FusionGroup_5 = graph(%0 : Float(*, *),
+      %1 : Float(*),
+      %2 : Tensor,
+      %3 : Float(*, *),
+      %4 : Tensor,
+      %5 : Float(*),
+      %6 : int[],
+      %7 : int[],
       %8 : int[]):
   %9 : int = prim::Constant[value=1]()
   %10 : Tensor = aten::mul(%4, %5)

--- a/test/expect/TestFuser.test_milstm_cuda-backward.expect
+++ b/test/expect/TestFuser.test_milstm_cuda-backward.expect
@@ -29,7 +29,7 @@ graph(%0 : Float(*, *)
       %outgate : Float(*, *)
       %29 : int[]
       %30 : int[]
-      %31 : Float(*, *)) {
+      %31 : Float(*, *)):
   %32 : int = prim::Constant[value=1]()
   %33 : int[] = aten::size(%outgate)
   %34 : int[] = aten::size(%31)
@@ -60,12 +60,11 @@ graph(%0 : Float(*, *)
   %62 : Float(*, *) = aten::t(%15)
   %63 : Float(*, *) = aten::mm(%62, %58)
   %64 : Float(*, *) = aten::t(%63)
-  return (%44, %grad_self.7, %grad_self.9, %grad_self.13, %61, %64);
-}
+  return (%44, %grad_self.7, %grad_self.9, %grad_self.13, %61, %64)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Float(*, *)
       %2 : Float(*, *)
-      %3 : int[]) {
+      %3 : int[]):
   %4 : int = prim::Constant[value=1]()
   %5 : Float(*, *) = aten::mul(%1, %2)
   %grad_self.1 : Tensor = aten::_grad_sum_to_size(%5, %3)
@@ -73,8 +72,7 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %8 : Float(*, *) = aten::add(%7, %4, %4)
   %9 : Float(*, *) = aten::mul(%8, %0)
   %10 : Tensor = aten::mul(%9, %grad_self.1)
-  return (%10);
-}
+  return (%10)
 with prim::FusionGroup_1 = graph(%0 : Float(*, *)
       %1 : Float(*, *)
       %2 : Float(*, *)
@@ -88,7 +86,7 @@ with prim::FusionGroup_1 = graph(%0 : Float(*, *)
       %10 : int[]
       %11 : int[]
       %12 : int[]
-      %13 : int[]) {
+      %13 : int[]):
   %14 : int = prim::Constant[value=1]()
   %15 : Float(*, *) = aten::neg(%7)
   %16 : Float(*, *) = aten::add(%15, %14, %14)
@@ -117,35 +115,31 @@ with prim::FusionGroup_1 = graph(%0 : Float(*, *)
   %39 : Tensor = aten::mul(%38, %0)
   %grad_self.5 : Tensor = aten::_grad_sum_to_size(%39, %8)
   %41 : Tensor = aten::mul(%17, %grad_self.5)
-  return (%41, %37, %34);
-}
+  return (%41, %37, %34)
 with prim::FusionGroup_2 = graph(%0 : Tensor
       %1 : Float(*, *)
-      %2 : int[]) {
+      %2 : int[]):
   %3 : Tensor = aten::mul(%0, %1)
   %grad_self.7 : Tensor = aten::_grad_sum_to_size(%3, %2)
-  return (%grad_self.7);
-}
+  return (%grad_self.7)
 with prim::FusionGroup_3 = graph(%0 : Tensor
       %1 : Float(*, *)
-      %2 : int[]) {
+      %2 : int[]):
   %3 : Tensor = aten::mul(%0, %1)
   %grad_self.9 : Tensor = aten::_grad_sum_to_size(%3, %2)
-  return (%grad_self.9);
-}
+  return (%grad_self.9)
 with prim::FusionGroup_4 = graph(%0 : Tensor
       %1 : Float(*, *)
       %2 : Tensor
       %3 : Float(*)
-      %4 : int[]) {
+      %4 : int[]):
   %5 : int = prim::Constant[value=1]()
   %6 : Tensor = aten::mul(%2, %3)
   %grad_other.7 : Tensor = aten::_grad_sum_to_size(%6, %4)
   %8 : Tensor = aten::mul(%0, %1)
   %grad_other.11 : Tensor = aten::_grad_sum_to_size(%8, %4)
   %10 : Tensor = aten::add(%grad_other.7, %grad_other.11, %5)
-  return (%10);
-}
+  return (%10)
 with prim::FusionGroup_5 = graph(%0 : Float(*, *)
       %1 : Float(*)
       %2 : Tensor
@@ -154,7 +148,7 @@ with prim::FusionGroup_5 = graph(%0 : Float(*, *)
       %5 : Float(*)
       %6 : int[]
       %7 : int[]
-      %8 : int[]) {
+      %8 : int[]):
   %9 : int = prim::Constant[value=1]()
   %10 : Tensor = aten::mul(%4, %5)
   %grad_other.9 : Tensor = aten::_grad_sum_to_size(%10, %7)
@@ -165,5 +159,4 @@ with prim::FusionGroup_5 = graph(%0 : Float(*, *)
   %16 : Tensor = aten::add(%grad_other.9, %grad_other.13, %9)
   %17 : Tensor = aten::mul(%grad_self.11, %0)
   %grad_self.13 : Tensor = aten::_grad_sum_to_size(%17, %6)
-  return (%grad_self.13, %16);
-}
+  return (%grad_self.13, %16)

--- a/test/expect/TestFuser.test_milstm_cuda-forward.expect
+++ b/test/expect/TestFuser.test_milstm_cuda-forward.expect
@@ -1,23 +1,23 @@
-graph(%x : Float(*, *)
-      %hx : Float(*, *)
-      %cx : Float(*, *)
-      %w_ih : Float(*, *)
-      %w_hh : Float(*, *)
-      %alpha : Float(*)
-      %beta_i : Float(*)
-      %beta_h : Float(*)
+graph(%x : Float(*, *),
+      %hx : Float(*, *),
+      %cx : Float(*, *),
+      %w_ih : Float(*, *),
+      %w_hh : Float(*, *),
+      %alpha : Float(*),
+      %beta_i : Float(*),
+      %beta_h : Float(*),
       %bias : Float(*)):
   %hy : Float(*, *), %cy : Float(*, *) = prim::DifferentiableGraph_0(%cx, %bias, %beta_h, %beta_i, %alpha, %hx, %w_hh, %x, %w_ih)
   %11 : (Float(*, *), Float(*, *)) = prim::TupleConstruct(%hy, %cy)
   return (%11)
-with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
-      %1 : Float(*)
-      %2 : Float(*)
-      %3 : Float(*)
-      %4 : Float(*)
-      %5 : Float(*, *)
-      %6 : Float(*, *)
-      %7 : Float(*, *)
+with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *),
+      %1 : Float(*),
+      %2 : Float(*),
+      %3 : Float(*),
+      %4 : Float(*),
+      %5 : Float(*, *),
+      %6 : Float(*, *),
+      %7 : Float(*, *),
       %8 : Float(*, *)):
   %9 : Float(*, *) = aten::t(%8)
   %Wx.1 : Float(*, *) = aten::mm(%7, %9)
@@ -46,12 +46,12 @@ with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
   %44 : int[] = prim::BroadcastSizes(%42, %40)
   %45 : int[] = prim::BroadcastSizes(%43, %41)
   return (%hy, %cy, %Wx.1, %Uz.1, %13, %28, %25, %31, %30, %32, %14, %ingate.1, %forgetgate.1, %cellgate.1, %outgate.1, %44, %45, %34)
-with prim::FusionGroup_0 = graph(%0 : Float(*, *)
-      %1 : Tensor
-      %2 : Tensor
-      %3 : Tensor
-      %4 : Tensor
-      %5 : Tensor
+with prim::FusionGroup_0 = graph(%0 : Float(*, *),
+      %1 : Tensor,
+      %2 : Tensor,
+      %3 : Tensor,
+      %4 : Tensor,
+      %5 : Tensor,
       %6 : Tensor):
   %7 : Float(*, *), %8 : Float(*, *), %9 : Float(*, *), %10 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%6)
   %11 : Float(*, *), %12 : Float(*, *), %13 : Float(*, *), %14 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%5)

--- a/test/expect/TestFuser.test_milstm_cuda-forward.expect
+++ b/test/expect/TestFuser.test_milstm_cuda-forward.expect
@@ -6,11 +6,10 @@ graph(%x : Float(*, *)
       %alpha : Float(*)
       %beta_i : Float(*)
       %beta_h : Float(*)
-      %bias : Float(*)) {
+      %bias : Float(*)):
   %hy : Float(*, *), %cy : Float(*, *) = prim::DifferentiableGraph_0(%cx, %bias, %beta_h, %beta_i, %alpha, %hx, %w_hh, %x, %w_ih)
   %11 : (Float(*, *), Float(*, *)) = prim::TupleConstruct(%hy, %cy)
-  return (%11);
-}
+  return (%11)
 with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
       %1 : Float(*)
       %2 : Float(*)
@@ -19,7 +18,7 @@ with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
       %5 : Float(*, *)
       %6 : Float(*, *)
       %7 : Float(*, *)
-      %8 : Float(*, *)) {
+      %8 : Float(*, *)):
   %9 : Float(*, *) = aten::t(%8)
   %Wx.1 : Float(*, *) = aten::mm(%7, %9)
   %11 : Float(*, *) = aten::t(%6)
@@ -46,15 +45,14 @@ with prim::DifferentiableGraph_0 = graph(%0 : Float(*, *)
   %43 : int[] = aten::size(%ingate.1)
   %44 : int[] = prim::BroadcastSizes(%42, %40)
   %45 : int[] = prim::BroadcastSizes(%43, %41)
-  return (%hy, %cy, %Wx.1, %Uz.1, %13, %28, %25, %31, %30, %32, %14, %ingate.1, %forgetgate.1, %cellgate.1, %outgate.1, %44, %45, %34);
-}
+  return (%hy, %cy, %Wx.1, %Uz.1, %13, %28, %25, %31, %30, %32, %14, %ingate.1, %forgetgate.1, %cellgate.1, %outgate.1, %44, %45, %34)
 with prim::FusionGroup_0 = graph(%0 : Float(*, *)
       %1 : Tensor
       %2 : Tensor
       %3 : Tensor
       %4 : Tensor
       %5 : Tensor
-      %6 : Tensor) {
+      %6 : Tensor):
   %7 : Float(*, *), %8 : Float(*, *), %9 : Float(*, *), %10 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%6)
   %11 : Float(*, *), %12 : Float(*, *), %13 : Float(*, *), %14 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%5)
   %15 : Float(*, *), %16 : Float(*, *), %17 : Float(*, *), %18 : Float(*, *) = prim::ConstantChunk[chunks=4, dim=1](%4)
@@ -95,5 +93,4 @@ with prim::FusionGroup_0 = graph(%0 : Float(*, *)
   %cy : Float(*, *) = aten::add(%60, %61, %31)
   %63 : Float(*, *) = aten::tanh(%cy)
   %hy : Float(*, *) = aten::mul(%outgate.1, %63)
-  return (%hy, %63, %cy, %outgate.1, %cellgate.1, %forgetgate.1, %ingate.1);
-}
+  return (%hy, %63, %cy, %outgate.1, %cellgate.1, %forgetgate.1, %ingate.1)

--- a/test/expect/TestFuser.test_scalar.expect
+++ b/test/expect/TestFuser.test_scalar.expect
@@ -1,8 +1,8 @@
-graph(%x : Float()
+graph(%x : Float(),
       %y : Float()):
   %2 : Float() = prim::FusionGroup_0(%y, %x)
   return (%2)
-with prim::FusionGroup_0 = graph(%0 : Float()
+with prim::FusionGroup_0 = graph(%0 : Float(),
       %1 : Float()):
   %2 : int = prim::Constant[value=1]()
   %3 : int = prim::Constant[value=2]()

--- a/test/expect/TestFuser.test_scalar.expect
+++ b/test/expect/TestFuser.test_scalar.expect
@@ -1,13 +1,11 @@
 graph(%x : Float()
-      %y : Float()) {
+      %y : Float()):
   %2 : Float() = prim::FusionGroup_0(%y, %x)
-  return (%2);
-}
+  return (%2)
 with prim::FusionGroup_0 = graph(%0 : Float()
-      %1 : Float()) {
+      %1 : Float()):
   %2 : int = prim::Constant[value=1]()
   %3 : int = prim::Constant[value=2]()
   %4 : Float() = aten::mul(%1, %3)
   %5 : Float() = aten::add(%4, %0, %2)
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestJit.test_alexnet.expect
+++ b/test/expect/TestJit.test_alexnet.expect
@@ -1,19 +1,19 @@
-graph(%0 : Double(1, 3, 224, 224)
-      %1 : Double(64, 3, 11, 11)
-      %2 : Double(64)
-      %3 : Double(192, 64, 5, 5)
-      %4 : Double(192)
-      %5 : Double(384, 192, 3, 3)
-      %6 : Double(384)
-      %7 : Double(256, 384, 3, 3)
-      %8 : Double(256)
-      %9 : Double(256, 256, 3, 3)
-      %10 : Double(256)
-      %11 : Double(4096, 9216)
-      %12 : Double(4096)
-      %13 : Double(4096, 4096)
-      %14 : Double(4096)
-      %15 : Double(1000, 4096)
+graph(%0 : Double(1, 3, 224, 224),
+      %1 : Double(64, 3, 11, 11),
+      %2 : Double(64),
+      %3 : Double(192, 64, 5, 5),
+      %4 : Double(192),
+      %5 : Double(384, 192, 3, 3),
+      %6 : Double(384),
+      %7 : Double(256, 384, 3, 3),
+      %8 : Double(256),
+      %9 : Double(256, 256, 3, 3),
+      %10 : Double(256),
+      %11 : Double(4096, 9216),
+      %12 : Double(4096),
+      %13 : Double(4096, 4096),
+      %14 : Double(4096),
+      %15 : Double(1000, 4096),
       %16 : Double(1000)):
   %17 : int = prim::Constant[value=4](), scope: AlexNet/Sequential[features]/Conv2d[0]
   %18 : int[] = prim::ListConstruct(%17, %17), scope: AlexNet/Sequential[features]/Conv2d[0]

--- a/test/expect/TestJit.test_alexnet.expect
+++ b/test/expect/TestJit.test_alexnet.expect
@@ -14,7 +14,7 @@ graph(%0 : Double(1, 3, 224, 224)
       %13 : Double(4096, 4096)
       %14 : Double(4096)
       %15 : Double(1000, 4096)
-      %16 : Double(1000)) {
+      %16 : Double(1000)):
   %17 : int = prim::Constant[value=4](), scope: AlexNet/Sequential[features]/Conv2d[0]
   %18 : int[] = prim::ListConstruct(%17, %17), scope: AlexNet/Sequential[features]/Conv2d[0]
   %19 : int = prim::Constant[value=2](), scope: AlexNet/Sequential[features]/Conv2d[0]
@@ -58,5 +58,4 @@ graph(%0 : Double(1, 3, 224, 224)
   %input : Double(1, 4096) = aten::threshold_(%input.14, %28, %28), scope: AlexNet/Sequential[classifier]/ReLU[5]
   %61 : Double(4096!, 1000!) = aten::t(%15), scope: AlexNet/Sequential[classifier]/Linear[6]
   %62 : Double(1, 1000) = aten::addmm(%16, %input, %61, %21, %21), scope: AlexNet/Sequential[classifier]/Linear[6]
-  return (%62);
-}
+  return (%62)

--- a/test/expect/TestJit.test_batchnorm.expect
+++ b/test/expect/TestJit.test_batchnorm.expect
@@ -3,11 +3,10 @@ graph(%input : Double(2, 2, 2, 2)
       %2 : Double(2)
       %3 : Double(2)
       %4 : Double(2)
-      %5 : Long()) {
+      %5 : Long()):
   %6 : bool = prim::Constant[value=1](), scope: BatchNorm2d
   %7 : float = prim::Constant[value=0.1](), scope: BatchNorm2d
   %8 : float = prim::Constant[value=1e-05](), scope: BatchNorm2d
   %9 : bool = prim::Constant[value=1](), scope: BatchNorm2d
   %10 : Double(2, 2, 2, 2) = aten::batch_norm(%input, %1, %2, %3, %4, %6, %7, %8, %9), scope: BatchNorm2d
-  return (%10);
-}
+  return (%10)

--- a/test/expect/TestJit.test_batchnorm.expect
+++ b/test/expect/TestJit.test_batchnorm.expect
@@ -1,8 +1,8 @@
-graph(%input : Double(2, 2, 2, 2)
-      %1 : Double(2)
-      %2 : Double(2)
-      %3 : Double(2)
-      %4 : Double(2)
+graph(%input : Double(2, 2, 2, 2),
+      %1 : Double(2),
+      %2 : Double(2),
+      %3 : Double(2),
+      %4 : Double(2),
       %5 : Long()):
   %6 : bool = prim::Constant[value=1](), scope: BatchNorm2d
   %7 : float = prim::Constant[value=0.1](), scope: BatchNorm2d

--- a/test/expect/TestJit.test_conv.expect
+++ b/test/expect/TestJit.test_conv.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(20, 16, 50, 40)
+graph(%0 : Double(20, 16, 50, 40),
       %1 : Double(13, 16, 3, 3)):
   %2 : Tensor? = prim::None(), scope: Conv2d
   %3 : int = prim::Constant[value=1](), scope: Conv2d

--- a/test/expect/TestJit.test_conv.expect
+++ b/test/expect/TestJit.test_conv.expect
@@ -1,5 +1,5 @@
 graph(%0 : Double(20, 16, 50, 40)
-      %1 : Double(13, 16, 3, 3)) {
+      %1 : Double(13, 16, 3, 3)):
   %2 : Tensor? = prim::None(), scope: Conv2d
   %3 : int = prim::Constant[value=1](), scope: Conv2d
   %4 : int = prim::Constant[value=1](), scope: Conv2d
@@ -19,5 +19,4 @@ graph(%0 : Double(20, 16, 50, 40)
   %18 : bool = prim::Constant[value=0](), scope: Conv2d
   %19 : bool = prim::Constant[value=1](), scope: Conv2d
   %20 : Double(20, 13, 48, 38) = aten::_convolution(%0, %1, %2, %5, %8, %11, %12, %15, %16, %17, %18, %19), scope: Conv2d
-  return (%20);
-}
+  return (%20)

--- a/test/expect/TestJit.test_cpp_cuda.expect
+++ b/test/expect/TestJit.test_cpp_cuda.expect
@@ -1,78 +1,70 @@
 testBlocks
 graph(%a : Tensor
       %b : Tensor
-      %c : Tensor) {
+      %c : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)
   %5 : Tensor = prim::If(%c)
-    block0() {
+    block0():
       %6 : int = prim::Constant[value=1]()
       %7 : Tensor = aten::add(%3, %3, %6)
       -> (%7)
-    }
-    block1() {
+    block1():
       %8 : int = prim::Constant[value=1]()
       %9 : Tensor = aten::add(%b, %3, %8)
       %10 : int = prim::Constant[value=1]()
       %11 : Tensor = aten::add(%9, %3, %10)
       -> (%11)
-    }
   %12 : int = prim::Constant[value=1]()
   %13 : Tensor = aten::add(%5, %3, %12)
-  return (%13);
-}
+  return (%13)
 
 graph(%a : Tensor
       %b : Tensor
-      %c : Tensor) {
+      %c : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)
   %5 : Tensor = prim::If(%c)
-    block0() {
+    block0():
       %8 : int = prim::Constant[value=1]()
       %9 : Tensor = aten::add(%b, %3, %8)
       %10 : int = prim::Constant[value=1]()
       %11 : Tensor = aten::add(%9, %3, %10)
       -> (%11)
-    }
   %12 : int = prim::Constant[value=1]()
   %13 : Tensor = aten::add(%5, %3, %12)
-  return (%13);
-}
+  return (%13)
 
 graph(%a : Tensor
       %b : Tensor
-      %c : Tensor) {
+      %c : Tensor):
   %3 : int = prim::Constant[value=1]()
   %4 : Tensor = aten::add(%a, %b, %3)
   %5 : Tensor = prim::If(%c)
-    block0() {
+    block0():
       %6 : int = prim::Constant[value=1]()
       %7 : Tensor = aten::add(%b, %4, %6)
       %8 : int = prim::Constant[value=1]()
       %9 : Tensor = aten::add(%7, %4, %8)
       -> (%9)
-    }
   %10 : int = prim::Constant[value=1]()
   %11 : Tensor = aten::add(%5, %4, %10)
-  return (%11);
-}
+  return (%11)
 
 testCreateAutodiffSubgraphs
 graph(%0 : Tensor
       %1 : Tensor
       %2 : Tensor
       %3 : Tensor
-      %4 : Tensor) {
+      %4 : Tensor):
   %7 : int = prim::Constant[value=1]()
   %23 : Tensor, %24 : Tensor = prim::DifferentiableGraph_0(%2, %1, %4, %0, %3)
-  return (%23, %24);
-}
+  return (%23, %24)
 with prim::DifferentiableGraph_0 = graph(%13 : Tensor
       %32 : Tensor
       %33 : Tensor
       %35 : Tensor
-      %36 : Tensor) {
+      %36 : Tensor):
   %37 : Tensor = aten::mm(%35, %36)
   %34 : Tensor = aten::mm(%32, %33)
   %30 : int = prim::Constant[value=1]()
@@ -87,36 +79,33 @@ with prim::DifferentiableGraph_0 = graph(%13 : Tensor
   %8 : Tensor = aten::add(%14, %11, %30)
   %4 : Tensor = aten::tanh(%8)
   %2 : Tensor = aten::mul(%20, %4)
-  return (%2, %8);
-}
+  return (%2, %8)
 
 testDifferentiate
 graph(%0 : Float(2, 3, 4)
-      %1 : Float(2, 3, 4)) {
+      %1 : Float(2, 3, 4)):
   %2 : Float(2, 3, 4) = aten::mul(%0, %1)
   %3 : Float(2, 3, 4) = aten::mul(%2, %0)
   %4 : int = prim::Constant[value=1]()
   %7 : int[] = aten::size(%3)
   %5 : Float(2, 3, 4) = aten::add(%3, %1, %4)
-  return (%5, %2, %7);
-}
+  return (%5, %2, %7)
 graph(%0 : Float(2, 3, 4)
       %1 : Float(2, 3, 4)
       %2 : Float(2, 3, 4)
       %3 : Float(2, 3, 4)
       %4 : Float(2, 3, 4)
-      %5 : int[]) {
+      %5 : int[]):
   %7 : int = prim::Constant[value=1]()
   %6 : int[] = aten::size(%3)
   %8 : Tensor, %9 : Tensor = prim::GradOf[name="aten::add"](%0)
-    block0() {
+    block0():
       %10 : Tensor = aten::_grad_sum_to_size(%0, %5)
       %11 : Float(2, 3, 4) = aten::mul(%0, %7)
       %12 : Tensor = aten::_grad_sum_to_size(%11, %6)
       -> (%10, %12)
-    }
   %grad_self.2 : Tensor, %grad_other.2 : Tensor = prim::GradOf[name="aten::mul"](%8)
-    block0() {
+    block0():
       %15 : Tensor = aten::mul(%8, %2)
       %16 : int[] = aten::size(%4)
       %grad_self.1 : Tensor = aten::_grad_sum_to_size(%15, %16)
@@ -124,10 +113,9 @@ graph(%0 : Float(2, 3, 4)
       %19 : int[] = aten::size(%2)
       %grad_other.1 : Tensor = aten::_grad_sum_to_size(%18, %19)
       -> (%grad_self.1, %grad_other.1)
-    }
   %21 : Tensor = prim::AutogradAdd(%1, %grad_self.2)
   %grad_self : Tensor, %grad_other : Tensor = prim::GradOf[name="aten::mul"](%21)
-    block0() {
+    block0():
       %24 : Tensor = aten::mul(%21, %3)
       %25 : int[] = aten::size(%2)
       %grad_self.3 : Tensor = aten::_grad_sum_to_size(%24, %25)
@@ -135,15 +123,13 @@ graph(%0 : Float(2, 3, 4)
       %28 : int[] = aten::size(%3)
       %grad_other.3 : Tensor = aten::_grad_sum_to_size(%27, %28)
       -> (%grad_self.3, %grad_other.3)
-    }
   %30 : Tensor = prim::AutogradAdd(%grad_other.2, %grad_self)
   %31 : Tensor = prim::AutogradAdd(%9, %grad_other)
-  return (%30, %31);
-}
+  return (%30, %31)
 
 testDifferentiateWithRequiresGrad
 graph(%0 : Float(*)
-      %1 : Float(*)) {
+      %1 : Float(*)):
   %2 : Float(*) = aten::mul(%1, %1)
   %3 : int = prim::Constant[value=1]()
   %4 : Float(*) = aten::add(%2, %1, %3)
@@ -151,22 +137,20 @@ graph(%0 : Float(*)
   %7 : Float(*) = aten::mul(%6, %0)
   %11 : int[] = aten::size(%7)
   %9 : Float(*) = aten::add(%7, %1, %3)
-  return (%4, %9, %6, %11);
-}
+  return (%4, %9, %6, %11)
 graph(%0 : Float(*)
       %1 : Float(*)
       %2 : Float(*)
       %3 : Float(*)
-      %4 : int[]) {
+      %4 : int[]):
   %6 : int = prim::Constant[value=1]()
   %5 : int[] = aten::size(%2)
   %7 : Tensor = prim::GradOf[name="aten::add"](%0)
-    block0() {
+    block0():
       %8 : Tensor = aten::_grad_sum_to_size(%0, %4)
       -> (%8)
-    }
   %grad_self : Tensor, %grad_other : Tensor = prim::GradOf[name="aten::mul"](%7)
-    block0() {
+    block0():
       %11 : Tensor = aten::mul(%7, %2)
       %12 : int[] = aten::size(%3)
       %grad_self.1 : Tensor = aten::_grad_sum_to_size(%11, %12)
@@ -174,15 +158,12 @@ graph(%0 : Float(*)
       %15 : int[] = aten::size(%2)
       %grad_other.1 : Tensor = aten::_grad_sum_to_size(%14, %15)
       -> (%grad_self.1, %grad_other.1)
-    }
   %17 : Tensor = prim::AutogradAdd(%1, %grad_self)
   %18 : Tensor = prim::GradOf[name="aten::add"](%17)
-    block0() {
+    block0():
       %19 : Tensor = aten::mul(%17, %6)
       %20 : Tensor = aten::_grad_sum_to_size(%19, %5)
       -> (%20)
-    }
   %21 : Tensor = prim::AutogradAdd(%grad_other, %18)
-  return (%21);
-}
+  return (%21)
 

--- a/test/expect/TestJit.test_cpp_cuda.expect
+++ b/test/expect/TestJit.test_cpp_cuda.expect
@@ -1,6 +1,6 @@
 testBlocks
-graph(%a : Tensor
-      %b : Tensor
+graph(%a : Tensor,
+      %b : Tensor,
       %c : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)
@@ -19,8 +19,8 @@ graph(%a : Tensor
   %13 : Tensor = aten::add(%5, %3, %12)
   return (%13)
 
-graph(%a : Tensor
-      %b : Tensor
+graph(%a : Tensor,
+      %b : Tensor,
       %c : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)
@@ -35,8 +35,8 @@ graph(%a : Tensor
   %13 : Tensor = aten::add(%5, %3, %12)
   return (%13)
 
-graph(%a : Tensor
-      %b : Tensor
+graph(%a : Tensor,
+      %b : Tensor,
       %c : Tensor):
   %3 : int = prim::Constant[value=1]()
   %4 : Tensor = aten::add(%a, %b, %3)
@@ -52,18 +52,18 @@ graph(%a : Tensor
   return (%11)
 
 testCreateAutodiffSubgraphs
-graph(%0 : Tensor
-      %1 : Tensor
-      %2 : Tensor
-      %3 : Tensor
+graph(%0 : Tensor,
+      %1 : Tensor,
+      %2 : Tensor,
+      %3 : Tensor,
       %4 : Tensor):
   %7 : int = prim::Constant[value=1]()
   %23 : Tensor, %24 : Tensor = prim::DifferentiableGraph_0(%2, %1, %4, %0, %3)
   return (%23, %24)
-with prim::DifferentiableGraph_0 = graph(%13 : Tensor
-      %32 : Tensor
-      %33 : Tensor
-      %35 : Tensor
+with prim::DifferentiableGraph_0 = graph(%13 : Tensor,
+      %32 : Tensor,
+      %33 : Tensor,
+      %35 : Tensor,
       %36 : Tensor):
   %37 : Tensor = aten::mm(%35, %36)
   %34 : Tensor = aten::mm(%32, %33)
@@ -82,7 +82,7 @@ with prim::DifferentiableGraph_0 = graph(%13 : Tensor
   return (%2, %8)
 
 testDifferentiate
-graph(%0 : Float(2, 3, 4)
+graph(%0 : Float(2, 3, 4),
       %1 : Float(2, 3, 4)):
   %2 : Float(2, 3, 4) = aten::mul(%0, %1)
   %3 : Float(2, 3, 4) = aten::mul(%2, %0)
@@ -90,11 +90,11 @@ graph(%0 : Float(2, 3, 4)
   %7 : int[] = aten::size(%3)
   %5 : Float(2, 3, 4) = aten::add(%3, %1, %4)
   return (%5, %2, %7)
-graph(%0 : Float(2, 3, 4)
-      %1 : Float(2, 3, 4)
-      %2 : Float(2, 3, 4)
-      %3 : Float(2, 3, 4)
-      %4 : Float(2, 3, 4)
+graph(%0 : Float(2, 3, 4),
+      %1 : Float(2, 3, 4),
+      %2 : Float(2, 3, 4),
+      %3 : Float(2, 3, 4),
+      %4 : Float(2, 3, 4),
       %5 : int[]):
   %7 : int = prim::Constant[value=1]()
   %6 : int[] = aten::size(%3)
@@ -128,7 +128,7 @@ graph(%0 : Float(2, 3, 4)
   return (%30, %31)
 
 testDifferentiateWithRequiresGrad
-graph(%0 : Float(*)
+graph(%0 : Float(*),
       %1 : Float(*)):
   %2 : Float(*) = aten::mul(%1, %1)
   %3 : int = prim::Constant[value=1]()
@@ -138,10 +138,10 @@ graph(%0 : Float(*)
   %11 : int[] = aten::size(%7)
   %9 : Float(*) = aten::add(%7, %1, %3)
   return (%4, %9, %6, %11)
-graph(%0 : Float(*)
-      %1 : Float(*)
-      %2 : Float(*)
-      %3 : Float(*)
+graph(%0 : Float(*),
+      %1 : Float(*),
+      %2 : Float(*),
+      %3 : Float(*),
       %4 : int[]):
   %6 : int = prim::Constant[value=1]()
   %5 : int[] = aten::size(%2)

--- a/test/expect/TestJit.test_cse.expect
+++ b/test/expect/TestJit.test_cse.expect
@@ -1,5 +1,5 @@
 graph(%0 : Double(2)
-      %1 : Double(2)) {
+      %1 : Double(2)):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(2) = aten::add(%0, %1, %2)
   %4 : Double(2) = aten::mul(%3, %3)
@@ -7,5 +7,4 @@ graph(%0 : Double(2)
   %6 : Double(2) = aten::tanh(%5)
   %7 : Double(2) = aten::add(%6, %6, %2)
   %8 : Double(2) = aten::add(%5, %7, %2)
-  return (%8);
-}
+  return (%8)

--- a/test/expect/TestJit.test_cse.expect
+++ b/test/expect/TestJit.test_cse.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(2)
+graph(%0 : Double(2),
       %1 : Double(2)):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(2) = aten::add(%0, %1, %2)

--- a/test/expect/TestJit.test_decompose_addmm.expect
+++ b/test/expect/TestJit.test_decompose_addmm.expect
@@ -1,7 +1,7 @@
-graph(%mat : Tensor
-      %mat1 : Tensor
-      %mat2 : Tensor
-      %alpha : Tensor
+graph(%mat : Tensor,
+      %mat1 : Tensor,
+      %mat2 : Tensor,
+      %alpha : Tensor,
       %beta : Tensor):
   %5 : int = prim::Constant[value=1]()
   %6 : float = prim::Constant[value=4.2]()

--- a/test/expect/TestJit.test_decompose_addmm.expect
+++ b/test/expect/TestJit.test_decompose_addmm.expect
@@ -2,7 +2,7 @@ graph(%mat : Tensor
       %mat1 : Tensor
       %mat2 : Tensor
       %alpha : Tensor
-      %beta : Tensor) {
+      %beta : Tensor):
   %5 : int = prim::Constant[value=1]()
   %6 : float = prim::Constant[value=4.2]()
   %7 : float = prim::Constant[value=2]()
@@ -19,5 +19,4 @@ graph(%mat : Tensor
   %18 : Tensor = aten::add(%10, %13, %5)
   %19 : Tensor = aten::add(%18, %c, %5)
   %20 : Tensor = aten::add(%19, %d, %5)
-  return (%20);
-}
+  return (%20)

--- a/test/expect/TestJit.test_dropout.expect
+++ b/test/expect/TestJit.test_dropout.expect
@@ -1,6 +1,5 @@
-graph(%input : Double(2, 2)) {
+graph(%input : Double(2, 2)):
   %1 : float = prim::Constant[value=0.6](), scope: Dropout
   %2 : bool = prim::Constant[value=1](), scope: Dropout
   %3 : Double(2, 2) = aten::dropout(%input, %1, %2), scope: Dropout
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestJit.test_inplace_copy.expect
+++ b/test/expect/TestJit.test_inplace_copy.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(4, 4)) {
+graph(%0 : Double(4, 4)):
   %1 : int = prim::Constant[value=0]()
   %2 : int = aten::size(%0, %1)
   %3 : Long() = prim::NumToTensor(%2)
@@ -13,5 +13,4 @@ graph(%0 : Double(4, 4)) {
   %12 : Device = prim::Constant[value="cpu"]()
   %13 : Double(4, 4) = aten::zeros(%9, %10, %11, %12)
   %14 : Double(4, 4) = aten::copy_(%13, %0)
-  return (%14);
-}
+  return (%14)

--- a/test/expect/TestJit.test_inplace_transplant.expect
+++ b/test/expect/TestJit.test_inplace_transplant.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(1)) {
+graph(%0 : Double(1)):
   %1 : Double(1) = aten::clone(%0)
   %2 : Long() = prim::Constant[value={2}]()
   %3 : int = prim::Constant[value=1]()
@@ -6,5 +6,4 @@ graph(%0 : Double(1)) {
   %5 : Long() = prim::Constant[value={3}]()
   %6 : int = prim::Constant[value=1]()
   %7 : Double(1) = aten::add_(%4, %5, %6)
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestJit.test_nested_inplace.expect
+++ b/test/expect/TestJit.test_nested_inplace.expect
@@ -1,6 +1,5 @@
-graph(%x : Double(2, 2)) {
+graph(%x : Double(2, 2)):
   %1 : int = prim::Constant[value=0]()
   %2 : int = prim::Constant[value=0]()
   %3 : Double(2, 2) = aten::threshold_(%x, %1, %2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestJit.test_peephole.expect
+++ b/test/expect/TestJit.test_peephole.expect
@@ -1,4 +1,3 @@
 graph(%x : Double(1)
-      %y : Double(1)) {
-  return (%x);
-}
+      %y : Double(1)):
+  return (%x)

--- a/test/expect/TestJit.test_peephole.expect
+++ b/test/expect/TestJit.test_peephole.expect
@@ -1,3 +1,3 @@
-graph(%x : Double(1)
+graph(%x : Double(1),
       %y : Double(1)):
   return (%x)

--- a/test/expect/TestJit.test_peephole_cuda-different_device.expect
+++ b/test/expect/TestJit.test_peephole_cuda-different_device.expect
@@ -1,5 +1,4 @@
 graph(%0 : Double(1)
-      %1 : Double(1)) {
+      %1 : Double(1)):
   %2 : Double(1) = aten::type_as(%0, %1)
-  return (%2);
-}
+  return (%2)

--- a/test/expect/TestJit.test_peephole_cuda-different_device.expect
+++ b/test/expect/TestJit.test_peephole_cuda-different_device.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(1)
+graph(%0 : Double(1),
       %1 : Double(1)):
   %2 : Double(1) = aten::type_as(%0, %1)
   return (%2)

--- a/test/expect/TestJit.test_peephole_cuda-same_device.expect
+++ b/test/expect/TestJit.test_peephole_cuda-same_device.expect
@@ -1,4 +1,3 @@
 graph(%x : Double(1)
-      %y : Double(1)) {
-  return (%x);
-}
+      %y : Double(1)):
+  return (%x)

--- a/test/expect/TestJit.test_peephole_cuda-same_device.expect
+++ b/test/expect/TestJit.test_peephole_cuda-same_device.expect
@@ -1,3 +1,3 @@
-graph(%x : Double(1)
+graph(%x : Double(1),
       %y : Double(1)):
   return (%x)

--- a/test/expect/TestJit.test_python_ir.expect
+++ b/test/expect/TestJit.test_python_ir.expect
@@ -1,10 +1,9 @@
 graph(%0 : Tensor
-      %1 : Tensor) {
+      %1 : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(1) = aten::add(%0, %1, %2)
   %4 : Double(1) = aten::mul(%0, %3)
   %5 : Double(1) = aten::tanh(%4)
   %6 : Double(1) = aten::sigmoid(%5)
   %7 : Tensor = prim::TensorTest[a= 1  1  1  1 [ Variable[CPUDoubleType]{2,2} ]]()
-  return (%6);
-}
+  return (%6)

--- a/test/expect/TestJit.test_python_ir.expect
+++ b/test/expect/TestJit.test_python_ir.expect
@@ -1,4 +1,4 @@
-graph(%0 : Tensor
+graph(%0 : Tensor,
       %1 : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(1) = aten::add(%0, %1, %2)

--- a/test/expect/TestJit.test_recursive_cse.expect
+++ b/test/expect/TestJit.test_recursive_cse.expect
@@ -1,15 +1,12 @@
 graph(%x : Tensor
-      %y : Tensor) {
+      %y : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%x, %y, %2)
   %4 : Tensor = aten::gt(%3, %x)
   %5 : bool = prim::Bool(%4)
   %z : Tensor = prim::If(%5)
-    block0() {
+    block0():
       -> (%3)
-    }
-    block1() {
+    block1():
       -> (%x)
-    }
-  return (%z);
-}
+  return (%z)

--- a/test/expect/TestJit.test_recursive_cse.expect
+++ b/test/expect/TestJit.test_recursive_cse.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor
+graph(%x : Tensor,
       %y : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%x, %y, %2)

--- a/test/expect/TestJit.test_repeated_input.expect
+++ b/test/expect/TestJit.test_repeated_input.expect
@@ -1,6 +1,5 @@
 graph(%a : Tensor
-      %b : Tensor) {
+      %b : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestJit.test_repeated_input.expect
+++ b/test/expect/TestJit.test_repeated_input.expect
@@ -1,4 +1,4 @@
-graph(%a : Tensor
+graph(%a : Tensor,
       %b : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)

--- a/test/expect/TestJit.test_repeated_output.expect
+++ b/test/expect/TestJit.test_repeated_output.expect
@@ -1,7 +1,6 @@
 graph(%a : Tensor
-      %b : Tensor) {
+      %b : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)
   %4 : (Tensor, Tensor) = prim::TupleConstruct(%3, %3)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestJit.test_repeated_output.expect
+++ b/test/expect/TestJit.test_repeated_output.expect
@@ -1,4 +1,4 @@
-graph(%a : Tensor
+graph(%a : Tensor,
       %b : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%a, %b, %2)

--- a/test/expect/TestJit.test_scopes_identity_node.expect
+++ b/test/expect/TestJit.test_scopes_identity_node.expect
@@ -1,8 +1,7 @@
 graph(%0 : Double(1, 3, 227, 227)
       %1 : Double(64, 3, 11, 11)
-      %2 : Double(64)) {
+      %2 : Double(64)):
   %3 : Double(1, 64, 56, 56) = onnx::Conv[dilations=[1, 1], group=1, kernel_shape=[11, 11], pads=[2, 2, 2, 2], strides=[4, 4]](%0, %1, %2), scope: Net/Sequential[features]/Conv2d[0]
   %4 : Double(1, 64, 56, 56) = onnx::Relu(%3), scope: Net/Sequential[features]/ReLU[1]
   %5 : Double(1, 64, 27, 27) = onnx::MaxPool[kernel_shape=[3, 3], pads=[0, 0, 0, 0], strides=[2, 2]](%4), scope: Net/Sequential[features]/MaxPool2d[2]
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestJit.test_scopes_identity_node.expect
+++ b/test/expect/TestJit.test_scopes_identity_node.expect
@@ -1,5 +1,5 @@
-graph(%0 : Double(1, 3, 227, 227)
-      %1 : Double(64, 3, 11, 11)
+graph(%0 : Double(1, 3, 227, 227),
+      %1 : Double(64, 3, 11, 11),
       %2 : Double(64)):
   %3 : Double(1, 64, 56, 56) = onnx::Conv[dilations=[1, 1], group=1, kernel_shape=[11, 11], pads=[2, 2, 2, 2], strides=[4, 4]](%0, %1, %2), scope: Net/Sequential[features]/Conv2d[0]
   %4 : Double(1, 64, 56, 56) = onnx::Relu(%3), scope: Net/Sequential[features]/ReLU[1]

--- a/test/expect/TestJit.test_scopes_intermediate_node.expect
+++ b/test/expect/TestJit.test_scopes_intermediate_node.expect
@@ -1,4 +1,3 @@
-graph(%x : Double(2)) {
+graph(%x : Double(2)):
   %1 : Double(2) = onnx::LogSoftmax[axis=0](%x), scope: Net
-  return (%1);
-}
+  return (%1)

--- a/test/expect/TestJit.test_shape_analysis_broadcast.expect
+++ b/test/expect/TestJit.test_shape_analysis_broadcast.expect
@@ -1,6 +1,5 @@
 graph(%a : Double(3, 1, 5)
-      %b : Double(4, 1, 8, 5)) {
+      %b : Double(4, 1, 8, 5)):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(4, 3, 8, 5) = aten::add(%a, %b, %2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestJit.test_shape_analysis_broadcast.expect
+++ b/test/expect/TestJit.test_shape_analysis_broadcast.expect
@@ -1,4 +1,4 @@
-graph(%a : Double(3, 1, 5)
+graph(%a : Double(3, 1, 5),
       %b : Double(4, 1, 8, 5)):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(4, 3, 8, 5) = aten::add(%a, %b, %2)

--- a/test/expect/TestJit.test_shared_param.expect
+++ b/test/expect/TestJit.test_shared_param.expect
@@ -1,7 +1,6 @@
 graph(%0 : Double(2, 2)
-      %1 : Double(2, 2)) {
+      %1 : Double(2, 2)):
   %2 : Double(2, 2) = aten::mul(%0, %1), scope: MyModule
   %3 : int = prim::Constant[value=1](), scope: MyModule
   %4 : Double(2, 2) = aten::add(%2, %1, %3), scope: MyModule
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestJit.test_shared_param.expect
+++ b/test/expect/TestJit.test_shared_param.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(2, 2)
+graph(%0 : Double(2, 2),
       %1 : Double(2, 2)):
   %2 : Double(2, 2) = aten::mul(%0, %1), scope: MyModule
   %3 : int = prim::Constant[value=1](), scope: MyModule

--- a/test/expect/TestJit.test_trace_detach.expect
+++ b/test/expect/TestJit.test_trace_detach.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(3, 4)
+graph(%x : Double(3, 4),
       %w : Double(4, 5)):
   %2 : Double(3, 5) = aten::matmul(%x, %w)
   %3 : Double(3, 5) = aten::detach(%2)

--- a/test/expect/TestJit.test_trace_detach.expect
+++ b/test/expect/TestJit.test_trace_detach.expect
@@ -1,6 +1,5 @@
 graph(%x : Double(3, 4)
-      %w : Double(4, 5)) {
+      %w : Double(4, 5)):
   %2 : Double(3, 5) = aten::matmul(%x, %w)
   %3 : Double(3, 5) = aten::detach(%2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestJit.test_trace_detach_inplace.expect
+++ b/test/expect/TestJit.test_trace_detach_inplace.expect
@@ -1,6 +1,5 @@
 graph(%x : Double(3, 4)
-      %w : Double(4, 5)) {
+      %w : Double(4, 5)):
   %y : Double(3, 5) = aten::matmul(%x, %w)
   %3 : Double(3, 5) = aten::detach(%y)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestJit.test_trace_detach_inplace.expect
+++ b/test/expect/TestJit.test_trace_detach_inplace.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(3, 4)
+graph(%x : Double(3, 4),
       %w : Double(4, 5)):
   %y : Double(3, 5) = aten::matmul(%x, %w)
   %3 : Double(3, 5) = aten::detach(%y)

--- a/test/expect/TestJit.test_trace_size.expect
+++ b/test/expect/TestJit.test_trace_size.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(5, 2, 4)) {
+graph(%0 : Double(5, 2, 4)):
   %1 : int = prim::Constant[value=1]()
   %2 : int = aten::size(%0, %1)
   %3 : Long() = prim::NumToTensor(%2)
@@ -12,5 +12,4 @@ graph(%0 : Double(5, 2, 4)) {
   %11 : int = prim::Constant[value=2]()
   %12 : int[] = prim::ListConstruct(%6, %10, %11)
   %13 : Double(4, 5, 2) = aten::view(%0, %12)
-  return (%13);
-}
+  return (%13)

--- a/test/expect/TestJit.test_trace_size_with_grad.expect
+++ b/test/expect/TestJit.test_trace_size_with_grad.expect
@@ -1,4 +1,4 @@
-graph(%0 : Double(5, 2, 4)) {
+graph(%0 : Double(5, 2, 4)):
   %1 : int = prim::Constant[value=1]()
   %2 : int = aten::size(%0, %1)
   %3 : Long() = prim::NumToTensor(%2)
@@ -12,5 +12,4 @@ graph(%0 : Double(5, 2, 4)) {
   %11 : int = prim::Constant[value=2]()
   %12 : int[] = prim::ListConstruct(%6, %10, %11)
   %13 : Double(4, 5, 2) = aten::view(%0, %12)
-  return (%13);
-}
+  return (%13)

--- a/test/expect/TestJit.test_trace_tuple.expect
+++ b/test/expect/TestJit.test_trace_tuple.expect
@@ -1,9 +1,8 @@
 graph(%x : Double(2, 2)
-      %1 : (Double(2, 2), Double(2, 2))) {
+      %1 : (Double(2, 2), Double(2, 2))):
   %2 : Double(2, 2), %3 : Double(2, 2) = prim::TupleUnpack(%1)
   %4 : Double(2, 2) = aten::mul(%x, %3)
   %5 : Double(2, 2) = aten::mul(%x, %2)
   %6 : (Double(2, 2), Double(2, 2)) = prim::TupleConstruct(%4, %5)
   %7 : (Double(2, 2), (Double(2, 2), Double(2, 2))) = prim::TupleConstruct(%x, %6)
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestJit.test_trace_tuple.expect
+++ b/test/expect/TestJit.test_trace_tuple.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(2, 2)
+graph(%x : Double(2, 2),
       %1 : (Double(2, 2), Double(2, 2))):
   %2 : Double(2, 2), %3 : Double(2, 2) = prim::TupleUnpack(%1)
   %4 : Double(2, 2) = aten::mul(%x, %3)

--- a/test/expect/TestJit.test_warnings.expect
+++ b/test/expect/TestJit.test_warnings.expect
@@ -1,15 +1,12 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : string = prim::Constant[value="x is less than 2"]()
   %2 : int = prim::Constant[value=2]()
   %3 : Tensor = aten::lt(%x, %2)
   %4 : bool = prim::Bool(%3)
    = prim::If(%4)
-    block0() {
+    block0():
        = aten::warn(%1, %2)
       -> ()
-    }
-    block1() {
+    block1():
       -> ()
-    }
-  return (%x);
-}
+  return (%x)

--- a/test/expect/TestScript.test_addmm_fusion-jit.expect
+++ b/test/expect/TestScript.test_addmm_fusion-jit.expect
@@ -1,5 +1,5 @@
-graph(%x : Double(*, *)
-      %y : Double(*, *)
+graph(%x : Double(*, *),
+      %y : Double(*, *),
       %c : Double(*, *)):
   %3 : int = prim::Constant[value=1](), scope: AddmmWrapper
   %4 : Double(*, *) = aten::mm(%x, %y), scope: AddmmWrapper

--- a/test/expect/TestScript.test_addmm_fusion-jit.expect
+++ b/test/expect/TestScript.test_addmm_fusion-jit.expect
@@ -1,8 +1,7 @@
 graph(%x : Double(*, *)
       %y : Double(*, *)
-      %c : Double(*, *)) {
+      %c : Double(*, *)):
   %3 : int = prim::Constant[value=1](), scope: AddmmWrapper
   %4 : Double(*, *) = aten::mm(%x, %y), scope: AddmmWrapper
   %5 : Double(*, *) = aten::add(%4, %c, %3), scope: AddmmWrapper
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestScript.test_augmented_assign.expect
+++ b/test/expect/TestScript.test_augmented_assign.expect
@@ -1,10 +1,9 @@
 graph(%a.1 : Tensor
-      %b : Tensor) {
+      %b : Tensor):
   %2 : int = prim::Constant[value=1]()
   %a.2 : Tensor = aten::add_(%a.1, %b, %2)
   %a.3 : Tensor = aten::sub_(%a.2, %b, %2)
   %a.4 : Tensor = aten::div_(%a.3, %b)
   %a : Tensor = aten::mul_(%a.4, %b)
   %7 : (Tensor, Tensor) = prim::TupleConstruct(%a, %b)
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestScript.test_augmented_assign.expect
+++ b/test/expect/TestScript.test_augmented_assign.expect
@@ -1,4 +1,4 @@
-graph(%a.1 : Tensor
+graph(%a.1 : Tensor,
       %b : Tensor):
   %2 : int = prim::Constant[value=1]()
   %a.2 : Tensor = aten::add_(%a.1, %b, %2)

--- a/test/expect/TestScript.test_call_python_fn_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_script_fn.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : Tensor = ^python_fn()(%x)
   %3 : Tensor = aten::add(%2, %1, %1)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_python_fn_from_script_module.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_script_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Tensor
-      %1 : Tensor) {
+      %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Tensor = ^python_fn()(%2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_python_fn_from_script_module.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_script_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor
+graph(%x : Tensor,
       %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Tensor = ^python_fn()(%2)

--- a/test/expect/TestScript.test_call_python_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_traced_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(3, 4)
+graph(%x : Double(3, 4),
       %1 : Double(4, 3)):
   %2 : Double(3, 4) = aten::neg(%x), scope: TracedModule
   %3 : Double(3, 3) = aten::mm(%2, %1), scope: TracedModule

--- a/test/expect/TestScript.test_call_python_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_traced_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Double(3, 4)
-      %1 : Double(4, 3)) {
+      %1 : Double(4, 3)):
   %2 : Double(3, 4) = aten::neg(%x), scope: TracedModule
   %3 : Double(3, 3) = aten::mm(%2, %1), scope: TracedModule
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_python_fn_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_python_fn_from_tracing_fn.expect
@@ -1,7 +1,6 @@
-graph(%x : Double(3, 4)) {
+graph(%x : Double(3, 4)):
   %1 : Double(3, 4) = aten::neg(%x)
   %2 : Long() = prim::Constant[value={1}]()
   %3 : int = prim::Constant[value=1]()
   %4 : Double(3, 4) = aten::add(%1, %2, %3)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_python_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_script_fn.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %2 : int = prim::Constant[value=1]()
   %1 : Tensor = ^<python_value>()(%x)
   %4 : Tensor = aten::add(%1, %2, %2)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_python_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_script_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor
+graph(%x : Tensor,
       %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Tensor = ^<python_value>()(%2)

--- a/test/expect/TestScript.test_call_python_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_script_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Tensor
-      %1 : Tensor) {
+      %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Tensor = ^<python_value>()(%2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_python_mod_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_traced_module.expect
@@ -1,10 +1,9 @@
 graph(%x.1 : Double(3, 4)
       %1 : Double(4, 5)
-      %2 : Double(5, 7)) {
+      %2 : Double(5, 7)):
   %x : Double(3, 5) = aten::mm(%x.1, %1), scope: TracedModule
   %4 : Double(3, 7) = aten::mm(%x, %2), scope: TracedModule/PythonModule[mod]
   %5 : Double() = prim::Constant[value={1}](), scope: TracedModule
   %6 : int = prim::Constant[value=1](), scope: TracedModule
   %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestScript.test_call_python_mod_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_traced_module.expect
@@ -1,5 +1,5 @@
-graph(%x.1 : Double(3, 4)
-      %1 : Double(4, 5)
+graph(%x.1 : Double(3, 4),
+      %1 : Double(4, 5),
       %2 : Double(5, 7)):
   %x : Double(3, 5) = aten::mm(%x.1, %1), scope: TracedModule
   %4 : Double(3, 7) = aten::mm(%x, %2), scope: TracedModule/PythonModule[mod]

--- a/test/expect/TestScript.test_call_python_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_python_mod_from_tracing_fn.expect
@@ -1,8 +1,7 @@
-graph(%x : Double(3, 4)) {
+graph(%x : Double(3, 4)):
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: PythonMod
   %2 : Double(3, 3) = aten::mm(%x, %1), scope: PythonMod
   %3 : Double() = prim::Constant[value={1}]()
   %4 : int = prim::Constant[value=1]()
   %5 : Double(3, 3) = aten::add(%2, %3, %4)
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestScript.test_call_script_fn_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_script_fn.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : Tensor = aten::neg(%x)
   %3 : Tensor = aten::add(%2, %1, %1)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_script_fn_from_script_module.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_script_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor
+graph(%x : Tensor,
       %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Tensor = aten::neg(%2)

--- a/test/expect/TestScript.test_call_script_fn_from_script_module.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_script_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Tensor
-      %1 : Tensor) {
+      %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Tensor = aten::neg(%2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_script_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_traced_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Double(3, 4)
-      %1 : Double(4, 5)) {
+      %1 : Double(4, 5)):
   %2 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %3 : Double(*, *) = aten::neg(%2), scope: TracedModule/ScriptModule
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_script_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_traced_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(3, 4)
+graph(%x : Double(3, 4),
       %1 : Double(4, 5)):
   %2 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %3 : Double(*, *) = aten::neg(%2), scope: TracedModule/ScriptModule

--- a/test/expect/TestScript.test_call_script_fn_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_script_fn_from_tracing_fn.expect
@@ -1,7 +1,6 @@
-graph(%0 : Double(3, 4)) {
+graph(%0 : Double(3, 4)):
   %1 : Double(*, *) = aten::neg(%0), scope: ScriptModule
   %2 : Long() = prim::Constant[value={1}]()
   %3 : int = prim::Constant[value=1]()
   %4 : Double(3, 4) = aten::add(%1, %2, %3)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_fn.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=3]()
   %2 : int = prim::Constant[value=4]()
   %3 : int = prim::Constant[value=6]()
@@ -9,5 +9,4 @@ graph(%x : Tensor) {
   %8 : Tensor = aten::zeros(%7, %3, %4, %5)
   %9 : Tensor = aten::mm(%x, %8)
   %10 : Tensor = aten::add(%9, %6, %6)
-  return (%10);
-}
+  return (%10)

--- a/test/expect/TestScript.test_call_script_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_module.expect
@@ -1,5 +1,5 @@
-graph(%x : Tensor
-      %1 : Tensor
+graph(%x : Tensor,
+      %1 : Tensor,
       %2 : Tensor):
   %3 : Tensor = aten::mm(%x, %1)
   %4 : Tensor = aten::mm(%3, %2)

--- a/test/expect/TestScript.test_call_script_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_script_module.expect
@@ -1,7 +1,6 @@
 graph(%x : Tensor
       %1 : Tensor
-      %2 : Tensor) {
+      %2 : Tensor):
   %3 : Tensor = aten::mm(%x, %1)
   %4 : Tensor = aten::mm(%3, %2)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_script_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_script_mod_from_tracing_fn.expect
@@ -1,8 +1,7 @@
-graph(%0 : Double(3, 4)) {
+graph(%0 : Double(3, 4)):
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: ScriptMod
   %2 : Double(*, *) = aten::mm(%0, %1), scope: ScriptMod
   %3 : Double() = prim::Constant[value={1}]()
   %4 : int = prim::Constant[value=1]()
   %5 : Double(3, 3) = aten::add(%2, %3, %4)
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestScript.test_call_script_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_script_module_from_traced_module.expect
@@ -1,5 +1,5 @@
-graph(%x : Double(3, 4)
-      %1 : Double(4, 5)
+graph(%x : Double(3, 4),
+      %1 : Double(4, 5),
       %2 : Double(5, 7)):
   %3 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %4 : Double(*, *) = aten::mm(%3, %2), scope: TracedModule/ScriptMod[mod]

--- a/test/expect/TestScript.test_call_script_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_script_module_from_traced_module.expect
@@ -1,10 +1,9 @@
 graph(%x : Double(3, 4)
       %1 : Double(4, 5)
-      %2 : Double(5, 7)) {
+      %2 : Double(5, 7)):
   %3 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %4 : Double(*, *) = aten::mm(%3, %2), scope: TracedModule/ScriptMod[mod]
   %5 : Double() = prim::Constant[value={1}](), scope: TracedModule
   %6 : int = prim::Constant[value=1](), scope: TracedModule
   %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestScript.test_call_traced_fn_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_script_fn.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %2 : int = prim::Constant[value=1]()
   %1 : Double(3, 4) = aten::neg(%x)
   %4 : Tensor = aten::add(%1, %2, %2)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_traced_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_traced_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(3, 4)
+graph(%x : Double(3, 4),
       %1 : Double(4, 5)):
   %2 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %3 : Double(*, *) = aten::neg(%2), scope: TracedModule/traced_fn

--- a/test/expect/TestScript.test_call_traced_fn_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_traced_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Double(3, 4)
-      %1 : Double(4, 5)) {
+      %1 : Double(4, 5)):
   %2 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %3 : Double(*, *) = aten::neg(%2), scope: TracedModule/traced_fn
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_traced_fn_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_traced_fn_from_tracing_fn.expect
@@ -1,7 +1,6 @@
-graph(%0 : Double(3, 4)) {
+graph(%0 : Double(3, 4)):
   %1 : Double(*, *) = aten::neg(%0), scope: traced_fn1
   %2 : Long() = prim::Constant[value={1}]()
   %3 : int = prim::Constant[value=1]()
   %4 : Double(3, 4) = aten::add(%1, %2, %3)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_script_fn.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %6 : Device = prim::Constant[value="cpu"](), scope: TracedModule
   %5 : int = prim::Constant[value=0](), scope: TracedModule
   %4 : int = prim::Constant[value=7](), scope: TracedModule
@@ -9,5 +9,4 @@ graph(%x : Tensor) {
   %7 : Double(4, 3) = aten::zeros(%3, %4, %5, %6), scope: TracedModule
   %8 : Double(3, 3) = aten::mm(%x, %7), scope: TracedModule
   %11 : Tensor = aten::add(%8, %9, %9)
-  return (%11);
-}
+  return (%11)

--- a/test/expect/TestScript.test_call_traced_mod_from_tracing_fn.expect
+++ b/test/expect/TestScript.test_call_traced_mod_from_tracing_fn.expect
@@ -1,8 +1,7 @@
-graph(%0 : Double(3, 4)) {
+graph(%0 : Double(3, 4)):
   %1 : Double(4, 3) = prim::Constant[value=<Tensor>](), scope: TracedModule[TracedModule]
   %2 : Double(*, *) = aten::mm(%0, %1), scope: TracedModule
   %3 : Double() = prim::Constant[value={1}]()
   %4 : int = prim::Constant[value=1]()
   %5 : Double(3, 3) = aten::add(%2, %3, %4)
-  return (%5);
-}
+  return (%5)

--- a/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
@@ -1,5 +1,5 @@
-graph(%x : Double(3, 4)
-      %1 : Double(4, 5)
+graph(%x : Double(3, 4),
+      %1 : Double(4, 5),
       %2 : Double(5, 7)):
   %3 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %4 : Double(*, *) = aten::mm(%3, %2), scope: TracedModule1

--- a/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
+++ b/test/expect/TestScript.test_call_traced_module_from_traced_module.expect
@@ -1,10 +1,9 @@
 graph(%x : Double(3, 4)
       %1 : Double(4, 5)
-      %2 : Double(5, 7)) {
+      %2 : Double(5, 7)):
   %3 : Double(3, 5) = aten::mm(%x, %1), scope: TracedModule
   %4 : Double(*, *) = aten::mm(%3, %2), scope: TracedModule1
   %5 : Double() = prim::Constant[value={1}](), scope: TracedModule
   %6 : int = prim::Constant[value=1](), scope: TracedModule
   %7 : Double(3, 7) = aten::add(%4, %5, %6), scope: TracedModule
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestScript.test_call_tracing_fn_from_script_module.expect
+++ b/test/expect/TestScript.test_call_tracing_fn_from_script_module.expect
@@ -1,6 +1,5 @@
 graph(%x : Tensor
-      %1 : Tensor) {
+      %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Double(3, 3) = aten::neg(%2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_call_tracing_fn_from_script_module.expect
+++ b/test/expect/TestScript.test_call_tracing_fn_from_script_module.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor
+graph(%x : Tensor,
       %1 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %3 : Double(3, 3) = aten::neg(%2)

--- a/test/expect/TestScript.test_call_tracing_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_tracing_mod_from_script_module.expect
@@ -1,7 +1,6 @@
 graph(%x : Tensor
       %1 : Tensor
-      %3 : Tensor) {
+      %3 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %4 : Double(3, 5) = aten::mm(%2, %3), scope: TracedMod
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_call_tracing_mod_from_script_module.expect
+++ b/test/expect/TestScript.test_call_tracing_mod_from_script_module.expect
@@ -1,5 +1,5 @@
-graph(%x : Tensor
-      %1 : Tensor
+graph(%x : Tensor,
+      %1 : Tensor,
       %3 : Tensor):
   %2 : Tensor = aten::mm(%x, %1)
   %4 : Double(3, 5) = aten::mm(%2, %3), scope: TracedMod

--- a/test/expect/TestScript.test_cat_lifts.expect
+++ b/test/expect/TestScript.test_cat_lifts.expect
@@ -1,18 +1,15 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : Tensor[] = prim::ListConstruct(%x, %x)
   %3 : Tensor = aten::cat(%2, %1)
-  return (%3);
-}
-graph(%x : Tensor) {
+  return (%3)
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : Tensor[] = prim::ListConstruct()
   %3 : Tensor = aten::cat(%2, %1)
-  return (%3);
-}
-graph(%x : Tensor) {
+  return (%3)
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : Tensor[] = prim::ListConstruct(%x)
   %3 : Tensor = aten::cat(%2, %1)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_constant_pooling.expect
+++ b/test/expect/TestScript.test_constant_pooling.expect
@@ -1,4 +1,4 @@
-graph(%cond : Tensor) {
+graph(%cond : Tensor):
   %1 : int[] = prim::Constant[value=[1]]()
   %2 : int[] = prim::Constant[value=[0]]()
   %3 : int = prim::Constant[value=3]()
@@ -12,23 +12,18 @@ graph(%cond : Tensor) {
   %11 : Device = prim::Constant[value="cpu"]()
   %12 : bool = prim::Bool(%cond)
   %c : int, %y : Tensor = prim::If(%12)
-    block0() {
+    block0():
       -> (%3, %4)
-    }
-    block1() {
+    block1():
       %y.2 : Tensor = aten::rand(%2, %10, %c.1, %11)
       %16 : bool = prim::Bool(%cond)
       %y.4 : Tensor = prim::If(%16)
-        block0() {
+        block0():
           %y.3 : Tensor = aten::rand(%1, %10, %c.1, %11)
           -> (%y.3)
-        }
-        block1() {
+        block1():
           -> (%y.2)
-        }
        = prim::Print(%d, %e, %d, %5, %y.4, %5)
       -> (%c.1, %y.4)
-    }
   %19 : (int, int, int, Tensor, Tensor) = prim::TupleConstruct(%a, %3, %c, %5, %y)
-  return (%19);
-}
+  return (%19)

--- a/test/expect/TestScript.test_erase_number_types.expect
+++ b/test/expect/TestScript.test_erase_number_types.expect
@@ -1,4 +1,4 @@
-graph(%a : Tensor) {
+graph(%a : Tensor):
   %1 : Long() = prim::Constant[value={7}]()
   %2 : Long() = prim::Constant[value={1}]()
   %3 : Long() = prim::Constant[value={3}]()
@@ -6,5 +6,4 @@ graph(%a : Tensor) {
   %b : Long() = aten::add(%4, %3)
   %c.1 : Tensor = aten::add(%a, %b, %2)
   %c : Tensor = aten::add(%c.1, %b, %2)
-  return (%c);
-}
+  return (%c)

--- a/test/expect/TestScript.test_if_for_in_range.expect
+++ b/test/expect/TestScript.test_if_for_in_range.expect
@@ -1,4 +1,4 @@
-graph(%a.1 : Dynamic
+graph(%a.1 : Dynamic,
       %b.1 : Dynamic):
   %d.1 : Long() = prim::Constant[value={3}]()
   %3 : Long() = prim::Constant[value={20}]()

--- a/test/expect/TestScript.test_if_for_in_range.expect
+++ b/test/expect/TestScript.test_if_for_in_range.expect
@@ -1,26 +1,22 @@
 graph(%a.1 : Dynamic
-      %b.1 : Dynamic) {
+      %b.1 : Dynamic):
   %d.1 : Long() = prim::Constant[value={3}]()
   %3 : Long() = prim::Constant[value={20}]()
   %4 : Byte() = prim::Constant[value={1}]()
   %a : Dynamic, %d : Long(), %b : Dynamic = prim::Loop(%3, %4, %a.1, %d.1, %b.1)
-    block0(%_ : Dynamic, %6 : Dynamic, %10 : Long(), %14 : Dynamic) {
+    block0(%_ : Dynamic, %6 : Dynamic, %10 : Long(), %14 : Dynamic):
       %7 : Long() = prim::Constant[value={10}]()
       %8 : Dynamic = aten::gt(%6, %7)
       %a.3 : Dynamic, %b.3 : Dynamic, %d.3 : Long() = prim::If(%8)
-        block0() {
+        block0():
           %9 : Long() = prim::Constant[value={3}]()
           %a.2 : Dynamic = aten::add[alpha={1}](%9, %10)
           -> (%a.2, %14, %10)
-        }
-        block1() {
+        block1():
           %12 : Long() = prim::Constant[value={3}]()
           %b.2 : Dynamic = aten::add[alpha={1}](%12, %10)
           %d.2 : Long() = prim::Constant[value={4}]()
           -> (%6, %b.2, %d.2)
-        }
       %20 : Byte() = prim::Constant[value={1}]()
       -> (%20, %a.3, %d.3, %b.3)
-    }
-  return (%d);
-}
+  return (%d)

--- a/test/expect/TestScript.test_if_is_none_dispatch.expect
+++ b/test/expect/TestScript.test_if_is_none_dispatch.expect
@@ -1,4 +1,4 @@
-graph(%input : Tensor
+graph(%input : Tensor,
       %opt.1 : Tensor?):
   %2 : None = prim::None()
   %3 : int = prim::Constant[value=1]()

--- a/test/expect/TestScript.test_if_is_none_dispatch.expect
+++ b/test/expect/TestScript.test_if_is_none_dispatch.expect
@@ -1,5 +1,5 @@
 graph(%input : Tensor
-      %opt.1 : Tensor?) {
+      %opt.1 : Tensor?):
   %2 : None = prim::None()
   %3 : int = prim::Constant[value=1]()
   %4 : int = prim::Constant[value=2]()
@@ -7,23 +7,18 @@ graph(%input : Tensor
   %x.1 : Tensor = aten::add(%input, %4, %3)
   %7 : bool = aten::__isnot__(%opt.1, %2)
   %opt.4 : Tensor?, %x.3 : Tensor = prim::If(%7)
-    block0() {
+    block0():
       %opt.2 : Tensor = prim::unchecked_unwrap_optional(%opt.1)
       %opt.3 : Tensor = aten::_unwrap_optional(%opt.2)
       %x.2 : Tensor = aten::add(%opt.3, %x.1, %3)
       -> (%opt.3, %x.2)
-    }
-    block1() {
+    block1():
       -> (%opt.1, %x.1)
-    }
   %13 : bool = aten::__is__(%opt.4, %2)
   %x : Tensor = prim::If(%13)
-    block0() {
+    block0():
       %x.4 : Tensor = aten::add(%x.3, %5, %3)
       -> (%x.4)
-    }
-    block1() {
+    block1():
       -> (%x.3)
-    }
-  return (%x);
-}
+  return (%x)

--- a/test/expect/TestScript.test_if_list.expect
+++ b/test/expect/TestScript.test_if_list.expect
@@ -1,15 +1,12 @@
-graph(%x : Double(*, *)) {
+graph(%x : Double(*, *)):
   %1 : int = prim::Constant[value=0]()
   %2 : bool = prim::Constant[value=1]()
   %c : Tensor[] = prim::If(%2)
-    block0() {
+    block0():
       %c.1 : Tensor[] = prim::ListConstruct(%x, %x)
       -> (%c.1)
-    }
-    block1() {
+    block1():
       %c.2 : Tensor[] = prim::ListConstruct(%x, %x, %x)
       -> (%c.2)
-    }
   %6 : Tensor = aten::cat(%c, %1)
-  return (%6);
-}
+  return (%6)

--- a/test/expect/TestScript.test_if_supertype.expect
+++ b/test/expect/TestScript.test_if_supertype.expect
@@ -1,14 +1,11 @@
 graph(%x.1 : Float(*, *)
       %y.1 : Long(*, *)
-      %z.1 : Float(*, *)) {
+      %z.1 : Float(*, *)):
   %3 : bool = prim::Constant[value=1]()
   %x : Float(*, *), %y : Tensor, %z : Tensor = prim::If(%3)
-    block0() {
+    block0():
       -> (%x.1, %y.1, %z.1)
-    }
-    block1() {
+    block1():
       -> (%x.1, %x.1, %y.1)
-    }
   %7 : (Float(*, *), Tensor, Tensor) = prim::TupleConstruct(%x, %y, %z)
-  return (%7);
-}
+  return (%7)

--- a/test/expect/TestScript.test_if_supertype.expect
+++ b/test/expect/TestScript.test_if_supertype.expect
@@ -1,5 +1,5 @@
-graph(%x.1 : Float(*, *)
-      %y.1 : Long(*, *)
+graph(%x.1 : Float(*, *),
+      %y.1 : Long(*, *),
       %z.1 : Float(*, *)):
   %3 : bool = prim::Constant[value=1]()
   %x : Float(*, *), %y : Tensor, %z : Tensor = prim::If(%3)

--- a/test/expect/TestScript.test_index_put_trace_with_view.expect
+++ b/test/expect/TestScript.test_index_put_trace_with_view.expect
@@ -1,6 +1,6 @@
 graph(%target : Double(100)
       %indices.1 : Long(4)
-      %rhs : Double(1, 1, 1, 4)) {
+      %rhs : Double(1, 1, 1, 4)):
   %3 : int = prim::Constant[value=4]()
   %4 : int[] = prim::ListConstruct(%3)
   %5 : Double(4) = aten::view(%rhs, %4)
@@ -13,5 +13,4 @@ graph(%target : Double(100)
   %12 : Tensor?[] = prim::ListConstruct(%indices)
   %13 : bool = prim::Constant[value=0]()
   %14 : Double(100) = aten::index_put_(%target, %12, %5, %13)
-  return (%14);
-}
+  return (%14)

--- a/test/expect/TestScript.test_index_put_trace_with_view.expect
+++ b/test/expect/TestScript.test_index_put_trace_with_view.expect
@@ -1,5 +1,5 @@
-graph(%target : Double(100)
-      %indices.1 : Long(4)
+graph(%target : Double(100),
+      %indices.1 : Long(4),
       %rhs : Double(1, 1, 1, 4)):
   %3 : int = prim::Constant[value=4]()
   %4 : int[] = prim::ListConstruct(%3)

--- a/test/expect/TestScript.test_index_put_trace_without_view.expect
+++ b/test/expect/TestScript.test_index_put_trace_without_view.expect
@@ -1,5 +1,5 @@
-graph(%target : Double(100)
-      %indices.1 : Long(4)
+graph(%target : Double(100),
+      %indices.1 : Long(4),
       %rhs : Double(4)):
   %3 : int = prim::Constant[value=4]()
   %4 : int = prim::Constant[value=0]()

--- a/test/expect/TestScript.test_index_put_trace_without_view.expect
+++ b/test/expect/TestScript.test_index_put_trace_without_view.expect
@@ -1,6 +1,6 @@
 graph(%target : Double(100)
       %indices.1 : Long(4)
-      %rhs : Double(4)) {
+      %rhs : Double(4)):
   %3 : int = prim::Constant[value=4]()
   %4 : int = prim::Constant[value=0]()
   %5 : Device = prim::Constant[value="cpu"]()
@@ -10,5 +10,4 @@ graph(%target : Double(100)
   %9 : Tensor?[] = prim::ListConstruct(%indices)
   %10 : bool = prim::Constant[value=0]()
   %11 : Double(100) = aten::index_put_(%target, %9, %rhs, %10)
-  return (%11);
-}
+  return (%11)

--- a/test/expect/TestScript.test_index_select_shape_prop.expect
+++ b/test/expect/TestScript.test_index_select_shape_prop.expect
@@ -1,6 +1,5 @@
 graph(%x : Double(2, 2)
-      %y : Long(4)) {
+      %y : Long(4)):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(2, 4) = aten::index_select(%x, %2, %y)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_index_select_shape_prop.expect
+++ b/test/expect/TestScript.test_index_select_shape_prop.expect
@@ -1,4 +1,4 @@
-graph(%x : Double(2, 2)
+graph(%x : Double(2, 2),
       %y : Long(4)):
   %2 : int = prim::Constant[value=1]()
   %3 : Double(2, 4) = aten::index_select(%x, %2, %y)

--- a/test/expect/TestScript.test_logical_short_circuit.expect
+++ b/test/expect/TestScript.test_logical_short_circuit.expect
@@ -1,39 +1,30 @@
-graph(%t : Tensor) {
+graph(%t : Tensor):
   %1 : bool = prim::Constant[value=1]()
   %2 : bool = prim::Constant[value=0]()
   %c1.1 : int = prim::Constant[value=1]()
   %4 : int = prim::Constant[value=0]()
   %5 : bool = prim::If(%2)
-    block0() {
+    block0():
       %6 : Tensor = aten::select(%t, %4, %c1.1)
       %7 : bool = prim::Bool(%6)
       -> (%7)
-    }
-    block1() {
+    block1():
       -> (%2)
-    }
   %8 : bool = prim::If(%5)
-    block0() {
+    block0():
       -> (%5)
-    }
-    block1() {
+    block1():
       %9 : bool = prim::If(%1)
-        block0() {
+        block0():
           -> (%1)
-        }
-        block1() {
+        block1():
           %10 : Tensor = aten::select(%t, %4, %c1.1)
           %11 : bool = prim::Bool(%10)
           -> (%11)
-        }
       -> (%9)
-    }
   %c1 : int = prim::If(%8)
-    block0() {
+    block0():
       -> (%4)
-    }
-    block1() {
+    block1():
       -> (%c1.1)
-    }
-  return (%c1);
-}
+  return (%c1)

--- a/test/expect/TestScript.test_loop_unroll_unused_counter.expect
+++ b/test/expect/TestScript.test_loop_unroll_unused_counter.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : bool = prim::Constant[value=1]()
   %y.1 : int = prim::Constant[value=0]()
   %3 : int = prim::Constant[value=1]()
@@ -9,7 +9,7 @@ graph(%x : Tensor) {
   %8 : int = aten::mul(%6, %7)
   %9 : int = aten::sub(%4, %8)
   %y.3 : int = prim::Loop(%6, %1, %y.1)
-    block0(%11 : int, %12 : int) {
+    block0(%11 : int, %12 : int):
       %y.12 : int = aten::add(%12, %3)
       %y.5 : int = aten::add(%y.12, %3)
       %y.6 : int = aten::add(%y.5, %3)
@@ -19,11 +19,8 @@ graph(%x : Tensor) {
       %y.10 : int = aten::add(%y.9, %3)
       %y.11 : int = aten::add(%y.10, %3)
       -> (%1, %y.11)
-    }
   %y : int = prim::Loop(%9, %1, %y.3)
-    block0(%22 : int, %23 : int) {
+    block0(%22 : int, %23 : int):
       %y.4 : int = aten::add(%23, %3)
       -> (%1, %y.4)
-    }
-  return (%y);
-}
+  return (%y)

--- a/test/expect/TestScript.test_loop_unrolling.expect
+++ b/test/expect/TestScript.test_loop_unrolling.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : bool = prim::Constant[value=1]()
   %y.1 : int = prim::Constant[value=0]()
   %3 : int = prim::Int(%x)
@@ -9,7 +9,7 @@ graph(%x : Tensor) {
   %8 : int = aten::mul(%6, %7)
   %9 : int = aten::sub(%3, %8)
   %10 : int, %y.3 : int = prim::Loop(%6, %1, %4, %y.1)
-    block0(%i.1 : int, %13 : int, %14 : int) {
+    block0(%i.1 : int, %13 : int, %14 : int):
       %y.12 : int = aten::add(%14, %13)
       %16 : int = prim::Constant[value=1]()
       %17 : int = aten::add(%13, %16)
@@ -35,13 +35,10 @@ graph(%x : Tensor) {
       %37 : int = prim::Constant[value=1]()
       %38 : int = aten::add(%35, %37)
       -> (%1, %38, %y.11)
-    }
   %39 : int, %y : int = prim::Loop(%9, %1, %10, %y.3)
-    block0(%i : int, %42 : int, %43 : int) {
+    block0(%i : int, %42 : int, %43 : int):
       %y.4 : int = aten::add(%43, %42)
       %45 : int = prim::Constant[value=1]()
       %46 : int = aten::add(%42, %45)
       -> (%1, %46, %y.4)
-    }
-  return (%y);
-}
+  return (%y)

--- a/test/expect/TestScript.test_loop_unrolling_const-add_const.expect
+++ b/test/expect/TestScript.test_loop_unrolling_const-add_const.expect
@@ -1,4 +1,4 @@
-graph() {
+graph():
   %y.1 : int = prim::Constant[value=0]()
   %1 : int = prim::Constant[value=1]()
   %y.11 : int = aten::add(%y.1, %1)
@@ -11,5 +11,4 @@ graph() {
   %y.8 : int = aten::add(%y.7, %1)
   %y.9 : int = aten::add(%y.8, %1)
   %y.10 : int = aten::add(%y.9, %1)
-  return (%y.10);
-}
+  return (%y.10)

--- a/test/expect/TestScript.test_loop_unrolling_const-add_iter.expect
+++ b/test/expect/TestScript.test_loop_unrolling_const-add_iter.expect
@@ -1,4 +1,4 @@
-graph() {
+graph():
   %y.1 : int = prim::Constant[value=0]()
   %1 : int = prim::Constant[value=0]()
   %y.11 : int = aten::add(%y.1, %1)
@@ -29,5 +29,4 @@ graph() {
   %27 : int = prim::Constant[value=1]()
   %28 : int = aten::add(%25, %27)
   %y.10 : int = aten::add(%y.9, %28)
-  return (%y.10);
-}
+  return (%y.10)

--- a/test/expect/TestScript.test_loop_unrolling_nested.expect
+++ b/test/expect/TestScript.test_loop_unrolling_nested.expect
@@ -1,9 +1,9 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : bool = prim::Constant[value=1]()
   %y.1 : int = prim::Constant[value=0]()
   %3 : int = prim::Constant[value=10]()
   %y : int = prim::Loop(%3, %1, %y.1)
-    block0(%5 : int, %6 : int) {
+    block0(%5 : int, %6 : int):
       %7 : int = prim::Int(%x)
       %8 : int = prim::Constant[value=0]()
       %9 : int = prim::Constant[value=8]()
@@ -12,7 +12,7 @@ graph(%x : Tensor) {
       %12 : int = aten::mul(%10, %11)
       %13 : int = aten::sub(%7, %12)
       %14 : int, %y.4 : int = prim::Loop(%10, %1, %8, %6)
-        block0(%j.1 : int, %17 : int, %18 : int) {
+        block0(%j.1 : int, %17 : int, %18 : int):
           %y.13 : int = aten::add(%18, %17)
           %20 : int = prim::Constant[value=1]()
           %21 : int = aten::add(%17, %20)
@@ -38,15 +38,11 @@ graph(%x : Tensor) {
           %41 : int = prim::Constant[value=1]()
           %42 : int = aten::add(%39, %41)
           -> (%1, %42, %y.12)
-        }
       %43 : int, %y.3 : int = prim::Loop(%13, %1, %14, %y.4)
-        block0(%j : int, %46 : int, %47 : int) {
+        block0(%j : int, %46 : int, %47 : int):
           %y.5 : int = aten::add(%47, %46)
           %49 : int = prim::Constant[value=1]()
           %50 : int = aten::add(%46, %49)
           -> (%1, %50, %y.5)
-        }
       -> (%1, %y.3)
-    }
-  return (%y);
-}
+  return (%y)

--- a/test/expect/TestScript.test_math_numbers-float.expect
+++ b/test/expect/TestScript.test_math_numbers-float.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : float = prim::Constant[value=1.1]()
   %2 : float = prim::Constant[value=3.1]()
   %3 : float = aten::add(%1, %2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_math_numbers-int.expect
+++ b/test/expect/TestScript.test_math_numbers-int.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=7]()
   %2 : int = prim::Constant[value=8]()
   %3 : int = aten::add(%1, %2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_math_schema.expect
+++ b/test/expect/TestScript.test_math_schema.expect
@@ -1,6 +1,5 @@
 graph(%x : Tensor
-      %y : Tensor) {
+      %y : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%x, %y, %2)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_math_schema.expect
+++ b/test/expect/TestScript.test_math_schema.expect
@@ -1,4 +1,4 @@
-graph(%x : Tensor
+graph(%x : Tensor,
       %y : Tensor):
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%x, %y, %2)

--- a/test/expect/TestScript.test_math_tensor_number.expect
+++ b/test/expect/TestScript.test_math_tensor_number.expect
@@ -1,6 +1,5 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : int = prim::Constant[value=7]()
   %3 : Tensor = aten::add(%x, %2, %1)
-  return (%3);
-}
+  return (%3)

--- a/test/expect/TestScript.test_mutable_dce.expect
+++ b/test/expect/TestScript.test_mutable_dce.expect
@@ -1,4 +1,4 @@
-graph() {
+graph():
   %0 : int = prim::Constant[value=1]()
   %1 : Device = prim::Constant[value="cpu"]()
   %2 : int = prim::Constant[value=0]()
@@ -10,5 +10,4 @@ graph() {
   %8 : int[] = prim::ListConstruct(%4, %5)
   %9 : Tensor = aten::rand(%8, %3, %2, %1)
   %a : Tensor = aten::add_(%a.1, %9, %0)
-  return (%a);
-}
+  return (%a)

--- a/test/expect/TestScript.test_mutable_dce_block.expect
+++ b/test/expect/TestScript.test_mutable_dce_block.expect
@@ -1,4 +1,4 @@
-graph() {
+graph():
   %0 : int = prim::Constant[value=1]()
   %1 : Device = prim::Constant[value="cpu"]()
   %2 : int = prim::Constant[value=0]()
@@ -17,14 +17,11 @@ graph() {
   %15 : Tensor = aten::gt(%a.2, %14)
   %16 : bool = prim::Bool(%15)
   %b : Tensor = prim::If(%16)
-    block0() {
+    block0():
       %18 : int[] = prim::ListConstruct(%4, %5)
       %19 : Tensor = aten::rand(%18, %3, %2, %1)
       %b.2 : Tensor = aten::add_(%b.1, %19, %0)
       -> (%b.2)
-    }
-    block1() {
+    block1():
       -> (%b.1)
-    }
-  return (%b);
-}
+  return (%b)

--- a/test/expect/TestScript.test_mutable_dce_graph_input.expect
+++ b/test/expect/TestScript.test_mutable_dce_graph_input.expect
@@ -1,4 +1,4 @@
-graph(%a.1 : Tensor) {
+graph(%a.1 : Tensor):
   %1 : None = prim::None()
   %2 : int = prim::Constant[value=1]()
   %3 : Device = prim::Constant[value="cpu"]()
@@ -9,5 +9,4 @@ graph(%a.1 : Tensor) {
   %8 : int[] = prim::ListConstruct(%6, %7)
   %9 : Tensor = aten::rand(%8, %5, %4, %3)
   %a : Tensor = aten::add_(%a.1, %9, %2)
-  return (%1);
-}
+  return (%1)

--- a/test/expect/TestScript.test_mutable_dce_list.expect
+++ b/test/expect/TestScript.test_mutable_dce_list.expect
@@ -1,4 +1,4 @@
-graph(%a : Tensor) {
+graph(%a : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : Device = prim::Constant[value="cpu"]()
   %3 : int = prim::Constant[value=6]()
@@ -13,5 +13,4 @@ graph(%a : Tensor) {
   %12 : int[] = prim::ListConstruct(%5, %6)
   %13 : Tensor = aten::rand(%12, %3, %4, %2)
   %c : Tensor = aten::add_(%c.1, %13, %1)
-  return (%b);
-}
+  return (%b)

--- a/test/expect/TestScript.test_mutable_dce_loop.expect
+++ b/test/expect/TestScript.test_mutable_dce_loop.expect
@@ -1,4 +1,4 @@
-graph(%a : Tensor) {
+graph(%a : Tensor):
   %1 : Device = prim::Constant[value="cpu"]()
   %2 : int = prim::Constant[value=6]()
   %i.1 : int = prim::Constant[value=0]()
@@ -12,7 +12,7 @@ graph(%a : Tensor) {
   %b : Tensor = aten::rand(%10, %2, %i.1, %1)
   %12 : bool = aten::lt(%i.1, %7)
   %i : int = prim::Loop(%6, %12, %i.1)
-    block0(%14 : int, %15 : int) {
+    block0(%14 : int, %15 : int):
       %c.1 : Tensor = aten::select(%l, %i.1)
       %17 : int[] = prim::ListConstruct(%4, %5)
       %18 : Tensor = aten::rand(%17, %2, %i.1, %1)
@@ -20,6 +20,4 @@ graph(%a : Tensor) {
       %i.2 : int = aten::add(%15, %7)
       %21 : bool = aten::lt(%i.2, %7)
       -> (%21, %i.2)
-    }
-  return (%b);
-}
+  return (%b)

--- a/test/expect/TestScript.test_string_cu.expect
+++ b/test/expect/TestScript.test_string_cu.expect
@@ -1,7 +1,6 @@
-graph(%a : Tensor) {
+graph(%a : Tensor):
   %3 : string = prim::Constant[value="aa"]()
   %1 : string = prim::Constant[value="a\n\tb\n"]()
   %2 : int = prim::Constant[value=2]()
    = prim::Print(%a, %1, %2, %3)
-  return (%a);
-}
+  return (%a)

--- a/test/expect/TestScript.test_sum-1.expect
+++ b/test/expect/TestScript.test_sum-1.expect
@@ -1,7 +1,6 @@
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : bool = prim::Constant[value=0]()
   %2 : int = prim::Constant[value=4]()
   %3 : int[] = prim::ListConstruct(%2)
   %4 : Tensor = aten::sum(%x, %3, %1)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_sum-2.expect
+++ b/test/expect/TestScript.test_sum-2.expect
@@ -1,7 +1,6 @@
-graph(%x : Double(*, *, *, *, *)) {
+graph(%x : Double(*, *, *, *, *)):
   %1 : bool = prim::Constant[value=0]()
   %2 : int = prim::Constant[value=4]()
   %3 : int[] = prim::ListConstruct(%2)
   %4 : Tensor = aten::sum(%x, %3, %1)
-  return (%4);
-}
+  return (%4)

--- a/test/expect/TestScript.test_trace_contiguous_short_circuit.expect
+++ b/test/expect/TestScript.test_trace_contiguous_short_circuit.expect
@@ -1,4 +1,3 @@
-graph(%x : Double(2, 3, 4)) {
+graph(%x : Double(2, 3, 4)):
   %1 : Double(2, 3, 4) = aten::contiguous(%x)
-  return (%1);
-}
+  return (%1)

--- a/test/expect/TestScript.test_tuple_indexing.expect
+++ b/test/expect/TestScript.test_tuple_indexing.expect
@@ -1,19 +1,16 @@
-graph(%a : Tensor) {
+graph(%a : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : int = prim::Constant[value=2]()
   %3 : int = prim::Constant[value=0]()
   %4 : bool = prim::Bool(%a)
   %b : (int, int) = prim::If(%4)
-    block0() {
+    block0():
       %b.1 : (int, int) = prim::TupleConstruct(%1, %2)
       -> (%b.1)
-    }
-    block1() {
+    block1():
       %b.2 : (int, int) = prim::TupleConstruct(%3, %2)
       -> (%b.2)
-    }
   %8 : int = prim::TupleIndex[index=0](%b)
   %9 : int = prim::TupleIndex[index=1](%b)
   %10 : (int, int) = prim::TupleConstruct(%8, %9)
-  return (%10);
-}
+  return (%10)

--- a/test/expect/TestScript.test_tuple_slicing.expect
+++ b/test/expect/TestScript.test_tuple_slicing.expect
@@ -1,19 +1,16 @@
-graph(%a : Tensor) {
+graph(%a : Tensor):
   %1 : int = prim::Constant[value=1]()
   %2 : int = prim::Constant[value=2]()
   %3 : int = prim::Constant[value=3]()
   %4 : int = prim::Constant[value=4]()
   %5 : bool = prim::Bool(%a)
   %b : (int, int, int, int) = prim::If(%5)
-    block0() {
+    block0():
       %b.1 : (int, int, int, int) = prim::TupleConstruct(%1, %2, %3, %4)
       -> (%b.1)
-    }
-    block1() {
+    block1():
       %b.2 : (int, int, int, int) = prim::TupleConstruct(%4, %3, %2, %1)
       -> (%b.2)
-    }
   %c : (int, int, int, int) = prim::TupleSlice[beg=0, end=4](%b)
   %e : (int, int) = prim::TupleSlice[beg=1, end=3](%c)
-  return (%e);
-}
+  return (%e)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11820,10 +11820,9 @@ class TestCustomOperators(JitTestCase):
         input = torch.ones(5, 5)
         trace = torch.jit.trace(torch.ops.aten.relu, [input])
         self.assertExpectedInline(canonical(trace.graph), '''\
-graph(%0 : Double(5, 5)) {
+graph(%0 : Double(5, 5)):
   %1 : Double(5, 5) = aten::relu(%0)
-  return (%1);
-}
+  return (%1)
 ''')
 
     def test_script_graph_contains_custom_op(self):
@@ -11831,10 +11830,9 @@ graph(%0 : Double(5, 5)) {
         def func(x):
             return torch.ops.aten.relu(x)
         self.assertExpectedInline(canonical(func.graph), '''\
-graph(%x : Tensor) {
+graph(%x : Tensor):
   %1 : Tensor = aten::relu(%x)
-  return (%1);
-}
+  return (%1)
 ''')
 
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -78,23 +78,18 @@ std::ostream& operator<<(std::ostream& out, const at::ArrayRef<Value*>& nodes) {
 
 struct const_value_list_with_types {
   const ArrayRef<const Value*> values;
-  bool use_newlines;
+  std::string delim;
   const_value_list_with_types(
       ArrayRef<const Value*> values,
-      bool use_newlines = false)
-      : values(values), use_newlines(use_newlines) {}
+      const std::string& delim = ", ")
+      : values(values), delim(delim) {}
 };
 
 std::ostream& operator<<(std::ostream& out, const_value_list_with_types l) {
   size_t i = 0;
   for (auto n : l.values) {
     if (i++ > 0) {
-      if (l.use_newlines) {
-        // TODO: Indent here is hard-coded for "graph(": un-hard-code it
-        out << "\n      ";
-      } else {
-        out << ", ";
-      }
+      out << l.delim;
     }
     printValueRef(out, n);
     out << " : ";
@@ -253,7 +248,7 @@ std::ostream& Node::print(
   for (size_t i = 0; i < blocks().size(); ++i) {
     auto b = blocks()[i];
     indent(out, level + 1) << "block" << i << "("
-                           << const_value_list_with_types(b->inputs(), false)
+                           << const_value_list_with_types(b->inputs())
                            << "):\n";
     for (auto nested : b->nodes()) {
       nested->print(out, level + 2, groups);
@@ -268,7 +263,8 @@ std::ostream& operator<<(std::ostream& out, const Node& n) {
 }
 
 std::ostream& operator<<(std::ostream& out, const Graph& g) {
-  out << "graph(" << const_value_list_with_types(g.inputs(), true) << "):\n";
+  out << "graph(" << const_value_list_with_types(g.inputs(), ",\n      ")
+      << "):\n";
   std::vector<const Node*> groups;
   for (auto n : g.nodes()) {
     n->print(out, 1, &groups);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -254,12 +254,11 @@ std::ostream& Node::print(
     auto b = blocks()[i];
     indent(out, level + 1) << "block" << i << "("
                            << const_value_list_with_types(b->inputs(), false)
-                           << ") {\n";
+                           << "):\n";
     for (auto nested : b->nodes()) {
       nested->print(out, level + 2, groups);
     }
     indent(out, level + 2) << "-> (" << b->outputs() << ")\n";
-    indent(out, level + 1) << "}\n";
   }
   return out;
 }
@@ -269,12 +268,12 @@ std::ostream& operator<<(std::ostream& out, const Node& n) {
 }
 
 std::ostream& operator<<(std::ostream& out, const Graph& g) {
-  out << "graph(" << const_value_list_with_types(g.inputs(), true) << ") {\n";
+  out << "graph(" << const_value_list_with_types(g.inputs(), true) << "):\n";
   std::vector<const Node*> groups;
   for (auto n : g.nodes()) {
     n->print(out, 1, &groups);
   }
-  out << "  return (" << g.outputs() << ");\n}\n";
+  out << "  return (" << g.outputs() << ")\n";
   size_t i = 0;
   for (auto fg : groups) {
     out << "with " << fg->kind().toQualString() << "_" << i++ << " = "
@@ -1195,7 +1194,9 @@ Node* Graph::createFusionGroup() {
   return n;
 }
 
-Node* Graph::createTuple(at::ArrayRef<Value*> values, c10::OptNameList field_names) {
+Node* Graph::createTuple(
+    at::ArrayRef<Value*> values,
+    c10::OptNameList field_names) {
   auto types = fmap(values, [](Value* v) { return v->type(); });
   auto tt = TupleType::create(std::move(types), std::move(field_names));
   auto n = create(prim::TupleConstruct, values);
@@ -1263,7 +1264,7 @@ Node* Graph::createDict(
     AT_ASSERT(keys[i]->type()->isSubtypeOf(key_type));
     AT_ASSERT(values[i]->type()->isSubtypeOf(value_type));
 
-    n->addInput(keys[i]) ;
+    n->addInput(keys[i]);
     n->addInput(values[i]);
   }
   n->output()->setType(DictType::create(key_type, value_type));


### PR DESCRIPTION
This removes curly braces from the outputs (we have indentation to indicate scopes), also adds ':' after graph and blocks declaration and removes ';' from the return line. ".expect" tests are updated to keep up with it.