### PR TITLE
[jit] Serialize attribute module as torch.jit._pickle

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -28,7 +28,7 @@ const std::string& getClassName(PicklerClass cls) {
 }
 
 const std::string& getModuleName() {
-  static const std::string module_name("__main__\n");
+  static const std::string module_name("torch.jit._pickle\n");
   return module_name;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19617 [jit] Serialize attribute module as torch.jit._pickle**

