### PR TITLE
Fix windows msbuild bug

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -265,6 +265,7 @@ def build_caffe2(version,
             check_call(['cmake', '--build', '.', '--target', 'install', '--config', build_type, '--', '-j', str(j)],
                        cwd=build_dir, env=my_env)
         else:
+            j = max_jobs or str(multiprocessing.cpu_count())
             check_call(['msbuild', 'INSTALL.vcxproj', '/p:Configuration={} /maxcpucount:{}'.format(build_type, j)],
                        cwd=build_dir, env=my_env)
     else:


### PR DESCRIPTION
Fix the bug introduced by #18681 where an undefined variable was being used to limit max cpu count when building for Windows without Ninja.