### PR TITLE
Update docs for `mark_non_differentiable` method

### DIFF
--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -51,8 +51,9 @@ class _ContextMethodMixin(object):
         This will mark outputs as not requiring gradients, increasing the
         efficiency of backward computation. You still need to accept a gradient
         for each output in :meth:`~Function.backward`, but it's always going to
-        be ``None``.
-
+        be a zero tensor with the same shape as the shape of a corresponding 
+        output.
+       
         This is used e.g. for indices returned from a max :class:`Function`.
         """
         self.non_differentiable = args


### PR DESCRIPTION
The current documentation doesn't reflect the real values of tensor during the backward pass.
This issue is mentioned in https://github.com/pytorch/pytorch/issues/12631

