### PR TITLE
Simplify storage wrapping in TH.

### DIFF
--- a/aten/src/TH/THStorageFunctions.hpp
+++ b/aten/src/TH/THStorageFunctions.hpp
@@ -36,10 +36,3 @@ TH_API ptrdiff_t THStorage_size(const THStorage *self);
 
 TH_API void THStorage_retain(THStorage *storage);
 TH_API void THStorage_resize(THStorage *storage, ptrdiff_t size);
-
-// Returns a Storage given a StorageImpl. The StorageImpl remains valid after the
-// the Storage is destroyed.
-inline c10::Storage THStorage_wrap(THStorage* storage) {
-  c10::raw::intrusive_ptr::incref(storage);
-  return c10::Storage(c10::intrusive_ptr<c10::StorageImpl>::reclaim(storage));
-}

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -217,7 +217,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, at::IntArrayR
   // on the current device [via THCTensor_(new)] and then swapping out the storage later can change
   // the device out from under the tensor.  Having the device be consistent through a Tensor's lifetime
   // is an invariant we wish to keep to support caching, simplicity, etc.
-  auto storage = THStorage_wrap(tensor->storage().unsafeGetStorageImpl());
+  auto storage = tensor->storage();
   THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     std::move(storage),
     at::CUDATensorId(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18855 Simplify storage wrapping in TH.**
* #18833 [STACK] Cache device on TensorImpl; clean up TensorImpl constructors.

It's unnecessary to emulate the TensorAPI ath the TH level (e.g. with THStorage_wrap).

Differential Revision: [D14790669](https://our.internmc.facebook.com/intern/diff/D14790669)