### PR TITLE
Allow registering ops without specifying the full schema

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -83,6 +83,11 @@ inline bool operator==(const Argument& lhs, const Argument& rhs) {
           && lhs.alias_info() == rhs.alias_info();
 }
 
+struct OperatorName final {
+  std::string name;
+  std::string overload_name;
+};
+
 struct FunctionSchema {
   FunctionSchema(
       std::string name,
@@ -91,8 +96,7 @@ struct FunctionSchema {
       std::vector<Argument> returns,
       bool is_vararg = false,
       bool is_varret = false)
-      : name_(std::move(name)),
-        overload_name_(std::move(overload_name)),
+      : name_({std::move(name), std::move(overload_name)}),
         arguments_(std::move(arguments)),
         returns_(std::move(returns)),
         is_vararg_(is_vararg),
@@ -115,8 +119,7 @@ struct FunctionSchema {
             is_varret) {}
 
 private:
-  const std::string name_;
-  const std::string overload_name_;
+  OperatorName name_;
   const std::vector<Argument> arguments_;
   const std::vector<Argument> returns_;
   // if true then this schema takes an arbitrary number of additional arguments
@@ -128,10 +131,10 @@ private:
 
 public:
   const std::string& name() const {
-    return name_;
+    return name_.name;
   }
   const std::string& overload_name() const {
-    return overload_name_;
+    return name_.overload_name;
   }
   const std::vector<Argument>& arguments() const {
     return arguments_;

--- a/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 
 /**
  * This file tests the legacy function-based API for registering kernels.
@@ -449,6 +450,20 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenFallbackKernelWith
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
+  return {};
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", &kernelForSchemaInference);
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 template<class Return, class... Args> struct kernel_func final {

--- a/aten/src/ATen/core/op_registration/kernel_function_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::kernel;
@@ -455,6 +456,20 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenFallbackKernelWithoutTen
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
+  return {};
+}
+
+TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", kernel<decltype(kernelForSchemaInference), &kernelForSchemaInference>());
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 template<class Return, class... Args> struct kernel_func final {

--- a/aten/src/ATen/core/op_registration/kernel_functor_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_functor_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::OperatorKernel;
@@ -598,6 +599,22 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenFallbackKernelWithoutTens
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+struct KernelForSchemaInference final : OperatorKernel {
+  std::tuple<int64_t, Tensor> operator()(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
+    return {};
+  }
+};
+
+TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", kernel<KernelForSchemaInference>());
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 template<class Return, class... Args> struct KernelFunc final : OperatorKernel{

--- a/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 
 /**
  * This file tests the legacy lambda-based API for registering kernels:
@@ -400,6 +401,16 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenFallbackKernelWithou
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", [] (Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) -> std::tuple<int64_t, Tensor> {return {};});
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {

--- a/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::kernel;
@@ -417,6 +418,16 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenFallbackKernelWithoutTenso
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", kernel([] (Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) -> std::tuple<int64_t, Tensor> {return {};}));
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {

--- a/aten/src/ATen/core/op_registration/kernel_stackbased_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_stackbased_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::kernel;
@@ -138,6 +139,15 @@ TEST(OperatorRegistrationTest_StackBasedKernel, givenFallbackKernelWithoutTensor
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+void kernelForSchemaInference(Stack* stack, KernelCache* cache) {
+}
+
+TEST(OperatorRegistrationTest_StackBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenFailsBecauseItCannotInferFromStackBasedKernel) {
+  expectThrows<c10::Error>([] {
+      RegisterOperators().op("_test::no_schema_specified", kernel(&kernelForSchemaInference, &noCache));
+  }, "Cannot infer schema from this kernel function. Please explicitly specify the operator schema.");
 }
 
 struct Cache final : KernelCache {

--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -56,8 +56,33 @@ private:
   bool owns_registration_;
 };
 
-void RegisterOperators::registerOp_(const std::string& schemaStr, detail::KernelRegistrationConfig&& config) {
-  registerOp_(torch::jit::parseSchema(schemaStr), std::move(config));
+void RegisterOperators::checkSchemaAndRegisterOp_(const std::string& schemaOrNameStr, detail::KernelRegistrationConfig&& config) {
+  either<OperatorName, FunctionSchema> schemaOrName = torch::jit::parseSchemaOrName(schemaOrNameStr);
+  if (schemaOrName.is_right()) {
+    // schema was explicitly specified. Check it matches the inferred one and register the op.
+    checkSchemaAndRegisterOp_(std::move(schemaOrName).right(), std::move(config));
+  } else {
+    // schema wasn't explicitly specified. Take the inferred schema for registering the op.
+    AT_ASSERTM(nullptr != config.inferred_function_schema.get(), "Cannot infer schema from this kernel function. Please explicitly specify the operator schema.");
+    OperatorName name = std::move(schemaOrName).left();
+    FunctionSchema inferredSchema(
+      std::move(name.name),
+      std::move(name.overload_name),
+      config.inferred_function_schema->arguments(),
+      config.inferred_function_schema->returns(),
+      config.inferred_function_schema->is_vararg(),
+      config.inferred_function_schema->is_varret()
+    );
+    registerOp_(std::move(inferredSchema), std::move(config));
+  }
+}
+
+void RegisterOperators::checkSchemaAndRegisterOp_(FunctionSchema&& schema, detail::KernelRegistrationConfig&& config) {
+  if (config.inferred_function_schema.get() != nullptr) {
+    assertSchemasHaveSameSignature(*config.inferred_function_schema, schema);
+  }
+
+  registerOp_(std::move(schema), std::move(config));
 }
 
 void RegisterOperators::registerOp_(FunctionSchema&& schema, detail::KernelRegistrationConfig&& config) {
@@ -67,10 +92,6 @@ void RegisterOperators::registerOp_(FunctionSchema&& schema, detail::KernelRegis
 
   // if kernel_func is set, so must be cache_creator_func, the API shouldn't allow anything else.
   AT_ASSERT((config.kernel_func != nullptr) == static_cast<bool>(config.cache_creator_func));
-
-  if (config.inferred_function_schema.get() != nullptr) {
-    assertSchemasHaveSameSignature(*config.inferred_function_schema, schema);
-  }
 
   registrars_.emplace_back(std::move(schema), config.dispatch_key, config.kernel_func, std::move(config.cache_creator_func));
 }

--- a/torch/csrc/jit/function_schema_parser.cpp
+++ b/torch/csrc/jit/function_schema_parser.cpp
@@ -8,9 +8,13 @@
 #include <vector>
 
 using c10::FunctionSchema;
+using c10::OperatorName;
 using c10::Argument;
 using c10::IValue;
 using c10::ListType;
+using c10::either;
+using c10::make_right;
+using c10::make_left;
 using at::TypeKind;
 
 namespace torch {
@@ -22,16 +26,15 @@ struct SchemaParser {
   SchemaParser(const std::string& str)
       : L(str), type_parser(L, /*parse_complete_tensor_types*/ false) {}
 
-  FunctionSchema parseDeclaration() {
-    std::string name = L.expect(TK_IDENT).text();
-    if (L.nextIf(':')) {
-      L.expect(':');
-      name = name + "::" + L.expect(TK_IDENT).text();
+  either<OperatorName, FunctionSchema> parseDeclaration() {
+    OperatorName name = parseName();
+
+    // If there is no parentheses coming, then this is just the operator name
+    // without an argument list
+    if (L.cur().kind != '(') {
+      return make_left<OperatorName, FunctionSchema>(std::move(name));
     }
-    std::string overload_name = "";
-    if (L.nextIf('.')) {
-      overload_name = L.expect(TK_IDENT).text();
-    }
+
     std::vector<Argument> arguments;
     std::vector<Argument> returns;
     bool kwarg_only = false;
@@ -61,12 +64,25 @@ struct SchemaParser {
       returns.push_back(
           parseArgument(0, /*is_return=*/true, /*kwarg_only=*/false));
     }
-    return FunctionSchema{
-        std::move(name), std::move(overload_name), std::move(arguments), std::move(returns), is_vararg, false};
+    return make_right<OperatorName, FunctionSchema>(
+        std::move(name.name), std::move(name.overload_name), std::move(arguments), std::move(returns), is_vararg, false);
   }
 
-  std::vector<FunctionSchema> parseDeclarations() {
-    std::vector<FunctionSchema> results;
+  c10::OperatorName parseName() {
+    std::string name = L.expect(TK_IDENT).text();
+    if (L.nextIf(':')) {
+      L.expect(':');
+      name = name + "::" + L.expect(TK_IDENT).text();
+    }
+    std::string overload_name = "";
+    if (L.nextIf('.')) {
+      overload_name = L.expect(TK_IDENT).text();
+    }
+    return {name, overload_name};
+  }
+
+  std::vector<either<OperatorName, FunctionSchema>> parseDeclarations() {
+    std::vector<either<OperatorName, FunctionSchema>> results;
     do {
       results.push_back(parseDeclaration());
     } while (L.nextIf(TK_NEWLINE));
@@ -255,8 +271,14 @@ struct SchemaParser {
 } // namespace
 } // namespace script
 
+either<OperatorName, FunctionSchema> parseSchemaOrName(const std::string& schemaOrName) {
+  return script::SchemaParser(schemaOrName).parseDeclarations().at(0);
+}
+
 FunctionSchema parseSchema(const std::string& schema) {
-  return script::SchemaParser(schema).parseDeclarations().at(0);
+  auto parsed = parseSchemaOrName(schema);
+  AT_CHECK(parsed.is_right(), "Tried to parse a function schema but only the operator name was given");
+  return parsed.right();
 }
 
 } // namespace jit

--- a/torch/csrc/jit/function_schema_parser.h
+++ b/torch/csrc/jit/function_schema_parser.h
@@ -2,12 +2,14 @@
 
 #include <ATen/core/function_schema.h>
 #include <ATen/core/Macros.h>
+#include <c10/util/either.h>
 #include <string>
 
 namespace torch {
 namespace jit {
 
-CAFFE2_API ::c10::FunctionSchema parseSchema(const std::string& schema);
+CAFFE2_API c10::either<c10::OperatorName, c10::FunctionSchema> parseSchemaOrName(const std::string& schemaOrName);
+CAFFE2_API c10::FunctionSchema parseSchema(const std::string& schema);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18863 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675350/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18864 [wip] Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675355/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18865 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14675343/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18866 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14780297/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18867 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14678983/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18868 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14732749/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18869 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14766170/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18870 Allow registering ops without specifying the full schema**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14765108/)

The operator registration API now allows registering an operator by only giving the operator name and not the full operator schema,
as long as the operator schema can be inferred from the kernel function.

Differential Revision: [D14765108](https://our.internmc.facebook.com/intern/diff/D14765108/)