### PR TITLE
Fix deviceCount on FakeGuardImpl.

### DIFF
--- a/c10/core/impl/FakeGuardImpl.h
+++ b/c10/core/impl/FakeGuardImpl.h
@@ -55,7 +55,7 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
     return Stream(Stream::UNSAFE, s.device(), old_id);
   }
   DeviceIndex deviceCount() const noexcept override {
-    return 1;
+    return kFakeGuardImplMaxDevices;
   }
   // Convenience methods for testing
   static DeviceIndex getDeviceIndex() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18745 Fix deviceCount on FakeGuardImpl.**

The fake device type has eight devices, not one, as per
other comments in the file.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14759198](https://our.internmc.facebook.com/intern/diff/D14759198)