### PR TITLE
Add tests for argument types

### DIFF
--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -15,6 +15,7 @@ using c10::OperatorKernel;
 using c10::kernel;
 using c10::dispatchKey;
 using c10::Dispatcher;
+using c10::IValue;
 using at::Tensor;
 
 namespace {
@@ -217,6 +218,267 @@ TEST(OperatorRegistrationTest, givenOpWithMultipleKernels_whenKernelsHaveSameDis
   expectThrows<c10::Error>([&] {
     c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", kernel<DummyKernel>(), dispatchKey(TensorType1()));
   }, "Tried to register multiple kernels with same dispatch key");
+}
+
+
+/**
+ * This is used to check that a given type works correctly when passed as input
+ * to or as output from a kernel.
+ *
+ * Call ArgTypeTestKernel<Input, Output>::test(input, inputExpectation, output, outputExpectation, schema)
+ * to test that a kernel with `Input` as input type and `Output` as output types,
+ * when called with `input` fulfills `inputExpectation` inside the kernel, then
+ * returns `output` and the returned value fulfills `outputExpectation`.
+ *
+ * Optionally, you can specify the argument list part of a function schema
+ * (e.g. "(Tensor a) -> Tensor") as an additional argument to use when
+ * registering the kernel.
+ */
+template<class InputType, class OutputType = InputType>
+struct ArgTypeTestKernel final : OperatorKernel {
+  explicit ArgTypeTestKernel(InputType input, std::function<void(const InputType&)> inputExpectation, OutputType output)
+  : input_(std::move(input)), inputExpectation_(std::move(inputExpectation)), output_(std::move(output)) {}
+
+  OutputType operator()(InputType input) const {
+    inputExpectation_(std::move(input));
+    return output_;
+  }
+
+  static void test(InputType input, std::function<void(const InputType&)> inputExpectation, OutputType output, std::function<void(const IValue&)> outputExpectation, const std::string& schema = "") {
+    auto registry = c10::RegisterOperators().op("_test::my_op" + schema, kernel<ArgTypeTestKernel>(input, std::move(inputExpectation), std::move(output)));
+    auto op = Dispatcher::singleton().findSchema("_test::my_op", "");
+    ASSERT_TRUE(op.has_value()); // assert schema is registered
+    auto actualOutput = callOp(*op, std::move(input));
+    EXPECT_EQ(1, actualOutput.size());
+    outputExpectation(actualOutput[0]);
+  }
+
+private:
+  InputType input_;
+  std::function<void(const InputType&)> inputExpectation_;
+  OutputType output_;
+  std::string schema_;
+};
+
+TEST(OperatorRegistrationTest, testAvailableArgTypes) {
+  // primitive types
+  ArgTypeTestKernel<double>::test(
+    1.5, [] (const double& v) {EXPECT_EQ(1.5, v);},
+    2.5, [] (const IValue& v) {EXPECT_EQ(2.5, v.toDouble());});
+  ArgTypeTestKernel<double>::test(
+    1.5, [] (const double& v) {EXPECT_EQ(1.5, v);},
+    2.5, [] (const IValue& v) {EXPECT_EQ(2.5, v.toDouble());},
+    "(float a) -> float");
+  ArgTypeTestKernel<int64_t>::test(
+    1, [] (const int64_t& v) {EXPECT_EQ(1, v);},
+    2, [] (const IValue& v) {EXPECT_EQ(2, v.toInt());});
+  ArgTypeTestKernel<int64_t>::test(
+    1, [] (const int64_t& v) {EXPECT_EQ(1, v);},
+    2, [] (const IValue& v) {EXPECT_EQ(2, v.toInt());},
+    "(int a) -> int");
+  ArgTypeTestKernel<bool>::test(
+    true, [] (const bool& v) {EXPECT_EQ(true, v);},
+    false, [] (const IValue& v) {EXPECT_EQ(false, v.toBool());});
+  ArgTypeTestKernel<bool>::test(
+    true, [] (const bool& v) {EXPECT_EQ(true, v);},
+    false, [] (const IValue& v) {EXPECT_EQ(false, v.toBool());},
+    "(bool a) -> bool");
+  ArgTypeTestKernel<bool>::test(
+    false, [] (const bool& v) {EXPECT_EQ(false, v);},
+    true, [] (const IValue& v) {EXPECT_EQ(true, v.toBool());});
+  ArgTypeTestKernel<bool>::test(
+    false, [] (const bool& v) {EXPECT_EQ(false, v);},
+    true, [] (const IValue& v) {EXPECT_EQ(true, v.toBool());},
+    "(bool a) -> bool");
+  ArgTypeTestKernel<std::string>::test(
+    "string1", [] (const std::string& v) {EXPECT_EQ("string1", v);},
+    "string2", [] (const IValue& v) {EXPECT_EQ("string2", v.toString()->string());});
+  ArgTypeTestKernel<std::string>::test(
+    "string1", [] (const std::string& v) {EXPECT_EQ("string1", v);},
+    "string2", [] (const IValue& v) {EXPECT_EQ("string2", v.toString()->string());},
+    "(str a) -> str");
+  ArgTypeTestKernel<Tensor>::test(
+    dummyTensor(TensorType1()), [] (const Tensor& v) {EXPECT_EQ(TensorType1(), v.type_id());},
+    dummyTensor(TensorType2()), [] (const IValue& v) {EXPECT_EQ(TensorType2(), v.toTensor().type_id());});
+  ArgTypeTestKernel<Tensor>::test(
+    dummyTensor(TensorType1()), [] (const Tensor& v) {EXPECT_EQ(TensorType1(), v.type_id());},
+    dummyTensor(TensorType2()), [] (const IValue& v) {EXPECT_EQ(TensorType2(), v.toTensor().type_id());},
+    "(Tensor a) -> Tensor");
+
+
+  // optional types (with has_value() == true)
+  ArgTypeTestKernel<c10::optional<double>>::test(
+    c10::optional<double>(1.5), [] (const c10::optional<double>& v) {EXPECT_EQ(1.5, v.value());},
+    c10::optional<double>(2.5), [] (const IValue& v) {EXPECT_EQ(2.5, v.toDouble());});
+  ArgTypeTestKernel<c10::optional<double>>::test(
+    c10::optional<double>(1.5), [] (const c10::optional<double>& v) {EXPECT_EQ(1.5, v.value());},
+    c10::optional<double>(2.5), [] (const IValue& v) {EXPECT_EQ(2.5, v.toDouble());},
+    "(float? a) -> float?");
+  ArgTypeTestKernel<c10::optional<int64_t>>::test(
+    c10::optional<int64_t>(1), [] (const c10::optional<int64_t>& v) {EXPECT_EQ(1, v.value());},
+    c10::optional<int64_t>(2), [] (const IValue& v) {EXPECT_EQ(2, v.toInt());});
+  ArgTypeTestKernel<c10::optional<int64_t>>::test(
+    c10::optional<int64_t>(1), [] (const c10::optional<int64_t>& v) {EXPECT_EQ(1, v.value());},
+    c10::optional<int64_t>(2), [] (const IValue& v) {EXPECT_EQ(2, v.toInt());},
+    "(int? a) -> int?");
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(true), [] (const c10::optional<bool>& v) {EXPECT_EQ(true, v.value());},
+    c10::optional<bool>(false), [] (const IValue& v) {EXPECT_EQ(false, v.toBool());});
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(true), [] (const c10::optional<bool>& v) {EXPECT_EQ(true, v.value());},
+    c10::optional<bool>(false), [] (const IValue& v) {EXPECT_EQ(false, v.toBool());},
+    "(bool? a) -> bool?");
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(false), [] (const c10::optional<bool>& v) {EXPECT_EQ(false, v.value());},
+    c10::optional<bool>(true), [] (const IValue& v) {EXPECT_EQ(true, v.toBool());});
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(false), [] (const c10::optional<bool>& v) {EXPECT_EQ(false, v.value());},
+    c10::optional<bool>(true), [] (const IValue& v) {EXPECT_EQ(true, v.toBool());},
+    "(bool? a) -> bool?");
+  ArgTypeTestKernel<c10::optional<std::string>>::test(
+    c10::optional<std::string>("string1"), [] (const c10::optional<std::string>& v) {EXPECT_EQ("string1", v.value());},
+    c10::optional<std::string>("string2"), [] (const IValue& v) {EXPECT_EQ("string2", v.toString()->string());});
+  ArgTypeTestKernel<c10::optional<std::string>>::test(
+    c10::optional<std::string>("string1"), [] (const c10::optional<std::string>& v) {EXPECT_EQ("string1", v.value());},
+    c10::optional<std::string>("string2"), [] (const IValue& v) {EXPECT_EQ("string2", v.toString()->string());},
+    "(str? a) -> str?");
+  ArgTypeTestKernel<c10::optional<Tensor>>::test(
+    c10::optional<Tensor>(dummyTensor(TensorType1())), [] (const c10::optional<Tensor>& v) {EXPECT_EQ(TensorType1(), v.value().type_id());},
+    c10::optional<Tensor>(dummyTensor(TensorType2())), [] (const IValue& v) {EXPECT_EQ(TensorType2(), v.toTensor().type_id());});
+  ArgTypeTestKernel<c10::optional<Tensor>>::test(
+    c10::optional<Tensor>(dummyTensor(TensorType1())), [] (const c10::optional<Tensor>& v) {EXPECT_EQ(TensorType1(), v.value().type_id());},
+    c10::optional<Tensor>(dummyTensor(TensorType2())), [] (const IValue& v) {EXPECT_EQ(TensorType2(), v.toTensor().type_id());},
+    "(Tensor? a) -> Tensor?");
+
+
+  // optional types (with has_value() == false)
+  ArgTypeTestKernel<c10::optional<double>>::test(
+    c10::optional<double>(), [] (const c10::optional<double>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<double>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());});
+  ArgTypeTestKernel<c10::optional<double>>::test(
+    c10::optional<double>(), [] (const c10::optional<double>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<double>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());},
+    "(float? a) -> float?");
+  ArgTypeTestKernel<c10::optional<int64_t>>::test(
+    c10::optional<int64_t>(), [] (const c10::optional<int64_t>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<int64_t>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());});
+  ArgTypeTestKernel<c10::optional<int64_t>>::test(
+    c10::optional<int64_t>(), [] (const c10::optional<int64_t>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<int64_t>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());},
+    "(int? a) -> int?");
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(), [] (const c10::optional<bool>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<bool>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());});
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(), [] (const c10::optional<bool>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<bool>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());},
+    "(bool? a) -> bool?");
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(), [] (const c10::optional<bool>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<bool>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());});
+  ArgTypeTestKernel<c10::optional<bool>>::test(
+    c10::optional<bool>(), [] (const c10::optional<bool>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<bool>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());},
+    "(bool? a) -> bool?");
+  ArgTypeTestKernel<c10::optional<std::string>>::test(
+    c10::optional<std::string>(), [] (const c10::optional<std::string>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<std::string>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());});
+  ArgTypeTestKernel<c10::optional<std::string>>::test(
+    c10::optional<std::string>(), [] (const c10::optional<std::string>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<std::string>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());},
+    "(str? a) -> str?");
+  ArgTypeTestKernel<c10::optional<Tensor>>::test(
+    c10::optional<Tensor>(), [] (const c10::optional<Tensor>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<Tensor>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());});
+  ArgTypeTestKernel<c10::optional<Tensor>>::test(
+    c10::optional<Tensor>(), [] (const c10::optional<Tensor>& v) {EXPECT_FALSE(v.has_value());},
+    c10::optional<Tensor>(), [] (const IValue& v) {EXPECT_TRUE(v.isNone());},
+    "(Tensor? a) -> Tensor?");
+
+
+  // list types (with empty list)
+  ArgTypeTestKernel<c10::ArrayRef<double>, std::vector<double>>::test(
+    c10::ArrayRef<double>(), [] (c10::ArrayRef<double> v) {EXPECT_EQ(0, v.size());},
+    std::vector<double>(), [] (const IValue& v) {EXPECT_EQ(0, v.toDoubleListRef().size());});
+  ArgTypeTestKernel<c10::ArrayRef<double>, std::vector<double>>::test(
+    c10::ArrayRef<double>(), [] (c10::ArrayRef<double> v) {EXPECT_EQ(0, v.size());},
+    std::vector<double>(), [] (const IValue& v) {EXPECT_EQ(0, v.toDoubleListRef().size());},
+    "(float[] a) -> float[]");
+  ArgTypeTestKernel<c10::ArrayRef<int64_t>, std::vector<int64_t>>::test(
+    c10::ArrayRef<int64_t>(), [] (c10::ArrayRef<int64_t> v) {EXPECT_EQ(0, v.size());},
+    std::vector<int64_t>(), [] (const IValue& v) {EXPECT_EQ(0, v.toIntListRef().size());});
+  ArgTypeTestKernel<c10::ArrayRef<int64_t>, std::vector<int64_t>>::test(
+    c10::ArrayRef<int64_t>(), [] (c10::ArrayRef<int64_t> v) {EXPECT_EQ(0, v.size());},
+    std::vector<int64_t>(), [] (const IValue& v) {EXPECT_EQ(0, v.toIntListRef().size());},
+    "(int[] a) -> int[]");
+  // TODO Converting std::vector<bool> to ArrayRef<bool> doesn't work, so we
+  //      need to find an alternative
+  // ArgTypeTestKernel<c10::ArrayRef<bool>, std::vector<bool>>::test(
+  //   c10::ArrayRef<bool>(), [] (c10::ArrayRef<bool> v) {EXPECT_EQ(0, v.size());},
+  //   std::vector<bool>(), [] (const IValue& v) {EXPECT_EQ(0, v.toBoolListRef().size());});
+  // ArgTypeTestKernel<c10::ArrayRef<bool>, std::vector<bool>>::test(
+  //   c10::ArrayRef<bool>(), [] (c10::ArrayRef<bool> v) {EXPECT_EQ(0, v.size());},
+  //   std::vector<bool>(), [] (const IValue& v) {EXPECT_EQ(0, v.toBoolListRef().size());},
+  //   "(bool[] a) -> bool[]");
+  // ArgTypeTestKernel<c10::ArrayRef<bool>, std::vector<bool>>::test(
+  //   c10::ArrayRef<bool>(), [] (c10::ArrayRef<bool> v) {EXPECT_EQ(0, v.size());},
+  //   std::vector<bool>(), [] (const IValue& v) {EXPECT_EQ(0, v.toBoolListRef().size());});
+  // ArgTypeTestKernel<c10::ArrayRef<bool>, std::vector<bool>>::test(
+  //   c10::ArrayRef<bool>(), [] (c10::ArrayRef<bool> v) {EXPECT_EQ(0, v.size());},
+  //   std::vector<bool>(), [] (const IValue& v) {EXPECT_EQ(0, v.toBoolListRef().size());},
+  //   "(bool[] a) -> bool[]");
+  // TODO We currently don't support str[] (i.e. string list) as type. Do we want to?
+  // ArgTypeTestKernel<c10::ArrayRef<std::string>, std::vector<std::string>>::test(
+  //   c10::ArrayRef<std::string>(), [] (c10::ArrayRef<std::string> v) {EXPECT_EQ(0, v.size());},
+  //   std::vector<std::string>(), [] (const IValue& v) {EXPECT_EQ(0, v.toStringListRef().size());});
+  // ArgTypeTestKernel<c10::ArrayRef<std::string>, std::vector<std::string>>::test(
+  //   c10::ArrayRef<std::string>(), [] (c10::ArrayRef<std::string> v) {EXPECT_EQ(0, v.size());},
+  //   std::vector<std::string>(), [] (const IValue& v) {EXPECT_EQ(0, v.toStringListRef().size());},
+  //   "(str[] a) -> str[]");
+
+
+  // list types (with non-empty list)
+  ArgTypeTestKernel<c10::ArrayRef<double>, std::vector<double>>::test(
+    c10::ArrayRef<double>({1.5, 2.5}), [] (c10::ArrayRef<double> v) {EXPECT_EQ(c10::ArrayRef<double>({1.5, 2.5}), v);},
+    std::vector<double>({3.5, 4.5}), [] (const IValue& v) {EXPECT_EQ(std::vector<double>({3.5, 4.5}), v.toDoubleListRef());});
+  ArgTypeTestKernel<c10::ArrayRef<double>, std::vector<double>>::test(
+    c10::ArrayRef<double>({1.5, 2.5}), [] (c10::ArrayRef<double> v) {EXPECT_EQ(c10::ArrayRef<double>({1.5, 2.5}), v);},
+    std::vector<double>({3.5, 4.5}), [] (const IValue& v) {EXPECT_EQ(std::vector<double>({3.5, 4.5}), v.toDoubleListRef());},
+    "(float[] a) -> float[]");
+  ArgTypeTestKernel<c10::ArrayRef<int64_t>, std::vector<int64_t>>::test(
+    c10::ArrayRef<int64_t>({1, 2}), [] (c10::ArrayRef<int64_t> v) {EXPECT_EQ(c10::ArrayRef<int64_t>({1, 2}), v);},
+    std::vector<int64_t>({3, 4}), [] (const IValue& v) {EXPECT_EQ(std::vector<int64_t>({3, 4}), v.toIntListRef());});
+  ArgTypeTestKernel<c10::ArrayRef<int64_t>, std::vector<int64_t>>::test(
+    c10::ArrayRef<int64_t>({1, 2}), [] (c10::ArrayRef<int64_t> v) {EXPECT_EQ(c10::ArrayRef<int64_t>({1, 2}), v);},
+    std::vector<int64_t>({3, 4}), [] (const IValue& v) {EXPECT_EQ(std::vector<int64_t>({3, 4}), v.toIntListRef());},
+    "(int[] a) -> int[]");
+  // TODO When fixing bool[] and str[] (see above), also add them here
+  ArgTypeTestKernel<c10::ArrayRef<Tensor>, std::vector<Tensor>>::test(
+    c10::ArrayRef<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType2())}), [] (c10::ArrayRef<Tensor> v) {
+      EXPECT_EQ(2, v.size());
+      EXPECT_EQ(TensorType1(), v[0].type_id());
+      EXPECT_EQ(TensorType2(), v[1].type_id());
+    },
+    std::vector<Tensor>({dummyTensor(TensorType2()), dummyTensor(TensorType1())}), [] (const IValue& v) {
+      EXPECT_EQ(2, v.toTensorListRef().size());
+      EXPECT_EQ(TensorType2(), v.toTensorListRef()[0].type_id());
+      EXPECT_EQ(TensorType1(), v.toTensorListRef()[1].type_id());
+    });
+  ArgTypeTestKernel<c10::ArrayRef<Tensor>, std::vector<Tensor>>::test(
+    c10::ArrayRef<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType2())}), [] (c10::ArrayRef<Tensor> v) {
+      EXPECT_EQ(2, v.size());
+      EXPECT_EQ(TensorType1(), v[0].type_id());
+      EXPECT_EQ(TensorType2(), v[1].type_id());
+    },
+    std::vector<Tensor>({dummyTensor(TensorType2()), dummyTensor(TensorType1())}), [] (const IValue& v) {
+      EXPECT_EQ(2, v.toTensorListRef().size());
+      EXPECT_EQ(TensorType2(), v.toTensorListRef()[0].type_id());
+      EXPECT_EQ(TensorType1(), v.toTensorListRef()[1].type_id());
+    },
+    "(Tensor[] a) -> Tensor[]");
+
+
+  // TODO Do we want to support list of optional / optional of list ?
 }
 
 }

