### PR TITLE
Add debug logic to c2_ref_test and its helpers

### DIFF
--- a/caffe2/python/onnx/helper.py
+++ b/caffe2/python/onnx/helper.py
@@ -36,7 +36,7 @@ def c2_native_run_op(op_def, inputs):
     return ws, namedtupledict('Outputs', output_names)(*output_values)
 
 
-def c2_native_run_net(init_net, predict_net, inputs):
+def c2_native_run_net(init_net, predict_net, inputs, debug_arg=None):
     ws = Workspace()
     if init_net:
         ws.RunNetOnce(init_net)
@@ -54,6 +54,14 @@ def c2_native_run_net(init_net, predict_net, inputs):
         else:
             # If everything is initialized,
             # we just initialized the first len(inputs) external_input.
+            # Added some extra logging to help debug sporadic sandcastle fails
+            if len(inputs) > len(predict_net.external_input):
+                print("c2_native_run_net assert. len(inputs)=", len(inputs),
+                      "len(predict_net.external_input)=",
+                      len(predict_net.external_input))
+                print("debug_arg: ", debug_arg)
+                print("predict_net ", type(predict_net), ":", predict_net)
+                print("inputs ", type(inputs), ":", inputs)
             assert(len(inputs) <= len(predict_net.external_input))
             for i in range(len(inputs)):
                 ws.FeedBlob(predict_net.external_input[i], inputs[i],

--- a/caffe2/python/onnx/tests/c2_ref_test.py
+++ b/caffe2/python/onnx/tests/c2_ref_test.py
@@ -736,16 +736,18 @@ class TestCaffe2End2End(TestCase):
                   decimal=7):
         np.random.seed(seed=0)
         try:
-            c2_init_net, c2_predict_net, value_info = self.model_downloader.get_c2_model(net_name)
+            c2_init_net, c2_predict_net, value_info, debug_str = self.model_downloader.get_c2_model_dbg(net_name)
         except (OSError, IOError) as e:
             # catch IOError/OSError that is caused by FileNotFoundError and PermissionError
+            # This is helpful because sometimes we get errors due to gfs not available
+            print("\n_test_net exception: ", e)
             self.skipTest(str(e))
 
         # start to run the model and compare outputs
         n, c, h, w = input_blob_dims
         data = np.random.randn(n, c, h, w).astype(np.float32)
         inputs = [data]
-        _, c2_outputs = c2_native_run_net(c2_init_net, c2_predict_net, inputs)
+        _, c2_outputs = c2_native_run_net(c2_init_net, c2_predict_net, inputs, debug_str)
         del _
 
         model = c2_onnx.caffe2_net_to_onnx_model(


### PR DESCRIPTION
Summary:
Even with file IO exception handling, some of the sandcastle c2_ref_tests are still failing in length-check assert, as can be seen here:
https://our.intern.facebook.com/intern/test/844424932589974?ref_report_id=0

This is an attempt to add printing logic to debug what's going on.

Differential Revision: D14966274

