### PR TITLE
Make InsertObserverPass work on module level.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1178,7 +1178,7 @@ graph(%x : Tensor,
 
         m = torch.jit.script(fn)
         # Insert observers
-        torch._C._jit_pass_insert_observers(m.graph, observe)
+        torch._C._jit_pass_insert_observers(m, observe)
 
         # Collect statistics
         m.forward(x1, y1)

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -169,6 +169,18 @@ void InsertObserverNodes(std::shared_ptr<Graph>& graph, Node* observer_node) {
   }
 }
 
+std::shared_ptr<script::Module> InsertObserverNodes(
+    std::shared_ptr<script::Module> module,
+    Node* observer_node) {
+  // TODO: Deep-copy the module
+  const auto& methods = module->get_methods();
+  for (const auto& m : methods) {
+    auto g = m->function().graph();
+    InsertObserverNodes(g, observer_node);
+  }
+  return module;
+}
+
 void InsertQuantDequantNodes(std::shared_ptr<Graph>& graph) {
   std::stack<Block*> blocks_to_visit;
   blocks_to_visit.push(graph->block());

--- a/torch/csrc/jit/passes/quantization.h
+++ b/torch/csrc/jit/passes/quantization.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/script/module.h>
 
 namespace torch {
 namespace jit {
@@ -22,12 +23,12 @@ TORCH_API void PropagateQuantInfo(std::shared_ptr<Graph>& graph);
  * a tensor.
  *
  * The distribution can then be used for computing qparams for quantization.
- * \param graph is the graph that would be instrumented.
+ * \param module is the module whose methods would be instrumented,
  * \param observer_node is a Node representing a call to observer function. It
  * will be cloned into all the places where we need to add instrumentation.
  */
-TORCH_API void InsertObserverNodes(
-    std::shared_ptr<Graph>& graph,
+TORCH_API std::shared_ptr<script::Module> InsertObserverNodes(
+    std::shared_ptr<script::Module> module,
     Node* observer_node);
 
 /** \brief Inserts quant-dequant nodes.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19386 Make InsertObserverPass work on module level.**
* #19385 Clang-format torch/csrc/jit/passes/quantization.cpp.

Differential Revision: [D14991916](https://our.internmc.facebook.com/intern/diff/D14991916)