### PR TITLE
Bool tensor creation (cpu)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -3,6 +3,7 @@
   cname: set
   variants: function
   cpu_half: True
+  cpu_bool: True
   device_guard: False
   return: argument 0
   options:
@@ -39,6 +40,7 @@
   cname: fill
   variants: function
   cpu_half: True
+  cpu_bool: True
   options:
     - arguments:
       - THTensor* self
@@ -54,6 +56,7 @@
   variants:
     - function
   cpu_half: True
+  cpu_bool: True
   device_guard: False
   return: bool
   arguments:
@@ -120,6 +123,7 @@
   variants:
     - function
   cpu_half: True
+  cpu_bool: True
   arguments:
     - THTensor* self
 ]]
@@ -238,6 +242,7 @@
   variants:
     - function
   cpu_half: True
+  cpu_bool: True
   device_guard: False
   return: argument 0
   arguments:
@@ -1693,6 +1698,7 @@
   cname: zero
   return: self
   cpu_half: True
+  cpu_bool: True
   variants:
     - function
   arguments:
@@ -2561,6 +2567,7 @@
     - CPU
     - CUDA
   return: self
+  cpu_bool: True
   variants: function
   options:
     - cname: random
@@ -2785,6 +2792,7 @@
   name: _th_alias
   return: THTensor*
   cpu_half: True
