### PR TITLE
Use `fbgemm` for quantize/dequantize ops

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -39,7 +39,8 @@ inline QTensor new_qtensor_cpu(
   auto* allocator = at::getCPUAllocator();
   int64_t nelements = at::prod_intlist(sizes);
   auto dtype = options.dtype();
-  AT_CHECK(isQIntType(typeMetaToScalarType(dtype)), "ScalarType not supported for QTensor in new_qtensor_cpu.");
+  AT_CHECK(isQIntType(typeMetaToScalarType(dtype)),
+           "ScalarType not supported for QTensor in new_qtensor_cpu.");
   auto storage = c10::make_intrusive<StorageImpl>(
       dtype,
       nelements,
@@ -96,7 +97,10 @@ QTensor PerTensorAffineQuantizer::quantize(RealTensor tensor) {
   qparams.scale = scale_;
   qparams.zero_point = zero_point_;
   qparams.precision = 8;
-  fbgemm::Quantize<uint8_t>(svd, qvd, tensor.numel(), qparams);
+  fbgemm::Quantize<uint8_t>(/*src=*/svd,
+                            /*dst=*/qvd,
+                            /*len=*/tensor.numel(),
+                            /*qparams=*/qparams);
 #else
   auto qvd = qv.data<qint8>();
   for (int i = 0; i < tensor.numel(); ++i) {
@@ -120,7 +124,10 @@ RealTensor PerTensorAffineQuantizer::dequantize(QTensor tensor) {
   qparams.scale = scale_;
   qparams.zero_point = zero_point_;
   qparams.precision = 8;
-  fbgemm::Dequantize<uint8_t>(qvd, rvd, tensor.numel(), qparams);
+  fbgemm::Dequantize<uint8_t>(/*src=*/qvd,
+                              /*dst=*/rvd,
+                              /*len=*/tensor.numel(),
+                              /*qparams=*/qparams);
 #else
   const auto* qvd = tensor.data<qint8>();
   for (auto i = 0; i < tensor.numel(); ++i) {

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Type.h>
 #include <ATen/native/TensorFactories.h>
 #include <ATen/quantized/QTensorImpl.h>
+#include <fbgemm/QuantUtils.h>
 
 namespace at {
 
@@ -49,9 +50,7 @@ inline QTensor new_qtensor_cpu(
 }
 
 qint8 quantize_uint8(float scale, uint8_t zero_point, float value) {
-  const int32_t qmin = std::numeric_limits<uint8_t>::min();
-  const int32_t qmax = std::numeric_limits<uint8_t>::max();
-
+  // Internally, fbgemm::Quantize uses std::nearbyint.
   // std::nearbyint results in nearest integer value according to the current
   // rounding mode and the default rounding mode is rounds to even in half-way
   // cases in most popular processor architectures like x86 and ARM. This is
@@ -59,9 +58,8 @@ qint8 quantize_uint8(float scale, uint8_t zero_point, float value) {
   // cases away from zero, and can be consistent with SIMD implementations for
   // example in x86 using _mm512_cvtps_epi32 or mm512_round_ps with
   // _MM_FROUND_CUR_DIRECTION option that also follow the current rounding mode.
-  int32_t r = zero_point + static_cast<int32_t>(std::nearbyint(value / scale));
-  r = std::max(r, qmin);
-  r = std::min(r, qmax);
+  auto r = fbgemm::Quantize<uint8_t>(value, zero_point, scale,
+                                     /*result_precision=*/8);
   return static_cast<qint8>(r);
 }
 
@@ -76,12 +74,17 @@ QTensor PerTensorAffineQuantizer::quantize(RealTensor tensor) {
       sizes,
       tensor.options().dtype(at::kQInt8),
       intrusive_from_this());
-  auto qvd = qv.data<qint8>();
-  tensor.contiguous();
+
+  tensor = tensor.contiguous();
   const float* svd = tensor.data<float>();
-  for (int i = 0; i < tensor.numel(); ++i) {
-    qvd[i] = quantize_uint8(scale_, zero_point_, svd[i]);
-  }
+  auto qvd = reinterpret_cast<uint8_t*>(qv.data<qint8>());
+
+  fbgemm::TensorQuantizationParams qparams;
+  qparams.scale = scale_;
+  qparams.zero_point = zero_point_;
+  qparams.precision = 8;
+  fbgemm::Quantize<uint8_t>(svd, qvd, tensor.numel(), qparams);
+
   return qv;
 }
 
@@ -90,14 +93,16 @@ RealTensor PerTensorAffineQuantizer::dequantize(QTensor tensor) {
   at::TensorOptions real_options = tensor.options().dtype(at::kFloat);
 
   RealTensor rv = at::empty(sizes, real_options);
-  tensor.contiguous();
-  const auto* qvd = tensor.data<qint8>();
+  tensor = tensor.contiguous();
+  const auto* qvd = reinterpret_cast<const uint8_t*>(tensor.data<qint8>());
   float* rvd = rv.data<float>();
-  for (auto i = 0; i < tensor.numel(); ++i) {
-    // We need to convert the qint8 value to float to ensure the subtraction
-    // subexpression returns a float
-    rvd[i] = (static_cast<float>(qvd[i].val_) - zero_point_) * scale_;
-  }
+
+  fbgemm::TensorQuantizationParams qparams;
+  qparams.scale = scale_;
+  qparams.zero_point = zero_point_;
+  qparams.precision = 8;
+  fbgemm::Dequantize<uint8_t>(qvd, rvd, tensor.numel(), qparams);
+
   return rv;
 }
 

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -4,7 +4,10 @@
 #include <ATen/Type.h>
 #include <ATen/native/TensorFactories.h>
 #include <ATen/quantized/QTensorImpl.h>
+
+#ifdef USE_FBGEMM
 #include <fbgemm/QuantUtils.h>
+#endif
 
 namespace at {
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19500 Use `fbgemm` for quantize/dequantize ops**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15014561/)

Changes the `quantize_linear` and `dequantize` to `fbgemm`-based implementation.

Differential Revision: [D15014561](https://our.internmc.facebook.com/intern/diff/D15014561/)