### PR TITLE
Fix filler for SparseLengthsSum

### DIFF
--- a/caffe2/core/operator_schema.cc
+++ b/caffe2/core/operator_schema.cc
@@ -338,7 +338,8 @@ void SparseLengthsFillerHelper(
     std::vector<TensorFiller>* fillers) {
   CAFFE_ENFORCE_EQ(shapes[length_index].size(), 1);
   // filler.h: SparseLengths->FixedSum will select FD_FIXEDSUM distribution
-  (*fillers)[length_index].SparseLengths(shapes[value_index].front());
+  (*fillers)[length_index].SparseLengths(
+      shapes[value_index].front(), shapes[length_index].front());
 }
 
 void SparseWeightsFillerHelper(

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -425,6 +425,24 @@ class CAFFE2_API OpSchema {
   OpSchema&
   SliceInputFillers(size_t value_index, size_t starts_index, size_t ends_index);
 
+  // The helper is build input with starts and ends; e.g.:
+  //  data  = [ 1, 2,  3,   4,   5,       6]
+  //            ^       \___/    ^        ^
+  //            |         ^      |        |
+  //            |         |      |        |
+  //          [0, 1]   [2, 2] [4, 1]   [5, 1]
+  //  ranges = [
+  //    [
+  //      [0, 1],
+  //      [2, 2],
+  //    ],
+  //    [
+  //      [4, 1],
+  //      [5, 1],
+  //    ]
+  //  ]
+  OpSchema& GatherRangesInputFillers(size_t value_index, size_t ranges_index);
+
   OpSchema& DisallowInputFillers();
 
   std::vector<TensorFiller> InputFillers(

--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -1,13 +1,14 @@
 #ifndef CAFFE2_CORE_OPERATOR_SCHEMA_H_
 #define CAFFE2_CORE_OPERATOR_SCHEMA_H_
 
+#include <algorithm>
 #include <climits>
 #include <functional>
 #include <initializer_list>
 #include <ostream>
 #include <set>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "c10/util/Registry.h"
 #include "caffe2/core/common.h"
@@ -405,6 +406,24 @@ class CAFFE2_API OpSchema {
   //            \_____/  \________/  \__/
   // lengths =    [3,        4,       2]
   OpSchema& ValueLengthInputFillers(size_t value_index, size_t length_index);
+
+  // The helper is filling the starts and ends; e.g.:
+  //         1
+  //         |
+  //         V
+  // data = [
+  //     [1, 2, 3, 4],  <- 0
+  //     [5, 6, 7, 8],  <- -1
+  // ]
+  //            ^
+  //            |
+  //            3
+  //
+  // starts = [0, 1]
+  // ends = [-1, 3]
+  //
+  OpSchema&
+  SliceInputFillers(size_t value_index, size_t starts_index, size_t ends_index);
 
   OpSchema& DisallowInputFillers();
 

--- a/caffe2/operators/slice_op.cc
+++ b/caffe2/operators/slice_op.cc
@@ -9,7 +9,10 @@ REGISTER_CPU_GRADIENT_OPERATOR(SliceGradient, SliceGradientOp<CPUContext>);
 OPERATOR_SCHEMA(Slice)
     .NumInputs(1, 3)
     .NumOutputs(1)
-    .DisallowInputFillers() // the filler cannot be enabled without output dims
+    .SliceInputFillers(
+        0, // value
+        1, // starts
+        2) // ends
     .SetDoc(R"DOC(
 Produces a slice of the input tensor.
 

--- a/caffe2/utils/filler.h
+++ b/caffe2/utils/filler.h
@@ -80,9 +80,10 @@ class TensorFiller {
   // A helper function to construct the lengths vector for sparse features
   // We try to pad least one index per batch unless the total_length is 0
   template <class Type>
-  TensorFiller& SparseLengths(Type total_length) {
+  TensorFiller& SparseLengths(Type total_length, size_t num_elems) {
+    Type min_value = total_length / num_elems;
     return FixedSum(total_length)
-        .Min(std::min(static_cast<Type>(1), total_length))
+        .Min(std::min(static_cast<Type>(1), min_value))
         .Max(total_length);
   }
 


### PR DESCRIPTION
Summary:
Based on the filler implementation, num_element * min_value should be smaller than fixed_sum. So the min_value should be in the range of [1, fixed_sum / num_element].

Based on Mingzhe's stack D13201113.

Differential Revision: D14585582
