### PR TITLE
caffe2 - Util to cleanup external inputs and outputs from a NetDef

### DIFF
--- a/caffe2/utils/proto_utils.h
+++ b/caffe2/utils/proto_utils.h
@@ -329,6 +329,14 @@ bool inline operator==(const DeviceOption& dl, const DeviceOption& dr) {
   return IsSameDevice(dl, dr);
 }
 
+// Given a net, modify the external inputs/outputs if necessary so that
+// the following conditions are met
+// - No duplicate external inputs
+// - No duplicate external outputs
+// - Going through list of ops in order, all op inputs must be outputs
+// from other ops, or registered as external inputs.
+// - All external outputs must be outputs of some operators.
+CAFFE2_API void cleanupExternalInputsAndOutputs(NetDef* net);
 
 } // namespace caffe2
 

--- a/caffe2/utils/proto_utils_test.cc
+++ b/caffe2/utils/proto_utils_test.cc
@@ -1,5 +1,7 @@
-#include "caffe2/utils/proto_utils.h"
 #include <gtest/gtest.h>
+
+#include "caffe2/core/test_utils.h"
+#include "caffe2/utils/proto_utils.h"
 
 namespace caffe2 {
 
@@ -29,4 +31,33 @@ TEST(ProtoUtilsTest, SimpleReadWrite) {
   EXPECT_EQ(content, read_back);
 }
 
-}  // namespace caffe2
+TEST(ProtoUtilsTest, CleanupExternalInputsAndOutputs) {
+  caffe2::NetDef net;
+  caffe2::testing::NetMutator(&net)
+      .newOp("op1", {"X1", "X2"}, {"Y"})
+      .newOp("op2", {"W", "Y"}, {"Z1", "Z2"})
+      .newOp("op3", {"Z2", "W"}, {"O"})
+      .externalInputs({"X1", "X3", "X1", "W"})
+      .externalOutputs({"O", "Z2", "Z3", "O", "X3"});
+  cleanupExternalInputsAndOutputs(&net);
+
+  std::vector<std::string> externalInputs;
+  for (const auto& inputName : net.external_input()) {
+    externalInputs.emplace_back(inputName);
+  }
+  // The 2nd X1 is removed because of duplication.
+  // X2 is added because it should be a missing external input.
+  std::vector<std::string> expectedExternalInputs{"X1", "X3", "W", "X2"};
+  EXPECT_EQ(externalInputs, expectedExternalInputs);
+
+  std::vector<std::string> externalOutputs;
+  for (const auto& outputName : net.external_output()) {
+    externalOutputs.emplace_back(outputName);
+  }
+  // Z3 is removed because it's not an output of any operator in the net.
+  // The 2nd O is removed because of duplication.
+  std::vector<std::string> expectedexternalOutputs{"O", "Z2", "X3"};
+  EXPECT_EQ(externalOutputs, expectedexternalOutputs);
+}
+
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Add a util method to cleanup external inputs and outputs from a NetDef

The following conditions will be met after the modification
- No duplicate external inputs
- No duplicate external outputs
- Going through list of ops in order, all op inputs must be outputs
from other ops, or registered as external inputs.
- All external outputs must be outputs of some operators.

Differential Revision: D14528589
