### PR TITLE
[jit] Make `Graph` clone operations more const correct

### DIFF
--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -927,7 +927,7 @@ static value_list getReverseCaptures(Gradient& grad_desc) {
 // and replicate, and so it's better to just copy them into the reverse graph,
 // without polluting the output lists unnecessarily.
 static void liftConstants(Gradient& grad_desc, ReverseDetails& rev_info) {
-  static const auto err = [](Value*) -> Value* {
+  static const auto err = [](const Value*) -> Value* {
     throw std::runtime_error("unexpected input");
   };
   auto& graph = *grad_desc.f;
@@ -1125,7 +1125,7 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
   // afterward inputs: [output vjps][temporary vjps][captures]
   // construct a map from captured 'value' to the index in the input list
   // used to extract this block into its own function
-  std::unordered_map<Value*, size_t> capture_to_formal_index;
+  std::unordered_map<const Value*, size_t> capture_to_formal_index;
   const auto& add_capture = [&](Value* captured) {
     capture_to_formal_index[captured] = reverse_block->inputs().size();
     reverse_block->addInput()->copyMetadata(captured);
@@ -1136,7 +1136,7 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
     add_capture(graph.outputs()[offset]);
 
   grad_desc.df = std::make_shared<Graph>();
-  grad_desc.df->block()->cloneFrom(reverse_block, [&](Value* v) {
+  grad_desc.df->block()->cloneFrom(reverse_block, [&](const Value* v) {
     return grad_desc.df->inputs()[capture_to_formal_index.at(v)];
   });
   // reverse_node was just to hold onto reverse_block in a debuggable way

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -221,7 +221,7 @@ struct Value {
   //          %5 = h(%6, %6)
   TORCH_API void replaceAllUsesWith(Value* newValue);
 
-  TORCH_API Value* copyMetadata(Value* from);
+  TORCH_API Value* copyMetadata(const Value* from);
 };
 
 struct Node {
@@ -803,7 +803,7 @@ struct Node {
   // of a node in another graph. It should allocate a new instance of the same
   // concrete type as 'this', but in graph 'g' which might be different
   // than graph_
-  virtual Node* allocNewInstance(Graph* g) {
+  virtual Node* allocNewInstance(Graph* g) const {
     return new Node(g, kind());
   }
   // create a copy of all properties of Node s into this.
@@ -811,7 +811,7 @@ struct Node {
   // 'this' will be allocated with s->allocNewInstance(g) so it should have
   // the same concrete type as 's'
   //
-  TORCH_API virtual void cloneFrom(Node* s);
+  TORCH_API virtual void cloneFrom(const Node* s);
 };
 
 struct Block {
@@ -904,7 +904,7 @@ struct Block {
   // to the inputs, nodes, and outputs of this block
   // value_map is used whenever a node in src references a free variable
   // in src to look up its corresponding value
-  TORCH_API void cloneFrom(Block* src, std::function<Value*(Value*)> value_map);
+  TORCH_API void cloneFrom(const Block* src, std::function<Value*(const Value*)> value_map);
 
  private:
   void reIndexTopology();
@@ -1068,8 +1068,8 @@ struct Graph {
   // if copy_blocks is false, it will not recursively clone the nested blocks
   // this node contains.
   TORCH_API Node* createClone(
-      Node* n,
-      const std::function<Value*(Value*)>& value_map,
+      const Node* n,
+      const std::function<Value*(const Value*)>& value_map,
       bool copy_blocks = true);
 
 
@@ -1149,7 +1149,7 @@ struct Graph {
   TORCH_API std::ostream& prettyPrint(std::ostream& out);
   TORCH_API void dumpPretty();
 
-  TORCH_API std::shared_ptr<Graph> copy();
+  TORCH_API std::shared_ptr<Graph> copy() const;
 
  private:
   TORCH_API void freeNode(Node* n);
@@ -1251,8 +1251,8 @@ struct PythonOp : public Node {
   std::vector<THPObjectPtr> scalar_args;
   virtual std::string name() const = 0;
   virtual void writeScalars(std::ostream& out) const = 0;
-  void cloneFrom(Node* other_) override = 0;
-  Node* allocNewInstance(Graph* g) override = 0;
+  void cloneFrom(const Node* other_) override = 0;
+  Node* allocNewInstance(Graph* g) const override = 0;
   // recover the autograd.Function instance, if this PythonOp's function
   // was originally SomeFunction.apply
   // used in ONNX for discovering symbolics

--- a/torch/csrc/jit/passes/canonicalize.cpp
+++ b/torch/csrc/jit/passes/canonicalize.cpp
@@ -12,8 +12,8 @@ std::shared_ptr<Graph> Canonicalize(
     const std::shared_ptr<Graph>& graph,
     bool keep_unique_names) {
   auto r = std::make_shared<Graph>(graph->current_scope());
-  std::unordered_map<Value*, Value*> rn_env;
-  auto rn_fn = [&](Value* v) { return rn_env.at(v); };
+  std::unordered_map<const Value*, Value*> rn_env;
+  auto rn_fn = [&](const Value* v) { return rn_env.at(v); };
   for (auto* input : graph->inputs()) {
     auto* r_input = r->addInput();
     r_input->copyMetadata(input);

--- a/torch/csrc/jit/passes/lower_grad_of.cpp
+++ b/torch/csrc/jit/passes/lower_grad_of.cpp
@@ -17,7 +17,7 @@ void LowerGradOf(Graph& g) {
       auto if_stat =
           g.insertNode(g.create(prim::If, {cond}, it->outputs().size()));
       if_stat->addBlock()->cloneFrom(
-          it->blocks().at(0), [](Value* v) { return v; });
+          it->blocks().at(0), [](const Value* v) { return const_cast<Value*>(v); });
       auto else_block = if_stat->addBlock();
       auto undef = g.createUndefined()
                        ->insertBefore(else_block->return_node())

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<Graph> ToONNX(
     std::shared_ptr<Graph>& graph,
     ::torch::onnx::OperatorExportTypes operator_export_type) {
   auto new_graph = std::make_shared<Graph>(graph->current_scope());
-  std::unordered_map<Value*, Value*> env;
+  std::unordered_map<const Value*, Value*> env;
   removePrintOps(graph);
   BlockToONNX(graph->block(), new_graph->block(), operator_export_type, env);
   return new_graph;
@@ -53,7 +53,7 @@ void BlockToONNX(
     Block* old_block,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    std::unordered_map<Value*, Value*> env) {
+    std::unordered_map<const Value*, Value*> env) {
   torch::autograd::SymbolicContext ctx{};
   ctx.block = new_block;
 
@@ -61,7 +61,7 @@ void BlockToONNX(
   py::object onnx_symbolic = py::module::import("torch.onnx.symbolic");
 
   // Returns a node that n maps to in the new graph
-  auto envFn = [&env](Value* n) -> Value* {
+  auto envFn = [&env](const Value* n) -> Value* {
     auto it = env.find(n);
     AT_CHECK(it != env.end(), "Dangling node reference");
     AT_CHECK(it->second, "Unused node was subsequently used");

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -13,7 +13,7 @@ TORCH_API void BlockToONNX(
     Block* old_block,
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
-    std::unordered_map<Value*, Value*> env);
+    std::unordered_map<const Value*, Value*> env);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/to_batch.h
+++ b/torch/csrc/jit/passes/to_batch.h
@@ -18,8 +18,8 @@ class ToBatch {
   std::unordered_map<Value*, std::vector<Value*>> batch_map;
   // mapping from input in original graph to new input in new graph - used in
   // createClone
-  std::unordered_map<Value*, Value*> rn_env;
-  std::function<Value*(Value*)> rn_fn = [this](Value* v) {
+  std::unordered_map<const Value*, Value*> rn_env;
+  std::function<Value*(const Value*)> rn_fn = [this](const Value* v) {
     return rn_env.at(v);
   };
 

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -54,7 +54,7 @@ void mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode) {
   auto subgraph = getSubgraph(subgraphNode);
 
   // Map from values in the surrounding graph to inputs in the subgraph
-  std::unordered_map<Value*, Value*> inputsMap;
+  std::unordered_map<const Value*, Value*> inputsMap;
 
   AT_ASSERT(subgraphNode->inputs().size() == subgraph->inputs().size());
   size_t idx = 0;
@@ -86,7 +86,7 @@ void mergeNodeIntoSubgraph(Node* toMerge, Node* subgraphNode) {
 
   // Merge the node into the graph
   auto mergedNode = subgraph->insertNode(
-      subgraph->createClone(toMerge, [&](Value* v) { return inputsMap[v]; }));
+      subgraph->createClone(toMerge, [&](const Value* v) { return inputsMap[v]; }));
 
   // If n's outputs were inputs to `group`, remove them since we just merged
   // n in.
@@ -148,7 +148,7 @@ std::vector<Value*> inlineGraph(
   // Clone all nodes
   for (auto inner : subgraph->nodes()) {
     Node* outer = outerGraph->createClone(
-        inner, [&](Value* k) -> Value* { return innerToOuter.at(k); });
+        inner, [&](const Value* k) -> Value* { return innerToOuter.at(k); });
     outer->insertBefore(insertBefore);
     const auto innerOutputs = inner->outputs();
     const auto outerOutputs = outer->outputs();

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -133,9 +133,9 @@ struct ConcretePythonOp : public PythonOp {
       return getPythonName(pyobj.get());
     }
   }
-  void cloneFrom(Node* other_) override {
+  void cloneFrom(const Node* other_) override {
     Node::cloneFrom(other_);
-    auto other = other_->cast<PythonOp>();
+    auto other = const_cast<Node*>(other_)->cast<PythonOp>();
     this->cconv = other->cconv;
     Py_INCREF(other->pyobj.get());
     this->pyobj = THPObjectPtr(other->pyobj.get());
@@ -144,7 +144,7 @@ struct ConcretePythonOp : public PythonOp {
       this->scalar_args.emplace_back(sa.get());
     }
   }
-  Node* allocNewInstance(Graph* g) override {
+  Node* allocNewInstance(Graph* g) const override {
     return new ConcretePythonOp(g);
   }
   // recover the autograd.Function instance, if this PythonOp's function
@@ -348,7 +348,7 @@ void initPythonIRBindings(PyObject* module_) {
           "createClone",
           [](Graph& g, Node* n, py::object fn) {
             return g.createClone(
-                n, [&](Value* e) { return fn(e).cast<Value*>(); });
+                n, [&](const Value* e) { return fn(e).cast<Value*>(); });
           })
       .GS(appendNode)
       .GS(prependNode)

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -771,13 +771,13 @@ struct to_ir {
     Node* unpack_context =
         subgraph->insertNode(subgraph->create(prim::TupleUnpack, {context}, 0));
 
-    std::unordered_map<Value*, Value*> captures;
-    auto env = [&](Value* v) -> Value* {
+    std::unordered_map<const Value*, Value*> captures;
+    auto env = [&](const Value* v) -> Value* {
       auto it = captures.find(v);
       if (it != captures.end()) {
         return it->second;
       }
-      pack_context->addInput(v);
+      pack_context->addInput(const_cast<Value*>(v));
       Value* r = unpack_context->addOutput()->copyMetadata(v);
       captures[v] = r;
       return r;
@@ -2678,12 +2678,12 @@ void lambdaLiftFork(Node* fork_node) {
 
   // Make sure we capture everything in the new graph.
   // The uncaptured values will be added to the fork signature.
-  std::unordered_map<Value*, Value*> uncaptures_map;
-  auto env = [&](Value* v) -> Value* {
+  std::unordered_map<const Value*, Value*> uncaptures_map;
+  auto env = [&](const Value* v) -> Value* {
     if (!uncaptures_map.count(v)) {
       // Capture values for both graphs
       uncaptures_map[v] = forked_graph->addInput()->copyMetadata(v);
-      fork_node->addInput(v);
+      fork_node->addInput(const_cast<Value*>(v));
     }
     return uncaptures_map[v];
   };


### PR DESCRIPTION
The idea here is that we should be able to clone a `const Graph&` as nothing about the operation mutates the underlying graph.  There are some peculiarities in the codebase that require calls to `const_cast<Value*>()`; not sure if that is something we want (I can try to refactor it away if need be).