### PR TITLE
Change is_variable() to check existence of AutogradMeta, and remove is_variable_

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -20,7 +20,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
   // public constructor for now...
   OpaqueTensorImpl(at::TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::Device device,
                    OpaqueHandle opaque_handle, c10::IntArrayRef sizes)
-  :   TensorImpl(type_id, data_type, device, false),
+  :   TensorImpl(type_id, data_type, device),
       opaque_handle_(std::move(opaque_handle))
   {
     sizes_ = sizes.vec();

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -36,7 +36,7 @@ SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, const caffe2::TypeM
       , at::empty({0}, at::initialTensorOptions().device(sparseTensorIdToDeviceType(type_id)).dtype(data_type))) {}
 
 SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, const caffe2::TypeMeta& data_type, at::Tensor indices, at::Tensor values)
-    : TensorImpl(type_id, data_type, values.device(), false)
+    : TensorImpl(type_id, data_type, values.device())
     , sparse_dim_(1)
     , dense_dim_(0)
     , indices_(std::move(indices))

--- a/aten/src/ATen/core/op_registration/test_helpers.h
+++ b/aten/src/ATen/core/op_registration/test_helpers.h
@@ -23,7 +23,7 @@ inline at::Tensor dummyTensor(c10::TensorTypeId dispatch_key) {
     allocator->allocate(nelements * dtype.itemsize()),
     allocator,
     /*resizable=*/true);
-  return at::detail::make_tensor<c10::TensorImpl>(storage_impl, dispatch_key, false);
+  return at::detail::make_tensor<c10::TensorImpl>(storage_impl, dispatch_key);
 }
 
 template<class... Args>

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -319,16 +319,16 @@ CHECKED_USE_NULLABLE = CodeTemplate('${arg_name}_ ? ${usage} : NULL')
 ALLOC_NOARGS_WRAP = {
     'THTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
                  '(c10::Storage(caffe2::TypeMeta::Make<${ScalarType}>(), 0, allocator(), true),'
-                 '${Backend}TensorId(), false).release()',
+                 '${Backend}TensorId()).release()',
     'THByteTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
                      '(c10::Storage(scalarTypeToTypeMeta(ScalarType::Byte), 0, allocator(), true),'
-                     '${Backend}TensorId(), false).release()',
+                     '${Backend}TensorId()).release()',
     'THIndexTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
                      '(c10::Storage(scalarTypeToTypeMeta(ScalarType::Long), 0, allocator(), true),'
-                     '${Backend}TensorId(), false).release()',
+                     '${Backend}TensorId()).release()',
     'THIntegerTensor*': 'c10::make_intrusive<TensorImpl, UndefinedTensorImpl>'
                         '(c10::Storage(scalarTypeToTypeMeta(ScalarType::Int), 0, allocator(), true),'
-                        '${Backend}TensorId(), false).release()',
+                        '${Backend}TensorId()).release()',
 }
 
 ALLOC_WRAP = {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -103,7 +103,7 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options) {
     allocator,
     /*resizeable=*/true);
 
-  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, at::CPUTensorId(), false);
+  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, at::CPUTensorId());
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -304,7 +304,7 @@ Tensor as_strided(const Tensor& self, IntArrayRef size, IntArrayRef stride, opti
   AT_CHECK(
       tid == CPUTensorId() || tid == CUDATensorId(),
       "as_strided is only implemented for strided CPU and CUDA tensors.");
-  auto result = detail::make_tensor<TensorImpl>(Storage(self.storage()), tid, false);
+  auto result = detail::make_tensor<TensorImpl>(Storage(self.storage()), tid);
   setStrided(result, size, stride, storage_offset);
   return result;
 }

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -58,7 +58,7 @@ Tensor empty_cuda(IntArrayRef size, const TensorOptions& options) {
     allocator,
     /*resizeable=*/true);
 
-  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, CUDATensorId(), false);
+  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, CUDATensorId());
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);

