### PR TITLE
[jit] Fix ord() when dealing with utf8 chars

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10920,6 +10920,13 @@ a")
         self.checkScript(fn, ("h"))
         self.checkScript(fn, ("y"))
 
+        def index_str_to_tensor(s):
+            # type: (str) -> int
+            return torch.tensor(ord(s))
+
+        s = u'\u00a3'.encode('utf8')[:1]
+        self.checkScript(index_str_to_tensor, (s,))
+
     def test_string_slicing(self):
         def fn1(x):
             # type: (str) -> str

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1805,7 +1805,8 @@ RegisterOperators reg2({
               string.size() == 1,
               "String for ord() must be 1 character, found",
               string.size());
-          push(stack, int64_t(string.at(0)));
+          uint8_t ord = string.at(0);
+          push(stack, int64_t(ord));
           return 0;
         }),
 #define CREATE_COPY_OP(other_type, c_type)                                 \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19423 [jit] Fix ord() when dealing with utf8 chars**

Differential Revision: [D15002847](https://our.internmc.facebook.com/intern/diff/D15002847)

Previously utf-8 bytes > 127 were wrapping around to negative values, casting to a `uint8_t` fixes this.