### PR TITLE
correct comments in group_norm_op

### DIFF
--- a/caffe2/operators/group_norm_op.cc
+++ b/caffe2/operators/group_norm_op.cc
@@ -15,12 +15,12 @@ namespace caffe2 {
 // Math:
 // Y = gamma * (X - mu) * rsig + beta
 // let s = gamma * rsig
-// let b = beta - mu * rsig
+// let b = beta - gamma * mu * rsig
 // Y = s * X + b
 // let n = K * HxW
 // dL/dX = dL/dY * dY/dX = dL/dY * (d(s * X)/dX + db/dX)
 // d(s * X)/dX = s + X * ds/dX = s + gamma * X * drsig/dX
-// db/dX = -u * drsig/dX - rsig * dmu/dX
+// db/dX = -gamma * u * drsig/dX - gamma * rsig * dmu/dX
 // drsig/dX = -rsig^3 * (X - mu) / n
 // dmu/dX = 1 / n
 

--- a/caffe2/operators/group_norm_op.cu
+++ b/caffe2/operators/group_norm_op.cu
@@ -139,12 +139,12 @@ __global__ void ComputeInternalGradientsNCHWCUDAKernel(
 // Math:
 // Y = gamma * (X - mu) * rsig + beta
 // let s = gamma * rsig
-// let b = beta - mu * rsig
+// let b = beta - gamma * mu * rsig
 // Y = s * X + b
 // let n = K * HxW
 // dL/dX = dL/dY * dY/dX = dL/dY * (d(s * X)/dX + db/dX)
 // d(s * X)/dX = s + X * ds/dX = s + gamma * X * drsig/dX
-// db/dX = -u * drsig/dX - rsig * dmu/dX
+// db/dX = -gamma * u * drsig/dX - gamma * rsig * dmu/dX
 // drsig/dX = -rsig^3 * (X - mu) / n
 // dmu/dX = 1 / n
 template <typename T>


### PR DESCRIPTION
Summary: Part of comments for group_norm_op is not accurate (i.e., the math part), this diff will fix it.

Differential Revision: D15048695

