### PR TITLE
[DO NOT MERGE] example pickle for serialization of attributes discussion

### DIFF
--- a/p.py
+++ b/p.py
@@ -1,0 +1,10 @@
+import torch
+import pickle
+import pickletools
+r = [1, 2, (3.4, 4.4, 4.4, 5.) , { 'a' : 3, 'b' : 400000 }, [3, 4, 'a']]
+
+d = pickle.dumps(r, protocol=2)
+
+pickletools.dis(d)
+
+torch._C.print_pickle(d)


### PR DESCRIPTION
Example showing what parsing the pickle format into IValues looks like.

Context: we are discussing how to serialize script attributes, and one option is to use a subset of Python's pickle language since it makes it possible to load the attributes in python for debugging purposes.

Some notes:

* Format itself is actually pretty simple, and resembles what we might implement as a custom binary format.
* We can probably use protocol '2', which can still be read by python 3
* Since python does not have a concept of specialized lists (e.g. a list of only ints), we would need to decide how we would encode the IValue equivalents. We can make up our own thing, but then the files would not be readable. We can pretend 'IntList' was a class whose arguments were the list, but I don't know how classes are encoded yet so I am not sure.
* Size limit concerns are pretty minimal. There is no overall size limit for the pickle arena, even in protocol 2. However, there is a limit on the total number of non-primitive objects (at most 2^32 non-primitives), and strings are limited to 4Gb each. Even when we have big attribute dictionaries, I do not think we will hit these limits since they won't have 2^32 _entries_. Protocol 4 probably has some way around these limits as well.
* Some weird big endian float encoding is used (see float4 in https://svn.python.org/projects/python/trunk/Lib/pickletools.py for details).
@driazati @dzhulgakov 