### PR TITLE
[HOTFIX] Pin nvidia-container-runtime version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ setup_ci_environment: &setup_ci_environment
       linux-image-generic \
       moreutils \
       docker-ce=5:18.09.4~3-0~ubuntu-xenial \
+      nvidia-container-runtime=2.0.0+docker18.09.4-1 \
       nvidia-docker2=2.0.3+docker18.09.4-1 \
       expect-dev
 

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -223,6 +223,7 @@ setup_ci_environment: &setup_ci_environment
       linux-image-generic \
       moreutils \
       docker-ce=5:18.09.4~3-0~ubuntu-xenial \
+      nvidia-container-runtime=2.0.0+docker18.09.4-1 \
       nvidia-docker2=2.0.3+docker18.09.4-1 \
       expect-dev
 


### PR DESCRIPTION
This PR is to fix the CI error:
```
nvidia-docker2 : Depends: nvidia-container-runtime (= 2.0.0+docker18.09.4-1) but 2.0.0+docker18.09.5-1 is to be installed
E: Unable to correct problems, you have held broken packages.
Exited with code 100
```