### PR TITLE
Suppress C408 lint (don't use dict constructor)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
 max-line-length = 120
-ignore = E203,E305,E402,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504
+# C408 ignored because we like the dict keyword argument syntax
+ignore = E203,E305,E402,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504,C408
 exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install,build,torch/include


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17813 Suppress C408 lint (don't use dict constructor)**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14390136/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17820 Fix lint in test_dataloader.py&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14392864/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17821 Fix lint in test_distributions.py&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14392899/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17823 Fix lint in test_jit.py&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14392996/)

We have a lot of manually written out dict() constructors,
and (1) I don't think use of curly brace syntax is much
of an improvement and (2) it seems like a waste of time to
fix them all.

Differential Revision: [D14390136](https://our.internmc.facebook.com/intern/diff/D14390136/)