### PR TITLE
Stop generating autograd functions for derivatives.yaml entries that only specify output differentiability.

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -511,9 +511,9 @@ def emit_body(declaration):
     non_differentiable_arg_names = func['non_differentiable_arg_names'] if func else []
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
-    if func is not None and func.get('output_differentiability') is not None:
+    if declaration['output_differentiability'] is not None:
         differentiable_outputs = []
-        output_differentiability = func.get('output_differentiability')
+        output_differentiability = declaration['output_differentiability']
         for differentiable, output in zip(output_differentiability, returns):
             if differentiable:
                 differentiable_outputs.append(output)
@@ -528,7 +528,8 @@ def emit_body(declaration):
         strategy == 'use_derived')
 
     if func is not None and not requires_derivative:
-        print('WARNING: derivative ignored for {}'.format(name), file=sys.stderr)
+        raise RuntimeError('ERROR: derivative ignored for {} -- specified an autograd function without derivative'
+                           .format(name))
 
     def emit_save_inputs():
         setup = []

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -23,7 +23,6 @@
 #     differentiable subcomponents.
 #
 from __future__ import print_function
-import sys
 from .utils import CodeTemplate, nested_dict, write, uninplace_api_name
 from .gen_autograd import VIEW_FUNCTIONS
 from .gen_autograd_functions import uses_single_grad

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -19,18 +19,30 @@ def load_derivatives(path, declarations):
     for declaration in declarations:
         declarations_by_signature[get_signature(declaration)].append(declaration)
 
