### PR TITLE
Fixing function schema parser for Android

### DIFF
--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <cstdlib>
+#include <c10/macros/Macros.h>
 
 /*
  * This header adds some polyfills with C++14 and C++17 functionality
@@ -254,6 +256,32 @@ struct to_string_<T, void_t<decltype(std::to_string(std::declval<T>()))>> final 
 }
 template<class T> inline std::string to_string(T value) {
     return detail::to_string_<T>::call(value);
+}
+
+inline long long stoll(const std::string& str) {
+#if defined(C10_ANDROID)
+  // std::stoll doesn't exist in our Android environment, we need to implement
+  // it ourselves.
+  std::istringstream s(str);
+  long long result;
+  s >> result;
+  return result;
+#else
+  return std::stoll(str);
+#endif
+}
+
+inline double stod(const std::string& str) {
+#if defined(C10_ANDROID)
+  // std::stod doesn't exist in our Android environment, we need to implement
+  // it ourselves.
+  std::istringstream s(str);
+  double result;
+  s >> result;
+  return result;
+#else
+  return std::stod(str);
+#endif
 }
 
 }}

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -110,6 +110,7 @@ libtorch_sources = [
     "torch/csrc/jit/hooks_for_testing.cpp",
     "torch/csrc/jit/script/builtin_functions.cpp",
     "torch/csrc/jit/script/lexer.cpp",
+    "torch/csrc/jit/script/strtod.cpp",
     "torch/csrc/jit/script/module.cpp",
     "torch/csrc/jit/tracer.cpp",
     "torch/csrc/utils/tensor_flatten.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -187,6 +187,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/script/builtin_functions.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/edit_distance.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
+  ${TORCH_SRC_DIR}/csrc/jit/script/strtod.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/logging.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
   ${TORCH_SRC_DIR}/csrc/jit/tracer.cpp
@@ -529,6 +530,7 @@ if (BUILD_PYTHON)
     ${TORCH_SRC_DIR}/csrc/jit/python_tracer.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/init.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/script/strtod.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/python_tree_views.cpp
     ${TORCH_SRC_DIR}/csrc/multiprocessing/init.cpp

--- a/torch/csrc/jit/function_schema_parser.cpp
+++ b/torch/csrc/jit/function_schema_parser.cpp
@@ -86,7 +86,7 @@ struct SchemaParser {
     if (L.nextIf('[')) {
       // note: an array with a size hint can only occur at the Argument level
       type = ListType::create(type);
-      N = std::stoll(L.expect(TK_NUMBER).text());
+      N = c10::guts::stoll(L.expect(TK_NUMBER).text());
       L.expect(']');
       auto container = type_parser.parseAliasAnnotation();
       if (container && alias_info) {
@@ -153,9 +153,9 @@ struct SchemaParser {
           n = L.expect(TK_NUMBER).text();
         if (kind == TypeKind::FloatType || n.find('.') != std::string::npos ||
             n.find('e') != std::string::npos) {
-          return std::stod(n);
+          return c10::guts::stod(n);
         } else {
-          int64_t v = std::stoll(n);
+          int64_t v = c10::guts::stoll(n);
           return v;
         }
     }

--- a/torch/csrc/jit/script/lexer.cpp
+++ b/torch/csrc/jit/script/lexer.cpp
@@ -89,7 +89,7 @@ std::string kindToString(int kind) {
     TC_FORALL_TOKEN_KINDS(DEFINE_CASE)
 #undef DEFINE_CASE
     default:
-      throw std::runtime_error("Unknown kind: " + std::to_string(kind));
+      throw std::runtime_error("Unknown kind: " + c10::guts::to_string(kind));
   }
 }
 

--- a/torch/csrc/jit/script/lexer.cpp
+++ b/torch/csrc/jit/script/lexer.cpp
@@ -97,6 +97,7 @@ SharedParserData& sharedParserData() {
   static SharedParserData data; // safely handles multi-threaded init
   return data;
 }
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -2,8 +2,11 @@
 #include <c10/util/Exception.h>
 #include <c10/util/C++17.h>
 #include <torch/csrc/jit/source_range.h>
+#include <torch/csrc/jit/script/strtod.h>
 #include <algorithm>
 #include <clocale>
+#include <cstring>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -160,29 +163,7 @@ struct SharedParserData {
     TC_FORALL_TOKEN_KINDS(ADD_CASE)
 #undef ADD_CASE
   }
-#ifdef _WIN32
-  static double strtod_c(const char* str, char** end) {
-    /// NOLINTNEXTLINE(hicpp-signed-bitwise)
-    static _locale_t loc = _create_locale(LC_ALL, "C");
-    return _strtod_l(str, end, loc);
-  }
-//TODO #elif defined(C10_ANDROID)
-#else
-  static double strtod_c(const char* str, const char** end) {
-    std::istringstream s(str);
-    s.imbue(std::locale::classic());
-    double result;
-    s >> result;
-    *end = str + s.tellg();
-    return result;
-  }
-// TODO #else
-//   static double strtod_c(const char* str, char** end) {
-//     /// NOLINTNEXTLINE(hicpp-signed-bitwise)
-//     static locale_t loc = newlocale(LC_ALL_MASK, "C", nullptr);
-//     return strtod_l(str, end, loc);
-//   }
-#endif
+
   // 1. skip whitespace
   // 2. handle comment or newline
   //
@@ -195,8 +176,8 @@ struct SharedParserData {
     if (first == '-' || first == '+' || isalpha(first))
       return false;
     const char* startptr = str.c_str() + start;
-    const char* endptr;
-    strtod_c(startptr, &endptr);
+    char* endptr;
+    torch::jit::script::strtod_c(startptr, &endptr);
     *len = endptr - startptr;
     return *len > 0;
   }

--- a/torch/csrc/jit/script/schema_type_parser.cpp
+++ b/torch/csrc/jit/script/schema_type_parser.cpp
@@ -105,7 +105,7 @@ c10::optional<AliasInfo> SchemaTypeParser::parseAliasAnnotation() {
     L.expect(')');
   } else if (L.nextIf('!')) {
     alias_info.addBeforeSet(
-        Symbol::fromQualString("alias::$" + std::to_string(next_id++)));
+        Symbol::fromQualString("alias::$" + c10::guts::to_string(next_id++)));
     alias_info.setIsWrite(true);
   } else {
     return c10::nullopt;

--- a/torch/csrc/jit/script/strtod.cpp
+++ b/torch/csrc/jit/script/strtod.cpp
@@ -1,0 +1,262 @@
+// Taken from https://github.com/JuliaLang/julia/blob/v1.1.0/src/support/strtod.c
+
+#include <stdlib.h>
+#include <locale.h>
+#include <ATen/core/Macros.h>
+
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <xlocale.h>
+#endif
+
+// The following code is derived from the Python function _PyOS_ascii_strtod
+// see http://hg.python.org/cpython/file/default/Python/pystrtod.c
+//
+// Copyright © 2001-2014 Python Software Foundation; All Rights Reserved
+//
+// The following modifications have been made:
+// - Leading spaces are ignored
+// - Parsing of hex floats is supported in the derived version
+// - Python functions for tolower, isdigit and malloc have been replaced by the respective
+//   C stdlib functions
+
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <string.h>
+
+#define D_PNAN ((double)+NAN)
+#define D_PINF ((double)+INFINITY)
+
+namespace {
+int case_insensitive_match(const char *s, const char *t)
+{
+    while (*t && tolower(*s) == *t) {
+        s++;
+        t++;
+    }
+    return *t ? 0 : 1;
+}
+
+double parse_inf_or_nan(const char *p, char **endptr)
+{
+    double retval;
+    const char *s;
+    int negate = 0;
+
+    s = p;
+    if (*s == '-') {
+        negate = 1;
+        s++;
+    }
+    else if (*s == '+') {
+        s++;
+    }
+    if (case_insensitive_match(s, "inf")) {
+        s += 3;
+        if (case_insensitive_match(s, "inity"))
+            s += 5;
+        retval = negate ? -D_PINF : D_PINF;
+    }
+    else if (case_insensitive_match(s, "nan")) {
+        s += 3;
+        retval = negate ? -D_PNAN : D_PNAN;
+    }
+    else {
+        s = p;
+        retval = -1.0;
+    }
+    *endptr = (char *)s;
+    return retval;
+}
+
+}
+
+namespace torch {
+namespace jit {
+namespace script {
+
+C10_EXPORT double strtod_c(const char *nptr, char **endptr)
+{
+    char *fail_pos;
+    double val;
+    struct lconv *locale_data;
+    const char *decimal_point;
+    size_t decimal_point_len;
+    const char *p, *decimal_point_pos;
+    const char *end = NULL; /* Silence gcc */
+    const char *digits_pos = NULL;
+    int negate = 0;
+
+    fail_pos = NULL;
+
+    locale_data = localeconv();
+    decimal_point = locale_data->decimal_point;
+    decimal_point_len = strlen(decimal_point);
+
+    decimal_point_pos = NULL;
+
+    /* Parse infinities and nans */
+    val = parse_inf_or_nan(nptr, endptr);
+    if (*endptr != nptr)
+        return val;
+
+    /* Set errno to zero, so that we can distinguish zero results
+       and underflows */
+    errno = 0;
+
+    /* We process the optional sign manually, then pass the remainder to
+       the system strtod.  This ensures that the result of an underflow
+       has the correct sign.  */
+    p = nptr;
+
+    /* parse leading spaces */
+    while (isspace((unsigned char)*p)) {
+        p++;
+    }
+
+    /* Process leading sign, if present */
+    if (*p == '-') {
+        negate = 1;
+        p++;
+    }
+    else if (*p == '+') {
+        p++;
+    }
+
+    /* This code path is used for hex floats */
+    if (*p == '0' && (*(p+1) == 'x' || *(p+1) == 'X')) {
+        digits_pos = p;
+        p += 2;
+        /* Check that what's left begins with a digit or decimal point */
+        if (!isxdigit(*p) && *p != '.')
+            goto invalid_string;
+
+
+        if (decimal_point[0] != '.' || decimal_point[1] != 0) {
+            /* Look for a '.' in the input; if present, it'll need to be
+               swapped for the current locale's decimal point before we
+               call strtod.  On the other hand, if we find the current
+               locale's decimal point then the input is invalid. */
+            while (isxdigit(*p))
+                p++;
+
+            if (*p == '.') {
+                decimal_point_pos = p++;
+
+                /* locate end of number */
+                while (isxdigit(*p))
+                    p++;
+
+                if (*p == 'p' || *p == 'P')
+                    p++;
+                if (*p == '+' || *p == '-')
+                    p++;
+                while (isdigit(*p))
+                    p++;
+                end = p;
+            }
+            else if (strncmp(p, decimal_point, decimal_point_len) == 0)
+                goto invalid_string;
+            /* For the other cases, we need not convert the decimal point */
+        }
+    }
+    else {
+        /* Check that what's left begins with a digit or decimal point */
+        if (!isdigit(*p) && *p != '.')
+            goto invalid_string;
+
+        digits_pos = p;
+        if (decimal_point[0] != '.' || decimal_point[1] != 0) {
+            /* Look for a '.' in the input; if present, it'll need to be
+               swapped for the current locale's decimal point before we
+               call strtod.  On the other hand, if we find the current
+               locale's decimal point then the input is invalid. */
+            while (isdigit(*p))
+                p++;
+
+            if (*p == '.') {
+                decimal_point_pos = p++;
+
+                /* locate end of number */
+                while (isdigit(*p))
+                    p++;
+
+                if (*p == 'e' || *p == 'E')
+                    p++;
+                if (*p == '+' || *p == '-')
+                    p++;
+                while (isdigit(*p))
+                    p++;
+                end = p;
+            }
+            else if (strncmp(p, decimal_point, decimal_point_len) == 0)
+                goto invalid_string;
+            /* For the other cases, we need not convert the decimal point */
+        }
+    }
+
+    if (decimal_point_pos) {
+        char *copy, *c;
+        /* Create a copy of the input, with the '.' converted to the
+           locale-specific decimal point */
+        copy = (char *)malloc(end - digits_pos +
+                                    1 + decimal_point_len);
+        if (copy == NULL) {
+            *endptr = (char *)nptr;
+            errno = ENOMEM;
+            return val;
+        }
+
+        c = copy;
+        memcpy(c, digits_pos, decimal_point_pos - digits_pos);
+        c += decimal_point_pos - digits_pos;
+        memcpy(c, decimal_point, decimal_point_len);
+        c += decimal_point_len;
+        memcpy(c, decimal_point_pos + 1,
+               end - (decimal_point_pos + 1));
+        c += end - (decimal_point_pos + 1);
+        *c = 0;
+
+        val = strtod(copy, &fail_pos);
+
+        if (fail_pos)
+        {
+            if (fail_pos > decimal_point_pos)
+                fail_pos = (char *)digits_pos +
+                    (fail_pos - copy) -
+                    (decimal_point_len - 1);
+            else
+                fail_pos = (char *)digits_pos +
+                    (fail_pos - copy);
+        }
+
+        free(copy);
+    }
+    else {
+        val = strtod(digits_pos, &fail_pos);
+    }
+
+    if (fail_pos == digits_pos)
+        goto invalid_string;
+
+    if (negate && fail_pos != nptr)
+        val = -val;
+    *endptr = fail_pos;
+
+    return val;
+
+invalid_string:
+    *endptr = (char*)nptr;
+    errno = EINVAL;
+    return -1.0;
+}
+
+
+C10_EXPORT float strtof_c(const char *nptr, char **endptr)
+{
+    return (float) strtod_c(nptr, endptr);
+}
+
+}
+}
+}

