### PR TITLE
[JIT][fuser] Improve precision of emitted code for prim::Constant

### DIFF
--- a/torch/csrc/jit/fuser/executor.cpp
+++ b/torch/csrc/jit/fuser/executor.cpp
@@ -224,7 +224,7 @@ void launchFusion(
   }
 
   // compute number of scalar inputs and convert them to float
-  std::vector<float> scalar_inputs;
+  std::vector<double> scalar_inputs;
   scalar_inputs.reserve(all_inputs.size());
   for (auto const &input: all_inputs){
     if (input.isDouble()) scalar_inputs.push_back(input.to<float>());
@@ -283,7 +283,7 @@ void launchFusion(
     }
   }
   // Adds scalar arguments
-  for (float &s: scalar_inputs){
+  for (double &s: scalar_inputs){
     arguments.push_back(&s);
   }
 


### PR DESCRIPTION
Stacked on https://github.com/pytorch/pytorch/pull/18815 and https://github.com/pytorch/pytorch/pull/18811.

This makes it so that we emit a higher-precision literal for float values in the fusion kernel, as well as assign that to a `double` variable. This prevents us from losing precision for values such as `pi`, but with the previous fixes this will also get downcasted to `float` if downstream operations require it. Therefore, we should not lose performance because of implicit promotions