### PR TITLE
mapping Upsample to UpsampleBilinear rather than ResizeNearest in caf…

### DIFF
--- a/caffe2/onnx/backend.cc
+++ b/caffe2/onnx/backend.cc
@@ -1225,7 +1225,7 @@ Caffe2Ops Caffe2Backend::CreateUpsample(
     c2_op = ret.ops.Add();
     BuildOperator(
         c2_op,
-        "ResizeNearest",
+        "UpsampleBilinear",
         {node.input(0), sliced_input},
         {node.output(0)},
         {});

--- a/caffe2/python/onnx/ONNXOpCoverage.md
+++ b/caffe2/python/onnx/ONNXOpCoverage.md
@@ -103,7 +103,7 @@ This doc keeps tracking why operators are not covered by the testcases.
 |Tile||OK|&#x1F49B;OK, need some enhance|
 |TopK||OK|&#x1F49A;OK|
 |Transpose|Yes|OK|&#x1F49A;OK|
-|Upsample|||&#x1F49B;No bilinear|
+|Upsample||OK|&#x1F49A;OK|
 |Xor|Yes||&#x1F49A;OK|
 |experimental ATen|||&#x1F49A;OK|
 |experimental Affine|||&#x1F494;No op|

--- a/caffe2/python/onnx/backend.py
+++ b/caffe2/python/onnx/backend.py
@@ -162,7 +162,6 @@ class Caffe2Backend(Backend):
         'BatchNormalization':    'SpatialBN',
         'InstanceNormalization': 'InstanceNorm',
         'MatMul':                'BatchMatMul',
-        'Upsample':              'ResizeNearest',
         'Identity':              'Copy',
         'InstanceNormalization': 'InstanceNorm',
         'Equal':                 'EQ',
@@ -196,7 +195,6 @@ class Caffe2Backend(Backend):
         'RNN': '_create_rnn_variant',
         'Loop': '_create_loop',
         'If': '_create_if',
-        'Upsample': '_create_upsample',
         'RandomNormal': '_create_gaussian_fill'
     }
 

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -155,7 +155,6 @@ if (NOT BUILD_ATEN_MOBILE)
   EXECUTE_PROCESS(
       COMMAND ${GEN_COMMAND}
         --output-dependencies ${CMAKE_BINARY_DIR}/aten/src/ATen/generated_cpp.txt
-        --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen
       RESULT_VARIABLE RETURN_VALUE
   )
   if (NOT RETURN_VALUE EQUAL 0)
@@ -179,7 +178,6 @@ if (NOT BUILD_ATEN_MOBILE)
 
   add_custom_command(OUTPUT ${generated_cpp} ${cuda_generated_cpp}
     COMMAND ${GEN_COMMAND}
-      --install_dir ${CMAKE_BINARY_DIR}/aten/src/ATen
     DEPENDS ${all_python} ${all_templates} ${cwrap_files} ${core_gen_checked_inputs})
 
   # Generated headers used from a CUDA (.cu) file are


### PR DESCRIPTION
This fix is based on https://github.com/pytorch/pytorch/pull/13272, and tested on ONNX OPSET 9.