+  cpu_bool: True
   variants:
     - function
   options:

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -125,3 +125,4 @@ struct MyTemplate<at::ScalarType::Bool> {
       default:                                                                                  \
         AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'");                    \
     }                                                                                           \
+  }()

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -125,4 +125,3 @@ struct MyTemplate<at::ScalarType::Bool> {
       default:                                                                                  \
         AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'");                    \
     }                                                                                           \
-  }()

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -84,6 +84,11 @@ struct MyTemplate<at::ScalarType::Half> {
   using type = at::Half;
 };
 
+template<>
+struct MyTemplate<at::ScalarType::Bool> {
+  using type = bool;
+};
+
 #define AT_DISPATCH_ALL_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)                    \
   [&] {                                                                           \
     switch (TYPE) {                                                               \
@@ -100,23 +105,24 @@ struct MyTemplate<at::ScalarType::Half> {
     }                                                                             \
   }()
 
-#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, TYPE, NAME, ...)        \
-  [&] {                                                                           \
-    switch (TYPE) {                                                               \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)            \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)             \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)           \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)             \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)             \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)            \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)           \
-      AT_PRIVATE_CASE_TYPE(at::ScalarType::Bool, bool, __VA_ARGS__)               \
-      AT_PRIVATE_CASE_TYPE(SCALARTYPE, MyTemplate<SCALARTYPE>::type, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                       \
-          at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)         \
-      AT_PRIVATE_CASE_TYPE(                                                       \
-          at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)       \
-      default:                                                                    \
-        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");           \
-    }                                                                             \
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)        \
+  [&] {                                                                                         \
+    const at::Type& the_type = TYPE;                                                            \
+    switch (the_type.scalarType()) {                                                            \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)                          \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)                           \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                         \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                           \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)                           \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)                          \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                         \
+      AT_PRIVATE_CASE_TYPE(SCALARTYPE1, MyTemplate<SCALARTYPE1>::type, __VA_ARGS__)             \
+      AT_PRIVATE_CASE_TYPE(SCALARTYPE2, MyTemplate<SCALARTYPE2>::type, __VA_ARGS__)             \
+      AT_PRIVATE_CASE_TYPE(                                                                     \
+          at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)                       \
+      AT_PRIVATE_CASE_TYPE(                                                                     \
+          at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)                     \
+      default:                                                                                  \
+        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'");                    \
+    }                                                                                           \
   }()

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -110,6 +110,7 @@ struct MyTemplate<at::ScalarType::Half> {
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)             \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)            \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)           \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Bool, bool, __VA_ARGS__)               \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE, MyTemplate<SCALARTYPE>::type, __VA_ARGS__) \
       AT_PRIVATE_CASE_TYPE(                                                       \
           at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)         \

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -491,6 +491,7 @@ FunctionOption = TypedDict('FunctionOption', {
     'with_gil': bool,
     'cpu_half': bool,
     'deprecated': bool,
+    'cpu_bool': bool,
     # See Note [field_name versus name]
     'field_name': str,
     'formals_list': List[AtFormal],

--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -19,7 +19,7 @@ Scalar item(const Tensor& self) {
 Scalar _local_scalar_dense_cpu(const Tensor& self) {
   Scalar r;
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(
-    at::ScalarType::Half, self.scalar_type(), "_local_scalar_dense_cpu", [&] {
+    at::ScalarType::Half, at::ScalarType::Bool, self.type(), "_local_scalar_dense_cpu", [&] {
         scalar_t value = *self.data<scalar_t>();
         r = Scalar(value);
       });

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -553,6 +553,7 @@
 - func: s_copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)
   matches_jit_signature: True
   cpu_half: True
+  cpu_bool: True
   dispatch:
     CPU: _s_copy__cpu
     CUDA: _s_copy__cuda
@@ -560,12 +561,14 @@
 - func: _s_copy_from(Tensor self, Tensor dst, bool non_blocking=False) -> Tensor
   matches_jit_signature: True
   cpu_half: True
+  cpu_bool: True
   dispatch:
     CUDA: _s_copy_from_cuda
 
 - func: _copy_same_type_(Tensor(a!) self, Tensor src) -> void
   matches_jit_signature: True
   cpu_half: True
+  cpu_bool: True
   dispatch:
     CPU: _copy_same_type__cpu
 
@@ -837,6 +840,7 @@
 
 - func: empty(int[] size, TensorOptions options=[]) -> Tensor
   cpu_half: True
+  cpu_bool: True
   dispatch:
     CPU: empty_cpu
     CUDA: empty_cuda
@@ -846,6 +850,7 @@
 - func: resize_(Tensor(a!) self, int[] size) -> Tensor(a!)
   matches_jit_signature: True
   variants: method
+  cpu_bool: True
   cpu_half: True
   device_guard: False
   dispatch:
@@ -2988,6 +2993,7 @@
 - func: _local_scalar_dense(Tensor self) -> Scalar
   matches_jit_signature: True
   cpu_half: True
+  cpu_bool: True
   dispatch:
     CPU: _local_scalar_dense_cpu
     CUDA: _local_scalar_dense_cuda

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -561,7 +561,6 @@
 - func: _s_copy_from(Tensor self, Tensor dst, bool non_blocking=False) -> Tensor
   matches_jit_signature: True
   cpu_half: True
-  cpu_bool: True
   dispatch:
     CUDA: _s_copy_from_cuda
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -561,6 +561,7 @@
 - func: _s_copy_from(Tensor self, Tensor dst, bool non_blocking=False) -> Tensor
   matches_jit_signature: True
   cpu_half: True
+  cpu_bool: True
   dispatch:
     CUDA: _s_copy_from_cuda
 

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -308,6 +308,7 @@ def run(paths):
                 declaration['requires_tensor'] = func.get('requires_tensor', False)
                 declaration['matches_jit_signature'] = func.get('matches_jit_signature', False)
                 declaration['cpu_half'] = func.get('cpu_half', False)
+                declaration['cpu_bool'] = func.get('cpu_bool', False)
                 declaration['deprecated'] = func.get('deprecated', False)
                 declaration['device_guard'] = func.get('device_guard', True)
                 declaration['arguments'] = func.get('arguments', arguments)

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -14,7 +14,8 @@ type_map = {
         'Char',
         'Short',
         'Int',
-        'Long'
+        'Long',
+        'Bool'
     ],
 }
 
@@ -61,9 +62,12 @@ def process_types_and_backends(option):
         if arg['type'] == 'THSTensor*':
             pairs.discard(('CUDA', 'Half'))
 
-    # special case remove Half for cpu unless it is explicitly enabled,
+    # special case remove Half and Bool for cpu unless it is explicitly enabled,
     if not option.get('cpu_half', False):
         pairs.discard(('CPU', 'Half'))
+
+    if not option.get('cpu_bool', False):
+        pairs.discard(('CPU', 'Bool'))
 
     # sort the result for easy reading
     option['backend_type_pairs'] = sorted([p for p in pairs])

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -69,6 +69,10 @@ def process_types_and_backends(option):
     if not option.get('cpu_bool', False):
         pairs.discard(('CPU', 'Bool'))
 
+    # Temporary hack that will be removed in the next PR which will enable
+    # bool tensor for CUDA
+    pairs.discard(('CUDA', 'Bool'))
+
     # sort the result for easy reading
     option['backend_type_pairs'] = sorted([p for p in pairs])
 

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -69,8 +69,7 @@ def process_types_and_backends(option):
     if not option.get('cpu_bool', False):
         pairs.discard(('CPU', 'Bool'))
 
-    # Temporary hack that will be removed in the next PR which will enable
-    # bool tensor for CUDA
+    # TODO: remove this hack once support for a bool tensor for CUDA is enabled
     pairs.discard(('CUDA', 'Bool'))
 
     # sort the result for easy reading

--- a/aten/src/TH/THGenerateBoolType.h
+++ b/aten/src/TH/THGenerateBoolType.h
@@ -2,16 +2,18 @@
 #error "You must define TH_GENERIC_FILE before including THGenerateBoolType.h"
 #endif
 
-// TODO: define accreal type once the correct value is known.
 #define scalar_t bool
 #define ureal bool
+#define accreal int64_t
 #define Real Bool
+#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
 #define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define TH_REAL_IS_BOOL
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
 #undef ureal
+#undef accreal
 #undef Real
 #undef TH_REAL_IS_BOOL
 #undef TH_CONVERT_REAL_TO_ACCREAL

--- a/aten/src/TH/THGenerateBoolType.h
+++ b/aten/src/TH/THGenerateBoolType.h
@@ -2,18 +2,16 @@
 #error "You must define TH_GENERIC_FILE before including THGenerateBoolType.h"
 #endif
 
+// TODO: define accreal type once the correct value is known.
 #define scalar_t bool
 #define ureal bool
-#define accreal int64_t
 #define Real Bool
-#define TH_CONVERT_REAL_TO_ACCREAL(_val) (accreal)(_val)
 #define TH_CONVERT_ACCREAL_TO_REAL(_val) (scalar_t)(_val)
 #define TH_REAL_IS_BOOL
 #line 1 TH_GENERIC_FILE
 #include TH_GENERIC_FILE
 #undef scalar_t
 #undef ureal
-#undef accreal
 #undef Real
 #undef TH_REAL_IS_BOOL
 #undef TH_CONVERT_REAL_TO_ACCREAL

--- a/aten/src/TH/THTensor.h
+++ b/aten/src/TH/THTensor.h
@@ -21,6 +21,9 @@
 #include <TH/generic/THTensorRandom.h>
 #include <TH/THGenerateAllTypes.h>
 
+#include <TH/generic/THTensorRandom.h>
+#include <TH/THGenerateBoolType.h>
+
 /* maths */
 #include <TH/generic/THTensorMath.h>
 #include <TH/THGenerateAllTypes.h>

--- a/aten/src/TH/THTensor.h
+++ b/aten/src/TH/THTensor.h
@@ -35,6 +35,9 @@
 #include <TH/generic/THTensorFill.h>
 #include <TH/THGenerateHalfType.h>
 
+#include <TH/generic/THTensorFill.h>
+#include <TH/THGenerateBoolType.h>
+
 /* convolutions */
 #include <TH/generic/THTensorConv.h>
 #include <TH/THGenerateAllTypes.h>

--- a/aten/src/TH/THTensorFill.cpp
+++ b/aten/src/TH/THTensorFill.cpp
@@ -6,3 +6,6 @@
 
 #include <TH/generic/THTensorFill.cpp>
 #include <TH/THGenerateHalfType.h>
+
+#include <TH/generic/THTensorFill.cpp>
+#include <TH/THGenerateBoolType.h>

--- a/aten/src/TH/THTensorRandom.cpp
+++ b/aten/src/TH/THTensorRandom.cpp
@@ -3,3 +3,6 @@
 
 #include <TH/generic/THTensorRandom.cpp>
 #include <TH/THGenerateAllTypes.h>
+
+#include <TH/generic/THTensorRandom.cpp>
+#include <TH/THGenerateBoolType.h>

--- a/aten/src/TH/THVector.cpp
+++ b/aten/src/TH/THVector.cpp
@@ -24,8 +24,14 @@
 #include <TH/generic/THVectorDefault.cpp>
 #include <TH/THGenerateHalfType.h>
 
+#include <TH/generic/THVectorDefault.cpp>
+#include <TH/THGenerateBoolType.h>
+
 #include <TH/generic/THVectorDispatch.cpp>
 #include <TH/THGenerateAllTypes.h>
 
 #include <TH/generic/THVectorDispatch.cpp>
 #include <TH/THGenerateHalfType.h>
+
+#include <TH/generic/THVectorDispatch.cpp>
+#include <TH/THGenerateBoolType.h>

--- a/aten/src/TH/THVector.h
+++ b/aten/src/TH/THVector.h
@@ -14,4 +14,7 @@
 #include <TH/generic/THVector.h>
 #include <TH/THGenerateHalfType.h>
 
+#include <TH/generic/THVector.h>
+#include <TH/THGenerateBoolType.h>
+
 #endif // TH_VECTOR_INC

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -156,26 +156,3 @@ if (std::isnan(val)) break;
 #else
 #define th_isnan_break(val)
 #endif
-<<<<<<< HEAD
-=======
-
-static inline scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
-#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
-  return powf(x, y);
-#elif defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_BOOL)
-  return pow(x, y);
-#else
-  THArgCheck(y >= 0, 1,
-      "Integers to negative integer powers are not allowed");
-  scalar_t result = 1;
-  while (y) {
-    if (y & 1) {
-       result *= x;
-    }
-    y /= 2;
-    x *= x;
-  }
-  return result;
-#endif
-}
->>>>>>> d514aadbc... Initial commit for bool tensor (CPU)

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -156,3 +156,26 @@ if (std::isnan(val)) break;
 #else
 #define th_isnan_break(val)
 #endif
+<<<<<<< HEAD
+=======
+
+static inline scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
+  return powf(x, y);
+#elif defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_BOOL)
+  return pow(x, y);
+#else
+  THArgCheck(y >= 0, 1,
+      "Integers to negative integer powers are not allowed");
+  scalar_t result = 1;
+  while (y) {
+    if (y & 1) {
+       result *= x;
+    }
+    y /= 2;
+    x *= x;
+  }
+  return result;
+#endif
+}
+>>>>>>> d514aadbc... Initial commit for bool tensor (CPU)

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -156,23 +156,3 @@ if (std::isnan(val)) break;
 #else
 #define th_isnan_break(val)
 #endif
-
-static inline scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
-#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
-  return powf(x, y);
-#elif defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_BOOL)
-  return pow(x, y);
-#else
-  THArgCheck(y >= 0, 1,
-      "Integers to negative integer powers are not allowed");
-  scalar_t result = 1;
-  while (y) {
-    if (y & 1) {
-       result *= x;
-    }
-    y /= 2;
-    x *= x;
-  }
-  return result;
-#endif
-}

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -160,7 +160,7 @@ if (std::isnan(val)) break;
 static inline scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
   return powf(x, y);
