### PR TITLE
add slow tests annotation to some jit tests

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18,7 +18,7 @@ from torch.onnx import OperatorExportTypes
 from torch._six import inf, PY2, builtins
 from common_utils import TestCase, run_tests, IS_WINDOWS, TEST_WITH_UBSAN, \
     skipIfRocm, skipIfNoLapack, suppress_warnings, load_tests, IS_SANDCASTLE, \
-    freeze_rng_state, set_rng_seed
+    freeze_rng_state, set_rng_seed, slowTest
 from common_nn import module_tests, new_module_tests, criterion_tests
 from textwrap import dedent
 from functools import wraps
@@ -2853,6 +2853,7 @@ class TestBatched(TestCase):
                          w_hi, w_hf, w_ho, w_hc, b_i, b_f, b_o, b_c)
         self.assertEqual(ys, ybs.examples())
 
+    @slowTest
     def test_greedy_search(self):
         def greedy(x, h, c, embed, w_xi, w_xf, w_xo, w_xc, w_hi, w_hf, w_ho, w_hc,
                    b_i, b_f, b_o, b_c, w_hs, b_s, iter_num):
@@ -2916,6 +2917,7 @@ class TestBatched(TestCase):
                            w_hi, w_hf, w_ho, w_hc, b_i, b_f, b_o, b_c, w_hs, b_s, iter_num_batch)
         self.assertEqual(ys, ybs.examples())
 
+    @slowTest
     def test_beam_search(self):
         def beam(x, h, c, embed, w_xi, w_xf, w_xo, w_xc, w_hi, w_hf, w_ho, w_hc,
                  b_i, b_f, b_o, b_c, w_hs, b_s, iter_num, idx):
@@ -7463,6 +7465,7 @@ a")
         self.assertEqual(m_orig.doit3(input), m_import.doit3(input))
         self.assertEqual(m_orig.forward(input), m_import.forward(input))
 
+    @slowTest
     @skipIfNoTorchVision
     def test_script_module_trace_resnet18(self):
         x = torch.ones(1, 3, 224, 224)
@@ -7482,6 +7485,7 @@ a")
         self.assertEqual(output_orig, output_import)
         self.assertEqual(grad_orig, grad_import)
 
+    @slowTest
     @skipIfNoTorchVision
     def test_script_module_script_resnet(self):
         def conv1x1(in_planes, out_planes, stride=1):


### PR DESCRIPTION
Adds slow test annotation to the following very slow tests - 

70.33s     test/test_jit.py::TestScript::test_script_module_script_resnet
32.33s     test/test_jit.py::TestBatched::test_beam_search
17.70s     test/test_jit.py::TestBatched::test_greedy_search
15.58s     test/test_jit.py::TestScript::test_script_module_trace_resnet18

The list of remaining slow tests is below. Let me know if you think any of the others should be added to slow tests as well. Slow tests will only run on master.

15.28s call     test/test_jit.py::TestJit::test_export_batchnorm
12.96s call     test/test_jit.py::TestEndToEndHybridFrontendModels::test_snli
11.65s call     test/test_jit.py::TestEndToEndHybridFrontendModels::test_neural_style
6.38s call     test/test_jit.py::TestJitGeneratedModule::test_nn_LocalResponseNorm_1d
5.96s call     test/test_jit.py::TestJitGeneratedModule::test_nn_LocalResponseNorm_2d_uneven_pad
5.91s call     test/test_jit.py::TestJitGeneratedModule::test_nn_LocalResponseNorm_3d_custom_params
4.76s call     test/test_jit.py::TestJit::test_alexnet
3.82s call     test/test_jit.py::TestScript::test_number_math
3.81s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_no_bias
3.76s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_groups_thnn
3.65s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_stride_pad1circular
3.49s call     test/test_jit.py::TestBatched::test_lstm
3.33s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_pad2circular
3.19s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv1d_stride1_pad2circular
3.11s call     test/test_jit.py::TestEndToEndHybridFrontendModels::test_dcgan_models
3.11s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_stride_padding
3.11s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_stride
3.08s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_no_bias
3.08s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv1d_stride1_pad1circular
3.07s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_groups
3.05s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_dilated
3.05s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_depthwise_with_multiplier
3.04s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_groups
3.03s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_dilated
3.02s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv2d_depthwise_dilated
3.02s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_dilated_strided

