### PR TITLE
[jit] fix double free in test_jit

### DIFF
--- a/test/cpp/jit/test_base.h
+++ b/test/cpp/jit/test_base.h
@@ -32,7 +32,9 @@
 
 #endif // defined(USE_GTEST)
 
-bool isSandcastle() {
-  return ((std::getenv("SANDCASTLE")) || \
-    (std::getenv("TW_JOB_USER") && std::string(std::getenv("TW_JOB_USER")) == "sandcastle"));
+static inline bool isSandcastle() {
+  return (
+      (std::getenv("SANDCASTLE")) ||
+      (std::getenv("TW_JOB_USER") &&
+       std::string(std::getenv("TW_JOB_USER")) == "sandcastle"));
 }

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -79,7 +79,7 @@ std::ostream& operator<<(std::ostream& out, const std::vector<T>& list) {
   out << "}";
   return out;
 }
-auto ct = CodeTemplate(R"(
+static const auto ct = CodeTemplate(R"(
 int foo($args) {
 
     $bar
@@ -89,7 +89,7 @@ int foo($args) {
 int commatest(int a${,stuff})
 int notest(int a${,empty,})
 )");
-auto ct_expect = R"(
+static const auto ct_expect = R"(
 int foo(hi, 8) {
 
     what
@@ -475,7 +475,7 @@ void testRegisterFusionCachesKernel(std::ostream& out = std::cout) {
   ASSERT_EQ(second_key, expected_key);
 }
 
-const auto cf_examples = R"JIT(
+static const auto cf_examples = R"JIT(
   def if_test(a, b):
       # FIXME: use 0 instead of a.
       # c = 0

--- a/torch/csrc/jit/code_template.h
+++ b/torch/csrc/jit/code_template.h
@@ -97,7 +97,7 @@ struct TemplateEnv {
 struct CodeTemplate {
   /* implicit */ CodeTemplate(std::string t) : template_text(std::move(t)) {}
 
-  std::string format(const TemplateEnv& env) {
+  std::string format(const TemplateEnv& env) const {
     std::stringstream out;
     size_t pos = 0;
     size_t indent = 0;
@@ -141,7 +141,7 @@ struct CodeTemplate {
 
  private:
   using string_list = std::vector<std::string>;
-  char charAt(size_t p) {
+  char charAt(size_t p) const {
     if (p >= template_text.size())
       throw std::logic_error("EOS found in key");
     return template_text[p];
@@ -150,7 +150,7 @@ struct CodeTemplate {
       size_t pos,
       std::ostream& k,
       bool& comma_before,
-      bool& comma_after) {
+      bool& comma_after) const {
     comma_before = false;
     comma_after = false;
     pos++;
@@ -173,7 +173,7 @@ struct CodeTemplate {
       return parseIdent(pos, k);
     }
   }
-  size_t parseIdent(size_t pos, std::ostream& k) {
+  size_t parseIdent(size_t pos, std::ostream& k) const {
     while (pos < template_text.size() &&
            (isalnum(template_text[pos]) || template_text[pos] == '_')) {
       k << template_text[pos];
@@ -185,7 +185,7 @@ struct CodeTemplate {
       std::ostream& out,
       const string_list& strings,
       bool comma_before,
-      bool comma_after) {
+      bool comma_after) const {
     if (comma_before && strings.size() > 0)
       out << ", ";
     for (size_t i = 0; i < strings.size(); ++i) {
@@ -200,7 +200,7 @@ struct CodeTemplate {
   // leading or trailing newlines when the input string does not have leading
   // or trailing newlines. It's the responsibility of the calling function
   // to indent correctly in the context.
-  void emitIndent(std::ostream& out, size_t indent) {
+  void emitIndent(std::ostream& out, size_t indent) const {
     for (size_t i = 0; i < indent; ++i) {
       out << " ";
     }
@@ -208,7 +208,7 @@ struct CodeTemplate {
   void emitStringWithIndents(
       std::ostream& out,
       size_t indent,
-      const std::string& str) {
+      const std::string& str) const {
     for (auto c : str) {
       out << c;
       if (c == '\n') {
@@ -219,7 +219,7 @@ struct CodeTemplate {
   void emitLinesIndented(
       std::stringstream& out,
       size_t indent,
-      const string_list& strings) {
+      const string_list& strings) const {
     for (size_t i = 0; i < strings.size(); ++i) {
       if (i > 0)
         emitIndent(out, indent);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18121 [jit] fix double free in test_jit**

These definitions used to be in anonymous namespace so they weren't exported from the translation unit. #18071 put those in a `test` namespace so I guess they were getting their destructors called twice on exit somehow. Making them static again fixes the problem.

Differential Revision: [D14498349](https://our.internmc.facebook.com/intern/diff/D14498349)