### PR TITLE
Fix the slowness of mvn's log_prob

### DIFF
--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -40,10 +40,10 @@ def _batch_mahalanobis(bL, bx):
     shape, but `bL` one should be able to broadcasted to `bx` one.
     """
     n = bx.size(-1)
-
     bx_batch_shape = bx.shape[:-1]
+
     # Assume that bL.shape = (i, 1, n, n), bx.shape = (..., i, j, n),
-    # we are going to make bx have shape (..., i, 1, n) to apply _batch_trtrs_lower
+    # we are going to make bx have shape (..., 1, j,  i, 1, n) to apply _batch_trtrs_lower
     bx_batch_dims = len(bx_batch_shape)
     bL_batch_dims = bL.dim() - 2
     outer_batch_dims = bx_batch_dims - bL_batch_dims

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -40,12 +40,43 @@ def _batch_mahalanobis(bL, bx):
     shape, but `bL` one should be able to broadcasted to `bx` one.
     """
     n = bx.size(-1)
-    bL = bL.expand(bx.shape[bx.dim() - bL.dim() + 1:] + (n,))
+    # Broadcast singleton dimensions of bx into the corresponding dimensions of bL
+    bx, _ = torch.broadcast_tensors(bx, bL[..., 0])
+
+    bx_batch_shape = bx.shape[:-1]
+    # Assume that bL.shape = (i, 1, n, n), bx.shape = (..., i, j, n),
+    # we are going to make bx have shape (..., i, 1, n) to apply _batch_trtrs_lower
+    bx_batch_dims = len(bx_batch_shape)
+    bL_batch_dims = bL.dim() - 2
+    outer_batch_dims = bx_batch_dims - bL_batch_dims
+    old_batch_dims = outer_batch_dims + bL_batch_dims
+    new_batch_dims = outer_batch_dims + 2 * bL_batch_dims
+    # Reshape bx with the shape (..., 1, i, j, 1, n)
+    bx_new_shape = bx.shape[:outer_batch_dims]
+    for (sL, sx) in zip(bL.shape[:-2], bx.shape[outer_batch_dims:-1]):
+        bx_new_shape += (sx // sL, sL)
+    bx_new_shape += (n,)
+    bx = bx.reshape(bx_new_shape)
+    # Permute bx to make it have shape (..., 1, j, i, 1, n)
+    permute_dims = (list(range(outer_batch_dims)) +
+                    list(range(outer_batch_dims, new_batch_dims, 2)) +
+                    list(range(outer_batch_dims + 1, new_batch_dims, 2)) +
+                    [new_batch_dims])
+    bx = bx.permute(permute_dims)
+
     flat_L = bL.reshape(-1, n, n)  # shape = b x n x n
     flat_x = bx.reshape(-1, flat_L.size(0), n)  # shape = c x b x n
     flat_x_swap = flat_x.permute(1, 2, 0)  # shape = b x n x c
     M_swap = _batch_trtrs_lower(flat_x_swap, flat_L).pow(2).sum(-2)  # shape = b x c
-    return M_swap.t().reshape(bx.shape[:-1])
+    M = M_swap.t()  # shape = c x b
+
+    # Now we revert the above reshape and permute operators.
+    permuted_M = M.reshape(bx.shape[:-1])  # shape = (..., 1, j, i, 1)
+    permute_inv_dims = list(range(outer_batch_dims))
+    for i in range(bL_batch_dims):
+        permute_inv_dims += [outer_batch_dims + i, old_batch_dims + i]
+    reshaped_M = permuted_M.permute(permute_inv_dims)  # shape = (..., 1, i, j, 1)
+    return reshaped_M.reshape(bx_batch_shape)
 
 
 class MultivariateNormal(Distribution):

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -40,8 +40,6 @@ def _batch_mahalanobis(bL, bx):
     shape, but `bL` one should be able to broadcasted to `bx` one.
     """
     n = bx.size(-1)
-    # Broadcast singleton dimensions of bx into the corresponding dimensions of bL
-    bx, _ = torch.broadcast_tensors(bx, bL[..., 0])
 
     bx_batch_shape = bx.shape[:-1]
     # Assume that bL.shape = (i, 1, n, n), bx.shape = (..., i, j, n),


### PR DESCRIPTION
This PR addresses the slowness of MVN's log_prob as reported in #17206.

@t-vi I find it complicated to handle permutation dimensions if we squeeze singleton dimensions of bL, so I leave it as-is and keep the old approach. What do you think?