### PR TITLE
fix tuple matching

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -177,7 +177,7 @@ TypePtr attemptToRecoverType(const IValue& ivalue) {
 // Checks if input_ivalue is a subvalue of type.
 bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
   if (ivalue.isTuple()) {
-    auto ivalue_elem = ivalue.toTuple()->elements();
+    const auto& ivalue_elem = ivalue.toTuple()->elements();
     auto tuple_type = type->cast<TupleType>();
     if (!tuple_type || tuple_type->elements().size() != ivalue_elem.size()) {
       return false;

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -176,6 +176,19 @@ TypePtr attemptToRecoverType(const IValue& ivalue) {
 
 // Checks if input_ivalue is a subvalue of type.
 bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
+  if (ivalue.isTuple()) {
+    auto ivalue_elem = ivalue.toTuple()->elements();
+    auto tuple_type = type->cast<TupleType>();
+    if (!tuple_type || tuple_type->elements().size() != ivalue_elem.size()) {
+      return false;
+    }
+    auto type_elem = tuple_type->elements();
+    bool is_subvalue = true;
+    for (size_t i = 0; i < type_elem.size() && is_subvalue; ++i) {
+      is_subvalue = isSubvalueOf(ivalue_elem[i], type_elem[i]);
+    }
+    return is_subvalue;
+  }
   if (ivalue.isGenericList()) {
     auto list_type = type->cast<ListType>();
     if (!list_type) {

--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -98,3 +98,17 @@ TEST(TorchScriptTest, TestDictArgMatching) {
   auto output = module->run_method("dict_op", dict, std::string("hello"));
   ASSERT_EQ(1, output.toTensor()[0].item<int64_t>());
 }
+
+TEST(TorchScriptTest, TestTupleArgMatching) {
+  auto module = torch::jit::compile(R"JIT(
+      def tuple_op(a: Tuple[List[int]]):
+        return a
+    )JIT");
+
+  std::vector<int64_t> int_list = {1};
+  auto tuple_generic_list = torch::jit::Tuple::create({ int_list });
+
+  // doesn't fail on arg matching
+  module->run_method("tuple_op", tuple_generic_list);
+
+}


### PR DESCRIPTION
Check for Tuple Matching in isSubvalueOf, since they may contain container types that need to be recursed within isSubvalueOf

Fix for https://github.com/pytorch/pytorch/issues/17650