### PR TITLE
Assert against using Operator methods not supported when exporting it to c10, part 2

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -183,6 +183,10 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "Output(idx) not supported for operators exported to c10. Please use XOutput instead.");
+
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use Output<Tensor>(int, DeviceType) for "
@@ -295,15 +299,24 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline T* Output(int idx, T* allocated) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "Output(idx, allocated) not supported for operators exported to c10. Please use XOutput.");
     outputs_.at(idx)->Reset(allocated);
     return allocated;
   }
 
   inline const Blob& InputBlob(int idx) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "InputBlob(idx) not (yet) supported for operators exported to c10.");
     return *inputs_.at(idx);
   }
 
   inline Blob* OutputBlob(int idx) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputBlob(idx) not (yet) supported for operators exported to c10.");
     return outputs_.at(idx);
   }
 
@@ -319,6 +332,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
 
   template <typename T>
   inline bool InputIsType(int idx) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "InputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use InputIsTensorType(int, DeviceType) for "
@@ -327,11 +343,17 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool InputIsTensorType(int idx, DeviceType device_type) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "InputIsTensorType(idx, device_type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*inputs_.at(idx), device_type);
   }
 
   template <typename T>
   inline bool OutputIsType(int idx) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputIsType(idx) not (yet) supported for operators exported to c10.");
     static_assert(
         !std::is_same<T, Tensor>::value,
         "You should use OutputIsTensorType(int, DeviceType) for "
@@ -340,6 +362,9 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
   }
 
   inline bool OutputIsTensorType(int idx, DeviceType type) {
+    CAFFE_ENFORCE(
+        isLegacyOperator(),
+        "OutputIsTensorType(idx, type) not (yet) supported for operators exported to c10.");
     return BlobIsTensorType(*outputs_.at(idx), type);
   }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #17818 Assert against using Operator methods not supported when exporting it to c10&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14392459/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#17946 Assert against using Operator methods not supported when exporting it to c10, part 2**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14430749/)

Some of these are probably implementable for exported operators,
but aren't implemented yet and for now it's better to assert than to just return wrong results.

Differential Revision: [D14430749](https://our.internmc.facebook.com/intern/diff/D14430749/)