### PR TITLE
[jit] allow lists to contain any tensor type

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10313,6 +10313,19 @@ a")
         a_dict = {'a': torch.ones(1), 'b': torch.ones(1) + 1, 'c': torch.ones(1) + 2}
         self.checkScript(fn, (a_dict, ('a', 'c')))
 
+    def test_tensor_import_export(self):
+        @torch.jit.script
+        def foo(x):
+            a = torch.tensor(1)
+            b = torch.tensor([1, 2])
+            c = [a, b]
+            return c
+
+        self.run_pass('constant_propagation', foo.graph)
+        m = torch.jit.ScriptModule()
+        m._create_method_from_graph("forward", foo.graph)
+        self.getExportImportCopy(m)
+
 
 class MnistNet(nn.Module):
     def __init__(self):

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2243,6 +2243,13 @@ struct to_ir {
         } else if (!values.empty()) {
           elem_type = values.at(0)->type();
         }
+
+        // If we inferred the elem_type to be a specialized tensor type, relax
+        // elem_type to be a dynamic Tensor type. This is to allow lists that
+        // look like: [CompleteTensorType, TensorType, ...]
+        if (elem_type->isSubtypeOf(TensorType::get())) {
+          elem_type = TensorType::get();
+        }
         for (auto v : values) {
           if (!v->type()->isSubtypeOf(elem_type)) {
             throw ErrorReport(tree)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2244,11 +2244,13 @@ struct to_ir {
           elem_type = values.at(0)->type();
         }
 
-        // If we inferred the elem_type to be a specialized tensor type, relax
-        // elem_type to be a dynamic Tensor type. This is to allow lists that
-        // look like: [CompleteTensorType, TensorType, ...]
+        // Tensors are special because they have dymnamic properties. So any
+        // list containing tensors should be typed with the unified typeof all
+        // the elements.
         if (elem_type->isSubtypeOf(TensorType::get())) {
-          elem_type = TensorType::get();
+          for (const auto& value : values) {
+            elem_type = unifyTypes(elem_type, value->type()).value();
+          }
         }
         for (auto v : values) {
           if (!v->type()->isSubtypeOf(elem_type)) {


### PR DESCRIPTION
If something is a TensorList, it should be a list of `TensorType`, not a list of some specialized type. 
Fixes #17140, #15642