### PR TITLE
Specify overload name in function schema

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -67,11 +67,13 @@ private:
 struct FunctionSchema {
   FunctionSchema(
       std::string name,
+      std::string overload_name,
       std::vector<Argument> arguments,
       std::vector<Argument> returns,
       bool is_vararg = false,
       bool is_varret = false)
       : name_(std::move(name)),
+        overload_name_(std::move(overload_name)),
         arguments_(std::move(arguments)),
         returns_(std::move(returns)),
         is_vararg_(is_vararg),
@@ -79,6 +81,7 @@ struct FunctionSchema {
 
   FunctionSchema(
       Symbol name,
+      std::string overload_name,
       std::vector<Argument> arguments,
       std::vector<Argument> returns,
       bool is_vararg = false,
@@ -86,6 +89,7 @@ struct FunctionSchema {
       std::vector<std::string> writes = {})
       : FunctionSchema(
             name.toQualString(),
+            std::move(overload_name),
             std::move(std::move(arguments)),
             std::move(std::move(returns)),
             is_vararg,
@@ -93,6 +97,7 @@ struct FunctionSchema {
 
 private:
   const std::string name_;
+  const std::string overload_name_;
   const std::vector<Argument> arguments_;
   const std::vector<Argument> returns_;
   // if true then this schema takes an arbitrary number of additional arguments
@@ -105,6 +110,9 @@ private:
 public:
   const std::string& name() const {
     return name_;
+  }
+  const std::string& overload_name() const {
+    return overload_name_;
   }
   const std::vector<Argument>& arguments() const {
     return arguments_;

--- a/caffe2/core/c10_operator.h
+++ b/caffe2/core/c10_operator.h
@@ -99,8 +99,10 @@ inline c10::FunctionSchema make_function_schema_for_c10(const char* OperatorName
       IValue());
 
   return c10::FunctionSchema(
-    std::string("_caffe2::") + OperatorName,
-    std::move(actual_inputs), std::move(outputs));
+      std::string("_caffe2::") + OperatorName,
+      "",
+      std::move(actual_inputs),
+      std::move(outputs));
 }
 
 }

--- a/caffe2/operators/experimental/c10/schemas/add.cc
+++ b/caffe2/operators/experimental/c10/schemas/add.cc
@@ -6,17 +6,18 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Add, FunctionSchema(
-    "_c10_experimental::Add",
-    (std::vector<c10::Argument>{
-      c10::Argument("input1"),
-      c10::Argument("input2"),
-      c10::Argument("output"),
-      c10::Argument("legacy_broadcast", BoolType::get()),
-      c10::Argument("axis", IntType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Add,
+    FunctionSchema(
+        "_c10_experimental::Add",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("input1"),
+            c10::Argument("input2"),
+            c10::Argument("output"),
+            c10::Argument("legacy_broadcast", BoolType::get()),
+            c10::Argument("axis", IntType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/averaged_loss.cc
+++ b/caffe2/operators/experimental/c10/schemas/averaged_loss.cc
@@ -7,14 +7,14 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(AveragedLoss, FunctionSchema(
-    "_c10_experimental::AveragedLoss",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    AveragedLoss,
+    FunctionSchema(
+        "_c10_experimental::AveragedLoss",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input"),
+                                    c10::Argument("output")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/batch_gather.cc
+++ b/caffe2/operators/experimental/c10/schemas/batch_gather.cc
@@ -7,15 +7,15 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(BatchGather, FunctionSchema(
-    "_c10_experimental::BatchGather",
-    (std::vector<c10::Argument>{
-      c10::Argument("data"),
-      c10::Argument("indices"),
-      c10::Argument("output")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    BatchGather,
+    FunctionSchema(
+        "_c10_experimental::BatchGather",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("data"),
+                                    c10::Argument("indices"),
+                                    c10::Argument("output")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/batch_matmul.cc
+++ b/caffe2/operators/experimental/c10/schemas/batch_matmul.cc
@@ -7,18 +7,19 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(BatchMatmul, FunctionSchema(
-    "_c10_experimental::BatchMatmul",
-    (std::vector<c10::Argument>{
-      c10::Argument("A"),
-      c10::Argument("B"),
-      c10::Argument("output"),
-      c10::Argument("trans_a", IntType::get()),
-      c10::Argument("trans_b", IntType::get()),
-      c10::Argument("broadcast", IntType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    BatchMatmul,
+    FunctionSchema(
+        "_c10_experimental::BatchMatmul",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("A"),
+            c10::Argument("B"),
+            c10::Argument("output"),
+            c10::Argument("trans_a", IntType::get()),
+            c10::Argument("trans_b", IntType::get()),
+            c10::Argument("broadcast", IntType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/cast.cc
+++ b/caffe2/operators/experimental/c10/schemas/cast.cc
@@ -8,15 +8,17 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Cast, FunctionSchema(
-    "_c10_experimental::Cast",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output"),
-      c10::Argument("to_dtype", IntType::get()),
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Cast,
+    FunctionSchema(
+        "_c10_experimental::Cast",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("input"),
+            c10::Argument("output"),
+            c10::Argument("to_dtype", IntType::get()),
+        }),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/concat.cc
+++ b/caffe2/operators/experimental/c10/schemas/concat.cc
@@ -7,17 +7,18 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Concat, FunctionSchema(
-    "_c10_experimental::Concat",
-    (std::vector<c10::Argument>{
-      c10::Argument("inputs", ListType::ofTensors()),
-      c10::Argument("output"),
-      c10::Argument("split_info", FloatType::get()),
-      c10::Argument("add", IntType::get()),
-      c10::Argument("add_axis", IntType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Concat,
+    FunctionSchema(
+        "_c10_experimental::Concat",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("inputs", ListType::ofTensors()),
+            c10::Argument("output"),
+            c10::Argument("split_info", FloatType::get()),
+            c10::Argument("add", IntType::get()),
+            c10::Argument("add_axis", IntType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/enforce_finite.cc
+++ b/caffe2/operators/experimental/c10/schemas/enforce_finite.cc
@@ -7,13 +7,13 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(EnforceFinite, FunctionSchema(
-    "_c10_experimental::EnforceFinite",
-    (std::vector<c10::Argument>{
-      c10::Argument("input")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    EnforceFinite,
+    FunctionSchema(
+        "_c10_experimental::EnforceFinite",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/expand_dims.cc
+++ b/caffe2/operators/experimental/c10/schemas/expand_dims.cc
@@ -9,15 +9,15 @@ using c10::ivalue::IntList;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(ExpandDims, FunctionSchema(
-    "_c10_experimental::ExpandDims",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output"),
-      c10::Argument("dims", ListType::ofInts())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    ExpandDims,
+    FunctionSchema(
+        "_c10_experimental::ExpandDims",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input"),
+                                    c10::Argument("output"),
+                                    c10::Argument("dims", ListType::ofInts())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/fc.cc
+++ b/caffe2/operators/experimental/c10/schemas/fc.cc
@@ -7,18 +7,18 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(FullyConnected, FunctionSchema(
-    "_c10_experimental::FullyConnected",
-    (std::vector<c10::Argument>{
-      c10::Argument("X"),
-      c10::Argument("W"),
-      c10::Argument("b"),
-      c10::Argument("output"),
-      c10::Argument("axis", IntType::get()),
-      c10::Argument("axis_w", IntType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    FullyConnected,
+    FunctionSchema(
+        "_c10_experimental::FullyConnected",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("X"),
+                                    c10::Argument("W"),
+                                    c10::Argument("b"),
+                                    c10::Argument("output"),
+                                    c10::Argument("axis", IntType::get()),
+                                    c10::Argument("axis_w", IntType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/filler.cc
+++ b/caffe2/operators/experimental/c10/schemas/filler.cc
@@ -11,68 +11,76 @@ using c10::intrusive_ptr;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema strings instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(ConstantFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
-    (std::vector<c10::Argument>{
-      c10::Argument("inputs", ListType::ofTensors()),
-      c10::Argument("output"),
-      c10::Argument("shape", ListType::ofInts()),
-      c10::Argument("extra_shape", ListType::ofInts()),
-      c10::Argument("input_as_shape", BoolType::get()),
-      c10::Argument("dtype", IntType::get()),
-      c10::Argument("value", NumberType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
-C10_DEFINE_OP_SCHEMA(UniformFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
-    (std::vector<c10::Argument>{
-      c10::Argument("inputs", ListType::ofTensors()),
-      c10::Argument("output"),
-      c10::Argument("shape", ListType::ofInts()),
-      c10::Argument("extra_shape", ListType::ofInts()),
-      c10::Argument("input_as_shape", BoolType::get()),
-      c10::Argument("min", FloatType::get()),
-      c10::Argument("max", FloatType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
-C10_DEFINE_OP_SCHEMA(GivenTensorFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
-    (std::vector<c10::Argument>{
-      c10::Argument("inputs", ListType::ofTensors()),
-      c10::Argument("output"),
-      c10::Argument("shape", ListType::ofInts()),
-      c10::Argument("extra_shape", ListType::ofInts()),
-      c10::Argument("input_as_shape", BoolType::get()),
-      c10::Argument("values"),
-    }), (std::vector<c10::Argument>{
-    })
-));
-C10_DEFINE_OP_SCHEMA(GivenTensorIntFill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
-    (std::vector<c10::Argument>{
-      c10::Argument("inputs", ListType::ofTensors()),
-      c10::Argument("output"),
-      c10::Argument("shape", ListType::ofInts()),
-      c10::Argument("extra_shape", ListType::ofInts()),
-      c10::Argument("input_as_shape", BoolType::get()),
-      c10::Argument("values"),
-    }), (std::vector<c10::Argument>{
-    })
-));
-C10_DEFINE_OP_SCHEMA(GivenTensorInt64Fill, FunctionSchema(
-    "_c10_experimental::ConstantFill",
-    (std::vector<c10::Argument>{
-      c10::Argument("inputs", ListType::ofTensors()),
-      c10::Argument("output"),
-      c10::Argument("shape", ListType::ofInts()),
-      c10::Argument("extra_shape", ListType::ofInts()),
-      c10::Argument("input_as_shape", BoolType::get()),
-      c10::Argument("values"),
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    ConstantFill,
+    FunctionSchema(
+        "_c10_experimental::ConstantFill",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("inputs", ListType::ofTensors()),
+            c10::Argument("output"),
+            c10::Argument("shape", ListType::ofInts()),
+            c10::Argument("extra_shape", ListType::ofInts()),
+            c10::Argument("input_as_shape", BoolType::get()),
+            c10::Argument("dtype", IntType::get()),
+            c10::Argument("value", NumberType::get())}),
+        (std::vector<c10::Argument>{})));
+C10_DEFINE_OP_SCHEMA(
+    UniformFill,
+    FunctionSchema(
+        "_c10_experimental::ConstantFill",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("inputs", ListType::ofTensors()),
+            c10::Argument("output"),
+            c10::Argument("shape", ListType::ofInts()),
+            c10::Argument("extra_shape", ListType::ofInts()),
+            c10::Argument("input_as_shape", BoolType::get()),
+            c10::Argument("min", FloatType::get()),
+            c10::Argument("max", FloatType::get())}),
+        (std::vector<c10::Argument>{})));
+C10_DEFINE_OP_SCHEMA(
+    GivenTensorFill,
+    FunctionSchema(
+        "_c10_experimental::ConstantFill",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("inputs", ListType::ofTensors()),
+            c10::Argument("output"),
+            c10::Argument("shape", ListType::ofInts()),
+            c10::Argument("extra_shape", ListType::ofInts()),
+            c10::Argument("input_as_shape", BoolType::get()),
+            c10::Argument("values"),
+        }),
+        (std::vector<c10::Argument>{})));
+C10_DEFINE_OP_SCHEMA(
+    GivenTensorIntFill,
+    FunctionSchema(
+        "_c10_experimental::ConstantFill",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("inputs", ListType::ofTensors()),
+            c10::Argument("output"),
+            c10::Argument("shape", ListType::ofInts()),
+            c10::Argument("extra_shape", ListType::ofInts()),
+            c10::Argument("input_as_shape", BoolType::get()),
+            c10::Argument("values"),
+        }),
+        (std::vector<c10::Argument>{})));
+C10_DEFINE_OP_SCHEMA(
+    GivenTensorInt64Fill,
+    FunctionSchema(
+        "_c10_experimental::ConstantFill",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("inputs", ListType::ofTensors()),
+            c10::Argument("output"),
+            c10::Argument("shape", ListType::ofInts()),
+            c10::Argument("extra_shape", ListType::ofInts()),
+            c10::Argument("input_as_shape", BoolType::get()),
+            c10::Argument("values"),
+        }),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/flatten.cc
+++ b/caffe2/operators/experimental/c10/schemas/flatten.cc
@@ -7,15 +7,15 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Flatten, FunctionSchema(
-    "_c10_experimental::Flatten",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output"),
-      c10::Argument("axis", IntType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Flatten,
+    FunctionSchema(
+        "_c10_experimental::Flatten",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input"),
+                                    c10::Argument("output"),
+                                    c10::Argument("axis", IntType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/mul.cc
+++ b/caffe2/operators/experimental/c10/schemas/mul.cc
@@ -7,17 +7,18 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Mul, FunctionSchema(
-    "_c10_experimental::Mul",
-    (std::vector<c10::Argument>{
-      c10::Argument("input1"),
-      c10::Argument("input2"),
-      c10::Argument("output"),
-      c10::Argument("legacy_broadcast", BoolType::get()),
-      c10::Argument("axis", IntType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Mul,
+    FunctionSchema(
+        "_c10_experimental::Mul",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("input1"),
+            c10::Argument("input2"),
+            c10::Argument("output"),
+            c10::Argument("legacy_broadcast", BoolType::get()),
+            c10::Argument("axis", IntType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/relu.cc
+++ b/caffe2/operators/experimental/c10/schemas/relu.cc
@@ -7,14 +7,14 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Relu, FunctionSchema(
-    "_c10_experimental::Relu",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Relu,
+    FunctionSchema(
+        "_c10_experimental::Relu",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input"),
+                                    c10::Argument("output")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/sigmoid.cc
+++ b/caffe2/operators/experimental/c10/schemas/sigmoid.cc
@@ -7,14 +7,14 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(Sigmoid, FunctionSchema(
-    "_c10_experimental::Sigmoid",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    Sigmoid,
+    FunctionSchema(
+        "_c10_experimental::Sigmoid",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input"),
+                                    c10::Argument("output")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/sigmoid_cross_entropy_with_logits.cc
+++ b/caffe2/operators/experimental/c10/schemas/sigmoid_cross_entropy_with_logits.cc
@@ -7,17 +7,18 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(SigmoidCrossEntropyWithLogits, FunctionSchema(
-    "_c10_experimental::SigmoidCrossEntropyWithLogits",
-    (std::vector<c10::Argument>{
-      c10::Argument("input1"),
-      c10::Argument("input2"),
-      c10::Argument("output"),
-      c10::Argument("log_D_trick", BoolType::get()),
-      c10::Argument("unjoined_lr_loss", BoolType::get())
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    SigmoidCrossEntropyWithLogits,
+    FunctionSchema(
+        "_c10_experimental::SigmoidCrossEntropyWithLogits",
+        "",
+        (std::vector<c10::Argument>{
+            c10::Argument("input1"),
+            c10::Argument("input2"),
+            c10::Argument("output"),
+            c10::Argument("log_D_trick", BoolType::get()),
+            c10::Argument("unjoined_lr_loss", BoolType::get())}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/sparse_lengths_sum.cc
+++ b/caffe2/operators/experimental/c10/schemas/sparse_lengths_sum.cc
@@ -7,16 +7,16 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(SparseLengthsSum, FunctionSchema(
-    "_c10_experimental::SparseLengthsSum",
-    (std::vector<c10::Argument>{
-      c10::Argument("data"),
-      c10::Argument("indices"),
-      c10::Argument("lengths"),
-      c10::Argument("output")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    SparseLengthsSum,
+    FunctionSchema(
+        "_c10_experimental::SparseLengthsSum",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("data"),
+                                    c10::Argument("indices"),
+                                    c10::Argument("lengths"),
+                                    c10::Argument("output")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/caffe2/operators/experimental/c10/schemas/stop_gradient.cc
+++ b/caffe2/operators/experimental/c10/schemas/stop_gradient.cc
@@ -7,14 +7,14 @@ using caffe2::CPUContext;
 namespace caffe2 {
 namespace ops {
 // TODO Parse schema string instead of creating FunctionSchema manually
-C10_DEFINE_OP_SCHEMA(StopGradient, FunctionSchema(
-    "_c10_experimental::StopGradient",
-    (std::vector<c10::Argument>{
-      c10::Argument("input"),
-      c10::Argument("output")
-    }), (std::vector<c10::Argument>{
-    })
-));
+C10_DEFINE_OP_SCHEMA(
+    StopGradient,
+    FunctionSchema(
+        "_c10_experimental::StopGradient",
+        "",
+        (std::vector<c10::Argument>{c10::Argument("input"),
+                                    c10::Argument("output")}),
+        (std::vector<c10::Argument>{})));
 }
 }
 

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -90,6 +90,7 @@ RegisterOperators reg({
     Operator(
         FunctionSchema(
             prim::Constant,
+            "",
             {},
             {},
             /*is_vararg=*/false,

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -81,7 +81,7 @@ FunctionSchema createFunctionSchemaFromTraits(const std::string& name) {
       typename MakeIndices<FunctionTraits::number_of_parameters>::indices{});
   auto returns = createReturns(static_cast<ReturnType*>(nullptr));
 
-  return {name, arguments, returns};
+  return {name, "", arguments, returns};
 }
 
 /// Adds the elements of the `tuple` as input nodes to the traced graph.

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -352,6 +352,8 @@ void initJITBindings(PyObject* module) {
       .def_property_readonly(
           "name", [](FunctionSchema& self) { return self.name(); })
       .def_property_readonly(
+          "overload_name", [](FunctionSchema& self) { return self.overload_name(); })
+      .def_property_readonly(
           "arguments", [](FunctionSchema& self) { return self.arguments(); })
       .def_property_readonly(
           "returns", [](FunctionSchema& self) { return self.returns(); });

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -25,10 +25,14 @@ struct SchemaParser {
       : L(str), type_parser(L, /*parse_complete_tensor_types*/ false) {}
 
   FunctionSchema parseDeclaration() {
-    auto name = L.expect(TK_IDENT).text();
+    std::string name = L.expect(TK_IDENT).text();
     if (L.nextIf(':')) {
       L.expect(':');
       name = name + "::" + L.expect(TK_IDENT).text();
+    }
+    std::string overload_name = "";
+    if (L.nextIf('.')) {
+      overload_name = L.expect(TK_IDENT).text();
     }
     std::vector<Argument> arguments;
     std::vector<Argument> returns;
@@ -60,7 +64,7 @@ struct SchemaParser {
           parseArgument(0, /*is_return=*/true, /*kwarg_only=*/false));
     }
     return FunctionSchema{
-        name, std::move(arguments), std::move(returns), is_vararg, false};
+        std::move(name), std::move(overload_name), std::move(arguments), std::move(returns), is_vararg, false};
   }
 
   std::vector<FunctionSchema> parseDeclarations() {

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -74,6 +74,7 @@ struct TORCH_API Operator {
       : Operator(
             FunctionSchema(
                 name,
+                "",
                 {},
                 {},
                 /*is_vararg*/ true,

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -471,7 +471,8 @@ RegisterOperators reg(
          }),
      Operator(
          FunctionSchema(
-             "aten::warn",
+             "aten::warn(str message, *, int stacklevel=2)",
+             "",
              {Argument("message", StringType::get()),
               Argument("stacklevel", IntType::get(), c10::nullopt, 2, true)},
              {}),

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -579,7 +579,7 @@ struct to_ir {
     auto stmts_list = moveAllReturnsToEnd(def.statements());
     emitStatements(stmts_list.begin(), stmts_list.end());
     std::vector<Argument> returns = {emitOutput(def.range(), schema, block)};
-    return {def.name().name(), std::move(arguments), std::move(returns)};
+    return {def.name().name(), "", std::move(arguments), std::move(returns)};
   }
 
   std::vector<IValue> evaluateDefaults(
@@ -698,7 +698,7 @@ struct to_ir {
     std::vector<Argument> args = parseArgsFromDecl(def.decl(), self);
     std::vector<Argument> returns = parseReturnFromDecl(def.decl());
     return FunctionSchema(
-        name, std::move(args), std::move(returns), false, false);
+        name, "", std::move(args), std::move(returns), false, false);
   }
 
   std::vector<Argument> emitFormalArguments(

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -116,7 +116,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
       }
       rets.push_back(Argument("0", ret_type, {}, {}, false));
     }
-    return FunctionSchema("", std::move(args), std::move(rets));
+    return FunctionSchema("", "", std::move(args), std::move(rets));
   }
 
   // call it like a function, e.g. `outputs = this(inputs)`
@@ -657,6 +657,7 @@ FunctionSchema getSchemaWithNameAndDefaults(
 
   return FunctionSchema(
       new_name.value_or(schema.name()),
+      schema.overload_name(),
       new_args,
       schema.returns(),
       schema.is_vararg(),

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -256,7 +256,7 @@ struct Method {
     for (size_t i = 0; i < g.outputs().size(); ++i) {
       returns.emplace_back("", unshapedType(g.outputs()[i]->type()));
     }
-    return {method.name(), std::move(args), std::move(returns)};
+    return {method.name(), "", std::move(args), std::move(returns)};
   }
 
   GraphExecutor& get_executor() {

--- a/torch/csrc/jit/symbolic_script.cpp
+++ b/torch/csrc/jit/symbolic_script.cpp
@@ -911,6 +911,7 @@ void loadModule(const std::shared_ptr<script::Module>& module) {
     const FunctionSchema& loaded_schema = method->getSchema();
     FunctionSchema actual_schema(
         Symbol::aten(loaded_schema.name()),
+        loaded_schema.overload_name(),
         loaded_schema.arguments(),
         {originalReturnType(new_tuple->type()->expect<TupleType>())});
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18033 Expose c10 cuda ops to caffe2&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14467672/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18034 Specify overload name in function schema**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14467671/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18035 [wip] Allow registering same operator schema multiple times&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14467670/)

The FunctionSchema can now store an overload name and the parser knows how to parse it. Specify like this:

    my_func.overload1(arg1: Tensor) -> Tensor
    my_func.overload2(arg1: Tensor, arg2: Tensor) -> Tensor

Differential Revision: [D14467671](https://our.internmc.facebook.com/intern/diff/D14467671/)