### PR TITLE
[jit] Remove try/catch in constant propagation

### DIFF
--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -8,9 +8,12 @@ namespace torch {
 namespace jit {
 
 bool canInsertConstant(const IValue& val) {
-  return val.isTensor() || val.isInt() || val.isDouble() || val.isBool() ||
+  bool can_insert = val.isInt() || val.isDouble() || val.isBool() ||
       val.isBoolList() || val.isIntList() || val.isTensorList() ||
       val.isString() || val.isDevice() || val.isNone();
+  can_insert =
+      can_insert || (val.isTensor() && !val.toTensor().requires_grad());
+  return can_insert;
 }
 
 // IValue -> Constant node

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -7,6 +7,12 @@
 namespace torch {
 namespace jit {
 
+bool canInsertConstant(const IValue& val) {
+  return val.isTensor() || val.isInt() || val.isDouble() || val.isBool() ||
+      val.isBoolList() || val.isIntList() || val.isTensorList() ||
+      val.isString() || val.isDevice() || val.isNone();
+}
+
 // IValue -> Constant node
 Value* insertConstant(
     Graph& g,

--- a/torch/csrc/jit/constants.h
+++ b/torch/csrc/jit/constants.h
@@ -32,6 +32,11 @@ TORCH_API Value* insertConstant(
     c10::optional<SourceRange> loc = c10::nullopt,
     c10::optional<ScopePtr> scope = c10::nullopt);
 
+
+// Test if this IValue can be inserted into a graph as a constant
+TORCH_API bool canInsertConstant(const IValue& val);
+
+
 //////////////////////////////////////////////////////////////////////////////////
 // Helper for retrieving constants
 //////////////////////////////////////////////////////////////////////////////////

--- a/torch/csrc/jit/constants.h
+++ b/torch/csrc/jit/constants.h
@@ -21,10 +21,7 @@ struct TORCH_API constant_not_supported_error : public std::runtime_error {
   using runtime_error::runtime_error;
 };
 
-// note: prefer g.insertConsant(val, loc) which does exactly the same thing
-// this function is only declared/defined here because its implementation is
-// closely related to the implementation of prim::Constant that is also in
-// constants.cpp
+
 TORCH_API Value* insertConstant(
     Graph& g,
     const IValue& val,
@@ -32,14 +29,23 @@ TORCH_API Value* insertConstant(
     c10::optional<SourceRange> loc = c10::nullopt,
     c10::optional<ScopePtr> scope = c10::nullopt);
 
+// note: prefer g.insertConsant(val, loc) which does exactly the same thing
+// this function is only declared/defined here because its implementation is
+// closely related to the implementation of prim::Constant that is also in
+// constants.cpp.
+//
+// returns a c10::nullopt if the IValue kind cannot be inserted as a constant
+TORCH_API c10::optional<Value*> tryInsertConstant(
+    Graph& g,
+    const IValue& val,
+    const c10::TypePtr& result_type = nullptr,
+    c10::optional<SourceRange> loc = c10::nullopt,
+    c10::optional<ScopePtr> scope = c10::nullopt);
 
-// Test if this IValue can be inserted into a graph as a constant
-TORCH_API bool canInsertConstant(const IValue& val);
 
-
-//////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 // Helper for retrieving constants
-//////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 // attempt to convert a (possibly constant) Value* into an intepreter value
 // (IValue). returns c10::nullopt if the Value* was not constant

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -63,17 +63,16 @@ void propagateNode(Node* n) {
   auto graph = n->owningGraph();
   WithInsertPoint guard(n);
   for (size_t i = 0; i < outputs.size(); ++i) {
-    try {
+    if (canInsertConstant(outputs[i])) {
       auto new_output = graph->insertConstant(outputs[i]);
       if (outputs[i].isNone()) {
         new_output->setType(n->outputs()[i]->type());
       }
       n->outputs()[i]->replaceAllUsesWith(new_output);
-    } catch (constant_not_supported_error& err) {
-      // we cannot actually represent the IValue as a constant node,
-      // so we give up replacing it
+    } else {
+      // If we cannot insert the IValue as a
+      // constant, give up replacing it and let DCE remove it.
     }
-    // let dce elimination remove n
   }
 }
 

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -69,10 +69,9 @@ void propagateNode(Node* n) {
         new_output->setType(n->outputs()[i]->type());
       }
       n->outputs()[i]->replaceAllUsesWith(new_output);
-    } else {
-      // If we cannot insert the IValue as a
-      // constant, give up replacing it and let DCE remove it.
     }
+    // If we cannot insert the IValue as a constant, give up replacing the node
+    // and let DCE remove it
   }
 }
 

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -38,6 +38,7 @@ std::vector<IValue> runNode(Node* n) {
       auto t = std::move(v).toTensor();
       if (t.defined()) {
         if (t.requires_grad()) {
+          // error gets caught within propagateNode()
           throw c10::Error("Can't insert requires grad as constant", "");
         }
         return IValue(autograd::as_variable_ref(t).data());
@@ -66,7 +67,6 @@ void propagateNode(Node* n) {
 
     auto new_output = tryInsertConstant(*graph, outputs[i]);
     if (new_output) {
-      // auto new_output = tryInsertConstant(graph, outputs[i]);
       if (outputs[i].isNone()) {
         (*new_output)->setType(n->outputs()[i]->type());
       }

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -63,12 +63,14 @@ void propagateNode(Node* n) {
   auto graph = n->owningGraph();
   WithInsertPoint guard(n);
   for (size_t i = 0; i < outputs.size(); ++i) {
-    if (canInsertConstant(outputs[i])) {
-      auto new_output = graph->insertConstant(outputs[i]);
+
+    auto new_output = tryInsertConstant(*graph, outputs[i]);
+    if (new_output) {
+      // auto new_output = tryInsertConstant(graph, outputs[i]);
       if (outputs[i].isNone()) {
-        new_output->setType(n->outputs()[i]->type());
+        (*new_output)->setType(n->outputs()[i]->type());
       }
-      n->outputs()[i]->replaceAllUsesWith(new_output);
+      n->outputs()[i]->replaceAllUsesWith(*new_output);
     }
     // If we cannot insert the IValue as a constant, give up replacing the node
     // and let DCE remove it


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19686 [jit] Remove try/catch in constant propagation**

The try-catch here gets tripped pretty often when constant prop is run which screws up `catch throw` in gdb. 
Differential Revision: [D15170134](https://our.internmc.facebook.com/intern/diff/15170134/)