### PR TITLE
Make finding unused model parameters optional

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2069,6 +2069,69 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             unbox=lambda obj: obj["list"][3],
         )
 
+    @skip_if_not_nccl
+    @skip_if_not_multigpu
+    def test_find_unused_parameters_kwarg(self):
+        """
+        Note: this test can be sped up by only running it on a CPU module
+        once DistributedDataParallel supports them.
+        """
+        store = c10d.FileStore(self.file.name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        class FindUnusedParametersModule(nn.Module):
+            def __init__(self):
+                super(FindUnusedParametersModule, self).__init__()
+                self.fc1 = nn.Linear(2, 10, bias=False)
+                self.fc2 = nn.Linear(10, 4, bias=False)
+                self.fc3 = nn.Linear(4, 4, bias=False)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.relu(self.fc1(x))
+                x = self.relu(self.fc2(x))
+                # Return the fc3 module so that the caller can invoke it
+                # outside of the forward function. While this is bad practice,
+                # we can use it to trigger a reducer error.
+                return (F.softmax(x, dim=1), self.fc3)
+
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        batch_size = 4
+        criterion = nn.CrossEntropyLoss()
+        input = torch.rand([batch_size, 2], dtype=torch.float)
+        target = torch.LongTensor([random.randrange(4) for _ in range(batch_size)]).to(device_id)
+
+        def test_find_unused_parameters(find_unused_parameters):
+            model = DistributedDataParallel(
+                FindUnusedParametersModule().float().to(device_id),
+                device_ids=[device_id],
+                process_group=process_group,
+                find_unused_parameters=find_unused_parameters,
+            )
+
+            output, fc3 = model(input)
+            output = fc3(output)
+            loss = criterion(output, target)
+            loss.backward()
+
+        # First test that the default behavior under these conditions is to
+        # trigger an error when `backward` is called (because fc3 is an unused
+        # parameter and will therefore be marked ready twice).
+        try:
+            test_find_unused_parameters(True)
+        except Exception as ex:
+            self.assertTrue(
+                str(ex).startswith("Expected to mark a variable ready only once."))
+        else:
+            self.fail("Expected exception")
+
+        # Then test that the default behavior can be overridden by setting
+        # `find_unused_parameters=False`.
+        try:
+            test_find_unused_parameters(False)
+        except Exception as ex:
+            self.fail("Unexpected exception: %s" % ex)
+
 
 class ReducerModule(nn.Module):
     def __init__(self):

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -55,6 +55,7 @@ class Reducer {
 
   bool expect_autograd_hooks_;
   bool has_queued_final_callback_;
+  bool has_marked_unused_parameters_;
   size_t next_bucket_;
 
   void mark_variable_ready(


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19515 Make finding unused model parameters optional**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15016381/)

This is still done by default, but can now be disabled by specifying
`find_unused_parameters=False`. There are use cases where finding
unused parameters results in erroneous behavior, because a subset of
model parameters is used *outside* the `forward` function. One can
argue that doing this is not a good idea, but we should not break
existing use cases without an escape hatch. This configuration
parameter is that escape hatch.

Differential Revision: [D15016381](https://our.internmc.facebook.com/intern/diff/D15016381/)