### PR TITLE
caffe2 - enable caffe2_operator_throw_if_fp_exceptions in unit tests

### DIFF
--- a/caffe2/contrib/gloo/gloo_test.py
+++ b/caffe2/contrib/gloo/gloo_test.py
@@ -15,7 +15,7 @@ import pickle
 import tempfile
 import shutil
 
-from caffe2.python import core, workspace, dyndep
+from caffe2.python import core, test_util, workspace, dyndep
 import caffe2.python.hypothesis_test_util as hu
 from gloo.python import IoError
 
@@ -321,6 +321,7 @@ class TestCase(hu.HypothesisTestCase):
                     workspace.FetchBlob(blobs[i]),
                     (num_blobs * comm_size) * (num_blobs * comm_size - 1) / 2)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(comm_size=st.integers(min_value=2, max_value=8),
            blob_size=st.integers(min_value=1e3, max_value=1e6),
            num_blobs=st.integers(min_value=1, max_value=4),
@@ -409,6 +410,7 @@ class TestCase(hu.HypothesisTestCase):
         for _tmp in range(4):
             workspace.RunNet(net.Name())
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(comm_size=st.integers(min_value=2, max_value=8),
            blob_size=st.integers(min_value=1e3, max_value=1e6),
            num_blobs=st.integers(min_value=1, max_value=4),

--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -12,7 +12,7 @@ import hypothesis.strategies as st
 import unittest
 import os
 
-from caffe2.python import core, workspace, tt_core, dyndep
+from caffe2.python import core, test_util, workspace, tt_core, dyndep
 import caffe2.python.hypothesis_test_util as hu
 from caffe2.proto import caffe2_pb2
 
@@ -566,6 +566,7 @@ class TestOperators(hu.HypothesisTestCase):
         w[np.abs(z) <= lambda1] = 0
         return (w, np.stack([n, z], axis=-1))
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            in_place=st.booleans(),
            alpha=st.floats(min_value=0.01, max_value=0.1),
@@ -634,6 +635,7 @@ class TestOperators(hu.HypothesisTestCase):
         z = z.reshape(old_shape)
         return (w, np.stack([n, z], axis=-1))
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            in_place=st.booleans(),
            alpha=st.floats(min_value=0.01, max_value=0.1),
@@ -662,6 +664,7 @@ class TestOperators(hu.HypothesisTestCase):
             gc, op, [var, nz, grad],
             partial(self._dense_gftrl, alpha, beta, lambda1, lambda2))
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            alpha=st.floats(min_value=0.01, max_value=0.1),
            beta=st.floats(min_value=0.1, max_value=0.9),
@@ -704,6 +707,7 @@ class TestOperators(hu.HypothesisTestCase):
         return TestOperators._dense_ftrl(alpha, beta, lambda1, lambda2, w, nz,
                                          g)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            in_place=st.booleans(),
            alpha=st.floats(min_value=0.01, max_value=0.1),
@@ -733,6 +737,7 @@ class TestOperators(hu.HypothesisTestCase):
             gc, op, [var, nz, grad, alpha],
             partial(self._dense_ftrl_send_alpha_by_input, beta, lambda1, lambda2))
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            alpha=st.floats(min_value=0.01, max_value=0.1),
            beta=st.floats(min_value=0.1, max_value=0.9),
