### PR TITLE
Have _embedding_bag_dense_backward match JIT signature.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -667,8 +667,7 @@
 
 - func: _embedding_bag_sparse_backward(Tensor grad, Tensor indices, Tensor offsets, Tensor offset2bag, Tensor bag_size, int num_weights, bool scale_grad_by_freq, int mode, Tensor? per_sample_weights) -> Tensor
 
-- func: _embedding_bag_dense_backward(Tensor grad, IndexTensor indices, IndexTensor offsets, IndexTensor offset2bag, IndexTensor bag_size, IndexTensor maximum_indices, int num_weights, bool scale_grad_by_freq, int mode, Tensor? per_sample_weights) -> Tensor
-  matches_jit_signature: False
+- func: _embedding_bag_dense_backward(Tensor grad, Tensor indices, Tensor offsets, Tensor offset2bag, Tensor bag_size, Tensor maximum_indices, int num_weights, bool scale_grad_by_freq, int mode, Tensor? per_sample_weights) -> Tensor
   dispatch:
     CPU: _embedding_bag_dense_backward_cpu
     CUDA: _embedding_bag_dense_backward_cuda

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -958,6 +958,13 @@
   weight: _embedding_bag_backward(grad, indices, offsets, result1, result2, result3, weight.size(0), scale_grad_by_freq, mode, sparse, per_sample_weights)
   per_sample_weights: _embedding_bag_per_sample_weights_backward(grad, weight, indices, result1, mode)
 
+- name: _embedding_bag_dense_backward(Tensor grad, Tensor indices, Tensor offsets, Tensor offset2bag, Tensor bag_size, Tensor maximum_indices, int64_t num_weights, bool scale_grad_by_freq, int64_t mode, Tensor per_sample_weights)
+  indices: non_differentiable
+  offsets: non_differentiable
+  offset2bag: non_differentiable
+  bag_size: non_differentiable
+  maximum_indices: non_differentiable
+
 - name: embedding_renorm_(Tensor self, Tensor indices, double max_norm, double norm_type)
   indices: non_differentiable
   self: not_implemented("embedding_renorm")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19524 Make one_hot non-differentiable.
* #19523 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* **#19522 Have _embedding_bag_dense_backward match JIT signature.**
* #19521 Have embedding_dense_backward match JIT signature.
* #19520 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19519 Move non_differentiable_arg_names from autograd functions to differentiability_info.

As before, we move the non-differentiable specification from native_functions to derivatives.

Differential Revision: [D15021419](https://our.internmc.facebook.com/intern/diff/D15021419)