### PR TITLE
Caffe2: crash op

### DIFF
--- a/caffe2/operators/crash_op.cc
+++ b/caffe2/operators/crash_op.cc
@@ -1,0 +1,25 @@
+#if defined(__linux__)
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+
+namespace caffe2 {
+
+class CrashOp final : public Operator<CPUContext> {
+ public:
+  CrashOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CPUContext>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    raise(SIGABRT);
+    return true;
+  }
+};
+
+OPERATOR_SCHEMA(Crash).NumInputs(0).NumOutputs(0).SetDoc(
+    R"DOC(Crashes the program. Use for testing)DOC");
+
+REGISTER_CPU_OPERATOR(Crash, CrashOp);
+
+} // namespace caffe2
+#endif


### PR DESCRIPTION
Summary:
this is handy when testing various core dump related
things. If in the future we want to unit test our future gdb debugger
extensions, we can use this op to generate a core dump for us within a
unit test.

Differential Revision: D14482186
