### PR TITLE
Support multiprocessing context in Pool constructor

### DIFF
--- a/torch/multiprocessing/pool.py
+++ b/torch/multiprocessing/pool.py
@@ -20,8 +20,12 @@ class Pool(multiprocessing.pool.Pool):
     serializing the underlying data."""
 
     def _setup_queues(self):
-        self._inqueue = SimpleQueue()
-        self._outqueue = SimpleQueue()
+        if hasattr(self, "_ctx"):
+            self._inqueue = self._ctx.SimpleQueue()
+            self._outqueue = self._ctx.SimpleQueue()
+        else:
+            self._inqueue = SimpleQueue()
+            self._outqueue = SimpleQueue()
         self._quick_put = self._inqueue._writer.send
         self._quick_get = self._outqueue._reader.recv
 


### PR DESCRIPTION
Summary:
Python 3.4 added contexts in the multiprocessing module (see https://github.com/python/cpython/commit/b1694cf588ca915c003b9b79c9fdeab82deb9476). PyTorch's wrapper of the Pool class needs to handle them.

Fixes #16954.

Differential Revision: D14042859
