### PR TITLE
Remove useless input shape checker in conv

### DIFF
--- a/caffe2/ideep/operators/conv_op.cc
+++ b/caffe2/ideep/operators/conv_op.cc
@@ -61,8 +61,7 @@ class IDEEPConvOp : public IDEEPConvPoolOpBase {
     }
 
     bool weights_changed = (cached_weights_descriptor_ != filter.get_descriptor());
-    if (!training_mode_ &&
-        (weights_changed || (input_changed && algo_ == ialgo::convolution_winograd))) {
+    if (!training_mode_ && weights_changed) {
       op_key_.clear();
       cached_weights_descriptor_ = filter.dup_descriptor();
       auto filter_in = filter.as_weights();

--- a/caffe2/ideep/operators/quantization/int8_conv_op.cc
+++ b/caffe2/ideep/operators/quantization/int8_conv_op.cc
@@ -54,7 +54,7 @@ class IDEEPInt8ConvOp : public IDEEPConvPoolOpBase {
     }
 
     bool weights_changed = (cached_weights_descriptor_ != filter.get_descriptor());
-    if (weights_changed || (input_changed && algo_ == ialgo::convolution_winograd)) {
+    if (weights_changed) {
       op_key_.clear();
       cached_weights_descriptor_ = filter.dup_descriptor();
       CAFFE_ENFORCE(filter.get_data_type() == idtype::s8 && filter.has_scale());


### PR DESCRIPTION
The input shape checkers in conv/int8_conv operator is aims to avoid the issue when running with mkldnn winograd, the weigths has to be reordered each time if input shape changed.
However, the checkers result to big performance regression due to frequent reorder. 

Meanwhile, in mkldnn-bridge, such case has been already fixed by correcting the prop_kind.
Therefore, we have to remove the useless checker to fix the performance regression.

