### PR TITLE
Fix batch insert

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -46,7 +46,7 @@ void BoundShapeInferencer::InferBoundShapeAndType(
   shape_info_ = info;
 
   for (const auto& op : net.op()) {
-    LOG(INFO) << op.type();
+    VLOG(1) << op.type();
     if (op.type() == "SparseLengthsSum" ||
         op.type() == "SparseLengthsSumFused8BitRowwise" ||
         op.type() == "SparseLengthsWeightedSum" ||

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -22,7 +22,8 @@ def onnxifi_caffe2_net(
         max_batch_size=1,
         max_seq_size=1,
         debug=False,
-        use_onnx=True):
+        use_onnx=True,
+        black_list=None):
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
@@ -31,6 +32,7 @@ def onnxifi_caffe2_net(
         shape_hints[k] = v
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
                              shape_hints,
+                             black_list if black_list else [],
                              max_batch_size,
                              max_seq_size,
                              debug,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1605,6 +1605,7 @@ void addGlobalMethods(py::module& m) {
       "onnxifi",
       [](const py::bytes& pred_net_str,
          const std::unordered_map<std::string, std::vector<int>>& shapes,
+         const std::vector<int>& black_list,
          int max_batch_size,
          int max_seq_size,
          bool debug_builder,
@@ -1626,13 +1627,11 @@ void addGlobalMethods(py::module& m) {
         opts.use_onnx = use_onnx;
         OnnxifiTransformer ts(opts);
         Workspace* curr_ws = GetCurrentWorkspace();
+        std::unordered_set<int> blacklist_set(
+            black_list.begin(), black_list.end());
         auto weight_names = curr_ws->Blobs();
         ts.transform(
-            curr_ws,
-            &pred_net,
-            weight_names,
-            tensor_shapes,
-            std::unordered_set<int>());
+            curr_ws, &pred_net, weight_names, tensor_shapes, blacklist_set);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);


### PR DESCRIPTION
Summary:
Because of Reshape op, batch size can be changed. This diff addresses first order issue raised from multiple batch size system. We need to export different real_batch_size for different max_batch_size input and attach it to the right output.

It also fixes a false exception.

Differential Revision: D14099541
