### PR TITLE
Fix aten op output assignment

### DIFF
--- a/caffe2/contrib/aten/aten_test.py
+++ b/caffe2/contrib/aten/aten_test.py
@@ -16,10 +16,10 @@ class TestATen(hu.HypothesisTestCase):
     @given(inputs=hu.tensors(n=2), **hu.gcs)
     def test_add(self, inputs, gc, dc):
         op = core.CreateOperator(
-             "ATen",
-             ["X", "Y"],
-             ["Z"],
-             operator="add")
+            "ATen",
+            ["X", "Y"],
+            ["Z"],
+            operator="add")
 
         def ref(X, Y):
             return [X + Y]
@@ -28,10 +28,10 @@ class TestATen(hu.HypothesisTestCase):
     @given(inputs=hu.tensors(n=2, dtype=np.float16), **hu.gcs_gpu_only)
     def test_add_half(self, inputs, gc, dc):
         op = core.CreateOperator(
-             "ATen",
-             ["X", "Y"],
-             ["Z"],
-             operator="add")
+            "ATen",
+            ["X", "Y"],
+            ["Z"],
+            operator="add")
 
         def ref(X, Y):
             return [X + Y]
@@ -76,19 +76,6 @@ class TestATen(hu.HypothesisTestCase):
 
         self.assertReferenceChecks(gc, op, inputs, ref)
 
-    # @given(**hu.gcs)
-    # def test_ones(self, gc, dc):
-        # op = core.CreateOperator(
-            # "ATen",
-            # [],
-            # ["Z"],
-            # operator="ones", type="float", size={2, 4})
-
-        # def ref():
-            # return [np.ones([2, 4])]
-
-        # self.assertReferenceChecks(gc, op, [], ref)
-
     @given(**hu.gcs)
     def test_index_put(self, gc, dc):
         op = core.CreateOperator(
@@ -112,7 +99,7 @@ class TestATen(hu.HypothesisTestCase):
         op = core.CreateOperator(
             "ATen",
             ['self'],
-            ["output", "inverse_indices"],
+            ["output", "return_inverse"],
             sorted=True,
             return_inverse=True,
             # return_counts=False,
@@ -120,12 +107,11 @@ class TestATen(hu.HypothesisTestCase):
 
         def ref(self):
             index, inverse = np.unique(self, return_index=False, return_inverse=True, return_counts=False)
-            return (index, inverse, np.array([]))
+            return (index, inverse)
 
         tensor = np.array([1, 2, 6, 4, 2, 3, 2])
         print(ref(tensor))
         self.assertReferenceChecks(gc, op, [tensor], ref)
-
 
 
 if __name__ == "__main__":

--- a/caffe2/contrib/aten/aten_test.py
+++ b/caffe2/contrib/aten/aten_test.py
@@ -99,15 +99,15 @@ class TestATen(hu.HypothesisTestCase):
         op = core.CreateOperator(
             "ATen",
             ['self'],
-            ["output", "return_inverse"],
+            ["output"],
             sorted=True,
             return_inverse=True,
             # return_counts=False,
             operator="_unique")
 
         def ref(self):
-            index, inverse = np.unique(self, return_index=False, return_inverse=True, return_counts=False)
-            return (index, inverse)
+            index, _ = np.unique(self, return_index=False, return_inverse=True, return_counts=False)
+            return (index,)
 
         tensor = np.array([1, 2, 6, 4, 2, 3, 2])
         print(ref(tensor))

--- a/caffe2/contrib/aten/aten_test.py
+++ b/caffe2/contrib/aten/aten_test.py
@@ -76,18 +76,18 @@ class TestATen(hu.HypothesisTestCase):
 
         self.assertReferenceChecks(gc, op, inputs, ref)
 
-    @given(**hu.gcs)
-    def test_ones(self, gc, dc):
-        op = core.CreateOperator(
-            "ATen",
-            [],
-            ["Z"],
-            operator="ones", type="float", size={2, 4})
+    # @given(**hu.gcs)
+    # def test_ones(self, gc, dc):
+        # op = core.CreateOperator(
+            # "ATen",
+            # [],
+            # ["Z"],
+            # operator="ones", type="float", size={2, 4})
 
-        def ref():
-            return [np.ones([2, 4])]
+        # def ref():
+            # return [np.ones([2, 4])]
 
-        self.assertReferenceChecks(gc, op, [], ref)
+        # self.assertReferenceChecks(gc, op, [], ref)
 
     @given(**hu.gcs)
     def test_index_put(self, gc, dc):
@@ -101,12 +101,30 @@ class TestATen(hu.HypothesisTestCase):
             self[indices] = values
             return (self,)
 
-
         tensor = np.random.randn(3, 3).astype(np.float32)
         mask = np.array([[True, True, True], [True, False, False], [True, True, False]])
         values = np.random.randn(6).astype(np.float32)
 
         self.assertReferenceChecks(gc, op, [tensor, mask, values], ref)
+
+    @given(**hu.gcs)
+    def test_unique(self, gc, dc):
+        op = core.CreateOperator(
+            "ATen",
+            ['self'],
+            ["output", "inverse_indices"],
+            sorted=True,
+            return_inverse=True,
+            # return_counts=False,
+            operator="_unique")
+
+        def ref(self):
+            index, inverse = np.unique(self, return_index=False, return_inverse=True, return_counts=False)
+            return (index, inverse, np.array([]))
+
+        tensor = np.array([1, 2, 6, 4, 2, 3, 2])
+        print(ref(tensor))
+        self.assertReferenceChecks(gc, op, [tensor], ref)
 
 
 

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -150,7 +150,7 @@ def supports(o, factory_methods):
 OPTION_TEMPLATE = CT("""\
 case ${key}: { // ${name}
     ${initialization}
-    run_op = [&] {
+    run_op = [=] {
         ${statements}
         auto the_result = ${invocation};
         ${assignments}


### PR DESCRIPTION
Fixes the problem of #18391 

The issue is that when we code gen the ATenOp, we always generated static number of outputs for each operator. E.g. If there's operator from a old model that only requires two outputs, in its createOperator it will only allocate two output blobs, while the newer version of the operator (`unique` in this case) requires more output blob to be allocated. 