### PR TITLE
Enabled HALF for fill() and zero() methods. Moved them into THTensorFill

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -38,6 +38,7 @@
   return: self
   cname: fill
   variants: function
+  cpu_half: True
   options:
     - arguments:
       - THTensor* self
@@ -1748,6 +1749,7 @@
   name: _th_zero_
   cname: zero
   return: self
+  cpu_half: True
   variants:
     - function
   arguments:

--- a/aten/src/TH/CMakeLists.txt
+++ b/aten/src/TH/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ATen_TH_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/THStorageFunctions.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/THTensor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/THTensorRandom.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/THTensorFill.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/THTensorMath.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/THTensorMoreMath.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/THTensorEvenMoreMath.cpp
@@ -112,6 +113,8 @@ INSTALL(FILES
   generic/THTensor.hpp
   generic/THTensorConv.cpp
   generic/THTensorConv.h
+  generic/THTensorFill.cpp
+  generic/THTensorFill.h
   generic/THTensorLapack.cpp
   generic/THTensorLapack.h
   generic/THTensorMath.cpp

--- a/aten/src/TH/THTensor.h
+++ b/aten/src/TH/THTensor.h
@@ -25,6 +25,13 @@
 #include <TH/generic/THTensorMath.h>
 #include <TH/THGenerateAllTypes.h>
 
+/* fill and zero*/
+#include <TH/generic/THTensorFill.h>
+#include <TH/THGenerateAllTypes.h>
+
+#include <TH/generic/THTensorFill.h>
+#include <TH/THGenerateHalfType.h>
+
 /* convolutions */
 #include <TH/generic/THTensorConv.h>
 #include <TH/THGenerateAllTypes.h>

--- a/aten/src/TH/THTensorFill.cpp
+++ b/aten/src/TH/THTensorFill.cpp
@@ -1,0 +1,8 @@
+#include <TH/THTensor.hpp>
+#include <TH/THVector.h>
+
+#include <TH/generic/THTensorFill.cpp>
+#include <TH/THGenerateAllTypes.h>
+
+#include <TH/generic/THTensorFill.cpp>
+#include <TH/THGenerateHalfType.h>

--- a/aten/src/TH/THVector.cpp
+++ b/aten/src/TH/THVector.cpp
@@ -21,5 +21,11 @@
 #include <TH/generic/THVectorDefault.cpp>
 #include <TH/THGenerateAllTypes.h>
 
+#include <TH/generic/THVectorDefault.cpp>
+#include <TH/THGenerateHalfType.h>
+
 #include <TH/generic/THVectorDispatch.cpp>
 #include <TH/THGenerateAllTypes.h>
+
+#include <TH/generic/THVectorDispatch.cpp>
+#include <TH/THGenerateHalfType.h>

--- a/aten/src/TH/THVector.h
+++ b/aten/src/TH/THVector.h
@@ -11,4 +11,7 @@
 #include <TH/generic/THVector.h>
 #include <TH/THGenerateAllTypes.h>
 
+#include <TH/generic/THVector.h>
+#include <TH/THGenerateHalfType.h>
+
 #endif // TH_VECTOR_INC

--- a/aten/src/TH/generic/THTensorApply.hpp
+++ b/aten/src/TH/generic/THTensorApply.hpp
@@ -13,12 +13,12 @@
 
 #ifdef _OPENMP
 
-#ifdef _WIN32  
-// MSVC doesing support loop pragmas, but does support others. Create a new macro to account for those differences.  
-#define PRAGMA_LOOP(P)    // Noop  
+#ifdef _WIN32
+// MSVC doesing support loop pragmas, but does support others. Create a new macro to account for those differences.
+#define PRAGMA_LOOP(P)    // Noop
 #define PRAGMA(P)         __pragma(P)
 #else
-#define PRAGMA_LOOP(P)    _Pragma(#P)  
+#define PRAGMA_LOOP(P)    _Pragma(#P)
 #define PRAGMA(P)         _Pragma(#P)
 #endif
 
@@ -158,7 +158,7 @@ if (std::isnan(val)) break;
 #endif
 
 static inline scalar_t THTensor_(powOne)(scalar_t x, scalar_t y) {
-#if defined(TH_REAL_IS_FLOAT)
+#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_HALF)
   return powf(x, y);
 #elif defined(TH_REAL_IS_DOUBLE)
   return pow(x, y);

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -4,29 +4,6 @@
 
 #include <TH/generic/THTensorApply.hpp>
 
-void THTensor_(fill)(THTensor *r_, scalar_t value)
-{
-  if (THTensor_(isContiguous)(r_) || THTensor_(isTransposed)(r_)) {
-    TH_TENSOR_APPLY_CONTIG(scalar_t, r_, THVector_(fill)(r__data, value, r__len););
-  } else {
-    TH_TENSOR_APPLY(scalar_t, r_,
-      if (r__stride == 1) {
-        THVector_(fill)(r__data, value, r__size);
-        r__i = r__size;
-        r__data += r__stride * r__size;
-        break;
-      } else {
-        *r__data = value;
-      }
-      );
-  }
-}
-
-void THTensor_(zero)(THTensor *r_)
-{
-  THTensor_(fill)(r_, 0);
-}
-
 void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
 {
 #ifdef _OPENMP

--- a/aten/src/TH/generic/THTensorFill.cpp
+++ b/aten/src/TH/generic/THTensorFill.cpp
@@ -1,0 +1,30 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "TH/generic/THTensorFill.cpp"
+#else
+
+#include <TH/generic/THTensorApply.hpp>
+
+void THTensor_(fill)(THTensor *r_, scalar_t value)
+{
+  if (THTensor_(isContiguous)(r_) || THTensor_(isTransposed)(r_)) {
+    TH_TENSOR_APPLY_CONTIG(scalar_t, r_, THVector_(fill)(r__data, value, r__len););
+  } else {
+    TH_TENSOR_APPLY(scalar_t, r_,
+      if (r__stride == 1) {
+        THVector_(fill)(r__data, value, r__size);
+        r__i = r__size;
+        r__data += r__stride * r__size;
+        break;
+      } else {
+        *r__data = value;
+      }
+      );
+  }
+}
+
+void THTensor_(zero)(THTensor *r_)
+{
+  THTensor_(fill)(r_, 0);
+}
+
+#endif

--- a/aten/src/TH/generic/THTensorFill.h
+++ b/aten/src/TH/generic/THTensorFill.h
@@ -1,0 +1,8 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "TH/generic/THTensorFill.h"
+#else
+
+TH_API void THTensor_(fill)(THTensor *r_, scalar_t value);
+TH_API void THTensor_(zero)(THTensor *r_);
+
+#endif

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -2,9 +2,6 @@
 #define TH_GENERIC_FILE "TH/generic/THTensorMath.h"
 #else
 
-TH_API void THTensor_(fill)(THTensor *r_, scalar_t value);
-TH_API void THTensor_(zero)(THTensor *r_);
-
 TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
 TH_API void THTensor_(maskedSelect)(THTensor *tensor, THTensor* src, THByteTensor *mask);


### PR DESCRIPTION
For some additional context on this change, please, see this [PR](https://github.com/pytorch/pytorch/pull/17376)

As a part of work on Bool Tensor, we will need to add support for a bool type to _fill() and _zero() methods that are currently located in THTensorMath. As we don't need anything else and those methods are not really math related - we are moving them out into separate THTensorFill for simplicity. 

Change: 
-moved _fill() and _zero() from THTensorMath.h to THTensorFill
-enabled _fill() and _zero() for HALF type.