-#elif defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_BOOL)
+#elif defined(TH_REAL_IS_DOUBLE)
   return pow(x, y);
 #else
   THArgCheck(y >= 0, 1,

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -160,7 +160,7 @@ if (std::isnan(val)) break;
 static inline scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
   return powf(x, y);
-#elif defined(TH_REAL_IS_DOUBLE)
+#elif defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_BOOL)
   return pow(x, y);
 #else
   THArgCheck(y >= 0, 1,

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -253,6 +253,26 @@ void THTensor_(pow)(THTensor *r_, THTensor *t, scalar_t value)
 #endif
 }
 
+scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
+  return powf(x, y);
+#elif defined(TH_REAL_IS_DOUBLE)
+  return pow(x, y);
+#else
+  THArgCheck(y >= 0, 1,
+      "Integers to negative integer powers are not allowed");
+  scalar_t result = 1;
+  while (y) {
+    if (y & 1) {
+       result *= x;
+    }
+    y /= 2;
+    x *= x;
+  }
+  return result;
+#endif
+}
+
 void THTensor_(cpow)(THTensor *r_, THTensor *t, THTensor *src)
 {
   THTensor_(resizeAs)(r_, t);

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -27,6 +27,8 @@ static inline bool modulo_wrap(scalar_t a, scalar_t b) {
   return (a != 0) && (a < 0) != (b < 0);
 }
 
+#if !defined(TH_REAL_IS_BOOL)
+
 void THTensor_(bitor)(THTensor *r_, THTensor *t, scalar_t value)
 {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_HALF)
@@ -1176,5 +1178,7 @@ void THTensor_(addbmm)(THTensor *result, scalar_t beta, THTensor *t, scalar_t al
   c10::raw::intrusive_ptr::decref(matrix1);
   c10::raw::intrusive_ptr::decref(matrix2);
 }
+
+#endif
 
 #endif /* TH_GENERIC_FILE */

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -27,6 +27,8 @@ static inline bool modulo_wrap(scalar_t a, scalar_t b) {
   return (a != 0) && (a < 0) != (b < 0);
 }
 
+#if !defined(TH_REAL_IS_BOOL)
+
 void THTensor_(bitor)(THTensor *r_, THTensor *t, scalar_t value)
 {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_HALF)
@@ -1196,5 +1198,7 @@ void THTensor_(addbmm)(THTensor *result, scalar_t beta, THTensor *t, scalar_t al
   c10::raw::intrusive_ptr::decref(matrix1);
   c10::raw::intrusive_ptr::decref(matrix2);
 }
+
+#endif
 
 #endif /* TH_GENERIC_FILE */

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -27,8 +27,6 @@ static inline bool modulo_wrap(scalar_t a, scalar_t b) {
   return (a != 0) && (a < 0) != (b < 0);
 }
 
-#if !defined(TH_REAL_IS_BOOL)
-
 void THTensor_(bitor)(THTensor *r_, THTensor *t, scalar_t value)
 {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_HALF)
@@ -1198,7 +1196,5 @@ void THTensor_(addbmm)(THTensor *result, scalar_t beta, THTensor *t, scalar_t al
   c10::raw::intrusive_ptr::decref(matrix1);
   c10::raw::intrusive_ptr::decref(matrix2);
 }
-
-#endif
 
 #endif /* TH_GENERIC_FILE */

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -27,8 +27,6 @@ static inline bool modulo_wrap(scalar_t a, scalar_t b) {
   return (a != 0) && (a < 0) != (b < 0);
 }
 
-#if !defined(TH_REAL_IS_BOOL)
-
 void THTensor_(bitor)(THTensor *r_, THTensor *t, scalar_t value)
 {
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE) || defined(TH_REAL_IS_HALF)
@@ -1178,7 +1176,5 @@ void THTensor_(addbmm)(THTensor *result, scalar_t beta, THTensor *t, scalar_t al
   c10::raw::intrusive_ptr::decref(matrix1);
   c10::raw::intrusive_ptr::decref(matrix2);
 }
-
-#endif
 
 #endif /* TH_GENERIC_FILE */

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -91,7 +91,11 @@ TH_API void THTensor_(cmin)(THTensor *r, THTensor *t, THTensor *src);
 TH_API void THTensor_(cmaxValue)(THTensor *r, THTensor *t, scalar_t value);
 TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, scalar_t value);
 
