### PR TITLE
Make autograd profiler thread-local

### DIFF
--- a/test/cpp/jit/gtest.cpp
+++ b/test/cpp/jit/gtest.cpp
@@ -15,6 +15,7 @@ using namespace torch::jit;
 
 JIT_TEST(ADFormulas)
 JIT_TEST(Attributes)
+JIT_TEST(AutogradProfiler)
 JIT_TEST(Blocks)
 JIT_TEST(CodeTemplate)
 JIT_TEST(ControlFlow)

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -177,13 +177,13 @@ class profile(object):
         self.entered = True
         profiler_kind = torch.autograd.ProfilerState.CUDA if self.use_cuda \
             else torch.autograd.ProfilerState.CPU
-        torch.autograd._enable_profiler(profiler_kind)
+        self.old_state = torch.autograd._enable_profiler(profiler_kind)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if not self.enabled:
             return
-        records = torch.autograd._disable_profiler()
+        records = torch.autograd._disable_profiler(self.old_state)
         self.function_events = EventList(parse_cpu_trace(records))
         return False
 

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -45,6 +45,11 @@ PyObject * THPAutograd_initExtension(PyObject *_unused)
   m.def("_enable_profiler", torch::autograd::profiler::enableProfiler);
   m.def("_disable_profiler", torch::autograd::profiler::disableProfiler);
 