--- a/torch/csrc/jit/script/strtod.h
+++ b/torch/csrc/jit/script/strtod.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <ATen/core/Macros.h>
+
+namespace torch {
+namespace jit {
+namespace script {
+
+CAFFE2_API double strtod_c(const char *nptr, char **endptr);
+CAFFE2_API float strtof_c(const char *nptr, char **endptr);
+
+}
+}
+}

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <torch/csrc/jit/script/error_report.h>
 #include <torch/csrc/jit/script/tree.h>
+#include <torch/csrc/jit/script/strtod.h>
 
 #include <functional>
 #include <string>
@@ -739,7 +740,7 @@ struct Const : public Expr {
     return std::stoll(subtree(0)->stringValue());
   }
   double asFloatingPoint() const {
-    return SharedParserData::strtod_c(
+    return torch::jit::script::strtod_c(
         subtree(0)->stringValue().c_str(), nullptr);
   }
   const std::string& text() const {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18863 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675350/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18864 [wip] Fixing function schema parser for Android**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675355/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18865 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675343/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18866 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14780297/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18867 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14678983/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18868 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14732749/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18869 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14766170/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18870 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14765108/)

String<->Number conversions aren't available in the STL used in our Android environment.
This diff adds workarounds for that so that the function schema parser can be compiled for android

Differential Revision: [D14675355](https://our.internmc.facebook.com/intern/diff/D14675355/)