### PR TITLE
Throw exception when foxi is not checked out

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,7 @@ def build_deps():
     check_file(os.path.join(third_party_path, "pybind11", "CMakeLists.txt"))
     check_file(os.path.join(third_party_path, 'cpuinfo', 'CMakeLists.txt'))
     check_file(os.path.join(third_party_path, 'onnx', 'CMakeLists.txt'))
+    check_file(os.path.join(third_party_path, 'foxi', 'CMakeLists.txt'))
     check_file(os.path.join(third_party_path, 'QNNPACK', 'CMakeLists.txt'))
     check_file(os.path.join(third_party_path, 'fbgemm', 'CMakeLists.txt'))
 


### PR DESCRIPTION
Add check and provide useful warning/error information to user if foxi is not checked out.