### PR TITLE
Add parsing to file check

### DIFF
--- a/test/cpp/jit/test_irparser.h
+++ b/test/cpp/jit/test_irparser.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/irparser.h>
+#include <torch/csrc/jit/testing/file_check.h>
 #include "test/cpp/jit/test_base.h"
 
 #include <sstream>
@@ -210,6 +211,19 @@ graph(%0 : Tensor,
       error_thrown = true;
     }
     AT_ASSERT(error_thrown);
+  }
+
+  {
+    auto graph = std::make_shared<Graph>();
+    const std::string& text =
+        R"IR(
+    graph(%a):
+    # CHECK: return
+      return (%a))IR";
+
+    script::parseIR(text, &*graph);
+    graph->inputs()[0]->type()->expect<TensorType>();
+    torch::jit::testing::FileCheck().run(text, *graph);
   }
 }
 } // namespace jit

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6025,6 +6025,62 @@ a")
             with self.assertRaisesRegex(RuntimeError, 'Expected to not find "1"'):
                 fb.run("22 1 22")
 
+    def test_filecheck_parse(self):
+        def test_check():
+            file = """
+                # CHECK: 2
+                # CHECK: 3
+                # CHECK: 2
+                232
+                """
+            FileCheck().run(checks_file=file, test_file=file)
+            file = """
+                # CHECK: 232
+                232
+                """
+            FileCheck().run(file, "232")
+            with self.assertRaisesRegex(RuntimeError, 'Expected to find "232"'):
+                FileCheck().run(file, "22")
+            with self.assertRaisesRegex(RuntimeError, 'Expected to find "22"'):
+                FileCheck().run("# CHECK: 22", "23")
+        test_check()
+
+        def test_check_count():
+            file = "22222"
+            FileCheck().run("# CHECK-COUNT-5: 2")
+            FileCheck().run("# CHECK-COUNT-EXACTLY-5: 2", file)
+            FileCheck().run("# CHECK-COUNT-2: 22", file)
+            FileCheck().run("# CHECK-COUNT-1: 222", file)
+
+            with self.assertRaisesRegex(RuntimeError, 'Expected to not find'):
+                FileCheck().run("# CHECK-COUNT-EXACTLY-2: 2", file)
+        test_check_count()
+
+        def test_check_same():
+            file = "22\n33"
+            FileCheck().run("# CHECK-SAME: 22", file)
+
+            with self.assertRaisesRegex(RuntimeError, "Expected to not find"):
+                FileCheck().run("# CHECK-SAME: 33", file)
+
+            file = "22  1  3"
+
+            FileCheck().run("# CHECK: 2\n # CHECK-SAME: 3", file)
+            FileCheck().run("# CHECK-COUNT-2: 2\n # CHECK-SAME: 3", file)
+        test_check_same()
+
+        def test_bad_input():
+            with self.assertRaisesRegex(RuntimeError, "Check for bad input"):
+                FileCheck().run("#CHECK: 1", "1")
+
+            with self.assertRaisesRegex(RuntimeError, "Check for bad input"):
+                FileCheck().run("", "1")
+
+            with self.assertRaisesRegex(RuntimeError, "Could not parse check"):
+                FileCheck().run("# CHECK1", "")
+
+        test_bad_input()
+
     def test_script_module_call_noscript(self):
         class M(torch.jit.ScriptModule):
             def __init__(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -43,7 +43,7 @@ from common_methods_invocations import create_input, unpack_variables, \
     exclude_tensor_method, non_differentiable, EXCLUDE_GRADCHECK, EXCLUDE_FUNCTIONAL
 from torch.testing import FileCheck
 from torch._C import TensorType, TupleType, FloatType, IntType, \
-    ListType, StringType, DictType
+    ListType, StringType, DictType, parseIR
 from copy import deepcopy
 import random
 from typing import List, Dict, Optional, Tuple
@@ -5932,6 +5932,14 @@ a")
         m2.sub.weight = nn.Parameter(torch.zeros_like(m2.sub.weight))
         m2.sub2.a.data.zero_()
         self.assertEqual(torch.zeros(2, 2), m2.forward(torch.randn(3, 2)))
+
+    def test_irparser(self):
+        graph_str = """graph(%0 : Double(5, 5)):
+          # CHECK: aten::relu
+          %1 : Double(5, 5) = aten::relu(%0)
+          return (%1)
+        """
+        FileCheck().run(graph_str, parseIR(graph_str))
 
     def test_filecheck(self):
         def test_check():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -43,7 +43,7 @@ from common_methods_invocations import create_input, unpack_variables, \
     exclude_tensor_method, non_differentiable, EXCLUDE_GRADCHECK, EXCLUDE_FUNCTIONAL
 from torch.testing import FileCheck
 from torch._C import TensorType, TupleType, FloatType, IntType, \
-    ListType, StringType, DictType, parseIR
+    ListType, StringType, DictType, parse_ir
 from copy import deepcopy
 import random
 from typing import List, Dict, Optional, Tuple
@@ -5939,7 +5939,7 @@ a")
           %1 : Double(5, 5) = aten::relu(%0)
           return (%1)
         """
-        FileCheck().run(graph_str, parseIR(graph_str))
+        FileCheck().run(graph_str, parse_ir(graph_str))
 
     def test_filecheck(self):
         def test_check():
@@ -6055,7 +6055,7 @@ a")
 
         def test_check_count():
             file = "22222"
-            FileCheck().run("# CHECK-COUNT-5: 2")
+            FileCheck().run("# CHECK-COUNT-5: 2", file)
             FileCheck().run("# CHECK-COUNT-EXACTLY-5: 2", file)
             FileCheck().run("# CHECK-COUNT-2: 22", file)
             FileCheck().run("# CHECK-COUNT-1: 222", file)
@@ -6078,9 +6078,6 @@ a")
         test_check_same()
 
         def test_bad_input():
-            with self.assertRaisesRegex(RuntimeError, "Check for bad input"):
-                FileCheck().run("#CHECK: 1", "1")
-
             with self.assertRaisesRegex(RuntimeError, "Check for bad input"):
                 FileCheck().run("", "1")
 

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/fuser/kernel_cache.h>
 #include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/import.h>
+#include <torch/csrc/jit/irparser.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/canonicalize_ops.h>
@@ -76,7 +77,6 @@ bool loadPythonClasses() {
 
   return true;
 }
-
 } // anonymous namespace
 
 #if defined(_WIN32)
@@ -348,11 +348,18 @@ void initJITBindings(PyObject* module) {
       },
       py::arg("qualified_name"));
 
+  m.def("parseIR", [](const std::string& input) {
+    auto graph = std::make_shared<Graph>();
+    script::parseIR(input, &*graph);
+    return graph;
+  });
+
   py::class_<FunctionSchema>(m, "FunctionSchema")
       .def_property_readonly(
           "name", [](FunctionSchema& self) { return self.name(); })
       .def_property_readonly(
-          "overload_name", [](FunctionSchema& self) { return self.overload_name(); })
+          "overload_name",
+          [](FunctionSchema& self) { return self.overload_name(); })
       .def_property_readonly(
           "arguments", [](FunctionSchema& self) { return self.arguments(); })
       .def_property_readonly(
@@ -464,6 +471,5 @@ void initJITBindings(PyObject* module) {
   initBatchTensorBindings(module);
   initRegisterBatchOpsBindings(module);
 }
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -348,7 +348,7 @@ void initJITBindings(PyObject* module) {
       },
       py::arg("qualified_name"));
 
-  m.def("parseIR", [](const std::string& input) {
+  m.def("parse_ir", [](const std::string& input) {
     auto graph = std::make_shared<Graph>();
     script::parseIR(input, &*graph);
     return graph;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -13,6 +13,7 @@
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/hooks_for_testing.h>
 #include <torch/csrc/jit/import_source.h>
+#include <torch/csrc/jit/irparser.h>
 #include <torch/csrc/jit/passes/python_print.h>
 #include <torch/csrc/jit/passes/to_batch.h>
 #include <torch/csrc/jit/pybind_utils.h>
@@ -1078,9 +1079,24 @@ void initJitScriptBindings(PyObject* module) {
           [](testing::FileCheck& f, const std::string& str) {
             return f.run(str);
           })
-      .def("run", [](testing::FileCheck& f, const Graph& g) {
-        return f.run(g);
-      });
+      .def(
+          "run", [](testing::FileCheck& f, const Graph& g) { return f.run(g); })
+      .def(
+          "run",
+          [](testing::FileCheck& f,
+             const std::string& input,
+             const std::string& output) { return f.run(input, output); },
+          "Run",
+          py::arg("checks_file"),
+          py::arg("test_file"))
+      .def(
+          "run",
+          [](testing::FileCheck& f, const std::string& input, const Graph& g) {
+            return f.run(input, g);
+          },
+          "Run",
+          py::arg("checks_file"),
+          py::arg("graph"));
 }
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -257,7 +257,7 @@ struct FileCheckImpl {
       return start;
     }
     start += 1;
-    static const size_t max_whitespace = 6;
+    static constexpr size_t max_whitespace = 6;
     size_t i = 0;
     while (start + i < checks_file->size() && i < max_whitespace) {
       auto c = checks_file->at(start + i);
@@ -266,7 +266,7 @@ struct FileCheckImpl {
       }
       i++;
     }
-    const static std::string check = "CHECK";
+    static const std::string check = "CHECK";
     if (checks_file->substr(start + i, check.size()) == check) {
       return start + i + check.size();
     } else {

--- a/torch/csrc/jit/testing/file_check.h
+++ b/torch/csrc/jit/testing/file_check.h
@@ -23,6 +23,14 @@ struct FileCheck {
   // Run FileCheck against dump of graph IR
   TORCH_API void run(const Graph& graph);
 
+  // Parsing input checks string and run against test string / dump of graph IR
+  TORCH_API void run(
+      const std::string& input_checks_string,
+      const std::string& test_string);
+  TORCH_API void run(
+      const std::string& input_checks_string,
+      const Graph& graph);
+
   // Checks that the string occurs, starting at the end of the most recent match
   TORCH_API FileCheck* check(const std::string& str);
 


### PR DESCRIPTION
This allows you to embed checks in IR, making the test more readable.

E.g.
```
graph_str = 'graph(%0 : Double(5, 5)):
          # CHECK: aten::relu
          %1 : Double(5, 5) = aten::relu(%0)
          return (%1)'       
FileCheck().run(graph_str, parseIR(graph_str))
```
