### PR TITLE
Make checkpointing evaluate only the related tasks

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2921,15 +2921,15 @@ class TestAutograd(TestCase):
         b = checkpoint(lambda b: Log.apply(b, 'b'), b)
         out = torch.cat((a, b)).sum()
 
-        #           +--> Log --> a
-        # Sum --> Cat
-        #           +--> Checkpoint(Log) --> b
+        #                 +--> Log[a] --> a
+        # Sum --> Cat[a, b]
+        #                 +--> Checkpoint(Log[b]) --> b
         out.backward()
 
         assert timeline == \
             ['a:forward', 'b:forward', 'b:forward', 'b:backward', 'a:backward']
         #    |----------------------|  |-----------------------|  |----------|
-        #          forward pass             b's checkpoint        a's backward
+        #          forward pass            Checkpoint(Log[b])        Log[a]
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2917,6 +2917,9 @@ class TestAutograd(TestCase):
         a = torch.rand(1, requires_grad=True)
         b = torch.rand(1, requires_grad=True)
 
+        # Increase the next function sequence number.
+        a + 1 + 2 + 3 + 4 + 5
+
         a = Log.apply(a, 'a')
         b = checkpoint(lambda b: Log.apply(b, 'b'), b)
         out = torch.cat((a, b)).sum()

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -612,15 +612,20 @@ auto Engine::execute(const edge_list& roots,
   if (!outputs.empty()) {
     graph_task.init_to_execute(*graph_root, outputs);
   }
-  ready_queue(at::kCPU).push(FunctionTask(&graph_task, std::move(graph_root), InputBuffer(0)));
+
+  auto task = FunctionTask(&graph_task, std::move(graph_root), InputBuffer(0));
 
   // Not a worker
   if (worker_device == NO_DEVICE) {
+    ready_queue(at::kCPU).push(std::move(task));
+
     // Wait for all tasks to complete
     graph_task.not_done.wait(lock, [&graph_task]{
       return graph_task.outstanding_tasks.load() == 0;
     });
   } else {
+    ready_queue_by_index(worker_device).push(std::move(task));
+
     // Get back to work while we wait for our new graph_task to
     // complete!
     // See Note [Reentrant backwards]


### PR DESCRIPTION
This patch fixes https://github.com/pytorch/pytorch/issues/18566 what I reported.

> When the autograd graph has parallel lanes, and a checkpointing is on one of the lanes, the checkpointing evaluates irrelevant backwards on another lane.

For example, in the below autograd graph, `Checkpoint(Eval2)` evaluates `Eval1` as its recursive call:
```
          +--> Eval1 --> AccumulateGrad1
Sum --> Cat
          +--> Checkpoint(Eval2) --> AccumulateGrad2
```

The reason I found is the order of priority between `Eval1` and `Eval2` which is recomputed by `Checkpoint(Eval2)`. In the autograd engine, the order priority relies on a function's sequence number. The sequence number generator is thread-local. `Eval1` is computed on the main thread but `Eval2` is recomputed on the worker thread. So there's no logical synchronization between them.

## How `Eval1` evaluates during `Checkpoint(Eval2)`

Let's suppose there were 10 autograd functions before this case. The sequence numbers of the functions would be like:
```
Eval1: 10
Checkpoint(Eval2): 11
Cat: 12
Sum: 13

Recomputed Eval2: 0
```

The autograd engine evaluates a task with a function having a higher sequence number first. Thus, the tasks/functions will be evaluated in the following order: (I omitted `GraphRoot` to simplify)

1. Evaluate `Sum: 13`, then schedule `Cat`.
1. Evaluate `Cat: 12`, then schedule `Eval1` and `Checkpoint(Eval2)`.
1. Evaluate `Checkpoint(Eval2): 11` which has a higher priority than `Eval1: 1`, then schedule a new recomputed `Eval2: 0`.
   1. **(recursion) Evaluate `Eval1: 10` which has a higher priority than `Eval2: 0`**
   1. (recursion) Evaluate `Eval2: 0`

`Eval1: 10` should be evaluated AFTER `Checkpoint(Eval2): 11` done. But it is evaluated WITHIN `Checkpoint(Eval2): 11`.

## How this patch fixes it

I propose a stack depth counter for nested backward. Now the autograd engine evaluates a deeply nested task first even it has a lower sequence number. Nested backward would evaluate only the tasks created in the backward.

The priority is modified like: (depth, sequence number)

```
Eval1: (0, 10)
Checkpoint(Eval2): (0, 11)
Cat: (0, 12)
Sum: (0, 13)

Recomputed Eval2: (1, 0)
```

Please review my pull request. I would be happy to discuss this approach.