### PR TITLE
Fix clang-format.

### DIFF
--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -22,10 +22,10 @@
 #include <torch/csrc/jit/passes/loop_unrolling.h>
 #include <torch/csrc/jit/passes/lower_tuples.h>
 #include <torch/csrc/jit/passes/onnx.h>
+#include <torch/csrc/jit/passes/onnx/constant_fold.h>
 #include <torch/csrc/jit/passes/onnx/fixup_onnx_loop.h>
 #include <torch/csrc/jit/passes/onnx/peephole.h>
 #include <torch/csrc/jit/passes/onnx/prepare_division_for_onnx.h>
-#include <torch/csrc/jit/passes/onnx/constant_fold.h>
 #include <torch/csrc/jit/passes/peephole.h>
 #include <torch/csrc/jit/passes/quantization.h>
 #include <torch/csrc/jit/passes/remove_expands.h>
@@ -103,12 +103,13 @@ void initJITBindings(PyObject* module) {
       .def("_jit_pass_lower_all_tuples", LowerAllTuples)
       .def("_jit_pass_onnx_peephole", PeepholeOptimizeONNX)
       .def(
-           "_jit_pass_onnx_constant_fold",
-           [](std::shared_ptr<Graph>& graph,
-               std::map<std::string, at::Tensor>& paramsDict) {
-           ConstantFoldONNX(graph->block(), paramsDict); // overload resolution
-           return paramsDict;
-          }, pybind11::return_value_policy::move)
+          "_jit_pass_onnx_constant_fold",
+          [](std::shared_ptr<Graph>& graph,
+             std::map<std::string, at::Tensor>& paramsDict) {
+            ConstantFoldONNX(graph->block(), paramsDict); // overload resolution
+            return paramsDict;
+          },
+          pybind11::return_value_policy::move)
       .def("_jit_pass_fuse", FuseGraph)
       .def(
           "_jit_pass_dce",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19551 [JIT] IRParser: optionally create name->value map of the parsed IR.
* **#19550 Fix clang-format.**

Differential Revision: [D15028055](https://our.internmc.facebook.com/intern/diff/D15028055)