--- a/aten/src/ATen/core/op_registration/test_helpers.h
+++ b/aten/src/ATen/core/op_registration/test_helpers.h
@@ -8,9 +8,35 @@
 #include <ATen/core/ivalue.h>
 #include <c10/core/CPUAllocator.h>
 
+template<class T>
+struct InputToIValue final {
+  template<class T_>
+  static c10::IValue call(T_&& v) {
+    return c10::IValue(std::forward<T_>(v));
+  }
+};
+template<class T>
+struct InputToIValue<c10::optional<T>> final {
+  template<class T_>
+  static c10::IValue call(T_&& v) {
+    if (v.has_value()) {
+      return c10::IValue(std::move(*v));
+    } else {
+      return c10::IValue();
+    }
+  }
+};
+template<class T>
+struct InputToIValue<c10::ArrayRef<T>> final {
+  template<class T_>
+  static c10::IValue call(T_&& v) {
+    return c10::IValue(v.vec());
+  }
+};
+
 template<class... Inputs>
 inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
-  return {std::forward<Inputs>(inputs)...};
+  return {InputToIValue<c10::guts::decay_t<Inputs>>::call(std::forward<Inputs>(inputs))...};
 }
 
 inline at::Tensor dummyTensor(c10::TensorTypeId dispatch_key) {

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -80,8 +80,10 @@ class ArrayRef final {
       : Data(Vec.data()), Length(Vec.size()) {}
 
   /// Construct an ArrayRef from a std::vector.
-  template <typename A>
-  /* implicit */ ArrayRef(const std::vector<T, A>& Vec)
+  // The enable_if stuff here makes sure that this isn't used for std::vector<bool>,
+  // because ArrayRef can't work on a std::vector<bool> bitfield.
+  template <typename A, class _T=T, class Enable = c10::guts::enable_if_t<std::is_same<T, _T>::value && !std::is_same<T, bool>::value>>
+  /* implicit */ ArrayRef(const std::vector<_T, A>& Vec)
       : Data(Vec.data()), Length(Vec.size()) {}
 
   /// Construct an ArrayRef from a std::array


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18935 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796425/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18936 Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796426/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18937 Dirsync caffe2/torch/csrc/jit/script to xplat&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796428/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18938 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796430/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18939 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796431/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18940 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796433/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18941 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796434/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18942 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796437/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18943 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14796438/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18970 [wip] improve tests&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14815839/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18971 Optional inputs and outputs&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14815850/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19067 Add tests for argument types**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14853721/)

Add test cases for the supported argument types
And TODOs for some unsupported ones that we might want to support.

Differential Revision: [D14853721](https://our.internmc.facebook.com/intern/diff/D14853721/)