### PR TITLE
use relative path to load libthnvrtc

### DIFF
--- a/torch/csrc/jit/fuser/cpu/dynamic_library.h
+++ b/torch/csrc/jit/fuser/cpu/dynamic_library.h
@@ -17,8 +17,6 @@ struct DynamicLibrary {
 
   ~DynamicLibrary();
 
-  static std::string directoryOf(void* addr);
-
  private:
   void* handle = nullptr;
 };

--- a/torch/csrc/jit/fuser/cpu/dynamic_library_unix.cpp
+++ b/torch/csrc/jit/fuser/cpu/dynamic_library_unix.cpp
@@ -33,17 +33,6 @@ DynamicLibrary::~DynamicLibrary() {
   dlclose(handle);
 }
 
-std::string DynamicLibrary::directoryOf(void* addr) {
-  Dl_info info = {};
-  if (!dladdr(addr, &info)) {
-    AT_ERROR("could not look up address: ", addr);
-  }
-  std::string name = info.dli_fname;
-  std::vector<char> path(name.begin(), name.end());
-  char* directory = dirname(path.data());
-  return directory;
-}
-
 } // namespace cpu
 } // namespace fuser
 } // namespace jit

--- a/torch/csrc/jit/fuser/cpu/dynamic_library_win.cpp
+++ b/torch/csrc/jit/fuser/cpu/dynamic_library_win.cpp
@@ -16,10 +16,6 @@ void* DynamicLibrary::sym(const char* name) {
   AT_ERROR("NYI: DynamicLibrary on Windows");
 }
 
-std::string DynamicLibrary::directoryOf(void* addr) {
-  AT_ERROR("NYI: DynamicLibrary on Windows");
-}
-
 DynamicLibrary::~DynamicLibrary() {}
 
 } // namespace cpu

--- a/torch/csrc/jit/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/fuser/cuda/fused_kernel.cpp
@@ -57,11 +57,10 @@ std::pair<std::unique_ptr<cpu::DynamicLibrary>, THNVRTC*> loadNVRTC() {
 }
 #else
 std::pair<std::unique_ptr<cpu::DynamicLibrary>, THNVRTC*> loadNVRTC() {
-  std::string path = cpu::DynamicLibrary::directoryOf((void*)checkCUDAVersion);
 #ifdef __APPLE__
-  std::string libthnvrtc = path + "/libthnvrtc.dylib";
+  std::string libthnvrtc = "libthnvrtc.dylib";
 #else
-  std::string libthnvrtc = path + "/libthnvrtc.so";
+  std::string libthnvrtc = "libthnvrtc.so";
 #endif
   std::unique_ptr<cpu::DynamicLibrary> libnvrtc_stub(
       new cpu::DynamicLibrary(libthnvrtc.c_str()));


### PR DESCRIPTION
We had a few hard to repro cases where very occasionally libthnvrtc failed to be loaded due to what looked like garbled dladdr return in `info.dli_fname` field. We could not root cause why this is happening, but this workaround avoids the problem altogether. $ORIGIN is already added to RPATH as the first search location, so dlopen("libthnnvrtc.so") will look for libthnvrtc in the caller (`libtorch.so.1`) directory, which was the purpose of the previous code that was getting `libtorch.so.1` directory using dladdr. 
```
root@4ec0aab027a0:/opt/conda/lib/python3.6/site-packages/torch/lib# readelf -d ./libtorch.so.1 | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN:/usr/local/cuda/lib64:/opt/conda/lib]
```
Hopefully, same should be happening on Mac. 
cc @zdevito @ezyang 