+TH_API void THTensor_(zerosLike)(THTensor *r_, THTensor *input);
+TH_API void THTensor_(onesLike)(THTensor *r_, THTensor *input);
 TH_API void THTensor_(diag)(THTensor *r_, THTensor *t, int k);
+TH_API void THTensor_(eye)(THTensor *r_, int64_t n, int64_t m);
+TH_API void THTensor_(randperm)(THTensor *r_, THGenerator *_generator, int64_t n);
 
 TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder);
 TH_API void THTensor_(topk)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int64_t k, int dim, int dir, int sorted);
@@ -166,6 +170,7 @@ TH_API void THTensor_(round)(THTensor *r_, THTensor *t);
 TH_API void THTensor_(trunc)(THTensor *r_, THTensor *t);
 TH_API void THTensor_(frac)(THTensor *r_, THTensor *t);
 
+TH_API void THTensor_(mean)(THTensor *r_, THTensor *t, int dimension, int keepdim);
 TH_API void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int keepdim);
 TH_API void THTensor_(var)(THTensor *r_, THTensor *t, int dimension, int biased, int keepdim);
 TH_API void THTensor_(norm)(THTensor *r_, THTensor *t, scalar_t value, int dimension, int keepdim);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -129,7 +129,7 @@ TH_API void THTensor_(eqTensorT)(THTensor *r_, THTensor *ta, THTensor *tb);
 
 TH_API void THTensor_(pow)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(tpow)(THTensor *r_, scalar_t value, THTensor *t);
-
+TH_API scalar_t THTensor_(powOne)(scalar_t x, scalar_t y);
 TH_API void THTensor_(abs)(THTensor *r_, THTensor *t);
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)

--- a/aten/src/TH/generic/THTensorRandom.cpp
+++ b/aten/src/TH/generic/THTensorRandom.cpp
@@ -29,6 +29,8 @@ void THTensor_(random)(THTensor *self, THGenerator *_generator)
   TH_TENSOR_APPLY(scalar_t, self, *self_data = (float)(THRandom_random(_generator) % ((1ULL << FLT_MANT_DIG) + 1)););
 #elif defined(TH_REAL_IS_DOUBLE)
   TH_TENSOR_APPLY(scalar_t, self, *self_data = (double)(THRandom_random64(_generator) % ((1ULL << DBL_MANT_DIG) + 1)););
+#elif defined(TH_REAL_IS_BOOL)
+    TH_TENSOR_APPLY(scalar_t, self, *self_data = (bool)(THRandom_random(_generator) % 2););
 #else
 #error "Unknown type"
 #endif

--- a/aten/src/TH/generic/THVector.h
+++ b/aten/src/TH/generic/THVector.h
@@ -6,6 +6,9 @@
 struct THGenerator;
 
 TH_API void THVector_(fill)(scalar_t *x, const scalar_t c, const ptrdiff_t n);
+
+#if !defined(TH_REAL_IS_BOOL) /* non bool only part */
+
 TH_API void THVector_(cadd)(scalar_t *z, const scalar_t *x, const scalar_t *y, const scalar_t c, const ptrdiff_t n);
 TH_API void THVector_(adds)(scalar_t *y, const scalar_t *x, const scalar_t c, const ptrdiff_t n);
 TH_API void THVector_(cmul)(scalar_t *z, const scalar_t *x, const scalar_t *y, const ptrdiff_t n);
@@ -60,5 +63,7 @@ TH_API void THVector_(frac)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(cinv)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 
 #endif /* floating point only part */
+
+#endif /* non bool only part */
 
 #endif

--- a/aten/src/TH/generic/THVector.h
+++ b/aten/src/TH/generic/THVector.h
@@ -66,4 +66,6 @@ TH_API void THVector_(cinv)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 
 #endif /* floating point only part */
 
+#endif /* non bool only part */
+
 #endif

--- a/aten/src/TH/generic/THVector.h
+++ b/aten/src/TH/generic/THVector.h
@@ -66,6 +66,4 @@ TH_API void THVector_(cinv)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 
 #endif /* floating point only part */
 
-#endif /* non bool only part */
-
 #endif

--- a/aten/src/TH/generic/THVector.h
+++ b/aten/src/TH/generic/THVector.h
@@ -22,6 +22,8 @@ TH_API void THVector_(normal_fill)(scalar_t *data,
 								   const scalar_t mean,
 								   const scalar_t stddev);
 
+#endif /* non bool only part */
+
 #if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
 TH_API void THVector_(abs)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 #endif
@@ -63,7 +65,5 @@ TH_API void THVector_(frac)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(cinv)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 
 #endif /* floating point only part */
-
-#endif /* non bool only part */
 
 #endif

--- a/aten/src/TH/generic/THVectorDefault.cpp
+++ b/aten/src/TH/generic/THVectorDefault.cpp
@@ -4,21 +4,6 @@
 
 #include <TH/THRandom.h>
 
