### PR TITLE
Optional inputs and outputs

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
@@ -456,6 +456,104 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenFallbackKernelWith
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
+c10::optional<Tensor> called_arg2;
+c10::optional<int64_t> called_arg3;
+c10::optional<std::string> called_arg4;
+
+void kernelWithOptInputWithoutOutput(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+  called = true;
+  called_arg2 = arg2;
+  called_arg3 = arg3;
+  called_arg4 = arg4;
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()", &kernelWithOptInputWithoutOutput);
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+c10::optional<Tensor> kernelWithOptInputWithOutput(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+  called = true;
+  called_arg2 = arg2;
+  called_arg3 = arg3;
+  called_arg4 = arg4;
+  return arg2;
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?", &kernelWithOptInputWithOutput);
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+std::tuple<c10::optional<Tensor>, c10::optional<int64_t>, c10::optional<std::string>>
+kernelWithOptInputWithMultipleOutputs(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+  return std::make_tuple(arg2, arg3, arg4);
+}
+
+TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)", &kernelWithOptInputWithMultipleOutputs);
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+  EXPECT_TRUE(outputs[1].isNone());
+  EXPECT_EQ("text", outputs[2].toString()->string());
+
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+  EXPECT_EQ(4, outputs[1].toInt());
+  EXPECT_TRUE(outputs[2].isNone());
+}
+
 std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
   return {};
 }

--- a/aten/src/ATen/core/op_registration/kernel_function_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_test.cpp
@@ -458,6 +458,104 @@ TEST(OperatorRegistrationTest_FunctionBasedKernel, givenFallbackKernelWithoutTen
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
+c10::optional<Tensor> called_arg2;
+c10::optional<int64_t> called_arg3;
+c10::optional<std::string> called_arg4;
+
+void kernelWithOptInputWithoutOutput(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+  called = true;
+  called_arg2 = arg2;
+  called_arg3 = arg3;
+  called_arg4 = arg4;
+}
+
+TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()", kernel<decltype(kernelWithOptInputWithoutOutput), &kernelWithOptInputWithoutOutput>(), dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+c10::optional<Tensor> kernelWithOptInputWithOutput(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+  called = true;
+  called_arg2 = arg2;
+  called_arg3 = arg3;
+  called_arg4 = arg4;
+  return arg2;
+}
+
+TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?", kernel<decltype(kernelWithOptInputWithOutput), &kernelWithOptInputWithOutput>(), dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+std::tuple<c10::optional<Tensor>, c10::optional<int64_t>, c10::optional<std::string>>
+kernelWithOptInputWithMultipleOutputs(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+  return std::make_tuple(arg2, arg3, arg4);
+}
+
+TEST(OperatorRegistrationTest_FunctionBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)", kernel<decltype(kernelWithOptInputWithMultipleOutputs), &kernelWithOptInputWithMultipleOutputs>(), dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+  EXPECT_TRUE(outputs[1].isNone());
+  EXPECT_EQ("text", outputs[2].toString()->string());
+
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+  EXPECT_EQ(4, outputs[1].toInt());
+  EXPECT_TRUE(outputs[2].isNone());
+}
+
 std::tuple<int64_t, Tensor> kernelForSchemaInference(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
   return {};
 }

