### PR TITLE
Better error when module attr is used

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6365,6 +6365,21 @@ a")
         with self.assertRaisesRegex(RuntimeError, "Did you forget to add it to __constants"):
             a = M(nn.ModuleList([nn.ReLU()]))
 
+    def test_attr_module_constants_error(self):
+        class M2(torch.jit.ScriptModule):
+            def __init__(self, mod_list):
+                super(M2, self).__init__(False)
+                self.mods = mod_list
+
+            @torch.jit.script_method
+            def forward(self, v):
+                return self.mods.forward(x)
+
+        with self.assertRaisesRegex(RuntimeError, "Did you forget to add it to __constants"):
+            M2(nn.Sequential(nn.ReLU()))
+        with self.assertRaisesRegex(RuntimeError, "Did you forget to add it to __constants"):
+            M2(nn.ModuleList([nn.ReLU()]))
+
     def test_script_sequential_for(self):
         class Sub(torch.jit.ScriptModule):
             def __init__(self):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -184,6 +184,20 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     throw ErrorReport(loc) << ss.str();
   }
 
+  std::shared_ptr<SugaredValue> attr(
+      const SourceRange& loc,
+      Method& m,
+      const std::string& field) override {
+    const std::string type_str = typeString(self);
+    std::stringstream ss;
+    ss << "attribute lookup is not defined on " << kind();
+    auto nn = py::module::import("torch.nn");
+    if (py::isinstance(self, nn.attr("Module"))) {
+      ss << ". Did you forget to add it to __constants__? ";
+    }
+    throw ErrorReport(loc) << ss.str();
+  }
+
  protected:
   py::object getattr(const SourceRange& loc, const std::string& name) {
     try {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -195,7 +195,6 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
     const std::string type_str = typeString(self);
     std::stringstream ss;
     ss << "attribute lookup is not defined on " << kind();
-    auto nn = py::module::import("torch.nn");
     checkForAddToConstantsError(ss);
     throw ErrorReport(loc) << ss.str();
   }


### PR DESCRIPTION
Adds a suggestion to add to __constants__ when a torch.nn.Module attr is accessed