### PR TITLE
Eliminate most usages of Type::scalarType()

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -8,11 +8,11 @@
 using namespace std;
 namespace at {
 
-static DLDataType getDLDataType(const Type& type) {
+static DLDataType getDLDataType(const Tensor& t) {
   DLDataType dtype;
   dtype.lanes = 1;
-  dtype.bits = type.elementSizeInBytes() * 8;
-  switch (type.scalarType()) {
+  dtype.bits = t.dtype().itemsize() * 8;
+  switch (t.scalar_type()) {
     case ScalarType::Byte:
       dtype.code = DLDataTypeCode::kDLUInt;
       break;
@@ -160,7 +160,7 @@ DLManagedTensor* toDLPack(const Tensor& src) {
   }
   atDLMTensor->tensor.dl_tensor.ctx = getDLContext(src.type(), device_id);
   atDLMTensor->tensor.dl_tensor.ndim = src.dim();
-  atDLMTensor->tensor.dl_tensor.dtype = getDLDataType(src.type());
+  atDLMTensor->tensor.dl_tensor.dtype = getDLDataType(src);
   atDLMTensor->tensor.dl_tensor.shape = const_cast<int64_t*>(src.sizes().data());
   atDLMTensor->tensor.dl_tensor.strides = const_cast<int64_t*>(src.strides().data());
   atDLMTensor->tensor.dl_tensor.byte_offset = 0;

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -12,31 +12,28 @@
 
 #define AT_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)                          \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)        \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_FLOATING_TYPES_AND_HALF(TYPE, NAME, ...)                 \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, at::Half, __VA_ARGS__)      \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(TYPE, NAME, ...)              \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, at::Half, __VA_ARGS__)      \
@@ -47,28 +44,26 @@
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexHalf, std::complex<at::Half>, __VA_ARGS__)  \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_INTEGRAL_TYPES(TYPE, NAME, ...)                          \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_ALL_TYPES(TYPE, NAME, ...)                               \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
@@ -77,14 +72,13 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_ALL_TYPES_AND_HALF(TYPE, NAME, ...)                      \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
@@ -94,27 +88,25 @@
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, at::Half, __VA_ARGS__)      \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_COMPLEX_TYPES(TYPE, NAME, ...)                           \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)    \
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)  \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_ALL_TYPES_AND_COMPLEX(TYPE, NAME, ...)                   \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
@@ -127,14 +119,13 @@
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)  \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()
 
 #define AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX(TYPE, NAME, ...)          \
   [&] {                                                                      \
-    const at::Type& the_type = TYPE;                                         \
-    switch (the_type.scalarType()) {                                         \
+    switch (TYPE) {                                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Byte, uint8_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Char, int8_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
@@ -148,6 +139,6 @@
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)  \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", the_type.toString(), "'"); \
+        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
     }                                                                        \
   }()

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -89,7 +89,7 @@ void SparseTensorImpl::set_indices_and_values_unsafe(const Tensor& indices, cons
   AT_CHECK(!values.is_sparse(), "expected values to be a dense tensor, but got values of layout ", values.layout());
 
   AT_CHECK(values.type().toSparse() == legacyTensorType(*this), "values type must match sparse tensor type");
-  AT_CHECK(indices.type().scalarType() == kLong, "indices must be an int64 tensor");
+  AT_CHECK(indices.scalar_type() == kLong, "indices must be an int64 tensor");
   AT_CHECK(indices.type().backend() == values.type().backend(), "backend of indices (", indices.type().backend(), ") must match backend of values (", values.type().backend(), ")");
   AT_CHECK(!indices.is_cuda() || indices.get_device() == values.get_device(), "device of indices (", indices.get_device(), ") must match device of values (", values.get_device(), ")");
 

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -142,7 +142,7 @@ void checkSameType(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
 
 void checkScalarType(CheckedFrom c, const TensorArg& t, ScalarType ty) {
   AT_CHECK(
-    t->type().scalarType() == ty,
+    t->scalar_type() == ty,
     "Expected tensor for ", t, " to have scalar type ", toString(ty),
     "; but got ", t->toString(), " instead (while checking arguments for ", c,
     ")");
@@ -150,7 +150,7 @@ void checkScalarType(CheckedFrom c, const TensorArg& t, ScalarType ty) {
 
 void checkScalarTypes(CheckedFrom c, const TensorArg& t,
                       at::ArrayRef<ScalarType> l) {
-    if (std::find(l.begin(), l.end(), t->type().scalarType()) == l.end()) {
+    if (std::find(l.begin(), l.end(), t->scalar_type()) == l.end()) {
       std::ostringstream oss;
       oss << "Expected tensor for " << t << " to have one of the following "
           << "scalar types: ";

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1336,11 +1336,11 @@ inline bool is_sparse(Tensor self) {
   template <>                                    \
   inline T* Tensor::data() const {               \
     AT_CHECK(                                    \
-        type().scalarType() == ScalarType::name, \
+        scalar_type() == ScalarType::name,       \
         "expected scalar type ",                 \
         #name,                                   \
         " but found ",                           \
-        c10::toString(type().scalarType()));     \
+        c10::toString(scalar_type()));           \
     return static_cast<T*>(this->data_ptr());    \
   }
 

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -368,7 +368,7 @@ struct CAFFE2_API DimensionedTensorType : public TensorType {
 
 protected:
   DimensionedTensorType(const at::Tensor& tensor, TypeKind kind=TypeKind::DimensionedTensorType)
-    : DimensionedTensorType(tensor.type().scalarType(),
+    : DimensionedTensorType(tensor.scalar_type(),
                  tensor.device(),
                  tensor.dim(),
                  tensor.is_variable() && tensor.requires_grad(),

--- a/aten/src/ATen/cudnn/Descriptors.cpp
+++ b/aten/src/ATen/cudnn/Descriptors.cpp
@@ -10,8 +10,8 @@ namespace at { namespace native {
 
 namespace {
 
-inline cudnnDataType_t getDataType(const at::Type& t) {
-  auto scalar_type = t.scalarType();
+inline cudnnDataType_t getDataType(const at::Tensor& t) {
+  auto scalar_type = t.scalar_type();
   if (scalar_type == at::kFloat) {
     return CUDNN_DATA_FLOAT;
   } else if (scalar_type == at::kHalf) {
@@ -20,10 +20,6 @@ inline cudnnDataType_t getDataType(const at::Type& t) {
     return CUDNN_DATA_DOUBLE;
   }
   throw std::runtime_error("TensorDescriptor only supports double, float and half tensors");
-}
-
-inline cudnnDataType_t getDataType(const at::Tensor& t) {
-  return getDataType(t.type());
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/cudnn/Types.cpp
+++ b/aten/src/ATen/cudnn/Types.cpp
@@ -5,15 +5,15 @@
 namespace at { namespace native {
 
 cudnnDataType_t getCudnnDataType(const at::Tensor& tensor) {
-  if (tensor.type().scalarType() == at::kFloat) {
+  if (tensor.scalar_type() == at::kFloat) {
     return CUDNN_DATA_FLOAT;
-  } else if (tensor.type().scalarType() == at::kDouble) {
+  } else if (tensor.scalar_type() == at::kDouble) {
     return CUDNN_DATA_DOUBLE;
-  } else if (tensor.type().scalarType() == at::kHalf) {
+  } else if (tensor.scalar_type() == at::kHalf) {
     return CUDNN_DATA_HALF;
   }
   std::string msg("getCudnnDataType() not supported for ");
-  msg += toString(tensor.type().scalarType());
+  msg += toString(tensor.scalar_type());
   throw std::runtime_error(msg);
 }
 

--- a/aten/src/ATen/detail/ScalarTypeConversions.h
+++ b/aten/src/ATen/detail/ScalarTypeConversions.h
@@ -9,14 +9,14 @@ namespace at { namespace detail {
 
 template <typename T>
 inline T load(const void* data, ScalarType src_type) {
-  return AT_DISPATCH_ALL_TYPES(CPU(src_type), "load", [&]() {
+  return AT_DISPATCH_ALL_TYPES(src_type, "load", [&]() {
     return at::convert<T>(*(scalar_t*)data);
   });
 }
 
 template <typename T>
 inline void store(T value, void* dst, ScalarType dst_type) {
-  AT_DISPATCH_ALL_TYPES(CPU(dst_type), "store", [&]() {
+  AT_DISPATCH_ALL_TYPES(dst_type, "store", [&]() {
     *(scalar_t*)dst = at::convert<scalar_t>(value);
   });
 }

--- a/aten/src/ATen/miopen/Descriptors.cpp
+++ b/aten/src/ATen/miopen/Descriptors.cpp
@@ -5,18 +5,14 @@ namespace at { namespace native {
 
 namespace {
 
-inline miopenDataType_t getDataType(const at::Type& t) {
-  auto scalar_type = t.scalarType();
+inline miopenDataType_t getDataType(const at::Tensor& t) {
+  auto scalar_type = t.scalar_type();
   if (scalar_type == at::kFloat) {
     return miopenFloat;
   } else if (scalar_type == at::kHalf) {
     return miopenHalf;
   }
   throw std::runtime_error("TensorDescriptor only supports float and half tensors");
-}
-
-inline miopenDataType_t getDataType(const at::Tensor& t) {
-  return getDataType(t.type());
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/miopen/Types.cpp
+++ b/aten/src/ATen/miopen/Types.cpp
@@ -6,13 +6,13 @@
 namespace at { namespace native {
 
 miopenDataType_t getMiopenDataType(const at::Tensor& tensor) {
-  if (tensor.type().scalarType() == at::kFloat) {
+  if (tensor.scalar_type() == at::kFloat) {
     return miopenFloat;
-  } else if (tensor.type().scalarType() == at::kHalf) {
+  } else if (tensor.scalar_type() == at::kHalf) {
     return miopenHalf;
   }
   std::string msg("getMiopenDataType() not supported for ");
-  msg += toString(tensor.type().scalarType());
+  msg += toString(tensor.scalar_type());
   throw std::runtime_error(msg);
 }
 

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -150,7 +150,7 @@ Tensor prelu_cpu(const Tensor& self, const Tensor& weight_) {
 
   // case1: shared weight for all channels
   if (weight_num == 1) {
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "prelu_cpu", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "prelu_cpu", [&] {
       prelu_cpu_kernel_share_weights<scalar_t>(result, input, weight);
     });
   }
@@ -171,7 +171,7 @@ Tensor prelu_cpu(const Tensor& self, const Tensor& weight_) {
       "Mismatch of parameter numbers and input channel size. Found parameter numbers = ", weight_num,
       " and channel size = ", channel_size, ".");
 
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "prelu_cpu", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "prelu_cpu", [&] {
       prelu_cpu_kernel_multi_weights<scalar_t>(
         result,
         input,
@@ -277,7 +277,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
 
   // case1: shared parameter for all channels
   if (weight_num == 1) {
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "prelu_backward_cpu", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "prelu_backward_cpu", [&] {
       prelu_cpu_backward_kernel_share_weights<scalar_t>(input, weight, grad_out, input_grad, weight_grad);
     });
   }
@@ -298,7 +298,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
       "Mismatch of parameter numbers and input channel size. Found parameter numbers = ", weight_num,
       " and channel size = ", channel_size, ".");
 
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "prelu_backward_cpu", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "prelu_backward_cpu", [&] {
       prelu_cpu_backward_kernel_multi_weights<scalar_t>(
         input,
         weight,
@@ -326,7 +326,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cpu(const Tensor& grad_out_, const Ten
 // -----------------------------------
 Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
   auto out_tensor = at::empty_like(self);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_cpu", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "hardshrink_cpu", [&] {
     auto lambd_val = lambd.to<scalar_t>();
     at::CPU_tensor_apply2<scalar_t, scalar_t>(
       self,
@@ -342,7 +342,7 @@ Tensor hardshrink_cpu(const Tensor & self, Scalar lambd) {
 
 Tensor hardshrink_backward_cpu(const Tensor & grad, const Tensor & self, Scalar lambd) {
   auto out_tensor = at::empty_like(self);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "hardshrink_backward_cpu", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "hardshrink_backward_cpu", [&] {
     auto lambd_val = lambd.to<scalar_t>();
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
       self,

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -102,7 +102,7 @@ namespace {
     {
       output.resize_({sizeD, osizeH, osizeW});
 
-      AT_DISPATCH_FLOATING_TYPES(input.type(), "adaptive_avg_pool2d", [&] {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d", [&] {
           auto input_data = input.data<scalar_t>();
           auto output_data = output.data<scalar_t>();
           adaptive_avg_pool2d_out_frame<scalar_t>(input_data, output_data,
@@ -121,7 +121,7 @@ namespace {
     #pragma omp parallel for private(b)
       for (b = 0; b < input.size(0); b++)
       {
-        AT_DISPATCH_FLOATING_TYPES(input.type(), "adaptive_avg_pool2d", [&] {
+        AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d", [&] {
             auto input_data = input.data<scalar_t>();
             auto output_data = output.data<scalar_t>();
             adaptive_avg_pool2d_out_frame<scalar_t>(input_data+b*input.stride(0), output_data+b*sizeD*osizeH*osizeW,
@@ -203,7 +203,7 @@ namespace {
     if (input.ndimension() == 3)
     {
       AT_DISPATCH_FLOATING_TYPES(
-        input.type(), "adaptive_avg_pool2d_backward", [&] {
+        input.scalar_type(), "adaptive_avg_pool2d_backward", [&] {
           /* get raw pointers */
           scalar_t *gradInput_data = gradInput.data<scalar_t>();
           scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
@@ -223,7 +223,7 @@ namespace {
       for (b = 0; b < input.size(0); b++)
       {
         AT_DISPATCH_FLOATING_TYPES(
-          input.type(), "adaptive_avg_pool2d_backward", [&] {
+          input.scalar_type(), "adaptive_avg_pool2d_backward", [&] {
             /* get raw pointers */
             scalar_t *gradInput_data = gradInput.data<scalar_t>();
             scalar_t *gradOutput_data = gradOutput.data<scalar_t>();

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -149,7 +149,7 @@ std::tuple<Tensor, Tensor> _gesv_helper_cpu(const Tensor& self, const Tensor& A)
   auto self_working_copy = cloneBatchedColumnMajor(self);
   auto A_working_copy = cloneBatchedColumnMajor(A);
   std::vector<int64_t> infos(batchCount(self), 0);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "gesv", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "gesv", [&]{
     apply_gesv<scalar_t>(self_working_copy, A_working_copy, infos);
   });
   if (self.dim() > 2) {
@@ -172,7 +172,7 @@ std::tuple<Tensor,Tensor> gesv(const Tensor& self, const Tensor& A) {
 }
 
 std::tuple<Tensor&,Tensor&> gesv_out(Tensor& solution, Tensor& lu, const Tensor& self, const Tensor& A) {
-  AT_CHECK(self.dim() == 2 && A.dim() == 2, 
+  AT_CHECK(self.dim() == 2 && A.dim() == 2,
            "torch.gesv() with the `out` keyword does not support batching. "
            "b.dim() (", self.dim(), ") and A.dim() (", A.dim(), ") must both be 2.");
   Tensor solution_tmp, lu_tmp;
@@ -229,7 +229,7 @@ static void apply_inverse(Tensor& self, std::vector<int64_t>& infos) {
 Tensor _inverse_helper_cpu(const Tensor& self) {
   std::vector<int64_t> infos(batchCount(self), 0);
   auto self_working_copy = cloneBatchedColumnMajor(self);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "inverse", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "inverse", [&]{
     apply_inverse<scalar_t>(self_working_copy, infos);
   });
   batchCheckErrors(infos, "inverse");
@@ -294,7 +294,7 @@ Tensor _cholesky_solve_helper_cpu(const Tensor& self, const Tensor& A, bool uppe
   auto self_working_copy = cloneBatchedColumnMajor(self);
   auto A_working_copy = cloneBatchedColumnMajor(A);
   std::vector<int64_t> infos(batchCount(self), 0);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "cholesky_solve", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "cholesky_solve", [&]{
     apply_cholesky_solve<scalar_t>(self_working_copy, A_working_copy, upper, infos);
   });
   if (self.dim() > 2) {
@@ -358,7 +358,7 @@ static void apply_cholesky(Tensor& self, bool upper, std::vector<int64_t>& infos
 Tensor _cholesky_helper_cpu(const Tensor& self, bool upper) {
   std::vector<int64_t> infos(batchCount(self), 0);
   auto self_working_copy = cloneBatchedColumnMajor(self);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "cholesky", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "cholesky", [&]{
     apply_cholesky<scalar_t>(self_working_copy, upper, infos);
   });
   if (self.dim() > 2) {
@@ -474,7 +474,7 @@ Tensor& tril_cpu_(Tensor &self, int64_t k) {
   bool inplace = checkTrilTriuBatchContiguous(self);
   Tensor self_c = inplace ? self : self.contiguous();
   Tensor result = inplace ? self : at::empty_like(self);
-  AT_DISPATCH_ALL_TYPES(self.type(), "tril", [&]{
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "tril", [&]{
     apply_triu_tril<scalar_t, false>(result, self_c, inplace, k);
   });
   if (!inplace) self.copy_(result);
@@ -489,7 +489,7 @@ Tensor& tril_cpu_out(Tensor &result, const Tensor& self, int64_t k) {
     return result;
   }
   Tensor self_c = checkTrilTriuBatchContiguous(self) ? self : self.contiguous();
-  AT_DISPATCH_ALL_TYPES(self.type(), "tril", [&]{
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "tril", [&]{
     apply_triu_tril<scalar_t, false>(result, self_c, false, k);
   });
   return result;
@@ -508,7 +508,7 @@ Tensor& triu_cpu_(Tensor &self, int64_t k) {
   bool inplace = checkTrilTriuBatchContiguous(self);
   Tensor self_c = inplace ? self : self.contiguous();
   Tensor result = inplace ? self : at::empty_like(self);
-  AT_DISPATCH_ALL_TYPES(self.type(), "triu", [&]{
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "triu", [&]{
     apply_triu_tril<scalar_t, true>(result, self_c, inplace, k);
   });
   if (!inplace) self.copy_(result);
@@ -523,7 +523,7 @@ Tensor& triu_cpu_out(Tensor &result, const Tensor& self, int64_t k) {
     return result;
   }
   Tensor self_c = checkTrilTriuBatchContiguous(self) ? self : self.contiguous();
-  AT_DISPATCH_ALL_TYPES(self.type(), "triu", [&]{
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "triu", [&]{
     apply_triu_tril<scalar_t, true>(result, self_c, false, k);
   });
   return result;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -128,7 +128,7 @@ auto ConvParams::use_cudnn(const at::Tensor& input) const -> bool {
 
 auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
 
-  return ((input.type().scalarType() == at::kFloat) || (input.type().scalarType() == at::kHalf))
+  return ((input.scalar_type() == at::kFloat) || (input.scalar_type() == at::kHalf))
          && detail::getCUDAHooks().compiledWithMIOpen()
          && input.is_cuda()
          && input.dim() <= MIOPEN_DIM_MAX
@@ -142,7 +142,7 @@ auto ConvParams::use_miopen(const at::Tensor& input) const -> bool {
 auto ConvParams::use_mkldnn(const at::Tensor& input) const -> bool {
 #if AT_MKLDNN_ENABLED()
   return input.type().backend() == at::Backend::CPU &&
-         input.type().scalarType() == kFloat && // only on CPU Float Tensors
+         input.scalar_type() == kFloat && // only on CPU Float Tensors
          !is_dilated() && // doesn't support dilation
          !transposed && // or transposed tensors
          input.ndimension() == 4; // must be in NCHW format
@@ -153,7 +153,7 @@ auto ConvParams::use_nnpack(const at::Tensor& input) const -> bool {
 #if AT_NNPACK_ENABLED()
   return at::_nnpack_available() &&
          input.type().backend() == at::Backend::CPU &&
-         input.type().scalarType() == kFloat && // only on CPU Float Tensors
+         input.scalar_type() == kFloat && // only on CPU Float Tensors
          !is_strided() && // doesn't support strides
          !is_dilated() && // or dilation
          !transposed &&   // or transposed tensors

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -20,7 +20,7 @@ void _copy__cpu(at::Tensor& self, const at::Tensor& src) {
 template <typename self_T>
 void _copy__cpu(at::Tensor& self, const at::Tensor& src) {
   AT_CHECK(self.numel() == src.numel(), "sizes do not match");
-  AT_DISPATCH_ALL_TYPES_AND_HALF(src.type(), "_copy__cpu", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(src.scalar_type(), "_copy__cpu", [&]() {
     _copy__cpu<self_T, scalar_t>(self, src);
   });
 }
@@ -43,7 +43,7 @@ Tensor& _s_copy__cpu(Tensor& self, const Tensor& src, bool non_blocking) {
     return self;
   }
   AT_DISPATCH_ALL_TYPES_AND_HALF(
-      self.type(), "_copy__cpu", [&]() { ::_copy__cpu<scalar_t>(self, src); });
+      self.scalar_type(), "_copy__cpu", [&]() { ::_copy__cpu<scalar_t>(self, src); });
   return self;
 }
 
@@ -59,7 +59,7 @@ void _copy_same_type_transpose_(Tensor& self, const Tensor& src) {
   Tensor buf = empty({BLOCK_SZ, BLOCK_SZ}, self.options());
 
   AT_DISPATCH_ALL_TYPES_AND_HALF(
-      self.type(), "_copy_same_type_transpose_", [&]() {
+      self.scalar_type(), "_copy_same_type_transpose_", [&]() {
         scalar_t* sp = src.data<scalar_t>();
         scalar_t* rp = self.data<scalar_t>();
         scalar_t* bp = buf.data<scalar_t>();
@@ -114,7 +114,7 @@ void _copy_same_type__cpu(Tensor& self, const Tensor& src) {
     } else {
 #ifdef _OPENMP
       if (!in_parallel_region()) {
-        AT_DISPATCH_ALL_TYPES_AND_HALF(self.type(), "_copy_same_type_", [&]() {
+        AT_DISPATCH_ALL_TYPES_AND_HALF(self.scalar_type(), "_copy_same_type_", [&]() {
           at::CPU_tensor_parallel_apply2<scalar_t, scalar_t>(
               self, src, [](scalar_t& self_val, const scalar_t& src_val) {
                 self_val = src_val;
@@ -132,7 +132,7 @@ void _copy_same_type__cpu(Tensor& self, const Tensor& src) {
   }
 
   if (serial_path) {
-    AT_DISPATCH_ALL_TYPES_AND_HALF(self.type(), "_copy_same_type_", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_HALF(self.scalar_type(), "_copy_same_type_", [&]() {
       at::CPU_tensor_apply2<scalar_t, scalar_t>(
           self, src, [](scalar_t& self_val, const scalar_t& src_val) {
             self_val = src_val;

--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -18,18 +18,18 @@ Tensor pairwise_distance(const Tensor& x1, const Tensor& x2, double p, double ep
 Tensor pdist(const Tensor& self, const double p) {
   AT_CHECK(self.dim() == 2,
       "pdist only supports 2D tensors, got: ", self.dim(), "D");
-  AT_CHECK(at::isFloatingType(self.type().scalarType()), "pdist only supports floating-point dtypes");
+  AT_CHECK(at::isFloatingType(self.scalar_type()), "pdist only supports floating-point dtypes");
   AT_CHECK(p >= 0, "pdist only supports non-negative p values");
   return at::_pdist_forward(self.contiguous(), p);
 }
 
 Tensor cdist(const Tensor& x1, const Tensor& x2, const double p) {
   AT_CHECK(x1.dim() == 2, "cdist only supports 2D tensors, X1 got: ", x1.dim(), "D");
-  AT_CHECK(at::isFloatingType(x1.type().scalarType()), "cdist only supports floating-point dtypes, X1 got: ", x1.type().scalarType());
+  AT_CHECK(at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X1 got: ", x1.scalar_type());
   auto device1 = x1.type().device_type();
   AT_CHECK(device1 == kCPU || device1 == kCUDA, "cdist only supports CPU and CUDA devices, X1 got: ", device1);
   AT_CHECK(x2.dim() == 2, "cdist only supports 2D tensors, X2 got: ", x2.dim(), "D");
-  AT_CHECK(at::isFloatingType(x1.type().scalarType()), "cdist only supports floating-point dtypes, X2 got: ", x2.type().scalarType());
+  AT_CHECK(at::isFloatingType(x1.scalar_type()), "cdist only supports floating-point dtypes, X2 got: ", x2.scalar_type());
   auto device2 = x2.type().device_type();
   AT_CHECK(device2 == kCPU || device2 == kCUDA, "cdist only supports CPU and CUDA devices, X2 got: ", device2);
   AT_CHECK(p >= 0, "cdist only supports non-negative p values");

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -126,7 +126,7 @@ Tensor& bernoulli_out(Tensor& result, const Tensor& self, Generator* gen) {
 }
 
 Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
-  AT_DISPATCH_ALL_TYPES(self.type(), "bernoulli_tensor_cpu_self_", [&] {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "bernoulli_tensor_cpu_self_", [&] {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);
     using self_t = scalar_t;
@@ -137,7 +137,7 @@ Tensor& bernoulli_tensor_cpu_(Tensor& self, const Tensor& p_, Generator* gen) {
           ret_val = static_cast<self_t>(THRandom_bernoulli(generator, p_val));
         });
     } else {
-      AT_DISPATCH_FLOATING_TYPES(p_.type(), "bernoulli_tensor_cpu_p_", [&] {
+      AT_DISPATCH_FLOATING_TYPES(p_.scalar_type(), "bernoulli_tensor_cpu_p_", [&] {
         auto p = std::get<0>(expand_inplace(self, p_.to(kCPU)));
         using p_t = scalar_t;
         CPU_tensor_apply2<self_t, p_t>(
@@ -160,7 +160,7 @@ Tensor& bernoulli_scalar_cpu_(Tensor& self, double p, Generator* gen) {
     return self;
   }
 #endif
-  AT_DISPATCH_ALL_TYPES(self.type(), "bernoulli_scalar_cpu_", [&] {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "bernoulli_scalar_cpu_", [&] {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);
     CPU_tensor_apply1<scalar_t>(
@@ -174,7 +174,7 @@ Tensor& bernoulli_scalar_cpu_(Tensor& self, double p, Generator* gen) {
 
 Tensor _standard_gamma_grad_cpu(const Tensor& self, const Tensor& output) {
   Tensor ret = at::empty(self.sizes(), self.options());
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "_standard_gamma_grad", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "_standard_gamma_grad", [&] {
     CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(ret, self, output,
       [](scalar_t& ret_val, const scalar_t& self_val, const scalar_t &output_val) {
         ret_val = standard_gamma_grad_one<scalar_t, double>(self_val, output_val);
@@ -190,7 +190,7 @@ Tensor _standard_gamma_grad_cpu(const Tensor& self, const Tensor& output) {
 
 Tensor _s_poisson_cpu(const Tensor& lambda, Generator *gen) {
   Tensor ret = at::zeros(lambda.sizes(), lambda.options());
-  AT_DISPATCH_FLOATING_TYPES(ret.type(), "poisson", [&] {
+  AT_DISPATCH_FLOATING_TYPES(ret.scalar_type(), "poisson", [&] {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);
     CPU_tensor_apply2<scalar_t, scalar_t>(ret, lambda,
@@ -204,7 +204,7 @@ Tensor _s_poisson_cpu(const Tensor& lambda, Generator *gen) {
 
 Tensor _s_gamma_cpu(const Tensor& alpha, Generator *gen) {
   Tensor ret = at::zeros(alpha.sizes(), alpha.options());
-  AT_DISPATCH_FLOATING_TYPES(ret.type(), "gamma", [&] {
+  AT_DISPATCH_FLOATING_TYPES(ret.scalar_type(), "gamma", [&] {
     THGenerator* generator = get_generator(gen);
     std::lock_guard<std::mutex> lock(generator->mutex);
     CPU_tensor_apply2<scalar_t, scalar_t>(ret, alpha,

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -199,7 +199,7 @@ _embedding_bag_cpu(const Tensor &weight, const Tensor &indices,
     return std::tuple<Tensor, Tensor, Tensor, Tensor>(ret, offset2bag, bag_size, bag_size);
   } else { // MODE_MAX
     return AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      weight.type(), "embedding_bag_cpu_max", [&]() {
+      weight.scalar_type(), "embedding_bag_cpu_max", [&]() {
         return embedding_bag_cpu_max<scalar_t>(weight, indices, offset2bag, output, bag_size, offsets);
       }
     );

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -178,7 +178,7 @@ void fractional_max_pool2d_out_cpu_template(
     indices.resize_({numBatch, numPlanes, outputH, outputW});
   }
 
-  AT_DISPATCH_FLOATING_TYPES(input.type(),
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
   "fractional_max_pool2d_out_frame", [&] {
     auto input_data = input.data<scalar_t>();
     auto output_data = output.data<scalar_t>();
@@ -295,7 +295,7 @@ Tensor& fractional_max_pool2d_backward_out_cpu_template(
 
   /* backprop */
   AT_DISPATCH_FLOATING_TYPES(
-    input.type(), "fractional_max_pool2d_backward_out_frame", [&] {
+    input.scalar_type(), "fractional_max_pool2d_backward_out_frame", [&] {
       auto gradInput_data = gradInput.data<scalar_t>();
       auto gradOutput_data = gradOutput.data<scalar_t>();
       auto indices_data = indices.data<int64_t>();

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -201,7 +201,7 @@ void fractional_max_pool3d_out_cpu_template(
     indices.resize_({numBatch, numPlanes, outputT, outputH, outputW});
   }
   AT_DISPATCH_FLOATING_TYPES(
-    input.type(),
+    input.scalar_type(),
     "fractional_max_pool3d_out_frame",
     [&] {
       fractional_max_pool3d_out_frame<scalar_t>(
@@ -330,7 +330,7 @@ void fractional_max_pool3d_backward_out_cpu_template(
 
   /* backprop */
   AT_DISPATCH_FLOATING_TYPES(
-    input.type(),
+    input.scalar_type(),
     "fractional_max_pool3d_backward_out_frame",
     [&]{
       fractional_max_pool3d_backward_out_frame<scalar_t>(

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -534,7 +534,7 @@ DEFINE_DISPATCH(grid_sampler_2d_cpu_kernel);
 // No shape checking needed here. See # NOTE [ grid_sampler Native Functions ].
 Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,
                            int64_t interpolation_mode, int64_t padding_mode) {
-  return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler3d_cpu", [&] {
+  return AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler3d_cpu", [&] {
     return grid_sampler_3d_cpu_impl<scalar_t>(
       input, grid, static_cast<GridSamplerInterpolation>(interpolation_mode),
       static_cast<GridSamplerPadding>(padding_mode));
@@ -554,7 +554,7 @@ DEFINE_DISPATCH(grid_sampler_2d_backward_cpu_kernel);
 std::tuple<Tensor, Tensor>
 grid_sampler_3d_backward_cpu(const Tensor& grad_output, const Tensor& input, const Tensor& grid,
                              int64_t interpolation_mode, int64_t padding_mode) {
-  return AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_3d_backward_cpu", [&] {
+  return AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler_3d_backward_cpu", [&] {
     return grid_sampler_3d_backward_cpu_impl<scalar_t>(
       grad_output, input, grid,
       static_cast<GridSamplerInterpolation>(interpolation_mode),

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -78,8 +78,7 @@ static void invalid_mask(const Tensor & self, int64_t idx, const Tensor & mask, 
 static void checkIndexTensorTypes(TensorList indices) {
   for (auto& tensor : indices) {
     if (tensor.defined()) {
-      auto& type = tensor.type();
-      auto scalarType = type.scalarType();
+      auto scalarType = tensor.scalar_type();
       if (scalarType != kLong && scalarType != kByte) {
           AT_INDEX_ERROR("tensors used as indices must be long or byte tensors");
       }
@@ -91,7 +90,7 @@ static std::vector<Tensor> expandByteTensors(const Tensor & self, TensorList ind
   // Expands byte tensors (masks) into the equivalent indexing by LongTensors
   std::vector<Tensor> result;
   for (auto & index : indices) {
-    if (index.type().scalarType() == kByte) {
+    if (index.scalar_type() == kByte) {
       // The sizes of the ByteTensor mask must match the sizes of the
       // corresponding dimensions in self
       for (int64_t j = 0; j < index.dim(); j++) {
@@ -409,7 +408,7 @@ static AdvancedIndex make_info(Tensor self, TensorList orig) {
 static std::unique_ptr<TensorIterator> make_index_iterator(const AdvancedIndex& info) {
   auto builder = TensorIterator::Builder();
   builder.dont_compute_common_dtype();
-  builder.add_output(Tensor(), &info.src.type());
+  builder.add_output(Tensor(), info.src.type().backend(), info.src.scalar_type());
   builder.add_input(info.src);
   for (auto& index : info.indices) {
     builder.add_input(index);
@@ -426,7 +425,7 @@ static std::unique_ptr<TensorIterator> make_index_put_iterator(const AdvancedInd
   builder.dont_compute_common_dtype();
   builder.dont_resize_outputs();
   builder.add_output(info.src);
-  builder.add_input(value, &info.src.type());
+  builder.add_input(value, info.src.type().backend(), info.src.scalar_type());
   for (auto& index : info.indices) {
     builder.add_input(index);
   }
@@ -475,7 +474,7 @@ Tensor & index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Ten
   if (source.dim() == 0 && numIndices != 1) {
     AT_INDEX_ERROR("index_copy_(): When source is scalar, index should have one element (got ", numIndices, ")");
   }
-  if (index.type().scalarType() != ScalarType::Long) {
+  if (index.scalar_type() != ScalarType::Long) {
     AT_INDEX_ERROR("index_copy_(): Expected LongTensor for index");
   }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -35,7 +35,7 @@ static inline std::tuple<double, Tensor, int> _lu_det_P_diag_U_info(const Tensor
 }
 
 Tensor det(const Tensor& self) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()) &&
+  AT_CHECK(at::isFloatingType(self.scalar_type()) &&
            self.dim() == 2 && self.size(0) == self.size(1),
            "det(", self.type(), "{", self.sizes(), "}): expected a 2D square tensor "
            "of floating types");
@@ -51,7 +51,7 @@ Tensor det(const Tensor& self) {
 }
 
 Tensor logdet(const Tensor& self) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()) &&
+  AT_CHECK(at::isFloatingType(self.scalar_type()) &&
            self.dim() == 2 && self.size(0) == self.size(1),
            "logdet(", self.type(), "{", self.sizes(), "}): expected a 2D square tensor "
            "of floating types");
@@ -72,7 +72,7 @@ Tensor logdet(const Tensor& self) {
 }
 
 std::tuple<Tensor, Tensor> slogdet(const Tensor& self) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()) &&
+  AT_CHECK(at::isFloatingType(self.scalar_type()) &&
            self.dim() == 2 && self.size(0) == self.size(1),
            "slogdet(", self.type(), "{", self.sizes(), "}): expected a 2D square tensor "
            "of floating types");
@@ -89,7 +89,7 @@ std::tuple<Tensor, Tensor> slogdet(const Tensor& self) {
 }
 
 Tensor pinverse(const Tensor& self, double rcond) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()) && self.dim() == 2,
+  AT_CHECK(at::isFloatingType(self.scalar_type()) && self.dim() == 2,
            "pinverse(", self.type(), "{", self.sizes(), "}): expected a 2D tensor "
            "of floating types");
   if (self.numel() == 0) {
@@ -117,7 +117,7 @@ static inline Tensor _matrix_rank_helper(const Tensor& self, bool symmetric) {
 }
 
 Tensor matrix_rank(const Tensor& self, double tol, bool symmetric) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()) && self.dim() == 2,
+  AT_CHECK(at::isFloatingType(self.scalar_type()) && self.dim() == 2,
            "matrix_rank(", self.type(), "{", self.sizes(), "}): expected a 2D tensor "
            "of floating types");
 
@@ -126,12 +126,12 @@ Tensor matrix_rank(const Tensor& self, double tol, bool symmetric) {
 }
 
 Tensor matrix_rank(const Tensor& self, bool symmetric) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()) && self.dim() == 2,
+  AT_CHECK(at::isFloatingType(self.scalar_type()) && self.dim() == 2,
            "matrix_rank(", self.type(), "{", self.sizes(), "}): expected a 2D tensor "
            "of floating types");
 
   Tensor S = _matrix_rank_helper(self, symmetric);
-  double tol = _get_epsilon(self.type().scalarType()) * std::max(self.size(0), self.size(1));
+  double tol = _get_epsilon(self.scalar_type()) * std::max(self.size(0), self.size(1));
   return (S > S.max().mul_(tol)).sum();
 }
 
@@ -299,11 +299,11 @@ static inline Tensor& bmm_out_or_baddbmm_(Tensor& self_or_result, const Tensor& 
 
   if (contraction_size * res_rows * res_cols < 400) {
     if (is_bmm_out) {
-      AT_DISPATCH_ALL_TYPES(batch1.type(), "bmm", [&] {
+      AT_DISPATCH_ALL_TYPES(batch1.scalar_type(), "bmm", [&] {
           baddbmm_cpu_kernel<scalar_t, true>(self_or_result, batch1, batch2, beta, alpha);
         });
     } else {
-      AT_DISPATCH_ALL_TYPES(batch1.type(), "baddbmm", [&] {
+      AT_DISPATCH_ALL_TYPES(batch1.scalar_type(), "baddbmm", [&] {
           baddbmm_cpu_kernel<scalar_t, false>(self_or_result, batch1, batch2, beta, alpha);
         });
     }
@@ -484,7 +484,7 @@ Tensor& matmul_out(Tensor &result, const Tensor & tensor1, const Tensor & tensor
 }
 
 Tensor matrix_power(const Tensor& a, int64_t n) {
-  AT_CHECK(a.dim() >= 2 && at::isFloatingType(a.type().scalarType()),
+  AT_CHECK(a.dim() >= 2 && at::isFloatingType(a.scalar_type()),
            "matrix_power(", a.type(), "{", a.sizes(), "}): expected a tensor "
            "of floating types with dim at least 2");
   if (n == 0) {
@@ -532,7 +532,7 @@ Tensor frobenius_norm(const Tensor& self, IntArrayRef dim, bool keepdim) {
       dim.size(),
       " dimensions instead.");
   if (dim.size() == 1) {
-    return at::norm(self, 2, dim, keepdim, self.type().scalarType());
+    return at::norm(self, 2, dim, keepdim, self.scalar_type());
   }
   return at::sqrt(at::sum(self * self, dim, keepdim));
 }
@@ -548,7 +548,7 @@ Tensor &frobenius_norm_out(
       dim.size(),
       " dimensions instead.");
   if (dim.size() == 1) {
-    return at::norm_out(result, self, 2, dim, keepdim, self.type().scalarType());
+    return at::norm_out(result, self, 2, dim, keepdim, self.scalar_type());
   }
   return at::sqrt_out(result, at::sum(self * self, dim, keepdim));
 }

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -70,7 +70,7 @@ Tensor kl_div(const Tensor& input, const Tensor& target, int64_t reduction) {
 Tensor kl_div_backward_cpu(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
   auto grad_input = at::zeros_like(input);
   auto grad_expand = grad.expand_as(input);
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "kl_div_backward", [&]() {
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "kl_div_backward", [&]() {
     at::CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
         grad_input,
         target,

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -307,8 +307,8 @@ Tensor ctc_loss_backward_cpu_template(const Tensor& grad_out, const Tensor& log_
 
 std::tuple<Tensor, Tensor> ctc_loss_cpu(const Tensor& log_probs, const Tensor& targets, IntArrayRef input_lengths, IntArrayRef target_lengths, int64_t BLANK, bool zero_infinity) {
   (void)zero_infinity; // only used for backwards
-  return AT_DISPATCH_FLOATING_TYPES(log_probs.type(), "ctc_loss", [&] {
-      if (targets.type().scalarType() == kLong) {
+  return AT_DISPATCH_FLOATING_TYPES(log_probs.scalar_type(), "ctc_loss", [&] {
+      if (targets.scalar_type() == kLong) {
 	return ctc_loss_cpu_template<scalar_t, kLong>(log_probs, targets, input_lengths, target_lengths, BLANK);
       } else {
 	return ctc_loss_cpu_template<scalar_t, kInt>(log_probs, targets, input_lengths, target_lengths, BLANK);
@@ -318,8 +318,8 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu(const Tensor& log_probs, const Tensor& t
 
 Tensor ctc_loss_backward_cpu(const Tensor& grad, const Tensor& log_probs, const Tensor& targets, IntArrayRef input_lengths, IntArrayRef target_lengths,
                              const Tensor& neg_log_likelihood, const Tensor& log_alpha, int64_t BLANK, bool zero_infinity) {
-  return AT_DISPATCH_FLOATING_TYPES(log_probs.type(), "ctc_loss_backward", [&] {
-      if (targets.type().scalarType() == kLong) {
+  return AT_DISPATCH_FLOATING_TYPES(log_probs.scalar_type(), "ctc_loss_backward", [&] {
+      if (targets.scalar_type() == kLong) {
 	return ctc_loss_backward_cpu_template<scalar_t,kLong>(grad, log_probs, targets, input_lengths, target_lengths, neg_log_likelihood, log_alpha, BLANK, zero_infinity);
       } else {
 	return ctc_loss_backward_cpu_template<scalar_t,kInt>(grad, log_probs, targets, input_lengths, target_lengths, neg_log_likelihood, log_alpha, BLANK, zero_infinity);
@@ -338,8 +338,8 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntArrayRef inpu
     (detail::getCUDAHooks().versionCuDNN() >= 7000) &&
     ctx.userEnabledCuDNN() &&
     (BLANK == 0) && (targets.dim()==1) &&
-    (log_probs.type().scalarType() == at::kFloat) &&
-    (targets.type().scalarType() == at::kInt) &&
+    (log_probs.scalar_type() == at::kFloat) &&
+    (targets.scalar_type() == at::kInt) &&
     (log_probs.type().backend() == Backend::CUDA);
 
   if (use_cudnn) {
@@ -374,8 +374,8 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntArrayRef inpu
 
 // Convenience function accepting Tensors
 Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, const Tensor& input_lengths, const Tensor& target_lengths, int64_t BLANK, int64_t reduction, bool zero_infinity) {
-  AT_CHECK(isIntegralType(input_lengths.type().scalarType()), "input_lenghts must be integral");
-  AT_CHECK(isIntegralType(target_lengths.type().scalarType()), "target_lenghts must be integral");
+  AT_CHECK(isIntegralType(input_lengths.scalar_type()), "input_lenghts must be integral");
+  AT_CHECK(isIntegralType(target_lengths.scalar_type()), "target_lenghts must be integral");
 
   Tensor ilc = input_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();
   Tensor tlc = target_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -279,8 +279,8 @@ std::tuple<Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
 
   bool use_cudnn = false;
   use_cudnn = (input.is_cuda()
-               && (input.type().scalarType() != at::kHalf
-                 || weight.type().scalarType() == at::kFloat)
+               && (input.scalar_type() != at::kHalf
+                 || weight.scalar_type() == at::kFloat)
                && weight.defined() && bias.defined()
                && ((running_mean.defined() && running_var.defined())
                  || (!running_mean.defined() && !running_var.defined() && training))
@@ -301,8 +301,8 @@ std::tuple<Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
 
   bool use_miopen = (input.is_cuda()
                && input.dim() <= MIOPEN_DIM_MAX
-               && input.type().scalarType() != at::kDouble
-               && (weight.type().scalarType() != at::kHalf)
+               && input.scalar_type() != at::kDouble
+               && (weight.scalar_type() != at::kHalf)
                && weight.defined() && bias.defined()
                && ((running_mean.defined() && running_var.defined())
                  || (!running_mean.defined() && !running_var.defined() && training))
@@ -486,7 +486,7 @@ Tensor group_norm(const Tensor& input, int64_t num_groups,
 
 std::tuple<Tensor, Tensor> batch_norm_update_stats_cpu(
         const Tensor& self, const Tensor& running_mean, const Tensor& running_var, double momentum) {
-  return AT_DISPATCH_FLOATING_TYPES(self.type(), "batch_norm_update_stats", [&] {
+  return AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "batch_norm_update_stats", [&] {
       return batch_norm_cpu_update_stats_template<scalar_t, Var>(self, running_mean, running_var, momentum, 0);
     });
 }
@@ -496,7 +496,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cpu(const Tensor& self, const Tens
                                                   bool train, double momentum, double eps) {
   checkBackend("batch_norm_cpu", {self, weight, bias, running_mean, running_var}, Backend::CPU);
 
-  return AT_DISPATCH_FLOATING_TYPES(self.type(), "batch_norm", [&] {
+  return AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "batch_norm", [&] {
       if (!train) {
         return batch_norm_cpu_transform_input_template<scalar_t>(self, weight, bias, {}, {}, running_mean, running_var, train, eps);
       } else {
@@ -509,7 +509,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cpu(const Tensor& self, const Tens
 std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cpu(const Tensor& grad_out, const Tensor& self, const Tensor& weight,
                                                            const Tensor& running_mean, const Tensor& running_var, const Tensor& save_mean, const Tensor& save_invstd,
                                                            bool train, double eps, std::array<bool,3> grad_input_mask) {
-  return AT_DISPATCH_FLOATING_TYPES(self.type(), "batch_norm_backward", [&] {
+  return AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "batch_norm_backward", [&] {
       return batch_norm_backward_cpu_template<scalar_t>(grad_out, self, weight, running_mean, running_var, save_mean, save_invstd, train, eps, grad_input_mask);
     });
 }

--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -5,7 +5,7 @@ namespace at { namespace native {
 
 void checkLongTensor(const Tensor& tensor) {
   auto & t = tensor.type();
-  AT_CHECK(tensor.dim() == 1 && t.device_type() == at::kCPU && t.scalarType() == at::kLong,
+  AT_CHECK(tensor.dim() == 1 && t.device_type() == at::kCPU && tensor.scalar_type() == at::kLong,
            "'lengths' argument should be a 1D CPU int64 tensor");
 }
 

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -21,7 +21,7 @@ Tensor& linspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
   } else if (steps == 1) {
     r.fill_(start);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.type(), "linspace", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "linspace", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t *data_ptr = r.data<scalar_t>();
@@ -54,7 +54,7 @@ Tensor& logspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
   } else if (steps == 1) {
     r.fill_(std::pow(10.0, start.to<double>()));
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.type(), "logspace", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "logspace", [&]() {
       scalar_t base10 = 10;
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
@@ -76,7 +76,7 @@ Tensor& logspace_cpu_out(Tensor& result, Scalar start, Scalar end, int64_t steps
 }
 
 Tensor& range_cpu_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
-  AT_DISPATCH_ALL_TYPES(result.type(), "range", [&]() {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "range", [&]() {
     using accscalar_t = at::acc_type<scalar_t, false>;
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();
@@ -110,7 +110,7 @@ Tensor& range_cpu_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
 }
 
 Tensor& arange_cpu_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
-  AT_DISPATCH_ALL_TYPES(result.type(), "arange", [&]() {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "arange", [&]() {
     using accscalar_t = at::acc_type<scalar_t, false>;
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -31,7 +31,7 @@ DEFINE_DISPATCH(min_values_stub);
 DEFINE_DISPATCH(max_values_stub);
 
 static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dtype) {
-  ScalarType scalarType = self.type().scalarType();
+  ScalarType scalarType = self.scalar_type();
   ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType) ? ScalarType::Long : scalarType);
   return self.toType(upcast_scalarType);
 }
@@ -92,9 +92,9 @@ static std::unique_ptr<TensorIterator> make_reduction(
 {
   // check that result type and dtype match if provided
   AT_CHECK(
-      !result.defined() || result.type().scalarType() == dtype,
+      !result.defined() || result.scalar_type() == dtype,
       name, ": provided dtype must match dtype of result. Got ",
-      toString(result.type().scalarType()),
+      toString(result.scalar_type()),
       " and ",
       toString(dtype),
       ".");
@@ -107,8 +107,8 @@ static std::unique_ptr<TensorIterator> make_reduction(
   // efficiency.
   // not generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
-  if (self.type().scalarType() == dtype ||
-      (self.is_cuda() && self.type().scalarType() == kHalf && dtype == kFloat)) {
+  if (self.scalar_type() == dtype ||
+      (self.is_cuda() && self.scalar_type() == kHalf && dtype == kFloat)) {
     return TensorIterator::reduce_op(viewed_result, self);
   }
   return TensorIterator::reduce_op(viewed_result, self.to(dtype));
@@ -137,13 +137,13 @@ Tensor cumsum(const Tensor& self, int64_t dim) {
 static inline Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
   AT_CHECK(
-      !dtype.has_value() || (result.type().scalarType() == dtype.value()),
+      !dtype.has_value() || (result.scalar_type() == dtype.value()),
       "provided dtype must match dtype of result in cumsum. Got ",
-      toString(result.type().scalarType()),
+      toString(result.scalar_type()),
       " and ",
       toString(dtype.value()),
       ".");
-  return at::legacy::th::_th_cumsum_out(result, self.toType(result.type().scalarType()), dim);
+  return at::legacy::th::_th_cumsum_out(result, self.toType(result.scalar_type()), dim);
 }
 
 Tensor& cumsum_out(Tensor& result, const Tensor& self, int64_t dim, ScalarType dtype) {
@@ -169,13 +169,13 @@ Tensor cumprod(const Tensor& self, int64_t dim) {
 static inline Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, optional<ScalarType> dtype) {
   // result type is favored over dtype; check that they match if provided (NumPy doesn't check)
   AT_CHECK(
-      !dtype.has_value() || (result.type().scalarType() == dtype.value()),
+      !dtype.has_value() || (result.scalar_type() == dtype.value()),
       "provided dtype must match dtype of result in cumprod. Got ",
-      toString(result.type().scalarType()),
+      toString(result.scalar_type()),
       " and ",
       toString(dtype.value()),
       ".");
-  return at::legacy::th::_th_cumprod_out(result, self.toType(result.type().scalarType()), dim);
+  return at::legacy::th::_th_cumprod_out(result, self.toType(result.scalar_type()), dim);
 }
 
 Tensor& cumprod_out(Tensor& result, const Tensor& self, int64_t dim, ScalarType dtype) {
@@ -193,9 +193,9 @@ static ScalarType get_dtype(Tensor& result, const Tensor& self, optional<ScalarT
   if (dtype.has_value()) {
     return dtype.value();
   } else if (result.defined()) {
-    return result.type().scalarType();
+    return result.scalar_type();
   }
-  ScalarType src_type = self.type().scalarType();
+  ScalarType src_type = self.scalar_type();
   if (promote_integers && at::isIntegralType(src_type)) {
     return kLong;
   }
@@ -256,7 +256,7 @@ Tensor prod(const Tensor &self) {
 
 static inline Tensor &mean_out(Tensor &result, const Tensor &self, IntArrayRef dim,
                  bool keepdim, optional<ScalarType> opt_dtype) {
-  ScalarType scalarType = opt_dtype.has_value() ? opt_dtype.value() : self.type().scalarType();
+  ScalarType scalarType = opt_dtype.has_value() ? opt_dtype.value() : self.scalar_type();
   AT_CHECK(
       at::isFloatingType(scalarType),
       "Can only calculate the mean of floating types. Got ",
@@ -422,7 +422,7 @@ static Tensor& norm_out(Tensor &result, const Tensor &self, optional<Scalar> opt
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "norm only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
 
-  ScalarType scalarType = opt_dtype.has_value() ? opt_dtype.value() : self.type().scalarType();
+  ScalarType scalarType = opt_dtype.has_value() ? opt_dtype.value() : self.scalar_type();
   AT_CHECK(
       at::isFloatingType(scalarType),
       "Can only calculate the mean of floating types. Got ",
@@ -445,7 +445,7 @@ static inline Tensor _norm(const Tensor &self, Scalar p) {
   } else {
     AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
              "norm only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
-    AT_CHECK(at::isFloatingType(self.type().scalarType()), "norm only supports floating-point dtypes");
+    AT_CHECK(at::isFloatingType(self.scalar_type()), "norm only supports floating-point dtypes");
 
     Tensor result;
     return at::native::norm_out(result, self, p, {}, false, c10::nullopt);
@@ -497,7 +497,7 @@ Tensor all(const Tensor& self) {
   AT_CHECK(self.type().backend() == Backend::CPU ||
     self.type().backend() == Backend::CUDA, "all only supports CPU AND CUDA "
     "backend, got: ", toString(self.type().backend()));
-  AT_CHECK(self.type().scalarType() == at::ScalarType::Byte,
+  AT_CHECK(self.scalar_type() == at::ScalarType::Byte,
     "all only supports torch.uint8 dtype");
 
   Tensor result = at::empty({0}, self.options());
@@ -515,7 +515,7 @@ Tensor &all_out(Tensor &result, const Tensor &self, int64_t dim, bool keepdim) {
   AT_CHECK(self.type().backend() == Backend::CPU ||
     self.type().backend() == Backend::CUDA, "all only supports CPU AND CUDA "
     "backend, got: ", toString(self.type().backend()));
-  AT_CHECK(self.type().scalarType() == at::ScalarType::Byte,
+  AT_CHECK(self.scalar_type() == at::ScalarType::Byte,
     "all only supports torch.uint8 dtype");
   dim = maybe_wrap_dim(dim, self.dim());
   if (_dimreduce_return_trivial(result, self, 1, dim, keepdim)) {
@@ -541,7 +541,7 @@ Tensor any(const Tensor& self) {
   AT_CHECK(self.type().backend() == Backend::CPU ||
     self.type().backend() == Backend::CUDA, "any only supports CPU AND CUDA "
     "backend, got: ", toString(self.type().backend()));
-  AT_CHECK(self.type().scalarType() == at::ScalarType::Byte,
+  AT_CHECK(self.scalar_type() == at::ScalarType::Byte,
     "any only supports torch.uint8 dtype");
 
   Tensor result = at::empty({0}, self.options());
@@ -559,7 +559,7 @@ Tensor &any_out(Tensor &result, const Tensor &self, int64_t dim, bool keepdim) {
   AT_CHECK(self.type().backend() == Backend::CPU ||
     self.type().backend() == Backend::CUDA, "any only supports CPU AND CUDA "
     "backend, got: ", toString(self.type().backend()));
-  AT_CHECK(self.type().scalarType() == at::ScalarType::Byte,
+  AT_CHECK(self.scalar_type() == at::ScalarType::Byte,
     "any only supports torch.uint8 dtype");
   dim = maybe_wrap_dim(dim, self.dim());
   if (_dimreduce_return_trivial(result, self, 0, dim, keepdim)) {
@@ -600,7 +600,7 @@ Tensor max_values(const Tensor& self, IntArrayRef dims, bool keepdim) {
 static Tensor &std_var_out(Tensor &result, const Tensor &self, IntArrayRef dim, bool unbiased, bool keepdim, bool take_sqrt) {
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "std and var only support CPU AND CUDA backend, got: ", toString(self.type().backend()));
-  AT_CHECK(at::isFloatingType(self.type().scalarType()), "std and var only support floating-point dtypes");
+  AT_CHECK(at::isFloatingType(self.scalar_type()), "std and var only support floating-point dtypes");
   ScalarType dtype = get_dtype(result, self, {}, true);
   auto iter = make_reduction("std or var", result, self, dim, keepdim, dtype);
   if (iter->numel() == 0) {
@@ -614,7 +614,7 @@ static Tensor &std_var_out(Tensor &result, const Tensor &self, IntArrayRef dim, 
 Tensor var(const Tensor& self, bool unbiased) {
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "var only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
-  AT_CHECK(at::isFloatingType(self.type().scalarType()), "var only supports floating-point dtypes");
+  AT_CHECK(at::isFloatingType(self.scalar_type()), "var only supports floating-point dtypes");
   auto trivial_return = _allreduce_return_trivial(self, std::numeric_limits<double>::quiet_NaN());
   return trivial_return.has_value() ? trivial_return.value() : at::legacy::th::_th_var(self, unbiased);
 }
@@ -631,7 +631,7 @@ Tensor &var_out(Tensor &result, const Tensor &self, IntArrayRef dim, bool unbias
 Tensor std(const Tensor& self, bool unbiased) {
   AT_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
            "std only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
-  AT_CHECK(at::isFloatingType(self.type().scalarType()), "std only supports floating-point dtypes");
+  AT_CHECK(at::isFloatingType(self.scalar_type()), "std only supports floating-point dtypes");
   auto trivial_return = _allreduce_return_trivial(self, std::numeric_limits<double>::quiet_NaN());
   return trivial_return.has_value() ? trivial_return.value() : at::legacy::th::_th_std(self, unbiased);
 }

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -91,7 +91,7 @@ void reflection_pad1d_out_template(
   /* resize output */
   if (input.ndimension() == 2) {
     output.resize_({nplane, output_w});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "reflection_pad1d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "reflection_pad1d", [&] {
       reflection_pad1d_out_frame<scalar_t>(
         input.data<scalar_t>(), output.data<scalar_t>(),
         nplane,
@@ -100,7 +100,7 @@ void reflection_pad1d_out_template(
     });
   } else {
     output.resize_({nbatch, nplane, output_w});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "reflection_pad1d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "reflection_pad1d", [&] {
       reflection_pad1d_out_loop<scalar_t>(
         input.data<scalar_t>(), output.data<scalar_t>(),
         nbatch, nplane,
@@ -187,7 +187,7 @@ void reflection_pad1d_backward_out_template(
   /* backprop */
   if (input.ndimension() == 2) {
     AT_DISPATCH_FLOATING_TYPES(
-      grad_input.type(), "reflection_pad1d_backward", [&] {
+      grad_input.scalar_type(), "reflection_pad1d_backward", [&] {
         reflection_pad1d_backward_out_frame(
           grad_input.data<scalar_t>(), grad_output.data<scalar_t>(),
           nplane,
@@ -197,7 +197,7 @@ void reflection_pad1d_backward_out_template(
     );
   } else {
     AT_DISPATCH_FLOATING_TYPES(
-      grad_input.type(), "reflection_pad1d_backward", [&] {
+      grad_input.scalar_type(), "reflection_pad1d_backward", [&] {
         reflection_pad1d_backward_out_loop(
           grad_input.data<scalar_t>(),
           grad_output.data<scalar_t>(),
@@ -322,7 +322,7 @@ void reflection_pad2d_out_template(
   if (input.ndimension() == 3) {
     /* resize output */
     output.resize_({nplane, output_h, output_w});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "reflection_pad2d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "reflection_pad2d", [&] {
       reflection_pad2d_out_frame(
         input.data<scalar_t>(), output.data<scalar_t>(),
         nplane,
@@ -332,7 +332,7 @@ void reflection_pad2d_out_template(
   } else {
     /* resize output */
     output.resize_({nbatch, nplane, output_h, output_w});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "reflection_pad2d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "reflection_pad2d", [&] {
       reflection_pad2d_out_loop(
         input.data<scalar_t>(), output.data<scalar_t>(),
         nbatch, nplane,
@@ -448,7 +448,7 @@ void reflection_pad2d_backward_out_template(
   /* backprop */
   if (input.ndimension() == 3) {
     AT_DISPATCH_FLOATING_TYPES(
-      grad_output.type(), "reflection_pad2d_backward", [&] {
+      grad_output.scalar_type(), "reflection_pad2d_backward", [&] {
         reflection_pad2d_backward_out_frame(
           grad_input.data<scalar_t>(), grad_output.data<scalar_t>(),
           nplane,
@@ -458,7 +458,7 @@ void reflection_pad2d_backward_out_template(
     );
   } else {
     AT_DISPATCH_FLOATING_TYPES(
-      grad_output.type(), "reflection_pad2d_backward", [&] {
+      grad_output.scalar_type(), "reflection_pad2d_backward", [&] {
         reflection_pad2d_backward_out_loop(
           grad_input.data<scalar_t>(), grad_output.data<scalar_t>(),
           nbatch, nplane,

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -97,7 +97,7 @@ void replication_pad1d_out_cpu_template(
   if (input.ndimension() == 2)
   {
     output.resize_({nslices, owidth});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "replication_pad1d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "replication_pad1d", [&] {
       auto input_data = input.data<scalar_t>();
       auto output_data = output.data<scalar_t>();
       replication_pad1d_out_frame<scalar_t>(
@@ -113,7 +113,7 @@ void replication_pad1d_out_cpu_template(
   else
   {
     output.resize_({nbatch, nslices, owidth});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "replication_pad1d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "replication_pad1d", [&] {
       auto input_data = input.data<scalar_t>();
       auto output_data = output.data<scalar_t>();
       replication_pad1d_out_batch<scalar_t>(
@@ -219,7 +219,7 @@ Tensor& replication_pad1d_backward_out_cpu_template(
   if (input.ndimension() == 2)
   {
     AT_DISPATCH_FLOATING_TYPES(
-      input.type(), "replication_pad1d_backward", [&] {
+      input.scalar_type(), "replication_pad1d_backward", [&] {
       scalar_t *gradInput_data = gradInput.data<scalar_t>();
       scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
 
@@ -236,7 +236,7 @@ Tensor& replication_pad1d_backward_out_cpu_template(
   else
   {
     AT_DISPATCH_FLOATING_TYPES(
-      input.type(), "replication_pad1d_backward", [&] {
+      input.scalar_type(), "replication_pad1d_backward", [&] {
       scalar_t *gradInput_data = gradInput.data<scalar_t>();
       scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
 
@@ -365,7 +365,7 @@ void replication_pad2d_out_cpu_template(Tensor& output,
   if (input.dim() == 3)
   {
     output.resize_({nslices, oheight, owidth});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "replication_pad2d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "replication_pad2d", [&] {
       auto input_data = input.data<scalar_t>();
       auto output_data = output.data<scalar_t>();
       replication_pad2d_out_frame<scalar_t> (input_data, output_data,
@@ -380,7 +380,7 @@ void replication_pad2d_out_cpu_template(Tensor& output,
   else
   {
     output.resize_({nbatch, nslices, oheight, owidth});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "replication_pad2d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "replication_pad2d", [&] {
       auto input_data = input.data<scalar_t>();
       auto output_data = output.data<scalar_t>();
       replication_pad2d_out_batch<scalar_t> (input_data, output_data,
@@ -511,7 +511,7 @@ Tensor& replication_pad2d_backward_out_cpu_template(
   if (input.dim() == 3)
   {
     AT_DISPATCH_FLOATING_TYPES(
-      input.type(), "replication_pad2d_backward", [&] {
+      input.scalar_type(), "replication_pad2d_backward", [&] {
       replication_pad2d_backward_out_frame<scalar_t>(
         gradInput.data<scalar_t>(),
         gradOutput.data<scalar_t>(),
@@ -526,7 +526,7 @@ Tensor& replication_pad2d_backward_out_cpu_template(
   else
   {
     AT_DISPATCH_FLOATING_TYPES(
-      input.type(), "replication_pad2d_backward", [&] {
+      input.scalar_type(), "replication_pad2d_backward", [&] {
       replication_pad2d_backward_out_batch<scalar_t>(
         gradInput.data<scalar_t>(),
         gradOutput.data<scalar_t>(),
@@ -709,7 +709,7 @@ void replication_pad3d_out_cpu_template(
   if (input.dim() == 4)
   {
     output.resize_({nslices, odepth, oheight, owidth});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "replication_pad3d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "replication_pad3d", [&] {
       auto input_data = input.data<scalar_t>();
       auto output_data = output.data<scalar_t>();
       replication_pad3d_out_frame<scalar_t>(
@@ -722,7 +722,7 @@ void replication_pad3d_out_cpu_template(
   else
   {
     output.resize_({nbatch, nslices, odepth, oheight, owidth});
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "replication_pad3d", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "replication_pad3d", [&] {
       auto input_data = input.data<scalar_t>();
       auto output_data = output.data<scalar_t>();
       replication_pad3d_out_batch<scalar_t>(
@@ -871,7 +871,7 @@ Tensor& replication_pad3d_backward_out_cpu_template(
   if (input.dim() == 4)
   {
     AT_DISPATCH_FLOATING_TYPES(
-      input.type(), "replication_pad3d_backward", [&] {
+      input.scalar_type(), "replication_pad3d_backward", [&] {
       replication_pad3d_backward_out_frame<scalar_t> (
         gradInput.data<scalar_t>(),
         gradOutput.data<scalar_t>(),
@@ -887,7 +887,7 @@ Tensor& replication_pad3d_backward_out_cpu_template(
   else
   {
     AT_DISPATCH_FLOATING_TYPES(
-      input.type(), "replication_pad3d_backward", [&] {
+      input.scalar_type(), "replication_pad3d_backward", [&] {
       replication_pad3d_backward_out_batch<scalar_t> (
         gradInput.data<scalar_t>(),
         gradOutput.data<scalar_t>(),

--- a/aten/src/ATen/native/Scalar.cpp
+++ b/aten/src/ATen/native/Scalar.cpp
@@ -19,7 +19,7 @@ Scalar item(const Tensor& self) {
 Scalar _local_scalar_dense_cpu(const Tensor& self) {
   Scalar r;
   AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX(
-      self.type(), "_local_scalar_dense_cpu", [&] {
+      self.scalar_type(), "_local_scalar_dense_cpu", [&] {
         scalar_t value = *self.data<scalar_t>();
         r = Scalar(value);
       });

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -132,7 +132,7 @@ Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_
   if (input.ndimension() > 0 && dim == input.ndimension() - 1) {
     softmax_lastdim_kernel(kCPU, output, input);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "softmax", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "softmax", [&] {
       host_softmax<scalar_t, false>(output, input, dim);
     });
   }
@@ -152,7 +152,7 @@ Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half
   if (input.ndimension() > 0 && dim == input.ndimension() - 1) {
     log_softmax_lastdim_kernel(kCPU, output, input);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(input.type(), "log_softmax", [&] {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "log_softmax", [&] {
       host_softmax<scalar_t, true>(output, input, dim);
     });
   }
@@ -181,7 +181,7 @@ Tensor softmax_backward_cpu(
   if (grad.ndimension() > 0 && dim == grad.ndimension() - 1) {
     softmax_backward_lastdim_kernel(kCPU, grad_input, grad, output);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(grad.type(), "softmax_backward", [&] {
+    AT_DISPATCH_FLOATING_TYPES(grad.scalar_type(), "softmax_backward", [&] {
       host_softmax_backward<scalar_t, false>(grad_input, grad, output, dim);
     });
   }
@@ -210,7 +210,7 @@ Tensor log_softmax_backward_cpu(
   if (grad.ndimension() > 0 && dim == grad.ndimension() - 1) {
     log_softmax_backward_lastdim_kernel(kCPU, grad_input, grad, output);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(grad.type(), "log_softmax_backward", [&] {
+    AT_DISPATCH_FLOATING_TYPES(grad.scalar_type(), "log_softmax_backward", [&] {
       host_softmax_backward<scalar_t, true>(grad_input, grad, output, dim);
     });
   }
@@ -222,7 +222,7 @@ Tensor softmax(const Tensor& input_, const int64_t dim_) {
 }
 
 Tensor softmax(const Tensor& input_, const int64_t dim_, ScalarType dtype) {
-  if (input_.is_cuda() && input_.type().scalarType() == ScalarType::Half && dtype == ScalarType::Float){
+  if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
       return at::_softmax(input_, dim_, true);
   } else {
       return at::_softmax(input_.toType(dtype), dim_, false);
@@ -234,7 +234,7 @@ Tensor log_softmax(const Tensor& input_, const int64_t dim_) {
 }
 
 Tensor log_softmax(const Tensor& input_, const int64_t dim_, ScalarType dtype) {
-  if (input_.is_cuda() && input_.type().scalarType() == ScalarType::Half && dtype == ScalarType::Float){
+  if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
       return at::_log_softmax(input_, dim_, true);
   } else {
       return at::_log_softmax(input_.toType(dtype), dim_, false);

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -27,7 +27,7 @@ static inline Tensor _fft(const Tensor &self, const int64_t signal_ndim,
   AT_CHECK(signal_ndim >= 1 && signal_ndim <= 3,
            "Expected signal_ndim to be 1, 2, or 3, but got signal_ndim=",
            signal_ndim);
-  AT_CHECK(at::isFloatingType(self.type().scalarType()),
+  AT_CHECK(at::isFloatingType(self.scalar_type()),
            "Expected an input tensor of floating types, but got input=",
            self.type(), self.sizes());
 
@@ -191,7 +191,7 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
   auto hop_length = hop_lengthOpt.value_or(n_fft >> 2);
   auto win_length = win_lengthOpt.value_or(n_fft);
 
-  if (!at::isFloatingType(self.type().scalarType()) || self.dim() > 2 || self.dim() < 1) {
+  if (!at::isFloatingType(self.scalar_type()) || self.dim() > 2 || self.dim() < 1) {
     std::ostringstream ss;
     REPR(ss) << ": expected a 1D or 2D tensor of floating types";
     AT_ERROR(ss.str());

--- a/aten/src/ATen/native/SummaryOps.cpp
+++ b/aten/src/ATen/native/SummaryOps.cpp
@@ -55,8 +55,8 @@ Tensor _bincount_cpu_template(
 
 Tensor
 _bincount_cpu(const Tensor& self, const Tensor& weights, int64_t minlength) {
-  return AT_DISPATCH_INTEGRAL_TYPES(self.type(), "bincount", [&] {
-    const auto scalar = weights.type().scalarType();
+  return AT_DISPATCH_INTEGRAL_TYPES(self.scalar_type(), "bincount", [&] {
+    const auto scalar = weights.scalar_type();
     if (scalar == ScalarType::Undefined || scalar == ScalarType::Float)
       return _bincount_cpu_template<scalar_t, float>(self.contiguous(), weights.contiguous(), minlength);
     return _bincount_cpu_template<scalar_t, double>(

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -44,7 +44,7 @@ Tensor isclose(const Tensor& self, const Tensor& other, double rtol, double atol
   auto max_error = atol + rtol * other.abs();
   auto close = actual_error <= max_error;
 
-  if (isFloatingType(self.type().scalarType()) && isFloatingType(other.type().scalarType())) {
+  if (isFloatingType(self.scalar_type()) && isFloatingType(other.scalar_type())) {
     // Handle +/-inf
     close.__ior__(self == other);
     close.__iand__((self == INFINITY) == (other == INFINITY));
@@ -80,9 +80,9 @@ bool is_nonzero(const Tensor& self) {
 }
 
 Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
-  if (condition.type().scalarType() != ScalarType::Byte) {
+  if (condition.scalar_type() != ScalarType::Byte) {
     AT_ERROR("Expected condition to have ScalarType Byte, but got ScalarType ",
-                  toString(condition.type().scalarType()));
+                  toString(condition.scalar_type()));
   }
   Tensor b_condition, b_self, b_other;
   std::tie(b_condition, b_self, b_other) = expand_outplace(condition, self, other, "where");
@@ -91,7 +91,7 @@ Tensor where(const Tensor& condition, const Tensor& self, const Tensor& other) {
 
 Tensor _s_where_cpu(const Tensor& condition, const Tensor& self, const Tensor& other) {
   Tensor ret = at::empty(self.sizes(), self.options());
-  AT_DISPATCH_ALL_TYPES(ret.type(), "where", [&] {
+  AT_DISPATCH_ALL_TYPES(ret.scalar_type(), "where", [&] {
     where_cpu<scalar_t>(ret, condition, self, other);
   });
   return ret;

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -184,7 +184,7 @@ Tensor& eye_out_cpu(Tensor& result, int64_t n, int64_t m) {
   result.zero_();
 
   int64_t sz = std::min<int64_t>(n, m);
-  AT_DISPATCH_ALL_TYPES(result.type(), "eye", [&]() -> void {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "eye", [&]() -> void {
     scalar_t* result_data = result.data<scalar_t>();
     for(int64_t i = 0; i < sz; i++) {
       result_data[i*(result.strides()[0] + result.strides()[1])] = 1;
@@ -453,7 +453,7 @@ Tensor& randperm_out_cpu(Tensor& result, int64_t n, Generator* generator) {
   AT_CHECK(n >= 0, "n must be non-negative, got", n);
   result.resize_({n});
   auto gen = get_generator(generator);
-  AT_DISPATCH_ALL_TYPES(result.type(), "randperm", [&]() -> void {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "randperm", [&]() -> void {
     randperm_cpu<scalar_t>(result, n, gen);
   });
 
@@ -501,7 +501,7 @@ Tensor tril_indices_cpu(
   //
   // 3. sequential RAM + transpose: create an n X 2 Tensor, fill the Tensor
   //    sequentially, and then transpose it.
-  AT_DISPATCH_ALL_TYPES(result.type(), "tril_indices", [&]() -> void {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "tril_indices", [&]() -> void {
     // fill the Tensor with correct values
     scalar_t* result_data = result.data<scalar_t>();
     int64_t i = 0;
@@ -534,7 +534,7 @@ Tensor triu_indices_cpu(
   // create an empty Tensor with correct size
   auto result = at::empty({2, triu_size}, options);
 
-  AT_DISPATCH_ALL_TYPES(result.type(), "triu_indices", [&]() -> void {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "triu_indices", [&]() -> void {
     // fill the Tensor with correct values
     scalar_t* result_data = result.data<scalar_t>();
     int64_t i = 0;
@@ -705,7 +705,7 @@ template <typename T>
 Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
   auto result = at::empty(values.size(), options);
   AT_ASSERT(result.is_contiguous());
-  AT_DISPATCH_ALL_TYPES(result.type(), "tensor_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "tensor_cpu", [&] {
     std::copy(values.begin(), values.end(), result.template data<scalar_t>());
   });
   return result;

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -73,7 +73,7 @@ compute_result_type(at::ArrayRef<OperandInfo> operands, const F& predicate) {
   for (auto& op : operands) {
     if (!op.tensor.defined()) continue;
     if (!predicate(op.tensor)) continue;
-    auto dtype = op.tensor.type().scalarType();;
+    auto dtype = op.tensor.scalar_type();;
     result_type = (result_type == ScalarType::Undefined
         ? dtype
         : promoteTypes(result_type, dtype));
@@ -87,53 +87,57 @@ compute_result_type(at::ArrayRef<OperandInfo> operands, const F& predicate) {
 void TensorIterator::compute_types() {
   bool missing_dtypes = false;
   for (auto& op : operands_) {
-    if (!op.tensor.defined() && !op.type) {
+    if (!op.tensor.defined() && (op.dtype == ScalarType::Undefined || op.backend == Backend::Undefined)) {
       missing_dtypes = true;
     }
   }
 
   if (missing_dtypes || compute_common_dtype_) {
-    auto& type = compute_common_type();
+    ScalarType common_dtype;
+    Backend common_backend;
+    std::tie(common_backend, common_dtype) = compute_common_type();
     for (auto& op : operands_) {
-      auto& op_tensor_type = at::globalContext().getNonVariableType(op.tensor.type().backend(), op.tensor.type().scalarType());
-      if (!op.type) {
-        op.type = &type;
-      } else if (compute_common_dtype_ && op.type != &type) {
+      if (op.dtype == ScalarType::Undefined || op.backend == Backend::Undefined) {
+        op.dtype = common_dtype;
+        op.backend = common_backend;
+      } else if (compute_common_dtype_ && (op.dtype != common_dtype || op.backend != common_backend)) {
         if (allow_cpu_scalars_ && op.tensor.defined() && op.tensor.dim() == 0 &&
-            type.device_type() == kCUDA && op_tensor_type.device_type() == kCPU) {
+            common_backend == Backend::CUDA && op.tensor.type().backend() == Backend::CPU) {
           // don't cast CPU scalars in CUDA ops that directly support them
-          op.type = &op_tensor_type;
+          op.dtype = op.tensor.scalar_type();
+          op.backend = op.tensor.type().backend();
         } else if (promote_gpu_output_dtypes_ && op.tensor.defined() &&
-            !op.is_output && op_tensor_type.scalarType() == kHalf &&
-            type.scalarType() == kFloat && type.device_type() == kCUDA &&
-            op_tensor_type.device_type() == kCUDA) {
+            !op.is_output && op.tensor.scalar_type() == kHalf &&
+            common_dtype == kFloat && common_backend == Backend::CUDA &&
+            op.tensor.type().backend() == Backend::CUDA) {
           // allow input tensor type upcasting for fp16 to fp32 in fused kernel
           // on GPU
-          op.type = &op_tensor_type;
+          op.dtype = op.tensor.scalar_type();
+          op.backend = op.tensor.type().backend();
         } else {
-          op.type = &type;
+          op.dtype = common_dtype;
+          op.backend = common_backend;
         }
       }
     }
   }
 
   for (auto& op : operands_) {
-    auto& op_tensor_type = at::globalContext().getNonVariableType(op.tensor.type().backend(), op.tensor.type().scalarType());
-    if (op.tensor.defined() && op_tensor_type != *op.type) {
+    if (op.tensor.defined() && (op.dtype != op.tensor.scalar_type() || op.backend != op.tensor.type().backend())) {
       if (op.is_output) {
-        AT_ERROR("output with type ", op_tensor_type.toString(),
-                 " doesn't match the desired type ", op.type->toString());
+        AT_ERROR("output with backend ", toString(op.tensor.type().backend()), " and dtype ", toString(op.tensor.scalar_type()),
+                 " doesn't match the desired backend ", toString(op.backend), " and dtype ", toString(op.dtype));
       } else if (op.tensor.dim() == 0) {
-        op.tensor = op.tensor.to(*op.type);
+        op.tensor = op.tensor.to(TensorOptions(op.backend).dtype(op.dtype));
       } else {
-        AT_ERROR("expected type ", op.type->toString(), " but got ",
-            op_tensor_type.toString());
+        AT_ERROR("expected backend ", toString(op.backend), " and dtype ", toString(op.dtype),
+                 " but got backend ", toString(op.tensor.type().backend()), " and dtype ", toString(op.tensor.scalar_type()));
       }
     }
   }
 }
 
-Type& TensorIterator::compute_common_type() {
+std::pair<Backend, ScalarType> TensorIterator::compute_common_type() {
   // See [Result type computation] in TensorIterator.h
   auto result_type = ScalarType::Undefined;
   auto backend = Backend::Undefined;
@@ -154,7 +158,7 @@ Type& TensorIterator::compute_common_type() {
   AT_ASSERT(result_type != ScalarType::Undefined);
   AT_ASSERT(backend != Backend::Undefined);
 
-  return at::globalContext().getNonVariableType(backend, result_type);
+  return std::make_pair(backend, result_type);
 }
 
 DimVector TensorIterator::compatible_stride(int element_size) const {
@@ -182,8 +186,8 @@ void TensorIterator::allocate_outputs() {
   for (int i = 0; i < num_outputs_; i++) {
     auto& op = operands_[i];
     if (!op.tensor.defined()) {
-      AT_ASSERTM(op.type, "no type for operand", i);
-      int element_size = op.type->elementSizeInBytes();
+      AT_ASSERTM(op.backend != Backend::Undefined && op.dtype != ScalarType::Undefined, "no type for operand", i);
+      int element_size = elementSize(op.dtype);
       op.stride_bytes = compatible_stride(element_size);
 
       auto tensor_shape = invert_perm(shape_);
@@ -191,7 +195,7 @@ void TensorIterator::allocate_outputs() {
       for (int dim = 0; dim < ndim(); dim++) {
         tensor_stride[dim] /= element_size;
       }
-      op.tensor = at::empty_strided(tensor_shape, tensor_stride, op.type->options());
+      op.tensor = at::empty_strided(tensor_shape, tensor_stride, TensorOptions(op.backend).dtype(op.dtype));
     }
   }
 }
@@ -420,7 +424,7 @@ bool TensorIterator::is_scalar(int arg) const {
 }
 
 bool TensorIterator::is_cpu_scalar(int arg) const {
-  return is_scalar(arg) && operands_[arg].tensor.type().device_type() == kCPU;
+  return is_scalar(arg) && device_type(arg) == kCPU;
 }
 
 void* TensorIterator::data_ptr(int arg) const {

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -66,10 +66,11 @@ struct DimCounter {
 };
 struct CAFFE2_API OperandInfo {
   OperandInfo() {}
-  OperandInfo(const Tensor& t, const Type* type=nullptr)
-    : tensor(t), type(const_cast<Type*>(type)) {
-      if (t.defined() && !type) {
-        this->type = &t.type();
+  OperandInfo(const Tensor& t, const Backend backend=Backend::Undefined, const ScalarType dtype=ScalarType::Undefined)
+    : tensor(t), backend(backend), dtype(dtype) {
+      if (t.defined() && (backend != Backend::Undefined || dtype != ScalarType::Undefined)) {
+        this->backend = t.type().backend();
+        this->dtype = t.scalar_type();
       }
   }
 
@@ -85,7 +86,8 @@ struct CAFFE2_API OperandInfo {
   /// input should be converted to this type if necessary. For outputs, this
   /// specifies which type to allocate. Note that there is very limited support
   /// for type conversions currently: they are only allowed for zero-dim tensors.
-  Type* type = nullptr;
+  Backend backend = Backend::Undefined;
+  ScalarType dtype = ScalarType::Undefined;
 
   /// The data pointer. This may be different from tensor.data_ptr() if the
   /// iterator is split.
@@ -147,13 +149,9 @@ struct CAFFE2_API TensorIterator {
   /// Accessors for each operand
   IntArrayRef strides(int arg) const { return operands_[arg].stride_bytes; }
   void* data_ptr(int arg) const;
-  const Type& type(int arg=0) const {
-    AT_ASSERT(operands_[arg].type);
-    return *operands_[arg].type;
-  }
-  ScalarType dtype(int arg) const { return type(arg).scalarType(); }
-  DeviceType device_type(int arg=0) const { return type(arg).device_type(); }
-  int64_t element_size(int arg) const { return type(arg).elementSizeInBytes(); }
+  ScalarType dtype(int arg=0) const { return operands_[arg].dtype; }
+  DeviceType device_type(int arg=0) const { return backendToDeviceType(operands_[arg].backend); }
+  int64_t element_size(int arg) const { return elementSize(dtype(arg)); }
   bool is_scalar(int arg) const;
   bool is_cpu_scalar(int arg) const;
 
@@ -186,7 +184,7 @@ struct CAFFE2_API TensorIterator {
   template <typename T>
   T scalar_value(int arg) {
     auto& op = operands_[arg];
-    return at::detail::load<T>(op.data, op.tensor.type().scalarType());
+    return at::detail::load<T>(op.data, op.tensor.scalar_type());
   }
 
   void for_each(const loop_t& loop);
@@ -236,7 +234,7 @@ protected:
   void reorder_dimensions();
   void permute_dimensions(IntArrayRef perm);
   void compute_types();
-  Type& compute_common_type();
+  std::pair<Backend, ScalarType> compute_common_type();
   void allocate_outputs();
   void coalesce_dimensions();
 
@@ -260,13 +258,13 @@ struct TensorIterator::Builder {
 
   Builder() : iter_(new TensorIterator()) {};
 
-  void add_output(const Tensor& output, const Type* type=nullptr) {
-    iter_->operands_.emplace_back(output, type);
+  void add_output(const Tensor& output, const Backend backend=Backend::Undefined, const ScalarType dtype=ScalarType::Undefined) {
+    iter_->operands_.emplace_back(output, backend, dtype);
     iter_->num_outputs_++;
   }
 
-  void add_input(const Tensor& input, const Type* type=nullptr) {
-    iter_->operands_.emplace_back(input, type);
+  void add_input(const Tensor& input, const Backend backend=Backend::Undefined, const ScalarType dtype=ScalarType::Undefined) {
+    iter_->operands_.emplace_back(input, backend, dtype);
   }
 
   void dont_compute_common_dtype() {

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -26,7 +26,7 @@ int64_t stride(const Tensor& self, int64_t dim) {
 bool cudnn_is_acceptable(const Tensor& self) {
   if (!globalContext().userEnabledCuDNN()) return false;
   if (!self.is_cuda()) return false;
-  auto st = self.type().scalarType();
+  auto st = self.scalar_type();
   if (!(st == kDouble || st == kFloat || st == kHalf)) return false;
   if (!detail::getCUDAHooks().compiledWithCuDNN()) return false;
   // cuDNN functions like grid_sampler returns CUDNN_STATUS_BAD_PARAM on empty

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -60,7 +60,7 @@ Tensor flip_cpu(const Tensor& self, IntArrayRef dims) {
     }
   }
 
-  AT_DISPATCH_ALL_TYPES(in_tensor.type(), "flip_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES(in_tensor.scalar_type(), "flip_cpu", [&] {
     flip_cpu_kernel<scalar_t>(
       total_dims,
       stride_contiguous_v,

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -14,18 +14,18 @@ bool is_distributed(const Tensor& self) {
 }
 
 bool is_complex(const Tensor& self) {
-  return at::isComplexType(self.type().scalarType());
+  return at::isComplexType(self.scalar_type());
 }
 
 bool is_floating_point(const Tensor& self) {
-  return at::isFloatingType(self.type().scalarType());
+  return at::isFloatingType(self.scalar_type());
 }
 
 bool is_signed(const Tensor &self) {
-  if (self.type().scalarType() == ScalarType::Half) {
+  if (self.scalar_type() == ScalarType::Half) {
     return true;
   }
-  return AT_DISPATCH_ALL_TYPES(self.type(), "is_signed", [&]() -> bool {
+  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "is_signed", [&]() -> bool {
     return std::is_signed<scalar_t>();
   });
 }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -92,7 +92,7 @@ Tensor& fill_(Tensor& self, const Tensor& value) {
 }
 
 Tensor mvlgamma(const Tensor& self, int64_t p) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()),
+  AT_CHECK(at::isFloatingType(self.scalar_type()),
            "mvlgamma is not implemented for ", self.type());
   AT_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");
@@ -103,7 +103,7 @@ Tensor mvlgamma(const Tensor& self, int64_t p) {
 }
 
 Tensor& mvlgamma_(Tensor& self, int64_t p) {
-  AT_CHECK(at::isFloatingType(self.type().scalarType()),
+  AT_CHECK(at::isFloatingType(self.scalar_type()),
            "mvlgamma is not implemented for ", self.type());
   AT_CHECK((self > 0.5 * (p - 1.)).all().item<uint8_t>(),
            "Condition for computing multivariate log-gamma not met");

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -127,14 +127,14 @@ std::tuple<Tensor, Tensor> _unique_dim_cpu_template(
 
 std::tuple<Tensor, Tensor>
 _unique_cpu(const Tensor& self, const bool sorted, const bool return_inverse) {
-  return AT_DISPATCH_ALL_TYPES(self.type(), "unique", [&] {
+  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "unique", [&] {
     return _unique_cpu_template<scalar_t>(self, sorted, return_inverse);
   });
 }
 
 std::tuple<Tensor, Tensor>
 _unique_dim_cpu(const Tensor& self, const int64_t dim, const bool sorted, const bool return_inverse) {
-  return AT_DISPATCH_ALL_TYPES(self.type(), "unique_dim", [&] {
+  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "unique_dim", [&] {
     // The current implementation using `dim` always sorts due to unhashable tensors
     return _unique_dim_cpu_template<scalar_t>(self, dim, return_inverse);
   });

--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -93,7 +93,7 @@ std::tuple<Tensor, Tensor> _weight_norm_differentiable_backward
 
   // ...but saved_norms might be Float when saved_g and saved_v are half.
   // To consider:  saved_norms.to(..., True /*non_blocking*/);
-  auto norms = saved_norms.to(saved_g.type().scalarType());
+  auto norms = saved_norms.to(saved_g.scalar_type());
 
   std::vector<int64_t> bcast_size(saved_v.dim(), 1);
 

--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -9,7 +9,7 @@ namespace at { namespace native {
 namespace {
 
 static void threshold_kernel(TensorIterator& iter, Scalar threshold_scalar, Scalar value_scalar) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "threshold", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "threshold", [&] {
     using Vec = Vec256<scalar_t>;
     scalar_t threshold = threshold_scalar.to<scalar_t>();
     scalar_t value = value_scalar.to<scalar_t>();

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -14,7 +14,7 @@ namespace {
 using namespace vec256;
 
 void add_kernel(TensorIterator& iter, Scalar alpha_scalar) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "add", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "add", [&]() {
     auto alpha = alpha_scalar.to<scalar_t>();
     auto alpha_vec = Vec256<scalar_t>(alpha);
     binary_kernel_vec(iter,
@@ -30,7 +30,7 @@ void sub_kernel(TensorIterator& iter, Scalar alpha_scalar) {
 }
 
 void mul_kernel(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "mul", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "mul", [&]() {
     binary_kernel_vec(iter,
       [=](scalar_t a, scalar_t b) -> scalar_t { return a * b; },
       [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
@@ -40,16 +40,16 @@ void mul_kernel(TensorIterator& iter) {
 }
 
 void div_kernel(TensorIterator& iter) {
-  if (isIntegralType(iter.type().scalarType())) {
+  if (isIntegralType(iter.dtype())) {
     // There's no SIMD integer division, so don't try to vectorize it.
     // TODO: if the divisor is a scalar, rewrite as multiplication by a constant.
-    AT_DISPATCH_INTEGRAL_TYPES(iter.type(), "div", [&]() {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "div", [&]() {
       binary_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
         return a / b;
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES(iter.type(), "div", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "div", [&]() {
       binary_kernel_vec(iter,
         [=](scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
            return a / b;

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -14,7 +14,7 @@ namespace {
 constexpr int64_t COPY_GRAIN_SIZE = 20000;
 
 static void copy_kernel_impl(Tensor& dst, const Tensor& src) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(dst.type(), "copy_kernel_impl", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(dst.scalar_type(), "copy_kernel_impl", [&]() {
     scalar_t* self_ptr = dst.data<scalar_t>();
     scalar_t* src_ptr = src.data<scalar_t>();
 

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -270,19 +270,19 @@ struct PDist {
 };
 
 void pdist_forward_kernel_impl(Tensor& result, const Tensor& self, const double p) {
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "pdist", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist", [&] {
     PDist<scalar_t>::apply(result, self, p);
   });
 }
 
 static void pdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor& self, const double p, const Tensor& dist) {
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "pdist_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist_backward", [&] {
     PDist<scalar_t>::apply_backward(result, grad, self, p, dist);
   });
 }
 
 static void cdist_kernel_impl(Tensor& result, const Tensor& x1, const Tensor& x2, const double p) {
-  AT_DISPATCH_FLOATING_TYPES(result.type(), "cdist", [&] {
+  AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "cdist", [&] {
     PDist<scalar_t>::apply_cdist(result, x1, x2, p);
   });
 }

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -308,8 +308,8 @@ static inline void
 mask_scatter_add(const scalar_t *src, scalar_t* base_addr,
                  const int_same_size_t<scalar_t> *offsets,
                  const int_same_size_t<scalar_t> *mask, int64_t len) {
-  #ifndef _MSC_VER  
-  # pragma unroll  
+  #ifndef _MSC_VER
+  # pragma unroll
   #endif
   for (int64_t i = 0; i < len; i++) {
     if (mask[i] & 0x01) {
@@ -431,8 +431,8 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear, padding>
     auto i_sw_offset = i_nw_offset + iVec(inp_sH);
     auto i_se_offset = i_sw_offset + iVec(inp_sW);
 
-    #ifndef _MSC_VER  
-    # pragma unroll  
+    #ifndef _MSC_VER
+    # pragma unroll
     #endif
     for (int64_t c = 0; c < C; ++c) {
       auto inp_slice_C_ptr = inp_slice[c].data();
@@ -505,8 +505,8 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Bilinear, padding>
     scalar_t gInp_corner_arr[Vec::size()];
 
     auto gx = Vec(0), gy = Vec(0);
-    #ifndef _MSC_VER  
-    # pragma unroll  
+    #ifndef _MSC_VER
+    # pragma unroll
     #endif
     for (int64_t c = 0; c < C; ++c) {
       auto inp_slice_C_ptr = inp_slice[c].data();
@@ -598,8 +598,8 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest, padding> 
     auto out_ptr = out_slice.data() + offset;
     auto out_sC = out_slice.stride(0);
     auto inp_slice_ptr = inp_slice.data();
-    #ifndef _MSC_VER  
-    # pragma unroll  
+    #ifndef _MSC_VER
+    # pragma unroll
     #endif
     for (int c = 0; c < C; ++c, out_ptr += out_sC, inp_slice_ptr += inp_sC) {
       // mask_gather zeros out the mask, so we need to make a copy
@@ -635,8 +635,8 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest, padding> 
     integer_t gInp_offset_arr[iVec::size()];
     i_gInp_offset.store(gInp_offset_arr);
 
-    #ifndef _MSC_VER  
-    # pragma unroll  
+    #ifndef _MSC_VER
+    # pragma unroll
     #endif
     for (int64_t c = 0; c < C; ++c) {
       mask_scatter_add(gOut_slice[c].data() + offset, gInp_slice[c].data(),
@@ -743,15 +743,15 @@ static inline void grid_sample_2d_grid_slice_iterator(
     auto spatial_offset = 0;
     auto i_offsets_delta = iVec(grid_sW * step);
 
-    #ifndef _MSC_VER  
-    # pragma unroll  
+    #ifndef _MSC_VER
+    # pragma unroll
     #endif
     for (int64_t h = 0; h < out_H; h++) {
       auto grid_ptr_x = grid_ptr + h * grid_sH;
       auto grid_ptr_y = grid_ptr_x + grid_sCoor;
       auto i_offsets = iVec::arange(0, grid_sW);
-      #ifndef _MSC_VER  
-      # pragma unroll  
+      #ifndef _MSC_VER
+      # pragma unroll
       #endif
       for (int64_t w = 0; w < out_W; w += step) {
         auto len = std::min(step, out_W - w);
@@ -815,7 +815,7 @@ Tensor grid_sampler_2d_cpu_kernel_impl(const Tensor& input, const Tensor& grid,
     return;                                                            \
   }
 
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_2d_cpu_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler_2d_cpu_kernel_impl", [&] {
     auto out_acc = output.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<scalar_t, 4>();
     auto grid_acc = grid.accessor<scalar_t, 4>();
@@ -878,7 +878,7 @@ grid_sampler_2d_backward_cpu_kernel_impl(const Tensor& grad_output_,
     return;                                                            \
   }
 
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "grid_sampler_2d_backward_cpu_kernel_impl", [&] {
     auto gInp_acc = grad_input.accessor<scalar_t, 4>();
     auto gGrid_acc = grad_grid.accessor<scalar_t, 4>();
     auto inp_acc = input.accessor<scalar_t, 4>();

--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -92,7 +92,7 @@ void cpu_index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
 }
 
 void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride) {
-  AT_DISPATCH_ALL_TYPES(iter.type(0), "index", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(0), "index", [&] {
     cpu_index_kernel<scalar_t>(iter, index_size, index_stride, [](char* dst, char* src, int64_t offset) {
       *(scalar_t*)dst = *(scalar_t*)(src + offset);
     });
@@ -101,7 +101,7 @@ void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef inde
 
 void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride, bool accumulate) {
   // NOTE: duplicate indices are only supported if accumulate is true.
-  AT_DISPATCH_ALL_TYPES(iter.type(0), "index_put", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(0), "index_put", [&] {
     if (accumulate) {
       // TODO: investigate parallelization of the accumulate kernel. Unlike the non-accumulate case,
       // this needs to be thread-safe.

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -15,7 +15,7 @@ namespace at { namespace native { namespace {
 using namespace vec256;
 
 static void sum_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "sum", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "sum", [&] {
     binary_kernel_reduce_vec(
       iter,
       [=](scalar_t a, scalar_t b) -> scalar_t { return a + b; },
@@ -24,7 +24,7 @@ static void sum_kernel_impl(TensorIterator& iter) {
 }
 
 static void mean_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "mean", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "mean", [&] {
     scalar_t factor = scalar_t(iter.num_output_elements()) / iter.numel();
     binary_kernel_reduce(
       iter,
@@ -35,7 +35,7 @@ static void mean_kernel_impl(TensorIterator& iter) {
 }
 
 static void std_var_kernel_impl(TensorIterator &iter, bool unbiased, bool take_sqrt) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.type(), "std", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "std", [&] {
     binary_kernel_reduce(
       iter,
       WelfordOps<scalar_t, double> { unbiased, take_sqrt },
@@ -45,7 +45,7 @@ static void std_var_kernel_impl(TensorIterator &iter, bool unbiased, bool take_s
 }
 
 static void prod_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "prod", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "prod", [&] {
     binary_kernel_reduce_vec(
       iter,
       [=](scalar_t a, scalar_t b) -> scalar_t { return a * b; },
@@ -68,7 +68,7 @@ static void norm_kernel_tensor_iterator_impl(
 
 
   if (val == 0) {
-    AT_DISPATCH_FLOATING_TYPES(iter.type(), "norm", [&] {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "norm", [&] {
       binary_kernel_reduce(
         iter,
         NormZeroOps<scalar_t>(),
@@ -76,7 +76,7 @@ static void norm_kernel_tensor_iterator_impl(
       );
     });
   } else if (val == 1) {
-    AT_DISPATCH_FLOATING_TYPES(iter.type(), "norm", [&] {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "norm", [&] {
       binary_kernel_reduce(
         iter,
         NormOneOps<scalar_t>(),
@@ -84,7 +84,7 @@ static void norm_kernel_tensor_iterator_impl(
       );
     });
   } else if (val == INFINITY) {
-    AT_DISPATCH_FLOATING_TYPES(iter.type(), "norm", [&] {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "norm", [&] {
       binary_kernel_reduce(
         iter,
         AbsMaxOps<scalar_t>(),
@@ -92,7 +92,7 @@ static void norm_kernel_tensor_iterator_impl(
       );
     });
   } else if (val == -INFINITY) {
-    AT_DISPATCH_FLOATING_TYPES(iter.type(), "norm", [&] {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "norm", [&] {
       binary_kernel_reduce(
         iter,
         AbsMinOps<scalar_t>(),
@@ -100,7 +100,7 @@ static void norm_kernel_tensor_iterator_impl(
       );
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES(iter.type(), "norm", [&] {
+    AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "norm", [&] {
       binary_kernel_reduce(
         iter,
         NormOps<scalar_t> { scalar_t(val) },
@@ -149,7 +149,7 @@ static void or_kernel_impl(TensorIterator& iter) {
 }
 
 static void min_values_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "min_values", [&iter] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "min_values", [&iter] {
     binary_kernel_reduce_vec(
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return std::min(a, b); },
@@ -158,7 +158,7 @@ static void min_values_kernel_impl(TensorIterator& iter) {
 }
 
 static void max_values_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "min_values", [&iter] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "min_values", [&iter] {
     binary_kernel_reduce_vec(
       iter,
       [](scalar_t a, scalar_t b) -> scalar_t { return std::max(a, b); },

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -218,7 +218,7 @@ struct vec_host_softmax_backward_lastdim {
 };
 
 static void softmax_lastdim_kernel_impl(Tensor& result, const Tensor& self) {
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "softmax_lastdim_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "softmax_lastdim_kernel_impl", [&] {
     vec_host_softmax_lastdim<scalar_t, false>::apply(result, self);
   });
 }
@@ -227,7 +227,7 @@ static void log_softmax_lastdim_kernel_impl(
     Tensor& result,
     const Tensor& self) {
   AT_DISPATCH_FLOATING_TYPES(
-      self.type(), "log_softmax_lastdim_kernel_impl", [&] {
+      self.scalar_type(), "log_softmax_lastdim_kernel_impl", [&] {
         vec_host_softmax_lastdim<scalar_t, true>::apply(result, self);
       });
 }
@@ -237,7 +237,7 @@ static void softmax_backward_lastdim_kernel_impl(
     const Tensor& grad,
     const Tensor& output) {
   AT_DISPATCH_FLOATING_TYPES(
-      grad.type(), "softmax_backward_lastdim_kernel_impl", [&] {
+      grad.scalar_type(), "softmax_backward_lastdim_kernel_impl", [&] {
         vec_host_softmax_backward_lastdim<scalar_t, false>::apply(
             grad_input, grad, output);
       });
@@ -248,7 +248,7 @@ static void log_softmax_backward_lastdim_kernel_impl(
     const Tensor& grad,
     const Tensor& output) {
   AT_DISPATCH_FLOATING_TYPES(
-      grad.type(), "log_softmax_backward_lastdim_kernel_impl", [&] {
+      grad.scalar_type(), "log_softmax_backward_lastdim_kernel_impl", [&] {
         vec_host_softmax_backward_lastdim<scalar_t, true>::apply(
             grad_input, grad, output);
       });

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -97,7 +97,7 @@ static void max_kernel_impl(
     Tensor& max_indices,
     const Tensor& self,
     c10::optional<int64_t> dim) {
-  AT_DISPATCH_ALL_TYPES(self.type(), "max", [&] {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "max", [&] {
     Reduction<scalar_t, int64_t>::apply(max, max_indices, self, dim, true);
   });
 }
@@ -107,7 +107,7 @@ static void min_kernel_impl(
     Tensor& min_indices,
     const Tensor& self,
     c10::optional<int64_t> dim) {
-  AT_DISPATCH_ALL_TYPES(self.type(), "min", [&] {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "min", [&] {
     Reduction<scalar_t, int64_t>::apply(min, min_indices, self, dim, false);
   });
 }

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -81,7 +81,7 @@ int64_t _sigmoid(double* x, double* y, int64_t size) {
 }
 
 static void sigmoid_kernel(Tensor& result, const Tensor& self) {
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "sigmoid", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "sigmoid", [&] {
     using Vec = Vec256<scalar_t>;
     CPU_tensor_parallel_kernel_apply2<scalar_t, scalar_t>(
         result,
@@ -133,7 +133,7 @@ void bernoulli_mkl_kernel(Tensor &self, const double p, Generator* gen) {
   int64_t n = self.numel();
   bool contig = self.is_contiguous();
 
-  AT_DISPATCH_ALL_TYPES(self.type(), "bernoulli_scalar_cpu_", [&] {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "bernoulli_scalar_cpu_", [&] {
     at::Tensor tmp_int_tensor;
     if (std::is_same<scalar_t, int>::value && contig) {
       tmp_int_tensor = self;
@@ -177,7 +177,7 @@ void bernoulli_mkl_kernel(Tensor &self, const double p, Generator* gen) {
 #define IMPLEMENT_FLOAT_KERNEL(dispatchtypes, op)                          \
   static void op##_kernel(Tensor& result, const Tensor& self) {            \
     checkBackend(#op, {result}, Backend::CPU);                             \
-    AT_DISPATCH_##dispatchtypes##_TYPES(self.type(), #op, [&] {            \
+    AT_DISPATCH_##dispatchtypes##_TYPES(self.scalar_type(), #op, [&] {     \
       if (self.is_contiguous() && result.is_contiguous()) {                \
         vml::v##op(                                                        \
             result.data<scalar_t>(), self.data<scalar_t>(), self.numel()); \

--- a/aten/src/ATen/native/cuda/Activation.cu
+++ b/aten/src/ATen/native/cuda/Activation.cu
@@ -62,7 +62,7 @@ Tensor prelu_cuda(const Tensor& self, const Tensor& weight_) {
 
   // case1: shared weight for all channels
   if (weight_num == 1) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "prelu_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "prelu_cuda", [&] {
       prelu_cuda_kernel_share_weights<scalar_t>(
         input,
         result,
@@ -94,7 +94,7 @@ Tensor prelu_cuda(const Tensor& self, const Tensor& weight_) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream(curDevice);
     AT_CHECK(cuda::getApplyGrid(input_numel, grid, curDevice), "prelu: input too large or too many dimensions");
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "prelu_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "prelu_cuda", [&] {
       prelu_cuda_kernel_multi_weights<scalar_t>
       <<<grid, block, 0, stream>>>(
         result.data<scalar_t>(),
@@ -175,7 +175,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cuda(const Tensor& grad_out_, const Te
   Tensor weight_grad_collector = at::empty_like(input);
   // case1: shared parameter for all channels
   if (weight_num == 1) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "prelu_backward_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "prelu_backward_cuda", [&] {
       prelu_cuda_backward_kernel_share_weights<scalar_t>(
         input,
         grad_out,
@@ -210,7 +210,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cuda(const Tensor& grad_out_, const Te
     cudaStream_t stream = at::cuda::getCurrentCUDAStream(curDevice);
     AT_CHECK(cuda::getApplyGrid(input_numel, grid, curDevice), "prelu_backward_cuda: input too large or too many dimensions");
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "prelu_backward_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "prelu_backward_cuda", [&] {
       prelu_cuda_backward_kernel_multi_weights<scalar_t>
       <<<grid, block, 0, stream>>>(
         input.data<scalar_t>(),
@@ -264,7 +264,7 @@ void hardshrink_backward_cuda_kernel(const Tensor& self, Tensor& out_tensor, sca
 
 Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
   auto out_tensor = at::empty_like(self);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "hardshrink_cuda", [&] {
     hardshrink_cuda_kernel<scalar_t>(self, out_tensor, lambd.to<scalar_t>());
   });
   return out_tensor;
@@ -272,7 +272,7 @@ Tensor hardshrink_cuda(const Tensor & self, Scalar lambd) {
 
 Tensor hardshrink_backward_cuda(const Tensor & grad, const Tensor & self, Scalar lambd) {
   auto out_tensor = at::empty_like(grad);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "hardshrink_backward_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "hardshrink_backward_cuda", [&] {
     hardshrink_backward_cuda_kernel<scalar_t>(self, out_tensor, lambd.to<scalar_t>(), grad);
   });
   return out_tensor;
@@ -286,7 +286,7 @@ void threshold_kernel_impl(TensorIterator& iter, scalar_t threshold, scalar_t va
 }
 
 static void threshold_kernel(TensorIterator& iter, Scalar threshold, Scalar value) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.type(), "threshold", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.dtype(), "threshold", [&] {
     threshold_kernel_impl<scalar_t>(iter, threshold.to<scalar_t>(), value.to<scalar_t>());
   });
 }

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -244,7 +244,7 @@ namespace {
        output.resize_({sizeD, osizeH, osizeW});
     }
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        input_.type(), "adaptive_avg_pool2d", [&] {
+        input_.scalar_type(), "adaptive_avg_pool2d", [&] {
           scalar_t *input_data = input_.data<scalar_t>();
           scalar_t *output_data = output.data<scalar_t>();
 
@@ -284,13 +284,13 @@ namespace {
 
     int64_t osizeH = gradOutput.size(-2);
     int64_t osizeW = gradOutput.size(-1);
-    
+
     int64_t grid_x = sizeD;
     if (input.ndimension() == 4) grid_x *= input.size(-4);
 
       //bool atomic = (isizeW%osizeW != 0) || (isizeH%osizeH != 0);
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        input.type(), "adaptive_avg_pool2d_backward", [&] {
+        input.scalar_type(), "adaptive_avg_pool2d_backward", [&] {
           scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
           scalar_t *gradInput_data = gradInput.data<scalar_t>();
 

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -260,7 +260,7 @@ std::tuple<Tensor, Tensor> _gesv_helper_cuda(const Tensor& self, const Tensor& A
   auto self_working_copy = cloneBatchedColumnMajor(self);
   auto A_working_copy = cloneBatchedColumnMajor(A);
   std::vector<int64_t> infos(batchCount(self), 0);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "gesv", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "gesv", [&]{
     apply_gesv<scalar_t>(self_working_copy, A_working_copy, infos);
   });
   if (self.dim() > 2) {
@@ -327,7 +327,7 @@ Tensor _inverse_helper_cuda(const Tensor& self) {
   std::vector<int64_t> infos(batchCount(self), 0);
   auto self_working_copy = cloneBatchedColumnMajor(self);
   auto self_inv_working_copy = cloneBatchedColumnMajor(self);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "inverse", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "inverse", [&]{
     apply_inverse<scalar_t>(
       self_working_copy, self_inv_working_copy, infos);
   });
@@ -386,7 +386,7 @@ Tensor _cholesky_solve_helper_cuda(const Tensor& self, const Tensor& A, bool upp
   int64_t info = 0;
   auto self_working_copy = cloneBatchedColumnMajor(self);
   auto A_working_copy = cloneBatchedColumnMajor(A);
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "cholesky_solve", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "cholesky_solve", [&]{
     apply_cholesky_solve<scalar_t>(self_working_copy, A_working_copy, upper, info);
   });
   AT_CHECK(info == 0, "MAGMA cholesky_solve : invalid argument: ", -info);
@@ -446,7 +446,7 @@ Tensor _cholesky_helper_cuda(const Tensor& self, bool upper) {
     self_working_copy = cloneBatchedColumnMajor(self);
   }
 
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "cholesky", [&]{
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "cholesky", [&]{
     apply_cholesky<scalar_t>(self_working_copy, false, infos);
   });
   if (self.dim() > 2) {
@@ -493,7 +493,7 @@ Tensor& triu_tril_cuda_template(Tensor& result, const Tensor& self, int64_t k, c
           self_row_stride = self.stride(-2), self_col_stride = self.stride(-1);
   dim3 dim_block = cuda::getApplyBlock();
   dim3 dim_grid((mat_size + dim_block.x - 1) / dim_block.x, n_batches);
-  AT_DISPATCH_ALL_TYPES_AND_HALF(self.type(), name, [&]{
+  AT_DISPATCH_ALL_TYPES_AND_HALF(self.scalar_type(), name, [&]{
     triu_tril_kernel<scalar_t, upper>
       <<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
         result.data<scalar_t>(), self.data<scalar_t>(), k, mat_size,

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -22,7 +22,7 @@ void add_kernel_impl(TensorIterator& iter, Scalar alpha_scalar) {
 }
 
 static void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.type(), "add", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.dtype(), "add", [&]() {
     add_kernel_impl<scalar_t>(iter, alpha_scalar);
   });
 }
@@ -46,21 +46,21 @@ void div_constant_impl(TensorIterator& iter, scalar_t inv_b) {
 }
 
 static void div_kernel_cuda(TensorIterator& iter) {
-  if (isIntegralType(iter.type().scalarType())) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.type(), "div", [&]() {
+  if (isIntegralType(iter.dtype())) {
+    AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "div", [&]() {
       div_kernel_impl<scalar_t>(iter);
     });
   } else if (iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.type(), "div", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "div", [&]() {
       auto inv_b = scalar_t(1.0 / iter.scalar_value<scalar_t>(2));
       iter.remove_operand(2);
       div_constant_impl<scalar_t>(iter, inv_b);
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.type(), "div", [&]() {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "div", [&]() {
       div_kernel_impl<scalar_t>(iter);
     });
   }
@@ -74,7 +74,7 @@ void mul_kernel_impl(TensorIterator& iter) {
 }
 
 static void mul_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.type(), "mul", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.dtype(), "mul", [&]() {
     mul_kernel_impl<scalar_t>(iter);
   });
 }

--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -10,7 +10,7 @@ namespace native {
 Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
   AT_DISPATCH_ALL_TYPES_AND_HALF(
-      self.type(), "_local_scalar_dense_cuda", [&] {
+      self.scalar_type(), "_local_scalar_dense_cuda", [&] {
         scalar_t value;
         cudaStream_t stream = at::cuda::getCurrentCUDAStream();
         AT_CUDA_CHECK(cudaMemcpyAsync(&value, self.data<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream));

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -176,7 +176,7 @@ void copy_from_cpu(Tensor& dst, const Tensor& src) {
       cudaMemcpyHostToDevice,
       stream));
   AT_CUDA_CHECK(cudaStreamSynchronize(stream));
-  AT_DISPATCH_ALL_TYPES_AND_HALF(src.type(), "copy_from_cpu", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(src.scalar_type(), "copy_from_cpu", [&]() {
     copy_device_to_device<scalar_t, scalar_t>(dst, dst_contig);
   });
 }
@@ -209,7 +209,7 @@ void copy_from_cpu_async_(Tensor& dst, const Tensor& src) {
   CUDAGuard device_guard(dst.device());
   CUDAStream stream = getCurrentCUDAStream();
 
-  AT_DISPATCH_ALL_TYPES_AND_HALF(src.type(), "copy_from_cpu_async", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(src.scalar_type(), "copy_from_cpu_async", [&]() {
     AT_CUDA_CHECK(cudaMemcpyAsync(
         dst.data<scalar_t>(),
         src.data<scalar_t>(),
@@ -232,7 +232,7 @@ void copy_to_cpu_async_(Tensor& dst, const Tensor& src) {
   CUDAGuard device_guard(src.device());
   CUDAStream stream = getCurrentCUDAStream();
 
-  AT_DISPATCH_ALL_TYPES_AND_HALF(src.type(), "copy_to_cpu_async", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(src.scalar_type(), "copy_to_cpu_async", [&]() {
     AT_CUDA_CHECK(cudaMemcpyAsync(
         dst.data<scalar_t>(),
         src.data<scalar_t>(),
@@ -247,7 +247,7 @@ void copy_to_cpu_async_(Tensor& dst, const Tensor& src) {
 template <typename dst_T>
 void _copy__cuda(Tensor& dst, const Tensor& src, bool non_blocking) {
   AT_CHECK(dst.numel() == src.numel(), "sizes do not match");
-  AT_DISPATCH_ALL_TYPES_AND_HALF(src.type(), "_copy__cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(src.scalar_type(), "_copy__cuda", [&]() {
     if (dst.is_cuda() && src.is_cuda()) {
       copy_device_to_device<dst_T, scalar_t>(dst, src);
     } else if (dst.is_cuda()) {
@@ -286,7 +286,7 @@ namespace at {
 namespace native {
 
 Tensor& _s_copy__cuda(Tensor& self, const Tensor& src, bool non_blocking) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(self.type(), "_copy__cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(self.scalar_type(), "_copy__cuda", [&]() {
     ::_copy__cuda<scalar_t>(self, src, non_blocking);
   });
   return self;

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -37,7 +37,7 @@ static inline void setCuFFTParams(CuFFTParams* params,
     bool complex_output, IntArrayRef checked_signal_sizes, bool onesided) {
 
   memset(params, 0, sizeof(CuFFTParams));
-  params->scalar_type_ = input.type().scalarType();
+  params->scalar_type_ = input.scalar_type();
   for (int i = 0; i != input.dim(); ++i) {
     params->input_sizes_[i] = input.size(i);
     if (input.size(i) != 1) {
@@ -106,7 +106,7 @@ public:
     // For half, base strides on the real part of real-to-complex and
     // complex-to-real transforms are not supported. Since our output is always
     // contiguous, only need to check real-to-complex case.
-    if (input.type().scalarType() == ScalarType::Half) {
+    if (input.scalar_type() == ScalarType::Half) {
       // cuFFT on half requires compute capability of at least SM_53
       auto dev_prop = at::cuda::getCurrentDeviceProperties();
       AT_CHECK(dev_prop->major >= 5 && !(dev_prop->major == 5 && dev_prop->minor < 3),
@@ -196,7 +196,7 @@ public:
 #ifdef __HIP_PLATFORM_HCC__
 
     hipfftType exec_type;
-    if (input.type().scalarType() == ScalarType::Float) {
+    if (input.scalar_type() == ScalarType::Float) {
       if (complex_input && complex_output) {
         exec_type = HIPFFT_C2C;
       } else if (complex_input && !complex_output) {
@@ -206,7 +206,7 @@ public:
       } else {
         AT_ERROR("hipFFT doesn't support r2r (float)");
       }
-    } else if (input.type().scalarType() == ScalarType::Double) {
+    } else if (input.scalar_type() == ScalarType::Double) {
       if (complex_input && complex_output) {
         exec_type = HIPFFT_Z2Z;
       } else if (complex_input && !complex_output) {
@@ -219,28 +219,28 @@ public:
     } else {
       std::ostringstream ss;
       ss << "hipFFT doesn't support tensor of type: "
-         << toString(input.type().scalarType());
+         << toString(input.scalar_type());
       AT_ERROR(ss.str());
     }
 
 #else
     cudaDataType itype, otype, exec_type;
-    if (input.type().scalarType() == ScalarType::Float) {
+    if (input.scalar_type() == ScalarType::Float) {
       itype = complex_input ? CUDA_C_32F : CUDA_R_32F;
       otype = complex_output ? CUDA_C_32F : CUDA_R_32F;
       exec_type = CUDA_C_32F;
-    } else if (input.type().scalarType() == ScalarType::Double) {
+    } else if (input.scalar_type() == ScalarType::Double) {
       itype = complex_input ? CUDA_C_64F : CUDA_R_64F;
       otype = complex_output ? CUDA_C_64F : CUDA_R_64F;
       exec_type = CUDA_C_64F;
-    } else if (input.type().scalarType() == ScalarType::Half) {
+    } else if (input.scalar_type() == ScalarType::Half) {
       itype = complex_input ? CUDA_C_16F : CUDA_R_16F;
       otype = complex_output ? CUDA_C_16F : CUDA_R_16F;
       exec_type = CUDA_C_16F;
     } else {
       std::ostringstream ss;
       ss << "cuFFT doesn't support tensor of type: "
-         << toString(input.type().scalarType());
+         << toString(input.scalar_type());
       AT_ERROR(ss.str());
     }
 #endif

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -188,7 +188,7 @@ void cdist_kernel_impl(Tensor& result, const Tensor& x1, const Tensor& x2, doubl
   const dim3 grid(r1*r2);
   const dim3 block(forward_threads);
 
-  AT_DISPATCH_FLOATING_TYPES(x1.type(), "cdist_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES(x1.scalar_type(), "cdist_cuda", [&] {
     if (p == 0.0) {
       cdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::zero><<<grid, block>>>(result.data<scalar_t>(), x1.data<scalar_t>(), x2.data<scalar_t>(), p, r1, r2, m);
     } else if (p == 1.0) {
@@ -213,7 +213,7 @@ void pdist_forward_kernel_impl(Tensor& result, const Tensor& self, double p) {
   const double n2 = n - .5;
   const double n2_squared_minus_1 = n2 * n2 - 1;
 
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "pdist_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist_cuda", [&] {
     if (p == 0.0) {
       pdist_kernel_cuda_impl<scalar_t, dists<scalar_t>::zero><<<grid, block>>>(result.data<scalar_t>(), self.data<scalar_t>(), n, m, p, n2, n2_squared_minus_1);
     } else if (p == 1.0) {
@@ -252,7 +252,7 @@ void pdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   const double n2_squared_minus_1 = n2 * n2 - 1;
 
   Tensor buffer = at::empty({n - 1, result.size(0), result.size(1)}, result.options());
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "pdist_cuda_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "pdist_cuda_backward", [&] {
     if (p == 1.0) {
       pdist_backward_kernel_cuda_impl<scalar_t, dists<scalar_t>::one><<<grid, block>>>(buffer.data<scalar_t>(), grad.data<scalar_t>(), self.data<scalar_t>(), dist.data<scalar_t>(), grad.stride(0), n, m, dist.numel(), p, n2, n2_squared_minus_1);
     } else if (p < 2.0) {

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -186,7 +186,7 @@ void bernoulli_scalar_cuda_kernel(
 namespace at { namespace native {
 Tensor _s_poisson_cuda(const Tensor& lambda, Generator* gen) {
   Tensor ret = at::empty(lambda.sizes(), lambda.options());
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.type(), "poisson", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.scalar_type(), "poisson", [&] {
     poisson_cuda_kernel<scalar_t>(ret, lambda, next_philox_seed(gen, 20));
   });
   return ret;
@@ -194,7 +194,7 @@ Tensor _s_poisson_cuda(const Tensor& lambda, Generator* gen) {
 
 Tensor _s_gamma_cuda(const Tensor& alpha, Generator* gen) {
   Tensor ret = at::empty(alpha.sizes(), alpha.options());
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.type(), "gamma", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.scalar_type(), "gamma", [&] {
      gamma_cuda_kernel<scalar_t>(ret, alpha, next_philox_seed(gen, 10));
    });
   return ret;
@@ -202,7 +202,7 @@ Tensor _s_gamma_cuda(const Tensor& alpha, Generator* gen) {
 
 Tensor _standard_gamma_grad_cuda(const Tensor& self, const Tensor& output) {
   Tensor ret = at::empty(self.sizes(), self.options());
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "_standard_gamma_grad", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "_standard_gamma_grad", [&] {
      gamma_grad_cuda_kernel<scalar_t>(ret, self, output);
    });
   return ret;
@@ -210,11 +210,10 @@ Tensor _standard_gamma_grad_cuda(const Tensor& self, const Tensor& output) {
 
 Tensor& bernoulli_tensor_cuda_(Tensor &self, const Tensor& p_, Generator* gen) {
   auto p = std::get<0>(expand_inplace(self, p_.to(kCUDA)));
-  AT_DISPATCH_ALL_TYPES_AND_HALF(self.type(), "bernoulli_tensor_cuda_self_", [&] {
-    const at::Type& p_type = p.type();
+  AT_DISPATCH_ALL_TYPES_AND_HALF(self.scalar_type(), "bernoulli_tensor_cuda_self_", [&] {
     using self_t = scalar_t;
     auto seeds = next_philox_seed(gen, 10);
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(p.type(), "bernoulli_tensor_cuda_p_", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(p.scalar_type(), "bernoulli_tensor_cuda_p_", [&] {
       using p_t = scalar_t;
       return bernoulli_tensor_cuda_kernel<self_t, p_t>(self, p, seeds);
     });
@@ -224,7 +223,7 @@ Tensor& bernoulli_tensor_cuda_(Tensor &self, const Tensor& p_, Generator* gen) {
 
 Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
   AT_CHECK(0 <= p && p <= 1, "bernoulli_ expects p to be in [0, 1], but got p=", p);
-  AT_DISPATCH_ALL_TYPES_AND_HALF(self.type(), "bernoulli_scalar_cuda_", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(self.scalar_type(), "bernoulli_scalar_cuda_", [&] {
     auto seeds = next_philox_seed(gen, 10);
     bernoulli_scalar_cuda_kernel<scalar_t>(self, p, seeds);
    });

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -108,7 +108,7 @@ fused_dropout_cuda(const Tensor& self, double p, Generator * gen){
 //number of times random will be generated per thread, to offset philox counter in thc random state
   int64_t counter_offset = ((nelem - 1)/(block_size*grid.x*UNROLL)+1)*UNROLL;
   if (cuda::detail::canUse32BitIndexMath(self)){
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "fused_dropout", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "fused_dropout", [&] {
       using accscalar_t = acc_type<scalar_t, true>;
       accscalar_t pa = (accscalar_t)(p);
       auto self_info = cuda::detail::getTensorInfo<scalar_t, unsigned int>(self);
@@ -126,7 +126,7 @@ fused_dropout_cuda(const Tensor& self, double p, Generator * gen){
       }
    });
   } else {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "fused_dropout", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "fused_dropout", [&] {
       using accscalar_t = acc_type<scalar_t, true>;
       accscalar_t pa = (accscalar_t)(p);
       auto self_info = cuda::detail::getTensorInfo<scalar_t, uint64_t>(self);
@@ -150,8 +150,8 @@ fused_dropout_cuda(const Tensor& self, double p, Generator * gen){
 
 Tensor masked_scale_cuda(const Tensor& self, const Tensor& mask, double scale){
    Tensor ret = at::empty_like(self);
-   AT_CHECK(mask.type().scalarType() == at::ScalarType::Byte, "mask should be torch.uint8 dtype");
-   AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.type(), "masked_scale", [&] {
+   AT_CHECK(mask.scalar_type() == at::ScalarType::Byte, "mask should be torch.uint8 dtype");
+   AT_DISPATCH_FLOATING_TYPES_AND_HALF(ret.scalar_type(), "masked_scale", [&] {
       using accscalar_t = acc_type<scalar_t, true>;
       accscalar_t pa = (accscalar_t)(scale);
     masked_scale_kernel<scalar_t>(ret, self, mask, pa);

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -243,7 +243,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
     dim3 block(WARP_SIZE, BLOCKDIMY);
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF
-      (grad.type(),
+      (grad.scalar_type(),
        "embedding_backward",
        [&]
        {
@@ -326,7 +326,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
   dim3 grid(THCCeilDiv(num_indices, (int64_t) 4), THCCeilDiv(stride, (int64_t) 128));
   dim3 block(32, 4);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.type(), "embedding_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "embedding_backward", [&] {
     embedding_backward_kernel<<<grid, block, 0, stream>>>(
       sorted_indices.data<int64_t>(),
       orig_indices.data<int64_t>(),
@@ -371,7 +371,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   dim3 block(128);
   int dim = self.stride(0);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "embedding_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "embedding_backward", [&] {
     using accscalar_t = acc_type<scalar_t, true>;
     renorm_kernel<<<grid, block, 128 * sizeof(accscalar_t), stream>>>(
       self.data<scalar_t>(),

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -248,7 +248,7 @@ Tensor embedding_bag_backward_cuda_sum_avg(
   dim3 grid(THCCeilDiv(numel, (ptrdiff_t)4), THCCeilDiv(stride, (int64_t)128));
   dim3 block(32, 4);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.type(), "embedding_bag_backward_cuda_sum_avg_kernel", [&] {
+      grad.scalar_type(), "embedding_bag_backward_cuda_sum_avg_kernel", [&] {
         EmbeddingBag_accGradParametersKernel_sum_avg<
             scalar_t><<<grid, block, 0, stream>>>(
             sorted_indices.data<int64_t>(), orig_indices.data<int64_t>(),
@@ -304,7 +304,7 @@ Tensor embedding_bag_backward_cuda_max(const Tensor &grad,
   int grid = 1024;
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.type(), "embedding_bag_backward_cuda_max", [&] {
+      grad.scalar_type(), "embedding_bag_backward_cuda_max", [&] {
         EmbeddingBag_accGradParametersKernel_max<
             scalar_t><<<grid, block, 0, stream>>>(
             max_indices.data<int64_t>(), grad.data<scalar_t>(),
@@ -353,7 +353,7 @@ _embedding_bag_cuda(const Tensor &weight, const Tensor &indices,
 
   dim3 block = dim3(32, 8);
   int grid = 1024;
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(weight.type(), "embedding_bag_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(weight.scalar_type(), "embedding_bag_cuda", [&] {
     EmbeddingBag_updateOutputKernel<scalar_t><<<grid, block, 0, stream>>>(
         indices.data<int64_t>(), offsets.data<int64_t>(),
         weight.data<scalar_t>(), output.data<scalar_t>(),

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -195,7 +195,7 @@ void fractional_max_pool2d_out_cuda_template(
             input_.size(0));
   dim3 block(outputPlaneSize > 128 ? 128 : outputPlaneSize);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(),
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(),
     "fractional_max_pool2d_out_cuda_frame",
     [&] {
       auto devInput = input_.packed_accessor<scalar_t, 4>();
@@ -267,7 +267,7 @@ void fractional_max_pool2d_backward_out_cuda_template(
   dim3 block(outputPlaneSize > 128 ? 128 : outputPlaneSize);
 
   auto devIndices = indices.packed_accessor<int64_t, 4>();
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(gradOutput.type(),
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(gradOutput.scalar_type(),
     "fractional_max_pool2d_backward_out_cuda_frame",
     [&] {
       auto devGradInput = gradInput_.packed_accessor<scalar_t, 4>();

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -231,7 +231,7 @@ void fractional_max_pool3d_out_cuda_template(
     dim3 block(outputPlaneSize > 128 ? 128 : outputPlaneSize);
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(),
+      input.scalar_type(),
       "fractional_max_pool3d_out_frame",
       [&]{
         fractional_max_pool3d_out_frame<scalar_t>
@@ -321,7 +321,7 @@ void fractional_max_pool3d_backward_out_cuda_template(
     dim3 block(outputPlaneSize > 128 ? 128 : outputPlaneSize);
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      gradOutput.type(),
+      gradOutput.scalar_type(),
       "fractional_max_pool3d_backward_out_frame",
       [&] {
         fractional_max_pool3d_backward_out_frame<scalar_t>

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -791,7 +791,7 @@ Tensor grid_sampler_2d_cuda(const Tensor& input, const Tensor& grid,
   auto output = at::empty({N, input.size(1), H, W}, input.options());
   int count = static_cast<int>(N * H * W);
   if (count > 0) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_cuda", [&] {
       grid_sampler_2d_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
           count,
@@ -815,7 +815,7 @@ Tensor grid_sampler_3d_cuda(const Tensor& input, const Tensor& grid,
   auto output = at::empty({N, input.size(1), D, H, W}, input.options());
   int count = static_cast<int>(N * D * H * W);
   if (count > 0) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_cuda", [&] {
       grid_sampler_3d_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
           count,
@@ -840,7 +840,7 @@ grid_sampler_2d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto grad_grid = at::empty_like(grid);
   int count = static_cast<int>(N * H * W);
   if (count > 0) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_2d_backward_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_2d_backward_cuda", [&] {
       grid_sampler_2d_backward_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
           count,
@@ -868,7 +868,7 @@ grid_sampler_3d_backward_cuda(const Tensor& grad_output, const Tensor& input, co
   auto grad_grid = at::empty_like(grid);
   int count = static_cast<int>(N * D * H * W);
   if (count > 0) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "grid_sampler_3d_backward_cuda", [&] {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "grid_sampler_3d_backward_cuda", [&] {
       grid_sampler_3d_backward_kernel<scalar_t>
         <<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
           count,

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -81,7 +81,7 @@ void index_put_kernel_impl(TensorIterator& iter, IntArrayRef index_size, IntArra
 }
 
 static void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.type(), "index", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.dtype(), "index", [&] {
     using dtype = OpaqueType<sizeof(scalar_t)>;
     index_kernel_impl<dtype>(iter, index_size, index_stride);
   });
@@ -90,7 +90,7 @@ static void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayR
 
 static void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride, bool accumulate) {
   AT_ASSERTM(!accumulate, "index_put does not support accumulate=true");
-  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.type(), "index_put", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(iter.dtype(), "index_put", [&] {
     using dtype = OpaqueType<sizeof(scalar_t)>;
     index_put_kernel_impl<dtype>(iter, index_size, index_stride);
   });

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -28,7 +28,7 @@ namespace at { namespace native {
 Tensor kl_div_backward_cuda(const Tensor& grad, const Tensor& input, const Tensor& target, int64_t reduction) {
   auto grad_input = at::zeros_like(input);
   Tensor grad_expand = grad.expand_as(input);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "kl_div_backward", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "kl_div_backward", [&]() {
     kl_div_backward_kernel<scalar_t>(grad_input, target, grad_expand);
   });
   if (reduction == Reduction::Mean) {

--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -631,8 +631,8 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
 
 std::tuple<Tensor, Tensor> ctc_loss_gpu(const Tensor& log_probs, const Tensor& targets, IntArrayRef input_lengths, IntArrayRef target_lengths, int64_t BLANK, bool zero_infinity) {
   (void)zero_infinity; // only used for backward
-  return AT_DISPATCH_FLOATING_TYPES(log_probs.type(), "ctc_loss", [&] {
-      if (targets.type().scalarType() == kLong) {
+  return AT_DISPATCH_FLOATING_TYPES(log_probs.scalar_type(), "ctc_loss", [&] {
+      if (targets.scalar_type() == kLong) {
 	return ctc_loss_gpu_template<scalar_t, kLong>(log_probs, targets, input_lengths, target_lengths, BLANK);
       } else {
 	return ctc_loss_gpu_template<scalar_t, kInt>(log_probs, targets, input_lengths, target_lengths, BLANK);
@@ -642,8 +642,8 @@ std::tuple<Tensor, Tensor> ctc_loss_gpu(const Tensor& log_probs, const Tensor& t
 
 Tensor ctc_loss_backward_gpu(const Tensor& grad, const Tensor& log_probs, const Tensor& targets, IntArrayRef input_lengths, IntArrayRef target_lengths,
                              const Tensor& neg_log_likelihood, const Tensor& log_alpha, int64_t BLANK, bool zero_infinity) {
-  return AT_DISPATCH_FLOATING_TYPES(log_probs.type(), "ctc_loss_backward", [&] {
-      if (targets.type().scalarType() == kLong) {
+  return AT_DISPATCH_FLOATING_TYPES(log_probs.scalar_type(), "ctc_loss_backward", [&] {
+      if (targets.scalar_type() == kLong) {
 	return ctc_loss_backward_gpu_template<scalar_t, kLong>(grad, log_probs, targets, input_lengths, target_lengths, neg_log_likelihood, log_alpha, BLANK, zero_infinity);
       } else {
 	return ctc_loss_backward_gpu_template<scalar_t, kInt>(grad, log_probs, targets, input_lengths, target_lengths, neg_log_likelihood, log_alpha, BLANK, zero_infinity);

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -4,7 +4,7 @@ namespace at { namespace native {
 
 std::tuple<Tensor, Tensor, Tensor> batch_norm_cuda(const Tensor& self, const Tensor& weight, const Tensor& bias,
                                                    const Tensor& running_mean, const Tensor& running_var, bool train, double momentum, double epsilon) {
-  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "batch_norm", [&] {
+  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "batch_norm", [&] {
       if (cuda::detail::canUse32BitIndexMath(self)) {
         return batch_norm_cuda_template<scalar_t, int32_t>(self, weight, bias, running_mean, running_var, train, momentum, epsilon);
       } else {
@@ -15,7 +15,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cuda(const Tensor& self, const Ten
 
 std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cuda(const Tensor& grad_out, const Tensor& self, const Tensor& weight, const Tensor& running_mean, const Tensor& running_var,
                                                             const Tensor& save_mean, const Tensor& save_invstd, bool train, double epsilon, std::array<bool,3> grad_input_mask) {
-  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "batch_norm_backward", [&] {
+  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "batch_norm_backward", [&] {
       if (cuda::detail::canUse32BitIndexMath(self)) {
         return batch_norm_backward_cuda_template<scalar_t, int32_t>(grad_out, self, weight, running_mean, running_var, save_mean, save_invstd, train, epsilon, grad_input_mask);
       } else {
@@ -26,7 +26,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cuda(const Tensor& grad_o
 
 std::tuple<Tensor, Tensor> batch_norm_update_stats_cuda(
         const Tensor& self, const Tensor& running_mean, const Tensor& running_var, double momentum) {
-  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.type(), "batch_norm_backward", [&] {
+  return AT_DISPATCH_FLOATING_TYPES_AND_HALF(self.scalar_type(), "batch_norm_backward", [&] {
       auto mean_st = running_mean.dtype();
       auto var_st = running_var.dtype();
       AT_CHECK(mean_st == var_st, "running_mean and running_var need to have the same data types");

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -414,7 +414,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cuda_template(const Tensor& input_
   auto features = input_reshaped.size(2);
   auto input = input_reshaped.packed_accessor<scalar_t, 3, RestrictPtrTraits, index_t>();
   auto input_options = input_.options();
-  if (input_.type().scalarType() == at::ScalarType::Half) {
+  if (input_.scalar_type() == at::ScalarType::Half) {
     input_options = input_options.dtype(ScalarType::Float);
   }
   if (train) {
@@ -519,7 +519,7 @@ std::tuple<Tensor, Tensor> batch_norm_update_stats_cuda_template(
   auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
 
   auto input_options = input_.options();
-  if (input_.type().scalarType() == at::ScalarType::Half) {
+  if (input_.scalar_type() == at::ScalarType::Half) {
     input_options = input_options.dtype(ScalarType::Float);
   }
   Tensor save_mean_ = at::empty({n_channels}, input_options);

--- a/aten/src/ATen/native/cuda/RNN.cu
+++ b/aten/src/ATen/native/cuda/RNN.cu
@@ -501,7 +501,7 @@ std::tuple<Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_cuda(
   auto workspace = at::empty_like(input_gates);
   auto hy = at::empty_like(cx);
   auto cy = at::empty_like(cx);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_gates.type(), "_thnn_fused_lstm_cell_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_gates.scalar_type(), "_thnn_fused_lstm_cell_cuda", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       lstm_forward_impl<scalar_t, int32_t>(input_gates, hidden_gates, input_bias, hidden_bias, cx, hy, cy, workspace);
     } else {
@@ -540,7 +540,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_lstm_cell_backwar
 
   auto grad_gates = at::empty_like(workspace);
   auto grad_cx = at::empty_like(cx);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(workspace.type(), "_thnn_fused_lstm_cell_cuda_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(workspace.scalar_type(), "_thnn_fused_lstm_cell_cuda_backward", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       lstm_backward_impl<scalar_t, int32_t>(grad_hy, grad_cy, cx, cy, workspace, grad_gates, grad_cx);
     } else {
@@ -565,7 +565,7 @@ std::tuple<Tensor, Tensor> _thnn_fused_gru_cell_cuda(
 
   auto workspace = at::empty({hx.size(0), hx.size(1) * GRU_WORKSPACE_MULTIPLIER}, hx.options());
   auto hy = at::empty_like(hx);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_gates.type(), "_thnn_fused_gru_cell_cuda", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input_gates.scalar_type(), "_thnn_fused_gru_cell_cuda", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       gru_forward_impl<scalar_t, int32_t>(input_gates, hidden_gates, input_bias, hidden_bias, hx, hy, workspace);
     } else {
@@ -589,7 +589,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_fused_gru_cell_backward
   auto grad_input_gates = at::empty({workspace.size(0), hidden_size * 3}, workspace.options());
   auto grad_hidden_gates = at::empty({workspace.size(0), hidden_size * 3}, workspace.options());
   auto grad_hx = at::empty_like(grad_hy);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_hy.type(), "_thnn_fused_gru_cell_cuda_backward", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_hy.scalar_type(), "_thnn_fused_gru_cell_cuda_backward", [&] {
     if (canUse32BitIndexMath(workspace)) { // See Note [64-bit index math check elision]
       gru_backward_impl<scalar_t, int32_t>(grad_hy, workspace, grad_input_gates, grad_hidden_gates, grad_hx);
     } else {

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -51,7 +51,7 @@ Tensor& linspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   } else if (steps == 1) {
     r.fill_(start);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.type(), "linspace", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "linspace", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
@@ -81,7 +81,7 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
   } else if (steps == 1) {
     r.fill_(std::pow(10.0, start.to<double>()));
   } else {
-    AT_DISPATCH_FLOATING_TYPES(r.type(), "logspace", [&]() {
+    AT_DISPATCH_FLOATING_TYPES(r.scalar_type(), "logspace", [&]() {
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();
       scalar_t step = (scalar_end - scalar_start) / static_cast<scalar_t>(steps - 1);
@@ -99,7 +99,7 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, int64_t step
 }
 
 Tensor& range_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(result.type(), "range", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(result.scalar_type(), "range", [&]() {
     using accscalar_t = at::acc_type<scalar_t, true>;
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();
@@ -130,7 +130,7 @@ Tensor& range_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
 }
 
 Tensor& arange_cuda_out(Tensor& result, Scalar start, Scalar end, Scalar step) {
-  AT_DISPATCH_ALL_TYPES_AND_HALF(result.type(), "arange", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(result.scalar_type(), "arange", [&]() {
     using accscalar_t = at::acc_type<scalar_t, true>;
     auto xstart = start.to<accscalar_t>();
     auto xend = end.to<accscalar_t>();

--- a/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
@@ -41,7 +41,7 @@ void prod_kernel_impl(TensorIterator& iter) {
 }
 
 static void std_var_kernel_cuda(TensorIterator& iter, bool unbiased, bool take_sqrt) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.type(), "std", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "std", [&]() {
     std_var_kernel_impl<scalar_t>(iter, unbiased, take_sqrt);
   });
 }
@@ -77,46 +77,46 @@ void norm_kernel_cuda_impl(TensorIterator& iter, Scalar val) {
 }
 
 static void sum_kernel_cuda(TensorIterator& iter) {
-  if (iter.type().scalarType() == kHalf) {
+  if (iter.dtype() == kHalf) {
     return sum_kernel_impl<at::Half, float>(iter);
-  } else if (iter.type(1).scalarType() == kHalf && iter.type().scalarType() == kFloat) {
+  } else if (iter.dtype(1) == kHalf && iter.dtype() == kFloat) {
     // type promotion that does cast and reduction in a single kernel
     return sum_kernel_impl<at::Half, float, float>(iter);
   }
-  AT_DISPATCH_ALL_TYPES(iter.type(), "sum", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "sum", [&]() {
     sum_kernel_impl<scalar_t>(iter);
   });
 }
 
 static void prod_kernel_cuda(TensorIterator& iter) {
-  if (iter.type().scalarType() == kHalf) {
+  if (iter.dtype() == kHalf) {
     return prod_kernel_impl<at::Half, float>(iter);
   }
-  AT_DISPATCH_ALL_TYPES(iter.type(), "prod", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "prod", [&]() {
     prod_kernel_impl<scalar_t>(iter);
   });
 }
 
 static void mean_kernel_cuda(TensorIterator& iter) {
-  if (iter.type().scalarType() == kHalf) {
+  if (iter.dtype() == kHalf) {
     return mean_kernel_impl<at::Half, float>(iter);
-  } else if (iter.type(1).scalarType() == kHalf && iter.type().scalarType() == kFloat) {
+  } else if (iter.dtype(1) == kHalf && iter.dtype() == kFloat) {
     // type promotion that does cast and reduction in a single kernel
     return mean_kernel_impl<at::Half, float, float>(iter);
   }
-  AT_DISPATCH_ALL_TYPES(iter.type(), "mean", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "mean", [&]() {
     mean_kernel_impl<scalar_t>(iter);
   });
 }
 
 static void norm_kernel_cuda(TensorIterator& iter, Scalar p) {
-  if (iter.type().scalarType() == kHalf) {
+  if (iter.dtype() == kHalf) {
     return norm_kernel_cuda_impl<at::Half, float>(iter, p);
-  } else if (iter.type(1).scalarType() == kHalf && iter.type().scalarType() == kFloat) {
+  } else if (iter.dtype(1) == kHalf && iter.dtype() == kFloat) {
     // type promotion that does cast and reduction in a single kernel
     return norm_kernel_cuda_impl<at::Half, float, float>(iter, p);
   }
-  AT_DISPATCH_FLOATING_TYPES(iter.type(), "norm", [&]() {
+  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "norm", [&]() {
     norm_kernel_cuda_impl<scalar_t>(iter, p);
   });
 }
@@ -152,13 +152,13 @@ void min_values_kernel_cuda_impl(TensorIterator& iter) {
 }
 
 void max_values_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "max_values", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "max_values", [&]() {
     max_values_kernel_cuda_impl<scalar_t>(iter);
   });
 }
 
 void min_values_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.type(), "min_values", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "min_values", [&]() {
     min_values_kernel_cuda_impl<scalar_t>(iter);
   });
 }

--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -191,7 +191,7 @@ void reflection_pad1d_out_template(
   Tensor input = input_.contiguous();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    input.type(), "reflection_pad1d_out_template", [&] {
+    input.scalar_type(), "reflection_pad1d_out_template", [&] {
       reflection_pad1d_out_kernel<<<
         grid_size, block_size, 0, at::cuda::getCurrentCUDAStream()>>>(
           input.data<scalar_t>(), output.data<scalar_t>(),
@@ -239,7 +239,7 @@ void reflection_pad1d_backward_out_template(
   dim3 grid_size((int) ::ceil(output_w / 256.0), nplane, nbatch);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    grad_input.type(), "reflection_pad1d_backward_out_template", [&] {
+    grad_input.scalar_type(), "reflection_pad1d_backward_out_template", [&] {
       reflection_pad1d_backward_out_kernel<<<
         grid_size, block_size, 0, at::cuda::getCurrentCUDAStream()>>>(
           grad_input.data<scalar_t>(), grad_output.data<scalar_t>(),
@@ -311,7 +311,7 @@ void reflection_pad2d_out_template(
     (int) std::ceil(output_plane_size/256.0), nplane, nbatch);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    input.type(), "reflection_pad2d_out_template", [&] {
+    input.scalar_type(), "reflection_pad2d_out_template", [&] {
       reflection_pad2d_out_kernel<<<
         grid_size, block_size, 0, at::cuda::getCurrentCUDAStream()>>>(
           input.data<scalar_t>(), output.data<scalar_t>(),
@@ -368,7 +368,7 @@ void reflection_pad2d_backward_out_template(
     (int) std::ceil(output_plane_size/256.0), nplane, nbatch);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    input.type(), "reflection_pad2d_backward_out_template", [&] {
+    input.scalar_type(), "reflection_pad2d_backward_out_template", [&] {
       reflection_pad2d_backward_out_kernel<<<
         grid_size, block_size, 0, at::cuda::getCurrentCUDAStream()>>>(
           grad_input.data<scalar_t>(), grad_output.data<scalar_t>(),

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -235,7 +235,7 @@ void replication_pad1d_out_cuda_template(
 
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(), "replication_pad1d", [&] {
+      input.scalar_type(), "replication_pad1d", [&] {
 
 
       if (numInputDims == 2) {
@@ -306,7 +306,7 @@ void replication_pad1d_backward_out_cuda_template(
   gradInput.zero_();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(), "replication_pad1d_backward", [&] {
+      input.scalar_type(), "replication_pad1d_backward", [&] {
 
       auto gradInput_ = gradInput;
       auto gradOutput_ = gradOutput;
@@ -372,7 +372,7 @@ void replication_pad2d_out_cuda_template(
       " Calculated output H: ", outputH, " W: ", outputW);
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(), "replication_pad2d", [&] {
+      input.scalar_type(), "replication_pad2d", [&] {
 
 
       if (numInputDims == 3) {
@@ -403,7 +403,7 @@ void replication_pad2d_out_cuda_template(
         dim3 blockSize(outputPlaneSize > 256 ? 256 : outputPlaneSize);
 
         replication_pad_forward_kernel2d <<<gridSize, blockSize, 0,
-                                       at::cuda::getCurrentCUDAStream()>>>(devInput, devOutput, 
+                                       at::cuda::getCurrentCUDAStream()>>>(devInput, devOutput,
                                            padT, padB, padL, padR);
       }
       }
@@ -427,7 +427,7 @@ void replication_pad2d_backward_out_cuda_template(
   int padL = paddingSize[0];
   int padR = paddingSize[1];
   int padT = paddingSize[2];
-  int padB = paddingSize[3]; 
+  int padB = paddingSize[3];
   int planeDim = 0;
   int dimh = 1;
   int dimw = 2;
@@ -454,7 +454,7 @@ void replication_pad2d_backward_out_cuda_template(
   gradInput.zero_();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(), "replication_pad2d_backward", [&] {
+      input.scalar_type(), "replication_pad2d_backward", [&] {
 
         auto gradInput_ = gradInput;
         auto gradOutput_ = gradOutput;
@@ -483,7 +483,7 @@ static inline void shapeCheck3d(
     int pleft, int pright,
     int ptop, int pbottom,
     int pfront, int pback) {
-  AT_CHECK(at::cuda::detail::canUse32BitIndexMath(input), 
+  AT_CHECK(at::cuda::detail::canUse32BitIndexMath(input),
       "input tensor must fit into 32-bit index math");
   int numInputDims = input.dim();
 
@@ -521,7 +521,7 @@ static inline void shapeAndGradOutputCheck3d(
     int pleft, int pright,
     int ptop, int pbottom,
     int pfront, int pback) {
-  AT_CHECK(at::cuda::detail::canUse32BitIndexMath(input), 
+  AT_CHECK(at::cuda::detail::canUse32BitIndexMath(input),
       "input tensor must fit into 32-bit index math");
   int numInputDims = input.dim();
 
@@ -579,7 +579,7 @@ void replication_pad3d_out_cuda_template(
   int ptop = paddingSize[2];
   int pbottom = paddingSize[3];
   int pfront = paddingSize[4];
-  int pback = paddingSize[5]; 
+  int pback = paddingSize[5];
   shapeCheck3d(input, pleft, pright, ptop,
       pbottom, pfront, pback);
 
@@ -608,7 +608,7 @@ void replication_pad3d_out_cuda_template(
   int outputW  = inputW + pleft + pright;
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(), "replication_pad3d", [&] {
+      input.scalar_type(), "replication_pad3d", [&] {
 
       if (numInputDims == 4) {
         output.resize_({numPlanes, outputD, outputH, outputW});
@@ -660,7 +660,7 @@ void replication_pad3d_backward_out_cuda_template(
   int ptop = paddingSize[2];
   int pbottom = paddingSize[3];
   int pfront = paddingSize[4];
-  int pback = paddingSize[5]; 
+  int pback = paddingSize[5];
   shapeAndGradOutputCheck3d(input, gradOutput, pleft, pright, ptop,
       pbottom, pfront, pback);
 
@@ -681,7 +681,7 @@ void replication_pad3d_backward_out_cuda_template(
   gradInput.zero_();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      input.type(), "replication_pad3d_backward", [&] {
+      input.scalar_type(), "replication_pad3d_backward", [&] {
 
       auto gradInput_ = gradInput;
       auto gradOutput_ = gradOutput;

--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -114,7 +114,7 @@ static void _fft_fill_with_conjugate_symmetry_(Tensor& input,
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
   auto policy = thrust::cuda::par(allocator).on(stream);
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "_fft_fill_with_conjugate_symmetry_", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "_fft_fill_with_conjugate_symmetry_", [&] {
     typedef thrust::device_ptr<scalar_t> device_ptr;
     typedef thrust::counting_iterator<int64_t> counter;
     typedef thrust::transform_iterator<cnt_to_dst_idx_functor, counter> dst_idx_iterator;
@@ -194,7 +194,7 @@ static inline Tensor _run_cufft(
 
   // run
 #ifdef __HIP_PLATFORM_HCC__
-  if (input.type().scalarType() == ScalarType::Float) {
+  if (input.scalar_type() == ScalarType::Float) {
       if (complex_input && complex_output) {
         CUFFT_CHECK(hipfftExecC2C(plan, static_cast<hipfftComplex*>(input.data_ptr()),
           static_cast<hipfftComplex*>(output.data_ptr()),
@@ -208,7 +208,7 @@ static inline Tensor _run_cufft(
       } else {
         AT_ERROR("hipFFT doesn't support r2r (float)");
       }
-    } else if (input.type().scalarType() == ScalarType::Double) {
+    } else if (input.scalar_type() == ScalarType::Double) {
       if (complex_input && complex_output) {
         CUFFT_CHECK(hipfftExecZ2Z(plan, static_cast<hipfftDoubleComplex*>(input.data_ptr()),
           static_cast<hipfftDoubleComplex*>(output.data_ptr()),
@@ -225,7 +225,7 @@ static inline Tensor _run_cufft(
     } else {
       std::ostringstream ss;
       ss << "hipFFT doesn't support tensor of type: "
-         << toString(input.type().scalarType());
+         << toString(input.scalar_type());
       AT_ERROR(ss.str());
     }
 #else

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -330,8 +330,8 @@ Tensor _bincount_cuda(
     const Tensor& self,
     const Tensor& weights,
     int64_t minlength) {
-  return AT_DISPATCH_INTEGRAL_TYPES(self.type(), "bincount", [&] {
-    const auto scalar = weights.type().scalarType();
+  return AT_DISPATCH_INTEGRAL_TYPES(self.scalar_type(), "bincount", [&] {
+    const auto scalar = weights.scalar_type();
     if (scalar == ScalarType::Undefined || scalar == ScalarType::Float)
       return _bincount_cuda_template<scalar_t, float>(self, weights, minlength);
     return _bincount_cuda_template<scalar_t, double>(
@@ -344,10 +344,10 @@ Tensor _histc_cuda(
     int64_t nbins,
     Scalar min,
     Scalar max) {
-  if (self.type().scalarType() == ScalarType::Half) {
+  if (self.scalar_type() == ScalarType::Half) {
     AT_ERROR("HalfTensor is not supported");
   }
-  return AT_DISPATCH_ALL_TYPES(self.type(), "histc", [&] {
+  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "histc", [&] {
     return _histc_cuda_template<scalar_t>(self, nbins, min.to<scalar_t>(), max.to<scalar_t>());
   });
 }

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -33,7 +33,7 @@ Tensor _s_where_cuda(
     const Tensor& self,
     const Tensor& other) {
   Tensor ret = at::empty(self.sizes(), self.options());
-  AT_DISPATCH_ALL_TYPES_AND_HALF(ret.type(), "where", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(ret.scalar_type(), "where", [&] {
     where_cuda<scalar_t>(ret, condition, self, other);
   });
   return ret;

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -79,7 +79,7 @@ Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
 
   result.resize_({n});
 
-  if (result.type().scalarType() == at::ScalarType::Half) {
+  if (result.scalar_type() == at::ScalarType::Half) {
     auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
     result.copy_(randperm_out_cuda(result_float, n, generator));
   } else {
@@ -90,7 +90,7 @@ Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
     } else {
       // Generate random values for the keys array
       AT_DISPATCH_ALL_TYPES(
-        result.type(), "randperm_out_cuda", [&] {
+        result.scalar_type(), "randperm_out_cuda", [&] {
           auto keys = at::empty(result.sizes(), result.options()).random_(generator);
 
           auto result_data = thrust::device_ptr<scalar_t>(result.data<scalar_t>());
@@ -322,7 +322,7 @@ Tensor tril_indices_cuda(
       cuda::getApplyGrid(tril_size, dim_grid, tensor.get_device()),
       "unable to get dim grid");
 
-    AT_DISPATCH_ALL_TYPES_AND_HALF(tensor.type(), "tril_indices_cuda", [&] {
+    AT_DISPATCH_ALL_TYPES_AND_HALF(tensor.scalar_type(), "tril_indices_cuda", [&] {
       tril_indices_kernel<<<
           dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
         tensor.data<scalar_t>(),
@@ -398,7 +398,7 @@ Tensor triu_indices_cuda(
       cuda::getApplyGrid(triu_size, dim_grid, tensor.get_device()),
       "unable to get dim grid");
 
-    AT_DISPATCH_ALL_TYPES_AND_HALF(tensor.type(), "triu_indices_cuda", [&] {
+    AT_DISPATCH_ALL_TYPES_AND_HALF(tensor.scalar_type(), "triu_indices_cuda", [&] {
       triu_indices_kernel<<<
           dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
         tensor.data<scalar_t>(),

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -87,7 +87,7 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
 
   // use kernel_pointwise_flip_apply2 only when to-flip dim is the 1st or last dim, where collapseDims can reduce the amount of work
   if (flip_dims_size == 1 && in_tensor.is_contiguous() && (flip_dims[0] == 0 || flip_dims[0] == total_dims - 1)) {
-    AT_DISPATCH_ALL_TYPES_AND_HALF(in_tensor.type(), "flip_cuda", [&] {
+    AT_DISPATCH_ALL_TYPES_AND_HALF(in_tensor.scalar_type(), "flip_cuda", [&] {
       auto in_tensor_info = cuda::detail::getTensorInfo<scalar_t, int64_t>(in_tensor);
       auto out_tensor_info = cuda::detail::getTensorInfo<scalar_t, int64_t>(out_tensor);
       int flip_dim = in_tensor_info.collapseDims(flip_dims[0]);
@@ -119,7 +119,7 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
     }
   }
 
-  AT_DISPATCH_ALL_TYPES_AND_HALF(in_tensor.type(), "flip_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(in_tensor.scalar_type(), "flip_cuda", [&] {
     flip_cuda_kernel<<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
       in_tensor.data<scalar_t>(), out_tensor.data<scalar_t>(), N, flip_dims_t.toType(CUDA(kLong)).data<int64_t>(), flip_dims_size,
       strides_t.toType(CUDA(kLong)).data<int64_t>(), stride_contiguous.toType(CUDA(kLong)).data<int64_t>(), shape_t.toType(CUDA(kLong)).data<int64_t>(), total_dims);
@@ -177,7 +177,7 @@ Tensor roll_cuda(const Tensor& self, IntArrayRef shifts, IntArrayRef dims) {
 
   auto total_dims = in_tensor.dim();
 
-  AT_DISPATCH_ALL_TYPES_AND_HALF(in_tensor.type(), "roll_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND_HALF(in_tensor.scalar_type(), "roll_cuda", [&] {
     roll_cuda_kernel<<<dim_grid, dim_block, 0, at::cuda::getCurrentCUDAStream()>>>(
       in_tensor.data<scalar_t>(), out_tensor.data<scalar_t>(), N,
       dim, start,

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -146,7 +146,7 @@ template <typename scalar_t>
 
 std::tuple<Tensor, Tensor>
 _unique_cuda(const Tensor& self, const bool sorted, const bool return_inverse) {
-  return AT_DISPATCH_ALL_TYPES(self.type(), "unique", [&] {
+  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "unique", [&] {
     // The current CUDA implementation of unique always sort due to the
     // lack of hashtable implementation in thrust
     return _unique_cuda_template<scalar_t>(self, return_inverse);
@@ -155,7 +155,7 @@ _unique_cuda(const Tensor& self, const bool sorted, const bool return_inverse) {
 
 std::tuple<Tensor, Tensor>
 _unique_dim_cuda(const Tensor& self, const int64_t dim, const bool sorted, const bool return_inverse) {
-  return AT_DISPATCH_ALL_TYPES(self.type(), "unique_dim", [&] {
+  return AT_DISPATCH_ALL_TYPES(self.scalar_type(), "unique_dim", [&] {
     return _unique_dim_cuda_template<scalar_t>(self, dim, return_inverse);
   });
 }

--- a/aten/src/ATen/native/cuda/WeightNorm.cu
+++ b/aten/src/ATen/native/cuda/WeightNorm.cu
@@ -7,7 +7,7 @@
 #include <THC/THCDeviceUtils.cuh>
 #include <THC/THCTensorMathReduce.cuh>
 
-namespace at { 
+namespace at {
 namespace native {
 namespace {
 
@@ -15,15 +15,15 @@ namespace {
 // Currently, kernels are non-persistent.
 // Dialing up the block size to, say 1024, can improve performance by
 // increase the amount of cache available per block, which can improve cache hit rate.
-// However, this is less efficient for short rows.  256 is pretty versatile. 
+// However, this is less efficient for short rows.  256 is pretty versatile.
 // May be worth implementing heuristics later.
 #define BLOCK 256
 
 // Block size for weight_norm_*_last_dim_kernel.
-// This is tricker than the first_dim case because we must make blocks 
+// This is tricker than the first_dim case because we must make blocks
 // at least 16 fast elements wide to ensure fully-coalesced half-precision accesses.
-// Since output-element parallelism is along the fast dimension, this reduces the number of 
-// blocks we can launch by 16X.  
+// Since output-element parallelism is along the fast dimension, this reduces the number of
+// blocks we can launch by 16X.
 #define TILE_W 16
 // Somewhat versatile strategy: max out intra-block parallelism by extending
 // blocks across the slow dimension up to the hardware-max block size of 1024.
@@ -31,11 +31,11 @@ namespace {
 
 template<typename T, typename ReduceOp>
 __device__ __forceinline__ void reduce_block_into_lanes
-  (T *x, 
-   T val, 
+  (T *x,
+   T val,
    int lanes, // lanes is intended to be <= 32.
-   ReduceOp reduceOp) 
-{ 
+   ReduceOp reduceOp)
+{
   int tid = threadIdx.x + threadIdx.y*blockDim.x;
   int blockSize = blockDim.x*blockDim.y; // blockSize is intended to be a multiple of 32.
 
@@ -44,16 +44,16 @@ __device__ __forceinline__ void reduce_block_into_lanes
     x[tid] = val;
     __syncthreads();
   }
-  
+
   #pragma unroll
-  for(int i = (blockSize >> 1); i >= 64; i >>= 1) 
+  for(int i = (blockSize >> 1); i >= 64; i >>= 1)
   {
     if(tid < i)
       x[tid] = reduceOp(x[tid], x[tid+i]);
     __syncthreads();
   }
 
-  if(tid < 32) 
+  if(tid < 32)
   {
     T final;
     if(blockSize >= 64)
@@ -66,7 +66,7 @@ __device__ __forceinline__ void reduce_block_into_lanes
     for(int i = 16; i >= lanes; i >>= 1)
       final = reduceOp(final, WARP_SHFL_DOWN(final, i));
 
-    if(tid < lanes) 
+    if(tid < lanes)
       x[tid] = final; // EpilogueOp
   }
 
@@ -75,14 +75,14 @@ __device__ __forceinline__ void reduce_block_into_lanes
 }
 
 template
-  <typename scalar_t, 
+  <typename scalar_t,
    typename accscalar_t>
 __global__ void weight_norm_fwd_first_dim_kernel
   (scalar_t* __restrict__ w,
    accscalar_t* __restrict__ norms,
    const scalar_t* __restrict__ v,
    const scalar_t* __restrict__ g,
-   const int rowSize) 
+   const int rowSize)
 {
   // We are norming each slowest-dim row of the tensor separately.
   // For now, assign one block to each row.
@@ -98,11 +98,11 @@ __global__ void weight_norm_fwd_first_dim_kernel
   // extern __shared__ accscalar_t s[]; // error: declaration is incompatible with previous "s"
   extern __shared__ char buf[];
   accscalar_t* s = (accscalar_t*)buf;
-  
+
   accscalar_t thread_sum = 0.f;
-  for(int i = tid; i < rowSize; i += stride ) 
+  for(int i = tid; i < rowSize; i += stride )
   {
-    accscalar_t val_f = scalar_cast<accscalar_t>(v[i+rowStart]); 
+    accscalar_t val_f = scalar_cast<accscalar_t>(v[i+rowStart]);
     thread_sum += val_f*val_f; // AccumOp, could do Kahan here
   }
 
@@ -110,7 +110,7 @@ __global__ void weight_norm_fwd_first_dim_kernel
   accscalar_t result = s[0];
 
   result = sqrtf(result);
-  
+
   if(tid == 0)
     norms[row] = result;
 
@@ -120,7 +120,7 @@ __global__ void weight_norm_fwd_first_dim_kernel
   accscalar_t rnorm = 1.f/result; // for consistency with backward kernel
 
   // Write data to output
-  for(int i = tid; i < rowSize; i += stride ) 
+  for(int i = tid; i < rowSize; i += stride )
   {
     accscalar_t val_f = scalar_cast<accscalar_t>(v[i+rowStart]);
     w[i+rowStart] = scalar_cast<scalar_t>(g_this_row*val_f*rnorm);
@@ -128,7 +128,7 @@ __global__ void weight_norm_fwd_first_dim_kernel
 }
 
 template
-  <typename scalar_t, 
+  <typename scalar_t,
    typename accscalar_t>
 __global__ void weight_norm_fwd_last_dim_kernel
 (
@@ -154,13 +154,13 @@ __global__ void weight_norm_fwd_last_dim_kernel
   if(fast_dim_location < fast_dim_size)
     while(slower_dims_location < slower_dims_size)
     {
-      accscalar_t val_f = scalar_cast<accscalar_t>(v[currentIdx]); 
+      accscalar_t val_f = scalar_cast<accscalar_t>(v[currentIdx]);
       thread_sum += val_f*val_f; // AccumOp, could do Kahan here
       currentIdx += blockDim.y*fast_dim_size;
-      slower_dims_location += blockDim.y; 
+      slower_dims_location += blockDim.y;
     }
 
-  reduce_block_into_lanes(s, thread_sum, blockDim.x, ReduceAdd<accscalar_t>()); 
+  reduce_block_into_lanes(s, thread_sum, blockDim.x, ReduceAdd<accscalar_t>());
 
   // Better to pass an EpilogueOp to reduce_block_into_lanes?
   if(threadIdx.y == 0)
@@ -170,26 +170,26 @@ __global__ void weight_norm_fwd_last_dim_kernel
     norms[fast_dim_location] = norm_this_col;
     rnorms_this_block[threadIdx.x] = 1.f/norm_this_col;
   }
-   
-  __syncthreads(); 
 
-  accscalar_t g_this_col = scalar_cast<accscalar_t>(g[fast_dim_location]);     
-  accscalar_t rnorm = rnorms_this_block[threadIdx.x]; 
+  __syncthreads();
+
+  accscalar_t g_this_col = scalar_cast<accscalar_t>(g[fast_dim_location]);
+  accscalar_t rnorm = rnorms_this_block[threadIdx.x];
 
   slower_dims_location = threadIdx.y;
   currentIdx = fast_dim_location + fast_dim_size*slower_dims_location;
   if(fast_dim_location < fast_dim_size)
     while(slower_dims_location < slower_dims_size)
     {
-      accscalar_t val_f = scalar_cast<accscalar_t>(v[currentIdx]); 
+      accscalar_t val_f = scalar_cast<accscalar_t>(v[currentIdx]);
       w[currentIdx] = scalar_cast<scalar_t>(g_this_col*val_f*rnorm);
       currentIdx += blockDim.y*fast_dim_size;
-      slower_dims_location += blockDim.y; 
-    } 
+      slower_dims_location += blockDim.y;
+    }
 }
 
 template
-  <typename scalar_t, 
+  <typename scalar_t,
    typename accscalar_t>
 __global__ void weight_norm_bwd_first_dim_kernel
   (scalar_t* __restrict__ grad_v,
@@ -213,12 +213,12 @@ __global__ void weight_norm_bwd_first_dim_kernel
   // extern __shared__ accscalar_t s[]; // error: declaration is incompatible with previous "s"
   extern __shared__ char buf[];
   accscalar_t* s = (accscalar_t*)buf;
-  
+
   accscalar_t thread_sum = 0.f;
-  for(int i = tid; i < rowSize; i += stride ) 
+  for(int i = tid; i < rowSize; i += stride )
   {
-    accscalar_t grad_wi = scalar_cast<accscalar_t>(grad_w[i+rowStart]); 
-    accscalar_t saved_vi = scalar_cast<accscalar_t>(saved_v[i+rowStart]); 
+    accscalar_t grad_wi = scalar_cast<accscalar_t>(grad_w[i+rowStart]);
+    accscalar_t saved_vi = scalar_cast<accscalar_t>(saved_v[i+rowStart]);
     thread_sum += grad_wi*saved_vi; // AccumOp, could do Kahan here
   }
 
@@ -228,7 +228,7 @@ __global__ void weight_norm_bwd_first_dim_kernel
   // Could choose to save reciprocal of norm instead I suppose, but norms is probably
   // more handy to keep around.
   // Broadcast load; could use shared memory instead.
-  accscalar_t rnorm = 1.f/saved_norms[row];  
+  accscalar_t rnorm = 1.f/saved_norms[row];
   accscalar_t rnorm3 = rnorm*rnorm*rnorm;
 
   // Write g gradients.
@@ -237,20 +237,20 @@ __global__ void weight_norm_bwd_first_dim_kernel
 
   // Broadcast load, could use shared memory instead.
   accscalar_t g_this_row = scalar_cast<accscalar_t>(saved_g[row]);
-   
-  // Write v gradients.  We are reusing values that were loaded earlier, so there 
+
+  // Write v gradients.  We are reusing values that were loaded earlier, so there
   // is an optimization opportunity here (store values persistently).
-  for(int j = tid; j < rowSize; j += stride ) 
+  for(int j = tid; j < rowSize; j += stride )
   {
-    accscalar_t grad_wj = scalar_cast<accscalar_t>(grad_w[j+rowStart]);  
-    accscalar_t saved_vj = scalar_cast<accscalar_t>(saved_v[j+rowStart]);  
+    accscalar_t grad_wj = scalar_cast<accscalar_t>(grad_w[j+rowStart]);
+    accscalar_t saved_vj = scalar_cast<accscalar_t>(saved_v[j+rowStart]);
     accscalar_t grad_vj = g_this_row*(rnorm*grad_wj - rnorm3*saved_vj*result);
     grad_v[j+rowStart] = scalar_cast<scalar_t>(grad_vj);
   }
 }
 
-template 
-  <typename scalar_t, 
+template
+  <typename scalar_t,
    typename accscalar_t>
 __global__ void weight_norm_bwd_last_dim_kernel
   (scalar_t* __restrict__ grad_v,
@@ -274,18 +274,18 @@ __global__ void weight_norm_bwd_last_dim_kernel
   if(fast_dim_location < fast_dim_size)
     while(slower_dims_location < slower_dims_size)
     {
-      accscalar_t grad_wi = scalar_cast<accscalar_t>(grad_w[currentIdx]); 
-      accscalar_t saved_vi = scalar_cast<accscalar_t>(saved_v[currentIdx]); 
+      accscalar_t grad_wi = scalar_cast<accscalar_t>(grad_w[currentIdx]);
+      accscalar_t saved_vi = scalar_cast<accscalar_t>(saved_v[currentIdx]);
       thread_sum += grad_wi*saved_vi; // AccumOp, could do Kahan here
       currentIdx += blockDim.y*fast_dim_size;
-      slower_dims_location += blockDim.y; 
+      slower_dims_location += blockDim.y;
     }
 
-  reduce_block_into_lanes(s, thread_sum, blockDim.x, ReduceAdd<accscalar_t>()); 
+  reduce_block_into_lanes(s, thread_sum, blockDim.x, ReduceAdd<accscalar_t>());
   accscalar_t result = s[threadIdx.x];
 
   // Broadcast load; could use shared memory instead.
-  accscalar_t rnorm = 1.f/saved_norms[fast_dim_location];  
+  accscalar_t rnorm = 1.f/saved_norms[fast_dim_location];
   accscalar_t rnorm3 = rnorm*rnorm*rnorm;
 
   // Write g gradients.
@@ -301,13 +301,13 @@ __global__ void weight_norm_bwd_last_dim_kernel
   if(fast_dim_location < fast_dim_size)
     while(slower_dims_location < slower_dims_size)
     {
-      accscalar_t grad_wj = scalar_cast<accscalar_t>(grad_w[currentIdx]);  
-      accscalar_t saved_vj = scalar_cast<accscalar_t>(saved_v[currentIdx]);  
+      accscalar_t grad_wj = scalar_cast<accscalar_t>(grad_w[currentIdx]);
+      accscalar_t saved_vj = scalar_cast<accscalar_t>(saved_v[currentIdx]);
       accscalar_t grad_vj = g_this_col*(rnorm*grad_wj - rnorm3*saved_vj*result);
       grad_v[currentIdx] = scalar_cast<scalar_t>(grad_vj);
       currentIdx += blockDim.y*fast_dim_size;
-      slower_dims_location += blockDim.y; 
-    } 
+      slower_dims_location += blockDim.y;
+    }
 }
 
 } // anonymous namespace
@@ -315,7 +315,7 @@ __global__ void weight_norm_bwd_last_dim_kernel
 std::tuple<Tensor,Tensor> weight_norm_cuda
   (const Tensor & v,
    const Tensor & g,
-   int64_t dim) 
+   int64_t dim)
 {
   auto w = at::empty_like(v);
 
@@ -323,17 +323,17 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
   // sends the unpacked g.data() as the argument.  In other words, we expect "g" is a bare Tensor here.
 
   // norms is only needed to stash for backward.
-  // g.type().scalarType() may be at::ScalarType::Double, Float, or Half.  
+  // g.scalar_type() may be at::ScalarType::Double, Float, or Half.
   // If Half, stash norms as float.
-  at::ScalarType AccType = g.type().scalarType() == at::ScalarType::Half ?
-                           at::ScalarType::Float : g.type().scalarType();
-  // Will this create norms on the same device as g, regardless of what the thread's default 
+  at::ScalarType AccType = g.scalar_type() == at::ScalarType::Half ?
+                           at::ScalarType::Float : g.scalar_type();
+  // Will this create norms on the same device as g, regardless of what the thread's default
   // current device is?  I believe so, because Type::* functions are DeviceGuard()ed.
   auto norms = at::empty_strided(g.sizes(), g.strides(), g.options().dtype(AccType));
 
   const int ndims = v.dim();
 
-  if(dim == 0) 
+  if(dim == 0)
   {
     // Find logical size of each flattened slowest-dim row
     int rowSize = 1;
@@ -343,21 +343,21 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF
-      (v.type(), 
-       "weight_norm_fwd_first_dim_kernel",  
+      (v.scalar_type(),
+       "weight_norm_fwd_first_dim_kernel",
        [&]
        {
          using accscalar_t = acc_type<scalar_t, true>;
 
          weight_norm_fwd_first_dim_kernel<scalar_t, accscalar_t>
-           <<<v.size(0), 
-              BLOCK, 
+           <<<v.size(0),
+              BLOCK,
               BLOCK*sizeof(accscalar_t),
               stream>>>
-           (w.data<scalar_t>(), 
+           (w.data<scalar_t>(),
             norms.data<accscalar_t>(),
-            v.data<scalar_t>(),  
-            g.data<scalar_t>(),  
+            v.data<scalar_t>(),
+            g.data<scalar_t>(),
             rowSize);
        });
   }
@@ -369,16 +369,16 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
       slower_dims_size *= v.size(i);
 
     int fast_dim_size = v.size(ndims-1);
- 
+
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF
-      (v.type(), 
-       "weight_norm_fwd_last_dim_kernel",  
+      (v.scalar_type(),
+       "weight_norm_fwd_last_dim_kernel",
        [&]
        {
          using accscalar_t = acc_type<scalar_t, true>;
-        
+
          weight_norm_fwd_last_dim_kernel<scalar_t, accscalar_t>
            <<<(fast_dim_size+TILE_W-1)/TILE_W,
               dim3(TILE_W,TILE_H),
@@ -395,7 +395,7 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
 
   // The kernel execution is asynchronous, so this will only catch errors on the kernel launch,
   // not the kernel's execution.  Errors in kernel execution aren't guaranteed to be caught
-  // until a later error check on a synchronizing CUDA call.  Unfortunately, without manually 
+  // until a later error check on a synchronizing CUDA call.  Unfortunately, without manually
   // synchronizing here, this is the best we can do.
   THCudaCheck(cudaGetLastError());
 
@@ -403,9 +403,9 @@ std::tuple<Tensor,Tensor> weight_norm_cuda
 }
 
 std::tuple<Tensor, Tensor> weight_norm_cuda_backward
-  (const Tensor & grad_w, 
-   const Tensor & saved_v, 
-   const Tensor & saved_g, 
+  (const Tensor & grad_w,
+   const Tensor & saved_v,
+   const Tensor & saved_g,
    const Tensor & saved_norms,
    int64_t dim)
 {
@@ -421,7 +421,7 @@ std::tuple<Tensor, Tensor> weight_norm_cuda_backward
 
   const int ndims = saved_v.dim();
 
-  if(dim == 0) 
+  if(dim == 0)
   {
     // Find logical size of each flattened slowest-dim row
     int rowSize = 1;
@@ -431,15 +431,15 @@ std::tuple<Tensor, Tensor> weight_norm_cuda_backward
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF
-      (saved_v.type(), 
-       "weight_norm_bwd_first_dim_kernel",  
+      (saved_v.scalar_type(),
+       "weight_norm_bwd_first_dim_kernel",
        [&]
        {
          using accscalar_t = acc_type<scalar_t, true>;
 
 	 weight_norm_bwd_first_dim_kernel<scalar_t, accscalar_t>
-	   <<<grad_w.size(0), 
-	      BLOCK, 
+	   <<<grad_w.size(0),
+	      BLOCK,
 	      BLOCK*sizeof(accscalar_t),
               stream>>>
 	   (grad_v.data<scalar_t>(),
@@ -463,15 +463,15 @@ std::tuple<Tensor, Tensor> weight_norm_cuda_backward
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF
-      (saved_v.type(), 
-       "weight_norm_bwd_last_dim_kernel",  
+      (saved_v.scalar_type(),
+       "weight_norm_bwd_last_dim_kernel",
        [&]
        {
          using accscalar_t = acc_type<scalar_t, true>;
 
          weight_norm_bwd_last_dim_kernel<scalar_t, accscalar_t>
            <<<(fast_dim_size+TILE_W-1)/TILE_W,
-              dim3(TILE_W,TILE_H), 
+              dim3(TILE_W,TILE_H),
               (TILE_W*TILE_H + TILE_W)*sizeof(accscalar_t),
               stream>>>
            (grad_v.data<scalar_t>(),
@@ -487,7 +487,7 @@ std::tuple<Tensor, Tensor> weight_norm_cuda_backward
 
   // The kernel execution is asynchronous, so this will only catch errors on the kernel launch,
   // not the kernel's execution.  Errors in kernel execution aren't guaranteed to be caught
-  // until a later error check on a synchronizing CUDA call.  Unfortunately, without manually 
+  // until a later error check on a synchronizing CUDA call.  Unfortunately, without manually
   // synchronizing here, this is the best we can do.
   THCudaCheck(cudaGetLastError());
 

--- a/aten/src/ATen/native/cudnn/BatchNorm.cpp
+++ b/aten/src/ATen/native/cudnn/BatchNorm.cpp
@@ -67,7 +67,7 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm(
     checkAllDefined(c, {running_mean, running_var});
   }
   checkAllSameGPU(c, {input, weight, bias, running_mean, running_var});
-  if (input->type().scalarType() == ScalarType::Half) {
+  if (input->scalar_type() == ScalarType::Half) {
     checkScalarType(c, weight, ScalarType::Float);
   } else {
     checkAllSameType(c, {input, weight});
@@ -163,7 +163,7 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm_backward(
 
   checkAllDefined(c, {input, grad_output, weight, save_mean, save_var});
   checkAllSameGPU(c, {input, grad_output, weight, save_mean, save_var});
-  if (input->type().scalarType() == ScalarType::Half) {
+  if (input->scalar_type() == ScalarType::Half) {
     checkScalarType(c, weight, ScalarType::Float);
   } else {
     checkAllSameType(c, {input, weight});

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -69,7 +69,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     checkAllDefined(c, {running_mean, running_var});
   }
   checkAllSameGPU(c, {input, weight, bias, running_mean, running_var});
-  if (input->type().scalarType() != ScalarType::Half) {
+  if (input->scalar_type() != ScalarType::Half) {
     checkAllSameType(c, {input, weight});
   }
   checkAllSameType(c, {weight, bias, running_mean, running_var});
@@ -155,7 +155,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
 
   checkAllDefined(c, {input, grad_output, weight, save_mean, save_var});
   checkAllSameGPU(c, {input, grad_output, weight, save_mean, save_var});
-  if (input->type().scalarType() == ScalarType::Half) {
+  if (input->scalar_type() == ScalarType::Half) {
     checkScalarType(c, weight, ScalarType::Float);
   } else {
     checkAllSameType(c, {input, weight});

--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -83,7 +83,7 @@ static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, c
 
 Tensor& _baddbmm_mkl_(Tensor& self, const Tensor& batch1, const Tensor& batch2, Scalar beta, Scalar alpha) {
   // checks are done in native/LinearAlgebra.cpp
-  AT_DISPATCH_FLOATING_TYPES(self.type(), "baddbmm__mkl", [&] {
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "baddbmm__mkl", [&] {
       baddbmm_mkl_template<scalar_t>(self, batch1, batch2, beta, alpha);
     });
 

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -145,7 +145,7 @@ static inline void _fft_fill_with_conjugate_symmetry_(Tensor& input,
     {
       int tid = omp_get_thread_num();
       int64_t start = tid * num_slices_per_thread;
-      AT_DISPATCH_FLOATING_TYPES(input.type(), "_fft_fill_with_conjugate_symmetry", [&] {
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "_fft_fill_with_conjugate_symmetry", [&] {
         _fft_fill_with_conjugate_symmetry_slice<scalar_t>(input, signal_ndim, size_last_dim,
             last_dim_start_slice, start, std::min(num_slices_per_thread, num - start));
       });
@@ -153,7 +153,7 @@ static inline void _fft_fill_with_conjugate_symmetry_(Tensor& input,
     return;
   }
 #endif
-  AT_DISPATCH_FLOATING_TYPES(input.type(), "_fft_fill_with_conjugate_symmetry", [&] {
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "_fft_fill_with_conjugate_symmetry", [&] {
     _fft_fill_with_conjugate_symmetry_slice<scalar_t>(input, signal_ndim, size_last_dim,
         last_dim_start_slice, 0, num);
   });
@@ -211,14 +211,14 @@ Tensor _fft_mkl(const Tensor& self, int64_t signal_ndim,
 
   // precision
   DFTI_CONFIG_VALUE prec;
-  if (input.type().scalarType() == ScalarType::Float) {
+  if (input.scalar_type() == ScalarType::Float) {
     prec = DFTI_SINGLE;
-  } else if (input.type().scalarType() == ScalarType::Double) {
+  } else if (input.scalar_type() == ScalarType::Double) {
     prec = DFTI_DOUBLE;
   } else {
     std::ostringstream ss;
     ss << "MKL FFT doesn't support tensor of type: "
-       << toString(input.type().scalarType());
+       << toString(input.scalar_type());
     AT_ERROR(ss.str());
   }
   // signal type
@@ -291,4 +291,3 @@ Tensor _fft_mkl(const Tensor& self, int64_t signal_ndim,
 }} // namespace at::native
 
 #endif
-

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -287,7 +287,7 @@ SparseTensor dense_to_sparse(const Tensor& self, int64_t sparse_dim){
   // TODO: it seems like sparse_dim == 0 could be supported even if self.dim() > 0,
   // but this would take some work and doesn't seem particularly useful.
   AT_CHECK(sparse_dim > 0 || self.dim() == 0, "sparse_dim must be >0 if dimensionality > 0");
-  AT_CHECK(sparse_dim <= dims, 
+  AT_CHECK(sparse_dim <= dims,
     "sparse_dim must be less than or equal to self.dim()");
   at::TensorOptions sparse_options = self.options().layout(kSparse);
   std::vector<int64_t> sizes = self.sizes().vec();
@@ -376,7 +376,7 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
 
   int64_t i = -1;
   AT_DISPATCH_ALL_TYPES(
-      values.type(), "coalesce", [&] {
+      values.scalar_type(), "coalesce", [&] {
         int64_t prev = -1;
         int64_t blockSize = values.stride(0);
         scalar_t* values_ptr = values.data<scalar_t>();
@@ -483,7 +483,7 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
     // TODO: Re-audit this; it used to be an indexSelect directly into r_values
     at::index_select_out(r_values, t_view, 0, indices);
   } else {
-    AT_DISPATCH_ALL_TYPES(r_values.type(), "sparse_mask", [&] {
+    AT_DISPATCH_ALL_TYPES(r_values.scalar_type(), "sparse_mask", [&] {
       sparse_mask_out_cpu_kernel<scalar_t>(
         r_values,
         t,

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -226,7 +226,7 @@ SparseTensor& add_out_sparse_cpu(SparseTensor& r, const SparseTensor& t, const S
   auto src_indices_accessor = src_indices.accessor<int64_t, 2>();
 
   AT_DISPATCH_ALL_TYPES(
-      t_values.type(), "cadd_sparse", [&] {
+      t_values.scalar_type(), "cadd_sparse", [&] {
         scalar_t* t_values_ptr = t_values.data<scalar_t>();
         scalar_t* s_values_ptr = s_values.data<scalar_t>();
         scalar_t* r_values_ptr = r_values.data<scalar_t>();
@@ -347,7 +347,7 @@ Tensor& add_out_dense_sparse_cpu(Tensor& r, const Tensor& dense, SparseTensorRef
     }
   } else {
     AT_DISPATCH_ALL_TYPES(
-        values.type(), "add_dense_sparse", [&] {
+        values.scalar_type(), "add_dense_sparse", [&] {
           add_dense_sparse_worker_cpu<scalar_t>(r, value, sparse, indices, values);
         });
   }
@@ -435,7 +435,7 @@ SparseTensor& mul_out_sparse_cpu(SparseTensor& r, const Tensor& t_, const Tensor
     }
   } else {
     AT_DISPATCH_ALL_TYPES(
-        r_values.type(), "mul_out_sparse", [&] {
+        r_values.scalar_type(), "mul_out_sparse", [&] {
           auto r_accessor = r_values.accessor<scalar_t, 1>();
           auto t_accessor = t_values.accessor<scalar_t, 1>();
           auto s_accessor = s_values.accessor<scalar_t, 1>();
@@ -551,7 +551,7 @@ Tensor& s_addmm_out_sparse_dense_cpu(
   Tensor values      = sparse_._values();
 
   AT_DISPATCH_ALL_TYPES(
-      values.type(), "addmm_sparse_dense", [&] {
+      values.scalar_type(), "addmm_sparse_dense", [&] {
         s_addmm_out_sparse_dense_worker<scalar_t>(nnz, dim_i, dim_j, dim_k, r, beta, t, alpha, indices, values, dense);
       }
   );
@@ -757,7 +757,7 @@ SparseTensor& _sspaddmm_out_cpu(
   int64_t newv_stride0 = newv.stride(0);
 
   AT_DISPATCH_ALL_TYPES(
-      values.type(), "sspmm", [&] {
+      values.scalar_type(), "sspmm", [&] {
         auto values_accessor = values.accessor<scalar_t, 1>();
         scalar_t* dense_ptr = dense.data<scalar_t>();
         scalar_t* newv_ptr = newv.data<scalar_t>();

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -95,7 +95,7 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
     dim3 grid(THCCeilDiv(newNnz, (int64_t) 4), THCCeilDiv(stride, (int64_t) 128));
     dim3 block(32, 4);
     AT_DISPATCH_ALL_TYPES_AND_HALF(
-        values.type(), "coalesce_sparse_cuda", [&] {
+        values.scalar_type(), "coalesce_sparse_cuda", [&] {
           using cuda_accscalar_t = acc_type<scalar_t, /* is_cuda */ true>;
           apply::coalesceValuesKernel<scalar_t, cuda_accscalar_t><<<grid, block, 0, stream>>>(
             uniqueOffsets.data<int64_t>(),

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -91,7 +91,7 @@ Tensor& s_addmm_out_sparse_dense_cuda(Tensor& r_, const Tensor& t, const SparseT
   // No half support, so we don't have to use CUDATypeConversion
   Tensor r__;
   AT_DISPATCH_FLOATING_TYPES(
-      values.type(), "addmm_sparse_cuda", [&] {
+      values.scalar_type(), "addmm_sparse_cuda", [&] {
         scalar_t cast_beta = beta.to<scalar_t>();
         scalar_t cast_alpha = alpha.to<scalar_t>();
         if (cast_beta == 0) {
@@ -296,7 +296,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, SparseTensorR
       AT_CHECK(cuda::getApplyGrid(nnz, grid, curDevice), "add: Argument #0: tensor too large or too many dimensions");
 
       AT_DISPATCH_ALL_TYPES_AND_HALF(
-          values.type(), "add_out_dense_sparse_cuda", [&] {
+          values.scalar_type(), "add_out_dense_sparse_cuda", [&] {
             apply::sparseElementwiseKernelScalar<TensorCAddOp<scalar_t>, uint64_t, scalar_t>
               <<<grid, block, 0, stream>>>(
                 TensorCAddOp<scalar_t>(value.to<scalar_t>()),
@@ -310,7 +310,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, SparseTensorR
       values = values.contiguous();
 
       AT_DISPATCH_ALL_TYPES_AND_HALF(
-          values.type(), "add_out_dense_sparse_cuda", [&] {
+          values.scalar_type(), "add_out_dense_sparse_cuda", [&] {
             apply::sparseElementwiseKernel<TensorCAddOp<scalar_t>, uint64_t, scalar_t>
               <<<grid, block, 0, stream>>>(
                 TensorCAddOp<scalar_t>(value.to<scalar_t>()),
@@ -324,7 +324,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, SparseTensorR
     // FIXME: at some point we can wrap the scale into indexAdd
     // NB: Purposely not inplace!
     AT_DISPATCH_ALL_TYPES_AND_HALF(
-        values.type(), "add_out_dense_sparse_cuda", [&] {
+        values.scalar_type(), "add_out_dense_sparse_cuda", [&] {
           if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
             values = values.mul(value);
           }
@@ -379,7 +379,7 @@ SparseTensor& add_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t, const
   Tensor s_values_ = src._values();
 
   AT_DISPATCH_ALL_TYPES_AND_HALF(
-      s_values_.type(), "add_out_sparse_cuda", [&] {
+      s_values_.scalar_type(), "add_out_sparse_cuda", [&] {
         if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
           s_values_ = s_values_.mul(value);
         }
@@ -449,7 +449,7 @@ SparseTensor& mul_out_sparse_cuda(SparseTensor& r_, const SparseTensor& t_, cons
 
   LongTensor resultNnz = at::empty({1}, CUDA(kLong));
   AT_DISPATCH_ALL_TYPES_AND_HALF(
-      t_values_.type(), "mul_out_sparse_cuda", [&] {
+      t_values_.scalar_type(), "mul_out_sparse_cuda", [&] {
         apply::valueSparseIntersectionKernel<TensorMulOp<scalar_t>, uint64_t, scalar_t>
           <<<grid, block, 0, stream>>>(
             TensorMulOp<scalar_t>(),
@@ -620,7 +620,7 @@ Tensor _sparse_sum_backward_cuda(const Tensor& grad_, const SparseTensor& input_
       auto input_indices_ti = getTensorInfo<int64_t, int64_t>(input_indices_1D);
       auto input_indices_pos_ti = getTensorInfo<int64_t, int64_t>(input_indices_pos);
 
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_values.type(), "_sparse_sum_backward_cuda", [&] {
+      AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_values.scalar_type(), "_sparse_sum_backward_cuda", [&] {
         auto grad_values_expand_ti = getTensorInfo<scalar_t, int64_t>(grad_values_expand);
         auto grad_input_values_ti = getTensorInfo<scalar_t, int64_t>(grad_input_values);
 

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -116,11 +116,11 @@ inline bool is_sparse(Tensor self) {
   template <>                                    \
   inline T* Tensor::data() const {               \
     AT_CHECK(                                    \
-        type().scalarType() == ScalarType::name, \
+        scalar_type() == ScalarType::name,       \
         "expected scalar type ",                 \
         #name,                                   \
         " but found ",                           \
-        c10::toString(type().scalarType()));     \
+        c10::toString(scalar_type()));           \
     return static_cast<T*>(this->data_ptr());    \
   }
 

--- a/aten/src/ATen/test/apply_utils_test.cpp
+++ b/aten/src/ATen/test/apply_utils_test.cpp
@@ -27,7 +27,7 @@ void test(Type& type, IntArrayRef shape, int64_t a = 0, int64_t b = 1) {
   auto zero_dim = at::empty({}, type);
   zero_dim.fill_(2);
   zero_dim.exp_();
-  AT_DISPATCH_FLOATING_TYPES(zero_dim.type(), "test0", [&] {
+  AT_DISPATCH_FLOATING_TYPES(zero_dim.scalar_type(), "test0", [&] {
     ASSERT(zero_dim.data<scalar_t>()[0] == std::exp(2));
   });
 
@@ -50,7 +50,7 @@ void test(Type& type, IntArrayRef shape, int64_t a = 0, int64_t b = 1) {
     }
   }
 
-  AT_DISPATCH_FLOATING_TYPES(a0.type(), "test1", [&] {
+  AT_DISPATCH_FLOATING_TYPES(a0.scalar_type(), "test1", [&] {
     CPU_tensor_apply2<scalar_t, scalar_t>(
         a0, a1, [](scalar_t& y, const scalar_t& x) { y = x * x; });
     CPU_tensor_apply2<double, scalar_t>(
@@ -62,7 +62,7 @@ void test(Type& type, IntArrayRef shape, int64_t a = 0, int64_t b = 1) {
     }
   });
 
-  AT_DISPATCH_FLOATING_TYPES(a0.type(), "test2", [&] {
+  AT_DISPATCH_FLOATING_TYPES(a0.scalar_type(), "test2", [&] {
     CPU_tensor_apply3<scalar_t, scalar_t, scalar_t>(
         a0, a1, a2, [](scalar_t& y, const scalar_t& x, const scalar_t& z) {
           y = x * x + z;
@@ -79,7 +79,7 @@ void test(Type& type, IntArrayRef shape, int64_t a = 0, int64_t b = 1) {
     }
   });
 
-  AT_DISPATCH_FLOATING_TYPES(a0.type(), "test3", [&] {
+  AT_DISPATCH_FLOATING_TYPES(a0.scalar_type(), "test3", [&] {
     CPU_tensor_apply4<scalar_t, scalar_t, scalar_t, scalar_t>(
         a0,
         a1,

--- a/aten/src/ATen/test/scalar_test.cpp
+++ b/aten/src/ATen/test/scalar_test.cpp
@@ -101,7 +101,7 @@ TEST(TestScalar, TestScalar) {
   ASSERT_EQ(scalar_to_tensor(ones({}).item()).scalar_type(), kDouble);
 
   if (x.scalar_type() != ScalarType::Half) {
-    AT_DISPATCH_ALL_TYPES(x.type(), "foo", [&] {
+    AT_DISPATCH_ALL_TYPES(x.scalar_type(), "foo", [&] {
       scalar_t s = 1;
       std::stringstream ss;
       ASSERT_NO_THROW(

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -40,7 +40,7 @@ private:
   at::Backend backend() const;
 
   TypeMeta typeMetaFor(const at::Tensor & t) {
-    return typeMetaFor(t.type().scalarType());
+    return typeMetaFor(t.scalar_type());
   }
   TypeMeta typeMetaFor(at::ScalarType st) {
     #define DEFINE_CASE(ctype,aten_name,_) \
@@ -129,8 +129,8 @@ private:
     return s.toLong();
   }
 
-  void assignTo(Tensor* dst, at::Type& inferred_type, at::Scalar scalar) {
-    switch(inferred_type.scalarType()) {
+  void assignTo(Tensor* dst, at::ScalarType scalar_type, at::Scalar scalar) {
+    switch(scalar_type) {
       #define DEFINE_CASE(ctype,aten_name,native) \
         case at::k##aten_name: { \
           auto value = extract_##native(scalar); \
@@ -224,10 +224,6 @@ private:
   }
   at::TypeExtendedInterface & stringToType(const std::string & name) {
     return at::getNonVariableType(backend(), stringToScalarType(name));
-  }
-  at::TypeExtendedInterface * readTypeAttribute(const std::string & name) {
-    CAFFE_ENFORCE(OperatorBase::HasSingleArgumentOfType<std::string>(name));
-    return &stringToType(OperatorBase::GetSingleArgument<std::string>(name, ""));
   }
 };
 

--- a/test/cpp/api/tensor_options.cpp
+++ b/test/cpp/api/tensor_options.cpp
@@ -22,7 +22,7 @@ using namespace at;
 #define REQUIRE_TENSOR_OPTIONS(device_, index_, type_, layout_)            \
   ASSERT_EQ(tensor.device().type(), Device((device_), (index_)).type());   \
   ASSERT_EQ(tensor.device().index(), Device((device_), (index_)).index()); \
-  ASSERT_EQ(tensor.type().scalarType(), (type_));                          \
+  ASSERT_EQ(tensor.scalar_type(), (type_));                          \
   ASSERT_TRUE(tensor.type().layout() == (layout_))
 
 TEST(TensorOptionsTest, DefaultsToTheRightValues) {

--- a/test/cpp/api/tensor_options_cuda.cpp
+++ b/test/cpp/api/tensor_options_cuda.cpp
@@ -32,7 +32,7 @@ at::Device CUDADevice(DeviceIndex index) {
 #define REQUIRE_TENSOR_OPTIONS(device_, index_, type_, layout_)                \
   ASSERT_EQ(tensor.device().type(), Device((device_), (index_)).type());   \
   ASSERT_EQ(tensor.device().index(), Device((device_), (index_)).index()); \
-  ASSERT_EQ(tensor.type().scalarType(), (type_));                          \
+  ASSERT_EQ(tensor.scalar_type(), (type_));                          \
   ASSERT_TRUE(tensor.type().layout() == (layout_))
 
 TEST(TensorOptionsTest, ConstructsWellFromCUDATypes_CUDA) {

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -998,7 +998,7 @@ bool isEqual(const CompleteArgumentInfo& ti, const autograd::Variable& v) {
   if (!ti.defined())
     return ti.defined() == v.defined();
   return ti.device() == device(v) && ti.requires_grad() == v.requires_grad() &&
-      ti.type() == v.type().scalarType() && isEqual(ti.sizes(), v.sizes()) &&
+      ti.type() == v.scalar_type() && isEqual(ti.sizes(), v.sizes()) &&
       isEqual(ti.strides(), v.strides());
 }
 

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -338,7 +338,7 @@ class TestCppExtension(common.TestCase):
 
         torch::Tensor half_test(torch::Tensor input) {
             auto output = torch::empty(1, input.options().dtype(torch::kFloat));
-            AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.type(), "half_test", [&] {
+            AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "half_test", [&] {
                 half_test_kernel<scalar_t><<<1, 1>>>(
                     input.data<scalar_t>(),
                     output.data<float>());

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -245,7 +245,7 @@
   self: cumsum_backward(grad, dim)
 
 - name: cumsum(Tensor self, int64_t dim, *, ScalarType dtype)
-  self: cumsum_backward(grad, dim, self.type().scalarType())
+  self: cumsum_backward(grad, dim, self.scalar_type())
 
 - name: conv_tbc(Tensor self, Tensor weight, Tensor bias, int64_t pad)
   self, weight, bias: conv_tbc_backward(grad, self, weight, bias, pad)
@@ -492,16 +492,16 @@
   self: grad.expand(self.sizes()) / self.numel()
 
 - name: mean(Tensor self, ScalarType dtype)
-  self: grad.expand(self.sizes()).to(self.type().scalarType()) / self.numel()
+  self: grad.expand(self.sizes()).to(self.scalar_type()) / self.numel()
 
 - name: mean(Tensor self, IntArrayRef dim, bool keepdim)
   self: sum_backward(grad, self.sizes(), dim, keepdim) / _safe_size(self.sizes(), dim)
 
 - name: mean(Tensor self, IntArrayRef dim, ScalarType dtype)
-  self: sum_backward(grad, self.sizes(), dim, false).to(self.type().scalarType()) / _safe_size(self.sizes(), dim)
+  self: sum_backward(grad, self.sizes(), dim, false).to(self.scalar_type()) / _safe_size(self.sizes(), dim)
 
 - name: mean(Tensor self, IntArrayRef dim, bool keepdim, ScalarType dtype)
-  self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.type().scalarType()) / _safe_size(self.sizes(), dim)
+  self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.scalar_type()) / _safe_size(self.sizes(), dim)
 
 - name: median(Tensor self)
   self: select_equals_backward(grad, self, result)
@@ -579,11 +579,11 @@
   self: norm_backward(grad, self, p, result, dim, keepdim)
 
 - name: norm(Tensor self, Scalar? p, ScalarType dtype)
-  self: norm_backward(grad, self.to(grad.type().scalarType()), p, result).to(self.type().scalarType())
+  self: norm_backward(grad, self.to(grad.scalar_type()), p, result).to(self.scalar_type())
 
 
 - name: norm(Tensor self, Scalar? p, IntArrayRef dim, bool keepdim, ScalarType dtype)
-  self: norm_backward(grad, self.to(grad.type().scalarType()), p, result, dim, keepdim).to(self.type().scalarType())
+  self: norm_backward(grad, self.to(grad.scalar_type()), p, result, dim, keepdim).to(self.scalar_type())
 
 - name: _pdist_forward(Tensor self, double p)
   self: _pdist_backward(grad, self, p, result)
@@ -638,16 +638,16 @@
   self: prod_backward(grad, self, result)
 
 - name: prod(Tensor self, ScalarType dtype)
-  self: prod_backward(grad, self.to(grad.type().scalarType()), result).to(self.type().scalarType())
+  self: prod_backward(grad, self.to(grad.scalar_type()), result).to(self.scalar_type())
 
 - name: prod(Tensor self, int64_t dim, bool keepdim)
   self: prod_backward(grad, self, result, dim, keepdim)
 
 - name: prod(Tensor self, int64_t dim, ScalarType dtype)
-  self: prod_backward(grad, self.to(grad.type().scalarType()), result, dim, false).to(self.type().scalarType())
+  self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, false).to(self.scalar_type())
 
 - name: prod(Tensor self, int64_t dim, bool keepdim, ScalarType dtype)
-  self: prod_backward(grad, self.to(grad.type().scalarType()), result, dim, keepdim).to(self.type().scalarType())
+  self: prod_backward(grad, self.to(grad.scalar_type()), result, dim, keepdim).to(self.scalar_type())
 
 - name: pstrf(Tensor self, bool upper, Scalar tol)
   self: not_implemented("pstrf")
@@ -777,16 +777,16 @@
   self: grad.expand(self.sizes())
 
 - name: sum(Tensor self, ScalarType dtype)
-  self: grad.expand(self.sizes()).to(self.type().scalarType())
+  self: grad.expand(self.sizes()).to(self.scalar_type())
 
 - name: sum(Tensor self, IntArrayRef dim, bool keepdim)
   self: sum_backward(grad, self.sizes(), dim, keepdim)
 
 - name: sum(Tensor self, IntArrayRef dim, ScalarType dtype)
-  self: sum_backward(grad, self.sizes(), dim, false).to(self.type().scalarType())
+  self: sum_backward(grad, self.sizes(), dim, false).to(self.scalar_type())
 
 - name: sum(Tensor self, IntArrayRef dim, bool keepdim, ScalarType dtype)
-  self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.type().scalarType())
+  self: sum_backward(grad, self.sizes(), dim, keepdim).to(self.scalar_type())
 
 - name: svd(Tensor self, bool some, bool compute_uv)
   self: svd_backward(grads, self, some, compute_uv, U, S, V)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -1943,10 +1943,10 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   }
   // for half inputs, save_mean, save_invstd are float (ideally, we would cast
   // everything else, but not now)
-  auto mu = unsqueeze_dim1(training ? save_mean.to(input.type().scalarType()) : running_mean, input);
+  auto mu = unsqueeze_dim1(training ? save_mean.to(input.scalar_type()) : running_mean, input);
   auto input_sub_mu = input - mu;
   auto sigma2_eps_neg_1_2 = unsqueeze_dim1(
-      training ? save_invstd.to(input.type().scalarType())
+      training ? save_invstd.to(input.scalar_type())
                : running_var.add(Scalar(eps)).pow(-0.5),
       input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -17,6 +17,7 @@
 namespace torch { namespace autograd {
 
 struct Variable;
+using at::Backend;
 using at::Context;
 using at::Device;
 using at::Generator;
@@ -51,8 +52,8 @@ struct TORCH_API VariableType final : public at::TypeDefault {
 
   static at::TypeExtendedInterface* getVariableTypeFromBaseType(const at::Type& baseType);
   static bool isVariableType(const at::Type& type);
-  static std::vector<at::Type*> allCUDATypes();
-  static std::vector<at::Type*> allCPUTypes();
+  static std::vector<std::pair<Backend, ScalarType>> allCUDATypes();
+  static std::vector<std::pair<Backend, ScalarType>> allCPUTypes();
 
   void backward(
       Tensor& self,

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -49,7 +49,7 @@ static void check_out_type_matches(Tensor result,
   if (scalarType_is_none && layout_is_none && device_is_none) {  // common case
     return;
   }
-  auto scalarType_arg = scalarType_is_none ? result.type().scalarType() : scalarType;
+  auto scalarType_arg = scalarType_is_none ? result.scalar_type() : scalarType;
   auto layout_arg = layout_is_none ? *torch::getLayout(result.type().backend()) : layout;
   auto device_type_arg = device_is_none ? torch::getDeviceType(result.type()) : device.type();
   const auto& type = torch::getVariableType(scalarType_arg, layout_arg, device_type_arg);

--- a/tools/autograd/templates/python_torch_functions_dispatch.h
+++ b/tools/autograd/templates/python_torch_functions_dispatch.h
@@ -25,7 +25,7 @@ using at::Storage;
 using at::TensorOptions;
 
 static at::Type& default_type() {
-  return torch::tensors::get_default_tensor_type();
+  return *torch::tensors::get_default_tensor_type().aten_type();
 }
 
 static void maybe_initialize_cuda(const at::TensorOptions& options) {

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -218,7 +218,7 @@ static PyObject * THPVariable_integral_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   jit::tracer::warn("Converting a tensor to a Python integer", jit::tracer::WARN_PYTHON_DATAFLOW);
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  if (isFloatingType(self_.type().scalarType())) {
+  if (isFloatingType(self_.scalar_type())) {
     // we can't dispatch to item<int64_t> here because we want to avoid ATen overflow checks;
     // the python integral type (long in python2) can't overflow.
     return THPUtils_packDoubleAsInt(dispatch_to_CDouble(self_));
@@ -236,7 +236,7 @@ static PyObject * THPVariable_index_scalar(PyObject* self, PyObject* args) {
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   // TODO: change the condition to `self_.dim() != 0` once we expose scalars
   // in PyTorch.
-  if (!isIntegralType(self_.type().scalarType()) || self_.numel() != 1) {
+  if (!isIntegralType(self_.scalar_type()) || self_.numel() != 1) {
     throw TypeError("only integer tensors of a single element can be converted to an index");
   }
   return wrap(dispatch_to_CLong(self_));
@@ -252,7 +252,7 @@ static Tensor dispatch_invert(const Tensor & self) {
 static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  if (self_.type().scalarType() != at::kByte) {
+  if (self_.scalar_type() != at::kByte) {
     throw TypeError("~ (operator.invert) is only implemented on byte tensors");
   }
   return THPVariable_Wrap(dispatch_invert(self_));
@@ -592,7 +592,7 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.isNone(0)) {
-    return THPUtils_packString(torch::utils::type_to_string(self_.type()));
+    return THPUtils_packString(torch::utils::type_to_string(self_));
   }
   auto obj = r.pyobject(0);
   std::string type_name;
@@ -615,9 +615,9 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
   if (is_dtype) {
     scalar_type = r.scalartype(0);
   } else {
-    auto& type = torch::utils::type_from_string(type_name);
-    scalar_type = type.scalarType();
-    auto device_type = backendToDeviceType(type.backend());
+    Backend backend;
+    std::tie(backend, scalar_type) = torch::utils::type_from_string(type_name);
+    auto device_type = at::backendToDeviceType(backend);
     if (device_type != device.type()) {
       device = at::Device(device_type);
     }

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -82,9 +82,8 @@ static PyObject * THPGenerator_setState(THPGenerator *self, PyObject *_new_state
     throw TypeError("expected a torch.ByteTensor, but got %s", Py_TYPE(_new_state)->tp_name);
   }
   auto& tensor = ((THPVariable*)_new_state)->cdata.data();
-  auto& tensor_type = at::globalContext().getNonVariableType(tensor.type().backend(), tensor.type().scalarType());
-  if (tensor_type != CPU(kByte)) {
-    auto type_name = torch::utils::type_to_string(tensor_type);
+  if (tensor.type().backend() != at::Backend::CPU || tensor.scalar_type() == at::kByte) {
+    auto type_name = torch::utils::type_to_string(tensor);
     throw TypeError("expected a torch.ByteTensor, but got %s", type_name.c_str());
   }
   THGenerator *generator = THPGenerator_TH_CData(self);

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -405,7 +405,7 @@ PyObject *THPModule_setFlushDenormal(PyObject *_unused, PyObject *arg) {
 PyObject *THPModule_getDefaultDtype(PyObject *_unused, PyObject *arg) {
   HANDLE_TH_ERRORS
   auto& type = torch::tensors::get_default_tensor_type();
-  auto dtype = (PyObject*)torch::getDtype(type.scalarType());
+  auto dtype = (PyObject*)torch::getDtype(static_cast<at::ScalarType>(type.scalar_type));
   Py_INCREF(dtype);
   return dtype;
   END_HANDLE_TH_ERRORS
@@ -413,7 +413,7 @@ PyObject *THPModule_getDefaultDtype(PyObject *_unused, PyObject *arg) {
 
 PyObject *THPModule_isDefaultTypeCuda(PyObject *_unused, PyObject *arg) {
   HANDLE_TH_ERRORS
-  if (torch::tensors::get_default_tensor_type().is_cuda()) {
+  if (torch::tensors::get_default_tensor_type().is_cuda) {
     Py_RETURN_TRUE;
   }
   Py_RETURN_FALSE;

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -58,7 +58,7 @@ PyObject* THPFInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   AT_CHECK(r.idx < 2, "Not a type");
   at::ScalarType scalar_type;
   if (r.idx == 1) {
-    scalar_type = torch::tensors::get_default_tensor_type().scalarType();
+    scalar_type = static_cast<at::ScalarType>(torch::tensors::get_default_tensor_type().scalar_type);
     // The default tensor type can only be set to a floating point type/
     AT_ASSERT(at::isFloatingType(scalar_type));
   } else {
@@ -119,7 +119,7 @@ static PyObject* THPDTypeInfo_bits(THPDTypeInfo* self, void*) {
 
 static PyObject* THPFInfo_eps(THPFInfo* self, void*) {
   return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
-      at::CPU(self->type), "epsilon", [] {
+      self->type, "epsilon", [] {
         return PyFloat_FromDouble(
             std::numeric_limits<
                 at::scalar_value_type<scalar_t>::type>::epsilon());
@@ -127,33 +127,33 @@ static PyObject* THPFInfo_eps(THPFInfo* self, void*) {
 }
 
 static PyObject* THPFInfo_max(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(at::CPU(self->type), "max", [] {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self->type, "max", [] {
     return PyFloat_FromDouble(
         std::numeric_limits<at::scalar_value_type<scalar_t>::type>::max());
   });
 }
 
 static PyObject* THPFInfo_min(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(at::CPU(self->type), "min", [] {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self->type, "min", [] {
     return PyFloat_FromDouble(
         std::numeric_limits<at::scalar_value_type<scalar_t>::type>::lowest());
   });
 }
 
 static PyObject* THPIInfo_max(THPFInfo* self, void*) {
-  return AT_DISPATCH_INTEGRAL_TYPES(at::CPU(self->type), "max", [] {
+  return AT_DISPATCH_INTEGRAL_TYPES(self->type, "max", [] {
     return THPUtils_packInt64(std::numeric_limits<scalar_t>::max());
   });
 }
 
 static PyObject* THPIInfo_min(THPFInfo* self, void*) {
-  return AT_DISPATCH_INTEGRAL_TYPES(at::CPU(self->type), "min", [] {
+  return AT_DISPATCH_INTEGRAL_TYPES(self->type, "min", [] {
     return THPUtils_packInt64(std::numeric_limits<scalar_t>::lowest());
   });
 }
 
 static PyObject* THPFInfo_tiny(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(at::CPU(self->type), "min", [] {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self->type, "min", [] {
     return PyFloat_FromDouble(
         std::numeric_limits<at::scalar_value_type<scalar_t>::type>::min());
   });

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -147,15 +147,15 @@ at::TypeExtendedInterface* VariableType::getVariableTypeFromBaseType(const at::T
 }
 
 namespace {
-std::vector<at::Type*> allTypesForBackends(at::ArrayRef<at::Backend> backends) {
+std::vector<std::pair<Backend, ScalarType>> allTypesForBackends(at::ArrayRef<at::Backend> backends) {
   auto& context = at::globalContext();
-  std::vector<Type*> res;
+  std::vector<std::pair<Backend, ScalarType>> res;
   res.reserve(backends.size() * static_cast<int>(ScalarType::NumOptions));
   for (auto p : backends) {
     for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); s++) {
       auto baseType = context.getNonVariableTypeRaw(static_cast<Backend>(p), static_cast<ScalarType>(s));
       if (baseType) {
-        res.emplace_back(VariableType::getVariableTypeFromBaseType(*baseType));
+        res.emplace_back(std::make_pair(static_cast<Backend>(p), static_cast<ScalarType>(s)));
       }
     }
   }
@@ -163,11 +163,11 @@ std::vector<at::Type*> allTypesForBackends(at::ArrayRef<at::Backend> backends) {
 }
 }
 
-std::vector<at::Type*> VariableType::allCPUTypes() {
+std::vector<std::pair<Backend, ScalarType>> VariableType::allCPUTypes() {
   return allTypesForBackends({ Backend::CPU, Backend::SparseCPU });
 }
 
-std::vector<at::Type*> VariableType::allCUDATypes() {
+std::vector<std::pair<Backend, ScalarType>> VariableType::allCUDATypes() {
   at::globalContext().lazyInitCUDA();
   return allTypesForBackends({ Backend::CUDA, Backend::SparseCUDA });
 }
@@ -265,7 +265,7 @@ Tensor & VariableType::s_copy_(Tensor & self, const Tensor & src, bool non_block
   check_inplace(self);
   std::shared_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);
-  requires_grad &= isFloatingPoint(self.type().scalarType());
+  requires_grad &= isFloatingPoint(self.scalar_type());
   if (requires_grad) {
     grad_fn = std::make_shared<CopyBackwards>();
     grad_fn->set_next_edges(collect_next_edges(self, src));

--- a/torch/csrc/autograd/python_legacy_variable.cpp
+++ b/torch/csrc/autograd/python_legacy_variable.cpp
@@ -46,7 +46,7 @@ static PyObject *THPVariable_pynew(PyTypeObject* type, PyObject *args, PyObject 
   if (!data || data == Py_None) {
     // For legacy serialization code, create an empty tensor. This is also used
     // by nn.Parameter() with no arguments.
-    auto var = at::empty({0}, torch::tensors::get_default_tensor_type().options());
+    auto var = at::empty({0}, torch::tensors::get_default_tensor_type().aten_type()->options());
     tensor = static_cast<Variable&>(var).data();
   } else if (THPVariable_Check(data)) {
     tensor = ((THPVariable*)data)->cdata.data();

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -127,8 +127,8 @@ static PyObject *THPVariable_pynew(PyTypeObject *type, PyObject *args, PyObject 
 {
   HANDLE_TH_ERRORS
   jit::tracer::warn("torch.Tensor", jit::tracer::WARN_CONSTRUCTOR);
-  auto& default_type = torch::tensors::get_default_tensor_type();
-  auto tensor = torch::utils::legacy_tensor_ctor(default_type, args, kwargs);
+  auto default_type = torch::tensors::get_default_tensor_type().aten_type();
+  auto tensor = torch::utils::legacy_tensor_ctor(*default_type, args, kwargs);
   return THPVariable_NewWithVar(type, std::move(tensor));
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -47,7 +47,7 @@ static int64_t count_specified_dimensions(PyObject* index) {
     PyObject* obj = PyTuple_GET_ITEM(index, i); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     if (THPVariable_Check(obj)) {
       auto& var = reinterpret_cast<THPVariable*>(obj)->cdata;
-      if (var.type().scalarType() == kByte) {
+      if (var.scalar_type() == kByte) {
         count += var.dim();
       } else {
         count++;
@@ -166,7 +166,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
       handle_var(boolToIndexingTensor(result, obj == Py_True)); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
-      auto scalar_type = var.type().scalarType();
+      auto scalar_type = var.scalar_type();
       if (var.dim() == 0 && at::isIntegralType(scalar_type)) {
         if (scalar_type != at::kByte) {
           result = applySelect(result, dim, THPUtils_unpackLong(obj), i);

--- a/torch/csrc/autograd/utils/python_arg_parsing.h
+++ b/torch/csrc/autograd/utils/python_arg_parsing.h
@@ -32,7 +32,7 @@ inline std::tuple<c10::optional<at::Device>, c10::optional<at::ScalarType>, bool
       throw std::runtime_error(".to() does not accept copy argument");
     return std::make_tuple(
       torch::tensors::getDevice(tensor),
-      tensor.type().scalarType(),
+      tensor.scalar_type(),
       r.toBool(1),
       r.toBool(2)
     );

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -150,7 +150,7 @@ PyObject * THCPModule_setRNGState(PyObject *_unused, PyObject *obj)
 {
   HANDLE_TH_ERRORS
   if (!THPVariable_Check(obj) ||
-      at::globalContext().getNonVariableType(THPVariable_Unpack(obj).type().backend(), THPVariable_Unpack(obj).type().scalarType()).ID() != at::TypeID::CPUByte) {
+      at::globalContext().getNonVariableType(THPVariable_Unpack(obj).type().backend(), THPVariable_Unpack(obj).scalar_type()).ID() != at::TypeID::CPUByte) {
     throw TypeError("set_rng_state expects a torch.ByteTensor, but got %s",
         Py_TYPE(obj)->tp_name);
   }

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -81,11 +81,11 @@ ArrayRef<ncclComm_t> _get_communicators(TensorList inputs) {
   return it->second.ref();
 }
 
-ncclDataType_t _get_data_type(const Type& type) {
-  if (type.backend() != Backend::CUDA) {
+ncclDataType_t _get_data_type(const Tensor& t) {
+  if (t.type().backend() != Backend::CUDA) {
     throw std::runtime_error("Unconvertible NCCL type");
   }
-  switch (type.scalarType()) {
+  switch (t.scalar_type()) {
     case at::kFloat:
       return ncclFloat;
     case at::kHalf:
@@ -233,7 +233,7 @@ void broadcast(
 #ifdef USE_NCCL
   using namespace torch::cuda::nccl::detail;
   _check_inputs(tensors, tensors, 1, 1);
-  ncclDataType_t data_type = _get_data_type(tensors[0].type());
+  ncclDataType_t data_type = _get_data_type(tensors[0]);
   int64_t numel = tensors[0].numel();
 
   std::lock_guard<std::mutex> free_mutex(
@@ -281,7 +281,7 @@ void reduce(
   _check_inputs(inputs, outputs, 1, 1);
   const auto len = inputs.size();
 
-  ncclDataType_t data_type = _get_data_type(inputs[0].type());
+  ncclDataType_t data_type = _get_data_type(inputs[0]);
 
   const auto count = inputs[0].numel();
   std::lock_guard<std::mutex> lock(*(c10::cuda::CUDACachingAllocator::getFreeMutex()));

--- a/torch/csrc/jit/argument_spec.h
+++ b/torch/csrc/jit/argument_spec.h
@@ -93,7 +93,7 @@ struct ArgumentSpec {
         arg.requires_grad_ = with_grad && autograd::Variable(t).requires_grad();
         arg.dim_ = t.dim();
         arg.device_ = t.is_cuda() ? t.get_device() : -1;
-        arg.type_ = static_cast<unsigned>(t.type().scalarType());
+        arg.type_ = static_cast<unsigned>(t.scalar_type());
       }
 
       arg.is_tensor_ = true;
@@ -229,7 +229,7 @@ struct CompleteArgumentSpec {
         at::Tensor t = inputs[i].toTensor();
         pod.defined = t.defined();
         if (pod.defined) {
-          pod.type = static_cast<int>(t.type().scalarType());
+          pod.type = static_cast<int>(t.scalar_type());
           pod.device = (!t.is_cuda()) ? -1 : t.get_device();
           pod.requires_grad =
               with_grad && autograd::as_variable_ref(t).requires_grad();

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -431,7 +431,7 @@ void GraphEncoder::EncodeTensor(
   for (auto d : tensor.sizes()) {
     tensor_proto->add_dims(d);
   }
-  tensor_proto->set_data_type(ATenTypeToOnnxType(tensor.type().scalarType()));
+  tensor_proto->set_data_type(ATenTypeToOnnxType(tensor.scalar_type()));
   // CPU's HalfTensor doesn't have contiguous(), so first calling contiguous()
   auto t = tensor.contiguous().cpu();
   // Add a buffer to the raw_data_export_map for the caller to dump into an
@@ -581,7 +581,7 @@ void ScriptModuleSerializer::convertAndWriteTensor(
     tensor_proto->add_strides(s);
   }
   tensor_proto->set_data_type(caffe2::TypeMetaToDataType(
-      at::scalarTypeToTypeMeta(tensor.type().scalarType())));
+      at::scalarTypeToTypeMeta(tensor.scalar_type())));
   tensor_proto->set_offset(tensor.storage_offset());
 
   tensor_proto->set_requires_grad(tensor.requires_grad());

--- a/torch/csrc/jit/fuser/executor.cpp
+++ b/torch/csrc/jit/fuser/executor.cpp
@@ -265,7 +265,7 @@ void launchFusion(
       addTensorInfo(fusion.inputDesc()[i], tensor);
     } else {
       size_t chunk_offset = map_size[chunk.dim()] * tensor.stride(chunk.dim()) *
-          elementSize(tensor.type().scalarType());
+          elementSize(tensor.scalar_type());
       char* data_ptr = reinterpret_cast<char*>(tensor.data_ptr());
       for (size_t chunks = 0; chunks < chunk.nSubTensors(); ++chunks) {
         addTensorInfoRaw(

--- a/torch/csrc/jit/fuser/tensor_desc.h
+++ b/torch/csrc/jit/fuser/tensor_desc.h
@@ -39,7 +39,7 @@ struct TORCH_API TensorDesc {
       : TensorDesc(type, TensorDesc::findContiguous(sizes, strides)) {}
 
   TensorDesc(const at::Tensor& t)
-      : TensorDesc(t.type().scalarType(), t.sizes(), t.strides()) {}
+      : TensorDesc(t.scalar_type(), t.sizes(), t.strides()) {}
 
   TensorDesc(const c10::CompleteTensorTypePtr& type)
       : TensorDesc(type->scalarType(), type->sizes(), type->strides()) {}

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -206,7 +206,7 @@ struct DifferentiableGraphOp {
         // NB: since our requires_grad setting is only a heuristic we might end
         // up wanting to differentiate through integral tensors, which is
         // generally a hard error in autograd.
-        if (at::isFloatingType(output.type().scalarType())) {
+        if (at::isFloatingType(output.scalar_type())) {
           autograd::create_gradient_edge(output, grad_fn);
           output.set_requires_grad(true);
         } else {

--- a/torch/csrc/jit/python_arg_flatten.h
+++ b/torch/csrc/jit/python_arg_flatten.h
@@ -17,7 +17,7 @@ struct IODescriptor {
   struct VariableMetadata {
     VariableMetadata(const autograd::Variable& var)
         : sizes(var.sizes().vec()),
-          type(var.type().scalarType()),
+          type(var.scalar_type()),
           device(var.device()),
           requires_grad(var.requires_grad()) {}
 

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -55,9 +55,9 @@ void checkImplicitTensorToNum(at::Tensor t, bool toInt) {
   }
   if (toInt &&
       !isIntegralType(
-          autograd::as_variable_ref(t).data().type().scalarType())) {
+          autograd::as_variable_ref(t).data().scalar_type())) {
     std::stringstream ss;
-    ss << "Cannot input a tensor of type " << t.type().scalarType()
+    ss << "Cannot input a tensor of type " << t.scalar_type()
        << " as an integral argument";
     throw std::runtime_error(ss.str());
   }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -163,7 +163,7 @@ struct Method {
     }
     AT_ASSERT(retval->inputs().size() == inputs.size());
     for (size_t i = 0; i < retval->inputs().size(); ++i) {
-      auto scalar_type = inputs[i].type().scalarType();
+      auto scalar_type = inputs[i].scalar_type();
       auto sizes = inputs[i].sizes();
       auto type =
           torch::jit::CompleteTensorType::create(scalar_type, at::kCPU, sizes);
@@ -177,7 +177,7 @@ struct Method {
     }
     AT_ASSERT(output_values.size() == outputs.size());
     for (size_t i = 0; i < retval->outputs().size(); ++i) {
-      auto scalar_type = outputs[i].type().scalarType();
+      auto scalar_type = outputs[i].scalar_type();
       auto sizes = outputs[i].sizes();
       auto type =
           torch::jit::CompleteTensorType::create(scalar_type, at::kCPU, sizes);

--- a/torch/csrc/nn/type_checks.h
+++ b/torch/csrc/nn/type_checks.h
@@ -11,8 +11,8 @@ namespace torch { namespace nn {
 
 inline bool check_type(PyObject* obj, at::TypeID typeID) {
   if (THPVariable_Check(obj)) {
-    auto& data_type = ((THPVariable*)obj)->cdata.type();
-    return at::globalContext().getNonVariableType(data_type.backend(), data_type.scalarType()).ID() == typeID;
+    auto& tensor = ((THPVariable*)obj)->cdata;
+    return at::globalContext().getNonVariableType(tensor.type().backend(), tensor.scalar_type()).ID() == typeID;
   }
   return false;
 }

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -1,6 +1,5 @@
 #include <torch/csrc/tensor/python_tensor.h>
 
-#include <structmember.h>
 #include <pybind11/pybind11.h>
 
 #include <torch/csrc/Dtype.h>
@@ -29,33 +28,18 @@ namespace torch { namespace tensors {
 using namespace at;
 using namespace torch::autograd;
 
-struct PyTensorType {
-  PyTypeObject py_type;
-  at::Type* aten_type_;
-  THPDtype* dtype;
-  THPLayout* layout;
-  bool is_cuda;
-  char name[64];
-  int backend;
-  int scalar_type;
+at::Type* PyTensorType::aten_type() {
+ if (!aten_type_) {
+   if (is_cuda) {
+     torch::utils::cuda_lazy_init();
+   }
+   auto* baseType = globalContext().getNonVariableTypeOpt(static_cast<at::Backend>(backend), static_cast<at::ScalarType>(scalar_type));
+   aten_type_ = baseType ? torch::autograd::VariableType::getVariableTypeFromBaseType(*baseType) : nullptr;
+ }
+ return aten_type_;
+}
 
-  // Precondition: Access to this struct is protected by the GIL
-  at::Type* aten_type() {
-    if (!aten_type_) {
-      if (is_cuda) {
-        torch::utils::cuda_lazy_init();
-      }
-      auto* baseType = globalContext().getNonVariableTypeOpt(static_cast<at::Backend>(backend), static_cast<at::ScalarType>(scalar_type));
-      aten_type_ = baseType ? torch::autograd::VariableType::getVariableTypeFromBaseType(*baseType) : nullptr;
-    }
-    return aten_type_;
-  }
-};
-
-static_assert(std::is_standard_layout<PyTensorType>::value, "PyTensorType must be standard layout");
-
-// This is always an instance of VariableType
-static at::Type* default_tensor_type;
+static PyTensorType* default_tensor_type;
 
 static void py_bind_tensor_types(const std::vector<PyTensorType>& tensor_types);
 
@@ -184,12 +168,12 @@ static std::string get_name(Backend backend, ScalarType scalarType) {
   return ss.str();
 }
 
-static THPObjectPtr get_storage_obj(const Type& type) {
-  auto module_name = get_module(type.backend());
+static THPObjectPtr get_storage_obj(const PyTensorType& type) {
+  auto module_name = get_module(static_cast<Backend>(type.backend));
   auto module_obj = THPObjectPtr(PyImport_ImportModule(module_name));
   if (!module_obj) throw python_error();
 
-  auto storage_name = std::string(toString(type.scalarType())) + "Storage";
+  auto storage_name = std::string(toString(static_cast<ScalarType>(type.scalar_type))) + "Storage";
   THPObjectPtr storage(PyObject_GetAttrString(module_obj.get(), storage_name.c_str()));
   if (!storage.get()) {
     throw TypeError("couldn't find storage object %s", storage_name.c_str());
@@ -252,6 +236,17 @@ static void initialize_aten_types(std::vector<PyTensorType>& tensor_types) {
   }
 }
 
+static PyTensorType& get_tensor_type(THPDtype *dtype, THPLayout *layout, bool is_cuda) {
+  auto it = std::find_if(tensor_types.begin(), tensor_types.end(),
+    [dtype, layout, is_cuda](const PyTensorType& x) {
+      return x.dtype == dtype && x.layout == layout && x.is_cuda == is_cuda;
+    });
+  if (it == tensor_types.end()) {
+    throw TypeError("invalid dtype object");
+  }
+  return *it;
+}
+
 void initialize_python_bindings() {
   // Initialize the at::Type* pointers, name, and properties of the PyTensorType
   // vector. After this call, the vector must not be resized.
@@ -278,7 +273,7 @@ void initialize_python_bindings() {
   py_bind_tensor_types(tensor_types);
 
   // Use torch.float32 as the default tensor type
-  set_default_tensor_type(at::globalContext().getVariableType(at::Backend::CPU, at::kFloat));
+  set_default_tensor_type(get_tensor_type(torch::getDtype(at::kFloat), torch::getLayout(at::Backend::CPU), false));
 }
 
 static void py_bind_tensor_types(const std::vector<PyTensorType>& tensor_types) {
@@ -316,17 +311,6 @@ static bool PyTensorType_Check(PyObject* obj) {
   return it != tensor_types.end();
 }
 
-static PyTensorType& get_tensor_type(THPDtype *dtype, THPLayout *layout, bool is_cuda) {
-  auto it = std::find_if(tensor_types.begin(), tensor_types.end(),
-    [dtype, layout, is_cuda](const PyTensorType& x) {
-      return x.dtype == dtype && x.layout == layout && x.is_cuda == is_cuda;
-    });
-  if (it == tensor_types.end()) {
-    throw TypeError("invalid dtype object");
-  }
-  return *it;
-}
-
 void py_set_default_tensor_type(PyObject* obj) {
   PyTensorType *type;
   if (PyTensorType_Check(obj)) {
@@ -338,15 +322,15 @@ void py_set_default_tensor_type(PyObject* obj) {
   if (!aten_type) {
     throw unavailable_type(*type);
   }
-  set_default_tensor_type(*aten_type);
+  set_default_tensor_type(*type);
 }
 
 void py_set_default_dtype(PyObject* obj) {
   PyTensorType *type;
   if (THPDtype_Check(obj)) {
-    auto &current_default = get_default_tensor_type();
-    type = &get_tensor_type((THPDtype*)obj, torch::getLayout(current_default.backend()),
-                            torch::getDeviceType(current_default) == at::Device::Type::CUDA);
+    auto current_default = get_default_tensor_type().aten_type();
+    type = &get_tensor_type((THPDtype*)obj, torch::getLayout(current_default->backend()),
+                            torch::getDeviceType(*current_default) == at::Device::Type::CUDA);
   } else {
     throw TypeError("invalid type object");
   }
@@ -354,25 +338,25 @@ void py_set_default_dtype(PyObject* obj) {
   if (!aten_type) {
     throw unavailable_type(*type);
   }
-  set_default_tensor_type(*aten_type);
+  set_default_tensor_type(*type);
 }
 
-void set_default_tensor_type(const at::Type& type) {
-  if (!at::isFloatingType(type.scalarType())) {
+void set_default_tensor_type(PyTensorType& type) {
+  auto aten_type = type.aten_type();
+  if (!at::isFloatingType(aten_type->scalarType())) {
     throw TypeError("only floating-point types are supported as the default type");
   }
-  if (!type.is_variable() && !type.is_undefined()) {
+  if (!aten_type->is_variable() && !aten_type->is_undefined()) {
     throw TypeError("only variable types are supported");
   }
-  if (type.is_sparse()) {
+  if (aten_type->is_sparse()) {
     throw TypeError("only dense types are supported as the default type");
   }
 
   // get the storage first, so if it doesn't exist we don't change the default tensor type
   THPObjectPtr storage = get_storage_obj(type);
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  default_tensor_type = const_cast<Type*>(&type);
-  at::set_default_dtype(default_tensor_type->typeMeta());
+  default_tensor_type = &type;
+  at::set_default_dtype(aten_type->typeMeta());
 
   auto torch_module = THPObjectPtr(PyImport_ImportModule("torch"));
   if (!torch_module) throw python_error();
@@ -383,7 +367,7 @@ void set_default_tensor_type(const at::Type& type) {
   }
 }
 
-at::Type& get_default_tensor_type() {
+PyTensorType& get_default_tensor_type() {
   AT_ASSERT(default_tensor_type);
   return *default_tensor_type;
 }

--- a/torch/csrc/tensor/python_tensor.h
+++ b/torch/csrc/tensor/python_tensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/python_headers.h>
+#include <type_traits>
 
 namespace c10 {
 struct Device;
@@ -11,7 +12,26 @@ struct Type;
 class Tensor;
 } // namespace at
 
+struct THPDtype;
+struct THPLayout;
+
 namespace torch { namespace tensors {
+
+struct PyTensorType {
+  PyTypeObject py_type;
+  at::Type* aten_type_;
+  THPDtype* dtype;
+  THPLayout* layout;
+  bool is_cuda;
+  char name[64];
+  int backend;
+  int scalar_type;
+
+  // Precondition: Access to this struct is protected by the GIL
+  at::Type* aten_type();
+};
+
+static_assert(std::is_standard_layout<PyTensorType>::value, "PyTensorType must be standard layout");
 
 // Initializes the Python tensor type objects: torch.FloatTensor,
 // torch.DoubleTensor, etc. and binds them in their containing modules.
@@ -19,7 +39,7 @@ void initialize_python_bindings();
 
 // Sets the concrete type constructed by calls to torch.Tensor() and most
 // factory methods on the torch module.
-void set_default_tensor_type(const at::Type& type);
+void set_default_tensor_type(PyTensorType& type);
 
 // Same as set_default_tensor_type() but takes a PyObject*
 void py_set_default_tensor_type(PyObject* type_obj);
@@ -28,8 +48,8 @@ void py_set_default_tensor_type(PyObject* type_obj);
 void py_set_default_dtype(PyObject* dtype_obj);
 
 // Gets the ATen type object for the default tensor type. Note that the
-// returned value will be a VariableType instance.
-at::Type& get_default_tensor_type();
+// returned value will be a PyTensorType instance.
+PyTensorType& get_default_tensor_type();
 
 // Gets the torch::Device object of a given at::Tensor
 c10::Device getDevice(const at::Tensor& tensor);

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -127,7 +127,7 @@ bool FunctionParameter::check(PyObject* obj) {
       }
       if (THPVariable_Check(obj)) {
         auto& var = ((THPVariable*)obj)->cdata;
-        return at::isIntegralType(var.type().scalarType()) && !var.requires_grad() && var.dim() == 0;
+        return at::isIntegralType(var.scalar_type()) && !var.requires_grad() && var.dim() == 0;
       }
       return false;
     }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -331,7 +331,7 @@ inline at::ScalarType PythonArgs::scalartype(int i) {
   if (!args[i]) {
     auto scalartype = signature.params[i].default_scalartype;
     return (scalartype == at::ScalarType::Undefined) ?
-            torch::tensors::get_default_tensor_type().scalarType() : scalartype;
+            static_cast<at::ScalarType>(torch::tensors::get_default_tensor_type().scalar_type) : scalartype;
   }
   return reinterpret_cast<THPDtype*>(args[i])->scalar_type;
 }
@@ -359,8 +359,8 @@ static std::string cpu_prefix = "cpu:";
 
 inline at::Device PythonArgs::device(int i) {
   if (!args[i]) {
-    const auto& default_tensor_type = torch::tensors::get_default_tensor_type();
-    return at::Device(default_tensor_type.device_type());
+    const auto default_tensor_type = torch::tensors::get_default_tensor_type().aten_type();
+    return at::Device(default_tensor_type->device_type());
   }
   if (THPDevice_Check(args[i])) {
     const auto device = reinterpret_cast<THPDevice*>(args[i]);

--- a/torch/csrc/utils/tensor_apply.cpp
+++ b/torch/csrc/utils/tensor_apply.cpp
@@ -57,7 +57,7 @@ Tensor & apply_(Tensor & self, PyObject* fn) {
   if (self.type().backend() != Backend::CPU) {
     throw TypeError("apply_ is only implemented on CPU tensors");
   }
-  auto scalarType = self.type().scalarType();
+  auto scalarType = self.scalar_type();
   recursive_apply<1>(self.sizes(), scalarType, 0, fn, {{ self }});
   return self;
 }
@@ -72,7 +72,7 @@ Tensor & map_(Tensor & self, const Tensor & other_, PyObject* fn) {
   }
   Tensor other;
   std::tie(other) = expand_inplace(self, other_, "map_");
-  auto scalarType = self.type().scalarType();
+  auto scalarType = self.scalar_type();
   recursive_apply<2>(self.sizes(), scalarType, 0, fn, {{ self, other }});
   return self;
 }
@@ -91,7 +91,7 @@ Tensor & map2_(Tensor & self, const Tensor & x_, const Tensor & y_, PyObject* fn
   }
   Tensor other1, other2;
   std::tie(other1, other2) = expand_inplace(self, x_, y_, "map2_");
-  auto scalarType = self.type().scalarType();
+  auto scalarType = self.scalar_type();
   recursive_apply<3>(self.sizes(), scalarType, 0, fn, {{ self, other1, other2 }});
   return self;
 }

--- a/torch/csrc/utils/tensor_list.cpp
+++ b/torch/csrc/utils/tensor_list.cpp
@@ -35,10 +35,9 @@ PyObject* tensor_to_list(const Tensor& tensor) {
       data = data.toBackend(Backend::CPU);
     });
   }
-  auto& type = data.type();
   return recursive_to_list(
       (char*)data.data_ptr(), data.sizes(), data.strides(), 0,
-      type.scalarType(), type.elementSizeInBytes());
+      data.scalar_type(), data.dtype().itemsize());
 }
 
 }}  // namespace torch::utils

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -14,47 +14,48 @@ using namespace at;
 
 namespace torch { namespace utils {
 
-static const char* backend_to_string(const at::Type& type) {
-  switch (type.backend()) {
+static const char* backend_to_string(const at::Backend backend) {
+  switch (backend) {
     case at::Backend::CPU: return "torch";
     case at::Backend::CUDA: return "torch.cuda";
     case at::Backend::SparseCPU: return "torch.sparse";
     case at::Backend::SparseCUDA: return "torch.cuda.sparse";
-    default: AT_ERROR("Unimplemented backend ", type.backend());
+    default: AT_ERROR("Unimplemented backend ", backend);
   }
 }
 
-std::string type_to_string(const at::Type& type) {
+std::string type_to_string(const at::Backend backend, const at::ScalarType scalar_type) {
   std::ostringstream ss;
-  ss << backend_to_string(type) << "." << toString(type.scalarType()) << "Tensor";
+  ss << backend_to_string(backend) << "." << toString(scalar_type) << "Tensor";
   return ss.str();
 }
 
-at::Type& type_from_string(const std::string& str) {
+std::pair<Backend, ScalarType> type_from_string(const std::string& str) {
   static std::string cuda_prefix("torch.cuda.");
   static std::once_flag cpu_once;
   static std::once_flag cuda_once;
-  static std::unordered_map<std::string, Type*> cpu_map;
-  static std::unordered_map<std::string, Type*> cuda_map;
+  static std::unordered_map<std::string, std::pair<Backend, ScalarType>> cpu_map;
+  static std::unordered_map<std::string, std::pair<Backend, ScalarType>> cuda_map;
 
-  const std::unordered_map<std::string, Type*>* map = nullptr;
+  const std::unordered_map<std::string, std::pair<Backend, ScalarType>>* map = nullptr;
 
   if (str == "torch.Tensor") {
-    return torch::tensors::get_default_tensor_type();
+    auto default_type = torch::tensors::get_default_tensor_type();
+    return std::make_pair(static_cast<Backend>(default_type.backend), static_cast<ScalarType>(default_type.scalar_type));
   }
 
   if (std::mismatch(cuda_prefix.begin(), cuda_prefix.end(), str.begin()).first == cuda_prefix.end()) {
     // torch.cuda. is prefix of str
     std::call_once(cuda_once, []() {
-      for (auto type : autograd::VariableType::allCUDATypes()) {
-        cuda_map.emplace(type_to_string(*type), type);
+      for (auto type_pair : autograd::VariableType::allCUDATypes()) {
+        cuda_map.emplace(type_to_string(type_pair.first, type_pair.second), type_pair);
       }
     });
     map = &cuda_map;
   } else {
     std::call_once(cpu_once, []() {
-      for (auto type : autograd::VariableType::allCPUTypes()) {
-        cpu_map.emplace(type_to_string(*type), type);
+      for (auto type_pair : autograd::VariableType::allCPUTypes()) {
+        cpu_map.emplace(type_to_string(type_pair.first, type_pair.second), type_pair);
       }
     });
     map = &cpu_map;
@@ -64,7 +65,7 @@ at::Type& type_from_string(const std::string& str) {
   if (it == map->end()) {
     throw ValueError("invalid type: '%s'", str.c_str());
   }
-  return *it->second;
+  return it->second;
 }
 
 std::vector<std::pair<Backend, ScalarType>> all_declared_types() {

--- a/torch/csrc/utils/tensor_types.h
+++ b/torch/csrc/utils/tensor_types.h
@@ -6,8 +6,8 @@
 
 namespace torch { namespace utils {
 
-std::string type_to_string(const at::Type& type);
-at::Type& type_from_string(const std::string& str);
+std::string type_to_string(const at::Tensor& tensor);
+std::pair<at::Backend, at::ScalarType> type_from_string(const std::string& str);
 
 // return a vector of all "declared" types, even those that weren't compiled
 std::vector<std::pair<at::Backend, at::ScalarType>> all_declared_types();

--- a/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelGloo.cpp
@@ -210,7 +210,7 @@ void DataChannelGloo::allGather(
     assertSameSizeAndType(out_tensor, input, "allGather");
 
   GENERATE_ALL_TYPES(
-      input.type().scalarType(), allGatherT, output, input, group_id)
+      input.scalar_type(), allGatherT, output, input, group_id)
 }
 
 // XXX: `gather` is not supported by Gloo yet.
@@ -259,7 +259,7 @@ void DataChannelGloo::allReduce(
     THDGroup group_id) {
   RETURN_IF_NOT_IN_GROUP
   GENERATE_ALL_TYPES(
-      data.type().scalarType(), allReduceT, data, operation, group_id)
+      data.scalar_type(), allReduceT, data, operation, group_id)
 }
 
 // XXX: `reduce` is not supported by Gloo yet.
@@ -305,7 +305,7 @@ void DataChannelGloo::broadcast(
     THDGroup group_id) {
   RETURN_IF_NOT_IN_GROUP
   GENERATE_ALL_TYPES(
-      data.type().scalarType(), broadcastT, data, src_rank, group_id)
+      data.scalar_type(), broadcastT, data, src_rank, group_id)
 }
 
 void DataChannelGloo::send(Scalar& data, rank_type dst_rank) {

--- a/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelMPI.cpp
@@ -169,10 +169,10 @@ void DataChannelMPI::allGather(
   MPI_Allgather(
       contig_input.data_ptr(),
       contig_input.numel(),
-      mpi_datatype.at(contig_input.type().scalarType()),
+      mpi_datatype.at(contig_input.scalar_type()),
       recv_buffer.data_ptr(),
       contig_input.numel(),
-      mpi_datatype.at(recv_buffer.type().scalarType()),
+      mpi_datatype.at(recv_buffer.scalar_type()),
       comm);
 
   for (size_t i = 0; i < output.size(); ++i)
@@ -213,10 +213,10 @@ void DataChannelMPI::gather(
   MPI_Gather(
       contig_input.data_ptr(),
       input.numel(),
-      mpi_datatype.at(input.type().scalarType()),
+      mpi_datatype.at(input.scalar_type()),
       recvbuf,
       input.numel(),
-      mpi_datatype.at(input.type().scalarType()),
+      mpi_datatype.at(input.scalar_type()),
       group_dst_rank,
       comm);
 
@@ -263,10 +263,10 @@ void DataChannelMPI::scatter(
   MPI_Scatter(
       sendbuf,
       output.numel(),
-      mpi_datatype.at(output.type().scalarType()),
+      mpi_datatype.at(output.scalar_type()),
       output.data_ptr(),
       output.numel(),
-      mpi_datatype.at(output.type().scalarType()),
+      mpi_datatype.at(output.scalar_type()),
       group_src_rank,
       comm);
 }
@@ -286,7 +286,7 @@ void DataChannelMPI::allReduce(
       MPI_IN_PLACE,
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       mpi_op.at(operation),
       comm);
 }
@@ -311,7 +311,7 @@ void DataChannelMPI::reduce(
       sendbuf,
       recvbuf,
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       mpi_op.at(operation),
       group_dst_rank,
       comm);
@@ -333,7 +333,7 @@ void DataChannelMPI::broadcast(
   MPI_Bcast(
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       group_src_rank,
       comm);
 }
@@ -355,7 +355,7 @@ void DataChannelMPI::send(at::Tensor& data, rank_type dst_rank) {
   MPI_Send(
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       dst_rank,
       0,
       MPI_COMM_WORLD);
@@ -380,7 +380,7 @@ rank_type DataChannelMPI::receive(at::Tensor& data) {
   MPI_Recv(
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       MPI_ANY_SOURCE,
       0,
       MPI_COMM_WORLD,
@@ -395,7 +395,7 @@ void DataChannelMPI::receive(at::Tensor& data, rank_type src_rank) {
   MPI_Recv(
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       src_rank,
       0,
       MPI_COMM_WORLD,
@@ -422,7 +422,7 @@ DataChannelMPI::RequestMPI* DataChannelMPI::isend(
   MPI_Isend(
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       dst_rank,
       0,
       MPI_COMM_WORLD,
@@ -443,7 +443,7 @@ DataChannelMPI::RequestMPI* DataChannelMPI::ireceive(
   MPI_Irecv(
       data.data_ptr(),
       data.numel(),
-      mpi_datatype.at(data.type().scalarType()),
+      mpi_datatype.at(data.scalar_type()),
       src_rank,
       0,
       MPI_COMM_WORLD,

--- a/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
+++ b/torch/lib/THD/base/data_channels/DataChannelNccl.cpp
@@ -341,7 +341,7 @@ bool DataChannelNccl::_tensorCheckHelper(
   usedDevices.reserve(input.size());
 
   uint64_t inputNumElement = input[0].numel();
-  auto elementType = input[0].type().scalarType();
+  auto elementType = input[0].scalar_type();
 
   for (size_t i = 0; i < input.size(); ++i) {
     //  Check to make sure it's a GPU dense tensor
@@ -352,8 +352,8 @@ bool DataChannelNccl::_tensorCheckHelper(
           "collective operations");
     }
     // Check the tensor type is identical
-    if (input[i].type().scalarType() != elementType ||
-        output[i].type().scalarType() != elementType) {
+    if (input[i].scalar_type() != elementType ||
+        output[i].scalar_type() != elementType) {
       throw std::runtime_error(
           "Expecting all GPU tensors to have identical "
           "type");
@@ -424,7 +424,7 @@ void DataChannelNccl::allReduce(
         data[i].data_ptr(),
         data[i].data_ptr(),
         data[i].numel(),
-        _getNcclDataType(data[i].type().scalarType()),
+        _getNcclDataType(data[i].scalar_type()),
         ncclOp[operation],
         (*comms)[i],
         stream));
@@ -480,7 +480,7 @@ void DataChannelNccl::allGather(
         input[i].data_ptr(),
         output[i].data_ptr(),
         input[i].numel(),
-        _getNcclDataType(input[i].type().scalarType()),
+        _getNcclDataType(input[i].scalar_type()),
         (*comms)[i],
         stream));
   }
@@ -537,7 +537,7 @@ void DataChannelNccl::reduce(
         data[i].data_ptr(),
         data[i].data_ptr(),
         data[i].numel(),
-        _getNcclDataType(data[i].type().scalarType()),
+        _getNcclDataType(data[i].scalar_type()),
         ncclOp[operation],
         dstRank * data.size(),
         (*comms)[i],
@@ -595,7 +595,7 @@ void DataChannelNccl::broadcast(
     NCCL_CHECK(ncclBcast(
         data[i].data_ptr(),
         data[i].numel(),
-        _getNcclDataType(data[i].type().scalarType()),
+        _getNcclDataType(data[i].scalar_type()),
         srcRank * data.size(),
         (*comms)[i],
         stream));

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -1011,7 +1011,7 @@ class AsyncGatherWork : public ProcessGroupGloo::AsyncWork {
   void gather(
       std::vector<std::vector<at::Tensor>>& outputs,
       std::vector<at::Tensor>& inputs) {
-    const auto scalarType = inputs[0].type().scalarType();
+    const auto scalarType = inputs[0].scalar_type();
     gloo::GatherOptions opts(context);
     opts.setRoot(root);
     opts.setTag(tag);
@@ -1208,7 +1208,7 @@ class AsyncScatterWork : public ProcessGroupGloo::AsyncWork {
   void scatter(
       std::vector<at::Tensor>& outputs,
       std::vector<std::vector<at::Tensor>>& inputs) {
-    const auto scalarType = outputs[0].type().scalarType();
+    const auto scalarType = outputs[0].scalar_type();
     gloo::ScatterOptions opts(context);
     opts.setRoot(root);
     opts.setTag(tag);

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -351,7 +351,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::broadcast(
         MPI_CHECK(MPI_Bcast(
             data.data_ptr(),
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             opts.rootRank,
             pgComm_));
       };
@@ -376,7 +376,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
             MPI_IN_PLACE,
             data.data_ptr(),
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             mpiOp.at(opts.reduceOp),
             pgComm_));
       };
@@ -405,7 +405,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce(
             sendbuf,
             recvbuf,
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             mpiOp.at(opts.reduceOp),
             opts.rootRank,
             pgComm_));
@@ -446,10 +446,10 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather(
         MPI_CHECK(MPI_Allgather(
             data.data_ptr(),
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             flatOutputTensor.data_ptr(),
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             pgComm_));
 
         for (size_t i = 0; i < outputDataVec.size(); ++i) {
@@ -503,10 +503,10 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
         MPI_CHECK(MPI_Gather(
             data.data_ptr(),
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             recvbuf,
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             opts.rootRank,
             pgComm_));
 
@@ -578,10 +578,10 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
         MPI_CHECK(MPI_Scatter(
             sendbuf,
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             data.data_ptr(),
             data.numel(),
-            mpiDatatype.at(data.type().scalarType()),
+            mpiDatatype.at(data.scalar_type()),
             opts.rootRank,
             pgComm_));
       };
@@ -615,7 +615,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
     MPI_CHECK(MPI_Isend(
         tensor.data_ptr(),
         tensor.numel(),
-        mpiDatatype.at(tensor.type().scalarType()),
+        mpiDatatype.at(tensor.scalar_type()),
         dstRank,
         tag,
         pgComm_,
@@ -643,7 +643,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
     MPI_CHECK(MPI_Irecv(
         tensor.data_ptr(),
         tensor.numel(),
-        mpiDatatype.at(tensor.type().scalarType()),
+        mpiDatatype.at(tensor.scalar_type()),
         srcRank,
         tag,
         pgComm_,
@@ -670,7 +670,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
     MPI_CHECK(MPI_Irecv(
         tensor.data_ptr(),
         tensor.numel(),
-        mpiDatatype.at(tensor.type().scalarType()),
+        mpiDatatype.at(tensor.scalar_type()),
         MPI_ANY_SOURCE,
         tag,
         pgComm_,

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -301,7 +301,7 @@ void ProcessGroupNCCL::tensorCheckHelper(
   usedDevices.reserve(input.size());
 
   auto inputNumElement = input[0].numel();
-  auto elementType = input[0].type().scalarType();
+  auto elementType = input[0].scalar_type();
 
   for (size_t i = 0; i < input.size(); ++i) {
     //  Check to make sure it's a GPU dense tensor
@@ -312,8 +312,8 @@ void ProcessGroupNCCL::tensorCheckHelper(
           "collective operations");
     }
     // Check the tensor type is identical
-    if (input[i].type().scalarType() != elementType ||
-        output[i].type().scalarType() != elementType) {
+    if (input[i].scalar_type() != elementType ||
+        output[i].scalar_type() != elementType) {
       throw std::runtime_error(
           "Expecting all GPU tensors to have identical "
           "type");
@@ -382,7 +382,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
         tensors[i].data_ptr(),
         tensors[i].data_ptr(),
         tensors[i].numel(),
-        getNcclDataType(tensors[i].type().scalarType()),
+        getNcclDataType(tensors[i].scalar_type()),
         ncclOp[opts.reduceOp],
         ncclComms[i]->getNcclComm(),
         ncclStream.stream()));
@@ -430,7 +430,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
     C10D_NCCL_CHECK(ncclBcast(
         tensors[i].data_ptr(),
         tensors[i].numel(),
-        getNcclDataType(tensors[i].type().scalarType()),
+        getNcclDataType(tensors[i].scalar_type()),
         root,
         ncclComms[i]->getNcclComm(),
         ncclStream.stream()));
@@ -479,7 +479,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
         tensors[i].data_ptr(),
         tensors[i].data_ptr(),
         tensors[i].numel(),
-        getNcclDataType(tensors[i].type().scalarType()),
+        getNcclDataType(tensors[i].scalar_type()),
         ncclOp[opts.reduceOp],
         root,
         ncclComms[i]->getNcclComm(),
@@ -547,7 +547,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
         inputTensors[i].data_ptr(),
         flattenOutputTensors[i].data_ptr(),
         inputTensors[i].numel(),
-        getNcclDataType(inputTensors[i].type().scalarType()),
+        getNcclDataType(inputTensors[i].scalar_type()),
         ncclComms[i]->getNcclComm(),
         ncclStream.stream()));
   }

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -144,7 +144,7 @@ def _if_scalar_type_as(g, self, tensor):
     if isinstance(self, torch._C.Value):
         return self
     elif tensor.type().kind() == "DimensionedTensorType" or tensor.type().kind() == "CompleteTensorType":
-        ty = tensor.type().scalarType().lower()
+        ty = tensor.scalar_type().lower()
         return getattr(self, ty)()
     else:
         return self
@@ -165,7 +165,7 @@ def _unimplemented(op, msg):
 def _try_get_scalar_type(*args):
     for arg in args:
         try:
-            return arg.type().scalarType()
+            return arg.scalar_type()
         except RuntimeError:
             pass
     return None
@@ -893,12 +893,12 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
     if weight is None or weight.node().mustBeNone():
         assert len(input_sizes) > 1
         weight_value = torch.tensor([1.] * input_sizes[1]).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            'torch.' + input.scalar_type() + 'Tensor')
         weight = g.op("Constant", value_t=weight_value)
     if bias is None or bias.node().mustBeNone():
         assert len(input_sizes) > 1
         bias_value = torch.tensor([0.] * input_sizes[1]).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            'torch.' + input.scalar_type() + 'Tensor')
         bias = g.op("Constant", value_t=bias_value)
     out = g.op("BatchNormalization", input, weight, bias, running_mean, running_var,
                epsilon_f=eps,
@@ -925,12 +925,12 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
     if weight is None or weight.node().mustBeNone():
         assert len(input_sizes) > 1
         weight_value = torch.tensor([1.] * input_sizes[1]).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            'torch.' + input.scalar_type() + 'Tensor')
         weight = g.op("Constant", value_t=weight_value)
     if bias is None or bias.node().mustBeNone():
         assert len(input_sizes) > 1
         bias_value = torch.tensor([0.] * input_sizes[1]).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            'torch.' + input.scalar_type() + 'Tensor')
         bias = g.op("Constant", value_t=bias_value)
     return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
 
@@ -971,11 +971,11 @@ def index_put(g, self, indices_list_value, values, accumulate):
 
 
 def type_as(g, self, other):
-    if self.isTensor() and other.isTensor() and self.type().scalarType() == other.type().scalarType():
+    if self.isTensor() and other.isTensor() and self.scalar_type() == other.scalar_type():
         return self
 
     if other.isTensor():
-        other_type_name = other.type().scalarType()
+        other_type_name = other.scalar_type()
         return g.op("Cast", self, to_i=cast_pytorch_to_onnx[other_type_name])
     else:
         # We don't know the type of other, bail by emitting ATen
@@ -1518,7 +1518,7 @@ def _pack_padded_sequence(g, input, lengths, batch_first):
     # We know it's a TensorType so this check is now safe.
     # It's really only necessary beacuse those operators expand to something that
     # only works with int32 types in Caffe2...
-    if lengths.type().scalarType() != 'Int':
+    if lengths.scalar_type() != 'Int':
         lengths = _cast_Int(g, lengths, False)
     return g.op("prim::PackPadded", input, lengths, outputs=2)
 


### PR DESCRIPTION
In preparation for eliminating Type::scalarType() completely.

Many of these are just replacing tensor.type().scalarType() with tensor.scalar_type()

Changes to note:
- Changed Dispatch.h to take ScalarType rather than Type
- Store default type in python_tensor.cpp as PyTensorType rather than Type
- Store ScalarType and Backend instead of Type in TensorIterator

Remaining usages of scalarType are in the factory functions and their python bindings.