### PR TITLE
Fix ONNX symbolic for argmin and argmax

### DIFF
--- a/test/onnx/expect/TestOperators.test_argmax.expect
+++ b/test/onnx/expect/TestOperators.test_argmax.expect
@@ -3,7 +3,7 @@ producer_name: "pytorch"
 producer_version: "1.1"
 graph {
   node {
-    input: "x"
+    input: "0"
     output: "1"
     op_type: "ArgMax"
     attribute {
@@ -19,7 +19,7 @@ graph {
   }
   name: "torch-jit-export"
   input {
-    name: "x"
+    name: "0"
     type {
       tensor_type {
         elem_type: 1

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1690,10 +1690,10 @@ def narrow(g, input, dim, start, length):
 
 
 @parse_args('v', 'i', 'i')
-def _argmax(g, input, dim, keepdim):
+def argmax(g, input, dim, keepdim):
     return g.op('ArgMax', input, axis_i=dim, keepdims_i=keepdim)
 
 
 @parse_args('v', 'i', 'i')
-def _argmin(g, input, dim, keepdim):
+def argmin(g, input, dim, keepdim):
     return g.op('ArgMin', input, axis_i=dim, keepdims_i=keepdim)


### PR DESCRIPTION
Fix the problem introduced in https://github.com/pytorch/pytorch/pull/17103