### PR TITLE
[jit] add resolveType to Resolver

### DIFF
--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -97,6 +97,10 @@ struct SourceResolver : public Resolver {
     return it->second;
   }
 
+  TypePtr resolveType(const std::string& name) const override {
+    return ClassType::get(name);
+  }
+
  private:
   std::unordered_map<std::string, std::shared_ptr<SugaredValue>> env_;
 };

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1,9 +1,9 @@
-#include <torch/csrc/jit/passes/python_print.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/attributes.h>
 #include <torch/csrc/jit/export.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/ir_views.h>
+#include <torch/csrc/jit/passes/python_print.h>
 #include <torch/csrc/jit/resource_guard.h>
 #include <torch/csrc/jit/script/error_report.h>
 #include <torch/csrc/jit/script/module.h>

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -523,6 +523,7 @@ struct to_ir {
       : method(method),
         graph(method.graph()),
         resolver(std::move(resolver_)),
+        typeParser_(resolver),
         environment_stack(nullptr) {
     AT_ASSERT(resolver);
     pushFrame(graph->block(), /*starts_def=*/true);
@@ -2766,6 +2767,10 @@ struct MethodResolver : public Resolver {
       return std::make_shared<MethodValue>(c10::nullopt, *it->second);
     }
     return otherResolver_->resolveValue(name, m, loc);
+  }
+
+  TypePtr resolveType(const std::string& name) const override {
+    return otherResolver_->resolveType(name);
   }
 
  private:

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -655,6 +655,10 @@ struct PythonResolver : public Resolver {
     return toSugaredValue(obj, m, loc);
   }
 
+  TypePtr resolveType(const std::string& name) const override {
+    return ClassType::get(name);
+  }
+
  private:
   ResolutionCallback rcb_;
 };

--- a/torch/csrc/jit/script/resolver.h
+++ b/torch/csrc/jit/script/resolver.h
@@ -29,6 +29,9 @@ struct Resolver {
       const std::string& name,
       Function& m,
       const SourceRange& loc) const = 0;
+
+  // Resolve `name` to a TypePtr.
+  virtual TypePtr resolveType(const std::string& name) const = 0;
 };
 
 // A resolver that only understands "torch.foo()" lookups.
@@ -41,6 +44,10 @@ struct NativeResolver : public Resolver {
       return std::make_shared<BuiltinModule>("aten");
     }
     return nullptr;
+  }
+
+  TypePtr resolveType(const std::string& name) const override {
+    return ClassType::get(name);
   }
 };
 } // namespace script

--- a/torch/csrc/jit/script/script_type_parser.cpp
+++ b/torch/csrc/jit/script/script_type_parser.cpp
@@ -166,8 +166,10 @@ TypePtr ScriptTypeParser::parseTypeFromExpr(const Expr& expr) const {
     if (itr != ident_to_type_lut().end()) {
       return itr->second;
     }
-    if (auto typePtr = ClassType::get(*name)) {
-      return typePtr;
+    if (resolver_) {
+      if (auto typePtr = resolver_->resolveType(*name)) {
+        return typePtr;
+      }
     }
     throw ErrorReport(expr) << "Unknown type name " << *name;
   }

--- a/torch/csrc/jit/script/script_type_parser.h
+++ b/torch/csrc/jit/script/script_type_parser.h
@@ -2,7 +2,9 @@
 #include <ATen/core/jit_type.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/script/parser.h>
+#include <torch/csrc/jit/script/resolver.h>
 #include <torch/csrc/jit/script/tree_views.h>
+
 namespace torch {
 namespace jit {
 namespace script {
@@ -15,6 +17,9 @@ namespace script {
  */
 class TORCH_API ScriptTypeParser {
  public:
+  explicit ScriptTypeParser() {}
+  explicit ScriptTypeParser(ResolverPtr resolver)
+      : resolver_(std::move(resolver)) {}
   c10::optional<std::string> parseBaseTypeName(const Expr& expr) const;
 
   c10::TypePtr parseTypeFromExpr(const Expr& expr) const;
@@ -28,6 +33,7 @@ class TORCH_API ScriptTypeParser {
   at::TypePtr subscriptToType(
       const std::string& typeName,
       const Subscript& subscript) const;
+  ResolverPtr resolver_ = nullptr;
 };
 } // namespace script
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19235 [jit] Allow for segmented printing in PythonPrint
* **#19234 [jit] add resolveType to Resolver**
* #19233 Enable working ROCm tests (#19169)

Now that we have first-class types, various things will need to resolve
name strings into actual typeptrs. Currently we do this just be looking
up the name in our global registry, but once we add namespacing that will
no longer be sufficient.

This PR adds the infrastructure for resolving types, although the
functionality is the same as before.

Test Plan:
jit tests