### PR TITLE
[pytorch] add Android NDK param to CI docker build script

### DIFF
--- a/docker/caffe2/jenkins/build.sh
+++ b/docker/caffe2/jenkins/build.sh
@@ -58,6 +58,10 @@ if [[ "$image" == *-android-* ]]; then
   # The Android NDK requires CMake 3.6 or higher.
   # See https://github.com/caffe2/caffe2/pull/1740 for more info.
   CMAKE_VERSION=3.6.3
+
+  if [[ "$image" == *-ndk-* ]]; then
+    ANDROID_NDK_VERSION="$(echo "${image}" | perl -n -e'/-ndk-([^-]+)/ && print $1')"
+  fi
 fi
 
 if [[ "$image" == *-gcc* ]]; then
@@ -98,6 +102,7 @@ docker build \
        --build-arg "CUDNN_VERSION=${CUDNN_VERSION}" \
        --build-arg "MKL=${MKL}" \
        --build-arg "ANDROID=${ANDROID}" \
+       --build-arg "ANDROID_NDK=${ANDROID_NDK_VERSION}" \
        --build-arg "GCC_VERSION=${GCC_VERSION}" \
        --build-arg "CLANG_VERSION=${CLANG_VERSION}" \
        --build-arg "CMAKE_VERSION=${CMAKE_VERSION:-}" \

--- a/docker/caffe2/jenkins/common/install_android.sh
+++ b/docker/caffe2/jenkins/common/install_android.sh
@@ -2,13 +2,15 @@
 
 set -ex
 
+[ -n "${ANDROID_NDK}" ] || ANDROID_NDK=r13b
+
 apt-get update
 apt-get install -y --no-install-recommends autotools-dev autoconf unzip
 apt-get autoclean && apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 pushd /tmp
-curl -Os https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+curl -Os https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK}-linux-x86_64.zip
 popd
 _ndk_dir=/opt/ndk
 mkdir -p "$_ndk_dir"

--- a/docker/caffe2/jenkins/ubuntu/Dockerfile
+++ b/docker/caffe2/jenkins/ubuntu/Dockerfile
@@ -31,6 +31,7 @@ RUN rm install_mkl.sh
 
 # (optional) Install Android NDK
 ARG ANDROID
+ARG ANDROID_NDK
 ADD ./install_android.sh install_android.sh
 RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
 RUN rm install_android.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18782 [pytorch] add Android NDK param to CI docker build script**

Summary:
Inspired by discussion: https://github.com/pytorch/pytorch/pull/16242

Test Plan:
- Make sure the original build command still works (with default NDK r13b):

./build.sh caffe2-py2-android-ubuntu16.04-build
...
+ '[' -n '' ']'
+ ANDROID_NDK=r13b
...
+ curl -Os https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
...
Successfully built f852d884820e

docker run -it f852d884820e /bin/bash
cat /opt/ndk/source.properties
Pkg.Revision = 13.1.3345770

- Verify the new param works:

./build.sh caffe2-py2-android-ndk-r19c-ubuntu16.04-build
...
+ [[ caffe2-py2-android-ndk-r19c-ubuntu16.04-build == *-ndk-* ]]
++ echo caffe2-py2-android-ndk-r19c-ubuntu16.04-build
++ perl -n '-e/-ndk-([^-]+)/ && print $1'
+ ANDROID_NDK_VERSION=r19c
...
+ '[' -n r19c ']'
...
+ curl -Os https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip
...
Successfully built 118b3e4b3ca2

docker run -it 118b3e4b3ca2 /bin/bash
cat /opt/ndk/source.properties
Pkg.Revision = 19.2.5345600

Differential Revision: [D14739471](https://our.internmc.facebook.com/intern/diff/D14739471)