### PR TITLE
[wip] Allow registering same operator schema multiple times

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -39,15 +39,89 @@ C10_EXPORT Dispatcher& Dispatcher::singleton() {
   return _singleton;
 }
 
+namespace {
+class SchemaEqualsCheck final {
+public:
+  SchemaEqualsCheck(const FunctionSchema& expected, const FunctionSchema& actual)
+  : expected_(expected), actual_(actual) {}
+
+  void check() {
+    // this function should only be called when name and overload_name are already equal.
+    AT_ASSERT(expected_.name() == actual_.name());
+    AT_ASSERT(expected_.overload_name() == actual_.overload_name());
+
+    if (!argumentsEqual(expected_.arguments(), actual_.arguments())) {
+      reportSchemaNotEquals("they have different arguments");
+    }
+    if (!argumentsEqual(expected_.returns(), actual_.returns())) {
+      reportSchemaNotEquals("they have different returns");
+    }
+    if (expected_.is_vararg() != actual_.is_vararg()) {
+      reportSchemaNotEquals("one of them has varargs and one doesn't");
+    }
+    if (expected_.is_vararg() != actual_.is_vararg()) {
+      reportSchemaNotEquals("one of them has variable returns and one doesn't");
+    }
+  }
+
+private:
+  C10_NORETURN void reportSchemaNotEquals(const std::string& message) {
+      throw std::logic_error("Tried to register multiple operator schemas for " + expected_.name() + "." + expected_.overload_name() + ", but: " + message);
+  }
+
+  bool argumentsEqual(const std::vector<Argument>& expected, const std::vector<Argument>& actual) {
+    if(expected.size() != actual.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+      if (!argumentEquals(expected[i], actual[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool argumentEquals(const Argument& expected, const Argument& actual) {
+    return expected.name() == actual.name()
+        && expected.type() == actual.type()
+        && expected.N() == actual.N()
+        // TODO && expected.default_value() == actual.default_value()
+        && expected.kwarg_only() == actual.kwarg_only()
+        ;// TODO && expected.alias_info() == actual.alias_info();
+  }
+
+  const FunctionSchema& expected_;
+  const FunctionSchema& actual_;
+};
+
+}
+
+std::list<Dispatcher::OperatorDef>::iterator Dispatcher::findOrRegisterSchema_(FunctionSchema&& schema) {
+  const auto found = std::find_if(operators_.begin(), operators_.end(), [&] (const OperatorDef& opDef) {
+    return opDef.schema.name() == schema.name() && opDef.schema.overload_name() == schema.overload_name();
+  });
+  if (found != operators_.end()) {
+    SchemaEqualsCheck(found->schema, schema).check();
+    return found;
+  }
+
+  operators_.emplace_back(std::move(schema));
+  return --operators_.end();
+}
+
 OperatorHandle Dispatcher::registerSchema(FunctionSchema schema) {
   // we need a lock to avoid concurrent writes
   std::lock_guard<std::mutex> lock(mutex_);
 
-  operators_.emplace_back(std::move(schema));
-  auto op = OperatorHandle(--operators_.end());
+  auto op = OperatorHandle(findOrRegisterSchema_(std::move(schema)));
 
-  // note: call listeners *after* operator is added, i.e. dispatcher is already valid for new op
-  listeners_->callOnOperatorRegistered(op);
+  ++op.operatorDefIterator_->refcount;
+  if (1 == op.operatorDefIterator_->refcount) {
+    // note: call listeners *after* operator is added, i.e. dispatcher is already valid for new op
+    listeners_->callOnOperatorRegistered(op);
+  }
 
   return op;
 }
@@ -60,10 +134,14 @@ void Dispatcher::deregisterSchema(const OperatorHandle& op) {
     AT_ERROR("Tried to deregister op schema that still has kernels registered");
   }
 
-  // note: call listeners *before* operator is removed, i.e. dispatcher is still valid for removed op
-  listeners_->callOnOperatorDeregistered(op);
+  // reduce refcount and actually deregister if no references left
+  --op.operatorDefIterator_->refcount;
+  if (0 == --op.operatorDefIterator_->refcount) {
+    // note: call listeners *before* operator is removed, i.e. dispatcher is still valid for removed op
+    listeners_->callOnOperatorDeregistered(op);
 
-  operators_.erase(op.operatorDefIterator_);
+    operators_.erase(op.operatorDefIterator_);
+  }
 }
 
 void Dispatcher::registerKernel(const OperatorHandle& op, TensorTypeId dispatch_key, KernelFunction* kernel_func, KernelCacheCreatorFunction* cache_creator_func) {

--- a/caffe2/operators/experimental/c10/schemas/filler.cc
+++ b/caffe2/operators/experimental/c10/schemas/filler.cc
@@ -26,7 +26,7 @@ C10_DEFINE_OP_SCHEMA(ConstantFill, FunctionSchema(
     })
 ));
 C10_DEFINE_OP_SCHEMA(UniformFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
+    "_c10_experimental::UniformFill",
     "",
     (std::vector<c10::Argument>{
       c10::Argument("inputs", ListType::ofTensors()),
@@ -40,7 +40,7 @@ C10_DEFINE_OP_SCHEMA(UniformFill, FunctionSchema(
     })
 ));
 C10_DEFINE_OP_SCHEMA(GivenTensorFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
+    "_c10_experimental::GivenTensorFill",
     "",
     (std::vector<c10::Argument>{
       c10::Argument("inputs", ListType::ofTensors()),
@@ -53,7 +53,7 @@ C10_DEFINE_OP_SCHEMA(GivenTensorFill, FunctionSchema(
     })
 ));
 C10_DEFINE_OP_SCHEMA(GivenTensorIntFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
+    "_c10_experimental::GivenTensorIntFill",
     "",
     (std::vector<c10::Argument>{
       c10::Argument("inputs", ListType::ofTensors()),
@@ -66,7 +66,7 @@ C10_DEFINE_OP_SCHEMA(GivenTensorIntFill, FunctionSchema(
     })
 ));
 C10_DEFINE_OP_SCHEMA(GivenTensorInt64Fill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
+    "_c10_experimental::GivenTensorInt64Fill",
     "",
     (std::vector<c10::Argument>{
       c10::Argument("inputs", ListType::ofTensors()),


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17660 Specify overload name in function schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14293878/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17673 [wip] Allow registering same operator schema multiple times**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14316791/)

Now that we have named overloads, we can allow registering the same function schema multiple times and just check it's identical.

This is going to be used in custom op registration since they register the schema every time a kernel is registered.

Differential Revision: [D14316791](https://our.internmc.facebook.com/intern/diff/D14316791/)