### PR TITLE
Disable flaky test_proper_exit test.

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -721,6 +721,7 @@ class TestDataLoader(TestCase):
 
     @skipIfRocm
     @unittest.skipIf(not HAS_PSUTIL, "psutil not found")
+    @unittest.skip("this test is flaky, see https://github.com/pytorch/pytorch/issues/14501")
     def test_proper_exit(self):
         (r'''There might be ConnectionResetError or leaked semaphore warning '''
          r'''(due to dirty process exit), but they are all safe to ignore''')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#18950 Disable flaky test_proper_exit test.**

Bug is tracked in https://github.com/pytorch/pytorch/issues/14501

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14802009](https://our.internmc.facebook.com/intern/diff/D14802009)