### PR TITLE
Decompose more Windows scripts

### DIFF
--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -11,7 +11,7 @@ fi
 
 COMPACT_JOB_NAME=pytorch-win-ws2016-cuda9-cudnn7-py3-build
 
-SCRIPT_PARENT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_PARENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$SCRIPT_PARENT_DIR/common.sh"
 
 export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
@@ -22,15 +22,8 @@ fi
 export TMP_DIR="${PWD}/build/win_tmp"
 export TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")
 
-CI_SCRIPTS_DIR=$TMP_DIR/ci_scripts
-mkdir -p $CI_SCRIPTS_DIR
+export SCRIPT_HELPERS_DIR=$SCRIPT_PARENT_DIR/win-test-helpers
 
-
-SCRIPT_HELPERS_DIR=$SCRIPT_PARENT_DIR/win-test-helpers
-
-
-# upload_image.py is called by build_pytorch.bat:
-cp $SCRIPT_HELPERS_DIR/upload_image.py $CI_SCRIPTS_DIR
 
 $SCRIPT_HELPERS_DIR/build_pytorch.bat
 

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -6,61 +6,14 @@ if "%DEBUG%" == "1" (
 
 set PATH=C:\Program Files\CMake\bin;C:\Program Files\7-Zip;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\cmd;C:\Program Files\Amazon\AWSCLI;%PATH%
 
-:: Install MKL
-if "%REBUILD%"=="" (
-  if "%BUILD_ENVIRONMENT%"=="" (
-    curl -k https://s3.amazonaws.com/ossci-windows/mkl_2018.2.185.7z --output %TMP_DIR_WIN%\mkl.7z
-  ) else (
-    aws s3 cp s3://ossci-windows/mkl_2018.2.185.7z %TMP_DIR_WIN%\mkl.7z --quiet
-  )
-  7z x -aoa %TMP_DIR_WIN%\mkl.7z -o%TMP_DIR_WIN%\mkl
-)
-set CMAKE_INCLUDE_PATH=%TMP_DIR_WIN%\mkl\include
-set LIB=%TMP_DIR_WIN%\mkl\lib;%LIB
 
-:: Install MAGMA
-if "%REBUILD%"=="" (
-  if "%BUILD_ENVIRONMENT%"=="" (
-    curl -k https://s3.amazonaws.com/ossci-windows/magma_2.5.0_cuda90_%BUILD_TYPE%.7z --output %TMP_DIR_WIN%\magma_2.5.0_cuda90_%BUILD_TYPE%.7z
-  ) else (
-    aws s3 cp s3://ossci-windows/magma_2.5.0_cuda90_%BUILD_TYPE%.7z %TMP_DIR_WIN%\magma_2.5.0_cuda90_%BUILD_TYPE%.7z --quiet
-  )
-  7z x -aoa %TMP_DIR_WIN%\magma_2.5.0_cuda90_%BUILD_TYPE%.7z -o%TMP_DIR_WIN%\magma
-)
-set MAGMA_HOME=%TMP_DIR_WIN%\magma
+set INSTALLER_DIR=%SCRIPT_HELPERS_DIR%\installation-helpers
 
-:: Install sccache
-mkdir %TMP_DIR_WIN%\bin
-if "%REBUILD%"=="" (
-  :check_sccache
-  %TMP_DIR_WIN%\bin\sccache.exe --show-stats || (
-    taskkill /im sccache.exe /f /t || ver > nul
-    del %TMP_DIR_WIN%\bin\sccache.exe
-    if "%BUILD_ENVIRONMENT%"=="" (
-      curl -k https://s3.amazonaws.com/ossci-windows/sccache.exe --output %TMP_DIR_WIN%\bin\sccache.exe
-    ) else (
-      aws s3 cp s3://ossci-windows/sccache.exe %TMP_DIR_WIN%\bin\sccache.exe
-    )
-    goto :check_sccache
-  )
-)
+call %INSTALLER_DIR%\install_mkl.bat
+call %INSTALLER_DIR%\install_magma.bat
+call %INSTALLER_DIR%\install_sccache.bat
+call %INSTALLER_DIR%\install_miniconda3.bat
 
-:: Install Miniconda3
-if "%BUILD_ENVIRONMENT%"=="" (
-  set CONDA_PARENT_DIR=%CD%
-) else (
-  set CONDA_PARENT_DIR=C:\Jenkins
-)
-if "%REBUILD%"=="" (
-  IF EXIST %CONDA_PARENT_DIR%\Miniconda3 ( rd /s /q %CONDA_PARENT_DIR%\Miniconda3 )
-  curl -k https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe --output %TMP_DIR_WIN%\Miniconda3-latest-Windows-x86_64.exe
-  %TMP_DIR_WIN%\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=%CONDA_PARENT_DIR%\Miniconda3
-)
-call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
-if "%REBUILD%"=="" (
-  :: We have to pin Python version to 3.6.7, until mkl supports Python 3.7
-  call conda install -y -q python=3.6.7 numpy cffi pyyaml boto3
-)
 
 :: Install ninja
 if "%REBUILD%"=="" ( pip install -q ninja )
@@ -115,10 +68,10 @@ if not "%USE_CUDA%"=="0" (
 
   python setup.py install --cmake && sccache --show-stats && (
     if "%BUILD_ENVIRONMENT%"=="" (
-      echo NOTE: To run \`import torch\`, please make sure to activate the conda environment by running \`call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3\` in Command Prompt before running Git Bash.
+      echo NOTE: To run `import torch`, please make sure to activate the conda environment by running `call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3` in Command Prompt before running Git Bash.
     ) else (
       mv %CD%\build\bin\test_api.exe %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch\lib
-      7z a %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\caffe2 && python %TMP_DIR_WIN%\ci_scripts\upload_image.py %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z
+      7z a %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\caffe2 && python %SCRIPT_HELPERS_DIR%\upload_image.py %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z
     )
   )
 )

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
@@ -1,0 +1,9 @@
+if "%REBUILD%"=="" (
+  if "%BUILD_ENVIRONMENT%"=="" (
+    curl -k https://s3.amazonaws.com/ossci-windows/magma_2.5.0_cuda90_%BUILD_TYPE%.7z --output %TMP_DIR_WIN%\magma_2.5.0_cuda90_%BUILD_TYPE%.7z
+  ) else (
+    aws s3 cp s3://ossci-windows/magma_2.5.0_cuda90_%BUILD_TYPE%.7z %TMP_DIR_WIN%\magma_2.5.0_cuda90_%BUILD_TYPE%.7z --quiet
+  )
+  7z x -aoa %TMP_DIR_WIN%\magma_2.5.0_cuda90_%BUILD_TYPE%.7z -o%TMP_DIR_WIN%\magma
+)
+set MAGMA_HOME=%TMP_DIR_WIN%\magma

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat
@@ -1,0 +1,15 @@
+if "%BUILD_ENVIRONMENT%"=="" (
+  set CONDA_PARENT_DIR=%CD%
+) else (
+  set CONDA_PARENT_DIR=C:\Jenkins
+)
+if "%REBUILD%"=="" (
+  IF EXIST %CONDA_PARENT_DIR%\Miniconda3 ( rd /s /q %CONDA_PARENT_DIR%\Miniconda3 )
+  curl -k https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe --output %TMP_DIR_WIN%\Miniconda3-latest-Windows-x86_64.exe
+  %TMP_DIR_WIN%\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /AddToPath=0 /D=%CONDA_PARENT_DIR%\Miniconda3
+)
+call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
+if "%REBUILD%"=="" (
+  :: We have to pin Python version to 3.6.7, until mkl supports Python 3.7
+  call conda install -y -q python=3.6.7 numpy cffi pyyaml boto3
+)

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_mkl.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_mkl.bat
@@ -1,0 +1,10 @@
+if "%REBUILD%"=="" (
+  if "%BUILD_ENVIRONMENT%"=="" (
+    curl -k https://s3.amazonaws.com/ossci-windows/mkl_2018.2.185.7z --output %TMP_DIR_WIN%\mkl.7z
+  ) else (
+    aws s3 cp s3://ossci-windows/mkl_2018.2.185.7z %TMP_DIR_WIN%\mkl.7z --quiet
+  )
+  7z x -aoa %TMP_DIR_WIN%\mkl.7z -o%TMP_DIR_WIN%\mkl
+)
+set CMAKE_INCLUDE_PATH=%TMP_DIR_WIN%\mkl\include
+set LIB=%TMP_DIR_WIN%\mkl\lib;%LIB

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_sccache.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_sccache.bat
@@ -1,0 +1,15 @@
+mkdir %TMP_DIR_WIN%\bin
+
+if "%REBUILD%"=="" (
+  :check_sccache
+  %TMP_DIR_WIN%\bin\sccache.exe --show-stats || (
+    taskkill /im sccache.exe /f /t || ver > nul
+    del %TMP_DIR_WIN%\bin\sccache.exe
+    if "%BUILD_ENVIRONMENT%"=="" (
+      curl -k https://s3.amazonaws.com/ossci-windows/sccache.exe --output %TMP_DIR_WIN%\bin\sccache.exe
+    ) else (
+      aws s3 cp s3://ossci-windows/sccache.exe %TMP_DIR_WIN%\bin\sccache.exe
+    )
+    goto :check_sccache
+  )
+)

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -41,7 +41,7 @@ set NUMBAPRO_NVVM=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0\nvvm\b
 
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     pushd %TMP_DIR_WIN%\build
-    python %TMP_DIR_WIN%\ci_scripts\download_image.py %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z
+    python %SCRIPT_HELPERS_DIR%\download_image.py %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z
     :: 7z: -aos skips if exists because this .bat can be called multiple times
     7z x %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z -aos
     popd

--- a/.jenkins/pytorch/win-test-helpers/test_custom_script_ops.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_custom_script_ops.bat
@@ -1,6 +1,6 @@
-call %TMP_DIR%/ci_scripts/setup_pytorch_env.bat
+call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
-cd test/custom_operator
+cd test\custom_operator
 
 :: Build the custom operator library.
 mkdir build

--- a/.jenkins/pytorch/win-test-helpers/test_libtorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_libtorch.bat
@@ -1,4 +1,5 @@
-call %TMP_DIR%/ci_scripts/setup_pytorch_env.bat
+call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+
 dir
 dir %TMP_DIR_WIN%\build
 dir %TMP_DIR_WIN%\build\torch

--- a/.jenkins/pytorch/win-test-helpers/test_python_all_except_nn.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_all_except_nn.bat
@@ -1,2 +1,2 @@
-call %TMP_DIR%/ci_scripts/setup_pytorch_env.bat
+call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 cd test && python run_test.py --exclude nn --verbose && cd ..

--- a/.jenkins/pytorch/win-test-helpers/test_python_nn.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_nn.bat
@@ -1,4 +1,4 @@
-call %TMP_DIR%/ci_scripts/setup_pytorch_env.bat
+call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
 echo Some smoke tests
 cd test

--- a/.jenkins/pytorch/win-test-helpers/upload_image.py
+++ b/.jenkins/pytorch/win-test-helpers/upload_image.py
@@ -7,7 +7,6 @@ IMAGE_COMMIT_TAG = os.getenv('IMAGE_COMMIT_TAG')
 session = boto3.session.Session()
 s3 = session.resource('s3')
 with open(sys.argv[1], 'rb') as data:
-  s3.Bucket('ossci-windows-build').put_object(Key='pytorch/' + IMAGE_COMMIT_TAG + '.7z', Body=data)
+    s3.Bucket('ossci-windows-build').put_object(Key='pytorch/' + IMAGE_COMMIT_TAG + '.7z', Body=data)
 object_acl = s3.ObjectAcl('ossci-windows-build', 'pytorch/' + IMAGE_COMMIT_TAG + '.7z')
 response = object_acl.put(ACL='public-read')
-

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -2,7 +2,7 @@
 
 COMPACT_JOB_NAME=pytorch-win-ws2016-cuda9-cudnn7-py3-test
 
-SCRIPT_PARENT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_PARENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "$SCRIPT_PARENT_DIR/common.sh"
 
 export IMAGE_COMMIT_TAG=${BUILD_ENVIRONMENT}-${IMAGE_COMMIT_ID}
@@ -13,22 +13,20 @@ fi
 export TMP_DIR="${PWD}/build/win_tmp"
 export TMP_DIR_WIN=$(cygpath -w "${TMP_DIR}")
 
+
+mkdir -p $TMP_DIR/build/torch
+
+
+# This directory is used only to hold "pytorch_env_restore.bat", called via "setup_pytorch_env.bat"
 CI_SCRIPTS_DIR=$TMP_DIR/ci_scripts
 mkdir -p $CI_SCRIPTS_DIR
-mkdir -p $TMP_DIR/build/torch
 
 if [ -n "$(ls $CI_SCRIPTS_DIR/*)" ]; then
     rm $CI_SCRIPTS_DIR/*
 fi
 
 
-SCRIPT_HELPERS_DIR=$SCRIPT_PARENT_DIR/win-test-helpers
-
-# Used by setup_pytorch_env.bat:
-cp $SCRIPT_HELPERS_DIR/download_image.py $CI_SCRIPTS_DIR
-
-# Used by all the other scripts:
-cp $SCRIPT_HELPERS_DIR/setup_pytorch_env.bat $CI_SCRIPTS_DIR
+export SCRIPT_HELPERS_DIR=$SCRIPT_PARENT_DIR/win-test-helpers
 
 
 run_tests() {


### PR DESCRIPTION
This PR:

* pulls four distinct installation steps out of `build_pytorch.bat` and into their own scripts.
* eliminates the copy step for helper scripts called by `win-build.sh` and `win-test.sh`