### PR TITLE
Moving at::Tensor into caffe2::Tensor without bumping refcount

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -14,6 +14,9 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 
+namespace caffe2 {
+class Tensor;
+}
 namespace c10{
 struct TensorOptions;
 }
@@ -761,6 +764,8 @@ class CAFFE2_API Tensor {
   friend struct WeakTensor;
 
 protected:
+  friend class ::caffe2::Tensor;
+
   void enforce_invariants();
   c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl> impl_;
 };

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -14,6 +14,9 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 
+namespace caffe2 {
+class Tensor;
+}
 namespace c10{
 struct TensorOptions;
 }
@@ -349,6 +352,8 @@ class CAFFE2_API Tensor {
   friend struct WeakTensor;
 
 protected:
+  friend class ::caffe2::Tensor;
+
   void enforce_invariants();
   c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl> impl_;
 };

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -115,8 +115,8 @@ class CAFFE2_API Tensor final {
    * The tensor will share the same instance (data, strides, sizes, etc) but
    * a different subset of APIs would be available
    */
-  explicit Tensor(const at::Tensor& tensor)
-      : impl_(std::move(tensor.getIntrusivePtr())) {
+  explicit Tensor(at::Tensor tensor)
+      : impl_(std::move(tensor.impl_)) {
     enforce_invariants();
   }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19388 Moving at::Tensor into caffe2::Tensor without bumping refcount**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14986815/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19389 Store nullptr instead of UndefinedTensorImpl&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14992857/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19390 Fix SIOF&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14992856/)

The old implementation forced a refcount bump when converting at::Tensor to caffe2::Tensor.
Now, it is possible to move it without a refcount bump.

Differential Revision: [D14986815](https://our.internmc.facebook.com/intern/diff/D14986815/)