### PR TITLE
[jit] Fix clamp fusion on missing limits

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11571,10 +11571,16 @@ class TestFuser(JitTestCase):
         def funcInf(a, b):
             return torch.clamp(a + b, min=0, max=float('inf'))
 
+        def funcOptMin(a, b):
+            return torch.clamp(a + b, max=2)
+
+        def funcOptMax(a, b):
+            return torch.clamp(a + b, min=0)
+
         a = torch.randn(4, 4, dtype=torch.float, device='cuda', requires_grad=True)
         b = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
-        funcs = (func2, funcInf)
+        funcs = (func2, funcInf, funcOptMin, funcOptMax)
         for f in funcs:
             s = self.checkScript(f, (a, b))
             self.assertAllFused(s.graph_for(a, b), except_for={'aten::size'})


### PR DESCRIPTION
Fixes #17449 

Context: before #17186, we don't fuse `clamp` for the case when `min/max` are missing inputs,  because they are `prim::None` node, after #17186, we make None a `prim::Constant` node which enables the fusion for `clamp`. But codegen.cpp does not handle the case when `prim::Constant` is not a Double/Int/Bool, this PR makes it so that missing inputs are treated as `NAN` in the codegen. This might not be a sweet solution since we don't actually want `NAN` for clamp anymore, but since the codestring does not support optional inputs, this might be a better way to do. 