### PR TITLE
[WIP] CUDA deterministic flag

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -115,6 +115,12 @@ class CAFFE2_API Context {
   }
   bool setFlushDenormal(bool on);
 
+  // ErrorLevel for deterministic flag
+  enum ErrorLevel { None, Warn, Error };
+
+  ErrorLevel deterministicCUDA();
+  void setDeterministicCUDA(ErrorLevel e);
+
   // NB: This method is *purely* whether or not a user requested
   // that CuDNN was enabled, it doesn't actually say anything about
   // whether or not CuDNN is actually usable.  Use cudnn_is_acceptable
@@ -149,6 +155,7 @@ private:
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
   bool benchmark_cudnn = false;
+  ErrorLevel deterministic_cuda = ErrorLevel::None;
   std::atomic<size_t> next_id;
   std::unique_ptr<THCState, void(*)(THCState*)> thc_state;
   std::unique_ptr<THHState, void(*)(THHState*)> thh_state;
@@ -238,5 +245,7 @@ static inline void manual_seed(uint64_t seed) {
     globalContext().defaultGenerator(DeviceType::CUDA).manualSeedAll(seed);
   }
 }
+
+CAFFE2_API void alertCUDADeterministic(const char* caller);
 
 } // namespace at

--- a/aten/src/ATen/native/LegacyNNDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyNNDefinitions.cpp
@@ -130,10 +130,16 @@ Tensor nll_loss2d(const Tensor & self, const Tensor & target, const Tensor & wei
 }
 
 std::tuple<Tensor &,Tensor &> nll_loss2d_forward_out(Tensor & output, Tensor & total_weight, const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
+  if (self.type().backend() == Backend::CUDA) {
+    alertCUDADeterministic("nll_loss2d");
+  }
   return at::legacy::th::_thnn_nll_loss2d_forward_out(output, total_weight, self, target, weight, reduction, ignore_index);
 }
 
 std::tuple<Tensor,Tensor> nll_loss2d_forward(const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
+  if (self.type().backend() == Backend::CUDA) {
+    alertCUDADeterministic("nll_loss2d");
+  }
   return at::legacy::th::_thnn_nll_loss2d_forward(self, target, weight, reduction, ignore_index);
 }
 

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -840,6 +840,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto grad_grid = at::empty_like(grid);
   int count = static_cast<int>(N * H * W);
   if (count > 0) {
+    alertCUDADeterministic("grid_sampler_2d_backward_cuda");
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_backward_cuda", [&] {
       grid_sampler_2d_backward_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
@@ -868,6 +869,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto grad_grid = at::empty_like(grid);
   int count = static_cast<int>(N * D * H * W);
   if (count > 0) {
+    alertCUDADeterministic("grid_sampler_3d_backward_cuda");
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_3d_backward_cuda", [&] {
       grid_sampler_3d_backward_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -351,6 +351,21 @@ PyObject *THPModule_fromDLPack(PyObject *_unused, PyObject *data)
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* THPModule_setDeterministicCUDA(PyObject* _unused, PyObject* arg) {
+  THPUtils_assert(
+      PyLong_Check(arg),
+      "set_deterministic_cuda expects an int, "
+      "but got %s",
+      THPUtils_typename(arg));
+  at::globalContext().setDeterministicCUDA(
+      static_cast<at::Context::ErrorLevel>(PyLong_AsLong(arg)));
+  Py_RETURN_NONE;
+}
+
+PyObject* THPModule_deterministicCUDA(PyObject* _unused) {
+  return PyLong_FromUnsignedLongLong(at::globalContext().deterministicCUDA());
+}
+
 PyObject *THPModule_setUserEnabledCuDNN(PyObject *_unused, PyObject *arg)
 {
   THPUtils_assert(PyBool_Check(arg), "set_enabled_cudnn expects a bool, "
@@ -439,6 +454,8 @@ static PyMethodDef TorchMethods[] = {
   {"_get_backcompat_keepdim_warn", (PyCFunction)THPModule_getBackcompatKeepdimWarn, METH_NOARGS, nullptr},
   {"get_num_threads", (PyCFunction)THPModule_getNumThreads,     METH_NOARGS,  nullptr},
   {"set_num_threads", (PyCFunction)THPModule_setNumThreads,     METH_O,       nullptr},
+  {"_get_cuda_deterministic", (PyCFunction)THPModule_deterministicCUDA, METH_NOARGS, nullptr},
+  {"_set_cuda_deterministic", (PyCFunction)THPModule_setDeterministicCUDA, METH_O, nullptr},
   {"_get_cudnn_enabled", (PyCFunction)THPModule_userEnabledCuDNN, METH_NOARGS,     nullptr},
   {"_set_cudnn_enabled", (PyCFunction)THPModule_setUserEnabledCuDNN, METH_O,  nullptr},
   {"_get_cudnn_benchmark", (PyCFunction)THPModule_benchmarkCuDNN, METH_NOARGS,     nullptr},


### PR DESCRIPTION
This is a start/discussion basis for #15359 .
Test with:
```python
torch._C._set_cuda_deterministic(2) # 2=Error 1=Warn 0=Nothing
# not very useful, but show what it does:
torch.grid_sampler_2d(torch.randn(1,1,5,5, requires_grad=True, device='cuda'), torch.randn(1,1,5,2, requires_grad=True, device='cuda'), 0, 0).sum().backward()    
```

- Right now there only is `torch._C._get_cuda_deterministic` and `torch._C._set_cuda_deterministic` and they take/produce ints (0 = None, 1 = ). In terms of nice user-facing solution, I'd think that taking a str and filling that into the enum might be best, but I'm unsure whether to put the conversion method into ATen (next to the enum definition) or into the Python Module csrc or into the Python wrapper (the latter being what reduction does).
Currently
- It is named CUDA, because I don't really know much about CPU determinism issues, while I think I have a good handle on CUDA (which is atomics). I'd be happy to rename it, but that would mean it may be inaccurate.
- It doesn't interact with CuDNN deterministic / benchmark yet. One could just `||` the flag to deterministic.
- Given that this will now warn whenever you use a function that isn't deterministic, so it would warn a lot if you have anything in your training loop. Is this something that can be mitigated by Python's warning settings?
- The nll_loss2d example is currently misleading, as it's deterministic if reduction=None.
- Of course, I'd also be happy about your feedback about the other details (like where to put what).

If it's roughly reasonable, I'll flag all CUDA methods next and produce a Python wrapper.
