### PR TITLE
[TESTING ONLY] Compiler uses first-class modules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-/docs/cpp @goldsborough @ebetica @yf225
-/torch/csrc/api/ @ebetica @goldsborough @yf225
-/test/cpp/api/ @ebetica @goldsborough @yf225
+/docs/cpp @ebetica @yf225
+/torch/csrc/api/ @ebetica @yf225
+/test/cpp/api/ @ebetica @yf225
 /torch/lib/c10d/ @apaszke @pietern @mrshenli
 /torch/csrc/distributed/ @apaszke @pietern @mrshenli
 /torch/distributed/ @apaszke @pietern @mrshenli
 /test/test_c10d.py @apaszke @pietern @mrshenli
-/torch/utils/cpp_extension.py @goldsborough @fmassa @apaszke @soumith @ezyang
+/torch/utils/cpp_extension.py @fmassa @apaszke @soumith

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 --------------------------------------------------------------------------------
 
+arfy
+
 PyTorch is a Python package that provides two high-level features:
 - Tensor computation (like NumPy) with strong GPU acceleration
 - Deep neural networks built on a tape-based autograd system

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -164,6 +164,16 @@ public:
     }
     return c10::nullopt;
   }
+  FunctionSchema withArguments(std::vector<Argument> new_arguments) const {
+    return FunctionSchema(
+        name(),
+        overload_name(),
+        std::move(new_arguments),
+        returns(),
+        is_vararg(),
+        is_varret());
+  }
+  void checkInputs(std::vector<IValue>& inputs) const;
 };
 
 inline bool operator==(const FunctionSchema& lhs, const FunctionSchema& rhs) {
@@ -225,6 +235,48 @@ inline std::string toString(const FunctionSchema& schema) {
   std::ostringstream str;
   str << schema;
   return str.str();
+}
+
+inline void FunctionSchema::checkInputs(std::vector<IValue>& inputs) const {
+  // Do we have more inputs than the schema accepts?
+  AT_CHECK(
+      inputs.size() <= arguments().size(),
+      "Expected at most ",
+      arguments().size(),
+      " argument(s) for operator '",
+      name(),
+      "', but received ",
+      inputs.size(),
+      " argument(s). Declaration: ",
+      *this);
+
+  for (size_t pos = 0; pos < arguments().size(); ++pos) {
+    const auto& argument = arguments()[pos];
+    if (pos < inputs.size()) {
+      if (!isSubvalueOf(inputs[pos], argument.type())) {
+        AT_ERROR(
+            "Expected value of type ",
+            *argument.type(),
+            " for argument '",
+            argument.name(),
+            "' in position ",
+            pos,
+            ", but instead got value of type ",
+            attemptToRecoverType(inputs[pos])->str(),
+            ". Declaration: ",
+            *this);
+      }
+    } else if (argument.default_value()) {
+      inputs.push_back(*argument.default_value());
+    } else {
+      AT_ERROR(
+          name(),
+          "() is missing value for argument '",
+          argument.name(),
+          "'. Declaration: ",
+          *this);
+    }
+  }
 }
 
 } // namespace c10

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -472,18 +472,18 @@ ClassTypeRegistry& getRegistry() {
 
 ClassTypePtr ClassType::create(
     const std::string& name,
-    std::shared_ptr<Module> module) {
+    std::shared_ptr<CompilationUnit> module) {
   auto ptr = ClassTypePtr(new ClassType(name, std::move(module)));
   getRegistry().registerType(name, ptr);
   return ptr;
 }
 
-ClassTypePtr ClassType::createModuleType() {
-  return ClassTypePtr(new ClassType("Module", nullptr));
+ClassTypePtr ClassType::createModuleType(std::shared_ptr<CompilationUnit> module) {
+  return ClassTypePtr(new ClassType("Module", std::move(module)));
 }
 
 ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
-  auto ptr = ClassTypePtr(new ClassType(typename_, module_));
+  auto ptr = ClassTypePtr(new ClassType(typename_, compilation_unit_));
   AT_ASSERT(numAttributes() == refined_slots.size());
   for(size_t i = 0; i < attributeNames_.size(); ++i) {
     AT_ASSERT(refined_slots[i]->isSubtypeOf(attributeTypes_[i]));

--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -65,7 +65,8 @@ namespace jit {
   _(NoneSchemaMatch)               \
   _(ClassParser)                   \
   _(PeepholeOptimize)              \
-  _(RecordFunction)
+  _(RecordFunction)                \
+  _(ModuleDefine)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/expect/TestScript.test_onnx_export_script_inline_params.expect
+++ b/test/expect/TestScript.test_onnx_export_script_inline_params.expect
@@ -5,14 +5,14 @@ ModelProto {
   graph:
     GraphProto {
       name: "torch-jit-export"
-      inputs: [{name: "x", type:Tensor dims: 2 3},{name: "1", type:Tensor dims: 3 3},{name: "2", type:Tensor dims: 3 4}]
+      inputs: [{name: "x", type:Tensor dims: 2 3},{name: "1", type:Tensor dims: 3 4},{name: "2", type:Tensor dims: 3 3}]
       outputs: [{name: "6", type:Tensor dims: 2 4}]
-      initializers: [TensorProto shape: [3 3],TensorProto shape: [3 4]]
+      initializers: [TensorProto shape: [3 4],TensorProto shape: [3 3]]
       nodes: [
         Node {type: "Constant", inputs: [], outputs: [3], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: [1]}]},
-        Node {type: "Gemm", inputs: [x,1,3], outputs: [4], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 0}]},
+        Node {type: "Gemm", inputs: [x,2,3], outputs: [4], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 0}]},
         Node {type: "Constant", inputs: [], outputs: [5], attributes: [{ name: 'value', type: tensor, value:TensorProto shape: [1]}]},
-        Node {type: "Gemm", inputs: [4,2,5], outputs: [6], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 0}]}
+        Node {type: "Gemm", inputs: [4,1,5], outputs: [6], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 0}]}
       ]
     }
   opset_import: [OperatorSetIdProto { domain: }],

