### PR TITLE
Add IterableDataset

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -23,7 +23,7 @@ Dataset Types
 Map-style datasets
 ^^^^^^^^^^^^^^^^^^
 
-A map-style dataset is one that implements the :meth:`__getitem__` and
+A map-style dataset is one that implements the :meth:`__getitem__` and (ideally)
 :meth:`__len__` protocols, and represents a map from (possibly non-integral)
 indices/keys to data samples. E.g., such a dataset, when called ``dataset[idx]``
 could read and the ``idx``-th image and its corresponding label from a folder

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -156,7 +156,9 @@ and loading from an iterable-style dataset is roughly equivalent with::
     for indices in batch_sampler:
         yield collate_fn([next(dataset_iter) for _ in indices])
 
-See `this section <dataloader-collate_fn_>`_ on more about :attr:`collate_fn`.
+A custom :attr:`collate_fn` can be used to customize collation, e.g., padding
+sequential data to max length of a batch. See
+`this section <dataloader-collate_fn_>`_ on more about :attr:`collate_fn`.
 
 Disable automatic batching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +227,8 @@ properties:
   for ``list`` s, ``tuple`` s, ``namedtuple`` s, etc.
 
 Users may use customized :attr:`collate_fn` to achieve custom batching, e.g.,
-along a dimension other than the first, or to add support for custom data types.
+collating along a dimension other than the first, padding sequences of
+various lengths, or adding support for custom data types.
 
 Single- and Multi-process Data Loading
 --------------------------------------

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -2,11 +2,342 @@ torch.utils.data
 ===================================
 
 .. automodule:: torch.utils.data
