### PR TITLE
make momentum non negative in adagrad test

### DIFF
--- a/caffe2/python/operator_test/adagrad_test.py
+++ b/caffe2/python/operator_test/adagrad_test.py
@@ -28,6 +28,7 @@ class TestAdagrad(serial.SerializedTestCase):
     )
     def test_adagrad(self, inputs, lr, epsilon, gc, dc):
         param, momentum, grad = inputs
+        momentum = np.abs(momentum)
         lr = np.array([lr], dtype=np.float32)
 
         op = core.CreateOperator(
@@ -57,6 +58,7 @@ class TestAdagrad(serial.SerializedTestCase):
     )
     def test_adagrad_output_effective_lr(self, inputs, lr, epsilon, gc, dc):
         param, momentum, grad = inputs
+        momentum = np.abs(momentum)
         lr = np.array([lr], dtype=np.float32)
 
         op = core.CreateOperator(
@@ -86,6 +88,7 @@ class TestAdagrad(serial.SerializedTestCase):
     )
     def test_adagrad_output_effective_lr_and_update(self, inputs, lr, epsilon, gc, dc):
         param, momentum, grad = inputs
+        momentum = np.abs(momentum)
         lr = np.array([lr], dtype=np.float32)
 
         op = core.CreateOperator(


### PR DESCRIPTION
Summary: momentum should be initialized with non-negative values

Differential Revision: D14450841
