### PR TITLE
Print CuDNN version correctly.

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -150,9 +150,18 @@ std::string CUDAHooks::showConfig() const {
 
 #ifndef __HIP_PLATFORM_HCC__
 #if AT_CUDNN_ENABLED()
+
+
+  auto printCudnnStyleVersion = [&](int v) {
+    oss << (v / 1000) << "." << (v / 100 % 10);
+    if (v % 100 != 0) {
+      oss << "." << (v % 100);
+    }
+  };
+
   size_t cudnnVersion = cudnnGetVersion();
   oss << "  - CudNN ";
-  printCudaStyleVersion(cudnnVersion);
+  printCudnnStyleVersion(cudnnVersion);
   size_t cudnnCudartVersion = cudnnGetCudartVersion();
   if (cudnnCudartVersion != CUDART_VERSION) {
     oss << "  (built against CUDA ";
@@ -162,7 +171,7 @@ std::string CUDAHooks::showConfig() const {
   oss << "\n";
   if (cudnnVersion != CUDNN_VERSION) {
     oss << "  - Built with CuDNN ";
-    printCudaStyleVersion(CUDNN_VERSION);
+    printCudnnStyleVersion(CUDNN_VERSION);
     oss << "\n";
   }
 #endif

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -160,7 +160,7 @@ std::string CUDAHooks::showConfig() const {
   };
 
   size_t cudnnVersion = cudnnGetVersion();
-  oss << "  - CudNN ";
+  oss << "  - CuDNN ";
   printCudnnStyleVersion(cudnnVersion);
   size_t cudnnCudartVersion = cudnnGetCudartVersion();
   if (cudnnCudartVersion != CUDART_VERSION) {
@@ -170,7 +170,7 @@ std::string CUDAHooks::showConfig() const {
   }
   oss << "\n";
   if (cudnnVersion != CUDNN_VERSION) {
-    oss << "  - Built with CuDNN ";
+    oss << "    - Built with CuDNN ";
     printCudnnStyleVersion(CUDNN_VERSION);
     oss << "\n";
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19110 Print CuDNN version correctly.**

Output after the change:

```
PyTorch built with:
  - GCC 4.8
  - Intel(R) Math Kernel Library Version 2019.0.3 Product Build 20190125 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v0.18.1 (Git Hash 7de7e5d02bf687f971e7668963649728356e0c20)
  - OpenMP 201107 (a.k.a. OpenMP 3.1)
  - NNPACK is enabled
  - CUDA Runtime 9.2
  - NVCC architecture flags: -gencode;arch=compute_52,code=sm_52
  - CuDNN 7.4.2
    - Built with CuDNN 7.1.2
  - Magma 2.5.0
  - Build settings: BLAS=MKL, BUILD_TYPE=Release, CXX_FLAGS=  -Wno-deprecated -fvisibility-inlines-hidden -fopenmp -O2 -fPIC -Wno-narrowing -Wall -Wextra -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-result -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -Wno-unused-but-set-variable -Wno-maybe-uninitialized, DISABLE_NUMA=1, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, USE_CUDA=True, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=True, USE_NNPACK=True, USE_OPENMP=ON, 
```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D14874497](https://our.internmc.facebook.com/intern/diff/D14874497)