### PR TITLE
Fix the depthwise 3x3x3 fast path criteria for the stride

### DIFF
--- a/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
@@ -167,7 +167,9 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         check_quantized_results_close(outputs, symmetric=preserve_activation_sparsity)
 
     @given(
-        stride=st.integers(1, 2),
+        stride_0=st.integers(1, 2),
+        stride_1=st.integers(1, 2),
+        stride_2=st.integers(1, 2),
         size=st.integers(5, 12),
         # depthwise 3x3x3 fast path only works for a multiple of 8
         group=st.sampled_from([8, 24, 32]),
@@ -182,7 +184,9 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
     )
     def test_dnnlowp_depthwise_3x3x3_conv(
         self,
-        stride,
+        stride_0,
+        stride_1,
+        stride_2,
         size,
         group,
         batch_size,
@@ -203,7 +207,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         order = "NHWC"
 
         X, W, b = generate_convnd_inputs(
-            (stride,) * 3,
+            (stride_0, stride_1, stride_2),
             (pad,) * 3,
             (kernel,) * 3,
             (dilation,) * 3,
@@ -266,7 +270,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                 op_type,
                 ["X_q" if do_quantize else "X", "W", "b"],
                 ["Y_q" if do_dequantize else "Y"],
-                strides=[stride] * 3,
+                strides=[stride_0, stride_1, stride_2],
                 kernels=[kernel] * 3,
                 dilations=[dilation] * 3,
                 pads=[pad] * (3 * 2),

--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -97,9 +97,9 @@ bool ConvDNNLowPOp<T, ReluFused>::TakeDepthWise3x3x3FastPath_() {
       !Acc16() && group_ == X.dim32(X.dim() - 1) && group_ % 8 == 0 &&
       this->kernel_.size() == 3 && this->kernel_[0] == 3 &&
       this->kernel_[1] == 3 && this->kernel_[2] == 3 &&
-      this->stride_[0] == this->stride_[1] &&
-      this->stride_[0] == this->stride_[2] &&
       (this->stride_[0] == 1 || this->stride_[0] == 2) &&
+      (this->stride_[1] == 1 || this->stride_[1] == 2) &&
+      (this->stride_[2] == 1 || this->stride_[2] == 2) &&
       this->dilation_[0] == 1 && this->dilation_[1] == 1 &&
       this->dilation_[2] == 1 &&
       accumulate(

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -357,9 +357,9 @@ bool ConvDNNLowPPackWeightOp::TakeDepthWise3x3x3FastPath_() {
   bool ret = this->debug_def().engine() != "DNNLOWP_ACC16" && group_ == M &&
       C_per_group == 1 && group_ % 8 == 0 && this->kernel_.size() == 3 &&
       this->kernel_[0] == 3 && this->kernel_[1] == 3 && this->kernel_[2] == 3 &&
-      this->stride_[0] == this->stride_[1] &&
-      this->stride_[0] == this->stride_[2] &&
       (this->stride_[0] == 1 || this->stride_[0] == 2) &&
+      (this->stride_[1] == 1 || this->stride_[1] == 2) &&
+      (this->stride_[2] == 1 || this->stride_[2] == 2) &&
       this->dilation_[0] == 1 && this->dilation_[1] == 1 &&
       this->dilation_[2] == 1 &&
       accumulate(


### PR DESCRIPTION
Summary: Remove the requirement on stride for the optimized depthwise 3x3x3 kernels.

Differential Revision: D15070214

