### PR TITLE
Match JIT signature with triu_indices / tril_indices.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2952,14 +2952,12 @@
 - func: tril(Tensor self, int diagonal=0) -> Tensor
   variants: method, function
 
-- func: tril_indices(int row, int col, int offset=0, *, TensorOptions options=at::kLong) -> Tensor
-  matches_jit_signature: False
+- func: tril_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CPU: tril_indices_cpu
     CUDA: tril_indices_cuda
 
-- func: triu_indices(int row, int col, int offset=0, *, TensorOptions options=at::kLong) -> Tensor
-  matches_jit_signature: False
+- func: triu_indices(int row, int col, int offset=0, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:
     CPU: triu_indices_cpu
     CUDA: triu_indices_cuda

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -233,7 +233,8 @@ def parse_arguments(args, func_variants, declaration, func_return):
     corresponding_topts.append(corresponding_topts[1].copy())
     corresponding_topts[2]['default'] = '{}'
     corresponding_topts.append(
-        {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None, 'kwarg_only': True, 'default': 'at::kLong'})
+        {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None,
+         'kwarg_only': True, 'default': 'at::kLong'})
 
     def check_topt_representation(topt_representation):
         for idx, supported_topt in enumerate(supported_topt_arguments):

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -211,6 +211,15 @@ def parse_arguments(args, func_variants, declaration, func_return):
     supported_topt_arguments.append(copy.deepcopy(supported_topt_arguments[1]))
     for arg in supported_topt_arguments[2]:
         arg.update({'default': 'c10::nullopt', 'is_nullable': True})
+    # add explicit support for what is needed for tril_indices / triu_indices
+    supported_topt_arguments.append(
+        [
+            {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True, 'default': 'long', 'is_nullable': True},
+            {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
+            {'name': 'device', 'type': 'Device', 'annotation': None,  'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
+            {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
+        ]
+    )
 
     corresponding_topts = [
         {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None},
@@ -219,6 +228,8 @@ def parse_arguments(args, func_variants, declaration, func_return):
     corresponding_topts[1]['kwarg_only'] = True
     corresponding_topts.append(corresponding_topts[1].copy())
     corresponding_topts[2]['default'] = '{}'
+    corresponding_topts.append(
+        {'type': 'TensorOptions', 'name': 'options', 'is_nullable': False, 'annotation': None, 'kwarg_only': True, 'default': 'at::kLong'})
 
     def check_topt_representation(topt_representation):
         for idx, supported_topt in enumerate(supported_topt_arguments):

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -216,7 +216,7 @@ def parse_arguments(args, func_variants, declaration, func_return):
         [
             {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True, 'default': 'long', 'is_nullable': True},
             {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
-            {'name': 'device', 'type': 'Device', 'annotation': None,  'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
+            {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
             {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
         ]
     )

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -214,10 +214,14 @@ def parse_arguments(args, func_variants, declaration, func_return):
     # add explicit support for what is needed for tril_indices / triu_indices
     supported_topt_arguments.append(
         [
-            {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True, 'default': 'long', 'is_nullable': True},
-            {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
-            {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
-            {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True, 'default': 'c10::nullopt', 'is_nullable': True},
+            {'name': 'dtype', 'type': 'ScalarType', 'annotation': None, 'kwarg_only': True,
+             'default': 'long', 'is_nullable': True},
+            {'name': 'layout', 'type': 'Layout', 'annotation': None, 'kwarg_only': True,
+             'default': 'c10::nullopt', 'is_nullable': True},
+            {'name': 'device', 'type': 'Device', 'annotation': None, 'kwarg_only': True,
+             'default': 'c10::nullopt', 'is_nullable': True},
+            {'name': 'pin_memory', 'type': 'bool', 'annotation': None, 'kwarg_only': True,
+             'default': 'c10::nullopt', 'is_nullable': True},
         ]
     )
 


### PR DESCRIPTION
This just plugs into the existing mechanism to do a direct translation to TensorOptions in the backend, so no codegen changes.

After this lands, all native_functions will match the JIT signature.

