### PR TITLE
[DOC] Update README.md: PyTorch supports only 64-bit version of python.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,14 @@ PyTorch supports only 64-bit version of python.
 To check your python version, you may run:
 ```python
 python
-import platform
-platform.architecture()
+import struct
+print( 8 * struct.calcsize("P"))
 ```
 The output should be:
 ```python
-('64bit', ...)
+64
 ```
-In case of '32bit', please install a 64-bit version of python (if it is not installed as well) and set the path to it in your environment.
+Otherwise, please install a 64-bit version of python (if it is not installed as well) and set the path to it in your environment.
 
 #### Install Dependencies
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ If you want to compile with CUDA support, install
 If you want to disable CUDA support, export environment variable `NO_CUDA=1`.
 Other potentially useful environment variables may be found in `setup.py`.
 
+PyTorch supports only 64-bit version of python.
+To check your python version, you may run:
+```python
+python
+import platform
+platform.architecture()
+```
+The output should be:
+```python
+('64bit', ...)
+```
+In case of '32bit', please install a 64-bit version of python (if it is not installed as well) and set the path to it in your environment.
+
 #### Install Dependencies
 
 Common


### PR DESCRIPTION
+ Add a few words about how to check python version.

