### PR TITLE
Turn the Half::from_bits into a constexpr function to avoid unresolve…

### DIFF
--- a/aten/src/ATen/cuda/NumericLimits.cuh
+++ b/aten/src/ATen/cuda/NumericLimits.cuh
@@ -80,10 +80,10 @@ struct numeric_limits<int64_t> {
 
 template <>
 struct numeric_limits<at::Half> {
-  static inline __host__ __device__ at::Half lowest() { return at::Half(0xFBFF, at::Half::from_bits); }
-  static inline __host__ __device__ at::Half max() { return at::Half(0x7BFF, at::Half::from_bits); }
-  static inline __host__ __device__ at::Half lower_bound() { return at::Half(0xFC00, at::Half::from_bits); }
-  static inline __host__ __device__ at::Half upper_bound() { return at::Half(0x7C00, at::Half::from_bits); }
+  static inline __host__ __device__ at::Half lowest() { return at::Half(0xFBFF, at::Half::from_bits()); }
+  static inline __host__ __device__ at::Half max() { return at::Half(0x7BFF, at::Half::from_bits()); }
+  static inline __host__ __device__ at::Half lower_bound() { return at::Half(0xFC00, at::Half::from_bits()); }
+  static inline __host__ __device__ at::Half upper_bound() { return at::Half(0x7C00, at::Half::from_bits()); }
 };
 
 template <>

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -254,31 +254,31 @@ class numeric_limits<c10::Half> {
   static constexpr auto tinyness_before =
       numeric_limits<float>::tinyness_before;
   static constexpr c10::Half min() {
-    return c10::Half(0x0400, c10::Half::from_bits);
+    return c10::Half(0x0400, c10::Half::from_bits());
   }
   static constexpr c10::Half lowest() {
-    return c10::Half(0xFBFF, c10::Half::from_bits);
+    return c10::Half(0xFBFF, c10::Half::from_bits());
   }
   static constexpr c10::Half max() {
-    return c10::Half(0x7BFF, c10::Half::from_bits);
+    return c10::Half(0x7BFF, c10::Half::from_bits());
   }
   static constexpr c10::Half epsilon() {
-    return c10::Half(0x1400, c10::Half::from_bits);
+    return c10::Half(0x1400, c10::Half::from_bits());
   }
   static constexpr c10::Half round_error() {
-    return c10::Half(0x3800, c10::Half::from_bits);
+    return c10::Half(0x3800, c10::Half::from_bits());
   }
   static constexpr c10::Half infinity() {
-    return c10::Half(0x7C00, c10::Half::from_bits);
+    return c10::Half(0x7C00, c10::Half::from_bits());
   }
   static constexpr c10::Half quiet_NaN() {
-    return c10::Half(0x7E00, c10::Half::from_bits);
+    return c10::Half(0x7E00, c10::Half::from_bits());
   }
   static constexpr c10::Half signaling_NaN() {
-    return c10::Half(0x7D00, c10::Half::from_bits);
+    return c10::Half(0x7D00, c10::Half::from_bits());
   }
   static constexpr c10::Half denorm_min() {
-    return c10::Half(0x0001, c10::Half::from_bits);
+    return c10::Half(0x0001, c10::Half::from_bits());
   }
 };
 

--- a/c10/util/Half.cpp
+++ b/c10/util/Half.cpp
@@ -4,8 +4,6 @@
 
 namespace c10 {
 
-constexpr Half::from_bits_t Half::from_bits;
-
 static_assert(
     std::is_standard_layout<Half>::value,
     "c10::Half must be standard layout.");

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -325,7 +325,9 @@ struct alignas(2) Half {
   unsigned short x;
 
   struct from_bits_t {};
-  static constexpr from_bits_t from_bits = from_bits_t();
+  static constexpr from_bits_t from_bits() {
+    return from_bits_t();
+  }
 
   // HIP wants __host__ __device__ tag, CUDA does not
 #ifdef __HIP_PLATFORM_HCC__


### PR DESCRIPTION
…d symbol errors when building in DEBUG mode.

