### PR TITLE
Improve embedding_bag add kernel

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -469,6 +469,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
     const Tensor& grad,
     const Tensor& weight,  // NB: embedding table, not per_sample_weights
     const Tensor& indices,
+    const Tensor& offsets,
     const Tensor& offset2bag,
     int64_t mode) {
   AT_CHECK(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -675,7 +675,7 @@
     CPU: _embedding_bag_dense_backward_cpu
     CUDA: _embedding_bag_dense_backward_cuda
 
-- func: _embedding_bag_per_sample_weights_backward(Tensor grad, Tensor weight, Tensor indices, Tensor offset2bag, int mode) -> Tensor
+- func: _embedding_bag_per_sample_weights_backward(Tensor grad, Tensor weight, Tensor indices, Tensor offsets, Tensor offset2bag, int mode) -> Tensor
   dispatch:
     CPU: _embedding_bag_per_sample_weights_backward_cpu
     CUDA: _embedding_bag_per_sample_weights_backward_cuda

--- a/caffe2/perfkernels/embedding_lookup.h
+++ b/caffe2/perfkernels/embedding_lookup.h
@@ -28,6 +28,9 @@ namespace caffe2 {
  *   if (normalize_weights && lengths[i] > 0)
  *     for (k = 0..block_size-1)
  *       out[i*block_size + k] /= lengths[i]
+ *
+ * TODO: make this API also take "offsets" rather than "lengths" to match the
+ *       API for PyTorch's EmbeddingBag
  */
 template <
     typename IndexType,

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -955,7 +955,7 @@
   indices: not_differentiable
   offsets: not_differentiable
   weight: _embedding_bag_backward(grad, indices, offsets, result1, result2, result3, weight.size(0), scale_grad_by_freq, mode, sparse, per_sample_weights)
-  per_sample_weights: _embedding_bag_per_sample_weights_backward(grad, weight, indices, result1, mode)
+  per_sample_weights: _embedding_bag_per_sample_weights_backward(grad, weight, indices, offsets, result1, mode)
 
 - name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
   indices: not_differentiable


### PR DESCRIPTION
This PR makes it so that we call into the high-performance `EmbeddingLookup` function from C2 within embedding_bag for `add` mode. This is highly-optimized and does dynamic dispatch based on cpuid. It also makes it so that we elide creating the offset2bag tensor in the fast path case. That operation was contributing a significant portion of runtime to the operator.

Benchmark script (with a hack to make jit not DCE/CSE): https://gist.github.com/jamesr66a/73baed47400dcf2221bad996c4b57782

=== Baseline (master) === 

```
time_per_iter 8.726580142974853e-05
GB/s 4.588097438402839
```

== Test (this PR) ===

```
time_per_iter 2.5180697441101074e-05
GB/s 15.900433295643158
```

