### PR TITLE
[pt1][quant] Move _th_fill_ to ATen and implement that for QInt8

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -159,6 +159,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Int, int32_t, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::QInt8, uint8_t, __VA_ARGS__)      \
       default:                                                               \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -177,6 +177,26 @@ class CAFFE2_API Tensor {
     return impl_->is_contiguous();
   }
 
+  bool is_transposed() const {
+    if (is_contiguous()) {
+      return false;
+    }
+    int64_t max_stride = 1;
+    int64_t size_max_stride = 1;
+    int64_t z = 1;
+    int d;
+    for (d = 0; d < dim(); ++d) {
+      if (stride(d) == 0 && size(d) != 1)
+        return false;
+      if (stride(d) > max_stride) {
+        max_stride = stride(d);
+        size_max_stride = size(d);
+      }
+      z *= size(d);
+    }
+    return z == max_stride * size_max_stride;
+  }
+
   // Total bytes consumed by the "view" of elements of the array.  Does not
   // include size of metadata.  The number reported here does not necessarily
   // correspond to the true physical memory consumed by a tensor; instead,

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -17,6 +17,8 @@
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/TensorIterator.h>
 
+#include <ATen/native/cpu/Loops.h>
+
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -85,8 +87,16 @@ Tensor& _clamp_min_out_cpu(Tensor& result, const Tensor& self, Scalar min) {
   return legacy::th::_th_clamp_min_out(result, self, min);
 }
 
-Tensor& fill_(Tensor& self, Scalar value) {
-  return at::legacy::th::_th_fill_(self, value);
+Tensor& _fill__cpu(Tensor& self, Scalar value) {
+  auto iter = TensorIterator::unary_op(self, self);
+  AT_DISPATCH_ALL_TYPES(iter->dtype(), "fill_cpu", [&]() {
+      scalar_t fill_value = value.to<scalar_t>();
+      unary_kernel(
+          *iter,
+          [=](scalar_t a) -> scalar_t { return fill_value; }
+      );
+    });
+  return self;
 }
 
 Tensor& fill_(Tensor& self, const Tensor& value) {

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/LegacyTHFunctions.h>
 
 namespace at { namespace native {
 
@@ -37,6 +38,10 @@ Tensor& _clamp_min__cuda(Tensor& self, Scalar min) {
 
 Tensor& _clamp_min_out_cuda(Tensor& result, const Tensor& self, Scalar min) {
   return _th_clamp_min_out(result, self, min);
+}
+
+Tensor& _fill__cuda(Tensor& self, Scalar value) {
+  return legacy::th::_th_fill_(self, value);
 }
 
 // These are just forwarding stubs

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -793,6 +793,9 @@
 
 - func: fill_(Tensor(a!) self, Scalar value) -> Tensor(a!)
   variants: function, method
+  dispatch:
+    CPU: _fill__cpu
+    CUDA: _fill__cuda
 
 - func: fill_(Tensor(a!) self, Tensor value) -> Tensor(a!)
   variants: function, method

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -177,6 +177,26 @@ class CAFFE2_API Tensor {
     return impl_->is_contiguous();
   }
 
+  bool is_transposed() const {
+    if (is_contiguous()) {
+      return false;
+    }
+    int64_t max_stride = 1;
+    int64_t size_max_stride = 1;
+    int64_t z = 1;
+    int d;
+    for (d = 0; d < dim(); ++d) {
+      if (stride(d) == 0 && size(d) != 1)
+        return false;
+      if (stride(d) > max_stride) {
+        max_stride = stride(d);
+        size_max_stride = size(d);
+      }
+      z *= size(d);
+    }
+    return z == max_stride * size_max_stride;
+  }
+
   // Total bytes consumed by the "view" of elements of the array.  Does not
   // include size of metadata.  The number reported here does not necessarily
   // correspond to the true physical memory consumed by a tensor; instead,

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -247,8 +247,9 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   }
 
   if (isQIntType(a) || isQIntType(b)) {
-    AT_ERROR(
-        "promoteTypes with quantized numbers is not handled yet; figure out what the correct rules should be");
+    return ScalarType::Undefined;
+    // AT_ERROR(
+    //     "promoteTypes with quantized numbers is not handled yet; figure out what the correct rules should be");
   }
 
   // this matrix has to be consistent with AT_FORALL_SCALAR_TYPES_WITH_COMPLEX

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2681,10 +2681,9 @@ class _TestTorchMixin(object):
         qr = r.quantize_linear(scale, zero_point)
         self.assertEqual(qr.item(), 1)
         self.assertEqual(qr[0].item(), 1)
-        # assignment
         # This calls _th_fill_
-        # qr[0] = 8 # float asignment
-        # self.assertEqual(qr.item(), 8)
+        #qr[0] = 8.3 # float assignment
+        #self.assertEqual(qr.item(), 8)
 
 
     @unittest.skipIf(torch.cuda.device_count() < 2, 'fewer than 2 GPUs detected')


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18546 [pt1][quant] Add Quantized Backend&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14637671/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18814 [pt1][quant] Add slicing and int_repr() to QTensor&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14756833/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19211 [pt1][quant] Move _th_fill_ to ATen and implement that for QInt8**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14781825/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18960 [pt1][quant] Add empty_quantized&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14810261/)

Implement _th_fill for QInt8 so we can assign to QTensor
```
r = torch.ones(1, dtype=torch.float)
scale = 1
zero_point = 2
qr = r.quantize_linear(scale, zero_point)
qr[0] = 8 # 8 will be quantized and then assigned to q.
# qr.item() == 8
```

Differential Revision: [D14781825](https://our.internmc.facebook.com/intern/diff/D14781825/)