### PR TITLE
Add more options to the quantization model exporter

### DIFF
--- a/caffe2/quantization/server/caffe2_dnnlowp_utils.cc
+++ b/caffe2/quantization/server/caffe2_dnnlowp_utils.cc
@@ -237,7 +237,8 @@ void ReportQuantizationError(
     const QuantizationErrorStats& stat) {
   if (stat.sum_sq == 0) {
     LOG(INFO) << " output " << op->debug_def().output(0) << " of operator "
-              << op << " with type " << op->debug_def().type()
+              << op << " with type " << op->debug_def().type() << " and engine "
+              << op->debug_def().engine()
               << " has l2 relative error nan (stat.sum_err_sq "
               << stat.sum_err_sq << " stat.sum_sq 0)"
               << " and max abs error " << stat.max_abs_err << " (reference is "
@@ -247,8 +248,8 @@ void ReportQuantizationError(
               << " cnt " << stat.measure_cnt;
   } else {
     LOG(INFO) << " output " << op->debug_def().output(0) << " of operator "
-              << op << " with type " << op->debug_def().type()
-              << " has l2 relative error "
+              << op << " with type " << op->debug_def().type() << " and engine "
+              << op->debug_def().engine() << " has l2 relative error "
               << std::sqrt(stat.sum_err_sq) / std::sqrt(stat.sum_sq)
               << " and max abs error " << stat.max_abs_err << " (reference is "
               << stat.max_err_ref << " and actual is " << stat.max_err_actual
@@ -305,18 +306,19 @@ static unique_ptr<QuantizationFactory> GetQuantizationFactoryOf_(
           "weight_quantization_kind",
           FLAGS_caffe2_dnnlowp_weight_quantization_kind);
 
-  VLOG(2) << "Quantization method for op with output " << op_def.output(0)
-          << " activation_precision " << activation_precision
-          << " weight_precision " << weight_precision
-          << " requantization_multiplier_precision "
-          << requantization_multiplier_precision
-          << " eltwise_quantization_precision "
-          << eltwise_quantization_precision << " preserve_activation_sparsity "
-          << preserve_activation_sparsity << " preserve_weight_sparsity "
-          << preserve_weight_sparsity << " force_scale_power_of_two "
-          << force_scale_power_of_two << " activation_quantization_kind "
-          << activation_quantization_kind << " weight_quantization_kind "
-          << weight_quantization_kind;
+  LOG(WARNING) << "Quantization method for op with output " << op_def.output(0)
+               << " engine " << op_def.engine() << " activation_precision "
+               << activation_precision << " weight_precision "
+               << weight_precision << " requantization_multiplier_precision "
+               << requantization_multiplier_precision
+               << " eltwise_quantization_precision "
+               << eltwise_quantization_precision
+               << " preserve_activation_sparsity "
+               << preserve_activation_sparsity << " preserve_weight_sparsity "
+               << preserve_weight_sparsity << " force_scale_power_of_two "
+               << force_scale_power_of_two << " activation_quantization_kind "
+               << activation_quantization_kind << " weight_quantization_kind "
+               << weight_quantization_kind;
 
   return unique_ptr<QuantizationFactory>(new QuantizationFactory(
       activation_precision,


### PR DESCRIPTION
Summary: Add command line options for different quantization schemes.

Reviewed By: amylittleyang

Differential Revision: D14476862
