### PR TITLE
Added bool and half support for resize_as_ and view methods

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -136,6 +136,9 @@
 [[
   name: _th_view
   cname: newView
+  cpu_half: True
+  cpu_bool: True
+  cuda_bool: True
   variants:
     - function
   device_guard: False
@@ -148,6 +151,9 @@
 [[
   name: _th_resize_as_
   cname: resizeAs
+  cpu_half: True
+  cpu_bool: True
+  cuda_bool: True
   variants:
     - function
   return: self

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2553,6 +2553,9 @@
 
 - func: resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
   matches_jit_signature: True
+  cpu_bool: True
+  cuda_bool: True
+  cpu_half: True
   variants: function, method
   dispatch:
     CPU: resize_as_
@@ -3206,6 +3209,9 @@
   variants: function, method
 
 - func: view(Tensor(a) self, int[] size) -> Tensor(a)
+  cpu_half: True
+  cpu_bool: True
+  cuda_bool: True
   matches_jit_signature: True
   variants: method
   device_guard: False

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2957,6 +2957,20 @@ class _TestTorchMixin(object):
                 x.resize_(shape)
                 self.assertEqual(shape, x.shape)
 
+    def test_resize_as_all_dtypes_and_devices(self):
+        for device in torch.testing.get_all_device_types():
+            for dt in torch.testing.get_all_dtypes():
+                x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
+                y = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=dt, device=device)
+                x.resize_as_(y)
+                self.assertEqual(y.shape, x.shape)
+
+    def test_view_all_dtypes_and_devices(self):
+        for device in torch.testing.get_all_device_types():
+            for dt in torch.testing.get_all_dtypes():
+                x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
+                self.assertEqual(x.view(6).shape, [6])
+
     def test_fill_all_dtypes_and_devices(self):
         for device in torch.testing.get_all_device_types():
             for dt in torch.testing.get_all_dtypes():


### PR DESCRIPTION
Enabled **resize_as_** and **view** methods for bool and half tensors.
tested via unit tests