### PR TITLE
Allow registering ops without specifying the full schema

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -84,6 +84,11 @@ inline bool operator==(const Argument& lhs, const Argument& rhs) {
           && lhs.alias_info() == rhs.alias_info();
 }
 
+struct OperatorName final {
+  std::string name;
+  std::string overload_name;
+};
+
 struct FunctionSchema {
   FunctionSchema(
       std::string name,
@@ -92,8 +97,7 @@ struct FunctionSchema {
       std::vector<Argument> returns,
       bool is_vararg = false,
       bool is_varret = false)
-      : name_(std::move(name)),
-        overload_name_(std::move(overload_name)),
+      : name_({std::move(name), std::move(overload_name)}),
         arguments_(std::move(arguments)),
         returns_(std::move(returns)),
         is_vararg_(is_vararg),
@@ -116,8 +120,7 @@ struct FunctionSchema {
             is_varret) {}
 
 private:
-  const std::string name_;
-  const std::string overload_name_;
+  OperatorName name_;
   const std::vector<Argument> arguments_;
   const std::vector<Argument> returns_;
   // if true then this schema takes an arbitrary number of additional arguments
@@ -130,10 +133,10 @@ private:
 
 public:
   const std::string& name() const {
-    return name_;
+    return name_.name;
   }
   const std::string& overload_name() const {
-    return overload_name_;
+    return name_.overload_name;
   }
   const std::vector<Argument>& arguments() const {
     return arguments_;
@@ -149,7 +152,7 @@ public:
   }
   bool is_mutable() const {
     // see [custom operator aliasing]
-    const auto kind = Symbol::fromQualString(name_);
+    const auto kind = Symbol::fromQualString(name_.name);
     const auto is_custom_op = !kind.is_aten() && !kind.is_prim();
     return is_custom_op ||
         std::any_of(

--- a/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/script/function_schema_parser.h>
 
 /**
  * This file tests the legacy function-based API for registering kernels.
@@ -453,6 +454,20 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenFallbackKernelWith
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
+  return {};
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", &kernelForSchemaInference);
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 template<class Return, class... Args> struct kernel_func final {

--- a/aten/src/ATen/core/op_registration/kernel_function_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/script/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::kernel;
@@ -455,6 +456,20 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenFallbackKernelWithoutTen
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
+  return {};
+}
+
+TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", kernel<decltype(kernelForSchemaInference), &kernelForSchemaInference>());
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 template<class Return, class... Args> struct kernel_func final {

--- a/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/script/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::kernel;
@@ -417,6 +418,16 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenFallbackKernelWithoutTenso
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
+  auto registrar = RegisterOperators()
+      .op("_test::no_schema_specified", kernel([] (Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) -> std::tuple<int64_t, Tensor> {return {};}));
+
+  auto op = c10::Dispatcher::singleton().findSchema("_test::no_schema_specified", "");
+  ASSERT_TRUE(op.has_value());
+
+  c10::assertSchemasHaveSameSignature(torch::jit::parseSchema("_test::no_schema_specified(Tensor arg1, int arg2, Tensor[] arg3) -> (int, Tensor)"), op->schema());
 }
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenMismatchedKernel_withDifferentNumArguments_whenRegistering_thenFails) {

--- a/aten/src/ATen/core/op_registration/kernel_stackbased_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_stackbased_test.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/core/Tensor.h>
+#include <torch/csrc/jit/script/function_schema_parser.h>
 
 using c10::RegisterOperators;
 using c10::kernel;
@@ -138,6 +139,15 @@ TEST(OperatorRegistrationTest_StackBasedKernel, givenFallbackKernelWithoutTensor
   auto outputs = callOp(*op, 3);
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(4, outputs[0].toInt());
+}
+
+void kernelForSchemaInference(Stack* stack, KernelCache* cache) {
+}
+
+TEST(OperatorRegistrationTest_StackBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenFailsBecauseItCannotInferFromStackBasedKernel) {
+  expectThrows<c10::Error>([] {
+      RegisterOperators().op("_test::no_schema_specified", kernel(&kernelForSchemaInference, &noCache));
+  }, "Cannot infer schema from this kernel function. Please explicitly specify the operator schema.");
 }
 
 struct Cache final : KernelCache {

--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -56,8 +56,33 @@ private:
   bool owns_registration_;
 };
 
-void RegisterOperators::registerOp_(const std::string& schemaStr, detail::KernelRegistrationConfig&& config) {
-  registerOp_(torch::jit::parseSchema(schemaStr), std::move(config));
+void RegisterOperators::checkSchemaAndRegisterOp_(const std::string& schemaOrNameStr, detail::KernelRegistrationConfig&& config) {
+  either<OperatorName, FunctionSchema> schemaOrName = torch::jit::parseSchemaOrName(schemaOrNameStr);
+  if (schemaOrName.is_right()) {
+    // schema was explicitly specified. Check it matches the inferred one and register the op.
+    checkSchemaAndRegisterOp_(std::move(schemaOrName).right(), std::move(config));
+  } else {
+    // schema wasn't explicitly specified. Take the inferred schema for registering the op.
+    AT_ASSERTM(nullptr != config.inferred_function_schema.get(), "Cannot infer schema from this kernel function. Please explicitly specify the operator schema.");
+    OperatorName name = std::move(schemaOrName).left();
+    FunctionSchema inferredSchema(
+      std::move(name.name),
+      std::move(name.overload_name),
+      config.inferred_function_schema->arguments(),
+      config.inferred_function_schema->returns(),
+      config.inferred_function_schema->is_vararg(),
+      config.inferred_function_schema->is_varret()
+    );
+    registerOp_(std::move(inferredSchema), std::move(config));
+  }
+}
+
+void RegisterOperators::checkSchemaAndRegisterOp_(FunctionSchema&& schema, detail::KernelRegistrationConfig&& config) {
+  if (config.inferred_function_schema.get() != nullptr) {
+    assertSchemasHaveSameSignature(*config.inferred_function_schema, schema);
+  }
+
+  registerOp_(std::move(schema), std::move(config));
 }
 
 void RegisterOperators::registerOp_(FunctionSchema&& schema, detail::KernelRegistrationConfig&& config) {
@@ -67,10 +92,6 @@ void RegisterOperators::registerOp_(FunctionSchema&& schema, detail::KernelRegis
 
   // if kernel_func is set, so must be cache_creator_func, the API shouldn't allow anything else.
   AT_ASSERT((config.kernel_func != nullptr) == static_cast<bool>(config.cache_creator_func));
-
-  if (config.inferred_function_schema.get() != nullptr) {
-    assertSchemasHaveSameSignature(*config.inferred_function_schema, schema);
-  }
 
   registrars_.emplace_back(std::move(schema), config.dispatch_key, config.kernel_func, std::move(config.cache_creator_func));
 }

--- a/torch/csrc/jit/script/function_schema_parser.h
+++ b/torch/csrc/jit/script/function_schema_parser.h
@@ -2,12 +2,14 @@
 
 #include <ATen/core/function_schema.h>
 #include <ATen/core/Macros.h>
+#include <c10/util/either.h>
 #include <string>
 
 namespace torch {
 namespace jit {
 
-CAFFE2_API ::c10::FunctionSchema parseSchema(const std::string& schema);
+CAFFE2_API c10::either<c10::OperatorName, c10::FunctionSchema> parseSchemaOrName(const std::string& schemaOrName);
+CAFFE2_API c10::FunctionSchema parseSchema(const std::string& schema);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19280 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931651/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19281 Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931649/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19282 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14931922/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19283 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931919/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19284 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931926/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19285 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931923/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19286 Allow registering ops without specifying the full schema**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931921/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19287 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931925/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19288 Add some tests&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931924/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19289 Optional inputs and outputs&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931927/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19290 Add tests for argument types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931920/)

The operator registration API now allows registering an operator by only giving the operator name and not the full operator schema,
as long as the operator schema can be inferred from the kernel function.

Differential Revision: [D14931921](https://our.internmc.facebook.com/intern/diff/D14931921/)