### PR TITLE
[jit] Error on using script/script_method in the wrong place

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10158,7 +10158,6 @@ a")
             def fn():
                 return 4
 
-
         with self.assertRaisesRegex(RuntimeError, "not a function"):
             class M(torch.jit.ScriptModule):
                 def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10152,6 +10152,23 @@ a")
         a_dict = {'a': torch.ones(1), 'b': torch.ones(1) + 1, 'c': torch.ones(1) + 2}
         self.checkScript(fn, (a_dict, ('a', 'c')))
 
+    def test_wrong_decorator(self):
+        with self.assertRaisesRegex(RuntimeError, "not a method"):
+            @torch.jit.script_method
+            def fn():
+                return 4
+
+
+        with self.assertRaisesRegex(RuntimeError, "not a function"):
+            class M(torch.jit.ScriptModule):
+                def __init__(self):
+                    super(M, self).__init__()
+                    self.weight = torch.nn.Parameter(torch.randn(5, 5))
+
+                @torch.jit.script
+                def forward(self, x):
+                    return x
+
 
 class MnistNet(nn.Module):
     def __init__(self):


### PR DESCRIPTION
When decorated, methods aren't bound so their `type` is function, so this determines if it's defined in a class by searching for a method named `__init__` defined at the same level as the function