### PR TITLE
[wip][jit] Refactor math ops to use custom op bindings

### DIFF
--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -182,6 +182,20 @@ Operator createOperator(
 
   auto schema = torch::jit::detail::inferAndCheckSchema<Traits>(schemaOrName);
 
+  // [custom operator aliasing] Currently, we have no way for the user to
+  // specify the alias annotations for a custom op. Therefore, we have to:
+  //   1. Assume that custom ops will mutate all inputs, have side effects, and
+  //      produce wildcard outputs.
+  //   2. Have some way of distinguishing between a custom op and a builtin op
+  //      so that we can apply the above rule.
+  // We do this by manually whitelisting "aten" and "prim" namespaces as
+  // builtins.
+  //
+  // We don't want to preserve this distinction between custom/builtin ops, as
+  // it is fragile and hard to maintain. When we provide a way for op
+  // registration to specify alias annotations, we should fix up builtins to
+  // use that and remove all references to this note.
+
   return Operator(
       schema,
       [implementation, schema](Stack& stack) {

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -182,26 +182,6 @@ Operator createOperator(
 
   auto schema = torch::jit::detail::inferAndCheckSchema<Traits>(schemaOrName);
 
-  // [custom operator aliasing] Currently, we have no way for the user to
-  // specify the alias annotations for a custom op. Therefore, we have to:
-  //   1. Assume that custom ops will mutate all inputs, have side effects, and
-  //      produce wildcard outputs.
-  //   2. Have some way of distinguishing between a custom op and a builtin op
-  //      so that we can apply the above rule.
-  // We do this by manually whitelisting "aten" and "prim" namespaces as
-  // builtins.
-  //
-  // We don't want to preserve this distinction between custom/builtin ops, as
-  // it is fragile and hard to maintain. When we provide a way for op
-  // registration to specify alias annotations, we should fix up builtins to
-  // use that and remove all references to this note.
-  Symbol name = Symbol::fromQualString(schema.name());
-  if (name.is_aten() || name.is_prim() || name.is_onnx()) {
-    AT_ERROR(
-        "Tried to register a custom operator to a reserved namespace: ",
-        name.ns().toUnqualString());
-  }
-
   return Operator(
       schema,
       [implementation, schema](Stack& stack) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1999,7 +1999,7 @@ auto math_ops =
         .op("aten::abs", static_cast<double (*)(double)>(&std::abs))
         .op("aten::floor", static_cast<double (*)(double)>(&std::floor))
         .op("aten::pow", static_cast<double (*)(double, double)>(&std::pow))
-        .op("aten::pow", static_cast<double (*)(double, int)>(&std::pow))
+        .op("aten::pow", static_cast<double (*)(double, int64_t)>(&std::pow))
         .op("aten::exp", static_cast<double (*)(int64_t)>(&std::exp))
         .op("aten::exp", static_cast<double (*)(double)>(&std::exp))
         .op("aten::sqrt", static_cast<double (*)(int64_t)>(&std::sqrt))

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1991,26 +1991,41 @@ RegisterOperators reg2({
     Operator("aten::hash(float t) -> int", hashValue<double>),
 });
 
+auto pure_op = OperatorOptions().aliasAnalysis(AliasAnalysisKind::PURE);
 
 auto math_ops =
     RegisterOperators()
         // the static_cast<...> business is to select a specific overload
-        .op("aten::abs", static_cast<int64_t (*)(int64_t)>(&std::abs))
-        .op("aten::abs", static_cast<double (*)(double)>(&std::abs))
-        .op("aten::floor", static_cast<double (*)(double)>(&std::floor))
-        .op("aten::pow", static_cast<double (*)(double, double)>(&std::pow))
-        .op("aten::pow", static_cast<double (*)(double, int64_t)>(&std::pow))
-        .op("aten::exp", static_cast<double (*)(int64_t)>(&std::exp))
-        .op("aten::exp", static_cast<double (*)(double)>(&std::exp))
-        .op("aten::sqrt", static_cast<double (*)(int64_t)>(&std::sqrt))
-        .op("aten::sqrt", static_cast<double (*)(double)>(&std::sqrt))
-        .op("aten::log10", static_cast<double (*)(int64_t)>(&std::log10))
-        .op("aten::log10", static_cast<double (*)(double)>(&std::log10))
-        .op("aten::log1p", static_cast<double (*)(int64_t)>(&std::log1p))
-        .op("aten::log1p", static_cast<double (*)(double)>(&std::log1p))
-        .op("aten::ceil", static_cast<double (*)(double)>(&std::ceil))
-        .op("aten::log", static_cast<double (*)(int64_t)>(&std::log))
-        .op("aten::log", static_cast<double (*)(double)>(&std::log));
+        .op("aten::abs", static_cast<int64_t (*)(int64_t)>(&std::abs), pure_op)
+        .op("aten::abs", static_cast<double (*)(double)>(&std::abs), pure_op)
+        .op("aten::floor",
+            static_cast<double (*)(double)>(&std::floor),
+            pure_op)
+        .op("aten::pow",
+            static_cast<double (*)(double, double)>(&std::pow),
+            pure_op)
+        .op("aten::pow",
+            static_cast<double (*)(double, int64_t)>(&std::pow),
+            pure_op)
+        .op("aten::exp", static_cast<double (*)(int64_t)>(&std::exp), pure_op)
+        .op("aten::exp", static_cast<double (*)(double)>(&std::exp), pure_op)
+        .op("aten::sqrt", static_cast<double (*)(int64_t)>(&std::sqrt), pure_op)
+        .op("aten::sqrt", static_cast<double (*)(double)>(&std::sqrt), pure_op)
+        .op("aten::log10",
+            static_cast<double (*)(int64_t)>(&std::log10),
+            pure_op)
+        .op("aten::log10",
+            static_cast<double (*)(double)>(&std::log10),
+            pure_op)
+        .op("aten::log1p",
+            static_cast<double (*)(int64_t)>(&std::log1p),
+            pure_op)
+        .op("aten::log1p",
+            static_cast<double (*)(double)>(&std::log1p),
+            pure_op)
+        .op("aten::ceil", static_cast<double (*)(double)>(&std::ceil), pure_op)
+        .op("aten::log", static_cast<double (*)(int64_t)>(&std::log), pure_op)
+        .op("aten::log", static_cast<double (*)(double)>(&std::log), pure_op);
 
 // reference: _output_size in torch/nn/functional.py
 // size can be none, int or intlist

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1861,22 +1861,6 @@ RegisterOperators reg2({
     DEFINE_INT_OP(aten::__xor__, a ^ b),
 
     Operator(
-        "prim::abs(int x) -> int",
-        [](Stack& stack) {
-          int64_t x;
-          pop(stack, x);
-          push(stack, std::abs(x));
-          return 0;
-        }),
-    Operator(
-        "prim::abs(float x) -> float",
-        [](Stack& stack) {
-          float x;
-          pop(stack, x);
-          push(stack, std::abs(x));
-          return 0;
-        }),
-    Operator(
         "prim::abs(Tensor x) -> Tensor",
         [](Stack& stack) {
           at::Tensor x;
@@ -1900,127 +1884,6 @@ RegisterOperators reg2({
           double a, b;
           pop(stack, a, b);
           push(stack, a / b);
-          return 0;
-        }),
-
-    Operator(
-        "aten::pow(float a, float b) -> float",
-        [](Stack& stack) {
-          double a, b;
-          pop(stack, a, b);
-          push(stack, std::pow(a, b));
-          return 0;
-        }),
-    Operator(
-        "aten::pow(float a, int b) -> float",
-        [](Stack& stack) {
-          double a;
-          int b;
-          pop(stack, a, b);
-          push(stack, std::pow(a, b));
-          return 0;
-        }),
-
-    Operator(
-        "aten::floor(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::floor(a));
-          return 0;
-        }),
-
-    Operator(
-        "aten::ceil(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::ceil(a));
-          return 0;
-        }),
-
-    Operator(
-        "aten::log(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::log(a));
-          return 0;
-        }),
-    Operator(
-        "aten::log(int a) -> float",
-        [](Stack& stack) {
-          int64_t a;
-          pop(stack, a);
-          push(stack, std::log(a));
-          return 0;
-        }),
-
-    Operator(
-        "aten::log1p(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::log1p(a));
-          return 0;
-        }),
-    Operator(
-        "aten::log1p(int a) -> float",
-        [](Stack& stack) {
-          int64_t a;
-          pop(stack, a);
-          push(stack, std::log1p(a));
-          return 0;
-        }),
-
-    Operator(
-        "aten::log10(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::log10(a));
-          return 0;
-        }),
-    Operator(
-        "aten::log10(int a) -> float",
-        [](Stack& stack) {
-          int64_t a;
-          pop(stack, a);
-          push(stack, std::log10(a));
-          return 0;
-        }),
-
-    Operator(
-        "aten::exp(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::exp(a));
-          return 0;
-        }),
-    Operator(
-        "aten::exp(int a) -> float",
-        [](Stack& stack) {
-          int64_t a;
-          pop(stack, a);
-          push(stack, std::exp(a));
-          return 0;
-        }),
-
-    Operator(
-        "aten::sqrt(float a) -> float",
-        [](Stack& stack) {
-          double a;
-          pop(stack, a);
-          push(stack, std::sqrt(a));
-          return 0;
-        }),
-    Operator(
-        "aten::sqrt(int a) -> float",
-        [](Stack& stack) {
-          int64_t a;
-          pop(stack, a);
-          push(stack, std::sqrt(a));
           return 0;
         }),
 
@@ -2127,6 +1990,27 @@ RegisterOperators reg2({
     Operator("aten::hash(int t) -> int", hashValue<int>),
     Operator("aten::hash(float t) -> int", hashValue<double>),
 });
+
+
+auto math_ops =
+    RegisterOperators()
+        // the static_cast<...> business is to select a specific overload
+        .op("aten::abs", static_cast<int64_t (*)(int64_t)>(&std::abs))
+        .op("aten::abs", static_cast<double (*)(double)>(&std::abs))
+        .op("aten::floor", static_cast<double (*)(double)>(&std::floor))
+        .op("aten::pow", static_cast<double (*)(double, double)>(&std::pow))
+        .op("aten::pow", static_cast<double (*)(double, int)>(&std::pow))
+        .op("aten::exp", static_cast<double (*)(int64_t)>(&std::exp))
+        .op("aten::exp", static_cast<double (*)(double)>(&std::exp))
+        .op("aten::sqrt", static_cast<double (*)(int64_t)>(&std::sqrt))
+        .op("aten::sqrt", static_cast<double (*)(double)>(&std::sqrt))
+        .op("aten::log10", static_cast<double (*)(int64_t)>(&std::log10))
+        .op("aten::log10", static_cast<double (*)(double)>(&std::log10))
+        .op("aten::log1p", static_cast<double (*)(int64_t)>(&std::log1p))
+        .op("aten::log1p", static_cast<double (*)(double)>(&std::log1p))
+        .op("aten::ceil", static_cast<double (*)(double)>(&std::ceil))
+        .op("aten::log", static_cast<double (*)(int64_t)>(&std::log))
+        .op("aten::log", static_cast<double (*)(double)>(&std::log));
 
 // reference: _output_size in torch/nn/functional.py
 // size can be none, int or intlist


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19373 [jit] Refactor math ops to use custom op bindings**

Differential Revision: [D14987159](https://our.internmc.facebook.com/intern/diff/D14987159)

~~Now that we have a way to specify basic aliasing behavior for custom ops, we can register math ops as custom ops (and hopefully more things in register_prim_ops). Due to this we don't need to manually whitelist `aten` and `prim` for alias anaylsis, so the restriction when binding custom ops can be deleted.~~

TODO: right now aten ops are assumed to be pure and custom ops are assumed to be side effectful. we should merge these so everything is assumed to be side effectful unless stated otherwise