### PR TITLE
Export ElementwiseLinear to ONNX (Mul + Add). (#16716)

### DIFF
--- a/caffe2/onnx/onnx_exporter.h
+++ b/caffe2/onnx/onnx_exporter.h
@@ -69,6 +69,10 @@ class CAFFE2_API OnnxExporter {
       const caffe2::OperatorDef& def,
       const std::unordered_map<std::string, caffe2::TensorShape>& shapes);
 
+  ConvertedResult CreateElementwiseLinearNodes(
+      const caffe2::OperatorDef& def,
+      const std::unordered_map<std::string, caffe2::TensorShape>& shapes);
+
   ConvertedResult CreateConvPoolNodes(
       const caffe2::OperatorDef& def,
       const std::unordered_map<std::string, caffe2::TensorShape>& shapes);

--- a/caffe2/operators/elementwise_linear_op.cc
+++ b/caffe2/operators/elementwise_linear_op.cc
@@ -154,11 +154,26 @@ Y:
 </details>
 
   )DOC")
-    .Input(0, "X", "2D input tensor of size $NxD$. This input represents the input data to be operated on.")
-    .Input(1, "w", "1D scaling factors, or weights, of size $D$. This input contains the weights that will be multiplied by the data.")
-    .Input(2, "b", "1D biases of size $D$. This input contains the biases that will be added to the products of the weights and data.")
-    .Output(0, "Y", "2D output tensor of size $NxD$. Calculated as described above.")
-    .Arg("axis", "*(type: int; default: 1)* Describes the axis of the inputs; defaults to one because the 0th axis most likely describes the batch size.");
+    .Input(
+        0,
+        "X",
+        "2D input tensor of size $NxD$. This input represents the input data to be operated on.")
+    .Input(
+        1,
+        "w",
+        "1D scaling factors, or weights, of size $D$. This input contains the weights that will be multiplied by the data.")
+    .Input(
+        2,
+        "b",
+        "1D biases of size $D$. This input contains the biases that will be added to the products of the weights and data.")
+    .Output(
+        0,
+        "Y",
+        "2D output tensor of size $NxD$. Calculated as described above.")
+    .Arg(
+        "axis",
+        "*(type: int; default: 1)* Describes the axis of the inputs; defaults to one because the 0th axis most likely describes the batch size.")
+    .InheritOnnxSchema();
 
 OPERATOR_SCHEMA(ElementwiseLinearGradient)
   .NumInputs(3)


### PR DESCRIPTION
Summary:
Reshape-based approach to support dynamic shape.
The first Reshape flatten inner dimensions and the second one recover the actual shape.
No Shape/Reshape will be generated unless necessary.

![image](https://user-images.githubusercontent.com/5203025/52215001-114ace80-28ce-11e9-815f-28ad190d3189.png)
Pull Request resolved: https://github.com/pytorch/pytorch/pull/16716

Differential Revision: D14094532
