### PR TITLE
Set the default ONNX opset to the latest stable opset (i.e., 9)

### DIFF
--- a/test/onnx/expect/TestOperators.test_acos.expect
+++ b/test/onnx/expect/TestOperators.test_acos.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_add_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_broadcast.expect
@@ -56,5 +56,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
@@ -56,5 +56,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
@@ -56,5 +56,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_addconstant.expect
+++ b/test/onnx/expect/TestOperators.test_addconstant.expect
@@ -55,5 +55,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_addmm.expect
+++ b/test/onnx/expect/TestOperators.test_addmm.expect
@@ -100,5 +100,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_argmax.expect
+++ b/test/onnx/expect/TestOperators.test_argmax.expect
@@ -49,5 +49,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_asin.expect
+++ b/test/onnx/expect/TestOperators.test_asin.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_at_op.expect
+++ b/test/onnx/expect/TestOperators.test_at_op.expect
@@ -48,5 +48,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_atan.expect
+++ b/test/onnx/expect/TestOperators.test_atan.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_basic.expect
+++ b/test/onnx/expect/TestOperators.test_basic.expect
@@ -71,5 +71,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_batchnorm.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm.expect
@@ -159,5 +159,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
@@ -167,5 +167,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
@@ -147,5 +147,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_batchnorm_training.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_training.expect
@@ -163,5 +163,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_chunk.expect
+++ b/test/onnx/expect/TestOperators.test_chunk.expect
@@ -61,5 +61,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_clip.expect
+++ b/test/onnx/expect/TestOperators.test_clip.expect
@@ -52,5 +52,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_concat2.expect
+++ b/test/onnx/expect/TestOperators.test_concat2.expect
@@ -64,5 +64,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_conv.expect
+++ b/test/onnx/expect/TestOperators.test_conv.expect
@@ -117,5 +117,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_convtranspose.expect
+++ b/test/onnx/expect/TestOperators.test_convtranspose.expect
@@ -123,5 +123,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_cos.expect
+++ b/test/onnx/expect/TestOperators.test_cos.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_dropout.expect
+++ b/test/onnx/expect/TestOperators.test_dropout.expect
@@ -41,5 +41,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_elu.expect
+++ b/test/onnx/expect/TestOperators.test_elu.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -100,5 +100,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_equal.expect
+++ b/test/onnx/expect/TestOperators.test_equal.expect
@@ -81,5 +81,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_erf.expect
+++ b/test/onnx/expect/TestOperators.test_erf.expect
@@ -54,5 +54,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_exp.expect
+++ b/test/onnx/expect/TestOperators.test_exp.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_flatten2D.expect
+++ b/test/onnx/expect/TestOperators.test_flatten2D.expect
@@ -53,5 +53,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_full.expect
+++ b/test/onnx/expect/TestOperators.test_full.expect
@@ -137,5 +137,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_full_like.expect
+++ b/test/onnx/expect/TestOperators.test_full_like.expect
@@ -55,5 +55,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_ge.expect
+++ b/test/onnx/expect/TestOperators.test_ge.expect
@@ -74,5 +74,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_gt.expect
+++ b/test/onnx/expect/TestOperators.test_gt.expect
@@ -81,5 +81,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_hardtanh.expect
+++ b/test/onnx/expect/TestOperators.test_hardtanh.expect
@@ -52,5 +52,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_implicit_expand.expect
+++ b/test/onnx/expect/TestOperators.test_implicit_expand.expect
@@ -55,5 +55,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_index.expect
+++ b/test/onnx/expect/TestOperators.test_index.expect
@@ -57,5 +57,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_le.expect
+++ b/test/onnx/expect/TestOperators.test_le.expect
@@ -74,5 +74,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_linear.expect
+++ b/test/onnx/expect/TestOperators.test_linear.expect
@@ -101,5 +101,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_log_sigmoid.expect
+++ b/test/onnx/expect/TestOperators.test_log_sigmoid.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_logsoftmax.expect
+++ b/test/onnx/expect/TestOperators.test_logsoftmax.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_lt.expect
+++ b/test/onnx/expect/TestOperators.test_lt.expect
@@ -81,5 +81,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_master_opset.expect
+++ b/test/onnx/expect/TestOperators.test_master_opset.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 9
+  version: 10
 }

