### PR TITLE
Override torch._ops with torch.fb._ops in FBCode

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -4,9 +4,9 @@ import contextlib
 import ctypes
 import sys
 import types
-import os.path
 
 import torch.jit
+import torch._utils_internal
 
 # Query `hasattr` only once.
 _SET_GLOBAL_FLAGS = hasattr(sys, 'getdlopenflags') and hasattr(sys, 'setdlopenflags')
@@ -94,7 +94,7 @@ class _Ops(types.ModuleType):
         Arguments:
             path (str): A path to a shared library to load.
         """
-        path = os.path.realpath(path)
+        path = torch._utils_internal.resolve_library_path(path)
         with dl_open_guard():
             # Import the shared library into the process, thus running its
             # static (global) initialization code in order to register custom

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -29,5 +29,9 @@ def prepare_multiprocessing_environment(path):
     pass
 
 
+def resolve_library_path(path):
+    return os.path.realpath(path)
+
+
 TEST_MASTER_ADDR = '127.0.0.1'
 TEST_MASTER_PORT = 29500


### PR DESCRIPTION
Summary: The following problems have been addressed: 1) import torch.ops correctly, 2) make realpath call optional

Differential Revision: D14094358
