### PR TITLE
Removing unnecessary iterator operations from op_apply

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -140,7 +140,7 @@ inline Tensor sort_strides(Tensor& tensor_) {
   return tensor;
 }
 
-template <typename T, int N>
+template <typename T, int N, bool CanOverflow = true>
 struct strided_tensor_iter_fixed {
  public:
   T* data_ = NULL;
@@ -151,6 +151,7 @@ struct strided_tensor_iter_fixed {
   int64_t strides_[N] = {0};
 
   strided_tensor_iter_fixed(strided_tensor_iter_fixed const&) = delete;
+  operator bool() const { return CanOverflow; };
   void operator=(strided_tensor_iter_fixed const& x) = delete;
   strided_tensor_iter_fixed(strided_tensor_iter_fixed&&) = default;
   strided_tensor_iter_fixed(Tensor& tensor, bool sort_strides = false)
@@ -180,6 +181,7 @@ struct strided_tensor_iter {
   std::vector<int64_t> strides_;
 
   strided_tensor_iter(strided_tensor_iter const&) = delete;
+  operator bool() const { return true; };
   void operator=(strided_tensor_iter const& x) = delete;
   strided_tensor_iter(strided_tensor_iter&&) = default;
   strided_tensor_iter(Tensor& tensor)
@@ -241,7 +243,9 @@ inline void iterate(int64_t size){};
 
 template <typename Arg, typename... Args>
 inline void iterate(int64_t size, Arg& iter, Args&... iter_tail) {
-  iter.counter_[iter.dim_ - 1] += size;
+  if (iter) {
+    iter.counter_[iter.dim_ - 1] += size;
+  }
   iter.data_ = iter.data_ + size * iter.strides_[iter.dim_ - 1];
   iterate(size, iter_tail...);
 }
@@ -252,8 +256,11 @@ inline bool iterate_continue() {
 
 template <typename Arg, typename... Args>
 inline bool iterate_continue(Arg& iter, Args&... iter_tail) {
-  return iter.counter_[iter.dim_ - 1] < iter.sizes_[iter.dim_ - 1] &&
-      iterate_continue(iter_tail...);
+  if (iter) {
+    return iter.counter_[iter.dim_ - 1] < iter.sizes_[iter.dim_ - 1] &&
+        iterate_continue(iter_tail...);
+  }
+  return iterate_continue(iter_tail...);
 }
 
 inline int64_t max_iterate_size() {
@@ -271,13 +278,15 @@ inline void iterate_overflow(){};
 
 template <typename Arg, typename... Args>
 inline void iterate_overflow(Arg& iter, Args&... iter_tail) {
-  if (iter.counter_[iter.dim_ - 1] == iter.sizes_[iter.dim_ - 1]) {
-    for (int64_t i = iter.dim_ - 1; i > 0; i--) {
-      if (iter.counter_[i] == iter.sizes_[i]) {
-        iter.counter_[i] = 0;
-        iter.counter_[i - 1]++;
-        iter.data_ = iter.data_ - (iter.sizes_[i] * iter.strides_[i]) +
-            iter.strides_[i - 1];
+  if (iter) {
+    if (iter.counter_[iter.dim_ - 1] == iter.sizes_[iter.dim_ - 1]) {
+      for (int64_t i = iter.dim_ - 1; i > 0; i--) {
+        if (iter.counter_[i] == iter.sizes_[i]) {
+          iter.counter_[i] = 0;
+          iter.counter_[i - 1]++;
+          iter.data_ = iter.data_ - (iter.sizes_[i] * iter.strides_[i]) +
+              iter.strides_[i - 1];
+        }
       }
     }
   }
@@ -423,12 +432,23 @@ inline void CPU_tensor_apply2(Tensor tensor1, Tensor tensor2, const Op op) {
   if (!_apply_preamble({tensor1, tensor2}))
     return;
   if (_max_dim_tensors({tensor1, tensor2}) <= 8) {
-    apply_op(
-        tensor1.numel(),
-        0,
-        op,
-        strided_tensor_iter_fixed<scalar1, 8>(tensor1),
-        strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+    auto iterator1 = strided_tensor_iter_fixed<scalar1, 8>(tensor1);
+    auto iterator2 = strided_tensor_iter_fixed<scalar2, 8>(tensor2);
+    if (iterator1.dim_ == 1 && iterator2.dim_ == 1) {
+      apply_op(
+          tensor1.numel(),
+          0,
+          op,
+          strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
+          strided_tensor_iter_fixed<scalar2, 8, false>(tensor2));
+    } else {
+      apply_op(
+          tensor1.numel(),
+          0,
+          op,
+          strided_tensor_iter_fixed<scalar1, 8>(tensor1),
+          strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+    }
   } else {
     apply_op(
         tensor1.numel(),
@@ -538,18 +558,35 @@ inline void CPU_tensor_parallel_apply2(
   if (!_apply_preamble({tensor1, tensor2}))
     return;
   if (tensor1.ndimension() < 8 && tensor2.ndimension() < 8) {
-    parallel_for(
-        0,
-        tensor1.numel(),
-        grain_size,
-        [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
-          apply_op(
-              end - begin,
-              begin,
-              op,
-              strided_tensor_iter_fixed<scalar1, 8>(tensor1),
-              strided_tensor_iter_fixed<scalar2, 8>(tensor2));
-        });
+    auto iterator1 = strided_tensor_iter_fixed<scalar1, 8>(tensor1);
+    auto iterator2 = strided_tensor_iter_fixed<scalar2, 8>(tensor2);
+    if (iterator1.dim_ == 1) {
+      parallel_for(
+          0,
+          tensor1.numel(),
+          grain_size,
+          [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
+            apply_op(
+                end - begin,
+                begin,
+                op,
+                strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
+                strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+          });
+    } else {
+      parallel_for(
+          0,
+          tensor1.numel(),
+          grain_size,
+          [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
+            apply_op(
+                end - begin,
+                begin,
+                op,
+                strided_tensor_iter_fixed<scalar1, 8>(tensor1),
+                strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+          });
+    }
   } else {
     parallel_for(
         0,

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -557,20 +557,18 @@ inline void CPU_tensor_parallel_apply2(
     return;
   if (tensor1.ndimension() < 8 && tensor2.ndimension() < 8) {
     if (tensor1.is_contiguous()) {
-      auto call = [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
-        apply_op(
-            end - begin,
-            begin,
-            op,
-            strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
-            strided_tensor_iter_fixed<scalar2, 8>(tensor2));
-      };
-
       parallel_for(
           0,
           tensor1.numel(),
           grain_size,
-          call);
+          [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
+            apply_op(
+                end - begin,
+                begin,
+                op,
+                strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
+                strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+          });
     } else {
       parallel_for(
           0,

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -151,7 +151,7 @@ struct strided_tensor_iter_fixed {
   int64_t strides_[N] = {0};
 
   strided_tensor_iter_fixed(strided_tensor_iter_fixed const&) = delete;
-  bool Overflow() const { return CanOverflow; };
+  bool overflow() const { return CanOverflow; };
   void operator=(strided_tensor_iter_fixed const& x) = delete;
   strided_tensor_iter_fixed(strided_tensor_iter_fixed&&) = default;
   strided_tensor_iter_fixed(Tensor& tensor, bool sort_strides = false)
@@ -181,7 +181,7 @@ struct strided_tensor_iter {
   std::vector<int64_t> strides_;
 
   strided_tensor_iter(strided_tensor_iter const&) = delete;
-  bool Overflow() const { return true; };
+  bool overflow() const { return true; };
   void operator=(strided_tensor_iter const& x) = delete;
   strided_tensor_iter(strided_tensor_iter&&) = default;
   strided_tensor_iter(Tensor& tensor)
@@ -243,7 +243,7 @@ inline void iterate(int64_t size){};
 
 template <typename Arg, typename... Args>
 inline void iterate(int64_t size, Arg& iter, Args&... iter_tail) {
-  if (iter.Overflow()) {
+  if (iter.overflow()) {
     iter.counter_[iter.dim_ - 1] += size;
   }
   iter.data_ = iter.data_ + size * iter.strides_[iter.dim_ - 1];
@@ -256,7 +256,7 @@ inline bool iterate_continue() {
 
 template <typename Arg, typename... Args>
 inline bool iterate_continue(Arg& iter, Args&... iter_tail) {
-  if (iter.Overflow()) {
+  if (iter.overflow()) {
     return iter.counter_[iter.dim_ - 1] < iter.sizes_[iter.dim_ - 1] &&
         iterate_continue(iter_tail...);
   }
@@ -278,7 +278,7 @@ inline void iterate_overflow(){};
 
 template <typename Arg, typename... Args>
 inline void iterate_overflow(Arg& iter, Args&... iter_tail) {
-  if (iter.Overflow()) {
+  if (iter.overflow()) {
     if (iter.counter_[iter.dim_ - 1] == iter.sizes_[iter.dim_ - 1]) {
       for (int64_t i = iter.dim_ - 1; i > 0; i--) {
         if (iter.counter_[i] == iter.sizes_[i]) {


### PR DESCRIPTION
In many cases we are iterating tensors with one continuous memory (any stride size). That means there is no need to check overflow/increase counters. It saves 3 asm operations per tensor (out of 13 in copy case).

Simple test:

```
import torch
torch.set_num_threads(1)
i = torch.arange(100000000).type(torch.DoubleTensor).reshape(20,500,100,100)
timeit i.transpose(0,2).transpose(1,2).clone()
```

With optimization:
962 ms ± 17.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Without:
1.03 s ± 22.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

There is still room to apply it in all CPU_tensor_* functions. I just covered most common ones.
