### PR TITLE
Fix linking errors when building dataloader test binaries on Windows

### DIFF
--- a/torch/csrc/api/include/torch/data/samplers/distributed.h
+++ b/torch/csrc/api/include/torch/data/samplers/distributed.h
@@ -38,11 +38,11 @@ class DistributedSampler : public Sampler<BatchRequest> {
 
   /// Set the epoch for the current enumeration. This can be used to alter the
   /// sample selection and shuffling behavior.
-  TORCH_API void set_epoch(size_t epoch) {
+  void set_epoch(size_t epoch) {
     epoch_ = epoch;
   }
 
-  TORCH_API size_t epoch() const {
+  size_t epoch() const {
     return epoch_;
   }
 


### PR DESCRIPTION
Fixes #17489.