### PR TITLE
Change fake tqdm constructor to match real tqdm

### DIFF
--- a/torch/utils/model_zoo.py
+++ b/torch/utils/model_zoo.py
@@ -125,7 +125,7 @@ if tqdm is None:
     # fake tqdm if it's not installed
     class tqdm(object):
 
-        def __init__(self, total, disable=False):
+        def __init__(self, total=None, disable=False):
             self.total = total
             self.disable = disable
             self.n = 0


### PR DESCRIPTION
Currently, the fake tqdm implementation requires an input (whereas real tqdm does not).

This caused a problem in torchvision (https://github.com/pytorch/vision/pull/770), and seems likely to cause minor irritations elsewhere.