### PR TITLE
Fix op benchmarks error in OSS environment

### DIFF
--- a/benchmarks/operator_benchmark/README.md
+++ b/benchmarks/operator_benchmark/README.md
@@ -1,0 +1,7 @@
+# PyTorch/Caffe2 Operator Micro-benchmarks
+
+## Run benchmarks
+Go to `pytorch-src-folder/benchmarks`
+`python -m operator_benchmark.ops.matmul_test`
+
+should report the execution time of matmul operator with PyTorch and Caffe2 

--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from caffe2.python import core, workspace
-from benchmarks.operator_benchmark import benchmark_core, benchmark_utils
+from operator_benchmark import benchmark_core, benchmark_utils
 
 """Caffe2 performance microbenchmarks.
 

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -8,7 +8,7 @@ import numpy as np
 import timeit
 import json
 
-from benchmarks.operator_benchmark import benchmark_utils
+from operator_benchmark import benchmark_utils
 
 """Performance microbenchmarks.
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from benchmarks.operator_benchmark import benchmark_core, benchmark_utils
+from operator_benchmark import benchmark_core, benchmark_utils
 
 import torch
 

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -8,7 +8,7 @@ import argparse
 
 from caffe2.python import workspace
 
-from benchmarks.operator_benchmark import benchmark_core
+from operator_benchmark import benchmark_core
 
 """Performance microbenchmarks's main binary.
 

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from benchmarks.operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
-from benchmarks.operator_benchmark.benchmark_pytorch import PyTorchOperatorTestCase
-from benchmarks.operator_benchmark.benchmark_utils import * # noqa
+from operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
+from operator_benchmark.benchmark_pytorch import PyTorchOperatorTestCase
+from operator_benchmark.benchmark_utils import * # noqa
 
 
 def generate_test(configs, map_config, ops, OperatorTestCase):

--- a/benchmarks/operator_benchmark/ops/add_test.py
+++ b/benchmarks/operator_benchmark/ops/add_test.py
@@ -3,8 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from benchmarks.operator_benchmark import benchmark_core, benchmark_runner
-from benchmarks.operator_benchmark.benchmark_test_generator import *
+from operator_benchmark import benchmark_core, benchmark_runner
+from operator_benchmark.benchmark_test_generator import *
 
 import torch
 

--- a/benchmarks/operator_benchmark/ops/benchmark_all_test.py
+++ b/benchmarks/operator_benchmark/ops/benchmark_all_test.py
@@ -3,14 +3,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import importlib
-import os
 from benchmarks.operator_benchmark import benchmark_runner
+from benchmarks.operator_benchmark.ops import ( # noqa
+    add_test, # noqa
+    matmul_test) # noqa
+
 
 if __name__ == "__main__":
-    # TODO: current way of importing other tests are fragile, so we need to have a robust way
-    for module in os.listdir(os.path.dirname(__file__)):
-        if module == '__init__.py' or not module.endswith('_test.py'):
-            continue
-        importlib.import_module("benchmarks.operator_benchmark.ops." + module[:-3])
     benchmark_runner.main()

--- a/benchmarks/operator_benchmark/ops/benchmark_all_test.py
+++ b/benchmarks/operator_benchmark/ops/benchmark_all_test.py
@@ -3,8 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from benchmarks.operator_benchmark import benchmark_runner
-from benchmarks.operator_benchmark.ops import ( # noqa
+from operator_benchmark import benchmark_runner
+from operator_benchmark.ops import ( # noqa
     add_test, # noqa
     matmul_test) # noqa
 

--- a/benchmarks/operator_benchmark/ops/matmul_test.py
+++ b/benchmarks/operator_benchmark/ops/matmul_test.py
@@ -3,8 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from benchmarks.operator_benchmark import benchmark_core, benchmark_runner
-from benchmarks.operator_benchmark.benchmark_test_generator import *
+from operator_benchmark import benchmark_core, benchmark_runner
+from operator_benchmark.benchmark_test_generator import *
 
 import torch
 


### PR DESCRIPTION
Summary: Previous design needs to run the op benchmarks from PyTorch root directory which could lead to `module not found` error in OSS environment. This diff fixes that issue by making the benchmark to be launched in the `benchmarks` folder.

Differential Revision: D15020787