+
+At the heart of PyTorch data loading utility is the :class:`torch.utils.data.DataLoader`
+class.  It represents an Python Iterable over a dataset, with
+`the iterating strategy <Data Loading Strategies_>`_ specified by
+`the type of the given dataset <Dataset Types_>`_  and the constructor arguments.
+Moreover, it supports
+`both single- and multi-process data loading <Single- and Multi-process Data Loading_>`_,
+as well as automatic `memory pinning <Memory Pinning_>`_.
+
+Dataset Types
+-------------
+
+:class:`~torch.utils.data.DataLoader` supports two different types of datasets:
+
+* `map-style datasets <Map-style datasets_>`_
+
+* `iterable-style datasets <Iterable-style datasets_>`_
+
+Map-style datasets
+^^^^^^^^^^^^^^^^^^
+
+A map-style dataset is one that implements the ``__getitem__`` protocol,
+and represents a map from (possibly non-integral) indices/keys to data samples.
+E.g., such a dataset, when called ``dataset[idx]`` could read and the ``idx``-th
+image and its corresponding label from a folder on the disk.
+
+.. note::
+  :class:`~torch.utils.data.DataLoader` by default constructs a index sampler
+  that yields integral indices.  To make it work with a map-style dataset with
+  non-integral indices/keys, a custom sampler must be provided.
+
+See :class:`~torch.utils.data.Dataset` for more details.
+
+Iterable-style datasets
+^^^^^^^^^^^^^^^^^^^^^^^
+
+An iterable-style dataset is one that implements the ``__iter__`` protocol,
+and represents an iterable over data samples. This type of datasets is
+particularly suitable for cases where random reads are expensive or even
+improbable. E.g., such a dataset, when called ``iter(dataset)``, could return a
+stream of data reading from a database, a remote server, or even logs generated
+in real time.
+
+See :class:`~torch.utils.data.IterableDataset` for more details.
+
+.. note:: When using an :class:`~torch.utils.data.IterableDataset` with
+          `multi-process data loading <Multi-process data loading_>`_. The same
+          dataset object is replicated on each worker process, and thus the
+          replicas must be configured differently to avoid duplicate data. See
+          :class:`~torch.utils.data.IterableDataset` documentations for how to
+          achieve this.
+
+Samplers
+--------
+
+For `map-style datasets <Map-style datasets_>`_, we need a way to specify the
+sequence of indices/keys used in data loading.  The :class:`torch.utils.data.Sampler`
+classes are created for this purpose. They represent iterable objects over the
+indices to map-style datasets.  E.g., in the common case with stochastic
+gradient decent (SGD), a :class:`~torch.utils.data.Sampler` could randomly
+permute a list of indices and yield each one at a time, or yield a small number
+of them for mini-batch SGD.
+
+`Data Loading Strategies`_ section talks about how to use a :class:`~torch.utils.data.Sampler`
+with a :class:`~torch.utils.data.DataLoader`.
+
+Data Loading Strategies
+-----------------------
+
+:class:`~torch.utils.data.DataLoader` constructor receives a
+:attr:`dataset` object as its first argument. Based on the other provided
+arguments, a :class:`~torch.utils.data.DataLoader` operates in one of three
+following strategies:
+
+* `Batched loading from a map-style dataset (default)`_
+
+* `Loading individual members of a map-style dataset`_
+
+* `Loading from an iterable-style dataset`_
+
+Batched loading from a map-style dataset (default)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the most common case, and corresponds to fetching a minibatch of
+data and collating them into batched Tensors, i.e., Tensors with one dimension
+being the batch dimension (usually the first). Two combinations of arguments
+that starts this mode are:
+
+* (default) Using arguments :attr:`batch_size`, :attr:`shuffle`,
+  :attr:`sampler`, and :attr:`drop_last` to specify the batch indices sampling
+  behavior.
+
+  With the default arguments, a :class:`~torch.utils.data.DataLoader`
+  loads data as batches of size ``1`` with indices sampled without replacement.
+
+* Setting argument :attr:`batch_sampler` to a custom sampler returning a list
+  of indices at each time, representing the indices for a batch.
+
+After fetching a list of samples using the indices from sampler, the function
+passed as the :attr:`collate_fn` argument is used to collate the list of samples
+into batched Tensors.
+
+The behavior of this mode is roughly equivalent with::
+
+    for indices in batch_sampler:
+        yield collate_fn([dataset[i] for i in indices])
+
+
+Working with :attr:`collate_fn`
+"""""""""""""""""""""""""""""""
+
+For instance, if each data sample consists of a 3-channeled image and an
+integral class label, i.e., each element of the dataset returns a tuple
+``(image, class_index)``, the default :attr:`collate_fn` collates a list of such
+tuples into a single tuple of a batched image tensor and a batched class label
+Tensor. In particular, the default :attr:`collate_fn` has the following
+properties:
+
+* It always prepends a new dimension as the batch dimension.
+
+* It automatically converts NumPy arrays and Python numerical values into
+  PyTorch Tensors.
+
+* It preserves the data structure, e.g., if each sample is a dictionary, it
+  outputs a dictionary with the same set of keys but batched Tensors as values
+  (or lists if the values can not be converted into Tensors). Same
+  for ``list`` s, ``tuple`` s, ``namedtuple`` s, etc.
+
+Users may use customized :attr:`collate_fn` to achieve custom batching, e.g.,
+along a dimension other than the first.
+
+Loading individual members of a map-style dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes it is cheaper to directly load batched data (e.g., bulk reads from a
+database or a remote server), or your program is designed for working on
+individual samples.  In such cases, it's probably better to not use the above
+loading strategy (where :attr:`collate_fn` is used to collate the samples), but
+let the data loader directly return each member of the :attr:`dataset` object.
+
+To start this mode, simply set ``batch_size=None``.  If :attr:`sampler` is set,
+it will be used to sample the indices/keys to :attr:`dataset`. Otherwise, a
+sampler will be constructed according to :attr:`shuffle` argument.
+
+Each sample is processed with the function passed as the :attr:`convert_fn`
+argument. The default :attr:`convert_fn` simply converts NumPy arrays and
+Python numerical values into PyTorch Tensors.
+
+The behavior of this mode is roughly equivalent with::
+
+    for index in sampler:
+        yield convert_fn(dataset[index])
+
+
+Loading from an iterable-style dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When loading from an iterable-style dataset (i.e., a :class:`~torch.utils.data.IterableDataset`),
+there is no  notion of a :attr:`sampler`. The data samples are read from the
+iterable generated by the :class:`~torch.utils.data.IterableDataset`.
+
+To start this mode, simply passing an :class:`~torch.utils.data.IterableDataset`
+instance as the :attr:`dataset` argument.
+
+Each sample is processed with the function passed as the :attr:`convert_fn`
+argument. The default :attr:`convert_fn` simply converts NumPy arrays and
+Python numerical values into PyTorch Tensors.
+
+For single-process loading, the behavior of this mode is roughly equivalent
+with::
+
+    for data in iter(dataset):
+        yield convert_fn(data)
+
+
+For multi-process loading, each worker process gets a different copy of
+:attr:`dataset`, so it is often desired to configure each copy independently to
+avoid having duplicate data returned from the workers. See the documentations of
+:class:`~torch.utils.data.IterableDataset` for details on this.
+
+Single- and Multi-process Data Loading
+--------------------------------------
+
+A :class:`~torch.utils.data.DataLoader` uses single-process data loading by
+default.
+
+Within a Python process, the `global interpreter lock <https://wiki.python.org/moin/GlobalInterpreterLock>`_
+prevents true fully parallelizing Python code across threads. To avoid blocking
+computation code with data loading, PyTorch provides an easy switch to perform
+multi-process data loading by simply setting the argument :attr:`num_workers`
+to a positive integer.
+
+Single-process data loading (default)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this mode, data fetching is done in the same process a
+:class:`~torch.utils.data.DataLoader` is initialized.  Therefore, data loading
+may block computing.  However, this mode may be preferred when resource(s) used
+for sharing data among processes (e.g., shared memory, file descriptors) is
+limited.  Additionally, single-process loading often shows more readable error
+traces and thus is useful for debugging.
+
+
+Multi-process data loading
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Setting the argument :attr:`num_workers` as a positive integer will
+turn on multi-process data loading with the specified number of loader worker
+processes.
+
+In this mode, each time an iterator of a :class:`~torch.utils.data.DataLoader`
+is created (e.g., when you call ``enumerate(dataloader, 0)``), :attr:`num_workers`
+worker processes are created. At this point, the :attr:`dataset`, :attr:`collate_fn`,
+:attr:`convert_fn` and :attr:`worker_init_fn` are passed to each
+worker, where they are used to initialize, and fetch data. This means that
+dataset access together with its  internal IO, transforms
+(including :attr:`collate_fn` and :attr:`convert_fn`) runs in the worker process.
+
+For map-style datasets, the main process generates the indices using :attr:`sampler`
+and sends them to the workers. So any shuffle randomization is done in the main
+process which guides loading by assigning indices to load.
+
+Workers are shut down once the end of the iteration is reached, or when the
+iterator becomes garbage collected.
+
+.. warning::
+  It is generally not recommended to return CUDA tensors in multi-process
+  loading because of many subtleties in using CUDA and sharing CUDA tensors in
+  multiprocessing (see :ref:`multiprocessing-cuda-note`). Instead, we recommend
+  using `automatic memory pinning <Memory Pinning_>`_ (i.e., setting
+  :attr:``pin_memory=True``), which enables fast data transfer to CUDA-enabled
+  GPUs.
+
+Platform-specific behaviors
+"""""""""""""""""""""""""""
+
+Since workers rely on Python ``multiprocessing``, worker launch behavior is
+different on Windows compared to Unix.
+
+* On Unix, ``fork`` is the default ``multiprocessing`` start method. Using ``fork``,
+  child workers typically can access the :attr:`dataset` and Python argument
+  functions directly through the cloned address space.
+
+* On Windows, ``spawn`` is the default ``multiprocessing`` start method. Using
+  ``spawn``, another interpreter is launched which runs your main script,
+  followed by the internal worker function that receives the :attr:`dataset`,
+  :attr:`collate_fn` and other arguments through `Pickle <https://docs.python.org/3/library/pickle.html>`_
+  serialization.
+
+This separate serialization means that you should take two steps to ensure you
+are compatible with Windows while using multi-process data loading:
+
+- Wrap most of you main script's code within ``if __name__ == '__main__':`` block,
+  to make sure it doesn't run again (most likely generating error) when each worker
+  process is launched. You can place your dataset and :class:`~torch.utils.data.DataLoader`
+  instance creation logic here, as it doesn't need to be re-executed in workers.
+
+- Make sure that any custom :attr:`collate_fn`, :attr:`convert_fn`, :attr:`worker_init_fn`
+  or dataset code is declared as top level definitions, outside of the ``__main__``
+  check. This ensures that they are available in workers.
+  (this is needed since functions are pickled as references only, not ``bytecode``.)
+
+Randomness in multi-process data loading
+""""""""""""""""""""""""""""""""""""""""""
+
+By default, each worker will have its PyTorch seed set to
+``base_seed + worker_id``, where ``base_seed`` is a long generated
+by main process using its RNG. However, seeds for other libraies
+may be duplicated upon initializing workers (w.g., NumPy), causing
+each worker to return identical random numbers. (See
+:ref:`this section <dataloader-workers-random-seed>` in FAQ.)
+
+In :attr:`worker_init_fn`, you may access the PyTorch seed set for each worker
+with either :func:`torch.utils.data.get_worker_info().seed <torch.utils.data.get_worker_info>`
+or :func:`torch.initial_seed()`, and use it to seed other libraries before data
+loading.
+
+Memory Pinning
+--------------
+
+Host to GPU copies are much faster when they originate from pinned (page-locked)
+memory. See :ref:`cuda-memory-pinning` for more details on when and how to use
+pinned memory generally.
+
+For data loading, passing :attr:``pin_memory=True`` to a
+:class:`~torch.utils.data.DataLoader` will automatically put the fetched data
+Tensors in pinned memory, and thus enables faster data transfer to CUDA-enabled
+GPUs.
+
+The default memory pinning logic only recognizes Tensors and maps and iterables
+containing Tensors.  By default, if the pinning logic sees a batch that is a
+custom type (which will occur if you have a :attr:`collate_fn` that returns a
+custom batch type), or if each element of your batch is a custom type, the
+pinning logic will not recognize them, and it will return that batch (or those
+elements) without pinning the memory.  To enable memory pinning for custom batch
+or data types, define a :meth:`pin_memory` method on your custom type(s).
+
+See the example below.
+
+Example::
+
+    class SimpleCustomBatch:
+        def __init__(self, data):
+            transposed_data = list(zip(*data))
+            self.inp = torch.stack(transposed_data[0], 0)
+            self.tgt = torch.stack(transposed_data[1], 0)
+
+        # custom memory pinning method on custom type
+        def pin_memory(self):
+            self.inp = self.inp.pin_memory()
+            self.tgt = self.tgt.pin_memory()
+            return self
+
+    def collate_wrapper(batch):
+        return SimpleCustomBatch(batch)
+
+    inps = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
+    tgts = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
+    dataset = TensorDataset(inps, tgts)
+
+    loader = DataLoader(dataset, batch_size=2, collate_fn=collate_wrapper,
+                        pin_memory=True)
+
+    for batch_ndx, sample in enumerate(loader):
+        print(sample.inp.is_pinned())
+        print(sample.tgt.is_pinned())
+
+
+.. autoclass:: DataLoader
 .. autoclass:: Dataset
+.. autoclass:: IterableDataset
 .. autoclass:: TensorDataset
 .. autoclass:: ConcatDataset
+.. autoclass:: ChainDataset
 .. autoclass:: Subset
-.. autoclass:: DataLoader
+.. autofunction:: torch.utils.data.get_worker_info
 .. autofunction:: torch.utils.data.random_split
 .. autoclass:: torch.utils.data.Sampler
 .. autoclass:: torch.utils.data.SequentialSampler

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -23,10 +23,11 @@ Dataset Types
 Map-style datasets
 ^^^^^^^^^^^^^^^^^^
 
-A map-style dataset is one that implements the ``__getitem__`` protocol,
-and represents a map from (possibly non-integral) indices/keys to data samples.
-E.g., such a dataset, when called ``dataset[idx]`` could read and the ``idx``-th
-image and its corresponding label from a folder on the disk.
+A map-style dataset is one that implements the :meth:`__getitem__` and
+:meth:`__len__` protocols, and represents a map from (possibly non-integral)
+indices/keys to data samples. E.g., such a dataset, when called ``dataset[idx]``
+could read and the ``idx``-th image and its corresponding label from a folder
+on the disk.
 
 .. note::
   :class:`~torch.utils.data.DataLoader` by default constructs a index sampler
@@ -38,7 +39,7 @@ See :class:`~torch.utils.data.Dataset` for more details.
 Iterable-style datasets
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-An iterable-style dataset is one that implements the ``__iter__`` protocol,
+An iterable-style dataset is one that implements the :meth:`__iter__` protocol,
 and represents an iterable over data samples. This type of datasets is
 particularly suitable for cases where random reads are expensive or even
 improbable. E.g., such a dataset, when called ``iter(dataset)``, could return a
@@ -76,14 +77,14 @@ Data Loading Strategies
 arguments, a :class:`~torch.utils.data.DataLoader` operates in one of three
 following strategies:
 
-* `Batched loading from a map-style dataset (default)`_
+* `Batched loading from a map-style dataset`_
 
 * `Loading individual members of a map-style dataset`_
 
 * `Loading from an iterable-style dataset`_
 
-Batched loading from a map-style dataset (default)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Batched loading from a map-style dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is the most common case, and corresponds to fetching a minibatch of
 data and collating them into batched Tensors, i.e., Tensors with one dimension
@@ -94,8 +95,9 @@ that starts this mode are:
   :attr:`sampler`, and :attr:`drop_last` to specify the batch indices sampling
   behavior.
 
-  With the default arguments, a :class:`~torch.utils.data.DataLoader`
-  loads data as batches of size ``1`` with indices sampled without replacement.
+  With the default arguments :attr:`batch_size=1`, :attr:`shuffle=False`,
+  :attr:`sampler=None` and :attr:`drop_last=False`, :class:`~torch.utils.data.DataLoader`
+  loads data as batches of size ``1`` sequentially.
 
 * Setting argument :attr:`batch_sampler` to a custom sampler returning a list
   of indices at each time, representing the indices for a batch.
@@ -113,8 +115,8 @@ The behavior of this mode is roughly equivalent with::
 Working with :attr:`collate_fn`
 """""""""""""""""""""""""""""""
 
-For instance, if each data sample consists of a 3-channeled image and an
-integral class label, i.e., each element of the dataset returns a tuple
+For instance, if each data sample consists of a 3-channel image and an integral
+class label, i.e., each element of the dataset returns a tuple
 ``(image, class_index)``, the default :attr:`collate_fn` collates a list of such
 tuples into a single tuple of a batched image tensor and a batched class label
 Tensor. In particular, the default :attr:`collate_fn` has the following
@@ -131,7 +133,7 @@ properties:
   for ``list`` s, ``tuple`` s, ``namedtuple`` s, etc.
 
 Users may use customized :attr:`collate_fn` to achieve custom batching, e.g.,
-along a dimension other than the first.
+along a dimension other than the first, or to add support for custom data types.
 
 Loading individual members of a map-style dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -179,7 +181,7 @@ with::
 
 For multi-process loading, each worker process gets a different copy of
 :attr:`dataset`, so it is often desired to configure each copy independently to
-avoid having duplicate data returned from the workers. See the documentations of
+avoid having duplicate data returned from the workers. See the documentation of
 :class:`~torch.utils.data.IterableDataset` for details on this.
 
 Single- and Multi-process Data Loading

--- a/docs/source/notes/cuda.rst
+++ b/docs/source/notes/cuda.rst
@@ -262,6 +262,7 @@ also preserve :class:`torch.device` and :class:`torch.dtype` of a Tensor).
     y_cpu = torch.ones_like(x_cpu)
     y_gpu = torch.zeros_like(x_gpu)
 
+.. _cuda-memory-pinning:
 
 Use pinned memory buffers
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -22,6 +22,8 @@ memory and will only send a handle to another process.
 This allows to implement various training methods, like Hogwild, A3C, or any
 others that require asynchronous operation.
 
+.. _multiprocessing-cuda-note:
+
 CUDA in multiprocessing
 -----------------------
 

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -1,3 +1,5 @@
+.. _multiprocessing-best-practices:
+
 Multiprocessing best practices
 ==============================
 

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -236,6 +236,8 @@ def set_faulthander_if_available(_=None):
             faulthandler.register(signal.SIGUSR1, chain=False)
 
 
+set_faulthander_if_available()
+
 # Process `pid` must have called `set_faulthander_if_available`
 def print_traces_of_all_threads(pid):
     if HAS_FAULTHANDLER:
@@ -818,7 +820,8 @@ class TestDataLoader(TestCase):
         expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
         assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
         dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
-        dataloader = DataLoader(dataset, num_workers=num_workers)
+        dataloader = DataLoader(dataset, num_workers=num_workers,
+                                worker_init_fn=set_faulthander_if_available)
         dataloader_iter = iter(dataloader)
         fetched = sorted([d.item() for d in dataloader_iter])
 
@@ -889,7 +892,8 @@ class TestDataLoader(TestCase):
         # worker 0 should return 0 batches
         # worker 1 should return 1 batches
         # worker 2 should return 3 batches
-        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=7, drop_last=True)
+        dataloader = DataLoader(dataset, num_workers=num_workers, batch_size=7, drop_last=True,
+                                worker_init_fn=set_faulthander_if_available)
         dataloader_iter = iter(dataloader)
         fetched = list(dataloader_iter)
         self.assertEqual(len(fetched), 2)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -614,10 +614,6 @@ def _test_get_worker_info():
 def init_fn(worker_id):
     torch.manual_seed(12345)
 
-# used with test_error_in_init
-def error_worker_init_fn(_):
-    raise RuntimeError("Error in worker_init_fn")
-
 
 # used with test_error_in_init
 class ErrorIterableDataset(IterableDataset):
@@ -692,11 +688,6 @@ class TestDataLoader(TestCase):
                 setattr(dl, attr, {})
 
             self.assertRaises(ValueError, fn)
-
-    def test_error_in_init(self):
-        loader = DataLoader(self.dataset, num_workers=2, worker_init_fn=error_worker_init_fn)
-        with self.assertRaisesRegex(RuntimeError, 'Error in worker_init_fn'):
-            list(iter(loader))
 
     def test_sequential(self):
         self._test_sequential(DataLoader(self.dataset))

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -763,6 +763,22 @@ class TestDataLoader(TestCase):
                 p.terminate()
 
     def test_iterable_dataset(self):
+        # Test that unsupported options raises error
+        dataset = CountingIterableDataset(20)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified shuffle"):
+            DataLoader(dataset, shuffle=True)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified shuffle"):
+            DataLoader(dataset, shuffle=3)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified sampler"):
+            DataLoader(dataset, sampler=torch.utils.data.SequentialSampler(dataset))
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified sampler"):
+            DataLoader(dataset, sampler=3)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified batch_sampler"):
+            DataLoader(dataset, batch_sampler=torch.utils.data.BatchSampler(
+                torch.utils.data.SequentialSampler(dataset), 3, False))
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified batch_sampler"):
+            DataLoader(dataset, batch_sampler=3)
+
         # [non-batched] single process loading
         dataset = CountingIterableDataset(20)
         fetched = list(DataLoader(dataset))

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -619,26 +619,6 @@ def error_worker_init_fn(_):
     raise RuntimeError("Error in worker_init_fn")
 
 
-def test_iterable_dataset_multiprocessing():
-    num_workers = 3
-    sizes_for_all_workers = [0, 4, 20]
-    expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
-    assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
-    dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
-    dataloader = DataLoader(dataset, num_workers=num_workers)
-    dataloader_iter = iter(dataloader)
-    retrieved = sorted([d.item() for d in dataloader_iter])
-
-    for a, b in zip(retrieved, expected):
-        assert a == b
-
-    workers = dataloader_iter.workers
-    del dataloader_iter
-    for w in workers:
-        w.join(JOIN_TIMEOUT)
-        assert not w.is_alive()
-
-
 # used with test_error_in_init
 class ErrorIterableDataset(IterableDataset):
     def __iter__(self):
@@ -793,14 +773,29 @@ class TestDataLoader(TestCase):
             self.assertEqual(d, i)
 
         # multiprocessing loading
-        p = ErrorTrackingProcess(target=test_iterable_dataset_multiprocessing, disable_stderr=False)
-        p.start()
-        p.join(JOIN_TIMEOUT)
+        num_workers = 3
+        sizes_for_all_workers = [0, 4, 20]
+        expected = sorted(sum((list(range(s)) for s in sizes_for_all_workers), []))
+        assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
+        dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+        dataloader = DataLoader(dataset, num_workers=num_workers)
+        dataloader_iter = iter(dataloader)
+        retrieved = sorted([d.item() for d in dataloader_iter])
+
+        for a, b in zip(retrieved, expected):
+            self.assertEqual(a, b)
+
+        # test that workers exit gracefully
+        workers = dataloader_iter.workers
+        del dataloader_iter
         try:
-            self.assertFalse(p.is_alive())
-            self.assertEqual(p.exitcode, 0)
+            for w in workers:
+                w.join(JOIN_TIMEOUT)
+                self.assertFalse(w.is_alive())
+                self.assertEqual(w.exitcode, 0)
         finally:
-            p.terminate()
+            for w in workers:
+                w.terminate()
 
     def test_chain_iterable_dataset(self):
         # chaining (concatenation)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -309,6 +309,7 @@ import torch.testing
 import torch.backends.cuda
 import torch.backends.mkl
 import torch.backends.openmp
+import torch.utils.data
 import torch.__config__
 import torch.__future__
 

--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -1,4 +1,4 @@
 from .sampler import Sampler, SequentialSampler, RandomSampler, SubsetRandomSampler, WeightedRandomSampler, BatchSampler  # noqa: F401
 from .distributed import DistributedSampler  # noqa: F401
 from .dataset import Dataset, IterableDataset, TensorDataset, ConcatDataset, ChainDataset, Subset, random_split  # noqa: F401
-from .dataloader import DataLoader, _DataLoaderStrategy, get_worker_info  # noqa: F401
+from .dataloader import DataLoader, _DatasetKind, get_worker_info  # noqa: F401

--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -1,4 +1,4 @@
 from .sampler import Sampler, SequentialSampler, RandomSampler, SubsetRandomSampler, WeightedRandomSampler, BatchSampler  # noqa: F401
 from .distributed import DistributedSampler  # noqa: F401
-from .dataset import Dataset, TensorDataset, ConcatDataset, Subset, random_split  # noqa: F401
-from .dataloader import DataLoader  # noqa: F401
+from .dataset import Dataset, IterableDataset, TensorDataset, ConcatDataset, ChainDataset, Subset, random_split  # noqa: F401
+from .dataloader import DataLoader, _DataLoaderStrategy, get_worker_info  # noqa: F401

--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -58,4 +58,4 @@ def _set_python_exit_flag():
 atexit.register(_set_python_exit_flag)
 
 
-from . import worker, signal_handling, pin_memory, collate  # noqa: F401
+from . import worker, signal_handling, pin_memory, collate, fetch  # noqa: F401

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -44,10 +44,6 @@ def default_convert(data):
     raise TypeError("default_convert: found unexpected input type {}".format(elem_type))
 
 
-_use_shared_memory = False
-r"""Whether to collate into shared memory in default_collate"""
-
-
 default_collate_err_msg_format = (
     "default_collate: batch must contain tensors, numpy arrays, numbers, "
     "dicts or lists; found {}")
@@ -60,7 +56,7 @@ def default_collate(batch):
     elem_type = type(elem)
     if isinstance(elem, torch.Tensor):
         out = None
-        if _use_shared_memory:
+        if torch.utils.data.get_worker_info() is not None:
             # If we're in a background process, concatenate directly into a
             # shared memory tensor to avoid an extra copy
             numel = sum([x.numel() for x in batch])

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -9,37 +9,63 @@ import torch
 import re
 from torch._six import container_abcs, string_classes, int_classes
 
-_use_shared_memory = False
-r"""Whether to use shared memory in default_collate"""
-
 np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
-error_msg_fmt = "batch must contain tensors, numbers, dicts or lists; found {}"
 
-numpy_type_map = {
-    'float64': torch.DoubleTensor,
-    'float32': torch.FloatTensor,
-    'float16': torch.HalfTensor,
-    'int64': torch.LongTensor,
-    'int32': torch.IntTensor,
-    'int16': torch.ShortTensor,
-    'int8': torch.CharTensor,
-    'uint8': torch.ByteTensor,
-}
+default_convert_err_msg_format = (
+    "default_convert: data must contain tensors, numpy arrays, numbers, "
+    "dicts or lists; found {}")
+
+
+def default_convert(data):
+    r"""Puts each data field into a tensor"""
+
+    elem_type = type(data)
+    if isinstance(data, torch.Tensor):
+        return data
+    elif elem_type.__module__ == 'numpy' and elem_type.__name__ != 'str_' \
+            and elem_type.__name__ != 'string_':
+        # array of string classes and object
+        if elem_type.__name__ == 'ndarray' \
+                and np_str_obj_array_pattern.search(elem.dtype.str) is not None:
+            raise TypeError(default_convert_err_msg_format.format(elem.dtype))
+        return torch.as_tensor(data)
+    elif isinstance(data, int_classes):
+        return torch.tensor(data, dtype=torch.long)
+    elif isinstance(data, float):
+        return torch.tensor(data, dtype=torch.double)
+    elif isinstance(data, string_classes):
+        return data
+    elif isinstance(data, container_abcs.Mapping):
+        return {key: default_convert(data[key]) for key in data}
+    elif isinstance(data, container_abcs.Sequence):
+        return [default_convert(d) for d in data]
+
+    raise TypeError("default_convert: found unexpected input type {}".format(elem_type))
+
+
+_use_shared_memory = False
+r"""Whether to collate into shared memory in default_collate"""
+
+
+default_collate_err_msg_format = (
+    "default_collate: batch must contain tensors, numpy arrays, numbers, "
+    "dicts or lists; found {}")
 
 
 def default_collate(batch):
     r"""Puts each data field into a tensor with outer dimension batch size"""
 
-    elem_type = type(batch[0])
-    if isinstance(batch[0], torch.Tensor):
+    elem = batch[0]
+    elem_type = type(elem)
+    if isinstance(elem, torch.Tensor):
         out = None
         if _use_shared_memory:
             # If we're in a background process, concatenate directly into a
             # shared memory tensor to avoid an extra copy
             numel = sum([x.numel() for x in batch])
-            storage = batch[0].storage()._new_shared(numel)
-            out = batch[0].new(storage)
+            storage = elem.storage()._new_shared(numel)
+            out = elem.new(storage)
         return torch.stack(batch, 0, out=out)
     elif elem_type.__module__ == 'numpy' and elem_type.__name__ != 'str_' \
             and elem_type.__name__ != 'string_':
@@ -47,24 +73,23 @@ def default_collate(batch):
         if elem_type.__name__ == 'ndarray':
             # array of string classes and object
             if np_str_obj_array_pattern.search(elem.dtype.str) is not None:
-                raise TypeError(error_msg_fmt.format(elem.dtype))
+                raise TypeError(default_collate_err_msg_format.format(elem.dtype))
 
-            return default_collate([torch.from_numpy(b) for b in batch])
-        if elem.shape == ():  # scalars
-            py_type = float if elem.dtype.name.startswith('float') else int
-            return numpy_type_map[elem.dtype.name](list(map(py_type, batch)))
-    elif isinstance(batch[0], float):
+            return default_collate([torch.as_tensor(b) for b in batch])
+        elif elem.shape == ():  # scalars
+            return torch.as_tensor(batch)
+    elif isinstance(elem, float):
         return torch.tensor(batch, dtype=torch.float64)
-    elif isinstance(batch[0], int_classes):
+    elif isinstance(elem, int_classes):
         return torch.tensor(batch)
-    elif isinstance(batch[0], string_classes):
+    elif isinstance(elem, string_classes):
         return batch
-    elif isinstance(batch[0], container_abcs.Mapping):
-        return {key: default_collate([d[key] for d in batch]) for key in batch[0]}
-    elif isinstance(batch[0], tuple) and hasattr(batch[0], '_fields'):  # namedtuple
-        return type(batch[0])(*(default_collate(samples) for samples in zip(*batch)))
-    elif isinstance(batch[0], container_abcs.Sequence):
+    elif isinstance(elem, container_abcs.Mapping):
+        return {key: default_collate([d[key] for d in batch]) for key in elem}
+    elif isinstance(elem, tuple) and hasattr(elem, '_fields'):  # namedtuple
+        return elem_type(*(default_collate(samples) for samples in zip(*batch)))
+    elif isinstance(elem, container_abcs.Sequence):
         transposed = zip(*batch)
         return [default_collate(samples) for samples in transposed]
 
-    raise TypeError((error_msg_fmt.format(type(batch[0]))))
+    raise TypeError(default_collate_err_msg_format.format(elem_type))

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -5,9 +5,9 @@ single- and multi-processing data loading.
 
 
 class _BaseDatasetFetcher(object):
-    def __init__(self, dataset, is_batched, collate_fn, drop_last):
+    def __init__(self, dataset, auto_collation, collate_fn, drop_last):
         self.dataset = dataset
-        self.is_batched = is_batched
+        self.auto_collation = auto_collation
         self.collate_fn = collate_fn
         self.drop_last = drop_last
 
@@ -16,12 +16,12 @@ class _BaseDatasetFetcher(object):
 
 
 class _IterableDatasetFetcher(_BaseDatasetFetcher):
-    def __init__(self, dataset, is_batched, collate_fn, drop_last):
-        super(_IterableDatasetFetcher, self).__init__(dataset, is_batched, collate_fn, drop_last)
+    def __init__(self, dataset, auto_collation, collate_fn, drop_last):
+        super(_IterableDatasetFetcher, self).__init__(dataset, auto_collation, collate_fn, drop_last)
         self.dataset_iter = iter(dataset)
 
     def fetch(self, possibly_batched_index):
-        if self.is_batched:
+        if self.auto_collation:
             data = []
             for _ in possibly_batched_index:
                 try:
@@ -36,11 +36,11 @@ class _IterableDatasetFetcher(_BaseDatasetFetcher):
 
 
 class _MapDatasetFetcher(_BaseDatasetFetcher):
-    def __init__(self, dataset, is_batched, collate_fn, drop_last):
-        super(_MapDatasetFetcher, self).__init__(dataset, is_batched, collate_fn, drop_last)
+    def __init__(self, dataset, auto_collation, collate_fn, drop_last):
+        super(_MapDatasetFetcher, self).__init__(dataset, auto_collation, collate_fn, drop_last)
 
     def fetch(self, possibly_batched_index):
-        if self.is_batched:
+        if self.auto_collation:
             data = [self.dataset[idx] for idx in possibly_batched_index]
         else:
             data = self.dataset[possibly_batched_index]

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -29,7 +29,7 @@ class _IterableDatasetFetcher(_BaseDatasetFetcher):
                 except StopIteration:
                     break
             if len(data) == 0 or (self.drop_last and len(data) < len(possibly_batched_index)):
-                raise StopIteration()
+                raise StopIteration
         else:
             data = next(self.dataset_iter)
         return self.collate_fn(data)

--- a/torch/utils/data/_utils/fetch.py
+++ b/torch/utils/data/_utils/fetch.py
@@ -1,0 +1,47 @@
+r""""Contains definitions of the methods used by the _DataLoaderIter to fetch
+data from an iterable-style or map-style dataset. This logic is shared in both
+single- and multi-processing data loading.
+"""
+
+
+class _BaseDatasetFetcher(object):
+    def __init__(self, dataset, is_batched, collate_fn, drop_last):
+        self.dataset = dataset
+        self.is_batched = is_batched
+        self.collate_fn = collate_fn
+        self.drop_last = drop_last
+
+    def fetch(self, possibly_batched_index):
+        raise NotImplementedError()
+
+
+class _IterableDatasetFetcher(_BaseDatasetFetcher):
+    def __init__(self, dataset, is_batched, collate_fn, drop_last):
+        super(_IterableDatasetFetcher, self).__init__(dataset, is_batched, collate_fn, drop_last)
+        self.dataset_iter = iter(dataset)
+
+    def fetch(self, possibly_batched_index):
+        if self.is_batched:
+            data = []
+            for _ in possibly_batched_index:
+                try:
+                    data.append(next(self.dataset_iter))
+                except StopIteration:
+                    break
+            if len(data) == 0 or (self.drop_last and len(data) < len(possibly_batched_index)):
+                raise StopIteration()
+        else:
+            data = next(self.dataset_iter)
+        return self.collate_fn(data)
+
+
+class _MapDatasetFetcher(_BaseDatasetFetcher):
+    def __init__(self, dataset, is_batched, collate_fn, drop_last):
+        super(_MapDatasetFetcher, self).__init__(dataset, is_batched, collate_fn, drop_last)
+
+    def fetch(self, possibly_batched_index):
+        if self.is_batched:
+            data = [self.dataset[idx] for idx in possibly_batched_index]
+        else:
+            data = self.dataset[possibly_batched_index]
+        return self.collate_fn(data)

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -38,24 +38,24 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
         else:
             idx, data = r
             try:
-                data = pin_memory_data(data)
+                data = pin_memory(data)
             except Exception:
                 out_queue.put((idx, ExceptionWrapper(sys.exc_info())))
             else:
                 out_queue.put((idx, data))
 
 
-def pin_memory_data(data):
+def pin_memory(data):
     if isinstance(data, torch.Tensor):
         return data.pin_memory()
     elif isinstance(data, string_classes):
         return data
     elif isinstance(data, container_abcs.Mapping):
-        return {k: pin_memory_data(sample) for k, sample in data.items()}
+        return {k: pin_memory(sample) for k, sample in data.items()}
     elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
-        return type(data)(*(pin_memory_data(sample) for sample in data))
+        return type(data)(*(pin_memory(sample) for sample in data))
     elif isinstance(data, container_abcs.Sequence):
-        return [pin_memory_data(sample) for sample in data]
+        return [pin_memory(sample) for sample in data]
     elif hasattr(data, "pin_memory"):
         return data.pin_memory()
     else:

--- a/torch/utils/data/_utils/pin_memory.py
+++ b/torch/utils/data/_utils/pin_memory.py
@@ -36,27 +36,27 @@ def _pin_memory_loop(in_queue, out_queue, device_id, done_event):
         elif isinstance(r[1], ExceptionWrapper):
             out_queue.put(r)
         else:
-            idx, batch = r
+            idx, data = r
             try:
-                batch = pin_memory_batch(batch)
+                data = pin_memory_data(data)
             except Exception:
                 out_queue.put((idx, ExceptionWrapper(sys.exc_info())))
             else:
-                out_queue.put((idx, batch))
+                out_queue.put((idx, data))
 
 
-def pin_memory_batch(batch):
-    if isinstance(batch, torch.Tensor):
-        return batch.pin_memory()
-    elif isinstance(batch, string_classes):
-        return batch
-    elif isinstance(batch, container_abcs.Mapping):
-        return {k: pin_memory_batch(sample) for k, sample in batch.items()}
-    elif isinstance(batch, tuple) and hasattr(batch, '_fields'):  # namedtuple
-        return type(batch)(*(pin_memory_batch(sample) for sample in batch))
-    elif isinstance(batch, container_abcs.Sequence):
-        return [pin_memory_batch(sample) for sample in batch]
-    elif hasattr(batch, "pin_memory"):
-        return batch.pin_memory()
+def pin_memory_data(data):
+    if isinstance(data, torch.Tensor):
+        return data.pin_memory()
+    elif isinstance(data, string_classes):
+        return data
+    elif isinstance(data, container_abcs.Mapping):
+        return {k: pin_memory_data(sample) for k, sample in data.items()}
+    elif isinstance(data, tuple) and hasattr(data, '_fields'):  # namedtuple
+        return type(data)(*(pin_memory_data(sample) for sample in data))
+    elif isinstance(data, container_abcs.Sequence):
+        return [pin_memory_data(sample) for sample in data]
+    elif hasattr(data, "pin_memory"):
+        return data.pin_memory()
     else:
-        return batch
+        return data

--- a/torch/utils/data/_utils/signal_handling.py
+++ b/torch/utils/data/_utils/signal_handling.py
@@ -32,9 +32,12 @@ multiprocessing data loading robust to errors.
 
 import signal
 import threading
-from torch._C import _set_worker_pids, _remove_worker_pids, _error_if_any_worker_fails, _set_worker_signal_handlers  # noqa: F401
 from . import IS_WINDOWS
 
+# Some of the following imported functions are not used in this file, but are to
+# be used `_utils.signal_handling.XXXXX`.
+from torch._C import _set_worker_pids, _remove_worker_pids  # noqa: F401
+from torch._C import _error_if_any_worker_fails, _set_worker_signal_handlers  # noqa: F401
 
 _SIGCHLD_handler_set = False
 r"""Whether SIGCHLD handler is set for DataLoader worker failures. Only one

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -10,8 +10,7 @@ import sys
 import os
 from collections import namedtuple
 from torch._six import queue
