### PR TITLE
Update argument names of torch::autograd::FunctionPostHook

### DIFF
--- a/torch/csrc/autograd/function_hook.h
+++ b/torch/csrc/autograd/function_hook.h
@@ -16,7 +16,9 @@ struct FunctionPreHook {
 
 struct FunctionPostHook {
   virtual ~FunctionPostHook() = default;
-  virtual variable_list operator()(const variable_list& grad_input, const variable_list& grad_output) = 0;
+  virtual variable_list operator()(
+    const variable_list& outputs /* grad_inputs */,
+    const variable_list& inputs /* grad_outputs */) = 0;
 };
 
 }} // namespace torch::autograd


### PR DESCRIPTION
They are called as (outputs, inputs) and were named (inputs, outputs).

Possible follow up fix is to make the outputs argument an lvalue to allow for calling multiple post hooks without ever copying outputs vector. It looks like the copy is now forced because the hook takes a const reference as input and returns an value. This would change the prototype of the function, so needs further discussion.

