### PR TITLE
Drop instead of pop

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -120,7 +120,7 @@ namespace detail {
       constexpr size_t num_inputs = guts::infer_function_traits_t<KernelFunctor>::number_of_parameters;
       KernelFunctor* functor = static_cast<KernelFunctor*>(cache);
       auto output = call_functor_with_ivalue_args<KernelFunctor>(functor, torch::jit::last(*stack, num_inputs));
-      torch::jit::pop(*stack, num_inputs);
+      torch::jit::drop(*stack, num_inputs);
       push_outputs<typename guts::infer_function_traits_t<KernelFunctor>::return_type>::call(std::move(output), stack);
     }
   };


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19503 Drop instead of pop**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15016023/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19511 Disallow std::vector arguments&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15017423/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19516 Explicitly define supported types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15020306/)

After reading the arguments from the stack, the c10 kernel wrapper accidentally popped them again, causing a vector to be allocated.
Instead, it should just drop them because they have already been read.

Differential Revision: [D15016023](https://our.internmc.facebook.com/intern/diff/D15016023/)