### PR TITLE
Automatic update of fbcode/onnx to e18bb41d255a23daf368ffd62a2645db55db4c72

### DIFF
--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -53,6 +53,7 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_constantofshape_int.*'  # Needs implementation
                      '|test_where.*'  # Needs implementation
                      '|test_shrink.*'  # Needs implementation
+                     '|test_strnorm.*'  # Needs implementation
                      '|test_nonzero.*'  # Needs implementation
                      '|test_tfidfvectorizer.*'  # Needs implementation
                      ')')


### PR DESCRIPTION
Summary:
Previous import was 4c091e048ca42682d63ccd3c1811560bc12b732d

Included changes:
- **[e18bb41](https://github.com/onnx/onnx/commit/e18bb41)**: Infer shape of the second output of Dropout op (#1822) <Shinichiro Hamaji>
- **[cb544d0](https://github.com/onnx/onnx/commit/cb544d0)**: Clarify dtype of Dropout's mask output (#1826) <Shinichiro Hamaji>
- **[b60f693](https://github.com/onnx/onnx/commit/b60f693)**: Fix shape inference when auto_pad  is notset (#1824) <Li-Wen Chang>
- **[80346bd](https://github.com/onnx/onnx/commit/80346bd)**: update test datat (#1825) <Rui Zhu>
- **[b37fc6d](https://github.com/onnx/onnx/commit/b37fc6d)**: Add stringnormalizer operator to ONNX (#1745) <Dmitri Smirnov>

Differential Revision: D14206264