--- a/test/onnx/expect/TestOperators.test_max.expect
+++ b/test/onnx/expect/TestOperators.test_max.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_maxpool.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool.expect
@@ -64,5 +64,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_maxpool_indices.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool_indices.expect
@@ -126,5 +126,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_mean.expect
+++ b/test/onnx/expect/TestOperators.test_mean.expect
@@ -47,5 +47,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_min.expect
+++ b/test/onnx/expect/TestOperators.test_min.expect
@@ -59,5 +59,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_mm.expect
+++ b/test/onnx/expect/TestOperators.test_mm.expect
@@ -83,5 +83,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_ne.expect
+++ b/test/onnx/expect/TestOperators.test_ne.expect
@@ -86,5 +86,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_nonzero.expect
+++ b/test/onnx/expect/TestOperators.test_nonzero.expect
@@ -45,5 +45,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_norm.expect
+++ b/test/onnx/expect/TestOperators.test_norm.expect
@@ -61,5 +61,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_ones_like.expect
+++ b/test/onnx/expect/TestOperators.test_ones_like.expect
@@ -55,5 +55,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_pad.expect
+++ b/test/onnx/expect/TestOperators.test_pad.expect
@@ -71,5 +71,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_params.expect
+++ b/test/onnx/expect/TestOperators.test_params.expect
@@ -87,5 +87,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_permute2.expect
+++ b/test/onnx/expect/TestOperators.test_permute2.expect
@@ -76,5 +76,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_pow.expect
+++ b/test/onnx/expect/TestOperators.test_pow.expect
@@ -77,5 +77,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_prod.expect
+++ b/test/onnx/expect/TestOperators.test_prod.expect
@@ -47,5 +47,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_randn.expect
+++ b/test/onnx/expect/TestOperators.test_randn.expect
@@ -67,5 +67,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
+++ b/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
@@ -49,5 +49,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduced_mean.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean.expect
@@ -61,5 +61,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
@@ -64,5 +64,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduced_prod.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod.expect
@@ -61,5 +61,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
@@ -64,5 +64,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduced_sum.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum.expect
@@ -61,5 +61,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
@@ -64,5 +64,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reducemax.expect
+++ b/test/onnx/expect/TestOperators.test_reducemax.expect
@@ -47,5 +47,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_reducemin.expect
+++ b/test/onnx/expect/TestOperators.test_reducemin.expect
@@ -47,5 +47,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_repeat.expect
+++ b/test/onnx/expect/TestOperators.test_repeat.expect
@@ -68,5 +68,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
+++ b/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
@@ -81,5 +81,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_rrelu.expect
+++ b/test/onnx/expect/TestOperators.test_rrelu.expect
@@ -70,5 +70,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_rsub.expect
+++ b/test/onnx/expect/TestOperators.test_rsub.expect
@@ -55,5 +55,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_selu.expect
+++ b/test/onnx/expect/TestOperators.test_selu.expect
@@ -54,5 +54,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_sin.expect
+++ b/test/onnx/expect/TestOperators.test_sin.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_slice.expect
+++ b/test/onnx/expect/TestOperators.test_slice.expect
@@ -77,5 +77,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_split.expect
+++ b/test/onnx/expect/TestOperators.test_split.expect
@@ -88,5 +88,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_split_with_sizes.expect
+++ b/test/onnx/expect/TestOperators.test_split_with_sizes.expect
@@ -88,5 +88,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_sqrt.expect
+++ b/test/onnx/expect/TestOperators.test_sqrt.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_sum.expect
+++ b/test/onnx/expect/TestOperators.test_sum.expect
@@ -47,5 +47,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_tan.expect
+++ b/test/onnx/expect/TestOperators.test_tan.expect
@@ -42,5 +42,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_transpose.expect
+++ b/test/onnx/expect/TestOperators.test_transpose.expect
@@ -37,5 +37,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_type_as.expect
+++ b/test/onnx/expect/TestOperators.test_type_as.expect
@@ -31,5 +31,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_unsqueeze.expect
+++ b/test/onnx/expect/TestOperators.test_unsqueeze.expect
@@ -50,5 +50,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_view.expect
+++ b/test/onnx/expect/TestOperators.test_view.expect
@@ -44,5 +44,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -192,5 +192,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/expect/TestOperators.test_zeros_like.expect
+++ b/test/onnx/expect/TestOperators.test_zeros_like.expect
@@ -55,5 +55,5 @@ graph {
   }
 }
 opset_import {
-  version: 10
+  version: 9
 }

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -539,10 +539,10 @@ class TestOperators(TestCase):
         x = torch.tensor([[[2., 2.], [1., 0.]], [[0., 0.], [1., 1.]]], requires_grad=True)
         self.assertONNX(lambda x: torch.nonzero(x), x)
 
-    def test_stable_opset(self):
+    def test_master_opset(self):
         x = torch.randn(2, 3).float()
         y = torch.randn(2, 3).float()
-        self.assertONNX(lambda x, y: x + y, (x, y), opset_version=9)
+        self.assertONNX(lambda x, y: x + y, (x, y), opset_version=10)
 
 
 if __name__ == '__main__':

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -196,16 +196,18 @@ def _try_get_scalar_type(*args):
 # and the symbolic functions should check it to determine the behavior
 # of the exporter.
 
-_default_onnx_opset_version = 10
-_export_onnx_opset_version = _default_onnx_opset_version
+
+_default_onnx_opset_version = 9
+_onnx_master_opset = 10
 _onnx_stable_opsets = [9]
+_export_onnx_opset_version = _default_onnx_opset_version
 
 
 def _set_opset_version(opset_version):
     global _export_onnx_opset_version
     if opset_version == _default_onnx_opset_version:
         return
-    if opset_version in _onnx_stable_opsets:
+    if opset_version in _onnx_stable_opsets + [_onnx_master_opset]:
         _export_onnx_opset_version = opset_version
         return
     raise ValueError("Unsupported ONNX opset version: " + str(opset_version))

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -92,8 +92,10 @@ def export(model, args, f, export_params=True, verbose=False, training=False,
             OperatorExportTypes.RAW: export raw ir.
         opset_version (int, default is 9): by default we export the model to the
             opset version of the onnx submodule. Since ONNX's latest opset may
-            evolve before next stable release, we may want to export to some stable
+            evolve before next stable release, by default we export to one stable
             opset version. Right now, supported stable opset version is 9.
+            The opset_version must be _onnx_master_opset or in _onnx_stable_opsets
+            which are defined in torch/onnx/symbolic.py
     """
     if aten or export_raw_ir:
         assert operator_export_type is None


### PR DESCRIPTION
1) The changes in the new opset won't affect internal pipeline.
2) The CI won't be affected by the ONNX changes.