### PR TITLE
Remove Bool/IndexTensor from schema for native functions with derivatives

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -781,7 +781,7 @@
 - func: einsum(str equation, Tensor[] tensors) -> Tensor
   matches_jit_signature: True
 
-- func: embedding(Tensor weight, IndexTensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
+- func: embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
 
 - func: embedding_backward(Tensor grad, IndexTensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq, bool sparse) -> Tensor
 
@@ -790,7 +790,7 @@
     CPU: embedding_dense_backward_cpu
     CUDA: embedding_dense_backward_cuda
 
-- func: embedding_renorm_(Tensor(a!) self, IndexTensor indices, float max_norm, float norm_type) -> Tensor(a!)
+- func: embedding_renorm_(Tensor(a!) self, Tensor indices, float max_norm, float norm_type) -> Tensor(a!)
   dispatch:
     CPU: embedding_renorm_cpu_
     CUDA: embedding_renorm_cuda_

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -782,6 +782,7 @@
   matches_jit_signature: True
 
 - func: embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
+  matches_jit_signature: True
 
 - func: embedding_backward(Tensor grad, IndexTensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq, bool sparse) -> Tensor
 
@@ -791,6 +792,7 @@
     CUDA: embedding_dense_backward_cuda
 
 - func: embedding_renorm_(Tensor(a!) self, Tensor indices, float max_norm, float norm_type) -> Tensor(a!)
+  matches_jit_signature: True
   dispatch:
     CPU: embedding_renorm_cpu_
     CUDA: embedding_renorm_cuda_

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -47,7 +47,8 @@
   dispatch:
     CUDA: _cudnn_rnn_flatten_weight
 
-- func: _cudnn_rnn(Tensor input, Tensor[] weight, int weight_stride0, Tensor? weight_buf, Tensor hx, Tensor? cx, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, BoolTensor? dropout_state) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
+- func: _cudnn_rnn(Tensor input, Tensor[] weight, int weight_stride0, Tensor? weight_buf, Tensor hx, Tensor? cx, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
+  matches_jit_signature: True
   dispatch:
     CUDA: _cudnn_rnn
 
@@ -2289,7 +2290,8 @@
 - func: where(BoolTensor condition, Tensor self, Tensor other) -> Tensor
   variants: function, method
 
-- func: _s_where(BoolTensor condition, Tensor self, Tensor other) -> Tensor
+- func: _s_where(Tensor condition, Tensor self, Tensor other) -> Tensor
+  matches_jit_signature: True
   variants: function
   dispatch:
     CPU: _s_where_cpu

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -9,7 +9,8 @@
 #     formula for multiple input names, by specifying a key
 #     "input1, input2" (see atan2 for an example).
 #   - An argument can be flagged as 'not_differentiable'. That means this
-#     argument may not be used in derivative calculations.
+#     argument cannot have a derivative defined and must not be used in any
+#     derivative calculations.
 #   - Optional entry with key 'output_differentiability' and value a list of the
 #     same length as the number of outputs from the forward function. The list
 #     should contain only booleans, specifying whether each of the output Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -8,10 +8,15 @@
 #     Note that a single gradient entry can specify the gradient
 #     formula for multiple input names, by specifying a key
 #     "input1, input2" (see atan2 for an example).
-#   - An argument can be flagged as 'not_differentiable'. That means this
-#     argument cannot have a derivative defined and must not be used in any
-#     derivative calculations. These arguments will effectively be ignored
-#     during code generation.
+#   - An argument can be flagged as 'not_differentiable'.
+#     In general there are 3 possibilities:
+#       1. An argument has an entry with a specified gradient
+#       2. An argument has an entry specified as not differentiable
+#       3. An argument has no entry
+#     Using the flag 'not_differentiable' resolves to the second case.
+#     The second case was introduced in support for arguments of
+#     type e.g. IndexTensor for 'embedding', that are not differentiable.
+#     TODO: Determine whether case 3 and case 2 can be replaced by one concept.
 #   - Optional entry with key 'output_differentiability' and value a list of the
 #     same length as the number of outputs from the forward function. The list
 #     should contain only booleans, specifying whether each of the output Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -10,7 +10,8 @@
 #     "input1, input2" (see atan2 for an example).
 #   - An argument can be flagged as 'not_differentiable'. That means this
 #     argument cannot have a derivative defined and must not be used in any
-#     derivative calculations.
+#     derivative calculations. These arguments will effectively be ignored
+#     during code generation.
 #   - Optional entry with key 'output_differentiability' and value a list of the
 #     same length as the number of outputs from the forward function. The list
 #     should contain only booleans, specifying whether each of the output Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -8,6 +8,8 @@
 #     Note that a single gradient entry can specify the gradient
 #     formula for multiple input names, by specifying a key
 #     "input1, input2" (see atan2 for an example).
+#   - An argument can be flagged as 'not_differentiable'. That means this
+#     argument may not be used in derivative calculations.
 #   - Optional entry with key 'output_differentiability' and value a list of the
 #     same length as the number of outputs from the forward function. The list
 #     should contain only booleans, specifying whether each of the output Tensor
@@ -870,7 +872,7 @@
   self: grad.reshape(self.sizes())
 
 - name: _s_where(Tensor condition, Tensor self, Tensor other)
-  condition: none
+  condition: not_differentiable
   self: where(condition, grad, zeros_like(grad))
   other: where(condition, zeros_like(grad), grad)
 
@@ -922,12 +924,14 @@
   target: binary_cross_entropy_with_logits_target_backward(grad, self, target, weight, pos_weight, reduction)
 
 - name: embedding(Tensor weight, Tensor indices, int64_t padding_idx, bool scale_grad_by_freq, bool sparse)
+  indices: not_differentiable
   weight: embedding_backward(grad, indices, weight.size(0), padding_idx, scale_grad_by_freq, sparse)
 
 - name: _embedding_bag(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq, int64_t mode, bool sparse)
   weight: _embedding_bag_backward(grad, indices, offsets, result1, result2, result3, weight.size(0), scale_grad_by_freq, mode, sparse)
 
 - name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
+  indices: not_differentiable
   self: not_implemented("embedding_renorm")
 
 - name: kl_div(Tensor self, Tensor target, int64_t reduction)
@@ -1378,7 +1382,7 @@
 # Only frst three of _cudnn_rnn outputs can have gradients.
 # _cudnn_rnn outputs: (output, hy, cy, reserve, weight_buf)
 - name: _cudnn_rnn(Tensor input, TensorList weight, int64_t weight_stride0, Tensor weight_buf, Tensor hx, Tensor cx, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntArrayRef batch_sizes, Tensor dropout_state)
-  dropout_state: none
+  dropout_state: not_differentiable
   output_differentiability: [True, True, True, False, False]
   input, hx, cx, weight: "_cudnn_rnn_backward(input, weight, weight_stride0, result4, hx, cx, result0, grads[0], grads[1], grads[2], mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, retain_variables ? result3.clone() : result3, grad_input_mask)"
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -870,6 +870,7 @@
   self: grad.reshape(self.sizes())
 
 - name: _s_where(Tensor condition, Tensor self, Tensor other)
+  condition: none
   self: where(condition, grad, zeros_like(grad))
   other: where(condition, zeros_like(grad), grad)
 
@@ -1377,6 +1378,7 @@
 # Only frst three of _cudnn_rnn outputs can have gradients.
 # _cudnn_rnn outputs: (output, hy, cy, reserve, weight_buf)
 - name: _cudnn_rnn(Tensor input, TensorList weight, int64_t weight_stride0, Tensor weight_buf, Tensor hx, Tensor cx, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntArrayRef batch_sizes, Tensor dropout_state)
+  dropout_state: none
   output_differentiability: [True, True, True, False, False]
   input, hx, cx, weight: "_cudnn_rnn_backward(input, weight, weight_stride0, result4, hx, cx, result0, grads[0], grads[1], grads[2], mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, retain_variables ? result3.clone() : result3, grad_input_mask)"
 

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -124,7 +124,7 @@ def process_function(func):
     unpack = []
 
     env['compute_index_ranges'] = []
-    for arg in func['args_with_gradients']:
+    for arg in func['args_with_derivatives']:
         if arg['type'] == 'TensorList':
             size = '{}_size_'.format(arg['name'])
             saved_list_sizes.append('size_t {}_size_;'.format(arg['name']))

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -505,9 +505,7 @@ def emit_body(declaration):
     inputs = [arg for arg in arguments if not arg.get('output', False)]
     differentiable_inputs = list(filter(is_differentiable, inputs))
     args_with_derivatives = find_args_with_derivatives(differentiable_inputs)
-    args_with_no_gradients = []
-    if func:
-        args_with_no_gradients += func['args_with_no_gradients']
+    args_with_no_gradients = func['args_with_no_gradients'] if func else []
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
     if func is not None and func.get('output_differentiability') is not None:

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -505,7 +505,7 @@ def emit_body(declaration):
     inputs = [arg for arg in arguments if not arg.get('output', False)]
     differentiable_inputs = list(filter(is_differentiable, inputs))
     args_with_derivatives = find_args_with_derivatives(differentiable_inputs)
-    args_with_no_derivatives = func['args_with_no_derivatives'] if func else []
+    not_differentiable_args = func['not_differentiable_args'] if func else []
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
     if func is not None and func.get('output_differentiability') is not None:
@@ -622,7 +622,7 @@ def emit_body(declaration):
             if arg in args_with_derivatives:
                 continue
             name = arg['name']
-            if name in args_with_no_derivatives:
+            if name in not_differentiable_args:
                 continue
             if name == 'output':
                 # Double-backwards definitions sometimes take in 'input' and

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -505,7 +505,7 @@ def emit_body(declaration):
     inputs = [arg for arg in arguments if not arg.get('output', False)]
     differentiable_inputs = list(filter(is_differentiable, inputs))
     args_with_derivatives = find_args_with_derivatives(differentiable_inputs)
-    not_differentiable_args = func['not_differentiable_args'] if func else []
+    not_differentiable_args_names = func['not_differentiable_args_names'] if func else []
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
     if func is not None and func.get('output_differentiability') is not None:
@@ -622,7 +622,7 @@ def emit_body(declaration):
             if arg in args_with_derivatives:
                 continue
             name = arg['name']
-            if name in not_differentiable_args:
+            if name in not_differentiable_args_names:
                 continue
             if name == 'output':
                 # Double-backwards definitions sometimes take in 'input' and

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -483,6 +483,11 @@ def emit_body(declaration):
         if 'Tensor' not in arg['type']:
             return False
         if arg['dynamic_type'] in {'IndexTensor', 'BoolTensor'}:
+            # TODO: Enable this after native_functions.yaml schema unification.
+            # These are necessary for legacy code and should be
+            # used by legacy code only!
+            # assert name.startswith('_th_'), \
+            # "IndexTensor and BoolTensor are restricted to legacy _th_ functions only.
             return False
         return True
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -509,9 +509,6 @@ def emit_body(declaration):
     if func:
         for not_derivative in func['not_derivatives']:
             not_args_with_derivatives += not_derivative['var_names']
-#    args_with_derivatives = list(filter(lambda x: x not in func['not_derivatives'], args_with_derivatives))
-#    if name == "_s_where":
-#        import pdb; pdb.set_trace()
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
     if func is not None and func.get('output_differentiability') is not None:

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -505,10 +505,9 @@ def emit_body(declaration):
     inputs = [arg for arg in arguments if not arg.get('output', False)]
     differentiable_inputs = list(filter(is_differentiable, inputs))
     args_with_derivatives = find_args_with_derivatives(differentiable_inputs)
-    not_args_with_derivatives = []
+    args_with_no_gradients = []
     if func:
-        for not_derivative in func['not_derivatives']:
-            not_args_with_derivatives += not_derivative['var_names']
+        args_with_no_gradients += func['args_with_no_gradients']
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
     if func is not None and func.get('output_differentiability') is not None:
@@ -625,7 +624,7 @@ def emit_body(declaration):
             if arg in args_with_derivatives:
                 continue
             name = arg['name']
-            if name in not_args_with_derivatives:
+            if name in args_with_no_gradients:
                 continue
             if name == 'output':
                 # Double-backwards definitions sometimes take in 'input' and

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -148,16 +148,15 @@ def process_definition(defn, declarations_by_signature):
         for raw_names in sorted(defn.keys()):
             formula = defn[raw_names]
             names = split_names(raw_names)
+            derivative = create_derivative(declaration['arguments'], declaration['returns'],
+                                           declaration['name'], formula, names)
             if formula.lower().strip() == 'not_differentiable':
-                derivative = create_derivative(declaration['arguments'], declaration['returns'],
-                                               declaration['name'], formula, names)
                 assert not sum([type(var_name) == list
                                 for var_name in derivative['var_names']]), \
                     "Variable names associated to a formula should be a flat list"
                 args_with_no_gradients += derivative['var_names']
             else:
-                derivatives.append(create_derivative(declaration['arguments'], declaration['returns'],
-                                                     declaration['name'], formula, names))
+                derivatives.append(derivative)
         args_with_gradients = list(filter(lambda x: x['name'] not in args_with_no_gradients, args_with_gradients))
 
         # Test to see if the use of 'grads' makes sense.

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -149,14 +149,14 @@ def process_definition(defn, declarations_by_signature):
         for raw_names in sorted(defn.keys()):
             formula = defn[raw_names]
             names = split_names(raw_names)
-            if formula == 'none':
-                derivative = create_derivative(declaration['arguments'], declaration['returns'], declaration['name'], formula, names)
+            if formula.lower().strip() == 'not_differentiable':
+                derivative = create_derivative(declaration['arguments'], declaration['returns'],
+                                               declaration['name'], formula, names)
                 not_derivatives.append(derivative)
                 not_args_with_gradients += derivative['var_names']
             else:
-                derivatives.append(create_derivative(declaration['arguments'], declaration['returns'], declaration['name'], formula, names))
-#        if defn_name == '_s_where':
-#            import pdb; pdb.set_trace()
+                derivatives.append(create_derivative(declaration['arguments'], declaration['returns'],
+                                                     declaration['name'], formula, names))
         args_with_gradients = list(filter(lambda x: x['name'] not in not_args_with_gradients, args_with_gradients))
 
         # Test to see if the use of 'grads' makes sense.

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -29,7 +29,7 @@ def load_derivatives(path, declarations):
 
 
 # How do you feel about pasting declaration inside autograd function...
-def create_autograd_function(name, derivatives, args_with_derivatives, not_differentiable_args,
+def create_autograd_function(name, derivatives, args_with_derivatives, not_differentiable_args_names,
                              signature, declaration, output_differentiability):
     op = to_camel_case(name) + 'Backward'
     op = op.replace('ForwardBackward', 'Backward')
@@ -38,7 +38,7 @@ def create_autograd_function(name, derivatives, args_with_derivatives, not_diffe
         'op': op,
         'declaration': declaration,
         'args_with_derivatives': args_with_derivatives,
-        'not_differentiable_args': not_differentiable_args,
+        'not_differentiable_args_names': not_differentiable_args_names,
         'signature': signature,
         'derivatives': derivatives,
         'saved_inputs': all_saved_variables(derivatives, 'saved_inputs'),
@@ -144,7 +144,7 @@ def process_definition(defn, declarations_by_signature):
 
         # Set up the derivative information
         derivatives = []
-        not_differentiable_args = []
+        not_differentiable_args_names = []
         for raw_names in sorted(defn.keys()):
             formula = defn[raw_names]
             names = split_names(raw_names)
@@ -154,15 +154,15 @@ def process_definition(defn, declarations_by_signature):
                 assert not sum([type(var_name) == list
                                 for var_name in derivative['var_names']]), \
                     "Variable names associated to a formula should be a flat list"
-                not_differentiable_args += derivative['var_names']
+                not_differentiable_args_names += derivative['var_names']
             else:
                 derivatives.append(derivative)
-        args_with_derivatives = list(filter(lambda x: x['name'] not in not_differentiable_args, args_with_derivatives))
+        args_with_derivatives = list(filter(lambda x: x['name'] not in not_differentiable_args_names, args_with_derivatives))
 
         # Test to see if the use of 'grads' makes sense.
         check_grad_usage(defn_name, declaration, derivatives)
 
-        return derivatives, args_with_derivatives, not_differentiable_args
+        return derivatives, args_with_derivatives, not_differentiable_args_names
 
     def unzip(xs):
         return zip(*xs)
@@ -205,8 +205,8 @@ def process_definition(defn, declarations_by_signature):
                                'Declarations.yaml ({})'
                                .format(i, defn_name, x, y))
 
-    derivatives, args_with_derivatives, not_differentiable_args = set_up_derivatives(defn_name, defn, canonical)
-    return create_autograd_function(defn_name, derivatives, args_with_derivatives, not_differentiable_args,
+    derivatives, args_with_derivatives, not_differentiable_args_names = set_up_derivatives(defn_name, defn, canonical)
+    return create_autograd_function(defn_name, derivatives, args_with_derivatives, not_differentiable_args_names,
                                     signature, canonical, output_differentiability)
 
 

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -157,7 +157,8 @@ def process_definition(defn, declarations_by_signature):
                 not_differentiable_args_names += derivative['var_names']
             else:
                 derivatives.append(derivative)
-        args_with_derivatives = list(filter(lambda x: x['name'] not in not_differentiable_args_names, args_with_derivatives))
+        args_with_derivatives = list(filter(lambda x: x['name'] not in not_differentiable_args_names,
+                                            args_with_derivatives))
 
         # Test to see if the use of 'grads' makes sense.
         check_grad_usage(defn_name, declaration, derivatives)


### PR DESCRIPTION
This only deals with four functions, but is an important first step towards removing BoolTensor and IndexTensor entirely.