### PR TITLE
Change ReinitializeTensor to use C10_LOG_FIRST_N

### DIFF
--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -40,6 +40,13 @@ C10_DECLARE_bool(caffe2_use_fatal_for_enforce);
 #define C10_LOG_EVERY_MS(severity, ms) LOG(severity)
 #endif
 
+// Same for LOG_FIRST_N
+#ifdef LOG_FIRST_N
+#define C10_LOG_FIRST_N(severity, n) LOG_FIRST_N(severity, n)
+#else
+#define C10_LOG_FIRST_N(severity, n) LOG(severity)
+#endif
+
 namespace c10 {
 
 using std::string;

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -142,7 +142,7 @@ void ReinitializeTensor(
       if (tensor->dtype() == options.dtype()) {
         tensor->raw_mutable_data();
       } else {
-        C10_LOG_FIRST_N(WARNING, 10)
+        C10_LOG_FIRST_N(WARNING, 1)
             << "Changing the data type of Tensor is discouraged."
             << " Attempt to change data type from: " << tensor->dtype()
             << " to: " << options.dtype();

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -142,7 +142,7 @@ void ReinitializeTensor(
       if (tensor->dtype() == options.dtype()) {
         tensor->raw_mutable_data();
       } else {
-        C10_LOG_EVERY_MS(WARNING, 1000)
+        C10_LOG_FIRST_N(WARNING, 10)
             << "Changing the data type of Tensor is discouraged."
             << " Attempt to change data type from: " << tensor->dtype()
             << " to: " << options.dtype();


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18531 Change ReinitializeTensor to use C10_LOG_FIRST_N**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14647704/)

Currently we use C10_LOG_EVERY_MS to log the data type change, but it pollutes the log of some service,
we would like to change it to C10_LOG_FIRST_N to prevent that.

Differential Revision: [D14647704](https://our.internmc.facebook.com/intern/diff/D14647704/)