### PR TITLE
Assert tensor isn't sparse in enforce_invariants.

### DIFF
--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -21,7 +21,7 @@ void Tensor::enforce_invariants() {
           "Partially-initialized tensor not supported by at::Tensor");
       AT_ASSERTM(
           !impl_->is_sparse(),
-          "Sparse Tensors are supported by at::Tensor, but invariants aren't implemented.  Please file a bug.");
+          "Sparse Tensors are supported by at::Tensor, but invariant checking isn't implemented.  Please file a bug.");
       AT_ASSERTM(
           impl_->storage_initialized(),
           "Partially-initialized tensor not supported by at::Tensor");

--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -20,6 +20,9 @@ void Tensor::enforce_invariants() {
           impl_->dtype_initialized(),
           "Partially-initialized tensor not supported by at::Tensor");
       AT_ASSERTM(
+          !impl_->is_sparse(),
+          "Sparse Tensors are supported by at::Tensor, but invariants aren't implemented.  Please file a bug.");
+      AT_ASSERTM(
           impl_->storage_initialized(),
           "Partially-initialized tensor not supported by at::Tensor");
     }


### PR DESCRIPTION
There's no reason we can't check this, but I'm punting on implementing it for now.  But it currently segfaults, so this is an improvements.

