### PR TITLE
Increase line-width of Declarations.yaml

### DIFF
--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -249,7 +249,7 @@ def format_yaml(data):
     noalias_dumper.ignore_aliases = lambda self, data: True
     # Support serializing OrderedDict
     noalias_dumper.add_representer(OrderedDict, dict_representer)
-    return yaml.dump(data, default_flow_style=False, Dumper=noalias_dumper)
+    return yaml.dump(data, default_flow_style=False, Dumper=noalias_dumper, width=2048)
 
 
 def generate_storage_type_and_tensor(backend, density, scalar_type, declarations):

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -249,7 +249,8 @@ def format_yaml(data):
     noalias_dumper.ignore_aliases = lambda self, data: True
     # Support serializing OrderedDict
     noalias_dumper.add_representer(OrderedDict, dict_representer)
-    return yaml.dump(data, default_flow_style=False, Dumper=noalias_dumper, width=2048)
+    # width=float('Inf') tunes off line breaks for portability of yaml-parser.
+    return yaml.dump(data, default_flow_style=False, Dumper=noalias_dumper, width=float('Inf'))
 
 
 def generate_storage_type_and_tensor(backend, density, scalar_type, declarations):

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -249,7 +249,9 @@ def format_yaml(data):
     noalias_dumper.ignore_aliases = lambda self, data: True
     # Support serializing OrderedDict
     noalias_dumper.add_representer(OrderedDict, dict_representer)
-    # width=float('Inf') tunes off line breaks for portability of yaml-parser.
+    # Some yaml parsers (e.g. Haskell's) don't understand line breaks.
+    # width=float('Inf') turns off optional line breaks and improves
+    # the portability of the outputted yaml.
     return yaml.dump(data, default_flow_style=False, Dumper=noalias_dumper, width=float('Inf'))
 
 


### PR DESCRIPTION
There are some line breaks in schema_string of Declarations.yaml.
Is this valid yaml? I am reading yaml-spec.
It seems that the “|” indicator or single/double quote is required to insert line-break.
https://yaml.org/spec/1.2/spec.html 
![image](https://user-images.githubusercontent.com/2469618/54405834-1e53ac80-471b-11e9-9925-be13a109eb46.png)
Could you increase line-width of yaml to avoid newline?