### PR TITLE
bug fix when we prepack weight and bias together

### DIFF
--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -553,10 +553,10 @@ bool FullyConnectedDNNLowPOp<T>::GetQuantizationParameters_() {
   if (!is_weight_constant_ || (!b_quantized_data_ && !b_dequantized_data_) ||
       in_qparams_[0].scale != in_qparams0_scale_old_ ||
       in_qparams_[0].zero_point != in_qparams0_zero_point_old_) {
-    if (this->template InputIsType<Int8FCDNNLowPPackedWeightBlob>(2) &&
-        this->template Input<Int8FCDNNLowPPackedWeightBlob>(2).bias.get()) {
+    if (this->template InputIsType<Int8FCDNNLowPPackedWeightBlob>(1) &&
+        this->template Input<Int8FCDNNLowPPackedWeightBlob>(1).bias.get()) {
       const auto& packed_filter =
-          this->template Input<Int8FCDNNLowPPackedWeightBlob>(2);
+          this->template Input<Int8FCDNNLowPPackedWeightBlob>(1);
       CAFFE_ENFORCE(!dequantize_output_);
       b_quantized_ = packed_filter.bias;
       b_quantized_data_ = b_quantized_->data();


### PR DESCRIPTION
Summary: Prepacked weight contains both weight and bias, so the bias should be obtained from input index 1, not from 2

Differential Revision: D14097281
