### PR TITLE
Convert test_recursive_cse to use Filecheck inline annotations.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1086,18 +1086,26 @@ class TestJit(JitTestCase):
         self.assertExportImport(trace, (x, y))
 
     def test_recursive_cse(self):
-        x = torch.tensor([0.1])
-        y = torch.tensor([0.2])
-
-        def fn(x, y):
-            z = x
-            if bool(x + y > x):
-                z = x + y
-            return z
-
-        graph = torch.jit.script(fn).graph
+        input_str = """
+graph(%x : Tensor,
+      %y : Tensor):
+  %2 : int = prim::Constant[value=1]()
+  %3 : Tensor = aten::add(%x, %y, %2)
+  %4 : Tensor = aten::gt(%3, %x)
+  %5 : bool = prim::Bool(%4)
+  %z : Tensor = prim::If(%5)
+    # CHECK: block
+    block0():
+      # CHECK-NOT: aten::add
+      %z.1 : Tensor = aten::add(%x, %y, %2)
+      -> (%z.1)
+    block1():
+      -> (%x)
+  return (%z)
+"""
+        graph = parse_ir(input_str)
         self.run_pass('cse', graph)
-        FileCheck().check("block").check_not("aten::add").check_not("aten::gt").run(str(graph))
+        FileCheck().run(input_str, graph)
 
     def test_expand_propagate_qinfo(self):
         pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19032 Convert test_recursive_cse to use Filecheck inline annotations.**

Differential Revision: [D14836689](https://our.internmc.facebook.com/intern/diff/D14836689)