### PR TITLE
[jit] user defined types

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -164,6 +164,7 @@ namespace c10 {
   _(namespaces, onnx)              \
   _(namespaces, attr)              \
   _(namespaces, scope)             \
+  _(namespaces, user)              \
   _(namespaces, namespaces)
 #endif
 

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -17,6 +17,7 @@ namespace c10 {
   _(namespaces, onnx)              \
   _(namespaces, attr)              \
   _(namespaces, scope)             \
+  _(namespaces, user)              \
   _(namespaces, namespaces)        \
   _(prim, Assign)                  \
   _(prim, BroadcastingChunk)       \
@@ -154,7 +155,8 @@ namespace c10 {
   _(attr, b)                       \
   _(attr, beg)                     \
   _(attr, idx)                     \
-  _(attr, split)
+  _(attr, split)                   \
+  _(attr, slot)
 #else
 #define FORALL_NS_SYMBOLS(_) \
   _(namespaces, prim)              \
@@ -228,6 +230,7 @@ struct CAFFE2_API Symbol {
   static Symbol aten(const std::string & s);
   static Symbol onnx(const std::string & s);
   static Symbol prim(const std::string & s);
+  static Symbol user(const std::string & s);
   // TODO: eliminate me
   static Symbol scope(const std::string & s);
 
@@ -235,6 +238,7 @@ struct CAFFE2_API Symbol {
   bool is_aten() const;
   bool is_prim() const;
   bool is_onnx() const;
+  bool is_user() const;
 
   // So we can switch on this
   constexpr operator unique_t() const {
@@ -293,10 +297,12 @@ inline Symbol Symbol::aten(const std::string & s)  { return Symbol::fromQualStri
 inline Symbol Symbol::onnx(const std::string & s)  { return Symbol::fromQualString("onnx::" + s); }
 inline Symbol Symbol::prim(const std::string & s)  { return Symbol::fromQualString("prim::" + s); }
 inline Symbol Symbol::scope(const std::string & s) { return Symbol::fromQualString("scope::" + s); }
+inline Symbol Symbol::user(const std::string & s) { return Symbol::fromQualString("user::" + s); }
 inline bool Symbol::is_attr() const { return ns() == namespaces::attr; }
 inline bool Symbol::is_aten() const { return ns() == namespaces::aten; }
 inline bool Symbol::is_prim() const { return ns() == namespaces::prim; }
 inline bool Symbol::is_onnx() const { return ns() == namespaces::onnx; }
+inline bool Symbol::is_user() const { return ns() == namespaces::user; }
 
 } // namespace c10
 

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -82,6 +82,9 @@ namespace c10 {
   _(prim, fork)                    \
   _(prim, RaiseException)          \
   _(prim, Function)                \
+  _(prim, CreateUserObject)        \
+  _(prim, SetAttr)                 \
+  _(prim, GetAttr)                 \
   _(aten, append)                  \
   _(aten, format)                  \
   _(aten, __not__)                 \

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -93,6 +93,10 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       return out << v.toDevice();
     case IValue::Tag::GenericDict:
       return printDict(out, v.toGenericDict());
+    case IValue::Tag::UserObject:
+      // TODO we should print the object contents
+      return out << "UserObject<" << v.toUserObject()->name().toUnqualString()
+                 << ">";
   }
   AT_ERROR("Tag not found\n");
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -91,38 +91,7 @@ using DoubleList = List<double>;
 using BoolList = List<bool>;
 using GenericList = List<IValue>;
 
-// User-defined object.
-template <typename Elem>
-struct CAFFE2_API UserObjectGeneric final : c10::intrusive_ptr_target {
- public:
-  UserObjectGeneric(Symbol name, size_t numSlots) : typename_(std::move(name)) {
-    attrs_.resize(numSlots);
-  }
-
-  static c10::intrusive_ptr<UserObjectGeneric> create(
-      Symbol name,
-      size_t numSlots) {
-    return c10::make_intrusive<UserObjectGeneric>(std::move(name), numSlots);
-  }
-
-  void setAttr(size_t slot, Elem v) {
-    attrs_[slot] = v;
-  }
-
-  Elem getAttr(size_t slot) const {
-    return attrs_.at(slot);
-  }
-
-  Symbol name() const {
-    return typename_;
-  }
-
- private:
-  const Symbol typename_;
-  std::vector<Elem> attrs_;
-};
-
-using UserObject = UserObjectGeneric<IValue>;
+struct UserObject;
 }
 
 // IValue is the generic tagged union used by the interpreter to hold
@@ -707,6 +676,36 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
   std::vector<std::function<void(void)>> callbacks;
   bool has_error = false;
   FutureError error;
+};
+
+// User-defined object.
+struct C10_EXPORT ivalue::UserObject final : c10::intrusive_ptr_target {
+ public:
+  UserObject(Symbol name, size_t numSlots) : typename_(std::move(name)) {
+    attrs_.resize(numSlots);
+  }
+
+  static c10::intrusive_ptr<UserObject> create(
+      Symbol name,
+      size_t numSlots) {
+    return c10::make_intrusive<UserObject>(std::move(name), numSlots);
+  }
+
+  void setAttr(size_t slot, IValue v) {
+    attrs_[slot] = v;
+  }
+
+  IValue getAttr(size_t slot) const {
+    return attrs_.at(slot);
+  }
+
+  Symbol name() const {
+    return typename_;
+  }
+
+ private:
+  const Symbol typename_;
+  std::vector<IValue> attrs_;
 };
 
 struct C10_EXPORT ivalue::GenericDict : c10::intrusive_ptr_target {

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -682,7 +682,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
 struct C10_EXPORT ivalue::UserObject final : c10::intrusive_ptr_target {
  public:
   UserObject(Symbol name, size_t numSlots) : typename_(std::move(name)) {
-    attrs_.resize(numSlots);
+    slots_.resize(numSlots);
   }
 
   static c10::intrusive_ptr<UserObject> create(
@@ -691,12 +691,12 @@ struct C10_EXPORT ivalue::UserObject final : c10::intrusive_ptr_target {
     return c10::make_intrusive<UserObject>(std::move(name), numSlots);
   }
 
-  void setAttr(size_t slot, IValue v) {
-    attrs_[slot] = v;
+  void setSlot(size_t slot, IValue v) {
+    slots_[slot] = v;
   }
 
-  IValue getAttr(size_t slot) const {
-    return attrs_.at(slot);
+  IValue getSlot(size_t slot) const {
+    return slots_.at(slot);
   }
 
   Symbol name() const {
@@ -705,7 +705,7 @@ struct C10_EXPORT ivalue::UserObject final : c10::intrusive_ptr_target {
 
  private:
   const Symbol typename_;
-  std::vector<IValue> attrs_;
+  std::vector<IValue> slots_;
 };
 
 struct C10_EXPORT ivalue::GenericDict : c10::intrusive_ptr_target {

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -91,28 +91,35 @@ using DoubleList = List<double>;
 using BoolList = List<bool>;
 using GenericList = List<IValue>;
 
-
 // User-defined object.
-// TODO this is templated to avoid circularity with IValue. Should be a better
-// way to do this
 template <typename Elem>
 struct CAFFE2_API UserObjectGeneric final : c10::intrusive_ptr_target {
  public:
-  UserObjectGeneric(std::string name) : typename_(std::move(name)) {}
-  static c10::intrusive_ptr<UserObjectGeneric> create(std::string name) {
-    return c10::make_intrusive<UserObjectGeneric>(std::move(name));
-  }
-  void setAttr(const std::string& name, Elem v) {
-    namespace_[name] = v;
+  UserObjectGeneric(Symbol name, size_t numSlots) : typename_(std::move(name)) {
+    attrs_.resize(numSlots);
   }
 
-  Elem getAttr(const std::string& name) const {
-    return namespace_.at(name);
+  static c10::intrusive_ptr<UserObjectGeneric> create(
+      Symbol name,
+      size_t numSlots) {
+    return c10::make_intrusive<UserObjectGeneric>(std::move(name), numSlots);
+  }
+
+  void setAttr(size_t slot, Elem v) {
+    attrs_[slot] = v;
+  }
+
+  Elem getAttr(size_t slot) const {
+    return attrs_.at(slot);
+  }
+
+  Symbol name() const {
+    return typename_;
   }
 
  private:
-  const std::string typename_;
-  std::unordered_map<std::string, Elem> namespace_;
+  const Symbol typename_;
+  std::vector<Elem> attrs_;
 };
 
 using UserObject = UserObjectGeneric<IValue>;

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -92,6 +92,30 @@ using BoolList = List<bool>;
 using GenericList = List<IValue>;
 
 
+// User-defined object.
+// TODO this is templated to avoid circularity with IValue. Should be a better
+// way to do this
+template <typename Elem>
+struct CAFFE2_API UserObjectGeneric final : c10::intrusive_ptr_target {
+ public:
+  UserObjectGeneric(std::string name) : typename_(std::move(name)) {}
+  static c10::intrusive_ptr<UserObjectGeneric> create(std::string name) {
+    return c10::make_intrusive<UserObjectGeneric>(std::move(name));
+  }
+  void setAttr(const std::string& name, Elem v) {
+    namespace_[name] = v;
+  }
+
+  Elem getAttr(const std::string& name) const {
+    return namespace_.at(name);
+  }
+
+ private:
+  const std::string typename_;
+  std::unordered_map<std::string, Elem> namespace_;
+};
+
+using UserObject = UserObjectGeneric<IValue>;
 }
 
 // IValue is the generic tagged union used by the interpreter to hold
@@ -117,7 +141,8 @@ using GenericList = List<IValue>;
   _(GenericList) \
   _(GenericDict) \
   _(Future) \
-  _(Device)
+  _(Device) \
+  _(UserObject)
 
 struct CAFFE2_API IValue final {
   IValue()
@@ -391,6 +416,18 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<ivalue::GenericDict> toGenericDict() const & {
     AT_ASSERT(isGenericDict());
     return toIntrusivePtr<ivalue::GenericDict>();
+  }
+
+  // UserType
+  IValue(c10::intrusive_ptr<ivalue::UserObject> v);
+  bool isUserObject() const { return tag == Tag::UserObject; }
+  c10::intrusive_ptr<ivalue::UserObject> toUserObject() && {
+    AT_ASSERT(isUserObject());
+    return toIntrusivePtr<ivalue::UserObject>();
+  }
+  c10::intrusive_ptr<ivalue::UserObject> toUserObject() const & {
+    AT_ASSERT(isUserObject());
+    return toIntrusivePtr<ivalue::UserObject>();
   }
 
   // None
@@ -737,6 +774,7 @@ DEFINE_TO(c10::intrusive_ptr<ivalue::TensorList>, toTensorList)
 DEFINE_TO(c10::intrusive_ptr<ivalue::GenericList>, toGenericList)
 DEFINE_TO(c10::intrusive_ptr<ivalue::GenericDict>, toGenericDict)
 DEFINE_TO(c10::intrusive_ptr<ivalue::ConstantString>, toString)
+DEFINE_TO(c10::intrusive_ptr<ivalue::UserObject>, toUserObject)
 DEFINE_TO(at::Scalar, toScalar)
 DEFINE_TO(std::vector<int64_t>, toIntListRef)
 DEFINE_TO(std::vector<double>, toDoubleListRef)
@@ -808,6 +846,10 @@ inline IValue::IValue(c10::intrusive_ptr<ivalue::GenericDict> v)
 inline IValue::IValue(ivalue::UnorderedMap v)
 : IValue(ivalue::GenericDict::create(std::move(v))) {}
 
+inline IValue::IValue(c10::intrusive_ptr<ivalue::UserObject> v)
+: tag(Tag::UserObject), is_intrusive_ptr(true) {
+  payload.as_intrusive_ptr = v.release();
+}
 inline IValue::IValue(c10::intrusive_ptr<ivalue::Future> v)
 : tag(Tag::Future), is_intrusive_ptr(true) {
   payload.as_intrusive_ptr = v.release();

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -9,7 +9,6 @@
 #include <caffe2/core/common.h>
 
 #include <c10/util/Optional.h>
-#include <torch/csrc/api/include/torch/ordered_dict.h>
 
 #include <memory>
 #include <iostream>

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -415,4 +415,43 @@ bool Type::isSubtypeOf(const TypePtr rhs) const {
   return *this == *rhs;
 }
 
+namespace {
+class UserTypeRegistry {
+ public:
+  void registerType(std::string name, UserTypePtr type) {
+    std::lock_guard<std::mutex> g(mutex_);
+    // TODO: new type registrations will override the old ones. Is this safe?
+    reg_[name] = type;
+  }
+
+  UserTypePtr getType(const std::string& name) {
+    std::lock_guard<std::mutex> g(mutex_);
+    if (reg_.count(name)) {
+      return reg_.at(name);
+    }
+    return nullptr;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::unordered_map<std::string, UserTypePtr> reg_;
+};
+
+UserTypeRegistry& getRegistry() {
+  static UserTypeRegistry r;
+  return r;
+}
+} // namespace
+
+UserTypePtr UserType::create(
+    const std::string& name,
+    std::shared_ptr<Module> module) {
+  auto ptr = UserTypePtr(new UserType(name, std::move(module)));
+  getRegistry().registerType(name, ptr);
+  return ptr;
+}
+
+UserTypePtr UserType::get(const std::string& name) {
+  return getRegistry().getType(name);
+}
 } // namespace c10

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4346,21 +4346,21 @@ a")
             assert 1 == 1, "hello"
             return x
 
-        ast = torch.jit.frontend.get_jit_ast(fn, is_method=False)
+        ast = torch.jit.frontend.get_jit_def(fn)
         self.assertExpected(str(ast))
 
     @unittest.skipIf(not PY2, "Requires python 2")
     def test_python_frontend_py2(self):
         def fn():
             raise Exception("hello")
-        ast = torch.jit.frontend.get_jit_ast(fn, is_method=False)
+        ast = torch.jit.frontend.get_jit_def(fn)
         self.assertExpected(str(ast))
 
     @unittest.skipIf(PY2, "Requires python 3")
     def test_python_frontend_py3(self):
         def fn():
             raise Exception("hello")
-        ast = torch.jit.frontend.get_jit_ast(fn, is_method=False)
+        ast = torch.jit.frontend.get_jit_def(fn)
         self.assertExpected(str(ast))
 
     def _make_scalar_vars(self, arr, dtype):
@@ -13395,6 +13395,114 @@ class TestDataParallel(JitTestCase):
         r1_forward = replica[1].forward(x1)
         self.assertEqual(first_forward, r1_forward)
 
+
+class TestUserType(JitTestCase):
+    def test_get_with_method(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            @torch.jit.script
+            class Foo:
+                def __init__(self, x):
+                    self.foo = x
+
+                def getFoo(self):
+                    return self.foo
+
+            @torch.jit.script
+            def fn(x):
+                foo = Foo(x)
+                return foo.getFoo()
+
+            input = torch.ones(2, 3)
+            self.assertEqual(fn(input), input)
+
+    def test_get_attr(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            @torch.jit.script
+            class Foo:
+                def __init__(self, x):
+                    self.foo = x
+
+            @torch.jit.script
+            def fn(x):
+                foo = Foo(x)
+                return foo.foo
+
+            input = torch.ones(2, 3)
+            self.assertEqual(fn(input), input)
+
+    def test_set_attr_in_method(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            @torch.jit.script
+            class Foo:
+                def __init__(self, x):
+                    # type: (int)
+                    self.foo = x
+
+                def incFoo(self, y):
+                    # type: (int)
+                    self.foo = self.foo + y
+
+            @torch.jit.script
+            def fn(x):
+                # type: (int)
+                foo = Foo(x)
+                foo.incFoo(2)
+                return foo.foo
+
+            self.assertEqual(fn(1), 3)
+
+    def test_set_attr_type_mismatch(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            with self.assertRaisesRegex(RuntimeError, "Wrong type for attribute assignment"):
+                @torch.jit.script
+                class Foo:
+                    def __init__(self, x):
+                        self.foo = x
+                        self.foo = 10  # should error since int != Tensor
+
+    def test_get_attr_not_initialized(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            with self.assertRaisesRegex(RuntimeError, "Tried to access to nonexistent attribute"):
+                @torch.jit.script
+                class Foo:
+                    def __init__(self, x):
+                        self.foo = x
+
+                    def get_non_initialized(self):
+                        return self.asdf  # asdf isn't an attr
+
+    def test_set_attr_non_initialized(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            with self.assertRaisesRegex(RuntimeError, "Tried to assign to nonexistent attribute"):
+                @torch.jit.script
+                class Foo:
+                    def __init__(self, x):
+                        self.foo = x
+
+                    def set_non_initialized(self, y):
+                        self.bar = y  # can't assign to non-initialized attr
+
+    def test_type_annotations(self):
+        # Remove this when import/export is implemented for classes
+        with self.disableModuleHook():
+            with self.assertRaisesRegex(RuntimeError, "expected a value of type bool"):
+                @torch.jit.script
+                class Foo:
+                    def __init__(self, x):
+                        # type: (bool)
+                        self.foo = x
+
+                @torch.jit.script
+                def fn(x):
+                    Foo(x)
+
+                fn(2)
 
 for test in autograd_method_tests():
     add_autograd_test(*test)

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -98,6 +98,7 @@ libtorch_sources = [
     "torch/csrc/jit/script/script_type_parser.cpp",
     "torch/csrc/jit/script/sugared_value.cpp",
     "torch/csrc/jit/script/schema_matching.cpp",
+    "torch/csrc/jit/script/user_type.cpp",
     "torch/csrc/jit/script/parser.cpp",
     "torch/csrc/jit/testing/file_check.cpp",
     "torch/csrc/jit/import_method.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -177,6 +177,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/script/schema_type_parser.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/script_type_parser.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/sugared_value.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/user_type.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/parser.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/builtin_functions.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/edit_distance.cpp

--- a/torch/csrc/jit/import_method.cpp
+++ b/torch/csrc/jit/import_method.cpp
@@ -23,7 +23,7 @@ struct ModuleAccessorValue : public script::SugaredValue {
       return std::make_shared<script::SimpleValue>(
           m.get_or_add_parameter(v->slot()));
     } else if (script::Method* m = module->find_method(field)) {
-      return std::make_shared<script::MethodValue>(module, *m);
+      return std::make_shared<script::MethodValue>(shared_from_this(), *m);
     } else {
       throw script::ErrorReport(loc) << "unknown attr: " << field;
     }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1315,26 +1315,21 @@ Node* Graph::createUserObject(const UserTypePtr& type) {
   return result;
 }
 
-Node* Graph::createSetAttr(Value* obj, const std::string& field, Value* newValue) {
-  const auto userType = obj->type()->cast<UserType>();
-  AT_ASSERT(userType);
+Node* Graph::createSetAttr(
+    Value* obj,
+    const std::string& field,
+    Value* newValue) {
+  const auto userType = obj->type()->expect<UserType>();
 
   auto n = create(prim::SetAttr, {obj, newValue}, /*num_outputs=*/0);
-  n->i_(attr::slot, userType->getAttributeSlot(field));
-
-  // Not strictly necessary but makes graphs more readable
   n->s_(attr::name, field);
   return n;
 }
 
 Node* Graph::createGetAttr(Value* obj, const std::string& field) {
-  const auto userType = obj->type()->cast<UserType>();
-  AT_ASSERT(userType);
+  const auto userType = obj->type()->expect<UserType>();
 
   auto n = create(prim::GetAttr, {obj}, /*num_outputs=*/1);
-  n->i_(attr::slot, userType->getAttributeSlot(field));
-
-  // Not strictly necessary but makes graphs more readable
   n->s_(attr::name, field);
 
   const auto outputType = userType->getAttribute(field);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1309,7 +1309,7 @@ Node* Graph::createImplicitTensorToNum(const TypePtr& type, Value* value) {
   return result;
 }
 
-Node* Graph::createUserObject(UserTypePtr type) {
+Node* Graph::createUserObject(const UserTypePtr& type) {
   auto result = create(prim::CreateUserObject);
   result->output()->setType(type);
   return result;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1062,7 +1062,7 @@ struct Graph {
   TORCH_API Node* createDictIndex(Value* dict, Value* index);
   TORCH_API Node* createNumToTensor(Value* value);
   TORCH_API Node* createImplicitTensorToNum(const TypePtr& type, Value* value);
-  TORCH_API Node* createUserObject(UserTypePtr type);
+  TORCH_API Node* createUserObject(const UserTypePtr& type);
   TORCH_API Node* createSetAttr(
       Value* obj,
       const std::string& field,

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1062,6 +1062,12 @@ struct Graph {
   TORCH_API Node* createDictIndex(Value* dict, Value* index);
   TORCH_API Node* createNumToTensor(Value* value);
   TORCH_API Node* createImplicitTensorToNum(const TypePtr& type, Value* value);
+  TORCH_API Node* createUserObject(UserTypePtr type);
+  TORCH_API Node* createSetAttr(
+      Value* obj,
+      const std::string& field,
+      Value* newValue);
+  TORCH_API Node* createGetAttr(Value* obj, const std::string& field);
   Node* createPythonOp(
       THPObjectPtr&& pyobj,
       const std::string& cconv,

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -12,6 +12,7 @@ bool shouldAnnotate(const TypePtr& type) {
       type->kind() == TypeKind::TupleType ||
       type->kind() == TypeKind::DictType || type->kind() == TypeKind::VarType ||
       type->kind() == TypeKind::FutureType ||
+      type->kind() == TypeKind::UserType ||
       (type->kind() == TypeKind::OptionalType &&
        shouldAnnotate(type->cast<OptionalType>()->getElementType()));
 }
@@ -202,6 +203,7 @@ void AliasDb::analyze(const std::shared_ptr<Graph>& graph) {
   std::map<TypeKind, std::vector<Value*>> listTypes;
   std::unordered_map<TupleTypePtr, std::vector<Value*>> tupleTypes;
   std::unordered_map<DictTypePtr, std::vector<Value*>> dictTypes;
+  std::unordered_map<UserTypePtr, std::vector<Value*>> userTypes;
   std::vector<Value*> tensors;
 
   for (auto input : graph->inputs()) {
@@ -227,6 +229,9 @@ void AliasDb::analyze(const std::shared_ptr<Graph>& graph) {
     } else if (inputType->kind() == TypeKind::DictType) {
       auto dictType = inputType->cast<DictType>();
       dictTypes[dictType].push_back(input);
+    } else if (inputType->kind() == TypeKind::UserType) {
+      auto userType = inputType->cast<UserType>();
+      userTypes[userType].push_back(input);
     } else {
       AT_ASSERT(!shouldAnnotate(input));
     }
@@ -240,6 +245,9 @@ void AliasDb::analyze(const std::shared_ptr<Graph>& graph) {
     makeAllAlias(pr.second, *aliasTracker_);
   }
   for (const auto& pr : dictTypes) {
+    makeAllAlias(pr.second, *aliasTracker_);
+  }
+  for (const auto& pr : userTypes) {
     makeAllAlias(pr.second, *aliasTracker_);
   }
   makeAllAlias(tensors, *aliasTracker_);
@@ -292,6 +300,7 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::BroadcastSizes:
     case prim::ChunkSizes:
     case prim::Function:
+    case prim::CreateUserObject:
       return analyzeCreator(node);
     case prim::TupleUnpack:
     case prim::TupleIndex:
@@ -299,11 +308,14 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::TupleSlice:
     case prim::ListUnpack:
     case prim::PythonOp:
+    case prim::GetAttr:
       return analyzeExtractor(node);
     case prim::ConstantChunk:
       return analyzeChunk(node);
     case prim::BroadcastingChunk:
       return analyzeBroadcastingChunk(node);
+    case prim::SetAttr:
+      return analyzeSetAttr(node);
     case aten::add:
     case aten::sub:
     case aten::mul:
@@ -496,7 +508,9 @@ void AliasDb::analyzeCreator(Node* node) {
 // gives up and creates wildcards for everything.
 void AliasDb::analyzeExtractor(Node* node) {
   for (const auto output : node->outputs()) {
-    aliasTracker_->setWildcard(output);
+    if (shouldAnnotate(output)) {
+      aliasTracker_->setWildcard(output);
+    }
   }
 }
 
@@ -571,6 +585,13 @@ void AliasDb::analyzeWait(Node* node) {
       aliasTracker_->registerWrite(write, node);
     }
   }
+}
+
+// SetAttr: writes to the `self` field
+void AliasDb::analyzeSetAttr(Node* node) {
+  const auto self = node->inputs().at(0);
+  AT_ASSERT(self->type()->kind() == TypeKind::UserType);
+  aliasTracker_->registerWrite(self, node);
 }
 
 // BroadcastingChunk: all inputs are broadcasted, and then individually chunked.
@@ -1000,6 +1021,9 @@ TORCH_API bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::ConstantChunk,
       prim::BroadcastingChunk,
       prim::fork,
+      prim::CreateUserObject,
+      prim::GetAttr,
+      prim::SetAttr,
       aten::wait,
       aten::add,
       aten::sub,

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -114,6 +114,7 @@ class AliasDb {
   void analyzeBroadcastingChunk(Node* node);
   void analyzeFork(Node* node);
   void analyzeWait(Node* node);
+  void analyzeSetAttr(Node* node);
 
   void makeAliasOf(const Value* value, const Value* to);
   void mapAliases(at::ArrayRef<Value*> to, at::ArrayRef<Value*> from);

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -194,7 +194,7 @@ class DeadCodeEliminator {
     if (!aliasDb_) {
       // If we don't have alias information, all mutable ops have unknown
       // effects and can't be considered for elimination.
-      if (!node->kind().is_aten()) {
+      if (!node->kind().is_aten() && !node->kind().is_prim()) {
         return false;
       }
       // onnx export calls EliminateDeadCode but sometimes passes invalid

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -839,6 +839,10 @@ struct PythonPrintPass {
             [graph, name, this] { printFunctionDefinition(*graph, name); });
         stmt << "self." << name;
       } break;
+      case prim::CreateUserObject:
+      case prim::SetAttr:
+      case prim::GetAttr:
+        throw std::runtime_error("NYI");
       default: {
         Symbol kind = node->kind();
         if (kind.is_aten()) {
@@ -1082,6 +1086,9 @@ TORCH_API bool printerHasSpecialCaseFor(Symbol sym) {
       prim::TupleSlice,
       prim::TupleUnpack,
       prim::Undefined,
+      prim::CreateUserObject,
+      prim::GetAttr,
+      prim::SetAttr,
   };
 
   // WARNING: by adding a value to this set, you are asserting that your

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -222,6 +222,7 @@ inline IValue toIValue(
     case TypeKind::GeneratorType:
     case TypeKind::VarType:
     case TypeKind::FutureType:
+    case TypeKind::UserType:
       break;
   }
   AT_ERROR(

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -816,7 +816,38 @@ RegisterOperators reg({
           }
           return 0;
         }),
-});
+     Operator(
+         prim::CreateUserObject,
+         [](const Node* node) {
+           auto type = node->output()->type()->cast<UserType>();
+           AT_ASSERT(type);
+           return [=](Stack& stack) {
+             auto userObj = c10::ivalue::UserObject::create(type->name());
+             push(stack, userObj);
+             return 0;
+           };
+         }),
+     // TODO schematize?
+     Operator(
+         prim::GetAttr,
+         [](const Node* node) {
+           return [](Stack& stack) {
+             auto fieldname = pop(stack).toString();
+             auto userObj = pop(stack).toUserObject();
+             auto value = userObj->getAttr(*fieldname);
+             push(stack, value);
+             return 0;
+           };
+         }), // TODO schematize?
+     Operator(prim::SetAttr, [](const Node* node) {
+       return [](Stack& stack) {
+         auto v = pop(stack);
+         auto fieldname = pop(stack).toString();
+         auto userObj = pop(stack).toUserObject();
+         userObj->setAttr(*fieldname, v);
+         return 0;
+       };
+     })});
 
 // define implementations for primitive number ops
 #define DEFINE_GENERIC_OP(aten_op, int_op, float_op, int_result, float_result) \

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -833,7 +833,7 @@ RegisterOperators reg({
          prim::GetAttr,
          [](const Node* node) {
            const auto type = node->input()->type()->expect<UserType>();
-           const auto field = node->s(attr::name);
+           const auto& field = node->s(attr::name);
            const auto slot = type->getAttributeSlot(field);
            return [slot](Stack& stack) {
              auto userObj = pop(stack).toUserObject();
@@ -844,7 +844,7 @@ RegisterOperators reg({
          }),
      Operator(prim::SetAttr, [](const Node* node) {
        const auto type = node->inputs().at(0)->type()->expect<UserType>();
-       const auto field = node->s(attr::name);
+       const auto& field = node->s(attr::name);
        const auto slot = type->getAttributeSlot(field);
        return [slot](Stack& stack) {
          auto v = pop(stack);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/jit/script/compiler.h>
+
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/hooks_for_testing.h>
 #include <torch/csrc/jit/interpreter.h>
@@ -566,6 +567,7 @@ struct to_ir {
       const SugaredValuePtr& self,
       Block* block) {
     auto schema = extractSchemaFromDef(def, self);
+    // TODO need guards on init returning none
     if (schema.returns().size() == 1) {
       def_stack_.back().declared_return_type_ = schema.returns().at(0).type();
     }
@@ -620,8 +622,9 @@ struct to_ir {
       const SugaredValuePtr& self) {
     auto params_begin = decl.params().begin();
     auto params_end = decl.params().end();
-    if (self)
+    if (self && !dynamic_cast<UserTypeValue*>(self.get())) {
       ++params_begin;
+    }
     std::vector<Argument> retval;
 
     std::vector<Expr> default_types;
@@ -690,7 +693,7 @@ struct to_ir {
   FunctionSchema extractSchemaFromDef(
       const Def& def,
       const SugaredValuePtr& self) {
-    auto name = def.name().name();
+    const auto name = def.name().name();
     std::vector<Argument> args = parseArgsFromDecl(def.decl(), self);
     std::vector<Argument> returns = parseReturnFromDecl(def.decl());
     return FunctionSchema(
@@ -706,8 +709,11 @@ struct to_ir {
     // inputs
     auto it = def.decl().params().begin();
     auto end = def.decl().params().end();
-    auto expected_annotation_size =
-        self ? def.decl().params().size() - 1 : def.decl().params().size();
+    auto userType = dynamic_cast<UserTypeValue*>(self.get());
+    auto expected_annotation_size = def.decl().params().size();
+    if (self && !userType) {
+      expected_annotation_size--;
+    }
     if (schema.arguments().size() != expected_annotation_size) {
       throw ErrorReport(def.decl().params().range())
           << "Number of type annotations for"
@@ -715,12 +721,25 @@ struct to_ir {
           << " does not match the number of parameters on the function ("
           << expected_annotation_size << ")!";
     }
+
+    size_t arg_annotation_idx = 0;
     if (self) {
       AT_ASSERT(it != end);
-      environment_stack->setSugaredVar(def.range(), (*it).ident().name(), self);
+      const auto& name = (*it).ident().name();
+      environment_stack->setSugaredVar(def.range(), name, self);
+      // If this is a first-class type, we also need to bind "self" to a block
+      // input.
+      // TODO simplify this code and merge with below
+      if (userType) {
+        Value* new_input = block->addInput();
+        new_input->setUniqueName(name);
+        userType->value_ = new_input;
+
+        arguments.push_back(schema.arguments().at(arg_annotation_idx++));
+        new_input->setType(arguments.back().type());
+      }
       ++it;
     }
-    size_t arg_annotation_idx = 0;
     for (; it != end; ++it) {
       auto& name = (*it).ident().name();
       // Add the input to the graph
@@ -1796,6 +1815,9 @@ struct to_ir {
       case TK_TUPLE_LITERAL:
         emitTupleAssign(TupleLiteral(stmt.lhs()), stmt.rhs());
         break;
+      case '.':
+        emitSelectAssign(stmt);
+        break;
       case TK_SUBSCRIPT:
         emitSubscriptAssign(stmt.range(), Subscript(stmt.lhs()), stmt.rhs());
         break;
@@ -1803,6 +1825,15 @@ struct to_ir {
         throw ErrorReport(stmt.lhs())
             << "unexpected expression on left-hand side of assignment.";
     }
+  }
+
+  void emitSelectAssign(const Assign& stmt) {
+    const auto lhs = Select(stmt.lhs());
+    const auto basename = Var(lhs.value()).name();
+    const auto rhsValue =
+        emitSugaredExpr(stmt.rhs(), 1)->asValue(stmt.rhs().range(), method);
+    auto userObject = environment_stack->getSugaredVar(basename);
+    userObject->assign(stmt.range(), method, lhs.selector().name(), rhsValue);
   }
 
   NodeKind getNodeKind(int kind, int ninputs) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -311,7 +311,7 @@ struct ModuleValue : public SugaredValue {
     if (NamedModule* v = module->find_module(field)) {
       return std::make_shared<ModuleValue>(v->module);
     } else if (Method* v = module->find_method(field)) {
-      return std::make_shared<MethodValue>(module, *v);
+      return std::make_shared<MethodValue>(shared_from_this(), *v);
     } else if (NamedParameter* v = module->find_parameter(field)) {
       return std::make_shared<SimpleValue>(m.get_or_add_parameter(v->slot()));
     }
@@ -523,6 +523,15 @@ std::shared_ptr<SugaredValue> toSugaredValue(
       throw ErrorReport()
           << "Attempted to inline a Module with parameters. "
              "Stateful modules to be inlined must be submodules of the callee.";
+    }
+    const auto script_class_type =
+        py::module::import("torch.jit").attr("ScriptClass");
+    const bool is_user_type = py::isinstance(obj, script_class_type);
+    if (is_user_type) {
+      const auto classname = py::cast<std::string>(py::getattr(obj, "_name"));
+      auto userType = UserType::get(classname);
+      AT_ASSERT(userType);
+      return std::make_shared<UserTypeValue>(std::move(userType));
     }
     return std::make_shared<ModuleValue>(mod);
   } else if (py::isinstance<py::module>(obj)) {
@@ -956,6 +965,26 @@ void initJitScriptBindings(PyObject* module) {
             def.range(), method.getSchema(), def.name().name(), defaults));
         didFinishEmitModule(mod);
         return mod;
+      });
+
+  m.def(
+      "_jit_script_class_compile",
+      [](std::shared_ptr<Module> module,
+         const ClassDef& def,
+         ResolutionCallback rcb) {
+        auto userType = UserType::create(def.name().name(), module);
+        std::vector<Resolver> rcbs;
+        std::vector<Def> methodDefs;
+        for (const auto& def : def.defs()) {
+          methodDefs.push_back(def);
+          rcbs.push_back(pythonResolver(rcb));
+        }
+        defineMethodsInModule(
+            module,
+            methodDefs,
+            rcbs,
+            std::make_shared<UserTypeValue>(userType));
+        return module;
       });
 
   m.def("parse_type_comment", [](const std::string& comment) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -970,12 +970,12 @@ void initJitScriptBindings(PyObject* module) {
   m.def(
       "_jit_script_class_compile",
       [](std::shared_ptr<Module> module,
-         const ClassDef& def,
+         const ClassDef& classDef,
          ResolutionCallback rcb) {
-        auto userType = UserType::create(def.name().name(), module);
+        auto userType = UserType::create(classDef.name().name(), module);
         std::vector<Resolver> rcbs;
         std::vector<Def> methodDefs;
-        for (const auto& def : def.defs()) {
+        for (const auto& def : classDef.defs()) {
           methodDefs.push_back(def);
           rcbs.push_back(pythonResolver(rcb));
         }

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -95,7 +95,8 @@ namespace script {
   _(TK_RAISE, "raise", "raise")                  \
   _(TK_ASSERT, "assert", "assert")               \
   _(TK_DOTS, "dots", "...")                      \
-  _(TK_PASS, "pass", "pass")
+  _(TK_PASS, "pass", "pass")                     \
+  _(TK_CLASS_DEF, "class", "class")
 
 static const char* valid_single_char_tokens = "+-*/%@()[]:,={}><.?!&^|";
 

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -62,6 +62,7 @@ Value* try_emit_call_to(
 Value* Method::emit_call_to(
     const SourceRange& loc,
     Method& callee,
+    c10::optional<NamedValue> self,
     ArrayRef<NamedValue> args,
     ArrayRef<NamedValue> kwargs) {
   AT_ASSERT(!executor);
@@ -70,7 +71,7 @@ Value* Method::emit_call_to(
           *graph(),
           loc,
           callee,
-          c10::nullopt,
+          self,
           args,
           kwargs,
           failure_messages,

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -62,7 +62,6 @@ Value* try_emit_call_to(
 Value* Method::emit_call_to(
     const SourceRange& loc,
     Method& callee,
-    c10::optional<NamedValue> self,
     ArrayRef<NamedValue> args,
     ArrayRef<NamedValue> kwargs) {
   AT_ASSERT(!executor);
@@ -71,7 +70,7 @@ Value* Method::emit_call_to(
           *graph(),
           loc,
           callee,
-          self,
+          c10::nullopt,
           args,
           kwargs,
           failure_messages,

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -108,7 +108,6 @@ struct Method {
   Value* emit_call_to(
       const SourceRange& loc,
       Method& callee,
-      c10::optional<NamedValue> self,
       ArrayRef<NamedValue> args,
       ArrayRef<NamedValue> kwargs);
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -108,6 +108,7 @@ struct Method {
   Value* emit_call_to(
       const SourceRange& loc,
       Method& callee,
+      c10::optional<NamedValue> self,
       ArrayRef<NamedValue> args,
       ArrayRef<NamedValue> kwargs);
 

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -120,6 +120,11 @@ void initTreeViewBindings(PyObject* module) {
         const auto& r = name.range();
         return Def::create(r, name, decl, wrap_list(r, std::move(body)));
       }));
+  py::class_<ClassDef, TreeView>(m, "ClassDef")
+      .def(py::init([](const Ident& name, std::vector<Def> body) {
+        const auto& r = name.range();
+        return ClassDef::create(r, name, wrap_list(r, std::move(body)));
+      }));
   py::class_<Decl, TreeView>(m, "Decl").def(py::init(
       [](const SourceRange& r, std::vector<Param> params, Expr* return_type) {
         return Decl::create(

--- a/torch/csrc/jit/script/script_type_parser.cpp
+++ b/torch/csrc/jit/script/script_type_parser.cpp
@@ -178,6 +178,9 @@ TypePtr parseTypeFromExpr(const Expr& expr) {
     if (itr != ident_to_type_lut().end()) {
       return itr->second;
     }
+    if (auto typePtr = UserType::get(*name)) {
+      return typePtr;
+    }
     throw ErrorReport(expr) << "Unknown type name " << *name;
   }
   throw ErrorReport(expr.range())

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -73,11 +73,11 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     Method& m,
     const std::string& field) {
   // Allow method-style casts on Tensor types. e.g. x.int()
-  if (value->type()->isSubtypeOf(TensorType::get())) {
+  if (value_->type()->isSubtypeOf(TensorType::get())) {
     if (builtin_cast_methods().count(field)) {
       return std::make_shared<BuiltinFunction>(
           Symbol::aten(builtin_cast_methods().at(field)),
-          NamedValue(loc, "self", value));
+          NamedValue(loc, "self", value_));
     }
     // functions that are just direct property lookups on tensor
     // must be registered as prim::<name>(Tensor t) -> <return_type>
@@ -90,15 +90,14 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     };
     if (fields.count(field)) {
       auto r =
-          m.graph()->insert(Symbol::fromQualString("prim::" + field), {value});
+          m.graph()->insert(Symbol::fromQualString("prim::" + field), {value_});
       return std::make_shared<SimpleValue>(r);
     }
   }
-  if (getValue()->type()->isSubtypeOf(NumberType::get())) {
+  if (value_->type()->isSubtypeOf(NumberType::get())) {
     throw ErrorReport(loc) << "Cannot call methods on numbers";
   }
-  if (getValue()->type()->kind() == TypeKind::TupleType) {
-    auto tuple_type = getValue()->type()->expect<TupleType>();
+  if (auto tuple_type = value_->type()->cast<TupleType>()) {
     if (!tuple_type->hasNames()) {
       throw ErrorReport(loc) << "Getting attributes of tuples is not supported";
     }
@@ -106,15 +105,32 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     for (size_t i = 0; i < names.size(); i++) {
       if (names[i] == field) {
         auto r = m.graph()
-                     ->insertNode(m.graph()->createTupleIndex(getValue(), i))
+                     ->insertNode(m.graph()->createTupleIndex(value_, i))
                      ->output();
         return std::make_shared<SimpleValue>(r);
       }
     }
     throw ErrorReport(loc) << "Unknown attribute to named tuple";
   }
+
+  if (auto userType = value_->type()->cast<UserType>()) {
+    // This is a user-defined type, emit the proper attribute lookup
+    if (auto method = userType->getMethod(field)) {
+      return std::make_shared<MethodValue>(shared_from_this(), *method);
+    }
+
+    if (!userType->hasAttribute(field)) {
+      throw ErrorReport(loc)
+          << "Tried to access to nonexistent attribute " << field
+          << ". Did you forget to initialize it in __init__()?";
+    }
+    auto& g = *m.graph();
+    auto n = g.insertNode(g.createGetAttr(value_, field));
+    return std::make_shared<SimpleValue>(n->output());
+  }
+
   return std::make_shared<BuiltinFunction>(
-      Symbol::aten(field), NamedValue(loc, "self", value));
+      Symbol::aten(field), NamedValue(loc, "self", value_));
 }
 
 std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(
@@ -125,38 +141,53 @@ std::vector<std::shared_ptr<SugaredValue>> SimpleValue::asTuple(
       [](Value* v) -> std::shared_ptr<SugaredValue> {
     return std::make_shared<SimpleValue>(v);
   };
-  if (value->type()->kind() == TypeKind::TupleType) {
-    auto outputs = createTupleUnpack(value);
+  if (value_->type()->kind() == TypeKind::TupleType) {
+    auto outputs = createTupleUnpack(value_);
     return fmap(outputs, make_simple_value);
-  } else if (value->type()->kind() == TypeKind::ListType) {
+  } else if (value_->type()->kind() == TypeKind::ListType) {
     if (!size_hint) {
       throw ErrorReport(loc)
           << "cannot statically infer the expected size of a list in this context";
     }
-    auto graph = value->owningGraph();
+    auto graph = value_->owningGraph();
     Node* unpack =
-        graph->insertNode(graph->createListUnpack(value, *size_hint));
+        graph->insertNode(graph->createListUnpack(value_, *size_hint));
     return fmap(unpack->outputs(), make_simple_value);
   }
-  throw ErrorReport(loc) << value->type()->str()
+  throw ErrorReport(loc) << value_->type()->str()
                          << " cannot be used as a tuple";
 }
 
-void UserTypeValue::assign(
+void SimpleValue::setAttr(
     const SourceRange& loc,
     Method& m,
     const std::string& field,
-    Value* newValue) {
-  auto expectedType = type_->getAttribute(field);
+    Value* newValue,
+    bool shouldDefine) {
+  const auto userType = value_->type()->cast<UserType>();
+  if (!userType) {
+    throw ErrorReport(loc) << "Tried to set an attribute: " << field
+                           << " on a non-user-defined type: "
+                           << value_->type()->str();
+  }
+
+  auto expectedType = userType->getAttribute(field);
   if (!expectedType) {
     // We don't have an attribute with this name, either add it to the type
     // definition or throw an error
-    if (m.name() == "__init__") {
-      type_->addAttribute(field, newValue->type());
+    if (shouldDefine) {
+      userType->addAttribute(field, newValue->type());
       expectedType = newValue->type();
+      const auto insertPoint = m.graph()->insertPoint();
+      const auto topLevelBlock = m.graph()->block();
+      if (insertPoint->owningBlock() != topLevelBlock) {
+        throw ErrorReport(loc)
+            << "First assignment cannot be in a control-flow block. "
+            << "Initialize the field at the top level first.";
+      }
     } else {
       throw ErrorReport(loc)
-          << "Tried to assign to nonexistent attribute " << field
+          << "Tried to set nonexistent attribute: " << field
           << ". Did you forget to initialize it in __init__()?";
     }
   }
@@ -173,25 +204,6 @@ void UserTypeValue::assign(
   g.insertNode(g.createSetAttr(value_, field, newValue));
 }
 
-std::shared_ptr<SugaredValue> UserTypeValue::attr(
-    const SourceRange& loc,
-    Method& m,
-    const std::string& field) {
-  AT_ASSERT(value_);
-  if (auto method = type_->module()->find_method(field)) {
-    return std::make_shared<MethodValue>(shared_from_this(), *method);
-  }
-
-  if (!type_->hasAttribute(field)) {
-    throw ErrorReport(loc)
-        << "Tried to access to nonexistent attribute " << field
-        << ". Did you forget to initialize it in __init__()?";
-  }
-  auto& g = *m.graph();
-  auto n = g.insertNode(g.createGetAttr(value_, field));
-  return std::make_shared<SimpleValue>(n->output());
-}
-
 std::shared_ptr<SugaredValue> UserTypeValue::call(
     const SourceRange& loc,
     Method& m,
@@ -204,17 +216,15 @@ std::shared_ptr<SugaredValue> UserTypeValue::call(
   // Generate a new object of the right type, then call `__init__` on it
   auto& g = *m.graph();
   auto createNode = g.insertNode(g.createUserObject(type_));
-  value_ = createNode->output();
+  auto self = std::make_shared<SimpleValue>(createNode->output());
 
-  auto initMethod = type_->module()->find_method("__init__");
+  auto initMethod = type_->getMethod("__init__");
   AT_ASSERT(initMethod);
 
   // Call the init function
-  MethodValue(shared_from_this(), *initMethod)
-      .call(loc, m, inputs, attributes, n_binders);
+  MethodValue(self, *initMethod).call(loc, m, inputs, attributes, n_binders);
 
-  // Return `self`
-  return shared_from_this();
+  return self;
 }
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -22,6 +22,7 @@ namespace script {
 //
 // Decl  = Decl(List<Param> params, Maybe<Expr> return_type)            TK_DECL
 // Def   = Def(Ident name, Decl decl, List<Stmt> body)                  TK_DEF
+// ClassDef = ClassDef(Ident name, List<Def> body)                      TK_CLASS_DEF
 //
 // Stmt  = If(Expr cond, List<Stmt> true_body, List<Stmt> false_body)   TK_IF
 //       | For(List<Expr> targets, List<Expr> iters, List<Stmt> body)   TK_FOR
@@ -397,6 +398,28 @@ struct Def : public TreeView {
       const Decl& decl,
       const List<Stmt>& stmts) {
     return Def(Compound::create(TK_DEF, range, {name, decl, stmts}));
+  }
+};
+
+struct ClassDef : public TreeView {
+  explicit ClassDef(const TreeRef& tree) : TreeView(tree) {
+    tree->match(TK_CLASS_DEF);
+  }
+  ClassDef withName(std::string new_name) const {
+    auto new_ident = Ident::create(name().range(), std::move(new_name));
+    return create(range(), new_ident, defs());
+  }
+  Ident name() const {
+    return Ident(subtree(0));
+  }
+  List<Def> defs() const {
+    return List<Def>(subtree(1));
+  }
+  static ClassDef create(
+      const SourceRange& range,
+      const Ident& name,
+      const List<Def>& defs) {
+    return ClassDef(Compound::create(TK_CLASS_DEF, range, {name, defs}));
   }
 };
 

--- a/torch/csrc/jit/script/user_type.cpp
+++ b/torch/csrc/jit/script/user_type.cpp
@@ -1,0 +1,12 @@
+#include <ATen/core/jit_type.h>
+#include <torch/csrc/jit/script/module.h>
+
+namespace c10 {
+
+// This file exists because we need to reference module.h, which we can't from
+// c10. Sigh...
+Method* UserType::getMethod(const std::string& name) const {
+  return module_->find_method(name);
+}
+
+} // namespace c10

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -3,7 +3,7 @@ from torch import Tensor
 from torch.autograd import Variable, function
 from torch.serialization import validate_cuda_device
 from torch.nn import Module, ModuleList, ParameterList, Parameter, Sequential
-from torch.jit.frontend import get_jit_ast, get_default_args
+from torch.jit.frontend import get_jit_class_def, get_jit_def, get_default_args
 import torch.backends.cudnn as cudnn
 import torch.jit.annotations
 import torch._jit_internal as _jit_internal
@@ -56,6 +56,7 @@ _enabled = _parse_env('PYTORCH_JIT', True, "> Using PyTorch JIT", "> PyTorch JIT
 _flatten = torch._C._jit_flatten
 _unflatten = torch._C._jit_unflatten
 _jit_script_compile = torch._C._jit_script_compile
+_jit_script_class_compile = torch._C._jit_script_class_compile
 BatchTensor = torch._C._jit.BatchTensor
 
 Future = torch._C.Future
@@ -712,17 +713,23 @@ def _try_compile_weak_script(fn):
         return entry["compiled_fn"]
 
 
-def script(fn, optimize=True, _frames_up=0, _rcb=None):
+def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if not _enabled:
-        return fn
+        return obj
     if _rcb is None:
         _rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
-    ast = get_jit_ast(fn, is_method=False)
-    mod = ScriptModule()
-    _jit_script_compile(mod, ast, _rcb, get_default_args(fn))
+    if inspect.isclass(obj):
+        mod = ScriptClass(obj.__name__)
+        ast = get_jit_class_def(obj)
+        _jit_script_class_compile(mod, ast, _rcb)
+    else:
+        mod = ScriptModule()
+        ast = get_jit_def(obj)
+        _jit_script_compile(mod, ast, _rcb, get_default_args(obj))
     # Forward docstrings
-    mod.__doc__ = fn.__doc__
+    mod.__doc__ = obj.__doc__
     return mod
+
 
 ScriptMethodStub = namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))
 
@@ -744,7 +751,7 @@ def script_method(fn, _rcb=None):
     # function (the calling function). Adding 2 gets us to the proper surrounding scope.
     if _rcb is None:
         _rcb = _jit_internal.createResolutionCallback(frames_up=2)
-    ast = get_jit_ast(fn, is_method=True)
+    ast = get_jit_def(fn, self_name="ScriptModule")
     return ScriptMethodStub(_rcb, ast, fn)
 
 
@@ -1268,11 +1275,19 @@ if _enabled:
                                      "weak script module once it has been "
                                      "created".format(attr))
 
+    class ScriptClass(ScriptModule):
+        def __init__(self, name):
+            super(ScriptClass, self).__init__()
+            self._name = name
+
 else:
     class ScriptModule(torch.nn.Module):
         def __init__(self, optimize=True):
             super(ScriptModule, self).__init__()
 
+    class ScriptClass(ScriptModule):
+        def __init__(self, name):
+            super(ScriptClass, self).__init__()
 
 def _get_weak_stubs(cls):
     """

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1289,6 +1289,7 @@ else:
         def __init__(self, name):
             super(ScriptClass, self).__init__()
 
+
 def _get_weak_stubs(cls):
     """
     Calls script_method for each method on the type of the object passed in and

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -221,7 +221,7 @@ def build_param(ctx, py_arg, self_name, kwarg_only):
     r = ctx.make_range(py_arg.lineno, py_arg.col_offset, py_arg.col_offset + len(name))
     if getattr(py_arg, 'annotation', None) is not None:
         annotation_expr = build_expr(ctx, py_arg.annotation)
-    elif self_name is not None and py_arg.arg == 'self':
+    elif self_name is not None and name == 'self':
         annotation_expr = Var(Ident(r, self_name))
     else:
         annotation_expr = Var(Ident(r, 'Tensor'))

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -137,14 +137,26 @@ def _uses_true_division(fn):
             '_uses_true_division: expected function or method, got {}'.format(type(fn)))
 
 
-def get_jit_ast(fn, is_method):
+def get_jit_class_def(cls, self_name=None):
+    # Get defs for each method independently
+    methods = inspect.getmembers(cls, predicate=inspect.isfunction)
+    method_defs = [get_jit_def(method[1],
+                   self_name=cls.__name__) for method in methods]
+
+    source = dedent(inspect.getsource(cls))
+    py_ast = ast.parse(source)
+    ctx = SourceContext(source, False)
+    return build_class_def(ctx, py_ast.body[0], method_defs)
+
+
+def get_jit_def(fn, self_name=None):
     source = dedent(inspect.getsource(fn))
     py_ast = ast.parse(source)
     if len(py_ast.body) != 1 or not isinstance(py_ast.body[0], ast.FunctionDef):
         raise RuntimeError("expected a single top-level function")
     type_line = torch.jit.annotations.get_type_line(source)
     ctx = SourceContext(source, _uses_true_division(fn))
-    return build_def(ctx, py_ast.body[0], type_line, is_method)
+    return build_def(ctx, py_ast.body[0], type_line, self_name)
 
 
 # Thin wrapper around SourceRangeFactory to store extra metadata
@@ -163,17 +175,22 @@ class Builder(object):
         return method(ctx, node)
 
 
-def build_def(ctx, py_def, type_line, is_method):
-    returns = []
-    ret_body = []
+def build_class_def(ctx, py_def, methods):
+    r = ctx.make_range(py_def.lineno, py_def.col_offset,
+                       py_def.col_offset + len("class"))
+    return ClassDef(Ident(r, py_def.name), methods)
+
+
+def build_def(ctx, py_def, type_line, self_name=None):
     body = py_def.body
     r = ctx.make_range(py_def.lineno, py_def.col_offset,
                        py_def.col_offset + len("def"))
-    param_list = build_param_list(ctx, py_def.args)
+    param_list = build_param_list(ctx, py_def.args, self_name)
     return_type = None
     if getattr(py_def, 'returns', None) is not None:
         return_type = build_expr(ctx, py_def.returns)
     decl = Decl(r, param_list, return_type)
+    is_method = self_name is not None
     if type_line is not None:
         type_comment_decl = torch._C.parse_type_comment(type_line)
         decl = torch._C.merge_type_from_type_comment(decl, type_comment_decl, is_method)
@@ -186,24 +203,26 @@ _vararg_kwarg_err = ("Compiled functions can't take variable number of arguments
                      "or use keyword-only arguments with defaults")
 
 
-def build_param_list(ctx, py_args):
+def build_param_list(ctx, py_args, self_name):
     if py_args.vararg is not None or py_args.kwarg is not None:
         raise ValueError(_vararg_kwarg_err)
     if not PY2 and py_args.kw_defaults:
         raise ValueError(_vararg_kwarg_err)
-    result = [build_param(ctx, arg, False) for arg in py_args.args]
+    result = [build_param(ctx, arg, self_name, False) for arg in py_args.args]
     if not PY2:
-        result += [build_params(ctx, arg, True) for arg in py_args.kwonlyargs]
+        result += [build_params(ctx, arg, self_name, True) for arg in py_args.kwonlyargs]
     return result
 
 
-def build_param(ctx, py_arg, kwarg_only):
+def build_param(ctx, py_arg, self_name, kwarg_only):
     # NB: In Python3 py_arg is a pair of (str arg, expr? annotation)
     #     In Python2 py_arg is a Name (Expr subclass)
     name = py_arg.id if PY2 else py_arg.arg
     r = ctx.make_range(py_arg.lineno, py_arg.col_offset, py_arg.col_offset + len(name))
     if getattr(py_arg, 'annotation', None) is not None:
         annotation_expr = build_expr(ctx, py_arg.annotation)
+    elif self_name is not None and py_arg.arg == 'self':
+        annotation_expr = Var(Ident(r, self_name))
     else:
         annotation_expr = Var(Ident(r, 'Tensor'))
     return Param(annotation_expr, Ident(r, name), kwarg_only)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -139,7 +139,8 @@ def _uses_true_division(fn):
 
 def get_jit_class_def(cls, self_name=None):
     # Get defs for each method independently
-    methods = inspect.getmembers(cls, predicate=inspect.isfunction)
+    methods = inspect.getmembers(
+        cls, predicate=lambda m: inspect.ismethod(m) or inspect.isfunction(m))
     method_defs = [get_jit_def(method[1],
                    self_name=cls.__name__) for method in methods]
 


### PR DESCRIPTION
First pass at user defined types. The following is contained in this PR:
- `UserType` type, which contains a reference to a module with all methods for the type, and a separate namespace for data attributes (map of name -> TypePtr). 
- `UserTypeRegistry`, similar to the operator registry
- `UserObject` which is the runtime representation of the user type (just a map of names -> IValues)
- `UserTypeValue` SugaredValue, to manage getattr and setattr while generating IR, plus compiler.cpp changes to make that work.
- Frontend changes to get `@torch.jit.script` to work as a class decorator
- `ClassDef` node in our AST.
- primitive ops for object creation, setattr, and getattr, plus alias analysis changes to make mutation safe.

Things that definitely need to get done:
- Import/export, python_print support
- String frontend doesn't understand class definitions yet
- Python interop (using a user-defined type outside TorchScript) is completely broken
- Static methods (without `self`) don't work

Things that are nice but not essential:
- Method definition shouldn't matter (right now you can only reference a method that's already been defined)
- Class definitions can only contain defs, no other expressions are supported.

Things I definitely won't do initially:
- Polymorphism/inheritance