### PR TITLE
Disallow std::vector arguments

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -43,6 +43,12 @@ namespace detail {
     }
   };
   template<class T>
+  struct ivalue_to_arg_type<std::vector<T>> {
+    static ArrayRef<T> call(const IValue& v) {
+      static_assert(!std::is_same<std::vector<T>, std::vector<T>>::value, "You tried to register a kernel that has a std::vector<T> argument. Please use c10::ArrayRef<T> instead.");
+    }
+  };
+  template<class T>
   struct ivalue_to_arg_type<optional<T>> {
     static optional<T> call(const IValue& v) {
       if (v.isNone()) {

--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -45,7 +45,10 @@ namespace detail {
   template<class T>
   struct ivalue_to_arg_type<std::vector<T>> {
     static ArrayRef<T> call(const IValue& v) {
-      static_assert(!std::is_same<std::vector<T>, std::vector<T>>::value, "You tried to register a kernel that has a std::vector<T> argument. Please use c10::ArrayRef<T> instead.");
+      // We don't support std::vector because that would prevent us from doing
+      // internal optimization to how we represent lists (e.g. SmallVector).
+      // Users should use ArrayRef instead.
+      static_assert(guts::false_t<std::vector<T>>::value, "You tried to register a kernel with an unsupported argument type: std::vector<T>. Please use c10::ArrayRef<T> instead.");
     }
   };
   template<class T>


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19503 Drop instead of pop&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15016023/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19511 Disallow std::vector arguments**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15017423/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19516 Explicitly define supported types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15020306/)

In the c10 operator registration API, disallow std::vector arguments and show a nice error message
pointing users towards using ArrayRef instead.

Differential Revision: [D15017423](https://our.internmc.facebook.com/intern/diff/D15017423/)