### PR TITLE
make separate operators as independent binaries

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.python import core, workspace
-from caffe2.benchmarks.operator_benchmark import benchmark_core, benchmark_utils
+from benchmarks.operator_benchmark import benchmark_core, benchmark_utils
 
 """Caffe2 performance microbenchmarks.
 
@@ -15,10 +15,6 @@ microbenchmarks.
 
 def Caffe2OperatorTestCase(test_name, op_type, input_shapes, op_args, run_mode):
     """Benchmark Tester function for Caffe2 framework.
-    test_case is expected to be a Caffe2OperatorTestCase object. If not, the
-    function will return False.
-    It returns a function that contains the code to benchmarked
-    (operator execution).
     """
     idx = 0
     input_blobs = []

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -8,7 +8,7 @@ import numpy as np
 import timeit
 import json
 
-from caffe2.benchmarks.operator_benchmark import benchmark_utils
+from benchmarks.operator_benchmark import benchmark_utils
 
 """Performance microbenchmarks.
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.benchmarks.operator_benchmark import benchmark_core, benchmark_utils
+from benchmarks.operator_benchmark import benchmark_core, benchmark_utils
 
 import torch
 
@@ -16,10 +16,6 @@ microbenchmarks.
 
 def PyTorchOperatorTestCase(test_name, op_type, input_shapes, op_args, run_mode):
     """Benchmark Tester function for Pytorch framework.
-    test_case is expected to be a PyTorchOperatorTestCase object. If not, the
-    function will return False.
-    It returns a function that contains the code to benchmarked
-    (operator execution).
     """
     inputs = [torch.from_numpy(benchmark_utils.numpy_random_fp32(*input)) for input in input_shapes]
 

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -8,14 +8,7 @@ import argparse
 
 from caffe2.python import workspace
 
-from caffe2.benchmarks.operator_benchmark import benchmark_core
-
-import caffe2.benchmarks.operator_benchmark.benchmark_caffe2
-import caffe2.benchmarks.operator_benchmark.benchmark_pytorch
-import caffe2.benchmarks.operator_benchmark.benchmark_test_generator
-
-import caffe2.benchmarks.operator_benchmark.ops.add
-import caffe2.benchmarks.operator_benchmark.ops.matmul # noqa
+from benchmarks.operator_benchmark import benchmark_core
 
 """Performance microbenchmarks's main binary.
 
@@ -24,7 +17,7 @@ It also registers existing benchmark tests via Python module imports.
 """
 
 
