### PR TITLE
Automatic update of fbcode/onnx to c05f2ae412daf8fd64136ca354b97ccf73e0ea6c

### DIFF
--- a/caffe2/python/onnx/tests/conversion_test.py
+++ b/caffe2/python/onnx/tests/conversion_test.py
@@ -206,7 +206,9 @@ class TestConversion(TestCase):
                                             [3, 2],
                                             W.tolist())]
         )
-        model_def = helper.make_model(graph_def, producer_name='onnx-to-caffe2-test')
+        onnx_id = helper.make_opsetid("", 9)
+        model_def = helper.make_model(graph_def, producer_name='onnx-to-caffe2-test',
+                                      opset_imports=[onnx_id])
 
         p = c2.prepare(model_def)
         Y = np.matmul(X, W.reshape(3, 2))

--- a/caffe2/python/onnx/tests/onnx_backend_test.py
+++ b/caffe2/python/onnx/tests/onnx_backend_test.py
@@ -37,6 +37,7 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_prelu.*'  # PRelu is not compliant with ONNX yet
                      '|test_operator_repeat.*'  # Tile is not compliant with ONNX yet
                      '|test_.*pool_.*same.*'  # Does not support pool same.
+                     '|test_.*pool_.*ceil.*'  # Does not support pool same.
                      '|test_maxpool_with_argmax.*'  # MaxPool outputs indices in different format.
                      '|test_convtranspose.*'  # ConvTranspose needs some more complicated translation
                      '|test_mvn.*'  # MeanVarianceNormalization is experimental and not supported.
@@ -56,6 +57,9 @@ backend_test.exclude(r'(test_hardsigmoid'  # Does not support Hardsigmoid.
                      '|test_strnorm.*'  # Needs implementation
                      '|test_nonzero.*'  # Needs implementation
                      '|test_tfidfvectorizer.*'  # Needs implementation
+                     '|test_top_k.*'  # opset 10 is not supported yet
+                     '|test_resize.*'  # opset 10 is not supported yet
+                     '|test_slice.*'  # opset 10 is not supported yet
                      ')')
 
 # Quick patch to unbreak master CI, is working on the debugging.


### PR DESCRIPTION
Summary:
Previous import was 96c58ceeacf0f2b73d752e413e4fd78787a12da3

Included changes:
- **[c05f2ae4](https://github.com/onnx/onnx/commit/c05f2ae4)**: update both core and ml docs (#1879) <Lu Fang>
- **[f895279b](https://github.com/onnx/onnx/commit/f895279b)**: fix the problems introduced in previous PRs in operator registration (#1878) <Lu Fang>
- **[f6f80657](https://github.com/onnx/onnx/commit/f6f80657)**: Skip the schema check on ops in non-standard domain (#1876) <Lu Fang>
- **[8c8be722](https://github.com/onnx/onnx/commit/8c8be722)**: Introduce Function Body Helper  (#1868) <Sherlock>
- **[b605eafb](https://github.com/onnx/onnx/commit/b605eafb)**: Support down sampling for Upsample with scales < 1. (#1773) <Ke Zhang>
- **[47f7aa71](https://github.com/onnx/onnx/commit/47f7aa71)**: Remove scaledtanh (#1866) <Ashwini Khade>
- **[4dfc56de](https://github.com/onnx/onnx/commit/4dfc56de)**: Add Ceil support for Max and Average Pooling (#1860) <Lara Haidar>
- **[552a8efc](https://github.com/onnx/onnx/commit/552a8efc)**: Add testcase generator for functions (#1862) <Raymond Yang>
- **[fdb978a5](https://github.com/onnx/onnx/commit/fdb978a5)**: Promote Thresholded Relu Op (#1856) <Ashwini Khade>
- **[ce332628](https://github.com/onnx/onnx/commit/ce332628)**: Update Slice with dynamic input & optional input steps (#1836) <Bowen Bao>
- **[3a9a8787](https://github.com/onnx/onnx/commit/3a9a8787)**: Merge function into opschema (#1834) <Raymond Yang>
- **[3dbf8fe9](https://github.com/onnx/onnx/commit/3dbf8fe9)**: Handle string comparision represented as np.objects (#1851) <Dmitri Smirnov>
- **[3b0d3bb2](https://github.com/onnx/onnx/commit/3b0d3bb2)**: remove global variable in header file (#1850) <Lu Fang>
- **[1cca8733](https://github.com/onnx/onnx/commit/1cca8733)**: bump the version for drop out - fix the issue that the version was not bumped when changing its type constraint declaration. (#1848) <Ke Zhang>
- **[1ec81bc6](https://github.com/onnx/onnx/commit/1ec81bc6)**: Change TopK operator to allow dynamic 'k' (#1829) <Hariharan Seshadri>
- **[a89a4a16](https://github.com/onnx/onnx/commit/a89a4a16)**: Remove exp op: Affine, ImageScaler,ParametricSoftplus, Crop. (#1832) <Ke Zhang>

Differential Revision: D14566202
