### PR TITLE
Fix transpose axes for pixel_shuffle conversion

### DIFF
--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -1417,7 +1417,7 @@ def pixel_shuffle(g, self, upscale_factor):
     output_channel = dims[1] // upscale_factor // upscale_factor
     after_view = view(g, self, [-1, upscale_factor, upscale_factor,
                                 output_channel, dims[2], dims[3]])
-    after_transpose = g.op("Transpose", after_view, perm_i=[0, 1, 4, 2, 5, 3])
+    after_transpose = g.op("Transpose", after_view, perm_i=[0, 4, 1, 5, 2, 3])
     return view(g, after_transpose,
                 [-1, output_channel, dims[2] * upscale_factor, dims[3] *
                  upscale_factor])


### PR DESCRIPTION
Summary:
When converting pixel_shuffle to reshape + transpose, the transpose should be:

[-1, upscale_factor, upscale_factor, output_channel, dims[2], dims[3]]
=>
[-1, dims[2], upscale_factor, dims[3], upscale_factor, output_channel]

We want to vary the spatial dimensions slower than the upscale dim, otherwise
we get tiling instead of upscaling.

Differential Revision: D14817912
