### PR TITLE
[pt1][quant] Fix promoteTypes for QInt types

### DIFF
--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -246,6 +246,11 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
         "promoteTypes with complex numbers is not handled yet; figure out what the correct rules should be");
   }
 
+  // For QInt types, we only allow exact match
+  if (isQIntType(a) && a == b) {
+    return a;
+  }
+
   if (isQIntType(a) || isQIntType(b)) {
     AT_ERROR(
         "promoteTypes with quantized numbers is not handled yet; figure out what the correct rules should be");


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19182 [pt1][quant] Fix promoteTypes for QInt types**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14909172/)

This is a bug discovered by @zaf, right now if one of the tensor is QInt
type we'll return undefined, but actually we want to allow ops that accepts
Tensors of the same QInt type to work.

Differential Revision: [D14909172](https://our.internmc.facebook.com/intern/diff/D14909172/)