### PR TITLE
deal with bad input in batch_gather_ops shape inference

### DIFF
--- a/caffe2/operators/batch_gather_ops.cc
+++ b/caffe2/operators/batch_gather_ops.cc
@@ -15,10 +15,15 @@ OPERATOR_SCHEMA(BatchGather)
       const auto& data_dims = GetDimsVector(in[0]);
       const auto& indices_dims = GetDimsVector(in[1]);
 
-      vector<int> output_dims =
-          caffe2::gather_helper::calc_output_shape_vector<int>(
-              data_dims, indices_dims, 1);
-      out[0] = CreateTensorShape(output_dims, TensorProto::FLOAT);
+      if (data_dims.size() < 2) {
+        out[0].set_unknown_shape(true);
+      } else {
+        vector<int> output_dims =
+            caffe2::gather_helper::calc_output_shape_vector<int>(
+                data_dims, indices_dims, 1);
+        out[0] = CreateTensorShape(output_dims, TensorProto::FLOAT);
+      }
+
       return out;
     })
     .SetDoc(R"DOC(


### PR DESCRIPTION
Summary: In BatchGather, we require DATA to be rank r >= 2. In shape inference function, however, we do not do any check on the validity of the input. We have malformed model where DATA is only a 1 dimensional vector.  Calling shape inference will then result in a out of bound access in data_dims[1] in calc_output_shape_vector(). Fixed this by just return unknown shape if the input DATA doesn't have at least rank of 2.

Differential Revision: D14429901
