### PR TITLE
add dropout during eval

### DIFF
--- a/caffe2/python/layers/dropout.py
+++ b/caffe2/python/layers/dropout.py
@@ -16,6 +16,7 @@ class Dropout(ModelLayer):
             input_record,
             name='dropout',
             ratio=0.5,
+            dropout_for_eval=False,
             **kwargs):
 
         super(Dropout, self).__init__(model, name, input_record, **kwargs)
@@ -25,6 +26,7 @@ class Dropout(ModelLayer):
 
         self.output_schema = input_record.clone_schema()
         self.output_schema.set_value(self.get_next_blob_reference('output'))
+        self.dropout_for_eval = dropout_for_eval
 
         self.ratio = ratio
 
@@ -42,7 +44,7 @@ class Dropout(ModelLayer):
         self._add_ops(net, is_test=False)
 
     def add_eval_ops(self, net):
-        self._add_ops(net, is_test=True)
+        self._add_ops(net, is_test=(not self.dropout_for_eval))
 
     def add_ops(self, net):
         self.add_eval_ops(net)


### PR DESCRIPTION
Summary:
Currently Dropout is only enabled in training, we enable the option of having dropout in Eval.

This is to follow [1]. This functionality would be used for uncertainty estimation in exploration project.

[1] Gal, Yarin, and Zoubin Ghahramani. "Dropout as a bayesian approximation: Representing model uncertainty in deep learning." international conference on machine learning. 2016.

Differential Revision: D14216216
