### PR TITLE
Use QTensor with quantized FC operator (#19541)

### DIFF
--- a/aten/src/ATen/fbgemm_utils.h
+++ b/aten/src/ATen/fbgemm_utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef USE_FBGEMM
+#include "fbgemm/Fbgemm.h"
+#include "fbgemm/QuantUtils.h"
+
+// The struct for the packed weight matrix (PackBMatrix) and the corresponding
+// column offsets used for the fully connect layer, which are both prepared in
+// the prepacking step to save the computations in the inference. Note the
+// column offsets include the sum of the B columns as well as the scalar term
+// B_zero_point * K, whereas the row offsets created by
+// PackAWithQuantRowOffset/PackAWithIm2Col/PackAWithRowOffset are only the sum
+// of the A rows. The column offsets are needed for the asymmetric quantization
+// (affine quantization) of input matrix.
+// Note that in JIT mode we can think of a way to fuse col_offsets with bias.
+struct FBGEMM_API PackedFCWeight {
+  std::unique_ptr<fbgemm::PackBMatrix<int8_t>> w;
+  std::vector<int32_t> col_offsets;
+};
+
+#endif // USE_FBGEMM

--- a/aten/src/ATen/native/quantized/cpu/qfc.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qfc.cpp
@@ -1,0 +1,161 @@
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cpp_custom_type_hack.h>
+#include <ATen/fbgemm_utils.h>
+
+#include <algorithm>
+#include <tuple>
+
+namespace at {
+namespace native {
+namespace {
+
+class QFCInt8 final : public c10::OperatorKernel {
+ public:
+#ifdef USE_FBGEMM
+  std::tuple<at::Tensor, double, int64_t> operator()(
+      at::Tensor input,
+      double input_scale,
+      int64_t input_zero_point,
+      at::Tensor packed_weight,
+      double weight_scale,
+      int64_t weight_zero_point,
+      at::Tensor bias,
+      double output_scale,
+      int64_t output_zero_point) {
+    // uint8 * int8 -> uint8 (no quantization/dequantization)
+
+    // We make a strong guarantee that models using these operators will have
+    // the same numerics across different machines. Therefore, we do not provide
+    // a fallback path and rather fail loudly if we cannot run FBGEMM.
+    AT_ASSERTM(
+        fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
+
+    // TODO: contiguous is called for further jit optimizations.
+    auto input_contig = input.contiguous();
+    const auto* input_ptr = input_contig.data<uint8_t>();
+
+    AT_ASSERT(input.dim() >= 2);
+    // M refers to M in the standard GEMM notation for C(output) = A(input) x
+    // B(weight), where C, A, B are MxN, MxK, KxN matrices, respectively.
+    // M is not the number of output channels for some operators implemented in
+    // popular deep learning frameworks.
+    int64_t M = 1;
+    for (size_t i = 0; i < input.dim() - 1; ++i) {
+      M *= input.size(i);
+    }
+
+    // Pull out the PackBMatrix and col_offsets instance from the owning tensor.
+    auto& pack_ptr = cpp_custom_type_hack::cast<PackedFCWeight>(packed_weight);
+    auto packB = pack_ptr.w.get();
+    // packB->printPackedMatrix("packedB inside qfc: ");
+    auto& col_offsets = pack_ptr.col_offsets;
+
+    int64_t N = static_cast<int64_t>(packB->numCols());
+    int64_t K = input.size(input.dim() - 1);
+    AT_ASSERT(K == static_cast<int64_t>(packB->numRows()));
+    AT_ASSERT(bias.size(0) == N);
+    AT_ASSERT(bias.dim() == 1);
+
+    float input_scale_float = static_cast<float>(input_scale);
+    int32_t input_zero_point_int32 = static_cast<int32_t>(input_zero_point);
+
+    float weight_scale_float = static_cast<float>(weight_scale);
+    int32_t weight_zero_point_int32 = static_cast<int32_t>(weight_zero_point);
+
+    float output_multiplier_float = (input_scale_float * weight_scale_float) /
+        static_cast<float>(output_scale);
+    int32_t output_zero_point_int32 = static_cast<int32_t>(output_zero_point);
+
+    // This operation does the following:
+    // 1) Creates a "row buffer" vector with offset values that must be added
+    //    to the integer matrix multiplication operation to ensure correctness.
+    //    This "row buffer" is also called the row offset, and it is needed when
+    //    we use affine quantization for weights.
+    // 2) Packs the resulting quantized matrix into vector-register and cache
+    //    friendly tiles.
+    //
+    //  Note this is not executed eagerly, but rather within the fbgemmPacked
+    //  call below.
+    fbgemm::PackAWithRowOffset<uint8_t> packA(
+        /*trans=*/fbgemm::matrix_op_t::NoTranspose,
+        /*nRow=*/M,
+        /*nCol=*/K,
+        /*smat=*/input_ptr,
+        /*ld=*/K,
+        /*pmat=*/nullptr); // Currently, packA manages ownership of `pmat`.
+                           // TODO: Consider a way to pre-allocate and reuse
+                           // pmat buffer.
+
+    // ReQuantizeOutput requires pointers to the zero point values,
+    // since in the case of rowwise quantization these will be arrays rather
+    // than scalars. But in this case, we're doing whole-tensor quantization so
+    // we just pass a pointer to the scale values (and internally
+    // ReQuantizeOutput won't index past 0.
+
+    // This is the end of the pipeline, pass the resulting matrix through.
+    fbgemm::DoNothing<> doNothingObj{};
+
+    // TODO: contiguous is called for further jit optimizations.
+    auto bias_contig = bias.contiguous();
+
+    // After the uint8 * int8 matrix multiplication is performed, this operation
+    // does:
+    //  1) Add in row and column offsets to the rows and columns, respectively.
+    //  2) Add in the bias term.
+    fbgemm::ReQuantizeOutput<false /* FUSE_RELU*/> outputProcObj(
+        /*nextop=*/doNothingObj,
+        /*C_multiplier=*/&output_multiplier_float,
+        /*C_zero_point=*/output_zero_point_int32,
+        /*Aq_zero_point=*/input_zero_point_int32,
+        /*Bq_zero_point=*/&weight_zero_point_int32,
+        /*row_offsets=*/packA.getRowOffsetBuffer(),
+        /*col_offsets=*/col_offsets.data(),
+        /*bias=*/bias_contig.data<int32_t>(),
+        /*nCol=*/N);
+
+    // Allocate output Tensor and a buffer for fbgemmPacked to use
+    auto output = at::zeros({M, N}, input.options().dtype(at::kByte));
+
+    auto buffer = at::zeros_like(output, output.options().dtype(at::kInt));
+
+    // Do the GEMM
+    fbgemm::fbgemmPacked(
+        /*packA=*/packA,
+        /*packB=*/*packB,
+        /*C=*/output.data<uint8_t>(),
+        /*C_buffer=*/buffer.data<int32_t>(),
+        /*ldc=*/N,
+        /*outProcess=*/outputProcObj,
+        /*thread_id=*/0,
+        /*num_threads=*/1);
+
+    return std::make_tuple(output, output_scale, output_zero_point);
+  }
+#else // USE_FBGEMM
+  std::tuple<at::Tensor, double, int64_t> operator()(
+      at::Tensor /* input */,
+      double /* input_scale */,
+      int64_t /* input_zero_point */,
+      at::Tensor /* packed_weight */,
+      double /* weight_scale */,
+      int64_t /* weight_zero_point */,
+      at::Tensor /* bias */,
+      double /* output_scale */,
+      int64_t /* output_zero_point */) {
+    // We make a strong guarantee that models using these operators will have
+    // the same numerics across different machines. Therefore, we do not provide
+    // a fallback path and rather fail loudly if we cannot run FBGEMM.
+    AT_ASSERTM(
+        false, "This PyTorch installation was not built with FBGEMM operators");
+  }
+#endif // USE_FBGEMM
+};
+
+static auto registry = c10::RegisterOperators().op(
+    "quantized::fbgemm_fc(Tensor X, float X_scale, int X_zero_point, Tensor W_prepack, float W_scale, int W_zero_point, Tensor b, float Y_scale_i, int Y_zero_point_i) -> (Tensor Y, float Y_scale_o, int Y_zero_point_o)",
+    c10::kernel<QFCInt8>(),
+    c10::dispatchKey(CPUTensorId()));
+} // namespace
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qfc_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qfc_prepack.cpp
@@ -1,0 +1,95 @@
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/cpp_custom_type_hack.h>
+#include <ATen/fbgemm_utils.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace caffe2 {
+#ifdef USE_FBGEMM
+// Required for cpp_custom_type_hack to work
+CAFFE_KNOWN_TYPE(PackedFCWeight);
+#endif // USE_FBGEMM
+} // namespace caffe2
+
+namespace at {
+namespace native {
+namespace {
+
+class QFCPackWeightInt8 final : public c10::OperatorKernel {
+ public:
+#ifdef USE_FBGEMM
+  // Calculate the column offsets
+  // Note this includes the sum of the columns as well as the scalar term
+  // B_zero_point * K, whereas the row_offsets created by
+  // PackAWithQuantRowOffset is only the sum of the A rows.
+  void calc_col_offsets_transpose(
+      int K,
+      int N,
+      const int8_t* Bint8,
+      int32_t B_zero_point,
+      int32_t* col_offsets) {
+    for (size_t i = 0; i < N; ++i) {
+      int32_t sum = 0;
+      for (size_t j = 0; j < K; ++j) {
+        sum += Bint8[i * K + j];
+      }
+      col_offsets[i] = sum - B_zero_point * K;
+    }
+  }
+
+  at::Tensor operator()(at::Tensor weight, int64_t weight_zero_point) {
+    auto N = weight.size(0);
+    auto K = weight.size(1);
+
+    int32_t weight_zero_point_int32 = static_cast<int32_t>(weight_zero_point);
+
+    // TODO: contiguous is called for further jit optimizations.
+    auto weight_contig = weight.contiguous();
+    auto weight_ptr_int8 = weight_contig.data<int8_t>();
+
+    std::vector<int32_t> col_offsets(N);
+    calc_col_offsets_transpose(
+        /*K=*/K,
+        /*N=*/N,
+        /*Bint8=*/weight_ptr_int8,
+        /*B_zero_point=*/weight_zero_point_int32,
+        /*col_offsets=*/col_offsets.data());
+
+    auto ret_ptr = guts::make_unique<PackedFCWeight>(PackedFCWeight{
+        guts::make_unique<fbgemm::PackBMatrix<int8_t>>(
+            /*trans=*/fbgemm::matrix_op_t::Transpose,
+            /*nRow=*/K,
+            /*nCol=*/N,
+            /*smat=*/weight_ptr_int8,
+            /*ld=*/K,
+            /*pmat=*/nullptr, // PackBMatrix manages ownership of pmat
+            /*groups=*/1),
+        col_offsets});
+
+    // TODO: we will need to replace this with torchscript classes at a later
+    // point.
+    return cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
+  }
+#else // USE_FBGEMM
+  at::Tensor operator()(
+      at::Tensor /* weight */,
+      int64_t /* weight_zero_point */
+  ) {
+    // We make a strong guarantee that models using these operators will have
+    // the same numerics across different machines. Therefore, we do not provide
+    // a fallback path and rather fail loudly if we cannot run FBGEMM.
+    AT_ASSERTM(
+        false, "This PyTorch installation was not built with FBGEMM operators");
+  }
+#endif // USE_FBGEMM
+};
+
+static auto registry = c10::RegisterOperators().op(
+    "quantized::fbgemm_fc_packed(Tensor W, int W_zero_point) -> Tensor W_prepack",
+    c10::kernel<QFCPackWeightInt8>(),
+    c10::dispatchKey(CPUTensorId()));
+} // namespace
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qfc_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qfc_prepack.cpp
@@ -1,7 +1,9 @@
 #include <ATen/ATen.h>
+#include <ATen/core/Type.h>
 #include <ATen/core/op_registration/op_registration.h>
 #include <ATen/cpp_custom_type_hack.h>
 #include <ATen/fbgemm_utils.h>
+#include <ATen/quantized/Quantizer.h>
 
 #include <algorithm>
 #include <vector>
@@ -39,15 +41,15 @@ class QFCPackWeightInt8 final : public c10::OperatorKernel {
     }
   }
 
-  at::Tensor operator()(at::Tensor weight, int64_t weight_zero_point) {
+  at::QTensor operator()(at::QTensor weight) {
     auto N = weight.size(0);
     auto K = weight.size(1);
 
-    int32_t weight_zero_point_int32 = static_cast<int32_t>(weight_zero_point);
+    int32_t weight_zero_point_int32 = weight.q_zero_point().toInt();
 
     // TODO: contiguous is called for further jit optimizations.
     auto weight_contig = weight.contiguous();
-    auto weight_ptr_int8 = weight_contig.data<int8_t>();
+    auto weight_ptr_int8 = reinterpret_cast<int8_t*>(weight.data<c10::qint8>());
 
     std::vector<int32_t> col_offsets(N);
     calc_col_offsets_transpose(
@@ -70,12 +72,14 @@ class QFCPackWeightInt8 final : public c10::OperatorKernel {
 
     // TODO: we will need to replace this with torchscript classes at a later
     // point.
-    return cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
+    return cpp_custom_type_hack::create(
+        std::move(ret_ptr),
+        weight.options(),
+        weight.q_scale(),
+        weight.q_zero_point());
   }
 #else // USE_FBGEMM
-  at::Tensor operator()(
-      at::Tensor /* weight */,
-      int64_t /* weight_zero_point */
+  at::QTensor operator()(at::QTensor /* weight */
   ) {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
@@ -87,9 +91,9 @@ class QFCPackWeightInt8 final : public c10::OperatorKernel {
 };
 
 static auto registry = c10::RegisterOperators().op(
-    "quantized::fbgemm_fc_packed(Tensor W, int W_zero_point) -> Tensor W_prepack",
+    "quantized::fbgemm_fc_packed(Tensor W) -> Tensor W_prepack",
     c10::kernel<QFCPackWeightInt8>(),
-    c10::dispatchKey(CPUTensorId()));
+    c10::dispatchKey(QuantizedCPUTensorId()));
 } // namespace
 } // namespace native
 } // namespace at

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -4,11 +4,72 @@ import torch
 import torch.jit
 import numpy as np
 import unittest
-from common_utils import TestCase, run_tests, skipIfNotRegistered
+from common_utils import TEST_WITH_UBSAN, TestCase, run_tests, skipIfNotRegistered
 
 
 def canonical(graph):
     return str(torch._C._jit_pass_canonicalize(graph))
+
+
+def _quantize(x, scale, zero_point):
+    """Quantizes a numpy array."""
+    qx = np.round(x / scale).astype(np.uint8) + zero_point
+    return qx
+
+
+def _dequantize(qx, scale, zero_point):
+    """Dequantizes a numpy array."""
+    x = (qx - zero_point) * scale
+    return x
+
+
+# Make sure we won't have overflows from vpmaddubsw instruction used in FBGEMM
+def avoid_vpmaddubsw_overflow_fc(
+    batch_size, input_channels, output_channels, X, X_min, X_max, W, W_min, W_max
+):
+    for i, j in np.ndindex((batch_size, output_channels)):
+        for k in range(0, input_channels // 2 * 2, 2):
+            x0 = X[i, k] - X_min
+            x1 = X[i, k + 1] - X_min
+            w0 = W[j, k] - 128 - W_min
+            w1 = W[j, k + 1] - 128 - W_min
+            if x0 * w0 + x1 * w1 < -(1 << 15):
+                w1_adjusted = (-(1 << 15) - float(x0) * w0) / x1
+                W[j, k + 1] = int(w1_adjusted) + 128 + W_min
+            elif x0 * w0 + x1 * w1 > (1 << 15) - 1:
+                w1_adjusted = ((1 << 15) - 1 - float(x0) * w0) / x1
+                W[j, k + 1] = int(w1_adjusted) + 128 + W_min
+
+    # Go through the same loop again to double check we don't have any overflow
+    for i, j in np.ndindex((batch_size, output_channels)):
+        for k in range(0, input_channels // 2 * 2, 2):
+            x0 = X[i, k] - X_min
+            x1 = X[i, k + 1] - X_min
+            w0 = W[j, k] - 128 - W_min
+            w1 = W[j, k + 1] - 128 - W_min
+            assert -(1 << 15) <= x0 * w0 + x1 * w1 < (1 << 15)
+
+
+# Reference quantized FC operator
+def qfc_ref(X_q, X_scale, X_zp, W_q, W_scale, W_zp, b_q, Y_scale, Y_zp):
+    row_offsets_ref = X_q.sum(axis=1).astype(np.int32).reshape((-1, 1))
+    col_offsets_ref = W_q.sum(axis=1).astype(np.int32).reshape((1, -1))
+    assert X_q.ndim == 2
+    batch_size, input_channels = X_q.shape
+
+    Prod_XqWq_ref = (
+        np.matmul(X_q.astype(np.int32), W_q.astype(np.int32).T)
+        - W_zp * row_offsets_ref
+        - X_zp * col_offsets_ref
+        + input_channels * X_zp * W_zp
+    )
+
+    Y_q_ref = (
+        (np.round((Prod_XqWq_ref + b_q) * (X_scale * W_scale / Y_scale)) + Y_zp)
+        .clip(0, 255)
+        .astype(np.uint8)
+    )
+    return Y_q_ref
 
 
 @skipIfNotRegistered("Relu_ENGINE_DNNLOWP",
@@ -17,7 +78,9 @@ class TestQuantized(TestCase):
     def test_relu(self):
         a = (torch.tensor([4, 6, 1, 10], dtype=torch.uint8), 0.01, 5)
         r = torch.ops.c10.quantized_relu(a)
-        np.testing.assert_equal(r[0].numpy(), torch.tensor([5, 6, 5, 10], dtype=torch.uint8).numpy())
+        np.testing.assert_equal(
+            r[0].numpy(), torch.tensor([5, 6, 5, 10], dtype=torch.uint8).numpy()
+        )
         np.testing.assert_almost_equal(0.01, r[1])
         self.assertEqual(5, r[2])
 
@@ -38,15 +101,20 @@ class TestQuantized(TestCase):
         def foo(x):
             # type: (Tuple[Tensor, float, int]) -> Tuple[Tensor, float, int]
             return torch.ops.c10.quantized_relu(x)
-        self.assertExpectedInline(canonical(foo.graph), '''\
+
+        self.assertExpectedInline(
+            canonical(foo.graph),
+            """\
 graph(%x : (Tensor, float, int)):
   %1 : (Tensor, float, int) = c10::quantized_relu(%x)
   return (%1)
-''')
+""",
+        )
 
 
 class TestQuantizedRelu(unittest.TestCase):
     """Tests the correctness of the quantized::relu op."""
+
     def test_qrelu(self):
         relu = torch.ops.quantized.relu
 
@@ -65,5 +133,79 @@ class TestQuantizedRelu(unittest.TestCase):
         np.testing.assert_equal(Y_tensor, Y_hat_tensor)
 
 
-if __name__ == '__main__':
+@unittest.skipIf(
+    TEST_WITH_UBSAN or not torch.fbgemm_is_cpu_supported(),
+    " Quantized FC requires FBGEMM. FBGEMM does not play"
+    " well with UBSAN at the moment, so we skip the test if"
+    " we are in a UBSAN environment.",
+)
+class TestQuantizedFC(unittest.TestCase):
+    """Tests the correctness of the quantized::fc op."""
+
+    def test_qfc(self):
+        qfc_packed = torch.ops.quantized.fbgemm_fc_packed
+        qfc = torch.ops.quantized.fbgemm_fc
+
+        batch_size = 4
+        input_channels = 16
+        output_channels = 8
+
+        X_scale = 1.5
+        X_zp = 5
+        X_value_min = 0
+        X_value_max = 15
+        X_q = np.round(
+            np.random.rand(batch_size, input_channels) * (X_value_max - X_value_min)
+            + X_value_min
+        ).astype(np.uint8)
+
+        W_scale = 0.4
+        W_zp = 2
+        W_value_min = -10
+        W_value_max = 15
+        W_q = np.round(
+            np.random.rand(output_channels, input_channels)
+            * (W_value_max - W_value_min)
+            + W_value_min
+        ).astype(np.int8)
+
+        b_q = np.round(np.random.randn(output_channels) * 10 - 10).astype(np.int32)
+
+        Y_scale = 7.1234
+        Y_zp = 5
+
+        avoid_vpmaddubsw_overflow_fc(
+            batch_size,
+            input_channels,
+            output_channels,
+            X_q,
+            X_value_min,
+            X_value_max,
+            W_q,
+            W_value_min,
+            W_value_max,
+        )
+
+        # Reference quantized FC operator
+        Y_q_ref = qfc_ref(X_q, X_scale, X_zp, W_q, W_scale, W_zp, b_q, Y_scale, Y_zp)
+
+        # Weight prepacking operator for quantized FC
+        W_prepack = qfc_packed(torch.from_numpy(W_q), W_zp)
+        [Y_q, Y_scale, Y_zp] = qfc(
+            torch.from_numpy(X_q),
+            X_scale,
+            X_zp,
+            W_prepack,
+            W_scale,
+            W_zp,
+            torch.from_numpy(b_q),
+            Y_scale,
+            Y_zp,
+        )
+
+        # Assert equal
+        np.testing.assert_equal(Y_q_ref, Y_q.numpy())
+
+
+if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/19541

For the quantized FC operator, replace the tuple (Tensor, scale, zero_point) with QTensor.

Differential Revision: D14900407

