### PR TITLE
Rearrange the locking pattern in ThreadPool to avoid circumstances where the receiver of a  CV notification could be blocked on the sender, or vice versa.

### DIFF
--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -54,10 +54,11 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
   std::queue<task_element_t> tasks_;
   std::vector<std::thread> threads_;
   std::mutex mutex_;
+  std::mutex work_complete_mutex_;
   std::condition_variable condition_;
   std::condition_variable completed_;
   std::atomic_bool running_;
-  bool complete_;
+  std::atomic_bool complete_;
   std::size_t available_;
   std::size_t total_;
   int numa_node_id_;


### PR DESCRIPTION
The key feature here is to avoid sending a notification while holding a mutex that the
receiver will immediately try to acquire.  In most cases this is simply a matter of sending
the notification after releasing the mutex, but for work completion notifications this
necessitates splitting the underlying mutex.  This is fine because no data is actually being
guarded by that lock acquisition, it's just being used for spurious wakeup avoidance.

