### PR TITLE
Move test.cpp to python extension

### DIFF
--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -123,7 +123,6 @@ libtorch_sources = [
     "torch/csrc/jit/fuser/cpu/fused_kernel.cpp",
     "torch/csrc/jit/fuser/cpu/dynamic_library_unix.cpp",
     "torch/csrc/jit/fuser/interface.cpp",
-    "test/cpp/jit/test.cpp",
 ]
 
 libtorch_cuda_sources = [
@@ -240,6 +239,10 @@ def add_torch_libs():
         "torch/csrc/utils/tensor_numpy.cpp",
         "torch/csrc/utils/tensor_types.cpp",
         "torch/csrc/utils/tuple_parser.cpp",
+        # test.cpp included here to enable running cpp tests from python runner.
+        # Ideally we'd create a separate python extension for it, but it's too
+        # much hassle
+        "test/cpp/jit/test.cpp",
     ]
 
     common_flags = {

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -199,7 +199,6 @@ set(TORCH_SRCS
   ${TORCH_SRC_DIR}/csrc/jit/fuser/executor.cpp
   ${TORCH_SRC_DIR}/csrc/jit/fuser/codegen.cpp
   ${TORCH_SRC_DIR}/csrc/jit/fuser/fallback.cpp
-  ${TORCH_ROOT}/test/cpp/jit/test.cpp
   )
 
 if (WIN32)
@@ -550,6 +549,10 @@ if (BUILD_PYTHON)
     ${TORCH_SRC_DIR}/csrc/utils/tensor_numpy.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tensor_types.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tuple_parser.cpp
+    # test.cpp included here to enable running cpp tests from python runner.
+    # Ideally we'd create a separate python extension for it, but it's too much
+    # hassle
+    ${TORCH_ROOT}/test/cpp/jit/test.cpp
     )
 
   set(TORCH_PYTHON_INCLUDE_DIRECTORIES


### PR DESCRIPTION
Let's see whether it fixes build failures with duplicated symbols