### PR TITLE
accumulate grads

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2220,6 +2220,58 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         except Exception as ex:
             self.fail("Unexpected exception: %s" % ex)
 
+    @skip_if_not_multigpu
+    @skip_if_not_nccl
+    def test_accumulate_gradients(self):
+        gpus = gpus_for_rank(self.world_size)[self.rank]
+        store = c10d.FileStore(self.file.name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        local_batch_size = len(gpus)
+        global_batch_size = self.world_size * local_batch_size
+
+        model, ddp_model, input, target = \
+            self._prepare_single_device_module(
+                process_group, gpus, global_batch_size)
+
+        def step_model(model, input, target):
+            model.train()
+            output = model(input)
+            loss = F.mse_loss(output, target.to(output.device))
+            loss.backward()
+
+        # ensure accumulate grads works with no_grad
+        with torch.no_grad():
+            ddp_model.accumulate_gradients(False)
+            ddp_model.train()
+            ddp_model(input)
+
+        # check two model parameters over 2 iterations
+        for iteration in range(2):
+            if iteration % 2 == 0:
+                # accumulate grads locally when iteration == 0
+                ddp_model.accumulate_gradients(True)
+            else:
+                # sync grads when iteration == 1
+                ddp_model.accumulate_gradients(False)
+            # single cpu/gpu training
+            step_model(model, input, target)
+
+            # DDP training, DDP scatters subsets of input_cpu to nodes/GPUs
+            step_model(ddp_model,
+                       input[self.rank * local_batch_size: (self.rank + 1) * local_batch_size],
+                       target[self.rank * local_batch_size: (self.rank + 1) * local_batch_size])
+
+            for i, j in zip(model.parameters(), ddp_model.parameters()):
+                if ddp_model.accumulate_grads:
+                    self.assertNotEqual(i.grad, j.grad)
+                else:
+                    self.assertEqual(i.grad, j.grad)
+
+            # Shuffle the input so that DDP input is different
+            torch.manual_seed(1337 + iteration)
+            input = input[torch.randperm(global_batch_size)]
+
+
     @skip_if_not_nccl
     @skip_if_not_multigpu
     def test_multiple_outputs_multiple_backward(self):


### PR DESCRIPTION
Summary:
add flag to enable accumulate grads locally, this is a critial way to increase batch_size in big model training. (e.g bound by GPU memory).
This will also increase the training speed because it reduce the all-reduction call

Differential Revision: D15035604

