### PR TITLE
Add at::has_internal_overlap helper function

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -1,0 +1,20 @@
+#include <ATen/MemoryOverlap.h>
+#include <c10/core/Layout.h>
+
+namespace at {
+
+MemOverlap has_internal_overlap(const Tensor& t) {
+  if (t.is_contiguous()) {
+    return MemOverlap::kNo;
+  }
+
+  auto strides = t.strides();
+  if (std::find_if(
+        strides.begin(), strides.end(), [](int s) { return s == 0; })) {
+    return MemOverlap::kYes;
+  }
+
+  return MemOverlap::kTooHard;
+}
+
+}

--- a/aten/src/ATen/MemoryOverlap.h
+++ b/aten/src/ATen/MemoryOverlap.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace at {
+
+enum MemOverlap { kNo, kYes, kTooHard };
+
+MemOverlap has_internal_overlap(const Tensor& t);
+
+}

--- a/aten/src/ATen/native/Memory.cpp
+++ b/aten/src/ATen/native/Memory.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/Exception.h>
@@ -14,6 +15,11 @@ Tensor pin_memory(const Tensor& self) {
   auto tensor = self.type().tensorWithAllocator(self.sizes(), self.strides(), allocator);
   tensor.copy_(self);
   return tensor;
+}
+
+// Exposes at::has_internal_overlap as an operator for testing purposes
+int64_t _debug_has_internal_overlap(const Tensor& self) {
+  return at::has_internal_overlap(self);
 }
 
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -60,6 +60,9 @@
   dispatch:
     CUDA: _cudnn_init_dropout_state
 
+- func: _debug_has_internal_overlap(Tensor self) -> int
+  variants: function
+
 - func: _fused_dropout(Tensor self, float p, Generator? generator=None) -> (Tensor, Tensor)
   matches_jit_signature: True
   variants: function

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10222,6 +10222,20 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         self.assertEqual(c1, expected)
         self.assertEqual(c2, expected)
 
+    def test_has_internal_overlap(self):
+        OVERLAP_NO = 0
+        OVERLAP_YES = 1
+        OVERLAP_TOO_HARD = 2
+
+        # Check for contiguous tensors
+        a = torch.randn(3, 3)
+        self.assertEqual(torch._debug_has_internal_overlap(a), OVERLAP_NO)
+
+        # Checks for zero strides
+        b = torch.randn(1, 3)
+        b_expanded = b.expand(4, 3)
+        self.assertEqual(torch._debug_has_internal_overlap(b_expanded), OVERLAP_YES)
+
     @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
     def test_reverse_binary_ops_multiple_device(self):
         self.assertEqual(2 + torch.tensor(3), 2 + torch.tensor(3).to("cuda:1"))    # __radd__


### PR DESCRIPTION
Checks if a tensor's sizes/strides indicate that multiple elements share
the same memory location. This problem in general is hard so
at::has_internal_overlap implements two heuristics and avoids solving the general problem:

- if a tensor is contiguous, it cannot have internal overlap
- if a tensor has any zero strides, it does have internal overlap
- otherwise, return MemOverlap::kTooHard to indicate that there might be
  overlap, but we don't know.

Future
- Use this helper function to error out on some incorrect in-place ops (like
  sin_, cos_)
- We need another helper function, "tensors_share_memory(Tensor a,
  Tensor b)" to disable some potentially incorrect binary ops like
  a += b.

Test Plan
- New test

