### PR TITLE
Assert against using Operator methods not supported when exporting it to c10

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -37,6 +37,7 @@ OperatorBase::OperatorBase(const OperatorDef& operator_def, Workspace* ws)
       input_size_(operator_def.input_size()),
       event_(caffe2::make_unique<Event>(device_option_)) {
   static GlobalInitIsCalledGuard guard;
+  inputs_.reserve(operator_def.input_size());
   for (const string& input_str : operator_def.input()) {
     auto* blob = ws->GetBlob(input_str);
     CAFFE_ENFORCE(
@@ -50,6 +51,7 @@ OperatorBase::OperatorBase(const OperatorDef& operator_def, Workspace* ws)
 
   GetOperatorLogger()(operator_def);
 
+  outputs_.reserve(operator_def.output_size());
   for (const string& output_str : operator_def.output()) {
     outputs_.push_back(CHECK_NOTNULL(ws->CreateBlob(output_str)));
   }
@@ -99,6 +101,7 @@ OperatorBase::OperatorBase(
 }
 
 vector<TensorShape> OperatorBase::InputTensorShapes() const {
+  CAFFE_ENFORCE(isLegacyOperator(), "InputTensorShapes() not supported for operators exported to c10.");
   vector<TensorShape> tps;
   for (const auto& blob : inputs_) {
     tps.push_back(GetTensorShapeOfBlob(blob));

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -101,7 +101,9 @@ OperatorBase::OperatorBase(
 }
 
 vector<TensorShape> OperatorBase::InputTensorShapes() const {
-  CAFFE_ENFORCE(isLegacyOperator(), "InputTensorShapes() not supported for operators exported to c10.");
+  CAFFE_ENFORCE(
+      isLegacyOperator(),
+      "InputTensorShapes() not supported for operators exported to c10.");
   vector<TensorShape> tps;
   for (const auto& blob : inputs_) {
     tps.push_back(GetTensorShapeOfBlob(blob));

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -183,6 +183,8 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx) {
+    CAFFE_ENFORCE(isLegacyOperator(), "Output(idx) not supported for operators exported to c10. Please use XOutput instead.");
+
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use Output<Tensor>(int, DeviceType) for "
@@ -285,6 +287,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   Tensor* OutputTensorAlias(int idx, const Tensor& src) {
+    CAFFE_ENFORCE(isLegacyOperator(), "OutputTensorAlias(idx, src) not (yet) supported for operators exported to c10.");
     return BlobSetTensor(OutputBlob(idx),
                   src.Alias());
   }
@@ -292,15 +295,18 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx, T* allocated) {
+    CAFFE_ENFORCE(isLegacyOperator(), "Output(idx, allocated) not supported for operators exported to c10. Please use XOutput.");
     outputs_.at(idx)->Reset(allocated);
     return allocated;
   }
 
   inline const Blob& InputBlob(int idx) {
+    CAFFE_ENFORCE(isLegacyOperator(), "InputBlob(idx) not (yet) supported for operators exported to c10.");
     return *inputs_.at(idx);
   }
 
   inline Blob* OutputBlob(int idx) {
+    CAFFE_ENFORCE(isLegacyOperator(), "OutputBlob(idx) not (yet) supported for operators exported to c10.");
     return outputs_.at(idx);
   }
 
@@ -308,11 +314,13 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   // note this does not check if the two Blobs points to the same Tensor, or if
   // the Tensor pointers point to the same TensorImpl, or if the Storages alias
   inline bool IsInputOutputAlias(int i, int j) {
+    CAFFE_ENFORCE(isLegacyOperator(), "IsInputOutputAlias(i, j) not (yet) supported for operators exported to c10.");
     return inputs_.at(i) == outputs_.at(j);
   }
 
   template <typename T>
   inline bool InputIsType(int idx) {
+    CAFFE_ENFORCE(isLegacyOperator(), "InputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use InputIsTensorType(int, DeviceType) for "
@@ -321,11 +329,13 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool InputIsTensorType(int idx, DeviceType device_type) {
+    CAFFE_ENFORCE(isLegacyOperator(), "InputIsTensorType(idx, device_type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*inputs_.at(idx), device_type);
   }
 
   template <typename T>
   inline bool OutputIsType(int idx) {
+    CAFFE_ENFORCE(isLegacyOperator(), "OutputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use OutputIsTensorType(int, DeviceType) for "
@@ -334,6 +344,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool OutputIsTensorType(int idx, DeviceType type) {
+    CAFFE_ENFORCE(isLegacyOperator(), "OutputIsTensorType(idx, type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*outputs_.at(idx), type);
   }
 
@@ -347,8 +358,14 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     }
     return ivalue_outputs_.size();
   }
-  inline const vector<const Blob*>& Inputs() const { return inputs_; }
-  inline const vector<Blob*>& Outputs() { return outputs_; }
+  inline const vector<const Blob*>& Inputs() const {
+    CAFFE_ENFORCE(isLegacyOperator(), "Inputs() not supported for operators exported to c10.");
+    return inputs_;
+  }
+  inline const vector<Blob*>& Outputs() {
+    CAFFE_ENFORCE(isLegacyOperator(), "Outputs() not supported for operators exported to c10.");
+    return outputs_;
+  }
   vector<TensorShape> InputTensorShapes() const;
 
   virtual void WaitEvent(const Event& ev, int /*stream_id */ = -1) {
@@ -417,6 +434,8 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   virtual void AddRelatedBlobInfo(EnforceNotMet* err) {
+    CAFFE_ENFORCE(isLegacyOperator(), "AddRelatedBlobInfo(err) not supported for operators exported to c10.");
+
     if (!has_debug_def()) {
       return;
     }

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -183,10 +183,6 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "Output(idx) not supported for operators exported to c10. Please use XOutput instead.");
-
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use Output<Tensor>(int, DeviceType) for "
@@ -299,24 +295,15 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx, T* allocated) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "Output(idx, allocated) not supported for operators exported to c10. Please use XOutput.");
     outputs_.at(idx)->Reset(allocated);
     return allocated;
   }
 
   inline const Blob& InputBlob(int idx) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "InputBlob(idx) not (yet) supported for operators exported to c10.");
     return *inputs_.at(idx);
   }
 
   inline Blob* OutputBlob(int idx) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "OutputBlob(idx) not (yet) supported for operators exported to c10.");
     return outputs_.at(idx);
   }
 
@@ -332,9 +319,6 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline bool InputIsType(int idx) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "InputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use InputIsTensorType(int, DeviceType) for "
@@ -343,17 +327,11 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool InputIsTensorType(int idx, DeviceType device_type) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "InputIsTensorType(idx, device_type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*inputs_.at(idx), device_type);
   }
 
   template <typename T>
   inline bool OutputIsType(int idx) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "OutputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use OutputIsTensorType(int, DeviceType) for "
@@ -362,9 +340,6 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool OutputIsTensorType(int idx, DeviceType type) {
-    CAFFE_ENFORCE(
-        isLegacyOperator(),
-        "OutputIsTensorType(idx, type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*outputs_.at(idx), type);
   }
 

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -183,7 +183,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx) {
-    CAFFE_ENFORCE(isLegacyOperator(), "Output(idx) not supported for operators exported to c10. Please use XOutput instead.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "Output(idx) not supported for operators exported to c10. Please use XOutput instead.");
 
     static_assert(
         !std::is_same<T, Tensor>::value,
@@ -287,7 +289,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   Tensor* OutputTensorAlias(int idx, const Tensor& src) {
-    CAFFE_ENFORCE(isLegacyOperator(), "OutputTensorAlias(idx, src) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputTensorAlias(idx, src) not (yet) supported for operators exported to c10.");
     return BlobSetTensor(OutputBlob(idx),
                   src.Alias());
   }
@@ -295,18 +299,24 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx, T* allocated) {
-    CAFFE_ENFORCE(isLegacyOperator(), "Output(idx, allocated) not supported for operators exported to c10. Please use XOutput.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "Output(idx, allocated) not supported for operators exported to c10. Please use XOutput.");
     outputs_.at(idx)->Reset(allocated);
     return allocated;
   }
 
   inline const Blob& InputBlob(int idx) {
-    CAFFE_ENFORCE(isLegacyOperator(), "InputBlob(idx) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "InputBlob(idx) not (yet) supported for operators exported to c10.");
     return *inputs_.at(idx);
   }
 
   inline Blob* OutputBlob(int idx) {
-    CAFFE_ENFORCE(isLegacyOperator(), "OutputBlob(idx) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputBlob(idx) not (yet) supported for operators exported to c10.");
     return outputs_.at(idx);
   }
 
@@ -314,13 +324,17 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   // note this does not check if the two Blobs points to the same Tensor, or if
   // the Tensor pointers point to the same TensorImpl, or if the Storages alias
   inline bool IsInputOutputAlias(int i, int j) {
-    CAFFE_ENFORCE(isLegacyOperator(), "IsInputOutputAlias(i, j) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "IsInputOutputAlias(i, j) not (yet) supported for operators exported to c10.");
     return inputs_.at(i) == outputs_.at(j);
   }
 
   template <typename T>
   inline bool InputIsType(int idx) {
-    CAFFE_ENFORCE(isLegacyOperator(), "InputIsType(idx) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "InputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use InputIsTensorType(int, DeviceType) for "
@@ -329,13 +343,17 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool InputIsTensorType(int idx, DeviceType device_type) {
-    CAFFE_ENFORCE(isLegacyOperator(), "InputIsTensorType(idx, device_type) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "InputIsTensorType(idx, device_type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*inputs_.at(idx), device_type);
   }
 
   template <typename T>
   inline bool OutputIsType(int idx) {
-    CAFFE_ENFORCE(isLegacyOperator(), "OutputIsType(idx) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use OutputIsTensorType(int, DeviceType) for "
@@ -344,7 +362,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool OutputIsTensorType(int idx, DeviceType type) {
-    CAFFE_ENFORCE(isLegacyOperator(), "OutputIsTensorType(idx, type) not (yet) supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputIsTensorType(idx, type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*outputs_.at(idx), type);
   }
 
@@ -359,11 +379,15 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     return ivalue_outputs_.size();
   }
   inline const vector<const Blob*>& Inputs() const {
-    CAFFE_ENFORCE(isLegacyOperator(), "Inputs() not supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "Inputs() not supported for operators exported to c10.");
     return inputs_;
   }
   inline const vector<Blob*>& Outputs() {
-    CAFFE_ENFORCE(isLegacyOperator(), "Outputs() not supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "Outputs() not supported for operators exported to c10.");
     return outputs_;
   }
   vector<TensorShape> InputTensorShapes() const;
@@ -434,7 +458,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   virtual void AddRelatedBlobInfo(EnforceNotMet* err) {
-    CAFFE_ENFORCE(isLegacyOperator(), "AddRelatedBlobInfo(err) not supported for operators exported to c10.");
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "AddRelatedBlobInfo(err) not supported for operators exported to c10.");
 
     if (!has_debug_def()) {
       return;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17818 Assert against using Operator methods not supported when exporting it to c10**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14392459/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17946 Assert against using Operator methods not supported when exporting it to c10, part 2&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14430749/)

Some of these are probably implementable for exported operators,
but aren't implemented yet and for now it's better to assert than to just return wrong results.

Differential Revision: [D14392459](https://our.internmc.facebook.com/intern/diff/D14392459/)