### PR TITLE
Hook up non_differentiability in derivatives.yaml when no autograd function is generated.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -41,8 +41,7 @@
   dispatch:
     CUDA: _cudnn_rnn
 
-- func: _cudnn_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, BoolTensor? dropout_state, Tensor reserve, bool[4] output_mask) -> (Tensor, Tensor, Tensor, Tensor[])
-  matches_jit_signature: False
+- func: _cudnn_rnn_backward(Tensor input, Tensor[] weight, int weight_stride0, Tensor weight_buf, Tensor hx, Tensor? cx, Tensor output, Tensor? grad_output, Tensor? grad_hy, Tensor? grad_cy, int mode, int hidden_size, int num_layers, bool batch_first, float dropout, bool train, bool bidirectional, int[] batch_sizes, Tensor? dropout_state, Tensor reserve, bool[4] output_mask) -> (Tensor, Tensor, Tensor, Tensor[])
   dispatch:
     CUDA: _cudnn_rnn_backward
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1413,6 +1413,9 @@
   output_differentiability: [True, True, True, False, False]
   input, hx, cx, weight: "_cudnn_rnn_backward(input, weight, weight_stride0, result4, hx, cx, result0, grads[0], grads[1], grads[2], mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state, retain_variables ? result3.clone() : result3, grad_input_mask)"
 
+- name: _cudnn_rnn_backward(Tensor input, TensorList weight, int64_t weight_stride0, Tensor weight_buf, Tensor hx, Tensor cx, Tensor output, Tensor grad_output, Tensor grad_hy, Tensor grad_cy, int64_t mode, int64_t hidden_size, int64_t num_layers, bool batch_first, double dropout, bool train, bool bidirectional, IntArrayRef batch_sizes, Tensor dropout_state, Tensor reserve, std::array<bool,4> output_mask)
+  dropout_state: non_differentiable
+
 # miopen
 
 - name: miopen_convolution_transpose(Tensor self, Tensor weight, Tensor bias, IntArrayRef padding, IntArrayRef output_padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups, bool benchmark, bool deterministic)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -491,6 +491,8 @@ def emit_body(declaration):
             # assert name.startswith('_th_'), \
             # "IndexTensor and BoolTensor are restricted to legacy _th_ functions only.
             return False
+        if arg['name'] in declaration.get('non_differentiable_arg_names', []):
+            return False
         return True
 
     def find_args_with_derivatives(differentiable_inputs):

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -383,5 +383,5 @@ def match_declarations_with_differentiability_info(declarations, differentiabili
     for declaration in declarations:
         info = find_info(declaration)
         declaration['derivative'] = info['autograd_fn'] if info else None
-        declaration['non_differentiable_arg_names'] = info['non_differentiable_arg_names'] if info else None
+        declaration['non_differentiable_arg_names'] = info['non_differentiable_arg_names'] if info else []
         declaration['output_differentiability'] = info['output_differentiability'] if info else None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19524 Make one_hot non-differentiable.
* #19523 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19522 Have _embedding_bag_dense_backward match JIT signature.
* #19521 Have embedding_dense_backward match JIT signature.
* **#19520 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.**
* #19519 Move non_differentiable_arg_names from autograd functions to differentiability_info.

This essentially allows us to move a declaration of "BoolTensor/IndexTensor" to derivatives.yaml by specifying that the argument is non-differentiable.

We do this for _cudnn_rnn_backward and there is no codegen change.  This allows us to remove JIT signature mismatch cases.

Differential Revision: [D15021380](https://our.internmc.facebook.com/intern/diff/D15021380)