-from . import collate, signal_handling, MP_STATUS_CHECK_INTERVAL, \
-    ExceptionWrapper, IS_WINDOWS
+from . import signal_handling, MP_STATUS_CHECK_INTERVAL, ExceptionWrapper, IS_WINDOWS
 
 if IS_WINDOWS:
     import ctypes
@@ -111,8 +110,6 @@ def _worker_loop(mode, dataset, index_queue, data_queue, done_event, convert_fn,
     # logic of this function.
 
     try:
-        collate._use_shared_memory = True
-
         # Intialize C side signal handlers for SIGBUS and SIGSEGV. Python signal
         # module's handlers are executed after Python returns from C low-level
         # handlers, likely when the same fatal signal had already happened

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -8,6 +8,7 @@ import torch
 import random
 import sys
 import os
+from collections import namedtuple
 from torch._six import queue
 from . import collate, signal_handling, MP_STATUS_CHECK_INTERVAL, \
     ExceptionWrapper, IS_WINDOWS
@@ -54,8 +55,57 @@ else:
                 self.manager_dead = os.getppid() != self.manager_pid
             return not self.manager_dead
 
+_worker_info = None
 
-def _worker_loop(dataset, index_queue, data_queue, done_event, collate_fn, seed, init_fn, worker_id):
+
+class WorkerInfo(object):
+    __initialized = False
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        self.__initialized = True
+
+    def __setattr__(self, key, val):
+        if self.__initialized:
+            raise RuntimeError("Cannot assign attributes to {} objects".format(self.__class__.__name__))
+        return super(WorkerInfo, self).__setattr__(key, val)
+
+
+def get_worker_info():
+    r"""Returns the information about the current
+    :class:`~torch.utils.data.DataLoader` iterator worker process.
+
+    When called in a worker, this returns an object guaranteed to have the
+    following attributes:
+
+    * :attr:`id`: the current worker id.
+    * :attr:`num_workers`: the total number of workers.
+    * :attr:`seed`: the random seed set for the current worker. This value is
+      determined by main process RNG and the worker id. See
+      :class:`torch.utils.data.DataLoader`'s documentation for more details.
+    * :attr:`dataset`: the copy of the dataset object in **this** process. Note
+      that this will be a different object in a different process than the one
+      in the main process.
+
+    When called in the main process, this returns ``None``.
+
+    .. note::
+       When used in a :attr:`worker_init_fn` passed over to
+       :class:`~torch.utils.data.DataLoader`, this method can be useful to
+       set up each worker process differently. E.g., the :attr:`worker_init_fn`
+       can use the worker ``worker_id`` to configure the ``dataset`` object to
+       only read a specific fraction of a sharded dataset.
+    """
+    return _worker_info
+
+
+r"""Dummy class used to signal the end of an IterableDataset"""
+IterableDatasetStopIteration = namedtuple('IterableDatasetStopIteration', ['worker_id'])
+
+
+def _worker_loop(mode, dataset, index_queue, data_queue, done_event, convert_fn,
+                 collate_fn, seed, init_fn, worker_id, num_workers):
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
 
@@ -75,13 +125,37 @@ def _worker_loop(dataset, index_queue, data_queue, done_event, collate_fn, seed,
 
         data_queue.cancel_join_thread()
 
+        global _worker_info
+        _worker_info = WorkerInfo(id=worker_id, num_workers=num_workers,
+                                  seed=seed, dataset=dataset)
+
+        from torch.utils.data import _DataLoaderStrategy
+
         init_exception = None
 
-        if init_fn is not None:
-            try:
+        try:
+            if init_fn is not None:
                 init_fn(worker_id)
-            except Exception:
-                init_exception = ExceptionWrapper(sys.exc_info())
+
+            if mode == _DataLoaderStrategy.Iterable:
+                dataset_iter = iter(dataset)
+
+        except Exception:
+            init_exception = ExceptionWrapper(sys.exc_info())
+
+        # When using Iterable mode, some worker can exit earlier than others due
+        # to the IterableDataset behaving differently for different workers.
+        # When such things happen, an `IterableDatasetStopIteration` object is
+        # sent over to the main process with the ID of this worker, so that the
+        # main process won't send more tasks to this worker, and will send
+        # `None` to this worker to properly exit it.
+        #
+        # Note that we cannot set `done_event` from a worker as it is shared
+        # among all processes. Instead, we set the `iteration_end` flag to
+        # signify that the iterator is exhausted. When either `done_event` or
+        # `iteration_end` is set, we skip all processing step and just wait for
+        # `None`.
+        iteration_end = False
 
         watchdog = ManagerWatchdog()
 
@@ -92,27 +166,41 @@ def _worker_loop(dataset, index_queue, data_queue, done_event, collate_fn, seed,
                 continue
             if r is None:
                 # Received the final signal
-                assert done_event.is_set()
+                assert done_event.is_set() or iteration_end
                 return
-            elif done_event.is_set():
-                # Done event is set. But I haven't received the final signal
+            elif done_event.is_set() or iteration_end:
+                # `done_event` is set. But I haven't received the final signal
                 # (None) yet. I will keep continuing until get it, and skip the
                 # processing steps.
                 continue
-            idx, batch_indices = r
+            idx, index = r
             try:
                 if init_exception is not None:
-                    samples = init_exception
+                    data = init_exception
                     init_exception = None
                 else:
-                    samples = collate_fn([dataset[i] for i in batch_indices])
+                    if mode == _DataLoaderStrategy.Iterable:
+                        try:
+                            data = convert_fn(next(dataset_iter))
+                        except StopIteration:
+                            data = IterableDatasetStopIteration(worker_id)
+                            # Set `iteration_end`
+                            #   (1) to save future `next(...)` calls, and
+                            #   (2) to avoid sending multiple `IterableDatasetStopIteration`s.
+                            iteration_end = True
+                    elif mode == _DataLoaderStrategy.Map:
+                        data = convert_fn(dataset[index])
+                    else:
+                        # mode == _DataLoaderStrategy.MapWithBatchedRead:
+                        data = collate_fn([dataset[i] for i in index])
             except Exception:
                 # It is important that we don't store exc_info in a variable,
                 # see NOTE [ Python Traceback Reference Cycle Problem ]
                 data_queue.put((idx, ExceptionWrapper(sys.exc_info())))
             else:
-                data_queue.put((idx, samples))
-                del samples
+                data_queue.put((idx, data))
+                del data  # save memory
+            del idx, index, r  # save memory
     except KeyboardInterrupt:
         # Main process will raise KeyboardInterrupt anyways.
         pass

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -83,7 +83,7 @@ def get_worker_info():
     * :attr:`num_workers`: the total number of workers.
     * :attr:`seed`: the random seed set for the current worker. This value is
       determined by main process RNG and the worker id. See
-      :class:`torch.utils.data.DataLoader`'s documentation for more details.
+      :class:`~torch.utils.data.DataLoader`'s documentation for more details.
     * :attr:`dataset`: the copy of the dataset object in **this** process. Note
       that this will be a different object in a different process than the one
       in the main process.
@@ -93,9 +93,10 @@ def get_worker_info():
     .. note::
        When used in a :attr:`worker_init_fn` passed over to
        :class:`~torch.utils.data.DataLoader`, this method can be useful to
-       set up each worker process differently. E.g., the :attr:`worker_init_fn`
-       can use the worker ``worker_id`` to configure the ``dataset`` object to
-       only read a specific fraction of a sharded dataset.
+       set up each worker process differently, for instance, using ``worker_id``
+       to configure the ``dataset`` object to only read a specific fraction of a
+       sharded dataset, or use ``seed`` to seed other libraries used in dataset
+       code (e.g., NumPy).
     """
     return _worker_info
 

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -105,7 +105,7 @@ IterableDatasetStopIteration = namedtuple('IterableDatasetStopIteration', ['work
 
 
 def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
-                 is_batched, collate_fn, drop_last, seed, init_fn, worker_id,
+                 auto_collation, collate_fn, drop_last, seed, init_fn, worker_id,
                  num_workers):
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
@@ -136,7 +136,7 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
             if init_fn is not None:
                 init_fn(worker_id)
 
-            fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, is_batched, collate_fn, drop_last)
+            fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
         except Exception:
             init_exception = ExceptionWrapper(sys.exc_info())
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -81,46 +81,6 @@ class DataLoader(object):
             worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
             input, after seeding and before data loading. (default: ``None``)
 
-    .. note:: When ``num_workers != 0``, the corresponding worker processes are created each time
-              iterator for the DataLoader is obtained (as in when you call
-              ``enumerate(dataloader,0)``).
-              At this point, the dataset, ``collate_fn`` and ``worker_init_fn`` are passed to each
-              worker, where they are used to access and initialize data based on the indices
-              queued up from the main process. This means that dataset access together with
-              its internal IO, transforms and collation runs in the worker, while any
-              shuffle randomization is done in the main process which guides loading by assigning
-              indices to load. Workers are shut down once the end of the iteration is reached.
-
-              Since workers rely on Python multiprocessing, worker launch behavior is different
-              on Windows compared to Unix. On Unix fork() is used as the default
-              multiprocessing start method, so child workers typically can access the dataset and
-              Python argument functions directly through the cloned address space. On Windows, another
-              interpreter is launched which runs your main script, followed by the internal
-              worker function that receives the dataset, collate_fn and other arguments
-              through Pickle serialization.
-
-              This separate serialization means that you should take two steps to ensure you
-              are compatible with Windows while using workers
-              (this also works equally well on Unix):
-
-              - Wrap most of you main script's code within ``if __name__ == '__main__':`` block,
-                to make sure it doesn't run again (most likely generating error) when each worker
-                process is launched. You can place your dataset and DataLoader instance creation
-                logic here, as it doesn't need to be re-executed in workers.
-              - Make sure that ``collate_fn``, ``worker_init_fn`` or any custom dataset code
-                is declared as a top level def, outside of that ``__main__`` check. This ensures
-                they are available in workers as well
-                (this is needed since functions are pickled as references only, not bytecode).
-
-              By default, each worker will have its PyTorch seed set to
-              ``base_seed + worker_id``, where ``base_seed`` is a long generated
-              by main process using its RNG. However, seeds for other libraies
-              may be duplicated upon initializing workers (w.g., NumPy), causing
-              each worker to return identical random numbers. (See
-              :ref:`dataloader-workers-random-seed` section in FAQ.) You may
-              use :func:`torch.initial_seed()` to access the PyTorch seed for
-              each worker in :attr:`worker_init_fn`, and use it to set other
-              seeds before data loading.
 
     .. warning:: If ``spawn`` start method is used, :attr:`worker_init_fn` cannot be an
                  unpicklable object, e.g., a lambda function.

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -46,6 +46,12 @@ class _InfiniteConstantSampler(Sampler):
         while True:
             yield None
 
+    def __len__(self):
+        # This has to be a TypeError, otherwise, since this is used in
+        # `len(dataloader)`, `list(dataloader)` will fail.
+        # see NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
+        raise TypeError('Cannot determine the DataLoader length of a IterableDataset')
+
 
 class DataLoader(object):
     r"""
@@ -98,9 +104,11 @@ class DataLoader(object):
     .. note:: ``len(dataloader)`` heuristic based on the length of the sampler used.
               When :attr:`dataset` is a subclass of :class:`~torch.utils.data.IterableDataset`,
               an infinite sampler is used, whose :meth:`__len__` is not
-              implemented. So one should not query this method unless they work
-              with a map-style dataset. See `Dataset Types`_ for more details on
-              these two types of dataset.
+              implemented, because the actual length depends on both the
+              iterable as well as multi-process loading configurations. So one
+              should not query this method unless they work with a map-style
+              dataset. See `Dataset Types`_ for more details on these two types
+              of datasets.
     """
 
     __initialized = False
@@ -248,7 +256,7 @@ class DataLoader(object):
             return self.sampler
 
     def __len__(self):
-        return len(self._index_sampler)
+        return len(self._index_sampler)  # with iterable-style dataset, this will error
 
 
 class _BaseDataLoaderIter(object):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -467,8 +467,16 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
     #           It won't need to get from any queue, which would also need to be
     #           guarded by periodic status checks.
     #
-    #           Note that this may leave corrupted data in the queue, but we
-    #           don't care about the data anyways once we are shutting down.
+    #           Nonetheless, `cancel_join_thread` must only be called when the
+    #           queue is **not** going to be read from or write into by another
+    #           process, because it may hold onto a lock or leave corrupted data
+    #           in the queue, leading other readers/writers to hang.
+    #
+    #           `pin_memory_thread`'s `data_queue` is a `queue.Queue` that does
+    #           a blocking `put` if the queue is full. So there is no above
+    #           problem, but we do need to wrap the `put` in a loop that breaks
+    #           not only upon success, but also when the main process stops
+    #           reading, i.e., is shutting down.
     #
     #
     # Now let's get back to 1:
@@ -478,39 +486,72 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
     # To achieve this, we implement the following logic along with the design
     # choices mentioned above:
     #
-    # `done_event`:
-    #   A `multiprocessing.Event` shared among all processes and threads. This
-    #   is used to signal the workers and pin_memory_thread that the iterator is
+    # `workers_done_event`:
+    #   A `multiprocessing.Event` shared among the main process and all worker
+    #   processes. This is used to signal the workers that the iterator is
     #   shutting down. After it is set, they will not send processed data to
     #   queues anymore, and only wait for the final `None` before exiting.
     #   `done_event` isn't strictly needed. I.e., we can just check for `None`
     #   from the input queue, but it allows us to skip wasting resources
     #   processing data if we are already shutting down.
     #
-    # [worker processes]
+    # `pin_memory_thread_done_event`:
+    #   A `threading.Event` for a similar purpose to that of
+    #   `workers_done_event`, but is for the `pin_memory_thread`. The reason
+    #   that separate events are neede is that `pin_memory_thread` reads from
+    #   the output queue of the workers. But the workers, upon seeing that
+    #   `workers_done_event` is set, only wants to see the final `None`, and is
+    #   not required to flush all data in the output queue (e.g., it may call
+    #   `cancel_join_thread` on that queue if its `IterableDataset` iterator
+    #   happens to exhaust coincidentally, which is out of the control of the
+    #   main process). Thus, since we will exit `pin_memory_thread` before the
+    #   workers (see below), two separete events are used.
+    #
+    # NOTE: In short, the protocol is that the main process will set these
+    #       `done_event`s and then the corresponding processes/threads a `None`,
+    #       and that they may exit at any time after receiving the `None`.
+    #
+    # NOTE: Using `None` as the final signal is valid, since normal data will
+    #       always be a 2-tuple with the 1st element being the index of the data
+    #       transferred (different from dataset index/key), and the 2nd being
+    #       either the dataset key or the data sample (depending on which part
+    #       of the data model the queue is at).
+    #
+    # [ worker processes ]
     #   While loader process is alive:
-    #     Get from index_queue.
-    #       If got a `None`, exit.
+    #     Get from `index_queue`.
     #       If get anything else,
-    #          Check `done_event`.
+    #          Check `workers_done_event`.
     #            If set, continue to next iteration
     #                    i.e., keep getting until see the `None`, then exit.
-    #            Otherwise, process data.
+    #            Otherwise, process data:
+    #                If is fetching from an `IterableDataset` and the iterator
+    #                    is exhausted, send an `_IterableDatasetStopIteration`
+    #                    object to signal iteration end. The main process, upon
+    #                    receiving such an object, will send `None` to this
+    #                    worker and not use the corresponding `index_queue`
+    #                    anymore.
     #       If timed out,
-    #          No matter `done_event` is set (still need to see `None`) or not,
-    #          must continue to next iteration .
+    #          No matter `workers_done_event` is set (still need to see `None`)
+    #          or not, must continue to next iteration.
+    #   (outside loop)
+    #   If `workers_done_event` is set,  (this can be False with `IterableDataset`)
+    #     `data_queue.cancel_join_thread()`.  (Everything is ending here:
+    #                                          main process won't read from it;
+    #                                          other workers will also call
+    #                                          `cancel_join_thread`.)
     #
-    # [pin_memory_thread]
+    # [ pin_memory_thread ]
     #   # No need to check main thread. If this thread is alive, the main loader
     #   # thread must be alive, because this thread is set as daemonic.
-    #   While True:
-    #     Get from index_queue.
-    #       If got a `None`, exit.
-    #       If get anything else,
-    #          Check `done_event`.
-    #            If set, continue to next iteration
-    #                    i.e., keep getting until see the `None`, then exit.
-    #            Otherwise, process data.
+    #   While `pin_memory_thread_done_event` is not set:
+    #     Get from `index_queue`.
+    #       If timed out, continue to get in the next iteration.
+    #       Otherwise, process data.
+    #       While `pin_memory_thread_done_event` is not set:
+    #         Put processed data to `data_queue` (a `queue.Queue` with blocking put)
+    #         If timed out, continue to put in the next iteration.
+    #         Otherwise, break, i.e., continuing to the out loop.
     #
     #   NOTE: we don't check the status of the main thread because
     #           1. if the process is killed by fatal signal, `pin_memory_thread`
@@ -520,24 +561,27 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
     #              This won't busy-wait either because `.get(timeout)` does not
     #              busy-wait.
     #
-    # [main process]
+    # [ main process ]
     #   In the DataLoader Iter's `__del__`
-    #     a. Set `done_event` (shared with `pin_memory_thread` and workers).
-    #
-    #        Note: from here on, the workers & `pin_memory_thread` may exit at
-    #              any time after they receive `None`.
-    #
     #     b. Exit `pin_memory_thread`
-    #          i.   Put `None` in `worker_result_queue`.
-    #          ii.  Join the `pin_memory_thread`.
+    #          i.   Set `pin_memory_thread_done_event`.
+    #          ii   Put `None` in `worker_result_queue`.
+    #          iii. Join the `pin_memory_thread`.
+    #          iv.  `worker_result_queue.cancel_join_thread()`.
     #
     #     c. Exit the workers.
-    #          i.   Put `None` in each worker's `index_queue`.
-    #          ii.  Join the workers.
+    #          i.   Set `workers_done_event`.
+    #          ii.  Put `None` in each worker's `index_queue`.
+    #          iii. Join the workers.
+    #          iv.  Call `.cancel_join_thread()` on each worker's `index_queue`.
     #
-    #        NOTE: This has to be after (b) because it may leave corrupted data
-    #              in `worker_result_queue`, which `pin_memory_thread` reads
-    #              from.
+    #        NOTE: (c) is better placed after (b) because it may leave corrupted
+    #              data in `worker_result_queue`, which `pin_memory_thread`
+    #              reads from, in which case the `pin_memory_thread` can only
+    #              happen at timeing out, which is slow. Nonetheless, same thing
+    #              happens if a worker is killed by signal at unfortunate times,
+    #              but in other cases, we are better off having a non-corrupted
+    #              `worker_result_queue` for `pin_memory_thread`.
     #
     #   NOTE: If `pin_memory=False`, there is no `pin_memory_thread` and (b)
     #         can be omitted
@@ -564,7 +608,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         #                  \ (worker_id, data)   if data is already fetched (out-of-order)
         self.task_info = {}
         self.tasks_outstanding = 0  # always equal to count(v for v in task_info.values() if len(v) == 1)
-        self.done_event = multiprocessing.Event()
+        self.workers_done_event = multiprocessing.Event()
 
         self.index_queues = []
         self.workers = []
@@ -572,14 +616,14 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         # do, i.e., not having exhausted its iterable dataset object. It always
         # contains all `True`s if not using an iterable dataset
         # (i.e., if kind != Iterable).
-        self.worker_status = []
+        self.workers_status = []
         for i in range(self.num_workers):
             index_queue = multiprocessing.Queue()
-            index_queue.cancel_join_thread()
+            # index_queue.cancel_join_thread()
             w = multiprocessing.Process(
                 target=_utils.worker._worker_loop,
                 args=(self.dataset_kind, self.dataset, index_queue,
-                      self.worker_result_queue, self.done_event,
+                      self.worker_result_queue, self.workers_done_event,
                       self.auto_collation, self.collate_fn, self.drop_last,
                       self.base_seed + i, self.worker_init_fn, i, self.num_workers))
             w.daemon = True
@@ -592,14 +636,16 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             w.start()
             self.index_queues.append(index_queue)
             self.workers.append(w)
-            self.worker_status.append(True)
+            self.workers_status.append(True)
 
         if self.pin_memory:
+            self.pin_memory_thread_done_event = threading.Event()
             self.data_queue = queue.Queue()
             pin_memory_thread = threading.Thread(
                 target=_utils.pin_memory._pin_memory_loop,
                 args=(self.worker_result_queue, self.data_queue,
-                      torch.cuda.current_device(), self.done_event))
+                      torch.cuda.current_device(),
+                      self.pin_memory_thread_done_event))
             pin_memory_thread.daemon = True
             pin_memory_thread.start()
             # Similar to workers (see comment above), we only register
@@ -637,7 +683,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             # worker failures.
             failed_workers = []
             for worker_id, w in enumerate(self.workers):
-                if self.worker_status[worker_id] and not w.is_alive():
+                if self.workers_status[worker_id] and not w.is_alive():
                     failed_workers.append(w)
                     self._shutdown_worker(worker_id)
             if len(failed_workers) > 0:
@@ -687,12 +733,12 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             # we try to advance `self.rcvd_idx` to find the next valid index.
             #
             # This part needs to run in the loop because both the `self._get_data()`
-            # call and `IterableDatasetStopIteration` check below can mark
+            # call and `_IterableDatasetStopIteration` check below can mark
             # extra worker(s) as dead.
             while self.rcvd_idx < self.send_idx:
                 info = self.task_info[self.rcvd_idx]
                 worker_id = info[0]
-                if len(info) == 2 or self.worker_status[worker_id]:  # has data or is still active
+                if len(info) == 2 or self.workers_status[worker_id]:  # has data or is still active
                     break
                 del self.task_info[self.rcvd_idx]
                 self.rcvd_idx += 1
@@ -713,8 +759,8 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             self.tasks_outstanding -= 1
 
             if self.dataset_kind == _DatasetKind.Iterable:
-                # Check for IterableDatasetStopIteration
-                if isinstance(data, _utils.worker.IterableDatasetStopIteration):
+                # Check for _IterableDatasetStopIteration
+                if isinstance(data, _utils.worker._IterableDatasetStopIteration):
                     self._shutdown_worker(data.worker_id)
                     self._try_put_index()
                     continue
@@ -736,7 +782,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
             return
         for _ in range(self.num_workers):  # find the next active worker, if any
             worker_queue_idx = next(self.worker_queue_idx_cycle)
-            if self.worker_status[worker_queue_idx]:
+            if self.workers_status[worker_queue_idx]:
                 break
         else:
             # not found (i.e., didn't break)
@@ -764,14 +810,13 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         # exhausting an `IterableDataset`. This should be used only when this
         # `_DataLoaderIter` is going to continue running.
 
-        assert self.worker_status[worker_id]
+        assert self.workers_status[worker_id]
 
         # Signal termination to that specific worker.
         q = self.index_queues[worker_id]
         # Indicate that no more data will be put on this queue by the current
         # process.
         q.put(None)
-        q.close()
 
         # Note that we don't actually join the worker here, nor do we remove the
         # worker's pid from C side struct because (1) joining may be slow, and
@@ -781,7 +826,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         # Joinning is deferred to `_shutdown_workers`, which it is called when
         # all workers finish their jobs (e.g., `IterableDataset` replicas) or
         # when this iterator is garbage collected.
-        self.worker_status[worker_id] = False
+        self.workers_status[worker_id] = False
 
     def _shutdown_workers(self):
         # Called when shutting down this `_DataLoaderIter`.
@@ -796,33 +841,24 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         if not self.shutdown:
             self.shutdown = True
             try:
-                self.done_event.set()
-
                 # Exit `pin_memory_thread` first because exiting workers may leave
                 # corrupted data in `worker_result_queue` which `pin_memory_thread`
                 # reads from.
                 if hasattr(self, 'pin_memory_thread'):
+                    self.pin_memory_thread_done_event.set()
                     # Use hasattr in case error happens before we set the attribute.
-                    # First time do `worker_result_queue.put` in this process.
-
-                    # `cancel_join_thread` in case that `pin_memory_thread` exited.
-                    self.worker_result_queue.cancel_join_thread()
-                    self.worker_result_queue.put(None)
                     self.pin_memory_thread.join()
-                    # Indicate that no more data will be put on this queue by the
-                    # current process. This **must** be called after
-                    # `pin_memory_thread` is joined because that thread shares the
-                    # same pipe handles with this loader thread. If the handle is
-                    # closed, Py3 will error in this case, but Py2 will just time
-                    # out even if there is data in the queue.
-                    self.worker_result_queue.close()
 
                 # Exit workers now.
+                self.workers_done_event.set()
                 for worker_id in range(self.num_workers):
-                    if self.worker_status[worker_id]:
+                    if self.workers_status[worker_id]:
                         self._shutdown_worker(worker_id)
                 for w in self.workers:
                     w.join()
+                for q in self.index_queues:
+                    q.cancel_join_thread()
+                    q.close()
             finally:
                 # Even though all this function does is putting into queues that
                 # we have called `cancel_join_thread` on, weird things can

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -95,17 +95,12 @@ class DataLoader(object):
                  :ref:`multiprocessing-best-practices` on more details related
                  to multiprocessing in PyTorch.
 
-    .. note:: ``len(dataloader)`` is determined by length of the sampler used.
-              When :attr:`dataset` is an :class:`~torch.utils.data.IterableDataset`,
+    .. note:: ``len(dataloader)`` heuristic based on the length of the sampler used.
+              When :attr:`dataset` is a subclass of :class:`~torch.utils.data.IterableDataset`,
               an infinite sampler is used, whose :meth:`__len__` is not
-              implemented. With :class:`~torch.utils.data.IterableDataset` the
-              actual iterator size depends on :attr:`num_workers`.
-              If :attr:`num_workers > 0` (i.e., multi-process loading), each
-              worker gets a copy of the same iterable dataset object and can
-              return duplicate data, unless the dataset copies and/or the
-              workers are configured differently (e.g., in :meth:`__iter__`).
-              See :class:`~torch.utils.data.IterableDataset` for more details
-              and examples.
+              implemented. So one should not query this method unless they work
+              with a map-style dataset. See `Dataset Types`_ for more details on
+              these two types of dataset.
     """
 
     __initialized = False
@@ -612,9 +607,9 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
         self.index_queues = []
         self.workers = []
-        # A list of booleans representing whether each worker still has word to
+        # A list of booleans representing whether each worker still has work to
         # do, i.e., not having exhausted its iterable dataset object. It always
-        # contains all `True`s if not using an iterable dataset
+        # contains all `True`s if not using an iterable-style dataset
         # (i.e., if kind != Iterable).
         self.workers_status = []
         for i in range(self.num_workers):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -36,8 +36,8 @@ class _DatasetKind(object):
 
 
 class _InfiniteConstantSampler(Sampler):
-    r"""Analogous to itertools.repeat(None, None).
-    Used as sampler for IterableDataset.
+    r"""Analogous to ``itertools.repeat(None, None)``.
+    Used as sampler for :class:`~torch.utils.data.IterableDataset`.
     """
     def __init__(self):
         super(_InfiniteConstantSampler, self).__init__(None)
@@ -53,10 +53,10 @@ class DataLoader(object):
     the given dataset.
 
     The :class:`~torch.utils.data.DataLoader` supports both map-style and
-    iterable-style datasets with single- or multi-process loading strategies,
-    and optional automatic batching (collation).
+    iterable-style datasets with single- or multi-process loading, customizing
+    loading order and optional automatic batching (collation) and memory pinning.
 
-    See `Dataset Types`_ and `Data Loading Strategies`_ for more details.
+    See :py:mod:`torch.utils.data` documentation page for more details.
 
     Arguments:
         dataset (Dataset): dataset from which to load the data.
@@ -92,20 +92,20 @@ class DataLoader(object):
 
     .. warning:: If the ``spawn`` start method is used, :attr:`worker_init_fn`
                  cannot be an unpicklable object, e.g., a lambda function. See
-                 :ref:`_multiprocessing-best-practices` on more details related
+                 :ref:`multiprocessing-best-practices` on more details related
                  to multiprocessing in PyTorch.
 
     .. note:: ``len(dataloader)`` is determined by length of the sampler used.
               When :attr:`dataset` is an :class:`~torch.utils.data.IterableDataset`,
-              an infinite sampler is used, whose ``__len__`` is not implemented.
-              With :class:`~torch.utils.data.IterableDataset` the actual
-              iterator size depends on :attr:`num_workers`.
-              If ``num_workers > 0`` (i.e., multi-process loading), each worker
-              gets a copy of the same iterable dataset object and can return
-              duplicate data, unless the dataset copies and/or the workers are
-              configured differently (e.g., in ``__iter__``). See
-              :class:`~torch.utils.data.IterableDataset` for more details and
-              examples.
+              an infinite sampler is used, whose :meth:`__len__` is not
+              implemented. With :class:`~torch.utils.data.IterableDataset` the
+              actual iterator size depends on :attr:`num_workers`.
+              If :attr:`num_workers > 0` (i.e., multi-process loading), each
+              worker gets a copy of the same iterable dataset object and can
+              return duplicate data, unless the dataset copies and/or the
+              workers are configured differently (e.g., in :meth:`__iter__`).
+              See :class:`~torch.utils.data.IterableDataset` for more details
+              and examples.
     """
 
     __initialized = False

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -24,11 +24,11 @@ class Dataset(object):
     def __getitem__(self, index):
         raise NotImplementedError
 
-    def __len__(self):
-        raise NotImplementedError
-
     def __add__(self, other):
         return ConcatDataset([self, other])
+
+    # No `def __len__(self)` default?
+    # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
 
 
 class IterableDataset(Dataset):
@@ -140,13 +140,8 @@ class IterableDataset(Dataset):
     def __add__(self, other):
         return ChainDataset([self, other])
 
-    def __len__(self):
-        # Returning `NotImplemented` instead of raising `NotImplementedError`
-        # allows for properly triggering some fallback behavior. E.g., the
-        # built-in `list(X)` tries to call `len(X)` first, and executes a
-        # different code path if `NotImplemented` is returned, while raising
-        # `NotImplementedError` will propagate and and make the call fail.
-        return NotImplemented
+    # No `def __len__(self)` default?
+    # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
 
 
 class TensorDataset(Dataset):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -72,21 +72,21 @@ class IterableDataset(Dataset):
         ...             iter_end = min(iter_start + per_worker, self.end)
         ...         return iter(range(iter_start, iter_end))
         ...
-        >>> # should give same set of data as range(3, 11)
-        >>> ds = MyIterableDataset(start=3, end=11)
+        >>> # should give same set of data as range(3, 7), i.e., [3, 4, 5, 6].
+        >>> ds = MyIterableDataset(start=3, end=7)
 
         >>> # Single-process loading
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=0)))
-        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+        [tensor(3), tensor(4), tensor(5), tensor(6)]
 
         >>> # Mult-process loading with two worker processes
