### PR TITLE
Add some tests

### DIFF
--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -207,4 +207,16 @@ TEST(OperatorRegistrationTest, givenOpWithoutKernelsWithoutTensorInputs_whenRegi
   ASSERT_TRUE(op.has_value()); // assert schema is registered
 }
 
+TEST(OperatorRegistrationTest, givenOpWithMultipleKernels_whenKernelsHaveSameDispatchKey_thenFails) {
+  auto registrar = c10::RegisterOperators()
+      .op("_test::dummy(Tensor dummy) -> ()", kernel<DummyKernel>(), dispatchKey(TensorType1()));
+
+  auto op = Dispatcher::singleton().findSchema("_test::dummy", "");
+  ASSERT_TRUE(op.has_value()); // assert schema is registered
+
+  expectThrows<c10::Error>([&] {
+    c10::RegisterOperators().op("_test::dummy(Tensor dummy) -> ()", kernel<DummyKernel>(), dispatchKey(TensorType1()));
+  }, "Tried to register multiple kernels with same dispatch key");
+}
+
 }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19280 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931651/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19281 Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931649/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19282 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14931922/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19283 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931919/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19284 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931926/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19285 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931923/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19286 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931921/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19287 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931925/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19288 Add some tests**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931924/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19289 Optional inputs and outputs&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931927/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19290 Add tests for argument types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931920/)

-

Differential Revision: [D14931924](https://our.internmc.facebook.com/intern/diff/D14931924/)