--- a/aten/src/ATen/quantized/QTensorImpl.cpp
+++ b/aten/src/ATen/quantized/QTensorImpl.cpp
@@ -5,9 +5,8 @@ namespace at {
 QTensorImpl::QTensorImpl(
     Storage&& storage,
     TensorTypeId type_id,
-    bool is_variable,
     QuantizerPtr quantizer)
-    : TensorImpl(std::move(storage), type_id, is_variable),
+    : TensorImpl(std::move(storage), type_id),
       quantizer_(quantizer) {}
 
 } // namespace at

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -11,7 +11,6 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
   QTensorImpl(
       Storage&& storage,
       TensorTypeId type_id,
-      bool is_variable,
       QuantizerPtr quantizer);
 
   // TODO: Expose in PyTorch Frontend
@@ -21,7 +20,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
 
   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach() const override {
     auto impl = c10::make_intrusive<QTensorImpl>(
-        Storage(storage()), type_id(), is_variable(), quantizer_);
+        Storage(storage()), type_id(), quantizer_);
     impl->set_sizes_and_strides(sizes(), strides());
     impl->storage_offset_ = storage_offset_;
     impl->is_wrapped_number_ = is_wrapped_number_;

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -28,7 +28,6 @@ QTensorImpl* get_qtensorimpl(const QTensor& self) {
 inline QTensor new_qtensor(
     IntArrayRef sizes,
     const TensorOptions& options,
-    bool is_variable,
     QuantizerPtr quantizer) {
   AT_ASSERT(options.device().is_cpu());
 
@@ -44,7 +43,7 @@ inline QTensor new_qtensor(
       allocator,
       /*resizable=*/true);
   auto tensor = detail::make_tensor<QTensorImpl>(
-      storage_impl, at::CPUTensorId(), is_variable, quantizer);
+      storage_impl, at::CPUTensorId(), quantizer);
   get_qtensorimpl(tensor)->set_sizes_contiguous(sizes);
   return tensor;
 }
@@ -76,7 +75,6 @@ QTensor PerTensorAffineQuantizer::quantize(RealTensor tensor) {
   QTensor qv = new_qtensor(
       sizes,
       tensor.options().dtype(at::kQInt8),
-      tensor.is_variable(),
       intrusive_from_this());
   auto qvd = qv.data<qint8>();
   tensor.contiguous();

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -13,8 +13,7 @@ Tensor empty_override(IntArrayRef size, const TensorOptions & options) {
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       Storage(
           caffe2::TypeMeta::Make<float>(), 0, at::DataPtr(nullptr, Device(DeviceType::MSNPU, 1)), nullptr, false),
-      MSNPUTensorId(),
-      false);
+      MSNPUTensorId());
   return Tensor(std::move(tensor_impl));
 }
 

--- a/aten/src/ATen/test/xla_tensor_test.cpp
+++ b/aten/src/ATen/test/xla_tensor_test.cpp
@@ -27,8 +27,7 @@ TEST(XlaTensorTest, TestNoStorage) {
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       XLATensorId(),
       caffe2::TypeMeta::Make<float>(),
-      at::Device(DeviceType::XLA, 0),
-      /*is_variable=*/false);
+      at::Device(DeviceType::XLA, 0));
   at::Tensor t(std::move(tensor_impl));
   ASSERT_TRUE(t.device() == at::Device(DeviceType::XLA, 0));
 }

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -56,8 +56,7 @@ THTensor *THTensor_(new)(void)
 {
   return c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     c10::intrusive_ptr<at::StorageImpl>::reclaim(THStorage_(new)()),
-    at::CPUTensorId(),
-    false
+    at::CPUTensorId()
   ).release();
 }
 
@@ -66,8 +65,7 @@ THTensor *THTensor_(newWithTensor)(THTensor *tensor)
 {
   THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     c10::intrusive_ptr<at::StorageImpl>::reclaim(THStorage_(new)()),
-    at::CPUTensorId(),
-    false
+    at::CPUTensorId()
   ).release();
   THTensor_(setStorageNd)(self,
                           THTensor_getStoragePtr(tensor),
@@ -85,8 +83,7 @@ THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
   }
   THTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     c10::intrusive_ptr<at::StorageImpl>::reclaim(THStorage_(new)()),
