### PR TITLE
handle scenario when GPU support is not available and p2p_access_pattern is empty

### DIFF
--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -1062,7 +1062,7 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
             for i, peer in enumerate(devices):
                 if i == 0:
                     continue  # Skip the first device
-                if p2p_access_pattern is not None and not p2p_access_pattern[
+                if p2p_access_pattern is not None and p2p_access_pattern and not p2p_access_pattern[
                     devices[0], peer
                 ]:
                     # Copy from peer to d0

--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -1062,7 +1062,7 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
             for i, peer in enumerate(devices):
                 if i == 0:
                     continue  # Skip the first device
-                if p2p_access_pattern is not None and p2p_access_pattern and not p2p_access_pattern[
+                if p2p_access_pattern is not None and p2p_access_pattern.size and not p2p_access_pattern[
                     devices[0], peer
                 ]:
                     # Copy from peer to d0


### PR DESCRIPTION
Observed that when there is no GPU support available `workspace `sets `GetGpuPeerAccessPattern `to `[]` in 
https://github.com/pytorch/pytorch/blob/master/caffe2/python/workspace.py#L79 
and this case is not handled in https://github.com/pytorch/pytorch/blob/master/caffe2/python/data_parallel_model.py#L1065. 