### PR TITLE
PyPy compatibility: let unmodified slots be inherited in the standard way

### DIFF
--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -117,10 +117,10 @@ namespace {
 
 
 static PySequenceMethods THPSize_as_sequence = {
-  PyTuple_Type.tp_as_sequence->sq_length,
+  nullptr,                                          /* sq_length */
   wrap_tuple_fn<decltype(&sq_concat), &sq_concat>,
   wrap_tuple_fn<decltype(&sq_repeat), &sq_repeat>,
-  PyTuple_Type.tp_as_sequence->sq_item,
+  nullptr,                                          /* sq_item */
 #if PY_MAJOR_VERSION == 2
   wrap_tuple_fn<decltype(&sq_slice), &sq_slice>,
 #else
@@ -128,11 +128,11 @@ static PySequenceMethods THPSize_as_sequence = {
 #endif
   nullptr,                                          /* sq_ass_item */
   nullptr,                                          /* sq_ass_slice */
-  PyTuple_Type.tp_as_sequence->sq_contains
+  nullptr                                           /* sq_contains */
 };
 
 static PyMappingMethods THPSize_as_mapping = {
-    PyTuple_Type.tp_as_mapping->mp_length,
+    nullptr,                                        /* mp_length */
     wrap_tuple_fn<decltype(&mp_subscript), &mp_subscript>,
     nullptr
 };


### PR DESCRIPTION
This is needed to fix a segfault on PyPy 3.6, see https://bitbucket.org/pypy/pypy/issues/2968/segfault-calling-cpyext_tp_new_tuple and https://github.com/pytorch/pytorch/issues/17835