### PR TITLE
Profiler: add Self CPU Time Total, CPU time total and other general improvements

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2,6 +2,8 @@ import contextlib
 import gc
 import sys
 import math
+import tempfile
+import time
 import torch
 import unittest
 import warnings
@@ -13,7 +15,7 @@ from functools import reduce
 from torch._six import inf, nan, istuple
 from torch.autograd.gradcheck import gradgradcheck, gradcheck
 from torch.autograd.function import once_differentiable
-from torch.autograd.profiler import profile
+from torch.autograd.profiler import profile, format_time, EventList, FunctionEvent
 from torch.utils.checkpoint import checkpoint
 from common_utils import (TEST_MKL, TestCase, run_tests, skipIfNoLapack,
                           suppress_warnings, skipIfRocm,
@@ -2408,6 +2410,80 @@ class TestAutograd(TestCase):
             self.assertGreater(info.cpu_interval.start, last_end)
             self.assertEqual(info.name, expected_name)
             last_end = info.cpu_interval.end
+
+    def test_profiler_aggregation_fake(self):
+        events = EventList()
+        id = [0]
+
+        def get_id():
+            id[0] = id[0] + 1
+            return id[0]
+
+        # [[thread_id, [(start, end, id), ....]], ...]
+        # Using list instead of a dict so order is guaranteed for any Python
+        # version
+        threads = [
+            [1, [(0, 1, get_id()), (1, 2, get_id())]],
+            [0, [(0, 2, get_id()), (1, 2, get_id()), (1, 3, get_id())]],
+        ]
+        for thread, ranges in threads:
+            for range in ranges:
+                assert(len(range) == 3)
+                events.append(
+                    FunctionEvent(
+                        id=range[2],
+                        name="",
+                        thread=thread,
+                        cpu_start=range[0],
+                        cpu_end=range[1],
+                    )
+                )
+
+        events.populate_cpu_children()
+
+        print()
+        for event in events:
+            print(event)
+
+        # Note that [1, 3] pushes out [0, 2] first. Then we record [1, 2]
+        # as a child of [1, 3]
+        res = [[], [], [], [], [4]]
+
+        def get_children_ids(event):
+            return [child.id for child in event.cpu_children]
+
+        assert([get_children_ids(event) for event in events] == res)
+
+    def test_profiler_aggregation_lstm(self):
+        rnn = torch.nn.LSTM(10, 20, 2)
+        total_time_s = 0
+        with profile() as prof:
+            for i in range(20):
+                input = torch.randn(5, 3, 10)
+                h = torch.randn(2, 3, 20)
+                c = torch.randn(2, 3, 20)
+                start = time.time()
+                rnn(input, (h, c))
+                end = time.time()
+                total_time_s += end - start
+
+        print(prof.table(sort_by="self_cpu_time_total", row_limit=10))
+        print(prof.key_averages().table(sort_by="self_cpu_time_total", row_limit=10))
+
+        total_time_us = total_time_s * 1000.0 * 1000.0  # make it us which is profiler default
+        print(
+            "Total time based on python measurements: ",
+            format_time(total_time_us)
+        )
+        print(
+            "CPU time measurement python side overhead: {:.2f}%".format(
+                (total_time_us / prof.self_cpu_time_total - 1.0) * 100.0
+            )
+        )
+
+        if sys.platform != "win32":
+            with tempfile.NamedTemporaryFile() as trace_file:
+                prof.export_chrome_trace(trace_file.name)
 
     def test_dir(self):
         x = torch.randn(10, 10)


### PR DESCRIPTION
Summary:
Function profile events are typically nested. In this diff I
add parent child relationship to the intervals. This way we can
attribute self time easily. As a result, user printing a table from a
profiler trace gets self cpu time.

This diff doesn't try to address CUDA self time as CUDA kernels are
already getting special care in the profiler.

There are also some other minor improvements. Like reporting total CPU
time spent, reversed sorting, aggregated data after the table,
etc.

There is a new unit test added which tests more functionality than
previous profiler test

```
test/autograd -r profiler_agg
test_profiler_aggregation (test_autograd.TestAutograd) ... -----------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name                     Self CPU total %   Self CPU total      CPU total %        CPU total     CPU time avg     CUDA total %       CUDA total    CUDA time avg  Number of Calls
-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
lstm                               0.44%          2.502ms            7.16%         40.790ms         40.790ms              inf          0.000us          0.000us                1
lstm                               0.35%          1.987ms            5.53%         31.516ms         31.516ms              inf          0.000us          0.000us                1
lstm                               0.35%          1.968ms            5.47%         31.175ms         31.175ms              inf          0.000us          0.000us                1
lstm                               0.33%          1.863ms            5.03%         28.684ms         28.684ms              inf          0.000us          0.000us                1
lstm                               0.32%          1.837ms            5.03%         28.682ms         28.682ms              inf          0.000us          0.000us                1
lstm                               0.31%          1.789ms            4.94%         28.143ms         28.143ms              inf          0.000us          0.000us                1
lstm                               0.31%          1.778ms            4.87%         27.768ms         27.768ms              inf          0.000us          0.000us                1
lstm                               0.31%          1.776ms            4.89%         27.842ms         27.842ms              inf          0.000us          0.000us                1
lstm                               0.31%          1.743ms            4.82%         27.453ms         27.453ms              inf          0.000us          0.000us                1
lstm                               0.31%          1.742ms            4.69%         26.744ms         26.744ms              inf          0.000us          0.000us                1
-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Self CPU time total: 569.819ms
CUDA time total: 0.000us

-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Name                     Self CPU total %   Self CPU total      CPU total %        CPU total     CPU time avg     CUDA total %       CUDA total    CUDA time avg  Number of Calls
-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
sigmoid                           17.29%         98.528ms           17.29%         98.528ms        164.213us              inf          0.000us          0.000us              600
mul                               17.26%         98.378ms           17.26%         98.378ms        163.963us              inf          0.000us          0.000us              600
addmm                             16.46%         93.771ms           16.46%         93.771ms        234.427us              inf          0.000us          0.000us              400
add                               11.80%         67.225ms           11.80%         67.225ms        168.063us              inf          0.000us          0.000us              400
tanh                              10.83%         61.721ms           10.83%         61.721ms        154.303us              inf          0.000us          0.000us              400
split                              6.79%         38.688ms            6.79%         38.688ms        193.441us              inf          0.000us          0.000us              200
lstm                               6.29%         35.857ms          100.00%        569.819ms         28.491ms              inf          0.000us          0.000us               20
unsigned short                     5.41%         30.842ms            5.41%         30.842ms         77.104us              inf          0.000us          0.000us              400
stack                              3.39%         19.322ms            3.39%         19.322ms        241.524us              inf          0.000us          0.000us               80
unbind                             2.34%         13.334ms            2.34%         13.334ms        166.677us              inf          0.000us          0.000us               80
-----------------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------  ---------------
Self CPU time total: 569.819ms
CUDA time total: 0.000us

Total time based on python measurements:  589.088ms
CPU time measurement python side overhead: 3.38%
ok
```

Differential Revision: D14988612

