### PR TITLE
Allow ops without tensor args if only fallback kernel exists

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
@@ -415,6 +415,46 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithTensorLi
   EXPECT_EQ(2, outputs[0].toInt());
 }
 
+bool called = false;
+
+void kernelWithoutInputs() {
+  called = true;
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because there
+  // is no way to get the dispatch key. For operators that only have a fallback
+  // kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators()
+      .op("_test::no_tensor_args() -> ()", &kernelWithoutInputs);
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_tensor_args", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op);
+  EXPECT_TRUE(called);
+}
+
+int64_t kernelWithoutTensorInputs(int64_t arg) {
+  return arg + 1;
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenFallbackKernelWithoutTensorArguments_whenRegistered_thenCanBeCalled) {
+  // note: non-fallback kernels without tensor arguments don't work because there
+  // is no way to get the dispatch key. For operators that only have a fallback
+  // kernel, this must work for backwards compatibility.
+  auto registrar = RegisterOperators()
+      .op("_test::no_tensor_args(int arg) -> int", &kernelWithoutTensorInputs);
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_tensor_args", "");
+  ASSERT_TRUE(op.has_value());
+
+  auto outputs = callOp(*op, 3);
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_EQ(4, outputs[0].toInt());
+}
+
 template<class Return, class... Args> struct kernel_func final {
   static Return func(Args...) { return {}; }
 };

--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -49,6 +49,7 @@ namespace detail {
 
   template<class Functor, size_t... ivalue_arg_indices>
   typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_ivalue_args_(Functor* functor, ArrayRef<IValue> ivalue_args, guts::index_sequence<ivalue_arg_indices...>) {
+    (void)(ivalue_args); // when sizeof...(ivalue_arg_indices) == 0, this argument would be unused and we have to silence the compiler warning.
     using IValueArgTypes = typename guts::infer_function_traits_t<Functor>::parameter_types;
     return (*functor)(ivalue_to_arg_type<guts::remove_cv_t<guts::remove_reference_t<guts::typelist::element_t<ivalue_arg_indices, IValueArgTypes>>>>::call(ivalue_args[ivalue_arg_indices])...);
   }
@@ -75,7 +76,7 @@ namespace detail {
   private:
     template<size_t... indices>
     static void call_(std::tuple<OutputTypes...>&& output, Stack* stack, guts::index_sequence<indices...>) {
-      (void)(stack); // silence compiler warning of weird compilers somehow thinking this parameter is unused.
+      (void)(stack); // when sizeof...(indices) == 0, this argument would be unused and we have to silence the compiler warning.
       // iterate over all outputs and push them
       (void)std::initializer_list<int>{(
         torch::jit::push(*stack, return_type_to_ivalue(std::move(std::get<indices>(output))))

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -198,4 +198,13 @@ TEST(OperatorRegistrationTest, givenOpWithoutKernels_whenRegisteringKernelAfterw
   }, "Didn't find kernel to dispatch to for operator '_test::dummy'");
 }
 
+TEST(OperatorRegistrationTest, givenOpWithoutKernelsWithoutTensorInputs_whenRegistering_thenRegisters) {
+  // as long as we don't register non-fallback kernels, ops without tensor arguments are fine
+
+  auto registrar = c10::RegisterOperators().op("_test::dummy() -> ()");
+
+  auto op = Dispatcher::singleton().findSchema("_test::dummy", "");
+  ASSERT_TRUE(op.has_value()); // assert schema is registered
+}
+
 }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19280 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931651/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19281 Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931649/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19282 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14931922/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19283 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931919/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19284 Allow ops without tensor args if only fallback kernel exists**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931926/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19285 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931923/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19286 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931921/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19287 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931925/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19288 Add some tests&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931924/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19289 Optional inputs and outputs&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931927/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19290 Add tests for argument types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931920/)

Instantiating a dispatch table previously only worked when the op had a tensor argument we could dispatch on.
However, the legacy API for custom operators didn't have dispatch and also worked for operators without tensor arguments, so we need to continue supporting that.
It probably generally makes sense to support this as long as there's only a fallback kernel and no dispatched kernel registered.
This diff adds that functionality.

Differential Revision: [D14931926](https://our.internmc.facebook.com/intern/diff/D14931926/)