### PR TITLE
Remove second output of Reshape during ONNXIFI transform

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -66,6 +66,7 @@ class CAFFE2_API BoundShapeInferencer {
   void InferSparseLengthsSum(const OperatorDef& op);
   void InferFC(const OperatorDef& op);
   void InferConcat(const OperatorDef& op);
+  void InferReshape(const OperatorDef& op);
   void InferLengthsRangeFill(const OperatorDef& op);
 
   // Standard shape/type inference using op schema registered shape inference

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -89,7 +89,6 @@ class CAFFE2_API BoundShapeInferencer {
   ShapeInfo::DimType current_dim_type_{ShapeInfo::DimType::UNKNOWN};
   int64_t current_max_batch_size_{0};
   std::unordered_map<std::string, ShapeInfo> shape_info_;
-  std::unordered_set<std::string> visited_tensors_;
 };
 
 } // namespace caffe2

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "caffe2/core/logging.h"
+#include "caffe2/opt/shape_info.h"
 #include "caffe2/proto/caffe2_pb.h"
 
 #include <sstream>
@@ -9,20 +10,6 @@
 #include <unordered_set>
 
 namespace caffe2 {
-
-struct CAFFE2_API ShapeInfo {
-  enum DimType : int8_t { UNKNOWN = 0, CONSTANT = 1, BATCH = 2, SEQ = 3 };
-  ShapeInfo() {}
-  ShapeInfo(DimType t, TensorShape&& s) : dim_type(t), shape(std::move(s)) {}
-  ShapeInfo(DimType t, const TensorShape& s) : dim_type(t), shape(s) {}
-
-  // type of the shape according its first dim
-  DimType dim_type{DimType::UNKNOWN};
-  TensorShape shape;
-};
-
-using ShapeInfoMap = std::unordered_map<std::string, ShapeInfo>;
-
 // This struct stores the max bound size for batch in the general sense. We have
 // the conventioal batch size and the look-up sequence, which is also batch in a
 // sense.
@@ -51,7 +38,7 @@ class CAFFE2_API BoundShapeInferencer {
       const NetDef& net,
       const std::unordered_map<std::string, ShapeInfo>& info);
 
-  const std::unordered_map<std::string, ShapeInfo>& shape_info() const {
+  const ShapeInfoMap& shape_info() const {
     return shape_info_;
   }
 

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -97,12 +97,9 @@ ShapeInfoMap InferShapes(
     // Populate shapes from workplace
     const std::vector<std::string> ws_blobs = ws->Blobs();
     for (const auto& s : ws_blobs) {
-      auto shape = GetTensorShapeOfBlob(ws->GetBlob(s));
-      if (!shape.unknown_shape()) {
-        shape_map.emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(s),
-            std::forward_as_tuple(ShapeInfo::DimType::CONSTANT, shape));
+      auto shape_info = getShapeInfoFromBlob(ws->GetBlob(s));
+      if (shape_info.dim_type != ShapeInfo::DimType::UNKNOWN) {
+        shape_map[s] = shape_info;
       }
     }
     for (const auto& kv : *shape_hints_ordered) {

--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -1,0 +1,21 @@
+#include "caffe2/opt/shape_info.h"
+
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+ShapeInfo getShapeInfoFromBlob(const Blob* blob) {
+  ShapeInfo shape_info;
+  shape_info.shape = GetTensorShapeOfBlob(blob);
+  shape_info.dim_type = shape_info.shape.unknown_shape()
+      ? ShapeInfo::DimType::UNKNOWN
+      : ShapeInfo::DimType::CONSTANT;
+  return shape_info;
+}
+
+bool operator==(const ShapeInfo& lhs, const ShapeInfo& rhs) {
+  return lhs.dim_type == rhs.dim_type &&
+      lhs.shape.SerializeAsString() == rhs.shape.SerializeAsString();
+}
+
+} // namespace caffe2

--- a/caffe2/opt/shape_info.h
+++ b/caffe2/opt/shape_info.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+struct CAFFE2_API ShapeInfo {
+  enum DimType : int8_t { UNKNOWN = 0, CONSTANT = 1, BATCH = 2, SEQ = 3 };
+  ShapeInfo() {}
+  ShapeInfo(DimType t, TensorShape&& s) : dim_type(t), shape(std::move(s)) {}
+  ShapeInfo(DimType t, const TensorShape& s) : dim_type(t), shape(s) {}
+
+  // type of the shape according its first dim
+  DimType dim_type{DimType::UNKNOWN};
+  TensorShape shape;
+};
+
+using ShapeInfoMap = std::unordered_map<std::string, ShapeInfo>;
+
+// Generates ShapeInfo from Blob.
+ShapeInfo getShapeInfoFromBlob(const Blob* blob);
+
+bool operator==(const ShapeInfo& lhs, const ShapeInfo& rhs);
+
+} // namespace caffe2


### PR DESCRIPTION
Summary: Glow doesn't support second output of Reshape right now and it's useless. For correctness, we do make sure that the second output of Reshape is of Constant type during bound shape inference.

Differential Revision: D14056555
