### PR TITLE
Make Observer class as template Quant class for QuantConfig

### DIFF
--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -201,9 +201,6 @@ class QuantizerTestCase(TestCase):
         activationQuantObj = QuantConfigTemplate(tensorType='activation',
                                                  observerImpl=activationObserver,
                                                  calcQParamImpl=calcQParamFunc)
-        weightQuantObj = QuantConfigTemplate(tensorType='param',
-                                             observerImpl=weightObserver,
-                                             calcQParamImpl=calcQParamFunc)
 
         # This performs type analysis to identify tensors from other
         # types. This info needed for further quantizer passes
@@ -215,12 +212,10 @@ class QuantizerTestCase(TestCase):
         # Run ScriptM Model and Collect statistics
         scriptM.forward(data)
         activationQuantObj.calcQParam()
-        weightQuantObj.calcQParam()
 
         # Compare results for eager and graph mode
         eagerDict = eagerQuantObj.getQParamDict()
         activationDict = activationQuantObj.getQParamDict()
-        weightDict = weightQuantObj.getQParamDict()
 
         self.assertTrue('z' in eagerDict and 'z' in activationDict)
         self.assertAlmostEqual(eagerDict["z"][0], activationDict["z"][0], places=15)

--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -104,13 +104,13 @@ as arguments for quant ops in quantization pass.
 
 
 class QuantTemplate:
-    def __init__(self, tensorType, observerImpl=None, calcQParamImpl=None):
+    def __init__(self, qscheme, observerImpl=None, calcQParamImpl=None):
         self.value_stats = {}
         self.qparam_dict = {}
         self.averaging_constant = 0.001
         self.observerImpl = observerImpl
         self.calcQParamImpl = calcQParamImpl
-        self.tensor_type = tensorType
+        self.qscheme = qscheme
 
     def resetStats(self):
         self.value_stats = {}
@@ -136,7 +136,7 @@ class QuantTemplate:
             # This can change depending on type of quantization which will
             # be known to QuantTemplate object
             scale, zero_point = self.calcQParamImpl(name, self.value_stats)
-            self.qparam_dict.update({name: (self.tensor_type, scale, zero_point)})
+            self.qparam_dict.update({name: (self.qscheme, scale, zero_point)})
 
     def getQParam(self, name):
         if name in self.qparam_dict:
@@ -187,7 +187,7 @@ class QuantizerTestCase(TestCase):
         # Eager mode
 
         # Create QuantConfig object for eager mode
