### PR TITLE
Split python_ir.h in a more sensible way

### DIFF
--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -382,20 +382,8 @@ void Node::lint() const {
       break;
     case prim::PythonOp: {
       // Python operator cconv is correct
-      size_t n_scalars = 0, n_tensors = 0;
       auto* value = static_cast<const PythonOp*>(this);
-      for (auto c : value->cconv) {
-        if (c == 'c') {
-          n_scalars++;
-        } else if (c == 'd') {
-          n_tensors++;
-        } else {
-          AT_ASSERT(0);
-        }
-        AT_ASSERT(static_cast<bool>(value->pyobj));
-      }
-      AT_ASSERT(n_scalars == value->scalar_args.size());
-      AT_ASSERT(n_tensors == inputs_.size());
+      value->lint_python();
       break;
     }
     case prim::Eval:

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1458,19 +1458,5 @@ std::vector<Value*> inlineCallTo(
   return outputs;
 }
 
-PythonOp* defaultAllocPythonOp(Graph* g) {
-  throw std::runtime_error(
-      "Trying to allocate a Python object without python bindings loaded");
-}
-std::atomic<decltype(&defaultAllocPythonOp)> alloc_python_op;
-
-// patched in when python bindings are loaded
-PythonOp* allocPythonOp(Graph* g) {
-  return alloc_python_op.load()(g);
-}
-void setAllocPythonOp(PythonOp* (*v)(Graph* g)) {
-  alloc_python_op.store(v);
-}
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1265,9 +1265,6 @@ struct PythonOp : public Node {
 
   virtual void lint_python() const = 0;
 };
-// patched in when python bindings are loaded
-TORCH_API PythonOp* allocPythonOp(Graph* g);
-TORCH_API void setAllocPythonOp(PythonOp* (*v)(Graph* g));
 
 TORCH_API void LintGraph(std::shared_ptr<Graph>& graph);
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -7,7 +7,7 @@
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/utils/disallow_copy.h>
-#include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/utils/python_stub.h>
 
 #include <ATen/ATen.h>
 #include <ATen/core/function_schema.h>
@@ -22,6 +22,12 @@
 #include <iostream>
 #include <unordered_set>
 #include <vector>
+
+// Forward declare, the real meat is in python_ir.cpp
+template<class T>
+class THPPointer;
+using THPObjectPtr = THPPointer<PyObject>;
+using pyobj_list = std::vector<THPObjectPtr>;
 
 namespace torch {
 namespace jit {
@@ -134,7 +140,6 @@ struct Use {
 using node_list = std::vector<Node*>;
 using value_list = std::vector<Value*>;
 using use_list = std::vector<Use>;
-using pyobj_list = std::vector<THPObjectPtr>;
 template <typename T>
 using ArrayRef = at::ArrayRef<T>;
 using NodeKind = Symbol;
@@ -1069,6 +1074,7 @@ struct Graph {
       const std::string& field,
       Value* newValue);
   TORCH_API Node* createGetAttr(Value* obj, const std::string& field);
+  // Note: defined in python_ir.cpp and can be used only in python extension
   Node* createPythonOp(
       THPObjectPtr&& pyobj,
       const std::string& cconv,
@@ -1234,30 +1240,20 @@ inline const Graph* Value::owningGraph() const {
 
 // execute a Python function, used for Ops we can't optimize but that we want to
 // optimize around
+//
+// Note: actual implementation (ConcretePythonOp) is defined in python_ir.cpp
+// which is not included in libtorch.so. We still include some bits and pieces
+// of PythonOp here to enable writing simple passes generically. In general,
+// python-aware bits need to be moved to the descendant classes.
 struct PythonOp : public Node {
   static constexpr Symbol Kind = ::c10::prim::PythonOp;
 
-  PythonOp(Graph* graph) : Node(graph, ::c10::prim::PythonOp) {}
-  PythonOp* init(
-      THPObjectPtr&& pyobj,
-      const std::string& cconv,
-      pyobj_list&& scalar_args) {
-    this->pyobj = std::move(pyobj);
-    this->scalar_args = std::move(scalar_args);
-    this->cconv = cconv;
-    return this;
-  }
-  // The Python object which contains the implementation of this function.
-  // This is either a class (non-legacy) or an object (legacy).  See
-  // TraceInterpreterState for execution semantics.
-  THPObjectPtr pyobj;
-  // The calling convention for the Python function.
-  // 'c' -- constant argument
-  // 'd' -- dynamic argument
-  std::string cconv;
-  // Scalar arguments to the Python function.  Not necessarily passed to
-  // the function in this order; see cconv for the correct order.
-  std::vector<THPObjectPtr> scalar_args;
+  using Node::Node;
+
+  // should this Python function be skipped over when exported (i.e. for
+  // debugging functions that only run in Python)
+  bool ignore_on_export = false;
+
   virtual std::string name() const = 0;
   virtual void writeScalars(std::ostream& out) const = 0;
   void cloneFrom(Node* other_) override = 0;
@@ -1267,20 +1263,11 @@ struct PythonOp : public Node {
   // used in ONNX for discovering symbolics
   virtual c10::optional<THPObjectPtr> autogradFunction() const = 0;
 
-  // should this Python function be skipped over when exported (i.e. for
-  // debugging functions that only run in Python)
-  bool ignore_on_export = false;
+  virtual void lint_python() const = 0;
 };
 // patched in when python bindings are loaded
 TORCH_API PythonOp* allocPythonOp(Graph* g);
 TORCH_API void setAllocPythonOp(PythonOp* (*v)(Graph* g));
-inline Node* Graph::createPythonOp(
-    THPObjectPtr&& pyobj,
-    const std::string& cconv,
-    pyobj_list&& scalar_args) {
-  PythonOp* op = allocPythonOp(this);
-  return op->init(std::move(pyobj), cconv, std::move(scalar_args));
-}
 
 TORCH_API void LintGraph(std::shared_ptr<Graph>& graph);
 

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/symbolic.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/python_ir.h>
 #include <torch/csrc/utils/pybind.h>
 #include <sstream>
 #include <unordered_map>
@@ -287,7 +288,7 @@ void BlockToONNX(
     processSymbolicOutput(n->kind().toUnqualString(), n, raw_output);
   };
 
-  auto callPySymbolicMethod = [&](PythonOp* op) {
+  auto callPySymbolicMethod = [&](ConcretePythonOp* op) {
     // Test if there is a symbolic function; bail if there is not
     auto pyobj = py::handle(op->pyobj.get());
     auto func = op->autogradFunction();
@@ -342,7 +343,7 @@ void BlockToONNX(
       // Pass on Caffe2 opeartor, since we already preprocess it
       cloneNode(node);
     } else if (node->kind() == prim::PythonOp) {
-      callPySymbolicMethod(static_cast<PythonOp*>(node));
+      callPySymbolicMethod(static_cast<ConcretePythonOp*>(node));
     } else {
       callPySymbolicFunction(node);
     }

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -1,4 +1,4 @@
-#include <torch/csrc/python_headers.h>
+#include <torch/csrc/jit/python_ir.h>
 
 #include <torch/csrc/jit/argument_spec.h>
 #include <torch/csrc/jit/export.h>
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/passes/shape_analysis.h>
 #include <torch/csrc/jit/pybind.h>
 #include <torch/csrc/jit/python_tracer.h>
+#include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/auto_gil.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_strings.h>
@@ -121,68 +122,86 @@ Node* findNode(Block* block, Symbol kind, bool recurse = true) {
   return findNode(blocks, kind, recurse);
 }
 
-// execute a Python function, used for Ops we can't optimize but that we want to
-// optimize around
-struct ConcretePythonOp : public PythonOp {
-  ConcretePythonOp(Graph* graph) : PythonOp(graph) {}
-  std::string name() const override {
-    AutoGIL gil;
-    if (auto autograd = autogradFunction()) {
-      return getPythonName(autograd->get());
+std::string ConcretePythonOp::name() const {
+  AutoGIL gil;
+  if (auto autograd = autogradFunction()) {
+    return getPythonName(autograd->get());
+  } else {
+    return getPythonName(pyobj.get());
+  }
+}
+
+void ConcretePythonOp::cloneFrom(Node* other_) {
+  Node::cloneFrom(other_);
+  auto other = other_->cast<ConcretePythonOp>();
+  this->cconv = other->cconv;
+  Py_INCREF(other->pyobj.get());
+  this->pyobj = THPObjectPtr(other->pyobj.get());
+  for (auto& sa : other->scalar_args) {
+    Py_INCREF(sa.get());
+    this->scalar_args.emplace_back(sa.get());
+  }
+}
+
+// recover the autograd.Function instance, if this PythonOp's function
+// was originally SomeFunction.apply
+// used in ONNX for discovering symbolics
+c10::optional<THPObjectPtr> ConcretePythonOp::autogradFunction() const {
+  AutoGIL gil;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  py::handle obj = const_cast<PyObject*>(pyobj.get());
+
+  auto r = py::getattr(obj, "__self__", py::none());
+  if (r.is_none())
+    return c10::nullopt;
+
+  auto apply = py::getattr(r, "apply", py::none());
+  if (apply.is_none())
+    return c10::nullopt;
+
+  auto c = PyObject_RichCompareBool(apply.ptr(), obj.ptr(), Py_NE);
+  if (PyErr_Occurred())
+    throw py::error_already_set();
+  if (c)
+    return c10::nullopt;
+
+  return THPObjectPtr(r.release().ptr());
+}
+
+void ConcretePythonOp::writeScalars(std::ostream& out) const {
+  out << "(";
+  int i = 0;
+  for (auto& scalar : scalar_args) {
+    if (i++ > 0)
+      out << ", ";
+    printPyObject(out, scalar);
+  }
+  out << ")";
+}
+
+void ConcretePythonOp::lint_python() const {
+  size_t n_scalars = 0, n_tensors = 0;
+  for (auto c : cconv) {
+    if (c == 'c') {
+      n_scalars++;
+    } else if (c == 'd') {
+      n_tensors++;
     } else {
-      return getPythonName(pyobj.get());
+      AT_ASSERT(0);
     }
+    AT_ASSERT(static_cast<bool>(pyobj));
   }
-  void cloneFrom(Node* other_) override {
-    Node::cloneFrom(other_);
-    auto other = other_->cast<PythonOp>();
-    this->cconv = other->cconv;
-    Py_INCREF(other->pyobj.get());
-    this->pyobj = THPObjectPtr(other->pyobj.get());
-    for (auto& sa : other->scalar_args) {
-      Py_INCREF(sa.get());
-      this->scalar_args.emplace_back(sa.get());
-    }
-  }
-  Node* allocNewInstance(Graph* g) override {
-    return new ConcretePythonOp(g);
-  }
-  // recover the autograd.Function instance, if this PythonOp's function
-  // was originally SomeFunction.apply
-  // used in ONNX for discovering symbolics
-  c10::optional<THPObjectPtr> autogradFunction() const override {
-    AutoGIL gil;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    py::handle obj = const_cast<PyObject*>(pyobj.get());
+  AT_ASSERT(n_scalars == scalar_args.size());
+  AT_ASSERT(n_tensors == inputs().size());
+}
 
-    auto r = py::getattr(obj, "__self__", py::none());
-    if (r.is_none())
-      return c10::nullopt;
-
-    auto apply = py::getattr(r, "apply", py::none());
-    if (apply.is_none())
-      return c10::nullopt;
-
-    auto c = PyObject_RichCompareBool(apply.ptr(), obj.ptr(), Py_NE);
-    if (PyErr_Occurred())
-      throw py::error_already_set();
-    if (c)
-      return c10::nullopt;
-
-    return THPObjectPtr(r.release().ptr());
-  }
-
-  void writeScalars(std::ostream& out) const override {
-    out << "(";
-    int i = 0;
-    for (auto& scalar : scalar_args) {
-      if (i++ > 0)
-        out << ", ";
-      printPyObject(out, scalar);
-    }
-    out << ")";
-  }
-};
+Node* Graph::createPythonOp(
+    THPObjectPtr&& pyobj,
+    const std::string& cconv,
+    pyobj_list&& scalar_args) {
+  ConcretePythonOp* op = new ConcretePythonOp(this);
+  return op->init(std::move(pyobj), cconv, std::move(scalar_args));
+}
 
 PythonOp* pythonAllocPythonOp(Graph* g) {
   return new ConcretePythonOp(g);
@@ -583,13 +602,13 @@ void initPythonIRBindings(PyObject* module_) {
       .def(
           "pyobj",
           [](Node& n) {
-            return py::handle(n.expect<PythonOp>()->pyobj.get())
+            return py::handle(n.expect<ConcretePythonOp>()->pyobj.get())
                 .cast<py::object>();
           })
-      .def("cconv", [](Node& n) { return n.expect<PythonOp>()->cconv; })
-      .def("pyname", [](Node& n) { return n.expect<PythonOp>()->name(); })
+      .def("cconv", [](Node& n) { return n.expect<ConcretePythonOp>()->cconv; })
+      .def("pyname", [](Node& n) { return n.expect<ConcretePythonOp>()->name(); })
       .def("scalar_args", [](Node& n) {
-        auto op = n.expect<PythonOp>();
+        auto op = n.expect<ConcretePythonOp>();
         auto scalars = py::list();
         auto append = scalars.attr("append");
         for (auto& arg : op->scalar_args) {

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -203,13 +203,7 @@ Node* Graph::createPythonOp(
   return op->init(std::move(pyobj), cconv, std::move(scalar_args));
 }
 
-PythonOp* pythonAllocPythonOp(Graph* g) {
-  return new ConcretePythonOp(g);
-}
-
 void initPythonIRBindings(PyObject* module_) {
-  setAllocPythonOp(pythonAllocPythonOp);
-
   auto m = py::handle(module_).cast<py::module>();
 #define GS(name) def(#name, &Graph ::name)
   py::class_<Graph, std::shared_ptr<Graph>>(m, "Graph")

--- a/torch/csrc/jit/python_ir.h
+++ b/torch/csrc/jit/python_ir.h
@@ -1,11 +1,50 @@
 #pragma once
 
 #include <torch/csrc/jit/ir.h>
+#include <torch/csrc/utils/object_ptr.h>
 
 namespace torch {
 namespace jit {
 
 void initPythonIRBindings(PyObject* module);
+
+// execute a Python function, used for Ops we can't optimize but that we want to
+// optimize around
+struct ConcretePythonOp : public PythonOp {
+  ConcretePythonOp(Graph* graph) : PythonOp(graph, ::c10::prim::PythonOp) {}
+  ConcretePythonOp* init(
+      THPObjectPtr&& pyobj,
+      const std::string& cconv,
+      pyobj_list&& scalar_args) {
+    this->pyobj = std::move(pyobj);
+    this->scalar_args = std::move(scalar_args);
+    this->cconv = cconv;
+    return this;
+  }
+  // The Python object which contains the implementation of this function.
+  // This is either a class (non-legacy) or an object (legacy).  See
+  // TraceInterpreterState for execution semantics.
+  THPObjectPtr pyobj;
+  // The calling convention for the Python function.
+  // 'c' -- constant argument
+  // 'd' -- dynamic argument
+  std::string cconv;
+  // Scalar arguments to the Python function.  Not necessarily passed to
+  // the function in this order; see cconv for the correct order.
+  std::vector<THPObjectPtr> scalar_args;
+
+  std::string name() const override;
+  void cloneFrom(Node* other_) override;
+  Node* allocNewInstance(Graph* g) override {
+    return new ConcretePythonOp(g);
+  }
+  // recover the autograd.Function instance, if this PythonOp's function
+  // was originally SomeFunction.apply
+  // used in ONNX for discovering symbolics
+  c10::optional<THPObjectPtr> autogradFunction() const override;
+  void writeScalars(std::ostream& out) const override;
+  void lint_python() const override;
+};
 
 }
 } // namespace torch

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -11,7 +11,6 @@
 #include <torch/csrc/jit/script/parser.h>
 #include <torch/csrc/jit/script/schema_matching.h>
 #include <torch/csrc/jit/script/script_type_parser.h>
-#include <torch/csrc/utils/object_ptr.h>
 
 #include <torch/csrc/jit/constants.h>
 

--- a/torch/csrc/utils/object_ptr.h
+++ b/torch/csrc/utils/object_ptr.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/csrc/utils/python_stub.h>
+#include <torch/csrc/python_headers.h>
 
 template<class T>
 class THPPointer {


### PR DESCRIPTION
Files included in libtorch do depend on torch/csrc/utils/object_ptr.h, e.g. ir.cpp: https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/ir.h#L10 (including usage in std::vector that requires destructor for THPPointer)

However, object_ptr.h depends on python stub: https://github.com/pytorch/pytorch/blob/master/torch/csrc/utils/object_ptr.h#L3

Whereas object_ptr.cpp depends full on on python: https://github.com/pytorch/pytorch/blob/master/torch/csrc/utils/object_ptr.cpp#L8

`torch/csrc/utils/object_ptr.cpp` is included only in Python extension target: https://github.com/pytorch/pytorch/blob/master/torch/CMakeLists.txt#L541

The only reason it was working on master is that compiler was aggressive enough in pruning unused inline functions. With a bit of changes in flags, it started breaking (like in @kostmo's PR).

This PR splits out python-dependent bits more explicitly by forward declaring THPPointer for real.