### PR TITLE
Fixed typo in aten/src/ATen/native_parse.py

### DIFF
--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -88,7 +88,7 @@ def type_argument_translations(arg):
         match = re.match(r'bool\[(\d+)\]', t)
         t = 'std::array<bool,{}>'.format(match.group(1))
     elif re.match(r'std::array', t):
-        raise RuntimeError("Please use array notation, e.g. bool[3] and not std::aray. "
+        raise RuntimeError("Please use array notation, e.g. bool[3] and not std::array."
                            "See [temp translations] for details.")
 
     # Legacy type sanitization. TODO: Do we really need this?


### PR DESCRIPTION
Hi, there.
There is a typo in aten/src/ATen/native_parse.py, and I fix it.
`std::aray` -> `std::array`