### PR TITLE
Fix unclosed files in download.py, test_onnxifi.py, test_trt.py

### DIFF
--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -190,7 +190,8 @@ class ModelDownloader:
             c2_init_net.ParseFromString(f.read())
         c2_init_net.name = model_name + '_init'
 
-        value_info = json.load(open(os.path.join(model_dir, 'value_info.json')))
+        with open(os.path.join(model_dir, 'value_info.json')) as f:
+            value_info = json.load(f)
         return c2_init_net, c2_predict_net, value_info
 
 

--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -152,8 +152,10 @@ class OnnxifiTransformTest(TestCase):
         with open(c2_init_pb, 'rb') as f:
             c2_init_net.ParseFromString(f.read())
         c2_init_net.name = model_name + '_init'
-
-        value_info = json.load(open(os.path.join(model_dir, 'value_info.json')))
+        
+        with open(os.path.join(model_dir, 'value_info.json') as f:
+            value_info = json.load(f)
+        
         return c2_init_net, c2_predict_net, value_info
 
     def _add_head_tail(self, pred_net, new_head, new_tail):

--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -153,7 +153,7 @@ class OnnxifiTransformTest(TestCase):
             c2_init_net.ParseFromString(f.read())
         c2_init_net.name = model_name + '_init'
         
-        with open(os.path.join(model_dir, 'value_info.json') as f:
+        with open(os.path.join(model_dir, 'value_info.json')) as f:
             value_info = json.load(f)
         
         return c2_init_net, c2_predict_net, value_info

--- a/caffe2/python/trt/test_trt.py
+++ b/caffe2/python/trt/test_trt.py
@@ -198,7 +198,8 @@ class TensorRTTransformTest(DownloadingTestCase):
             c2_init_net.ParseFromString(f.read())
         c2_init_net.name = model_name + '_init'
 
-        value_info = json.load(open(os.path.join(model_dir, 'value_info.json')))
+        with open(os.path.join(model_dir, 'value_info.json')) as f:
+            value_info = json.load(f)
         return c2_init_net, c2_predict_net, value_info
 
     def _add_head_tail(self, pred_net, new_head, new_tail):


### PR DESCRIPTION
According to https://docs.python.org/3/tutorial/inputoutput.html, it is good practice to use the "with" keyword when dealing with file objects. If not, you should call f.close() to close the file and immediately free up any system resources used by it.  Thus, I adjust the open file function to "with open() as f". 