### PR TITLE
Catch and print exception traceback in parallel_apply() workers

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -12,8 +12,9 @@ import itertools
 import warnings
 from torch import multiprocessing as mp
 from torch.utils.data import _utils, Dataset, IterableDataset, TensorDataset, DataLoader, ConcatDataset, ChainDataset
-from torch.utils.data._utils import ExceptionWrapper, MP_STATUS_CHECK_INTERVAL
+from torch.utils.data._utils import MP_STATUS_CHECK_INTERVAL
 from torch.utils.data.dataset import random_split
+from torch._utils import ExceptionWrapper
 from common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, PY3,
                           IS_PYTORCH_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm,
                           load_tests)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -1,6 +1,8 @@
 import torch
 import warnings
 from collections import defaultdict
+import sys
+import traceback
 
 
 def _type(self, dtype=None, non_blocking=False, **kwargs):
@@ -326,3 +328,42 @@ def annotate(ret, **kwargs):
         fun.__annotations__['return'] = ret
         return fun
     return dec
+
+
+# NOTE [ Python Traceback Reference Cycle Problem ]
+#
+# When using sys.exc_info(), it is important to **not** store the exc_info[2],
+# which is the traceback, because otherwise you will run into the traceback
+# reference cycle problem, i.e., the traceback holding reference to the frame,
+# and the frame (which holds reference to all the object in its temporary scope)
+# holding reference the traceback.
+
+class KeyErrorMessage(str):
+    r"""str subclass that returns itself in repr"""
+    def __repr__(self):
+        return self
+
+
+class ExceptionWrapper(object):
+    r"""Wraps an exception plus traceback to communicate across threads"""
+    def __init__(self, exc_info=None, where="in background"):
+        # It is important that we don't store exc_info, see
+        # NOTE [ Python Traceback Reference Cycle Problem ]
+        if exc_info is None:
+            exc_info = sys.exc_info()
+        self.exc_type = exc_info[0]
+        self.exc_msg = "".join(traceback.format_exception(*exc_info))
+        self.where = where
+
+    def reraise(self):
+        r"""Reraises the wrapped exception in the current thread"""
+        # Format a message such as: "Caught ValueError in DataLoader worker
+        # process 2. Original Traceback:", followed by the traceback.
+        msg = "Caught {} {}.\nOriginal {}".format(
+            self.exc_type.__name__, self.where, self.exc_msg)
+        if self.exc_type == KeyError:
+            # KeyError calls repr() on its argument (usually a dict key). This
+            # makes stack traces unreadable. It will not be changed in Python
+            # (https://bugs.python.org/issue2651), so we work around it.
+            msg = KeyErrorMessage(msg)
+        raise self.exc_type(msg)

--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -10,6 +10,9 @@ folder.
 import sys
 import atexit
 
+# old private location of the ExceptionWrapper that some users rely on:
+from torch._utils import ExceptionWrapper  # noqa: F401
+
 
 IS_WINDOWS = sys.platform == "win32"
 

--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -8,29 +8,10 @@ folder.
 """
 
 import sys
-import traceback
 import atexit
 
 
 IS_WINDOWS = sys.platform == "win32"
-
-
-# NOTE [ Python Traceback Reference Cycle Problem ]
-#
-# When using sys.exc_info(), it is important to **not** store the exc_info[2],
-# which is the traceback, because otherwise you will run into the traceback
-# reference cycle problem, i.e., the traceback holding reference to the frame,
-# and the frame (which holds reference to all the object in its temporary scope)
-# holding reference the traceback.
-
-
-class ExceptionWrapper(object):
-    r"""Wraps an exception plus traceback to communicate across threads"""
-    def __init__(self, exc_info):
-        # It is important that we don't store exc_info, see
-        # NOTE [ Python Traceback Reference Cycle Problem ]
-        self.exc_type = exc_info[0]
-        self.exc_msg = "".join(traceback.format_exception(*exc_info))
 
 
 MP_STATUS_CHECK_INTERVAL = 5.0

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -5,10 +5,10 @@ These **needs** to be in global scope since Py2 doesn't support serializing
 static methods.
 """
 
-import sys
 import torch
 from torch._six import queue, container_abcs, string_classes
