### PR TITLE
Serialization supports pathlib.Path object for the input argument

### DIFF
--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -377,10 +377,12 @@ def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
     """
     new_fd = False
     if isinstance(f, str) or \
-            (sys.version_info[0] == 2 and isinstance(f, unicode)) or \
-            (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
+            (sys.version_info[0] == 2 and isinstance(f, unicode)):
         new_fd = True
         f = open(f, 'rb')
+    elif (sys.version_info[0] == 3 and isinstance(f, pathlib.Path)):
+        new_fd = True
+        f = f.open('rb')
     try:
         return _load(f, map_location, pickle_module, **pickle_load_args)
     finally:


### PR DESCRIPTION
This will allow pathlib.Path object to the torch.load as an input argument.
Fixes #16607