### PR TITLE
build_variables.py: turn on link_whole for _C_impl library.

### DIFF
--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -147,6 +147,9 @@ def add_torch_libs():
             "torch/csrc/distributed/**/*.cpp",
             # top-level hook of extension registration lives in a separate file
             "torch/csrc/stub.cpp",
+            # to avoid redefinitions of symbols defined in
+            # dynamic_library_unix.cpp
+            "torch/csrc/jit/fuser/cpu/dynamic_library_win.cpp",
         ],
     ) + [
         "torch/csrc/distributed/Module.cpp",
@@ -249,6 +252,7 @@ def add_torch_libs():
     cpp_library(
         name="_C_impl",
         srcs=libtorch_python_sources,
+        link_whole=True,
         deps=[
             ":libtorch_cuda",
             ":thnn",


### PR DESCRIPTION
Summary: Without `link_whole` flag in opt-builds some of the files are not linked into `_C_impl` library, which causes some of static initializers not to run (namely, registering an cutomPythonOperation from python_interpreter.cpp). This diff fixes it.

Differential Revision: D14732471
