### PR TITLE
Reinstate ncclCommDestroy

### DIFF
--- a/caffe2/contrib/nccl/cuda_nccl_gpu.cc
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.cc
@@ -1,15 +1,13 @@
 #include "cuda_nccl_gpu.h"
 
 namespace caffe2 {
-
 namespace nccl {
-
 namespace {
 
 std::vector<int> getDevices(const NCCLExecution& ex) {
   std::vector<int> result;
   result.reserve(ex.elements.size());
-  for (const auto& el: ex.elements) {
+  for (const auto& el : ex.elements) {
     result.push_back(el.device);
   }
   return result;
@@ -49,20 +47,9 @@ class NCCLContext {
     CUDAGuard g(master_gpu_id_);
     CUDA_ENFORCE(cudaEventDestroy(master_event_));
 
-    /*
-     * TODO(T30279827) Temporarily disable calling ncclCommDestroy
-     * Calling ncclCommDestroy while program exiting is undefined
-     * according to Nvidia, and will lead to segfault in NCCL 2
-     * (whether it is called before or after the CUDA runtime destructor).
-     * Temporarily disable it in destructor to avoid segfault.
-     * Following up with Nvidia for long term solution.
-     */
-
-    /*
     for (auto& comm : comms_) {
       ncclCommDestroy(comm);
     }
-    */
   }
 
   std::vector<int> devices_;
@@ -75,15 +62,13 @@ class NCCLContext {
   C10_DISABLE_COPY_AND_ASSIGN(NCCLContext);
 };
 
-// We share the contexts across multiple operators, hence the
-// thread-local cache
+// We share the contexts across multiple operators, hence the cache.
 static std::mutex& gContextsMutex() {
   static std::mutex m;
   return m;
 }
 
 std::unordered_map<std::string, std::unique_ptr<NCCLContext>>& gContexts() {
-  // Initiazed after CUDA, so guaranteed to be destructed before CUDA.
   static std::unordered_map<std::string, std::unique_ptr<NCCLContext>> m;
   return m;
 }
@@ -198,6 +183,12 @@ void runNCCL(const NCCLExecution& ex, InitF&& init_f, F&& f) {
   }
 }
 
+} // namespace
+
+void destroyContexts() {
+  std::lock_guard<std::mutex> g(gContextsMutex());
+  auto& contexts = gContexts();
+  contexts.clear();
 }
 
 template <typename T>
@@ -329,5 +320,6 @@ template class NCCL<int>;
 #ifdef CAFFE_HAS_CUDA_FP16
 template class NCCL<at::Half>;
 #endif
-}
-}
+
+} // namespace nccl
+} // namespace caffe2

--- a/caffe2/contrib/nccl/cuda_nccl_gpu.h
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.h
@@ -10,12 +10,12 @@
 #include <unordered_map>
 
 #define NCCL_VERSION_MIN(major, minor, patch) \
-  ((NCCL_MAJOR > major) || \
-    ((NCCL_MAJOR == major) && ((NCCL_MINOR > minor) || \
-      ((NCCL_MINOR == minor) && (NCCL_PATCH >= patch)) )))
+  ((NCCL_MAJOR > major) ||                    \
+   ((NCCL_MAJOR == major) &&                  \
+    ((NCCL_MINOR > minor) ||                  \
+     ((NCCL_MINOR == minor) && (NCCL_PATCH >= patch)))))
 
 namespace caffe2 {
-
 namespace nccl {
 
 #define CAFFE_NCCL_CHECK(condition)    \
@@ -45,6 +45,10 @@ struct NCCLExecution {
   size_t root{0};
 };
 
+// Called when the last NCCL op is destructed and all lazily created
+// NCCLContext instances can safely be destroyed.
+void destroyContexts();
+
 template <typename T>
 class NCCL {
  public:
@@ -54,5 +58,6 @@ class NCCL {
   static void AllGather(const NCCLExecution& ex);
   static void ReduceScatter(const NCCLExecution& ex);
 };
-}
-}
+
+} // namespace nccl
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Together with xw285cornell came up with a solution for static destruction
order fiasco that caused the NCCL context to be destroyed **after**
the CUDA context was already destroyed. In this commit we destroy all
cached NCCL contexts as soon as the last NCCL related Caffe2 operator
instance is destructed, thereby avoiding a dependency on static
variable destruction.

Differential Revision: D14429724
