### PR TITLE
Clear input/ouput shape cache for each inference

### DIFF
--- a/caffe2/operators/onnxifi_op.cc
+++ b/caffe2/operators/onnxifi_op.cc
@@ -169,6 +169,7 @@ OnnxifiOp<float, CPUContext>::buildInitializationList(
 template <>
 bool OnnxifiOp<float, CPUContext>::RunOnDevice() {
   CAFFE_ENFORCE_EQ(input_desc_.size(), InputSize());
+  input_shapes_.clear();
   for (unsigned i = 0U; i < InputSize(); ++i) {
     const auto& input_tensor = Input(i);
     const auto tensor_dims = input_tensor.sizes();
@@ -182,6 +183,7 @@ bool OnnxifiOp<float, CPUContext>::RunOnDevice() {
   }
 
   CAFFE_ENFORCE_EQ(output_desc_.size(), OutputSize());
+  output_shapes_.clear();
   for (unsigned i = 0U; i < OutputSize(); ++i) {
     std::vector<size_t> tensor_dims;
     uint64_t type = SetOutputShapeAndType(i, &tensor_dims);


### PR DESCRIPTION
Summary: This is a bug where input_shapes_ and output_shapes_ will grow indefinitely. Fix it here.

Reviewed By: bertmaher, rdzhabarov

Differential Revision: D14861695
