### PR TITLE
Generate cases for all ScalarTypes in Type functions that call to TH

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1837,7 +1837,7 @@
 ]]
 [[
   name: _th_dot
-  backend_type_pairs: [[CUDA,floating_point], [CPU,all]]
+  backend_types: {CUDA: [floating_point], CPU: [all]}
   cname: dot
   variants: function
   return: accreal

--- a/aten/src/ATen/templates/TypeDerived.h
+++ b/aten/src/ATen/templates/TypeDerived.h
@@ -27,6 +27,15 @@ struct ${Type} final : public ${DenseBackend}TypeDefault {
   // example
   // virtual Tensor * add(Tensor & a, Tensor & b) override;
   ${type_derived_method_declarations}
+
+ private:
+  ScalarType infer_scalar_type(const Tensor & t) const {
+    return t.scalar_type();
+  }
+  ScalarType infer_scalar_type(const TensorList & tl) const {
+    AT_CHECK(tl.size() > 0, "expected a non-empty list of Tensors");
+    return tl[0].scalar_type();
+  }
 };
 
 } // namespace at


### PR DESCRIPTION
This revamps the way functions that call into TH are generated. Now, CPUFloatType, CPUIntType, etc. all generate these functions identically. The next step is to deduplicate these into a single class.

note: This PR introduces a lot of redundant codegen, so I won't merge it until subsequent PRs that deduplicate the Type classes are ready.