### PR TITLE
Remove fake inference for shape info in ONNXIFI transform

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -22,8 +22,6 @@ class OnnxExporter;
 struct OnnxifiTransformerOptions {
   explicit OnnxifiTransformerOptions() : bound_shape_spec(0, 0) {}
 
-  // Run bound shape inference
-  bool infer_shapes{false};
   // Dump onnx model for debugging
   bool debug{false};
   // Pass serialized onnx model if true, otherwise pass serialized c2 model
@@ -41,7 +39,6 @@ class CAFFE2_API OnnxifiTransformer final {
   void Transform(
       Workspace* ws,
       NetDef* pred_net,
-      const std::vector<std::string>& external_inputs,
       const std::vector<std::string>& weight_names,
       const std::unordered_map<std::string, TensorShape>& shape_hints,
       const std::unordered_set<int>& blacklisted_ops);
@@ -83,7 +80,7 @@ class CAFFE2_API OnnxifiTransformer final {
       const std::vector<std::string>& external_inputs,
       const std::vector<std::string>& external_outputs);
 
-  CaffeMap<std::string, TensorShape> SsaRewriteAndMapNames(
+  std::unordered_map<std::string, TensorShape> SsaRewriteAndMapNames(
       Workspace* ws,
       NetDef* pred_net,
       const std::unordered_set<std::string>& weights,

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -19,7 +19,6 @@ import numpy as np
 def onnxifi_caffe2_net(
         pred_net,
         input_shapes,
-        infer_shapes=False,
         max_batch_size=1,
         max_seq_size=1,
         debug=False,
@@ -27,27 +26,11 @@ def onnxifi_caffe2_net(
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
-    # Inject an fake input tensor to help popluate the shape if we
-    # do not do shape inference
     shape_hints = {}
-    external_inputs = []
-    if not infer_shapes:
-        for k, v in input_shapes.items():
-            need_input_tensor = True
-            if workspace.HasBlob(k):
-                itensor = workspace.FetchBlob(k)
-                if itensor.shape == v:
-                    need_input_tensor = False
-            if need_input_tensor:
-                workspace.FeedBlob(k, np.random.randn(*v).astype(np.float32))
-                external_inputs.append(k)
-
     for k, v in input_shapes.items():
         shape_hints[k] = v
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
-                             external_inputs,
                              shape_hints,
-                             infer_shapes,
                              max_batch_size,
                              max_seq_size,
                              debug,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1604,9 +1604,7 @@ void addGlobalMethods(py::module& m) {
   m.def(
       "onnxifi",
       [](const py::bytes& pred_net_str,
-         const std::vector<std::string>& external_inputs,
          const std::unordered_map<std::string, std::vector<int>>& shapes,
-         bool infer_shapes,
          int max_batch_size,
          int max_seq_size,
          bool debug_builder,
@@ -1622,7 +1620,6 @@ void addGlobalMethods(py::module& m) {
               it.first, CreateTensorShape(it.second, TensorProto::FLOAT));
         }
         OnnxifiTransformerOptions opts;
-        opts.infer_shapes = infer_shapes;
         opts.bound_shape_spec.max_batch_size = max_batch_size;
         opts.bound_shape_spec.max_seq_size = max_seq_size;
         opts.debug = debug_builder;
@@ -1633,7 +1630,6 @@ void addGlobalMethods(py::module& m) {
         ts.Transform(
             curr_ws,
             &pred_net,
-            external_inputs,
             weight_names,
             tensor_shapes,
             std::unordered_set<int>());


### PR DESCRIPTION
Summary: As we are moving to use bound shape inference, we can remove the awkward fake inference run path and make the code cleaner.

Differential Revision: D14061501
