### PR TITLE
[Filecheck] Add a feature to parse check annotations from string.

### DIFF
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -1078,6 +1078,11 @@ void initJitScriptBindings(PyObject* module) {
           [](testing::FileCheck& f, const std::string& str) {
             return f.run(str);
           })
+      .def(
+          "run",
+          [](testing::FileCheck& f,
+             const std::string& output,
+             const std::string& expected) { return f.run(output, expected); })
       .def("run", [](testing::FileCheck& f, const Graph& g) {
         return f.run(g);
       });

--- a/torch/csrc/jit/testing/file_check.h
+++ b/torch/csrc/jit/testing/file_check.h
@@ -17,6 +17,9 @@ struct FileCheck {
   TORCH_API explicit FileCheck();
   TORCH_API ~FileCheck();
 
+  // Run FileCheck against test string with annotation parsed from `expected`.
+  TORCH_API void run(const std::string& output, const std::string& expected);
+
   // Run FileCheck against test string
   TORCH_API void run(const std::string& test_string);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #18307 Convert test_recursive_cse to use Filecheck inline annotations.
* **#18306 [Filecheck] Add a feature to parse check annotations from string.**
* #18305 Add python bindings for parseIR.
* #18303 Remove empty file (actual file_check.cpp resides in torch/csrc/jit/testing)

Differential Revision: [D14586002](https://our.internmc.facebook.com/intern/diff/D14586002)