### PR TITLE
Fix wrap(at::Scalar)

### DIFF
--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -55,7 +55,7 @@ inline PyObject* wrap(at::Tensor tensor) {
 }
 
 inline PyObject* wrap(at::Scalar scalar) {
-  return wrap(scalar_to_tensor(scalar));
+  return wrap(make_variable(scalar_to_tensor(scalar)));
 }
 
 inline PyObject* wrap(std::tuple<at::Tensor, at::Tensor> tensors) {


### PR DESCRIPTION
Problem:
```cpp
// This function expects a `Variable` as input
inline PyObject* wrap(at::Tensor tensor) {
  return THPVariable_Wrap(Variable(std::move(tensor)));
}

inline PyObject* wrap(at::Scalar scalar) {
  // This function calls `wrap(at::Tensor tensor)` (the function above), but since
  // `scalar_to_tensor(...)` returns a `Tensor` and not a `Variable`, the call to
  // `wrap(at::Tensor tensor)` will fail with "Tensor that was converted to Variable
  // was not actually a Variable", which is not what we want.
  return wrap(scalar_to_tensor(scalar));
}
```

The right fix is to call `make_variable(...)` with the tensor returned from `scalar_to_tensor(scalar)`.

This unblocks https://github.com/pytorch/pytorch/pull/18230 as it is the only patch that hits this code path now. All other native functions that return Scalar (such as `item()` or `_local_scalar_dense()`) either has custom-defined implementation that doesn't go through this path, or is not exposed to Python at all.