### PR TITLE
Remove no-fork workaround for running tests with ROCm

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -900,11 +900,6 @@ def set_running_script_path():
 def check_test_defined_in_running_script(test_case):
     if running_script_path is None:
         return
-    if TEST_WITH_ROCM:
-        # In ROCm CI, to avoid forking after HIP is initialized, we
-        # indeed load test module from test/run_test.py and run all
-        # tests in the same process.
-        return
     test_case_class_file = os.path.abspath(os.path.realpath(inspect.getfile(test_case.__class__)))
     assert test_case_class_file == running_script_path, "Class of loaded TestCase \"{}\" " \
         "is not defined in the running script \"{}\", but in \"{}\". Did you " \

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 
 import argparse
-from contextlib import contextmanager
 from datetime import datetime
 import os
 import shutil
@@ -11,7 +10,6 @@ import signal
 import subprocess
 import sys
 import tempfile
-import unittest
 
 import torch
 import torch._six
@@ -140,18 +138,6 @@ def shell(command, cwd=None):
         p.wait()
 
 
-@contextmanager
-def cd(path):
-    if not os.path.isabs(path):
-        raise RuntimeError('Can only cd to absolute path, got: {}'.format(path))
-    orig_path = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(orig_path)
-
-
 def run_test(executable, test_module, test_directory, options):
     unittest_args = options.additional_unittest_args
     if options.verbose:
@@ -160,16 +146,8 @@ def run_test(executable, test_module, test_directory, options):
     # in `if __name__ == '__main__': `. So call `python test_*.py` instead.
     argv = [test_module + '.py'] + unittest_args
 
-    # Forking after HIP is initialized could trigger random
-    # ihipException issue, see
-    # https://github.com/pytorch/pytorch/issues/14497
-    if TEST_WITH_ROCM:
-        with cd(test_directory):
-            res = unittest.main(argv=argv, module=test_module, exit=False).result
-        return int(bool(len(res.failures) + len(res.errors)))
-    else:
-        command = executable + argv
-        return shell(command, test_directory)
+    command = executable + argv
+    return shell(command, test_directory)
 
 
 def test_cpp_extensions(executable, test_module, test_directory, options):


### PR DESCRIPTION
This should have been fixed in newest ROCm version.