### PR TITLE
Restore current streams on dst device after switching streams

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1559,6 +1559,9 @@ class TestCuda(TestCase):
         s1 = torch.cuda.Stream(device=1)
         s2 = torch.cuda.Stream(device=0)
 
+        with torch.cuda.device(s1.device):
+            prev_stream_on_cuda1 = torch.cuda.current_stream()
+
         self.assertEqual(torch.cuda.current_stream(), s0)
         self.assertEqual(0, torch.cuda.current_device())
         with torch.cuda.stream(s1):
@@ -1574,6 +1577,9 @@ class TestCuda(TestCase):
                 self.assertEqual(0, torch.cuda.current_device())
             self.assertEqual(torch.cuda.current_stream(), s1)
             self.assertEqual(1, torch.cuda.current_device())
+
+        with torch.cuda.device(s1.device):
+            self.assertEqual(prev_stream_on_cuda1, torch.cuda.current_stream())
 
         self.assertEqual(torch.cuda.current_stream(), s0)
         self.assertEqual(0, torch.cuda.current_device())


### PR DESCRIPTION
When switching back to `d0` from a stream on a different device `d1`, we need to restore the current streams on both `d0` and `d1`. The current implementation only does that for `d0`.