### PR TITLE
Add qtensors in caffe2 protobuf argument

### DIFF
--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -163,6 +163,7 @@ message Argument {
   repeated bytes strings = 7;
   repeated TensorProto tensors = 11;
   repeated NetDef nets = 9;
+  repeated QTensorProto qtensors = 12;
 }
 
 // DeviceType that Caffe2 currently supports.


### PR DESCRIPTION
We are about to merge onnxifi quantization support soon. Before that, I would like to merge this diff seperately to make sure it doesnt break anything.