--- a/test/expect/TestScript.test_onnx_export_speculate-f2.expect
+++ b/test/expect/TestScript.test_onnx_export_speculate-f2.expect
@@ -5,9 +5,9 @@ ModelProto {
   graph:
     GraphProto {
       name: "torch-jit-export"
-      inputs: [{name: "x.1", type:Tensor dims: 1 10},{name: "1", type:Tensor dims: 20 10},{name: "2", type:Tensor dims: 20}]
+      inputs: [{name: "x.1", type:Tensor dims: 1 10},{name: "1", type:Tensor dims: 20},{name: "2", type:Tensor dims: 20 10}]
       outputs: [{name: "8", type:Tensor dims: 1 20}]
-      initializers: [TensorProto shape: [20 10],TensorProto shape: [20]]
+      initializers: [TensorProto shape: [20],TensorProto shape: [20 10]]
       nodes: [
         Node {type: "Add", inputs: [x.1,x.1], outputs: [3], attributes: []},
         Node {type: "ReduceSum", inputs: [3], outputs: [4], attributes: [{ name: 'keepdims', type: int, value: 0}]},
@@ -28,7 +28,7 @@ ModelProto {
                       outputs: [{name: "10", type:Tensor dims: 1 20}]
                       initializers: []
                       nodes: [
-                        Node {type: "Gemm", inputs: [3,1,2], outputs: [10], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
+                        Node {type: "Gemm", inputs: [3,2,1], outputs: [10], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
                       ]
                     }
 
@@ -39,7 +39,7 @@ ModelProto {
                       outputs: [{name: "11", type:Tensor dims: 1 20}]
                       initializers: []
                       nodes: [
-                        Node {type: "Gemm", inputs: [3,1,2], outputs: [11], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
+                        Node {type: "Gemm", inputs: [3,2,1], outputs: [11], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
                       ]
                     }
 
@@ -54,7 +54,7 @@ ModelProto {
               outputs: [{name: "12", type:Tensor dims: 1 20}]
               initializers: []
               nodes: [
-                Node {type: "Gemm", inputs: [3,1,2], outputs: [12], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
+                Node {type: "Gemm", inputs: [3,2,1], outputs: [12], attributes: [{ name: 'alpha', type: float, value: 1},{ name: 'beta', type: float, value: 1},{ name: 'transB', type: int, value: 1}]}
               ]
             }
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7361,7 +7361,7 @@ a")
             def foo(self, input):
                 self.call_foo(input)
 
-        with self.assertRaisesRegex(RuntimeError, 'called recursively involving'):
+        with self.assertRaisesRegex(RuntimeError, 'called recursively'):
             M()
 
     def test_script_kwargs_fn_call(self):

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -95,6 +95,7 @@ libtorch_sources = [
     "torch/csrc/jit/register_quantized_ops.cpp",
     "torch/csrc/jit/scope.cpp",
     "torch/csrc/jit/script/compiler.cpp",
+    "torch/csrc/api/src/jit.cpp",
     "torch/csrc/jit/script/edit_distance.cpp",
     "torch/csrc/jit/script/logging.cpp",
     "torch/csrc/jit/script/final_returns.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -175,6 +175,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/register_quantized_ops.cpp
   ${TORCH_SRC_DIR}/csrc/jit/scope.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/compiler.cpp
+  ${TORCH_SRC_DIR}/csrc/api/src/jit.cpp
   ${TORCH_SRC_DIR}/csrc/jit/testing/file_check.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/final_returns.cpp
   ${TORCH_SRC_DIR}/csrc/jit/script/schema_matching.cpp
@@ -236,7 +237,6 @@ if (NOT NO_API)
     ${TORCH_SRC_DIR}/csrc/api/src/data/samplers/random.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/data/samplers/sequential.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/data/samplers/stream.cpp
-    ${TORCH_SRC_DIR}/csrc/api/src/jit.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/init.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/module.cpp
     ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/batchnorm.cpp
@@ -528,7 +528,6 @@ if (BUILD_PYTHON)
     ${TORCH_SRC_DIR}/csrc/jit/python_tracer.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/init.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/lexer.cpp
-    ${TORCH_SRC_DIR}/csrc/jit/script/module.cpp
     ${TORCH_SRC_DIR}/csrc/jit/script/python_tree_views.cpp
     ${TORCH_SRC_DIR}/csrc/multiprocessing/init.cpp
     ${TORCH_SRC_DIR}/csrc/nn/THNN.cpp

--- a/torch/csrc/api/include/torch/jit.h
+++ b/torch/csrc/api/include/torch/jit.h
@@ -32,7 +32,7 @@ namespace jit {
 ///   )JIT");
 ///   IValue output = module->run_method("relu_script", a, b);
 /// \endrst
-TORCH_API std::shared_ptr<script::Module> compile(const std::string& source);
+TORCH_API std::shared_ptr<script::CompilationUnit> compile(const std::string& source);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -9,10 +9,9 @@
 namespace torch {
 namespace jit {
 
-std::shared_ptr<script::Module> compile(const std::string& source) {
-  auto module = std::make_shared<script::Module>();
-  defineMethodsInModule(
-      module, source, script::nativeResolver, /*self=*/c10::nullopt);
+std::shared_ptr<script::CompilationUnit> compile(const std::string& source) {
+  auto module = std::make_shared<script::CompilationUnit>();
+  module->define(source, script::nativeResolver, nullptr);
   return module;
 }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1069,6 +1069,10 @@ struct Graph {
       const std::string& field,
       Value* newValue);
   TORCH_API Node* createGetAttr(Value* obj, const std::string& field);
+  TORCH_API Value* insertGetAttr(Value* obj, const std::string& field) {
+    return insertNode(createGetAttr(obj, field))->output();
+  }
+
   Node* createPythonOp(
       THPObjectPtr&& pyobj,
       const std::string& cconv,

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -262,10 +262,9 @@ struct GraphFuser {
             norm_invstd = 1 / (eps + torch.sqrt(norm_var))
             return ((input - norm_mean) * norm_invstd)
       )SCRIPT";
-          auto module = std::make_shared<script::Module>();
-          defineMethodsInModule(
-              module, source, script::nativeResolver, /*self=*/c10::nullopt);
-          *graph_ptr = module->get_method("batch_norm").graph();
+          script::CompilationUnit cu;
+          cu.define(source, script::nativeResolver, nullptr);
+          *graph_ptr = cu.get_function("batch_norm").graph();
         },
         &bn_graph);
 

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1133,6 +1133,16 @@ struct PythonPrintPass {
         [](const Argument& arg) { return arg.default_value(); });
     printFunction(graph, name, is_class, defaults, ivalue_names);
   }
+  void printFunction(
+      script::Function& method,
+      bool is_class) {
+    const std::string& name = method.name();
+    Graph& graph = *method.graph();
+    auto defaults = fmap(
+        method.getSchema().arguments(),
+        [](const Argument& arg) { return arg.default_value(); });
+    printFunction(graph, name, is_class, defaults, {});
+  }
   void printModule(script::Module& module) {
     std::unordered_map<script::Slot, QualifiedNamePtr> extra_ivalue_names;
     createTensorToParameterNameMap(
@@ -1153,9 +1163,8 @@ struct PythonPrintPass {
     out << "class " << classType->name() << ":\n";
     {
       const auto guard = WithIndented();
-      std::unordered_map<script::Slot, QualifiedNamePtr> extra_ivalue_names;
       for (auto& method : classType->methods()) {
-        printMethod(*method, /*is_class=*/true, extra_ivalue_names);
+        printFunction(*method, /*is_class=*/true);
       }
     }
   }

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -137,6 +137,7 @@ struct ConcretePythonOp : public PythonOp {
     Node::cloneFrom(other_);
     auto other = other_->cast<PythonOp>();
     this->cconv = other->cconv;
+    this->ignore_on_export = other->ignore_on_export;
     Py_INCREF(other->pyobj.get());
     this->pyobj = THPObjectPtr(other->pyobj.get());
     for (auto& sa : other->scalar_args) {

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -37,8 +37,8 @@ def _${name}(x: BroadcastingList${Length}[${Scalar}]) -> List[${Scalar}]:
 )SCRIPT");
 
 struct BuiltinFunctionRegistry {
-  const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name) {
-    const static std::vector<Method*> empty;
+  const std::vector<Function*>& getAllBuiltinFunctionsFor(Symbol name) {
+    const static std::vector<Function*> empty;
     // when initializing the builtin function library, we will re-enter
     // getAllBuiltinFunctionsFor since it is called in the compiler to
     // lookup builtins and initializing the builtin functions calls the
@@ -62,11 +62,10 @@ struct BuiltinFunctionRegistry {
 
  private:
   void loadSource(const std::string& source) {
-    auto module = std::make_shared<script::Module>();
-    defineMethodsInModule(
-        module, source, script::nativeResolver, /*self=*/c10::nullopt);
-    modules.push_back(module);
-    for (auto& method : module->get_methods()) {
+    std::shared_ptr<CompilationUnit> cu = std::make_shared<CompilationUnit>();
+    modules.emplace_back(cu);
+    cu->define(source, script::nativeResolver, /*self=*/nullptr);
+    for (auto& method : cu->get_functions()) {
       builtins_by_name[Symbol::fromQualString("aten::" + method->name())]
           .push_back(method.get());
     }
@@ -97,11 +96,11 @@ struct BuiltinFunctionRegistry {
   }
   enum { UNINITIALIZED, INTIIALIZING, INITIALIZED } state = UNINITIALIZED;
   std::recursive_mutex mutex;
-  std::vector<std::shared_ptr<Module>> modules;
-  std::unordered_map<Symbol, std::vector<Method*>> builtins_by_name;
+  std::vector<std::shared_ptr<CompilationUnit>> modules;
+  std::unordered_map<Symbol, std::vector<Function*>> builtins_by_name;
 };
 
-TORCH_API const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name) {
+TORCH_API const std::vector<Function*>& getAllBuiltinFunctionsFor(Symbol name) {
   static BuiltinFunctionRegistry registry;
   return registry.getAllBuiltinFunctionsFor(name);
 }

--- a/torch/csrc/jit/script/builtin_functions.h
+++ b/torch/csrc/jit/script/builtin_functions.h
@@ -7,7 +7,7 @@ namespace torch {
 namespace jit {
 namespace script {
 
-TORCH_API const std::vector<Method*>& getAllBuiltinFunctionsFor(Symbol name);
+TORCH_API const std::vector<Function*>& getAllBuiltinFunctionsFor(Symbol name);
 
 }
 } // namespace jit

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -5,13 +5,20 @@ namespace c10 {
 
 // This file exists because we need to reference module.h, which we can't from
 // c10. Sigh...
-Method* ClassType::getMethod(const std::string& name) const {
-  return module_? module_->find_method(name) : nullptr;
+Function* ClassType::getMethod(const std::string& name) const {
+  return compilation_unit_->find_function(name).get();
 }
 
-std::vector<Method*> ClassType::methods() const {
-  std::vector<Method*> ret;
-  for (const auto& pr : module_->get_methods()) {
+CompilationUnit& ClassType::compilation_unit() {
+  return *compilation_unit_;
+}
+const CompilationUnit& ClassType::compilation_unit() const {
+  return *compilation_unit_;
+}
+
+std::vector<Function*> ClassType::methods() const {
+  std::vector<Function*> ret;
+  for (const auto& pr : compilation_unit().get_functions()) {
     ret.push_back(pr.get());
   }
   return ret;

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -1,0 +1,278 @@
+#pragma once
+#include <c10/util/Exception.h>
+#include <torch/csrc/jit/graph_executor.h>
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/source_range.h>
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/utils/memory.h>
+
+#include <ATen/core/function_schema.h>
+#include <c10/util/ArrayRef.h>
+#include <c10/util/Optional.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// This file contains classes which assist in desugaring Python style
+// modules and their methods into flattened graphs which don't have any
+// function calls.
+
+namespace torch {
+namespace jit {
+
+namespace script {
+
+struct Def;
+struct SugaredValue;
+struct Function;
+
+using Resolver = std::function<std::shared_ptr<SugaredValue>(
+    const std::string& name,
+    Function& f,
+    const SourceRange& loc)>;
+using Self = std::function<std::shared_ptr<SugaredValue>(Value*)>;
+
+struct TORCH_API Function {
+  Function(
+      std::string name,
+      bool optimize,
+      std::shared_ptr<Graph> graph,
+      std::function<void(Function&)> function_creator)
+      : name_(std::move(name)),
+        graph_(std::move(graph)),
+        optimize_(optimize),
+        function_creator_(std::move(function_creator)) {}
+
+  void run(Stack& stack) {
+    get_executor().run(stack);
+  }
+
+  void run(Stack&& stack) {
+    run(stack);
+  }
+
+  IValue operator()(std::vector<IValue> stack) {
+    getSchema().checkInputs(stack);
+    run(stack);
+    return stack.front();
+  }
+
+  std::shared_ptr<Graph> graph_for(Stack inputs) {
+    return get_executor().graphFor(inputs);
+  }
+
+  std::shared_ptr<Graph> graph() const {
+    return graph_;
+  }
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  // if this isn't yet defined, run its method_creator function
+  void ensure_defined();
+
+  size_t num_inputs() const {
+    return graph()->inputs().size();
+  }
+
+  Function& setSchema(FunctionSchema schema) {
+    schema_ = make_unique<FunctionSchema>(std::move(schema));
+    return *this;
+  }
+
+  const FunctionSchema& getSchema() const {
+    if (schema_ == nullptr) {
+      schema_ = make_unique<FunctionSchema>(defaultSchemaFor(*this));
+    }
+    return *schema_;
+  }
+
+  std::string pretty_print_schema() const {
+    AT_ASSERT(schema_);
+    std::stringstream ss;
+    ss << *schema_;
+    return ss.str();
+  }
+
+  GraphExecutorState getDebugState() {
+    return get_executor().getDebugState();
+  }
+
+  void debugDisableAutodiffSubgraphInlining() {
+    return get_executor().debugDisableAutodiffSubgraphInlining();
+  }
+
+  bool is_optimized() const {
+    return optimize_;
+  }
+
+  void check_single_output() {
+    AT_CHECK(
+        graph()->outputs().size() == 1,
+        "Method (but not graphs in general) require a single output. Use None/Tuple for 0 or 2+ outputs");
+  }
+
+  GraphExecutor& get_executor() {
+    std::call_once(executor_init_, [&] {
+      check_single_output();
+      executor_ = GraphExecutor(graph(), optimize_);
+    });
+    return executor_;
+  }
+
+  // returns nullptr and fills in failure_messages if the callee does not
+  // match the functions schema
+
+  // TODO: defined in module.cpp, move to compilation_unit.cpp
+  Value* try_emit_call(
+      Graph& graph,
+      const SourceRange& loc,
+      c10::optional<NamedValue> self,
+      ArrayRef<NamedValue> args,
+      ArrayRef<NamedValue> kwargs,
+      std::stringstream& failure_messages,
+      bool conv_tensors_to_nums);
+
+  Value* emit_call(
+      Graph& graph,
+      const SourceRange& loc,
+      ArrayRef<NamedValue> args,
+      ArrayRef<NamedValue> kwargs);
+
+ private:
+  static FunctionSchema defaultSchemaFor(const Function& function) {
+    std::vector<Argument> args;
+    std::vector<Argument> returns;
+    Graph& g = *function.graph();
+    size_t num_inputs = function.num_inputs();
+    for (size_t i = 0; i < num_inputs; ++i) {
+      const Value* v = g.inputs().at(i);
+      std::string name = v->hasUniqueName() ? v->uniqueNameBase()
+                                            : ("argument_" + std::to_string(i));
+      args.emplace_back(std::move(name), unshapedType(g.inputs()[i]->type()));
+    }
+    for (size_t i = 0; i < g.outputs().size(); ++i) {
+      returns.emplace_back("", unshapedType(g.outputs()[i]->type()));
+    }
+    return {function.name(), "", std::move(args), std::move(returns)};
+  }
+
+  std::string name_;
+  std::shared_ptr<Graph> graph_; // for debugging and for inlining
+  bool optimize_;
+
+  GraphExecutor executor_; // for execution
+
+  std::once_flag executor_init_;
+
+  // an optional function that actually creates the method when
+  // emit_call_to(this,...) is first called. this is used by the compiler so
+  // that it can construct methods out of order
+  std::function<void(Function&)> function_creator_;
+
+  // if absent, then we generate a default schema based on the graph
+  // mutable because getSchema caches the default schema if one is requested
+  // before a call to setSchema
+  mutable std::unique_ptr<FunctionSchema> schema_;
+};
+
+struct TORCH_API CompilationUnit {
+  std::shared_ptr<Function> find_function(const std::string& name) const {
+    auto it = dict_.find(name);
+    if (it == dict_.end())
+      return nullptr;
+    return functions_[it->second];
+  }
+
+  Function& get_function(const std::string& name) const {
+    if (auto r = find_function(name))
+      return *r;
+    AT_ERROR("attempted to get undefined function ", name);
+  }
+
+  void set_optimized(bool o) {
+    optimized_ = o;
+  }
+
+  bool is_optimized() const {
+    return optimized_;
+  }
+
+  // for historic reasons, these are defined in compiler.cpp
+  void define(
+      const std::vector<Def>& definitions,
+      const std::vector<Resolver>& resolvers, /* determines how we handle free
+                                                 variables in each definition*/
+      // if non-null, the first argument to each def, is bound to this value
+      const Self& self);
+
+  // same as above but parse the definitions from source
+  void define(
+      const std::string& source,
+      const Resolver& resolver,
+      const Self& self);
+
+  void clone_function(const Function& remote) {
+    create_function(remote.name(), remote.graph()->copy());
+  }
+
+  Function& create_function(std::string name, std::shared_ptr<Graph> graph) {
+    auto fn = std::make_shared<Function>(
+        std::move(name), is_optimized(), std::move(graph), nullptr);
+    return register_function(std::move(fn));
+  }
+
+  const std::vector<std::shared_ptr<Function>>& get_functions() const {
+    return functions_;
+  }
+
+  /// Run a method from this compilation.
+  ///
+  /// For example:
+  /// @code
+  ///   IValue output = module->run("relu_script", a, b);
+  /// @endcode
+  ///
+  /// To get a compile a module from a source string, see torch::jit::compile
+  ///
+  /// @param method_name The name of the method to run
+  /// @param args Arguments to be passed to the method
+  /// @return An IValue containing the return value (or values if it is a tuple)
+  /// from the method
+  template <typename... Types>
+  IValue run_method(const std::string& method_name, Types&&... args) {
+    return get_function(method_name)({IValue(std::forward<Types>(args))...});
+  }
+
+  void drop_all_functions() {
+    dict_.clear();
+    functions_.clear();
+  }
+
+ private:
+  Function& register_function(std::shared_ptr<Function> fn) {
+    AT_CHECK(
+        0 == dict_.count(fn->name()),
+        "method '",
+        fn->name(),
+        "' already defined.");
+    functions_.emplace_back(std::move(fn));
+    dict_[functions_.back()->name()] = functions_.size() - 1;
+    return *functions_.back();
+  }
+  std::vector<std::shared_ptr<Function>> functions_;
+  // for fast lookup
+  std::unordered_map<std::string, size_t> dict_;
+  bool optimized_ = true;
+};
+
+} // namespace script
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -26,7 +26,7 @@ namespace jit {
 namespace script {
 
 using SugaredValuePtr = std::shared_ptr<SugaredValue>;
-using FunctionTable = std::unordered_map<std::string, Method&>;
+using FunctionTable = std::unordered_map<std::string, Function&>;
 using ValueTable = std::unordered_map<std::string, SugaredValuePtr>;
 using AttributeMap = std::unordered_map<std::string, Const>;
 using ListAttributeMap = std::unordered_map<std::string, std::vector<Const>>;
@@ -191,7 +191,7 @@ static bool meaningfulName(const std::string& name) {
 //      delete unnecessary ones later with replaceAllusesWith().
 struct Environment {
   Environment(
-      Method& method,
+      Function& method,
       Resolver resolver,
       Block* b,
       std::shared_ptr<Environment> next = nullptr)
@@ -200,7 +200,7 @@ struct Environment {
         b(b),
         next(std::move(next)) {}
 
-  Method& method;
+  Function& method;
   Resolver resolver;
   std::vector<std::string> captured_inputs;
   std::unordered_map<std::string, std::string> error_messages;
@@ -519,8 +519,8 @@ struct to_ir {
   to_ir(
       const Def& def,
       Resolver resolver_,
-      const c10::optional<Self>& self,
-      Method& method) // method being constructed
+      const Self& self,
+      Function& method) // method being constructed
       : method(method),
         graph(method.graph()),
         resolver(std::move(resolver_)),
@@ -542,7 +542,7 @@ struct to_ir {
   }
 
  private:
-  Method& method;
+  Function& method;
   std::shared_ptr<Graph> graph;
   Resolver resolver;
   std::unordered_map<int64_t, Value*> integral_constants;
@@ -578,7 +578,7 @@ struct to_ir {
 
   FunctionSchema emitDef(
       const Def& def,
-      const c10::optional<Self>& self,
+      const Self& self,
       Block* block) {
     auto schema = extractSchemaFromDef(def, self);
     // TODO need guards on init returning none
@@ -625,15 +625,16 @@ struct to_ir {
         blank_decl,
         List<Stmt>::create(r, {ret}));
     auto m = std::make_shared<Module>();
-    defineMethodsInModule(m, {def}, {resolver}, c10::nullopt);
+    CompilationUnit cu;
+    cu.define({def}, {resolver}, nullptr);
     Stack stack;
-    m->get_method("defaults").run(stack);
+    cu.get_function("defaults").run(stack);
     return stack.at(0).toTuple()->elements();
   }
 
   std::vector<Argument> parseArgsFromDecl(
       const Decl& decl,
-      const c10::optional<Self>& self) {
+      const Self& self) {
     auto params_begin = decl.params().begin();
     auto params_end = decl.params().end();
     if (self) {
@@ -707,7 +708,7 @@ struct to_ir {
   }
   FunctionSchema extractSchemaFromDef(
       const Def& def,
-      const c10::optional<Self>& self) {
+      const Self& self) {
     const auto name = def.name().name();
     std::vector<Argument> args = parseArgsFromDecl(def.decl(), self);
     std::vector<Argument> returns = parseReturnFromDecl(def.decl());
@@ -717,9 +718,10 @@ struct to_ir {
 
   std::vector<Argument> emitFormalArguments(
       const Def& def,
-      const c10::optional<Self>& self,
+      const Self& self,
       const FunctionSchema& schema,
       Block* block) {
+
     std::vector<Argument> arguments; // for schema
     // inputs
     auto it = def.decl().params().begin();
@@ -739,14 +741,9 @@ struct to_ir {
     if (self) {
       AT_ASSERT(it != end);
       const auto& name = (*it).ident().name();
-      if (auto type = self->asFirstClass()) {
-        Value* new_input =
-            block->addInput()->setUniqueName(name)->setType(type);
-        environment_stack->setVar((*it).ident().range(), name, new_input);
-        arguments.emplace_back(name, type);
-      } else {
-        environment_stack->setSugaredVar(def.range(), name, self->asSugared());
-      }
+      Value* new_input = block->addInput()->setUniqueName(name);
+      environment_stack->setSugaredVar((*it).ident().range(), name, self(new_input));
+      arguments.emplace_back(name, new_input->type());
       ++it;
     }
     size_t arg_annotation_idx = 0;
@@ -832,7 +829,7 @@ struct to_ir {
       pushFrame(block, /*starts_def=*/true);
       emitDef(
           def,
-          c10::nullopt,
+          nullptr,
           block); // ignore schema return, we just wont use it for now since we
                   // never create a Method for the closure
       popFrame(/*ends_def=*/true);
@@ -2264,7 +2261,6 @@ struct to_ir {
       node_output = fork_node->output()->setType(
           FutureType::create(fn_simple_output->type()));
     }
-
     // Lambda lift block(0) into attr::Subgraph
     lambdaLiftFork(fork_node);
 
@@ -2756,15 +2752,14 @@ struct to_ir {
   }
 };
 
-void defineMethodsInModule(
-    const std::shared_ptr<Module>& m,
+void CompilationUnit::define(
     const std::vector<Def>& definitions,
     const std::vector<Resolver>& resolvers,
-    const c10::optional<Self>& self) {
+    const Self& self) {
   AT_ASSERT(definitions.size() == resolvers.size());
   auto resolver_it = resolvers.begin();
-  std::vector<Method*> methods;
-  std::unordered_map<std::string, Method*> function_table;
+  std::vector<Function*> methods;
+  std::unordered_map<std::string, Function*> function_table;
   for (const Def& def : definitions) {
     const std::string& name = def.name().name();
     auto resolver = *resolver_it++;
@@ -2775,37 +2770,34 @@ void defineMethodsInModule(
       // the function table so the methods can see each other
       resolver = [resolver, &function_table](
                      const std::string& name,
-                     Method& m,
+                     Function& m,
                      const SourceRange& loc) -> std::shared_ptr<SugaredValue> {
         auto it = function_table.find(name);
         if (it != function_table.end()) {
-          return std::make_shared<MethodValue>(nullptr, *it->second);
+          return std::make_shared<MethodValue>(c10::nullopt, *it->second);
         }
         return resolver(name, m, loc);
       };
     }
-    auto creator = [def, resolver, self](Method& method) {
+    auto creator = [def, resolver, self](Function& method) {
       AT_ASSERT(resolver);
       to_ir(def, resolver, self, method);
     };
-    Method& method = m->create_method(name, creator);
-    function_table[name] = &method;
-    methods.push_back(&method);
+    std::unique_ptr<Function> fn(
+        new Function(name, is_optimized(), std::make_shared<Graph>(), creator));
+    function_table[name] = fn.get();
+    methods.push_back(fn.get());
+    register_function(std::move(fn));
   }
-  for (Method* method : methods) {
+  for (Function* method : methods) {
     method->ensure_defined();
-  }
-  if (!self || !self->asFirstClass()) {
-    // Disable module hooks if the module is only used to store a class's code.
-    didFinishEmitModule(m);
   }
 }
 
-void defineMethodsInModule(
-    const std::shared_ptr<Module>& m,
+void CompilationUnit::define(
     const std::string& source,
     const Resolver& resolver,
-    const c10::optional<Self>& self) {
+    const Self& self) {
   Parser p(source);
   std::vector<Def> definitions;
   std::vector<Resolver> resolvers;
@@ -2814,7 +2806,7 @@ void defineMethodsInModule(
     definitions.push_back(def);
     resolvers.push_back(resolver);
   }
-  defineMethodsInModule(m, definitions, resolvers, self);
+  define(definitions, resolvers, self);
 }
 
 void lambdaLiftFork(Node* fork_node) {
@@ -2839,6 +2831,7 @@ void lambdaLiftFork(Node* fork_node) {
   fork_node->g_(attr::Subgraph, forked_graph);
   fork_node->eraseBlock(0);
 }
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -13,12 +13,9 @@ namespace torch {
 namespace jit {
 namespace script {
 
-using Resolver = std::function<std::shared_ptr<
-    SugaredValue>(const std::string& name, Method& m, const SourceRange& loc)>;
-
 inline std::shared_ptr<SugaredValue> nativeResolver(
     const std::string& name,
-    Method& m,
+    Function& m,
     const SourceRange& loc) {
   if (name == "torch") {
     return std::make_shared<BuiltinModule>("aten");
@@ -26,47 +23,6 @@ inline std::shared_ptr<SugaredValue> nativeResolver(
   return nullptr;
 }
 
-// Represents the `self` argument to a method. This wrapper class is necessary
-// because sometimes `self` sometimes is first class and sometimes not.
-//
-// `self` is first class when it refers to a ClassType. It will be bound as a
-// graph input argument.
-// `self` is sugared when it refers to a ModuleValue.
-class Self {
- public:
-  explicit Self(std::shared_ptr<SugaredValue> sugared)
-      : sugared_(std::move(sugared)) {}
-  explicit Self(ClassTypePtr type) : firstClass_(std::move(type)) {}
-
-  ClassTypePtr asFirstClass() const {
-    return firstClass_;
-  }
-  std::shared_ptr<SugaredValue> asSugared() const {
-    return sugared_;
-  }
-
- private:
-  // Used when `self` is not first-class and so we don't represent it in the
-  // graph. This is only ModuleValue.
-  std::shared_ptr<SugaredValue> sugared_ = nullptr;
-  // Used when `self` is a first-class type
-  ClassTypePtr firstClass_ = nullptr;
-};
-
-TORCH_API void defineMethodsInModule(
-    const std::shared_ptr<Module>& m,
-    const std::vector<Def>& definitions,
-    const std::vector<Resolver>& resolvers, /* determines how we handle free
-                                               variables in each definition*/
-    // if non-null, the first argument to each def, is bound to this value
-    const c10::optional<Self>& self);
-
-// same as above but parse the definitions from source
-TORCH_API void defineMethodsInModule(
-    const std::shared_ptr<Module>& m,
-    const std::string& source,
-    const Resolver& resolver,
-    const c10::optional<Self>& self);
 
 TORCH_API void lambdaLiftFork(Node* fork_node);
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -64,10 +64,9 @@ inline std::shared_ptr<SugaredValue> toSimple(Value* v) {
 // type, *add it in this function's implementation*.
 std::shared_ptr<SugaredValue> toSugaredValue(
     py::object obj,
-    Method& m,
+    Function& m,
     SourceRange loc,
-    bool is_constant = false,
-    bool is_submodule = false);
+    bool is_constant = false);
 
 struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   PythonValue(py::object self) : self(std::move(self)) {}
@@ -125,7 +124,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   // call it like a function, e.g. `outputs = this(inputs)`
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       at::ArrayRef<NamedValue> inputs_,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
@@ -182,7 +181,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
 
   std::vector<std::shared_ptr<SugaredValue>> asTuple(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const c10::optional<size_t>& size_hint = {}) override {
     const std::string type_str = typeString(self);
     std::stringstream ss;
@@ -193,7 +192,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
 
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) override {
     const std::string type_str = typeString(self);
     std::stringstream ss;
@@ -219,7 +218,7 @@ struct VISIBILITY_HIDDEN PythonModuleValue : public PythonValue {
 
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) override {
     py::object member = getattr(loc, field);
     // note: is_constant = true because we consider that global properties
@@ -234,7 +233,7 @@ struct VISIBILITY_HIDDEN ConstantPythonTupleValue : public PythonValue {
       : PythonValue(std::move(tup)) {}
   std::vector<std::shared_ptr<SugaredValue>> asTuple(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const c10::optional<size_t>& size_hint = {}) override {
     py::tuple tup = self;
     std::vector<std::shared_ptr<SugaredValue>> result;
@@ -246,7 +245,7 @@ struct VISIBILITY_HIDDEN ConstantPythonTupleValue : public PythonValue {
     return result;
   }
 
-  Value* asValue(const SourceRange& loc, Method& m) override {
+  Value* asValue(const SourceRange& loc, Function& m) override {
     std::vector<Value*> values;
     for (const auto& sugared_item : asTuple(loc, m)) {
       values.push_back(sugared_item->asValue(loc, m));
@@ -258,33 +257,65 @@ struct VISIBILITY_HIDDEN ConstantPythonTupleValue : public PythonValue {
 
 // Represents all the parameters of a module as a List[Tensor]
 struct VISIBILITY_HIDDEN ConstantParameterList : public SugaredValue {
-  ConstantParameterList(std::shared_ptr<Module> module)
-      : module_(std::move(module)) {}
-
+  ConstantParameterList(Value* the_list) : the_list_(the_list) {}
   std::string kind() const override {
     return "constant parameter list";
+  }
+  std::shared_ptr<SugaredValue> call(
+      const SourceRange& loc,
+      Function& caller,
+      at::ArrayRef<NamedValue> inputs,
+      at::ArrayRef<NamedValue> attributes,
+      size_t n_binders) override {
+    return toSimple(the_list_);
+  }
+
+ private:
+  Value* the_list_;
+};
+
+struct VISIBILITY_HIDDEN OverloadedFunctionValue : public SugaredValue {
+  OverloadedFunctionValue(Value* module, std::vector<std::string> method_names)
+      : module_(module), method_names_(std::move(method_names)) {}
+
+  std::string kind() const override {
+    return "overloaded function";
   }
 
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& caller,
+      Function& caller,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
-    // Add all module parameters as inputs to the graph
-    std::vector<Value*> params;
-    const auto& param_list = module_->get_parameters();
-    for (auto it = param_list.rbegin(); it != param_list.rend(); ++it) {
-      auto& param = *it;
-      params.push_back(caller.get_or_add_parameter(param));
+    std::stringstream err;
+    std::vector<NamedValue> new_inputs = inputs.vec();
+    new_inputs.insert(new_inputs.begin(), module_);
+
+    for (const std::string& method_name : method_names_) {
+      auto cls = module_->type()->expect<ClassType>();
+      Function* fn = cls->getMethod(method_name);
+      auto match = tryMatchSchema(
+          fn->getSchema(),
+          loc,
+          *caller.graph().get(),
+          c10::nullopt,
+          new_inputs,
+          attributes,
+          err,
+          true);
+      if (match) {
+        return MethodValue(module_, *fn)
+            .call(loc, caller, inputs, attributes, n_binders);
+      }
     }
-    auto list = caller.graph()->createList(TensorType::get(), params);
-    caller.graph()->insertNode(list);
-    return toSimple(list->output());
+    throw ErrorReport(loc) << "Could not find any matching overloads\n"
+                           << err.str();
   }
 
  private:
-  std::shared_ptr<Module> module_;
+  Value* module_;
+  std::vector<std::string> method_names_;
 };
 
 // defines how modules/methods behave inside the script subset.
@@ -295,7 +326,8 @@ struct VISIBILITY_HIDDEN ConstantParameterList : public SugaredValue {
 // holding the actual nn.Module class.
 
 struct ModuleValue : public SugaredValue {
-  ModuleValue(std::shared_ptr<Module> module) : module(std::move(module)) {}
+  ModuleValue(Value* self, std::shared_ptr<Module> module)
+      : self_(self), module_(std::move(module)) {}
 
   std::string kind() const override {
     return "module";
@@ -304,45 +336,60 @@ struct ModuleValue : public SugaredValue {
   // select an attribute on it, e.g. `this.field`
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) override {
     // workaround to make self.training work
     // it adds a buffer 'training' to the model if one doesn't exist
     // and then loads that parameter, casting it to bool
     if (field == "training") {
-      Slot* v = module->find_buffer(field);
+      Slot* v = module_->find_buffer(field);
       if (!v) {
-        py::object py_module = py::cast(module);
+        py::object py_module = py::cast(module_);
         bool training = py::cast<bool>(py::getattr(py_module, "training"));
         auto t =
             autograd::make_variable(at::full({}, training ? 1 : 0, at::kLong));
-        module->register_buffer("training", std::move(t));
-        v = module->find_buffer(field);
+        module_->register_buffer("training", std::move(t));
+        v = module_->find_buffer(field);
       }
-      Value* the_tensor = m.get_or_add_parameter(*v);
+      Value* the_tensor = m.graph()->insertGetAttr(self_, "training");
       Value* the_bool = m.graph()->insert(prim::Bool, {the_tensor});
       return std::make_shared<SimpleValue>(the_bool);
     }
 
-    if (std::shared_ptr<Module> v = module->find_module(field)) {
-      return std::make_shared<ModuleValue>(v);
-    } else if (Method* v = module->find_method(field)) {
-      return std::make_shared<MethodValue>(shared_from_this(), *v);
-    } else if (Slot* v = module->find_parameter(field)) {
-      return std::make_shared<SimpleValue>(m.get_or_add_parameter(*v));
-    } else if (Slot* v = module->find_attribute(field)) {
-      return std::make_shared<SimpleValue>(
-          m.get_or_add_attribute(*v));
+    if (std::shared_ptr<Module> v = module_->find_module(field)) {
+      return std::make_shared<ModuleValue>(
+          m.graph()->insertGetAttr(self_, field), v);
+    } else if (auto kind = module_->kind_of(field)) {
+      // methods, parameters, attributes, and buffers are all first class
+      return SimpleValue(self_).attr(loc, m, field);
     }
 
     // This can also be a call to a non-script module, or a plain
     // python method. If so return this as a python value.
-    py::object py_module = py::cast(module);
+    py::object py_module = py::cast(module_);
+
+    py::object overloads =
+        py_module.attr("_overloads").attr("get")(field, py::none());
+    if (!overloads.is_none()) {
+      return std::make_shared<OverloadedFunctionValue>(
+          self_, py::cast<std::vector<std::string>>(overloads));
+    }
+
     if (py::object attr = py::getattr(py_module, field.c_str(), py::none())) {
       if (py::isinstance<py::function>(attr) &&
           py::hasattr(attr, "_is_parameter_list") &&
           py::cast<bool>(py::getattr(attr, "_is_parameter_list"))) {
-        return std::make_shared<ConstantParameterList>(module);
+        Graph& g = *m.graph();
+        // Add all module parameters as inputs to the graph
+        std::vector<Value*> params;
+        const auto& param_list = module_->get_parameters();
+        for (auto it = param_list.rbegin(); it != param_list.rend(); ++it) {
+          auto& param = *it;
+          params.emplace_back(g.insertGetAttr(self_, param.name()));
+        }
+        auto list =
+            g.insertNode(g.createList(TensorType::get(), params))->output();
+        return std::make_shared<ConstantParameterList>(list);
       }
       if (py::isinstance<py::function>(attr) ||
           py::isinstance(attr, py::module::import("torch.nn").attr("Module")) ||
@@ -364,7 +411,7 @@ struct ModuleValue : public SugaredValue {
   // call module.forward
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& caller,
+      Function& caller,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
@@ -374,28 +421,35 @@ struct ModuleValue : public SugaredValue {
 
   std::vector<std::shared_ptr<SugaredValue>> asTuple(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const c10::optional<size_t>& size_hint = {}) override {
-    py::object py_module = py::cast(module);
+    py::object py_module = py::cast(module_);
     if (!py::isinstance(
             py_module,
             py::module::import("torch.jit").attr("_ConstModuleList")))
       return SugaredValue::asTuple(loc, m, size_hint);
     std::vector<std::shared_ptr<SugaredValue>> result;
-    for (py::handle module : py_module) {
-      py::object obj = py::reinterpret_borrow<py::object>(module);
-      result.push_back(toSugaredValue(
-          obj,
-          m,
-          loc,
-          /*is_constant =*/false,
-          /*is_submodule =*/true));
+    for (py::handle py_submodule : py_module) {
+      py::object obj = py::reinterpret_borrow<py::object>(py_submodule);
+      if (py::isinstance<Module>(obj)) {
+        auto sub_module = py::cast<std::shared_ptr<Module>>(obj);
+        Value* module_v = m.graph()->insertGetAttr(self_, sub_module->name());
+        result.emplace_back(
+            std::make_shared<ModuleValue>(module_v, sub_module));
+      } else {
+        result.push_back(toSugaredValue(
+            obj,
+            m,
+            loc,
+            /*is_constant =*/false));
+      }
     }
     return result;
   }
 
  private:
-  std::shared_ptr<Module> module;
+  Value* self_;
+  std::shared_ptr<Module> module_;
 };
 
 struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
@@ -408,7 +462,7 @@ struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
 
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& caller,
+      Function& caller,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
@@ -446,54 +500,31 @@ struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
   py::dict dispatched_fn_;
 };
 
-struct VISIBILITY_HIDDEN OverloadedFunctionValue : public SugaredValue {
-  OverloadedFunctionValue(py::list functions)
-      : possible_functions_(std::move(functions)) {}
+std::shared_ptr<MethodValue> moduleToMethod(
+    const std::shared_ptr<Module>& mod) {
+  // this path only supports calling raw script functions
+  // but because they are not distinguished from models, we have to check
+  // that they are function-like here. They must not have state, and they
+  // must have a forward method. When we expose functions to python
+  //  this will be replaced with a direct py::isinstance<Function> call.
 
-  std::string kind() const override {
-    return "overloaded function";
+  if (mod->get_parameters().size() != 0) {
+    throw ErrorReport()
+        << "Attempted to inline a Module with parameters. "
+           "Stateful modules to be inlined must be submodules of the callee.";
   }
-
-  std::shared_ptr<SugaredValue> call(
-      const SourceRange& loc,
-      Method& caller,
-      at::ArrayRef<NamedValue> inputs,
-      at::ArrayRef<NamedValue> attributes,
-      size_t n_binders) override {
-    std::stringstream err;
-    auto possible_functions =
-        py::cast<std::vector<py::object>>(possible_functions_);
-
-    for (const py::object& fn : possible_functions) {
-      auto& method = py::cast<Method&>(fn);
-      auto match = tryMatchSchema(
-          method.getSchema(),
-          loc,
-          *caller.graph().get(),
-          c10::nullopt,
-          inputs,
-          attributes,
-          err,
-          true);
-      if (match) {
-        return MethodValue(nullptr, method)
-            .call(loc, caller, inputs, attributes, n_binders);
-      }
-    }
-    throw ErrorReport(loc) << "Could not find any matching overloads\n"
-                           << err.str();
+  Method* forward = mod->find_method("forward");
+  if (!forward) {
+    throw ErrorReport() << " expected this module to have a forward function.";
   }
-
- private:
-  py::list possible_functions_;
-};
+  return std::make_shared<MethodValue>(at::nullopt, forward->function());
+}
 
 std::shared_ptr<SugaredValue> toSugaredValue(
     py::object obj,
-    Method& m,
+    Function& m,
     SourceRange loc,
-    bool is_constant,
-    bool is_submodule) {
+    bool is_constant) {
   // directly create SimpleValues when possible, because they are first-class
   // and can be re-assigned. Otherwise, this would be invalid:
   // f = python_constant
@@ -534,17 +565,12 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     obj = weak_obj;
   }
   if (py::isinstance<Module>(obj)) {
-    auto mod = py::cast<std::shared_ptr<Module>>(obj);
     // In the case that this Python object is not a submodule, inline *ONLY
     // PURE* ScriptModules. This allows us to call arbitrary @script functions
     // within a scripting context while still enforcing that parameters from
     // stateful submodules are properly accounted for.
-    if (!is_submodule && mod->get_parameters().size() != 0) {
-      throw ErrorReport()
-          << "Attempted to inline a Module with parameters. "
-             "Stateful modules to be inlined must be submodules of the callee.";
-    }
-    return std::make_shared<ModuleValue>(mod);
+    auto mod = py::cast<std::shared_ptr<Module>>(obj);
+    return moduleToMethod(mod);
   } else if (py::isinstance<py::module>(obj)) {
     return std::make_shared<PythonModuleValue>(obj);
   } else if (obj.ptr() == py::module::import("torch.jit").attr("_fork").ptr()) {
@@ -566,7 +592,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
         py::module::import("torch.jit").attr("_try_compile_weak_script")(obj);
     if (!compiled_fn.is(py::none())) {
       auto mod = py::cast<std::shared_ptr<Module>>(compiled_fn);
-      return std::make_shared<ModuleValue>(mod);
+      return moduleToMethod(mod);
     }
   }
 
@@ -574,12 +600,6 @@ std::shared_ptr<SugaredValue> toSugaredValue(
       py::module::import("torch.jit").attr("_try_get_dispatched_fn")(obj);
   if (!dispatched_fn.is_none()) {
     return std::make_shared<BooleanDispatchValue>(std::move(dispatched_fn));
-  }
-
-  py::object overloads =
-      py::module::import("torch.jit").attr("_try_get_overloaded_fn")(obj);
-  if (!overloads.is_none()) {
-    return std::make_shared<OverloadedFunctionValue>(std::move(overloads));
   }
 
   return std::make_shared<PythonValue>(obj);
@@ -621,7 +641,7 @@ static void gatherParametersAndBuffers(
 namespace {
 
 Resolver pythonResolver(const ResolutionCallback& rcb) {
-  return [rcb](const std::string& name, Method& m, const SourceRange& loc)
+  return [rcb](const std::string& name, Function& m, const SourceRange& loc)
              -> std::shared_ptr<SugaredValue> {
     AutoGIL ag;
     py::object obj = rcb(name);
@@ -673,6 +693,13 @@ FunctionSchema getSchemaWithNameAndDefaults(
       schema.is_varret());
 }
 
+static Self moduleSelf(const std::shared_ptr<Module>& m) {
+  return [m](Value* v) {
+    v->setType(m->module_object()->type());
+    return std::make_shared<ModuleValue>(v, m);
+  };
+}
+
 void initJitScriptBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
@@ -712,9 +739,12 @@ void initJitScriptBindings(PyObject* module) {
              bool has_self) {
             c10::optional<Self> self;
             if (has_self) {
-              self = Self(std::make_shared<ModuleValue>(m));
+              m->class_compilation_unit().define(
+                  script, pythonResolver(rcb), moduleSelf(m));
+            } else {
+              m->_define_lowered(script, pythonResolver(rcb));
             }
-            defineMethodsInModule(m, script, pythonResolver(rcb), self);
+            didFinishEmitModule(m);
           })
       .def(
           "_create_methods",
@@ -727,14 +757,13 @@ void initJitScriptBindings(PyObject* module) {
             for (auto& callback : rcbs) {
               resolvers.push_back(pythonResolver(callback));
             }
-            defineMethodsInModule(
-                m, defs, resolvers, Self(std::make_shared<ModuleValue>(m)));
-
+            m->class_compilation_unit().define(defs, resolvers, moduleSelf(m));
             // Stitch in default arguments for each Def if provided
             auto defaults_it = defaults.begin();
             auto defs_it = defs.begin();
             while (defs_it != defs.end()) {
-              auto& method = m->get_method((*defs_it).name().name());
+              auto& method = m->class_compilation_unit().get_function(
+                  (*defs_it).name().name());
               method.setSchema(getSchemaWithNameAndDefaults(
                   defs_it->range(),
                   method.getSchema(),
@@ -784,8 +813,7 @@ void initJitScriptBindings(PyObject* module) {
               auto& p = parameters[i];
               py::tuple r(2);
               result[i] = std::make_tuple(
-                  p.name(),
-                  autograd::as_variable_ref(p.value().toTensor()));
+                  p.name(), autograd::as_variable_ref(p.value().toTensor()));
             }
             return result;
           })
@@ -841,7 +869,7 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& self,
              const std::string& name,
              std::shared_ptr<Graph> graph) {
-            self.create_method(name, std::move(graph), {});
+            self._define_lowered(name, std::move(graph), {});
           })
       .def(
           "_create_method_from_trace",
@@ -865,7 +893,8 @@ void initJitScriptBindings(PyObject* module) {
                 var_lookup_fn,
                 force_outplace,
                 input_tuple.size());
-            self->create_method(name, std::move(graph), std::move(parameters));
+            self->_define_lowered(
+                name, std::move(graph), std::move(parameters));
             didFinishEmitModule(self);
           })
       .def(
@@ -890,7 +919,7 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& self) {
             if (self.find_method("forward")) {
               Method& m = self.get_method("forward");
-              return m.getDebugState();
+              return m.get_executor().getDebugState();
             }
             throw std::runtime_error(
                 "Attempted to call get_debug_state on a Module without a compiled forward()");
@@ -900,7 +929,7 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& self) {
             if (self.find_method("forward")) {
               Method& m = self.get_method("forward");
-              m.debugDisableAutodiffSubgraphInlining();
+              m.get_executor().debugDisableAutodiffSubgraphInlining();
             }
           })
       .def(
@@ -958,7 +987,8 @@ void initJitScriptBindings(PyObject* module) {
             }
 
             Method* orig_method = orig->find_method(name);
-            m->create_method(name, orig_method->graph()->copy(), member_inputs);
+            m->_define_lowered(
+                name, orig_method->graph()->copy(), std::move(member_inputs));
           });
 
   py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
@@ -972,10 +1002,27 @@ void initJitScriptBindings(PyObject* module) {
                 method, tuple_slice(std::move(args), 1), std::move(kwargs));
           })
       .def_property_readonly("graph", [](Method& m) { return m.graph(); })
-      .def("propagate_shapes", &Method::propagate_shapes)
+      .def(
+          "propagate_shapes",
+          [](Method& m, const std::vector<at::Tensor>& inputs, bool with_grad) {
+            return propagate_shapes(
+                *m.graph(), inputs, m.initial_ivalues(), with_grad);
+          })
       .def(
           "propagate_and_assign_input_and_output_shapes",
-          &Method::propagate_and_assign_input_and_output_shapes)
+          [](Method& m,
+             const std::vector<at::Tensor>& inputs,
+             std::vector<at::Tensor> outputs,
+             bool with_grad,
+             bool propagate) {
+            return propagate_and_assign_input_and_output_shapes(
+                *m.graph(),
+                inputs,
+                m.initial_ivalues(),
+                outputs,
+                with_grad,
+                propagate);
+          })
       .def(
           "initial_ivalues",
           [](Method& m) {
@@ -995,9 +1042,18 @@ void initJitScriptBindings(PyObject* module) {
           })
       .def(
           "debug_disable_autodiff_subgraph_inlining",
-          &Method::debugDisableAutodiffSubgraphInlining)
+          [](Method& m) {
+            return m.get_executor().debugDisableAutodiffSubgraphInlining();
+          })
       .def("schema", &Method::getSchema)
-      .def("pretty_print_schema", &Method::pretty_print_schema)
+      .def(
+          "pretty_print_schema",
+          [](Method& m) {
+            const FunctionSchema& schema = m.getSchema();
+            std::stringstream ss;
+            ss << schema;
+            return ss.str();
+          })
       .def(
           "python_print",
           [](Method& m) {
@@ -1022,29 +1078,30 @@ void initJitScriptBindings(PyObject* module) {
          ResolutionCallback rcb,
          FunctionDefaults defaults) {
         auto def_f = def.withName("forward");
-        defineMethodsInModule(
-            mod, {def_f}, {pythonResolver(rcb)}, c10::nullopt);
-        auto& method = mod->get_method("forward");
-        method.setSchema(getSchemaWithNameAndDefaults(
-            def.range(), method.getSchema(), def.name().name(), defaults));
+
+        mod->_define_lowered({def_f}, {pythonResolver(rcb)});
+        auto& func = mod->lowered_methods().get_function("forward");
+        func.setSchema(getSchemaWithNameAndDefaults(
+            def.range(), func.getSchema(), def.name().name(), defaults));
+        auto& func2 = mod->class_compilation_unit().get_function("forward");
+        func2.setSchema(getSchemaWithNameAndDefaults(
+            def.range(), func2.getSchema(), def.name().name(), defaults));
         didFinishEmitModule(mod);
         return mod;
       });
 
   m.def(
       "_jit_script_class_compile",
-      [](std::shared_ptr<Module> module,
-         const ClassDef& classDef,
-         ResolutionCallback rcb) {
-        auto classType = ClassType::create(classDef.name().name(), module);
+      [](const ClassDef& classDef, ResolutionCallback rcb) {
+        auto cu = std::make_shared<CompilationUnit>();
+        auto classType = ClassType::create(classDef.name().name(), cu);
         std::vector<Resolver> rcbs;
         std::vector<Def> methodDefs;
         for (const auto& def : classDef.defs()) {
           methodDefs.push_back(def);
           rcbs.push_back(pythonResolver(rcb));
         }
-        defineMethodsInModule(module, methodDefs, rcbs, Self(classType));
-        return module;
+        cu->define(methodDefs, rcbs, simpleSelf(classType));
       });
 
   m.def("parse_type_comment", [](const std::string& comment) {

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -2,6 +2,7 @@
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/export.h>
 #include <torch/csrc/jit/operator.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/script/compiler.h>
 #include <torch/csrc/jit/script/error_report.h>
 #include <torch/csrc/jit/script/schema_matching.h>
@@ -11,32 +12,39 @@ namespace jit {
 namespace script {
 
 struct RecursiveMethodCallError : public std::exception {};
-void placeholderCreator(Method&) {
+void placeholderCreator(Function&) {
   throw RecursiveMethodCallError();
 }
 
-Value* try_emit_call_to(
+void Function::ensure_defined() {
+  try {
+    if (function_creator_) {
+      auto creator = function_creator_;
+      function_creator_ = placeholderCreator;
+      creator(*this);
+      function_creator_ = nullptr;
+    }
+  } catch (RecursiveMethodCallError&) {
+    throw ErrorReport() // TODO: once lower_first_class methods is removed
+                        // re-establish callsite info for debugging
+        << " method '" << name() << "' is called recursively. "
+        << "Recursive calls are not supported";
+  }
+}
+
+Value* Function::try_emit_call(
     Graph& graph,
     const SourceRange& loc,
-    Method& callee,
     c10::optional<NamedValue> self,
     ArrayRef<NamedValue> args,
     ArrayRef<NamedValue> kwargs,
     std::stringstream& failure_messages,
-    Method* caller,
     bool conv_tensors_to_nums) {
-  try {
-    callee.ensure_defined();
-  } catch (RecursiveMethodCallError&) {
-    throw ErrorReport(loc)
-        << " method '" << callee.name()
-        << "' is called recursively involving this call site. "
-        << "Recursive calls are not supported";
-  }
-  auto fn = callee.graph();
+  ensure_defined();
+  auto fn = this->graph();
 
   auto matched_schema = tryMatchSchema(
-      callee.getSchema(),
+      getSchema(),
       loc,
       graph,
       std::move(self),
@@ -47,50 +55,27 @@ Value* try_emit_call_to(
   if (!matched_schema)
     return nullptr;
 
-  // parameters to callee method (which become parameters to _this_ method
-  // if they were not already)
-  for (const auto& member : callee.initial_ivalues()) {
-    if (!caller) {
-      throw ErrorReport(loc)
-          << " attempting to call a method with parameters/attributes"
-             " from a raw graph. File a bug report";
-    }
-    matched_schema->inputs.push_back(
-        caller->get_or_add_attribute(member));
-  }
-  callee.check_single_output();
-  return inlineCallTo(graph, *callee.graph(), matched_schema->inputs).at(0);
+  check_single_output();
+  return inlineCallTo(graph, *fn, matched_schema->inputs).at(0);
 }
 
-Value* Method::emit_call_to(
+Value* Function::emit_call(
+    Graph& graph,
     const SourceRange& loc,
-    Method& callee,
     ArrayRef<NamedValue> args,
     ArrayRef<NamedValue> kwargs) {
-  AT_ASSERT(!executor);
   std::stringstream failure_messages;
-  if (auto result = try_emit_call_to(
-          *graph(),
+  if (auto result = try_emit_call(
+          graph,
           loc,
-          callee,
           c10::nullopt,
           args,
           kwargs,
           failure_messages,
-          this,
           /*conv_tensors_to_nums=*/true)) {
     return result;
   }
   throw ErrorReport(loc) << failure_messages.str();
-}
-
-void Method::ensure_defined() {
-  if (method_creator) {
-    auto creator = method_creator;
-    method_creator = placeholderCreator;
-    creator(*this);
-    method_creator = nullptr;
-  }
 }
 
 void Module::to(at::Device device, at::ScalarType dtype, bool non_blocking) {
@@ -135,6 +120,249 @@ void Module::to_impl(
         non_blocking);
     variable.set_data(new_data);
   }
+}
+
+// lower_first_class_method and lift_lowered_method are transitionary functions
+// used to translate between module-as-first-class code generation,
+// and module-as-special execution. Once module-as-first-class execution is
+// debugged, then we can remove both and remove the lowered_functions_ table.
+
+// remove the first module argument, replacing any access of its
+// parameters/attributes with extra_ivalue input Slots that hold what value to
+// pass into the graph
+std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
+    const ModulePtr& self,
+    Graph& g_,
+    size_t self_offset = 0) {
+  std::shared_ptr<Graph> g = g_.copy();
+  std::vector<Slot> extra_ivalues;
+  std::unordered_map<Slot, size_t> slot_to_offset;
+  struct ToScan {
+    ModulePtr mod;
+    Node* n;
+    size_t offset;
+  };
+  std::vector<ToScan> to_scan;
+  std::vector<Node*> to_clean; // nodes that should be dead at the end
+  std::vector<Node*> forks_edited; // we need to potentially de-dup inputs
+                                   // to the fork node
+
+  auto getOrAddSlot = [&](const Slot& slot) -> Value* {
+    auto it = slot_to_offset.find(slot);
+    if (it != slot_to_offset.end()) {
+      size_t ivalues_start = g->inputs().size() - extra_ivalues.size();
+      return g->inputs().at(ivalues_start + it->second);
+    }
+    extra_ivalues.emplace_back(slot);
+    slot_to_offset[slot] = extra_ivalues.size() - 1;
+    return g->addInput()->setType(slot.type());
+  };
+
+  auto self_value = g->inputs().at(self_offset);
+
+  for (Use use : self_value->uses()) {
+    to_scan.emplace_back(ToScan{self, use.user, use.offset});
+  }
+  while (to_scan.size() > 0) {
+    auto e = to_scan.back();
+    to_scan.pop_back();
+
+    // when we lambda lift forks, first-class modules may be passed across
+    // forks. This code recursively lowers the module in the fork call.
+    if (e.n->kind() == prim::fork) {
+      auto subgraph = e.n->g(attr::Subgraph);
+      std::vector<Slot> new_slots;
+      std::tie(subgraph, new_slots) = lower_graph(e.mod, *subgraph, e.offset);
+      e.n->g_(attr::Subgraph, subgraph);
+      for (const Slot& slot : new_slots) {
+        e.n->addInput(getOrAddSlot(slot));
+      }
+      e.n->removeInput(e.offset);
+      forks_edited.emplace_back(e.n);
+      continue;
+    }
+    if (e.n->kind() != prim::GetAttr) {
+      throw ErrorReport(e.n->getSourceLocation())
+          << "temporary: the only valid use of a module is looking up an attribute";
+    }
+    Slot slot(e.mod, e.mod->type()->getAttributeSlot(e.n->s(attr::name)));
+    if (ClassTypePtr c = e.n->output()->type()->cast<ClassType>()) {
+      if (c->name() == "Module") {
+        auto obj = slot.value().toObject();
+        for (Use use : e.n->output()->uses()) {
+          to_scan.emplace_back(ToScan{obj, use.user, use.offset});
+        }
+        to_clean.emplace_back(e.n);
+        continue;
+      }
+    }
+    e.n->output()->replaceAllUsesWith(getOrAddSlot(slot));
+    e.n->destroy();
+  }
+
+  while (to_clean.size() > 0) {
+    Node* n = to_clean.back();
+    AT_ASSERT(!n->hasUses());
+    n->destroy();
+    to_clean.pop_back();
+  }
+  AT_ASSERT(!self_value->hasUses());
+  g->eraseInput(self_offset);
+
+  // for(Node* fork : forks_edited) {
+  //   std::unordered_map<Value*, size_t> input_to_offset;
+  //   auto subgraph = fork->g(attr::Subgraph);
+  //   for(size_t i = 0; i < fork->inputs().size();) {
+  //     Value* input = fork->inputs().at(i);
+  //     auto it = input_to_offset.find(input);
+  //     if (it == input_to_offset.end()) {
+  //       input_to_offset[input] = i;
+  //       ++i;
+  //       continue;
+  //     }
+  //     // remove duplicate for input at offset i with first use at offset
+  //     it->second fork->removeInput(i);
+  //     subgraph->inputs().at(i)->replaceAllUsesWith(
+  //         subgraph->inputs().at(it->second));
+  //     subgraph->eraseInput(i);
+  //   }
+  // }
+
+  return std::make_pair(std::move(g), std::move(extra_ivalues));
+}
+
+Method& Module::lower_first_class_method(Function* fn) {
+  fn->ensure_defined();
+  auto lowered = lower_graph(module_object(), *fn->graph());
+  Function& new_func =
+      lowered_methods_.create_function(fn->name(), lowered.first);
+
+  // generate the new schema
+  // slice away the self argument
+  std::vector<Argument> args(
+      fn->getSchema().arguments().begin() + 1,
+      fn->getSchema().arguments().end());
+  size_t id = 0;
+  for (const Slot& slot : lowered.second) {
+    std::ostringstream ss;
+    ss << "slot" << id++;
+    args.emplace_back(ss.str(), slot.type());
+  }
+  new_func.setSchema(fn->getSchema().withArguments(std::move(args)));
+  return _create_lowered_method(&new_func, std::move(lowered.second));
+}
+
+static void createFirstClassValues(
+    Module* module,
+    Value* self,
+    std::unordered_map<Slot, Value*>& result) {
+  auto& g = *self->owningGraph();
+
+  std::vector<Node*> created;
+  struct ToScan {
+    Module* mod;
+    Value* v; // value representing module in the graph
+  };
+  std::vector<ToScan> to_scan = {{module, self}};
+
+  while (!to_scan.empty()) {
+    auto s = to_scan.back();
+    to_scan.pop_back();
+    size_t offset = 0;
+    for (const std::string& name :
+         s.mod->module_object()->type()->attributeNames()) {
+      Value* v = g.insertGetAttr(s.v, name);
+      result[Slot(s.mod->module_object(), offset++)] = v;
+      if (std::shared_ptr<Module> sub = s.mod->find_module(name)) {
+        to_scan.emplace_back(ToScan{sub.get(), v});
+      }
+    }
+  }
+}
+
+void Module::lift_lowered_method(Method& m) {
+  auto graph = m.graph()->copy();
+  Value* self = graph->insertInput(0, "self")->setType(module_object()->type());
+  std::unordered_map<Slot, Value*> slot_to_value;
+  if (!m.initial_ivalues().empty()) {
+    WithInsertPoint guard(*graph->nodes().begin());
+    createFirstClassValues(this, self, slot_to_value);
+  }
+
+  size_t orig_graph_inputs_size = graph->inputs().size();
+  for (size_t i = 0; i < m.initial_ivalues().size(); ++i) {
+    size_t input_offset = orig_graph_inputs_size - i - 1;
+    size_t ivalue_offset = m.initial_ivalues().size() - i - 1;
+    graph->inputs()
+        .at(input_offset)
+        ->replaceAllUsesWith(
+            slot_to_value.at(m.initial_ivalues().at(ivalue_offset)));
+    graph->eraseInput(input_offset);
+  }
+
+  if (!m.initial_ivalues().empty()) {
+    // we added _all_ the submodules as first-class values but maybe did not use
+    // them. So remove any dead attribute lookups
+    EliminateDeadCode(graph);
+  }
+
+  Function& new_fn = class_cu().create_function(m.name(), std::move(graph));
+  // created lifted schema
+  std::vector<Argument> new_args = {Argument("_self", module_object()->type())};
+  const auto& lowered_args = m.function().getSchema().arguments();
+  new_args.insert(
+      new_args.end(),
+      lowered_args.begin(),
+      lowered_args.begin() + m.num_inputs());
+  new_fn.setSchema(m.function().getSchema().withArguments(std::move(new_args)));
+}
+
+Method& Module::_create_lowered_method(
+    Function* func,
+    std::vector<Slot> member_inputs) {
+  std::unique_ptr<Method> m(new Method(this, func, std::move(member_inputs)));
+  return *insert(func->name(), methods_, EntityType::METHOD, std::move(m));
+}
+
+void Module::lift_lowered_methods(size_t start) {
+  for (size_t i = start; i < lowered_methods_.get_functions().size(); ++i) {
+    Method& m = _create_lowered_method(
+        lowered_methods_.get_functions().at(i).get(), {});
+    lift_lowered_method(m);
+  }
+}
+
+void Module::_define_lowered(
+    const std::vector<Def>& definitions,
+    const std::vector<Resolver>& resolvers) {
+  size_t start = lowered_methods_.get_functions().size();
+  lowered_methods_.define(definitions, resolvers, nullptr);
+  lift_lowered_methods(start);
+  // call lift_lowered_method for each definition
+}
+
+void Module::_define_lowered(const std::string& src, const Resolver& resolver) {
+  size_t start = lowered_methods_.get_functions().size();
+  lowered_methods_.define(src, resolver, nullptr);
+  lift_lowered_methods(start);
+}
+
+Method& Module::_define_lowered(
+    std::string name,
+    std::shared_ptr<Graph> graph,
+    std::vector<Slot> slots) {
+  Method& m = _create_lowered_method(
+      &lowered_methods_.create_function(std::move(name), std::move(graph)),
+      std::move(slots));
+  lift_lowered_method(m);
+  return m;
+}
+
+void Module::define(const std::string& src, const Resolver& resolver) {
+  class_cu().define(
+      src,
+      resolver ? resolver : nativeResolver,
+      simpleSelf(module_object()->type()));
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -12,6 +12,7 @@
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/api/include/torch/ordered_dict.h>
+#include <torch/csrc/jit/script/compilation_unit.h>
 #include <torch/csrc/utils/memory.h>
 
 #include <ATen/core/function_schema.h>
@@ -39,6 +40,7 @@ using ::c10::FunctionSchema;
 // Map which stores filename to content.
 using ExtraFilesMap = std::unordered_map<std::string, std::string>;
 
+using ModulePtr = c10::intrusive_ptr<c10::ivalue::Object>;
 // A method in a module, e.g. f in:
 //
 // class M(ScriptModule):
@@ -53,186 +55,12 @@ struct Module;
 using ModuleLookup =
     std::function<std::shared_ptr<Module>(const std::vector<std::string>&)>;
 
-struct Method {
-  Method(
-      Module* owner,
-      std::string name,
-      bool optimize,
-      std::shared_ptr<Graph> graph,
-      std::vector<Slot> initial_members,
-      std::function<void(Method&)> method_creator)
+struct TORCH_API Method {
+  Method(Module* owner, Function* function, std::vector<Slot> initial_members)
       : owner_(owner),
-        name_(std::move(name)),
-        graph_(std::move(graph)),
-        optimize(optimize),
-        initial_ivalues_(std::move(initial_members)),
-        method_creator(std::move(method_creator)) {
-    AT_ASSERT(graph_->inputs().size() >= initial_ivalues_.size());
-    int i = graph_->inputs().size() - initial_ivalues_.size();
-    for (auto member : initial_ivalues_) {
-      initial_ivalue_index[member] = i++;
-    }
-  }
-
-  void run(Stack& stack) {
-    for (auto input : initial_ivalues_) {
-      push(stack, input.value());
-    }
-    get_executor().run(stack);
-  }
-
-  void run(Stack&& stack) {
-    run(stack);
-  }
-
-  IValue operator()(std::vector<IValue> stack) {
-    checkInputsAgainstSchema(stack);
-    run(stack);
-    return stack.front();
-  }
-
-  std::shared_ptr<Graph> graph_for(Stack inputs) {
-    for (auto tp : initial_ivalues_) {
-      inputs.emplace_back(tp.value());
-    }
-    return get_executor().graphFor(inputs);
-  }
-  TORCH_API std::shared_ptr<Graph> graph() const {
-    return graph_;
-  }
-
-  TORCH_API const std::string& name() const {
-    return name_;
-  }
-  // emit a function call by inlining the callees Graph into this one
-  // adding any extra parameters necessary to do this call
-
-  // defined here to keep details of member_input handling confined to this
-  // class
-  Value* emit_call_to(
-      const SourceRange& loc,
-      Method& callee,
-      ArrayRef<NamedValue> args,
-      ArrayRef<NamedValue> kwargs);
-
-  // if this isn't yet defined, run its method_creator function
-  TORCH_API void ensure_defined();
-
-  size_t num_inputs() const {
-    return graph()->inputs().size() - initial_ivalues_.size();
-  }
-  TORCH_API Value* get_or_add_parameter(Slot slot) {
-    AT_ASSERT(slot.value().isTensor());
-    return get_or_add_attribute(slot);
-  }
-  TORCH_API Value* get_or_add_attribute(Slot slot) {
-    auto it = initial_ivalue_index.find(slot);
-    if (it != initial_ivalue_index.end()) {
-      return graph()->inputs().at(it->second);
-    }
-    initial_ivalues_.push_back(slot);
-    initial_ivalue_index[slot] = graph()->inputs().size();
-    return graph()->addInput()->setType(slot.type());
-  }
-
-  static void setInputTensorTypes(Graph& g, const Stack& stack) {
-    AT_ASSERT(stack.size() == g.inputs().size());
-    for (size_t i = 0; i < stack.size(); ++i) {
-      g.inputs().at(i)->setType(
-          DimensionedTensorType::create(stack.at(i).toTensor()));
-    }
-  }
-
-  std::shared_ptr<Graph> propagate_shapes(
-      std::vector<at::Tensor> inputs,
-      bool with_grad = false) {
-    auto retval = graph_->copy();
-    Stack stack;
-    stack.reserve(inputs.size() + initial_ivalues_.size());
-    for (at::Tensor& i : inputs) {
-      stack.emplace_back(std::move(i));
-    }
-    for (const Slot& inp : initial_ivalues_) {
-      stack.push_back(inp.value());
-    }
-    setInputTensorTypes(*retval, stack);
-    PropagateInputShapes(retval);
-    return retval;
-  }
-
-  std::shared_ptr<Graph> propagate_and_assign_input_and_output_shapes(
-      std::vector<at::Tensor> inputs,
-      std::vector<at::Tensor> outputs,
-      bool with_grad = false,
-      bool propagate = true) {
-    auto retval = graph_->copy();
-    for (auto inp : initial_ivalues_) {
-      if (inp.value().isTensor()) {
-        inputs.push_back(inp.value().toTensor());
-      }
-    }
-    if (propagate) {
-      setInputTensorTypes(*retval, fmap<IValue>(inputs));
-      PropagateInputShapes(retval);
-    }
-    AT_ASSERT(retval->inputs().size() == inputs.size());
-    for (size_t i = 0; i < retval->inputs().size(); ++i) {
-      auto scalar_type = inputs[i].scalar_type();
-      auto sizes = inputs[i].sizes();
-      auto type =
-          torch::jit::CompleteTensorType::create(scalar_type, at::kCPU, sizes);
-      retval->inputs()[i]->setType(type);
-    }
-    at::ArrayRef<Value*> output_values = retval->outputs();
-    // patch this to still work if we are returning a tuple of multiple values
-    if (output_values.at(0)->type()->kind() == TupleType::Kind) {
-      AT_ASSERT(output_values.at(0)->node()->kind() == prim::TupleConstruct);
-      output_values = output_values.at(0)->node()->inputs();
-    }
-    AT_ASSERT(output_values.size() == outputs.size());
-    for (size_t i = 0; i < retval->outputs().size(); ++i) {
-      auto scalar_type = outputs[i].scalar_type();
-      auto sizes = outputs[i].sizes();
-      auto type =
-          torch::jit::CompleteTensorType::create(scalar_type, at::kCPU, sizes);
-      output_values[i]->setType(type);
-    }
-    return retval;
-  }
-
-  const std::vector<Slot>& initial_ivalues() const {
-    return initial_ivalues_;
-  }
-
-  Method& setSchema(FunctionSchema schema_) {
-    schema = make_unique<FunctionSchema>(std::move(schema_));
-    return *this;
-  }
-
-  TORCH_API const FunctionSchema& getSchema() const {
-    if (schema == nullptr) {
-      schema = make_unique<FunctionSchema>(defaultSchemaFor(*this));
-    }
-    return *schema;
-  }
-
-  std::string pretty_print_schema() const {
-    AT_ASSERT(schema);
-    std::stringstream ss;
-    ss << *schema;
-    return ss.str();
-  }
-
-  GraphExecutorState getDebugState() {
-    return get_executor().getDebugState();
-  }
-
-  void debugDisableAutodiffSubgraphInlining() {
-    return get_executor().debugDisableAutodiffSubgraphInlining();
-  }
-
-  bool is_optimized() const {
-    return optimize;
+        function_(function),
+        initial_ivalues_(std::move(initial_members)) {
+    AT_ASSERT(function->num_inputs() >= initial_ivalues_.size());
   }
 
   // the module that contains this method.
@@ -240,133 +68,97 @@ struct Method {
     return *owner_;
   }
 
-  void check_single_output() {
-    AT_CHECK(
-        graph()->outputs().size() == 1,
-        "Method (but not graphs in general) require a single output. Use None/Tuple for 0 or 2+ outputs");
+  void run(Stack& stack) {
+    for (auto input : initial_ivalues_) {
+      push(stack, input.value());
+    }
+    function_->run(stack);
+  }
+  void run(Stack&& stack) {
+    run(stack);
   }
 
- private:
-  static FunctionSchema defaultSchemaFor(const Method& method) {
-    std::vector<Argument> args;
-    std::vector<Argument> returns;
-    Graph& g = *method.graph();
-    size_t num_inputs = method.num_inputs();
-    for (size_t i = 0; i < num_inputs; ++i) {
-      const Value* v = g.inputs().at(i);
-      std::string name = v->hasUniqueName() ? v->uniqueNameBase()
-                                            : ("argument_" + std::to_string(i));
-      args.emplace_back(std::move(name), unshapedType(g.inputs()[i]->type()));
+  IValue operator()(std::vector<IValue> stack) {
+    getSchema().checkInputs(stack);
+    for (auto input : initial_ivalues_) {
+      push(stack, input.value());
     }
-    for (size_t i = 0; i < g.outputs().size(); ++i) {
-      returns.emplace_back("", unshapedType(g.outputs()[i]->type()));
+    // use run rather than operator() to skip the second schema check.
+    function_->run(std::move(stack));
+    return stack.front();
+  }
+
+  const std::vector<Slot>& initial_ivalues() const {
+    return initial_ivalues_;
+  }
+
+  // proxies for underlying unbound Function
+  std::shared_ptr<Graph> graph_for(Stack inputs) {
+    for (auto tp : initial_ivalues_) {
+      inputs.emplace_back(tp.value());
     }
-    return {method.name(), "", std::move(args), std::move(returns)};
+    return function_->get_executor().graphFor(inputs);
+  }
+
+  std::shared_ptr<Graph> graph() const {
+    return function_->graph();
+  }
+
+  const std::string& name() const {
+    return function_->name();
+  }
+
+  size_t num_inputs() const {
+    return function_->num_inputs() - initial_ivalues_.size();
+  }
+
+  FunctionSchema getSchema() const {
+    // we are required to slice out the slot inputs from the schema
+    // we can't cache this because setSchema on the underlying function
+    // will change the underlying schema
+    auto sliced = ArrayRef<Argument>(function_->getSchema().arguments())
+                      .slice(0, num_inputs());
+    return function_->getSchema().withArguments(sliced.vec());
   }
 
   GraphExecutor& get_executor() {
-    std::call_once(executor_init, [&] {
-      check_single_output();
-      executor = GraphExecutor(graph(), optimize);
-    });
-    return executor;
+    return function_->get_executor();
   }
 
-  void checkInputsAgainstSchema(std::vector<IValue>& inputs) {
-    const auto& schema = getSchema();
-    // Do we have more inputs than the schema accepts?
-    AT_CHECK(
-        inputs.size() <= schema.arguments().size(),
-        "Expected at most ",
-        schema.arguments().size(),
-        " argument(s) for operator '",
-        schema.name(),
-        "', but received ",
-        inputs.size(),
-        " argument(s). Declaration: ",
-        schema);
-
-    for (size_t pos = 0; pos < schema.arguments().size(); ++pos) {
-      const auto& argument = schema.arguments()[pos];
-      if (pos < inputs.size()) {
-        if (!isSubvalueOf(inputs[pos], argument.type())) {
-          AT_ERROR(
-              "Expected value of type ",
-              *argument.type(),
-              " for argument '",
-              argument.name(),
-              "' in position ",
-              pos,
-              ", but instead got value of type ",
-              attemptToRecoverType(inputs[pos])->str(),
-              ". Declaration: ",
-              schema);
-        }
-      } else if (argument.default_value()) {
-        inputs.push_back(*argument.default_value());
-      } else {
-        AT_ERROR(
-            schema.name(),
-            "() is missing value for argument '",
-            argument.name(),
-            "'. Declaration: ",
-            schema);
-      }
-    }
+  Function& function() const {
+    return *function_;
   }
 
+ private:
   // Methods are uniqued onwed by a single module. This raw pointer allows
   // looking up the module.
   Module* owner_;
 
-  std::string name_;
-  std::shared_ptr<Graph> graph_; // for debugging and for inlining
-  bool optimize;
+  // Underlying unbound function
+  Function* function_;
 
-  GraphExecutor executor; // for execution
-  // initial_ivalues are a list of additional arguments appended to graph
-  // that are inputs that come from the members of the Module or its submodules.
-  // each is a pointer to a slot in the module that owns this parameter
-  // parameters and submodules can only be _added_ to script Modules to ensure
-  // these pointers always stay valid
+  // parameters and attributes loaded from the Module and appending
+  // before calling function_
   std::vector<Slot> initial_ivalues_;
-
-  // map from a IValue* in initial_ivalues to the offset it appears at
-  // in graph. used to accelerate get_or_add_parameter
-  std::unordered_map<Slot, size_t> initial_ivalue_index;
-
-  // TODO: support that case where we allow _writes_ to parameters from
-  // compiled functions.
-  // This requires more sophisticated tracking of ssa values in Graphs so that
-  // stores to all modules can be lifted to the end of a graph execution.
-  // It also adds more complexity to adding actual module invocations
-  // to the executor, so currently it is not done.
-  // std::vector<at::Tensor*> member_outputs;
-
-  std::once_flag executor_init;
-
-  // an optional function that actually creates the method when
-  // emit_call_to(this,...) is first called. this is used by the compiler so
-  // that it can construct methods out of order
-  std::function<void(Method&)> method_creator;
-
-  // if absent, then we generate a default schema based on the graph
-  // mutable because getSchema caches the default schema if one is requested
-  // before a call to setSchema
-  mutable std::unique_ptr<FunctionSchema> schema;
 };
 
 struct Module;
 
-struct Module {
+struct TORCH_API Module {
   TH_DISALLOW_COPY_AND_ASSIGN(Module);
   Module()
       : name_("__main__"),
         module_value_(c10::ivalue::Object::create(
-            ClassType::createModuleType(),
-            0)),
-        optimize_(true) {}
+            ClassType::createModuleType(std::make_shared<CompilationUnit>()),
+            0)) {}
 
+  ~Module() {
+    // ClassType own the compilation unit of their Functions, but each
+    // Function has a self argument which owns the ClassType, created a
+    // referernce cycle. By dropping all the methods of the module's class
+    // here we break the cycle.
+    class_cu().drop_all_functions();
+  }
   const std::string& name() const {
     return name_;
   }
@@ -374,11 +166,11 @@ struct Module {
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
   void set_optimized(bool o) {
-    optimize_ = o;
+    class_cu().set_optimized(o);
   }
 
   bool is_optimized() const {
-    return optimize_;
+    return class_cu().is_optimized();
   }
 
   IValue forward(std::vector<IValue> inputs) {
@@ -395,7 +187,7 @@ struct Module {
         name,
         attributes_,
         EntityType::ATTRIBUTE,
-        appendSlot(name, TensorType::get(),std::move(v)));
+        appendSlot(name, TensorType::get(), std::move(v)));
   }
 
   void register_parameter(
@@ -420,7 +212,11 @@ struct Module {
       const std::string& name,
       const TypePtr type,
       IValue ivalue) {
-    insert(name, attributes_, EntityType::ATTRIBUTE, appendSlot(name, type, ivalue));
+    insert(
+        name,
+        attributes_,
+        EntityType::ATTRIBUTE,
+        appendSlot(name, type, ivalue));
   }
   void register_module(
       const std::string& name,
@@ -434,42 +230,15 @@ struct Module {
     //   AT_WARN(
     //       "Attempting to assign submodule '",
     //       name,
-    //       "' but it is already a submodule of another ScriptModule '", module->parent_->name(), "'",
-    //       " Modules of this form do not import and export correctly. This use is deprecated and may be"
-    //       " removed in a future version.");
+    //       "' but it is already a submodule of another ScriptModule '",
+    //       module->parent_->name(), "'", " Modules of this form do not import
+    //       and export correctly. This use is deprecated and may be" " removed
+    //       in a future version.");
     // }
     module->parent_ = this;
     module->name_ = name;
     appendSlot(name, module->module_value_->type(), module->module_value_);
     insert(name, modules_, EntityType::MODULE, std::move(module));
-  }
-
-  Method& create_method(
-      const std::string& name,
-      std::shared_ptr<Graph> graph,
-      std::vector<Slot> member_inputs) {
-    AT_ASSERT(graph);
-    std::unique_ptr<Method> method(new Method(
-        this,
-        name,
-        optimize_,
-        std::move(graph),
-        std::move(member_inputs),
-        nullptr));
-    return *insert(name, methods_, EntityType::METHOD, std::move(method));
-  }
-
-  Method& create_method(
-      const std::string& name,
-      std::function<void(Method&)> creator) {
-    std::unique_ptr<Method> method(new Method(
-        this,
-        name,
-        optimize_,
-        std::make_shared<Graph>(),
-        {},
-        std::move(creator)));
-    return *insert(name, methods_, EntityType::METHOD, std::move(method));
   }
 
   Slot parameter_slot(const std::string& name) const {
@@ -495,7 +264,14 @@ struct Module {
   // each module owns its method. The reference returned here
   // is guarenteed to stay valid until this module has been destroyed
   Method& get_method(const std::string& name) const {
-    return *methods_[get_offset(name, EntityType::METHOD)];
+    if (Method* method = find_method(name)) {
+      return *method;
+    }
+    // temporary: force the error message
+    // once the on-demand creation of Method is removed, this code
+    // can be removed as well
+    get_offset(name, EntityType::METHOD);
+    AT_ERROR("unreachable");
   }
 
   std::shared_ptr<Module> get_module(const std::string& name) const {
@@ -511,7 +287,12 @@ struct Module {
   c10::ArrayRef<Slot> get_attributes() const {
     return attributes_;
   }
-  c10::ArrayRef<std::unique_ptr<Method>> get_methods() const {
+  const std::vector<std::unique_ptr<Method>>& get_methods() const {
+    // force methods_ to be up to date by querying all
+    // methods. This will go away when lowered_methods_ is deleted
+    for (const auto& m : class_cu().get_functions()) {
+      get_method(m->name());
+    }
     return methods_;
   }
 
@@ -534,9 +315,17 @@ struct Module {
     auto offset = find_offset(name, EntityType::MODULE);
     return offset ? modules_[*offset] : nullptr;
   }
-  Method* find_method(const std::string& name) {
+  Method* find_method(const std::string& name) const {
     auto offset = find_offset(name, EntityType::METHOD);
-    return offset ? methods_[*offset].get() : nullptr;
+    if (offset) {
+      return methods_[*offset].get();
+    }
+
+    if (Function* fn = class_cu().find_function(name).get()) {
+      return &const_cast<Module*>(this)->lower_first_class_method(fn);
+    }
+
+    return nullptr;
   }
   void apply(std::function<void(Module&)> fn) {
     for (auto& submod : get_modules()) {
@@ -571,10 +360,7 @@ struct Module {
   /// destination is on the GPU or vice versa, the copy is performed
   /// asynchronously with respect to the host. Otherwise, the argument has no
   /// effect.
-  TORCH_API void to(
-      at::Device device,
-      at::ScalarType dtype,
-      bool non_blocking = false);
+  void to(at::Device device, at::ScalarType dtype, bool non_blocking = false);
 
   /// Recursively casts all parameters to the given dtype.
   ///
@@ -582,7 +368,7 @@ struct Module {
   /// destination is on the GPU or vice versa, the copy is performed
   /// asynchronously with respect to the host. Otherwise, the argument has no
   /// effect.
-  TORCH_API void to(at::ScalarType dtype, bool non_blocking = false);
+  void to(at::ScalarType dtype, bool non_blocking = false);
 
   /// Recursively moves all parameters to the given device.
   ///
@@ -590,7 +376,7 @@ struct Module {
   /// destination is on the GPU or vice versa, the copy is performed
   /// asynchronously with respect to the host. Otherwise, the argument has no
   /// effect.
-  TORCH_API void to(at::Device device, bool non_blocking = false);
+  void to(at::Device device, bool non_blocking = false);
 
   /// Run a method from this module.
   ///
@@ -646,26 +432,57 @@ struct Module {
       mod->copy_into(module_lookup, parameter_remap, names);
       names.pop_back();
     }
-    for (auto& method : get_methods()) {
-      std::vector<Slot> initial_ivalues;
-      for (auto& p : method->initial_ivalues()) {
-        initial_ivalues.push_back(parameter_remap.at(p));
-      }
-      curr->create_method(
-          method->name(), method->graph()->copy(), initial_ivalues);
+
+    for (auto& fn : class_cu().get_functions()) {
+      curr->class_cu().clone_function(*fn);
     }
   }
 
   enum class EntityType { MODULE, PARAMETER, ATTRIBUTE, METHOD };
 
   at::optional<EntityType> kind_of(const std::string& name) const {
+    // force lazy creation of Method if needed
+    // remove once lowered_methods_ is removed.
+    find_method(name);
+
     auto it = dict_.find(name);
     if (it == dict_.end())
       return at::nullopt;
     return it->second.type;
   }
 
+  ModulePtr module_object() const {
+    return module_value_;
+  }
+  CompilationUnit& class_compilation_unit() {
+    return module_object()->type()->compilation_unit();
+  }
+  CompilationUnit& lowered_methods() const {
+    return lowered_methods_;
+  }
+
+  // so that C++ users can easily add methods
+  void define(const std::string& src, const Resolver& resolver = nullptr);
+
+  void _define_lowered(
+      const std::vector<Def>& definitions,
+      const std::vector<Resolver>& resolvers);
+  void _define_lowered(const std::string& src, const Resolver& resolver);
+
+  Method& _define_lowered(
+      std::string name,
+      std::shared_ptr<Graph> graph,
+      std::vector<Slot> slots);
+
  private:
+  Method& _create_lowered_method(
+      Function* func,
+      std::vector<Slot> member_inputs);
+
+  Method& lower_first_class_method(Function* fn);
+  void lift_lowered_method(Method& fn);
+  void lift_lowered_methods(size_t start);
+
   void to_impl(
       const c10::optional<at::Device>& device,
       const c10::optional<at::ScalarType>& dtype,
@@ -753,6 +570,13 @@ struct Module {
     return Slot(module_value_, slot_index);
   }
 
+  CompilationUnit& class_cu() {
+    return module_value_->type()->compilation_unit();
+  }
+  const CompilationUnit& class_cu() const {
+    return module_value_->type()->compilation_unit();
+  }
+
   // modules have a single namespace, but spread over 4 different concepts:
   // parameters, attributes, methods, and sub-modules
   // we store individual lists of each concept, and a single map to
@@ -770,29 +594,96 @@ struct Module {
   std::unordered_map<std::string, Entry> dict_;
   std::string name_;
 
-
-  c10::intrusive_ptr<at::ivalue::Object> module_value_;
-
+  ModulePtr module_value_;
 
   // back reference to parent of this Module if present
   Module* parent_ = nullptr;
-  bool optimize_;
+
+  // Currently we are in a transitionary state
+  // where we construct such first class functions but we lower them
+  // to a form where the modules does not exist before execution.
+
+  // So each Method is actually stored twice once in first-class Module
+  // form and once in lowered form.
+
+  // first-class: module_value_->type().compilation_unit() holds Functions that
+  // treat modules as first class.
+
+  // lowered: In this lowered form, all the attributes/parameters are appended
+  // as additional inputs. lowered_methods_ holds this lowered form
+  // mutable because it is a cache for class_cu() methods
+  mutable CompilationUnit lowered_methods_;
 };
 
-// returns nullptr and fills in failure_messages if the callee does not
-// match the functions schema
-Value* try_emit_call_to(
+static void setInputTensorTypes(Graph& g, const Stack& stack) {
+  AT_ASSERT(stack.size() == g.inputs().size());
+  for (size_t i = 0; i < stack.size(); ++i) {
+    g.inputs().at(i)->setType(
+        DimensionedTensorType::create(stack.at(i).toTensor()));
+  }
+}
+
+inline std::shared_ptr<Graph> propagate_shapes(
     Graph& graph,
-    const SourceRange& loc,
-    Method& callee,
-    c10::optional<NamedValue> self,
-    ArrayRef<NamedValue> args,
-    ArrayRef<NamedValue> kwargs,
-    std::stringstream& failure_messages,
-    // when callee uses no parameters (e.g. it is a function in a compilation
-    // unit, and not a method), then nullptr can be passed as caller.
-    Method* caller,
-    bool conv_tensors_to_nums);
+    const std::vector<at::Tensor>& inputs,
+    const std::vector<Slot>& initial_ivalues,
+    bool with_grad = false) {
+  auto retval = graph.copy();
+  Stack stack;
+  stack.reserve(inputs.size() + initial_ivalues.size());
+  for (const at::Tensor& i : inputs) {
+    stack.emplace_back(std::move(i));
+  }
+  for (const Slot& inp : initial_ivalues) {
+    stack.push_back(inp.value());
+  }
+  setInputTensorTypes(*retval, stack);
+  PropagateInputShapes(retval);
+  return retval;
+}
+
+inline std::shared_ptr<Graph> propagate_and_assign_input_and_output_shapes(
+    Graph& graph,
+    std::vector<at::Tensor> inputs,
+    const std::vector<Slot>& initial_ivalues,
+    std::vector<at::Tensor> outputs,
+    bool with_grad = false,
+    bool propagate = true) {
+  auto retval = graph.copy();
+  for (auto inp : initial_ivalues) {
+    if (inp.value().isTensor()) {
+      inputs.push_back(inp.value().toTensor());
+    }
+  }
+  if (propagate) {
+    setInputTensorTypes(*retval, fmap<IValue>(inputs));
+    PropagateInputShapes(retval);
+  }
+  AT_ASSERT(retval->inputs().size() == inputs.size());
+  for (size_t i = 0; i < retval->inputs().size(); ++i) {
+    auto scalar_type = inputs[i].scalar_type();
+    auto sizes = inputs[i].sizes();
+    auto type =
+        torch::jit::CompleteTensorType::create(scalar_type, at::kCPU, sizes);
+    retval->inputs()[i]->setType(type);
+  }
+  at::ArrayRef<Value*> output_values = retval->outputs();
+  // patch this to still work if we are returning a tuple of multiple values
+  if (output_values.at(0)->type()->kind() == TupleType::Kind) {
+    AT_ASSERT(output_values.at(0)->node()->kind() == prim::TupleConstruct);
+    output_values = output_values.at(0)->node()->inputs();
+  }
+  AT_ASSERT(output_values.size() == outputs.size());
+  for (size_t i = 0; i < retval->outputs().size(); ++i) {
+    auto scalar_type = outputs[i].scalar_type();
+    auto sizes = outputs[i].sizes();
+    auto type =
+        torch::jit::CompleteTensorType::create(scalar_type, at::kCPU, sizes);
+    output_values[i]->setType(type);
+  }
+  return retval;
+}
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -421,16 +421,14 @@ Value* emitBuiltinCall(
         return emitBuiltinNode(*matched_schema, loc, graph, name);
       }
     }
-    for (Method* method : builtin_functions) {
-      if (auto result = try_emit_call_to(
+    for (Function* method : builtin_functions) {
+      if (auto result = method->try_emit_call(
               graph,
               loc,
-              *method,
               self,
               inputs,
               attributes,
               failure_messages,
-              nullptr,
               allow_conversions)) {
         return result;
       }

--- a/torch/csrc/jit/script/slot.h
+++ b/torch/csrc/jit/script/slot.h
@@ -33,6 +33,7 @@ private:
   c10::intrusive_ptr<c10::ivalue::Object> container_;
   size_t offset_;
   friend struct std::hash<Slot>;
+  friend struct Module;
 };
 
 }}}

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -28,14 +28,14 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
 
   // what can we do with this thing?
   // use it as a value e.g.  `this + 4`
-  virtual Value* asValue(const SourceRange& loc, Method& m) {
+  virtual Value* asValue(const SourceRange& loc, Function& m) {
     throw ErrorReport(loc) << kind() << " cannot be used as a value";
   }
 
   // select an attribute on it, e.g. `this.field`
   virtual std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) {
     throw ErrorReport(loc) << "attribute lookup is not defined on " << kind();
   }
@@ -43,7 +43,7 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
   // assign an attribute on it, e.g. `this.field = newValue`
   virtual void setAttr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field,
       Value* newValue) {
     throw ErrorReport(loc) << "attribute assignment is not defined on "
@@ -57,7 +57,7 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
   // a method invocation
   virtual std::vector<std::shared_ptr<SugaredValue>> asTuple(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const c10::optional<size_t>& size_hint = {}) {
     throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   }
@@ -65,7 +65,7 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
   // call it like a function, e.g. `outputs = this(inputs)`
   virtual std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       // note: names for args will be 'argument 0', 'argument 1', etc..
       at::ArrayRef<NamedValue> inputs_,
       at::ArrayRef<NamedValue> attributes,
@@ -97,7 +97,7 @@ struct TORCH_API SimpleValue : public SugaredValue {
   std::string kind() const override {
     return "value";
   }
-  Value* asValue(const SourceRange& range, Method& m) override {
+  Value* asValue(const SourceRange& range, Function& m) override {
     return value_;
   }
   NoneStatus isNone() override {
@@ -110,16 +110,16 @@ struct TORCH_API SimpleValue : public SugaredValue {
   }
   std::vector<std::shared_ptr<SugaredValue>> asTuple(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const c10::optional<size_t>& size_hint = {}) override;
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) override;
 
   void setAttr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field,
       Value* newValue) override;
 
@@ -146,7 +146,7 @@ struct TORCH_API BuiltinFunction : public SugaredValue {
   }
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       at::ArrayRef<NamedValue> attributes,
       at::ArrayRef<NamedValue> inputs,
       size_t n_binders) override;
@@ -161,7 +161,7 @@ struct TORCH_API BuiltinModule : public SugaredValue {
   }
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) override {
     return std::make_shared<BuiltinFunction>(
         Symbol::fromQualString(name + "::" + field), c10::nullopt);
@@ -183,14 +183,14 @@ struct TORCH_API ClassValue : public SugaredValue {
   //    n = Foo(constructor_arg)
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override;
 
   std::shared_ptr<SugaredValue> attr(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& field) override;
 
   std::string kind() const override {
@@ -202,34 +202,33 @@ struct TORCH_API ClassValue : public SugaredValue {
 
 // defines how a method obtained from a module behaves in script
 struct MethodValue : public SugaredValue {
-  MethodValue(std::shared_ptr<SugaredValue> self, Method& method)
+  MethodValue(c10::optional<NamedValue> self, Function& method)
       : self_(std::move(self)), method(method) {}
   std::string kind() const override {
     return "method";
   }
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& caller,
+      Function& f,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
-    if (auto classType = dynamic_cast<SimpleValue*>(self_.get())) {
-      // If self_ is a class, then it will be expected as part of
-      // the schema. Add it to the front of the inputs.
+    Graph& graph = *f.graph();
+    if (self_) {
       std::vector<NamedValue> inputsWithSelf;
-      inputsWithSelf.emplace_back(loc, classType->getValue());
+      inputsWithSelf.emplace_back(loc, self_->value(graph));
       inputsWithSelf.insert(inputsWithSelf.end(), inputs.begin(), inputs.end());
       return std::make_shared<SimpleValue>(
-          caller.emit_call_to(loc, method, inputsWithSelf, attributes));
+          method.emit_call(graph, loc, inputsWithSelf, attributes));
     }
 
     return std::make_shared<SimpleValue>(
-        caller.emit_call_to(loc, method, inputs, attributes));
+        method.emit_call(graph, loc, inputs, attributes));
   }
 
  private:
-  std::shared_ptr<SugaredValue> self_;
-  Method& method;
+  c10::optional<NamedValue> self_;
+  Function& method;
 };
 
 struct TORCH_API PrintValue : public SugaredValue {
@@ -238,7 +237,7 @@ struct TORCH_API PrintValue : public SugaredValue {
   }
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override;
@@ -252,7 +251,7 @@ struct TORCH_API CastValue : public BuiltinFunction {
       : BuiltinFunction(method, c10::nullopt), type_(std::move(type)) {}
   std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
       size_t n_binders) override {
@@ -316,7 +315,7 @@ struct TORCH_API ClassNewMethod : public SugaredValue {
 
   std::shared_ptr<SugaredValue> createObject(
       const SourceRange& loc,
-      Method& m,
+      Function& m,
       const std::string& classname) {
     if (classname != type_->name()) {
       throw ErrorReport(loc)
@@ -336,6 +335,13 @@ static inline std::vector<Value*> toValues(
     Graph& g,
     at::ArrayRef<NamedValue> nvs) {
   return fmap(nvs, [&](const NamedValue& v) { return v.value(g); });
+}
+
+static inline Self simpleSelf(const TypePtr& typ) {
+  return [typ](Value* v) {
+    v->setType(typ);
+    return std::make_shared<SimpleValue>(v);
+  };
 }
 
 } // namespace script

--- a/torch/csrc/jit/symbolic_script.cpp
+++ b/torch/csrc/jit/symbolic_script.cpp
@@ -1219,8 +1219,8 @@ bool isHelperFunction(const std::string& method_name) {
   return method_name.compare(0, helper_prefix.length(), helper_prefix) == 0;
 }
 
-void loadModule(const std::shared_ptr<script::Module>& module) {
-  for (const auto& method : module->get_methods()) {
+void loadModule(const script::CompilationUnit& module) {
+  for (const auto& method : module.get_functions()) {
     if (isHelperFunction(method->name()))
       continue;
 
@@ -1272,9 +1272,8 @@ void loadModule(const std::shared_ptr<script::Module>& module) {
 
 void loadFunctions() {
   for (const std::string& str : functions) {
-    auto cu = std::make_shared<script::Module>();
-    script::defineMethodsInModule(
-        cu, str, script::nativeResolver, c10::nullopt);
+    script::CompilationUnit cu;
+    cu.define(str, script::nativeResolver, nullptr);
     loadModule(cu);
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19112 [TESTING ONLY] Compiler uses first-class modules**

This PR propagates where we use first-class modules objects into the compiler. This creates a transitionary state where:

* compiler.cpp creates Graphs where `self` is a Module class and attributes/parameters/buffers/submodules are looked up with `prim::GetAttr`
* GraphExecutor still runs "lowered graphs" where the self object has been removed by a compiler pass `lower_first_class_method`.
* Tracing still creates "lowered graphs", and a pass "lift_lowered_method" creates a first-class method graph for things.

* This PR separates out Method and Function. A script::Function is a pure Graph with no `self` bound.  Similar to Python, a script::Method is just a bound `self` and its underlying `script::Function`.
* This PR also separates CompilationUnit from Module. A CompilationUnit is just a list of named script::Functions.  Class's have a CompilationUnit holding the class methods, and Modules also have a CompilationUnit holding their Methods. This avoids the weird circular case Module --has a-> Class -> has a -> Module ...

Details:
* In this transitionary state, we maintain two copies of a Graph, first-class module and lowered. Th first-class one has a self argument that is the module's class type. The lowered one is the lowered graph that uses the initial_ivalues inputs.
* When defining lowered methods using `_defined_lowered` we immediately create the first-class equivalent. The reverse is done lazily, creating lowered_methods on demand from the class.
* The two way conversions will be deleted in a future PR when the executor itself runs first-class objects. However this requires more changes to (1) the traces, (2) the python bindings, and (3) the onnx export pass and would make this PR way to large.

Unfinished PR.

* GraphExecutor still runs lowered graphs
* Temporary shims to translate between first-class and lowered modules

Differential Revision: [D14871428](https://our.internmc.facebook.com/intern/diff/D14871428)