### PR TITLE
[ONNX]Update nonzero onnx export

### DIFF
--- a/test/onnx/expect/TestOperators.test_nonzero.expect
+++ b/test/onnx/expect/TestOperators.test_nonzero.expect
@@ -7,6 +7,17 @@ graph {
     output: "1"
     op_type: "NonZero"
   }
+  node {
+    input: "1"
+    output: "2"
+    op_type: "Transpose"
+    attribute {
+      name: "perm"
+      ints: 1
+      ints: 0
+      type: INTS
+    }
+  }
   name: "torch-jit-export"
   input {
     name: "0"
@@ -28,7 +39,7 @@ graph {
     }
   }
   output {
-    name: "1"
+    name: "2"
     type {
       tensor_type {
         elem_type: 7

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1674,7 +1674,7 @@ def flatten(g, input, start_dim, end_dim):
 
 @parse_args('v')
 def nonzero(g, input):
-    return g.op('NonZero', input)
+    return t(g, g.op('NonZero', input))
 
 
 @parse_args('v', 'i', 'i', 'i')


### PR DESCRIPTION
The output format of NonZero in ONNX(numpy https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html) differs from that in PyTorch:
In ONNX: `[rank_of_input, num_of_nonzeros]`, whereas in PyTorch: `[num_of_nonzeros, rank_of_input]`. 
To resolve the difference a Transpose op after the nonzero output is added in the exporter.