### PR TITLE
[jit] Add serialization docs to jit/README

### DIFF
--- a/torch/csrc/jit/README.md
+++ b/torch/csrc/jit/README.md
@@ -64,10 +64,10 @@ Sections start with a reference to the source file where the code related to the
     + [`model.json`](#-modeljson-)
     + [`code`](#-code-)
     + [`tensors/`](#-tensors--)
-    + [`attributes`](#-attributes-)
-      - [Pickling and Unpickling](#pickling-and-unpickling)
+    + [`attributes.pkl`](#-attributespkl-)
     + [Implementation Details](#implementation-details)
 - [Python Bindings](#python-bindings)
+
 
 # Core Program Representation
 
@@ -572,14 +572,14 @@ TorchScript is executed using a interpreter attached to a JIT-optimizer and comp
 TorchScript programs implement a very small subset of Python of that is necessary to run models.
 
 TorchScript includes immutable value types:
-* int
-* float
-* Tuple[T0, T1, ...]
+* `int`
+* `float`
+* `Tuple[T0, T1, ...]`
 
 As well as mutable reference types:
-* Tensor
-* List[T]
-* Dict[K, V]
+* `Tensor`
+* `List[T]`
+* `Dict[K, V]`
 
 A value of a reference type points to an underlying memory location where the data for the reference type is stored, and variable assignment for a reference type can cause multiple values to point to the same underlying data. This is similar to Python's class model.
 
@@ -1177,7 +1177,7 @@ The `.pt` file is a zip archive (which can be opened with tools such as `unzip`)
   * code - the Python printed graph of a module
   * `model.json` - a JSON file of a model Protobuf def (defined in [torch.proto](caffe2/proto/torch.proto))
   * `tensors/` - each of the tensors of the model, with their tensor storage stored directly in a file
-  * `attributes` - a Python `pickle` archive of the attributes of a module
+  * `attributes.pkl` - a Python `pickle` archive of the attributes of a module
 
 ### `model.json`
 The `model.json` contains the structure information of the model. Each model must contain one main Module, and each module may contain multiple submodules, and each module contains a bunch of parameters (tensors). We serialize the metadata for each tensor inline in `model.json` (e.g., dims, strides, record name, etc).
@@ -1190,9 +1190,9 @@ TODO
 
 TODO
 
-### `attributes`
+### `attributes.pkl`
 
-Attributes are all module properties that are not parameters or constants. Attributes are saved in a list in the order they were defined on the module. The list is stored as a Python `pickle` archive in the top level of the model file in `attributes.pkl`. `pickle`'s format was chosen due to:
+Attributes are all module properties that are not parameters or constants. Attributes are saved in a list in the order they were defined on the module. The list is stored as a Python `pickle` archive. `pickle`'s format was chosen due to:
 * **user friendliness** - the attributes file can be loaded in Python with `pickle` without having PyTorch installed
 * **size limits** - formats such as Protobuf empose size limits on total message size, whereas pickle limits are on individual values (e.g. strings cannot be longer than 4 GB)
 * **standard format** - `pickle` is a standard Python module with a reasonably simple format. The format is a program to be consumed by a stack machine that is detailed in Python's [`pickletools.py`](https://svn.python.org/projects/python/trunk/Lib/pickletools.py)
@@ -1201,9 +1201,9 @@ Attributes are all module properties that are not parameters or constants. Attri
 * **eager mode save** - `torch.save()` already produces a `pickle` archive, so doing the same with attributes may ease unification of these formats in the future
 
 A given module may have many attributes of different types and many submodules, each with their own attributes. Attributes are recorded in `model.json`:
-* type - the full type of the attribute (in [Mypy syntax](https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html))
-* name - the attribute's name
-* id - the offset into the saved list of all model attributes
+* `type` - the full type of the attribute (in [Mypy syntax](https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html))
+* `name` - the attribute's name
+* `id` - the offset into the saved list of all model attributes
 
 ```json
 {

--- a/torch/csrc/jit/README.md
+++ b/torch/csrc/jit/README.md
@@ -1134,7 +1134,7 @@ def foo(a : Tensor, b : Tensor):
 ```
 Will produce a graph like this:
 
-![AliasTracker graph](/Users/davidriazati/Desktop/notes/assets/aliastracker_graph.png)
+![AliasTracker graph](https://github.com/pytorch/pytorch/blob/master/docs/source/_static/img/aliastracker_graph.png)
 
 A few things to note:
 - "Graph Input Element" is an example of an `Element` that isn't a first-class `Value`. Alias analysis happens on a per-function level, so we don't necessarily know the aliasing relationships of the inputs. The only safe assumption is that `a` and `b` may alias each other, so they point to a special `Element` that describes "the world outside of this function".

--- a/torch/csrc/jit/README.md
+++ b/torch/csrc/jit/README.md
@@ -15,6 +15,7 @@ Sections start with a reference to the source file where the code related to the
 ## Table of Contents
 
 - [JIT Technical Overview](#jit-technical-overview)
+  * [Table of Contents](#table-of-contents)
 - [Core Program Representation](#core-program-representation)
   * [Modules](#modules)
   * [Parameters](#parameters)
@@ -27,7 +28,7 @@ Sections start with a reference to the source file where the code related to the
     + [Loops](#loops)
   * [Value](#value)
   * [Type](#type)
-  * [Generating Programs](#generating-programs)
+- [Generating Programs](#generating-programs)
   * [Tracer](#tracer)
   * [Script](#script)
   * [Tree](#tree)
@@ -41,7 +42,7 @@ Sections start with a reference to the source file where the code related to the
   * [Resolver](#resolver)
   * [Environment](#environment)
   * [Python-Compiler Interaction](#python-compiler-interaction)
-  * [Executing Programs](#executing-programs)
+- [Executing Programs](#executing-programs)
   * [Evaluation Semantics](#evaluation-semantics)
   * [IValue](#ivalue)
   * [Operation](#operation)
@@ -64,6 +65,8 @@ Sections start with a reference to the source file where the code related to the
       - [`code`](#-code-)
       - [`tensors/`](#-tensors--)
       - [`attributes`](#-attributes-)
+        * [Pickling and Unpickling](#pickling-and-unpickling)
+      - [Implementation Details](#implementation-details)
   * [Python Bindings](#python-bindings)
 
 

--- a/torch/csrc/jit/README.md
+++ b/torch/csrc/jit/README.md
@@ -57,18 +57,17 @@ Sections start with a reference to the source file where the code related to the
     + [Aliasing and mutation annotations in FunctionSchema](#aliasing-and-mutation-annotations-in-functionschema)
     + [Alias Analysis in the IR](#alias-analysis-in-the-ir)
     + [Writing optimization passes with `AliasDb`](#writing-optimization-passes-with--aliasdb-)
-  * [Saving Programs](#saving-programs)
-    + [PythonPrint](#pythonprint)
-    + [Serialization](#serialization)
-      - [Overview](#overview)
-      - [`model.json`](#-modeljson-)
-      - [`code`](#-code-)
-      - [`tensors/`](#-tensors--)
-      - [`attributes`](#-attributes-)
-        * [Pickling and Unpickling](#pickling-and-unpickling)
-      - [Implementation Details](#implementation-details)
-  * [Python Bindings](#python-bindings)
-
+- [Saving Programs](#saving-programs)
+  * [PythonPrint](#pythonprint)
+  * [Serialization](#serialization)
+    + [Overview](#overview)
+    + [`model.json`](#-modeljson-)
+    + [`code`](#-code-)
+    + [`tensors/`](#-tensors--)
+    + [`attributes`](#-attributes-)
+      - [Pickling and Unpickling](#pickling-and-unpickling)
+    + [Implementation Details](#implementation-details)
+- [Python Bindings](#python-bindings)
 
 # Core Program Representation
 
@@ -1161,18 +1160,18 @@ TODO: differentiation, symbolic autograd,
 TODO: fusion, operators
 
 
-## Saving Programs
+# Saving Programs
 
 
-### PythonPrint
+## PythonPrint
 
 TODO: python_print
 
-### Serialization
+## Serialization
 
 TorchScript programs are serialized with a call to `torch.jit.save()`. The resulting file (ending in `.pt` by convention) can be loaded/executed in C++ and Python.
 
-#### Overview
+### Overview
 
 The `.pt` file is a zip archive (which can be opened with tools such as `unzip`) and contains:
   * code - the Python printed graph of a module
@@ -1180,18 +1179,18 @@ The `.pt` file is a zip archive (which can be opened with tools such as `unzip`)
   * `tensors/` - each of the tensors of the module, with their tensor storage stored directly in a file
   * `attributes` - a Python `pickle` archive of the attributes of a module
 
-#### `model.json`
+### `model.json`
 The `model.json` contains the structure information of the model. Each model must contain one main Module, and each module may contain multiple submodules, and each module contains a bunch of parameters (tensors). We serialize the metadata for each tensor inline in `model.json` (e.g., dims, strides, record name, etc).
 
-#### `code`
+### `code`
 
 TODO
 
-#### `tensors/`
+### `tensors/`
 
 TODO
 
-#### `attributes`
+### `attributes`
 
 Attributes are module properties that are not parameters or constants. Attributes are saved as list in the order they were defined on the module as a Python `pickle` archive. Only the subset of `pickle` is implemented. This was chosen due to:
 * **user friendliness** - the attributes file can be loaded in Python with `pickle` without having PyTorch installed
@@ -1238,7 +1237,7 @@ A given module may have many attributes of different types and many submodules, 
 }
 ```
 
-##### Pickling and Unpickling
+#### Pickling and Unpickling
 
 Attributes of the main module and its submodules are saved to a single file in the `zip` archive of a `.pt` file named `attributes.pkl`. Unpickling this will return a list of values corresponding to the attributes. Values appear in the list in the order they appear in `model.json` (i.e. submodule attributes come first, then main module attributes).
 
@@ -1261,11 +1260,11 @@ class JitUnpickler(pickle.Unpickler):
 JitUnpickler(open("my_model/attributes.pkl", "rb")).load()
 ```
 
-#### Implementation Details
+### Implementation Details
 
 [export.cpp](export.cpp) and [import.cpp](import.cpp) handle producing the proper protobuf definitions and serializing tensor data. They call out to [pickler.h](pickler.cpp) to handle attribute serialization.
 
 
-## Python Bindings
+# Python Bindings
 
 TODO: Script Module, torch.jit.trace, __constant__ handling, weak script modules

--- a/torch/csrc/jit/README.md
+++ b/torch/csrc/jit/README.md
@@ -1235,13 +1235,40 @@ The `.pt` file is a zip archive (which can be opened with tools such as `unzip`)
 ### `model.json`
 The `model.json` contains the structure information of the model. Each model must contain one main Module, and each module may contain multiple submodules, and each module contains a bunch of parameters (tensors). We serialize the metadata for each tensor inline in `model.json` (e.g., dims, strides, record name, etc).
 
-### `code`
+### `code/`
 
-TODO
+The `code` directory contains the Python Printed `Graph`s of the main module and its submodules.
 
 ### `tensors/`
 
-TODO
+During export a list of all the tensors in a model is created. Tensors can come from either module parameters or Tensor type attributes. Metadata about each tensor is stored in `model.json` with an index into this list. The `data` field refers to the file which contains the tensor storage data. Tensors are saved by directly writing the Tensor storage to a file.
+
+`model.json`
+```json
+{
+  ...
+  "tensors": [
+    {
+      "dims": [
+        "40",
+        "800"
+      ],
+      "offset": "0",
+      "strides": [
+        "800",
+        "1"
+      ],
+      "requiresGrad": true,
+      "dataType": "FLOAT",
+      "data": {
+        "key": "tensors/0"
+      },
+      "device": "cpu"
+    }
+  ],
+  ...
+}
+```
 
 ### `attributes.pkl`
 
@@ -1258,6 +1285,7 @@ A given module may have many attributes of different types and many submodules, 
 * `name` - the attribute's name
 * `id` - the offset into the saved list of all model attributes
 
+`model.json`
 ```json
 {
   "mainModule": {


### PR DESCRIPTION
Documents the serialization format for `torch.jit.save`. Some of the info is copied from @houseroad's internal doc.

[Formatted Markdown](https://github.com/driazati/pytorch/blob/serial_docs/torch/csrc/jit/README.md)

Also refactors the readme to have a heading hierarchy + table of contents