-        eagerQuantObj = QuantTemplate(tensorType='activation',
+        eagerQuantObj = QuantTemplate(qscheme='per_tensor_quant',
                                       observerImpl=activationObserver,
                                       calcQParamImpl=calcQParamFunc)
         eagerM = TestM(quantObj=eagerQuantObj)
@@ -200,7 +200,7 @@ class QuantizerTestCase(TestCase):
         scriptM = TestScriptM()
 
         # Create QuantConfig object for script mode
-        activationQuantObj = QuantTemplate(tensorType='activation',
+        activationQuantObj = QuantTemplate(qscheme='per_tensor_quant',
                                            observerImpl=activationObserver,
                                            calcQParamImpl=calcQParamFunc)
 

--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -10,8 +10,88 @@ import torch.nn.functional as F
 from common_utils import TestCase
 # TODO : Quantizer tests to be integrated with CI once quantizer intf hardened
 
+r"""
+Default Weight Observer:
+Stats needed for accumulation
+
+Arguments:
+    value: Tensor to be observed
+    stats: Computed stats. Injected by the observer
+wrapper
+
+Output:
+    value: Same as input tensor
 """
-This is an example observer Module which will be used to collect
+
+
+def weightObserver(value, stats):
+    stats[0] = torch.min(value)
+    stats[1] = torch.max(value)
+    return value
+
+
+r"""
+Default Activation Observer:
+This implementation averages over collected stats.
+
+Arguments:
+    value: Tensor to be observed
+    stats: Computed stats. Injected by the observer
+wrapper
+
+Output:
+    value: Same as input tensor
+"""
+
+
+def activationObserver(value, stats):
+    averaging_constant = 0.001
+    stats[0] = (1 - averaging_constant) * stats[0] + \
+        averaging_constant * torch.min(value)
+    stats[1] = (1 - averaging_constant) * stats[1] + \
+        averaging_constant * torch.max(value)
+    return value
+
+
+r"""
+Default QParam computation: This is stateless
+value_stats will be input from Observer
+
+Arguments:
+    name: Key name in the stats dictionary
+wrapper
+    value_stats: Stats dict from observer wrapper
+
+
+Output:
+    scale, zero_point
+"""
+
+
+def calcQParamFunc(name, value_stats):
+    scaleT = 2.0 * (torch.max(value_stats[name][1],
+                    -value_stats[name][0]) / 255.0)
+    scale = scaleT.item()
+    zero_point = 0
+    return scale, zero_point
+
+
+r"""
+ Unified Dictionary for all qparam
+"""
+
+
+def getAllQParamDict(allqparam_dict, quantObj):
+    if allqparam_dict is None:
+        allqparam_dict = {}
+    qparam_dict = quantObj.getQParamDict()
+    if qparam_dict is None:
+        return
+    allqparam_dict.update(qparam_dict)
+
+
+r"""
+This is an example QuantConfigTemplate which will be used to collect
 stats across batches by running torch script/trace module, from the
 observer nodes inserted in the graph. These stats are used to compute
 Quantization Parameters. These will be passed to quantizer to be used
@@ -19,49 +99,42 @@ as arguments for quant ops in quantization pass.
 """
 
 
-class ObserverModule:
-    def __init__(self, userObserver=None, userCalcQParam=None):
+class QuantConfigTemplate:
+    def __init__(self, tensorType, observerImpl=None, calcQParamImpl=None):
         self.value_stats = {}
         self.qparam_dict = {}
         self.averaging_constant = 0.001
-        if userObserver is not None:
-            self.observerImpl = userObserver
-        if userCalcQParam is not None:
-            self.calcQParamImpl = userCalcQParam
+        self.observerImpl = observerImpl
+        self.calcQParamImpl = calcQParamImpl
+        self.tensor_type = tensorType
 
     def resetStats(self):
         self.value_stats = {}
         return
 
-    def observerImpl(self, value, stats, avgconstant):
-        # Default observer. Stats needed for accumulation
-        stats[0] = torch.min(value)
-        stats[1] = torch.max(value)
-        return value
-
     def observer(self, value, name):
+        if self.observerImpl is None:
+            return
         if name not in self.value_stats:
             self.value_stats[name] = []
             stats = torch.zeros(2)
         else:
             stats = self.value_stats[name]
-        self.observerImpl(value, stats, self.averaging_constant)
+        self.observerImpl(value, stats)
         self.value_stats.update({name: stats})
         return value
 
-    def calcQParamImpl(self, qparam_dict, value_stats):
-        # Test QParam computation. Used by default for test
-        for name in value_stats:
-            qparam = torch.zeros(2)
-            scaleT = value_stats[name][0]
-            scale = scaleT.item()
-            zero_pointT = value_stats[name][1]
-            zero_point = zero_pointT.item()
-            qparam_dict.update({name: (scale, zero_point)})
-
     def calcQParam(self):
         self.qparam_dict = {}
-        self.calcQParamImpl(self.qparam_dict, self.value_stats)
+        if self.calcQParamImpl is None:
+            return
+        for name in self.value_stats:
+            scaleT = 2.0 * (torch.max(self.value_stats[name][1],
+                            -self.value_stats[name][0]) / 255.0)
+            scale = scaleT.item()
+            zero_point = 0
+            scale, zero_point = self.calcQParamImpl(name, self.value_stats)
+            self.qparam_dict.update({name: (self.tensor_type, scale, zero_point)})
 
     def getQParam(self, name):
         if name in self.qparam_dict:
@@ -90,20 +163,20 @@ class QuantizerTestCase(TestCase):
                 return z
 
         class TestM(nn.Module):
-            def __init__(self, obsObj=None):
+            def __init__(self, quantObj=None):
                 super(TestM, self).__init__()
                 self.conv1 = nn.Conv2d(1, 20, 5, 1)
                 self.conv1.weight.data.fill_(1.0)
                 self.conv1.bias.data.fill_(0.01)
-                self.obsObj = obsObj
+                self.quantObj = quantObj
 
             def forward(self, x):
                 y = F.relu(self.conv1(x))
-                if self.obsObj is not None:
-                    self.obsObj.observer(y, "y")
+                if self.quantObj is not None:
+                    self.quantObj.observer(y, "y")
                 z = F.max_pool2d(y, 2, 2)
-                if self.obsObj is not None:
-                    self.obsObj.observer(z, "z")
+                if self.quantObj is not None:
+                    self.quantObj.observer(z, "z")
                 return z
 
         # Test Data
@@ -111,125 +184,44 @@ class QuantizerTestCase(TestCase):
 
         # Eager mode
 
-        # Create observer object for eager mode
-        eagerObserver = ObserverModule()
-        eagerM = TestM(obsObj=eagerObserver)
+        # Create QuantConfig object for eager mode
+        eagerQuantObj = QuantConfigTemplate(tensorType='activation',
+                                            observerImpl=activationObserver,
+                                            calcQParamImpl=calcQParamFunc)
+        eagerM = TestM(quantObj=eagerQuantObj)
 
         # Run EagerMode Model and Collect stats
         eagerM.forward(data)
-        eagerM.obsObj.calcQParam()
+        eagerM.quantObj.calcQParam()
 
         # Script mode
         scriptM = TestScriptM()
 
-        # Create observer object for script mode
-        scriptObserver = ObserverModule()
+        # Create QuantConfig object for script mode
+        activationQuantObj = QuantConfigTemplate(tensorType='activation',
+                                                 observerImpl=activationObserver,
+                                                 calcQParamImpl=calcQParamFunc)
+        weightQuantObj = QuantConfigTemplate(tensorType='param',
+                                             observerImpl=weightObserver,
+                                             calcQParamImpl=calcQParamFunc)
 
         # This performs type analysis to identify tensors from other
         # types. This info needed for further quantizer passes
         torch._C._jit_pass_constant_propagation(scriptM.graph)
 
         # Insert observers
-        torch._C._jit_pass_insert_observers(scriptM.graph, scriptObserver.observer)
+        torch._C._jit_pass_insert_observers(scriptM.graph, activationQuantObj.observer)
 
         # Run ScriptM Model and Collect statistics
         scriptM.forward(data)
-        scriptObserver.calcQParam()
+        activationQuantObj.calcQParam()
+        weightQuantObj.calcQParam()
 
         # Compare results for eager and graph mode
-        eagerDict = eagerObserver.getQParamDict()
-        scriptDict = scriptObserver.getQParamDict()
+        eagerDict = eagerQuantObj.getQParamDict()
+        activationDict = activationQuantObj.getQParamDict()
+        weightDict = weightQuantObj.getQParamDict()
 
-        self.assertTrue('z' in eagerDict and 'z' in scriptDict)
-        self.assertAlmostEqual(eagerDict["z"][0], scriptDict["z"][0], places=15)
-        self.assertAlmostEqual(eagerDict["z"][1], scriptDict["z"][1], places=15)
-
-    def test_compare_qparam_eager_script_userobs(self):
-        # Simple test case with conv->relu->maxpool
-        class TestScriptM(torch.jit.ScriptModule):
-            def __init__(self, init_weight=None):
-                super(TestScriptM, self).__init__()
-                self.conv1 = nn.Conv2d(1, 20, 5, 1)
-                self.conv1.weight.data.fill_(1.0)
-                self.conv1.bias.data.fill_(0.01)
-
-            @torch.jit.script_method
-            def forward(self, x):
-                y = F.relu(self.conv1(x))
-                z = F.max_pool2d(y, 2, 2)
-                return z
-
-        class TestM(nn.Module):
-            def __init__(self, obsObj=None):
-                super(TestM, self).__init__()
-                self.conv1 = nn.Conv2d(1, 20, 5, 1)
-                self.conv1.weight.data.fill_(1.0)
-                self.conv1.bias.data.fill_(0.01)
-                self.obsObj = obsObj
-
-            def forward(self, x):
-                y = F.relu(self.conv1(x))
-                if self.obsObj is not None:
-                    self.obsObj.observer(y, "y")
-                z = F.max_pool2d(y, 2, 2)
-                if self.obsObj is not None:
-                    self.obsObj.observer(z, "z")
-                return z
-
-        # User defined observer and calcQParam
-        def userObserverImpl(value, stats, averaging_constant):
-            # This implementation averages over collected stats.
-            # It is stateless. value and stats will be input from Observer
-            stats[0] = (1 - averaging_constant) * stats[0] + averaging_constant * torch.min(value)
-            stats[1] = (1 - averaging_constant) * stats[1] + averaging_constant * torch.max(value)
-            return value
-
-        def userCalcQParamImpl(qparam_dict, value_stats):
-            # User defined QParam computation. This is stateless
-            # qparam_dict and value_stats will be input from Observer
-            for name in value_stats:
-                qparam = torch.zeros(2)
-                scaleT = 2.0 * (torch.max(value_stats[name][1], -value_stats[name][0]) / 255.0)
-                scale = scaleT.item()
-                zero_point = 0
-                qparam_dict.update({name: (scale, zero_point)})
-
-        # Test Data
-        data = torch.ones(1, 1, 28, 28)
-
-        # Eager mode
-
-        # Create observer object for eager mode
-        eagerObserver = ObserverModule(userObserver=userObserverImpl,
-                                       userCalcQParam=userCalcQParamImpl)
-        eagerM = TestM(obsObj=eagerObserver)
-
-        # Run EagerMode Model and Collect stats
-        eagerM.forward(data)
-        eagerM.obsObj.calcQParam()
-
-        # Script mode
-        scriptM = TestScriptM()
-
-        # Create observer object for script mode
-        scriptObserver = ObserverModule(userObserver=userObserverImpl,
-                                        userCalcQParam=userCalcQParamImpl)
-
-        # This performs type analysis to identify tensors from other
-        # types. This info needed for further quantizer passes
-        torch._C._jit_pass_constant_propagation(scriptM.graph)
-
-        # Insert observers
-        torch._C._jit_pass_insert_observers(scriptM.graph, scriptObserver.observer)
-
-        # Run ScriptM Model and Collect statistics
-        scriptM.forward(data)
-        scriptObserver.calcQParam()
-
-        # Compare results for eager and graph mode
-        eagerDict = eagerObserver.getQParamDict()
-        scriptDict = scriptObserver.getQParamDict()
-
-        self.assertTrue('z' in eagerDict and 'z' in scriptDict)
-        self.assertAlmostEqual(eagerDict["z"][0], scriptDict["z"][0], places=15)
-        self.assertAlmostEqual(eagerDict["z"][1], scriptDict["z"][1], places=15)
+        self.assertTrue('z' in eagerDict and 'z' in activationDict)
+        self.assertAlmostEqual(eagerDict["z"][0], activationDict["z"][0], places=15)
+        self.assertAlmostEqual(eagerDict["z"][1], activationDict["z"][1], places=15)

--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -91,7 +91,7 @@ def getAllQParamDict(allqparam_dict, quantObj):
 
 
 r"""
-This is an example QuantConfigTemplate which will be used to collect
+This is an example QuantTemplate which will be used to collect
 stats across batches by running torch script/trace module, from the
 observer nodes inserted in the graph. These stats are used to compute
 Quantization Parameters. These will be passed to quantizer to be used
@@ -99,7 +99,7 @@ as arguments for quant ops in quantization pass.
 """
 
 
-class QuantConfigTemplate:
+class QuantTemplate:
     def __init__(self, tensorType, observerImpl=None, calcQParamImpl=None):
         self.value_stats = {}
         self.qparam_dict = {}
@@ -185,9 +185,9 @@ class QuantizerTestCase(TestCase):
         # Eager mode
 
         # Create QuantConfig object for eager mode
-        eagerQuantObj = QuantConfigTemplate(tensorType='activation',
-                                            observerImpl=activationObserver,
-                                            calcQParamImpl=calcQParamFunc)
+        eagerQuantObj = QuantTemplate(tensorType='activation',
+                                      observerImpl=activationObserver,
+                                      calcQParamImpl=calcQParamFunc)
         eagerM = TestM(quantObj=eagerQuantObj)
 
         # Run EagerMode Model and Collect stats
@@ -198,9 +198,9 @@ class QuantizerTestCase(TestCase):
         scriptM = TestScriptM()
 
         # Create QuantConfig object for script mode
-        activationQuantObj = QuantConfigTemplate(tensorType='activation',
-                                                 observerImpl=activationObserver,
-                                                 calcQParamImpl=calcQParamFunc)
+        activationQuantObj = QuantTemplate(tensorType='activation',
+                                           observerImpl=activationObserver,
+                                           calcQParamImpl=calcQParamFunc)
 
         # This performs type analysis to identify tensors from other
         # types. This info needed for further quantizer passes

--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -20,7 +20,7 @@ Arguments:
 wrapper
 
 Output:
-    value: Same as input tensor
+    stats: Modified stats
 """
 
 
@@ -42,7 +42,7 @@ Arguments:
 wrapper
 
 Output:
-    value: Same as input tensor
+    stats: Modified stats
 """
 
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19418 Make Observer class as template Quant class for QuantConfig**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15000594/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19232 Add observer nodes for input data nodes&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14885485/)

This change makes Observer class template which always
takes an observer function as argument. Second test-case becomes redundant, hence removing
it.

Differential Revision: [D15000594](https://our.internmc.facebook.com/intern/diff/D15000594/)