### PR TITLE
try to make at::cat in mm_tree_reduction operate on contig tensors

### DIFF
--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -195,7 +195,7 @@ if __name__ == '__main__':
     parser.add_argument('--group', nargs='*', default=default_groups, help='Which group to run. cnns, rnns, etc.')
 
     args = parser.parse_args()
-    rnns = args.rnns or ['cudnn', 'aten', 'jit', 'jit_premul', 'jit_simple',
+    rnns = args.rnns or ['cudnn', 'aten', 'jit', 'jit_premul', 'jit_premul_bias', 'jit_simple',
                          'jit_multilayer', 'py']
     cnns = args.cnns or ['resnet18', 'resnet18_jit', 'resnet50', 'resnet50_jit']
     # TODO: Maybe add a separate section for the layernorm/dropout lstms

--- a/benchmarks/fastrnns/cells.py
+++ b/benchmarks/fastrnns/cells.py
@@ -57,8 +57,8 @@ def flat_lstm_cell(input, hx, cx, w_ih, w_hh, b_ih, b_hh):
     return hy, cy
 
 
-def premul_lstm_cell(igates, hidden, w_hh, b_ih, b_hh):
-    # type: (Tensor, Tuple[Tensor, Tensor], Tensor, Tensor, Tensor) -> Tuple[Tensor, Tensor]
+def premul_lstm_cell(igates, hidden, w_hh, b_hh):
+    # type: (Tensor, Tuple[Tensor, Tensor], Tensor, Tensor) -> Tuple[Tensor, Tensor]
     hx, cx = hidden
     gates = igates + torch.mm(hx, w_hh.t()) + b_hh
 

--- a/benchmarks/fastrnns/cells.py
+++ b/benchmarks/fastrnns/cells.py
@@ -60,7 +60,7 @@ def flat_lstm_cell(input, hx, cx, w_ih, w_hh, b_ih, b_hh):
 def premul_lstm_cell(igates, hidden, w_hh, b_ih, b_hh):
     # type: (Tensor, Tuple[Tensor, Tensor], Tensor, Tensor, Tensor) -> Tuple[Tensor, Tensor]
     hx, cx = hidden
-    gates = igates + torch.mm(hx, w_hh.t()) + b_ih + b_hh
+    gates = igates + torch.mm(hx, w_hh.t()) + b_hh
 
     ingate, forgetgate, cellgate, outgate = gates.chunk(4, 1)
 

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -372,7 +372,9 @@ def lstm_factory_premul(premul_cell, script):
         # type: (Tensor, Tuple[Tensor, Tensor], Tensor, Tensor, Tensor, Tensor) -> Tuple[Tensor, Tuple[Tensor, Tensor]]
         hx, cx = hidden
         outputs = []
-        inputs = torch.matmul(input, wih.t()).unbind(0)
+        inpSize = input.size()
+        inputs = torch.mm(input.view(-1, inpSize[2]), wih.t()) + bih
+        inputs = inputs.view(inpSize[0], inpSize[1], -1).unbind(0)
         hy, cy = hx[0], cx[0]
         for seq_idx in range(len(inputs)):
             hy, cy = premul_cell(inputs[seq_idx], (hy, cy), whh, bih, bhh)

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -2,7 +2,7 @@ import torch
 
 from collections import namedtuple
 
-from .cells import lstm_cell, premul_lstm_cell, flat_lstm_cell
+from .cells import lstm_cell, premul_lstm_cell, premul_lstm_cell_no_bias, flat_lstm_cell
 
 
 # list[list[T]] -> list[T]
@@ -124,6 +124,17 @@ def lstm_premul_creator(script=True, **kwargs):
         inputs=inputs,
         params=flatten_list(params),
         forward=lstm_factory_premul(premul_lstm_cell, script),
+        backward_setup=lstm_backward_setup,
+        backward=simple_backward)
+
+
+def lstm_premul_bias_creator(script=True, **kwargs):
+    input, hidden, params, _ = lstm_inputs(return_module=False, **kwargs)
+    inputs = [input, hidden] + params[0]
+    return ModelDef(
+        inputs=inputs,
+        params=flatten_list(params),
+        forward=lstm_factory_premul_bias(premul_lstm_cell_no_bias, script),
         backward_setup=lstm_backward_setup,
         backward=simple_backward)
 
