### PR TITLE
initial implementation of onnxifi_coverage

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1663,6 +1663,9 @@ void addGlobalMethods(py::module& m) {
         auto weight_names = curr_ws->Blobs();
         ts.transform(
             curr_ws, &pred_net, weight_names, tensor_shapes, blacklist_set);
+        if (opts.debug) {
+          WriteProtoToTextFile(pred_net, "debug_transformed_net.pb_txt");
+        }
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);


### PR DESCRIPTION
Summary:
first drop of code for onnxifi_coverage, it takes a net, onnxifies it and dumps the output

next steps are to apply the input shapes and types and deduce the specifics of each operator

Differential Revision: D14528558
