### PR TITLE
Сhange type of a tensor with bools

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -365,6 +365,7 @@
   name: _th_equal
   cpu_bool: True
   cname: equal
+  cpu_bool: True
   variants:
     - function
   return: bool

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1254,7 +1254,7 @@ inline at::ScalarType scalarTypeFromJitType(const c10::TypePtr& type) {
   } else if (type == IntType::get()) {
     return at::ScalarType::Long;
   } else if (type == BoolType::get()) {
-    return at::ScalarType::Byte;
+    return at::ScalarType::Bool;
   }
   AT_ASSERTM(
       0,

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1024,7 +1024,6 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
   }
 }
 
-<<<<<<< HEAD
 #define LAB_IMPLEMENT_BASIC_FUNCTION_3_ARGS(NAME, CFUNC, THRESHOLD) \
   void THTensor_(NAME)(THTensor *r_, THTensor *t) \
   { \
@@ -1033,23 +1032,6 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
     int r_Contig = THTensor_(isContiguous)(r_); \
     int tContig = THTensor_(isContiguous)(t); \
     TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = CFUNC(*t_data);, THRESHOLD); \
-=======
-#ifdef _OPENMP
-
-#define LAB_IMPLEMENT_BASIC_FUNCTION_3_ARGS(NAME, CFUNC, OMP_THRESHOLD)             \
-  void THTensor_(NAME)(THTensor *r_, THTensor *t)             \
-  {                                                           \
-    THTensor_(resizeAs)(r_, t);                               \
-    ptrdiff_t r_Size = THTensor_(nElement)(r_);               \
-    int r_Contig = THTensor_(isContiguous)(r_);               \
-    int tContig = THTensor_(isContiguous)(t);                 \
-    int inOMP = omp_in_parallel();                            \
-    if( !inOMP ){   \
-      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = CFUNC(*t_data);, OMP_THRESHOLD);        \
-    } else {                                                                                                   \
-      TH_TENSOR_APPLY2(scalar_t, r_, scalar_t, t, *r__data = CFUNC(*t_data););                                       \
-    }                                                                                                        \
->>>>>>> test
   }
 
 #define LAB_IMPLEMENT_BASIC_FUNCTION_2_ARGS(NAME, CFUNC) \

--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1024,6 +1024,7 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
   }
 }
 
+<<<<<<< HEAD
 #define LAB_IMPLEMENT_BASIC_FUNCTION_3_ARGS(NAME, CFUNC, THRESHOLD) \
   void THTensor_(NAME)(THTensor *r_, THTensor *t) \
   { \
@@ -1032,6 +1033,23 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
     int r_Contig = THTensor_(isContiguous)(r_); \
     int tContig = THTensor_(isContiguous)(t); \
     TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = CFUNC(*t_data);, THRESHOLD); \
+=======
+#ifdef _OPENMP
+
+#define LAB_IMPLEMENT_BASIC_FUNCTION_3_ARGS(NAME, CFUNC, OMP_THRESHOLD)             \
+  void THTensor_(NAME)(THTensor *r_, THTensor *t)             \
+  {                                                           \
+    THTensor_(resizeAs)(r_, t);                               \
+    ptrdiff_t r_Size = THTensor_(nElement)(r_);               \
+    int r_Contig = THTensor_(isContiguous)(r_);               \
+    int tContig = THTensor_(isContiguous)(t);                 \
+    int inOMP = omp_in_parallel();                            \
+    if( !inOMP ){   \
+      TH_TENSOR_APPLY2_OMP(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = CFUNC(*t_data);, OMP_THRESHOLD);        \
+    } else {                                                                                                   \
+      TH_TENSOR_APPLY2(scalar_t, r_, scalar_t, t, *r__data = CFUNC(*t_data););                                       \
+    }                                                                                                        \
+>>>>>>> test
   }
 
 #define LAB_IMPLEMENT_BASIC_FUNCTION_2_ARGS(NAME, CFUNC) \

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1007,7 +1007,7 @@ class TestDataLoader(TestCase):
         arr = [True, False]
         collated = _utils.collate.default_collate(arr)
         self.assertEqual(collated, torch.tensor(arr))
