### PR TITLE
Two amendments for the shape analysis

### DIFF
--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1268,12 +1268,14 @@ class ShapePropagator {
         node->output()->setType(type->withRequiresGrad(false));
         return true;
       }
-    } else if (node->matches("aten::batch_norm_stats(Tensor input, float eps) -> (Tensor, Tensor)")) {
+    } else if (
+        node->matches(
+            "aten::batch_norm_stats(Tensor input, float eps) -> (Tensor, Tensor)")) {
       if (auto type = input_type(0)) {
         if (type->scalarType() == at::kHalf) {
           type = type->toScalarType(at::kFloat);
         }
-	type = type->withDim(1);
+        type = type->withDim(1);
         node->outputs()[0]->setType(type);
         node->outputs()[1]->setType(type);
         return true;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -712,7 +712,6 @@ class ShapePropagator {
             "aten::narrow(Tensor self, int dim, int start, int length) -> Tensor",
             "aten::slice(Tensor self, int dim, int start, int end, int step) -> Tensor",
             "aten::alias(Tensor self) -> Tensor",
-            "aten::detach(Tensor self) -> Tensor",
             "aten::cumprod(Tensor self, int dim) -> Tensor",
             "aten::cumsum(Tensor self, int dim) -> Tensor",
 
@@ -1262,6 +1261,21 @@ class ShapePropagator {
       }
       if (auto type = input_type(0)) {
         node->output()->setType(type->withDim(1));
+        return true;
+      }
+    } else if (node->matches("aten::detach(Tensor self) -> Tensor")) {
+      if (auto type = input_type(0)) {
+        node->output()->setType(type->withRequiresGrad(false));
+        return true;
+      }
+    } else if (node->matches("aten::batch_norm_stats(Tensor input, float eps) -> (Tensor, Tensor)")) {
+      if (auto type = input_type(0)) {
+        if (type->scalarType() == at::kHalf) {
+          type = type->toScalarType(at::kFloat);
+        }
+	type = type->withDim(1);
+        node->outputs()[0]->setType(type);
+        node->outputs()[1]->setType(type);
         return true;
       }
     } else if (node->matches(


### PR DESCRIPTION
Two small refinements to the shape analysis:
- `detach` can set requires grad to false for dimensioned tensors (not sure if I would also need to deal with Complete?).
- add `batch_norm_stats`.

I noticed these while looking at what's going on when trying to code batch norm manually. (Hi @wanchaol )