### PR TITLE
improve error msg when module list isn't added to __constants__

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5689,6 +5689,23 @@ a")
         with self.assertRaisesRegex(RuntimeError, "cannot be used as a tuple"):
             M()
 
+    def test_script_module_list_sequential_error(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self, mod_list):
+                super(M, self).__init__(False)
+                self.mods = mod_list
+
+            @torch.jit.script_method
+            def forward(self, v):
+                for m in self.mods:
+                    v = m(v)
+                return v
+
+        with self.assertRaisesRegex(RuntimeError, "Did you forget to add it to __constants"):
+            a = M(nn.Sequential(nn.ReLU()))
+        with self.assertRaisesRegex(RuntimeError, "Did you forget to add it to __constants"):
+            a = M(nn.ModuleList([nn.ReLU()]))
+
     def test_script_sequential_for(self):
         class Sub(torch.jit.ScriptModule):
             def __init__(self):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -168,6 +168,19 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     return ss.str();
   }
 
+  std::vector<std::shared_ptr<SugaredValue>> asTuple(
+      const SourceRange& loc,
+      Method& m,
+      const c10::optional<size_t>& size_hint = {}) override {
+    const std::string type_str = typeString(self);
+    std::stringstream ss;
+    ss << kind() << " cannot be used as a tuple";
+    if (type_str == "ModuleList" || type_str == "Sequential") {
+      ss << ". Did you forget to add it to __constants__? ";
+    }
+    throw ErrorReport(loc) << ss.str();
+  }
+
  protected:
   py::object getattr(const SourceRange& loc, const std::string& name) {
     try {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -175,7 +175,9 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     const std::string type_str = typeString(self);
     std::stringstream ss;
     ss << kind() << " cannot be used as a tuple";
-    if (type_str == "ModuleList" || type_str == "Sequential") {
+    auto nn = py::module::import("torch.nn");
+    if (py::isinstance(self, nn.attr("ModuleList")) ||
+        py::isinstance(self, nn.attr("Sequential"))) {
       ss << ". Did you forget to add it to __constants__? ";
     }
     throw ErrorReport(loc) << ss.str();


### PR DESCRIPTION
Add suggestion to add to __constants__ when a ModuleList of Sequential module is used as a tuple

Addresses https://github.com/pytorch/pytorch/issues/13899