### PR TITLE
fix reordering of inlines

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1579,6 +1579,24 @@ class TestJit(JitTestCase):
         self.assertEqual(out, out_state)
         self.assertNotEqual(out, out_ones)
 
+    def test_export_no_reorder(self):
+        def func(a, b):
+            return a * b / (a - 2 * b) + b
+
+        recording_inputs = [torch.tensor([0.55619788169860839844], dtype=torch.float32, requires_grad=True),
+                            torch.tensor([0.25947844982147216797], dtype=torch.float32, requires_grad=True)]
+
+        ge1 = torch.jit.trace(func, recording_inputs, optimize=True)
+        ge2 = self.getExportImportCopy(ge1)
+
+        outputs_ge1 = ge1(*recording_inputs)
+        outputs_ge2 = ge2(*recording_inputs)
+
+        grad_ge1 = torch.autograd.grad(outputs_ge1, recording_inputs)
+        grad_ge2 = torch.autograd.grad(outputs_ge2, recording_inputs)
+        self.assertTrue(outputs_ge1 == outputs_ge2)
+        self.assertTrue(grad_ge1 == grad_ge2)
+
     def test_python_function(self):
         class MyFn(Function):
             @staticmethod

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1,9 +1,9 @@
+#include <torch/csrc/jit/passes/python_print.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/attributes.h>
 #include <torch/csrc/jit/export.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/ir_views.h>
-#include <torch/csrc/jit/passes/python_print.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/script/error_report.h>
 #include <torch/csrc/jit/script/module.h>
@@ -593,6 +593,61 @@ struct PythonPrintPass {
     }
   }
 
+  bool isLongLine(const std::string& str) {
+    return str.size() + level * 2 >= 40;
+  }
+
+  bool isLongInline(Node* node) {
+    return output_inline_.count(node) && isLongLine(useOf(node->output()));
+  }
+
+  bool isNonConstantInline(Value* input) {
+    return !isConstantLike(input->node()) &&
+        output_inline_.count(input->node());
+  }
+
+  // [reordering of inlines]
+  // We inline anything that is semantically legal to inline, but sometimes
+  // we find that these lines get too long. In that case we break the lines
+  /// and it  is important that we un-inline all the inputs preceeding the long
+  /// input:
+  //   r = foo(x.add_(b), some_long + expression)
+  //  wrong!
+  //   _0 = some_long + expression
+  //   r = foo(x.add_(b), _0) # wrong! _0 runs before mutating add_
+  // legal!
+  //   _0 = x.add_(b)
+  //   _1 = some_long + expression
+  //   r = foo(_0, _1)
+  void splitLongInlines(at::ArrayRef<Value*> inputs) {
+    size_t long_inline_slice = 0;
+    // find the last input that is too long
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      if (isLongInline(inputs[i]->node())) {
+        long_inline_slice = i + 1;
+      }
+    }
+    // un-inline everything through the last long line
+    // constants are ignored since long constants are never inlined in the
+    // first place
+    for (size_t i = 0; i < long_inline_slice; ++i) {
+      if (isNonConstantInline(inputs[i])) {
+        printOutputDefinition(inputs[i]->node(), useOf(inputs[i]));
+      }
+    }
+  }
+
+  void printOutputDefinition(Node* node, const std::string& str) {
+    assignValuesToTheirUniqueNames(node->outputs());
+    indent();
+    // Print outputs
+    if (node->outputs().size() > 0) {
+      printValueList(out, node->outputs());
+      out << " = ";
+    }
+    out << str << "\n";
+  }
+
   void printNode(Node* node, bool print_const) {
     if (!print_const && isConstantLike(node))
       return;
@@ -605,6 +660,7 @@ struct PythonPrintPass {
         return;
       }
     }
+    splitLongInlines(node->inputs());
     switch (node->kind()) {
       case prim::Return:
         if (enforce_importable_ && node->inputs().size() != 1) {
@@ -641,22 +697,17 @@ struct PythonPrintPass {
         std::stringstream ss;
         printRHS(ss, node);
 
-        // this node is safe to inline, so assign the output value
-        // to that expression directly
-        // guard against really long lines
-        if (output_inline_.count(node) > 0 &&
-            ss.str().size() + level * 2 < 40) {
+        // we prevent long constants from inlining here.
+        // it is not safe to do the same thing for non-constants here
+        // because of [reordering of inlines]
+        if (output_inline_.count(node) == 0 ||
+            (isConstantLike(node) && isLongLine(ss.str()))) {
+          printOutputDefinition(node, ss.str());
+        } else {
+          // this node is safe to inline, so assign the output value
+          // to that expression directly
           assignValue(node->output(), ss.str());
-          return;
         }
-        assignValuesToTheirUniqueNames(node->outputs());
-        indent();
-        // Print outputs
-        if (node->outputs().size() > 0) {
-          printValueList(out, node->outputs());
-          out << " = ";
-        }
-        out << ss.str() << "\n";
     }
   }
 


### PR DESCRIPTION
See comment inside of code. This fixes a bug where sometimes we would try to avoid printing long lines but would inadvertently reorder the expressions, which can change the semantics of the program