### PR TITLE
[pytorch] Fix several perma-failing dict/list trace input tests.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1707,7 +1707,6 @@ graph(%x : Tensor,
         with self.assertRaisesRegex(RuntimeError, 'consistent'):
             self.checkTrace(test, (inputs,))
 
-
     # TODO: adapt to a GraphExecutor test
     @unittest.skip("Need to instrument GraphExecutors a bit more")
     def test_flags(self):

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -51,9 +51,9 @@ inline TypedIValue toDictKeyIValue(py::handle key) {
   if (py::isinstance<py::str>(key)) {
     return TypedIValue(ConstantString::create(py::cast<std::string>(key)),
                        StringType::create());
-  } else if (PyLong_Check(key.ptr())) {
+  } else if (py::isinstance<py::int_>(key)) {
     return TypedIValue(py::cast<int64_t>(key), IntType::create());
-  } else if (PyFloat_Check(key.ptr())) {
+  } else if (py::isinstance<py::float_>(key)) {
     return TypedIValue(py::cast<double>(key), FloatType::create());
   } else {
     AT_ERROR("Dictionary inputs may only have string, int, or float keys");


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19528 [pytorch] Enforce consistent dict iteration order for trace inputs.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15023656/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19535 [pytorch] Fix several perma-failing dict/list trace input tests.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15024954/)

There are two fixes in this patch:

1) When linking against python 2.7, it's insufficient to chekc PyLong_Check, to
see if you have an int. Change to the more portable py::isinstance throughout.

2) Trivial lint fix which I forgot from review.

Differential Revision: [D15024954](https://our.internmc.facebook.com/intern/diff/D15024954/)