### PR TITLE
Improve onnxifi backend init time

### DIFF
--- a/caffe2/onnx/onnxifi_graph_info.cc
+++ b/caffe2/onnx/onnxifi_graph_info.cc
@@ -1,4 +1,5 @@
 #include "caffe2/onnx/onnxifi_graph_info.h"
+#include "caffe2/core/logging.h"
 
 namespace caffe2 {
 namespace onnx {
@@ -14,18 +15,19 @@ SharedPtrBackendGraphInfo OnnxBackendGraphMap::lookup(const std::string& key) {
 
 SharedPtrBackendGraphInfo OnnxBackendGraphMap::insert(
     const std::string& key,
-    BackendGraphInfo backend_graph_info) {
+    std::function<SharedPtrBackendGraphInfo()> creator) {
   // First acquire lock.
   std::lock_guard<std::mutex> guard(backend_graph_map_lock_);
   // Then check if the backend_graph_info already exists in the map.
   if (backend_graph_map_.find(key) != backend_graph_map_.end()) {
+    LOG(INFO) << "Reusing onnxifi backend for: " << key;
     // If it already exists, return it.
     // The onus is on the caller to release onnxGraph pointed by
     // backend_graph_info
     return backend_graph_map_[key];
   }
-  const auto& ret_pair = backend_graph_map_.emplace(
-      key, std::make_shared<BackendGraphInfo>(std::move(backend_graph_info)));
+  LOG(INFO) << "Creating onnxifi backend for: " << key;
+  const auto ret_pair = backend_graph_map_.emplace(key, creator());
   return ret_pair.first->second;
 }
 
@@ -36,6 +38,7 @@ void OnnxBackendGraphMap::remove(const std::string& key) {
     auto it = backend_graph_map_.find(key);
     if (it != backend_graph_map_.end()) {
       if (it->second.unique()) {
+        LOG(INFO) << "Removing onnxifi backend for " << key;
         tmp = it->second;
         backend_graph_map_.erase(it);
       }

--- a/caffe2/onnx/onnxifi_graph_info.h
+++ b/caffe2/onnx/onnxifi_graph_info.h
@@ -83,13 +83,15 @@ class OnnxBackendGraphMap {
 
   SharedPtrBackendGraphInfo lookup(const std::string& key);
 
-  // If acquisition of graph_ptr fails then graph already exists. And the
-  // corresponding SharedPtrBackendGraphInfo is returned. Otherwise graph_ptr is
-  // inserted in the map and the wrapper SharedPtrBackendGraphInfo is
-  // returned.teebfhlbnheuk
+  // If corresponding BackendGraphInfo already exists, return it directly.
+  // Otherwise we use creator to create the BackendGraphInfo shared_ptr and
+  // insert it into the map and return it. The whole process should be guarded
+  // by a lock. Note that since it will create the backend while holding the
+  // lock, expect latency during initialization phase when there are lots of
+  // models to compile.
   SharedPtrBackendGraphInfo insert(
       const std::string& key,
-      BackendGraphInfo graph);
+      std::function<SharedPtrBackendGraphInfo()> creator);
 
   void remove(const std::string& key);
 

--- a/caffe2/operators/onnxifi_op.cc
+++ b/caffe2/operators/onnxifi_op.cc
@@ -89,7 +89,7 @@ void BlobToTensorDescriptor(
 
 template <>
 std::vector<onnxTensorDescriptorV1>
-OnnxifiOp<float, CPUContext>::BuildInitializationList(
+OnnxifiOp<float, CPUContext>::buildInitializationList(
     Workspace* ws,
     std::unordered_set<std::string>* initialization_list,
     std::vector<std::string>* weight_names,

--- a/caffe2/operators/onnxifi_op.h
+++ b/caffe2/operators/onnxifi_op.h
@@ -87,7 +87,7 @@ class OnnxifiOp final : public Operator<Context> {
     Workspace mapped_ws(ws, input_mapping);
     std::vector<std::string> weight_names;
     std::vector<std::vector<uint64_t>> weight_shapes;
-    auto weight_descs = BuildInitializationList(
+    auto weight_descs = buildInitializationList(
         &mapped_ws, &initializer_set, &weight_names, &weight_shapes);
 
     BuildBackendAndGraph(property_pointers, onnx_model_str, weight_descs);
@@ -95,7 +95,6 @@ class OnnxifiOp final : public Operator<Context> {
 
   ~OnnxifiOp() {
     backend_graph_shared_ptr_.reset();
-
     backend_graph_map_ptr_->remove(op_id_string_);
   }
 
@@ -128,87 +127,74 @@ class OnnxifiOp final : public Operator<Context> {
       const std::string& onnx_model_str,
       const std::vector<onnxTensorDescriptorV1>& weight_descs) {
     op_id_string_ =
+        this->template GetSingleArgument<std::string>("model_id", "") + ":" +
         this->template GetSingleArgument<std::string>("net_pos", "");
-    auto net_id_string =
-        this->template GetSingleArgument<std::string>("model_id", "");
-    op_id_string_ += net_id_string;
 
-    backend_graph_shared_ptr_ = backend_graph_map_ptr_->lookup(op_id_string_);
-
-    if (backend_graph_shared_ptr_ == nullptr) {
-      // Build the Onnxifi engine
+    // Build the Onnxifi engine
+    auto backend_index = this->template GetSingleArgument<int>("backend_id", 0);
+    onnxifi_library* lib = lib_;
+    auto creator = [lib,
+                    property_pointers,
+                    backend_index,
+                    &onnx_model_str,
+                    &weight_descs]() {
       std::vector<onnxBackendID> backend_ids;
-      auto backend_index =
-          this->template GetSingleArgument<int>("backend_id", 0);
+      size_t num_backends{0};
       CAFFE_ENFORCE_EQ(
-          lib_->onnxGetBackendIDs(nullptr, &num_backends_),
+          lib->onnxGetBackendIDs(nullptr, &num_backends),
           ONNXIFI_STATUS_FALLBACK);
       CAFFE_ENFORCE_GT(
-          num_backends_, 0, "At least 1 onnxifi backend should be available");
+          num_backends, 0, "At least 1 onnxifi backend should be available");
       CAFFE_ENFORCE_LT(
           backend_index,
-          num_backends_,
+          num_backends,
           "Backend idx out of bound: ",
           backend_index,
           ", #backends: ",
-          num_backends_);
-      backend_ids.resize(num_backends_);
+          num_backends);
+      backend_ids.resize(num_backends);
       CAFFE_ENFORCE_EQ(
-          lib_->onnxGetBackendIDs(backend_ids.data(), &num_backends_),
+          lib->onnxGetBackendIDs(backend_ids.data(), &num_backends),
           ONNXIFI_STATUS_SUCCESS);
 
-      backend_id_ = backend_ids[backend_index];
+      onnxBackendID backend_id = backend_ids[backend_index];
+      onnxBackend backend{nullptr};
 
       CAFFE_ENFORCE_EQ(
-          lib_->onnxInitBackend(
-              backend_id_, property_pointers.data(), &backend_),
+          lib->onnxInitBackend(backend_id, property_pointers.data(), &backend),
           ONNXIFI_STATUS_SUCCESS);
 
       // Release unused backend ids.
-      for (auto i = 0; i < num_backends_; ++i) {
+      for (auto i = 0; i < num_backends; ++i) {
         if (i == backend_index) {
           continue;
         }
-        lib_->onnxReleaseBackendID(backend_ids[i]);
+        lib->onnxReleaseBackendID(backend_ids[i]);
       }
+      onnxGraph graph{nullptr};
+      CAFFE_ENFORCE_EQ(
+          lib->onnxInitGraph(
+              backend,
+              nullptr,
+              onnx_model_str.size(),
+              (const void*)(onnx_model_str.c_str()),
+              weight_descs.size(),
+              weight_descs.data(),
+              &graph),
+          ONNXIFI_STATUS_SUCCESS);
 
-      // Lookup the backend first, if it's not there, create our own and try
-      // submitting it to the backend_graph_map
-      backend_graph_shared_ptr_ = backend_graph_map_ptr_->lookup(op_id_string_);
-      if (!backend_graph_shared_ptr_) {
-        LOG(INFO) << "Creating backend for " << op_id_string_;
-        CAFFE_ENFORCE_EQ(
-            lib_->onnxInitGraph(
-                backend_,
-                nullptr,
-                onnx_model_str.size(),
-                (const void*)(onnx_model_str.c_str()),
-                weight_descs.size(),
-                weight_descs.data(),
-                &graph_),
-            ONNXIFI_STATUS_SUCCESS);
-        backend_graph_shared_ptr_ = backend_graph_map_ptr_->insert(
-            op_id_string_,
-            onnx::BackendGraphInfo(backend_id_, backend_, graph_, lib_));
-      } else {
-        LOG(INFO) << "Got cached backend for " << op_id_string_;
-      }
-      // This checks if our insertion was successful or some other thread did
-      // the insert in the meantime.
-      if (backend_graph_shared_ptr_->backend_id != backend_id_ ||
-          backend_graph_shared_ptr_->backend != backend_ ||
-          backend_graph_shared_ptr_->graph != graph_) {
-        lib_->onnxReleaseBackendID(backend_id_);
-        lib_->onnxReleaseBackend(backend_);
-        lib_->onnxReleaseGraph(graph_);
-      }
-    }
+      return std::make_shared<onnx::BackendGraphInfo>(
+          backend_id, backend, graph, lib);
+    };
+    backend_graph_shared_ptr_ =
+        backend_graph_map_ptr_->insert(op_id_string_, creator);
+
     backend_id_ = backend_graph_shared_ptr_->backend_id;
     backend_ = backend_graph_shared_ptr_->backend;
     graph_ = backend_graph_shared_ptr_->graph;
   }
 
-  std::vector<onnxTensorDescriptorV1> BuildInitializationList(
+  std::vector<onnxTensorDescriptorV1> buildInitializationList(
       Workspace* ws,
       std::unordered_set<std::string>* initialization_list,
       std::vector<std::string>* weight_names,
@@ -223,7 +209,6 @@ class OnnxifiOp final : public Operator<Context> {
   onnxBackend backend_{nullptr};
   onnxGraph graph_{nullptr};
   onnx::SharedPtrBackendGraphInfo backend_graph_shared_ptr_;
-  size_t num_backends_{0};
 
   // input/output descriptors
   std::vector<onnxTensorDescriptorV1> input_desc_;


### PR DESCRIPTION
Summary: Previously we create the onnxGraph first and take it to the onnx manager for registration. It doesn't work well in practice. This diff takes "bring your own constructor" approach to reduce the resource spent doing backend compilation.

Differential Revision: D14173793
