### PR TITLE
Added a static assert for the size of bool

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1583,4 +1583,5 @@ static_assert(sizeof(void*) != sizeof(int64_t) || // if 64-bit...
               "You changed the size of TensorImpl on 64-bit arch."
               "See Note [TensorImpl size constraints] on how to proceed.");
 
+static_assert(sizeof(bool) == 1, "Bool is not 8-bit");
 } // namespace c10


### PR DESCRIPTION
Verifying that bool is 1 byte on every platform that we support.