### PR TITLE
[jit] Support attributes when emitting function calls

### DIFF
--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -55,6 +55,7 @@ Value* try_emit_call_to(
           << " attempting to call a method with parameters/attributes"
              " from a raw graph. File a bug report";
     }
+    // TODO: preserve the type information so we don't have to infer it here
     auto type = incompleteInferTypeFrom(*member);
     matched_schema->inputs.push_back(
         caller->get_or_add_attribute(type, member));

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -55,7 +55,9 @@ Value* try_emit_call_to(
           << " attempting to call a method with parameters/attributes"
              " from a raw graph. File a bug report";
     }
-    matched_schema->inputs.push_back(caller->get_or_add_parameter(member));
+    auto type = incompleteInferTypeFrom(*member);
+    matched_schema->inputs.push_back(
+        caller->get_or_add_attribute(type, member));
   }
   callee.check_single_output();
   return inlineCallTo(graph, *callee.graph(), matched_schema->inputs).at(0);


### PR DESCRIPTION
The type of each `initial_ivalue` is completely known at some point but that information is discarded by the time a call to it is emitted. This PR is kind of a hack, as a better (longer) solution, the method should know about the type of each initial value.