### PR TITLE
Properly use cudaGetLastError return code.

### DIFF
--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -28,7 +28,8 @@ inline DeviceIndex device_count() noexcept {
     // Clear out the error state, so we don't spuriously trigger someone else.
     // (This shouldn't really matter, since we won't be running very much CUDA
     // code in this regime.)
-    cudaGetLastError();
+    cudaError_t last_err = cudaGetLastError();
+    (void)last_err;
     return 0;
   }
   return static_cast<DeviceIndex>(count);


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18485 Properly use cudaGetLastError return code.**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14621961/)

I don't know how (1) we landed the wrong version of the patch and (2) how
this passed the push blocking test

Differential Revision: [D14621961](https://our.internmc.facebook.com/intern/diff/D14621961/)