### PR TITLE
Set caffe2_cpu_numa_enabled to true by default

### DIFF
--- a/c10/util/numa.cpp
+++ b/c10/util/numa.cpp
@@ -1,6 +1,6 @@
 #include "c10/util/numa.h"
 
-C10_DEFINE_bool(caffe2_cpu_numa_enabled, false, "Use NUMA whenever possible.");
+C10_DEFINE_bool(caffe2_cpu_numa_enabled, true, "Use NUMA whenever possible.");
 
 #if defined(__linux__) && !defined(C10_DISABLE_NUMA) && C10_MOBILE == 0
 #include <numa.h>


### PR DESCRIPTION
Summary:
Flag caffe2_cpu_numa_enabled is used to turn on/off NUMA awareness support,
we do provide backward compatibility with all the code that is not NUMA-aware,
i.e. if device id is not set in CPU device option. NUMA pinning should be
enabled only in the nets that explicitly specify device id in CPU device
options.

Differential Revision: D14235816
