### PR TITLE
Caffe2 TARGETS for HIP

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -18,10 +18,32 @@ parser.add_argument(
     '--add-static-casts',
     action='store_true',
     help="Whether to automatically add static_casts to kernel arguments.")
+
+parser.add_argument(
+    '--project-directory',
+    type=str,
+    default='',
+    help="The root of the project.",
+    required=False)
+
+parser.add_argument(
+    '--output-directory',
+    type=str,
+    default='',
+    help="The Directory to Store the Hipified Project",
+    required=False)
+
 args = parser.parse_args()
 
 amd_build_dir = os.path.dirname(os.path.realpath(__file__))
 proj_dir = os.path.join(os.path.dirname(os.path.dirname(amd_build_dir)))
+
+if args.project_directory:
+    proj_dir = args.project_directory
+
+out_dir = proj_dir
+if args.output_directory:
+    out_dir = args.output_directory
 
 includes = [
     "caffe2/operators/*",
@@ -103,7 +125,7 @@ if not args.out_of_place_only:
 
 hipify_python.hipify(
     project_directory=proj_dir,
-    output_directory=proj_dir,
+    output_directory=out_dir,
     includes=includes,
     ignores=ignores,
     out_of_place_only=args.out_of_place_only,

--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -737,17 +737,15 @@ def get_hip_file_path(filepath):
     #
     #   - If the file name contains "CUDA", replace it with "HIP", AND
     #
-    # If NONE of the above occurred, then append "_hip" to the end of
-    # the filename (before the extension).
+    # If NONE of the above occurred, then insert "hip" in the file path
+    # as the direct parent folder of the file
     #
-    # Furthermore, ALWAYS replace '.cu' with '.hip'.
+    # Furthermore, ALWAYS replace '.cu' with '.hip', because those files
+    # contain CUDA kernels that needs to be hipified and processed with
+    # hcc compiler
     #
     # This isn't set in stone; we might adjust this to support other
     # naming conventions.
-    #
-    # In the near future, we intend to also change cu/cuh file extension
-    # to hcc/hcch rather than cc; however, the hcc compiler does not
-    # currently support this file extension.
 
     if ext == '.cu':
         ext = '.hip'


### PR DESCRIPTION
Summary: OSS: slightely change the tools/amd_build/build_amd.py to add the output_directory for internal use. Also modify the renaming convention in hipify script to reflect the updated rules.

Differential Revision: D13767218