-void THVector_(copy_DEFAULT)(scalar_t *x, const scalar_t *y, const ptrdiff_t n) {
-  ptrdiff_t i = 0;
-
-  for(; i <n-4; i+=4)
-  {
-    x[i] = y[i];
-    x[i+1] = y[i+1];
-    x[i+2] = y[i+2];
-    x[i+3] = y[i+3];
-  }
-
-  for(; i < n; i++)
-    x[i] = y[i];
-}
-
 void THVector_(fill_DEFAULT)(scalar_t *x, const scalar_t c, const ptrdiff_t n) {
   ptrdiff_t i = 0;
 
@@ -32,6 +17,23 @@ void THVector_(fill_DEFAULT)(scalar_t *x, const scalar_t c, const ptrdiff_t n) {
 
   for(; i < n; i++)
     x[i] = c;
+}
+
+#if !defined(TH_REAL_IS_BOOL) /* non bool only part */
+
+void THVector_(copy_DEFAULT)(scalar_t *x, const scalar_t *y, const ptrdiff_t n) {
+  ptrdiff_t i = 0;
+
+  for(; i <n-4; i+=4)
+  {
+    x[i] = y[i];
+    x[i+1] = y[i+1];
+    x[i+2] = y[i+2];
+    x[i+3] = y[i+3];
+  }
+
+  for(; i < n; i++)
+    x[i] = y[i];
 }
 
 void THVector_(cadd_DEFAULT)(scalar_t *z, const scalar_t *x, const scalar_t *y, const scalar_t c, const ptrdiff_t n)
@@ -271,5 +273,7 @@ VECTOR_IMPLEMENT_FUNCTION(cinv, TH_MATH_NAME(1.0) / )
 #endif /* floating point only part */
 
 VECTOR_IMPLEMENT_FUNCTION(neg,-)
+
+#endif /* non bool only part */
 
 #endif

--- a/aten/src/TH/generic/THVectorDispatch.cpp
+++ b/aten/src/TH/generic/THVectorDispatch.cpp
@@ -38,6 +38,8 @@ void THVector_(fill)(scalar_t *x, const scalar_t c, const ptrdiff_t n) {
   THVector_(fill_DISPATCHPTR)(x, c, n);
 }
 
+#if !defined(TH_REAL_IS_BOOL) /* non bool only part */
+
 static void (*THVector_(cadd_DISPATCHPTR))(scalar_t *, const scalar_t *, const scalar_t *, const scalar_t, const ptrdiff_t) = &THVector_(cadd_DEFAULT);
 static FunctionDescription THVector_(cadd_DISPATCHTABLE)[] = {
   #if defined(__NEON__)
@@ -236,5 +238,7 @@ struct THVector_(startup) {
 
 // Declare a global instance to force static initialization
 static THVector_(startup) THVector_(g_startup);
+
+#endif /* non bool only part */
 
 #endif

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -40,7 +40,8 @@ _(at::Half,Half,d) \
 _(float,Float,d)   \
 _(double,Double,d) \
 _(std::complex<float>,ComplexFloat,z) \
-_(std::complex<double>,ComplexDouble,z)
+_(std::complex<double>,ComplexDouble,z) \
+_(bool,Bool,i)
 
 #define AT_FORALL_SCALAR_TYPES(_) \
 _(uint8_t,Byte,i)  \

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -394,7 +394,7 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x.storage(), y.storage())
         elif ((isinstance(x, torch.BoolTensor) and isinstance(y, Number)) or
              (isinstance(y, torch.BoolTensor) and isinstance(x, Number))):
-                self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
+            self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
         elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             def assertTensorsEqual(a, b):
                 super(TestCase, self).assertEqual(a.size(), b.size(), message)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -390,11 +390,6 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x.item(), y, prec, message, allow_inf)
         elif isinstance(y, torch.Tensor) and isinstance(x, Number):
             self.assertEqual(x, y.item(), prec, message, allow_inf)
-        elif isinstance(x, torch.BoolTensor) and isinstance(y, torch.BoolTensor):
-            self.assertEqual(x.storage(), y.storage())
-        elif ((isinstance(x, torch.BoolTensor) and isinstance(y, Number)) or
-             (isinstance(y, torch.BoolTensor) and isinstance(x, Number))):
-            self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
         elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             def assertTensorsEqual(a, b):
                 if isinstance(x, torch.BoolTensor) and isinstance(y, torch.BoolTensor):

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -390,6 +390,11 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x.item(), y, prec, message, allow_inf)
         elif isinstance(y, torch.Tensor) and isinstance(x, Number):
             self.assertEqual(x, y.item(), prec, message, allow_inf)
+        elif isinstance(x, torch.BoolTensor) and isinstance(y, torch.BoolTensor):
+            self.assertEqual(x.storage(), y.storage())
+        elif ((isinstance(x, torch.BoolTensor) and isinstance(y, Number)) or
+             (isinstance(y, torch.BoolTensor) and isinstance(x, Number))):
+                self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
         elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             def assertTensorsEqual(a, b):
                 super(TestCase, self).assertEqual(a.size(), b.size(), message)
@@ -403,6 +408,7 @@ class TestCase(expecttest.TestCase):
                         b = b.to(a.dtype).to(a.device)
                     else:
                         b = b.to(a)
+
                     diff = a - b
                     if a.is_floating_point():
                         # check that NaNs are in the same locations

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -394,7 +394,7 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x.storage(), y.storage())
         elif ((isinstance(x, torch.BoolTensor) and isinstance(y, Number)) or
              (isinstance(y, torch.BoolTensor) and isinstance(x, Number))):
-                self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
+            self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
         elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             def assertTensorsEqual(a, b):
                 if isinstance(x, torch.BoolTensor) and isinstance(y, torch.BoolTensor):

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -390,6 +390,11 @@ class TestCase(expecttest.TestCase):
             self.assertEqual(x.item(), y, prec, message, allow_inf)
         elif isinstance(y, torch.Tensor) and isinstance(x, Number):
             self.assertEqual(x, y.item(), prec, message, allow_inf)
+        elif isinstance(x, torch.BoolTensor) and isinstance(y, torch.BoolTensor):
+            self.assertEqual(x.storage(), y.storage())
+        elif ((isinstance(x, torch.BoolTensor) and isinstance(y, Number)) or
+             (isinstance(y, torch.BoolTensor) and isinstance(x, Number))):
+                self.fail("Expected two boolean tensors - x={}, y={}".format(x, y))
         elif isinstance(x, torch.Tensor) and isinstance(y, torch.Tensor):
             def assertTensorsEqual(a, b):
                 if isinstance(x, torch.BoolTensor) and isinstance(y, torch.BoolTensor):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2478,8 +2478,6 @@ class _TestTorchMixin(object):
         # test boolean tensor
         res1 = torch.ones(1, 2, dtype=torch.bool)
         expected = torch.tensor([[True, True]], dtype=torch.bool)
