### PR TITLE
[jit] add clear functionality to list

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3972,6 +3972,22 @@ a")
 
         self.assertEqual(foo(), [1, 2, 3, 4])
 
+    def test_mutable_list_clear_empty(self):
+        def test_clear_empty():
+            a = torch.jit.annotate(List[int], [])
+            a.clear()
+
+            return a == []
+        self.checkScript(test_clear_empty, ())
+
+    def test_mutable_list_clear(self):
+        def test_clear():
+            a = [1, 2, 3, 4]
+            a.clear()
+
+            return a == []
+        self.checkScript(test_clear, ())
+
     def test_func_call(self):
         script = '''
         def add(a, b):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3972,6 +3972,7 @@ a")
 
         self.assertEqual(foo(), [1, 2, 3, 4])
 
+    @unittest.skipIf(sys.version_info < (3, 3), "clear not supported in version < 3.3")
     def test_mutable_list_clear_empty(self):
         def test_clear_empty():
             a = torch.jit.annotate(List[int], [])
@@ -3980,6 +3981,7 @@ a")
             return len(a) == 0
         self.checkScript(test_clear_empty, ())
 
+    @unittest.skipIf(sys.version_info < (3, 3), "clear not supported in version < 3.3")
     def test_mutable_list_clear(self):
         def test_clear():
             a = [1, 2, 3, 4]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3977,7 +3977,7 @@ a")
             a = torch.jit.annotate(List[int], [])
             a.clear()
 
-            return a == []
+            return len(a) == 0
         self.checkScript(test_clear_empty, ())
 
     def test_mutable_list_clear(self):
@@ -3985,7 +3985,7 @@ a")
             a = [1, 2, 3, 4]
             a.clear()
 
-            return a == []
+            return len(a) == 0
         self.checkScript(test_clear, ())
 
     def test_func_call(self):

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1003,6 +1003,19 @@ Operation listAppend(const Node* node) {
   };
 }
 
+template <typename TList>
+Operation listClear(const Node* node) {
+  return [](Stack& stack) {
+    TList a;
+    pop(stack, a);
+
+    a->elements().clear();
+    push(stack, a);
+
+    return 0;
+  };
+}
+
 template <typename T>
 Operation listSelect(const Node* node) {
   return [=](Stack& stack) {
@@ -1289,7 +1302,10 @@ RegisterOperators reg2({
       Operator(                                                             \
           "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type      \
           " el) -> " decl_type "[](a!)",                                    \
-          listSetItem<Shared<c_type>, c_type::ElemType>)
+          listSetItem<Shared<c_type>, c_type::ElemType>),                   \
+      Operator(                                                             \
+          "aten::clear( " decl_type "[](a!) self) -> ()",                   \
+          listClear<Shared<c_type>>)
 
     CREATE_MUTABLE_LIST_OPS("Tensor", TensorList),
 
@@ -1305,7 +1321,10 @@ RegisterOperators reg2({
       Operator(                                                        \
           "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type \
           " el) -> " decl_type "[](a!)",                               \
-          listSetItem<Shared<c_type>, c_type::ElemType>)
+          listSetItem<Shared<c_type>, c_type::ElemType>),              \
+      Operator(                                                        \
+          "aten::clear( " decl_type "[](a!) self) -> ()",              \
+          listClear<Shared<c_type>>)
 
     CREATE_IMMUTABLE_LIST_OPS("int", IntList),
     CREATE_IMMUTABLE_LIST_OPS("float", DoubleList),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1004,16 +1004,14 @@ Operation listAppend(const Node* node) {
 }
 
 template <typename TList>
-Operation listClear(const Node* node) {
-  return [](Stack& stack) {
-    TList a;
-    pop(stack, a);
+int listClear(Stack& stack) {
+  TList a;
+  pop(stack, a);
 
-    a->elements().clear();
-    push(stack, a);
+  a->elements().clear();
+  push(stack, a);
 
-    return 0;
-  };
+  return 0;
 }
 
 template <typename T>


### PR DESCRIPTION
Add clear functionality to list. See #16662

```python
import torch

@torch.jit.script
def foo():
    a = [1, 2, 3, 4]
	a.clear()

    return a
```