-    at::CPUTensorId(),
-    false
+    at::CPUTensorId()
   ).release();
   THTensor_(setStorageNd)(self, storage, storageOffset, sizes.size(),
                           const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -65,8 +65,7 @@ THCTensor *THCTensor_(new)(THCState *state)
 {
   return c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     c10::intrusive_ptr<at::StorageImpl>::reclaim(THCStorage_(new)(state)),
-    at::CUDATensorId(),
-    false
+    at::CUDATensorId()
   ).release();
 }
 
@@ -75,8 +74,7 @@ THCTensor *THCTensor_(newWithTensor)(THCState *state, THCTensor *tensor)
 {
   THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     c10::intrusive_ptr<at::StorageImpl>::reclaim(THCStorage_(new)(state)),
-    at::CUDATensorId(),
-    false
+    at::CUDATensorId()
   ).release();
   THCTensor_(setStorageNd)(state,
                            self,
@@ -95,8 +93,7 @@ THCTensor *THCTensor_(newWithStorage)(THCState *state, THCStorage *storage, ptrd
   }
   THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     c10::intrusive_ptr<at::StorageImpl>::reclaim(THCStorage_(new)(state)),
-    at::CUDATensorId(),
-    false
+    at::CUDATensorId()
   ).release();
   THCTensor_(setStorageNd)(state, self, storage, storageOffset, sizes.size(),
                            const_cast<int64_t*>(sizes.data()), const_cast<int64_t*>(strides.data()));
@@ -220,8 +217,7 @@ THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, at::IntArrayR
   auto storage = tensor->storage();
   THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
     std::move(storage),
-    at::CUDATensorId(),
-    false
+    at::CUDATensorId()
   ).release();
 
   THCTensor_setStorage(state, self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, stride_value);

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -33,22 +33,21 @@ const at::Tensor& TensorImpl::grad() const {
   }
 }
 
-TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, bool is_variable)
-    : TensorImpl(std::move(storage), type_id, storage.dtype(), storage.device(), is_variable) {}
+TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id)
+    : TensorImpl(std::move(storage), type_id, storage.dtype(), storage.device()) {}
 
-TensorImpl::TensorImpl(TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt, bool is_variable)
-    : TensorImpl({}, type_id, data_type, std::move(device_opt), is_variable) {}
+TensorImpl::TensorImpl(TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt)
+    : TensorImpl({}, type_id, data_type, std::move(device_opt)) {}
 
 TensorImpl::TensorImpl(Storage&& storage, TensorTypeId type_id, const caffe2::TypeMeta& data_type,
-                       c10::optional<c10::Device> device_opt, bool is_variable)
+                       c10::optional<c10::Device> device_opt)
     : storage_(std::move(storage)),
       sizes_{0},
       storage_offset_(0),
       numel_(0),
       data_type_(data_type),
       device_opt_(device_opt),
