### PR TITLE
[jit] fix bug in alias analysis

### DIFF
--- a/test/cpp/jit/test_alias_analysis.h
+++ b/test/cpp/jit/test_alias_analysis.h
@@ -507,25 +507,41 @@ void testWildcards() {
   const auto fresh = graph->insert(aten::rand, {constant});
   const auto fresh2 = graph->insert(aten::rand, {constant});
   const auto wildcard = graph->insert(returns_wildcard, {fresh});
+
+  {
+    graph->lint();
+    AliasDb aliasDb(graph);
+
+    ASSERT_FALSE(aliasDb.mayAlias(a, fresh));
+    ASSERT_TRUE(aliasDb.mayAlias(wildcard, fresh));
+    ASSERT_TRUE(aliasDb.mayAlias(wildcard, a));
+    ASSERT_FALSE(aliasDb.mayAlias(
+        std::unordered_set<const Value*>({wildcard}),
+        std::unordered_set<const Value*>()));
+    ASSERT_FALSE(aliasDb.hasWriters(wildcard->node()));
+  }
+
+  graph->insert(writes, {fresh2})->node();
+  {
+    graph->lint();
+    AliasDb aliasDb(graph);
+    // Any write should be considered a write to the wildcard
+    ASSERT_TRUE(aliasDb.hasWriters(wildcard->node()));
+  }
+
   const auto wildcardWrite = graph->insert(writes, {wildcard})->node();
-
-  graph->lint();
-  AliasDb aliasDb(graph);
-
-  ASSERT_FALSE(aliasDb.mayAlias(a, fresh));
-  ASSERT_TRUE(aliasDb.mayAlias(wildcard, fresh));
-  ASSERT_TRUE(aliasDb.mayAlias(wildcard, a));
-  ASSERT_FALSE(aliasDb.mayAlias(
-      std::unordered_set<const Value*>({wildcard}),
-      std::unordered_set<const Value*>()));
-
-  // Test writes to wildcards
-  ASSERT_TRUE(aliasDb.writesToAlias(
-      wildcardWrite, std::unordered_set<const Value*>{fresh}));
-  ASSERT_TRUE(aliasDb.writesToAlias(
-      wildcardWrite, std::unordered_set<const Value*>{fresh2}));
-  ASSERT_TRUE(aliasDb.writesToAlias(
-      wildcardWrite, std::unordered_set<const Value*>{a}));
+  {
+    graph->lint();
+    AliasDb aliasDb(graph);
+    // Test writes to wildcards
+    ASSERT_TRUE(aliasDb.writesToAlias(
+        wildcardWrite, std::unordered_set<const Value*>{fresh}));
+    ASSERT_TRUE(aliasDb.writesToAlias(
+        wildcardWrite, std::unordered_set<const Value*>{fresh2}));
+    ASSERT_TRUE(aliasDb.writesToAlias(
+        wildcardWrite, std::unordered_set<const Value*>{a}));
+    ASSERT_TRUE(aliasDb.hasWriters(wildcard->node()));
+  }
 }
 
 void testMemoryDAG() {

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -91,7 +91,7 @@ bool AliasDb::hasWriters(const Value* v) const {
     // If `n` has a wildcard, any write in the graph may write to it.
     // So the only way we know there are no writers is if there are no writes
     // at all.
-    return numWrites_ == 0;
+    return numWrites_ != 0;
   }
 
   if (!elementMap_.count(v)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18146 [jit] fix bug in alias analysis**

We handled hasWriters() incorrectly in the case of wildcards. There's
even a comment describing the correct behavior. Sad!

Much thanks to @t-vi for tracking this down and suggesting the fix!

Differential Revision: [D14524208](https://our.internmc.facebook.com/intern/diff/D14524208)