-        >>> # Worker 0 fetched [3, 4, 5, 6]. Worker 1 fetched [7, 8, 9, 10].
+        >>> # Worker 0 fetched [3, 4].  Worker 1 fetched [5, 6].
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2)))
-        [tensor(3), tensor(7), tensor(4), tensor(8), tensor(5), tensor(9), tensor(6), tensor(10)]
+        [tensor(3), tensor(5), tensor(4), tensor(6)]
 
         >>> # With even more workers
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=20)))
-        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+        [tensor(3), tensor(4), tensor(5), tensor(6)]
 
     Example 2: splitting workload across all workers using :attr:`worker_init_fn`::
 
@@ -100,16 +100,16 @@ class IterableDataset(Dataset):
         ...     def __iter__(self):
         ...         return iter(range(self.start, self.end))
         ...
-        >>> # should give same set of data as range(3, 11)
-        >>> ds = MyIterableDataset(start=3, end=11)
+        >>> # should give same set of data as range(3, 7), i.e., [3, 4, 5, 6].
+        >>> ds = MyIterableDataset(start=3, end=7)
 
         >>> # Single-process loading
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=0)))
-        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+        [tensor(3), tensor(4), tensor(5), tensor(6)]
         >>>
         >>> # Directly doing multi-process loading yields duplicate data
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2)))
-        [tensor(3), tensor(3), tensor(4), tensor(4), tensor(5), tensor(5), tensor(6), tensor(6), tensor(7), tensor(7), tensor(8), tensor(8), tensor(9), tensor(9), tensor(10), tensor(10)]
+        [tensor(3), tensor(3), tensor(4), tensor(4), tensor(5), tensor(5), tensor(6), tensor(6)]
 
         >>> # Define a `worker_init_fn` that configures each dataset copy differently
         >>> def worker_init_fn(worker_id):
