### PR TITLE
Added a few extra python bindings to help with walking the IR graph from Python

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2336,6 +2336,45 @@ class TestJit(JitTestCase):
         self.assertEqual(len(warns), 1)
         self.assertEqual(warns[0], "new_zeros is a legacy constructor and is not supported in the JIT.")
 
+    def test_python_bindings(self):
+        lstm_cell = torch.jit.script(LSTMCellS)
+
+        def lstm(x, hx, cx, w_ih, w_hh, b_ih, b_hh):
+            for i in range(x.size(0)):  
+                hx, cx = lstm_cell(x[i], hx, cx, w_ih, w_hh, b_ih, b_hh)
+            return hx
+
+        slstm = torch.jit.script(lstm)
+
+        inputs = get_lstm_inputs('cpu', training=True, seq_length=10)
+        slstm(*inputs).sum().backward()
+        global fw_graph
+        fw_graph = slstm.graph_for(*inputs)
+        nodes = [n for n in fw_graph.nodes()]
+        tested_blocks = False
+        for node in nodes:
+            for output in [o for o in node.outputs()]:
+                self.assertTrue(hasattr(output,'type'))
+                self.assertTrue(output.type() is not None)
+            for input in [i for i in node.inputs()]:
+                self.assertTrue(hasattr(input,'type'))
+                self.assertTrue(input.type() is not None)
+            for block in [b for b in node.blocks()]:
+                tested_blocks = True
+                self.assertTrue(hasattr(block,'inputs'))
+                self.assertTrue(hasattr(block,'outputs'))
+                for output in [o for o in block.outputs()]:
+                    self.assertTrue(hasattr(output,'type'))
+                    self.assertTrue(output.type() is not None)
+                for input in [i for i in block.inputs()]:
+                    self.assertTrue(hasattr(input,'type'))
+                    self.assertTrue(input.type() is not None)
+                self.assertTrue(hasattr(block,'returnNode'))
+                self.assertTrue(type(block.returnNode()) == torch._C.Node)
+                self.assertTrue(hasattr(block,'paramNode'))
+                self.assertTrue(type(block.paramNode()) == torch._C.Node)
+        self.assertTrue(tested_blocks)
+
 
 class TestBatched(TestCase):
     # generate random examples and create an batchtensor with them

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2340,7 +2340,7 @@ class TestJit(JitTestCase):
         lstm_cell = torch.jit.script(LSTMCellS)
 
         def lstm(x, hx, cx, w_ih, w_hh, b_ih, b_hh):
-            for i in range(x.size(0)):  
+            for i in range(x.size(0)):
                 hx, cx = lstm_cell(x[i], hx, cx, w_ih, w_hh, b_ih, b_hh)
             return hx
 
@@ -2354,24 +2354,24 @@ class TestJit(JitTestCase):
         tested_blocks = False
         for node in nodes:
             for output in [o for o in node.outputs()]:
-                self.assertTrue(hasattr(output,'type'))
+                self.assertTrue(hasattr(output, 'type'))
                 self.assertTrue(output.type() is not None)
             for input in [i for i in node.inputs()]:
-                self.assertTrue(hasattr(input,'type'))
+                self.assertTrue(hasattr(input, 'type'))
                 self.assertTrue(input.type() is not None)
             for block in [b for b in node.blocks()]:
                 tested_blocks = True
-                self.assertTrue(hasattr(block,'inputs'))
-                self.assertTrue(hasattr(block,'outputs'))
+                self.assertTrue(hasattr(block, 'inputs'))
+                self.assertTrue(hasattr(block, 'outputs'))
                 for output in [o for o in block.outputs()]:
-                    self.assertTrue(hasattr(output,'type'))
+                    self.assertTrue(hasattr(output, 'type'))
                     self.assertTrue(output.type() is not None)
                 for input in [i for i in block.inputs()]:
-                    self.assertTrue(hasattr(input,'type'))
+                    self.assertTrue(hasattr(input, 'type'))
                     self.assertTrue(input.type() is not None)
-                self.assertTrue(hasattr(block,'returnNode'))
+                self.assertTrue(hasattr(block, 'returnNode'))
                 self.assertTrue(type(block.returnNode()) == torch._C.Node)
-                self.assertTrue(hasattr(block,'paramNode'))
+                self.assertTrue(hasattr(block, 'paramNode'))
                 self.assertTrue(type(block.paramNode()) == torch._C.Node)
         self.assertTrue(tested_blocks)
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -386,7 +386,8 @@ void initPythonIRBindings(PyObject* module_) {
           })
       .VS(copyMetadata)
       .VS(isTensor)
-      .def("toIValue", [](Value& n) { return toIValue(&n); });
+      .def("toIValue", [](Value& n) { return toIValue(&n); })
+      .def("type", [](Value& v) { return v.type(); });
 #undef VS
 
   py::class_<Block, std::unique_ptr<Block, py::nodelete>>(m, "Block")
@@ -410,7 +411,27 @@ void initPythonIRBindings(PyObject* module_) {
           },
           "Find all nodes",
           py::arg("kind"),
-          py::arg("recurse") = true);
+          py::arg("recurse") = true)
+      .def(
+          "inputs",
+          [](Block& b) {
+            return py::make_iterator(b.inputs().begin(), b.inputs().end());
+          })
+      .def(
+          "outputs",
+          [](Block& b) {
+            return py::make_iterator(b.outputs().begin(), b.outputs().end());
+          })
+      .def(
+          "returnNode",
+          [](Block& b) {
+            return b.return_node();
+          })
+      .def(
+          "paramNode",
+          [](Block& b) {
+            return b.param_node();
+          });
 
 #define NS(name) def(#name, &Node ::name)
   py::class_<Node, std::unique_ptr<Node, py::nodelete>>(m, "Node")


### PR DESCRIPTION
These changes add the following new Python bindings:

- Values have a 'type' property now that allows getting to the 'type' object
- Blocks have now inputs and outputs as well as returnNode and paramNode properties