### PR TITLE
Fix the false generated_comment

### DIFF
--- a/aten/src/ATen/code_template.py
+++ b/aten/src/ATen/code_template.py
@@ -24,10 +24,11 @@ class CodeTemplate(object):
     @staticmethod
     def from_file(filename):
         with open(filename, 'r') as f:
-            return CodeTemplate(f.read())
+            return CodeTemplate(f.read(), filename)
 
-    def __init__(self, pattern):
+    def __init__(self, pattern, filename=""):
         self.pattern = pattern
+        self.filename = filename
 
     def substitute(self, env={}, **kwargs):
         def lookup(v):

--- a/tools/autograd/utils.py
+++ b/tools/autograd/utils.py
@@ -26,9 +26,8 @@ try:
 except ImportError:
     from yaml import Loader as YamlLoader
 
-
 GENERATED_COMMENT = CodeTemplate(
-    "@" + "generated from tools/autograd/templates/${filename}")
+    "@" + "generated from ${filename}")
 
 # Matches "foo" in "foo, bar" but not "foobar". Used to search for the
 # occurence of a parameter in the derivative formula
@@ -56,7 +55,7 @@ def uninplace_api_name(api_name):
 
 
 def write(dirname, name, template, env):
-    env['generated_comment'] = GENERATED_COMMENT.substitute(filename=name)
+    env['generated_comment'] = GENERATED_COMMENT.substitute(filename=template.filename)
     path = os.path.join(dirname, name)
     # See Note [Unchanging results for ninja]
     try:


### PR DESCRIPTION
The generated_comments are wrong to below generated files:
```bash
./torch/csrc/autograd/generated/VariableType_0.cpp:3:// @generated from tools/autograd/templates/VariableType_0.cpp
./torch/csrc/autograd/generated/VariableType_1.cpp:3:// @generated from tools/autograd/templates/VariableType_1.cpp
./torch/csrc/autograd/generated/VariableType_2.cpp:3:// @generated from tools/autograd/templates/VariableType_2.cpp
./torch/csrc/autograd/generated/VariableType_3.cpp:3:// @generated from tools/autograd/templates/VariableType_3.cpp
./torch/csrc/autograd/generated/VariableType_4.cpp:3:// @generated from tools/autograd/templates/VariableType_4.cpp
./torch/csrc/autograd/generated/VariableTypeEverything.cpp:3:// @generated from tools/autograd/templates/VariableTypeEverything.cpp

./torch/csrc/jit/generated/register_aten_ops_0.cpp:23:// @generated from tools/autograd/templates/register_aten_ops_0.cpp
./torch/csrc/jit/generated/register_aten_ops_1.cpp:23:// @generated from tools/autograd/templates/register_aten_ops_1.cpp
./torch/csrc/jit/generated/register_aten_ops_2.cpp:23:// @generated from tools/autograd/templates/register_aten_ops_2.cpp
```

These generated files were split to speed the compile, however, the template files are not.
After this fix, the comments will look like below:
```bash
./torch/csrc/autograd/generated/VariableType_0.cpp:3:// @generated from tools/autograd/templates/VariableType.cpp
./torch/csrc/autograd/generated/VariableType_1.cpp:3:// @generated from tools/autograd/templates/VariableType.cpp
......
```