### PR TITLE
Enable flake8-bugbear line length checking.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,10 @@
 [flake8]
+select = B,C,E,F,P,T4,W,B9
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
-ignore = E203,E305,E402,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504,C408
+# E501 is not flexible enough, we're using B950 instead
+ignore =
+    E203,E305,E402,E501,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504,C408,
+    # ignores below are temporary, fix them and remove please!
+    B005,B006,B007,B008,B902,B903
 exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install,build,torch/include

--- a/.jenkins/pytorch/perf_test/compare_with_baseline.py
+++ b/.jenkins/pytorch/perf_test/compare_with_baseline.py
@@ -62,8 +62,10 @@ print("z-value: ", z_value)
 if z_value >= 3:
     raise Exception('''\n
 z-value >= 3, there is high chance of perf regression.\n
-To reproduce this regression, run `cd .jenkins/pytorch/perf_test/ && bash ''' + test_name + '''.sh` on your local machine and compare the runtime before/after your code change.
-''')
+To reproduce this regression, run
+`cd .jenkins/pytorch/perf_test/ && bash {}.sh` on your local machine
+and compare the runtime before/after your code change.
+'''.format(test_name))
 else:
     print("z-value < 3, no perf regression detected.")
     if args.update:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
         script: cd .circleci && ./ensure-consistency.py
       - name: "Python 2.7 Lint"
         python: "2.7"
-        install: pip install flake8
+        install: pip install flake8 flake8-bugbear
         script: flake8
       - name: "Python 3.7 Lint"
         python: "3.7"
         dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
         sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
-        install: pip install flake8-mypy
+        install: pip install flake8-mypy flake8-bugbear
         script: flake8
       - name: "MyPy typecheck"
         python: "3.6"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #18184 Fix B903 lint: save memory for data classes with slots/namedtuple
* #18181 Fix B902 lint error: invalid first argument.
* #18178 Fix B006 lint errors: using mutable structure in default argument.
* #18177 Fix lstrip bug revealed by B005 lint
* **#18138 Enable flake8-bugbear line length checking.**

flake8-bugbear's line length checker (B950) which permits violations
of up to 10% but specifies the "true" limit when you go over.

I had to ignore a bunch of flake8-bugbear's other checks when I
turned this on.  They're good checks though (they're turned on
in fbcode) and we should fix them eventually.

Local manual tests:

```
(/Users/ezyang/Dev/pytorch-tmp-env) macbook-pro-116:pytorch-tmp ezyang$ tail -n1 test/test_torch.py
# 34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123
(/Users/ezyang/Dev/pytorch-tmp-env) macbook-pro-116:pytorch-tmp ezyang$ flake8 test/test_torch.py 
test/test_torch.py:10608:134: B950 line too long (133 > 120 characters)
(/Users/ezyang/Dev/pytorch-tmp-env) macbook-pro-116:pytorch-tmp ezyang$ tail -n1 test/test_torch.py 
# 3456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
(/Users/ezyang/Dev/pytorch-tmp-env) macbook-pro-116:pytorch-tmp ezyang$ flake8 test/test_torch.py 
(/Users/ezyang/Dev/pytorch-tmp-env) macbook-pro-116:pytorch-tmp ezyang$
```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14508678](https://our.internmc.facebook.com/intern/diff/D14508678)