--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -29,6 +29,7 @@ namespace detail {
   // cast it to the type that should be passed to the kernel function.
   // Examples: If the IValue contains a plain type like an int, return that.
   //           If the IValue contains an IntList, return it as ArrayRef<int>.
+  // TODO Should we move the IValue so we can avoid copying Tensor objects?
   template<class T>
   struct ivalue_to_arg_type {
     static T call(const IValue& v) {
@@ -41,10 +42,34 @@ namespace detail {
       return v.to<intrusive_ptr<ivalue::List<T>>>()->elements();
     }
   };
+  template<class T>
+  struct ivalue_to_arg_type<optional<T>> {
+    static optional<T> call(const IValue& v) {
+      if (v.isNone()) {
+        return nullopt;
+      }
+      return v.to<T>();
+    }
+  };
 
   template<class T>
-  IValue return_type_to_ivalue(T&& t) {
-    return IValue(std::forward<T>(t));
+  struct return_type_to_ivalue_ {
+    static IValue call(T&& v) {
+      return IValue(std::move(v));
+    }
+  };
+  template<class T>
+  struct return_type_to_ivalue_<optional<T>> {
+    static IValue call(optional<T>&& v) {
+      if (!v.has_value()) {
+        return IValue();
+      }
+      return IValue(std::move(*v));
+    }
+  };
+  template<class T>
+  IValue return_type_to_ivalue(T&& v) {
+    return return_type_to_ivalue_<guts::decay_t<T>>::call(std::move(v));
   }
 
   template<class Functor, size_t... ivalue_arg_indices>

--- a/aten/src/ATen/core/op_registration/kernel_functor_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_functor_test.cpp
@@ -601,6 +601,110 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenFallbackKernelWithoutTens
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
+c10::optional<Tensor> called_arg2;
+c10::optional<int64_t> called_arg3;
+c10::optional<std::string> called_arg4;
+
+struct KernelWithOptInputWithoutOutput final : OperatorKernel {
+  void operator()(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+    called = true;
+    called_arg2 = arg2;
+    called_arg3 = arg3;
+    called_arg4 = arg4;
+  }
+};
+
+TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()", kernel<KernelWithOptInputWithoutOutput>(), dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+struct KernelWithOptInputWithOutput final : OperatorKernel {
+  c10::optional<Tensor> operator()(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+    called = true;
+    called_arg2 = arg2;
+    called_arg3 = arg3;
+    called_arg4 = arg4;
+    return arg2;
+  }
+};
+
+TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?", kernel<KernelWithOptInputWithOutput>(), dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+struct KernelWithOptInputWithMultipleOutputs final : OperatorKernel {
+  std::tuple<c10::optional<Tensor>, c10::optional<int64_t>, c10::optional<std::string>>
+  operator()(Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+    return std::make_tuple(arg2, arg3, arg4);
+  }
+};
+
+TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op("_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)", kernel<KernelWithOptInputWithMultipleOutputs>(), dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+  EXPECT_TRUE(outputs[1].isNone());
+  EXPECT_EQ("text", outputs[2].toString()->string());
+
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+  EXPECT_EQ(4, outputs[1].toInt());
+  EXPECT_TRUE(outputs[2].isNone());
+}
+
 struct KernelForSchemaInference final : OperatorKernel {
   std::tuple<int64_t, Tensor> operator()(Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) {
     return {};

--- a/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
@@ -407,6 +407,114 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenFallbackKernelWithou
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
+TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+  bool called;
+  c10::optional<Tensor> called_arg2;
+  c10::optional<int64_t> called_arg3;
+  c10::optional<std::string> called_arg4;
+
+  auto registrar = RegisterOperators().op(
+    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
+    [&] (Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+      called = true;
+      called_arg2 = arg2;
+      called_arg3 = arg3;
+      called_arg4 = arg4;
+    });
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+  bool called;
+  c10::optional<Tensor> called_arg2;
+  c10::optional<int64_t> called_arg3;
+  c10::optional<std::string> called_arg4;
+
+  auto registrar = RegisterOperators().op(
+    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
+    [&] (Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+      called = true;
+      called_arg2 = arg2;
+      called_arg3 = arg3;
+      called_arg4 = arg4;
+      return arg2;
+    });
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  bool called;
+  c10::optional<Tensor> called_arg2;
+  c10::optional<int64_t> called_arg3;
+  c10::optional<std::string> called_arg4;
+
+  auto registrar = RegisterOperators().op(
+    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
+    [] (Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+      return std::make_tuple(arg2, arg3, arg4);
+    });
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+  EXPECT_TRUE(outputs[1].isNone());
+  EXPECT_EQ("text", outputs[2].toString()->string());
+
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+  EXPECT_EQ(4, outputs[1].toInt());
+  EXPECT_TRUE(outputs[2].isNone());
+}
+
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
   auto registrar = RegisterOperators()
       .op("_test::no_schema_specified", [] (Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) -> std::tuple<int64_t, Tensor> {return {};});

--- a/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
@@ -420,6 +420,106 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenFallbackKernelWithoutTenso
   EXPECT_EQ(4, outputs[0].toInt());
 }
 
+c10::optional<Tensor> called_arg2;
+c10::optional<int64_t> called_arg3;
+c10::optional<std::string> called_arg4;
+
+TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithOptionalInputs_withoutOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> ()",
+    kernel([] (Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+      called = true;
+      called_arg2 = arg2;
+      called_arg3 = arg3;
+      called_arg4 = arg4;
+    }),
+    dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(0, outputs.size());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithOptionalInputs_withOutput_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> Tensor?",
+    kernel([] (Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+      called = true;
+      called_arg2 = arg2;
+      called_arg3 = arg3;
+      called_arg4 = arg4;
+      return arg2;
+    }),
+    dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  called = false;
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(called_arg2.has_value());
+  EXPECT_EQ(called_arg2->type_id(), TensorType2());
+  EXPECT_FALSE(called_arg3.has_value());
+  EXPECT_TRUE(called_arg4.has_value());
+  EXPECT_EQ(*called_arg4, "text");
+
+  called = false;
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(1, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+
+  EXPECT_TRUE(called);
+  EXPECT_FALSE(called_arg2.has_value());
+  EXPECT_TRUE(called_arg3.has_value());
+  EXPECT_EQ(*called_arg3, 4);
+  EXPECT_FALSE(called_arg4.has_value());
+}
+
+TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithOptionalInputs_withMultipleOutputs_whenRegistered_thenCanBeCalled) {
+  auto registrar = RegisterOperators().op(
+    "_test::opt_input(Tensor arg1, Tensor? arg2, int? arg3, str? arg4) -> (Tensor?, int?, str?)",
+    kernel([] (Tensor arg1, const c10::optional<Tensor>& arg2, c10::optional<int64_t> arg3, c10::optional<std::string> arg4) {
+      return std::make_tuple(arg2, arg3, arg4);
+    }),
+    dispatchKey(TensorType1()));
+  auto op = c10::Dispatcher::singleton().findSchema("_test::opt_input", "");
+  ASSERT_TRUE(op.has_value());
+
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), c10::IValue(), std::string("text"));
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_EQ(TensorType2(), outputs[0].toTensor().type_id());
+  EXPECT_TRUE(outputs[1].isNone());
+  EXPECT_EQ("text", outputs[2].toString()->string());
+
+  outputs = callOp(*op, dummyTensor(TensorType1()), c10::IValue(), 4, c10::IValue());
+  EXPECT_EQ(3, outputs.size());
+  EXPECT_TRUE(outputs[0].isNone());
+  EXPECT_EQ(4, outputs[1].toInt());
+  EXPECT_TRUE(outputs[2].isNone());
+}
+
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernel_whenRegisteredWithoutSpecifyingSchema_thenInfersSchema) {
   auto registrar = RegisterOperators()
       .op("_test::no_schema_specified", kernel([] (Tensor arg1, int64_t arg2, ArrayRef<Tensor> arg3) -> std::tuple<int64_t, Tensor> {return {};}));


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19280 Split function schema parser from operator&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931651/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19281 Fixing function schema parser for Android&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931649/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19282 Move function schema parser to ATen/core build target&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14931922/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19283 String-based schemas in op registration API&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931919/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19284 Allow ops without tensor args if only fallback kernel exists&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931926/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19285 Add either type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931923/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19286 Allow registering ops without specifying the full schema&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931921/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19287 Use string based schema for exposing caffe2 ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931925/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19288 Add some tests&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931924/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19289 Optional inputs and outputs**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931927/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19290 Add tests for argument types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14931920/)

Allow optional inputs and outputs in native c10 operators

Differential Revision: [D14931927](https://our.internmc.facebook.com/intern/diff/D14931927/)