### PR TITLE
add function to select GPUs

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -303,6 +303,35 @@ def get_device_properties(device):
     return _get_device_properties(device)
 
 
+def select_GPUs(N, max_utilization=.5, max_memory_usage=.5):
+    '''
+    select `N` GPUs with *utilization* less than `max_utilization` and *memory usage* less than max_memory_usage
+    Arguments:
+        N (int): How many GPUs you want to select
+        max_utilization (float): GPU with utilization higher than `max_utilization` is considered as not available.
+        max_memory_usage (float): GPU with memory usage higher than `max_memory_usage` is considered as not available.
+
+    Returns:
+        list containing IDs of selected GPUs
+    '''
+    from subprocess import Popen, PIPE
+    cmd = ["nvidia-smi",
+           "--query-gpu=index,utilization.gpu,memory.total,memory.used",
+           "--format=csv,noheader,nounits"]
+    p = Popen(cmd, stdout=PIPE)
+    output = p.stdout.read().decode('UTF-8')
+    gpus = [[int(x) for x in line.split(',')] for line in output.splitlines()]
+    gpu_ids = []
+    for (index, utilization, total, used) in gpus:
+        if utilization / 100.0 < max_utilization:
+            if used * 1.0 / total < max_memory_usage:
+                gpu_ids.append(index)
+    if len(gpu_ids) < N:
+        raise Exception("Only %s GPU(s) available but %s GPU(s) are required!" % (len(gpu_ids), N))
+    selected = gpu_ids[:N]
+    return list(selected)
+
+
 @contextlib.contextmanager
 def stream(stream):
     r"""Context-manager that selects a given stream.


### PR DESCRIPTION
Currently, we only have the `torch.cuda.device_count` function. It would be better if we can know which devices are available.

Say that there are 8 GPUs on the server, but the GPU 2 & GPU 3 are often in usage cause they are Titan V while others are GTX 1080. If I want to use 4 GPUs, I should manually select 4 GPU IDs every time I run the code, which is painful and not elegant.

If we have a function to tell which devices are available, it would rescue people from manually selecting GPUs and eliminate the need of `--gpu` cmd argument :)