### PR TITLE
Fix interpolate tracing

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7710,7 +7710,7 @@ a")
 
             def forward(self, x):
                 y = self.conv(x)
-                w = nn.functional.interpolate(y, mode='bilinear', align_corners=False, scale_factor=0.5)
+                w = nn.functional.interpolate(y, mode='bilinear', align_corners=False, scale_factor=3)
                 return w
 
         f = test()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2495,7 +2495,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
 
         # make scale_factor a tensor in tracing so constant doesn't get baked in
         if torch._C._get_tracing_state():
-            return [(torch.floor(input.size(i + 2) * torch.tensor(scale_factors[i]))) for i in range(dim)]
+            return [(torch.floor(input.size(i + 2) * torch.tensor(float(scale_factors[i])))) for i in range(dim)]
         else:
             return [int(math.floor(int(input.size(i + 2)) * scale_factors[i])) for i in range(dim)]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19034 Fix interpolate tracing**

Summary: when the scale factor is convertible to an integer, it fails
with floor_vml_cpu not implemented for 'Long' because the expression is
a long tensor where the floor operator is a no-op.

Test Plan: test_jit.py

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D14837282](https://our.internmc.facebook.com/intern/diff/D14837282)