### PR TITLE
Enable working ROCm tests (#19169)

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2108,7 +2108,6 @@ class TestCuda(TestCase):
     def _select_broadcastable_dims(dims_full=None):
         return _TestTorchMixin._select_broadcastable_dims(dims_full)
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_inverse(self):
         _TestTorchMixin._test_inverse(self, lambda t: t.cuda())
@@ -2355,17 +2354,14 @@ class TestCuda(TestCase):
     def test_kthvalue(self):
         _TestTorchMixin._test_kthvalue(self, device='cuda')
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_lu(self):
         _TestTorchMixin._test_lu(self, lambda t: t.cuda())
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_lu_solve(self):
         _TestTorchMixin._test_lu_solve(self, lambda t: t.cuda())
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_lu_unpack(self):
         _TestTorchMixin._test_lu_unpack(self, lambda t: t.cuda())
@@ -2547,7 +2543,6 @@ class TestCuda(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @skipIfRocm
     def test_norm(self):
         _TestTorchMixin._test_norm(self, device='cuda')
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2068,7 +2068,6 @@ class TestNN(NNTestCase):
         self._test_embedding_dense_grad("cpu")
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @skipIfRocm
     def test_embedding_dense_grad_cuda(self):
         self._test_embedding_dense_grad("cuda")
 
@@ -2234,7 +2233,6 @@ class TestNN(NNTestCase):
         self._test_softmax_backward(torch.device('cpu'))
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @skipIfRocm
     def test_softmax_backward_cuda(self):
         self._test_softmax_backward(torch.device('cuda'))
 
@@ -3587,7 +3585,6 @@ class TestNN(NNTestCase):
         _assertGradAndGradgradChecks(self, lambda y: dp.scatter(y, (0, 1)), (x,))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
-    @skipIfRocm
     def test_scatter_cpu(self):
         self._test_scatter(torch.randn(4, 4))
 
@@ -3960,7 +3957,6 @@ class TestNN(NNTestCase):
         self.assertEqual(out, l(i))
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
-    @skipIfRocm
     def test_data_parallel_model_device(self):
         r"""Test device[0] check at forward time.
         """
@@ -4101,7 +4097,6 @@ class TestNN(NNTestCase):
         out = dp.data_parallel(l, i)
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
-    @skipIfRocm
     def test_data_parallel_sparse(self):
         l = nn.Embedding(10, 5, sparse=True).to("cuda:1")
         i = torch.randint(10, (20, 5), device="cuda:1", dtype=torch.long)

--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,7 +11,8 @@ namespace jit {
 
 std::shared_ptr<script::CompilationUnit> compile(const std::string& source) {
   auto module = std::make_shared<script::CompilationUnit>();
-  module->define(source, script::nativeResolver, nullptr);
+  auto resolver = std::make_shared<script::NativeResolver>();
+  module->define(source, std::move(resolver), nullptr);
   return module;
 }
 

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -284,7 +284,8 @@ struct GraphFuser {
            const char* source,
            const std::string& method_name) {
           script::CompilationUnit cu;
-          cu.define(source, script::nativeResolver, nullptr);
+          cu.define(
+              source, std::make_shared<script::NativeResolver>(), nullptr);
           *graph_ptr = cu.get_function(method_name).graph();
         },
         &nm_graph,

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -1,6 +1,6 @@
-#include <torch/csrc/jit/script/builtin_functions.h>
 #include <torch/csrc/api/include/torch/jit.h>
 #include <torch/csrc/jit/code_template.h>
+#include <torch/csrc/jit/script/builtin_functions.h>
 
 namespace torch {
 namespace jit {
@@ -64,7 +64,8 @@ struct BuiltinFunctionRegistry {
   void loadSource(const std::string& source) {
     std::shared_ptr<CompilationUnit> cu = std::make_shared<CompilationUnit>();
     modules.emplace_back(cu);
-    cu->define(source, script::nativeResolver, /*self=*/nullptr);
+    cu->define(
+        source, std::make_shared<script::NativeResolver>(), /*self=*/nullptr);
     for (auto& method : cu->get_functions()) {
       builtins_by_name[Symbol::fromQualString("aten::" + method->name())]
           .push_back(method.get());

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -27,11 +27,9 @@ namespace script {
 struct Def;
 struct SugaredValue;
 struct Function;
+struct Resolver;
 
-using Resolver = std::function<std::shared_ptr<SugaredValue>(
-    const std::string& name,
-    Function& f,
-    const SourceRange& loc)>;
+using ResolverPtr = std::shared_ptr<Resolver>;
 using Self = std::function<std::shared_ptr<SugaredValue>(Value*)>;
 
 // A Function is a pure Graph with no implicit `self` object bound.
@@ -215,7 +213,7 @@ struct TORCH_API CompilationUnit {
   // for historic reasons, these are defined in compiler.cpp
   void define(
       const std::vector<Def>& definitions,
-      const std::vector<Resolver>& resolvers, /* determines how we handle free
+      const std::vector<ResolverPtr>& resolvers, /* determines how we handle free
                                                  variables in each definition*/
       // if non-null, the first argument to each def, is bound to this value
       const Self& self);
@@ -223,7 +221,7 @@ struct TORCH_API CompilationUnit {
   // same as above but parse the definitions from source
   void define(
       const std::string& source,
-      const Resolver& resolver,
+      const ResolverPtr& resolver,
       const Self& self);
 
   void clone_function(const Function& remote) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -191,7 +191,7 @@ static bool meaningfulName(const std::string& name) {
 struct Environment {
   Environment(
       Function& method,
-      Resolver resolver,
+      ResolverPtr resolver,
       Block* b,
       std::shared_ptr<Environment> next = nullptr)
       : method(method),
@@ -200,7 +200,7 @@ struct Environment {
         next(std::move(next)) {}
 
   Function& method;
-  Resolver resolver;
+  ResolverPtr resolver;
   std::vector<std::string> captured_inputs;
   std::unordered_map<std::string, std::string> error_messages;
   Block* b;
@@ -420,7 +420,7 @@ struct Environment {
     }
 
     if (!retval) {
-      retval = resolver(ident, method, range);
+      retval = resolver->resolveValue(ident, method, range);
     }
 
     if (!retval && required) {
@@ -517,7 +517,7 @@ struct DefContext {
 struct to_ir {
   to_ir(
       const Def& def,
-      Resolver resolver_,
+      ResolverPtr resolver_,
       const Self& self,
       Function& method) // method being constructed
       : method(method),
@@ -543,7 +543,7 @@ struct to_ir {
  private:
   Function& method;
   std::shared_ptr<Graph> graph;
-  Resolver resolver;
+  ResolverPtr resolver;
   std::unordered_map<int64_t, Value*> integral_constants;
   std::unordered_map<double, Value*> fp_constants;
   ScriptTypeParser typeParser_;
@@ -2751,9 +2751,31 @@ struct to_ir {
   }
 };
 
+struct MethodResolver : public Resolver {
+  explicit MethodResolver(
+      const Resolver* otherResolver,
+      const std::unordered_map<std::string, Function*>& functionTable)
+      : otherResolver_(otherResolver), functionTable_(functionTable) {}
+
+  std::shared_ptr<SugaredValue> resolveValue(
+      const std::string& name,
+      Function& m,
+      const SourceRange& loc) const override {
+    auto it = functionTable_.find(name);
+    if (it != functionTable_.end()) {
+      return std::make_shared<MethodValue>(c10::nullopt, *it->second);
+    }
+    return otherResolver_->resolveValue(name, m, loc);
+  }
+
+ private:
+  const Resolver* otherResolver_;
+  const std::unordered_map<std::string, Function*>& functionTable_;
+};
+
 void CompilationUnit::define(
     const std::vector<Def>& definitions,
-    const std::vector<Resolver>& resolvers,
+    const std::vector<ResolverPtr>& resolvers,
     const Self& self) {
   AT_ASSERT(definitions.size() == resolvers.size());
   auto resolver_it = resolvers.begin();
@@ -2761,22 +2783,14 @@ void CompilationUnit::define(
   std::unordered_map<std::string, Function*> function_table;
   for (const Def& def : definitions) {
     const std::string& name = def.name().name();
-    auto resolver = *resolver_it++;
+    ResolverPtr resolver = *resolver_it++;
     AT_ASSERT(resolver);
     if (!self) {
       // if self is defined, then these are methods and do not go into the
       // global namespace otherwise, they get defined together so we add them to
       // the function table so the methods can see each other
-      resolver = [resolver, &function_table](
-                     const std::string& name,
-                     Function& m,
-                     const SourceRange& loc) -> std::shared_ptr<SugaredValue> {
-        auto it = function_table.find(name);
-        if (it != function_table.end()) {
-          return std::make_shared<MethodValue>(c10::nullopt, *it->second);
-        }
-        return resolver(name, m, loc);
-      };
+      resolver =
+          std::make_shared<MethodResolver>(resolver.get(), function_table);
     }
     auto creator = [def, resolver, self](Function& method) {
       AT_ASSERT(resolver);
@@ -2795,11 +2809,11 @@ void CompilationUnit::define(
 
 void CompilationUnit::define(
     const std::string& source,
-    const Resolver& resolver,
+    const ResolverPtr& resolver,
     const Self& self) {
   Parser p(source);
   std::vector<Def> definitions;
-  std::vector<Resolver> resolvers;
+  std::vector<ResolverPtr> resolvers;
   while (p.lexer().cur().kind != TK_EOF) {
     auto def = Def(p.parseFunction(/*is_method=*/bool(self)));
     definitions.push_back(def);

--- a/torch/csrc/jit/script/compiler.h
+++ b/torch/csrc/jit/script/compiler.h
@@ -6,23 +6,13 @@
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/script/error_report.h>
 #include <torch/csrc/jit/script/module.h>
+#include <torch/csrc/jit/script/resolver.h>
 #include <torch/csrc/jit/script/sugared_value.h>
 #include <torch/csrc/jit/script/tree_views.h>
 
 namespace torch {
 namespace jit {
 namespace script {
-
-inline std::shared_ptr<SugaredValue> nativeResolver(
-    const std::string& name,
-    Function& m,
-    const SourceRange& loc) {
-  if (name == "torch") {
-    return std::make_shared<BuiltinModule>("aten");
-  }
-  return nullptr;
-}
-
 
 TORCH_API void lambdaLiftFork(Node* fork_node);
 

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -314,14 +314,16 @@ void Module::lift_lowered_methods(size_t start) {
 
 void Module::_define_lowered(
     const std::vector<Def>& definitions,
-    const std::vector<Resolver>& resolvers) {
+    const std::vector<ResolverPtr>& resolvers) {
   size_t start = lowered_methods_.get_functions().size();
   lowered_methods_.define(definitions, resolvers, nullptr);
   lift_lowered_methods(start);
   // call lift_lowered_method for each definition
 }
 
-void Module::_define_lowered(const std::string& src, const Resolver& resolver) {
+void Module::_define_lowered(
+    const std::string& src,
+    const ResolverPtr& resolver) {
   size_t start = lowered_methods_.get_functions().size();
   lowered_methods_.define(src, resolver, nullptr);
   lift_lowered_methods(start);
@@ -338,10 +340,10 @@ Method& Module::_define_lowered(
   return m;
 }
 
-void Module::define(const std::string& src, const Resolver& resolver) {
+void Module::define(const std::string& src, const ResolverPtr& resolver) {
   class_cu().define(
       src,
-      resolver ? resolver : nativeResolver,
+      resolver ? resolver : std::make_shared<NativeResolver>(),
       simpleSelf(module_object()->type()));
 }
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -470,12 +470,12 @@ struct TORCH_API Module {
   }
 
   // so that C++ users can easily add methods
-  void define(const std::string& src, const Resolver& resolver = nullptr);
+  void define(const std::string& src, const ResolverPtr& resolver = nullptr);
 
   void _define_lowered(
       const std::vector<Def>& definitions,
-      const std::vector<Resolver>& resolvers);
-  void _define_lowered(const std::string& src, const Resolver& resolver);
+      const std::vector<ResolverPtr>& resolvers);
+  void _define_lowered(const std::string& src, const ResolverPtr& resolver);
 
   Method& _define_lowered(
       std::string name,

--- a/torch/csrc/jit/script/resolver.h
+++ b/torch/csrc/jit/script/resolver.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <aten/src/ATen/core/jit_type.h>
+#include <torch/csrc/jit/script/sugared_value.h>
+
+namespace torch {
+namespace jit {
+namespace script {
+
+struct Resolver;
+using ResolverPtr = std::shared_ptr<Resolver>;
+
+/**
+ * class Resolver
+ *
+ * Represents an "outer environment" in which we an look up names and return
+ * a corresponding SugaredValue. This is used during compilation to resolve
+ * references to names which are not defined internal to the graph.
+ *
+ * Example: PythonResolver looks at the enclosing Python scope for `name`.
+ */
+struct Resolver {
+  virtual ~Resolver() {}
+
+  // Resolve a given name to a SugaredValue. This takes the method `m` that the
+  // caller is currently constructing, since we may need to insert nodes into
+  // the graph to create a value.
+  virtual std::shared_ptr<SugaredValue> resolveValue(
+      const std::string& name,
+      Function& m,
+      const SourceRange& loc) const = 0;
+};
+
+// A resolver that only understands "torch.foo()" lookups.
+struct NativeResolver : public Resolver {
+  std::shared_ptr<SugaredValue> resolveValue(
+      const std::string& name,
+      Function& m,
+      const SourceRange& loc) const override {
+    if (name == "torch") {
+      return std::make_shared<BuiltinModule>("aten");
+    }
+    return nullptr;
+  }
+};
+} // namespace script
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -62,6 +62,12 @@ struct SugaredValue : public std::enable_shared_from_this<SugaredValue> {
     throw ErrorReport(loc) << kind() << " cannot be used as a tuple";
   }
 
+  virtual std::vector<std::shared_ptr<SugaredValue>> asType(
+      const SourceRange& loc,
+      Method& m) {
+    throw ErrorReport(loc) << kind() << " cannot be used as a type";
+  }
+
   // call it like a function, e.g. `outputs = this(inputs)`
   virtual std::shared_ptr<SugaredValue> call(
       const SourceRange& loc,

--- a/torch/csrc/jit/symbolic_script.cpp
+++ b/torch/csrc/jit/symbolic_script.cpp
@@ -1356,8 +1356,9 @@ void loadModule(const script::CompilationUnit& module) {
 
 void loadFunctions() {
   for (const std::string& str : functions) {
+    auto resolver = std::make_shared<script::NativeResolver>();
     script::CompilationUnit cu;
-    cu.define(str, script::nativeResolver, nullptr);
+    cu.define(str, std::move(resolver), nullptr);
     loadModule(cu);
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19235 [jit] Allow for segmented printing in PythonPrint
* #19234 [jit] add resolveType to Resolver
* **#19233 Enable working ROCm tests (#19169)**

Summary:
Enable multi-GPU tests that work with ROCm 2.2. Have been run three times on CI to ensure stability.

While there, remove skipIfRocm annotations for tests that depend on MAGMA. They still skip but now for the correct reason (no MAGMA) to improve our diagnostics.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/19169

Differential Revision: D14924812

Pulled By: bddppq

fbshipit-source-id: 8b88f58bba58a08ddcd439e899a0abc6198fef64