### PR TITLE
[C++ API] Support serializing std::vector<torch::Tensor>

### DIFF
--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -304,3 +304,23 @@ TEST(
   const int output = in->named_buffers()["a.c.foo"].sum().item<int>();
   ASSERT_EQ(output, 5);
 }
+
+TEST(SerializeTest, VectorOfTensors) {
+  torch::manual_seed(0);
+
+  std::vector<torch::Tensor> x_vec = { torch::randn({1, 2}), torch::randn({3, 4}) };
+
+  std::stringstream stream;
+  torch::save(x_vec, stream);
+
+  std::vector<torch::Tensor> y_vec;
+  torch::load(y_vec, stream);
+
+  for (int64_t i = 0; i < x_vec.size(); i++) {
+    auto& x = x_vec[i];
+    auto& y = y_vec[i];
+    ASSERT_TRUE(y.defined());
+    ASSERT_EQ(x.sizes().vec(), y.sizes().vec());
+    ASSERT_TRUE(x.allclose(y));
+  }
+}

--- a/torch/csrc/api/include/torch/serialize.h
+++ b/torch/csrc/api/include/torch/serialize.h
@@ -122,13 +122,13 @@ void load(std::vector<torch::Tensor>& tensor_vec, LoadFromArgs&&... args) {
 
   // NOTE: The number of elements in the serialized `std::vector<torch::Tensor>`
   // is not known ahead of time, so we need a while-loop to increment the index,
-  // and use `archive.has_key(...)` to check whether we have reached the end of
+  // and use `archive.try_read(...)` to check whether we have reached the end of
   // the serialized `std::vector<torch::Tensor>`.
   size_t index = 0;
-  while (archive.has_key(std::to_string(index))) {
-    torch::Tensor value;
-    archive.read(std::to_string(index), value);
-    tensor_vec.push_back(value);
+  torch::Tensor value;
+  while (archive.try_read(std::to_string(index), value)) {
+    tensor_vec.push_back(std::move(value));
+    value = torch::Tensor();
     index++;
   }
 }

--- a/torch/csrc/api/include/torch/serialize.h
+++ b/torch/csrc/api/include/torch/serialize.h
@@ -28,6 +28,8 @@ namespace torch {
 ///
 ///   torch::optim::SGD sgd(/*lr=*/0.9);
 ///   std::ostringstream stream;
+///   // Note that the same stream cannot be used in multiple torch::save(...)
+///   // invocations, otherwise the header will be corrupted.
 ///   torch::save(sgd, stream);
 ///
 ///   auto tensor = torch::ones({3, 4});
@@ -54,6 +56,8 @@ void save(const Value& value, SaveToArgs&&... args) {
 ///
 ///   std::vector<torch::Tensor> tensor_vec = { torch::randn({5, 6}), torch::randn({7, 8}) };
 ///   std::ostringstream stream;
+///   // Note that the same stream cannot be used in multiple torch::save(...)
+///   // invocations, otherwise the header will be corrupted.
 ///   torch::save(tensor_vec, stream);
 /// \endrst
 template <typename... SaveToArgs>

--- a/torch/csrc/api/include/torch/serialize/input-archive.h
+++ b/torch/csrc/api/include/torch/serialize/input-archive.h
@@ -44,8 +44,11 @@ class TORCH_API InputArchive final {
 
   ~InputArchive() = default;
 
-  /// Checks whether the `InputArchive` contains a given `key`.
-  bool has_key(const std::string& key);
+  /// Reads a `tensor` associated with a given `key`. If the `InputArchive` doesn't
+  /// contain `key`, this function returns false, otherwise it returns true.
+  /// If the tensor is expected to be a buffer (not differentiable), `is_buffer`
+  /// must be `true`.
+  bool try_read(const std::string& key, Tensor& tensor, bool is_buffer = false);
 
   /// Reads a `tensor` associated with a given `key`.
   /// If the tensor is expected to be a buffer (not differentiable), `is_buffer`

--- a/torch/csrc/api/include/torch/serialize/input-archive.h
+++ b/torch/csrc/api/include/torch/serialize/input-archive.h
@@ -44,6 +44,9 @@ class TORCH_API InputArchive final {
 
   ~InputArchive() = default;
 
+  /// Checks whether the `InputArchive` contains a given `key`.
+  bool has_key(const std::string& key);
+
   /// Reads a `tensor` associated with a given `key`.
   /// If the tensor is expected to be a buffer (not differentiable), `is_buffer`
   /// must be `true`.

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -19,23 +19,14 @@ namespace serialize {
 InputArchive::InputArchive()
     : module_(std::make_shared<jit::script::Module>()) {}
 
-bool InputArchive::has_key(const std::string& key) {
-  auto param = module_->find_parameter(key);
-  auto buffer = module_->find_buffer(key);
-  return param != nullptr || buffer != nullptr;
-}
-
-void InputArchive::read(
+bool InputArchive::try_read(
     const std::string& key,
     Tensor& tensor,
     bool is_buffer) {
   auto param = module_->find_parameter(key);
   auto buffer = module_->find_buffer(key);
-  AT_CHECK(
-      param != nullptr || buffer != nullptr,
-      "No such serialized tensor '",
-      key,
-      "'");
+  if (param == nullptr && buffer == nullptr) return false;
+
   // clang-format off
   auto read_param = is_buffer ? buffer : param;
   auto read_tensor = read_param->value().toTensor();
@@ -54,6 +45,18 @@ void InputArchive::read(
   } else {
     tensor = std::move(read_tensor);
   }
+  return true;
+}
+
+void InputArchive::read(
+    const std::string& key,
+    Tensor& tensor,
+    bool is_buffer) {
+  AT_CHECK(
+    try_read(key, tensor, is_buffer),
+    "No such serialized tensor '",
+    key,
+    "'");
 }
 
 void InputArchive::read(const std::string& key, InputArchive& archive) {

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -19,6 +19,12 @@ namespace serialize {
 InputArchive::InputArchive()
     : module_(std::make_shared<jit::script::Module>()) {}
 
+bool InputArchive::has_key(const std::string& key) {
+  auto param = module_->find_parameter(key);
+  auto buffer = module_->find_buffer(key);
+  return param != nullptr || buffer != nullptr;
+}
+
 void InputArchive::read(
     const std::string& key,
     Tensor& tensor,


### PR DESCRIPTION
In the distributed training development work, we need to be able to serialize a `std::vector` of `torch::Tensor`s. This PR adds support for serializing `std::vector<torch::Tensor>`.

cc. @mrshenli 