### PR TITLE
Keep the dim_type of hinted shape as BATCH if possible

### DIFF
--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -87,7 +87,7 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(*pred_net, shape_map);
   const auto& out_map = eng.shape_info();
-
+  shape_map.clear();
   for (const auto& kv : out_map) {
     shape_map.emplace(
         std::piecewise_construct,

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -320,7 +320,7 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
         w_shape.data_type());
   } else {
     ShapeInfo& x_shape_info = x_it->second;
-    if (x_shape_info.dim_type == ShapeInfo::DimType::UNKNOWN) {
+    if (x_shape_info.dim_type != ShapeInfo::DimType::BATCH) {
       CAFFE_ENFORCE_GE(x_shape_info.shape.dims_size(), 1);
       x_shape_info.shape.set_dims(0, spec_.max_batch_size);
       x_shape_info.dim_type = ShapeInfo::DimType::BATCH;


### PR DESCRIPTION
Summary: If input is not BATCH, we will skip adjust its batch size during onnxifi transformation. So when we take hints, we take it as CONSTANT but later need to change it to BATCH if possible.

Differential Revision: D14355983
