### PR TITLE
Changing the rounding in the QTensor

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -69,7 +69,7 @@ qint8 quantize_uint8(float scale, uint8_t zero_point, float value) {
 #else
   constexpr int32_t qmin = std::numeric_limits<uint8_t>::min();
   constexpr int32_t qmax = std::numeric_limits<uint8_t>::max();
-  qvalue = static_cast<int32>(std::nearbyint(value / scale + zero_point));
+  qvalue = static_cast<int32_t>(std::nearbyint(value / scale + zero_point));
   qvalue = std::max(qvalue, qmin);
   qvalue = std::min(qvalue, qmax);
 #endif

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -69,7 +69,7 @@ qint8 quantize_uint8(float scale, uint8_t zero_point, float value) {
 #else
   constexpr int32_t qmin = std::numeric_limits<uint8_t>::min();
   constexpr int32_t qmax = std::numeric_limits<uint8_t>::max();
-  qvalue = zero_point + static_cast<int32_t>(std::nearbyint(value / scale));
+  qvalue = static_cast<int32>(std::nearbyint(value / scale + zero_point));
   qvalue = std::max(qvalue, qmin);
   qvalue = std::min(qvalue, qmax);
 #endif

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -51,16 +51,19 @@ TEST(TestQTensor, RoundingMode) {
   // We assume that quantization is defined as:
   //   qx = clamp(round(x / scale + zero_point))
   // If the zero_point is added after rounding, the result will be wrong.
-  constexpr int N = 7;
-  float x_values[N] = {0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5};
-  int32_t zero_point = 1;
-  uint8_t qx_expect[N] = {2, 2, 4, 4, 6, 6, 8};  // scale = 1.0
+  int32_t zero_point = 5;
+  std::vector<float> x_values{
+    -5.5, -4.5, -3.5, -2.5, -1.5, -0.5,
+    0.5, 1.5, 2.5, 3.5, 4.5, 5.5};
+  std::vector<uint8_t> qx_expect{
+    0, 0, 2, 2, 4, 4,
+    6, 6, 8, 8, 10, 10};  // scale = 1.0
 
-  Tensor x = from_blob(x_values, {N});
+  Tensor x = from_blob(&x_values[0], x_values.size());
   Tensor qx = x.quantize_linear(/*scale=*/1.0, zero_point);
 
   auto qx_data = qx.data<qint8>();
-  for (int idx = 0; idx < N; ++idx) {
+  for (int idx = 0; idx < x_values.size(); ++idx) {
     ASSERT_EQ(qx_expect[idx], qx_data[idx].val_)
       << "Tie breaking during rounding element " << idx << " failed!";
   }

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -59,7 +59,7 @@ TEST(TestQTensor, RoundingMode) {
     0, 0, 2, 2, 4, 4,
     6, 6, 8, 8, 10, 10};  // scale = 1.0
 
-  Tensor x = from_blob(&x_values[0], x_values.size());
+  Tensor x = from_blob(x_values.data(), x_values.size());
   Tensor qx = x.quantize_linear(/*scale=*/1.0, zero_point);
 
   auto qx_data = qx.data<qint8>();

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -47,6 +47,25 @@ TEST(TestQTensor, QuantDequantAPIs) {
   }
 }
 
+TEST(TestQTensor, RoundingMode) {
+  // We assume that quantization is defined as:
+  //   qx = clamp(round(x / scale + zero_point))
+  // If the zero_point is added after rounding, the result will be wrong.
+  constexpr int N = 7;
+  float x_values[N] = {0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5};
+  int32_t zero_point = 1;
+  uint8_t qx_expect[N] = {2, 2, 4, 4, 6, 6, 8};  // scale = 1.0
+
+  Tensor x = from_blob(x_values, {N});
+  Tensor qx = x.quantize_linear(/*scale=*/1.0, zero_point);
+
+  auto qx_data = qx.data<qint8>();
+  for (int idx = 0; idx < N; ++idx) {
+    ASSERT_EQ(qx_expect[idx], qx_data[idx].val_)
+      << "Tie breaking during rounding element " << idx << " failed!";
+  }
+}
+
 TEST(TestQTensor, Item) {
   Tensor r = at::ones({1});
   const float scale = 1;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19714 Changing the rounding in the QTensor**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15077095/)

We had rounding in the quantizer set as `round(x/scale) + zp`. To make it consistent, converting it to `round(x/scale + zp)`.

Differential Revision: [D15077095](https://our.internmc.facebook.com/intern/diff/D15077095/)