### PR TITLE
Add c10_cuda to libraries in CUDAExtension for Windows

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -480,6 +480,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
     libraries.append('cudart')
     if IS_WINDOWS:
         libraries.append('c10')
+        libraries.append('c10_cuda')
         libraries.append('caffe2')
         libraries.append('torch')
         libraries.append('torch_python')


### PR DESCRIPTION
This change was necessary for me to compile [apex](https://github.com/NVIDIA/apex) on Windows.