### PR TITLE
Include vec256 headers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -755,6 +755,7 @@ if __name__ == '__main__':
                 'lib/*.h',
                 'include/ATen/*.h',
                 'include/ATen/cpu/*.h',
+                'include/ATen/cpu/vec256/*.h',
                 'include/ATen/core/*.h',
                 'include/ATen/cuda/*.cuh',
                 'include/ATen/cuda/*.h',


### PR DESCRIPTION
Fix #16650.

Headers such as `ATen/cpu/vml.h` contain `#include <ATen/cpu/vec256/vec256.h>`
for example, but these vec256 headers aren't included, due to commit e4c0bb1.

