### PR TITLE
Added the exception of ignore_index

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -113,9 +113,9 @@ class NLLLoss(_WeightedLoss):
     You may use `CrossEntropyLoss` instead, if you prefer not to add an extra
     layer.
 
-    The `target` that this loss expects is a class index in the range :math:`[0, C-1]`
-    where `C = number of classes`. Additionally to that range of values,
-    any integer specified by `ignore_index` is also allowed in `target`.
+    The `target` that this loss expects should be a class index in the range :math:`[0, C-1]`
+    where `C = number of classes`; if `ignore_index` is specified, this loss also accepts
+    this class index (this index may not necessarily be in the class range).
 
     The unreduced (i.e. with :attr:`reduction` set to ``'none'``) loss can be described as:
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -853,7 +853,7 @@ class CrossEntropyLoss(_WeightedLoss):
     with :math:`K \geq 1` for the `K`-dimensional case (described later).
 
     This criterion expects a class index in the range :math:`[0, C-1]` as the
-    `target`for each value of a 1D tensor of size `minibatch`; ; if `ignore_index`
+    `target`for each value of a 1D tensor of size `minibatch`; if `ignore_index`
     is specified, this criterion also accepts this class index (this index may not
     necessarily be in the class range).
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -853,9 +853,9 @@ class CrossEntropyLoss(_WeightedLoss):
     with :math:`K \geq 1` for the `K`-dimensional case (described later).
 
     This criterion expects a class index in the range :math:`[0, C-1]` as the
-    `target`for each value of a 1D tensor of size `minibatch`.
-    Additionally to that range of values, any integer specified by
-    `ignore_index` is also allowed in `target`.
+    `target`for each value of a 1D tensor of size `minibatch`; ; if `ignore_index`
+    is specified, this criterion also accepts this class index (this index may not
+    necessarily be in the class range).
 
     The loss can be described as:
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -114,8 +114,8 @@ class NLLLoss(_WeightedLoss):
     layer.
 
     The `target` that this loss expects is a class index in the range :math:`[0, C-1]`
-    (except in the case of `ignore_index`, which is used to specify
-    a target value that can be ignored) where `C = number of classes`.
+    where `C = number of classes`. Additionally to that range of values,
+    any integer specified by `ignore_index` is also allowed in `target`.
 
     The unreduced (i.e. with :attr:`reduction` set to ``'none'``) loss can be described as:
 
@@ -853,8 +853,9 @@ class CrossEntropyLoss(_WeightedLoss):
     with :math:`K \geq 1` for the `K`-dimensional case (described later).
 
     This criterion expects a class index in the range :math:`[0, C-1]` as the
-    `target` (except in the case of `ignore_index`, which is used to specify
-    a target value that can be ignored) for each value of a 1D tensor of size `minibatch`.
+    `target`for each value of a 1D tensor of size `minibatch`.
+    Additionally to that range of values, any integer specified by
+    `ignore_index` is also allowed in `target`.
 
     The loss can be described as:
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -114,7 +114,8 @@ class NLLLoss(_WeightedLoss):
     layer.
 
     The `target` that this loss expects is a class index in the range :math:`[0, C-1]`
-    where `C = number of classes`.
+    (except in the case of `ignore_index`, which is used to specify
+    a target value that can be ignored) where `C = number of classes`.
 
     The unreduced (i.e. with :attr:`reduction` set to ``'none'``) loss can be described as:
 
@@ -852,7 +853,8 @@ class CrossEntropyLoss(_WeightedLoss):
     with :math:`K \geq 1` for the `K`-dimensional case (described later).
 
     This criterion expects a class index in the range :math:`[0, C-1]` as the
-    `target` for each value of a 1D tensor of size `minibatch`.
+    `target` (except in the case of `ignore_index`, which is used to specify
+    a target value that can be ignored) for each value of a 1D tensor of size `minibatch`.
 
     The loss can be described as:
 


### PR DESCRIPTION
Fix #17801 to add an exception regarding `ignore_index` in the documentation for `torch.nn.CrossEntropyLoss` and `torch.nn.NLLLoss`

If any other files/functions are hit, I'd be glad to incorporate the changes there too! 😊 