### PR TITLE
Trim libshm deps, move tempfile.h to c10

### DIFF
--- a/c10/test/util/tempfile_test.cpp
+++ b/c10/test/util/tempfile_test.cpp
@@ -1,0 +1,9 @@
+#include <c10/util/tempfile.h>
+#include <gtest/gtest.h>
+
+#if !defined(_WIN32)
+TEST(TempFileTest, MatchesExpectedPattern) {
+  c10::TempFile pattern = c10::make_tempfile("test-pattern-");
+  ASSERT_NE(pattern.name.find("test-pattern-"), std::string::npos);
+}
+#endif // !defined(_WIN32)

--- a/c10/util/tempfile.h
+++ b/c10/util/tempfile.h
@@ -2,7 +2,6 @@
 
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
-#include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <cerrno>
 #include <cstdio>
@@ -16,8 +15,7 @@
 #include <unistd.h>
 #endif
 
-namespace torch {
-namespace utils {
+namespace c10 {
 namespace detail {
 // Creates the filename pattern passed to and completed by `mkstemp`.
 // Returns std::vector<char> because `mkstemp` needs a (non-const) `char*` and
@@ -102,5 +100,4 @@ inline TempFile make_tempfile(std::string name_prefix = "torch-file-") {
   }
   AT_ERROR("Error generating temporary file: ", std::strerror(errno));
 }
-} // namespace utils
-} // namespace torch
+} // namespace c10

--- a/test/cpp/api/misc.cpp
+++ b/test/cpp/api/misc.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <torch/csrc/utils/tempfile.h>
 #include <torch/nn/init.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/types.h>
@@ -52,10 +51,3 @@ TEST(NNInitTest, CanInitializeTensorThatRequiresGrad) {
       "has been used in an in-place operation");
   ASSERT_EQ(torch::nn::init::ones_(tensor).sum().item<int32_t>(), 12);
 }
-
-#if !defined(_WIN32)
-TEST(TempFileTest, MatchesExpectedPattern) {
-  torch::utils::TempFile pattern = torch::utils::make_tempfile("test-pattern-");
-  ASSERT_NE(pattern.name.find("test-pattern-"), std::string::npos);
-}
-#endif // !defined(_WIN32)

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <c10/util/tempfile.h>
+
 #include <torch/nn/modules/functional.h>
 #include <torch/nn/modules/linear.h>
 #include <torch/nn/modules/sequential.h>
@@ -54,7 +56,7 @@ TEST(SerializeTest, BasicToFile) {
 
   auto x = torch::randn({5, 5});
 
-  auto tempfile = torch::utils::make_tempfile();
+  auto tempfile = c10::make_tempfile();
   torch::save(x, tempfile.name);
 
   torch::Tensor y;
@@ -135,7 +137,7 @@ TEST(SerializeTest, XOR) {
     epoch++;
   }
 
-  auto tempfile = torch::utils::make_tempfile();
+  auto tempfile = c10::make_tempfile();
   torch::save(model, tempfile.name);
   torch::load(model2, tempfile.name);
 
@@ -149,7 +151,7 @@ TEST(SerializeTest, Optim) {
   auto model3 = Linear(5, 2);
 
   // Models 1, 2, 3 will have the same parameters.
-  auto model_tempfile = torch::utils::make_tempfile();
+  auto model_tempfile = c10::make_tempfile();
   torch::save(model1, model_tempfile.name);
   torch::load(model2, model_tempfile.name);
   torch::load(model3, model_tempfile.name);
@@ -194,7 +196,7 @@ TEST(SerializeTest, Optim) {
   // Do 2 steps of model 3 while saving the optimizer
   step(optim3, model3);
 
-  auto optim_tempfile = torch::utils::make_tempfile();
+  auto optim_tempfile = c10::make_tempfile();
   torch::save(optim3, optim_tempfile.name);
   torch::load(optim3_2, optim_tempfile.name);
   step(optim3_2, model3);
@@ -253,7 +255,7 @@ TEST(SerializeTest, XOR_CUDA) {
     epoch++;
   }
 
-  auto tempfile = torch::utils::make_tempfile();
+  auto tempfile = c10::make_tempfile();
   torch::save(model, tempfile.name);
   torch::load(model2, tempfile.name);
 
@@ -264,7 +266,7 @@ TEST(SerializeTest, XOR_CUDA) {
   loss = getLoss(model2, 100, true);
   ASSERT_LT(loss.item<float>(), 0.1);
 
-  auto tempfile2 = torch::utils::make_tempfile();
+  auto tempfile2 = c10::make_tempfile();
   torch::save(model2, tempfile2.name);
   torch::load(model3, tempfile2.name);
 

--- a/test/cpp/common/support.h
+++ b/test/cpp/common/support.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <torch/csrc/utils/tempfile.h>
-
 #include <c10/util/Exception.h>
 
 #include <gtest/gtest.h>

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -9,8 +9,7 @@
 #include <memory>
 #include <unordered_map>
 
-#include <torch/csrc/utils/tempfile.h>
-#include <c10/util/Optional.h>
+#include <c10/util/tempfile.h>
 
 #include <libshm/err.h>
 #include <libshm/socket.h>
@@ -87,7 +86,7 @@ int main(int argc, char *argv[]) {
 
   std::unique_ptr<ManagerServerSocket> srv_socket;
   const auto tempfile =
-      torch::utils::try_make_tempfile(/*name_prefix=*/"torch-shm-file-");
+      c10::try_make_tempfile(/*name_prefix=*/"torch-shm-file-");
   try {
     if (!tempfile.has_value()) {
       throw std::runtime_error(


### PR DESCRIPTION
Summary: libshm_manager doesn't need to depend on all of libtorch. It only uses tiny tempfile.h which can be moved to c10. I could just duplicate the file too, but it's not worth it as c10 is small enough.

Differential Revision: D14052688
