### PR TITLE
Skip tests if C2/ONNX models cannot be read

### DIFF
--- a/caffe2/python/models/download.py
+++ b/caffe2/python/models/download.py
@@ -147,37 +147,39 @@ def validModelName(name):
     return True
 
 class ModelDownloader:
+
+    def __init__(self, model_env_name='CAFFE2_MODELS'):
+        self.model_env_name = model_env_name
+
     def _model_dir(self, model):
         caffe2_home = os.path.expanduser(os.getenv('CAFFE2_HOME', '~/.caffe2'))
-        models_dir = os.getenv('CAFFE2_MODELS', os.path.join(caffe2_home, 'models'))
+        models_dir = os.getenv(self.model_env_name, os.path.join(caffe2_home, 'models'))
         return os.path.join(models_dir, model)
 
     def _download(self, model):
         model_dir = self._model_dir(model)
         assert not os.path.exists(model_dir)
         os.makedirs(model_dir)
+
         for f in ['predict_net.pb', 'init_net.pb', 'value_info.json']:
             url = getURLFromName(model, f)
             dest = os.path.join(model_dir, f)
             try:
-                try:
-                    downloadFromURLToFile(url, dest,
-                                          show_progress=False)
-                except TypeError:
-                    # show_progress not supported prior to
-                    # Caffe2 78c014e752a374d905ecfb465d44fa16e02a28f1
-                    # (Sep 17, 2017)
-                    downloadFromURLToFile(url, dest)
-            except Exception as e:
-                print("Abort: {reason}".format(reason=e))
-                print("Cleaning up...")
+                downloadFromURLToFile(url, dest, show_progress=False)
+            except TypeError:
+                # show_progress not supported prior to
+                # Caffe2 78c014e752a374d905ecfb465d44fa16e02a28f1
+                # (Sep 17, 2017)
+                downloadFromURLToFile(url, dest)
+            except Exception:
                 deleteDirectory(model_dir)
-                exit(1)
+                raise
 
     def get_c2_model(self, model_name):
         model_dir = self._model_dir(model_name)
         if not os.path.exists(model_dir):
             self._download(model_name)
+
         c2_predict_pb = os.path.join(model_dir, 'predict_net.pb')
         c2_predict_net = caffe2_pb2.NetDef()
         with open(c2_predict_pb, 'rb') as f:

--- a/caffe2/python/onnx/test_onnxifi.py
+++ b/caffe2/python/onnx/test_onnxifi.py
@@ -15,7 +15,7 @@ from onnx.backend.base import namedtupledict
 from onnx.helper import make_node, make_graph, make_tensor, make_tensor_value_info, make_model
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
-from caffe2.python.models.download import downloadFromURLToFile, getURLFromName, deleteDirectory
+from caffe2.python.models.download import ModelDownloader
 from caffe2.python.onnx.onnxifi import onnxifi_caffe2_net
 from caffe2.python.onnx.tests.test_utils import TestCase
 
@@ -109,54 +109,8 @@ class OnnxifiTest(TestCase):
 
 
 class OnnxifiTransformTest(TestCase):
