### PR TITLE
Fix contribution_guide docs

### DIFF
--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -78,7 +78,7 @@ here is the basic process.
 
    -  We'll try our best to minimize the number of review roundtrips and
       block PRs only when there are major issues. For the most common
-      issues in pull requests, take a look at `Common Mistakes </docs/community/contribution_guide.html#common-mistakes-to-avoid>`__.
+      issues in pull requests, take a look at `Common Mistakes <#common-mistakes-to-avoid>`__.
    -  Once a pull request is accepted and CI is passing, there is
       nothing else you need to do; we will merge the PR for you.
 

--- a/docs/source/community/contribution_guide.rst
+++ b/docs/source/community/contribution_guide.rst
@@ -282,7 +282,7 @@ Frequently asked questions
    master or rebase with latest changes. Pushing your changes should
    re-trigger CI tests. If the tests persist, you'll want to trace
    through the error messages and resolve the related issues.
--  **What are the most high risk changes?** Anything that tourhces build
+-  **What are the most high risk changes?** Anything that touches build
    configuration is an risky area. Please avoid changing these unless
    you've had a discussion with the team beforehand.
 -  **Hey, a commit showed up on my branch, what's up with that?**


### PR DESCRIPTION
Fixes Typo and a Link in the `docs/source/community/contribution_guide.rst`