### PR TITLE
Fix compilation on Windows 10 (CUDA 10.0, Visual Studio 2017)

### DIFF
--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -62,7 +62,7 @@ struct Tree : std::enable_shared_from_this<Tree> {
   }
   template <typename... Args>
   void matchD(int k, const char* filename, int lineno, Args&... args) {
-    std::initializer_list<TreeRef*> vars = {&args...};
+    std::initializer_list<TreeRef*> vars = {args...};
     matchNumSubtreesD(k, filename, lineno, vars.size(), true);
     size_t i = 0;
     for (TreeRef* v : vars) {


### PR DESCRIPTION
I want to use libtorch in a C++/CUDA project but as soon as I  include `<torch/torch.h>`, ".cu" files fail to compile:

`torch/csrc/jit/script/tree.h(64): error C3520: 'args': parameter pack must be expanded in this context`

This PR makes it build on my machine (don't know if it breaks anything though).