-    autograd_functions = [
+    differentiability_infos = [
         process_definition(defn, declarations_by_signature)
         for defn in definitions]
+
+    autograd_functions = [d['autograd_fn'] for d in differentiability_infos if d['autograd_fn'] is not None]
     ensure_unique_names(autograd_functions)
-    match_declarations_with_autograd_functions(declarations, autograd_functions)
+    match_declarations_with_differentiability_info(declarations, differentiability_infos)
 
     return autograd_functions
 
 
+def create_differentiability_info(signature, output_differentiability,
+                                  autograd_fn):
+    return {
+        'signature': signature,
+        'output_differentiability': output_differentiability,
+        'autograd_fn': autograd_fn,
+    }
+
+
 # How do you feel about pasting declaration inside autograd function...
-def create_autograd_function(name, derivatives, args_with_derivatives, non_differentiable_arg_names,
-                             signature, declaration, output_differentiability):
+def create_autograd_function(name, derivatives, args_with_derivatives,
+                             declaration, output_differentiability,
+                             non_differentiable_arg_names):
     op = to_camel_case(name) + 'Backward'
     op = op.replace('ForwardBackward', 'Backward')
     return {
@@ -39,11 +51,9 @@ def create_autograd_function(name, derivatives, args_with_derivatives, non_diffe
         'declaration': declaration,
         'args_with_derivatives': args_with_derivatives,
         'non_differentiable_arg_names': non_differentiable_arg_names,
-        'signature': signature,
         'derivatives': derivatives,
         'saved_inputs': all_saved_variables(derivatives, 'saved_inputs'),
         'saved_outputs': all_saved_variables(derivatives, 'saved_outputs'),
-        'output_differentiability': output_differentiability,
     }
 
 
@@ -207,8 +217,14 @@ def process_definition(defn, declarations_by_signature):
                                .format(i, defn_name, x, y))
 
     derivatives, args_with_derivatives, non_differentiable_arg_names = set_up_derivatives(defn_name, defn, canonical)
-    return create_autograd_function(defn_name, derivatives, args_with_derivatives, non_differentiable_arg_names,
-                                    signature, canonical, output_differentiability)
+    autograd_fn = None
+
+    # only create an autograd function if we are actually going to calculate a derivative
+    if len(args_with_derivatives) > 0:
+        autograd_fn = create_autograd_function(defn_name, derivatives, args_with_derivatives,
+                                               canonical, output_differentiability, non_differentiable_arg_names)
+
+    return create_differentiability_info(signature, output_differentiability, autograd_fn)
 
 
 def ensure_unique_names(autograd_functions):
@@ -343,24 +359,27 @@ def to_camel_case(name):
     return ''.join([p.title() for p in name.split('_')])
 
 
-def match_declarations_with_autograd_functions(declarations, autograd_functions):
-    """Sets the "derivative" key on declarations to matching autograd functions
+def match_declarations_with_differentiability_info(declarations, differentiability_infos):
+    """Sets the "derivative" and "output_differentiability" key on declarations
+    to matching differentiability info
 
     In-place functions will use the out-of-place derivative definition if there
     is no in-place specific derivative.
     """
 
-    functions_by_signature = {f['signature']: f for f in autograd_functions}
+    infos_by_signature = {f['signature']: f for f in differentiability_infos}
 
-    def find_function(declaration):
+    def find_info(declaration):
         signature = get_signature(declaration)
-        if signature in functions_by_signature:
-            return functions_by_signature[signature]
+        if signature in infos_by_signature:
+            return infos_by_signature[signature]
 
         # if there is no exact match look for the out-of-place signature.
         # i.e mul() for mul_() or mul_out()
         signature = get_signature(declaration, use_base_variant=True)
-        return functions_by_signature.get(signature)
+        return infos_by_signature.get(signature)
 
     for declaration in declarations:
-        declaration['derivative'] = find_function(declaration)
+        info = find_info(declaration)
+        declaration['derivative'] = info['autograd_fn'] if info else None
+        declaration['output_differentiability'] = info['output_differentiability'] if info else None

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -41,8 +41,7 @@ def create_differentiability_info(signature, output_differentiability,
 
 # How do you feel about pasting declaration inside autograd function...
 def create_autograd_function(name, derivatives, args_with_derivatives,
-                             declaration, output_differentiability,
-                             non_differentiable_arg_names):
+                             declaration, non_differentiable_arg_names):
     op = to_camel_case(name) + 'Backward'
     op = op.replace('ForwardBackward', 'Backward')
     return {
@@ -222,7 +221,7 @@ def process_definition(defn, declarations_by_signature):
     # only create an autograd function if we are actually going to calculate a derivative
     if len(args_with_derivatives) > 0:
         autograd_fn = create_autograd_function(defn_name, derivatives, args_with_derivatives,
-                                               canonical, output_differentiability, non_differentiable_arg_names)
+                                               canonical, non_differentiable_arg_names)
 
     return create_differentiability_info(signature, output_differentiability, autograd_fn)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19431 Get rid of unnecessary matches_jit_signature: True specifications.
* #19430 Make one_hot non-differentiable.
* #19429 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19428 Have _embedding_bag_dense_backward match JIT signature.
* #19427 Have embedding_dense_backward match JIT signature.
* #19426 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19425 Move non_differentiable_arg_names from autograd functions to differentiability_info.
* **#19424 Stop generating autograd functions for derivatives.yaml entries that only specify output differentiability.**
* #19272 Rename 'not_differentiable' to 'non_differentiable'.

the codegen for derivatives puts information about what is differentiable (inputs and outputs) together with the autograd function.
This is not a good idea, because it ties together the concept of "having an autograd function" with "specifying differentiability".

This results in a number of hacks.  One we fix here is wrt 'output_differentiability'.
Previously, we would generate autograd functions for entires that only specify output differentiability, e.g. values()/_values(),
and then warn that the actual autograd function was ignored.

Now, we avoid generating the autograd function and error out if we ever ignore an actual derivative specification.

Generated code difference: https://gist.github.com/gchanan/e10df0c68f9f9ca4dee33458763a24b7.

Differential Revision: [D15003380](https://our.internmc.facebook.com/intern/diff/D15003380)