### PR TITLE
Onnx exporter: add some support for in place operators

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -121,6 +121,10 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const ShapeInfoMap& shape_hints,
       std::unordered_set<int>* blacklisted_ops) const;
 
+  // Fix input and output name for inplace operators that might have been
+  // renamed by SsaRewrite.
+  void fixUpInplaceOperators(NetDef* net) const;
+
   // Determine backend id
   void getBackendId();
 


### PR DESCRIPTION
Summary:
In onnx export today we don't support in place operator super well. We currently always generate a new, unique versioned name for an output unless the output is a final external output.

This causes a problem for operators that update its input in place. For operators like ReLu where the in place update is allowed but not required, the current approach still is fine. However, for operator like ScatterAssgin where in place update is the only supported operation, we can no longer execute the graph after onnx transform (input matching output is validated by the operator schema).

We fix this by adding a pass at the end of the transform to specifically fix output to match the input for ScatterAssign.

Differential Revision: D14323827
