### PR TITLE
omit group conv NHWC test for GPU

### DIFF
--- a/caffe2/python/operator_test/group_conv_test.py
+++ b/caffe2/python/operator_test/group_conv_test.py
@@ -42,7 +42,11 @@ class TestGroupConvolution(hu.HypothesisTestCase):
                 assume(group == 1 and engine != "CUDNN")
         else:
             # TODO: Group conv in NHWC not implemented for GPU yet.
-            assume(group == 1 or order == "NCHW" or gc.device_type != caffe2_pb2.CUDA)
+            assume(group == 1 or order == "NCHW" or gc.device_type == caffe2_pb2.CPU)
+           
+            if group != 1 and order == "NHWC":
+                dc = [d for d in dc if d.device_type == caffe2_pb2.CPU]
+
         # Group conv not implemented with EIGEN engine.
         assume(group == 1 or engine != "EIGEN")
 


### PR DESCRIPTION
Observed the test `TestGroupConvolution.test_group_convolution` to fail with the following error:

```
Falsifying example: test_group_convolution(self=<caffe2.python.operator_test.group_conv_test.TestGroupConvolution testMethod=test_group_convolution>, stride=3, pad=0, kernel=5, size=8, group=4, input_channels_per_group=7, output_channels_per_group=8, batch_size=2, order='NHWC', engine='', use_bias=False, gc=, dc=[, device_type: 1])

You can reproduce this example by temporarily adding @reproduce_failure('3.59.1', b'AAAA') as a decorator on your test case
```
This example generated by hypothesis has `group=2, order='NHWC' and dc=[, device_type: 1])`.
I think this example should be skipped. 

I have mimicked the change corresponding to [PR#13554](https://github.com/pytorch/pytorch/pull/13554) to skip this example. 

