### PR TITLE
[jit] fix corner case for optional aliasing

### DIFF
--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -716,6 +716,9 @@ void AliasDb::makePointerTo(const Value* from, const Value* to) {
     return;
   }
 
+  // At this point, we should be dealing with two mutable types.
+  AT_ASSERT(shouldAnnotate(from) && shouldAnnotate(to));
+
   // If either value is a wildcard, don't insert anything into the graph;
   // wildcards are tracked separately since they have different aliasing rules.
   if (isWildcard(to) || isWildcard(from)) {
@@ -1178,6 +1181,9 @@ TORCH_API bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
 
 // Register `v` as a wildcard value.
 void AliasDb::setWildcard(const Value* v) {
+  if (!shouldAnnotate(v)) {
+    return;
+  }
   wildcards_.insert(v);
 }
 

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -709,6 +709,13 @@ void AliasDb::makePointerTo(const Value* from, const Value* to) {
     return;
   }
 
+  // Special case: if `from` is an optional, `to` could be a None. Don't
+  // create a pointer in that case
+  if (from->type()->kind() == TypeKind::OptionalType &&
+      to->type()->kind() == TypeKind::NoneType) {
+    return;
+  }
+
   // If either value is a wildcard, don't insert anything into the graph;
   // wildcards are tracked separately since they have different aliasing rules.
   if (isWildcard(to) || isWildcard(from)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18093 [jit] fix corner case for optional aliasing**

Occasionally the compiler can insert constant Nones to make types line
up. In that case, don't try to make a pointer from the optional type to
None, since we know statically that None won't be mutated or whatever.

Differential Revision: [D14493004](https://our.internmc.facebook.com/intern/diff/D14493004)