### PR TITLE
Resolve inconsistent dll linkage warnings on MSVC

### DIFF
--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -131,14 +131,14 @@ TORCH_API void addInputs(
     const std::unordered_map<K, V>& value);
 
 template<typename T>
-void addInputs(
+TORCH_API void addInputs(
     Node* n,
     const char* name,
     const std::vector<T>& value) {
   AT_ERROR("Tracing a list of arbitrary type is currently not supported!");
 }
 template<typename K, typename V>
-void addInputs(
+TORCH_API void addInputs(
     Node* n,
     const char* name,
     const std::unordered_map<K, V>& value) {
@@ -146,7 +146,7 @@ void addInputs(
 }
 
 template <size_t N>
-void addInputs(Node* n, const char* name, std::array<bool, N> value) {
+TORCH_API void addInputs(Node* n, const char* name, std::array<bool, N> value) {
   throw std::runtime_error(
       "Found an unsupported argument type in the JIT tracer. File a bug report.");
 }


### PR DESCRIPTION
Fixes warning:
torch/csrc/jit/tracer.h(137): warning C4273: 'torch::jit::tracer::addInputs': inconsistent dll linkage