### PR TITLE
Kill apt-daily with even more fire.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,14 @@ install_official_git_client: &install_official_git_client
   command: |
     set -ex
 
+    sudo systemctl stop apt-daily.service
+    sudo systemctl kill --kill-who=all apt-daily.service
+
+    while ! (systemctl list-units --all apt-daily.service | fgrep -q dead)
+    do
+      sleep 1;
+    done
+
     sudo killall apt-get || true
     sudo rm /var/lib/apt/lists/lock || true
     sudo rm /var/cache/apt/archives/lock || true

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -35,6 +35,14 @@ install_official_git_client: &install_official_git_client
   command: |
     set -ex
 
+    sudo systemctl stop apt-daily.service
+    sudo systemctl kill --kill-who=all apt-daily.service
+
+    while ! (systemctl list-units --all apt-daily.service | fgrep -q dead)
+    do
+      sleep 1;
+    done
+
     sudo killall apt-get || true
     sudo rm /var/lib/apt/lists/lock || true
     sudo rm /var/cache/apt/archives/lock || true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18743 Kill apt-daily with even more fire.**
* #18733 Emergency workaround for apt-get failure.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>