### PR TITLE
Make transpose consistent with numpy's behavior

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -627,22 +627,23 @@ static void check_t(const Tensor& self, const char *fn) {
   if (self.is_sparse()) {
     int64_t sparse_dim = self.sparse_dim();
     int64_t dense_dim = self.dense_dim();
-    AT_CHECK(sparse_dim == 2 && dense_dim == 0,
-             fn, " expects a tensor with 2 sparse and 0 dense dimensions, but got ",
+    AT_CHECK((sparse_dim == 2 || sparse_dim == 1) && dense_dim == 0,
+             fn, " expects a tensor with 1 or 2 sparse and 0 dense dimensions, but got ",
              sparse_dim, " sparse and ", dense_dim, " dense dimensions");
-  } else if (self.dim() != 2) {
-    AT_ERROR(fn, " expects a 2D tensor, but self is ", self.dim(), "D");
+  } else {
+    AT_CHECK((self.dim() == 1 || self.dim() == 2),
+             fn, " expects a 1D or 2D tensor, but self is ", self.dim(), "D");
   }
 }
 
 Tensor t(const Tensor & self) {
   check_t(self, "t()");
-  return self.transpose(0, 1);
+  return self.transpose(0, self.dim() == 1 ? 0 : 1);
 }
 
 Tensor & t_(Tensor & self) {
   check_t(self, "t_()");
-  return self.transpose_(0, 1);
+  return self.transpose_(0, self.dim() == 1 ? 0 : 1);
 }
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t> >

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4952,7 +4952,7 @@ a")
         @torch.jit.script
         def foo(a):
             return a.t()
-        s = Variable(torch.rand(10))
+        s = Variable(torch.rand(5, 5, 5))
         # XXX: this should stay quiet in stay propagation and only fail in the interpreter
         with self.assertRaisesRegex(RuntimeError, "failed in interpreter"):
             foo(s)
@@ -13124,7 +13124,7 @@ class TestAsync(JitTestCase):
 
         # two futures with a different error
         x = torch.rand(3, 4, 5)
-        with self.assertRaisesRegex(Exception, 'expects a 2D tensor'):
+        with self.assertRaisesRegex(Exception, 'expects a 1D or 2D tensor'):
             wait_script_nest(x)
 
     def test_async_grad_guard_with_grad(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6825,6 +6825,15 @@ class _TestTorchMixin(object):
         out.fill_(0.123)
         self.assertEqual(out, dest.view(-1))  # Must point to the same storage.
 
+    def test_t(self):
+        x = torch.arange(4)
+        self.assertEqual(x, x.t())
+        x = torch.rand((2, 2))
+        self.assertEqual(x.t(), x.transpose(0, 1))
+        x = torch.rand((2, 2, 2))
+        with self.assertRaisesRegex(RuntimeError, 'expects a 1D or 2D tensor, but self is 3D'):
+            x.t()
+
     def test_take(self):
         def check(src, idx):
             expected = src.contiguous().view(-1).index_select(


### PR DESCRIPTION
Pytorch's tensor.t() is now equivalent with Numpy's ndarray.T for 1D tensor
i.e. tensor.t() == tensor

Test case added:
- test_t

fixes #9687

