### PR TITLE
Catch exceptions in bound_shape_inference

### DIFF
--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -78,11 +78,15 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
       shape_map[s] = shape_info;
     }
   }
+  // We treat hinted shapes as BATCH. If there are shape hints on blobs in the
+  // workspace, since they are already inserted as CONSTANT, it will take effect
+  // here. For SEQ typed tensors, there are only a few of them and they will be
+  // handled by BoundShapeInferencer.
   for (const auto& kv : shape_hints_mapped) {
     shape_map.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(kv.first),
-        std::forward_as_tuple(ShapeInfo::DimType::CONSTANT, kv.second));
+        std::forward_as_tuple(ShapeInfo::DimType::BATCH, kv.second));
   }
   BoundShapeInferencer eng(spec);
   eng.InferBoundShapeAndType(*pred_net, shape_map);

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -63,6 +63,7 @@ class CAFFE2_API BoundShapeInferencer {
       std::vector<int64_t> bound_dims,
       TensorProto::DataType type);
 
+  void InferGivenTensorFill(const OperatorDef& op);
   void InferSparseLengthsSum(const OperatorDef& op);
   void InferFC(const OperatorDef& op);
   void InferConcat(const OperatorDef& op);
@@ -74,7 +75,7 @@ class CAFFE2_API BoundShapeInferencer {
   void InferCommonOp(const OperatorDef& op);
 
   const BoundShapeSpec spec_;
-  ShapeInfo::DimType current_dim_type_{ShapeInfo::DimType::UNKNOWN};
+  ShapeInfo::DimType current_dim_type_{ShapeInfo::DimType::BATCH};
   int64_t current_max_batch_size_{0};
   std::unordered_map<std::string, ShapeInfo> shape_info_;
 };

--- a/caffe2/utils/string_utils.h
+++ b/caffe2/utils/string_utils.h
@@ -21,6 +21,18 @@ CAFFE2_API inline bool StartsWith(const std::string& str, const std::string& pre
       prefix.end();
 }
 
+CAFFE2_API inline bool EndsWith(
+    const std::string& full,
+    const std::string& ending) {
+  if (full.length() >= ending.length()) {
+    return (
+        0 ==
+        full.compare(full.length() - ending.length(), ending.length(), ending));
+  } else {
+    return false;
+  }
+}
+
 CAFFE2_API int32_t editDistanceHelper(const char* s1,
   size_t s1_len,
   const char* s2,


### PR DESCRIPTION
Summary: InferShape is opportunistic and shouldn't throw in general.

Differential Revision: D14368735
