### PR TITLE
[codemod] Use move to avoid copying

### DIFF
--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -341,7 +341,7 @@ Tensor VariableType::detach(const Tensor & self) const {
   if (jit::tracer::isTracing()) {
     jit::tracer::addOutput(node, result);
   }
-  return result;
+  return std::move(result);
 }
 
 Tensor & VariableType::detach_(Tensor & self) const {


### PR DESCRIPTION
Summary:
[codemod] Use move to avoid copying

Using flag "-Wreturn-std-move", compiler can identify the cases where a copy
operation
is performed when a move operation would have been available. Wrapped return
statement with std::move to fix.

For some reason, these files are not automatically modded. With D14115372
we should be able to turn on the compile flag

Differential Revision: D14115786
