### PR TITLE
Checkout pytorch_sphinx_theme with https.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
--e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18859 Checkout pytorch_sphinx_theme with https.**

This makes it modestly easier to work with from FB
machines, where git:// proxying doesn't work by default.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14801989](https://our.internmc.facebook.com/intern/diff/D14801989)