### PR TITLE
handle dst_bin_width==0 case properly

### DIFF
--- a/caffe2/quantization/server/activation_distribution_observer.cc
+++ b/caffe2/quantization/server/activation_distribution_observer.cc
@@ -342,6 +342,10 @@ void HistogramNetObserver::DumpAndReset_(
                      << " has an empty range: min " << hist->Min()
                      << " and max " << hist->Max();
       }
+      if (hist->GetHistogram()->empty()) {
+        LOG(WARNING) << "Histogram of "
+                     << info->min_max_info.tensor_infos[i].name << " is empty";
+      }
 
       ostringstream ost;
       ost << op_index << " " << info->min_max_info.type << " " << i << " "
@@ -352,15 +356,11 @@ void HistogramNetObserver::DumpAndReset_(
         ost << " " << c;
       }
 
-      f << ost.str() << endl;
       if (print_total_min_max) {
         LOG(INFO) << this << " " << ost.str();
       }
 
-      if (hist->GetHistogram()->empty()) {
-        LOG(WARNING) << "Histogram of "
-                     << info->min_max_info.tensor_infos[i].name << " is empty";
-      }
+      f << ost.str() << endl;
 
       if (!print_total_min_max) {
         info->histograms[i] = DynamicHistogram(hist->GetHistogram()->size());
@@ -575,7 +575,8 @@ RegisterQuantizationParamsWithHistogramNetObserver::
         qparams = qfactory->ChooseQuantizationParams(hist, is_weight);
       } else {
         qparams.scale = 0.1f;
-        qparams.zero_point = -min / qparams.scale;
+        qparams.zero_point =
+            (isinf(min) || isnan(min)) ? 0 : -min / qparams.scale;
         qparams.precision = 8;
       }
 

--- a/caffe2/quantization/server/activation_distribution_observer.h
+++ b/caffe2/quantization/server/activation_distribution_observer.h
@@ -100,6 +100,13 @@ class HistogramObserver final : public ObserverBase<OperatorBase> {
 
 class HistogramNetObserver final : public NetObserver {
  public:
+  /**
+   * @params mul_nets true if we expect multiple nets with the same name so
+   *                  we include extra information in the file name to
+   *                  distinghuish them
+   * @params dump_freq if not -1 we dump histogram every dump_freq invocation
+   *                   of the net
+   */
   explicit HistogramNetObserver(
       NetBase* subject,
       const std::string& out_file_name,

--- a/caffe2/quantization/server/dynamic_histogram.cc
+++ b/caffe2/quantization/server/dynamic_histogram.cc
@@ -212,8 +212,8 @@ const Histogram* DynamicHistogram::Finalize() {
       // The remainder should go to dst_bin2
       // rint is the fastest way to round
       // (https://stackoverflow.com/questions/485525/round-for-float-in-c/5849630)
-      uint64_t dst_bin_cnt = src_bin_width == 0
-          ? 0
+      uint64_t dst_bin_cnt = (src_bin_width == 0 || dst_bin_width == 0)
+          ? bins[i]
           : std::min(
                 static_cast<uint64_t>(rint(
                     (dst_bin_end - src_bin_begin) / src_bin_width * bins[i])),


### PR DESCRIPTION
Summary: For rare cases when dst_bin_width == 0 we should just put all numbers to an arbitrary bin.

Differential Revision: D14544685
