### PR TITLE
Fix verbose compiler warning in flat_hash_map

### DIFF
--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -5,6 +5,7 @@
 // - replace size_t with uint64_t to fix it for 32bit
 // - add "GCC diagnostic" pragma to ignore -Wshadow
 // - make sherwood_v3_table::convertible_to_iterator public because GCC5 seems to have issues with it otherwise
+// - fix compiler warnings in operator templated_iterator<const value_type>
 
 //          Copyright Malte Skarupke 2017.
 // Distributed under the Boost Software License, Version 1.0.
@@ -506,7 +507,10 @@ public:
             return std::addressof(current->value);
         }
 
-        operator templated_iterator<const value_type>() const
+        // the template automatically disables the operator when value_type is already
+        // const, because that would cause a lot of compiler warnings otherwise.
+        template<class target_type = const value_type, class = typename std::enable_if<std::is_same<target_type, const value_type>::value && !std::is_same<target_type, value_type>::value>::type>
+        operator templated_iterator<target_type>() const
         {
             return { current };
         }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17561 Fix diagnostic pragmas&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14254500/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17562 Fix verbose compiler warning in flat_hash_map**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14254499/)

fixes https://github.com/pytorch/pytorch/issues/17332

Differential Revision: [D14254499](https://our.internmc.facebook.com/intern/diff/D14254499/)