### PR TITLE
[DOC][MINOR] Clarification of Lerp operation on tensors

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1317,14 +1317,14 @@ In-place version of :meth:`~Tensor.le`
 
 add_docstr_all('lerp',
                r"""
-lerp(start, end, weight) -> Tensor
+lerp(end, weight) -> Tensor
 
-Tensor usage is with `end`. See :func:`torch.lerp`
+See :func:`torch.lerp`
 """)
 
 add_docstr_all('lerp_',
                r"""
-lerp_(start, end, weight) -> Tensor
+lerp_(end, weight) -> Tensor
 
 In-place version of :meth:`~Tensor.lerp`
 """)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1319,14 +1319,12 @@ add_docstr_all('lerp',
                r"""
 lerp(start, end, weight) -> Tensor
 
-See :func:`torch.lerp`
+Tensor usage is with `end` passed as a argument. See :func:`torch.lerp`
 """)
 
 add_docstr_all('lerp_',
                r"""
 lerp_(start, end, weight) -> Tensor
-
-Tensor usage is with `end` passed as a argument.
 
 In-place version of :meth:`~Tensor.lerp`
 """)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1319,7 +1319,7 @@ add_docstr_all('lerp',
                r"""
 lerp(start, end, weight) -> Tensor
 
-Tensor usage is with `end` passed as a argument. See :func:`torch.lerp`
+Tensor usage is with `end`. See :func:`torch.lerp`
 """)
 
 add_docstr_all('lerp_',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1326,6 +1326,8 @@ add_docstr_all('lerp_',
                r"""
 lerp_(start, end, weight) -> Tensor
 
+Tensor usage is with `end` passed as a argument.
+
 In-place version of :meth:`~Tensor.lerp`
 """)
 


### PR DESCRIPTION
The `tensor` be used as `end` clarified in the docs. 

cc: @SsnL @fmassa @vishwakftw 

Ref 
#17205