-        print(res1.size())
-        print(expected.size())
         self.assertEqual(res1, expected)
 
     def test_ones_like(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2865,29 +2865,13 @@ class _TestTorchMixin(object):
     # This is a temporary test for a boolean tensors on CPU. Once the CUDA part
     # will be done, these test cases will be moved down to test_tensor_factories_empty test
     def test_tensor_factories_empty_bool(self):
-<<<<<<< HEAD
-<<<<<<< HEAD
         expectedShape = (1, 2)
-=======
-        expectedShape = (1,2)
->>>>>>> Added tests for a bool tensor (CPU)
-=======
-        expectedShape = (1, 2)
->>>>>>> Resolved some PR comments
         test = torch.empty(expectedShape, dtype=torch.bool)
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.empty_like(test).shape)
 
         test = torch.full(expectedShape, True, dtype=torch.bool)
-<<<<<<< HEAD
-<<<<<<< HEAD
         self.assertEqual(test, torch.tensor([[True, True]], dtype=torch.bool))
-=======
-        self.assertEqual(test, torch.tensor([True, True], dtype=torch.bool))
->>>>>>> Added tests for a bool tensor (CPU)
-=======
-        self.assertEqual(test, torch.tensor([[True, True]], dtype=torch.bool))
->>>>>>> Resolved some PR comments
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.full_like(test, True).shape)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2341,12 +2341,13 @@ class _TestTorchMixin(object):
         torch.zeros(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
-        res1 = torch.zeros(2, 2, dtype=torch.bool)
+        boolTensor = torch.zeros(2, 2, dtype=torch.bool)
         expected = torch.tensor([[False, False], [False, False]], dtype=torch.bool)
-        self.assertEqual(res1, expected)
+        self.assertEqual(boolTensor, expected)
 
         halfTensor = torch.zeros(1, 1, dtype=torch.half)
-        self.assertEqual(halfTensor, torch.tensor([[0.]], dtype=torch.float16))
+        expected = torch.tensor([[0.]], dtype=torch.float16)
+        self.assertEqual(halfTensor, expected)
 
     def test_zeros_like(self):
         expected = torch.zeros(100, 100)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2341,6 +2341,10 @@ class _TestTorchMixin(object):
         torch.zeros(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
+        res1 = torch.zeros(2, 2, dtype=torch.bool)
+        expected = torch.tensor([[False, False],[False, False]], dtype=torch.bool)
+        self.assertEqual(res1, expected)
+
     def test_zeros_like(self):
         expected = torch.zeros(100, 100)
 
@@ -2468,9 +2472,19 @@ class _TestTorchMixin(object):
         torch.ones(100, 100, out=res2)
         self.assertEqual(res1, res2)
 
+        # test boolean tensor
+        res1 = torch.ones([1,2], dtype=torch.bool)
+        expected = torch.tensor([True, True], dtype=torch.bool)
+        self.assertEqual(res1, expected)
+
     def test_ones_like(self):
         expected = torch.ones(100, 100)
 
+        res1 = torch.ones_like(expected)
+        self.assertEqual(res1, expected)
+
+        # test boolean tensor
+        expected = torch.tensor([True, True], dtype=torch.bool)
         res1 = torch.ones_like(expected)
         self.assertEqual(res1, expected)
 
@@ -2759,6 +2773,11 @@ class _TestTorchMixin(object):
                 a[0] = 7.
                 self.assertEqual(5., res1[0].item())
 
+        # test boolean tensor
+        a = torch.tensor([True, True, False, True, True], dtype=torch.bool)
+        b = torch.tensor([-1, -1.1, 0, 1, 1.1], dtype=torch.bool)
+        self.assertEqual(a, b)
+
     def test_tensor_factory_copy_var(self):
 
         def check_copy(copy, is_leaf, requires_grad, data_ptr=None):
@@ -2838,6 +2857,19 @@ class _TestTorchMixin(object):
         self.assertIs(torch.float64, x.dtype)
         self.assertTrue(x.is_cuda)
         torch.set_default_tensor_type(saved_type)
+
+    # This is a temporary test for a boolean tensors on CPU. Once the CUDA part
+    # will be done, these test cases will be moved down to test_tensor_factories_empty test
+    def test_tensor_factories_empty_bool(self):
+        expectedShape = (1,2)
+        test = torch.empty(expectedShape, dtype=torch.bool)
+        self.assertEqual(expectedShape, test.shape)
+        self.assertEqual(expectedShape, torch.empty_like(test).shape)
+
+        test = torch.full(expectedShape, True, dtype=torch.bool)
+        self.assertEqual(test, torch.tensor([True, True], dtype=torch.bool))
+        self.assertEqual(expectedShape, test.shape)
+        self.assertEqual(expectedShape, torch.full_like(test, True).shape)
 
     def test_tensor_factories_empty(self):
         # ensure we can create empty tensors from each factory function

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2342,8 +2342,11 @@ class _TestTorchMixin(object):
         self.assertEqual(res1, res2)
 
         res1 = torch.zeros(2, 2, dtype=torch.bool)
-        expected = torch.tensor([[False, False],[False, False]], dtype=torch.bool)
+        expected = torch.tensor([[False, False], [False, False]], dtype=torch.bool)
         self.assertEqual(res1, expected)
+
+        halfTensor = torch.zeros(1, 1, dtype=torch.half)
+        self.assertEqual(halfTensor, torch.tensor([[0.]], dtype=torch.float16))
 
     def test_zeros_like(self):
         expected = torch.zeros(100, 100)
@@ -2473,8 +2476,10 @@ class _TestTorchMixin(object):
         self.assertEqual(res1, res2)
 
         # test boolean tensor
-        res1 = torch.ones([1,2], dtype=torch.bool)
-        expected = torch.tensor([True, True], dtype=torch.bool)
+        res1 = torch.ones(1, 2, dtype=torch.bool)
+        expected = torch.tensor([[True, True]], dtype=torch.bool)
+        print(res1.size())
+        print(expected.size())
         self.assertEqual(res1, expected)
 
     def test_ones_like(self):
@@ -2861,13 +2866,13 @@ class _TestTorchMixin(object):
     # This is a temporary test for a boolean tensors on CPU. Once the CUDA part
     # will be done, these test cases will be moved down to test_tensor_factories_empty test
     def test_tensor_factories_empty_bool(self):
-        expectedShape = (1,2)
+        expectedShape = (1, 2)
         test = torch.empty(expectedShape, dtype=torch.bool)
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.empty_like(test).shape)
 
         test = torch.full(expectedShape, True, dtype=torch.bool)
-        self.assertEqual(test, torch.tensor([True, True], dtype=torch.bool))
+        self.assertEqual(test, torch.tensor([[True, True]], dtype=torch.bool))
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.full_like(test, True).shape)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2476,14 +2476,8 @@ class _TestTorchMixin(object):
         self.assertEqual(res1, res2)
 
         # test boolean tensor
