### PR TITLE
Fix syntax error in set instantiation

### DIFF
--- a/.circleci/generate-config-yml.py
+++ b/.circleci/generate-config-yml.py
@@ -107,12 +107,12 @@ def is_dict_like(data):
     return type(data) is dict or type(data) is OrderedDict
 
 
-FORCED_QUOTED_VALUE_KEYS = set(
+FORCED_QUOTED_VALUE_KEYS = {
     "DOCKER_IMAGE",
     "PYTHON_VERSION",
     "USE_CUDA_DOCKER_RUNTIME",
     "MULTI_GPU",
-)
+}
 
 
 def render_yaml(key, data, fh, depth=0):


### PR DESCRIPTION
Summary: Use curly braces syntax to avoid Lint complaint

Reviewed By: yf225

Differential Revision: D14111368
