### PR TITLE
Allow empty net type

### DIFF
--- a/caffe2/core/net.cc
+++ b/caffe2/core/net.cc
@@ -157,7 +157,7 @@ unique_ptr<NetBase> CreateNet(
     const std::shared_ptr<const NetDef>& net_def,
     Workspace* ws) {
   std::string net_type;
-  if (net_def->has_type()) {
+  if (net_def->has_type() && !net_def->type().empty()) {
     net_type = net_def->type();
   } else {
     // By default, we will return a simple network that just runs all operators


### PR DESCRIPTION
Summary: I recently saw some weird workflow error due to empty but set net_type. Maybe we should just fallback to simple net in this case.

Differential Revision: D14890072
