### PR TITLE
do not use constexpr with CUDA >= 9.2 compiler on Windows.

### DIFF
--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -213,10 +213,16 @@ constexpr auto apply(F&& f, Tuple&& t) -> decltype(detail::apply_impl(
 
 
 
+#if defined(_MSC_VER) && defined(__CUDACC__) && \
+    (__CUDACC_VER_MAJOR__ >= 10 || (__CUDACC_VER_MAJOR__ == 9 && __CUDACC_VER_MINOR__ >= 2))
+// workaround: CUDA >= v9.2 compiler cannot compile correctly on Windows.
+#  define AT_CPP14_CONSTEXPR
+#else
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 #  define AT_CPP14_CONSTEXPR constexpr
 #else
 #  define AT_CPP14_CONSTEXPR
+#endif
 #endif
 
 


### PR DESCRIPTION
Define `AT_CPP14_CONSTEXPR` from `constexpr` to empty on Windows with CUDA >= 9.2 as workaround.

Discussed in #18425.

When using CUDA 10.1 on Windows, I faced following errors:
~~~
D:/data/source/pytorch\c10/util/ArrayRef.h(144): error: variable in constexpr function does not have automatic storage duration
          detected during instantiation of "const T &c10::ArrayRef<T>::front() const [with T=at::Tensor]"
D:/data/source/pytorch/aten/src\ATen/DeviceGuard.h(30): here
~~~

From documentation of CUDA Toolkit v10.1.105, compiler supports `constexpr` and relaxing requirements (in C++14), but compilation failed.

I suppose this could be compiler bug and require this workaround.