### PR TITLE
Enable running of slow tests in CI.

### DIFF
--- a/.circleci/cimodel/pytorch_build_definitions.py
+++ b/.circleci/cimodel/pytorch_build_definitions.py
@@ -107,7 +107,7 @@ class Conf(object):
 
         if self.is_xla or phase == "test":
             val = OrderedDict()
-            if self.is_xla:
+            if self.is_xla or "slow" in self.parms:
                 # this makes the job run on merges rather than new PRs
                 # TODO Many of the binary build jobs on PRs could be moved to this mode as well
                 val["filters"] = {"branches": {"only": ["master"]}}
@@ -150,6 +150,7 @@ def gen_dependent_configs(xenial_parent_config):
         (["multigpu"], "large"),
         (["NO_AVX2"], "medium"),
         (["NO_AVX", "NO_AVX2"], "medium"),
+        (["slow"], "medium"),
     ]
 
     configs = []

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1247,6 +1247,15 @@ jobs:
     resource_class: gpu.medium
     <<: *pytorch_linux_test_defaults
 
+  pytorch_linux_xenial_cuda8_cudnn7_py3_slow_test:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda8-cudnn7-py3-slow-test
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda8-cudnn7-py3:291"
+      PYTHON_VERSION: "3.6"
+      USE_CUDA_DOCKER_RUNTIME: "1"
+    resource_class: gpu.medium
+    <<: *pytorch_linux_test_defaults
+
   pytorch_linux_xenial_cuda9_cudnn7_py2_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-build
@@ -3074,6 +3083,9 @@ workflows:
           requires:
             - pytorch_linux_xenial_cuda8_cudnn7_py3_build
       - pytorch_linux_xenial_cuda8_cudnn7_py3_NO_AVX_NO_AVX2_test:
+          requires:
+            - pytorch_linux_xenial_cuda8_cudnn7_py3_build
+      - pytorch_linux_xenial_cuda8_cudnn7_py3_slow_test:
           requires:
             - pytorch_linux_xenial_cuda8_cudnn7_py3_build
       - pytorch_short_perf_test_gpu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3086,6 +3086,10 @@ workflows:
           requires:
             - pytorch_linux_xenial_cuda8_cudnn7_py3_build
       - pytorch_linux_xenial_cuda8_cudnn7_py3_slow_test:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - pytorch_linux_xenial_cuda8_cudnn7_py3_build
       - pytorch_short_perf_test_gpu:

--- a/.jenkins/pytorch/enabled-configs.txt
+++ b/.jenkins/pytorch/enabled-configs.txt
@@ -50,5 +50,6 @@ pytorch-ppc64le-cuda9.1-cudnn7-py3-build
 pytorch-ppc64le-cuda9.1-cudnn7-py3-test
 pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX2-test
 pytorch-linux-xenial-cuda8-cudnn7-py3-NO_AVX-NO_AVX2-test
+pytorch-linux-xenial-cuda8-cudnn7-py3-slow-test
 pytorch-xla-linux-trusty-py3.6-gcc5.4-build
 pytorch-xla-linux-trusty-py3.6-gcc5.4-test

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -23,6 +23,11 @@ if [ -n "${IN_CIRCLECI}" ]; then
     sudo apt-get -qq install --no-install-recommends openssh-client openssh-server
     sudo mkdir -p /var/run/sshd
   fi
+
+  if [[ "$BUILD_ENVIRONMENT" == *-slow-* ]]; then
+    export PYTORCH_TEST_WITH_SLOW=1
+    export PYTORCH_TEST_SKIP_FAST=1
+  fi
 fi
 
 # --user breaks ppc64le builds and these packages are already in ppc64le docker


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18236 Enable running of slow tests in CI.**
* #18231 Add a decorator for marking slow tests.

These tests only run on master, as they are slow.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14563115](https://our.internmc.facebook.com/intern/diff/D14563115)