### PR TITLE
Use RAII stream guard in Operator

### DIFF
--- a/aten/src/ATen/core/context_base.h
+++ b/aten/src/ATen/core/context_base.h
@@ -12,6 +12,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Registry.h>
 #include <c10/core/CopyBytes.h>
+#include <c10/core/Stream.h>
 
 namespace caffe2 {
 class Event;
@@ -43,6 +44,8 @@ class CAFFE2_API BaseContext {
   inline void SwitchToDevice() {
     SwitchToDevice(0);
   }
+
+  virtual Stream GetStream(int /*stream_id*/) = 0;
 
   virtual void WaitEvent(const caffe2::Event& ev) = 0;
 

--- a/caffe2/core/context.h
+++ b/caffe2/core/context.h
@@ -56,6 +56,10 @@ class CAFFE2_API CPUContext final : public BaseContext {
 
   using BaseContext::SwitchToDevice;
 
+  inline c10::Stream GetStream(int /*stream_id*/) override {
+    return c10::Stream{c10::Stream::DEFAULT, Device(DeviceType::CPU, -1)};
+  }
+
   inline void WaitEvent(const Event& ev) override {
     ev.Wait(CPU, this);
   }

--- a/caffe2/core/context_gpu.h
+++ b/caffe2/core/context_gpu.h
@@ -190,6 +190,10 @@ class CAFFE2_CUDA_API CUDAContext final : public BaseContext {
   // void SwitchToDevice()
   using BaseContext::SwitchToDevice;
 
+  inline Stream GetStream(StreamId stream_id) override {
+    return getCudaObjects().GetCUDAStream(gpu_id_, stream_id);
+  }
+
   inline void WaitEvent(const Event& ev) override {
     ev.Wait(CUDA, this);
   }

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -10,6 +10,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "c10/core/StreamGuard.h"
 #include "c10/macros/Macros.h"
 #include "c10/util/Registry.h"
 #include "caffe2/core/blob.h"
@@ -825,7 +826,7 @@ class Operator : public OperatorBase {
     try {
       StartAllObservers();
 
-      context_.SwitchToDevice(stream_id);
+      c10::StreamGuard stream_guard{context_.GetStream(stream_id)};
 
       if (FLAGS_caffe2_operator_throw_if_fp_exceptions) {
         std::feclearexcept(FE_ALL_EXCEPT);
@@ -870,7 +871,8 @@ class Operator : public OperatorBase {
     try {
       StartAllObservers();
 
-      context_.SwitchToDevice(stream_id);
+      c10::StreamGuard stream_guard{context_.GetStream(stream_id)};
+
       auto result = RunOnDevice();
       if (result) {
         if (HasAsyncPart()) {

--- a/caffe2/ideep/utils/ideep_context.h
+++ b/caffe2/ideep/utils/ideep_context.h
@@ -26,6 +26,10 @@ class IDEEPContext final : public BaseContext {
   inline void SwitchToDevice(int /*stream_id*/) {}
   using BaseContext::SwitchToDevice;
 
+  inline Stream GetStream(int /*stream_id*/) override {
+    return Stream{Stream::DEFAULT, Device(DeviceType::CPU, -1)};
+  }
+
   inline void WaitEvent(const Event& ev) {
     ev.Wait(IDEEP, this);
   }


### PR DESCRIPTION
Summary: Currently we call `SwitchToDevice` to run operations on a device, which the device and stream are not automatically restored afterwards. We want to use a RAII guard, `StreamGuard`, to do the switching and automatically restore the device and stream afterwards.

Differential Revision: D14529276
