### PR TITLE
[pytorch][PR] [pt1][quant] Add slicing and int_repr() to QTensor

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -220,7 +220,8 @@ inline std::string _all_equal_numel_error(at::ArrayRef<Tensor> tensors) {
 }
 
 inline bool _apply_preamble(ArrayRef<Tensor> tensors) {
-  checkBackend("CPU_tensor_apply", tensors, Backend::CPU);
+  checkDeviceType("CPU_tensor_apply", tensors, kCPU);
+  checkLayout("CPU_tensor_apply", tensors, kStrided);
   if (!_all_equal_numel(tensors))
     AT_ERROR(_all_equal_numel_error(tensors));
   // An empty tensor has no elements

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -202,9 +202,37 @@ void checkBackend(CheckedFrom c, const Tensor& t, Backend backend) {
     "(while checking arguments for ", c, ")");
 }
 
-void checkBackend(CheckedFrom c, ArrayRef<Tensor> tensors, at::Backend backend) {
+void checkBackend(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::Backend backend) {
   for (auto &t : tensors) {
     checkBackend(c, t, backend);
+  }
+}
+
+void checkDeviceType(CheckedFrom c, const Tensor& t, DeviceType device_type) {
+  AT_CHECK(
+      !t.defined() || t.type().device_type() == device_type,
+      "Expected tensor to have ", device_type,
+      " DeviceType, but got tensor with ", t.type().device_type(), " DeviceType ",
+      "(while checking arguments for ", c, ")");
+}
+
+void checkDeviceType(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::DeviceType device_type) {
+  for (auto &t : tensors) {
+    checkDeviceType(c, t, device_type);
+  }
+}
+
+void checkLayout(CheckedFrom c, const Tensor& t, Layout layout) {
+  AT_CHECK(
+    !t.defined() || t.layout() == layout,
+    "Expected tensor to have ", layout,
+    " Layout, but got tensor with ", t.layout(), " Layout ",
+    "(while checking arguments for ", c, ")");
+}
+
+void checkLayout(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::Layout layout) {
+  for (auto &t : tensors) {
+    checkLayout(c, t, layout);
   }
 }
 

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -115,6 +115,15 @@ CAFFE2_API void checkBackend(
     at::ArrayRef<Tensor> t,
     at::Backend backend);
 
+CAFFE2_API void checkDeviceType(
+    CheckedFrom c,
+    at::ArrayRef<Tensor> tensors,
+    at::DeviceType device_type);
+
+CAFFE2_API void checkLayout(CheckedFrom c, const Tensor& t, Layout layout);
+
+CAFFE2_API void checkLayout(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::Layout layout);
+
 // Methods for getting data_ptr if tensor is defined
 CAFFE2_API void* maybe_data_ptr(const Tensor& tensor);
 CAFFE2_API void* maybe_data_ptr(const TensorArg& tensor);

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -590,6 +590,7 @@ class CAFFE2_API Tensor {
   Tensor dequantize() const;
   Scalar q_scale() const;
   Scalar q_zero_point() const;
+  Tensor int_repr() const;
   Tensor to(const TensorOptions & options, bool non_blocking=false, bool copy=false) const;
   Tensor to(Device device, ScalarType dtype, bool non_blocking=false, bool copy=false) const;
   Tensor to(ScalarType dtype, bool non_blocking=false, bool copy=false) const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -812,6 +812,9 @@ inline Scalar Tensor::q_scale() const {
 inline Scalar Tensor::q_zero_point() const {
     return dispatch_type().q_zero_point(*this);
 }
+inline Tensor Tensor::int_repr() const {
+    return dispatch_type().int_repr(*this);
+}
 inline Tensor Tensor::to(const TensorOptions & options, bool non_blocking, bool copy) const {
     return dispatch_type().to(*this, options, non_blocking, copy);
 }

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -461,6 +461,7 @@ struct CAFFE2_API Type {
   virtual Tensor dequantize(const Tensor & self) const = 0;
   virtual Scalar q_scale(const Tensor & self) const = 0;
   virtual Scalar q_zero_point(const Tensor & self) const = 0;
+  virtual Tensor int_repr(const Tensor & self) const = 0;
   virtual Tensor to(const Tensor & self, const TensorOptions & options, bool non_blocking, bool copy) const = 0;
   virtual Tensor to(const Tensor & self, Device device, ScalarType dtype, bool non_blocking, bool copy) const = 0;
   virtual Tensor to(const Tensor & self, ScalarType dtype, bool non_blocking, bool copy) const = 0;

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -204,6 +204,13 @@
 
 - func: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
   variants: function, method
+  cpu_half: True
+  cpu_bool: True
+  cuda_bool: True
+  dispatch:
+    CPU: as_strided_tensorimpl
+    CUDA: as_strided_tensorimpl
+    QuantizedCPU: as_strided_qtensorimpl
   device_guard: False
 
 - func: as_strided_(Tensor(a!) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a!)
@@ -2507,6 +2514,11 @@
   variants: function, method
   dispatch:
     QuantizedCPU: q_zero_point_quant
+
+- func: int_repr(Tensor self) -> Tensor
+  variants: function, method
+  dispatch:
+    QuantizedCPU: int_repr_quant
 
 # to(Device) must not exist because all constructors of Device also works for
 # TensorOptions. Otherwise, an ambiguity error is thrown.

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -32,5 +32,13 @@ Quantizer* quantizer(const QTensor& self) {
   return get_qtensorimpl(self)->quantizer().get();
 }
 
+Tensor int_repr_quant(const QTensor& self) {
+  Tensor dst = at::empty(self.sizes(), self.options().dtype(at::kByte));
+  uint8_t* self_data = reinterpret_cast<uint8_t *>(self.data<qint8>());
+  uint8_t* dst_data = dst.data<uint8_t>();
+  memcpy(dst_data, self_data, self.numel());
+  return dst;
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -36,7 +36,7 @@ inline QTensor new_qtensor(
   int64_t nelements = at::prod_intlist(sizes);
   auto dtype = options.dtype();
   AT_ASSERT(isQIntType(typeMetaToScalarType(dtype)));
-  auto storage_impl = c10::make_intrusive<StorageImpl>(
+  auto storage = c10::make_intrusive<StorageImpl>(
       dtype,
       nelements,
       allocator->allocate(nelements * dtype.itemsize()),
@@ -44,7 +44,7 @@ inline QTensor new_qtensor(
       /*resizable=*/true);
   // TODO: get TensorTypeId from quantizer
   auto tensor = detail::make_tensor<QTensorImpl>(
-      storage_impl, at::QuantizedCPUTensorId(), quantizer);
+      storage, at::QuantizedCPUTensorId(), quantizer);
   get_qtensorimpl(tensor)->set_sizes_contiguous(sizes);
   return tensor;
 }

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -21,6 +21,14 @@ TEST(TestQTensor, QuantDequantAPIs) {
   ASSERT_EQ(qr.q_scale().to<float>(), scale);
   ASSERT_EQ(qr.q_zero_point().to<int32_t>(), zero_point);
   ASSERT_TRUE(qr.is_quantized());
+  ASSERT_FALSE(r.is_quantized());
+
+  // int_repr
+  Tensor int_repr = qr.int_repr();
+  auto* int_repr_data = int_repr.data<uint8_t>();
+  for (auto i = 0; i < num_elements; ++i) {
+    ASSERT_EQ(int_repr_data[i], 3);
+  }
 
   // Check for correct quantization
   auto r_data = r.data<float>();

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -277,6 +277,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: index_select
    .. automethod:: indices
    .. automethod:: int
+   .. automethod:: int_repr
    .. automethod:: inverse
    .. automethod:: irfft
    .. automethod:: is_contiguous

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2663,13 +2663,26 @@ class _TestTorchMixin(object):
         self.assertEqual(qr.q_zero_point(), zero_point)
         self.assertTrue(qr.is_quantized)
         self.assertFalse(r.is_quantized)
+        # slicing and int_repr
+        int_repr = qr.int_repr()
+        for num in int_repr:
+            self.assertEqual(num, 3)
+        for num in qr[2:].int_repr():
+            self.assertEqual(num, 3)
+        # dequantize
         rqr = qr.dequantize()
         for i in range(num_elements):
             self.assertEqual(r[i], rqr[i])
-        # Testing item
+        # Scalar Tensor
+        # item
         r = torch.ones(1, dtype=torch.float)
         qr = r.quantize_linear(scale, zero_point)
         self.assertEqual(qr.item(), 1)
+        self.assertEqual(qr[0].item(), 1)
+        # assignment
+        # This calls _th_fill_
+        # qr[0] = 8 # float asignment
+        # self.assertEqual(qr.item(), 8)
 
     def test_qtensor_quant_dequant(self):
         r = np.random.rand(3, 2) * 2 - 4

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2533,6 +2533,16 @@ int() -> Tensor
 ``self.int()`` is equivalent to ``self.to(torch.int32)``. See :func:`to`.
 """)
 
+add_docstr_all('int_repr',
+               r"""
+int_repr() -> Tensor
+
+Given a quantized Tensor,
+``self.int_repr()`` returns a CPU Tensor with uint8_t as data type that stores the
+underlying uint8_t values of the given Tensor.
+""")
+
+
 add_docstr_all('long',
                r"""
 long() -> Tensor


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19296 [pytorch][PR] [pt1][quant] Add slicing and int_repr() to QTensor**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14756833/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18960 [pt1][quant] Add empty_quantized&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14810261/)

Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19296 [pt1][quant] Add slicing and int_repr() to QTensor**&nbsp;&nbsp;[:yellow_heart:](https://our.intern.facebook.com/intern/diff/D14756833/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #18960 [pt1][quant] Add empty_quantized&nbsp;&nbsp;[:yellow_heart:](https://our.intern.facebook.com/intern/diff/D14810261/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19312 Use the QTensor with QReLU&nbsp;&nbsp;[:yellow_heart:](https://our.intern.facebook.com/intern/diff/D14819460/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19319 [RFC] Quantized SumRelu&nbsp;&nbsp;[:yellow_heart:](https://our.intern.facebook.com/intern/diff/D14866442/)

Methods added to pytorch python frontend:
- int_repr() returns a CPUByte Tensor which copies the data of QTensor.
- Added as_strided for QTensorImpl which provides support for slicing a QTensor(see test_torch.py)
Pull Request resolved: https://github.com/pytorch/pytorch/pull/19296

Differential Revision: [D14756833](https://our.internmc.facebook.com/intern/diff/D14756833/)