### PR TITLE
Decorator to make sure we can import `core` from caffe2

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -140,6 +140,26 @@ def skipIfNoLapack(fn):
     return wrapper
 
 
+def skipIfNotRegistered(op_name, message):
+    """Wraps the decorator to hide the import of the `core`.
+
+    Args:
+        op_name: Check if this op is registered in `core._REGISTERED_OPERATORS`.
+        message: mesasge to fail with.
+
+    Usage:
+        @skipIfNotRegistered('MyOp', 'MyOp is not linked!')
+            This will check if 'MyOp' is in the caffe2.python.core
+    """
+    try:
+        from caffe2.python import core
+        skipper = unittest.skipIf(op_name not in core._REGISTERED_OPERATORS,
+                                  message)
+    except ImportError:
+        skipper = unittest.skip("Cannot import `caffe2.python.core`")
+    return skipper
+
+
 def slowTest(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -4,7 +4,6 @@ import torch
 import torch.jit
 import numpy as np
 import unittest
-# from caffe2.python import core
 from common_utils import TestCase, run_tests
 
 
@@ -12,8 +11,26 @@ def canonical(graph):
     return str(torch._C._jit_pass_canonicalize(graph))
 
 
-@unittest.skip("Skipping due to the protobuf dependency in the CI's")
-# @unittest.skipIf("Relu_ENGINE_DNNLOWP" not in core._REGISTERED_OPERATORS, "fbgemm-based Caffe2 ops are not linked")
+def skipIfNotRegistered(op_name, message):
+    """Wrap the decorator to hide the import of the `core`.
+
+    Args:
+        op_name: Check if this op is registered in `core._REGISTERED_OPERATORS`.
+        message: mesasge to fail with.
+    Returns:
+        unittest.skip decorator
+    """
+    try:
+        from caffe2.python import core
+        skipper = unittest.skipIf(op_name not in core._REGISTERED_OPERATORS,
+                                  message)
+    except ImportError:
+        skipper = unittest.skip("Cannot import `caffe2.python.core`")
+    return skipper
+
+
+@skipIfNotRegistered("Relu_ENGINE_DNNLOWP",
+                     "fbgemm-based Caffe2 ops are not linked")
 class TestQuantized(TestCase):
     def test_relu(self):
         a = (torch.tensor([4, 6, 1, 10], dtype=torch.uint8), 0.01, 5)

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -4,29 +4,11 @@ import torch
 import torch.jit
 import numpy as np
 import unittest
-from common_utils import TestCase, run_tests
+from common_utils import TestCase, run_tests, skipIfNotRegistered
 
 
 def canonical(graph):
     return str(torch._C._jit_pass_canonicalize(graph))
-
-
-def skipIfNotRegistered(op_name, message):
-    """Wrap the decorator to hide the import of the `core`.
-
-    Args:
-        op_name: Check if this op is registered in `core._REGISTERED_OPERATORS`.
-        message: mesasge to fail with.
-    Returns:
-        unittest.skip decorator
-    """
-    try:
-        from caffe2.python import core
-        skipper = unittest.skipIf(op_name not in core._REGISTERED_OPERATORS,
-                                  message)
-    except ImportError:
-        skipper = unittest.skip("Cannot import `caffe2.python.core`")
-    return skipper
 
 
 @skipIfNotRegistered("Relu_ENGINE_DNNLOWP",


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19273 Decorator to make sure we can import `core` from caffe2**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14936387/)

Some of the CIs are failing if the protobuf is not installed. Protobuf is imported as part of the `caffe2.python.core`, and this adds a skip decorator to avoid running tests that depend on `caffe2.python.core`

Differential Revision: [D14936387](https://our.internmc.facebook.com/intern/diff/D14936387/)