### PR TITLE
Don't have malloc-free pairs that cross DLL boundaries.

### DIFF
--- a/aten/src/TH/THGeneral.cpp
+++ b/aten/src/TH/THGeneral.cpp
@@ -196,7 +196,7 @@ void* THRealloc(void *ptr, ptrdiff_t size)
 
 void THFree(void *ptr)
 {
-  free(ptr);
+  c10::free_cpu(ptr);
 }
 
 double THLog10(const double x)

--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -28,6 +28,7 @@ C10_API void NoDelete(void*);
 C10_API void memset_junk(void* data, size_t num);
 
 C10_API void* alloc_cpu(size_t nbytes);
+C10_API void free_cpu(void* data);
 
 // Get the CPU Alloctor.
 C10_API at::Allocator* GetCPUAllocator();


### PR DESCRIPTION
See https://blogs.msdn.microsoft.com/oldnewthing/20060915-04/?p=29723
for more background on this requirement on Windows.

Fixes #17239.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

cc @xkszltl @peterjc123 