### PR TITLE
[jit] Use custom operator bindings for register_prim_ops

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5128,7 +5128,11 @@ a")
         def test_floor():
             return math.floor(1.5)
 
+        def test_sinh():
+            return math.sinh(1.5)
+
         self.checkScript(test_floor, ())
+        self.checkScript(test_sinh, ())
 
     def test_if_nest_while(self):
         def func(a, b):

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -161,6 +161,10 @@ FunctionSchema inferAndCheckSchema(const std::string& schemaOrName) {
 /// number of arguments with a type from the subset accepted by the PyTorch
 /// JIT/Script backend, and return a single type or a tuple of types.
 ///
+/// If an op is registered to an internal namespace (`aten::`, `onnx::`, or
+/// `prim::`), then it is assumed that it mutates none of its inputs and has
+/// no side effects.
+///
 /// Example invocation:
 /// ```
 /// createOperator(
@@ -194,12 +198,6 @@ Operator createOperator(
   // it is fragile and hard to maintain. When we provide a way for op
   // registration to specify alias annotations, we should fix up builtins to
   // use that and remove all references to this note.
-  Symbol name = Symbol::fromQualString(schema.name());
-  if (name.is_aten() || name.is_prim() || name.is_onnx()) {
-    AT_ERROR(
-        "Tried to register a custom operator to a reserved namespace: ",
-        name.ns().toUnqualString());
-  }
 
   return Operator(schema, [implementation, schema](Stack& stack) {
     ArgumentTuple tuple;

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1999,6 +1999,9 @@ RegisterOperators reg2({
     Operator("aten::hash(float t) -> int", hashValue<double>),
 });
 
+static auto math_ops = torch::jit::RegisterOperators()
+  .op("aten::sinh", static_cast<double (*)(double)>(&std::sinh));
+
 // reference: _output_size in torch/nn/functional.py
 // size can be none, int or intlist
 // scale_factors can be none, float, or floatlist

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1496,13 +1496,13 @@ def _get_builtin_table():
     _builtin_table[id(torch.nn.functional._no_grad_embedding_renorm_)] = "aten::_no_grad_embedding_renorm_"
 
     _builtin_table[id(math.floor)] = "aten::floor"
+    _builtin_table[id(math.sinh)] = "aten::sinh"
     _builtin_table[id(torch.nn.functional.interpolate)] = "aten::__interpolate"
     _builtin_table[id(torch.nn.functional.upsample_nearest)] = "aten::__upsample_nearest"
     _builtin_table[id(torch.nn.functional.upsample)] = "aten::__upsample"
     _builtin_table[id(torch.nn.functional.upsample_bilinear)] = "aten::__upsample_bilinear"
     _builtin_table[id(torch.nn.functional.assert_int_or_pair)] = "aten::_assert_int_or_pair"
     _builtin_table[id(torch.nn.utils.rnn.get_packed_sequence)] = "aten::_pack_sequence"
-
     return _builtin_table
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19171 [jit] Use custom operator bindings for register_prim_ops**

Adds a bool flag so that `aten::`-namespaced ops can be created from functions
