### PR TITLE
fix some issues found by enabling -Wshorten-64-to-32

### DIFF
--- a/caffe2/operators/concat_split_op.cc
+++ b/caffe2/operators/concat_split_op.cc
@@ -202,7 +202,7 @@ OpSchema::Cost CostInferenceForConcat(
   if (add_axis) {
     out_shape.insert(out_shape.begin() + canonical_axis, in.size());
   } else {
-    for (int i = 1; i < in.size(); ++i) {
+    for (size_t i = 1; i < in.size(); ++i) {
       out_shape[canonical_axis] += in[i].dims(canonical_axis);
     }
   }

--- a/caffe2/operators/conv_op_impl.h
+++ b/caffe2/operators/conv_op_impl.h
@@ -809,8 +809,8 @@ bool ConvGradientOp<T, Context>::RunOnDeviceWithOrderNHWC() {
 
   // The offset corresponding to a single input image, and a single output
   // image.
-  const int input_offset = C * input_image_size;
-  const int output_offset = dY.numel() / dY.dim32(0);
+  const size_t input_offset = C * input_image_size;
+  const size_t output_offset = dY.numel() / dY.dim32(0);
   for (int image_id = 0; image_id < N; ++image_id) {
     // When we compute the gradient with respect to the filters, we need to do
     // im2col to allow gemm-type computation.

--- a/caffe2/operators/ctc_greedy_decoder_op.cc
+++ b/caffe2/operators/ctc_greedy_decoder_op.cc
@@ -7,7 +7,7 @@ namespace {
 const float* getTensorDataPtr(const Tensor& tensor, int t, int n) {
   const auto dims = tensor.sizes();
   CAFFE_ENFORCE_EQ(dims.size(), 3);
-  int offset = (t * dims[1] + n) * dims[2];
+  int64_t offset = (t * dims[1] + n) * dims[2];
   CAFFE_ENFORCE_LT(offset, tensor.numel());
   return tensor.template data<float>() + offset;
 }

--- a/caffe2/operators/group_norm_op.h
+++ b/caffe2/operators/group_norm_op.h
@@ -41,7 +41,7 @@ class GroupNormOp final : public Operator<Context> {
     const int ndim = X.dim();
     const int N = X.dim32(0);
     const int C = order_ == StorageOrder::NCHW ? X.dim32(1) : X.dim32(ndim - 1);
-    const int HxW = X.numel() / (N * C);
+    const size_t HxW = X.numel() / (N * C);
     CAFFE_ENFORCE_EQ(C % group_, 0);
     CAFFE_ENFORCE_EQ(gamma.numel(), C);
     CAFFE_ENFORCE_EQ(beta.numel(), C);

--- a/caffe2/operators/h_softmax_op.cc
+++ b/caffe2/operators/h_softmax_op.cc
@@ -81,7 +81,7 @@ bool HSoftmaxOp<float, CPUContext>::RunOnDevice() {
   // Batch size
   int M = X.dim() > 1 ? X.dim32(0) : 1;
   // Input feature dimension
-  int K = X.numel() / M;
+  size_t K = X.numel() / M;
   CAFFE_ENFORCE_GE(W.dim(), 2); // N*K
   CAFFE_ENFORCE_EQ(b.dim(), 1); // N
   CAFFE_ENFORCE_EQ(K, W.numel() / (W.dim32(0)));

--- a/caffe2/operators/normalize_op.h
+++ b/caffe2/operators/normalize_op.h
@@ -27,9 +27,9 @@ class NormalizeOp final : public Operator<Context> {
 
     const auto canonical_axis = x.canonical_axis_index(
         this->template GetSingleArgument<int>("axis", -1));
-    const int m = x.dim32(canonical_axis);
-    const int n = x.numel() / m;
-    const int sf = x.size_from_dim(canonical_axis + 1);
+    const int64_t m = x.dim(canonical_axis);
+    const size_t n = x.numel() / m;
+    const size_t sf = x.size_from_dim(canonical_axis + 1);
     DoNormalize(xData, yData, m, n, sf);
     return true;
   }

--- a/caffe2/operators/reducer_functors.h
+++ b/caffe2/operators/reducer_functors.h
@@ -335,7 +335,7 @@ class BaseReducer {
 
     explicit Meta(bool first = true) : first_dim(first) {}
 
-    void computeMeta(at::IntArrayRef dims, int skip_dims) {
+    void computeMeta(at::IntArrayRef dims, size_t skip_dims) {
       first_dim ? block_shape.assign(dims.begin() + skip_dims, dims.end())
                 : block_shape.assign(dims.begin(), dims.end() - skip_dims);
       block_size = first_dim ? size_from_dim_(skip_dims, dims)

--- a/caffe2/operators/roi_align_rotated_op.cc
+++ b/caffe2/operators/roi_align_rotated_op.cc
@@ -311,7 +311,7 @@ bool RoIAlignRotatedOp<float, CPUContext>::RunOnDevice() {
         {R.dim32(0), X.dim32(1), pooled_height_, pooled_width_},
         at::dtype<float>());  // RoI pooled data
 
-    int output_size = Y->numel();
+    size_t output_size = Y->numel();
     ROIAlignRotatedForward<float>(
         output_size,
         X.data<float>(),
@@ -331,7 +331,7 @@ bool RoIAlignRotatedOp<float, CPUContext>::RunOnDevice() {
         0,
         {R.dim32(0), pooled_height_, pooled_width_, X.dim32(3)},
         at::dtype<float>());   // RoI pooled data
-    int output_size = Y->numel();
+    size_t output_size = Y->numel();
     ROIAlignRotatedForward<float>(
         output_size,
         X.data<float>(),

--- a/caffe2/operators/sparse_to_dense_mask_op.h
+++ b/caffe2/operators/sparse_to_dense_mask_op.h
@@ -43,7 +43,7 @@ class SparseToDenseMaskBase : public Operator<Context> {
 
   std::unordered_map<int64_t, int> sparse_;
   std::vector<int> dense_;
-  int featuresCount_;
+  size_t featuresCount_;
 
   inline int getFeatureIdx(int64_t id) const {
     if (id >= kMaxDenseSize) {
@@ -97,7 +97,7 @@ class SparseToDenseMaskOp : public SparseToDenseMaskBase<Context> {
     int64_t block_size = default_value.numel();
     size_t block_nbytes = default_value.nbytes();
 
-    const int cols = this->featuresCount_;
+    const size_t cols = this->featuresCount_;
     int rows = -1;
     int32_t sparse_indices_length = sparse_indices.dim32(0);
     const int32_t* lengths_vec = nullptr;
@@ -215,7 +215,7 @@ class SparseToDenseMaskGradientOp : public SparseToDenseMaskBase<Context> {
     int64_t block_size = gradient_output.size_from_dim(1);
     size_t block_nbytes = gradient_output.itemsize() * block_size;
 
-    const int cols = this->featuresCount_;
+    const size_t cols = this->featuresCount_;
     int rows = -1;
     int iter_offset = 1;
     int32_t default_length = sparse_indices.dim32(0);


### PR DESCRIPTION
Summary:
when enabling this flag, there were a lot of warnings, this pr focuses on the warnings where this comparison could be affecting array indices, which could be ones most prone to fail

the good news is that I didn't find anything obviously concerning

one degenerate case could be when the matrices we work with are too skinny could run into issues (dim1=1, dim2 needs to hold a big number)

Differential Revision: D14527182
