### PR TITLE
[jit] Attribute serialization improvements

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15,7 +15,7 @@ from torch.nn import Module
 from torch.autograd.function import traceable
 from torch.testing import assert_allclose
 from torch.onnx import OperatorExportTypes
-from torch._six import inf, PY2, builtins
+from torch._six import inf, PY2, builtins, StringIO
 from common_utils import TestCase, run_tests, IS_WINDOWS, TEST_WITH_UBSAN, \
     skipIfRocm, skipIfNoLapack, suppress_warnings, load_tests, IS_SANDCASTLE, \
     freeze_rng_state, set_rng_seed
@@ -10904,7 +10904,7 @@ a")
             archive = zipfile.ZipFile(fname, 'r')
             pickled_data = archive.read(os.path.join(archive_name, 'attributes.pkl'))
 
-            out = io.StringIO()
+            out = StringIO()
             pickletools.dis(pickled_data, out=out)
             disassembled = out.getvalue()
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -36,7 +36,10 @@ import warnings
 import math
 import types
 import pickle
+import pickletools
 import copy
+import zipfile
+
 
 from common_methods_invocations import method_tests as autograd_method_tests
 from common_methods_invocations import create_input, unpack_variables, \
@@ -10780,8 +10783,6 @@ a")
 
     @unittest.skipIf(IS_WINDOWS or IS_SANDCASTLE, "NYI: TemporaryFileName support for Windows or Sandcastle")
     def test_attribute_unpickling(self):
-        import zipfile
-
         class M(torch.jit.ScriptModule):
             def __init__(self):
                 super(M, self).__init__()
@@ -10848,6 +10849,69 @@ a")
         m = M()
         imported_m = self.getExportImportCopy(m)
         self.assertEqual(m(), imported_m())
+
+    def test_serialization_big_ints(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M, self).__init__()
+                self.int32_max = torch.jit.Attribute(2**31 - 1, int)
+                self.int32_min = torch.jit.Attribute(-2**31, int)
+                self.uint32_max = torch.jit.Attribute(2**32, int)
+
+                self.int64_max = torch.jit.Attribute(2**63 - 1, int)
+                self.int64_min = torch.jit.Attribute(-2**63, int)
+
+                self.tensor = torch.nn.Parameter(torch.ones(2, 2))
+
+            @torch.jit.script_method
+            def forward(self, x):
+                # type: (int) -> (int)
+                return x + (self.int32_max + self.int32_min) + (self.int64_max + self.int64_min)
+
+        m = M()
+        imported = self.getExportImportCopy(m)
+        self.assertEqual(m(10), imported(10))
+
+        self.assertEqual(m.int32_max, imported.int32_max)
+        self.assertEqual(m.int32_min, imported.int32_min)
+        self.assertEqual(m.uint32_max, imported.uint32_max)
+        self.assertEqual(m.int64_max, imported.int64_max)
+        self.assertEqual(m.int64_min, imported.int64_min)
+
+    def test_serialization_sharing(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M, self).__init__()
+                self.list = torch.jit.Attribute([], List[str])
+
+            @torch.jit.script_method
+            def forward(self, key):
+                # type: (str) -> List[str]
+                self.list.append(key)
+                self.list.append(key)
+                self.list.append(key)
+                return self.list
+
+        # the text of the string should only appear once in the pickling
+        m = M()
+        s1 = "a long string"
+        s2 = "a different, even longer string"
+        self.assertEqual(m(s1), [s1] * 3)
+        self.assertEqual(m(s2), [s1] * 3 + [s2] * 3)
+        with TemporaryFileName() as fname:
+            m.save(fname)
+            archive_name = os.path.basename(os.path.normpath(fname))
+            archive = zipfile.ZipFile(fname, 'r')
+            pickled_data = archive.read(os.path.join(archive_name, 'attributes.pkl'))
+
+            out = io.StringIO()
+            pickletools.dis(pickled_data, out=out)
+            disassembled = out.getvalue()
+
+            FileCheck().check_count(s1, 1, exactly=True) \
+                .check_count("BINGET", 2, exactly=True) \
+                .check_count(s2, 1, exactly=True) \
+                .check_count("BINGET", 2, exactly=True).run(out.getvalue())
 
     def test_optional_tuple(self):
         def fn(x=None):

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -136,6 +136,11 @@ if PY2:
 elif PY3:
     import builtins
 
+if PY2:
+    import StringIO
+    StringIO = StringIO.StringIO
+elif PY3:
+    import io.StringIO as StringIO
 
 # The codes below is not copied from the six package, so the copyright
 # declaration at the beginning does not apply.

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -141,7 +141,7 @@ if PY2:
     StringIO = StringIO.StringIO
 elif PY3:
     import io
-    StringIO = StringIO
+    StringIO = io.StringIO
 
 
 # The codes below is not copied from the six package, so the copyright

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -140,7 +140,8 @@ if PY2:
     import StringIO
     StringIO = StringIO.StringIO
 elif PY3:
-    import io.StringIO as StringIO
+    import io
+    StringIO = StringIO
 
 
 # The codes below is not copied from the six package, so the copyright

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -142,6 +142,7 @@ if PY2:
 elif PY3:
     import io.StringIO as StringIO
 