@@ -125,13 +125,13 @@ class IterableDataset(Dataset):
         ...
 
         >>> # Mult-process loading with the custom `worker_init_fn`
-        >>> # Worker 0 fetched [3, 4, 5, 6]. Worker 1 fetched [7, 8, 9, 10].
+        >>> # Worker 0 fetched [3, 4].  Worker 1 fetched [5, 6].
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2, worker_init_fn=worker_init_fn)))
-        [tensor(3), tensor(7), tensor(4), tensor(8), tensor(5), tensor(9), tensor(6), tensor(10)]
+        [tensor(3), tensor(5), tensor(4), tensor(6)]
 
         >>> # With even more workers
         >>> print(list(torch.utils.data.DataLoader(ds, num_workers=20, worker_init_fn=worker_init_fn)))
-        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+        [tensor(3), tensor(4), tensor(5), tensor(6)]
     """
 
     def __iter__(self):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -9,9 +9,9 @@ class Dataset(object):
     r"""An abstract class representing a :class:`Dataset`.
 
     All datasets that represent a map from keys to data samples should subclass
-    it. All subclasses should overrite ``__getitem__``, supporting fetching a
+    it. All subclasses should overrite :meth:`__getitem__`, supporting fetching a
     data sample for a given key. Subclasses could also optionally overwrite
