### PR TITLE
Add back option to not adjust output batch size

### DIFF
--- a/caffe2/operators/onnxifi_op.cc
+++ b/caffe2/operators/onnxifi_op.cc
@@ -168,6 +168,10 @@ OnnxifiOp<CPUContext>::buildInitializationList(
 
 template <>
 std::vector<int> OnnxifiOp<CPUContext>::extractOutputBatchSizes() const {
+  if (!adjust_output_batch_) {
+    return std::vector<int>();
+  }
+
   CAFFE_ENFORCE_EQ(
       input_shapes_.size(),
       InputSize(),
@@ -338,7 +342,9 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
         lib_->onnxReleaseEvent(output_fence.event), ONNXIFI_STATUS_SUCCESS);
   }
 
-  maybeAdjustOutputBatchSizes(output_batch_sizes);
+  if (adjust_output_batch_) {
+    maybeAdjustOutputBatchSizes(output_batch_sizes);
+  }
   return true;
 }
 

--- a/caffe2/operators/onnxifi_op.h
+++ b/caffe2/operators/onnxifi_op.h
@@ -66,6 +66,8 @@ class OnnxifiOp final : public Operator<Context> {
     }
 
     // Get output resizing hints
+    adjust_output_batch_ =
+        this->template GetSingleArgument<int>("adjust_output_batch", 0);
     auto output_resize_hints =
         this->template GetRepeatedArgument<int>("output_resize_hints");
     CAFFE_ENFORCE_EQ(
@@ -266,6 +268,9 @@ class OnnxifiOp final : public Operator<Context> {
 
   // output shape hints
   std::unordered_map<int, TensorInfo> output_shape_hints_;
+
+  // Whether we need to resize outputs or not
+  bool adjust_output_batch_{false};
 
   // Output resizing hint map
   // key: max batch size

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -25,6 +25,9 @@ struct OnnxifiTransformerOptions {
   // Pass serialized onnx model if true, otherwise pass serialized c2 model
   bool use_onnx{false};
 
+  // Whether to adjust batch at the ouptuts or not
+  bool adjust_batch{true};
+
   // Minimum number of ops to create an onnxifi op. If the subgraph is too
   // small, it doesn't make sense to lower it to backend.
   size_t min_ops{1};

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -23,6 +23,7 @@ def onnxifi_caffe2_net(
         max_seq_size=1,
         debug=False,
         use_onnx=True,
+        adjust_batch=True,
         black_list=None):
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
@@ -35,6 +36,7 @@ def onnxifi_caffe2_net(
                              black_list if black_list else [],
                              max_batch_size,
                              max_seq_size,
+                             adjust_batch,
                              debug,
                              use_onnx)
     pred_net_cut = caffe2_pb2.NetDef()

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1677,6 +1677,7 @@ void addGlobalMethods(py::module& m) {
          const std::vector<int>& black_list,
          int max_batch_size,
          int max_seq_size,
+         bool adjust_batch,
          bool debug_builder,
          bool use_onnx) -> py::bytes {
         caffe2::NetDef pred_net;
@@ -1692,6 +1693,7 @@ void addGlobalMethods(py::module& m) {
         OnnxifiTransformerOptions opts;
         opts.bound_shape_spec.max_batch_size = max_batch_size;
         opts.bound_shape_spec.max_seq_size = max_seq_size;
+        opts.adjust_batch = adjust_batch;
         opts.debug = debug_builder;
         opts.use_onnx = use_onnx;
         OnnxifiTransformer ts(opts);


### PR DESCRIPTION
Summary: For cases like CV, some of ops like transpose and tile will mangle the batch size so that we don't know how to adjust output batch size. In this case, the current solution is just fix the input batch statically and do not adjust output batch size.

Differential Revision: D15007237

