### PR TITLE
Fix precision issue with expansion that prefers 'probs' over 'logits'

### DIFF
--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -50,12 +50,12 @@ class Bernoulli(ExponentialFamily):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Bernoulli, _instance)
         batch_shape = torch.Size(batch_shape)
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         super(Bernoulli, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -53,7 +53,7 @@ class Bernoulli(ExponentialFamily):
         if 'logits' in self.__dict__:
             new.logits = self.logits.expand(batch_shape)
             new._param = new.logits
-        else:
+        if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
         super(Bernoulli, new).__init__(batch_shape, validate_args=False)

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -50,12 +50,12 @@ class Bernoulli(ExponentialFamily):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Bernoulli, _instance)
         batch_shape = torch.Size(batch_shape)
-        if 'probs' in self.__dict__:
-            new.probs = self.probs.expand(batch_shape)
-            new._param = new.probs
-        else:
+        if 'logits' in self.__dict__:
             new.logits = self.logits.expand(batch_shape)
             new._param = new.logits
+        else:
+            new.probs = self.probs.expand(batch_shape)
+            new._param = new.probs
         super(Bernoulli, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -55,12 +55,12 @@ class Binomial(Distribution):
         new = self._get_checked_instance(Binomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
-        else:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         super(Binomial, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -55,12 +55,12 @@ class Binomial(Distribution):
         new = self._get_checked_instance(Binomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         super(Binomial, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -61,12 +61,12 @@ class Categorical(Distribution):
         new = self._get_checked_instance(Categorical, _instance)
         batch_shape = torch.Size(batch_shape)
         param_shape = batch_shape + torch.Size((self._num_events,))
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(param_shape)
-            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(param_shape)
             new._param = new.probs
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(param_shape)
+            new._param = new.logits
         new._num_events = self._num_events
         super(Categorical, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -64,7 +64,7 @@ class Categorical(Distribution):
         if 'logits' in self.__dict__:
             new.logits = self.logits.expand(param_shape)
             new._param = new.logits
-        else:
+        if 'probs' in self.__dict__:
             new.probs = self.probs.expand(param_shape)
             new._param = new.probs
         new._num_events = self._num_events

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -61,12 +61,12 @@ class Categorical(Distribution):
         new = self._get_checked_instance(Categorical, _instance)
         batch_shape = torch.Size(batch_shape)
         param_shape = batch_shape + torch.Size((self._num_events,))
-        if 'probs' in self.__dict__:
-            new.probs = self.probs.expand(param_shape)
-            new._param = new.probs
-        else:
+        if 'logits' in self.__dict__:
             new.logits = self.logits.expand(param_shape)
             new._param = new.logits
+        else:
+            new.probs = self.probs.expand(param_shape)
+            new._param = new.probs
         new._num_events = self._num_events
         super(Categorical, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -49,10 +49,10 @@ class Geometric(Distribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Geometric, _instance)
         batch_shape = torch.Size(batch_shape)
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
-        else:
-            new.logits = self.logits.expand(batch_shape)
         super(Geometric, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -49,10 +49,10 @@ class Geometric(Distribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Geometric, _instance)
         batch_shape = torch.Size(batch_shape)
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
         super(Geometric, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -42,12 +42,12 @@ class NegativeBinomial(Distribution):
         new = self._get_checked_instance(NegativeBinomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         super(NegativeBinomial, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -42,12 +42,12 @@ class NegativeBinomial(Distribution):
         new = self._get_checked_instance(NegativeBinomial, _instance)
         batch_shape = torch.Size(batch_shape)
         new.total_count = self.total_count.expand(batch_shape)
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
-        else:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         super(NegativeBinomial, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -51,12 +51,12 @@ class LogitRelaxedBernoulli(Distribution):
         new = self._get_checked_instance(LogitRelaxedBernoulli, _instance)
         batch_shape = torch.Size(batch_shape)
         new.temperature = self.temperature
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
-        else:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         super(LogitRelaxedBernoulli, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -51,12 +51,12 @@ class LogitRelaxedBernoulli(Distribution):
         new = self._get_checked_instance(LogitRelaxedBernoulli, _instance)
         batch_shape = torch.Size(batch_shape)
         new.temperature = self.temperature
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
         if 'probs' in self.__dict__:
             new.probs = self.probs.expand(batch_shape)
             new._param = new.probs
+        if 'logits' in self.__dict__:
+            new.logits = self.logits.expand(batch_shape)
+            new._param = new.logits
         super(LogitRelaxedBernoulli, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new


### PR DESCRIPTION
I have experienced that sometimes both were in `__dict__`, but it chose to copy `probs` which loses precision over `logits`. This is especially important when training (bayesian) neural networks or doing other type of optimization, since the loss is heavily affected.