### PR TITLE
[pytorch] Fix DCHECK to handle dangling else

### DIFF
--- a/c10/test/util/logging_test.cpp
+++ b/c10/test/util/logging_test.cpp
@@ -77,6 +77,13 @@ TEST(LoggingTest, Join) {
   EXPECT_EQ(s, "1, 2, 3");
 }
 
+TEST(LoggingTest, TestDanglingElse) {
+  if (true)
+    DCHECK_EQ(1, 1);
+  else
+    GTEST_FAIL();
+}
+
 #if GTEST_HAS_DEATH_TEST
 TEST(LoggingDeathTest, TestEnforceUsingFatal) {
   bool kTrue = true;

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -120,7 +120,7 @@ static_assert(
 #else
 // Optimized version - generates no code.
 #define DCHECK(condition) \
-  if (false)              \
+  while (false)           \
   CHECK(condition)
 #endif // NDEBUG
 
@@ -146,22 +146,22 @@ static_assert(
 #else // !NDEBUG
 // These versions generate no code in optimized mode.
 #define DCHECK_EQ(val1, val2) \
-  if (false)                  \
+  while (false)               \
   CHECK_OP(val1, val2, ==)
 #define DCHECK_NE(val1, val2) \
-  if (false)                  \
+  while (false)               \
   CHECK_OP(val1, val2, !=)
 #define DCHECK_LE(val1, val2) \
-  if (false)                  \
+  while (false)               \
   CHECK_OP(val1, val2, <=)
 #define DCHECK_LT(val1, val2) \
-  if (false)                  \
+  while (false)               \
   CHECK_OP(val1, val2, <)
 #define DCHECK_GE(val1, val2) \
-  if (false)                  \
+  while (false)               \
   CHECK_OP(val1, val2, >=)
 #define DCHECK_GT(val1, val2) \
-  if (false)                  \
+  while (false)               \
   CHECK_OP(val1, val2, >)
 #endif // NDEBUG
 
@@ -178,7 +178,7 @@ static_assert(
 #else // !NDEBUG
 // Optimized version - generates no code.
 #define DCHECK_NOTNULL(val) \
-  if (false)                \
+  while (false)             \
   CHECK_NOTNULL(val)
 #endif // NDEBUG
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18295 [pytorch] Fix DCHECK to handle dangling else**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14569608/)

Replace "if (false)" with "while (false)" which fixes potential dangling else issue as shown in added test case.

Differential Revision: [D14569608](https://our.internmc.facebook.com/intern/diff/D14569608/)