### PR TITLE
Fix out-of-topological-order issue in Nomnigraph

### DIFF
--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -841,7 +841,8 @@ NetDef OnnxifiTransformer::TransformViaC2(
         return SubnetToOnnxifiOpViaC2(net, weights, shape_hints);
       };
 
-  return opt::OptimizeForBackend(*pred_net, c2_supports, c2_converter);
+  return opt::OptimizeForBackend(
+      *pred_net, c2_supports, c2_converter, opts_.debug);
 }
 
 NetDef OnnxifiTransformer::TransformViaOnnx(


### PR DESCRIPTION
Summary: The algorithm in https://fburl.com/ggh9iyvc fails to really ensure topological ordering of nodes. The fix is ugly but effective. I think we need a real topological sort to fix this issue more nicely. Mikhail Zolotukhin, Bram Wasti.

Differential Revision: D15011893

