### PR TITLE
Remove duplicate inlineCallToCode

### DIFF
--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -294,9 +294,7 @@ struct GraphFuser {
 
     AT_ASSERT(isFusableNorm(normalization_op));
     WithInsertPoint insert_guard{normalization_op};
-    Value* new_output =
-        SubgraphUtils::inlineGraph(nm_graph, inputs, normalization_op).at(0);
-    return new_output;
+    return  inlineCallTo(*normalization_op->owningGraph(), *nm_graph, inputs).at(0);
   }
 
   void decomposeNormalizationOps(Node* normalization_op) {

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -31,11 +31,6 @@ void unmergeSubgraph(Node* subgraphNode);
 // Convenience function
 std::shared_ptr<Graph> getSubgraph(Node* n);
 
-std::vector<Value*> inlineGraph(
-    const std::shared_ptr<Graph>& subgraph,
-    at::ArrayRef<Value*> outerInputs,
-    Node* insertBefore);
-
 } // namespace SubgraphUtils
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19694 Remove duplicate inlineCallToCode**
* #19603 Serialize first-class version of functions
* #19371 Trace directly into first-class module form.
* #19334 @torch.jit.script(fn) now is a torch.jit.Function
* #19333 pybind CompilationUnit and Function directly

subgraph_utils.h contains a re-implementation of inlineCallTo,
replace it with that.

Differential Revision: [D15071382](https://our.internmc.facebook.com/intern/diff/D15071382)