### PR TITLE
Fix no SIGCHLD checking in DataLoaderIter._shutdown_workers

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -19,6 +19,12 @@ export PATH="${PYTORCH_ENV_DIR}/miniconda3/bin:$PATH"
 source ${PYTORCH_ENV_DIR}/miniconda3/bin/activate
 conda install -y mkl mkl-include numpy pyyaml setuptools cmake cffi ninja six
 pip install -q hypothesis "librosa>=0.6.2" psutil
+
+# faulthandler become built-in since 3.3
+if [[ ! $(python -c "import sys; print(int(sys.version_info >= (3, 3)))") == "1" ]]; then
+  pip install -q faulthandler
+fi
+
 if [ -z "${IN_CIRCLECI}" ]; then
   rm -rf ${PYTORCH_ENV_DIR}/miniconda3/lib/python3.6/site-packages/torch*
 fi

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -47,6 +47,11 @@ if [[ "$BUILD_ENVIRONMENT" != *ppc64le* ]]; then
   pip install mypy --user || true
 fi
 
+# faulthandler become built-in since 3.3
+if [[ ! $(python -c "import sys; print(int(sys.version_info >= (3, 3)))") == "1" ]]; then
+  pip install -q faulthandler --user
+fi
+
 # DANGER WILL ROBINSON.  The LD_PRELOAD here could cause you problems
 # if you're not careful.  Check this if you made some changes and the
 # ASAN test is not working

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -22,6 +22,8 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
     call conda install -y -q python=3.6.7 numpy mkl cffi pyyaml boto3 protobuf numba
 )
 pip install -q ninja future hypothesis "librosa>=0.6.2" psutil
+:: No need to install faulthandler since we only test Python >= 3.6 on Windows
+:: faulthandler is builtin since Python 3.3
 
 pushd .
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -744,8 +744,9 @@ class TestDataLoader(TestCase):
             # not be called before process end. It is important to see that the
             # processes still exit in both cases.
 
-            if pin_memory and (not TEST_CUDA or NO_MULTIPROCESSING_SPAWN):
+            if pin_memory and (not TEST_CUDA or NO_MULTIPROCESSING_SPAWN or IS_WINDOWS):
                 # Can't use CUDA without spawn
+                # For windows, pin_memory sometimes causes CUDA oom.
                 continue
 
             # `exit_method` controls the way the loader process ends.

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -35,7 +35,7 @@ try:
     HAS_FAULTHANDLER = True
 except ImportError:
     HAS_FAULTHANDLER = False