-    ``__len__``, which is expected to return the size of the dataset by many
+    :meth:`__len__`, which is expected to return the size of the dataset by many
     :class:`~torch.utils.data.Sampler` implementations and the default options
     of :class:`~torch.utils.data.DataLoader`.
 
@@ -37,8 +37,8 @@ class IterableDataset(Dataset):
     All datasets that represent an iterable of data samples should subclass it.
     Such form of datasets is particularly useful when data come from a stream.
 
-    All subclasses should overrite ``__iter__``, which would return an iterator
-    of samples in this dataset.
+    All subclasses should overrite :meth:`__iter__`, which would return an
+    iterator of samples in this dataset.
 
     When a subclass is used with :class:`~torch.utils.data.DataLoader`, each
     item in the dataset will be yielded from the :class:`~torch.utils.data.DataLoader`
@@ -47,64 +47,91 @@ class IterableDataset(Dataset):
     each copy independently to avoid having duplicate data returned from the
     workers. :func:`~torch.utils.data.get_worker_info`, when called in a worker
     process, returns information about the worker. It can be used in either the
-    dataset's ``__iter__`` method or the :class:`~torch.utils.data.DataLoader` 's
+    dataset's :meth:`__iter__` method or the :class:`~torch.utils.data.DataLoader` 's
     :attr:`worker_init_fn` option to modify each copy's behavior.
 
