### PR TITLE
Add Python property bindings for itemsize and nbytes.

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10293,6 +10293,12 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         with self.assertRaisesRegex(RuntimeError, "expected both inputs to be on same device"):
             torch.tensor(2).to("cuda:1") // torch.tensor(3).to("cuda:0")
 
+    def test_nbytes(self):
+        self.assertEqual(torch.zeros(4, dtype=torch.float64).nbytes, 32)
+
+    def test_itemsize(self):
+        self.assertEqual(torch.zeros(4, dtype=torch.float64).itemsize, 8)
+
     def test_allow_tensor_metadata_change(self):
         def do_test(t):
             with self.assertRaisesRegex(

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -412,6 +412,18 @@ static PyObject * THPVariable_device(THPVariable* self) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_nbytes(THPVariable* self) {
+  HANDLE_TH_ERRORS
+  return PyInt_FromSize_t(self->cdata.nbytes());
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_itemsize(THPVariable* self) {
+  HANDLE_TH_ERRORS
+  return PyInt_FromSize_t(self->cdata.itemsize());
+  END_HANDLE_TH_ERRORS
+}
+
 static struct PyGetSetDef THPVariable_properties[] = {
   {"_cdata", (getter)THPVariable_get_cdata, nullptr, nullptr, nullptr},
   {"_version", (getter)THPVariable_get_version, nullptr, nullptr, nullptr},
@@ -433,6 +445,8 @@ static struct PyGetSetDef THPVariable_properties[] = {
   {"dtype", (getter)THPVariable_dtype, nullptr, nullptr, nullptr},
   {"layout", (getter)THPVariable_layout, nullptr, nullptr, nullptr},
   {"device", (getter)THPVariable_device, nullptr, nullptr, nullptr},
+  {"nbytes", (getter)THPVariable_nbytes, nullptr, nullptr, nullptr},
+  {"itemsize", (getter)THPVariable_itemsize, nullptr, nullptr, nullptr},
   {nullptr}
 };
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17810 Add nbytes, itemsize, element_size to at::Tensor.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14388790/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17811 Add Python property bindings for itemsize and nbytes.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14388791/)



Differential Revision: [D14388791](https://our.internmc.facebook.com/intern/diff/D14388791/)