### PR TITLE
Have embedding_dense_backward match JIT signature.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -635,8 +635,7 @@
 
 - func: embedding_backward(Tensor grad, Tensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq, bool sparse) -> Tensor
 
-- func: embedding_dense_backward(Tensor grad_output, IndexTensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq) -> Tensor
-  matches_jit_signature: False
+- func: embedding_dense_backward(Tensor grad_output, Tensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq) -> Tensor
   dispatch:
     CPU: embedding_dense_backward_cpu
     CUDA: embedding_dense_backward_cuda

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -950,6 +950,7 @@
 
 - name: embedding_dense_backward(Tensor grad_output, Tensor indices, int64_t num_weights, int64_t padding_idx, bool scale_grad_by_freq)
   grad_output: embedding_dense_double_backward(grad, indices)
+  indices: non_differentiable
 
 - name: _embedding_bag(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq, int64_t mode, bool sparse, Tensor per_sample_weights)
   indices: non_differentiable


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19524 Make one_hot non-differentiable.
* #19523 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19522 Have _embedding_bag_dense_backward match JIT signature.
* **#19521 Have embedding_dense_backward match JIT signature.**
* #19520 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19519 Move non_differentiable_arg_names from autograd functions to differentiability_info.

As before, we move the "non-differentiability" argument from native_functions to derivatives.

Differential Revision: [D15021376](https://our.internmc.facebook.com/intern/diff/D15021376)