### PR TITLE
change the epsilon for fp32/fp16 to uint8 to be the same

### DIFF
--- a/caffe2/python/lengths_reducer_fused_8bit_rowwise_ops_test.py
+++ b/caffe2/python/lengths_reducer_fused_8bit_rowwise_ops_test.py
@@ -7,6 +7,20 @@ from caffe2.python import core, workspace
 from hypothesis import given
 
 
+def compare_rowwise(emb_orig, emb_reconstructed):
+    assert(emb_orig.shape == emb_reconstructed.shape)
+    range = np.amax(emb_orig, axis=1) - np.amin(emb_orig, axis=1)
+    # TOOO: figure out the right threshold, this has to do with the
+    # fact that the data types are float16, in float32, it should be /1.9
+    threshold = range / 255.0 / 1.5
+    diff = np.amax(np.abs(emb_orig - emb_reconstructed), axis=1)
+    n_violated = ((threshold - diff) < 0).sum()
+    if n_violated > 0:
+        print(n_violated, threshold, diff, threshold < diff, emb_orig,
+              emb_reconstructed, emb_orig - emb_reconstructed)
+    assert(n_violated == 0)
+
+
 class TestLengthsReducerOpsFused8BitRowwise(hu.HypothesisTestCase):
     @given(
         batchsize=st.integers(1, 20),
@@ -14,15 +28,19 @@ class TestLengthsReducerOpsFused8BitRowwise(hu.HypothesisTestCase):
         weighted=st.booleans(),
         seed=st.integers(0, 2 ** 32 - 1),
         empty_indices=st.booleans(),
+        fp16=st.booleans(),
     )
     def test_sparse_lengths_sum(
-        self, batchsize, blocksize, weighted, seed, empty_indices
+        self, batchsize, blocksize, weighted, seed, empty_indices, fp16
     ):
         net = core.Net("bench")
 
         np.random.seed(seed)
 
-        input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
+        if (fp16):
+            input_data = np.random.rand(batchsize, blocksize).astype(np.float16)
+        else:
+            input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
         if empty_indices:
             lengths = np.zeros(batchsize, dtype=np.int32)
             num_indices = 0
@@ -42,12 +60,20 @@ class TestLengthsReducerOpsFused8BitRowwise(hu.HypothesisTestCase):
         )
         weights = np.random.uniform(size=[len(indices)]).astype(np.float32)
 
-        quantized_data = net.FloatToFused8BitRowwiseQuantized(
-            "input_data", "quantized_data"
-        )
-        dequantized_data = net.Fused8BitRowwiseQuantizedToFloat(
-            quantized_data, "dequantized_data"
-        )
+        if fp16:
+            quantized_data = net.HalfFloatToFused8BitRowwiseQuantized(
+                "input_data", "quantized_data"
+            )
+            dequantized_data = net.Fused8BitRowwiseQuantizedToHalfFloat(
+                quantized_data, "dequantized_data"
+            )
+        else:
+            quantized_data = net.FloatToFused8BitRowwiseQuantized(
+                "input_data", "quantized_data"
+            )
+            dequantized_data = net.Fused8BitRowwiseQuantizedToFloat(
+                quantized_data, "dequantized_data"
+            )
 
         if weighted:
             net.SparseLengthsWeightedSum(
@@ -74,22 +100,34 @@ class TestLengthsReducerOpsFused8BitRowwise(hu.HypothesisTestCase):
         workspace.CreateNet(net)
         workspace.RunNetOnce(net)
 
+        dequantized_data = workspace.FetchBlob("dequantized_data")
+        np.testing.assert_array_almost_equal(input_data, workspace.FetchBlob("input_data"))
+        compare_rowwise(input_data, dequantized_data)
+
         sum_reference = workspace.FetchBlob("sum_reference")
         sum_quantized = workspace.FetchBlob("sum_quantized")
-        np.testing.assert_array_almost_equal(sum_reference, sum_quantized)
+        if fp16:
+            np.testing.assert_array_almost_equal(sum_reference, sum_quantized, decimal=3)
+        else:
+            np.testing.assert_array_almost_equal(sum_reference, sum_quantized)
 
     @given(
         batchsize=st.integers(1, 20),
         blocksize=st.sampled_from([8, 16, 32, 64, 85, 96, 128, 163]),
         seed=st.integers(0, 2 ** 32 - 1),
         empty_indices=st.booleans(),
+        fp16=st.booleans(),
     )
-    def test_sparse_lengths_mean(self, batchsize, blocksize, seed, empty_indices):
+    def test_sparse_lengths_mean(self, batchsize, blocksize, seed, empty_indices, fp16):
         net = core.Net("bench")
 
         np.random.seed(seed)
 
-        input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
+        if fp16:
+            input_data = np.random.rand(batchsize, blocksize).astype(np.float16)
+        else:
+            input_data = np.random.rand(batchsize, blocksize).astype(np.float32)
+
         if empty_indices:
             lengths = np.zeros(batchsize, dtype=np.int32)
             num_indices = 0
@@ -109,12 +147,20 @@ class TestLengthsReducerOpsFused8BitRowwise(hu.HypothesisTestCase):
         )
         print(indices, lengths)
 
-        quantized_data = net.FloatToFused8BitRowwiseQuantized(
-            "input_data", "quantized_data"
-        )
-        dequantized_data = net.Fused8BitRowwiseQuantizedToFloat(
-            quantized_data, "dequantized_data"
-        )
+        if fp16:
+            quantized_data = net.HalfFloatToFused8BitRowwiseQuantized(
+                "input_data", "quantized_data"
+            )
+            dequantized_data = net.Fused8BitRowwiseQuantizedToHalfFloat(
+                quantized_data, "dequantized_data"
+            )
+        else:
+            quantized_data = net.FloatToFused8BitRowwiseQuantized(
+                "input_data", "quantized_data"
+            )
+            dequantized_data = net.Fused8BitRowwiseQuantizedToFloat(
+                quantized_data, "dequantized_data"
+            )
 
         net.SparseLengthsMean(
             [dequantized_data, "indices", "lengths"], "mean_reference"
@@ -131,6 +177,13 @@ class TestLengthsReducerOpsFused8BitRowwise(hu.HypothesisTestCase):
         workspace.CreateNet(net)
         workspace.RunNetOnce(net)
 
+        dequantized_data = workspace.FetchBlob("dequantized_data")
+        np.testing.assert_array_almost_equal(input_data, workspace.FetchBlob("input_data"))
+        compare_rowwise(input_data, dequantized_data)
+
         mean_reference = workspace.FetchBlob("mean_reference")
         mean_quantized = workspace.FetchBlob("mean_quantized")
-        np.testing.assert_array_almost_equal(mean_reference, mean_quantized)
+        if fp16:
+            np.testing.assert_array_almost_equal(mean_reference, mean_quantized, decimal=3)
+        else:
+            np.testing.assert_array_almost_equal(mean_reference, mean_quantized)


### PR DESCRIPTION
Summary:
from jiyan's training jobs it seems like we found a quantization bug

fp32
fp32->rowwise int8 is fine
fp16 is fine
fp16->rowwise int8 is not fine

we are preconverting everything to fp32 and using the existing code, so there is no need to change the epsilon in the case of fp16 since at the time of converting, everything is a float

Differential Revision: D14063271
