### PR TITLE
Remove 'Tensor' key from ATen codegen.

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -263,8 +263,6 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
     env['AccScalarName'] = accreal
     env['isFloatingType'] = is_floating_type
     env['isIntegralType'] = not is_floating_type
-    if density == 'Dense':
-        env['Tensor'] = "{}{}{}Tensor".format(density_tag, backend, scalar_name)
     env['Type'] = "{}{}{}Type".format(density_tag, backend, scalar_name)
     env['DenseTensor'] = "{}{}Tensor".format(backend, scalar_name)
     env['Backend'] = density_tag + backend

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -59,7 +59,7 @@ size_t ${Type}::elementSizeInBytes() const {
 
 /* example
 Tensor * ${Type}::add(Tensor & a, Tensor & b) {
-  std::cout << "add ${Tensor}\n";
+  std::cout << "add Tensor with backend ${Backend}\n";
   return &a;
 }
 */


### PR DESCRIPTION
We used to have different ATen Tensor types, but we don't anymore.  This was just being maintained by a codegen'ed comment.

