### PR TITLE
Avoid (future) cusparse name collision

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -10,7 +10,7 @@
 namespace at { namespace native { namespace sparse { namespace cuda {
 
 
-std::string cusparseGetErrorString(cusparseStatus_t status) {
+std::string getCusparseErrorString(cusparseStatus_t status) {
   switch(status)
   {
     case CUSPARSE_STATUS_SUCCESS:
@@ -55,7 +55,7 @@ std::string cusparseGetErrorString(cusparseStatus_t status) {
 inline void CUSPARSE_CHECK(cusparseStatus_t status)
 {
   if (status != CUSPARSE_STATUS_SUCCESS) {
-    AT_ERROR("cusparse runtime error: ", cusparseGetErrorString(status));
+    AT_ERROR("cusparse runtime error: ", getCusparseErrorString(status));
   }
 }
 


### PR DESCRIPTION
A future version of cusparse will define "cusparseGetErrorString." This PR simply updates PyTorch's name for this function to "getCusparseErrorString" to avoid the collision.  