### PR TITLE
Moderate the dim type after LengthsRangeFill

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -137,6 +137,7 @@ void BoundShapeInferencer::InferLengthsRangeFill(const OperatorDef& op) {
       ShapeInfo::DimType::SEQ,
       {spec_.max_seq_size},
       TensorProto_DataType_INT32);
+  current_dim_type_ = ShapeInfo::DimType::SEQ;
 }
 
 void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {


### PR DESCRIPTION
Summary: LengthsRangeFill will take a batch size of lengths input and expand it into sequence. Later op should follow this type until it hits another batch type moderating op, e.g. SparseLengthsSum.

Differential Revision: D14079422
