### PR TITLE
Refactor C2 pybind global workspace into a library

### DIFF
--- a/caffe2/core/global_workspace.cc
+++ b/caffe2/core/global_workspace.cc
@@ -1,0 +1,67 @@
+#include "caffe2/core/global_workspace.h"
+
+namespace caffe2 {
+
+GlobalWorkspaceUtil::GlobalWorkspaceUtil(const std::string& default_name) {
+  switchWorkspace(default_name, true);
+}
+
+GlobalWorkspaceUtil& GlobalWorkspaceUtil::get() {
+  static GlobalWorkspaceUtil gwu("default");
+  return gwu;
+}
+
+void GlobalWorkspaceUtil::switchWorkspace(
+    const std::string& name,
+    bool create_if_missing) {
+  if (gWorkspaces_.count(name)) {
+    gCurrentWorkspaceName_ = name;
+    gWorkspace_ = gWorkspaces_[name].get();
+    return;
+  }
+
+  CAFFE_ENFORCE(create_if_missing);
+  std::unique_ptr<Workspace> new_workspace(new Workspace());
+  gWorkspace_ = new_workspace.get();
+  gWorkspaces_.insert(std::make_pair(name, std::move(new_workspace)));
+  gCurrentWorkspaceName_ = name;
+}
+
+const std::string& GlobalWorkspaceUtil::currentWorkspaceName() const {
+  return gCurrentWorkspaceName_;
+}
+
+Workspace* GlobalWorkspaceUtil::getWorkspaceByName(
+    const std::string& name) const {
+  auto ws = gWorkspaces_.find(name);
+  CAFFE_ENFORCE(ws != gWorkspaces_.end());
+  CAFFE_ENFORCE(ws->second.get());
+  return ws->second.get();
+}
+
+Workspace* GlobalWorkspaceUtil::currentWorkspace() const {
+  return gWorkspace_;
+}
+
+void GlobalWorkspaceUtil::clear() {
+  gWorkspaces_.clear();
+}
+
+void GlobalWorkspaceUtil::resetCurrentWorkspace(std::unique_ptr<Workspace> ws) {
+  gWorkspace_ = ws.get();
+  gWorkspaces_[gCurrentWorkspaceName_] = std::move(ws);
+}
+
+std::vector<std::string> GlobalWorkspaceUtil::workspaces() {
+  std::vector<std::string> names;
+  for (const auto& kv : gWorkspaces_) {
+    names.push_back(kv.first);
+  }
+  return names;
+}
+
+void GlobalWorkspaceUtil::setCurrentWorkspace(Workspace* ws) {
+  gWorkspace_ = ws;
+}
+
+} // namespace caffe2

--- a/caffe2/core/global_workspace.h
+++ b/caffe2/core/global_workspace.h
@@ -1,0 +1,38 @@
+#ifndef CAFFE2_CORE_GOBAL_WORKSPACE_H_
+#define CAFFE2_CORE_GOBAL_WORKSPACE_H_
+
+#include <map>
+#include <memory>
+
+#include "caffe2/core/workspace.h"
+
+namespace caffe2 {
+
+// GlobalWorkspaceUtil defines a singleton workspace registry that allows us to
+// switch between multiple workspaces especially withing PythonOps.
+class GlobalWorkspaceUtil {
+ public:
+  static GlobalWorkspaceUtil& get();
+
+  void switchWorkspace(const std::string& name, bool create_if_missing);
+  const std::string& currentWorkspaceName() const;
+  Workspace* getWorkspaceByName(const std::string& name) const;
+  Workspace* currentWorkspace() const;
+  void clear();
+  void resetCurrentWorkspace(std::unique_ptr<Workspace> ws);
+  std::vector<std::string> workspaces();
+  void setCurrentWorkspace(Workspace* ws);
+
+ private:
+  GlobalWorkspaceUtil(const std::string& default_name);
+
+  std::map<std::string, std::unique_ptr<Workspace>> gWorkspaces_;
+  // gWorkspace is the pointer to the current workspace. The ownership is kept
+  // by the gWorkspaces_ map.
+  Workspace* gWorkspace_ = nullptr;
+  std::string gCurrentWorkspaceName_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_CORE_GOBAL_WORKSPACE_H_

--- a/caffe2/python/pybind_state.h
+++ b/caffe2/python/pybind_state.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 
 #include "caffe2/core/context.h"
+#include "caffe2/core/global_workspace.h"
 #include "caffe2/core/init.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/memonger.h"
@@ -48,9 +49,6 @@ namespace py = pybind11;
 void addGlobalMethods(pybind11::module& m);
 // Expose Workspace, Net, Blob
 void addObjectMethods(pybind11::module& m);
-
-// Get current workspace
-Workspace* GetCurrentWorkspace();
 
 class C10_EXPORT BlobFetcherBase {
  public:

--- a/caffe2/python/pybind_state_gpu.cc
+++ b/caffe2/python/pybind_state_gpu.cc
@@ -111,7 +111,10 @@ void addCUDAGlobalMethods(py::module& m) {
             verbosity,
             debug_builder,
             build_serializable_op);
-        ts.Transform(GetCurrentWorkspace(), &pred_net, tensor_shapes);
+        ts.Transform(
+            GlobalWorkspaceUtil::get().currentWorkspace(),
+            &pred_net,
+            tensor_shapes);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);


### PR DESCRIPTION
Summary:
Currently, we have a series of globals in C2 pybind for workspaces (i.e., `gWorkspace`). This allows us to access global workspace, or switch between workspaces at runtime, especially within PythonOps.

One usage of this global is where we want to run plans. For instance we can have the following:

```
with workspace.WorkspaceGuard(ws):
   ws._run_plan(plan)
```

where the `plan` contains a PythonOp that calls into `workspace.FetchBlob("my_blob")`. Although `"my_blob"` shouldn't be hard-coded in general case, this use-case is still possible and in-fact is being used in some of our code-base.

As an effort in moving plan execution inside C++, we need to be able to manipulate `gWorkspace` from C++ code. This diff proposes the following change:

`gWorkspace` is currently a global in pybind. We might as well move it into a separate file where we define is as a singleton to keep the same functionality for it as before. Converting `gWorkspace` into a singleton and having it as a "library" allows us to manipulate it from any code, be it from python plan runner, or from a C++ code that runs plans.

Differential Revision: D13934972
