### PR TITLE
Move GradMode / AutoGradMode / NoGradGuard to ATen core

### DIFF
--- a/aten/src/ATen/core/grad_mode.cpp
+++ b/aten/src/ATen/core/grad_mode.cpp
@@ -1,6 +1,6 @@
-#include <torch/csrc/autograd/grad_mode.h>
+#include <ATen/core/grad_mode.h>
 
-namespace torch { namespace autograd {
+namespace at {
 
 thread_local bool GradMode_enabled = true;
 
@@ -11,4 +11,4 @@ bool GradMode::is_enabled() {
 void GradMode::set_enabled(bool enabled) {
   GradMode_enabled = enabled;
 }
-}}
+}

--- a/aten/src/ATen/core/grad_mode.cpp
+++ b/aten/src/ATen/core/grad_mode.cpp
@@ -2,10 +2,10 @@
 
 namespace at {
 
-/// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
-/// thread_local is not supported. In that case, we don't provide
-/// `at::GradMode`.
-#ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
+/// thread_local is a feature that is not enabled by caffe2 mobile
+/// build (e.g. iOS). Therefore, we only provide `at::GradMode`
+/// when FEATURE_TORCH_MOBILE is on.
+#ifdef FEATURE_TORCH_MOBILE
 
 thread_local bool GradMode_enabled = true;
 
@@ -17,7 +17,7 @@ void GradMode::set_enabled(bool enabled) {
   GradMode_enabled = enabled;
 }
 
-#else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#else // defined(FEATURE_TORCH_MOBILE)
 
 bool GradMode::is_enabled() {
   throw std::runtime_error("GradMode is not supported on mobile");

--- a/aten/src/ATen/core/grad_mode.cpp
+++ b/aten/src/ATen/core/grad_mode.cpp
@@ -1,11 +1,14 @@
 #include <ATen/core/grad_mode.h>
 
+#include <stdexcept>
+
 namespace at {
 
-/// thread_local is a feature that is not enabled by caffe2 mobile
+/// thread_local is a feature that is not enabled by Caffe2 mobile
 /// build (e.g. iOS). Therefore, we only provide `at::GradMode`
-/// when FEATURE_TORCH_MOBILE is on.
-#ifdef FEATURE_TORCH_MOBILE
+/// when we are not in mobile build or when FEATURE_TORCH_MOBILE
+/// is on.
+#if !defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE)
 
 thread_local bool GradMode_enabled = true;
 
@@ -17,7 +20,7 @@ void GradMode::set_enabled(bool enabled) {
   GradMode_enabled = enabled;
 }
 
-#else // defined(FEATURE_TORCH_MOBILE)
+#else
 
 bool GradMode::is_enabled() {
   throw std::runtime_error("GradMode is not supported on mobile");

--- a/aten/src/ATen/core/grad_mode.cpp
+++ b/aten/src/ATen/core/grad_mode.cpp
@@ -28,3 +28,5 @@ void GradMode::set_enabled(bool enabled) {
 }
 
 #endif
+
+} // namespace at

--- a/aten/src/ATen/core/grad_mode.cpp
+++ b/aten/src/ATen/core/grad_mode.cpp
@@ -2,6 +2,11 @@
 
 namespace at {
 
+/// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
+/// thread_local is not supported. In that case, we don't provide
+/// `at::GradMode`.
+#ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
+
 thread_local bool GradMode_enabled = true;
 
 bool GradMode::is_enabled() {
@@ -11,4 +16,15 @@ bool GradMode::is_enabled() {
 void GradMode::set_enabled(bool enabled) {
   GradMode_enabled = enabled;
 }
+
+#else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+
+bool GradMode::is_enabled() {
+  throw std::runtime_error("GradMode is not supported on mobile");
 }
+
+void GradMode::set_enabled(bool enabled) {
+  throw std::runtime_error("GradMode is not supported on mobile");
+}
+
+#endif

--- a/aten/src/ATen/core/grad_mode.h
+++ b/aten/src/ATen/core/grad_mode.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace at {
+
+struct CAFFE2_API GradMode {
+  static bool is_enabled();
+  static void set_enabled(bool enabled);
+};
+
+// A RAII, thread local (!) guard that enables or disables grad mode upon
+// construction, and sets it back to the original value upon destruction.
+struct CAFFE2_API AutoGradMode {
+  AutoGradMode(bool enabled) : prev_mode(GradMode::is_enabled()) {
+    GradMode::set_enabled(enabled);
+  }
+  ~AutoGradMode() {
+    GradMode::set_enabled(prev_mode);
+  }
+  bool prev_mode;
+};
+
+// A RAII, thread local (!) guard that stops future operations from building
+// gradients.
+struct CAFFE2_API NoGradGuard : public AutoGradMode {
+  NoGradGuard() : AutoGradMode(/*enabled=*/false) {}
+};
+
+}

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -352,7 +352,6 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/autograd/functions/basic_ops.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/functions/tensor.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/functions/utils.cpp
-    ${TORCH_SRC_DIR}/csrc/autograd/grad_mode.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/input_buffer.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/profiler.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/record_function.cpp

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -43,7 +43,6 @@ libtorch_sources = [
     "torch/csrc/autograd/functions/basic_ops.cpp",
     "torch/csrc/autograd/functions/tensor.cpp",
     "torch/csrc/autograd/functions/utils.cpp",
-    "torch/csrc/autograd/grad_mode.cpp",
     "torch/csrc/autograd/input_buffer.cpp",
     "torch/csrc/autograd/profiler.cpp",
     "torch/csrc/autograd/record_function.cpp",

--- a/torch/csrc/api/include/torch/utils.h
+++ b/torch/csrc/api/include/torch/utils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/Parallel.h>
-#include <ATen/core/grad_mode.h>
+#include <torch/csrc/autograd/grad_mode.h>
 
 #include <cstdint>
 

--- a/torch/csrc/api/include/torch/utils.h
+++ b/torch/csrc/api/include/torch/utils.h
@@ -1,18 +1,13 @@
 #pragma once
 
 #include <ATen/Parallel.h>
-#include <torch/csrc/autograd/grad_mode.h>
+#include <ATen/core/grad_mode.h>
 
 #include <cstdint>
 
 namespace torch {
-using autograd::AutoGradMode;
 
-// A RAII, thread local (!) guard that stops future operations from building
-// gradients.
-struct TORCH_API NoGradGuard : public AutoGradMode {
-  NoGradGuard() : AutoGradMode(/*enabled=*/false) {}
-};
+using NoGradGuard = at::NoGradGuard;
 
 /// Sets the global random seed for all newly created CPU and CUDA tensors.
 using at::manual_seed;

--- a/torch/csrc/autograd/grad_mode.h
+++ b/torch/csrc/autograd/grad_mode.h
@@ -1,24 +1,11 @@
 #pragma once
 
+#include <ATen/core/grad_mode.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 namespace torch { namespace autograd {
 
-struct TORCH_API GradMode {
-  static bool is_enabled();
-  static void set_enabled(bool enabled);
-};
-
-// A RAII, thread local (!) guard that enables or disables grad mode upon
-// construction, and sets it back to the original value upon destruction.
-struct TORCH_API AutoGradMode {
-  AutoGradMode(bool enabled) : prev_mode(GradMode::is_enabled()) {
-    GradMode::set_enabled(enabled);
-  }
-  ~AutoGradMode() {
-    GradMode::set_enabled(prev_mode);
-  }
-  bool prev_mode;
-};
+using GradMode = at::GradMode;
+using AutoGradMode = at::AutoGradMode;
 
 }}


### PR DESCRIPTION
After the Variable/Tensor merge, code paths in ATen need to be able to check whether a tensor requires gradient, and throw errors in places where a `requires_grad=true` tensor is not allowed (such as https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/Utils.h#L76-L78 and https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/SparseTensorImpl.cpp#L86). Since the `GradMode` thread-local variable controls whether a tensor should accumulate gradients, we need to be able to check this variable from ATen when we determine whether a tensor requires gradient, hence the PR to move `GradMode` / `AutoGradMode` / `NoGradGuard` to ATen.

Note that we intentionally don't merge `at::GradMode` and `at::NonVariableTypeMode`, with the following reasoning:
Semantically, `at::GradMode` and `at::NonVariableTypeMode` actually mean different things: `at::GradMode` controls whether a tensor should accumulate gradients, and `at::NonVariableTypeMode` controls whether a Variable should be treated as a non-Variable tensor in type dispatches. There are places whether we *don't* want the tensor to accumulate gradients, but *still* want the Variable to be treated as a Variable. Here is one example:
```python
#  torch/tensor.py
with torch.no_grad():
   ...
   new_tensor = self.new()    # `at::GradMode` is false at this point
   ...
```
```cpp
// tools/autograd/templates/python_variable_methods.cpp
static PyObject * THPVariable_new(PyObject* self, PyObject* args, PyObject* kwargs)
{
  ...
  // if we merge `at::GradMode` and `at::NonVariableTypeMode`, since `at::GradMode` is false and `self_.type()` checks `at::GradMode` to decide whether to return non-Variable type, it will return a non-Variable type here, which is not what we want (and throws a "Tensor that was converted to Variable was not actually a Variable" error)
  return THPVariable_Wrap(torch::utils::legacy_tensor_new(self_.type(), args, kwargs));
  ...
}
```
For the above reason, we cannot merge `at::GradMode` and `at::NonVariableTypeMode`, as they have different purposes.