### PR TITLE
Dirsync caffe2/torch/csrc/jit/script to xplat

### DIFF
--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -769,7 +769,7 @@ void ScriptModuleSerializer::convertModule(
 
   for (const auto& elem : module.get_modules()) {
     torch::ModuleDef* sub_def = module_def->add_submodules();
-    convertModule(*elem.module, module_name.str(), elem.name, sub_def);
+    convertModule(*elem, module_name.str(), elem->name(), sub_def);
   }
 }
 

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -229,7 +229,7 @@ at::Tensor ScriptModuleDeserializer::loadTensor(
             .set_(storage_it->second, tensor_proto.offset(), dims, strides);
   } else if (device.type() == at::DeviceType::CUDA) {
     result =
-        at::empty({0}, c10::TensorOptions(type).device(storage_it->second.device()))
+        at::empty({0}, at::CUDA(type).options())
             .set_(storage_it->second, tensor_proto.offset(), dims, strides);
   }
   AT_ASSERT(result.defined());

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -19,8 +19,8 @@ struct ModuleAccessorValue : public SugaredValue {
       const SourceRange& loc,
       Method& m,
       const std::string& field) override {
-    if (NamedModule* v = module->find_module(field)) {
-      return std::make_shared<ModuleAccessorValue>(v->module);
+    if (std::shared_ptr<Module> v = module->find_module(field)) {
+      return std::make_shared<ModuleAccessorValue>(std::move(v));
     } else if (NamedIValue* v = module->find_parameter(field)) {
       return std::make_shared<SimpleValue>(m.get_or_add_parameter(v->slot()));
     } else if (NamedIValue* v = module->find_buffer(field)) {

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -139,7 +139,7 @@ void createTensorToParameterNameMap(
   }
   for (const auto& elem : module.get_modules()) {
     createTensorToParameterNameMap(
-        *elem.module, QualifiedName::create(prefix, elem.name), result);
+        *elem, QualifiedName::create(prefix, elem->name()), result);
   }
 }
 

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -767,42 +767,6 @@ class ShapePropagator {
             "aten::__ilshift__(Tensor self, Tensor other) -> Tensor",
             "aten::__irshift__(Tensor self, Tensor other) -> Tensor",
 
-            // Ops with Tensor-Tensor overloads only
-            "aten::atan2(Tensor self, Tensor other) -> Tensor",
-        },
-        [this](Node* node) -> type_vec_t {
-          if (auto maybe_tensor_types =
-                  gatherTensorTypes<DimensionedTensorType>(node)) {
-            AT_ASSERT(maybe_tensor_types->size() == 2);
-            auto first_scalar_type = (*maybe_tensor_types)[0]->scalarType();
-            auto second_scalar_type = (*maybe_tensor_types)[1]->scalarType();
-            size_t arg_for_type = 0;
-            if (c10::promoteTypes(first_scalar_type, second_scalar_type) != first_scalar_type) {
-              arg_for_type = 1;
-            }
-            return {broadcast(*maybe_tensor_types, arg_for_type)};
-          }
-          return {};
-        }};
-
-    static const register_formula_for fused_accum_binary_ops{
-        {
-            // Non-binary ops
-            "aten::addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value) -> Tensor",
-            "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value) -> Tensor",
-        },
-        [this](Node* node) -> type_vec_t {
-          if (auto maybe_tensor_types =
-                  gatherTensorTypes<DimensionedTensorType>(node)) {
-            return {broadcast(*maybe_tensor_types, 0)};
-          }
-          return {};
-        }};
-
-    // NB: we always take the scalar type of the Tensor
-    static const register_formula_for broadcasting_tensor_scalar_ops{
-        {
-
             // Tensor-Scalar operators
             "aten::add(Tensor self, Scalar other, Scalar alpha) -> Tensor",
             "aten::sub(Tensor self, Scalar other, Scalar alpha) -> Tensor",
@@ -822,6 +786,13 @@ class ShapePropagator {
             "aten::__ixor__(Tensor self, Scalar other) -> Tensor",
             "aten::__ilshift__(Tensor self, Scalar other) -> Tensor",
             "aten::__irshift__(Tensor self, Scalar other) -> Tensor",
+
+            // Ops with Tensor-Tensor overloads only
+            "aten::atan2(Tensor self, Tensor other) -> Tensor",
+
+            // Non-binary ops
+            "aten::addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value) -> Tensor",
+            "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value) -> Tensor",
         },
         [this](Node* node) -> type_vec_t {
           if (auto maybe_tensor_types =

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -324,8 +324,8 @@ struct ModuleValue : public SugaredValue {
       return std::make_shared<SimpleValue>(the_bool);
     }
 
-    if (NamedModule* v = module->find_module(field)) {
-      return std::make_shared<ModuleValue>(v->module);
+    if (std::shared_ptr<Module> v = module->find_module(field)) {
+      return std::make_shared<ModuleValue>(v);
     } else if (Method* v = module->find_method(field)) {
       return std::make_shared<MethodValue>(shared_from_this(), *v);
     } else if (NamedIValue* v = module->find_parameter(field)) {
@@ -614,7 +614,7 @@ static void gatherParametersAndBuffers(
     }
   }
   for (const auto& sub : m.get_modules()) {
-    gatherParametersAndBuffers(values, *sub.module);
+    gatherParametersAndBuffers(values, *sub);
   }
 }
 
@@ -771,7 +771,7 @@ void initJitScriptBindings(PyObject* module) {
             py::tuple result(modules.size());
             for (size_t i = 0; i < modules.size(); ++i) {
               auto& item = modules[i];
-              result[i] = std::make_pair(item.name, item.module);
+              result[i] = std::make_pair(item->name(), item);
             }
             return result;
           })

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -123,7 +123,7 @@ void Module::to_impl(
     bool non_blocking) {
   // First call `to()` on every child module.
   for (auto& child : get_modules()) {
-    child.module->to_impl(device, dtype, non_blocking);
+    child->to_impl(device, dtype, non_blocking);
   }
   // Then convert every of our parameters.
   for (auto& parameter : get_parameters()) {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -359,11 +359,6 @@ struct Method {
 
 struct Module;
 
-struct NamedModule {
-  std::string name;
-  std::shared_ptr<Module> module;
-};
-
 struct NamedIValue {
   NamedIValue(std::string name, TypePtr type, IValue ivalue)
       : name_(name),
@@ -388,16 +383,20 @@ struct NamedIValue {
 
 struct Module {
   TH_DISALLOW_COPY_AND_ASSIGN(Module);
-  Module() : optimize(true) {}
+  Module() : name_("__main__"), optimize_(true) {}
+
+  const std::string& name() const {
+    return name_;
+  }
 
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
   void set_optimized(bool o) {
-    optimize = o;
+    optimize_ = o;
   }
 
   bool is_optimized() const {
-    return optimize;
+    return optimize_;
   }
 
   IValue forward(std::vector<IValue> inputs) {
@@ -447,7 +446,15 @@ struct Module {
   void register_module(
       const std::string& name,
       std::shared_ptr<Module> module) {
-    insert(name, modules_, EntityType::MODULE, {name, std::move(module)});
+    if (module->parent_) {
+      AT_ERROR(
+          "Attempting to assign submodule '",
+          name,
+          "' but it is already a submodule of another ScriptModule '", module->parent_->name(), "'");
+    }
+    module->parent_ = this;
+    module->name_ = name;
+    insert(name, modules_, EntityType::MODULE, std::move(module));
   }
 
   Method& create_method(
@@ -458,7 +465,7 @@ struct Module {
     std::unique_ptr<Method> method(new Method(
         this,
         name,
-        optimize,
+        optimize_,
         std::move(graph),
         std::move(member_inputs),
         nullptr));
@@ -471,7 +478,7 @@ struct Module {
     std::unique_ptr<Method> method(new Method(
         this,
         name,
-        optimize,
+        optimize_,
         std::make_shared<Graph>(),
         {},
         std::move(creator)));
@@ -505,10 +512,10 @@ struct Module {
   }
 
   std::shared_ptr<Module> get_module(const std::string& name) const {
-    return modules_[get_offset(name, EntityType::MODULE)].module;
+    return modules_[get_offset(name, EntityType::MODULE)];
   }
 
-  c10::ArrayRef<NamedModule> get_modules() const {
+  c10::ArrayRef<std::shared_ptr<Module>> get_modules() const {
     return modules_;
   }
   c10::ArrayRef<NamedIValue> get_parameters() const {
@@ -536,9 +543,9 @@ struct Module {
     }
     return nullptr;
   }
-  NamedModule* find_module(const std::string& name) {
+  std::shared_ptr<Module> find_module(const std::string& name) {
     auto offset = find_offset(name, EntityType::MODULE);
-    return offset ? &modules_[*offset] : nullptr;
+    return offset ? modules_[*offset] : nullptr;
   }
   Method* find_method(const std::string& name) {
     auto offset = find_offset(name, EntityType::METHOD);
@@ -546,14 +553,14 @@ struct Module {
   }
   void apply(std::function<void(Module&)> fn) {
     for (auto& submod : get_modules()) {
-      submod.module->apply(fn);
+      submod->apply(fn);
     }
     fn(*this);
   }
   /// Enables "training" mode.
   void train(bool on = true) {
     for (auto& submod : get_modules()) {
-      submod.module->train(on);
+      submod->train(on);
     }
     register_buffer("training", torch::tensor(on ? 1 : 0, at::kLong));
   }
@@ -646,10 +653,10 @@ struct Module {
       parameter_remap[attr.slot()] = curr->find_buffer(attr.name())->slot();
     }
     for (auto& mod : get_modules()) {
-      names.push_back(mod.name);
+      names.push_back(mod->name());
       // Submodules must be translated first, otherwise parameter_remap entries
       // will not be filled in for methods of this module.
-      mod.module->copy_into(module_lookup, parameter_remap, names);
+      mod->copy_into(module_lookup, parameter_remap, names);
       names.pop_back();
     }
     for (auto& method : get_methods()) {
@@ -676,20 +683,6 @@ struct Module {
       const c10::optional<at::Device>& device,
       const c10::optional<at::ScalarType>& dtype,
       bool non_blocking);
-
-  // modules have a single namespace, but spread over 4 different concepts:
-  // parameters, attributes, methods, and sub-modules
-  // we store individual lists of each concept, and a single map to
-  // unify the namespace and ensure fast lookup
-
-  // invariant: to ensure initial_ivalues of Methods stay valid,
-  // it is only legal to _add_ new modules and parameters.
-  // removing them will allow initial_ivalues to point to invalid parameters
-  // no such restriction exists for methods
-  std::vector<NamedModule> modules_;
-  std::vector<NamedIValue> parameters_;
-  std::vector<NamedIValue> attributes_;
-  std::vector<std::unique_ptr<Method>> methods_;
 
   static const char* toString(EntityType t) {
     switch (t) {
@@ -762,9 +755,26 @@ struct Module {
     return list.back();
   }
 
-  std::unordered_map<std::string, Entry> dict_;
+  // modules have a single namespace, but spread over 4 different concepts:
+  // parameters, attributes, methods, and sub-modules
+  // we store individual lists of each concept, and a single map to
+  // unify the namespace and ensure fast lookup
 
-  bool optimize;
+  // invariant: to ensure initial_ivalues of Methods stay valid,
+  // it is only legal to _add_ new modules and parameters.
+  // removing them will allow initial_ivalues to point to invalid parameters
+  // no such restriction exists for methods
+  std::vector<std::shared_ptr<Module>> modules_;
+  std::vector<NamedIValue> parameters_;
+  std::vector<NamedIValue> attributes_;
+  std::vector<std::unique_ptr<Method>> methods_;
+
+  std::unordered_map<std::string, Entry> dict_;
+  std::string name_;
+
+  // back reference to parent of this Module if present
+  Module* parent_ = nullptr;
+  bool optimize_;
 };
 
 // returns nullptr and fills in failure_messages if the callee does not

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -511,7 +511,7 @@ void ensureUniqueIfOutOfPlaced(const char* name, const at::Tensor& tensor) {
        << " live references to the data region being modified when tracing in-place operator "
        << name
        << ". This might cause the trace to be incorrect, because all other views "
-       << "that also reference this data will not reflect this change in the trace! "
+       << "that also reference this data will not not reflect this change in the trace! "
        << "On the other hand, if all other views use the same memory chunk, but are disjoint (e.g. "
        << "are outputs of torch.split), this might still be safe.";
     warn(ss.str().c_str());


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18922 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795868/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18923 Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795870/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#18924 Dirsync caffe2/torch/csrc/jit to xplat**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795872/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18925 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795873/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18926 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795875/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18927 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795877/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18928 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795879/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18929 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795881/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18930 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14795882/)

We want to use some files from torch/csrc/jit/script in mobile but don't want to move the files.
This means we have to dirsync the jit/script folder to xplat.

Differential Revision: [D14795872](https://our.internmc.facebook.com/intern/diff/D14795872/)