-    def _model_dir(self, model):
-        caffe2_home = os.path.expanduser(os.getenv('CAFFE2_HOME', '~/.caffe2'))
-        models_dir = os.getenv('CAFFE2_MODELS', os.path.join(caffe2_home, 'models'))
-        return os.path.join(models_dir, model)
-
-    def _download(self, model):
-        model_dir = self._model_dir(model)
-        assert not os.path.exists(model_dir)
-        os.makedirs(model_dir)
-        for f in ['predict_net.pb', 'init_net.pb', 'value_info.json']:
-            url = getURLFromName(model, f)
-            dest = os.path.join(model_dir, f)
-            try:
-                try:
-                    downloadFromURLToFile(url, dest,
-                                          show_progress=False)
-                except TypeError:
-                    # show_progress not supported prior to
-                    # Caffe2 78c014e752a374d905ecfb465d44fa16e02a28f1
-                    # (Sep 17, 2017)
-                    downloadFromURLToFile(url, dest)
-            except Exception as e:
-                print("Abort: {reason}".format(reason=e))
-                print("Cleaning up...")
-                deleteDirectory(model_dir)
-                exit(1)
-
-    # TODO: we need to modulize this function
-    def _get_c2_model(self, model_name):
-        model_dir = self._model_dir(model_name)
-        if not os.path.exists(model_dir):
-            self._download(model_name)
-        c2_predict_pb = os.path.join(model_dir, 'predict_net.pb')
-        c2_predict_net = caffe2_pb2.NetDef()
-        with open(c2_predict_pb, 'rb') as f:
-            c2_predict_net.ParseFromString(f.read())
-        c2_predict_net.name = model_name
-
-        c2_init_pb = os.path.join(model_dir, 'init_net.pb')
-        c2_init_net = caffe2_pb2.NetDef()
-        with open(c2_init_pb, 'rb') as f:
-            c2_init_net.ParseFromString(f.read())
-        c2_init_net.name = model_name + '_init'
-        
-        with open(os.path.join(model_dir, 'value_info.json')) as f:
-            value_info = json.load(f)
-        
-        return c2_init_net, c2_predict_net, value_info
+    def setUp(self):
+        self.model_downloader = ModelDownloader()
 
     def _add_head_tail(self, pred_net, new_head, new_tail):
         orig_head = pred_net.external_input[0]
@@ -187,7 +141,7 @@ class OnnxifiTransformTest(TestCase):
         N = 1
         repeat = 1
         print("Batch size: {}, repeat inference {} times".format(N, repeat))
-        init_net, pred_net, _ = self._get_c2_model('resnet50')
+        init_net, pred_net, _ = self.model_downloader.get_c2_model('resnet50')
         self._add_head_tail(pred_net, 'real_data', 'real_softmax')
         input_blob_dims = (N, 3, 224, 224)
         input_name = "real_data"

--- a/caffe2/python/onnx/tests/test_utils.py
+++ b/caffe2/python/onnx/tests/test_utils.py
@@ -10,8 +10,6 @@ import os
 import unittest
 
 import numpy as np
-from caffe2.python.models.download import downloadFromURLToFile, getURLFromName, deleteDirectory
-
 
 class TestCase(unittest.TestCase):
 
@@ -31,27 +29,3 @@ class TestCase(unittest.TestCase):
             raise ValueError('Duplicated test name: {}'.format(name))
         setattr(self, name, test_func)
 
-
-class DownloadingTestCase(TestCase):
-
-    def _download(self, model):
-        model_dir = self._model_dir(model)
-        assert not os.path.exists(model_dir)
-        os.makedirs(model_dir)
-        for f in ['predict_net.pb', 'init_net.pb', 'value_info.json']:
-            url = getURLFromName(model, f)
-            dest = os.path.join(model_dir, f)
-            try:
-                try:
-                    downloadFromURLToFile(url, dest,
-                                          show_progress=False)
-                except TypeError:
-                    # show_progress not supported prior to
-                    # Caffe2 78c014e752a374d905ecfb465d44fa16e02a28f1
-                    # (Sep 17, 2017)
-                    downloadFromURLToFile(url, dest)
-            except Exception as e:
-                print("Abort: {reason}".format(reason=e))
-                print("Cleaning up...")
-                deleteDirectory(model_dir)
-                raise AssertionError("Test model downloading failed")


### PR DESCRIPTION
Summary:
Today we have some C2 end2end test run requiring reading model data from external filesystem (for example, Gluster and AWS). This could be a source for flaky test when the external filesystems are not reachable during the tests.

In this diff, we add try/catch logic around where we download models and open model files from external system. In case such attempts fails, we will catch the excption and let the unittest skip the current test instead of failure.

I also refactor the code a little bit by removing some duplicated logic on downloading and build the c2 model data. It has been duplicated in two classes and a few functions...

Differential Revision: D14442241
