### PR TITLE
[jit] Custom Fusion

### DIFF
--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -46,6 +46,7 @@ namespace jit {
   _(FromQualString)                \
   _(InternedStrings)               \
   _(IValue)                        \
+  _(PassManagement)                \
   _(Proto)                         \
   _(RegisterFusionCachesKernel)    \
   _(SchemaParser)                  \

--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -40,6 +40,7 @@ namespace jit {
   _(ControlFlow)                   \
   _(CreateAutodiffSubgraphs)       \
   _(CustomOperators)               \
+  _(CustomFusion)                  \
   _(Differentiate)                 \
   _(DifferentiateWithRequiresGrad) \
   _(DynamicDAG)                    \

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -16,6 +16,7 @@
 #include "torch/csrc/jit/fuser/interface.h"
 #include "torch/csrc/jit/import.h"
 #include "torch/csrc/jit/interpreter.h"
+#include "torch/csrc/jit/pass_manager.h"
 #include "torch/csrc/jit/passes/alias_analysis.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
 #include "torch/csrc/jit/passes/constant_propagation.h"
@@ -643,6 +644,23 @@ void testNoneSchemaMatch() {
   // checking that constant propagation ran wo/failure
   AT_ASSERT(std::distance(nodes.begin(), nodes.end()) == 1);
 }
+
+void fakePass(std::shared_ptr<Graph>&g) {
+  return;
+}
+
+RegisterPass p(fakePass);
+
+void testPassManagement() {
+  auto hit = false;
+  for (const auto& p : getPasses()) {
+    if (p == fakePass) {
+      hit = true;
+    }
+  }
+  AT_ASSERT(hit);
+}
+
 } // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -348,6 +348,36 @@ void testATenNativeBatchNorm() {
   assertAllClose(tensor_grads_out, expected_tensor_grads_out);
 }
 
