### PR TITLE
[jit] Fix the insert_guard for norm decomposation

### DIFF
--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -292,8 +292,6 @@ struct GraphFuser {
         source,
         method_name);
 
-    AT_ASSERT(isFusableNorm(normalization_op));
-    WithInsertPoint insert_guard{normalization_op};
     Value* new_output =
         SubgraphUtils::inlineGraph(nm_graph, inputs, normalization_op).at(0);
     return new_output;
@@ -327,6 +325,8 @@ struct GraphFuser {
 
             return (input - mean) * invstd
       )SCRIPT";
+    AT_ASSERT(isFusableNorm(normalization_op));
+    WithInsertPoint insert_guard{normalization_op};
     Value* input = normalization_op->namedInput(attr::input);
     if (normalization_op->kind() == aten::batch_norm) {
       Value* input_dim = graph_->insert(aten::dim, {input});


### PR DESCRIPTION
move the insert_guard all the way up to the beginning of the decomposation, this will fix the case that we lose insert_point context after decomposeCommonNormalization and we still need to modify the graph. 

fixes #19502