### PR TITLE
Avoid Output Uninitialized Blobs in Load with load_all=1

### DIFF
--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -105,17 +105,20 @@ class LoadOp final : public Operator<Context> {
         db_name_ = "";
       }
     }
-    CAFFE_ENFORCE(blob_names_.empty() || blob_names_.size() == OutputSize(),
-      "Number of output blobs and source_blob_names mismatch.");
-    CAFFE_ENFORCE(blob_names_.empty() || strip_prefix_.empty(),
+    CAFFE_ENFORCE(
+        blob_names_.empty() || blob_names_.size() == OutputSize(),
+        "Number of output blobs and source_blob_names mismatch.");
+    CAFFE_ENFORCE(
+        blob_names_.empty() || strip_prefix_.empty(),
         "strip_prefix and source_blob_names are mutually exclusive.");
-    CAFFE_ENFORCE(blob_names_.empty() || !load_all_,
+    CAFFE_ENFORCE(
+        blob_names_.empty() || !load_all_,
         "cannot load_all_ while using source_blob_names.");
     if (!load_all_) {
       // blob_names_ will be filled with ''source blob names'' in file/db
       // if argument source_blob_names is not given, then blob_names_ is
       // inferred from operator output
-      if(blob_names_.empty()) {
+      if (blob_names_.empty()) {
         for (const string& name : operator_def.output()) {
           blob_names_.push_back(name);
         }
@@ -123,8 +126,10 @@ class LoadOp final : public Operator<Context> {
       int idx = 0;
       std::set<std::string> name_set;
       for (const string& name : blob_names_) {
-        CAFFE_ENFORCE(name_set.insert(name).second,
-            "Duplicated source blob name: ", name);
+        CAFFE_ENFORCE(
+            name_set.insert(name).second,
+            "Duplicated source blob name: ",
+            name);
         output_indices_[name] = idx++;
       }
     }
@@ -161,8 +166,19 @@ class LoadOp final : public Operator<Context> {
 
     validateBlobStates(blob_states);
     // Loaded all the needed blobs.
-    if (load_all_ || total_loaded_blobs == OutputSize()) {
+    if (!load_all_ && total_loaded_blobs == OutputSize()) {
       VLOG(1) << "Loaded " << total_loaded_blobs << " blobs fully from db(s)";
+      return true;
+    }
+
+    if (load_all_) {
+      for (const string& name : this->debug_def().output()) {
+        CAFFE_ENFORCE(
+            blob_states.count(name),
+            "Output blob name ",
+            name,
+            " does not exist in the db(s).");
+      }
       return true;
     }
 

--- a/caffe2/python/operator_test/load_save_test.py
+++ b/caffe2/python/operator_test/load_save_test.py
@@ -116,6 +116,10 @@ class TestLoadSaveBase(test_util.TestCase):
             _LoadTest(0, dst_device_type, dst_gpu_id, [], 1)
             workspace.ResetWorkspace()
             _LoadTest(0, dst_device_type, dst_gpu_id, [], 1)
+            workspace.ResetWorkspace()
+            _LoadTest(1, src_device_type, src_gpu_id, blobs, 1)
+            workspace.ResetWorkspace()
+            _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 1)
         finally:
             # clean up temp folder.
             try:
@@ -186,6 +190,26 @@ class TestLoadSave(TestLoadSaveBase):
             db=tmp_file, db_type=self._db_type,
             load_all=False)
         with self.assertRaises(RuntimeError):
+            workspace.RunOperatorOnce(op)
+
+        op = core.CreateOperator(
+            "Load",
+            [], [str(len(arrays) + i) for i in [-1, 0]],
+            absolute_path=1,
+            db=tmp_file, db_type=self._db_type,
+            load_all=True)
+        with self.assertRaises(RuntimeError):
+            workspace.ResetWorkspace()
+            workspace.RunOperatorOnce(op)
+
+        op = core.CreateOperator(
+            "Load",
+            [], [str(len(arrays) + i) for i in range(2)],
+            absolute_path=1,
+            db=tmp_file, db_type=self._db_type,
+            load_all=True)
+        with self.assertRaises(RuntimeError):
+            workspace.ResetWorkspace()
             workspace.RunOperatorOnce(op)
 
         try:


### PR DESCRIPTION
Summary:
When output blob names are specified while load_all=1, output blob names are ignored. However, this behavior is not documented. In this diff, we just disallow users to provide blob names when load_all=1.

See discussion at https://fb.workplace.com/groups/1405155842844877/permalink/2714909788536136/

Differential Revision: D14883698