+void testCustomFusion() {
+  auto graph = std::make_shared<Graph>();
+  at::ScalarType s = at::ScalarType::Float;
+  auto type = CompleteTensorType::create(s, at::kCPU, {2, 3, 4}, {12, 4, 1});
+  auto a = SymbolicVariable::asNewInput(*graph, type);
+  auto b = SymbolicVariable::asNewInput(*graph, type);
+  auto c = a * b;
+  auto d = c * a;
+  graph->registerOutput(d.value());
+
+  torch::jit::overrideCanFuseOnCPU(true);
+  CustomFuseGraph(graph, [](Node* n) { return true; }, Symbol::fromQualString("prim::FusionGroup"));
+  torch::jit::overrideCanFuseOnCPU(false);
+
+  const auto& nodes = graph->nodes();
+  auto fusion_group =
+      std::find_if(nodes.begin(), nodes.end(), [](const Node* node) {
+        return node->kind() == Symbol::fromQualString("prim::FusionGroup");
+      });
+  AT_ASSERT(fusion_group != nodes.end());
+
+  auto subgraph = fusion_group->g(attr::Subgraph);
+  auto hits = 0;
+  // two multiplications
+  for (const auto& n : subgraph->nodes()) {
+    hits++;
+  }
+  AT_ASSERT(hits == 2);
+}
+
 static const auto cf_examples = R"JIT(
   def if_test(a, b):
       # FIXME: use 0 instead of a.

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -53,6 +53,7 @@ libtorch_sources = [
     "torch/csrc/jit/constants.cpp",
     "torch/csrc/jit/node_hashing.cpp",
     "torch/csrc/jit/export.cpp",
+    "torch/csrc/jit/pass_manager.cpp",
     "torch/csrc/jit/pickler.cpp",
     "torch/csrc/jit/graph_executor.cpp",
     "torch/csrc/jit/import.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -123,6 +123,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/autodiff.cpp
   ${TORCH_SRC_DIR}/csrc/jit/attributes.cpp
   ${TORCH_SRC_DIR}/csrc/jit/export.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/pass_manager.cpp
   ${TORCH_SRC_DIR}/csrc/jit/pickler.cpp
   ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_0.cpp
   ${TORCH_SRC_DIR}/csrc/jit/generated/register_aten_ops_1.cpp

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/interpreter.h>
 #include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/pass_manager.h>
 #include <torch/csrc/jit/passes/batch_mm.h>
 #include <torch/csrc/jit/passes/canonicalize_ops.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
@@ -517,6 +518,9 @@ struct GraphExecutorImpl {
   }
 
   void runNondiffOptimization(std::shared_ptr<Graph>& graph) {
+    for (const auto& pass : getPasses()) {
+      pass(graph);
+    }
     FuseGraph(graph);
   }
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1211,8 +1211,8 @@ Node* Graph::createNone(TypePtr typ) {
   return n;
 }
 
-Node* Graph::createFusionGroup() {
-  auto n = create(prim::FusionGroup, 0);
+Node* Graph::createFusionGroup(Symbol kind) {
+  auto n = create(kind, 0);
   n->g_(attr::Subgraph, std::make_shared<Graph>(current_scope()));
   return n;
 }

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1043,7 +1043,7 @@ struct Graph {
   TORCH_API Node* createNone(
       TypePtr typ); // value of None with type Optional[typ]
   TORCH_API Node* createAutogradZero();
-  TORCH_API Node* createFusionGroup();
+  TORCH_API Node* createFusionGroup(Symbol kind = prim::FusionGroup);
   TORCH_API Node* createDifferentiableSubgraph();
   TORCH_API Node* createTuple(
       at::ArrayRef<Value*> values,

--- a/torch/csrc/jit/pass_manager.cpp
+++ b/torch/csrc/jit/pass_manager.cpp
@@ -1,0 +1,16 @@
+#include <torch/csrc/jit/pass_manager.h>
+
+namespace torch {
+namespace jit {
+
+std::vector<Pass>& getPasses() {
+  static std::vector<Pass> passes;
+  return passes;
+}
+
+RegisterPass::RegisterPass(Pass p) {
+  getPasses().emplace_back(std::move(p));
+}
+
+}
+}

--- a/torch/csrc/jit/pass_manager.h
+++ b/torch/csrc/jit/pass_manager.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+
+/* `getPasses()` returns a vector of passes that will be executed after
+ * differentiation but before any fusion.  This is the de-facto location
+ * for compiler backends to insert passes.
+ *
+ * Static registration of a pass can be done by creating a global
+ * `RegisterPass r(Pass)` variable in a compilation unit.
+ *
+ * pass_manager.h uses a Meyer's singleton
+ * to store a vector of `Pass`es, which modify the IR graph in place.
+ */
+
+namespace torch {
+namespace jit {
+
+// A pass modifies a Graph in place.
+typedef void (*Pass)(std::shared_ptr<Graph>&);
+
+std::vector<Pass>& getPasses();
+
+struct RegisterPass {
+  RegisterPass(Pass p);
+};
+
+}
+}
+

--- a/torch/csrc/jit/passes/graph_fuser.h
+++ b/torch/csrc/jit/passes/graph_fuser.h
@@ -10,6 +10,8 @@ namespace jit {
 // On Windows will noop, NYI
 TORCH_API void FuseGraph(std::shared_ptr<Graph>& graph);
 
+TORCH_API void CustomFuseGraph(std::shared_ptr<Graph>& graph, std::function<bool(Node*)> fn, Symbol tag);
+
 TORCH_API bool trackSingleGradSumToSizeToOutputs(
     Value* gradSumToSizeOutput,
     std::vector<int64_t>* outputGradSumToSizes);


### PR DESCRIPTION
This should be rebased on PR #18532.

This is part of the migration to support requests from @soumith and @apaszke to move TVM to a new repo (pytorch/tvm).

The idea here is to allow users to register custom fusion functions (as seen in PR #18489), which will tag subgraphs for later compilation.