### PR TITLE
Make interpolate bicubic match opencv result

### DIFF
--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -134,7 +134,7 @@ static inline void upsample_3d_shape_check(
 }
 
 template <typename scalar_t>
-static inline scalar_t area_mode_compute_sclae(
+static inline scalar_t area_pixel_compute_scale(
     int64_t input_size,
     int64_t output_size,
     bool align_corners) {
@@ -159,7 +159,7 @@ static inline scalar_t area_mode_compute_sclae(
 }
 
 template <typename scalar_t>
-static inline scalar_t area_mode_compute_source_index(
+static inline scalar_t area_pixel_compute_source_index(
     scalar_t scale,
     int64_t dst_index,
     bool align_corners,

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -162,12 +162,17 @@ template <typename scalar_t>
 static inline scalar_t linear_upsample_compute_source_index(
     scalar_t scale,
     int64_t dst_index,
-    bool align_corners) {
+    bool align_corners,
+    bool cubic) {
   if (align_corners) {
     return scale * dst_index;
   } else {
     scalar_t src_idx = scale * (dst_index + 0.5) - 0.5;
-    return src_idx < 0 ? scalar_t(0) : src_idx;
+    // [Note] Follow Opencv resize logic:
+    // When doing cubic interpolation, we allow negative src_idx
+    //   to compute dx = src_idx - floorf(src_idx) later.
+    // For other modes, it's bounded by 0.
+    return (!cubic && src_idx < 0) ? scalar_t(0) : src_idx;
   }
 }
 

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -134,7 +134,7 @@ static inline void upsample_3d_shape_check(
 }
 
 template <typename scalar_t>
-static inline scalar_t linear_upsample_compute_scale(
+static inline scalar_t area_mode_compute_sclae(
     int64_t input_size,
     int64_t output_size,
     bool align_corners) {
@@ -159,7 +159,7 @@ static inline scalar_t linear_upsample_compute_scale(
 }
 
 template <typename scalar_t>
-static inline scalar_t linear_upsample_compute_source_index(
+static inline scalar_t area_mode_compute_source_index(
     scalar_t scale,
     int64_t dst_index,
     bool align_corners,

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -169,9 +169,17 @@ static inline scalar_t area_mode_compute_source_index(
   } else {
     scalar_t src_idx = scale * (dst_index + 0.5) - 0.5;
     // [Note] Follow Opencv resize logic:
-    // When doing cubic interpolation, we allow negative src_idx
-    //   to compute dx = src_idx - floorf(src_idx) later.
-    // For other modes, it's bounded by 0.
+    // We allow negative src_idx here and later will use
+    //   dx = src_idx - floorf(src_idx)
+    // to compute the "distance"(which affects weights).
+    // For linear modes, weight distribution doesn't matter
+    // for negative indices as they use 2 pixels to interpolate.
+    // For example, [-1, 0], they both use pixel 0 value so it
+    // doesn't affect if we bound the src_idx to 0 or not.
+    // TODO: Our current linear mode impls use unbound indices
+    // where we should and then remove this cubic flag.
+    // This matters in cubic mode, as we might need [-1, 0, 1, 2]
+    // to interpolate and the weights can be affected.
     return (!cubic && src_idx < 0) ? scalar_t(0) : src_idx;
   }
 }

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -35,9 +35,9 @@ static void upsample_bicubic2d_out_frame(
   }
 
   // Bicubic interpolation
-  const scalar_t height_scale = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t height_scale = area_mode_compute_sclae<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t width_scale = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t width_scale = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t output_y = 0; output_y < output_height; output_y++) {
@@ -45,11 +45,11 @@ static void upsample_bicubic2d_out_frame(
       scalar_t* in = idata;
       scalar_t* out = odata;
 
-      const scalar_t real_x = linear_upsample_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+      const scalar_t real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
       int64_t input_x = floorf(real_x);
       const scalar_t t_x = real_x - input_x;
 
-      const scalar_t real_y = linear_upsample_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+      const scalar_t real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
       int64_t input_y = floorf(real_y);
       const scalar_t t_y = real_y - input_y;
 
@@ -115,9 +115,9 @@ static void upsample_bicubic2d_backward_out_frame(
     return;
   }
 
-  const scalar_t height_scale = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t height_scale = area_mode_compute_sclae<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t width_scale = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t width_scale = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t output_y = 0; output_y < output_height; output_y++) {
@@ -125,11 +125,11 @@ static void upsample_bicubic2d_backward_out_frame(
       scalar_t* in = idata;
       scalar_t* out = odata;
 
-      const scalar_t real_x = linear_upsample_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+      const scalar_t real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
       int64_t input_x = floorf(real_x);
       scalar_t t_x = real_x - input_x;
 
-      const scalar_t real_y = linear_upsample_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+      const scalar_t real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
       int64_t input_y = floorf(real_y);
       scalar_t t_y = real_y - input_y;
 

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -45,12 +45,12 @@ static void upsample_bicubic2d_out_frame(
       scalar_t* in = idata;
       scalar_t* out = odata;
 
-      const scalar_t real_x = width_scale * output_x;
-      int64_t input_x = real_x;
+      const scalar_t real_x = linear_upsample_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+      int64_t input_x = floorf(real_x);
       const scalar_t t_x = real_x - input_x;
 
-      const scalar_t real_y = height_scale * output_y;
-      int64_t input_y = real_y;
+      const scalar_t real_y = linear_upsample_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+      int64_t input_y = floorf(real_y);
       const scalar_t t_y = real_y - input_y;
 
       for (int64_t c = 0; c < channels * nbatch; c++) {
@@ -125,12 +125,12 @@ static void upsample_bicubic2d_backward_out_frame(
       scalar_t* in = idata;
       scalar_t* out = odata;
 
-      scalar_t real_x = width_scale * output_x;
-      int64_t input_x = real_x;
+      const scalar_t real_x = linear_upsample_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+      int64_t input_x = floorf(real_x);
       scalar_t t_x = real_x - input_x;
 
-      scalar_t real_y = height_scale * output_y;
-      int64_t input_y = real_y;
+      const scalar_t real_y = linear_upsample_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+      int64_t input_y = floorf(real_y);
       scalar_t t_y = real_y - input_y;
 
       scalar_t x_coeffs[4];

--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -35,9 +35,9 @@ static void upsample_bicubic2d_out_frame(
   }
 
   // Bicubic interpolation
-  const scalar_t height_scale = area_mode_compute_sclae<scalar_t>(
+  const scalar_t height_scale = area_pixel_compute_scale<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t width_scale = area_mode_compute_sclae<scalar_t>(
+  const scalar_t width_scale = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t output_y = 0; output_y < output_height; output_y++) {
@@ -45,11 +45,11 @@ static void upsample_bicubic2d_out_frame(
       scalar_t* in = idata;
       scalar_t* out = odata;
 
-      const scalar_t real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+      const scalar_t real_x = area_pixel_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
       int64_t input_x = floorf(real_x);
       const scalar_t t_x = real_x - input_x;
 
-      const scalar_t real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+      const scalar_t real_y = area_pixel_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
       int64_t input_y = floorf(real_y);
       const scalar_t t_y = real_y - input_y;
 
@@ -115,9 +115,9 @@ static void upsample_bicubic2d_backward_out_frame(
     return;
   }
 
-  const scalar_t height_scale = area_mode_compute_sclae<scalar_t>(
+  const scalar_t height_scale = area_pixel_compute_scale<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t width_scale = area_mode_compute_sclae<scalar_t>(
+  const scalar_t width_scale = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t output_y = 0; output_y < output_height; output_y++) {
@@ -125,11 +125,11 @@ static void upsample_bicubic2d_backward_out_frame(
       scalar_t* in = idata;
       scalar_t* out = odata;
 
-      const scalar_t real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+      const scalar_t real_x = area_pixel_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
       int64_t input_x = floorf(real_x);
       scalar_t t_x = real_x - input_x;
 
-      const scalar_t real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+      const scalar_t real_y = area_pixel_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
       int64_t input_y = floorf(real_y);
       scalar_t t_y = real_y - input_y;
 

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -49,7 +49,7 @@ static void upsample_bilinear2d_out_frame(
 
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
     const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
-        rheight, h2, align_corners);
+        rheight, h2, align_corners, /*cubic=*/false);
 
     const int64_t h1 = h1r;
     const int64_t h1p = (h1 < input_height - 1) ? 1 : 0;
@@ -59,7 +59,7 @@ static void upsample_bilinear2d_out_frame(
 
     for (int64_t w2 = 0; w2 < output_width; ++w2) {
       const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
-          rwidth, w2, align_corners);
+          rwidth, w2, align_corners, /*cubic=*/false);
 
       const int64_t w1 = w1r;
       const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;
@@ -120,7 +120,7 @@ static void upsample_bilinear2d_backward_out_frame(
 
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
     const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
-        rheight, h2, align_corners);
+        rheight, h2, align_corners, /*cubic=*/false);
 
     const int64_t h1 = h1r;
     const int64_t h1p = (h1 < input_height - 1) ? 1 : 0;
@@ -130,7 +130,7 @@ static void upsample_bilinear2d_backward_out_frame(
 
     for (int64_t w2 = 0; w2 < output_width; ++w2) {
       const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
-          rwidth, w2, align_corners);
+          rwidth, w2, align_corners, /*cubic=*/false);
 
       const int64_t w1 = w1r;
       const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -41,14 +41,14 @@ static void upsample_bilinear2d_out_frame(
     }
     return;
   }
-  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rheight = area_pixel_compute_scale<scalar_t>(
       input_height, output_height, align_corners);
 
-  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rwidth = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
-    const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
+    const scalar_t h1r = area_pixel_compute_source_index<scalar_t>(
         rheight, h2, align_corners, /*cubic=*/false);
 
     const int64_t h1 = h1r;
@@ -58,7 +58,7 @@ static void upsample_bilinear2d_out_frame(
     const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
     for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
+      const scalar_t w1r = area_pixel_compute_source_index<scalar_t>(
           rwidth, w2, align_corners, /*cubic=*/false);
 
       const int64_t w1 = w1r;
@@ -113,13 +113,13 @@ static void upsample_bilinear2d_backward_out_frame(
     return;
   }
 
-  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rheight = area_pixel_compute_scale<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rwidth = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
-    const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
+    const scalar_t h1r = area_pixel_compute_source_index<scalar_t>(
         rheight, h2, align_corners, /*cubic=*/false);
 
     const int64_t h1 = h1r;
@@ -129,7 +129,7 @@ static void upsample_bilinear2d_backward_out_frame(
     const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
     for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
+      const scalar_t w1r = area_pixel_compute_source_index<scalar_t>(
           rwidth, w2, align_corners, /*cubic=*/false);
 
       const int64_t w1 = w1r;

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -41,14 +41,14 @@ static void upsample_bilinear2d_out_frame(
     }
     return;
   }
-  const scalar_t rheight = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
       input_height, output_height, align_corners);
 
-  const scalar_t rwidth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
-    const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
+    const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
         rheight, h2, align_corners, /*cubic=*/false);
 
     const int64_t h1 = h1r;
@@ -58,7 +58,7 @@ static void upsample_bilinear2d_out_frame(
     const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
     for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
+      const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
           rwidth, w2, align_corners, /*cubic=*/false);
 
       const int64_t w1 = w1r;
@@ -113,13 +113,13 @@ static void upsample_bilinear2d_backward_out_frame(
     return;
   }
 
-  const scalar_t rheight = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t rwidth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t h2 = 0; h2 < output_height; ++h2) {
-    const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
+    const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
         rheight, h2, align_corners, /*cubic=*/false);
 
     const int64_t h1 = h1r;
@@ -129,7 +129,7 @@ static void upsample_bilinear2d_backward_out_frame(
     const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
     for (int64_t w2 = 0; w2 < output_width; ++w2) {
-      const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
+      const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
           rwidth, w2, align_corners, /*cubic=*/false);
 
       const int64_t w1 = w1r;

--- a/aten/src/ATen/native/UpSampleLinear1d.cpp
+++ b/aten/src/ATen/native/UpSampleLinear1d.cpp
@@ -35,11 +35,11 @@ static void upsample_linear1d_out_frame(
     }
     return;
   }
-  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rwidth = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t w2 = 0; w2 < output_width; ++w2) {
-    const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
+    const scalar_t w1r = area_pixel_compute_source_index<scalar_t>(
         rwidth, w2, align_corners, /*cubic=*/false);
 
     const int64_t w1 = w1r;
@@ -84,11 +84,11 @@ static void upsample_linear1d_backward_out_frame(
     }
     return;
   }
-  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rwidth = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t w2 = 0; w2 < output_width; ++w2) {
-    const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
+    const scalar_t w1r = area_pixel_compute_source_index<scalar_t>(
         rwidth, w2, align_corners, /*cubic=*/false);
 
     const int64_t w1 = w1r;

--- a/aten/src/ATen/native/UpSampleLinear1d.cpp
+++ b/aten/src/ATen/native/UpSampleLinear1d.cpp
@@ -40,7 +40,7 @@ static void upsample_linear1d_out_frame(
 
   for (int64_t w2 = 0; w2 < output_width; ++w2) {
     const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
-        rwidth, w2, align_corners);
+        rwidth, w2, align_corners, /*cubic=*/false);
 
     const int64_t w1 = w1r;
     const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;
@@ -89,7 +89,7 @@ static void upsample_linear1d_backward_out_frame(
 
   for (int64_t w2 = 0; w2 < output_width; ++w2) {
     const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
-        rwidth, w2, align_corners);
+        rwidth, w2, align_corners, /*cubic=*/false);
 
     const int64_t w1 = w1r;
     const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;

--- a/aten/src/ATen/native/UpSampleLinear1d.cpp
+++ b/aten/src/ATen/native/UpSampleLinear1d.cpp
@@ -35,11 +35,11 @@ static void upsample_linear1d_out_frame(
     }
     return;
   }
-  const scalar_t rwidth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t w2 = 0; w2 < output_width; ++w2) {
-    const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
+    const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
         rwidth, w2, align_corners, /*cubic=*/false);
 
     const int64_t w1 = w1r;
@@ -84,11 +84,11 @@ static void upsample_linear1d_backward_out_frame(
     }
     return;
   }
-  const scalar_t rwidth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t w2 = 0; w2 < output_width; ++w2) {
-    const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
+    const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
         rwidth, w2, align_corners, /*cubic=*/false);
 
     const int64_t w1 = w1r;

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -51,14 +51,14 @@ static void upsample_trilinear3d_out_frame(
     }
     return;
   }
-  const scalar_t rdepth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rdepth = area_mode_compute_sclae<scalar_t>(
       input_depth, output_depth, align_corners);
-  const scalar_t rheight = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t rwidth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
   for (int64_t t2 = 0; t2 < output_depth; ++t2) {
-    const scalar_t t1r = linear_upsample_compute_source_index<scalar_t>(
+    const scalar_t t1r = area_mode_compute_source_index<scalar_t>(
         rdepth, t2, align_corners, /*cubic=*/false);
 
     const int64_t t1 = t1r;
@@ -67,7 +67,7 @@ static void upsample_trilinear3d_out_frame(
     const scalar_t t0lambda = static_cast<scalar_t>(1.) - t1lambda;
 
     for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
+      const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
           rheight, h2, align_corners, /*cubic=*/false);
 
       const int64_t h1 = h1r;
@@ -76,7 +76,7 @@ static void upsample_trilinear3d_out_frame(
       const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
       for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
+        const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
             rwidth, w2, align_corners, /*cubic=*/false);
 
         const int64_t w1 = w1r;
@@ -158,17 +158,17 @@ static void upsample_trilinear3d_backward_out_frame(
     }
     return;
   }
-  const scalar_t rdepth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rdepth = area_mode_compute_sclae<scalar_t>(
       input_depth, output_depth, align_corners);
 
-  const scalar_t rheight = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
       input_height, output_height, align_corners);
 
-  const scalar_t rwidth = linear_upsample_compute_scale<scalar_t>(
+  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t t2 = 0; t2 < output_depth; ++t2) {
-    const scalar_t t1r = linear_upsample_compute_source_index<scalar_t>(
+    const scalar_t t1r = area_mode_compute_source_index<scalar_t>(
         rdepth, t2, align_corners, /*cubic=*/false);
     const int64_t t1 = t1r;
     const int64_t t1p = (t1 < input_depth - 1) ? 1 : 0;
@@ -176,7 +176,7 @@ static void upsample_trilinear3d_backward_out_frame(
     const scalar_t t0lambda = static_cast<scalar_t>(1.) - t1lambda;
 
     for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
+      const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
           rheight, h2, align_corners, /*cubic=*/false);
       const int64_t h1 = h1r;
       const int64_t h1p = (h1 < input_height - 1) ? 1 : 0;
@@ -184,7 +184,7 @@ static void upsample_trilinear3d_backward_out_frame(
       const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
       for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
+        const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
             rwidth, w2, align_corners, /*cubic=*/false);
         const int64_t w1 = w1r;
         const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -59,7 +59,7 @@ static void upsample_trilinear3d_out_frame(
       input_width, output_width, align_corners);
   for (int64_t t2 = 0; t2 < output_depth; ++t2) {
     const scalar_t t1r = linear_upsample_compute_source_index<scalar_t>(
-        rdepth, t2, align_corners);
+        rdepth, t2, align_corners, /*cubic=*/false);
 
     const int64_t t1 = t1r;
     const int64_t t1p = (t1 < input_depth - 1) ? 1 : 0;
@@ -68,7 +68,7 @@ static void upsample_trilinear3d_out_frame(
 
     for (int64_t h2 = 0; h2 < output_height; ++h2) {
       const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
-          rheight, h2, align_corners);
+          rheight, h2, align_corners, /*cubic=*/false);
 
       const int64_t h1 = h1r;
       const int64_t h1p = (h1 < input_height - 1) ? 1 : 0;
@@ -77,7 +77,7 @@ static void upsample_trilinear3d_out_frame(
 
       for (int64_t w2 = 0; w2 < output_width; ++w2) {
         const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
-            rwidth, w2, align_corners);
+            rwidth, w2, align_corners, /*cubic=*/false);
 
         const int64_t w1 = w1r;
         const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;
@@ -169,7 +169,7 @@ static void upsample_trilinear3d_backward_out_frame(
 
   for (int64_t t2 = 0; t2 < output_depth; ++t2) {
     const scalar_t t1r = linear_upsample_compute_source_index<scalar_t>(
-        rdepth, t2, align_corners);
+        rdepth, t2, align_corners, /*cubic=*/false);
     const int64_t t1 = t1r;
     const int64_t t1p = (t1 < input_depth - 1) ? 1 : 0;
     const scalar_t t1lambda = t1r - t1;
@@ -177,7 +177,7 @@ static void upsample_trilinear3d_backward_out_frame(
 
     for (int64_t h2 = 0; h2 < output_height; ++h2) {
       const scalar_t h1r = linear_upsample_compute_source_index<scalar_t>(
-          rheight, h2, align_corners);
+          rheight, h2, align_corners, /*cubic=*/false);
       const int64_t h1 = h1r;
       const int64_t h1p = (h1 < input_height - 1) ? 1 : 0;
       const scalar_t h1lambda = h1r - h1;
@@ -185,7 +185,7 @@ static void upsample_trilinear3d_backward_out_frame(
 
       for (int64_t w2 = 0; w2 < output_width; ++w2) {
         const scalar_t w1r = linear_upsample_compute_source_index<scalar_t>(
-            rwidth, w2, align_corners);
+            rwidth, w2, align_corners, /*cubic=*/false);
         const int64_t w1 = w1r;
         const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;
         const scalar_t w1lambda = w1r - w1;

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -51,14 +51,14 @@ static void upsample_trilinear3d_out_frame(
     }
     return;
   }
-  const scalar_t rdepth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rdepth = area_pixel_compute_scale<scalar_t>(
       input_depth, output_depth, align_corners);
-  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rheight = area_pixel_compute_scale<scalar_t>(
       input_height, output_height, align_corners);
-  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rwidth = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
   for (int64_t t2 = 0; t2 < output_depth; ++t2) {
-    const scalar_t t1r = area_mode_compute_source_index<scalar_t>(
+    const scalar_t t1r = area_pixel_compute_source_index<scalar_t>(
         rdepth, t2, align_corners, /*cubic=*/false);
 
     const int64_t t1 = t1r;
@@ -67,7 +67,7 @@ static void upsample_trilinear3d_out_frame(
     const scalar_t t0lambda = static_cast<scalar_t>(1.) - t1lambda;
 
     for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
+      const scalar_t h1r = area_pixel_compute_source_index<scalar_t>(
           rheight, h2, align_corners, /*cubic=*/false);
 
       const int64_t h1 = h1r;
@@ -76,7 +76,7 @@ static void upsample_trilinear3d_out_frame(
       const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
       for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
+        const scalar_t w1r = area_pixel_compute_source_index<scalar_t>(
             rwidth, w2, align_corners, /*cubic=*/false);
 
         const int64_t w1 = w1r;
@@ -158,17 +158,17 @@ static void upsample_trilinear3d_backward_out_frame(
     }
     return;
   }
-  const scalar_t rdepth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rdepth = area_pixel_compute_scale<scalar_t>(
       input_depth, output_depth, align_corners);
 
-  const scalar_t rheight = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rheight = area_pixel_compute_scale<scalar_t>(
       input_height, output_height, align_corners);
 
-  const scalar_t rwidth = area_mode_compute_sclae<scalar_t>(
+  const scalar_t rwidth = area_pixel_compute_scale<scalar_t>(
       input_width, output_width, align_corners);
 
   for (int64_t t2 = 0; t2 < output_depth; ++t2) {
-    const scalar_t t1r = area_mode_compute_source_index<scalar_t>(
+    const scalar_t t1r = area_pixel_compute_source_index<scalar_t>(
         rdepth, t2, align_corners, /*cubic=*/false);
     const int64_t t1 = t1r;
     const int64_t t1p = (t1 < input_depth - 1) ? 1 : 0;
@@ -176,7 +176,7 @@ static void upsample_trilinear3d_backward_out_frame(
     const scalar_t t0lambda = static_cast<scalar_t>(1.) - t1lambda;
 
     for (int64_t h2 = 0; h2 < output_height; ++h2) {
-      const scalar_t h1r = area_mode_compute_source_index<scalar_t>(
+      const scalar_t h1r = area_pixel_compute_source_index<scalar_t>(
           rheight, h2, align_corners, /*cubic=*/false);
       const int64_t h1 = h1r;
       const int64_t h1p = (h1 < input_height - 1) ? 1 : 0;
@@ -184,7 +184,7 @@ static void upsample_trilinear3d_backward_out_frame(
       const scalar_t h0lambda = static_cast<scalar_t>(1.) - h1lambda;
 
       for (int64_t w2 = 0; w2 < output_width; ++w2) {
-        const scalar_t w1r = area_mode_compute_source_index<scalar_t>(
+        const scalar_t w1r = area_pixel_compute_source_index<scalar_t>(
             rwidth, w2, align_corners, /*cubic=*/false);
         const int64_t w1 = w1r;
         const int64_t w1p = (w1 < input_width - 1) ? 1 : 0;

--- a/aten/src/THCUNN/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBicubic.cu
@@ -17,6 +17,7 @@ __global__ void bicubic_interp2d_kernel(
   const int num_elements,
   const Acctype height_scale,
   const Acctype width_scale,
+  const bool align_corners,
   const THCDeviceTensor<Dtype, 4> in_data,
   THCDeviceTensor<Dtype, 4> out_data
 ) {
@@ -47,12 +48,12 @@ __global__ void bicubic_interp2d_kernel(
   }
 
   // Interpolation kernel
-  Acctype real_x = width_scale * output_x;
-  int in_x = real_x;
+  Acctype real_x = linear_upsampling_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+  int in_x = floorf(real_x);
   Acctype t_x = real_x - in_x;
 
-  Acctype real_y = height_scale * output_y;
-  int in_y = real_y;
+  Acctype real_y = linear_upsampling_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+  int in_y = floorf(real_y);
   Acctype t_y = real_y - in_y;
 
   for (int n = 0; n < batchsize ; n++) {
@@ -123,12 +124,12 @@ __global__ void bicubic_interp2d_backward_kernel(
     return;
   }
 
-  Acctype real_x = width_scale * output_x;
-  int input_x = real_x;
+  Acctype real_x = linear_upsampling_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+  int input_x = floorf(real_x);
   Acctype t_x = real_x - input_x;
 
-  Acctype real_y = height_scale * output_y;
-  int input_y = real_y;
+  Acctype real_y = linear_upsampling_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+  int input_y = floorf(real_y);
   Acctype t_y = real_y - input_y;
 
   Acctype x_coeffs[4];

--- a/aten/src/THCUNN/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBicubic.cu
@@ -48,11 +48,11 @@ __global__ void bicubic_interp2d_kernel(
   }
 
   // Interpolation kernel
-  Acctype real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+  Acctype real_x = area_pixel_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
   int in_x = floorf(real_x);
   Acctype t_x = real_x - in_x;
 
-  Acctype real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+  Acctype real_y = area_pixel_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
   int in_y = floorf(real_y);
   Acctype t_y = real_y - in_y;
 
@@ -124,11 +124,11 @@ __global__ void bicubic_interp2d_backward_kernel(
     return;
   }
 
-  Acctype real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+  Acctype real_x = area_pixel_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
   int input_x = floorf(real_x);
   Acctype t_x = real_x - input_x;
 
-  Acctype real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+  Acctype real_y = area_pixel_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
   int input_y = floorf(real_y);
   Acctype t_y = real_y - input_y;
 

--- a/aten/src/THCUNN/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBicubic.cu
@@ -48,11 +48,11 @@ __global__ void bicubic_interp2d_kernel(
   }
 
   // Interpolation kernel
-  Acctype real_x = linear_upsampling_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+  Acctype real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
   int in_x = floorf(real_x);
   Acctype t_x = real_x - in_x;
 
-  Acctype real_y = linear_upsampling_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+  Acctype real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
   int in_y = floorf(real_y);
   Acctype t_y = real_y - in_y;
 
@@ -124,11 +124,11 @@ __global__ void bicubic_interp2d_backward_kernel(
     return;
   }
 
-  Acctype real_x = linear_upsampling_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
+  Acctype real_x = area_mode_compute_source_index(width_scale, output_x, align_corners, /*cubic=*/true);
   int input_x = floorf(real_x);
   Acctype t_x = real_x - input_x;
 
-  Acctype real_y = linear_upsampling_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
+  Acctype real_y = area_mode_compute_source_index(height_scale, output_y, align_corners, /*cubic=*/true);
   int input_y = floorf(real_y);
   Acctype t_y = real_y - input_y;
 

--- a/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
@@ -42,13 +42,13 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -97,13 +97,13 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
@@ -42,13 +42,13 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_pixel_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_pixel_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -97,13 +97,13 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_pixel_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_pixel_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/SpatialUpSamplingBilinear.cu
@@ -42,13 +42,13 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners);
+    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -97,13 +97,13 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners);
+    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/TemporalUpSamplingLinear.cu
@@ -38,7 +38,7 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -81,7 +81,7 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/TemporalUpSamplingLinear.cu
@@ -38,7 +38,7 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -81,7 +81,7 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/TemporalUpSamplingLinear.cu
@@ -38,7 +38,7 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_pixel_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -81,7 +81,7 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_pixel_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/VolumetricUpSamplingTrilinear.cu
@@ -45,19 +45,19 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype t1r = linear_upsampling_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
+    const Acctype t1r = area_mode_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
     const int t1p = (t1 < depth1 - 1) ? 1 : 0;
     const Acctype t1lambda = t1r - t1;
     const Acctype t0lambda = Acctype(1) - t1lambda;
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -112,19 +112,19 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype t1r = linear_upsampling_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
+    const Acctype t1r = area_mode_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
     const int t1p = (t1 < depth1 - 1) ? 1 : 0;
     const Acctype t1lambda = t1r - t1;
     const Acctype t0lambda = Acctype(1) - t1lambda;
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/VolumetricUpSamplingTrilinear.cu
@@ -45,19 +45,19 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype t1r = area_mode_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
+    const Acctype t1r = area_pixel_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
     const int t1p = (t1 < depth1 - 1) ? 1 : 0;
     const Acctype t1lambda = t1r - t1;
     const Acctype t0lambda = Acctype(1) - t1lambda;
     //
-    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_pixel_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_pixel_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -112,19 +112,19 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype t1r = area_mode_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
+    const Acctype t1r = area_pixel_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
     const int t1p = (t1 < depth1 - 1) ? 1 : 0;
     const Acctype t1lambda = t1r - t1;
     const Acctype t0lambda = Acctype(1) - t1lambda;
     //
-    const Acctype h1r = area_mode_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
+    const Acctype h1r = area_pixel_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = area_mode_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
+    const Acctype w1r = area_pixel_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/VolumetricUpSamplingTrilinear.cu
@@ -45,19 +45,19 @@ __global__ void caffe_gpu_interp2_kernel(const int n,
       return;
     }
     //
-    const Acctype t1r = linear_upsampling_compute_source_index<Acctype>(rdepth, t2, align_corners);
+    const Acctype t1r = linear_upsampling_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
     const int t1p = (t1 < depth1 - 1) ? 1 : 0;
     const Acctype t1lambda = t1r - t1;
     const Acctype t0lambda = Acctype(1) - t1lambda;
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners);
+    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;
@@ -112,19 +112,19 @@ __global__ void caffe_gpu_interp2_kernel_backward(const int n,
       return;
     }
     //
-    const Acctype t1r = linear_upsampling_compute_source_index<Acctype>(rdepth, t2, align_corners);
+    const Acctype t1r = linear_upsampling_compute_source_index<Acctype>(rdepth, t2, align_corners, /*cubic=*/false);
     const int t1 = t1r;
     const int t1p = (t1 < depth1 - 1) ? 1 : 0;
     const Acctype t1lambda = t1r - t1;
     const Acctype t0lambda = Acctype(1) - t1lambda;
     //
-    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners);
+    const Acctype h1r = linear_upsampling_compute_source_index<Acctype>(rheight, h2, align_corners, /*cubic=*/false);
     const int h1 = h1r;
     const int h1p = (h1 < height1 - 1) ? 1 : 0;
     const Acctype h1lambda = h1r - h1;
     const Acctype h0lambda = Acctype(1) - h1lambda;
     //
-    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners);
+    const Acctype w1r = linear_upsampling_compute_source_index<Acctype>(rwidth, w2, align_corners, /*cubic=*/false);
     const int w1 = w1r;
     const int w1p = (w1 < width1 - 1) ? 1 : 0;
     const Acctype w1lambda = w1r - w1;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
@@ -58,8 +58,8 @@ void THNN_(SpatialUpSamplingBicubic_updateOutput)(
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
 
   // Get scaling factors
-  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
 
   const int num_output_elements = outputHeight * outputWidth;
   const int max_threads =
@@ -100,8 +100,8 @@ void THNN_(SpatialUpSamplingBicubic_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 4> in_data = toDeviceTensor<scalar_t, 4>(state, gradInput);
   THCDeviceTensor<scalar_t, 4> out_data = toDeviceTensor<scalar_t, 4>(state, gradOutput);
-  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
@@ -72,7 +72,7 @@ void THNN_(SpatialUpSamplingBicubic_updateOutput)(
     max_threads,
     0,
     stream
-  >>>(num_output_elements, rheight, rwidth, idata, odata);
+  >>>(num_output_elements, rheight, rwidth, align_corners, idata, odata);
   THCudaCheck(cudaGetLastError());
 }
 

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBicubic.cu
@@ -58,8 +58,8 @@ void THNN_(SpatialUpSamplingBicubic_updateOutput)(
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
 
   // Get scaling factors
-  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_pixel_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
 
   const int num_output_elements = outputHeight * outputWidth;
   const int max_threads =
@@ -100,8 +100,8 @@ void THNN_(SpatialUpSamplingBicubic_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 4> in_data = toDeviceTensor<scalar_t, 4>(state, gradInput);
   THCDeviceTensor<scalar_t, 4> out_data = toDeviceTensor<scalar_t, 4>(state, gradOutput);
-  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_pixel_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -56,8 +56,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
   THCDeviceTensor<scalar_t, 4> idata = toDeviceTensor<scalar_t, 4>(state, input);
   THCDeviceTensor<scalar_t, 4> odata = toDeviceTensor<scalar_t, 4>(state, output);
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -91,8 +91,8 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 4> data1 = toDeviceTensor<scalar_t, 4>(state, gradInput);
   THCDeviceTensor<scalar_t, 4> data2 = toDeviceTensor<scalar_t, 4>(state, gradOutput);
-  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/aten/src/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -56,8 +56,8 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
   THCDeviceTensor<scalar_t, 4> idata = toDeviceTensor<scalar_t, 4>(state, input);
   THCDeviceTensor<scalar_t, 4> odata = toDeviceTensor<scalar_t, 4>(state, output);
   THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_pixel_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -91,8 +91,8 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 4> data1 = toDeviceTensor<scalar_t, 4>(state, gradInput);
   THCDeviceTensor<scalar_t, 4> data2 = toDeviceTensor<scalar_t, 4>(state, gradOutput);
-  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rheight = area_pixel_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -51,7 +51,7 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
   THCDeviceTensor<scalar_t, 3> idata = toDeviceTensor<scalar_t, 3>(state, input);
   THCDeviceTensor<scalar_t, 3> odata = toDeviceTensor<scalar_t, 3>(state, output);
   THAssert(inputWidth > 0 && outputWidth > 0);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -82,7 +82,7 @@ void THNN_(TemporalUpSamplingLinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 3> data1 = toDeviceTensor<scalar_t, 3>(state, gradInput);
   THCDeviceTensor<scalar_t, 3> data2 = toDeviceTensor<scalar_t, 3>(state, gradOutput);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
+++ b/aten/src/THCUNN/generic/TemporalUpSamplingLinear.cu
@@ -51,7 +51,7 @@ void THNN_(TemporalUpSamplingLinear_updateOutput)(
   THCDeviceTensor<scalar_t, 3> idata = toDeviceTensor<scalar_t, 3>(state, input);
   THCDeviceTensor<scalar_t, 3> odata = toDeviceTensor<scalar_t, 3>(state, output);
   THAssert(inputWidth > 0 && outputWidth > 0);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -82,7 +82,7 @@ void THNN_(TemporalUpSamplingLinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 3> data1 = toDeviceTensor<scalar_t, 3>(state, gradInput);
   THCDeviceTensor<scalar_t, 3> data2 = toDeviceTensor<scalar_t, 3>(state, gradOutput);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -59,9 +59,9 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
   THCDeviceTensor<scalar_t, 5> idata = toDeviceTensor<scalar_t, 5>(state, input);
   THCDeviceTensor<scalar_t, 5> odata = toDeviceTensor<scalar_t, 5>(state, output);
   THAssert(inputDepth > 0 && inputHeight > 0 && inputWidth > 0 && outputDepth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rdepth = area_mode_compute_sclae<accreal>(inputDepth, outputDepth, align_corners);
-  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rdepth = area_pixel_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
+  const accreal rheight = area_pixel_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -97,9 +97,9 @@ void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 5> data1 = toDeviceTensor<scalar_t, 5>(state, gradInput);
   THCDeviceTensor<scalar_t, 5> data2 = toDeviceTensor<scalar_t, 5>(state, gradOutput);
-  const accreal rdepth = area_mode_compute_sclae<accreal>(inputDepth, outputDepth, align_corners);
-  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rdepth = area_pixel_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
+  const accreal rheight = area_pixel_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_pixel_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
+++ b/aten/src/THCUNN/generic/VolumetricUpSamplingTrilinear.cu
@@ -59,9 +59,9 @@ void THNN_(VolumetricUpSamplingTrilinear_updateOutput)(
   THCDeviceTensor<scalar_t, 5> idata = toDeviceTensor<scalar_t, 5>(state, input);
   THCDeviceTensor<scalar_t, 5> odata = toDeviceTensor<scalar_t, 5>(state, output);
   THAssert(inputDepth > 0 && inputHeight > 0 && inputWidth > 0 && outputDepth > 0 && outputHeight > 0 && outputWidth > 0);
-  const accreal rdepth = linear_upsampling_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
-  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rdepth = area_mode_compute_sclae<accreal>(inputDepth, outputDepth, align_corners);
+  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -97,9 +97,9 @@ void THNN_(VolumetricUpSamplingTrilinear_updateGradInput)(
   THCTensor_(zero)(state, gradInput);
   THCDeviceTensor<scalar_t, 5> data1 = toDeviceTensor<scalar_t, 5>(state, gradInput);
   THCDeviceTensor<scalar_t, 5> data2 = toDeviceTensor<scalar_t, 5>(state, gradOutput);
-  const accreal rdepth = linear_upsampling_compute_scale<accreal>(inputDepth, outputDepth, align_corners);
-  const accreal rheight = linear_upsampling_compute_scale<accreal>(inputHeight, outputHeight, align_corners);
-  const accreal rwidth = linear_upsampling_compute_scale<accreal>(inputWidth, outputWidth, align_corners);
+  const accreal rdepth = area_mode_compute_sclae<accreal>(inputDepth, outputDepth, align_corners);
+  const accreal rheight = area_mode_compute_sclae<accreal>(inputHeight, outputHeight, align_corners);
+  const accreal rwidth = area_mode_compute_sclae<accreal>(inputWidth, outputWidth, align_corners);
   const int num_kernels = outputDepth * outputHeight * outputWidth;
   const int num_threads =
     at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;

--- a/aten/src/THCUNN/upsampling.h
+++ b/aten/src/THCUNN/upsampling.h
@@ -25,12 +25,13 @@ static Acctype linear_upsampling_compute_scale(
 template<typename Acctype>
 __device__ __forceinline__
 static Acctype linear_upsampling_compute_source_index(
-                          Acctype scale, int dst_index, bool align_corners) {
+                          Acctype scale, int dst_index, bool align_corners, bool cubic) {
   if (align_corners) {
     return scale * dst_index;
   } else {
     Acctype src_idx = scale * (dst_index + Acctype(0.5)) - Acctype(0.5);
-    return src_idx < Acctype(0) ? Acctype(0) : src_idx;
+    // See Note[Follow Opencv resize logic]
+    return (!cubic && src_idx) < Acctype(0) ? Acctype(0) : src_idx;
   }
 }
 

--- a/aten/src/THCUNN/upsampling.h
+++ b/aten/src/THCUNN/upsampling.h
@@ -12,7 +12,7 @@
 
 template<typename Acctype>
 __host__ __forceinline__
-static Acctype linear_upsampling_compute_scale(
+static Acctype area_mode_compute_sclae(
                           int inputSize, int outputSize, bool align_corners) {
   if (outputSize > 1) {
     return align_corners ? (Acctype) (inputSize - 1) / (outputSize - 1)
@@ -24,7 +24,7 @@ static Acctype linear_upsampling_compute_scale(
 
 template<typename Acctype>
 __device__ __forceinline__
-static Acctype linear_upsampling_compute_source_index(
+static Acctype area_mode_compute_source_index(
                           Acctype scale, int dst_index, bool align_corners, bool cubic) {
   if (align_corners) {
     return scale * dst_index;

--- a/aten/src/THCUNN/upsampling.h
+++ b/aten/src/THCUNN/upsampling.h
@@ -12,7 +12,7 @@
 
 template<typename Acctype>
 __host__ __forceinline__
-static Acctype area_mode_compute_sclae(
+static Acctype area_pixel_compute_scale(
                           int inputSize, int outputSize, bool align_corners) {
   if (outputSize > 1) {
     return align_corners ? (Acctype) (inputSize - 1) / (outputSize - 1)
@@ -24,14 +24,14 @@ static Acctype area_mode_compute_sclae(
 
 template<typename Acctype>
 __device__ __forceinline__
-static Acctype area_mode_compute_source_index(
+static Acctype area_pixel_compute_source_index(
                           Acctype scale, int dst_index, bool align_corners, bool cubic) {
   if (align_corners) {
     return scale * dst_index;
   } else {
     Acctype src_idx = scale * (dst_index + Acctype(0.5)) - Acctype(0.5);
     // See Note[Follow Opencv resize logic]
-    return (!cubic && src_idx) < Acctype(0) ? Acctype(0) : src_idx;
+    return (!cubic && src_idx < Acctype(0)) ? Acctype(0) : src_idx;
   }
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7057,14 +7057,19 @@ class TestNN(NNTestCase):
                 gradcheck(lambda x: F.interpolate(x, out_size, **kwargs), [input])
 
     def test_upsamplingBicubic2d(self):
-        # test output against known input
-        in_t = torch.arange(4).view(1, 1, 2, 2).type(torch.FloatTensor)
+        # test output against known input: align_corners=False result must match opencv
+        in_t = torch.arange(8).view(1, 2, 2, 2).type(torch.FloatTensor)
         expected_out_t = torch.Tensor(
-            [[[[0.00000, 0.31481, 0.68519, 1.00000],
-               [0.62963, 0.94444, 1.31481, 1.62963],
-               [1.37037, 1.68518, 2.05556, 2.37037],
-               [2.00000, 2.31481, 2.68519, 3.00000]]]])
-        out_t = F.interpolate(in_t, scale_factor=2, mode='bicubic', align_corners=True)
+            [[[[-0.31641, 0.01562, 0.56250, 0.89453],
+              [0.34766, 0.67969, 1.22656, 1.55859],
+              [1.44141, 1.77344, 2.32031, 2.65234],
+              [2.10547, 2.43750, 2.98438, 3.31641]],
+
+             [[3.68359, 4.01562, 4.56250, 4.89453],
+              [4.34766, 4.67969, 5.22656, 5.55859],
+              [5.44141, 5.77344, 6.32031, 6.65234],
+              [6.10547, 6.43750, 6.98438, 7.31641]]]])
+        out_t = F.interpolate(in_t, scale_factor=2, mode='bicubic', align_corners=False)
         torch.set_printoptions(precision=5)
         self.assertEqual(out_t, expected_out_t)
 
@@ -7072,14 +7077,15 @@ class TestNN(NNTestCase):
             kwargs = dict(mode='bicubic', align_corners=align_corners)
 
             # test float scale factor up & downsampling
-            for scale_factor in [0.5, 1.5, 2]:
-                in_t = torch.ones(2, 2, 2, 2)
-                out_t = F.interpolate(in_t, scale_factor=scale_factor, **kwargs)
-                out_size = int(math.floor(in_t.shape[-1] * scale_factor))
-                self.assertEqual(torch.ones(2, 2, out_size, out_size), out_t.data)
+            for device in ['cpu', 'cuda']:
+                for scale_factor in [0.5, 1.5, 2]:
+                    in_t = torch.ones(2, 2, 2, 2).to(device)
+                    out_t = F.interpolate(in_t, scale_factor=scale_factor, **kwargs)
+                    out_size = int(math.floor(in_t.shape[-1] * scale_factor))
+                    self.assertEqual(torch.ones(2, 2, out_size, out_size), out_t.data)
 
-                input = torch.randn(2, 2, 2, 2, requires_grad=True)
-                gradcheck(lambda x: F.interpolate(x, out_size, **kwargs), [input])
+                    input = torch.randn(2, 2, 2, 2, requires_grad=True)
+                    gradcheck(lambda x: F.interpolate(x, out_size, **kwargs), [input])
 
     def test_upsamplingBilinear2d_spatial_invariance(self):
         m = nn.Upsample(scale_factor=3, mode='bilinear', align_corners=False)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7073,11 +7073,14 @@ class TestNN(NNTestCase):
         torch.set_printoptions(precision=5)
         self.assertEqual(out_t, expected_out_t)
 
+        device_list = ['cpu']
+        if TEST_CUDA:
+            device_list.append('cuda')
+
         for align_corners in [True, False]:
             kwargs = dict(mode='bicubic', align_corners=align_corners)
-
             # test float scale factor up & downsampling
-            for device in ['cpu', 'cuda']:
+            for device in device_list:
                 for scale_factor in [0.5, 1.5, 2]:
                     in_t = torch.ones(2, 2, 2, 2).to(device)
                     out_t = F.interpolate(in_t, scale_factor=scale_factor, **kwargs)


### PR DESCRIPTION
Fixes #19650 
When @driazati started bicubic implementation we used TF result as ground truth. It turns out opencv version bicubic resize is used more commonly. 
This PR does two things:
- Fix a bug where we didn't use area mode to compute source index
- Follow the Opencv logic to handle computed negative source indices(we used to bound them by 0). 