### PR TITLE
Undefined behavior with memset of std::string to 0

### DIFF
--- a/caffe2/operators/sequence_ops.cc
+++ b/caffe2/operators/sequence_ops.cc
@@ -203,7 +203,10 @@ bool PadEmptySamplesOp<CPUContext>::RunOnDevice() {
     Tensor zero{CPU};
     zero.Resize(block_size);
     auto zeroPtr = static_cast<char*>(zero.raw_mutable_data(features.dtype()));
-    memset(zeroPtr, 0, zero.nbytes());
+    // TODO Handle other composite types, such as vector<...>
+    if (!features.dtype().Match<std::string>()) {
+      memset(zeroPtr, 0, zero.nbytes());
+    }
     int start_dest = 0;
     int start_src = 0;
     for (int i = 0; i < lengths.numel(); ++i) {


### PR DESCRIPTION
Summary:
`zeroPtr` is sometimes a `std::string` tensor, so `memset` to 0 is undefined behavior.

This might be accidentally safe with the fbcode and iOS `std::string` implementation if they use SSO (Small String Optimization), but it's crashing on Android.

Differential Revision: D14714458
