### PR TITLE
[jit] fix corner case for optional aliasing

### DIFF
--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -709,6 +709,13 @@ void AliasDb::makePointerTo(const Value* from, const Value* to) {
     return;
   }
 
+  // Special case: if `from` is an optional, `to` could be a None. Don't
+  // create a pointer in that case
+  if (from->type()->kind() == TypeKind::OptionalType &&
+      to->type()->kind() == TypeKind::NoneType) {
+    return;
+  }
+
   // If either value is a wildcard, don't insert anything into the graph;
   // wildcards are tracked separately since they have different aliasing rules.
   if (isWildcard(to) || isWildcard(from)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18100 [jit] fix corner case for optional aliasing**

Occasionally the compiler can insert constant Nones to make types line
up. In that case, don't try to make a pointer from the optional type to
None, since we know statically that None won't be mutated or whatever.