### PR TITLE
Fix error reporting in NVRTC use of the fuser

### DIFF
--- a/torch/csrc/jit/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/fuser/cuda/fused_kernel.cpp
@@ -185,9 +185,9 @@ FusedKernelCUDA::FusedKernelCUDA(
       nvrtc().nvrtcCompileProgram(program, args.size(), args.data());
   if (result == NVRTC_ERROR_COMPILATION) {
     size_t logsize;
-    nvrtcGetProgramLogSize(program, &logsize);
+    nvrtc().nvrtcGetProgramLogSize(program, &logsize);
     std::vector<char> log(logsize);
-    nvrtcGetProgramLog(program, log.data());
+    nvrtc().nvrtcGetProgramLog(program, log.data());
     std::stringstream cu;
     cu << log.data();
     throw std::runtime_error(cu.str());

--- a/torch/csrc/jit/fuser/cuda/thnvrtc.h
+++ b/torch/csrc/jit/fuser/cuda/thnvrtc.h
@@ -16,6 +16,8 @@
   _(cuOccupancyMaxActiveBlocksPerMultiprocessor) \
   _(cuGetErrorString)                            \
   _(nvrtcGetErrorString)                         \
+  _(nvrtcGetProgramLogSize)                      \
+  _(nvrtcGetProgramLog)                          \
   _(cuLaunchKernel)                              \
   _(nvrtcCompileProgram)                         \
   _(cuCtxGetCurrent)                             \


### PR DESCRIPTION
Two functions were not directed ad NVRTC.
It's a bit hard to test this, as the fuser usually produces correct code - unless I try to hack on it. :)

