### PR TITLE
Delete TensorImpl::GetDevice()

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -883,14 +883,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   /**
-   * The device of a Tensor; e.g., Device(kCUDA, 1) (the 1-index CUDA
-   * device).
-   */
-  Device GetDevice() const {
-    return storage_.device();
-  }
-
-  /**
    * @brief Extends the outer-most dimension of this tensor by num elements,
    * preserving the existing data.
    *

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -192,7 +192,7 @@ class CAFFE2_API Tensor final {
   }
 
   at::Device GetDevice() const {
-    return impl_.get()->GetDevice();
+    return impl_.get()->device();
   }
 
   /**


### PR DESCRIPTION
Summary: Delete TensorImpl::GetDevice() and clean all its call sites.

Differential Revision: D14311902