+
 # The codes below is not copied from the six package, so the copyright
 # declaration at the beginning does not apply.
 #

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -827,9 +827,9 @@ struct PythonPrintPass {
         if (enforce_importable_) {
           throw script::ErrorReport(node->getSourceLocation())
               << "could not export python function call " << value->name()
-              << ". Remove calls to Python functions before export."
-              << "Did you forget add @script annotation? "
-              << "If this is a modulelist, add it to __constants__.";
+              << ". Remove calls to Python functions before export. "
+              << "Did you forget add @script or @script_method annotation? "
+              << "If this is a nn.ModuleList, add it to __constants__.";
         }
 
         stmt << "^" << value->name();

--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -112,12 +112,18 @@ class Pickler {
   void pushTuple(const IValue& ivalue);
   void pushDict(const IValue& ivalue);
   void pushClass(PicklerClass cls);
+  void pushInt(const IValue& ivalue);
   const void* getPointer(const IValue& ivalue);
 
-  void pushUint8(uint8_t value);
-  void pushOpCode(OpCode value);
-  void pushUint32(uint32_t value);
-  void pushInt32(int32_t value);
+  // These convert values to bytes and add them to the stack (NB: since T is to
+  // the left of a '::', its type cannot be deduced by the compiler so one must
+  // explicitly instantiate the template, i.e. push<int>(int) works, push(int)
+  // does not)
+  template<typename T>
+  void push(typename std::common_type<T>::type value) {
+    const char* begin = reinterpret_cast<const char*>(&value);
+    stack_.insert(stack_.end(), begin, begin + sizeof(T));
+  }
 
   // Stack of opcodes/data
   std::vector<char> stack_;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -753,6 +753,7 @@ void initJitScriptBindings(PyObject* module) {
       .def("_set_parameter", &Module::set_parameter)
       .def("_get_parameter", &Module::get_parameter)
       .def("_get_buffer", &Module::get_buffer)
+      .def("_get_attribute", &Module::get_attribute)
       .def("_get_module", &Module::get_module)
       .def(
           "_get_modules",
@@ -791,6 +792,11 @@ void initJitScriptBindings(PyObject* module) {
                   buffer.key(), buffer->type, toPyObject(std::move(v)));
             }
             return result;
+          })
+      .def(
+          "_has_attribute",
+          [](Module& self, const std::string& name) -> bool {
+            return self.find_attribute(name);
           })
       .def(
           "_has_parameter",

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -471,6 +471,9 @@ struct Module {
   autograd::Variable get_buffer(const std::string& name) const {
     return autograd::as_variable_ref(attributes.find(name)->slot()->toTensor());
   }
+  IValue get_attribute(const std::string& name) const {
+    return *attributes.find(name)->slot();
+  }
 
   // each module owns its method. The reference returned here
   // is guarenteed to stay valid until this module has been destroyed

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -10,6 +10,7 @@ import torch._jit_internal as _jit_internal
 from torch._six import raise_from, with_metaclass, get_function_from_type, \
     string_classes
 from torch._jit_internal import ignore
+from torch.jit._pickle import Unpickler
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple, \
     _list_with_default
 import torch.testing
@@ -1152,6 +1153,8 @@ if _enabled:
                     return self._get_method(attr)
             if attr == 'graph' and self._has_method('forward'):
                 return self.__getattr__('forward').graph
+            if self._has_attribute(attr):
+                return self._get_attribute(attr)
             return Module.__getattr__(self, attr)
 
         def __setattr__(self, attr, value):

--- a/torch/jit/_pickle.py
+++ b/torch/jit/_pickle.py
@@ -13,16 +13,6 @@ class IntList(object):
         self.data = data
 
 
-class LiteralTensor(object):
-    def __setstate__(self, data):
-        buffer = data[0].encode('utf-8')
-        sizes = data[1].data
-
-        num_elements = functools.reduce(lambda size, acc: size * acc, sizes)
-        storage = torch.Storage.from_buffer(buffer=buffer, byte_order="little", count=num_elements, offset=0)
-        self.tensor = torch.tensor(storage.tolist()).view(sizes)
-
-
 class Unpickler(pickle.Unpickler):
     def find_class(self, module, name):
         if not module == '__main__':

--- a/torch/jit/_pickle.py
+++ b/torch/jit/_pickle.py
@@ -1,0 +1,36 @@
+import torch
+import functools
+import pickle
+
+
+class TensorID(object):
+    def __setstate__(self, id):
+        self.id = id
+
+
+class IntList(object):
+    def __setstate__(self, data):
+        self.data = data
+
+
+class LiteralTensor(object):
+    def __setstate__(self, data):
+        buffer = data[0].encode('utf-8')
+        sizes = data[1].data
+
+        num_elements = functools.reduce(lambda size, acc: size * acc, sizes)
+        storage = torch.Storage.from_buffer(buffer=buffer, byte_order="little", count=num_elements, offset=0)
+        self.tensor = torch.tensor(storage.tolist()).view(sizes)
+
+
+class Unpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if not module == '__main__':
+            return None
+
+        if name == 'TensorID':
+            return TensorID
+        elif name == 'IntList':
+            return IntList
+        elif name == 'LiteralTensor':
+            return LiteralTensor


### PR DESCRIPTION
* adds attributes to `ScriptModule.__getattr__` so they can be accessed in Python after re-importing
* full support for all the possible values for an `int64_t`
    * this necessitated a bunch more `pushWhatever` functions, so re-introduced a templated version to cut down on duplicate code
* tests to validate references / value sharing works
* adds `torch.jit.Unpickler` which people can use to de-serialize the pickle files into Python / have a quick reference on how to do this without PyTorch