### PR TITLE
[docs] Warn about memory overlaps on expanded tensors

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2833,6 +2833,13 @@ memory.
 Args:
     *sizes (torch.Size or int...): the desired expanded size
 
+.. warning::
+
+    More than one element of an expanded tensor may refer to a single
+    memory location. As a result, in-place operations (especially ones that
+    are vectorized) may result in incorrect behavior. If you need to write
+    to the tensors, please clone them first.
+
 Example::
 
     >>> x = torch.tensor([[1], [2], [3]])

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -40,6 +40,13 @@ def broadcast_tensors(*tensors):
     Args:
         *tensors: any number of tensors of the same type
 
+    .. warning::
+
+        More than one element of a broadcasted tensor may refer to a single
+        memory location. As a result, in-place operations (especially ones that
+        are vectorized) may result in incorrect behavior. If you need to write
+        to the tensors, please clone them first.
+
     Example::
 
         >>> x = torch.arange(3).view(1, 3)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2943,6 +2943,14 @@ def unfold(input, kernel_size, dilation=1, padding=0, stride=1):
         Currently, only 4-D input tensors (batched image-like tensors) are
         supported.
 
+    .. warning::
+
+        More than one element of the unfolded tensor may refer to a single
+        memory location. As a result, in-place operations (especially ones that
+        are vectorized) may result in incorrect behavior. If you need to write
+        to the tensor, please clone it first.
+
+
     See :class:`torch.nn.Unfold` for details
     """
 


### PR DESCRIPTION
Eventually we should remove these when we're certain that all our ops
handle memory overlaps correctly.

Test Plan:
Build the docs
![image](https://user-images.githubusercontent.com/5652049/53576511-d3923c00-3b41-11e9-8850-1f6eedd33492.png)
(Ignore the font, there's something wrong with building the docs on my machine)