### PR TITLE
Add nets which include SigridTransform

### DIFF
--- a/caffe2/core/operator_schema.cc
+++ b/caffe2/core/operator_schema.cc
@@ -338,7 +338,8 @@ void SparseLengthsFillerHelper(
     std::vector<TensorFiller>* fillers) {
   CAFFE_ENFORCE_EQ(shapes[length_index].size(), 1);
   // filler.h: SparseLengths->FixedSum will select FD_FIXEDSUM distribution
-  (*fillers)[length_index].SparseLengths(shapes[value_index].front());
+  (*fillers)[length_index].SparseLengths(
+      shapes[value_index].front(), shapes[length_index].front());
 }
 
 void SparseWeightsFillerHelper(

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -425,6 +425,24 @@ class CAFFE2_API OpSchema {
   OpSchema&
   SliceInputFillers(size_t value_index, size_t starts_index, size_t ends_index);
 
+  // The helper is build input with starts and ends; e.g.:
+  //  data  = [ 1, 2,  3,   4,   5,       6]
+  //            ^       \___/    ^        ^
+  //            |         ^      |        |
+  //            |         |      |        |
+  //          [0, 1]   [2, 2] [4, 1]   [5, 1]
+  //  ranges = [
+  //    [
+  //      [0, 1],
+  //      [2, 2],
+  //    ],
+  //    [
+  //      [4, 1],
+  //      [5, 1],
+  //    ]
+  //  ]
+  OpSchema& GatherRangesInputFillers(size_t value_index, size_t ranges_index);
+
   OpSchema& DisallowInputFillers();
 
   std::vector<TensorFiller> InputFillers(

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -1,13 +1,14 @@
 #ifndef CAFFE2_CORE_OPERATOR_SCHEMA_H_
 #define CAFFE2_CORE_OPERATOR_SCHEMA_H_
 
+#include <algorithm>
 #include <climits>
 #include <functional>
 #include <initializer_list>
 #include <ostream>
 #include <set>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "c10/util/Registry.h"
 #include "caffe2/core/common.h"
@@ -405,6 +406,24 @@ class CAFFE2_API OpSchema {
   //            \_____/  \________/  \__/
   // lengths =    [3,        4,       2]
   OpSchema& ValueLengthInputFillers(size_t value_index, size_t length_index);
+
+  // The helper is filling the starts and ends; e.g.:
+  //         1
+  //         |
+  //         V
+  // data = [
+  //     [1, 2, 3, 4],  <- 0
+  //     [5, 6, 7, 8],  <- -1
+  // ]
+  //            ^
+  //            |
+  //            3
+  //
+  // starts = [0, 1]
+  // ends = [-1, 3]
+  //
+  OpSchema&
+  SliceInputFillers(size_t value_index, size_t starts_index, size_t ends_index);
 
   OpSchema& DisallowInputFillers();
 

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -9,7 +9,10 @@ REGISTER_CPU_GRADIENT_OPERATOR(SliceGradient, SliceGradientOp<CPUContext>);
 OPERATOR_SCHEMA(Slice)
     .NumInputs(1, 3)
     .NumOutputs(1)
-    .DisallowInputFillers() // the filler cannot be enabled without output dims
+    .SliceInputFillers(
+        0, // value
+        1, // starts
+        2) // ends
     .SetDoc(R"DOC(
 Produces a slice of the input tensor.
 

--- a/caffe2/predictor/emulator/data_filler.cc
+++ b/caffe2/predictor/emulator/data_filler.cc
@@ -96,6 +96,26 @@ DataRandomFiller::DataRandomFiller(
       }
     }
 
+    // the output shape of Slice op must match with the input shape of
+    // next op
+    if (op.type() == "Slice") {
+      for (size_t j = i + 1; j < run_net.op_size(); ++j) {
+        const auto& next_op = run_net.op(j);
+        auto found = false;
+        for (size_t k = 0; k < next_op.input_size(); ++k) {
+          if (op.output(0) == next_op.input(k)) {
+            inputs_[op.input(1)].first.FixedValue({0, 0});
+            inputs_[op.input(2)].first.FixedValue(input_dims[j][k]);
+            found = true;
+            break;
+          }
+        }
+        if (found) {
+          break;
+        }
+      }
+    }
+
     for (size_t j = 0; j < op.output_size(); ++j) {
       output_names.emplace(op.output(j));
     }

--- a/caffe2/predictor/emulator/data_filler.cc
+++ b/caffe2/predictor/emulator/data_filler.cc
@@ -126,7 +126,9 @@ DataRandomFiller::DataRandomFiller(
   for (size_t i = 0; i < run_net.arg_size(); ++i) {
     const auto& arg = run_net.arg(i);
     // TODO: replace "PredictorParameters" with the constant in OSS bbp
-    if (arg.has_name() && arg.name() == "PredictorParameters") {
+    if (arg.has_name() &&
+        ((arg.name() == "PredictorParameters") ||
+         arg.name().find("RemovedOp") != std::string::npos)) {
       parameters.reserve(arg.strings_size());
       for (size_t j = 0; j < arg.strings_size(); ++j) {
         parameters.emplace(arg.strings(j));

--- a/caffe2/utils/filler.h
+++ b/caffe2/utils/filler.h
@@ -80,9 +80,10 @@ class TensorFiller {
   // A helper function to construct the lengths vector for sparse features
   // We try to pad least one index per batch unless the total_length is 0
   template <class Type>
-  TensorFiller& SparseLengths(Type total_length) {
+  TensorFiller& SparseLengths(Type total_length, size_t num_elems) {
+    Type min_value = total_length / num_elems;
     return FixedSum(total_length)
-        .Min(std::min(static_cast<Type>(1), total_length))
+        .Min(std::min(static_cast<Type>(1), min_value))
         .Max(total_length);
   }
 


### PR DESCRIPTION
Summary:
Based on Mingzhe's stack D13201113.

In the inference benchmark, we currently filter out nets which include SigridTransform because we don't have fillers for these complex ops. However, many nets with the top number of runs include SigridTransforms. To make the inference benchmark run closer to production, we'd like to include running these nets.

In this diff, we fetch nets that include SigridTransform ops. We then remove the SigridTransform op, and then generate inputs for the ops running after SigridTransform. This relies on a couple diffs to supply fillers for downstream ops (Slice, GatherRanges, SparseLengthsSum). There are also a couple ops that we haven't supplied fillers for yet, but will do in subsequent diffs to increase the coverage (ClipRangesGatherSigridHash, CastedBatchOneHot).

Differential Revision: D14585634