-    err_msg = ("faulthandler not found. Some data loader tests uses it for error "
+    err_msg = ("faulthandler not found. Some data loader tests use it for error "
                "reporting (e.g., TestDataLoader.test_proper_exit).")
     if IS_PYTORCH_CI:
         raise ImportError(err_msg)
@@ -232,6 +232,7 @@ class ErrorTrackingProcess(mp.Process):
 
     def print_traces_of_all_threads(self):
         assert self.is_alive(), "can only use print_traces_of_all_threads if the process is alive"
+        assert not self.disable_stderr, "do not disable stderr if you use print_traces_of_all_threads"
         if HAS_FAULTHANDLER:
             if not IS_WINDOWS:
                 # use the custom signal if available
@@ -244,7 +245,7 @@ class ErrorTrackingProcess(mp.Process):
         else:
             # if there is no faulthandler, use SIGINT otherwise and hope for the best
             os.kill(self.pid, signal.SIGINT)
-        # don't error too fast, give it some time to print
+        # wait in parent process to give subprocess some time to print
         time.sleep(5)
 
     @property

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -221,7 +221,7 @@ class ErrorTrackingProcess(mp.Process):
                 # use SIGUSR if possible...
                 faulthandler.register(signal.SIGUSR1, chain=True)
             else:
-                # unless we are on some weird os like windows...
+                # unless we are on some weird OS like Windows...
                 faulthandler.register(signal.SIGINT, chain=True)
         if self.disable_stderr:
             # Disable polluting stderr with errors that are supposed to happen.
@@ -234,9 +234,11 @@ class ErrorTrackingProcess(mp.Process):
             raise
 
     def print_traces_of_all_threads(self):
-        if hasattr(signal, 'SIGUSR1'):
+        if HAS_FAULTHANDLER and hasattr(signal, 'SIGUSR1'):
+            # use the custom signal if it is registered by faulthandler
             os.kill(self.pid, signal.SIGUSR1)
         else:
+            # use SIGINT otherwise and hope for the best
             os.kill(self.pid, signal.SIGINT)
         # don't error too fast, give it some time to print
         time.sleep(5)

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -628,6 +628,9 @@ class _DataLoaderIter(object):
                     w.join()
             finally:
                 # Removes pids from the C side data structure finally
+                # FIXME: Unfortunately, for Windows, we are missing a worker
+                #        error detection mechanism here in this function, as it
+                #        doesn't provide a SIGCHLD handler.
                 if self.worker_pids_set:
                     _utils.signal_handling._remove_worker_pids(id(self))
                     self.worker_pids_set = False

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -596,41 +596,41 @@ class _DataLoaderIter(object):
         # See (1) and the second half of the note.
         if not self.shutdown:
             self.shutdown = True
-            # Removes pids from the C side data structure first so worker
-            # termination afterwards won't trigger false positive error report.
-            if self.worker_pids_set:
-                _utils.signal_handling._remove_worker_pids(id(self))
-                self.worker_pids_set = False
+            try:
+                self.done_event.set()
 
-            self.done_event.set()
+                # Exit `pin_memory_thread` first because exiting workers may leave
+                # corrupted data in `worker_result_queue` which `pin_memory_thread`
+                # reads from.
+                if hasattr(self, 'pin_memory_thread'):
+                    # Use hasattr in case error happens before we set the attribute.
+                    # First time do `worker_result_queue.put` in this process.
 
-            # Exit `pin_memory_thread` first because exiting workers may leave
-            # corrupted data in `worker_result_queue` which `pin_memory_thread`
-            # reads from.
-            if hasattr(self, 'pin_memory_thread'):
-                # Use hasattr in case error happens before we set the attribute.
-                # First time do `worker_result_queue.put` in this process.
+                    # `cancel_join_thread` in case that `pin_memory_thread` exited.
+                    self.worker_result_queue.cancel_join_thread()
+                    self.worker_result_queue.put(None)
+                    self.pin_memory_thread.join()
+                    # Indicate that no more data will be put on this queue by the
+                    # current process. This **must** be called after
+                    # `pin_memory_thread` is joined because that thread shares the
+                    # same pipe handles with this loader thread. If the handle is
+                    # closed, Py3 will error in this case, but Py2 will just time
+                    # out even if there is data in the queue.
+                    self.worker_result_queue.close()
 
-                # `cancel_join_thread` in case that `pin_memory_thread` exited.
-                self.worker_result_queue.cancel_join_thread()
-                self.worker_result_queue.put(None)
-                self.pin_memory_thread.join()
-                # Indicate that no more data will be put on this queue by the
-                # current process. This **must** be called after
-                # `pin_memory_thread` is joined because that thread shares the
-                # same pipe handles with this loader thread. If the handle is
-                # closed, Py3 will error in this case, but Py2 will just time
-                # out even if there is data in the queue.
-                self.worker_result_queue.close()
-
-            # Exit workers now.
-            for q in self.index_queues:
-                q.put(None)
-                # Indicate that no more data will be put on this queue by the
-                # current process.
-                q.close()
-            for w in self.workers:
-                w.join()
+                # Exit workers now.
+                for q in self.index_queues:
+                    q.put(None)
+                    # Indicate that no more data will be put on this queue by the
+                    # current process.
+                    q.close()
+                for w in self.workers:
+                    w.join()
+            finally:
+                # Removes pids from the C side data structure finally
+                if self.worker_pids_set:
+                    _utils.signal_handling._remove_worker_pids(id(self))
+                    self.worker_pids_set = False
 
     def __del__(self):
         if self.num_workers > 0:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -627,7 +627,13 @@ class _DataLoaderIter(object):
                 for w in self.workers:
                     w.join()
             finally:
-                # Removes pids from the C side data structure finally
+                # Even though all this function does is putting into queues that
+                # we have called `cancel_join_thread` on, weird things can
+                # happen when a worker is killed by a signal, e.g., hanging in
+                # `Event.set()`. So we need to guard this with SIGCHLD handler,
+                # and remove pids from the C side data structure only at the
+                # end.
+                #
                 # FIXME: Unfortunately, for Windows, we are missing a worker
                 #        error detection mechanism here in this function, as it
                 #        doesn't provide a SIGCHLD handler.


### PR DESCRIPTION
Also

1. Bump multiprocessing test timeout following python core tests
2. Fix one type of flakiness in `test_proper_exit`. 
3. Add trace reporting when loader process hangs in `test_proper_exit` using `faulthandler`.
3. Give `test_proper_exit` another try. 

I'll heavily retest this.