-<<<<<<< HEAD
         res1 = torch.ones(1, 2, dtype=torch.bool)
         expected = torch.tensor([[True, True]], dtype=torch.bool)
-=======
-        res1 = torch.ones([1,2], dtype=torch.bool)
-        expected = torch.tensor([True, True], dtype=torch.bool)
->>>>>>> Added tests for a bool tensor (CPU)
-        self.assertEqual(res1, expected)
 
     def test_ones_like(self):
         expected = torch.ones(100, 100)
@@ -2870,20 +2864,28 @@ class _TestTorchMixin(object):
     # will be done, these test cases will be moved down to test_tensor_factories_empty test
     def test_tensor_factories_empty_bool(self):
 <<<<<<< HEAD
+<<<<<<< HEAD
         expectedShape = (1, 2)
 =======
         expectedShape = (1,2)
 >>>>>>> Added tests for a bool tensor (CPU)
+=======
+        expectedShape = (1, 2)
+>>>>>>> Resolved some PR comments
         test = torch.empty(expectedShape, dtype=torch.bool)
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.empty_like(test).shape)
 
         test = torch.full(expectedShape, True, dtype=torch.bool)
 <<<<<<< HEAD
+<<<<<<< HEAD
         self.assertEqual(test, torch.tensor([[True, True]], dtype=torch.bool))
 =======
         self.assertEqual(test, torch.tensor([True, True], dtype=torch.bool))
 >>>>>>> Added tests for a bool tensor (CPU)
+=======
+        self.assertEqual(test, torch.tensor([[True, True]], dtype=torch.bool))
+>>>>>>> Resolved some PR comments
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.full_like(test, True).shape)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2478,6 +2478,7 @@ class _TestTorchMixin(object):
         # test boolean tensor
         res1 = torch.ones(1, 2, dtype=torch.bool)
         expected = torch.tensor([[True, True]], dtype=torch.bool)
+        self.assertEqual(res1, expected)
 
     def test_ones_like(self):
         expected = torch.ones(100, 100)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2476,8 +2476,13 @@ class _TestTorchMixin(object):
         self.assertEqual(res1, res2)
 
         # test boolean tensor
+<<<<<<< HEAD
         res1 = torch.ones(1, 2, dtype=torch.bool)
         expected = torch.tensor([[True, True]], dtype=torch.bool)
+=======
+        res1 = torch.ones([1,2], dtype=torch.bool)
+        expected = torch.tensor([True, True], dtype=torch.bool)
+>>>>>>> Added tests for a bool tensor (CPU)
         self.assertEqual(res1, expected)
 
     def test_ones_like(self):
@@ -2864,13 +2869,21 @@ class _TestTorchMixin(object):
     # This is a temporary test for a boolean tensors on CPU. Once the CUDA part
     # will be done, these test cases will be moved down to test_tensor_factories_empty test
     def test_tensor_factories_empty_bool(self):
+<<<<<<< HEAD
         expectedShape = (1, 2)
+=======
+        expectedShape = (1,2)
+>>>>>>> Added tests for a bool tensor (CPU)
         test = torch.empty(expectedShape, dtype=torch.bool)
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.empty_like(test).shape)
 
         test = torch.full(expectedShape, True, dtype=torch.bool)
+<<<<<<< HEAD
         self.assertEqual(test, torch.tensor([[True, True]], dtype=torch.bool))
+=======
+        self.assertEqual(test, torch.tensor([True, True], dtype=torch.bool))
+>>>>>>> Added tests for a bool tensor (CPU)
         self.assertEqual(expectedShape, test.shape)
         self.assertEqual(expectedShape, torch.full_like(test, True).shape)
 

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -10,6 +10,10 @@
 // largest integer that can be represented consecutively in a double
 const int64_t DOUBLE_INT_MAX = 9007199254740992;
 
+inline PyObject* THPUtils_packBool(bool value) {
+  return PyBool_FromLong(value);
+}
+
 inline PyObject* THPUtils_packInt64(int64_t value) {
 #if PY_MAJOR_VERSION == 2
   if (sizeof(long) == sizeof(int64_t)) {
@@ -57,6 +61,18 @@ inline int64_t THPUtils_unpackLong(PyObject* obj) {
     throw std::runtime_error("Overflow when unpacking long");
   }
   return (int64_t)value;
+}
+
+inline int64_t THPUtils_unpackBool(PyObject* obj) {
+  int overflow;
+  long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
+  if (value == -1 && PyErr_Occurred()) {
+    throw python_error();
+  }
+  if (overflow != 0) {
+    throw std::runtime_error("Overflow when unpacking long");
+  }
+  return (bool)(value);
 }
 
 inline bool THPUtils_checkIndex(PyObject *obj) {

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -10,10 +10,6 @@
 // largest integer that can be represented consecutively in a double
 const int64_t DOUBLE_INT_MAX = 9007199254740992;
 
-inline PyObject* THPUtils_packBool(bool value) {
-  return PyBool_FromLong(value);
-}
-
 inline PyObject* THPUtils_packInt64(int64_t value) {
 #if PY_MAJOR_VERSION == 2
   if (sizeof(long) == sizeof(int64_t)) {
@@ -61,18 +57,6 @@ inline int64_t THPUtils_unpackLong(PyObject* obj) {
     throw std::runtime_error("Overflow when unpacking long");
   }
   return (int64_t)value;
-}
-
-inline int64_t THPUtils_unpackBool(PyObject* obj) {
-  int overflow;
-  long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
-  if (value == -1 && PyErr_Occurred()) {
-    throw python_error();
-  }
-  if (overflow != 0) {
-    throw std::runtime_error("Overflow when unpacking long");
-  }
-  return (bool)(value);
 }
 
 inline bool THPUtils_checkIndex(PyObject *obj) {

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -22,6 +22,7 @@ inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
     case at::kDouble: *(double*)data = THPUtils_unpackDouble(obj); break;
     case at::kComplexFloat: *(std::complex<float>*)data = (std::complex<float>)THPUtils_unpackComplexDouble(obj); break;
     case at::kComplexDouble: *(std::complex<double>*)data = THPUtils_unpackComplexDouble(obj); break;
+    case at::kBool: *(bool*)data = (bool)THPUtils_unpackLong(obj); break;
     default: throw std::runtime_error("invalid type");
   }
 }
@@ -38,6 +39,7 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
     case at::kComplexFloat: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<float>*)data));
     case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<double>*)data));