-        self.assertEqual(collated.dtype, torch.uint8)
+        self.assertEqual(collated.dtype, torch.bool)
 
         # Should be a no-op
         arr = ['a', 'b', 'c']

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6812,7 +6812,7 @@ a")
             return torch.tensor([[1]])
 
         list_input = [func1, func2, func3, func4, func5, func6, func7]
-        expected_shape = ["Long(*)", ("Byte(*)"), "Double(*)", "Double()", "Long()", "Byte()", "Long(*, *)"]
+        expected_shape = ["Long(*)", ("Bool(*)"), "Double(*)", "Double()", "Long()", "Bool()", "Long(*, *)"]
 
         for fn, expect in zip(list_input, expected_shape):
             self.checkScript(fn, ())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3226,7 +3226,7 @@ class _TestTorchMixin(object):
             self.assertIs(default_dtype, torch.tensor(()).dtype)
             self.assertIs(default_dtype, torch.tensor(5.).dtype)
             self.assertIs(torch.int64, torch.tensor(5).dtype)
-            self.assertIs(torch.uint8, torch.tensor(True).dtype)
+            self.assertIs(torch.bool, torch.tensor(True).dtype)
             self.assertIs(torch.int32, torch.tensor(5, dtype=torch.int32).dtype)
             self.assertIs(default_dtype, torch.tensor(((7, 5), (9, 5.))).dtype)
             self.assertIs(default_dtype, torch.tensor(((5., 5), (3, 5))).dtype)

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -173,7 +173,11 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
           result = applySelect(result, dim, THPUtils_unpackLong(obj), i);
         } else {
           result = result.unsqueeze(dim);
-          handle_var(boolToIndexingTensor(result, var.item<uint8_t>() != 0));
+          if(scalar_type == at::kBool) {
+            handle_var(boolToIndexingTensor(result, var.item<bool>() != 0));
+          } else {
+            handle_var(boolToIndexingTensor(result, var.item<uint8_t>() != 0));
+          }
         }
       } else {
         handle_var(var);

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -40,18 +40,6 @@ void checkListInputType(const c10::TypePtr& elem_type, const Node* node) {
   }
 }
 
