### PR TITLE
Silence compiler warnings

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
@@ -12,6 +12,10 @@
  * >   .op("func(Tensor a) -> Tensor", &kernel);
  */
 
+// This intentionally tests a deprecated API
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using c10::RegisterOperators;
 using c10::FunctionSchema;
 using c10::Argument;
@@ -839,3 +843,5 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenMismatchedKernel_w
 }
 
 }
+
+#pragma GCC diagnostic pop

--- a/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
@@ -11,6 +11,10 @@
  * >    .op("myfunc(Tensor a) -> Tensor", [] (Tensor a) -> Tensor {...});
  */
 
+// This intentionally tests a deprecated API
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using c10::RegisterOperators;
 using c10::FunctionSchema;
 using c10::Argument;
@@ -791,3 +795,5 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenMismatchedKernel_wit
 }
 
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18912 Silence compiler warnings**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14792617/)

We intentionally test a deprecated API, no need to show the warnings here.

Differential Revision: [D14792617](https://our.internmc.facebook.com/intern/diff/D14792617/)