### PR TITLE
[JIT] Add an unused API

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -91,6 +91,7 @@ namespace c10 {
   _(prim, GetAttr)                 \
   _(prim, AddStatValue)            \
   _(prim, TimePoint)               \
+  _(prim, Unused)                  \
   _(aten, append)                  \
   _(aten, item)                    \
   _(aten, format)                  \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10678,6 +10678,15 @@ a")
             return a
         self.checkScript(foo, (torch.ones(4, 3), torch.ones(4, 3)))
 
+    def test_unused(self):
+        @torch.jit.script
+        def test_unused(x):
+            for i in range(300):
+                torch.jit._unused([])
+
+        FileCheck().check('prim::ListConstruct()').check('prim::Unused')\
+                   .run(test_unused.graph)
+
     def test_lhs_advanced_indexing_augmented_assignment(self):
         def foo(x, y):
             a = torch.exp(x)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -313,5 +313,7 @@ def compiled_with_cxx11_abi():
 # Import the ops "namespace"
 from torch._ops import ops  # noqa: F401
 
+torch.jit._unused = torch.ops.prim.Unused
+
 # Import the quasi random sampler
 import torch.quasirandom

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -835,6 +835,7 @@ bool Node::hasSideEffects() const {
     case aten::warn:
     case prim::AddStatValue:
     case prim::TimePoint:
+    case prim::Unused:
       return true;
   }
   // All other builtin ops are known to be safe.

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -889,7 +889,14 @@ RegisterOperators reg(
          userObj->setSlot(slot, std::move(v));
          return 0;
        };
-     })});
+        }),
+     Operator("prim::Unused(t item) -> ()", [](const Node* node) {
+       return [](Stack& stack) {
+         auto v = pop(stack);
+         return 0;
+       };
+        }),
+     });
 
 RegisterOperators logging_operators(
     {Operator(


### PR DESCRIPTION
This allows us to mark a value as unused, but we do not want its producer node to be DCE'd. This allows us to do things like benchmark a single op in a loop without unrolling/DCE getting in the way

Differential Revision: [D15361137](https://our.internmc.facebook.com/intern/diff/15361137/)