### PR TITLE
[jit] Fix clamp fusion on missing limits

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11587,10 +11587,16 @@ class TestFuser(JitTestCase):
         def funcInf(a, b):
             return torch.clamp(a + b, min=0, max=float('inf'))
 
+        def funcOptMin(a, b):
+            return torch.clamp(a + b, max=2)
+
+        def funcOptMax(a, b):
+            return torch.clamp(a + b, min=0)
+
         a = torch.randn(4, 4, dtype=torch.float, device='cuda', requires_grad=True)
         b = torch.randn(4, 4, dtype=torch.float, device='cuda')
 
-        funcs = (func2, funcInf)
+        funcs = (func2, funcInf, funcOptMin, funcOptMax)
         for f in funcs:
             s = self.checkScript(f, (a, b))
             self.assertAllFused(s.graph_for(a, b), except_for={'aten::size'})

--- a/torch/csrc/jit/fuser/codegen.cpp
+++ b/torch/csrc/jit/fuser/codegen.cpp
@@ -126,6 +126,36 @@ static std::string typeCastedValueName(
       "unknown scalar type during JIT fusion code generation");
 }
 
+// Writes RHS of special handling "simple mappable" ops
+static std::string encodeSpecialRHS(const Node* n, TemplateEnv& env) {
+  // special case for clamp fusion on missing min/max inputs
+  // Note: It may seem unusual to have the bounds as the first case below,
+  // this is so that if min or max is NaN, they are "ignored"
+  // and when the input is NaN, the output is, too
+  if (n->kind() == aten::clamp) {
+    const auto min = n->input(1);
+    const auto max = n->input(2);
+    env.s("0", valueName(n->input(0)));
+
+    if (!min->node()->mustBeNone() && !max->node()->mustBeNone()) {
+      env.s("1", valueName(min));
+      env.s("2", valueName(max));
+      return format("(${0} < ${1} ? ${1} : (${0} > ${2}? ${2} : ${0}))", env);
+    } else if (min->node()->mustBeNone()) {
+      env.s("1", valueName(max));
+      return format("(${0} > ${1} ? ${1} : ${0})", env);
+    } else if (max->node()->mustBeNone()) {
+      env.s("1", valueName(min));
+      return format("(${0} < ${1} ? ${1} : ${0})", env);
+    } else {
+      throw std::runtime_error(
+          "At least one of 'min' or 'max' must not be None");
+    }
+  } else {
+    throw std::runtime_error("Cannot encode RHS of the node, op not supported");
+  }
+}
+
 // Writes "simple mappable" ops
 static std::string encodeRHS(const Node* n) {
   static std::unordered_map<NodeKind, std::string> simple_map_ops = {
@@ -217,46 +247,29 @@ static std::string encodeRHS(const Node* n) {
   }
 
   TemplateEnv env;
-  size_t i = 0;
-  auto outtype = n->output()
-                     ->type()
-                     ->expect<c10::DimensionedTensorType const>()
-                     ->scalarType();
 
-  // special case for clamp fusion on missing min/max inputs
-  if (n->kind() == aten::clamp) {
-    const auto min = n->input(1);
-    const auto max = n->input(2);
-    env.s(std::to_string(i++), valueName(n->input(0)));
+  if (simple_map_ops.find(n->kind()) == simple_map_ops.end()) {
+    return encodeSpecialRHS(n, env);
+  } else {
+    size_t i = 0;
+    auto outtype = n->output()
+                       ->type()
+                       ->expect<c10::DimensionedTensorType const>()
+                       ->scalarType();
 
-    if (!min->node()->mustBeNone() && !max->node()->mustBeNone()) {
-      env.s(std::to_string(i++), valueName(min));
-      env.s(std::to_string(i++), valueName(max));
-      return format("(${0}<${1}?${1}:(${0}>${2}?${2}:${0}))", env);
-    } else if (min->node()->mustBeNone()) {
-      env.s(std::to_string(i++), valueName(max));
-      return format("(${0}<${1}?${0}:${1})", env);
-    } else if (max->node()->mustBeNone()) {
-      env.s(std::to_string(i++), valueName(min));
-      return format("(${0}>${1}?${0}:${1})", env);
-    } else {
-      throw std::runtime_error(
-          "At least one of 'min' or 'max' must not be None");
+    for (auto in : n->inputs()) {
+      // PyTorch converts (scalar) argument types to result before applying the
+      // operator e.g. 1.4-torch.tensor(3) = -2
+      env.s(std::to_string(i), valueName(in));
+      env.s(
+          std::string("cast_") + std::to_string(i),
+          typeCastedValueName(in->type(), outtype, valueName(in)));
+      i++;
     }
-  }
 
-  for (auto in : n->inputs()) {
-    // PyTorch converts (scalar) argument types to result before applying the
-    // operator e.g. 1.4-torch.tensor(3) = -2
-    env.s(std::to_string(i), valueName(in));
-    env.s(
-        std::string("cast_") + std::to_string(i),
-        typeCastedValueName(in->type(), outtype, valueName(in)));
-    i++;
+    const auto& str = simple_map_ops.at(n->kind());
+    return format(str, env);
   }
-
-  const auto& str = simple_map_ops.at(n->kind());
-  return format(str, env);
 }
 
 static void emitIndexingFor(
@@ -364,6 +377,8 @@ std::string generateKernel(
   // Generates code for intermediate nodes
   // Note: Concat and Chunk are implicitly generated
   // Note: Random number generation is only supported for CUDA kernels.
+  // Note: Constant None node is ignored and we will handle it in the
+  //       places where the constant None node is used
   for (const auto& n : graph.nodes()) {
     // Note: FusedConcat nodes work by narrowing the output Tensors before the
     // kernel runs
@@ -371,14 +386,13 @@ std::string generateKernel(
       continue;
     if (n->kind() == prim::ConstantChunk)
       continue;
+    if (n->mustBeNone())
+      continue;
     if (n->kind() == aten::rand_like) {
       AT_ASSERT(use_cuda);
       has_random = true;
     }
 
-    if (n->mustBeNone()) {
-      continue;
-    }
     env.s("node", valueName(n->output()));
     env.s("rhs", encodeRHS(n));
     env.s("lhs_type", variableType(n->output()->type()));


### PR DESCRIPTION
Fixes #17449

Context: before #17186, we don't fuse `clamp` for the case when `min/max` are missing inputs, because they are `prim::None` node, after #17186, we make None a `prim::Constant` node which enables the fusion for `clamp`. But codegen.cpp does not handle the case when `prim::Constant` is not a Double/Int/Bool, this PR makes it so that missing inputs are handled correctly, it is done in the following way:

1. emit nothing when you see `type? = prim::Constant()`
2. when emitRHS, do special casing for aten::clamp