-if __name__ == "__main__":
+def main():
     print("Python version " + str(sys.version_info[0]))
 
     parser = argparse.ArgumentParser(
@@ -89,3 +82,7 @@ if __name__ == "__main__":
     workspace.ClearGlobalNetObserver()
 
     benchmark_core.BenchmarkRunner(args).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -3,9 +3,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.benchmarks.operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
-from caffe2.benchmarks.operator_benchmark.benchmark_pytorch import PyTorchOperatorTestCase
-from caffe2.benchmarks.operator_benchmark.benchmark_utils import * # noqa
+
+from benchmarks.operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
+from benchmarks.operator_benchmark.benchmark_pytorch import PyTorchOperatorTestCase
+from benchmarks.operator_benchmark.benchmark_utils import * # noqa
 
 
 def generate_test(configs, map_config, ops, OperatorTestCase):
@@ -17,9 +18,14 @@ def generate_test(configs, map_config, ops, OperatorTestCase):
     """
     for config in configs:
         for case in config:
-            shapes_args_config = case[:-1]
-            mode = case[-1]
-            shapes_args = map_config(*shapes_args_config)
+            shapes = {}
+            for item in case:
+                if 'mode' in item:
+                    run_mode = item['mode']
+                    continue
+                shapes.update(item)
+            assert run_mode is not None, "Missing mode in configs"
+            shapes_args = map_config(**shapes)
             if shapes_args is not None:
                 for op in ops:
                     OperatorTestCase(
@@ -27,7 +33,7 @@ def generate_test(configs, map_config, ops, OperatorTestCase):
                         op_type=op[1],
                         input_shapes=shapes_args[0],
                         op_args=shapes_args[1],
-                        run_mode=mode)
+                        run_mode=run_mode)
 
 
 def generate_pt_test(configs, pt_map_func, pt_ops):

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -44,9 +44,20 @@ def generate_configs(**configs):
     Given configs from users, we want to generate different combinations of
     those configs
     For example, given M = ((1, 2), N = (4, 5)) and sample_func being cross_product,
-    we will generate ((1, 4), (1, 5), (2, 4), (2, 5))
+    we will generate (({'M': 1}, {'N' : 4}),
+                      ({'M': 1}, {'N' : 5}),
+                      ({'M': 2}, {'N' : 4}),
+                      ({'M': 2}, {'N' : 5}))
     """
     assert 'sample_func' in configs, "Missing sample_func to generat configs"
-    results = configs['sample_func'](
-        *[value for key, value in configs.items() if key != 'sample_func'])
+    result = []
+    for key, values in configs.items():
+        if key == 'sample_func':
+            continue
+        tmp_result = []
+        for value in values:
+            tmp_result.append({key : value})
+        result.append(tmp_result)
+
+    results = configs['sample_func'](*result)
     return results

--- a/benchmarks/operator_benchmark/ops/benchmark_all_test.py
+++ b/benchmarks/operator_benchmark/ops/benchmark_all_test.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import importlib
+import os
+from benchmarks.operator_benchmark import benchmark_runner
+
+if __name__ == "__main__":
+    # TODO: current way of importing other tests are fragile, so we need to have a robust way
+    for module in os.listdir(os.path.dirname(__file__)):
+        if module == '__init__.py' or not module.endswith('_test.py'):
+            continue
+        importlib.import_module("benchmarks.operator_benchmark.ops." + module[:-3])
+    benchmark_runner.main()

--- a/benchmarks/operator_benchmark/ops/matmul_test.py
+++ b/benchmarks/operator_benchmark/ops/matmul_test.py
@@ -3,24 +3,22 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from caffe2.benchmarks.operator_benchmark import benchmark_core
-from caffe2.benchmarks.operator_benchmark.benchmark_test_generator import *
+from benchmarks.operator_benchmark import benchmark_core, benchmark_runner
+from benchmarks.operator_benchmark.benchmark_test_generator import *
 
 import torch
 
 
-"""Microbenchmarks for element-wise Add operator. Supports both Caffe2/PyTorch."""
-
-# Input shapes that we test and the run mode for each shape.
-# Sum up two tensors with the same shape
-
+"""Microbenchmarks for MatMul operator. Supports both Caffe2/PyTorch."""
 # Long config
 long_config = generate_configs(
     M=get_n_rand_nums(min_val=1, max_val=128, n=2),
     N=get_n_rand_nums(min_val=1, max_val=128, n=2),
     K=get_n_rand_nums(min_val=1, max_val=128, n=2),
+    trans_a=[False, True],
+    trans_b=[True, False],
     mode=['long'],
-    sample_func=cross_product,
+    sample_func=cross_product
 )
 
 # Short config
@@ -28,29 +26,35 @@ short_config = generate_configs(
     M=[8, 16],
     N=[32, 64],
     K=[64, 128],
+    trans_a=[False, True],
+    trans_b=[True, False],
     mode=['short'],
     sample_func=cross_product
 )
 
 
 @torch.jit.script
-def torch_add(a, b, iterations):
+def torch_matmul(a, b, iterations):
     # type: (Tensor, Tensor, int)
     result = torch.jit.annotate(torch.Tensor, None)
     for _ in range(iterations):
-        result = torch.add(a, b)
+        result = torch.matmul(a, b)
     return result
 
 
 @benchmark_core.register_test
-def test_add():
+def test_matmul():
     generate_pt_test(
         [long_config, short_config],
-        map_pt_config_add,
-        [('add', torch_add)]
+        map_pt_config_matmul,
+        [('matmul', torch_matmul)]
     )
     generate_c2_test(
         [long_config, short_config],
-        map_c2_config_add,
-        [('add', 'Add')],
+        map_c2_config_matmul,
+        [('matmul', 'MatMul')],
     )
+
+
+if __name__ == "__main__":
+    benchmark_runner.main()


### PR DESCRIPTION
Summary: We want to make each operator benchmark as a separate binary. The previous way to run the benchmark is by collecting all operators into a single binary, it is unnecessary when we want to filter a specific operator. This diff aims to resolve that issue.

Differential Revision: D14808159

