### PR TITLE
Only look for Caffe2 package when shared

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -36,7 +36,9 @@ else()
 endif()
 
 # Library dependencies.
-find_package(Caffe2 REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
+if (@BUILD_SHARED_LIBS@)
+  find_package(Caffe2 REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
+endif()
 
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 add_library(torch UNKNOWN IMPORTED)


### PR DESCRIPTION
Previously it would look for the Config even if it was not written.

Fixed #18419

