### PR TITLE
Allow negative momentum in optimizers

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -33,7 +33,7 @@ class Adam(Optimizer):
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
             raise ValueError("Invalid epsilon value: {}".format(eps))
-        if not 0.0 <= betas[0] < 1.0:
+        if not -1.0 <= betas[0] < 1.0:
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -26,7 +26,7 @@ class Adamax(Optimizer):
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
             raise ValueError("Invalid epsilon value: {}".format(eps))
-        if not 0.0 <= betas[0] < 1.0:
+        if not -1.0 <= betas[0] < 1.0:
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -30,8 +30,6 @@ class RMSprop(Optimizer):
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
             raise ValueError("Invalid epsilon value: {}".format(eps))
-        if not 0.0 <= momentum:
-            raise ValueError("Invalid momentum value: {}".format(momentum))
         if not 0.0 <= weight_decay:
             raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
         if not 0.0 <= alpha:
@@ -70,7 +68,7 @@ class RMSprop(Optimizer):
                 if len(state) == 0:
                     state['step'] = 0
                     state['square_avg'] = torch.zeros_like(p.data)
-                    if group['momentum'] > 0:
+                    if group['momentum'] != 0:
                         state['momentum_buffer'] = torch.zeros_like(p.data)
                     if group['centered']:
                         state['grad_avg'] = torch.zeros_like(p.data)
@@ -92,7 +90,7 @@ class RMSprop(Optimizer):
                 else:
                     avg = square_avg.sqrt().add_(group['eps'])
 
-                if group['momentum'] > 0:
+                if group['momentum'] != 0:
                     buf = state['momentum_buffer']
                     buf.mul_(group['momentum']).addcdiv_(grad, avg)
                     p.data.add_(-group['lr'], buf)

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -52,14 +52,12 @@ class SGD(Optimizer):
                  weight_decay=0, nesterov=False):
         if lr is not required and lr < 0.0:
             raise ValueError("Invalid learning rate: {}".format(lr))
-        if momentum < 0.0:
-            raise ValueError("Invalid momentum value: {}".format(momentum))
         if weight_decay < 0.0:
             raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
 
         defaults = dict(lr=lr, momentum=momentum, dampening=dampening,
                         weight_decay=weight_decay, nesterov=nesterov)
-        if nesterov and (momentum <= 0 or dampening != 0):
+        if nesterov and (momentum == 0 or dampening != 0):
             raise ValueError("Nesterov momentum requires a momentum and zero dampening")
         super(SGD, self).__init__(params, defaults)
 

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -27,7 +27,7 @@ class SparseAdam(Optimizer):
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 < eps:
             raise ValueError("Invalid epsilon value: {}".format(eps))
-        if not 0.0 <= betas[0] < 1.0:
+        if not -1.0 <= betas[0] < 1.0:
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))


### PR DESCRIPTION
There are at least two papers that suggest negative values of momentum can be optimal in different setups:
1.[ Asynchrony begets Momentum, with an Application to Deep Learning](https://arxiv.org/pdf/1605.09774.pdf)
2. [Negative Momentum for Improved Game Dynamics](https://arxiv.org/pdf/1807.04740.pdf)

However, pytorch raises error when a negative value is used for momentum. This prevents the practitioners to fully optimize the value of momentum in hyper parameter search. I made some changes in several optimization algos in pytorch that raised error when momentum was negative. 

If you agree with this change, I will fix any test that breaks due to these changes. 