### PR TITLE
[jit] Allow for segmented printing in PythonPrint

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -110,7 +110,7 @@ void IValue::dump() const {
 
 
 const std::string& ivalue::Object::name() const {
-  return this->type_->name();
+  return this->type_->qualname();
 }
 
 void ivalue::Object::resizeObject(size_t slot) {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1107,7 +1107,7 @@ using ::torch::jit::script::Function;
 struct CAFFE2_API ClassType : public Type {
   // Create a user type and register it globally.
   static ClassTypePtr create(
-      const std::string& name,
+      const std::string& qualifiedName,
       std::shared_ptr<CompilationUnit> module);
 
   // Create a type representing a Module,
@@ -1115,14 +1115,14 @@ struct CAFFE2_API ClassType : public Type {
   static ClassTypePtr createModuleType(std::shared_ptr<CompilationUnit> module);
 
   // returns nullptr if there is no type with that name
-  static ClassTypePtr get(const std::string& name);
+  static ClassTypePtr get(const std::string& qualifiedName);
   // For testing: delete all registered types
   static void clearRegistry();
 
   DEFINE_IS_SUBCLASS(ClassType);
   bool operator==(const Type& rhs) const override {
     if (auto user_rhs = rhs.cast<ClassType>()) {
-      return typename_ == user_rhs->typename_;
+      return qualifiedName_ == user_rhs->qualifiedName_;
     }
     return false;
   }
@@ -1132,12 +1132,25 @@ struct CAFFE2_API ClassType : public Type {
     // same can subtype from each other.
     return *this == *rhs;
   }
+
   std::string str() const override {
-    return std::string("ClassType<") + typename_ + ">";
+    return std::string("ClassType<") + basename_ + ">";
   }
 
   std::string python_str() const override {
-    return typename_;
+    return qualifiedName_;
+  }
+
+  const std::string& qualname() const {
+    return qualifiedName_;
+  }
+
+  const std::string& qualifier() const {
+    return qualifier_;
+  }
+
+  const std::string& basename() const {
+    return basename_;
   }
 
   TypePtr getAttribute(const std::string& name) const {
@@ -1173,10 +1186,6 @@ struct CAFFE2_API ClassType : public Type {
   const CompilationUnit& compilation_unit() const;
   std::vector<Function*> methods() const;
 
-
-  const std::string& name() const {
-    return typename_;
-  }
 
   size_t numAttributes() const {
     AT_ASSERT(attributeNames_.size() == attributeTypes_.size());
@@ -1229,13 +1238,17 @@ struct CAFFE2_API ClassType : public Type {
   static const TypeKind Kind = TypeKind::ClassType;
 
  private:
-  ClassType(std::string name, std::shared_ptr<CompilationUnit> cu)
-      : Type(TypeKind::ClassType),
-        typename_(std::move(name)),
-        compilation_unit_(std::move(cu)) {}
+  ClassType(std::string qualifiedName, std::shared_ptr<CompilationUnit> cu);
 
-  // Name of type (note that this has to be globally unique).
-  std::string typename_;
+  // Fully qualified name of type (note that this has to be globally unique).
+  // Looks like: "foo.bar.Baz".
+  std::string qualifiedName_;
+
+  // We store the qualifier and base name for ease.
+  // Qualifier, like "foo.bar"
+  std::string qualifier_;
+  // Base name, like: "Baz".
+  std::string basename_;
 
   // Mapping of attribute names -> their type.
   // NOTE: this does not contain methods, which are stored in the module

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -471,19 +471,19 @@ ClassTypeRegistry& getRegistry() {
 } // namespace
 
 ClassTypePtr ClassType::create(
-    const std::string& name,
+    const std::string& qualifiedName,
     std::shared_ptr<CompilationUnit> cu) {
-  auto ptr = ClassTypePtr(new ClassType(name, std::move(cu)));
-  getRegistry().registerType(name, ptr);
+  auto ptr = ClassTypePtr(new ClassType(qualifiedName, std::move(cu)));
+  getRegistry().registerType(qualifiedName, ptr);
   return ptr;
 }
 
 ClassTypePtr ClassType::createModuleType(std::shared_ptr<CompilationUnit> cu) {
-  return ClassTypePtr(new ClassType("Module", std::move(cu)));
+  return ClassTypePtr(new ClassType("__torch__.Module", std::move(cu)));
 }
 
 ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
-  auto ptr = ClassTypePtr(new ClassType(typename_, compilation_unit_));
+  auto ptr = ClassTypePtr(new ClassType(qualifiedName_, compilation_unit_));
   AT_ASSERT(numAttributes() == refined_slots.size());
   for(size_t i = 0; i < attributeNames_.size(); ++i) {
     AT_ASSERT(refined_slots[i]->isSubtypeOf(attributeTypes_[i]));
@@ -492,13 +492,37 @@ ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
   return ptr;
 }
 
-ClassTypePtr ClassType::get(const std::string& name) {
-  return getRegistry().getType(name);
+ClassTypePtr ClassType::get(const std::string& qualifiedName) {
+  return getRegistry().getType(qualifiedName);
 }
 
 
 void ClassType::clearRegistry() {
   getRegistry().clear();
+}
+
+ClassType::ClassType(
+    std::string qualifiedName,
+    std::shared_ptr<CompilationUnit> cu)
+    : Type(TypeKind::ClassType),
+      qualifiedName_(std::move(qualifiedName)),
+      compilation_unit_(std::move(cu)) {
+  // Compute the base name based on the qualified name
+  const auto pos = qualifiedName_.rfind('.');
+  if (pos == std::string::npos) {
+    // If there are no delimiters, the qualname and name are the same
+    basename_ = qualifiedName_;
+  } else {
+    AT_ASSERTM(
+        pos < qualifiedName_.size() - 1,
+        "'.' can't be the last character in qualified name: ",
+        qualifiedName_);
+
+    // Otherwise take the name that trails the last '.'
+    basename_ = qualifiedName_.substr(pos + 1);
+    qualifier_ = qualifiedName_.substr(0, pos);
+  }
+  AT_ASSERT(qualifier_ + "." + basename_ == qualifiedName_);
 }
 
 } // namespace c10

--- a/caffe2/proto/torch.proto
+++ b/caffe2/proto/torch.proto
@@ -79,7 +79,7 @@ message LibDef {
 }
 
 enum ProtoVersion {
-  PROTO_VERSION_NEWEST = 0x0000000000000002;
+  PROTO_VERSION_NEWEST = 0x0000000000000003;
 }
 
 message ModelDef {
@@ -104,5 +104,5 @@ message ModelDef {
 
   // TorchScript code that this module hierarchy depends on
   // Libs will be loaded in before the main module is compiled.
-  optional LibDef libs = 9;
+  repeated LibDef libs = 9;
 }

--- a/torch/csrc/jit/argument_spec.cpp
+++ b/torch/csrc/jit/argument_spec.cpp
@@ -42,7 +42,7 @@ void ArgumentSpecCreator::scan(
     size_t pos = instructions_.size();
     instructions_.emplace_back(ENTER_OBJECT);
     for (size_t i = 0; i < cls->numAttributes(); ++i) {
-      auto key = cls->name() + cls->attributeNames().at(i);
+      auto key = cls->qualname() + cls->attributeNames().at(i);
       // it is only safe to specialize because someone might have written to it
       if (!written_slots.count(key)) {
         scan(cls->containedTypes().at(i), depth + 1, written_slots);
@@ -67,7 +67,7 @@ static void scanWrittenSlots(
   for (Node* n : block->nodes()) {
     if (n->kind() == prim::SetAttr) {
       if (auto cls = n->inputs().at(0)->type()->cast<ClassType>()) {
-        written_slots.insert(cls->name() + n->s(attr::name));
+        written_slots.insert(cls->qualname() + n->s(attr::name));
       }
     }
     for (Block* subblock : n->blocks()) {

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -120,21 +120,21 @@ class EncoderBase {
  protected:
   // Using std::map instead of std::unordered_map for initializers
   // in EncodeGraph cosntructor so that the order in which initializers
-  // get written to the ONNX graph is always the deterministic and 
-  // predictable. While this is not a ONNX requirement, it is needed 
+  // get written to the ONNX graph is always the deterministic and
+  // predictable. While this is not a ONNX requirement, it is needed
   // for testing purposes in tests that use _export_to_pretty_string()
   // for validating ONNX graphs.
   void EncodeGraph(
       onnx::GraphProto* graph_proto,
       const std::shared_ptr<Graph>& graph,
-      const std::map<std::string, at::Tensor>& initializers = 
-        std::map<std::string, at::Tensor>());
+      const std::map<std::string, at::Tensor>& initializers =
+          std::map<std::string, at::Tensor>());
 
   void EncodeBlock(
       onnx::GraphProto* graph_proto,
       const Block* block,
-      const std::map<std::string, at::Tensor>& initializers = 
-        std::map<std::string, at::Tensor>());
+      const std::map<std::string, at::Tensor>& initializers =
+          std::map<std::string, at::Tensor>());
 
   virtual void EncodeTensor(
       onnx::TensorProto* tensor_proto,
@@ -522,7 +522,7 @@ class ScriptModuleSerializer final {
       torch::ModuleDef* module_def);
 
   void convertParameter(
-      const script::Slot & param,
+      const script::Slot& param,
       torch::ParameterDef* param_def,
       bool is_parameter);
 
@@ -539,6 +539,7 @@ class ScriptModuleSerializer final {
   // all classes used by this module hierarchy
   std::vector<ClassTypePtr> class_table_;
   OrderedDict<ClassTypePtr, std::string> converted_classes_;
+  std::unordered_map<ClassTypePtr, std::vector<ClassTypePtr>> class_to_deps_;
 
   static const size_t op_version_set = 0;
 };
@@ -580,23 +581,49 @@ void ScriptModuleSerializer::serialize(
 }
 
 void ScriptModuleSerializer::writeLibs(torch::ModelDef* model_def) {
-  auto lib_def = model_def->mutable_libs();
-  std::ostringstream lib_stream;
-  lib_stream << "op_version_set = " << op_version_set << "\n";
-  // Convert all the classes that
+  // Convert all the classes that this model depends on
   for (const auto& class_type : class_table_) {
     convertClass(class_type, model_def);
   }
 
-  for (const auto& c : converted_classes_) {
-    lib_stream << *c << "\n";
+  // Mapping of filename => src. We need this because multiple clases may go in
+  // the same file (e.g. foo.bar.Baz and foo.bar.Qux)
+
+  // Aggregate classes into files by their qualified names
+  std::unordered_map<std::string, std::string> fileToSrc;
+  for (const auto& item : converted_classes_) {
+    const auto& class_type = item.key();
+    const auto& class_src = item.value();
+
+    // For the type, foo.bar.Baz
+    std::string class_path = class_type->qualifier();
+    std::replace_if(
+        class_path.begin(),
+        class_path.end(),
+        [](char c) { return c == '.'; },
+        '/');
+    std::string filename = "libs/" + class_path + ".py";
+    // End state: filename is "foo/bar.py", in which we will define a class
+    // named Baz
+    fileToSrc[filename] += class_src;
   }
 
-  torch::RecordRef* lib_record = lib_def->mutable_torchscript_arena();
-  const auto filename = "libs.py";
-  const auto& lib_str = lib_stream.str();
-  writer_.writeRecord(filename, lib_str.c_str(), lib_str.size());
-  lib_record->set_key(filename);
+  // Write out the files.
+  for (const auto& pr : fileToSrc) {
+    const auto& filename = pr.first;
+    const auto& src = pr.second;
+
+    std::ostringstream lib_stream;
+    lib_stream << "op_version_set = " << op_version_set << "\n";
+    lib_stream << src;
+    std::string lib_str = lib_stream.str();
+
+    auto lib_def = model_def->add_libs();
+    writer_.writeRecord(filename, lib_str.c_str(), lib_str.size());
+
+    torch::RecordRef* lib_record = lib_def->mutable_torchscript_arena();
+    lib_record->set_key(filename);
+  }
 }
 
 // python print the class and add to the converted_classes_. Recursively
@@ -616,6 +643,8 @@ void ScriptModuleSerializer::convertClass(
       tensor_table_,
       class_deps,
       /*enforce_importable=*/true);
+
+  class_to_deps_[class_type] = class_deps;
 
   for (const auto& c : class_deps) {
     if (c == class_type) {

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -18,6 +18,9 @@ TORCH_API void import_methods(
 
 // Defined the list of classes in `src`.
 TORCH_API void import_libs(
+    // The path to the class's source file. This is used to construct a
+    // qualified name for the class.
+    const std::string& class_path,
     const std::string& src,
     const std::vector<at::Tensor>& constant_table);
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -414,7 +414,8 @@ struct Environment {
     }
 
     if (!retval) {
-      if (auto class_type = ClassType::get(ident)) {
+      if (auto type = resolver->resolveType(ident)) {
+        const auto class_type = type->expect<ClassType>();
         retval = std::make_shared<script::ClassValue>(class_type);
       }
     }
@@ -2112,8 +2113,21 @@ struct to_ir {
       if (apply.inputs().size() != 1) {
         throw ErrorReport(loc) << "Only one argument to __new__ allowed";
       }
-      return classNew->createObject(
-          apply.range(), method, Var(apply.inputs()[0]).name().name());
+      auto arg = emitSugaredExpr(apply.inputs()[0], 1);
+      auto class_arg = dynamic_cast<ClassValue*>(arg.get());
+      if (!class_arg) {
+        throw ErrorReport(loc)
+            << "Expected class value as argument to __new__, got "
+            << arg->kind() << " instead";
+      }
+      if (class_arg->type_ != classNew->type_) {
+        throw ErrorReport(loc) << "Argument to __new__() must match the class "
+                               << "you are calling __new__() on. "
+                               << "Got: " << class_arg->type_->str()
+                               << ", expected: " << classNew->type_->str();
+      }
+
+      return classNew->createObject(apply.range(), method);
     } else {
       auto inputs = getNamedValues(apply.inputs(), true);
       auto attributes = emitAttributes(apply.attributes());

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -184,7 +184,7 @@ std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
     }
     Slot slot(e.mod, e.mod->type()->getAttributeSlot(e.n->s(attr::name)));
     if (ClassTypePtr c = e.n->output()->type()->cast<ClassType>()) {
-      if (c->name() == "Module") {
+      if (c->qualname() == "__torch__.Module") {
         auto obj = slot.value().toObject();
         for (Use use : e.n->output()->uses()) {
           to_scan.emplace_back(ToScan{obj, use.user, use.offset});

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -321,14 +321,7 @@ struct TORCH_API ClassNewMethod : public SugaredValue {
 
   std::shared_ptr<SugaredValue> createObject(
       const SourceRange& loc,
-      Function& m,
-      const std::string& classname) {
-    if (classname != type_->name()) {
-      throw ErrorReport(loc)
-          << "Argument to __new__() must match the class "
-          << "you are calling __new__() on. "
-          << "Got: " << classname << ", expected: " << type_->name();
-    }
+      Function& m) {
     auto& g = *m.graph();
     auto createNode = g.insertNode(g.createObject(type_));
     return std::make_shared<SimpleValue>(createNode->output());
@@ -349,6 +342,30 @@ static inline Self simpleSelf(const TypePtr& typ) {
     return std::make_shared<SimpleValue>(v);
   };
 }
+
+// Represents nested class namespaces, like `foo.bar.Baz`.
+// Right now these namespaces can only contain other namespaces or a class type.
+struct TORCH_API ClassNamespaceValue : public SugaredValue {
+  explicit ClassNamespaceValue(std::string name) : basename_(std::move(name)) {}
+
+  std::shared_ptr<SugaredValue> attr(
+      const SourceRange& loc,
+      Function& m,
+      const std::string& name) override {
+    const auto fullName = basename_ + "." + name;
+    if (auto classType = ClassType::get(fullName)) {
+      return std::make_shared<ClassValue>(classType);
+    }
+
+    return std::make_shared<ClassNamespaceValue>(fullName);
+  }
+  std::string kind() const override {
+    return "Class Namespace";
+  }
+
+ private:
+  std::string basename_;
+};
 
 } // namespace script
 } // namespace jit

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -727,6 +727,26 @@ def _is_new_style_class(cls):
         return ('__dict__' in dir(cls) or hasattr(cls, '__slots__'))
 
 
+# Retrieves a fully-qualified name (module hierarchy + classname) for a given obj.
+def _qualified_name(obj):
+    name = obj.__name__
+    module_name = obj.__module__
+    # The Python docs are very clear that `__module__` can be None, but I can't
+    # figure out when it actually would be.
+    if module_name is None:
+        raise RuntimeError("Could not get qualified name for class '{}': "
+                           "__module__ can't be None.")
+
+    # __main__ is a builtin module, so rewrite it to "__torch__".
+    if module_name == "__main__":
+        module_name = "__torch__"
+    else:
+        # Everything else gets a "__torch__" prefix to avoid name collisions
+        # with the names of user values.
+        module_name = "__torch__." + module_name
+    return module_name + "." + name
+
+
 def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if not _enabled:
         return obj
@@ -735,9 +755,10 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if inspect.isclass(obj):
         if not _is_new_style_class(obj):
             raise RuntimeError("TorchScript classes must be new-style classes. Please inherit from 'object'")
-        ast = get_jit_class_def(obj)
+        name = _qualified_name(obj)
+        ast = get_jit_class_def(obj, name)
         _jit_script_class_compile(ast, _rcb)
-        _add_script_class(obj, obj.__name__)
+        _add_script_class(obj, name)
         return obj
     else:
         mod = ScriptModule()
@@ -1511,6 +1532,7 @@ def _find_builtin(fn):
 _register_builtin(len, 'aten::len')
 _register_builtin(_wait, 'aten::wait')
 
+# qualified_name => ScriptClass mapping
 _script_classes = {}
 
 

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -135,17 +135,17 @@ def _uses_true_division(fn):
             '_uses_true_division: expected function or method, got {}'.format(type(fn)))
 
 
-def get_jit_class_def(cls, self_name=None):
+def get_jit_class_def(cls, self_name):
     # Get defs for each method independently
     methods = inspect.getmembers(
         cls, predicate=lambda m: inspect.ismethod(m) or inspect.isfunction(m))
     method_defs = [get_jit_def(method[1],
-                   self_name=cls.__name__) for method in methods]
+                   self_name=self_name) for method in methods]
 
     source = dedent(inspect.getsource(cls))
     py_ast = ast.parse(source)
     ctx = SourceContext(source, False)
-    return build_class_def(ctx, py_ast.body[0], method_defs)
+    return build_class_def(ctx, py_ast.body[0], method_defs, self_name)
 
 
 def get_jit_def(fn, self_name=None):
@@ -174,10 +174,10 @@ class Builder(object):
         return method(ctx, node)
 
 
-def build_class_def(ctx, py_def, methods):
+def build_class_def(ctx, py_def, methods, self_name):
     r = ctx.make_range(py_def.lineno, py_def.col_offset,
                        py_def.col_offset + len("class"))
-    return ClassDef(Ident(r, py_def.name), methods)
+    return ClassDef(Ident(r, self_name), methods)
 
 
 def build_def(ctx, py_def, type_line, self_name=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19235 [jit] Allow for segmented printing in PythonPrint**
* #19234 [jit] add resolveType to Resolver
* #19233 Enable working ROCm tests (#19169)

Make printing to the `out` param a separate step, which allows us to
prepare several portions of the output separately and print them at the
end. There's only one for now (`body_`) but this is necessary for import
statements.