### PR TITLE
calculate execution time based on final iterations

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -160,7 +160,7 @@ class BenchmarkRunner(object):
             run_time = 0
             iters = self.iters
             while True:
-                # Use Python's timeit module to measure execution time.
+                # Use Python's timeit module to measure execution time (unit: second).
                 # Each experiment consists of repeated execution of
                 # the benchmark_func a number of times (self.iters)
                 # because otherwise the duration is too short to get
@@ -170,8 +170,8 @@ class BenchmarkRunner(object):
                 # (num_repeats) and we then take the minimum execution
                 # time as the final measurement result (this is also
                 # recommended by timeit's doc).
-                run_time = run_time + min(timeit.repeat(functools.partial(benchmark_func, iters),
-                                          repeat=1, number=1))
+                run_time = min(timeit.repeat(functools.partial(benchmark_func, iters),
+                               repeat=1, number=1))
                 # Analyze time after each run to decide if the result is stable
                 results_are_significant = self.has_explicit_iteration_count or \
                     self._report_iteration_result(iters, run_time)


### PR DESCRIPTION
Summary:
I saw larger than 5% performance variation with small operators, this diff aims to reduce the variation by avoiding python overhead. Previously, in the benchmark, we run the main loop for 100 iterations then look at the time. If it's not significant, we will double the number of iterations to rerun and look at the result. We continue this process until it becomes significant. We calculate the time by total_time / number of iterations. The issue is that we are including multiple python trigger overhead.

Now, I change the logic to calculate execution time based on the last run instead of all runs, the equation is time_in_last_run/number of iterations.

Differential Revision: D14925287