@@ -368,6 +379,26 @@ def lstm_factory(cell, script):
 
 # premul: we're going to premultiply the inputs & weights
 def lstm_factory_premul(premul_cell, script):
+    def dynamic_rnn(input, hidden, wih, whh, bih, bhh):
+        # type: (Tensor, Tuple[Tensor, Tensor], Tensor, Tensor, Tensor, Tensor) -> Tuple[Tensor, Tuple[Tensor, Tensor]]
+        hx, cx = hidden
+        outputs = []
+        inputs = torch.matmul(input, wih.t()).unbind(0)
+        hy, cy = hx[0], cx[0]
+        for seq_idx in range(len(inputs)):
+            hy, cy = premul_cell(inputs[seq_idx], (hy, cy), whh, bih, bhh)
+            outputs += [hy]
+        return torch.stack(outputs), (hy.unsqueeze(0), cy.unsqueeze(0))
+
+    if script:
+        premul_cell = torch.jit.script(premul_cell)
+        dynamic_rnn = torch.jit.script(dynamic_rnn)
+
+    return dynamic_rnn
+
+
+# premul: we're going to premultiply the inputs & weights, and add bias
+def lstm_factory_premul_bias(premul_cell, script):
     def dynamic_rnn(input, hidden, wih, whh, bih, bhh):
         # type: (Tensor, Tuple[Tensor, Tensor], Tensor, Tensor, Tensor, Tensor) -> Tuple[Tensor, Tuple[Tensor, Tensor]]
         hx, cx = hidden

--- a/benchmarks/fastrnns/runner.py
+++ b/benchmarks/fastrnns/runner.py
@@ -52,6 +52,7 @@ nn_runners = {
     'aten': RNNRunner('aten', pytorch_lstm_creator, DisableCuDNN),
     'jit': RNNRunner('jit', lstm_creator, DummyContext),
     'jit_premul': RNNRunner('jit_premul', lstm_premul_creator, DummyContext),
+    'jit_premul_bias': RNNRunner('jit_premul_bias', lstm_premul_bias_creator, DummyContext),
     'jit_simple': RNNRunner('jit_simple', lstm_simple_creator, DummyContext),
     'jit_multilayer': RNNRunner('jit_multilayer', lstm_multilayer_creator, DummyContext),
     'jit_layernorm': RNNRunner('jit_layernorm', lnlstm_creator, DummyContext),

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -77,7 +77,6 @@ static constexpr size_t min_fusion_size = 4;
 
 bool have_same_shape(at::TensorList inputs) {
   auto expected_sizes = inputs[0].sizes();
-  auto expected_strides = inputs[0].strides();
   return (std::all_of(
       inputs.begin(), inputs.end(), [expected_sizes](const at::Tensor& t) {
         return t.sizes() == expected_sizes;

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -124,6 +124,8 @@ RegisterOperators mm_tree_reduction_reg(
         // failing
         if (have_same_shape(lhs_inputs) && have_same_shape(rhs_inputs) &&
             shape_is_fast_for_reduce(lhs_inputs[0], rhs_inputs[0])) {
+          //sometimes lhs_inputs or rhs_inputs are not contiguous, and that causes at::cat to go through slow path
+          //view them as contiguous if possible by transposing
           bool lhs_input_transposed = (!lhs_inputs[0].is_contiguous() && lhs_inputs[0].t().is_contiguous());
           bool rhs_input_transposed = (!rhs_inputs[0].is_contiguous() && rhs_inputs[0].t().is_contiguous());
           at::Tensor lhs, rhs;


### PR DESCRIPTION
Sometimes at::cat gets transposed inputs and goes on a slow path. Also, make jit_premul lstm benchmark add bias to the whole input tensor to avoid separate reduction kernels in the backward pass. 