### PR TITLE
[c10d] Remove unused parameter in ProcessGroupGloo

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -337,10 +337,7 @@ They are used in specifying strategies for reduction collectives, e.g.,
       .def(py::init<>())
       .def_readwrite("devices", &::c10d::ProcessGroupGloo::Options::devices)
       .def_readwrite("timeout", &::c10d::ProcessGroupGloo::Options::timeout)
-      .def_readwrite("threads", &::c10d::ProcessGroupGloo::Options::threads)
-      .def_readwrite(
-          "cacheNumAlgorithmEntries",
-          &::c10d::ProcessGroupGloo::Options::cacheNumAlgorithmEntries);
+      .def_readwrite("threads", &::c10d::ProcessGroupGloo::Options::threads);
 
   processGroupGloo.def_static(
       "create_tcp_device",

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -239,8 +239,7 @@ void ProcessGroupGloo::RecvWork::wait() {
 
 ProcessGroupGloo::Options::Options()
     : timeout(std::chrono::milliseconds(10 * 1000)),
-      threads(2),
-      cacheNumAlgorithmEntries(1) {}
+      threads(2) {}
 
 ProcessGroupGloo::ProcessGroupGloo(
     const std::shared_ptr<Store>& store,

--- a/torch/lib/c10d/ProcessGroupGloo.hpp
+++ b/torch/lib/c10d/ProcessGroupGloo.hpp
@@ -125,13 +125,6 @@ class ProcessGroupGloo : public ProcessGroup {
     std::vector<std::shared_ptr<::gloo::transport::Device>> devices;
     std::chrono::milliseconds timeout;
     int threads;
-
-    // This controls how many Gloo algorithm instances are created for
-    // a single identifying key. If you have many identical calls with
-    // tensors of identical size and need to parallelize, this should
-    // be greater than 1. More cache entries means more memory usage.
-    // The default value is 1.
-    int cacheNumAlgorithmEntries;
   };
 
   explicit ProcessGroupGloo(


### PR DESCRIPTION
This is not used anywhere and wasn't cleaned up prior to 1.0.