### PR TITLE
Fix cpp_custom_type_hack variable handling

### DIFF
--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -25,7 +25,7 @@ T& cast(const Tensor& packed) {
 }
 
 template<typename T>
-Tensor create(std::unique_ptr<T> ptr) {
+Tensor create(std::unique_ptr<T> ptr, TensorOptions options) {
   // We store this instance away in a Tensor and register a deleter function
   // so that we do not leak memory. On the other side, we pull out the storage's
   // data_ptr and get the right typed pointer.
@@ -38,9 +38,7 @@ Tensor create(std::unique_ptr<T> ptr) {
 
   // size doesn't really matter, but we can align it to the actual size
   // returning variables because one likely want to use this hack from python
-  auto retval = at::empty(
-      {sizeof(T)},
-      at::device(kCPU).dtype(at::kByte).is_variable(true).requires_grad(false));
+  auto retval = at::empty({sizeof(T)}, options.device(kCPU).dtype(at::kByte));
   retval.storage().set_data_ptr(std::move(at_ptr));
   return retval;
 }

--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -249,7 +249,7 @@ Tensor fbgemm_pack_quantized_matrix(
       /*ld=*/K,
       /*pmat=*/nullptr, // PackBMatrix manages ownership of pmat
       /*groups=*/1);
-  return cpp_custom_type_hack::create(std::move(ptr));
+  return cpp_custom_type_hack::create(std::move(ptr), weight.options());
 }
 
 #else // USE_FBGEMM


### PR DESCRIPTION
My bad - it might be called in variable and non-variable context. So it's better to just inherit variable-ness from the caller.