### PR TITLE
Stop generating unimplemented type methods.

### DIFF
--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -391,8 +391,6 @@ def run(paths):
                 declaration['arguments'] = func.get('arguments', arguments)
                 declaration['type_method_definition_dispatch'] = func.get('dispatch', declaration['name'])
                 declaration['python_module'] = func.get('python_module', '')
-                declaration['aten_sparse'] = has_sparse_dispatches(
-                    declaration['type_method_definition_dispatch'])
                 declarations.append(declaration)
             except Exception as e:
                 msg = '''Exception raised in processing function:

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -25,11 +25,6 @@ type_map['all'] = all_types
 all_backends = ['CPU', 'CUDA', 'SparseCPU', 'SparseCUDA']
 default_backends = ['CPU', 'CUDA']
 
-sparse_map = {
-    'CPU': 'SparseCPU',
-    'CUDA': 'SparseCUDA',
-}
-
 
 def process_types_and_backends(option):
     # if specific pairs were not listed, then enumerate them
@@ -37,8 +32,8 @@ def process_types_and_backends(option):
     # if backend or type is not defined, it is assumed to be all of them
     if 'backend_type_pairs' not in option:
         backends = option.get('backends', default_backends)
-        if option.get('aten_sparse', False):
-            backends.extend([sparse_map[p] for p in backends if p in sparse_map])
+        if isinstance(option.get('type_method_definition_dispatch'), dict):
+            backends = option.get('type_method_definition_dispatch').keys()
         backends = set(backends)
 
         types = option.get('types', all_types)


### PR DESCRIPTION
This gets rid of 'aten_sparse' which was used at one time with legacy THS code, but is now only overloaded in native_parse.py.
The way that 'aten_sparse' worked was wonky -- it extended all backends (default [CPU, CUDA]) to include sparse.
But this is totally unnecessary; we already have the backends we need to generate for from type_method_definition_dispatch.

codegen changes: https://github.com/gchanan/pytorch/blob/fc37c8e171b7ebd1b1755469cf6a146a2abedc13/diff.txt