### PR TITLE
Add support of count_include_pad and test end to end test for AveragePool

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -343,8 +343,8 @@ Caffe2Backend::get_special_operators() const {
               {"Constant", &Caffe2Backend::CreateConstant},
               {"ConstantOfShape", &Caffe2Backend::CreateConstantOfShape},
               {"Conv", &Caffe2Backend::CreateConvPoolOpBase},
-              {"AveragePool", &Caffe2Backend::CreatePadPool},
-              {"GlobalAveragePool", &Caffe2Backend::CreatePadPool},
+              {"AveragePool", &Caffe2Backend::CreateConvPoolOpBase},
+              {"GlobalAveragePool", &Caffe2Backend::CreateConvPoolOpBase},
               {"GlobalMaxPool", &Caffe2Backend::CreateConvPoolOpBase},
               {"MaxPool", &Caffe2Backend::CreateConvPoolOpBase},
               {"Reshape", &Caffe2Backend::CreateReshape},
@@ -543,27 +543,6 @@ Caffe2Ops Caffe2Backend::CreateConvPoolOpBase(
   }
 
   return CommonOnnxNodeToCaffe2Ops(onnx_node, ctx);
-}
-
-Caffe2Ops Caffe2Backend::CreatePadPool(
-    OnnxNode* onnx_node,
-    const ConversionContext& ctx) {
-  Caffe2Ops ret;
-  // Pad
-  bool padding = false;
-  const std::string pad_name = ctx.opset_version() < 2 ? "paddings" : "pads";
-  const auto pad_input = dummy_->NewDummyName();
-
-  // Pool
-  auto c2_ops = Caffe2Backend::CreateConvPoolOpBase(onnx_node, ctx);
-  auto* pool_op = c2_ops.ops.Mutable(0);
-  if (padding) {
-    pool_op->set_input(0, pad_input);
-  }
-  auto* c2_op = ret.ops.Add();
-  c2_op->CopyFrom(*pool_op);
-
-  return ret;
 }
 
 Caffe2Ops Caffe2Backend::CreateReshape(

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -555,6 +555,7 @@ Caffe2Ops Caffe2Backend::CreatePadPool(
   bool padding = false;
   const std::string pad_name = ctx.opset_version() < 2 ? "paddings" : "pads";
   const auto pad_input = dummy_->NewDummyName();
+/*
   if (attributes.HasAttribute("count_include_pad") &&
       attributes.HasAttribute(pad_name)) {
     auto count_include_pad = attributes.get<int64_t>("count_include_pad", 0L);
@@ -563,6 +564,7 @@ Caffe2Ops Caffe2Backend::CreatePadPool(
         attributes
             .get<::google::protobuf::RepeatedField<::google::protobuf::int64>>(
                 pad_name);
+
     if (count_include_pad == 1 && pads.size() == 4 &&
         !(pads.Get(0) == 0 && pads.Get(1) == 0 && pads.Get(2) == 0 &&
           pads.Get(3) == 0)) {
@@ -592,6 +594,7 @@ Caffe2Ops Caffe2Backend::CreatePadPool(
       }
     }
   }
+*/
   // Pool
   auto c2_ops = Caffe2Backend::CreateConvPoolOpBase(onnx_node, ctx);
   auto* pool_op = c2_ops.ops.Mutable(0);

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -555,46 +555,7 @@ Caffe2Ops Caffe2Backend::CreatePadPool(
   bool padding = false;
   const std::string pad_name = ctx.opset_version() < 2 ? "paddings" : "pads";
   const auto pad_input = dummy_->NewDummyName();
-/*
-  if (attributes.HasAttribute("count_include_pad") &&
-      attributes.HasAttribute(pad_name)) {
-    auto count_include_pad = attributes.get<int64_t>("count_include_pad", 0L);
-    ::google::protobuf::RepeatedField<::google::protobuf::int64> pads;
-    pads =
-        attributes
-            .get<::google::protobuf::RepeatedField<::google::protobuf::int64>>(
-                pad_name);
 
-    if (count_include_pad == 1 && pads.size() == 4 &&
-        !(pads.Get(0) == 0 && pads.Get(1) == 0 && pads.Get(2) == 0 &&
-          pads.Get(3) == 0)) {
-      padding = true;
-      attributes.remove(pad_name);
-      caffe2::Argument arg_pads;
-      arg_pads.add_ints(pads.Get(0));
-      arg_pads.add_ints(pads.Get(1));
-      arg_pads.add_ints(pads.Get(2));
-      arg_pads.add_ints(pads.Get(3));
-      arg_pads.set_name("pads");
-      auto* c2_op = ret.ops.Add();
-      BuildOperator(
-          c2_op, "PadImage", {node.input(0)}, {pad_input}, {arg_pads});
-    } else if (count_include_pad == 1) {
-      std::string str;
-      bool pads_flag = false;
-      str += "[";
-      for (const auto& i : pads) {
-        str += c10::to_string(i) + ",";
-        pads_flag = pads_flag || i > 0;
-      }
-      str += "]";
-      if (pads_flag == true) {
-        CAFFE_THROW(
-            "Caffe2 only supports padding 2D Tensor, whereas padding is ", str);
-      }
-    }
-  }
-*/
   // Pool
   auto c2_ops = Caffe2Backend::CreateConvPoolOpBase(onnx_node, ctx);
   auto* pool_op = c2_ops.ops.Mutable(0);

--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -548,8 +548,6 @@ Caffe2Ops Caffe2Backend::CreateConvPoolOpBase(
 Caffe2Ops Caffe2Backend::CreatePadPool(
     OnnxNode* onnx_node,
     const ConversionContext& ctx) {
-  auto& node = onnx_node->node;
-  auto& attributes = onnx_node->attributes;
   Caffe2Ops ret;
   // Pad
   bool padding = false;

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -664,8 +664,11 @@ class TestCaffe2Backend(unittest.TestCase):
         model = nn.MaxPool2d(5, padding=2)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
-#    @unittest.skip("C2 and PyTorch have small difference in padding implementation")
     def test_avgpool2d(self):
+        model = nn.AvgPool2d(5, padding=(2))
+        self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
+
+    def test_avgpool2d_count_include_pad(self):
         model = nn.AvgPool2d(5, padding=(2), count_include_pad=True)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -664,9 +664,9 @@ class TestCaffe2Backend(unittest.TestCase):
         model = nn.MaxPool2d(5, padding=2)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
-    @unittest.skip("C2 and PyTorch have small difference in padding implementation")
+#    @unittest.skip("C2 and PyTorch have small difference in padding implementation")
     def test_avgpool2d(self):
-        model = nn.AvgPool2d(5, padding=(2))
+        model = nn.AvgPool2d(5, padding=(2), count_include_pad=True)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
     def test_avgpool2d_no_padding(self):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -665,11 +665,11 @@ class TestCaffe2Backend(unittest.TestCase):
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
     def test_avgpool2d(self):
-        model = nn.AvgPool2d(5, padding=(2))
+        model = nn.AvgPool2d(5, padding=(2), count_include_pad=True)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
     def test_avgpool2d_count_include_pad(self):
-        model = nn.AvgPool2d(5, padding=(2), count_include_pad=True)
+        model = nn.AvgPool2d(5, padding=(2), count_include_pad=False)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
     def test_avgpool2d_no_padding(self):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -665,11 +665,15 @@ class TestCaffe2Backend(unittest.TestCase):
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
     def test_avgpool2d(self):
-        model = nn.AvgPool2d(5, padding=(2), count_include_pad=True)
+        model = nn.AvgPool2d(5, padding=(2))
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
-    def test_avgpool2d_count_include_pad(self):
-        model = nn.AvgPool2d(5, padding=(2), count_include_pad=False)
+    def test_avgpool2d_with_count_include_pad_set_false(self):
+        model = nn.AvgPool2d(7, padding=(2), count_include_pad=False)
+        self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
+
+    def test_avgpool2d_with_count_include_pad_set_true(self):
+        model = nn.AvgPool2d(7, padding=(2), count_include_pad=True)
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
 
     def test_avgpool2d_no_padding(self):


### PR DESCRIPTION
Add support of count_include_pad end to end test for AveragePool

We can export AveragePool from PyTorch with count_include_pad attribute. However, we don't directly support it in Caffe2's ONNX backend. 
We also want to check whether we can pass the end to end test for average pool operator with count_include_pad attribute (pytorch => onnx => caffe2)
