### PR TITLE
[ONNX] Removing unused arg f from _model_to_graph().

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -39,7 +39,7 @@ class TestUtilityFuns(TestCase):
 
         _set_opset_version(9)
         x = torch.ones(3, 2)
-        graph, _, __ = utils._model_to_graph(TransposeModule(), (x, ), None,
+        graph, _, __ = utils._model_to_graph(TransposeModule(), (x, ),
                                              do_constant_folding=True,
                                              _disable_torch_constant_prop=True)
         for node in graph.nodes():
@@ -57,7 +57,7 @@ class TestUtilityFuns(TestCase):
 
         _set_opset_version(9)
         x = torch.ones(1, 3)
-        graph, _, __ = utils._model_to_graph(SliceModule(), (x, ), None,
+        graph, _, __ = utils._model_to_graph(SliceModule(), (x, ),
                                              do_constant_folding=True,
                                              _disable_torch_constant_prop=True)
         for node in graph.nodes():
@@ -75,7 +75,7 @@ class TestUtilityFuns(TestCase):
 
         _set_opset_version(9)
         x = torch.ones(1, 2, 3)
-        graph, _, __ = utils._model_to_graph(UnsqueezeModule(), (x, ), None,
+        graph, _, __ = utils._model_to_graph(UnsqueezeModule(), (x, ),
                                              do_constant_folding=True,
                                              _disable_torch_constant_prop=True)
         for node in graph.nodes():
@@ -94,7 +94,7 @@ class TestUtilityFuns(TestCase):
 
         _set_opset_version(9)
         x = torch.ones(2, 3)
-        graph, _, __ = utils._model_to_graph(ConcatModule(), (x, ), None,
+        graph, _, __ = utils._model_to_graph(ConcatModule(), (x, ),
                                              do_constant_folding=True,
                                              _disable_torch_constant_prop=True)
         for node in graph.nodes():
@@ -115,7 +115,7 @@ class TestUtilityFuns(TestCase):
         _set_opset_version(9)
         input = torch.randn(5, 3, 7)
         h0 = torch.randn(1, 3, 3)
-        graph, _, __ = utils._model_to_graph(GruNet(), (input, h0), None,
+        graph, _, __ = utils._model_to_graph(GruNet(), (input, h0),
                                              do_constant_folding=True)
         for node in graph.nodes():
             assert node.kind() != "onnx::Slice"
@@ -134,7 +134,7 @@ class TestUtilityFuns(TestCase):
 
         _set_opset_version(9)
         A = torch.randn(2, 3)
-        graph, _, __ = utils._model_to_graph(MatMulNet(), (A), None,
+        graph, _, __ = utils._model_to_graph(MatMulNet(), (A),
                                              do_constant_folding=True)
         for node in graph.nodes():
             assert node.kind() != "onnx::Transpose"

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -231,7 +231,7 @@ def _trace_and_get_graph_from_model(model, args, training):
     return trace.graph(), torch_out
 
 
-def _model_to_graph(model, args, f, verbose=False, training=False,
+def _model_to_graph(model, args, verbose=False, training=False,
                     input_names=None, output_names=None,
                     operator_export_type=OperatorExportTypes.ONNX,
                     example_outputs=None, propagate=False,
@@ -325,7 +325,7 @@ def _export_to_pretty_string(model, args, f, export_params=True, verbose=False, 
     if opset_version is None:
         opset_version = _default_onnx_opset_version
     _set_opset_version(opset_version)
-    graph, params_dict, torch_out = _model_to_graph(model, args, f, verbose,
+    graph, params_dict, torch_out = _model_to_graph(model, args, verbose,
                                                     training, input_names,
                                                     output_names, operator_export_type,
                                                     example_outputs, propagate, _retain_param_name,
@@ -351,7 +351,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
         if opset_version is None:
             opset_version = _default_onnx_opset_version
         _set_opset_version(opset_version)
-        graph, params_dict, torch_out = _model_to_graph(model, args, f, verbose,
+        graph, params_dict, torch_out = _model_to_graph(model, args, verbose,
                                                         training, input_names,
                                                         output_names, operator_export_type,
                                                         example_outputs, propagate,


### PR DESCRIPTION
Input argument `f` in `_model_to_graph()` method in `torch/onnx/utils.py` is unused. This PR removes it. If there's a reason to keep it around, please let me know. 