### PR TITLE
amend D14778810

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op.cc
@@ -174,13 +174,12 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
       nbits_in_non_outlier_ < 8) {
     CAFFE_ENFORCE(!W_quantized_.empty());
 
-    Wq_outlier_.reset(ExtractOutlierMatrix(
+    int outlier_cnt = CountOutliers(
         group_,
         kernel_dim,
         num_out_channels,
         nbits_in_non_outlier_,
-        W_quantized_));
-    int outlier_cnt = Wq_outlier_->ColPtr()[num_out_channels];
+        W_quantized_);
 
     C10_LOG_FIRST_N(INFO, 10)
         << "Proportion of outlier for Conv layer with weight blob "
@@ -202,6 +201,13 @@ bool ConvDNNLowPAcc16Op<ReluFused>::GetQuantizationParameters_() {
       // We need to call GetQuantizationParameters_ again to pack for acc32
       return BaseType::GetQuantizationParameters_();
     }
+
+    Wq_outlier_.reset(ExtractOutlierMatrix(
+        group_,
+        kernel_dim,
+        num_out_channels,
+        nbits_in_non_outlier_,
+        W_quantized_));
   }
 
   bool packW = this->order_ == StorageOrder::NHWC && GetCpuId().avx2();

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
@@ -17,7 +17,7 @@ workspace.GlobalInit(
         "caffe2",
         "--caffe2_omp_num_threads=11",
         # Increase this threshold to test acc16 with randomly generated data
-        "--caffe2_dnnlowp_acc16_density_threshold=0.9",
+        "--caffe2_dnnlowp_acc16_density_threshold=0.5",
     ]
 )
 

--- a/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
@@ -17,7 +17,7 @@ workspace.GlobalInit(
         "caffe2",
         "--caffe2_omp_num_threads=11",
         # Increase this threshold to test acc16 with randomly generated data
-        "--caffe2_dnnlowp_acc16_density_threshold=0.9",
+        "--caffe2_dnnlowp_acc16_density_threshold=0.5",
     ]
 )
 

--- a/caffe2/quantization/server/fbgemm_pack_op.h
+++ b/caffe2/quantization/server/fbgemm_pack_op.h
@@ -82,6 +82,13 @@ void ComputeColumnOffsets(
     const vector<dnnlowp::TensorQuantizationParams>& qparams,
     vector<int32_t>& col_offsets);
 
+int CountOutliers(
+    int groups,
+    int kernel_dim,
+    int M,
+    int nbits_in_non_outlier,
+    vector<std::int8_t>& W_quantized);
+
 /**
  * @param W_quantized input quantized weight that is not packed yet
  */


### PR DESCRIPTION
Summary: Fix in D14778810 had an issue that when we fallback to acc32 because the density of outlier is too high W_quantized_ is already modified. In this diff we first just count the number of outliers (without modifying W_quantized_) and only when density is low enough and no need for fallback we modify W_quantized_ and construct an outlier matrix.

Differential Revision: D14785256