@@ -1140,6 +1145,7 @@ class TestOperators(hu.HypothesisTestCase):
             inputs=[input_tensor],
             reference=sin_ref)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(input_tensor=hu.arrays(
         dims=[10], elements=st.floats(allow_nan=False,
                                       allow_infinity=False)),

--- a/caffe2/python/models/resnet_test.py
+++ b/caffe2/python/models/resnet_test.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import numpy as np
 import time
 
-from caffe2.python import workspace, cnn, memonger, core
+from caffe2.python import workspace, cnn, memonger, core, test_util
 import caffe2.python.models.resnet as resnet
 import hypothesis.strategies as st
 from hypothesis import given, settings
@@ -106,6 +106,7 @@ class ResnetMemongerTest(hu.HypothesisTestCase):
         np.testing.assert_almost_equal(loss1, optimized_loss1)
         np.testing.assert_almost_equal(conv1_w_grad, optim_conv1_w_grad)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     def test_resnet_forward_only(self):
         model = cnn.CNNModelHelper(
             order="NCHW",
@@ -145,6 +146,7 @@ class ResnetMemongerTest(hu.HypothesisTestCase):
         self.assertTrue(num_shared_blobs < 7 and num_shared_blobs > 0)
         np.testing.assert_almost_equal(loss1, optimized_loss1)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     def test_resnet_forward_only_fast_simplenet(self):
         '''
         Test C++ memonger that is only for simple nets

--- a/caffe2/python/operator_test/adadelta_test.py
+++ b/caffe2/python/operator_test/adadelta_test.py
@@ -10,7 +10,7 @@ from hypothesis import given, settings, HealthCheck
 import hypothesis.strategies as st
 import numpy as np
 
-from caffe2.python import core
+from caffe2.python import core, test_util
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
@@ -45,6 +45,7 @@ class TestAdadelta(serial.SerializedTestCase):
             return (param_out.astype(np.float32), mom_out.astype(np.float32),
                     mom_delta_out.astype(np.float32))
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @serial.given(inputs=hu.tensors(n=4),
            lr=st.floats(min_value=0.01, max_value=0.99,
                         allow_nan=False, allow_infinity=False),
@@ -73,6 +74,7 @@ class TestAdadelta(serial.SerializedTestCase):
 
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
+    @test_util.caffe2_disable_fp_exceptions_throw
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
     @given(inputs=hu.tensors(n=4),
            lr=st.floats(min_value=0.01, max_value=0.99,

--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -10,7 +10,7 @@ from hypothesis import given
 import hypothesis.strategies as st
 import numpy as np
 
-from caffe2.python import core
+from caffe2.python import core, test_util
 import caffe2.python.hypothesis_test_util as hu
 
 
@@ -47,6 +47,7 @@ class TestAdam(hu.HypothesisTestCase):
         else:
             return param_out, mom1_out, mom2_out
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            ITER=st.integers(min_value=0, max_value=10000),
            LR=st.floats(min_value=0.01, max_value=0.99,
@@ -80,6 +81,7 @@ class TestAdam(hu.HypothesisTestCase):
                 beta1=beta1, beta2=beta2, epsilon=epsilon),
             input_device_options=input_device_options)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(inputs=hu.tensors(n=4),
            ITER=st.integers(min_value=0, max_value=10000),
            LR=st.floats(min_value=0.01, max_value=0.99,

--- a/caffe2/python/operator_test/batch_box_cox_test.py
+++ b/caffe2/python/operator_test/batch_box_cox_test.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.python import core
+from caffe2.python import core, test_util
 from hypothesis import given
 
 import caffe2.python.hypothesis_test_util as hu
@@ -53,6 +53,7 @@ def _inputs(draw):
 
 
 class TestBatchBoxCox(serial.SerializedTestCase):
+    @test_util.caffe2_disable_fp_exceptions_throw
     @serial.given(
         inputs=_inputs(),
         **hu.gcs_cpu_only
@@ -60,6 +61,7 @@ class TestBatchBoxCox(serial.SerializedTestCase):
     def test_batch_box_cox(self, inputs, gc, dc):
         self.batch_box_cox(inputs, gc, dc)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(**hu.gcs_cpu_only)
     def test_lambda1_is_all_zero(self, gc, dc):
         inputs = (1, 1, [[2]], [0], [0])
@@ -71,6 +73,7 @@ class TestBatchBoxCox(serial.SerializedTestCase):
         inputs = (2, 3, [[1, 2, 3], [4, 5, 6]], [0, 0, 0], [0, 0, 0])
         self.batch_box_cox(inputs, gc, dc)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(**hu.gcs_cpu_only)
     def test_lambda1_is_partially_zero(self, gc, dc):
         inputs = (1, 5, [[1, 2, 3, 4, 5]],
@@ -86,6 +89,7 @@ class TestBatchBoxCox(serial.SerializedTestCase):
                   [0, -.5, 0, .5, 0, 1, 0], [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         self.batch_box_cox(inputs, gc, dc)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(**hu.gcs_cpu_only)
     def test_bound_base_away_from_zero(self, gc, dc):
         inputs = (2, 3, [[1e-5, 1e-6, 1e-7], [1e-7, -1e-6, 1e-5]],

--- a/caffe2/python/operator_test/elementwise_op_broadcast_test.py
+++ b/caffe2/python/operator_test/elementwise_op_broadcast_test.py
@@ -10,7 +10,7 @@ import numpy as np
 import operator
 
 from caffe2.proto import caffe2_pb2
-from caffe2.python import core, workspace
+from caffe2.python import core, test_util, workspace
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
@@ -86,6 +86,7 @@ class TestElementwiseBroadcast(serial.SerializedTestCase):
     def test_broadcast_Sub(self, gc, dc):
         self.__test_binary_op(gc, dc, "Sub", operator.sub)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @serial.given(**hu.gcs)
     def test_broadcast_powt(self, gc, dc):
         np.random.seed(101)

--- a/caffe2/python/operator_test/elementwise_ops_test.py
+++ b/caffe2/python/operator_test/elementwise_ops_test.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.python import core, workspace
+from caffe2.python import core, test_util, workspace
 from hypothesis import given, assume
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
@@ -54,6 +54,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         self.assertDeviceChecks(dc, op, [X], [0])
         self.assertGradientChecks(gc, op, [X], 0, [0])
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(n=st.integers(0, 6), m=st.integers(4, 6),
            seed=st.integers(0, 1000), **hu.gcs)
     def test_log(self, n, m, gc, dc, seed):
@@ -79,6 +80,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         self.assertGradientChecks(
             gc, op, [X], 0, [0], stepsize=1e-4, threshold=1e-2)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(n=st.integers(0, 10), m=st.integers(4, 6),
            d=st.integers(2, 3), seed=st.integers(0, 1000), **hu.gcs)
     def test_powt(self, n, m, d, gc, dc, seed):
@@ -231,6 +233,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         )
         self.assertDeviceChecks(dc, op, [X], [0])
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(X=hu.tensor(dtype=np.float32), in_place=st.booleans(), **hu.gcs)
     def test_cbrt(self, X, in_place, gc, dc):
         op = core.CreateOperator(
@@ -556,6 +559,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         self._test_binary_op("Mul", np.multiply, n, m,
                              k, t, -0.5, True, gc, dc)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(n=st.integers(0, 5), m=st.integers(0, 5), k=st.integers(0, 5),
            t=st.integers(0, 5), **hu.gcs)
     def test_div(self, n, m, k, t, gc, dc):
@@ -563,6 +567,7 @@ class TestElementwiseOps(hu.HypothesisTestCase):
         self._test_binary_op_in_place(
             "Div", np.divide, n, m, 1.0, True, False, gc, dc)
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(n=st.integers(1, 5), m=st.integers(1, 5), broadcast=st.booleans(),
            **hu.gcs)
     def test_div_legacy_grad(self, n, m, broadcast, gc, dc):

--- a/caffe2/python/operator_test/locally_connected_op_test.py
+++ b/caffe2/python/operator_test/locally_connected_op_test.py
@@ -6,12 +6,13 @@ import numpy as np
 from hypothesis import given
 import hypothesis.strategies as st
 
-from caffe2.python import core, utils
+from caffe2.python import core, test_util, utils
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
 
 class TestLocallyConnectedOp(serial.SerializedTestCase):
+    @test_util.caffe2_disable_fp_exceptions_throw
     @serial.given(N=st.integers(1, 3),
            C=st.integers(1, 3),
            H=st.integers(1, 5),

--- a/caffe2/python/operator_test/math_ops_test.py
+++ b/caffe2/python/operator_test/math_ops_test.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.python import core
+from caffe2.python import core, test_util
 from hypothesis import given
 from hypothesis import strategies as st
 import caffe2.python.hypothesis_test_util as hu
@@ -15,6 +15,7 @@ import unittest
 
 class TestMathOps(serial.SerializedTestCase):
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     @given(X=hu.tensor(),
            exponent=st.floats(min_value=2.0, max_value=3.0),
            **hu.gcs)

--- a/caffe2/python/operator_test/pack_ops_test.py
+++ b/caffe2/python/operator_test/pack_ops_test.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.python import core, workspace
+from caffe2.python import core, test_util, workspace
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
 
@@ -184,6 +184,7 @@ class TestTensorPackOps(serial.SerializedTestCase):
             device_option=gc))
         assert((workspace.FetchBlob('newd') == workspace.FetchBlob('d')).all())
 
+    @test_util.caffe2_disable_fp_exceptions_throw
     def test_pad_minf(self):
         workspace.FeedBlob('l', np.array([1, 2, 3], dtype=np.int32))
         workspace.FeedBlob(

--- a/caffe2/python/optimizer_test.py
+++ b/caffe2/python/optimizer_test.py
@@ -11,7 +11,7 @@ from caffe2.python.optimizer_context import UseOptimizer
 from caffe2.python.optimizer_test_util import (
     OptimizerTestBase, LRModificationTestBase
 )
-from caffe2.python import core, workspace
+from caffe2.python import core, test_util, workspace
 from caffe2.python.test_util import TestCase
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -33,6 +33,10 @@ class TestLars(OptimizerTestBase, TestCase):
         for param in optimizer.get_auxiliary_parameters().shared:
             tensor = workspace.FetchBlob(param)
             np.testing.assert_allclose(np.array([1.0]), tensor, atol=1e-5)
+
+    @test_util.caffe2_disable_fp_exceptions_throw
+    def testDense(self):
+        super(TestLars, self).testDense()
 
 
 class TestMomentumSgd(OptimizerTestBase, TestCase):
@@ -135,6 +139,18 @@ class TestAdagrad(OptimizerTestBase, LRModificationTestBase, TestCase):
         self.assertTrue(optimizer.get_auxiliary_parameters().local)
         for param in optimizer.get_auxiliary_parameters().local:
             workspace.FetchBlob(param)
+
+    @test_util.caffe2_disable_fp_exceptions_throw
+    def testDense(self):
+        super(TestAdagrad, self).testDense()
+
+    @test_util.caffe2_disable_fp_exceptions_throw
+    def test_lr_injection(self):
+        super(TestAdagrad, self).test_lr_injection()
+
+    @test_util.caffe2_disable_fp_exceptions_throw
+    def test_global_norm_based_gradient_clipping(self):
+        super(TestAdagrad, self).test_global_norm_based_gradient_clipping()
 
 
 class TestRowWiseAdagrad(OptimizerTestBase, TestCase):


### PR DESCRIPTION
Summary: Enable unit test failures when floating point exceptions are detected

Differential Revision: D14506293
