### PR TITLE
[WIP] Replace TH_TENSOR_APPLY with at::CPU_tensor_apply

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -140,7 +140,7 @@ inline Tensor sort_strides(Tensor& tensor_) {
   return tensor;
 }
 
-template <typename T, int N>
+template <typename T, int N, bool CanOverflow = true>
 struct strided_tensor_iter_fixed {
  public:
   T* data_ = NULL;
@@ -151,6 +151,7 @@ struct strided_tensor_iter_fixed {
   int64_t strides_[N] = {0};
 
   strided_tensor_iter_fixed(strided_tensor_iter_fixed const&) = delete;
+  operator bool() const { return CanOverflow; };
   void operator=(strided_tensor_iter_fixed const& x) = delete;
   strided_tensor_iter_fixed(strided_tensor_iter_fixed&&) = default;
   strided_tensor_iter_fixed(Tensor& tensor, bool sort_strides = false)
@@ -180,6 +181,7 @@ struct strided_tensor_iter {
   std::vector<int64_t> strides_;
 
   strided_tensor_iter(strided_tensor_iter const&) = delete;
+  operator bool() const { return true; };
   void operator=(strided_tensor_iter const& x) = delete;
   strided_tensor_iter(strided_tensor_iter&&) = default;
   strided_tensor_iter(Tensor& tensor)
@@ -241,7 +243,9 @@ inline void iterate(int64_t size){};
 
 template <typename Arg, typename... Args>
 inline void iterate(int64_t size, Arg& iter, Args&... iter_tail) {
-  iter.counter_[iter.dim_ - 1] += size;
+  if (iter) {
+    iter.counter_[iter.dim_ - 1] += size;
+  }
   iter.data_ = iter.data_ + size * iter.strides_[iter.dim_ - 1];
   iterate(size, iter_tail...);
 }
@@ -252,8 +256,11 @@ inline bool iterate_continue() {
 
 template <typename Arg, typename... Args>
 inline bool iterate_continue(Arg& iter, Args&... iter_tail) {
-  return iter.counter_[iter.dim_ - 1] < iter.sizes_[iter.dim_ - 1] &&
-      iterate_continue(iter_tail...);
+  if (iter) {
+    return iter.counter_[iter.dim_ - 1] < iter.sizes_[iter.dim_ - 1] &&
+        iterate_continue(iter_tail...);
+  }
+  return iterate_continue(iter_tail...);
 }
 
 inline int64_t max_iterate_size() {
@@ -271,13 +278,15 @@ inline void iterate_overflow(){};
 
 template <typename Arg, typename... Args>
 inline void iterate_overflow(Arg& iter, Args&... iter_tail) {
-  if (iter.counter_[iter.dim_ - 1] == iter.sizes_[iter.dim_ - 1]) {
-    for (int64_t i = iter.dim_ - 1; i > 0; i--) {
-      if (iter.counter_[i] == iter.sizes_[i]) {
-        iter.counter_[i] = 0;
-        iter.counter_[i - 1]++;
-        iter.data_ = iter.data_ - (iter.sizes_[i] * iter.strides_[i]) +
-            iter.strides_[i - 1];
+  if (iter) {
+    if (iter.counter_[iter.dim_ - 1] == iter.sizes_[iter.dim_ - 1]) {
+      for (int64_t i = iter.dim_ - 1; i > 0; i--) {
+        if (iter.counter_[i] == iter.sizes_[i]) {
+          iter.counter_[i] = 0;
+          iter.counter_[i - 1]++;
+          iter.data_ = iter.data_ - (iter.sizes_[i] * iter.strides_[i]) +
+              iter.strides_[i - 1];
+        }
       }
     }
   }
@@ -423,12 +432,23 @@ inline void CPU_tensor_apply2(Tensor tensor1, Tensor tensor2, const Op op) {
   if (!_apply_preamble({tensor1, tensor2}))
     return;
   if (_max_dim_tensors({tensor1, tensor2}) <= 8) {
-    apply_op(
-        tensor1.numel(),
-        0,
-        op,
-        strided_tensor_iter_fixed<scalar1, 8>(tensor1),
-        strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+    auto iterator1 = strided_tensor_iter_fixed<scalar1, 8>(tensor1);
+    auto iterator2 = strided_tensor_iter_fixed<scalar2, 8>(tensor2);
+    if (iterator1.dim_ == 1 && iterator2.dim_ == 1) {
+      apply_op(
+          tensor1.numel(),
+          0,
+          op,
+          strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
+          strided_tensor_iter_fixed<scalar2, 8, false>(tensor2));
+    } else {
+      apply_op(
+          tensor1.numel(),
+          0,
+          op,
+          strided_tensor_iter_fixed<scalar1, 8>(tensor1),
+          strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+    }
   } else {
     apply_op(
         tensor1.numel(),
@@ -538,18 +558,35 @@ inline void CPU_tensor_parallel_apply2(
   if (!_apply_preamble({tensor1, tensor2}))
     return;
   if (tensor1.ndimension() < 8 && tensor2.ndimension() < 8) {
-    parallel_for(
-        0,
-        tensor1.numel(),
-        grain_size,
-        [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
-          apply_op(
-              end - begin,
-              begin,
-              op,
-              strided_tensor_iter_fixed<scalar1, 8>(tensor1),
-              strided_tensor_iter_fixed<scalar2, 8>(tensor2));
-        });
+    auto iterator1 = strided_tensor_iter_fixed<scalar1, 8>(tensor1);
+    auto iterator2 = strided_tensor_iter_fixed<scalar2, 8>(tensor2);
+    if (iterator1.dim_ == 1) {
+      parallel_for(
+          0,
+          tensor1.numel(),
+          grain_size,
+          [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
+            apply_op(
+                end - begin,
+                begin,
+                op,
+                strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
+                strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+          });
+    } else {
+      parallel_for(
+          0,
+          tensor1.numel(),
+          grain_size,
+          [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
+            apply_op(
+                end - begin,
+                begin,
+                op,
+                strided_tensor_iter_fixed<scalar1, 8>(tensor1),
+                strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+          });
+    }
   } else {
     parallel_for(
         0,

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -557,20 +557,18 @@ inline void CPU_tensor_parallel_apply2(
     return;
   if (tensor1.ndimension() < 8 && tensor2.ndimension() < 8) {
     if (tensor1.is_contiguous()) {
-      auto call = [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
-        apply_op(
-            end - begin,
-            begin,
-            op,
-            strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
-            strided_tensor_iter_fixed<scalar2, 8>(tensor2));
-      };
-
       parallel_for(
           0,
           tensor1.numel(),
           grain_size,
-          call);
+          [&tensor1, &tensor2, &op](int64_t begin, int64_t end) {
+            apply_op(
+                end - begin,
+                begin,
+                op,
+                strided_tensor_iter_fixed<scalar1, 8, false>(tensor1),
+                strided_tensor_iter_fixed<scalar2, 8>(tensor2));
+          });
     } else {
       parallel_for(
           0,

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -151,7 +151,7 @@ struct strided_tensor_iter_fixed {
   int64_t strides_[N] = {0};
 
   strided_tensor_iter_fixed(strided_tensor_iter_fixed const&) = delete;
-  bool Overflow() const { return CanOverflow; };
+  bool overflow() const { return CanOverflow; };
   void operator=(strided_tensor_iter_fixed const& x) = delete;
   strided_tensor_iter_fixed(strided_tensor_iter_fixed&&) = default;
   strided_tensor_iter_fixed(Tensor& tensor, bool sort_strides = false)
@@ -181,7 +181,7 @@ struct strided_tensor_iter {
   std::vector<int64_t> strides_;
 
   strided_tensor_iter(strided_tensor_iter const&) = delete;
-  bool Overflow() const { return true; };
+  bool overflow() const { return true; };
   void operator=(strided_tensor_iter const& x) = delete;
   strided_tensor_iter(strided_tensor_iter&&) = default;
   strided_tensor_iter(Tensor& tensor)
@@ -243,7 +243,7 @@ inline void iterate(int64_t size){};
 
 template <typename Arg, typename... Args>
 inline void iterate(int64_t size, Arg& iter, Args&... iter_tail) {
-  if (iter.Overflow()) {
+  if (iter.overflow()) {
     iter.counter_[iter.dim_ - 1] += size;
   }
   iter.data_ = iter.data_ + size * iter.strides_[iter.dim_ - 1];
@@ -256,7 +256,7 @@ inline bool iterate_continue() {
 
 template <typename Arg, typename... Args>
 inline bool iterate_continue(Arg& iter, Args&... iter_tail) {
-  if (iter.Overflow()) {
+  if (iter.overflow()) {
     return iter.counter_[iter.dim_ - 1] < iter.sizes_[iter.dim_ - 1] &&
         iterate_continue(iter_tail...);
   }
@@ -278,7 +278,7 @@ inline void iterate_overflow(){};
 
 template <typename Arg, typename... Args>
 inline void iterate_overflow(Arg& iter, Args&... iter_tail) {
-  if (iter.Overflow()) {
+  if (iter.overflow()) {
     if (iter.counter_[iter.dim_ - 1] == iter.sizes_[iter.dim_ - 1]) {
       for (int64_t i = iter.dim_ - 1; i > 0; i--) {
         if (iter.counter_[i] == iter.sizes_[i]) {

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -94,11 +94,11 @@ intermediate results tensor and degree of parallelization.
 ident: identity for binary combination function sf. sf(ident, x) needs to return
 x.
 
-f: function for reduction over a chunk. f needs to be of signature scalar_t
-f(int64_t partial_begin, int64_t partial_end, scalar_t identifiy)
+f: function for reduction over a chunk. f needs to be of signature scalar_t_tempname
+f(int64_t partial_begin, int64_t partial_end, scalar_t_tempname identifiy)
 
 sf: function to combine two partial results. sf needs to be of signature
-scalar_t sf(scalar_t x, scalar_t y)
+scalar_t_tempname sf(scalar_t_tempname x, scalar_t_tempname y)
 
 For example, you might have a tensor of 10000 entires and want to sum together
 all the elements. Parallel_reduce with a grain_size of 2500 will then allocate
@@ -114,20 +114,20 @@ two partial results and an identity.
 
 [1] https://software.intel.com/en-us/node/506154
 */
-template <class scalar_t, class F, class SF>
-inline scalar_t parallel_reduce(
+template <class scalar_t_tempname, class F, class SF>
+inline scalar_t_tempname parallel_reduce(
     const int64_t begin,
     const int64_t end,
     const int64_t grain_size,
-    const scalar_t ident,
+    const scalar_t_tempname ident,
     const F f,
     const SF sf) {
   if (get_num_threads() == 1) {
     return f(begin, end, ident);
   } else {
     const int64_t num_results = divup((end - begin), grain_size);
-    std::vector<scalar_t> results(num_results);
-    scalar_t* results_data = results.data();
+    std::vector<scalar_t_tempname> results(num_results);
+    scalar_t_tempname* results_data = results.data();
 #pragma omp parallel for if ((end - begin) >= grain_size)
     for (int64_t id = 0; id < num_results; id++) {
       int64_t i = begin + id * grain_size;


### PR DESCRIPTION
Exploring the opportunity to remove TH_TENSOR_APPLY macros. 
Ideally it should be TensorIterate, but this will require some additional time to implement and load-test.

Check only aten/src/TH/generic/THTensorEvenMoreMath.cpp rest is irrelevant.