### PR TITLE
Make one_hot non-differentiable.

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -817,6 +817,9 @@
 - name: t(Tensor self)
   self: grad.t()
 
+- name: one_hot(Tensor self, int64_t num_classes)
+  self: non_differentiable
+
 - name: flip(Tensor self, IntArrayRef dims)
   self: grad.flip(dims)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19524 Make one_hot non-differentiable.**
* #19523 Remove 'BoolTensor', 'IndexTensor' from frontend specifications.
* #19522 Have _embedding_bag_dense_backward match JIT signature.
* #19521 Have embedding_dense_backward match JIT signature.
* #19520 Hook up non_differentiability in derivatives.yaml when no autograd function is generated.
* #19519 Move non_differentiable_arg_names from autograd functions to differentiability_info.

In https://github.com/pytorch/pytorch/pull/18073 we moved this from IndexTensor to Tensor, but that was before we could put differentiability specifications in derivatives.yaml without triggering generation of an autograd function.
So this brings us back to baseline.

Differential Revision: [D15021417](https://our.internmc.facebook.com/intern/diff/D15021417)