### PR TITLE
Upgrade flake8-bugbear to master, fix the new lints.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,4 @@ ignore =
     E203,E305,E402,E501,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504,C408,
     # ignores below are temporary, fix them and remove please!
     B007,B008
-exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install,build,torch/include
+exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install,build,torch/include,torch/__init__.pyi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ matrix:
         python: "3.7"
         dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
         sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
-        install: pip install flake8-mypy flake8-bugbear
+        install:
+          - pip install flake8-mypy
+          # Apparently Facebook runs master (not released)
+          - pip install git+https://github.com/PyCQA/flake8-bugbear.git@d9444713a51a9fb6ee8cd2d88fca85e9ff0c2d58
         script: flake8
       - name: "MyPy typecheck"
         python: "3.6"

--- a/docs/cpp/source/conf.py
+++ b/docs/cpp/source/conf.py
@@ -195,7 +195,7 @@ def setup(app):
 
     # In Sphinx 1.8 it was renamed to `add_css_file`, 1.7 and prior it is
     # `add_stylesheet` (deprecated in 1.8).
-    add_css = getattr(app, 'add_css_file', getattr(app, 'add_stylesheet'))
+    add_css = getattr(app, 'add_css_file', app.add_stylesheet)
     for css_file in html_css_files:
         add_css(css_file)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,7 @@ def setup(app):
 
     # In Sphinx 1.8 it was renamed to `add_css_file`, 1.7 and prior it is
     # `add_stylesheet` (deprecated in 1.8).
-    add_css = getattr(app, 'add_css_file', getattr(app, 'add_stylesheet'))
+    add_css = getattr(app, 'add_css_file', app.add_stylesheet)
     for css_file in html_css_files:
         add_css(css_file)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -60,11 +60,11 @@ with warnings.catch_warnings(record=True) as warns:
 class FilelikeMock(object):
     def __init__(self, data, has_fileno=True, has_readinto=False):
         if has_readinto:
-            setattr(self, 'readinto', self.readinto_opt)
+            self.readinto = self.readinto_opt
         if has_fileno:
             # Python 2's StringIO.StringIO has no fileno attribute.
             # This is used to test that.
-            setattr(self, 'fileno', self.fileno_opt)
+            self.fileno = self.fileno_opt
 
         self.calls = set()
         self.bytesio = io.BytesIO(data)
@@ -1057,7 +1057,7 @@ class _TestTorchMixin(object):
             "std", "sum", "var", "max", "min"]
 
         def normfn_attr(t, dim, keepdim=False, out=None):
-            attr = getattr(torch, "norm")
+            attr = torch.norm
             return attr(t, 2, dim, keepdim, out=out)
 
         for fn_name in dim_red_fns:
@@ -3838,14 +3838,14 @@ class _TestTorchMixin(object):
 
             for lhs in lhsTensors:
                 lhs_expanded = lhs.expand(*(torch.Size(full_batch_dims) + torch.Size(lhs_mat_dims)))
-                lhs_expanded_matmul_fn = getattr(lhs_expanded, "matmul")
+                lhs_expanded_matmul_fn = lhs_expanded.matmul
                 for rhs in rhsTensors:
                     rhs_expanded = ((rhs if len(rhs_dims) != 1 else rhs.unsqueeze(-1)).
                                     expand(*(torch.Size(full_batch_dims) + torch.Size(rhs_mat_dims))))
                     truth = maybe_squeeze_result(lhs_expanded, rhs_expanded, lhs_expanded_matmul_fn(rhs_expanded))
                     for l in (lhs, lhs_expanded):
                         for r in (rhs, rhs_expanded):
-                            l_matmul_fn = getattr(l, "matmul")
+                            l_matmul_fn = l.matmul
                             result = maybe_squeeze_result(l, r, l_matmul_fn(r))
                             self.assertEqual(truth, result)
                             # test torch.matmul function as well

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -204,20 +204,26 @@ except ImportError:
             return TupleInstance(types)
 
     class TupleInstance(object):
+        __slots__ = ['__args__']
+
         def __init__(self, types):
-            setattr(self, '__args__', types)
+            self.__args__ = types
 
     class ListInstance(object):
+        __slots__ = ['__args__']
+
         def __init__(self, types):
-            setattr(self, '__args__', types)
+            self.__args__ = types
 
     class ListCls(object):
         def __getitem__(self, types):
             return TupleInstance(types)
 
     class DictInstance(object):
+        __slots__ = ['__args__']
+
         def __init__(self, types):
-            setattr(self, '__args__', types)
+            self.__args__ = types
 
     class DictCls(object):
         def __getitem__(self, types):

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -80,7 +80,7 @@ else:
 
 if PY3:
     import builtins
-    exec_ = getattr(builtins, "exec")
+    exec_ = builtins.exec
 else:
     def exec_(_code_, _globs_=None, _locs_=None):
         """Execute code in a namespace."""

--- a/torch/_six.py
+++ b/torch/_six.py
@@ -80,7 +80,8 @@ else:
 
 if PY3:
     import builtins
-    exec_ = builtins.exec
+    # See https://github.com/PyCQA/flake8-bugbear/issues/64
+    exec_ = getattr(builtins, "exec")  # noqa: B009
 else:
     def exec_(_code_, _globs_=None, _locs_=None):
         """Execute code in a namespace."""

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -94,14 +94,14 @@ class FunctionMeta(type):
                 has_static_forward = isinstance(forward, staticmethod) or isinstance(forward, classmethod)
                 break
 
-        setattr(cls, '_is_legacy', not has_static_forward)
+        cls._is_legacy = not has_static_forward
 
         # old-style functions
         if not has_static_forward:
             return super(FunctionMeta, cls).__init__(name, bases, attrs)
 
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})
-        setattr(cls, '_backward_cls', backward_fn)
+        cls._backward_cls = backward_fn
 
         return super(FunctionMeta, cls).__init__(name, bases, attrs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18507 Upgrade flake8-bugbear to master, fix the new lints.**

It turns out Facebook is internally using the unreleased master
flake8-bugbear, so upgrading it grabs a few more lints that Phabricator
was complaining about but we didn't get in open source.

A few of the getattr sites that I fixed look very suspicious (they're
written as if Python were a lazy language), but I didn't look more
closely into the matter.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14633682](https://our.internmc.facebook.com/intern/diff/D14633682)