### PR TITLE
Make one_hot non-differentiable.

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -817,6 +817,9 @@
 - name: t(Tensor self)
   self: grad.t()
 
+- name: one_hot(Tensor self, int64_t num_classes)
+  self: non_differentiable
+
 - name: flip(Tensor self, IntArrayRef dims)
   self: grad.flip(dims)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19431 Get rid of unnecessary matches_jit_signature: True specifications.
* **#19430 Make one_hot non-differentiable.**
* #19429 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19428 Have _embedding_bag_dense_backward match JIT signature.
* #19427 Have embedding_dense_backward match JIT signature.
* #19426 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19425 Move non_differentiable_arg_names from autograd functions to differentiability_info.
* #19424 Stop generating autograd functions for derivatives.yaml entries that only specify output differentiability.
* #19272 Rename 'not_differentiable' to 'non_differentiable'.

In https://github.com/pytorch/pytorch/pull/18073 we moved this from IndexTensor to Tensor, but that was before we could put differentiability specifications in derivatives.yaml without triggering generation of an autograd function.
So this brings us back to baseline.

Differential Revision: [D15003382](https://our.internmc.facebook.com/intern/diff/D15003382)