### PR TITLE
Fix BN tests for >= 8 GPU test environments

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -1516,7 +1516,7 @@ class _DistTestBase(object):
     def test_DistributedDataParallel_SyncBatchNorm(self):
         group, group_id, rank = self._init_global_test()
         rank_to_GPU = self._init_multigpu_helper()
-        # DDP does not support replicating BN layers within a process, hencing
+        # DDP does not support replicating BN layers within a process, hence
         # testing with one module replica per process
         gpus = [rank]
         self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank)

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -1516,7 +1516,9 @@ class _DistTestBase(object):
     def test_DistributedDataParallel_SyncBatchNorm(self):
         group, group_id, rank = self._init_global_test()
         rank_to_GPU = self._init_multigpu_helper()
-        gpus = list(rank_to_GPU[rank])
+        # DDP does not support replicating BN layers within a process, hencing
+        # testing with one module replica per process
+        gpus = [rank]
         self._test_DistributedDataParallel_SyncBatchNorm(gpu_subset=gpus, rank=rank)
 
         # test output_device


### PR DESCRIPTION
DDP does not support replicating BN layers within a process. Existing BN tests fail if the test environment has more than 8 GPUs. This is fixed by explicitly setting each process to use a single replica.