### PR TITLE
[ROCm] Add '--hip-clang-launch' to favor <<<>>>-based launch.

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -30,6 +30,12 @@ parser.add_argument(
     help="The Directory to Store the Hipified Project",
     required=False)
 
+# Hipify using HIP-Clang launch.
+parser.add_argument(
+    '--hip-clang-launch',
+    action='store_true',
+    help=argparse.SUPPRESS)
+
 args = parser.parse_args()
 
 amd_build_dir = os.path.dirname(os.path.realpath(__file__))
@@ -127,4 +133,5 @@ hipify_python.hipify(
     includes=includes,
     ignores=ignores,
     out_of_place_only=args.out_of_place_only,
-    json_settings=json_settings)
+    json_settings=json_settings,
+    hip_clang_launch=args.hip_clang_launch)

--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -1209,16 +1209,3 @@ def hipify(
         show_detailed=show_detailed,
         show_progress=show_progress,
         hip_clang_launch=hip_clang_launch)
-
-    # copy rccl compat file to c10d
-    rccl_compat_file = "rccl1_compat.h"
-    rccl_compat_src_filepath = os.path.join(os.path.dirname(__file__), rccl_compat_file)
-    if not os.path.exists(rccl_compat_src_filepath):
-      print("ERROR: File does not exist: " + rccl_compat_src_filepath)
-      sys.exit(1)
-    rccl_compat_dst_dir = os.path.join(output_directory, "torch", "lib", "c10d")
-    if not os.path.exists(rccl_compat_dst_dir):
-      print("ERROR: Directory does not exist: " + rccl_compat_dst_dir)
-      sys.exit(1)
-    rccl_compat_dst_filepath = os.path.join(rccl_compat_dst_dir, rccl_compat_file)
-    shutil.copy(rccl_compat_src_filepath, rccl_compat_dst_filepath)

--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -246,7 +246,8 @@ def preprocess(
         output_directory,
         all_files,
         show_detailed=False,
-        show_progress=True):
+        show_progress=True,
+        hip_clang_launch=False):
     """
     Call preprocessor on selected files.
 
@@ -258,7 +259,7 @@ def preprocess(
     stats = {"unsupported_calls": [], "kernel_launches": []}
 
     for filepath in all_files:
-        preprocessor(output_directory, filepath, stats)
+        preprocessor(output_directory, filepath, stats, hip_clang_launch)
         # Show what happened
         if show_progress:
             print(
@@ -880,7 +881,7 @@ RE_ANGLE_HEADER = re.compile(r'#include <([^>]+)>')
 RE_THC_GENERIC_FILE = re.compile(r'#define THC_GENERIC_FILE "([^"]+)"')
 RE_CU_SUFFIX = re.compile(r'\.cu\b')  # be careful not to pick up .cuh
 
-def preprocessor(output_directory, filepath, stats):
+def preprocessor(output_directory, filepath, stats, hip_clang_launch):
     """ Executes the CUDA -> HIP conversion on the specified file. """
     fin_path = os.path.join(output_directory, filepath)
     with open(fin_path, 'r') as fin:
@@ -920,7 +921,8 @@ def preprocessor(output_directory, filepath, stats):
             output_source = RE_CU_SUFFIX.sub('.hip', output_source)
 
         # Perform Kernel Launch Replacements
-        output_source = processKernelLaunches(output_source, stats)
+        if not hip_clang_launch:
+            output_source = processKernelLaunches(output_source, stats)
 
         # Disable asserts
         # if not filepath.endswith("THCGeneral.h.in"):
@@ -1089,6 +1091,7 @@ def hipify(
     out_of_place_only=False,
     ignores=(),
     show_progress=True,
+    hip_clang_launch=False,
 ):
     if project_directory == "":
         project_directory = os.getcwd()
@@ -1204,4 +1207,19 @@ def hipify(
         output_directory,
         all_files,
         show_detailed=show_detailed,
-        show_progress=show_progress)
+        show_progress=show_progress,
+        hip_clang_launch=hip_clang_launch)
+
+    # copy rccl compat file to c10d
+    rccl_compat_file = "rccl1_compat.h"
+    rccl_compat_src_filepath = os.path.join(os.path.dirname(__file__), rccl_compat_file)
+    if not os.path.exists(rccl_compat_src_filepath):
+      print("ERROR: File does not exist: " + rccl_compat_src_filepath)
+      sys.exit(1)
+    rccl_compat_dst_dir = os.path.join(output_directory, "torch", "lib", "c10d")
+    if not os.path.exists(rccl_compat_dst_dir):
+      print("ERROR: Directory does not exist: " + rccl_compat_dst_dir)
+      sys.exit(1)
+    rccl_compat_dst_filepath = os.path.join(rccl_compat_dst_dir, rccl_compat_file)
+    shutil.copy(rccl_compat_src_filepath, rccl_compat_dst_filepath)
+>>>>>>> 9b73dca2b... Add '--hip-clang-launch' to favor <<<>>>-based launch.

--- a/tools/amd_build/pyHIPIFY/hipify_python.py
+++ b/tools/amd_build/pyHIPIFY/hipify_python.py
@@ -1222,4 +1222,3 @@ def hipify(
       sys.exit(1)
     rccl_compat_dst_filepath = os.path.join(rccl_compat_dst_dir, rccl_compat_file)
     shutil.copy(rccl_compat_src_filepath, rccl_compat_dst_filepath)
->>>>>>> 9b73dca2b... Add '--hip-clang-launch' to favor <<<>>>-based launch.


### PR DESCRIPTION
hip-clang uses triple chevron kernel dispatch syntax. Add an option to the hipification script to skip translating triple chevron to hipLaunchKernelGGL.

Once we switch to hip-clang, this option will be default and subsequently removed.