### PR TITLE
disable flake8 E302 (two blank lines)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@ max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
-    E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,
+    E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,E302,
     # these ignores are from flake8-bugbear; please fix!
     B007,B008,
     # these ignores are from flake8-comprehensions; please fix!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19634 disable flake8 E302 (two blank lines)**

Is this the lowest-value lint error of all time? Quite possibly.

Differential Revision: [D15053466](https://our.internmc.facebook.com/intern/diff/D15053466)