### PR TITLE
[jit] allow bools to be used as attributes

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11229,6 +11229,7 @@ a")
                 self.table = torch.jit.Attribute({"I": "am", "a test": "test"}, Dict[str, str])
                 self.float = torch.jit.Attribute(2.3, float)
                 self.int = torch.jit.Attribute(99, int)
+                self.bool = torch.jit.Attribute(False, bool)
                 self.tuple = torch.jit.Attribute((1, 2, 3, 4), Tuple[int, int, int, int])
                 self.list = torch.jit.Attribute([(1, 2), (3, 4)], List[Tuple[int, int]])
                 self.tensor = torch.jit.Attribute(torch.randn(2, 2), torch.Tensor)
@@ -11236,7 +11237,7 @@ a")
 
             @torch.jit.script_method
             def forward(self):
-                return (self.table, self.float, self.int, self.tuple, self.list, self.int_list)
+                return (self.table, self.float, self.int, self.bool, self.tuple, self.list, self.int_list)
 
         m = M()
         imported_m = self.getExportImportCopy(m)

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -455,7 +455,7 @@ OpCode Unpickler::readInstruction() {
       }
     } break;
     default:
-      AT_ERROR("Unknown opcode for unpickling: ", static_cast<char>(opcode));
+      AT_ERROR("Unknown opcode for unpickling: ", static_cast<uint8_t>(opcode));
   }
   return opcode;
 }

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -368,6 +368,12 @@ OpCode Unpickler::readInstruction() {
       // Mark location of the container ivalue in the stack
       marks_.push_back(stack_.size());
     } break;
+    case OpCode::NEWTRUE: {
+      stack_.emplace_back(true);
+    } break;
+    case OpCode::NEWFALSE: {
+      stack_.emplace_back(false);
+    } break;
     case OpCode::BININT1: {
       int8_t value = read<int8_t>();
       stack_.emplace_back(int64_t(value));
@@ -449,7 +455,7 @@ OpCode Unpickler::readInstruction() {
       }
     } break;
     default:
-      AT_ERROR("Unknown opcode for unpickling");
+      AT_ERROR("Unknown opcode for unpickling: ", static_cast<char>(opcode));
   }
   return opcode;
 }

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -5,7 +5,7 @@ import torch
 from .._jit_internal import List, BroadcastingList1, BroadcastingList2, \
     BroadcastingList3, Tuple, is_tuple, is_list, Dict, is_dict
 from torch._C import TensorType, TupleType, FloatType, IntType, \
-    ListType, StringType, DictType
+    ListType, StringType, DictType, BoolType
 from textwrap import dedent
 
 
@@ -179,6 +179,8 @@ def ann_to_type(ann):
         return IntType.get()
     elif ann is str:
         return StringType.get()
+    elif ann is bool:
+        return BoolType.get()
     raise ValueError("Unknown type annotation: '{}'".format(ann.__name__))
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19440 [jit] allow bools to be used as attributes**

As title. Required adding NEWTRUE and NEWFALSE opcode handling to the
pickler. Fixes #19441

Differential Revision: [D15005723](https://our.internmc.facebook.com/intern/diff/D15005723)