### PR TITLE
Add external callbacks into RecordFunction

### DIFF
--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -63,7 +63,8 @@ namespace jit {
   _(ATenNativeBatchNorm)           \
   _(NoneSchemaMatch)               \
   _(ClassParser)                   \
-  _(PeepholeOptimize)
+  _(PeepholeOptimize)              \
+  _(RecordFunction)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -586,28 +586,28 @@ void invokeTestRecordFunction(at::Tensor& t) {
   t.add_(torch::ones_like(t));
 }
 
-std::string getFullName(const autograd::profiler::FunctionCallContext* ctx_ptr) {
+std::string getFullName(const autograd::profiler::RecordFunction* fn_ptr) {
   std::string full_name = "";
-  while (ctx_ptr != nullptr) {
+  while (fn_ptr != nullptr) {
     if (!full_name.empty()) {
-      full_name = std::string(ctx_ptr->name()) + "::" + full_name;
+      full_name = std::string(fn_ptr->name().str()) + "::" + full_name;
     } else {
-      full_name = ctx_ptr->name();
+      full_name = fn_ptr->name().str();
     }
-    ctx_ptr = ctx_ptr->parent().get();
+    fn_ptr = fn_ptr->parent();
   }
   return full_name;
 }
 
-void invokeTestRecordFunctionAsyncNested() {
+void invokeTestRecordFunctionNested() {
   autograd::profiler::RecordFunction guard("inner");
 }
 
 void testRecordFunction() {
   std::vector<std::vector<int64_t>> input_sizes;
   autograd::profiler::pushCallback([&input_sizes](
-      const autograd::profiler::FunctionCallContext& ctx) {
-    for (const auto& input : ctx.inputs()) {
+      const autograd::profiler::RecordFunction& fn) {
+    for (const auto& input : fn.inputs()) {
       if (input.isTensor()) {
         std::vector<int64_t> t = input.toTensor().sizes().vec();
         input_sizes.push_back(t);
@@ -623,23 +623,17 @@ void testRecordFunction() {
   AT_CHECK(input_sizes.size() == 1);
   AT_CHECK(input_sizes[0] == at::IntArrayRef({1, 2, 3}));
 
-  // test nested RecordFunctions, cover async execution test case
+  // test nested RecordFunctions
   std::vector<std::string> nested_names;
   autograd::profiler::pushCallback([&nested_names](
-      const autograd::profiler::FunctionCallContext& ctx) {
-    nested_names.push_back(getFullName(&ctx));
+      const autograd::profiler::RecordFunction& fn) {
+    nested_names.push_back(getFullName(&fn));
   });
 
-  std::thread test_thread;
   {
     autograd::profiler::RecordFunction guard("outer");
-    auto ctx = autograd::profiler::currentFunctionCallContext();
-    test_thread = std::thread([ctx](){
-      autograd::profiler::setCurrentFunctionCallContext(ctx);
-      invokeTestRecordFunctionAsyncNested();
-    });
+    invokeTestRecordFunctionNested();;
   }
-  test_thread.join(); // wait outside of "outer" scope
 
   autograd::profiler::popCallback();
   AT_CHECK(nested_names.size() == 2);

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -575,6 +575,102 @@ void testTopologicalIndex() {
   }
 }
 
+void invokeTestRecordFunction(at::Tensor& t) {
+  autograd::profiler::GetPackedInputsCallback inputs_cb =
+    [t]() {
+      Stack st;
+      pack(st, t);
+      return st;
+    };
+  autograd::profiler::RecordFunction guard("test", inputs_cb);
+  t.add_(torch::ones_like(t));
+}
+
+struct TestInputsCallback : public autograd::profiler::RecordFunctionCallback {
+  TestInputsCallback(
+      const autograd::profiler::FunctionCallContext& ctx,
+      std::vector<std::vector<int64_t>>& input_sizes) : input_sizes_(input_sizes) {
+    for (const auto& input : ctx.inputs()) {
+      if (input.isTensor()) {
+        std::vector<int64_t> t = input.toTensor().sizes().vec();
+        input_sizes_.push_back(t);
+      }
+    }
+  }
+
+  virtual ~TestInputsCallback() {}
+
+ private:
+  std::vector<std::vector<int64_t>>& input_sizes_;
+};
+
+struct TestNestedCallback : public autograd::profiler::RecordFunctionCallback {
+  TestNestedCallback(
+      const autograd::profiler::FunctionCallContext& ctx,
+      std::vector<std::string>& nested_names) : nested_names_(nested_names) {
+    nested_names.push_back(getFullName(&ctx));
+  }
+
+  virtual ~TestNestedCallback() {}
+
+ private:
+  static std::string getFullName(const autograd::profiler::FunctionCallContext* ctx_ptr) {
+    std::string full_name = "";
+    while (ctx_ptr != nullptr) {
+      if (!full_name.empty()) {
+        full_name = std::string(ctx_ptr->name()) + "::" + full_name;
+      } else {
+        full_name = ctx_ptr->name();
+      }
+      ctx_ptr = ctx_ptr->parent().get();
+    }
+    return full_name;
+  }
+
+  std::vector<std::string>& nested_names_;
+};
+
+void invokeTestRecordFunctionAsyncNested() {
+  autograd::profiler::RecordFunction guard("inner");
+}
+
+void testRecordFunction() {
+  std::vector<std::vector<int64_t>> input_sizes;
+  autograd::profiler::pushCallback([&](const autograd::profiler::FunctionCallContext& ctx) {
+    return c10::guts::make_unique<TestInputsCallback>(ctx, input_sizes);
+  });
+
+  auto t = torch::randn({1, 2, 3}, at::kCPU);
+  invokeTestRecordFunction(t);
+
+  autograd::profiler::popCallback();
+
+  AT_CHECK(input_sizes.size() == 1);
+  AT_CHECK(input_sizes[0] == at::IntArrayRef({1, 2, 3}));
+
+  // test nested RecordFunctions, cover async execution test case
+  std::vector<std::string> nested_names;
+  autograd::profiler::pushCallback([&](const autograd::profiler::FunctionCallContext& ctx) {
+    return c10::guts::make_unique<TestNestedCallback>(ctx, nested_names);
+  });
+
+  std::thread test_thread;
+  {
+    autograd::profiler::RecordFunction guard("outer");
+    auto ctx = autograd::profiler::currentFunctionCallContext();
+    test_thread = std::thread([ctx](){
+      autograd::profiler::setCurrentFunctionCallContext(ctx);
+      invokeTestRecordFunctionAsyncNested();
+    });
+  }
+  test_thread.join(); // wait outside of "outer" scope
+
+  autograd::profiler::popCallback();
+  AT_CHECK(nested_names.size() == 2);
+  AT_CHECK(nested_names[0] == "outer");
+  AT_CHECK(nested_names[1] == "outer::inner");
+}
+
 void testAutogradProfiler() {
   constexpr int batch_size = 4;
   constexpr int input_size = 256;

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -45,6 +45,7 @@ libtorch_sources = [
     "torch/csrc/autograd/grad_mode.cpp",
     "torch/csrc/autograd/input_buffer.cpp",
     "torch/csrc/autograd/profiler.cpp",
+    "torch/csrc/autograd/record_function.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/variable.cpp",
     "torch/csrc/Exceptions.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -117,6 +117,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/autograd/grad_mode.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/input_buffer.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/profiler.cpp
+  ${TORCH_SRC_DIR}/csrc/autograd/record_function.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/saved_variable.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/variable.cpp
   ${TORCH_SRC_DIR}/csrc/autograd/VariableTypeManual.cpp

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -98,13 +98,8 @@ enum class EventKind : uint16_t {
 };
 
 struct TORCH_API Event final {
-  Event(EventKind kind, std::string name, uint16_t thread_id, bool record_cuda)
-  : owned_name_(new std::string(std::move(name)))
-  , name_ptr_(owned_name_->c_str())
-  , kind_(kind)
-  , thread_id_(thread_id) { record(record_cuda); }
-  Event(EventKind kind, const char* name, uint16_t thread_id, bool record_cuda)
-  : name_ptr_(name)
+  Event(EventKind kind, StringView name, uint16_t thread_id, bool record_cuda)
+  : name_(std::move(name))
   , kind_(kind)
   , thread_id_(thread_id) { record(record_cuda); }
 
@@ -118,7 +113,7 @@ struct TORCH_API Event final {
     throw std::runtime_error("unknown EventKind");
   }
   const char* name() const {
-    return name_ptr_;
+    return name_.str();
   }
   uint16_t thread_id() const {
     return thread_id_;
@@ -135,11 +130,7 @@ struct TORCH_API Event final {
   }
 private:
   int64_t cpu_ns_ = 0; // signed to allow for negative intervals, initialized for safety.
-  // std::string is a very large object (usually around 32B),
-  // and this field is used only for user-created ranges, so
-  // it's better to save on size of Events.
-  std::unique_ptr<std::string> owned_name_;
-  const char * name_ptr_;
+  StringView name_;
   EventKind kind_;
   uint16_t thread_id_;
   int device_ = -1;

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -17,6 +17,7 @@
 #include <ctime>
 #endif
 
+#include <torch/csrc/autograd/record_function.h>
 #include <torch/csrc/jit/code_template.h>
 
 typedef struct CUevent_st* CUDAEventStub;
@@ -202,20 +203,6 @@ TORCH_API RangeEventList& getEventList();
 TORCH_API void mark(std::string name, bool include_cuda = true);
 TORCH_API void pushRange(std::string name);
 TORCH_API void popRange();
-
-struct TORCH_API RecordFunction {
-  explicit RecordFunction(Function* fn);
-
-  explicit RecordFunction(std::string name);
-
-  explicit RecordFunction(const char* name);
-
-  explicit RecordFunction(const char* name, int64_t current_sequence_nr);
-
-  ~RecordFunction() {
-    popRange();
-  }
-};
 
 using thread_event_lists = std::vector<std::vector<Event>>;
 // NOTE: changing profiler modes is **NOT THREAD SAFE**. You should ensure that

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -4,10 +4,10 @@
 namespace torch { namespace autograd { namespace profiler {
 
 namespace {
-std::atomic<bool> has_callbacks(false);
+bool has_callbacks = false;
 std::vector<RecordFunctionCallback> start_callbacks;
 std::vector<RecordFunctionCallback> end_callbacks;
-thread_local std::shared_ptr<FunctionCallContext> thread_local_ctx;
+thread_local RecordFunction* thread_local_func_ = nullptr;
 }
 
 void pushCallback(RecordFunctionCallback start, RecordFunctionCallback end) {
@@ -17,16 +17,7 @@ void pushCallback(RecordFunctionCallback start, RecordFunctionCallback end) {
 }
 
 void pushCallback(RecordFunctionCallback start) {
-  pushCallback(start, [](const FunctionCallContext&){});
-}
-
-const std::shared_ptr<FunctionCallContext>& currentFunctionCallContext() {
-  return thread_local_ctx;
-}
-
-void setCurrentFunctionCallContext(
-    const std::shared_ptr<FunctionCallContext>& ctx) {
-  thread_local_ctx = ctx;
+  pushCallback(start, [](const RecordFunction&){});
 }
 
 void popCallback() {
@@ -38,60 +29,54 @@ void popCallback() {
   has_callbacks = !start_callbacks.empty();
 }
 
-// typeid(*fn).name() would avoid an additional string allocation.
-// However, typeid(*fn).name() would cause nvtx annotations for all user-defined
-// (Python-side) custom autograd function backward() methods to have the same name,
-// because they route through the same C++ side class.
-// fn->name() ensures that nvtx annotations for custom function backward() methods
-// receive a relevant, demangled name.
-FunctionCallContext::FunctionCallContext(Function* fn, GetPackedInputsCallback cb)
-    : fn_(fn), owned_name_(new std::string(fn->name())), name_ptr_(owned_name_->c_str()),
-      sequence_nr_(fn->sequence_nr()), inputs_cb_(cb) {}
-
-FunctionCallContext::FunctionCallContext(
-    std::string name, int64_t sequence_nr, GetPackedInputsCallback cb)
-    : owned_name_(new std::string(std::move(name))), name_ptr_(owned_name_->c_str()),
-      sequence_nr_(sequence_nr), inputs_cb_(cb) {}
-
-FunctionCallContext::FunctionCallContext(
-    const char* name_ptr, int64_t sequence_nr, GetPackedInputsCallback cb)
-    : name_ptr_(name_ptr), sequence_nr_(sequence_nr), inputs_cb_(cb) {}
-
-
 RecordFunction::RecordFunction(Function* fn, GetPackedInputsCallback cb) {
-  processCallbacks(fn, cb);
+  if (!has_callbacks) {
+    return;
+  }
+  fn_ = fn;
+  name_ = StringView(fn->name());
+  sequence_nr_ = fn->sequence_nr();
+  inputs_cb_ = cb;
+  processCallbacks();
 }
 
 RecordFunction::RecordFunction(
     std::string name, int64_t sequence_nr, GetPackedInputsCallback cb) {
-  processCallbacks(name, sequence_nr, cb);
+  if (!has_callbacks) {
+    return;
+  }
+  name_ = StringView(std::move(name));
+  sequence_nr_ = sequence_nr;
+  inputs_cb_ = cb;
+  processCallbacks();
 }
 
 RecordFunction::RecordFunction(
     const char* name, int64_t sequence_nr, GetPackedInputsCallback cb) {
-  processCallbacks(name, sequence_nr, cb);
-}
-
-template<typename... Args>
-void RecordFunction::processCallbacks(Args&&... args) {
   if (!has_callbacks) {
     return;
   }
-  ctx_ = std::make_shared<FunctionCallContext>(std::forward<Args>(args)...);
-  ctx_->setParent(thread_local_ctx);
-  thread_local_ctx = ctx_;
+  name_ = StringView(name);
+  sequence_nr_ = sequence_nr;
+  inputs_cb_ = cb;
+  processCallbacks();
+}
 
-  for (size_t idx = 0; idx < start_callbacks.size(); ++idx) {
-    start_callbacks[idx](*ctx_);
+void RecordFunction::processCallbacks() {
+  parent_ = thread_local_func_;
+  thread_local_func_ = this;
+
+  for (const auto& cb : start_callbacks) {
+    cb(*this);
   }
 }
 
 RecordFunction::~RecordFunction() {
-  if (ctx_) {
-    for (size_t idx = 0; idx < end_callbacks.size(); ++idx) {
-      end_callbacks[idx](*ctx_);
+  if (has_callbacks) {
+    for (const auto& cb : end_callbacks) {
+      cb(*this);
     }
-    thread_local_ctx = ctx_->parent();
+    thread_local_func_ = parent_;
   }
 }
 

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -1,0 +1,88 @@
+#include <torch/csrc/autograd/record_function.h>
+#include <torch/csrc/autograd/function.h>
+
+namespace torch { namespace autograd { namespace profiler {
+
+namespace {
+std::atomic<bool> has_callbacks(false);
+std::vector<CallbackCreator> cbc;
+thread_local std::shared_ptr<FunctionCallContext> thread_local_ctx;
+}
+
+void pushCallback(CallbackCreator callback_creator) {
+  cbc.push_back(callback_creator);
+  has_callbacks = true;
+}
+
+const std::shared_ptr<FunctionCallContext>& currentFunctionCallContext() {
+  return thread_local_ctx;
+}
+
+void setCurrentFunctionCallContext(
+    const std::shared_ptr<FunctionCallContext>& ctx) {
+  thread_local_ctx = ctx;
+}
+
+void popCallback() {
+  if (cbc.empty()) {
+    throw std::runtime_error("Empty callbacks stack");
+  }
+  cbc.pop_back();
+  has_callbacks = !cbc.empty();
+}
+
+// typeid(*fn).name() would avoid an additional string allocation.
+// However, typeid(*fn).name() would cause nvtx annotations for all user-defined
+// (Python-side) custom autograd function backward() methods to have the same name,
+// because they route through the same C++ side class.
+// fn->name() ensures that nvtx annotations for custom function backward() methods
+// receive a relevant, demangled name.
+FunctionCallContext::FunctionCallContext(Function* fn, GetPackedInputsCallback cb)
+    : fn_(fn), owned_name_(new std::string(fn->name())), name_ptr_(owned_name_->c_str()),
+      sequence_nr_(fn->sequence_nr()), inputs_cb_(cb) {}
+
+FunctionCallContext::FunctionCallContext(
+    std::string name, int64_t sequence_nr, GetPackedInputsCallback cb)
+    : owned_name_(new std::string(std::move(name))), name_ptr_(owned_name_->c_str()),
+      sequence_nr_(sequence_nr), inputs_cb_(cb) {}
+
+FunctionCallContext::FunctionCallContext(
+    const char* name_ptr, int64_t sequence_nr, GetPackedInputsCallback cb)
+    : name_ptr_(name_ptr), sequence_nr_(sequence_nr), inputs_cb_(cb) {}
+
+
+RecordFunction::RecordFunction(Function* fn, GetPackedInputsCallback cb) {
+  processCallbacks(fn, cb);
+}
+
+RecordFunction::RecordFunction(
+    std::string name, int64_t sequence_nr, GetPackedInputsCallback cb) {
+  processCallbacks(name, sequence_nr, cb);
+}
+
+RecordFunction::RecordFunction(
+    const char* name, int64_t sequence_nr, GetPackedInputsCallback cb) {
+  processCallbacks(name, sequence_nr, cb);
+}
+
+template<typename... Args>
+void RecordFunction::processCallbacks(Args&&... args) {
+  if (!has_callbacks) {
+    return;
+  }
+  ctx_ = std::make_shared<FunctionCallContext>(std::forward<Args>(args)...);
+  ctx_->setParent(thread_local_ctx);
+  thread_local_ctx = ctx_;
+  for (size_t idx = 0; idx < cbc.size(); ++idx) {
+    auto cb_ptr = cbc[idx](*ctx_);
+    cbs_.push_back(std::move(cb_ptr));
+  }
+}
+
+RecordFunction::~RecordFunction() {
+  if (ctx_) {
+    thread_local_ctx = ctx_->parent();
+  }
+}
+
+}}}

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <ATen/core/ivalue.h>
+#include <c10/util/SmallVector.h>
+
+namespace torch { namespace autograd {
+
+struct Function;
+
+namespace profiler {
+
+using GetPackedInputsCallback = std::function<std::vector<c10::IValue>()>;
+
+struct FunctionCallContext {
+  explicit FunctionCallContext(
+      Function* fn, GetPackedInputsCallback cb = nullptr);
+  explicit FunctionCallContext(
+      std::string name, int64_t sequence_nr = -1, GetPackedInputsCallback cb = nullptr);
+  explicit FunctionCallContext(
+      const char* name_ptr, int64_t sequence_nr = -1, GetPackedInputsCallback cb = nullptr);
+
+  inline Function* func() const {
+    return fn_;
+  }
+
+  inline const char* name() const {
+    return name_ptr_;
+  }
+
+  inline int64_t seqNr() const {
+    return sequence_nr_;
+  }
+
+  inline bool hasOwnedName() const {
+    return owned_name_ != nullptr;
+  }
+
+  const std::vector<c10::IValue>& inputs() const {
+    if (inputs_cb_ && !inputs_initialized_) {
+      inputs_ = inputs_cb_();
+      inputs_initialized_ = true;
+    }
+    return inputs_;
+  }
+
+  inline const std::shared_ptr<FunctionCallContext>& parent() const {
+    return parent_ctx_;
+  }
+
+  inline void setParent(const std::shared_ptr<FunctionCallContext>& parent) {
+    parent_ctx_ = parent;
+  }
+
+ private:
+  Function* fn_ = nullptr;
+  std::unique_ptr<std::string> owned_name_;
+  const char* name_ptr_ = nullptr;
+  int64_t sequence_nr_ = -1;
+
+  std::shared_ptr<FunctionCallContext> parent_ctx_;
+
+  GetPackedInputsCallback inputs_cb_ = nullptr;
+  mutable bool inputs_initialized_ = false;
+  // initialized lazily by inputs_cb_
+  mutable std::vector<c10::IValue> inputs_;
+};
+
+
+struct RecordFunctionCallback {
+  virtual ~RecordFunctionCallback(){}
+};
+
+struct RecordFunction {
+  explicit RecordFunction(Function* fn, GetPackedInputsCallback cb = nullptr);
+
+  explicit RecordFunction(
+      std::string name,
+      int64_t current_sequence_nr = -1,
+      GetPackedInputsCallback cb = nullptr);
+
+  explicit RecordFunction(
+      const char* name,
+      int64_t current_sequence_nr = -1,
+      GetPackedInputsCallback cb = nullptr);
+
+  explicit RecordFunction(
+      std::string name,
+      GetPackedInputsCallback cb) : RecordFunction(name, -1, cb) {};
+
+  explicit RecordFunction(
+      const char* name,
+      GetPackedInputsCallback cb) : RecordFunction(name, -1, cb) {};
+
+  virtual ~RecordFunction();
+
+ private:
+  template<typename... Args>
+  void processCallbacks(Args&&... args);
+
+  std::shared_ptr<FunctionCallContext> ctx_;
+
+  c10::SmallVector<std::unique_ptr<RecordFunctionCallback>, 4> cbs_;
+};
+
+using CallbackCreator = std::function<std::unique_ptr<RecordFunctionCallback>(const FunctionCallContext&)>;
+// WARNING: all calls to pushCallback/popCallback are not thread safe and
+// must not overlap with other code execution
+void pushCallback(CallbackCreator callback_creator);
+void popCallback();
+// Functions to pass the context across fork calls
+const std::shared_ptr<FunctionCallContext>& currentFunctionCallContext();
+void setCurrentFunctionCallContext(const std::shared_ptr<FunctionCallContext>&);
+
+} // namespace profiler
+}} // namespace torch::autograd

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -65,11 +65,6 @@ struct FunctionCallContext {
   mutable std::vector<c10::IValue> inputs_;
 };
 
-
-struct RecordFunctionCallback {
-  virtual ~RecordFunctionCallback(){}
-};
-
 struct RecordFunction {
   explicit RecordFunction(Function* fn, GetPackedInputsCallback cb = nullptr);
 
@@ -98,14 +93,13 @@ struct RecordFunction {
   void processCallbacks(Args&&... args);
 
   std::shared_ptr<FunctionCallContext> ctx_;
-
-  c10::SmallVector<std::unique_ptr<RecordFunctionCallback>, 4> cbs_;
 };
 
-using CallbackCreator = std::function<std::unique_ptr<RecordFunctionCallback>(const FunctionCallContext&)>;
 // WARNING: all calls to pushCallback/popCallback are not thread safe and
 // must not overlap with other code execution
-void pushCallback(CallbackCreator callback_creator);
+using RecordFunctionCallback = std::function<void(const FunctionCallContext&)>;
+void pushCallback(RecordFunctionCallback, RecordFunctionCallback);
+void pushCallback(RecordFunctionCallback);
 void popCallback();
 // Functions to pass the context across fork calls
 const std::shared_ptr<FunctionCallContext>& currentFunctionCallContext();


### PR DESCRIPTION
Summary:
Add a way to insert external callbacks into PT's RecordFunction

Test Plan:
python setup.py develop --cmake
pytest -s -v test/test_autograd.py::TestAutograd::test_profiler

./build/bin/test_jit --gtest_filter=JitTest.RecordFunction