### PR TITLE
[not for commit] Disable Caffe2 benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import sys
 import argparse
 
-from caffe2.python import workspace
+#from caffe2.python import workspace
 
 from benchmarks.operator_benchmark import benchmark_core
 
@@ -78,8 +78,8 @@ def main():
 
     args = parser.parse_args()
 
-    workspace.GlobalInit(['caffe2', '--caffe2_log_level=0'])
-    workspace.ClearGlobalNetObserver()
+    #workspace.GlobalInit(['caffe2', '--caffe2_log_level=0'])
+    #workspace.ClearGlobalNetObserver()
 
     benchmark_core.BenchmarkRunner(args).run()
 

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from benchmarks.operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
+#from benchmarks.operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
 from benchmarks.operator_benchmark.benchmark_pytorch import PyTorchOperatorTestCase
 from benchmarks.operator_benchmark.benchmark_utils import * # noqa
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19455 [not for commit] Disable Caffe2 benchmarks**

Summary:
Temporary workaround to be able to run PyTorch benchmarks