### PR TITLE
Feature request: torch.broadcast_to

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -55,6 +55,29 @@ def broadcast_tensors(*tensors):
     return torch._C._VariableFunctions.broadcast_tensors(tensors)
 
 
+def broadcast_to(tensor, shape):
+    r""" broadcast_to(tensor, shape) -> Tensor
+    
+    Broadcast the given tensor to the given shape.
+    
+    Args:
+        tensor (Tensor): tensor to broadcast.
+        shape (list(int)): broadcasted shape
+
+    Example::
+        >>> broadcast_to(torch.ones(3), (4, 3)).shape
+        torch.Size([4, 3])
+        >>> broadcast_to(torch.ones(1, 3), (4, 3)).shape
+        torch.Size([4, 3])
+    """
+    delta_len = tensor.dim() - len(shape)
+    if delta_len > 0:
+        # add singleton dimensions
+        tensor = tensor[[slice(None)] * delta_len]
+
+    return tensor.expand(shape)
+
+
 def split(tensor, split_size_or_sections, dim=0):
     r"""Splits the tensor into chunks.
 

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -18,6 +18,7 @@ __all__ = [
     'chain_matmul',
     'einsum',
     'broadcast_tensors',
+    'broadcast_to',
     'isfinite',
     'isinf',
     'isnan',
@@ -57,9 +58,9 @@ def broadcast_tensors(*tensors):
 
 def broadcast_to(tensor, shape):
     r""" broadcast_to(tensor, shape) -> Tensor
-    
+
     Broadcast the given tensor to the given shape.
-    
+
     Args:
         tensor (Tensor): tensor to broadcast.
         shape (list(int)): broadcasted shape


### PR DESCRIPTION
I would like to have `broadcast_to`. Numpy has also a `broadcast_to` (https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.broadcast_to.html#numpy.broadcast_to).
`torch.broadcast_tensors` can solve some cases, but `broadcast_to` can solve more cases.

This PR is a suggestion for a python implementation.

Related to https://github.com/pytorch/pytorch/issues/8076 (`broadcast_tensors`).