-    Examples::
+    Example 1: splitting workload across all workers in :meth:`__iter__`::
 
-        >>> # Use `get_worker_info` in `worker_init_fn`
         >>> class MyIterableDataset(torch.utils.data.IterableDataset):
         ...     def __init__(self, start, end):
         ...         super(MyIterableDataset).__init__()
+        ...         assert end > start, "this example code only works with end >= start"
+        ...         self.start = start
+        ...         self.end = end
+        ...
+        ...     def __iter__(self):
+        ...         worker_info = torch.utils.data.get_worker_info()
+        ...         if worker_info is None:  # single-process data loading, return the full iterator
+        ...             iter_start = self.start
+        ...             iter_end = self.end
+        ...         else:  # in a worker process
+        ...             # split workload
+        ...             per_worker = int(math.ceil((self.end - self.start) / float(worker_info.num_workers)))
+        ...             worker_id = worker_info.id
+        ...             iter_start = self.start + worker_id * per_worker
+        ...             iter_end = min(iter_start + per_worker, self.end)
+        ...         return iter(range(iter_start, iter_end))
+        ...
+        >>> # should give same set of data as range(3, 11)
+        >>> ds = MyIterableDataset(start=3, end=11)
+
+        >>> # Single-process loading
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=0)))
+        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+
+        >>> # Mult-process loading with two worker processes
+        >>> # Worker 0 fetched [3, 4, 5, 6]. Worker 1 fetched [7, 8, 9, 10].
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2)))
+        [tensor(3), tensor(7), tensor(4), tensor(8), tensor(5), tensor(9), tensor(6), tensor(10)]
+
+        >>> # With even more workers
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=20)))
+        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+
+    Example 2: splitting workload across all workers using :attr:`worker_init_fn`::
+
+        >>> class MyIterableDataset(torch.utils.data.IterableDataset):
+        ...     def __init__(self, start, end):
+        ...         super(MyIterableDataset).__init__()
+        ...         assert end > start, "this example code only works with end >= start"
         ...         self.start = start
         ...         self.end = end
         ...
         ...     def __iter__(self):
         ...         return iter(range(self.start, self.end))
         ...
+        >>> # should give same set of data as range(3, 11)
+        >>> ds = MyIterableDataset(start=3, end=11)
+
+        >>> # Single-process loading
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=0)))
+        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+        >>>
+        >>> # Directly doing multi-process loading yields duplicate data
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2)))
+        [tensor(3), tensor(3), tensor(4), tensor(4), tensor(5), tensor(5), tensor(6), tensor(6), tensor(7), tensor(7), tensor(8), tensor(8), tensor(9), tensor(9), tensor(10), tensor(10)]
+
+        >>> # Define a `worker_init_fn` that configures each dataset copy differently
         >>> def worker_init_fn(worker_id):
-        ...     # Splits the overall workload across workers using `get_worker_info`
-        ...     info = torch.utils.data.get_worker_info()
-        ...     dataset = info.dataset  # info.dataset is the dataset copy in this worker process
+        ...     worker_info = torch.utils.data.get_worker_info()
+        ...     dataset = worker_info.dataset  # the dataset copy in this worker process
         ...     overall_start = dataset.start
         ...     overall_end = dataset.end
-        ...     # split workload
-        ...     per_worker = int(math.ceil((overall_end - overall_start) / float(info.num_workers)))
-        ...     worker_id = info.id
+        ...     # configure the dataset to only process the split workload
+        ...     per_worker = int(math.ceil((overall_end - overall_start) / float(worker_info.num_workers)))
+        ...     worker_id = worker_info.id
         ...     dataset.start = overall_start + worker_id * per_worker
         ...     dataset.end = min(dataset.start + per_worker, overall_end)
         ...
-        >>> ds = MyIterableDataset(start=3, end=11)
-        >>>
-        >>> # The `worker_init_fn` splits workload using `worker_info.num_workers`
-        >>> # so it works for different `num_workers` values.
-        >>>
-        >>> loader = torch.utils.data.DataLoader(ds, num_workers=0, worker_init_fn=worker_init_fn)
-        >>> print(list(loader))
-        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
-        >>>
-        >>> loader = torch.utils.data.DataLoader(ds, num_workers=2, worker_init_fn=worker_init_fn)
-        >>> print(list(loader))
-        [tensor(3), tensor(7), tensor(4), tensor(8), tensor(5), tensor(9), tensor(6), tensor(10)]
-        >>>
-        >>> loader = torch.utils.data.DataLoader(ds, num_workers=4, worker_init_fn=worker_init_fn)
-        >>> print(list(loader))
-        [tensor(3), tensor(5), tensor(7), tensor(9), tensor(4), tensor(6), tensor(8), tensor(10)]
 
-        >>> # Use `get_worker_info` in `__iter__`
-        >>> class MyIterableDataset(torch.utils.data.IterableDataset):
-        ...     def __iter__(self):
-        ...         worker_info = torch.utils.data.get_worker_info()
-        ...         assert worker_info is not None, "Not in a worker process"
-        ...         worker_id = worker_info.id
-        ...         return iter([-1, worker_id + 1, (worker_id + 1) * 10])
-        ...
-        >>> ds = MyIterableDataset()
-        >>> loader = torch.utils.data.DataLoader(ds, num_workers=2)
-        >>>
-        >>> # Worker 0 fetched [-1, 1, 10]. Worker 1 fetched [-1, 2, 20].
-        >>> print(list(loader))
-        [tensor(-1), tensor(-1), tensor(1), tensor(2), tensor(10), tensor(20)]
+        >>> # Mult-process loading with the custom `worker_init_fn`
+        >>> # Worker 0 fetched [3, 4, 5, 6]. Worker 1 fetched [7, 8, 9, 10].
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=2, worker_init_fn=worker_init_fn)))
+        [tensor(3), tensor(7), tensor(4), tensor(8), tensor(5), tensor(9), tensor(6), tensor(10)]
+
+        >>> # With even more workers
+        >>> print(list(torch.utils.data.DataLoader(ds, num_workers=20, worker_init_fn=worker_init_fn)))
+        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
     """
 
     def __iter__(self):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -42,7 +42,7 @@ class IterableDataset(Dataset):
 
     When a subclass is used with :class:`~torch.utils.data.DataLoader`, each
     item in the dataset will be yielded from the :class:`~torch.utils.data.DataLoader`
-    iterator. When ``num_workers > 0``, each worker process will have a
+    iterator. When :attr:`num_workers > 0`, each worker process will have a
     different copy of the dataset object, so it is often desired to configure
     each copy independently to avoid having duplicate data returned from the
     workers. :func:`~torch.utils.data.get_worker_info`, when called in a worker

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -6,11 +6,19 @@ from torch import randperm
 
 
 class Dataset(object):
-    """An abstract class representing a Dataset.
+    r"""An abstract class representing a :class:`Dataset`.
 
-    All other datasets should subclass it. All subclasses should override
-    ``__len__``, that provides the size of the dataset, and ``__getitem__``,
-    supporting integer indexing in range from 0 to len(self) exclusive.
+    All datasets that represent a map from keys to data samples should subclass
+    it. All subclasses should overrite ``__getitem__``, supporting fetching a
+    data sample for a given key. Subclasses could also optionally overwrite
+    ``__len__``, which is expected to return the size of the dataset by many
+    :class:`~torch.utils.data.Sampler` implementations and the default options
+    of :class:`~torch.utils.data.DataLoader`.
+
+    .. note::
+      :class:`~torch.utils.data.DataLoader` by default constructs a index
+      sampler that yields integral indices.  To make it work with a map-style
+      dataset with non-integral indices/keys, a custom sampler must be provided.
     """
 
     def __getitem__(self, index):
