### PR TITLE
Enable assignment for QTensor in pytorch frontend

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -446,6 +446,7 @@
   dispatch:
     CPU: _s_copy__cpu
     CUDA: _s_copy__cuda
+    QuantizedCPU: _s_copy__quantized
 
 - func: _s_copy_from(Tensor self, Tensor dst, bool non_blocking=False) -> Tensor
   cpu_half: True
@@ -690,7 +691,7 @@
 - func: _empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0) -> Tensor
   matches_jit_signature: True
   dispatch:
-    CPU: empty_affine_quantized_cpu
+    QuantizedCPU: empty_affine_quantized_cpu
 
 - func: resize_(Tensor(a!) self, int[] size) -> Tensor(a!)
   variants: method

--- a/aten/src/ATen/native/quantized/Copy.cpp
+++ b/aten/src/ATen/native/quantized/Copy.cpp
@@ -1,0 +1,21 @@
+#include <ATen/native/Copy.h>
+
+#include <ATen/ATen.h>
+#include <ATen/quantized/Quantizer.h>
+#include <ATen/CPUApplyUtils.h>
+
+namespace at { namespace native {
+Tensor& _s_copy__quantized(
+    Tensor& self,
+    const Tensor& src,
+    bool non_blocking) {
+  AT_CHECK(self.scalar_type() == at::kQInt8, "Quantized copy only works with kQInt8 as source Tensor");
+  AT_CHECK(src.scalar_type() == at::kFloat, "Quantized copy only works with kFloat as target Tensor");
+  qint8* self_data = self.data<qint8>();//reinterpret_cast<uint8_t *>(self.data<qint8>());
+  float* src_data = src.data<float>();
+  for (int i = 0; i < self.numel(); ++i) {
+    self_data[i] = quantize_uint8(self.q_scale().to<float>(), self.q_zero_point().to<uint8_t>(), src_data[i]);
+  }
+  return self;
+}
+}} // at::native

--- a/aten/src/ATen/native/quantized/Copy.cpp
+++ b/aten/src/ATen/native/quantized/Copy.cpp
@@ -9,9 +9,9 @@ Tensor& _s_copy__quantized(
     Tensor& self,
     const Tensor& src,
     bool non_blocking) {
-  AT_CHECK(self.scalar_type() == at::kQInt8, "Quantized copy only works with kQInt8 as source Tensor");
-  AT_CHECK(src.scalar_type() == at::kFloat, "Quantized copy only works with kFloat as target Tensor");
-  qint8* self_data = self.data<qint8>();//reinterpret_cast<uint8_t *>(self.data<qint8>());
+  AT_CHECK(self.scalar_type() == at::kQInt8, "Quantized copy only works with kQInt8 as target Tensor");
+  AT_CHECK(src.scalar_type() == at::kFloat, "Quantized copy only works with kFloat as source Tensor");
+  qint8* self_data = self.data<qint8>();
   float* src_data = src.data<float>();
   for (int i = 0; i < self.numel(); ++i) {
     self_data[i] = quantize_uint8(self.q_scale().to<float>(), self.q_zero_point().to<uint8_t>(), src_data[i]);

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -360,6 +360,9 @@ struct C10_API TensorOptions {
             if (isComplexType(typeMetaToScalarType(dtype()))) {
               return ComplexCPUTensorId();
             }
+            if (isQIntType(typeMetaToScalarType(dtype()))) {
+              return QuantizedCPUTensorId();
+            }
             return CPUTensorId();
           case DeviceType::CUDA:
             if (isComplexType(typeMetaToScalarType(dtype()))) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2680,9 +2680,9 @@ class _TestTorchMixin(object):
         self.assertEqual(qr.item(), 1)
         self.assertEqual(qr[0].item(), 1)
         # assignment
-        # This calls _th_fill_
-        # qr[0] = 8 # float asignment
-        # self.assertEqual(qr.item(), 8)
+        self.assertTrue(qr[0].is_quantized)
+        qr[0] = 11.3 # float asignment
+        self.assertEqual(qr.item(), 11)
 
     def test_qtensor_quant_dequant(self):
         r = np.random.rand(3, 2) * 2 - 4


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19530 Enable assignment for QTensor in pytorch frontend**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15008160/)

Make copy work with QTensor, enable assignment of QTensor in pytorch frontend.

Differential Revision: [D15008160](https://our.internmc.facebook.com/intern/diff/D15008160/)