### PR TITLE
JIT IR - Add option to remove prefix string when converting from JIT IR to NetDef

### DIFF
--- a/torch/csrc/jit/netdef_converter.h
+++ b/torch/csrc/jit/netdef_converter.h
@@ -28,11 +28,16 @@ void convertNetDefToIR(
  * both formats will converge to PyTorch IR, so for now we try to keep as close
  * to it as possible. For short-term applications we might add a separate pass
  * that would fold such const-nodes into their users.
+ * \p If Prefix is specified, the prefix will be removed from operator name when
+ * converting from IR to NetDef.
  *
  * TODO: We might need to do a better job at preserving names of the variables,
  * especially external_inputs/external_outputs.
  */
-void convertIRToNetDef(caffe2::NetDef* net, const Graph& graph);
+void convertIRToNetDef(
+    caffe2::NetDef* net,
+    const Graph& graph,
+    const std::string& prefix = "");
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: When converting from NetDef to IR and back, the prefix string should be removed so the operator types are preserved in caffe2.

Reviewed By: ZolotukhinM

Differential Revision: D14425954
