### PR TITLE
invoke NN smoketests from a python loop instead of a batch file

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/run_python_nn_smoketests.py
+++ b/.jenkins/pytorch/win-test-helpers/run_python_nn_smoketests.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import subprocess
+
+
+TESTS = [
+    (
+        "Checking that caffe2.python is available",
+        "from caffe2.python import core",
+    ),
+    (
+        "Checking that MKL is available",
+        "import torch; exit(0 if torch.backends.mkl.is_available() else 1)",
+    ),
+    (
+        "Checking that CUDA archs are setup correctly",
+        "import torch; torch.randn([3,5]).cuda()",
+    ),
+    (
+        "Checking that magma is available",
+        "import torch; torch.rand(1).cuda(); exit(0 if torch.cuda.has_magma else 1)",
+    ),
+    (
+        "Checking that CuDNN is available",
+        "import torch; exit(0 if torch.backends.cudnn.is_available() else 1)",
+    ),
+]
+
+
+if __name__ == "__main__":
+
+    for description, python_commands in TESTS:
+        print(description)
+        command_args = ["python", "-c", python_commands]
+        command_string = " ".join(command_args)
+        print("Command:", command_string)
+        subprocess.check_call(command_args)

--- a/.jenkins/pytorch/win-test-helpers/test_python_nn.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_nn.bat
@@ -1,29 +1,16 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
+
+pushd test
+
 echo Some smoke tests
-cd test
-
-echo Checking that caffe2.python is available
-python -c "from caffe2.python import core"
+python %SCRIPT_HELPERS_DIR%\run_python_nn_smoketests.py
 if ERRORLEVEL 1 exit /b 1
-
-echo Checking that MKL is available
-python -c "import torch; exit(0 if torch.backends.mkl.is_available() else 1)"
-if ERRORLEVEL 1 exit /b 1
-
-echo Checking that CUDA archs are setup correctly
-python -c "import torch; torch.randn([3,5]).cuda()"
-if ERRORLEVEL 1 exit /b 1
-
-echo Checking that magma is available
-python -c "import torch; torch.rand(1).cuda(); exit(0 if torch.cuda.has_magma else 1)"
-if ERRORLEVEL 1 exit /b 1
-
-echo Checking that CuDNN is available
-python -c "import torch; exit(0 if torch.backends.cudnn.is_available() else 1)"
-if ERRORLEVEL 1 exit /b 1
-
-cd ..
 
 echo Run nn tests
-cd test && python run_test.py --include nn --verbose && cd ..
+python run_test.py --include nn --verbose
+if ERRORLEVEL 1 exit /b 1
+
+popd
+
+


### PR DESCRIPTION
I tried first to convert the `.bat` script to a Bash `.sh` script, but I got this error:
```
[...]/build/win_tmp/ci_scripts/test_python_nn.sh: line 3: fg: no job control
```
Line 3 was where `%TMP_DIR%/ci_scripts/setup_pytorch_env.bat` was invoked.

I found a potential workaround on stack overflow of adding the `monitor` (`-m`) flag to the script, but hat didn't work either:

```
00:58:00 /bin/bash: cannot set terminal process group (3568): Inappropriate ioctl for device
00:58:00 /bin/bash: no job control in this shell
00:58:00 + %TMP_DIR%/ci_scripts/setup_pytorch_env.bat
00:58:00 /c/Jenkins/workspace/pytorch-builds/pytorch-win-ws2016-cuda9-cudnn7-py3-test1/build/win_tmp/ci_scripts/test_python_nn.sh: line 3: fg: no job control
```

So instead I decided to use Python to replace the `.bat` script.  I believe this is an improvement in that it's both "table-driven" now and cross-platform.