### PR TITLE
detect C++ ABI flag for cpp extensions from available runtime information

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -233,7 +233,7 @@ class BuildExtension(build_ext, object):
         for extension in self.extensions:
             self._add_compile_flag(extension, '-DTORCH_API_INCLUDE_EXTENSION_H')
             self._define_torch_extension_name(extension)
-            self._add_gnu_abi_flag_if_binary(extension)
+            self._add_gnu_cpp_abi_flag(extension)
 
         # Register .cu and .cuh as valid source extensions.
         self.compiler.src_extensions += ['.cu', '.cuh']
@@ -387,15 +387,10 @@ class BuildExtension(build_ext, object):
         define = '-DTORCH_EXTENSION_NAME={}'.format(name)
         self._add_compile_flag(extension, define)
 
-    def _add_gnu_abi_flag_if_binary(self, extension):
-        # If the version string looks like a binary build,
-        # we know that PyTorch was compiled with gcc 4.9.2.
-        # if the extension is compiled with gcc >= 5.1,
-        # then we have to define _GLIBCXX_USE_CXX11_ABI=0
-        # so that the std::string in the API is resolved to
-        # non-C++11 symbols
-        if _is_binary_build():
-            self._add_compile_flag(extension, '-D_GLIBCXX_USE_CXX11_ABI=0')
+    def _add_gnu_cpp_abi_flag(self, extension):
+        # use the same CXX ABI as what PyTorch was compiled with
+        self._add_compile_flag(extension, '-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI)))
+            
 
 
 def CppExtension(name, sources, *args, **kwargs):
@@ -1014,8 +1009,8 @@ def _write_ninja_file(path,
     common_cflags += ['-I{}'.format(include) for include in user_includes]
     common_cflags += ['-isystem {}'.format(include) for include in system_includes]
 
-    if _is_binary_build():
-        common_cflags += ['-D_GLIBCXX_USE_CXX11_ABI=0']
+
+    common_cflags += ['-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI))]
 
     cflags = common_cflags + ['-fPIC', '-std=c++11'] + extra_cflags
     if IS_WINDOWS:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -390,7 +390,6 @@ class BuildExtension(build_ext, object):
     def _add_gnu_cpp_abi_flag(self, extension):
         # use the same CXX ABI as what PyTorch was compiled with
         self._add_compile_flag(extension, '-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI)))
-            
 
 
 def CppExtension(name, sources, *args, **kwargs):
@@ -1008,7 +1007,6 @@ def _write_ninja_file(path,
     common_cflags.append('-DTORCH_API_INCLUDE_EXTENSION_H')
     common_cflags += ['-I{}'.format(include) for include in user_includes]
     common_cflags += ['-isystem {}'.format(include) for include in system_includes]
-
 
     common_cflags += ['-D_GLIBCXX_USE_CXX11_ABI=' + str(int(torch._C._GLIBCXX_USE_CXX11_ABI))]
 


### PR DESCRIPTION
Previously, when a user built PyTorch from source, but set the version string manually to be binary-formatted, it would've simply used CXX11_ABI=0 incorrectly.

We have this information available at runtime with `torch._C._GLIBCXX_USE_CXX11_ABI`, so this PR improves the situation by simply using that information.