### PR TITLE
Fix Windows build

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -419,10 +419,12 @@ struct Converter<
 
 // In some versions of MSVC, there will be a compiler error when building.
 // C4146: unary minus operator applied to unsigned type, result still unsigned
+// C4804: unsafe use of type 'bool' in operation
 // It can be addressed by disabling the following warning. 
 #ifdef _MSC_VER
 #pragma warning( push )
 #pragma warning( disable : 4146 )
+#pragma warning( disable : 4804 )
 #endif
 
 // skip isnan and isinf check for integral types
@@ -441,10 +443,6 @@ typename std::enable_if<std::is_integral<From>::value, bool>::type overflows(
   }
 }
 
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
-
 template <typename To, typename From>
 typename std::enable_if<std::is_floating_point<From>::value, bool>::type
 overflows(From f) {
@@ -457,6 +455,10 @@ overflows(From f) {
   }
   return f < limit::lowest() || f > limit::max();
 }
+
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 template <typename To, typename From>
 typename std::enable_if<is_complex_t<From>::value, bool>::type overflows(


### PR DESCRIPTION
Summary:
D14375995 introduced instantiation of the following templates with `bool` type (more specifically `To` is `int64_t`, `From` is `bool`):
```
template <typename To, typename From>
typename std::enable_if<std::is_integral<From>::value, bool>::type overflows(
    From f) {
  using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
  if (!limit::is_signed && std::numeric_limits<From>::is_signed) {
    // allow for negative numbers to wrap using two's complement arithmetic.
    // For example, with uint8, this allows for `a - b` to be treated as
    // `a + 255 * b`.
    return f > limit::max() ||
        (f < 0 && -static_cast<uint64_t>(f) > limit::max());
  } else {
    return f < limit::lowest() || f > limit::max();
  }
}

template <typename To, typename From>
typename std::enable_if<std::is_floating_point<From>::value, bool>::type
overflows(From f) {
  using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
  if (limit::has_infinity && std::isinf(static_cast<double>(f))) {
    return false;
  }
  if (!limit::has_quiet_NaN && (f != f)) {
    return true;
  }
  return f < limit::lowest() || f > limit::max();
}
```
MSVC gives C4804 warning and because "treat warnings as errors" is on it fails to build on Windows. Disabling such warning for those 2 templates.

Differential Revision: D14421157
