### PR TITLE
InferCommonOp: if all the inputs are DimType::Constant, then the output should be DimType::Constant too

### DIFF
--- a/caffe2/operators/batch_gather_ops.cc
+++ b/caffe2/operators/batch_gather_ops.cc
@@ -15,10 +15,15 @@ OPERATOR_SCHEMA(BatchGather)
       const auto& data_dims = GetDimsVector(in[0]);
       const auto& indices_dims = GetDimsVector(in[1]);
 
-      vector<int> output_dims =
-          caffe2::gather_helper::calc_output_shape_vector<int>(
-              data_dims, indices_dims, 1);
-      out[0] = CreateTensorShape(output_dims, TensorProto::FLOAT);
+      if (data_dims.size() < 2) {
+        out[0].set_unknown_shape(true);
+      } else {
+        vector<int> output_dims =
+            caffe2::gather_helper::calc_output_shape_vector<int>(
+                data_dims, indices_dims, 1);
+        out[0] = CreateTensorShape(output_dims, TensorProto::FLOAT);
+      }
+
       return out;
     })
     .SetDoc(R"DOC(

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -361,6 +361,8 @@ void BoundShapeInferencer::InferFC(const OperatorDef& op) {
 void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
   // First, we need to check that all the input shape/types are already
   // presented
+  bool input_all_constant = true;
+
   try {
   std::vector<TensorShape> input_shapes;
   for (const auto& input : op.input()) {
@@ -371,6 +373,14 @@ void BoundShapeInferencer::InferCommonOp(const OperatorDef& op) {
       return;
     }
     input_shapes.emplace_back(it->second.shape);
+
+    input_all_constant = input_all_constant &&
+        it->second.dim_type == ShapeInfo::DimType::CONSTANT;
+  }
+
+  // If input has only constant, then the output would be a constant.
+  if (input_all_constant) {
+    current_dim_type_ = ShapeInfo::DimType::CONSTANT;
   }
 
   const OpSchema* schema = OpSchemaRegistry::Schema(op.type());

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -121,6 +121,10 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const ShapeInfoMap& shape_hints,
       std::unordered_set<int>* blacklisted_ops) const;
 
+  // Fix input and output name for inplace operators that might have been
+  // renamed by SsaRewrite.
+  void fixUpInplaceOperators(NetDef* net) const;
+
   // Determine backend id
   void getBackendId();
 


### PR DESCRIPTION
Summary: As title. If all the inputs to an operator have the dim type of constant, then make the output also constant.

Differential Revision: D14430043