+    case at::kBool: return PyBool_FromLong(*(uint8_t*)data);
     default: throw std::runtime_error("invalid type");
   }
 }

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -39,7 +39,11 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
     case at::kComplexFloat: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<float>*)data));
     case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<double>*)data));
+<<<<<<< HEAD
     case at::kBool: return PyBool_FromLong(*(uint8_t*)data);
+=======
+    case at::kBool: return THPUtils_packBool(*(bool*)data);
+>>>>>>> d514aadbc... Initial commit for bool tensor (CPU)
     default: throw std::runtime_error("invalid type");
   }
 }

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -39,11 +39,7 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
     case at::kComplexFloat: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<float>*)data));
     case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<double>*)data));
-<<<<<<< HEAD
     case at::kBool: return PyBool_FromLong(*(uint8_t*)data);
-=======
-    case at::kBool: return THPUtils_packBool(*(bool*)data);
->>>>>>> d514aadbc... Initial commit for bool tensor (CPU)
     default: throw std::runtime_error("invalid type");
   }
 }

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -22,6 +22,7 @@ inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
     case at::kDouble: *(double*)data = THPUtils_unpackDouble(obj); break;
     case at::kComplexFloat: *(std::complex<float>*)data = (std::complex<float>)THPUtils_unpackComplexDouble(obj); break;
     case at::kComplexDouble: *(std::complex<double>*)data = THPUtils_unpackComplexDouble(obj); break;
+    case at::kBool: *(bool*)data = THPUtils_unpackBool(obj); break;
     default: throw std::runtime_error("invalid type");
   }
 }
@@ -38,6 +39,7 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
     case at::kComplexFloat: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<float>*)data));
     case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<double>*)data));
+    case at::kBool: return THPUtils_packBool(*(bool*)data);
     default: throw std::runtime_error("invalid type");
   }
 }

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -22,7 +22,6 @@ inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
     case at::kDouble: *(double*)data = THPUtils_unpackDouble(obj); break;
     case at::kComplexFloat: *(std::complex<float>*)data = (std::complex<float>)THPUtils_unpackComplexDouble(obj); break;
     case at::kComplexDouble: *(std::complex<double>*)data = THPUtils_unpackComplexDouble(obj); break;
-    case at::kBool: *(bool*)data = THPUtils_unpackBool(obj); break;
     default: throw std::runtime_error("invalid type");
   }
 }
@@ -39,7 +38,6 @@ inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
     case at::kDouble: return PyFloat_FromDouble(*(double*)data);
     case at::kComplexFloat: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<float>*)data));
     case at::kComplexDouble: return PyComplex_FromCComplex(*reinterpret_cast<Py_complex *>((std::complex<double>*)data));
-    case at::kBool: return THPUtils_packBool(*(bool*)data);
     default: throw std::runtime_error("invalid type");
   }
 }

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -72,7 +72,7 @@ std::vector<std::pair<Backend, ScalarType>> all_declared_types() {
   // can't easily iterate over enum classes
   std::vector<Backend> backends = { Backend::CPU, Backend::CUDA, Backend::SparseCPU, Backend::SparseCUDA };
   std::vector<ScalarType> scalar_types = { ScalarType::Byte, ScalarType::Char, ScalarType::Double, ScalarType::Float,
-                                           ScalarType::Int, ScalarType::Long, ScalarType::Short, ScalarType::Half};
+                                           ScalarType::Int, ScalarType::Long, ScalarType::Short, ScalarType::Half, ScalarType::Bool};
   for (auto& backend : backends) {
     for (auto& scalar_type : scalar_types) {
       // there is no sparse half types.

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -75,8 +75,8 @@ std::vector<std::pair<Backend, ScalarType>> all_declared_types() {
                                            ScalarType::Int, ScalarType::Long, ScalarType::Short, ScalarType::Half, ScalarType::Bool};
   for (auto& backend : backends) {
     for (auto& scalar_type : scalar_types) {
-      // there is no sparse half types.
-      if (scalar_type == ScalarType::Half && (backend == Backend::SparseCUDA || backend == Backend::SparseCPU)) {
+      // there are no sparse half or bool types.
+      if ((scalar_type == ScalarType::Half || scalar_type == ScalarType::Bool) && (backend == Backend::SparseCUDA || backend == Backend::SparseCPU)) {
         continue;
       }
       ret.emplace_back(std::make_pair(backend, scalar_type));


### PR DESCRIPTION
This PR enables bool tensor creation and some basic operations for the CPU backend. This is a part of Bool Tensor feature implementation work. The whole plan looks like this: 
    1. Storage Implementation [Done] 
    2. Tensor Creation.
        a) CPU (this PR)
        b) CUDA
    3. Tensor Conversions.
    4. Tensor Indexing.
    5. Tensor Operations.
    6. Back compatibility related changes.

**Change**:
Enable CPU tensors and these operations: 
- torch.zeros
- torch.tensor
- torch.ones
- torch.randint
- torch.full
- torch.full_like
- torch.empty
- torch.empty_like

**Tested via**:
1) unit tests 

2)
torch.zeros(2,2, dtype=torch.bool)
torch.tensor([True, False], dtype=torch.bool)
torch.tensor([-1, -1.1, 0, 1, 1.1, 2], dtype=torch.bool)
torch.ones([1,2], dtype=torch.bool)
torch.randint(10, (2, 2), dtype=torch.bool)
torch.full((2, 3), True, dtype=torch.bool)
torch.empty(4, dtype=torch.bool)

a = torch.tensor([0,0,1])
b = torch.full_like(a, True)