### PR TITLE
[jit] add a dump method to TreeViews

### DIFF
--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -79,11 +79,14 @@ void initTreeViewBindings(PyObject* module) {
 
   py::class_<TreeView>(m, "TreeView")
       .def("range", &TreeView::range)
-      .def("__str__", [](const TreeView& tree) {
-        std::ostringstream stream;
-        stream << tree.get();
-        return stream.str();
-      });
+      .def(
+          "__str__",
+          [](const TreeView& tree) {
+            std::ostringstream stream;
+            stream << tree.get();
+            return stream.str();
+          })
+      .def("dump", [](const TreeView& tree) { tree.dump(); });
 
   py::class_<Ident, TreeView>(m, "Ident")
       .def(py::init(&Ident::create))

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -109,6 +109,9 @@ struct TreeView {
   int kind() const {
     return tree_->kind();
   }
+  void dump() const {
+    std::cout << tree_;
+  }
 
  protected:
   const TreeRef& subtree(size_t i) const {


### PR DESCRIPTION
Stack:
* (to be filled)

Also added it to the python bindings. Not for any particular reason,
just because otherwise the function gets elided (even in debug mode!)
and thus can't be called from the debugger

Differential Revision: [D14442654](https://our.internmc.facebook.com/intern/diff/D14442654)