### PR TITLE
fix -Wsign-compare warnings for some files inside c2

### DIFF
--- a/caffe2/core/blob_serialization.h
+++ b/caffe2/core/blob_serialization.h
@@ -162,7 +162,7 @@ inline void CopyToProtoAsIs(
       "The source type and dest type cannot be copied as-is. Did "
       "you mean CopyToProtoWithCast?");
   field->Reserve(size);
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     field->Add(0);
   }
   context->template CopyToCPU<SrcType>(
@@ -183,7 +183,7 @@ inline void CopyToProtoWithCast(
   context->template CopyToCPU<SrcType>(size, src, buffer.get());
   context->FinishDeviceComputation();
   field->Reserve(size);
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     field->Add(static_cast<DstType>(buffer[i]));
   }
 }
@@ -214,7 +214,7 @@ inline void CopyFromProtoWithCast(
   // CPUContext. Remove it if it is performance critical.
   unique_ptr<DstType[]> buffer(new DstType[size]);
   const SrcType* src = field.data();
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     buffer[i] = static_cast<DstType>(src[i]);
   }
   context->template CopyFromCPU<DstType>(size, buffer.get(), dst);

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -83,7 +83,7 @@ class IDEEPContext final : public BaseContext {
           static_cast<const void*>(src),
           static_cast<void*>(dst));
     } else {
-      for (int i = 0; i < n; ++i) {
+      for (size_t i = 0; i < n; ++i) {
         dst[i] = src[i];
       }
     }

--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -738,7 +738,7 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
   CAFFE_ENFORCE_EQ(C, filter.dim32(filter.dim() - 1) * group_);
 
   int kernel_dims_size = 1;
-  for (int i = 0; i < kernel_.size(); ++i) {
+  for (size_t i = 0; i < kernel_.size(); ++i) {
     CAFFE_ENFORCE_EQ(filter.dim32(i + 1), kernel_[i]);
     kernel_dims_size *= kernel_[i];
   }

--- a/caffe2/operators/conv_pool_op_base.h
+++ b/caffe2/operators/conv_pool_op_base.h
@@ -138,7 +138,7 @@ class ConvPoolOpBase : public Operator<Context> {
     }
 
     if (global_pooling_) {
-      for (int dim = 0; dim < kernel_.size(); ++dim) {
+      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
         CAFFE_ENFORCE(
             pads_[2 * dim] == 0 && pads_[2 * dim + 1] == 0 &&
                 dilation_[dim] == 1 && stride_[dim] == 1,
@@ -151,7 +151,7 @@ class ConvPoolOpBase : public Operator<Context> {
     // need to clean this up.
     if (operator_def.name().find("Conv") == 0 ||
         operator_def.name().find("Pool") != std::string::npos) {
-      for (int dim = 0; dim < kernel_.size(); ++dim) {
+      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
         CAFFE_ENFORCE_GE(pads_[dim], 0);
         CAFFE_ENFORCE_GE(pads_[kernel_.size() + dim], 0);
         CAFFE_ENFORCE(
@@ -161,7 +161,7 @@ class ConvPoolOpBase : public Operator<Context> {
       }
     }
 
-    for (int dim = 0; dim < kernel_.size(); ++dim) {
+    for (size_t dim = 0; dim < kernel_.size(); ++dim) {
       CAFFE_ENFORCE_GE(kernel_[dim], 0);
       CAFFE_ENFORCE_GE(dilation_[dim], 0);
       CAFFE_ENFORCE_GE(stride_[dim], 0);
@@ -408,7 +408,7 @@ class ConvPoolOpBase : public Operator<Context> {
 
   bool RunOnDevice() override {
     if (!global_pooling_) {
-      for (int dim = 0; dim < kernel_.size(); ++dim) {
+      for (size_t dim = 0; dim < kernel_.size(); ++dim) {
         CAFFE_ENFORCE_GT(kernel_[dim], 0);
       }
     }

--- a/caffe2/operators/ctc_greedy_decoder_op.cc
+++ b/caffe2/operators/ctc_greedy_decoder_op.cc
@@ -57,7 +57,7 @@ bool CTCGreedyDecoderOp<CPUContext>::RunOnDevice() {
   auto* values =
       Output(VALUES, vector<int64_t>{values_cach_size}, at::dtype<int>());
   int* values_data = values->mutable_data<int>();
-  for (int i = 0; i < values_cach.size(); ++i) {
+  for (size_t i = 0; i < values_cach.size(); ++i) {
     values_data[i] = values_cach.at(i);
   }
   values_cach.clear();

--- a/caffe2/operators/dataset_ops.cc
+++ b/caffe2/operators/dataset_ops.cc
@@ -30,7 +30,7 @@ TreeIterator::TreeIterator(const std::vector<std::string>& fields) {
   // populate field vector and split field names
   fields_.resize(fields.size());
   std::vector<std::vector<std::string>> nameParts(fields_.size());
-  for (int i = 0; i < fields.size(); ++i) {
+  for (size_t i = 0; i < fields.size(); ++i) {
     auto& field = fields_.at(i);
     field.name = fields[i];
     field.id = i;
@@ -49,7 +49,7 @@ TreeIterator::TreeIterator(const std::vector<std::string>& fields) {
   // find length-field with maximum prefix matching for each field
   for (auto& field : fields_) {
     // by default, we are matching against the root domain
-    int maxMatchLevel = 1;
+    size_t maxMatchLevel = 1;
     int maxMatchLengthFieldId = -1;
     for (int j = 0; j < numLengthFields(); ++j) {
       const auto& lenField = lengthField(j);
@@ -260,12 +260,12 @@ class CheckDatasetConsistencyOp : public Operator<CPUContext> {
     sizes.resize(iterator_.numOffsetFields());
     // gather length data
     lengths.resize(iterator_.numLengthFields());
-    for (int i = 0; i < lengths.size(); ++i) {
+    for (size_t i = 0; i < lengths.size(); ++i) {
       lengths[i] = Input(iterator_.lengthField(i).id).data<TLength>();
     }
     // gather size limits
     limits.assign(sizes.size(), std::numeric_limits<TOffset>::max());
-    for (int i = 0; i < iterator_.fields().size(); ++i) {
+    for (size_t i = 0; i < iterator_.fields().size(); ++i) {
       int lengthIdx = iterator_.fields()[i].lengthFieldId + 1;
       CAFFE_ENFORCE_GT(Input(i).dim(), 0);
       TOffset size = (TOffset)Input(i).sizes()[0];
@@ -290,7 +290,7 @@ class CheckDatasetConsistencyOp : public Operator<CPUContext> {
     // advance to the end
     offsets.assign(sizes.size(), 0);
     iterator_.advance(lengths, offsets, sizes, limits, limits[0]);
-    for (int i = 0; i < limits.size(); ++i) {
+    for (size_t i = 0; i < limits.size(); ++i) {
       CAFFE_ENFORCE(limits[i] == offsets[i]);
     }
     return true;

--- a/caffe2/operators/expand_squeeze_dims_op.h
+++ b/caffe2/operators/expand_squeeze_dims_op.h
@@ -89,9 +89,9 @@ class SqueezeOp : public Operator<Context> {
   static std::vector<int> ComputeDims(
       at::IntArrayRef inputDims,
       std::vector<int> dims) {
-    int j = 0;
+    size_t j = 0;
     std::vector<int> newDims;
-    for (int i = 0; i < inputDims.size(); ++i) {
+    for (size_t i = 0; i < inputDims.size(); ++i) {
       if (j < dims.size() && dims[j] == i) {
         CAFFE_ENFORCE_EQ(
             inputDims[i],

--- a/caffe2/operators/experimental/c10/cpu/concat_cpu.cc
+++ b/caffe2/operators/experimental/c10/cpu/concat_cpu.cc
@@ -27,7 +27,7 @@ void concat_op_cpu_impl(
   int adj_size = Tensor(inputs[0]).dim() + (add_axis ? 1 : 0);
   int canonical_axis = caffe2::canonical_axis_index_(axis, adj_size);
   CAFFE_ENFORCE_LT(canonical_axis, adj_size, "Axis not in input ndim range.");
-  for (int i = 1; i < inputs.size(); ++i) {
+  for (size_t i = 1; i < inputs.size(); ++i) {
     CAFFE_ENFORCE(
         Tensor(inputs[i]).dtype() == Tensor(inputs[0]).dtype(),
         "All inputs must have the same type, expected: ",
@@ -51,7 +51,7 @@ void concat_op_cpu_impl(
       after *= dim;
     }
     // check the input dims are compatible.
-    for (int j = 1; j < inputs.size(); ++j) {
+    for (size_t j = 1; j < inputs.size(); ++j) {
       int dim_j = Tensor(inputs[j]).dim32(i);
       CAFFE_ENFORCE(
           dim == dim_j,
@@ -75,7 +75,7 @@ void concat_op_cpu_impl(
   }
 
   int output_channels = 0;
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (size_t i = 0; i < inputs.size(); ++i) {
     axis_data[i] = add_axis ? 1 : Tensor(inputs[i]).dim32(canonical_axis);
     output_channels += axis_data[i];
   }
@@ -86,7 +86,7 @@ void concat_op_cpu_impl(
   }
   output.Resize(output_dims);
   size_t output_offset = 0;
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (size_t i = 0; i < inputs.size(); ++i) {
     Tensor input(inputs[i]);
     auto axis_dim = add_axis ? 1 : input.dim32(canonical_axis);
     caffe2::math::CopyMatrix<Context>(

--- a/caffe2/operators/find_duplicate_elements_op.h
+++ b/caffe2/operators/find_duplicate_elements_op.h
@@ -43,7 +43,7 @@ class FindDuplicateElementsOp final : public Operator<Context> {
 
     auto* output = Output(0, {static_cast<int64_t>(dupSize)}, at::dtype<int64_t>());
     auto* out_ptr = output->template mutable_data<int64_t>();
-    for (int64_t i = 0; i < dupSize; ++i) {
+    for (size_t i = 0; i < dupSize; ++i) {
       out_ptr[i] = dupIndices[i];
     }
 

--- a/caffe2/operators/onnxifi_op.h
+++ b/caffe2/operators/onnxifi_op.h
@@ -56,7 +56,7 @@ class OnnxifiOp final : public Operator<Context> {
       if (!output_shape_hint.empty()) {
         TensorInfo info;
         info.onnxifi_type = output_shape_hint.front();
-        for (int i = 1; i < output_shape_hint.size(); ++i) {
+        for (size_t i = 1; i < output_shape_hint.size(); ++i) {
           info.dims.push_back(output_shape_hint[i]);
         }
         output_shape_hints_.emplace(output_idx, std::move(info));

--- a/caffe2/operators/reshape_op.h
+++ b/caffe2/operators/reshape_op.h
@@ -59,7 +59,7 @@ class ReshapeOp : public Operator<Context> {
     }
 
     // Copy over the dimensions for those that are specified zero.
-    for (int i = 0; i < actual_new_shape.size() && i < input.dim(); ++i) {
+    for (size_t i = 0; i < actual_new_shape.size() && i < input.dim(); ++i) {
       if (actual_new_shape[i] == 0) {
         actual_new_shape[i] = input.size(i);
       }

--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -129,7 +129,7 @@ bool SliceImpl(
 
     char* src_offset_bytes = src_bytes + itemsize * src_offset;
     char* dst_offset_bytes = dst_bytes;
-    for (int i = 0; i < num_blocks; ++i) {
+    for (size_t i = 0; i < num_blocks; ++i) {
       char* local_src_offset_bytes =
           src_offset_bytes + i * src_block_size_bytes;
       char* local_dst_offset_bytes =
@@ -175,7 +175,7 @@ bool SliceImpl(
       return true;
     }
 
-    for (int i = 0; i < num_blocks; ++i) {
+    for (size_t i = 0; i < num_blocks; ++i) {
       char* local_src_offset_bytes =
           src_offset_bytes + i * src_block_size_bytes;
       char* local_dst_offset_bytes =

--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -1107,7 +1107,7 @@ class GatherRangesOp : public Operator<Context> {
   template <typename Index>
   size_t accumulate(Index* ranges, size_t start, size_t end) {
     size_t result = 0;
-    for (int i = start + 1; i < end; i += 2) {
+    for (size_t i = start + 1; i < end; i += 2) {
       result += ranges[i];
     }
     return result;

--- a/caffe2/queue/blobs_queue.cc
+++ b/caffe2/queue/blobs_queue.cc
@@ -36,10 +36,10 @@ BlobsQueue::BlobsQueue(
     stats_.queue_dequeued_bytes.setDetails(fieldNames);
   }
   queue_.reserve(capacity);
-  for (auto i = 0; i < capacity; ++i) {
+  for (size_t i = 0; i < capacity; ++i) {
     std::vector<Blob*> blobs;
     blobs.reserve(numBlobs);
-    for (auto j = 0; j < numBlobs; ++j) {
+    for (size_t j = 0; j < numBlobs; ++j) {
       const auto blobName = queueName + "_" + to_string(i) + "_" + to_string(j);
       if (enforceUniqueName) {
         CAFFE_ENFORCE(

--- a/caffe2/queue/rebatching_queue.cc
+++ b/caffe2/queue/rebatching_queue.cc
@@ -19,7 +19,7 @@ void concat(
   // Precompute the output sizes to avoid resizing
   std::vector<std::vector<int64_t>> outputDims(numTensors);
 
-  for (int i = 0; i < numTensors; ++i) {
+  for (size_t i = 0; i < numTensors; ++i) {
     SmartTensorPrinter::PrintTensor(inputZero.at(i));
     outputDims[i] = inputZero.at(i).sizes().vec();
     outputDims[i].insert(outputDims[i].begin(), numRows);
@@ -27,12 +27,12 @@ void concat(
 
   // Resize to the final output size
   std::vector<void*> destinations(numTensors);
-  for (int i = 0; i < numTensors; ++i) {
+  for (size_t i = 0; i < numTensors; ++i) {
     outputs[i]->Resize(outputDims[i]);
     destinations[i] = outputs[i]->raw_mutable_data(inputZero[i].meta());
   }
 
-  for (int i = 0; i < numRows; ++i) {
+  for (size_t i = 0; i < numRows; ++i) {
     CAFFE_ENFORCE_EQ(inputs[i].size(), numTensors);
 
     for (int j = 0; j < numTensors; ++j) {

--- a/caffe2/transforms/pattern_net_transform.h
+++ b/caffe2/transforms/pattern_net_transform.h
@@ -28,7 +28,7 @@ class CAFFE2_API PatternNetTransform : public Transform {
         "External outputs do not match!");
     ordered_ops_ = GetPatternTraversalOrder(p_);
     inverse_ops_.resize(ordered_ops_.size());
-    for (int i = 0; i < ordered_ops_.size(); i++) {
+    for (size_t i = 0; i < ordered_ops_.size(); i++) {
       inverse_ops_[ordered_ops_[i]] = i;
     }
   }


### PR DESCRIPTION
Summary:
the motivation of this fix is to resolve things like:
for(auto i = 0; i < N; i++) where N is bigger than int32

These instances of comparison were found by enabling -Wsign-compare

There are way too many things to fix, so issuing this as a series of fixes

The plan is to fix all these issues and then enable this flag into Caffe2 to catch future instances

Differential Revision: D14497094
