### PR TITLE
[wip] fix function duplication in jit tests

### DIFF
--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -2,7 +2,9 @@ set(JIT_TEST_ROOT ${TORCH_ROOT}/test/cpp/jit)
 
 add_executable(test_jit
   ${TORCH_ROOT}/test/cpp/common/main.cpp
-  ${JIT_TEST_ROOT}/test.cpp)
+  ${JIT_TEST_ROOT}/test.cpp
+  ${JIT_TEST_ROOT}/test_utils.cpp
+)
 
 target_link_libraries(test_jit PRIVATE torch gtest)
 target_compile_definitions(test_jit PRIVATE USE_GTEST)

--- a/test/cpp/jit/test_utils.cpp
+++ b/test/cpp/jit/test_utils.cpp
@@ -1,0 +1,161 @@
+#include "caffe2/test/cpp/jit/test_utils.h"
+
+namespace torch {
+namespace jit {
+namespace test {
+
+using Var = SymbolicVariable;
+using tensor_list = std::vector<at::Tensor>;
+using namespace torch::autograd;
+
+// work around the fact that variable_tensor_list doesn't duplicate all
+// of std::vector's constructors.
+// most constructors are never used in the implementation, just in our tests.
+Stack createStack(std::vector<at::Tensor>&& list) {
+  return Stack(
+      std::make_move_iterator(list.begin()),
+      std::make_move_iterator(list.end()));
+}
+
+void assertAllClose(const tensor_list& a, const tensor_list& b) {
+  ASSERT_EQ(a.size(), b.size());
+  for (size_t i = 0; i < a.size(); ++i) {
+    ASSERT_TRUE(a[i].is_same_size(b[i]));
+    ASSERT_TRUE(a[i].allclose(b[i]));
+  }
+}
+
+std::vector<at::Tensor> run(
+    InterpreterState& interp,
+    const std::vector<at::Tensor>& inputs) {
+  std::vector<IValue> stack(inputs.begin(), inputs.end());
+  interp.run(stack);
+  return fmap(stack, [](const IValue& i) { return i.toTensor(); });
+}
+
+std::pair<tensor_list, tensor_list> runGradient(
+    Gradient& grad_spec,
+    tensor_list& tensors_in,
+    tensor_list& tensor_grads_in) {
+  static const auto as_tensorlist = [](const Stack& stack) {
+    return fmap(stack, [](const IValue& i) { return i.toTensor(); });
+  };
+  Code f_code{grad_spec.f}, df_code{grad_spec.df};
+  InterpreterState f_interpreter{f_code}, df_interpreter{df_code};
+
+  auto f_stack = fmap<IValue>(tensors_in);
+  f_interpreter.run(f_stack);
+
+  Stack df_stack;
+  df_stack.insert(
+      df_stack.end(), tensor_grads_in.begin(), tensor_grads_in.end());
+  for (auto offset : grad_spec.df_input_captured_inputs)
+    df_stack.push_back(tensors_in[offset]);
+  for (auto offset : grad_spec.df_input_captured_outputs)
+    df_stack.push_back(f_stack[offset]);
+  df_interpreter.run(df_stack);
+
+  // Outputs of f needs to be sliced
+  f_stack.erase(f_stack.begin() + grad_spec.f_real_outputs, f_stack.end());
+  return std::make_pair(as_tensorlist(f_stack), as_tensorlist(df_stack));
+}
+
+std::tuple<Var, Var> build_lstm_body(
+    Graph& g,
+    Var input,
+    Var hx,
+    Var cx,
+    Var w_ih,
+    Var w_hh) {
+  auto gates = input.mm(w_ih);
+  gates = gates + hx.mm(w_hh);
+  auto outputs = gates.chunk(4, 1);
+  auto ingate = outputs[0];
+  auto forgetgate = outputs[1];
+  auto cellgate = outputs[2];
+  auto outgate = outputs[3];
+  ingate = ingate.sigmoid();
+  outgate = outgate.sigmoid();
+  cellgate = cellgate.tanh();
+  forgetgate = forgetgate.sigmoid();
+
+  auto cy = forgetgate * cx;
+  cy = cy + ingate * cellgate;
+  auto hy = outgate * cy.tanh();
+
+  return std::make_tuple(hy, cy);
+}
+
+std::shared_ptr<Graph> build_lstm() {
+  auto r = std::make_shared<Graph>();
+  auto& g = *r;
+  Value* input = g.addInput();
+  Value* hx = g.addInput();
+  Value* cx = g.addInput();
+  Value* w_ih = g.addInput();
+  Value* w_hh = g.addInput();
+
+  Var hy;
+  Var cy;
+  std::tie(hy, cy) = build_lstm_body(g, input, hx, cx, w_ih, w_hh);
+
+  hy.addAsOutput();
+  cy.addAsOutput();
+  g.lint();
+
+  return r;
+}
+
+at::Tensor t_use(at::Tensor x) {
+  return x;
+}
+at::Tensor t_def(at::Tensor x) {
+  return x.t();
+}
+
+// given the difference of output vs expected tensor, check whether the
+// difference is within a relative tolerance range. This is a standard way of
+// matching tensor values upto certain precision
+bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
+  double maxValue = 0.0;
+  for (auto& tensor : inputs) {
+    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
+  }
+  return diff.abs().max().item<float>() < 2e-6 * maxValue;
+}
+bool almostEqual(const at::Tensor& a, const at::Tensor& b) {
+  return checkRtol(a - b, {a, b});
+}
+
+bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
+  return (a - b).abs().max().item<float>() == 0.f;
+}
+
+std::pair<at::Tensor, at::Tensor> lstm(
+    at::Tensor input,
+    at::Tensor hx,
+    at::Tensor cx,
+    at::Tensor w_ih,
+    at::Tensor w_hh) {
+  auto gates = input.mm(t_use(w_ih)) + hx.mm(t_use(w_hh));
+
+  auto chunked_gates = gates.chunk(4, 1);
+  auto ingate = chunked_gates[0];
+  auto forgetgate = chunked_gates[1];
+  auto cellgate = chunked_gates[2];
+  auto outgate = chunked_gates[3];
+
+  ingate = ingate.sigmoid();
+  outgate = outgate.sigmoid();
+  cellgate = cellgate.tanh();
+  forgetgate = forgetgate.sigmoid();
+
+  auto cy = (forgetgate * cx) + (ingate * cellgate);
+  auto hy = outgate * cy.tanh();
+
+  return {hy, cy};
+}
+
+} // namespace test
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/test_utils.h
+++ b/test/cpp/jit/test_utils.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <torch/csrc/jit/testing/file_check.h>
-#include "test/cpp/jit/test_base.h"
-#include "torch/csrc/jit/autodiff.h"
-#include "torch/csrc/jit/interpreter.h"
-#include "torch/csrc/jit/symbolic_variable.h"
+#include <test/cpp/jit/test_base.h>
+#include <torch/csrc/jit/autodiff.h>
+#include <torch/csrc/jit/interpreter.h>
+#include <torch/csrc/jit/symbolic_variable.h>
 
 namespace torch {
 namespace jit {
@@ -14,57 +14,18 @@ using Var = SymbolicVariable;
 using tensor_list = std::vector<at::Tensor>;
 using namespace torch::autograd;
 
-// work around the fact that variable_tensor_list doesn't duplicate all
-// of std::vector's constructors.
-// most constructors are never used in the implementation, just in our tests.
-Stack createStack(std::vector<at::Tensor>&& list) {
-  return Stack(
-      std::make_move_iterator(list.begin()),
-      std::make_move_iterator(list.end()));
-}
+Stack createStack(std::vector<at::Tensor>&& list);
 
-void assertAllClose(const tensor_list& a, const tensor_list& b) {
-  ASSERT_EQ(a.size(), b.size());
-  for (size_t i = 0; i < a.size(); ++i) {
-    ASSERT_TRUE(a[i].is_same_size(b[i]));
-    ASSERT_TRUE(a[i].allclose(b[i]));
-  }
-}
+void assertAllClose(const tensor_list& a, const tensor_list& b);
 
 std::vector<at::Tensor> run(
     InterpreterState& interp,
-    const std::vector<at::Tensor>& inputs) {
-  std::vector<IValue> stack(inputs.begin(), inputs.end());
-  interp.run(stack);
-  return fmap(stack, [](const IValue& i) { return i.toTensor(); });
-}
+    const std::vector<at::Tensor>& inputs);
 
 std::pair<tensor_list, tensor_list> runGradient(
     Gradient& grad_spec,
     tensor_list& tensors_in,
-    tensor_list& tensor_grads_in) {
-  static const auto as_tensorlist = [](const Stack& stack) {
-    return fmap(stack, [](const IValue& i) { return i.toTensor(); });
-  };
-  Code f_code{grad_spec.f}, df_code{grad_spec.df};
-  InterpreterState f_interpreter{f_code}, df_interpreter{df_code};
-
-  auto f_stack = fmap<IValue>(tensors_in);
-  f_interpreter.run(f_stack);
-
-  Stack df_stack;
-  df_stack.insert(
-      df_stack.end(), tensor_grads_in.begin(), tensor_grads_in.end());
-  for (auto offset : grad_spec.df_input_captured_inputs)
-    df_stack.push_back(tensors_in[offset]);
-  for (auto offset : grad_spec.df_input_captured_outputs)
-    df_stack.push_back(f_stack[offset]);
-  df_interpreter.run(df_stack);
-
-  // Outputs of f needs to be sliced
-  f_stack.erase(f_stack.begin() + grad_spec.f_real_outputs, f_stack.end());
-  return std::make_pair(as_tensorlist(f_stack), as_tensorlist(df_stack));
-}
+    tensor_list& tensor_grads_in);
 
 std::tuple<Var, Var> build_lstm_body(
     Graph& g,
@@ -72,95 +33,27 @@ std::tuple<Var, Var> build_lstm_body(
     Var hx,
     Var cx,
     Var w_ih,
-    Var w_hh) {
-  auto gates = input.mm(w_ih);
-  gates = gates + hx.mm(w_hh);
-  auto outputs = gates.chunk(4, 1);
-  auto ingate = outputs[0];
-  auto forgetgate = outputs[1];
-  auto cellgate = outputs[2];
-  auto outgate = outputs[3];
-  ingate = ingate.sigmoid();
-  outgate = outgate.sigmoid();
-  cellgate = cellgate.tanh();
-  forgetgate = forgetgate.sigmoid();
+    Var w_hh);
 
-  auto cy = forgetgate * cx;
-  cy = cy + ingate * cellgate;
-  auto hy = outgate * cy.tanh();
+std::shared_ptr<Graph> build_lstm();
 
-  return std::make_tuple(hy, cy);
-}
-
-std::shared_ptr<Graph> build_lstm() {
-  auto r = std::make_shared<Graph>();
-  auto& g = *r;
-  Value* input = g.addInput();
-  Value* hx = g.addInput();
-  Value* cx = g.addInput();
-  Value* w_ih = g.addInput();
-  Value* w_hh = g.addInput();
-
-  Var hy;
-  Var cy;
-  std::tie(hy, cy) = build_lstm_body(g, input, hx, cx, w_ih, w_hh);
-
-  hy.addAsOutput();
-  cy.addAsOutput();
-  g.lint();
-
-  return r;
-}
-
-at::Tensor t_use(at::Tensor x) {
-  return x;
-}
-at::Tensor t_def(at::Tensor x) {
-  return x.t();
-}
+at::Tensor t_use(at::Tensor x);
+at::Tensor t_def(at::Tensor x);
 
 // given the difference of output vs expected tensor, check whether the
 // difference is within a relative tolerance range. This is a standard way of
 // matching tensor values upto certain precision
-bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
-  double maxValue = 0.0;
-  for (auto& tensor : inputs) {
-    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
-  }
-  return diff.abs().max().item<float>() < 2e-6 * maxValue;
-}
-bool almostEqual(const at::Tensor& a, const at::Tensor& b) {
-  return checkRtol(a - b, {a, b});
-}
+bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs);
+bool almostEqual(const at::Tensor& a, const at::Tensor& b);
 
-bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
-  return (a - b).abs().max().item<float>() == 0.f;
-}
+bool exactlyEqual(const at::Tensor& a, const at::Tensor& b);
 
 std::pair<at::Tensor, at::Tensor> lstm(
     at::Tensor input,
     at::Tensor hx,
     at::Tensor cx,
     at::Tensor w_ih,
-    at::Tensor w_hh) {
-  auto gates = input.mm(t_use(w_ih)) + hx.mm(t_use(w_hh));
-
-  auto chunked_gates = gates.chunk(4, 1);
-  auto ingate = chunked_gates[0];
-  auto forgetgate = chunked_gates[1];
-  auto cellgate = chunked_gates[2];
-  auto outgate = chunked_gates[3];
-
-  ingate = ingate.sigmoid();
-  outgate = outgate.sigmoid();
-  cellgate = cellgate.tanh();
-  forgetgate = forgetgate.sigmoid();
-
-  auto cy = (forgetgate * cx) + (ingate * cellgate);
-  auto hy = outgate * cy.tanh();
-
-  return {hy, cy};
-}
+    at::Tensor w_hh);
 
 } // namespace test
 } // namespace jit

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -124,6 +124,7 @@ libtorch_sources = [
     "torch/csrc/jit/fuser/cpu/dynamic_library_unix.cpp",
     "torch/csrc/jit/fuser/interface.cpp",
     "test/cpp/jit/test.cpp",
+    "test/cpp/jit/test_utils.cpp",
 ]
 
 libtorch_cuda_sources = [

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -200,6 +200,7 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/fuser/codegen.cpp
   ${TORCH_SRC_DIR}/csrc/jit/fuser/fallback.cpp
   ${TORCH_ROOT}/test/cpp/jit/test.cpp
+  ${TORCH_ROOT}/test/cpp/jit/test_utils.cpp
   )
 
 if (WIN32)
@@ -332,6 +333,9 @@ if(OPENMP_FOUND)
   target_compile_options(torch INTERFACE ${OpenMP_CXX_FLAGS})
   target_link_libraries(torch ${OpenMP_CXX_LIBRARIES})
 endif()
+
+# For test_utils.cpp
+target_include_directories(torch PRIVATE ${TORCH_SRC_DIR}/../test/cpp/jit)
 
 if (NOT NO_API)
   target_include_directories(torch PUBLIC

--- a/torch/csrc/jit/testing/file_check.h
+++ b/torch/csrc/jit/testing/file_check.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#include <torch/csrc/jit/testing/file_check.h>
+#include <string>
+#include <memory>
 
 namespace torch {
 namespace jit {


### PR DESCRIPTION
Summary: There are functions defined in "caffe2/test/cpp/jit/test_utils.h" for which Buck complains about duplication.  This splits those function definitions into a separate .cpp file.

Differential Revision: D15037723