@@ -23,8 +31,99 @@ class Dataset(object):
         return ConcatDataset([self, other])
 
 
+class IterableDataset(Dataset):
+    r"""An iterable Dataset.
+
+    All datasets that represent an iterable of data samples should subclass it.
+    Such form of datasets is particularly useful when data come from a stream.
+
+    All subclasses should overrite ``__iter__``, which would return an iterator
+    of samples in this dataset.
+
+    When a subclass is used with :class:`~torch.utils.data.DataLoader`, each
+    item in the dataset will be yielded from the :class:`~torch.utils.data.DataLoader`
+    iterator. When ``num_workers > 0``, each worker process will have a
+    different copy of the dataset object, so it is often desired to configure
+    each copy independently to avoid having duplicate data returned from the
+    workers. :func:`~torch.utils.data.get_worker_info`, when called in a worker
+    process, returns information about the worker. It can be used in either the
+    dataset's ``__iter__`` method or the :class:`~torch.utils.data.DataLoader` 's
+    :attr:`worker_init_fn` option to modify each copy's behavior.
+
+    Examples::
+
+        >>> # Use `get_worker_info` in `worker_init_fn`
+        >>> class MyIterableDataset(torch.utils.data.IterableDataset):
+        ...     def __init__(self, start, end):
+        ...         super(MyIterableDataset).__init__()
+        ...         self.start = start
+        ...         self.end = end
+        ...
+        ...     def __iter__(self):
+        ...         return iter(range(self.start, self.end))
+        ...
+        >>> def worker_init_fn(worker_id):
+        ...     # Splits the overall workload across workers using `get_worker_info`
+        ...     info = torch.utils.data.get_worker_info()
+        ...     dataset = info.dataset  # info.dataset is the dataset copy in this worker process
+        ...     overall_start = dataset.start
+        ...     overall_end = dataset.end
+        ...     # split workload
+        ...     per_worker = int(math.ceil((overall_end - overall_start) / float(info.num_workers)))
+        ...     worker_id = info.id
+        ...     dataset.start = overall_start + worker_id * per_worker
+        ...     dataset.end = min(dataset.start + per_worker, overall_end)
+        ...
+        >>> ds = MyIterableDataset(start=3, end=11)
+        >>>
+        >>> # The `worker_init_fn` splits workload using `worker_info.num_workers`
+        >>> # so it works for different `num_workers` values.
+        >>>
+        >>> loader = torch.utils.data.DataLoader(ds, num_workers=0, worker_init_fn=worker_init_fn)
+        >>> print(list(loader))
+        [tensor(3), tensor(4), tensor(5), tensor(6), tensor(7), tensor(8), tensor(9), tensor(10)]
+        >>>
+        >>> loader = torch.utils.data.DataLoader(ds, num_workers=2, worker_init_fn=worker_init_fn)
+        >>> print(list(loader))
+        [tensor(3), tensor(7), tensor(4), tensor(8), tensor(5), tensor(9), tensor(6), tensor(10)]
+        >>>
+        >>> loader = torch.utils.data.DataLoader(ds, num_workers=4, worker_init_fn=worker_init_fn)
+        >>> print(list(loader))
+        [tensor(3), tensor(5), tensor(7), tensor(9), tensor(4), tensor(6), tensor(8), tensor(10)]
+
+        >>> # Use `get_worker_info` in `__iter__`
+        >>> class MyIterableDataset(torch.utils.data.IterableDataset):
+        ...     def __iter__(self):
+        ...         worker_info = torch.utils.data.get_worker_info()
+        ...         assert worker_info is not None, "Not in a worker process"
+        ...         worker_id = worker_info.id
+        ...         return iter([-1, worker_id + 1, (worker_id + 1) * 10])
+        ...
+        >>> ds = MyIterableDataset()
+        >>> loader = torch.utils.data.DataLoader(ds, num_workers=2)
+        >>>
+        >>> # Worker 0 fetched [-1, 1, 10]. Worker 1 fetched [-1, 2, 20].
+        >>> print(list(loader))
+        [tensor(-1), tensor(-1), tensor(1), tensor(2), tensor(10), tensor(20)]
+    """
+
+    def __iter__(self):
+        raise NotImplementedError
+
+    def __add__(self, other):
+        return ChainDataset([self, other])
+
+    def __len__(self):
+        # Returning `NotImplemented` instead of raising `NotImplementedError`
+        # allows for properly triggering some fallback behavior. E.g., the
+        # built-in `list(X)` tries to call `len(X)` first, and executes a
+        # different code path if `NotImplemented` is returned, while raising
+        # `NotImplementedError` will propagate and and make the call fail.
+        return NotImplemented
+
+
 class TensorDataset(Dataset):
-    """Dataset wrapping tensors.
+    r"""Dataset wrapping tensors.
 
     Each sample will be retrieved by indexing tensors along the first dimension.
 
@@ -44,11 +143,9 @@ class TensorDataset(Dataset):
 
 
 class ConcatDataset(Dataset):
-    """
-    Dataset to concatenate multiple datasets.
-    Purpose: useful to assemble different existing datasets, possibly
-    large-scale datasets as the concatenation operation is done in an
-    on-the-fly manner.
+    r"""Dataset as a concatenation of multiple datasets.
+
+    This class is useful to assemble different existing datasets.
 
     Arguments:
         datasets (sequence): List of datasets to be concatenated
@@ -67,6 +164,8 @@ class ConcatDataset(Dataset):
         super(ConcatDataset, self).__init__()
         assert len(datasets) > 0, 'datasets should not be an empty iterable'
         self.datasets = list(datasets)
+        for d in self.datasets:
+            assert not isinstance(d, IterableDataset), "ConcatDataset does not support IterableDataset"
         self.cumulative_sizes = self.cumsum(self.datasets)
 
     def __len__(self):
@@ -91,8 +190,36 @@ class ConcatDataset(Dataset):
         return self.cumulative_sizes
 
 
-class Subset(Dataset):
+class ChainDataset(IterableDataset):
+    r"""Dataset for chainning multiple :class:`IterableDataset` s.
+
+    This class is useful to assemble different existing dataset streams. The
+    chainning operation is done on-the-fly, so concatenating large-scale
+    datasets with this class will be efficient.
+
+    Arguments:
+        datasets (iterable of IterableDataset): datasets to be chained together
     """
+    def __init__(self, datasets):
+        super(ChainDataset, self).__init__()
+        self.datasets = datasets
+
+    def __iter__(self):
+        for d in self.datasets:
+            assert isinstance(d, IterableDataset), "ChainDataset only supports IterableDataset"
+            for x in d:
+                yield x
+
+    def __len__(self):
+        total = 0
+        for d in self.datasets:
+            assert isinstance(d, IterableDataset), "ChainDataset only supports IterableDataset"
+            total += len(d)
+        return total
+
+
+class Subset(Dataset):
+    r"""
     Subset of a dataset at specified indices.
 
     Arguments:
@@ -111,7 +238,7 @@ class Subset(Dataset):
 
 
 def random_split(dataset, lengths):
-    """
+    r"""
     Randomly split a dataset into non-overlapping new datasets of given lengths.
 
     Arguments:

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -39,7 +39,13 @@ class Sampler(object):
     #     raising an `NotImplementedError` will propagate and and make the call
     #     fail where it could have use `__iter__` to complete the call.
     #
-    # Thus, the only sensible thing to do is to **not** provide a default `__len__`.
+    # Thus, the only two sensible things to do are
+    #
+    #   + **not** provide a default `__len__`.
+    #
+    #   + raise a `TypeError` instead, which is what Python uses when users call
+    #     a method that is not defined on an object.
+    #     (@ssnl verifies that this works on at least Python 3.7.)
 
 
 class SequentialSampler(Sampler):

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -5,9 +5,13 @@ from torch._six import int_classes as _int_classes
 class Sampler(object):
     r"""Base class for all Samplers.
 
-    Every Sampler subclass has to provide an __iter__ method, providing a way
-    to iterate over indices of dataset elements, and a __len__ method that
-    returns the length of the returned iterators.
+    Every Sampler subclass has to provide an :meth:`__iter__` method, providing a
+    way to iterate over indices of dataset elements, and a :meth:`__len__` method
+    that returns the length of the returned iterators.
+
+    .. note:: The :meth:`__len__` method isn't strictly required by
+              :class:`~torch.utils.data.DataLoader`, but is expected in any
+              calculation involving the length of a :class:`~torch.utils.data.DataLoader`.
     """
 
     def __init__(self, data_source):
@@ -16,8 +20,26 @@ class Sampler(object):
     def __iter__(self):
         raise NotImplementedError
 
-    def __len__(self):
-        raise NotImplementedError
+    # NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
+    #
+    # Many times we have an abstract class representing a collection/iterable of
+    # data, e.g., `torch.utils.data.Sampler`, with its subclasses optionally
+    # implementing a `__len__` method. In such cases, we must make sure to not
+    # provide a default implementation, because both straightforward default
+    # implementations have their issues:
+    #
+    #   + `return NotImplemented`:
+    #     Calling `len(subclass_instance)` raises:
+    #       TypeError: 'NotImplementedType' object cannot be interpreted as an integer
+    #
+    #   + `raise NotImplementedError()`:
+    #     This prevents triggering some fallback behavior. E.g., the built-in
+    #     `list(X)` tries to call `len(X)` first, and executes a different code
+    #     path if the method is not found or `NotImplemented` is returned, while
+    #     raising an `NotImplementedError` will propagate and and make the call
+    #     fail where it could have use `__iter__` to complete the call.
+    #
+    # Thus, the only sensible thing to do is to **not** provide a default `__len__`.
 
 
 class SequentialSampler(Sampler):
@@ -39,7 +61,7 @@ class SequentialSampler(Sampler):
 
 class RandomSampler(Sampler):
     r"""Samples elements randomly. If without replacement, then sample from a shuffled dataset.
-    If with replacement, then user can specify ``num_samples`` to draw.
+    If with replacement, then user can specify :attr:`num_samples` to draw.
 
     Arguments:
         data_source (Dataset): dataset to sample from
@@ -100,7 +122,7 @@ class SubsetRandomSampler(Sampler):
 
 
 class WeightedRandomSampler(Sampler):
-    r"""Samples elements from [0,..,len(weights)-1] with given probabilities (weights).
+    r"""Samples elements from ``[0,..,len(weights)-1]`` with given probabilities (weights).
 
     Args:
         weights (sequence)   : a sequence of weights, not necessary summing up to one


### PR DESCRIPTION
This is a modified version of https://github.com/pytorch/pytorch/pull/14705 since commit structure for that PR is quite messy.

1. Add `IterableDataset`.
3. So we have 2 data loader mods: `Iterable` and `Map`.

    1. `Iterable` if the `dataset` is an instance of `IterableDataset`
    2. `Map` o.w.

3. Add better support for non-batch loading (i.e., `batch_size=None` and `batch_sampler=None`). This is useful in doing things like bulk loading.
3. Refactor `DataLoaderIter` into two classes, `_SingleProcessDataLoaderIter` and `_MultiProcessingDataLoaderIter`. Rename some methods to be more generic, e.g., `get_batch` -> `get_data`.
4. Add `torch.utils.data.get_worker_info` which returns worker information in a worker proc (e.g., worker id, dataset obj copy, etc.) and can be used in `IterableDataset.__iter__` and `worker_init_fn` to do per-worker configuration.
5. Add `ChainDataset`, which is the analog of `ConcatDataset` for `IterableDataset`.
7. Import torch.utils.data in `torch/__init__.py`
9. data loader examples and documentations
10. Use `get_worker_info` to detect whether we are in a worker process in `default_collate`


Closes https://github.com/pytorch/pytorch/issues/17909, https://github.com/pytorch/pytorch/issues/18096, https://github.com/pytorch/pytorch/issues/19946, and some of https://github.com/pytorch/pytorch/issues/13023