-      type_id_(type_id),
-      is_variable_(is_variable) {
+      type_id_(type_id) {
   AT_ASSERT(type_id == UndefinedTensorId() || data_type.id() ==  caffe2::TypeIdentifier::uninitialized() ||
             device_opt_.has_value());
   // we would also like to check that non-cpu devices have an index, but some Caffe2 operators create

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -215,19 +215,19 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Construct a 1-dim 0-size tensor backed by the given storage.
    */
-  TensorImpl(Storage&& storage, TensorTypeId type_id, bool is_variable);
+  TensorImpl(Storage&& storage, TensorTypeId type_id);
 
   /**
    * Construct a 1-dim 0 size tensor that doesn't have a storage.
    */
-  TensorImpl(TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt, bool is_variable);
+  TensorImpl(TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device> device_opt);
 
  private:
   // This constructor is private, because the data_type is redundant with
   // storage.  Still, we pass it in separately because it's easier to write
   // the initializer list if we're not worried about storage being moved out
   // from under us.
-  TensorImpl(Storage&& storage, TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device>, bool is_variable);
+  TensorImpl(Storage&& storage, TensorTypeId type_id, const caffe2::TypeMeta& data_type, c10::optional<c10::Device>);
 
  public:
   TensorImpl(const TensorImpl&) = delete;
@@ -808,7 +808,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * True if a tensor is a variable.  See Note [Tensor versus Variable in C++]
    */
-  bool is_variable() const { return is_variable_; };
+  bool is_variable() const { return autograd_meta_ != nullptr; };
 
   /**
    * Set whether a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
@@ -852,7 +852,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // `allow_tensor_metadata_change_` to false would prevent those changes from happening and is
   // undesirable.
   virtual c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach() const {
-    auto impl = c10::make_intrusive<TensorImpl>(Storage(storage()), type_id(), is_variable());
+    auto impl = c10::make_intrusive<TensorImpl>(Storage(storage()), type_id());
     impl->set_sizes_and_strides(sizes(), strides());
     impl->storage_offset_ = storage_offset_;
     impl->is_wrapped_number_ = is_wrapped_number_;
@@ -1419,7 +1419,6 @@ protected:
   // should pack this into a bitfield.
   TensorTypeId type_id_;
   bool is_contiguous_ = true;
-  bool is_variable_ = false;
   bool is_wrapped_number_ = false;
 
   // Previously, if we change the tensor metadata (e.g. sizes / strides / storage / storage_offset)

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -5,7 +5,7 @@ namespace c10 {
 
 // should this use the globalContext?  Can it get a context passed in somehow?
 UndefinedTensorImpl::UndefinedTensorImpl()
-: TensorImpl(UndefinedTensorId(), caffe2::TypeMeta(), c10::nullopt, /* is variable */ false) {
+: TensorImpl(UndefinedTensorId(), caffe2::TypeMeta(), c10::nullopt) {
 }
 
 IntArrayRef UndefinedTensorImpl::sizes() const {

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -72,8 +72,7 @@ class CAFFE2_API Tensor final {
   explicit Tensor(at::Device device)
     : impl_(c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
         Storage::create_legacy(device, TypeMeta()),
-        c10::computeTensorTypeId(at::device(device).layout(at::kStrided)),
-        /*is_variable=*/ false
+        c10::computeTensorTypeId(at::device(device).layout(at::kStrided))
       )) {
   }
 

--- a/test/cpp_extensions/msnpu_extension.cpp
+++ b/test/cpp_extensions/msnpu_extension.cpp
@@ -10,8 +10,7 @@ Tensor get_dtype_tensor(caffe2::TypeMeta dtype) {
   auto tensor_impl = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(
       Storage(
           dtype, 0, at::DataPtr(nullptr, Device(DeviceType::MSNPU, 0)), nullptr, false),
-      MSNPUTensorId(),
-      false);
+      MSNPUTensorId());
   return Tensor(std::move(tensor_impl));
 }
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -22,7 +22,7 @@
 namespace torch {
 namespace autograd {
 Variable::Impl::Impl(at::Tensor data, std::unique_ptr<Variable::AutogradMeta> autograd_meta, bool requires_grad, Edge gradient_edge)
-    : TensorImpl(data.type_id(), data.dtype(), data.device(), /* is variable */ true),
+    : TensorImpl(data.type_id(), data.dtype(), data.device()),
       data_(std::move(data)) {
   autograd_meta->grad_fn_ = std::move(gradient_edge.function);
   autograd_meta->requires_grad_ = false;
@@ -170,7 +170,6 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   data_type_ = new_data.type().typeMeta();
   device_opt_ = new_data.device();
   type_id_ = new_data.dispatch_type().type_id();
-  is_variable_ = true;
 
   auto new_data_copy = at::Tensor(new_data.getIntrusivePtr()->shallow_copy_and_detach());
   data_ = std::move(new_data_copy);


### PR DESCRIPTION
Currently, a TensorImpl's `is_variable_` is true if and only if the TensorImpl has AutogradMeta. This PR unifies these two concepts by removing `is_variable_` and change `is_variable()` to check existence of AutogradMeta instead.

Removing `is_variable_` is part of the work in Variable/Tensor merge. After the merge, all `at::Tensor`s are variables, and `Tensor.is_variable()` will always return true.