### PR TITLE
Emergency workaround for apt-get failure.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ install_official_git_client: &install_official_git_client
   command: |
     set -e
 
+    sudo killall apt-get
+
     sudo apt-get -q -y update
     sudo apt-get -q -y install openssh-client git
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ setup_linux_system_environment: &setup_linux_system_environment
   name: Set Up System Environment
   no_output_timeout: "1h"
   command: |
-    set -e
+    set -ex
 
     # Set up CircleCI GPG keys for apt, if needed
     curl -L https://packagecloud.io/circleci/trusty/gpgkey | sudo apt-key add -
@@ -33,9 +33,12 @@ install_official_git_client: &install_official_git_client
   name: Install Official Git Client
   no_output_timeout: "1h"
   command: |
-    set -e
+    set -ex
 
-    sudo killall apt-get
+    sudo killall apt-get || true
+    sudo rm /var/lib/apt/lists/lock || true
+    sudo rm /var/cache/apt/archives/lock || true
+    sudo rm /var/lib/dpkg/lock || true
 
     sudo apt-get -q -y update
     sudo apt-get -q -y install openssh-client git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,8 @@ install_official_git_client: &install_official_git_client
     sudo rm /var/lib/dpkg/lock || true
 
     cat /etc/apt/sources.list
-    sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
-    sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
-    sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    sudo sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    sudo sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
     cat /etc/apt/sources.list
 
     sudo apt-get -q -y update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,12 @@ install_official_git_client: &install_official_git_client
     sudo rm /var/cache/apt/archives/lock || true
     sudo rm /var/lib/dpkg/lock || true
 
+    cat /etc/apt/sources.list
+    sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
+    sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    cat /etc/apt/sources.list
+
     sudo apt-get -q -y update
     sudo apt-get -q -y install openssh-client git
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ install_official_git_client: &install_official_git_client
     cat /etc/apt/sources.list
     sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
     sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
-sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
     cat /etc/apt/sources.list
 
     sudo apt-get -q -y update

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -35,6 +35,8 @@ install_official_git_client: &install_official_git_client
   command: |
     set -e
 
+    sudo killall apt-get
+
     sudo apt-get -q -y update
     sudo apt-get -q -y install openssh-client git
 

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -22,7 +22,7 @@ setup_linux_system_environment: &setup_linux_system_environment
   name: Set Up System Environment
   no_output_timeout: "1h"
   command: |
-    set -e
+    set -ex
 
     # Set up CircleCI GPG keys for apt, if needed
     curl -L https://packagecloud.io/circleci/trusty/gpgkey | sudo apt-key add -
@@ -33,9 +33,12 @@ install_official_git_client: &install_official_git_client
   name: Install Official Git Client
   no_output_timeout: "1h"
   command: |
-    set -e
+    set -ex
 
-    sudo killall apt-get
+    sudo killall apt-get || true
+    sudo rm /var/lib/apt/lists/lock || true
+    sudo rm /var/cache/apt/archives/lock || true
+    sudo rm /var/lib/dpkg/lock || true
 
     sudo apt-get -q -y update
     sudo apt-get -q -y install openssh-client git

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -41,9 +41,8 @@ install_official_git_client: &install_official_git_client
     sudo rm /var/lib/dpkg/lock || true
 
     cat /etc/apt/sources.list
-    sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
-    sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
-    sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    sudo sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    sudo sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
     cat /etc/apt/sources.list
 
     sudo apt-get -q -y update

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -43,7 +43,7 @@ install_official_git_client: &install_official_git_client
     cat /etc/apt/sources.list
     sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
     sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
-sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+    sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
     cat /etc/apt/sources.list
 
     sudo apt-get -q -y update

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -40,7 +40,10 @@ install_official_git_client: &install_official_git_client
     sudo rm /var/cache/apt/archives/lock || true
     sudo rm /var/lib/dpkg/lock || true
 
+    cat /etc/apt/sources.list
     sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
+    sed -i 's#archive.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
+sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
     cat /etc/apt/sources.list
 
     sudo apt-get -q -y update

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -40,6 +40,9 @@ install_official_git_client: &install_official_git_client
     sudo rm /var/cache/apt/archives/lock || true
     sudo rm /var/lib/dpkg/lock || true
 
+    sudo sed -i 's|http://archive.ubuntu.com|http://us-east-1.ec2.archive.ubuntu.com|g' /etc/apt/sources.list
+    cat /etc/apt/sources.list
+
     sudo apt-get -q -y update
     sudo apt-get -q -y install openssh-client git
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #18743 Kill apt-daily with even more fire.
* **#18733 Emergency workaround for apt-get failure.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14725779](https://our.internmc.facebook.com/intern/diff/D14725779)