### PR TITLE
Get rid of unnecessary matches_jit_signature: True specifications.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -435,7 +435,6 @@
 - func: conv_transpose3d(Tensor input, Tensor weight, Tensor? bias=None, int[3] stride=1, int[3] padding=0, int[3] output_padding=0, int groups=1, int[3] dilation=1) -> Tensor
 
 - func: copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)
-  matches_jit_signature: True
   variants: function, method
   device_guard: False
 
@@ -688,7 +687,6 @@
     SparseCUDA: empty_sparse
 
 - func: empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0) -> Tensor
-  matches_jit_signature: True
   dispatch:
     CPU: empty_affine_quantized_cpu
 
@@ -1913,7 +1911,6 @@
     CUDA: _unique_cuda
 
 - func: unique_dim(Tensor self, int dim, bool sorted=True, bool return_inverse=False, bool return_counts=False) -> (Tensor, Tensor, Tensor)
-  matches_jit_signature: True
   variants: function
   dispatch:
     CPU: unique_dim_cpu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19431 Get rid of unnecessary matches_jit_signature: True specifications.**
* #19430 Make one_hot non-differentiable.
* #19429 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19428 Have _embedding_bag_dense_backward match JIT signature.
* #19427 Have embedding_dense_backward match JIT signature.
* #19426 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19425 Move non_differentiable_arg_names from autograd functions to differentiability_info.
* #19424 Stop generating autograd functions for derivatives.yaml entries that only specify output differentiability.
* #19272 Rename 'not_differentiable' to 'non_differentiable'.

Differential Revision: [D15005780](https://our.internmc.facebook.com/intern/diff/D15005780)