### PR TITLE
Eliminate the use of Type.

### DIFF
--- a/aten/src/ATen/ScalarOps.h
+++ b/aten/src/ATen/ScalarOps.h
@@ -10,10 +10,10 @@ namespace c10 {
 // to implement this without going through Derived Types (which are not part of core).
 inline at::Tensor scalar_to_tensor(Scalar s) {
   if (s.isFloatingPoint()) {
-    return at::scalar_tensor(s, at::CPU(kDouble).options());
+    return at::scalar_tensor(s, at::device(at::kCPU).dtype(at::kDouble));
   } else {
     AT_ASSERT(s.isIntegral());
-    return at::scalar_tensor(s, at::CPU(kLong).options());
+    return at::scalar_tensor(s, at::device(at::kCPU).dtype(at::kLong));
   }
 }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17804 Eliminate the use of Type.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14382165/)

at::CPU produces Type object which is then casted into TensorOptions, instead directly using TensorOptions.

Differential Revision: [D14382165](https://our.internmc.facebook.com/intern/diff/D14382165/)