### PR TITLE
Removing GetDevice from PyTorch

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -895,14 +895,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   /**
-   * The device of a Tensor; e.g., Device(kCUDA, 1) (the 1-index CUDA
-   * device).
-   */
-  Device GetDevice() const {
-    return storage_.device();
-  }
-
-  /**
    * @brief Extends the outer-most dimension of this tensor by num elements,
    * preserving the existing data.
    *

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -192,7 +192,7 @@ class CAFFE2_API Tensor final {
   }
 
   at::Device GetDevice() const {
-    return impl_.get()->GetDevice();
+    return impl_.get()->device();
   }
 
   /**


### PR DESCRIPTION
Summary:
GetDevice has been deprecated and is not used anymore. This diff removes it from the PyTorch codebase/repo.
No deprecation strategy has been implemented as per guideline from ezyang.

Differential Revision: D14784372
