### PR TITLE
[ONNX] Add constant folding to ONNX graph during export

### DIFF
--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -238,7 +238,7 @@ def set_training(model, mode):
             model.train(old_mode)
 
 
-def verify(model, args, backend, verbose=False, training=False, rtol=1e-3, atol=1e-7, test_args=2):
+def verify(model, args, backend, verbose=False, training=False, rtol=1e-3, atol=1e-7, test_args=2, do_constant_folding=False):
     """
     Export a model into ONNX, import it into a specified ONNX backend, and then
     on a few random inputs verify that PyTorch and the backend produced the same
@@ -351,13 +351,13 @@ def verify(model, args, backend, verbose=False, training=False, rtol=1e-3, atol=
 
     with set_training(model, training):
         proto_bytes = io.BytesIO()
-        torch_out = torch.onnx._export(model, args, proto_bytes, verbose=verbose)
+        torch_out = torch.onnx._export(model, args, proto_bytes, verbose=verbose, do_constant_folding=do_constant_folding)
         proto = load_bytes(proto_bytes)
         prepared = backend.prepare(proto)
 
         def run(args):
             alt_proto_bytes = io.BytesIO()
-            torch_out = torch.onnx._export(model, args, alt_proto_bytes, verbose=verbose)
+            torch_out = torch.onnx._export(model, args, alt_proto_bytes, verbose=verbose, do_constant_folding=do_constant_folding)
             alt_proto = load_bytes(alt_proto_bytes)
             if proto.SerializeToString() != alt_proto.SerializeToString():
                 # OK, let's try to figure out what happened.
@@ -429,6 +429,8 @@ def verify(model, args, backend, verbose=False, training=False, rtol=1e-3, atol=
             backend_out = prepared.run(backend_args(args))
             if isinstance(torch_out, torch.Tensor):
                 torch_out = (torch_out,)
+            if any(isinstance(o, tuple) for o in torch_out): # LSTM and GRU outputs can have nested tuples
+                torch_out, _ = torch._C._jit_flatten(torch_out)
             # NB: onnx backend NEVER returns bare numpy array
             msg = "ONNX backend returned different results from PyTorch"
             result_hint = ("If you are not using trained parameters, a difference in results\n"

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -116,7 +116,7 @@ class EncoderBase {
 
  protected:
   // Using std::map instead of std::unordered_map for initializers
-  // in EncodeGraph cosntructor so that the order in which initializers
+  // in EncodeGraph cosntructor, so that the order in which initializers
   // get written to the ONNX graph is always the deterministic and 
   // predictable. While this is not a ONNX requirement, it is needed 
   // for testing purposes in tests that use _export_to_pretty_string()
@@ -312,7 +312,8 @@ void EncoderBase::EncodeBlock(
     }
   }
   AT_ASSERT(block->inputs().size() >= initializers.size());
-  for (auto& name_tensor_pair : initializers) {
+  for (auto& name_tensor_pair : 
+        std::map<std::string, at::Tensor>(initializers.begin(), initializers.end())) {
     auto p = graph_proto->add_initializer();
     p->set_name(name_tensor_pair.first);
     EncodeTensor(p, name_tensor_pair.second, name_tensor_pair.first);

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -312,8 +312,7 @@ void EncoderBase::EncodeBlock(
     }
   }
   AT_ASSERT(block->inputs().size() >= initializers.size());
-  for (auto& name_tensor_pair : 
-        std::map<std::string, at::Tensor>(initializers.begin(), initializers.end())) {
+  for (auto& name_tensor_pair : initializers) {
     auto p = graph_proto->add_initializer();
     p->set_name(name_tensor_pair.first);
     EncodeTensor(p, name_tensor_pair.second, name_tensor_pair.first);

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -310,6 +310,7 @@ void initPythonIRBindings(PyObject* module_) {
           py::arg("recurse") = true)
       .def("addInput", [](Graph& g) { return g.addInput(); })
       .def("copy", [](Graph& g) { return g.copy(); })
+      .def("block", [](Graph& g) { return g.block(); })
       .GS(eraseInput)
       .GS(registerOutput)
       .def(
@@ -376,6 +377,7 @@ void initPythonIRBindings(PyObject* module_) {
       .VS(setUniqueName)
       .VS(offset)
       .VS(uses)
+      .VS(hasUses)
       .VS(replaceAllUsesWith)
       .def("node", [](Value& v) { return v.node(); })
       .def(


### PR DESCRIPTION
This PR adds the ability to do constant folding on ONNX graphs during PT->ONNX export. This is done mainly to optimize the graph and make it leaner. The two attached snapshots show a multiple-node LSTM model before and after constant folding. 
A couple of notes:
1. Constant folding is by default turned off for now. The goal is to turn it on by default once we have validated it through all the tests.
2. Support for folding in nested blocks is not in place, but will be added in the future. 

**Original Model:**
![multiple_lstm_original](https://user-images.githubusercontent.com/23646532/53987630-6ac53980-40d6-11e9-9702-1ccfee124a83.JPG)
**Constant-folded model:**
![multiple_lstm_constant_folded](https://user-images.githubusercontent.com/23646532/53987632-6c8efd00-40d6-11e9-81c5-362c16f68861.JPG)

