### PR TITLE
Completely synchronize behavior of Facebook flake8 and public flake8.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,15 @@
 [flake8]
-select = B,C,E,F,P,T4,W,B9
+# Notably, P is not included here; this is the Facebook internal
+# code for 'plow' (custom lint rules); they're not supported in OSS
+# and so we don't enforce them.
+select = B,C,E,F,T4,W,B9
 max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
     E203,E305,E402,E501,E721,E741,F401,F403,F405,F821,F841,F999,W503,W504,C408,
-    # ignores below are temporary, fix them and remove please!
-    B007,B008
+    # these ignores are from flake8-bugbear; please fix!
+    B007,B008,
+    # these ignores are from flake8-comprehensions; please fix!
+    C400,C401,C402,C403,C404,C405,C407,C411,
 exclude = docs/src,venv,third_party,caffe2,scripts,docs/caffe2,tools/amd_build/pyHIPIFY,torch/lib/include,torch/lib/tmp_install,build,torch/include,torch/__init__.pyi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ matrix:
         dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
         sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
         install:
-          - pip install flake8-mypy
-          # Apparently Facebook runs master (not released)
+          - pip install flake8 flake8-mypy flake8-comprehensions flake8-pyi mccabe pycodestyle pyflakes
+          # Apparently Facebook runs master of this one
+          # https://github.com/PyCQA/flake8-bugbear/issues/53
           - pip install git+https://github.com/PyCQA/flake8-bugbear.git@d9444713a51a9fb6ee8cd2d88fca85e9ff0c2d58
         script: flake8
       - name: "MyPy typecheck"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18538 Completely synchronize behavior of Facebook flake8 and public flake8.**

Previously, developers at Facebook had the very funny experience
wherein /usr/local/bin/flake8 behaved differently than a freshly
installed flake8 from pip.  In this commit, I add enough ignores to
.flake8 and install enough plugins to make the Facebook flake8
and public flake8 line up exactly.  These means you don't have
to care which flake8 you use; they all will report accurate information
on your Python files.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14652336](https://our.internmc.facebook.com/intern/diff/D14652336)