-at::ScalarType scalarTypeFromJitType(const c10::TypePtr& type) {
-  if (type == FloatType::get()) {
-    return at::ScalarType::Double;
-  } else if (type == IntType::get()) {
-    return at::ScalarType::Long;
-  } else if (type == BoolType::get()) {
-    return at::ScalarType::Bool;
-  }
-  AT_ASSERTM(0, "Add new condition, expected Float, Int, or Bool but got",
-      type->str());
-}
-
 int64_t list_size(const IValue& list) {
   if (list.isGenericList()) {
     return list.toGenericListRef().size();

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -111,8 +111,6 @@ void storeLastDimension(
   }
 }
 
-<<<<<<< HEAD
-// bool vector needs to be cast to uint8_t
 template <>
 void storeLastDimension<bool>(
     char* data,
@@ -121,12 +119,6 @@ void storeLastDimension<bool>(
     int64_t dim,
     int elementSize,
     const std::vector<bool>& obj) {
-=======
-// bool vector needs to be cast to uint8_t - nope
-template<>
-void storeLastDimension<bool>(char* data, const std::vector<int64_t>& sizes, const c10::ArrayRef<int64_t>& strides, int64_t dim,
-    int elementSize, const std::vector<bool>& obj) {
->>>>>>> test
   auto n = sizes[dim];
   auto seq_size = obj.size();
   checkSequenceSize(n, dim, seq_size);
@@ -277,7 +269,6 @@ RegisterOperators reg({
           };
         }),
 
-<<<<<<< HEAD
 #define DEFINE_TORCH_TENSOR_OP(operator_type, c_type, tensor_creation_op)     \
   Operator(                                                                   \
       "aten::tensor(" #operator_type                                          \
@@ -315,37 +306,6 @@ RegisterOperators reg({
 
     // reference python implementation: internal_new_from_data in
     // tensor_new.cpp
-=======
-#define DEFINE_TORCH_TENSOR_OP(operator_type, c_type, tensor_creation_op)             \
-Operator(                                                                             \
-  "aten::tensor(" #operator_type " t, *, ScalarType? dtype=None, Device? device=None"\
-      ") -> Tensor",                                                                  \
-  [](const Node* node) {                                                              \
-    auto initial_scalar_type = scalarTypeFromJitType(node->inputs().at(0)->type());   \
-    return [initial_scalar_type](Stack& stack) {                                      \
-      c_type scalar_val;                                                              \
-      IValue dtype;                                                                   \
-      IValue device;                                                                  \
-      pop(stack, scalar_val, dtype, device);                                          \
-      auto tensor = autograd::make_variable(tensor_creation_op);                      \
-      at::ScalarType scalar_type = dtype.isNone() ?                                   \
-        tensor.scalar_type() : dtype.toScalarType();                                  \
-      c10::Device dev = device.isNone() ? tensor.device() : device.toDevice();        \
-      if (scalar_type != initial_scalar_type || dev != tensor.device()) {             \
-        tensor = tensor.to(dev, scalar_type);                                         \
-      }                                                                               \
-      push(stack, tensor);                                                            \
-      return 0;                                                                       \
-    };                                                                                \
-  }),
-
-DEFINE_TORCH_TENSOR_OP(float, double, at::scalar_to_tensor(scalar_val))
-DEFINE_TORCH_TENSOR_OP(int, int64_t, at::scalar_to_tensor(scalar_val))
-DEFINE_TORCH_TENSOR_OP(bool, bool, at::empty({}, at::CPU(at::kBool).options()).fill_(scalar_val))
-
-
-    // reference python implementation: internal_new_from_data in tensor_new.cpp
->>>>>>> test
     Operator(
         "aten::_infer_size(int[] a, int[] b) -> int[]",
         [](const Node* node) {

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -290,7 +290,7 @@ RegisterOperators reg({
             DEFINE_TORCH_TENSOR_OP(
                 bool,
                 bool,
-                at::empty({}, at::CPU(at::kByte).options()).fill_(scalar_val))
+                at::empty({}, at::CPU(at::kBool).options()).fill_(scalar_val))
 
     // reference python implementation: internal_new_from_data in
     // tensor_new.cpp

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -124,8 +124,7 @@ ScalarType infer_scalar_type(PyObject *obj) {
     return ScalarType::Long;
   }
   if (PyBool_Check(obj)) {
-    // TODO: infer Bool when we have Bool ScalarType
-    return ScalarType::Byte;
+    return ScalarType::Bool;
   }
   if (THPVariable_Check(obj)) {
     auto var = reinterpret_cast<THPVariable*>(obj)->cdata;
@@ -477,7 +476,7 @@ Tensor indexing_tensor_from_data(
   // Specific to tensor indexing, converts an indexing list to an
   // indexing tensor (type Byte or Long)
   ScalarType inferred_scalar_type = infer_scalar_type(data);
-  if (inferred_scalar_type == ScalarType::Byte) {
+  if (inferred_scalar_type == ScalarType::Byte || inferred_scalar_type == ScalarType::Bool) {
     auto& idx_type = type.toScalarType(inferred_scalar_type);
     return internal_new_from_data(idx_type, inferred_scalar_type, std::move(device), data, false, false, false);
   } else {


### PR DESCRIPTION
**This is **bc-breaking** change**
Change dtype of a tensor which was created from bool data. 
Old behavior: torch.tensor([True, False]) -> uint8 tensor
Now: torch.tensor([True, False]) -> bool tensor

Tested via tests.