### PR TITLE
Move non_differentiable_arg_names from autograd functions to differentiability_info.

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -508,7 +508,7 @@ def emit_body(declaration):
     inputs = [arg for arg in arguments if not arg.get('output', False)]
     differentiable_inputs = list(filter(is_differentiable, inputs))
     args_with_derivatives = find_args_with_derivatives(differentiable_inputs)
-    non_differentiable_arg_names = func['non_differentiable_arg_names'] if func else []
+    non_differentiable_arg_names = declaration.get('non_differentiable_arg_names', [])
     candidate_differentiable_outputs = list(filter(is_differentiable, returns))
 
     if declaration['output_differentiability'] is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19431 Get rid of unnecessary matches_jit_signature: True specifications.
* #19430 Make one_hot non-differentiable.
* #19429 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19428 Have _embedding_bag_dense_backward match JIT signature.
* #19427 Have embedding_dense_backward match JIT signature.
* #19426 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* **#19425 Move non_differentiable_arg_names from autograd functions to differentiability_info.**
* #19424 Stop generating autograd functions for derivatives.yaml entries that only specify output differentiability.
* #19272 Rename 'not_differentiable' to 'non_differentiable'.

There was a similar problem with as with output_differentiability: if an autograd function is not generated, we just throw away this information.
This doesn't particularly matter in this case, because no codegen depends on it, I'm just moving all argument differentiability arguments off of the autograd function.

Differential Revision: [D15003384](https://our.internmc.facebook.com/intern/diff/D15003384)