### PR TITLE
Expand the list of ops that mutate an inputs shape

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -96,7 +96,23 @@ namespace c10 {
   _(aten, __is__)                  \
   _(aten, __isnot__)               \
   _(aten, copy_)                   \
+  _(aten, t_)                      \
+  _(aten, addbmm_)                 \
+  _(aten, addcdiv_)                \
+  _(aten, addcmul_)                \
+  _(aten, addmv_)                  \
+  _(aten, addr_)                   \
+  _(aten, baddbmm_)                \
+  _(aten, ge_)                     \
+  _(aten, gt_)                     \
+  _(aten, le_)                     \
+  _(aten, lerp_)                   \
+  _(aten, lt_)                     \
+  _(aten, ne_)                     \
+  _(aten, transpose_)              \
+  _(aten, unsqueeze_)              \
   _(aten, _set_item)               \
+  _(aten, set_)                    \
   _(aten, index_put_)              \
   _(aten, device)                  \
   _(aten, hash)                    \

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -89,8 +89,13 @@ class ShapePropagator {
 
   bool resizesInput(Node* n) {
     static std::unordered_set<Symbol> resize_ops{
-        aten::resize_,
-        aten::resize_as_,
+        aten::resize_,    aten::resize_as_, aten::copy_,    aten::set_,
+        aten::add_,       aten::addbmm_,    aten::addcdiv_, aten::addcmul_,
+        aten::addmv_,     aten::addr_,      aten::baddbmm_, aten::ge_,
+        aten::gt_,        aten::le_,        aten::lerp_,    aten::lt_,
+        aten::mul_,       aten::ne_,        aten::sub_,     aten::unsqueeze_,
+        aten::t_, // could preserve DimensionedTensorType Here
+        aten::transpose_,
     };
 
     if (resize_ops.count(n->kind()))


### PR DESCRIPTION
Expand the list of ops that resize an input in-place to include broadcasting ops and other ops that affect shape. Whoever is reviewing the PR could you please look through pytorch in place ops and see if I missed any.

Expanding the PR from: https://github.com/pytorch/pytorch/pull/17518

This is already being tested in test_resize_input_ops. 