-from . import MP_STATUS_CHECK_INTERVAL, ExceptionWrapper
+from . import MP_STATUS_CHECK_INTERVAL
+from torch._utils import ExceptionWrapper
 
 
 def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
@@ -26,7 +26,8 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
             try:
                 data = pin_memory(data)
             except Exception:
-                data = ExceptionWrapper(sys.exc_info())
+                data = ExceptionWrapper(
+                    where="in pin memory thread for device {}".format(device_id))
             r = (idx, data)
         while not done_event.is_set():
             try:

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -6,11 +6,11 @@ static methods.
 
 import torch
 import random
-import sys
 import os
 from collections import namedtuple
 from torch._six import queue
-from . import signal_handling, MP_STATUS_CHECK_INTERVAL, ExceptionWrapper, IS_WINDOWS
+from torch._utils import ExceptionWrapper
+from . import signal_handling, MP_STATUS_CHECK_INTERVAL, IS_WINDOWS
 
 if IS_WINDOWS:
     import ctypes
@@ -136,7 +136,8 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
 
             fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
         except Exception:
-            init_exception = ExceptionWrapper(sys.exc_info())
+            init_exception = ExceptionWrapper(
+                where="in DataLoader worker process {}".format(worker_id))
 
         # When using Iterable mode, some worker can exit earlier than others due
         # to the IterableDataset behaving differently for different workers.
@@ -186,7 +187,8 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                         # It is important that we don't store exc_info in a variable.
                         # `ExceptionWrapper` does the correct thing.
                         # See NOTE [ Python Traceback Reference Cycle Problem ]
-                        data = ExceptionWrapper(sys.exc_info())
+                        data = ExceptionWrapper(
+                            where="in DataLoader worker process {}".format(worker_id))
             data_queue.put((idx, data))
             del data, idx, index, r  # save memory
     except KeyboardInterrupt:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -9,6 +9,7 @@ import torch
 import torch.multiprocessing as multiprocessing
 from . import IterableDataset, Sampler, SequentialSampler, RandomSampler, BatchSampler
 from . import _utils
+from torch._utils import ExceptionWrapper
 import threading
 import itertools
 from torch._six import queue
@@ -801,13 +802,8 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
     def _process_data(self, data):
         self.rcvd_idx += 1
         self._try_put_index()
-        if isinstance(data, _utils.ExceptionWrapper):
-            # make multiline KeyError msg readable by working around
-            # a python bug https://bugs.python.org/issue2651
-            if data.exc_type == KeyError and "\n" in data.exc_msg:
-                raise Exception("KeyError:" + data.exc_msg)
-            else:
-                raise data.exc_type(data.exc_msg)
+        if isinstance(data, ExceptionWrapper):
+            data.reraise()
         return data
 
     def _shutdown_worker(self, worker_id):


### PR DESCRIPTION
When an exception occurs in one of the modules passed to `parallel_apply()`, it is caught and re-raised in the main thread. This preserves the original exception type and message, but has the traceback point at the position where it's re-raised, rather than the original point of failure.

This PR saves the exception information required to generate the traceback, and includes the original traceback in the message of the exception raised in the main thread.

Before:
```
  ...
  File ".../torch/nn/parallel/data_parallel.py", line 153, in parallel_apply
    return parallel_apply(replicas, inputs, kwargs, self.device_ids[:len(replicas)])
  File ".../torch/nn/parallel/parallel_apply.py", line 84, in parallel_apply
    raise output
RuntimeError: expected type torch.FloatTensor but got torch.cuda.FloatTensor
```

After:
```
  ...
  File ".../torch/nn/parallel/data_parallel.py", line 153, in parallel_apply
    return parallel_apply(replicas, inputs, kwargs, self.device_ids[:len(replicas)])
  File ".../torch/nn/parallel/parallel_apply.py", line 88, in parallel_apply
    ''.join(traceback.format_exception(*exc_info)))
RuntimeError: Caught exception in replica 0. Original traceback and message:
Traceback (most recent call last):
  ...
  File "../models/foo.py", line 319, in bar
    baz = asdf / ghij[:, np.newaxis]
RuntimeError: expected type torch.FloatTensor but got torch.cuda.FloatTensor
```

I took care to raise an exception of the original type (in case the main code checks for that), but replaced the message. It helped me find a bug that did not occur outside `data_parallel()`.