### PR TITLE
Kill LegacyBridge functions that don't do multiple dispatch.

### DIFF
--- a/aten/src/ATen/native/LegacyBridge.cpp
+++ b/aten/src/ATen/native/LegacyBridge.cpp
@@ -16,53 +16,6 @@ namespace {
   }
 }
 
-// These native operations are not "really" native; they're actually just bridge
-// functions that decide whether or not to call native sparse functions, or
-// TH functions.  This file should be temporary; when all of TH gets ported, we
-// can just use the native mechanism straight.
-
-// TODO: Maybe the foo_ variants should call th_foo_
-
-Tensor clone(const Tensor& self) {
-  if (_has_native(self)) {
-    return native_clone(self);
-  } else {
-    return legacy::th::_th_clone(self);
-  }
-}
-
-Tensor& resize_as_(Tensor& self, const Tensor& the_template) {
-  if (_has_native(self)) {
-    return native_resize_as_(self, the_template);
-  } else {
-    return legacy::th::_th_resize_as_(self, the_template);
-  }
-}
-
-Tensor& pow_out(Tensor& result, const Tensor& self, Scalar exponent) {
-  if (_has_native(self)) {
-    return native_pow_out(result, self, exponent);
-  } else {
-    return legacy::th::_th_pow_out(result, self, exponent);
-  }
-}
-
-Tensor pow(const Tensor& self, Scalar exponent) {
-  if (_has_native(self)) {
-    return native_pow(self, exponent);
-  } else {
-    return legacy::th::_th_pow(self, exponent);
-  }
-}
-
-Tensor& zero_(Tensor& self) {
-  if (_has_native(self)) {
-    return native_zero_(self);
-  } else {
-    return legacy::th::_th_zero_(self);
-  }
-}
-
 // Note [Multiple dispatch to sparse]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // In an ideal world, we would use direct support for multiple dispatch to

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -30,6 +30,26 @@ bool is_set_to(const Tensor& self, const Tensor & tensor) {
   return at::legacy::th::_th_is_set_to(self, tensor);
 }
 
+Tensor clone(const Tensor& self) {
+  return legacy::th::_th_clone(self);
+}
+
+Tensor& resize_as_(Tensor& self, const Tensor& the_template) {
+  return legacy::th::_th_resize_as_(self, the_template);
+}
+
+Tensor& pow_out(Tensor& result, const Tensor& self, Scalar exponent) {
+  return legacy::th::_th_pow_out(result, self, exponent);
+}
+
+Tensor pow(const Tensor& self, Scalar exponent) {
+  return legacy::th::_th_pow(self, exponent);
+}
+
+Tensor& zero_(Tensor& self) {
+  return legacy::th::_th_zero_(self);
+}
+
 Tensor & masked_fill_(Tensor& self, const Tensor & mask, Scalar value) {
   return at::legacy::th::_th_masked_fill_(self, mask, value);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2531,55 +2531,49 @@
   matches_jit_signature: True
   variants: function
 
-- func: native_clone(Tensor self) -> Tensor
-  matches_jit_signature: True
-  dispatch:
-    SparseCPU: clone_sparse
-    SparseCUDA: clone_sparse
-
 - func: clone(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: function, method
-
-- func: native_resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
-  matches_jit_signature: True
   dispatch:
-    SparseCPU: resize_as_sparse_
-    SparseCUDA: resize_as_sparse_
+    CPU: clone
+    CUDA: clone
+    SparseCPU: clone_sparse
+    SparseCUDA: clone_sparse
 
 - func: resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
   matches_jit_signature: True
   variants: function, method
-
-- func: native_pow(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
-  matches_jit_signature: True
   dispatch:
-    SparseCPU: pow_out_sparse_scalar
-    SparseCUDA: pow_out_sparse_scalar
-
-- func: native_pow(Tensor self, Scalar exponent) -> Tensor
-  matches_jit_signature: True
-  dispatch:
-    SparseCPU: pow_sparse_scalar
-    SparseCUDA: pow_sparse_scalar
+    CPU: resize_as_
+    CUDA: resize_as_
+    SparseCPU: resize_as_sparse_
+    SparseCUDA: resize_as_sparse_
 
 - func: pow(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
   matches_jit_signature: True
+  dispatch:
+    CPU: pow_out
+    CUDA: pow_out
+    SparseCPU: pow_out_sparse_scalar
+    SparseCUDA: pow_out_sparse_scalar
 
 - func: pow(Tensor self, Scalar exponent) -> Tensor
   matches_jit_signature: True
   variants: function, method
-  variants: method, function
-
-- func: native_zero_(Tensor(a!) self) -> Tensor(a!)
-  matches_jit_signature: True
   dispatch:
-    SparseCPU: zero_sparse_
-    SparseCUDA: zero_sparse_
+    CPU: pow
+    CUDA: pow
+    SparseCPU: pow_sparse_scalar
+    SparseCUDA: pow_sparse_scalar
 
 - func: zero_(Tensor(a!) self) -> Tensor(a!)
   matches_jit_signature: True
   variants: method, function
+  dispatch:
+    CPU: zero_
+    CUDA: zero_
+    SparseCPU: zero_sparse_
+    SparseCUDA: zero_sparse_
 
 - func: sub(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   matches_jit_signature: True

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2569,6 +2569,8 @@
 - func: zero_(Tensor(a!) self) -> Tensor(a!)
   matches_jit_signature: True
   variants: method, function
+  cpu_half: True
+  cpu_bool: True
   dispatch:
     CPU: zero_
     CUDA: zero_

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2534,6 +2534,8 @@
 - func: clone(Tensor self) -> Tensor
   matches_jit_signature: True
   variants: function, method
+  cpu_half: True
+  cpu_bool: True
   dispatch:
     CPU: clone
     CUDA: clone


### PR DESCRIPTION
At some point, we needed these functions to deal with autograd dispatching to the sparse of TH version of a backwards.  But we rewrote all backwards definitions in terms of native functions, so this is no longer necessary.

