### PR TITLE
caffe2:libtorch_cuda depends on caffe2:caffe2_gpu

### DIFF
--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -224,6 +224,7 @@ def add_torch_libs():
             "//caffe2/aten:ATen",
             "//caffe2/aten:generated-aten-headers-cuda",
             "//caffe2/caffe2:caffe2_cpu",
+            "//caffe2/caffe2:caffe2_gpu",
             "//caffe2/torch/lib/libshm:libshm",
         ],
         external_deps=[


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17729 caffe2:libtorch_cuda depends on caffe2:caffe2_gpu**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14353498/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17626 Reland D13935403&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14288239/)

When doing "import torch" in fbcode, previously the caffe2 cuda kernels weren't loaded because libcaffe2_gpu.so wasn't loaded.
Once you also did "from caffe2.python import workspace", then the cuda kernels were loaded because that triggered a runtime mechanism for loading libcaffe2_gpu.so.

We want the cuda kernels to always be available, so this diff adds a dependency from caffe2:libtorch_cuda to caffe2:caffe2_gpu.

Differential Revision: [D14353498](https://our.internmc.facebook.com/intern/diff/D14353498/)