### PR TITLE
Fix XOutput/XOutputTensor for ivalue based c2 operators

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -220,7 +220,11 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     CAFFE_ENFORCE_WITH_CALLER(
         options.device_opt() != c10::nullopt,
         "device must be provided in option.");
-    return XBlobGetMutableTensor(outputs_.at(idx), dims, options);
+    if (isLegacyOperator()) {
+      return XBlobGetMutableTensor(outputs_.at(idx), dims, options);
+    }
+
+    return OutputTensor(idx, dims, options)->UnsafeSharedInstance();
   }
 
   void SetOutputTensor(int idx, Tensor tensor) {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17579 Fix InputSize/OutputSize for ivalue based operators&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14253094/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17599 Fix XOutput/XOutputTensor for ivalue based c2 operators**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14274003/)

XOutput/XOutputTensor was broken for ivalue based operators. This diff fixes that.

Differential Revision: [D14274003](https://our.internmc.facebook.com/intern/diff/D14274003/)