### PR TITLE
Use string based schema for exposing caffe2 ops

### DIFF
--- a/caffe2/core/c10_operator.h
+++ b/caffe2/core/c10_operator.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/function_schema.h>
 #include <ATen/core/op_registration/op_registration.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 #include <vector>
 
 namespace caffe2 {
@@ -86,21 +87,23 @@ void call_caffe2_op_from_c10(
   _call_caffe2_op_from_c10(stack, Schema(), &_call_caffe2_op<Caffe2Operator>);
 }
 
-inline c10::FunctionSchema make_function_schema_for_c10(const char* OperatorName, std::vector<c10::Argument> inputs, std::vector<c10::Argument> outputs) {
-  // actual_inputs is the real inputs plus an optional tensor list argument
-  // for preallocated outputs
-  std::vector<c10::Argument> actual_inputs = std::move(inputs);
-  actual_inputs.emplace_back(
+inline FunctionSchema make_function_schema_for_c10(const char* schema_str) {
+  c10::FunctionSchema parsed_schema = torch::jit::parseSchema(schema_str);
+  std::vector<c10::Argument> arguments = parsed_schema.arguments();
+  arguments.emplace_back(
       PREALLOCATED_OUTPUT_ARGNAME,
       c10::OptionalType::create(c10::ListType::ofTensors()),
       nullopt,
       IValue());
 
-  return c10::FunctionSchema(
-      std::string("_caffe2::") + OperatorName,
-      "",
-      std::move(actual_inputs),
-      std::move(outputs));
+  return FunctionSchema(
+    parsed_schema.name(),
+    parsed_schema.overload_name(),
+    std::move(arguments),
+    parsed_schema.returns(),
+    parsed_schema.is_vararg(),
+    parsed_schema.is_varret()
+  );
 }
 
 inline std::unique_ptr<c10::KernelCache> noCache() {
@@ -123,14 +126,7 @@ inline std::unique_ptr<c10::KernelCache> noCache() {
  *
  * > C10_REGISTER_CAFFE2_OPERATOR_CPU(
  * >    C10MyOperator,
- * >    (std::vector<c10::Argument>{
- * >      c10::Argument("input1"),
- * >      c10::Argument("argument2", c10::IntType::get()),
- * >      c10::Argument("argument3", c10::FloatType::get())
- * >    }), (std::vector<c10::Argument>{
- * >      c10::Argument("output1"),
- * >      c10::Argument("output2")
- * >    }),
+ * >    "_caffe2::C10MyOperator(Tensor input1, int argument2, float argument3) -> (Tensor output1, Tensor output2)"
  * >    caffe2::MyOperator<caffe2::CPUContext> // This is the caffe2 operator
  * >                                           // class template
  * > )
@@ -158,20 +154,19 @@ inline std::unique_ptr<c10::KernelCache> noCache() {
 #define C10_DECLARE_CAFFE2_OPERATOR(OperatorName)                  \
   namespace caffe2 {                                               \
   namespace _c10_ops {                                             \
-  CAFFE2_API const ::c10::FunctionSchema& schema_##OperatorName(); \
+  CAFFE2_API const FunctionSchema& schema_##OperatorName();        \
   }                                                                \
   }
 
 // TODO This macro should take a JIT schema string instead of a vector of inputs and outputs.
 #define C10_REGISTER_CAFFE2_OPERATOR_CPU(                                    \
-    OperatorName, Inputs, Outputs, OperatorClass)                            \
+    OperatorName, OperatorSchema, OperatorClass)                             \
   /* Register the op schema with the c10 dispatcher */                       \
   namespace caffe2 {                                                         \
   namespace _c10_ops {                                                       \
-  C10_EXPORT const ::c10::FunctionSchema& schema_##OperatorName() {          \
-    static ::c10::FunctionSchema schema =                                    \
-        ::caffe2::detail::make_function_schema_for_c10(                      \
-            #OperatorName, Inputs, Outputs);                                 \
+  C10_EXPORT const FunctionSchema& schema_##OperatorName() {                 \
+    static const FunctionSchema schema =                                     \
+        ::caffe2::detail::make_function_schema_for_c10(OperatorSchema);      \
     return schema;                                                           \
   }                                                                          \
   }                                                                          \

--- a/caffe2/operators/bbox_transform_op.cc
+++ b/caffe2/operators/bbox_transform_op.cc
@@ -186,20 +186,19 @@ using BBoxTransformOpFloatCPU =
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     BBoxTransform,
-    (std::vector<c10::Argument>{
-        c10::Argument("rois"),
-        c10::Argument("deltas"),
-        c10::Argument("im_info"),
-        c10::Argument("weights", ListType::create(FloatType::get())),
-        c10::Argument("apply_scale", BoolType::get()),
-        c10::Argument("rotated", BoolType::get()),
-        c10::Argument("angle_bound_on", BoolType::get()),
-        c10::Argument("angle_bound_lo", IntType::get()),
-        c10::Argument("angle_bound_hi", IntType::get()),
-        c10::Argument("clip_angle_thresh", FloatType::get()),
-    }),
-    (std::vector<c10::Argument>{
-        c10::Argument("output_0"),
-        c10::Argument("output_1"),
-    }),
+    "_caffe2::BBoxTransform("
+      "Tensor rois, "
+      "Tensor deltas, "
+      "Tensor im_info, "
+      "float[] weights, "
+      "bool apply_scale, "
+      "bool rotated, "
+      "bool angle_bound_on, "
+      "int angle_bound_lo, "
+      "int angle_bound_hi, "
+      "float clip_angle_thresh"
+    ") -> ("
+      "Tensor output_0, "
+      "Tensor output_1"
+    ")",
     BBoxTransformOpFloatCPU);

--- a/caffe2/operators/box_with_nms_limit_op.cc
+++ b/caffe2/operators/box_with_nms_limit_op.cc
@@ -298,25 +298,24 @@ SHOULD_NOT_DO_GRADIENT(BoxWithNMSLimit);
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     BoxWithNMSLimit,
-    (std::vector<c10::Argument>{
-        c10::Argument("scores"),
-        c10::Argument("boxes"),
-        c10::Argument("batch_splits"),
-        c10::Argument("score_thresh", FloatType::get()),
-        c10::Argument("nms", FloatType::get()),
-        c10::Argument("detections_per_im", IntType::get()),
-        c10::Argument("soft_nms_enabled", BoolType::get()),
-        c10::Argument("soft_nms_method", StringType::get()),
-        c10::Argument("soft_nms_sigma", FloatType::get()),
-        c10::Argument("soft_nms_min_score_thres", FloatType::get()),
-        c10::Argument("rotated", BoolType::get()),
-    }),
-    (std::vector<c10::Argument>{
-        c10::Argument("scores"),
-        c10::Argument("boxes"),
-        c10::Argument("classes"),
-        c10::Argument("batch_splits"),
-        // c10::Argument("keeps"),
-        // c10::Argument("keeps_size"),
-    }),
+    "_caffe2::BoxWithNMSLimit("
+      "Tensor scores, "
+      "Tensor boxes, "
+      "Tensor batch_splits, "
+      "float score_thresh, "
+      "float nms, "
+      "int detections_per_im, "
+      "bool soft_nms_enabled, "
+      "str soft_nms_method, "
+      "float soft_nms_sigma, "
+      "float soft_nms_min_score_thres, "
+      "bool rotated"
+    ") -> ("
+      "Tensor scores, "
+      "Tensor boxes, "
+      "Tensor classes, "
+      "Tensor batch_splits"
+      //"Tensor keeps, "
+      //"Tensor keeps_size, "
+    ")",
     caffe2::BoxWithNMSLimitOp<caffe2::CPUContext>);

--- a/caffe2/operators/generate_proposals_op.cc
+++ b/caffe2/operators/generate_proposals_op.cc
@@ -408,23 +408,19 @@ SHOULD_NOT_DO_GRADIENT(GenerateProposalsCPP);
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     GenerateProposals,
-    (std::vector<c10::Argument>{
-        c10::Argument("scores"),
-        c10::Argument("bbox_deltas"),
-        c10::Argument("im_info"),
-        c10::Argument("anchors"),
-        c10::Argument("spatial_scale", FloatType::get()),
-        c10::Argument("pre_nms_topN", IntType::get()),
-        c10::Argument("post_nms_topN", IntType::get()),
-        c10::Argument("nms_thresh", FloatType::get()),
-        c10::Argument("min_size", FloatType::get()),
-        c10::Argument("angle_bound_on", BoolType::get()),
-        c10::Argument("angle_bound_lo", IntType::get()),
-        c10::Argument("angle_bound_hi", IntType::get()),
-        c10::Argument("clip_angle_thresh", FloatType::get()),
-    }),
-    (std::vector<c10::Argument>{
-        c10::Argument("output_0"),
-        c10::Argument("output_1"),
-    }),
+    "_caffe2::GenerateProposals("
+      "Tensor scores, "
+      "Tensor bbox_deltas, "
+      "Tensor im_info, "
+      "Tensor anchors, "
+      "float spatial_scale, "
+      "int pre_nms_topN, "
+      "int post_nms_topN, "
+      "float nms_thresh, "
+      "float min_size, "
+      "bool angle_bound_on, "
+      "int angle_bound_lo, "
+      "int angle_bound_hi, "
+      "float clip_angle_thresh"
+    ") -> (Tensor output_0, Tensor output_1)",
     caffe2::GenerateProposalsOp<caffe2::CPUContext>);

--- a/caffe2/operators/inference_lstm_op.cc
+++ b/caffe2/operators/inference_lstm_op.cc
@@ -51,13 +51,11 @@ NO_GRADIENT(InferenceLSTM);
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     InferenceLSTM,
-    (std::vector<c10::Argument>{
-        c10::Argument("input_list", ListType::ofTensors()),
-        c10::Argument("num_layers", IntType::get()),
-        c10::Argument("has_biases", BoolType::get()),
-        c10::Argument("batch_first", BoolType::get()),
-        c10::Argument("bidirectional", BoolType::get())}),
-    (std::vector<c10::Argument>{c10::Argument("output"),
-                                c10::Argument("hidden"),
-                                c10::Argument("cell")}),
+    "_caffe2::InferenceLSTM("
+      "Tensor[] input_list, "
+      "int num_layers, "
+      "bool has_biases, "
+      "bool batch_first, "
+      "bool bidirectional"
+    ") -> (Tensor output, Tensor hidden, Tensor cell)",
     caffe2::InferenceLSTMOp);

--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -188,13 +188,7 @@ to the end.)
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     LayerNorm,
-    (std::vector<c10::Argument>{
-        c10::Argument("input"),
-        c10::Argument("axis", c10::IntType::get()),
-        c10::Argument("epsilon", c10::FloatType::get())}),
-    (std::vector<c10::Argument>{c10::Argument("output"),
-                                c10::Argument("mean"),
-                                c10::Argument("stdev")}),
+    "_caffe2::LayerNorm(Tensor input, int axis, float epsilon) -> (Tensor output, Tensor mean, Tensor stdev)",
     caffe2::LayerNormOp<caffe2::CPUContext>)
 
 namespace caffe2 {

--- a/caffe2/operators/roi_align_op.cc
+++ b/caffe2/operators/roi_align_op.cc
@@ -378,16 +378,13 @@ using RoIAlignOpFloatCPU = caffe2::RoIAlignOp<float, caffe2::CPUContext>;
 
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     RoIAlign,
-    (std::vector<c10::Argument>{
-        c10::Argument("features"),
-        c10::Argument("rois"),
-        c10::Argument("order", StringType::get()),
-        c10::Argument("spatial_scale", FloatType::get()),
-        c10::Argument("pooled_h", IntType::get()),
-        c10::Argument("pooled_w", IntType::get()),
-        c10::Argument("sampling_ratio", IntType::get()),
-    }),
-    (std::vector<c10::Argument>{
-        c10::Argument("pooled_features"),
-    }),
+    "_caffe2::RoIAlign("
+      "Tensor features, "
+      "Tensor rois, "
+      "str order, "
+      "float spatial_scale, "
+      "int pooled_h, "
+      "int pooled_w, "
+      "int sampling_ratio"
+    ") -> Tensor",
     RoIAlignOpFloatCPU);


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18863 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675350/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18864 [wip] Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675355/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18865 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675343/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18866 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14780297/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18867 Use string based schema for exposing caffe2 ops**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14678983/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18868 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14732749/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18869 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14766170/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18870 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14765108/)

Since we now have a string-schema-based op registration API, we can also use it when exposing caffe2 operators.

Differential Revision: [D14678983](https://our.internmc.facebook.com/intern/diff/D14678983/)