### PR TITLE
Add torch/lib/protobuf to gitignore, fixes #18700

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ torch/lib/cmake
 torch/lib/include
 torch/lib/pkgconfig
 torch/lib/protoc
+torch/lib/protobuf/
 torch/lib/tmp_install
 torch/lib/torch_shm_manager
 torch/lib/site-packages/


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19019 Add torch/lib/protobuf to gitignore, fixes #18700**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14846615](https://our.internmc.facebook.com/intern/diff/D14846615)