### PR TITLE
Stop reinstalling openssh-client/git; assume the base image is up to date enough.

### DIFF
--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -58,10 +58,6 @@ install_official_git_client: &install_official_git_client
     sudo sed -i 's#security.ubuntu.com/ubuntu#us-east-1.ec2.archive.ubuntu.com/ubuntu#g' /etc/apt/sources.list
     cat /etc/apt/sources.list
 
-    ps ax | grep apt
-    sudo apt-get -q -y update
-    sudo apt-get -q -y install openssh-client git
-
 install_doc_push_script: &install_doc_push_script
   name: Install the doc push script
   no_output_timeout: "2m"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18747 Stop reinstalling openssh-client/git; assume the base image is up to date enough.**
* #18433 Switch our Linux machine AMI to a newer image.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>