### PR TITLE
Remove 'BoolTensor', 'IndexTensor' from frontend specifications.

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -969,8 +969,6 @@ def create_generic(top_env, declarations):
                 # type: (bool) -> Dict[str, str]
                 return {
                     'Tensor': 'const Tensor &' if const else 'Tensor &',
-                    'BoolTensor': 'const Tensor &' if const else 'Tensor &',
-                    'IndexTensor': 'const Tensor &' if const else 'Tensor &',
                     'Type': 'const Type &' if const else 'Type &',
                     'TensorOptions': 'const TensorOptions &' if const else 'TensorOptions &',
                     'TensorList': 'TensorList',

--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -57,12 +57,6 @@ signature.
   `Tensor!` - shorthand for Tensor(fresh\_identifier!)
   `Tensor(a! -> a|b)` - Tensor is in set `a`, written to, and after the write is in set `a` AND `b`.
   For more details on when and why this needs to happen, please see the section on annotations.
-- Tensors of specific types.  At the moment, valid type names are:
-    - `IntegerTensor` (a.k.a. `LongTensor`)
-    - `BoolTensor` (a.k.a. `ByteTensor`)
-    - `IndexTensor` (a.k.a. `IntTensor`)
-  These type names were inherited from TH, and may be renamed soon, so
-  don't commit them to memory.
 - `Tensor[]`.  A `Tensor[]` argument translates into a C++ argument of type `ArrayRef<Tensor>`
   (a.k.a. `TensorList`)
 - `int[]`.  `int[]` accepts an optional length specifier, e.g., `int[2]`, which

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -479,18 +479,16 @@ def emit_body(declaration):
     base_name = name[:-1] if inplace else name[:-4] if is_out_fn else name
     view_info = VIEW_FUNCTIONS.get(base_name, None)
 
-    # These exclude things like BoolTensor, int64_t, and Scalar
     def is_differentiable(arg):
         if 'TensorOptions' in arg['type']:
             return False
         if 'Tensor' not in arg['type']:
             return False
         if arg['dynamic_type'] in {'IndexTensor', 'BoolTensor'}:
-            # TODO: Enable this after native_functions.yaml schema unification.
             # These are necessary for legacy code and should be
             # used by legacy code only!
-            # assert name.startswith('_th_'), \
-            # "IndexTensor and BoolTensor are restricted to legacy _th_ functions only.
+            assert declaration['mode'] == 'TH' or declaration['mode'] == 'NN', \
+                "IndexTensor and BoolTensor are restricted to legacy TH/THNN functions only."
             return False
         if arg['name'] in declaration.get('non_differentiable_arg_names', []):
             return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19431 Get rid of unnecessary matches_jit_signature: True specifications.
* #19430 Make one_hot non-differentiable.
* **#19429 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.**
* #19428 Have _embedding_bag_dense_backward match JIT signature.
* #19427 Have embedding_dense_backward match JIT signature.
* #19426 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19425 Move non_differentiable_arg_names from autograd functions to differentiability_info.
* #19424 Stop generating autograd functions for derivatives.yaml entries that only specify output differentiability.
* #19272 Rename 'not_differentiable' to 'non_differentiable'.

They are still used in Declarations.cwrap, so need to be kept around for now, but hopefully we can get rid of them soon.

Differential Revision: [D15003387](https://our.internmc.facebook.com/intern/diff/D15003387)