### PR TITLE
Improve unique CPU performance for returning counts

### DIFF
--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -41,7 +41,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
   if (return_inverse || return_counts) {
     inverse_indices.resize_(input.sizes());
     int64_t* inverse_indices_data = inverse_indices.data<int64_t>();
-    std::unordered_map<scalar_t, std::atomic_int64_t> inverse_map;
+    std::unordered_map<scalar_t, int64_t> inverse_map;
     inverse_map.reserve(output.numel());
     for (int i = 0; i < output.numel(); ++i) {
       inverse_map[output_data[i]] = i;

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -47,7 +47,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
       inverse_map[output_data[i]] = i;
     }
     for(int64_t i = 0; i < numel; ++i) {
-       inverse_indices_data[i] = inverse_map[input_data[i]];
+      inverse_indices_data[i] = inverse_map[input_data[i]];
     }
     if (return_counts) {
       std::unordered_map<scalar_t, int64_t> counts_map;

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -42,6 +42,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
   if (return_inverse || return_counts) {
     inverse_indices.resize_(input.sizes());
     int64_t* inverse_indices_data = inverse_indices.data<int64_t>();
+    std::unordered_map<scalar_t, std::atomic_int64_t> inverse_map;
     inverse_map.reserve(output.numel());
     for (int i = 0; i < output.numel(); ++i) {
       inverse_map[output_data[i]] = i;

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -46,8 +46,8 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
     for (int i = 0; i < output.numel(); ++i) {
       inverse_map[output_data[i]] = i;
     }
-    for(int64_t i = 0; i < numel; i++) {
-        inverse_indices_data[i] = inverse_map[input_data[i]];
+    for(int64_t i = 0; i < numel; ++i) {
+       inverse_indices_data[i] = inverse_map[input_data[i]];
     }
     if (return_counts) {
       std::unordered_map<scalar_t, int64_t> counts_map;

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -43,7 +43,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
     int64_t* inverse_indices_data = inverse_indices.data<int64_t>();
     std::unordered_map<scalar_t, int64_t> inverse_map;
     inverse_map.reserve(output.numel());
-    for (int i = 0; i < output.numel(); ++i) {
+    for (int64_t i = 0; i < output.numel(); ++i) {
       inverse_map[output_data[i]] = i;
     }
     for(int64_t i = 0; i < numel; ++i) {
@@ -52,7 +52,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_template(
     if (return_counts) {
       std::unordered_map<scalar_t, int64_t> counts_map;
       counts_map.reserve(output.numel());
-      for (int i = 0; i < output.numel(); ++i) {
+      for (int64_t i = 0; i < output.numel(); ++i) {
         counts_map[output_data[i]] = 0;
       }
       for(int64_t i = 0; i < numel; i++) {
@@ -184,7 +184,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
   Tensor input_sorted;
   if (!consecutive) {
     input_sorted = at::empty(input_flat.sizes(), input_flat.options());
-    for (int i = 0; i < indices.size(); ++i) {
+    for (int64_t i = 0; i < indices.size(); ++i) {
       input_sorted[i] = input_flat[indices[i]];
     }
   } else {


### PR DESCRIPTION
Benchmark on a tensor of shape `torch.Size([15320, 2])`. Benchmark code:

```python
print(torch.__version__)
print()
a = tensor.flatten()
print('cpu, sorted=False:')
%timeit torch._unique2_temporary_will_remove_soon(a, sorted=False)
%timeit torch._unique2_temporary_will_remove_soon(a, sorted=False, return_inverse=True)
%timeit torch._unique2_temporary_will_remove_soon(a, sorted=False, return_counts=True)
%timeit torch._unique2_temporary_will_remove_soon(a, sorted=False, return_inverse=True, return_counts=True)
print()
print('cpu, sorted=True:')
%timeit torch._unique2_temporary_will_remove_soon(a)
%timeit torch._unique2_temporary_will_remove_soon(a, return_inverse=True)
%timeit torch._unique2_temporary_will_remove_soon(a, return_counts=True)
%timeit torch._unique2_temporary_will_remove_soon(a, return_inverse=True, return_counts=True)
print()
```

Before
```
1.1.0a0+36854fe

cpu, sorted=False:
340 µs ± 4.05 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
724 µs ± 6.28 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
54.3 ms ± 469 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
54.6 ms ± 659 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

cpu, sorted=True:
341 µs ± 7.21 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
727 µs ± 7.05 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
54.7 ms ± 795 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
54.3 ms ± 647 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After
```
1.1.0a0+261d9e8

cpu, sorted=False:
350 µs ± 865 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
771 µs ± 598 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.09 ms ± 6.86 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.09 ms ± 4.74 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

cpu, sorted=True:
324 µs ± 4.99 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
705 µs ± 3.18 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.09 ms ± 5.22 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.09 ms ± 5.63 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```