### PR TITLE
Fix interpolate trace

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7349,6 +7349,21 @@ a")
             mte, (torch.zeros(1, 2, 3),), None, verbose=False,
             example_outputs=outputs))
 
+    def test_interpolate_trace(self):
+        class test(nn.Module):
+            def __init__(self):
+                super(test, self).__init__()
+                self.conv = nn.Conv2d(1, 32, kernel_size=3, padding=1)
+
+            def forward(self, x):
+                y = self.conv(x)
+                w = nn.functional.interpolate(y, mode='bilinear', align_corners=False, scale_factor=0.5)
+                return w
+
+        f = test()
+        # no failure
+        torch.jit.trace(f, (torch.zeros(1, 1, 28, 28),))
+
     def test_trace_nested_datatypes(self):
         @torch.jit.script
         def foo(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7362,7 +7362,10 @@ a")
 
         f = test()
         # no failure
-        torch.jit.trace(f, (torch.zeros(1, 1, 28, 28),))
+        g = torch.jit.trace(f, (torch.zeros(1, 1, 28, 28),))
+        x = torch.zeros(1, 1, 14, 14)
+        # constants not baked in
+        self.assertEqual(g(x), f(x))
 
     def test_trace_nested_datatypes(self):
         @torch.jit.script

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2492,6 +2492,9 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
             return size
         scale_factors = _ntuple(dim)(scale_factor)
         # math.floor might return float in py2.7
+
+        # need to cast input.size to int so that in tracing the result is an int
+        # and not a tensor
         return [int(math.floor(int(input.size(i + 2)) * scale_factors[i])) for i in range(dim)]
 
     if mode in ('nearest', 'area'):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2492,7 +2492,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
             return size
         scale_factors = _ntuple(dim)(scale_factor)
         # math.floor might return float in py2.7
-        return [int(math.floor(input.size(i + 2) * scale_factors[i])) for i in range(dim)]
+        return [int(math.floor(int(input.size(i + 2)) * scale_factors[i])) for i in range(dim)]
 
     if mode in ('nearest', 'area'):
         if align_corners is not None:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/10654

The issue is that in tracing `.size` returns an int tensor, and when an int tensor is multiplied by a scalar the int dominates and the scalar gets casted 0. 