### PR TITLE
CUDA_NVCC_EXECUTABLE is not needed, as nvcc is in PATH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,7 +348,6 @@ ccache -F 0
 
 # deploy (and add to ~/.bashrc for later)
 export PATH="/usr/lib/ccache:$PATH"
-export CUDA_NVCC_EXECUTABLE=/usr/lib/ccache/nvcc
 ```
 
 ## CUDA Development tips


### PR DESCRIPTION
As indicated by @f0k: https://github.com/pytorch/pytorch/pull/18495#issuecomment-480178763
nvcc via ccache is already first in the PATH in the instructions I provided, so CUDA_NVCC_EXECUTABLE is not needed.

I re-built to test that it's so.

Thank you!

