### PR TITLE
Fix PySlice_Unpack not available on PyPy 3.6 yet

### DIFF
--- a/torch/csrc/utils/python_compat.h
+++ b/torch/csrc/utils/python_compat.h
@@ -2,7 +2,8 @@
 
 #include <torch/csrc/python_headers.h>
 
-#if PY_VERSION_HEX < 0x03060100
+// PyPy 3.6 does not yet have PySlice_Unpack
+#if PY_VERSION_HEX < 0x03060100 || defined(PYPY_VERSION)
 
 // PySlice_Unpack not introduced till python 3.6.1
 // included here for backwards compatibility


### PR DESCRIPTION
This is one of the fixes needed to support compilation on PyPy 3.6, see https://github.com/pytorch/pytorch/issues/17835