### PR TITLE
Don't make factory methods create a tensor and then immediately copy it

### DIFF
--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -13,7 +13,7 @@ inline at::Tensor ${name}(${formals}) {
   ${pre_record_trace}
   at::Tensor tensor = at::${name}(${actuals});
   at::Tensor result =
-    autograd::make_variable(tensor, /*requires_grad=*/${requires_grad});
+    autograd::make_variable(std::move(tensor), /*requires_grad=*/${requires_grad});
   ${post_record_trace}
   return result;
 }

--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -13,7 +13,7 @@ inline at::Tensor ${name}(${formals}) {
   ${pre_record_trace}
   at::Tensor tensor = at::${name}(${actuals});
   at::Tensor result =
-    autograd::make_variable(std::move(tensor), /*requires_grad=*/${requires_grad});
+    autograd::make_variable_consuming(std::move(tensor), /*requires_grad=*/${requires_grad});
   ${post_record_trace}
   return result;
 }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -148,7 +148,7 @@ inline std::vector<SavedVariable> make_saved_variable_list(TensorList tensors) {
 }
 
 inline Tensor as_variable(Tensor tensor) {
-  return make_variable(tensor, /*requires_grad=*/false);
+  return make_variable(std::move(tensor), /*requires_grad=*/false);
 }
 
 inline std::vector<Tensor> as_variable(TensorList tl) {

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -148,7 +148,7 @@ inline std::vector<SavedVariable> make_saved_variable_list(TensorList tensors) {
 }
 
 inline Tensor as_variable(Tensor tensor) {
-  return make_variable(std::move(tensor), /*requires_grad=*/false);
+  return make_variable(tensor, /*requires_grad=*/false);
 }
 
 inline std::vector<Tensor> as_variable(TensorList tl) {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -104,22 +104,23 @@ struct TORCH_API Variable : public at::Tensor {
       bool allow_tensor_metadata_change,
       Edge gradient_edge);
 
-  /// Creates a `Variable` from the given `Tensor`. `requires_grad` should be
+  /// Creates a `Variable` from the given `Tensor`, copying its underlying `TensorImpl`.
+  /// `requires_grad` should be
   /// set only for leaves, and determines whether the `Variable` will accumulate
   /// gradients. NOTE: `data` must *not* be a `Variable` already. Its dynamic
   /// type *must* be `Tensor`.
   friend Variable make_variable(
-      const at::Tensor& data,
+      at::Tensor data,
       bool requires_grad,
       bool allow_tensor_metadata_change);
 
-  /// Creates a `Variable` from the given `Tensor`, consuming it.
+  /// Creates a `Variable` from the given `Tensor`, consuming its underlying `TensorImpl`.
   /// This is intended to be used from functions that immediately create a `Tensor`,
   /// convert it to a `Variable`, and then free it; it has been found to
   /// decrease the overhead of those operations, in some situations.
   /// The comments about `requires_grad` and `data` on the above version also apply to this one.
-  friend Variable make_variable(
-      at::Tensor&& data,
+  friend Variable make_variable_consuming(
+      at::Tensor data,
       bool requires_grad,
       bool allow_tensor_metadata_change);
 
@@ -570,7 +571,7 @@ inline Variable make_variable_view(
 }
 
 inline Variable make_variable(
-    const at::Tensor& data,
+    at::Tensor data,
     bool requires_grad = false,
     bool allow_tensor_metadata_change = true) {
   AT_CHECK(
@@ -586,14 +587,15 @@ inline Variable make_variable(
   return Variable();
 }
 
-inline Variable make_variable(
-    at::Tensor&& data,
+inline Variable make_variable_consuming(
+    at::Tensor data,
     bool requires_grad = false,
     bool allow_tensor_metadata_change = true) {
   AT_CHECK(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
+    AT_ASSERT(data.getIntrusivePtr().use_count() == 1);
     data.unsafeGetTensorImpl()->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
     return Variable(c10::make_intrusive<Variable::Impl>(std::move(data), std::move(autograd_meta), requires_grad));

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -113,6 +113,11 @@ struct TORCH_API Variable : public at::Tensor {
       bool requires_grad,
       bool allow_tensor_metadata_change);
 
+  /// Creates a `Variable` from the given `Tensor`, consuming it.
+  /// This is intended to be used from functions that immediately create a `Tensor`,
+  /// convert it to a `Variable`, and then free it; it has been found to
+  /// decrease the overhead of those operations, in some situations.
+  /// The comments about `requires_grad` and `data` on the above version also apply to this one.
   friend Variable make_variable(
       at::Tensor&& data,
       bool requires_grad,
@@ -581,8 +586,6 @@ inline Variable make_variable(
   return Variable();
 }
 
-// Moves out of the tensor instead of copying it.
-// Can save ~10μs of overhead.
 inline Variable make_variable(
     at::Tensor&& data,
     bool requires_grad = false,

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -581,6 +581,8 @@ inline Variable make_variable(
   return Variable();
 }
 
+// Moves out of the tensor instead of copying it.
+// Can save ~10μs of overhead.
 inline Variable make_variable(
     at::Tensor&& data,
     bool requires_grad = false,


### PR DESCRIPTION
Create a `make_variable` override that moves out of a tensor instead of going through `shallow_copy_and_detach`. Call this override from factory methods like `empty` that create a brand new tensor, do nothing with it, and then copy it into a variable.

Will update this with actual numbers, but it seems to get rid of around 20-40% of the overhead of calling `torch.empty(0)`