+  py::class_<
+      torch::autograd::profiler::ProfilerInvocationState,
+      std::shared_ptr<torch::autograd::profiler::ProfilerInvocationState>>(
+      m, "ProfilerInvocationState");
+
   m.def("_push_range", [](std::string name) {
     torch::autograd::profiler::pushRange(std::move(name));
   });

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -178,9 +178,9 @@ thread_event_lists disableProfiler(
   if (invocation_state->state == ProfilerState::Disabled) {
     throw std::runtime_error("can't disable profiler when it's not running");
   }
-  auto old_state = invocation_state;
   mark("__stop_profile");
-  invocation_state = orig_state;
+  auto old_state = std::move(invocation_state);
+  invocation_state = std::move(orig_state);
   if (old_state->state == ProfilerState::NVTX) {
     return thread_event_lists();
   } else {

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -40,6 +40,7 @@ std::shared_ptr<ProfilerInvocationState> currState() {
 }
 
 RangeEventList& getEventList() {
+  // TODO: this won't work with interleaved computation
   if (!event_list || associated_invocation_state != invocation_state.get()) {
     std::lock_guard<std::mutex> guard(invocation_state->mutex);
     event_list = std::make_shared<RangeEventList>();

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -45,7 +45,9 @@ RangeEventList& getEventList() {
     if (thread_id == -1) {
       thread_id = next_thread_id++;
     }
-    event_list = invocation_state->all_event_lists[thread_id];
+    if (!invocation_state->all_event_lists[thread_id]) {
+      event_list = invocation_state->all_event_lists[thread_id] = std::make_shared<RangeEventList>();
+    }
     associated_invocation_state = invocation_state.get();
   }
   return *event_list;

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -24,15 +24,17 @@ thread_local std::shared_ptr<ProfilerInvocationState> invocation_state =
     std::make_shared<ProfilerInvocationState>();
 
 thread_local std::shared_ptr<RangeEventList> event_list;
+thread_local ProfilerInvocationState* associated_invocation_state = invocation_state.get();
 
 RangeEventList& getEventList() {
-  if (!event_list) {
+  if (!event_list || associated_invocation_state != invocation_state.get()) {
     std::lock_guard<std::mutex> guard(invocation_state->mutex);
     event_list = std::make_shared<RangeEventList>();
     if (thread_id == -1) {
       thread_id = next_thread_id++;
     }
     invocation_state->all_event_lists.emplace_front(event_list);
+    associated_invocation_state = invocation_state.get();
   }
   return *event_list;
 }

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -26,6 +26,19 @@ thread_local std::shared_ptr<ProfilerInvocationState> invocation_state =
 thread_local std::shared_ptr<RangeEventList> event_list;
 thread_local ProfilerInvocationState* associated_invocation_state = invocation_state.get();
 
+WorkerPushProfileState::WorkerPushProfileState(std::shared_ptr<ProfilerInvocationState> st) {
+  old_state = invocation_state;
+  invocation_state = st;
+}
+
+WorkerPushProfileState::~WorkerPushProfileState() {
+  invocation_state = old_state;
+}
+
+std::shared_ptr<ProfilerInvocationState> currState() {
+  return invocation_state;
+}
+
 RangeEventList& getEventList() {
   if (!event_list || associated_invocation_state != invocation_state.get()) {
     std::lock_guard<std::mutex> guard(invocation_state->mutex);

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -220,7 +220,8 @@ struct TORCH_API RecordFunction {
 struct ProfilerInvocationState {
   ProfilerState state = ProfilerState::Disabled;
   std::mutex mutex;
-  std::list<std::shared_ptr<RangeEventList>> all_event_lists;
+  std::unordered_map<int, std::shared_ptr<RangeEventList>> all_event_lists;
+
 };
 
 using thread_event_lists = std::vector<std::vector<Event>>;

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -252,5 +252,14 @@ private:
 };
 
 
+struct WorkerPushProfileState {
+  WorkerPushProfileState(std::shared_ptr<ProfilerInvocationState> st);
+  ~WorkerPushProfileState();
+
+  std::shared_ptr<ProfilerInvocationState> old_state;
+};
+
+std::shared_ptr<ProfilerInvocationState> currState();
+
 } // namespace profiler
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -217,12 +217,19 @@ struct TORCH_API RecordFunction {
   }
 };
 
+struct ProfilerInvocationState {
+  ProfilerState state = ProfilerState::Disabled;
+  std::mutex mutex;
+  std::list<std::shared_ptr<RangeEventList>> all_event_lists;
+};
+
 using thread_event_lists = std::vector<std::vector<Event>>;
 // NOTE: changing profiler modes is **NOT THREAD SAFE**. You should ensure that
 // there no autograd functions are being executed when these function are used.
-TORCH_API void enableProfiler(ProfilerState new_state);
-TORCH_API thread_event_lists disableProfiler();
-
+TORCH_API std::shared_ptr<ProfilerInvocationState> enableProfiler(
+    ProfilerState new_state);
+TORCH_API thread_event_lists
+disableProfiler(std::shared_ptr<ProfilerInvocationState> orig_state);
 
 // Usage:
 //   {
@@ -240,6 +247,8 @@ private:
   std::unique_ptr<std::ofstream> file_;
   std::ostream& out_;
   void processEvents(const std::vector<Event*>& events);
+
+  std::shared_ptr<ProfilerInvocationState> old_state;
 };
 
 

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -886,6 +886,7 @@ InterpreterState::InterpreterState(
 
 void InterpreterContinuation::operator()() {
   autograd::AutoGradMode grad_mode(grad_mode_enabled);
+  autograd::profiler::WorkerPushProfileState profile_state_guard(profiler_state);
   state.runAsync(stack);
 }
 } // namespace jit

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -6,6 +6,8 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <ATen/core/ivalue.h>
 
+#include <torch/csrc/autograd/profiler.h>
+
 namespace at {
 class Tensor;
 }
@@ -76,7 +78,8 @@ struct Suspend : public std::exception {
 
 struct InterpreterContinuation {
   InterpreterContinuation(InterpreterState state_, Stack stack_, bool grad_mode_enabled_)
-      : state(state_), stack(std::move(stack_)), grad_mode_enabled(grad_mode_enabled_) {}
+      : state(state_), stack(std::move(stack_)), grad_mode_enabled(grad_mode_enabled_),
+         profiler_state(autograd::profiler::currState()) {}
 
   void operator()();
 
@@ -84,6 +87,8 @@ struct InterpreterContinuation {
   InterpreterState state;
   Stack stack;
   bool grad_mode_enabled;
+
+  std::shared_ptr<autograd::profiler::ProfilerInvocationState> profiler_state;
 };
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This should be no-op for Python.

This allow us to, for example, record request-level traces in a production service. Threads in the autograd engine as well as the c10 thread pool inherit their "profiler state" from the thread that issued the work.