### PR TITLE
Fix remaining -Wreturn-std-move violations in fbcode

### DIFF
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -539,7 +539,7 @@ py::object unpackVariableTensorList(std::vector<at::Tensor> outputs) {
     for (size_t i = 0; i < outputs.size(); i++) {
       tuple[i] = py::cast(autograd::as_variable_ref(outputs[i]));
     }
-    return tuple;
+    return std::move(tuple);
   }
 }
 


### PR DESCRIPTION
Summary:
In some cases there is still no RVO/NRVO and std::move is still needed. Latest
Clang gained -Wreturn-std-move warning to detect cases like this (see
https://reviews.llvm.org/D43322).

Differential Revision: D14150915
