### PR TITLE
[jit] fix clang-tidy

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -81,8 +81,8 @@ struct const_value_list_with_types {
   std::string delim;
   const_value_list_with_types(
       ArrayRef<const Value*> values,
-      const std::string& delim = ", ")
-      : values(values), delim(delim) {}
+      std::string delim_ = ", ")
+      : values(values), delim(std::move(delim_)) {}
 };
 
 std::ostream& operator<<(std::ostream& out, const_value_list_with_types l) {


### PR DESCRIPTION
Stack:
* **#18030 [jit] fix clang-tidy**

fix the following complaint
```
pytorch/torch/csrc/jit/ir.cpp:84:7: error: pass by value and use std::move [modernize-pass-by-value,-warnings-as-errors]
      const std::string& delim = ", ")
      ^~~~~~~~~~~~~~~~~~
      std::string
```

Differential Revision: [D14466714](https://our.internmc.facebook.com/intern/diff/D14466714)