### PR TITLE
Re-enable caffe2 softmax tests on ROCm CI

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -92,7 +92,6 @@ if [[ $BUILD_ENVIRONMENT == *-rocm* ]]; then
 
   # Unknown reasons, need to debug
   rocm_ignore_test+=("--ignore $caffe2_pypath/python/operator_test/piecewise_linear_transform_test.py")
-  rocm_ignore_test+=("--ignore $caffe2_pypath/python/operator_test/softmax_ops_test.py")
 
   # On ROCm, RCCL (distributed) development isn't complete.
   # https://github.com/ROCmSoftwarePlatform/rccl

--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -77,11 +77,6 @@ backend_test.exclude('(test_pow_bcast'
 if 'JENKINS_URL' in os.environ:
     backend_test.exclude(r'(test_vgg19|test_vgg)')
 
-if workspace.has_hip_support:
-    # TODO: Investigate flakiness in ROCM Softmax (it sometimes give NaN).
-    backend_test.exclude(r'test_softmax_.*_cuda')
-    backend_test.exclude(r'test_logsoftmax_.*_cuda')
-
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test
                  .enable_report()


### PR DESCRIPTION
previously we saw random NaN issue, ~ROCm 2.2 should have fixed it~

