### PR TITLE
[jit] Fix ord() when dealing with utf8 chars

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10920,6 +10920,16 @@ a")
         self.checkScript(fn, ("h"))
         self.checkScript(fn, ("y"))
 
+        # in Python 3, encoded strings are bytes which ord() refuses to handle,
+        # so check it manually (here we're only matching Python 2 semantics)
+        @torch.jit.script
+        def fn_unicode(x, i):
+            # type: (str, int) -> int
+            return ord(x[i])
+
+        s = "中文".encode("utf-8")
+        self.assertEqual(fn_unicode(s, 0), s[0])
+
     def test_string_slicing(self):
         def fn1(x):
             # type: (str) -> str

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1805,7 +1805,8 @@ RegisterOperators reg2({
               string.size() == 1,
               "String for ord() must be 1 character, found",
               string.size());
-          push(stack, int64_t(string.at(0)));
+          uint8_t ord = string.at(0);
+          push(stack, int64_t(ord));
           return 0;
         }),
 #define CREATE_COPY_OP(other_type, c_type)                                 \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19384 [jit] Fix ord() when dealing with utf8 chars**

Differential Revision: [D14991896](https://our.internmc.facebook.com/intern/diff/D14991896)