### PR TITLE
Add python bindings for parseIR.

### DIFF
--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/fuser/kernel_cache.h>
 #include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/import.h>
+#include <torch/csrc/jit/irparser.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/canonicalize_ops.h>
@@ -103,6 +104,11 @@ void initJITBindings(PyObject* module) {
       .def("_jit_pass_lower_all_tuples", LowerAllTuples)
       .def("_jit_pass_onnx_peephole", PeepholeOptimizeONNX)
       .def("_jit_pass_fuse", FuseGraph)
+      .def(
+          "_jit_parse_ir",
+          [](const std::string& str, std::shared_ptr<Graph>& g) {
+            script::parseIR(str, g.get());
+          })
       .def(
           "_jit_pass_dce",
           [](std::shared_ptr<Graph>& g) {
@@ -352,7 +358,8 @@ void initJITBindings(PyObject* module) {
       .def_property_readonly(
           "name", [](FunctionSchema& self) { return self.name(); })
       .def_property_readonly(
-          "overload_name", [](FunctionSchema& self) { return self.overload_name(); })
+          "overload_name",
+          [](FunctionSchema& self) { return self.overload_name(); })
       .def_property_readonly(
           "arguments", [](FunctionSchema& self) { return self.arguments(); })
       .def_property_readonly(

--- a/torch/csrc/jit/irparser.cpp
+++ b/torch/csrc/jit/irparser.cpp
@@ -73,7 +73,7 @@ struct VarWithType {
   TypePtr type;
 };
 
-void parseIR(const std::string& str, torch::jit::Graph* graph) {
+TORCH_API void parseIR(const std::string& str, torch::jit::Graph* graph) {
   torch::jit::script::IRParser p(str, graph);
   p.parse();
 }

--- a/torch/csrc/jit/irparser.h
+++ b/torch/csrc/jit/irparser.h
@@ -1,3 +1,5 @@
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
 #include <string>
 
 namespace torch {
@@ -8,7 +10,7 @@ struct Graph;
 namespace script {
 
 // \brief Parse IR from \p STR constructing the corresponding IR in\ GRAPH.
-void parseIR(const std::string& str, torch::jit::Graph* graph);
+TORCH_API void parseIR(const std::string& str, torch::jit::Graph* graph);
 
 } // namespace script
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #18307 Convert test_recursive_cse to use Filecheck inline annotations.
* #18306 [Filecheck] Add a feature to parse check annotations from string.
* **#18305 Add python bindings for parseIR.**
* #18303 Remove empty file (actual file_check.cpp resides in torch/csrc/jit/testing)

Differential Revision: [D14586001](https://our.internmc.facebook.com/intern/diff/D14586001)