### PR TITLE
[WIP] Cleanup more allocation/overhead in EmbeddingBag

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -85,6 +85,7 @@ void index_select_add<float>(const Tensor &select_indices,
   if (isFastPathIndexSelect(src, output)) {
     auto accessor = offsets.accessor<int64_t, 1>();
     std::vector<int> lengths;
+    lengths.reserve(offsets.numel());
 
     int64_t lower = accessor[0];
     for (size_t i = 1; i < offsets.numel(); ++i) {


### PR DESCRIPTION
1. `bag_size` is not used if mode is 'sum', so avoid allocating the tensor for it.
2. The output tensor doesn't need to be zero-initialized. afaict none of the downstream implementations rely on a zero-initialized output tensor.
3. Reserve `lengths` vector based on its expected size.

Benchmark script:
```
import torch

dim = 64
nemb = 1000000

input = torch.LongTensor(1500).random_(0, nemb)
offsets = torch.zeros(dim, dtype=torch.int64)
weight = torch.empty(nemb, dim)
weight.add_(1)

class TestMod(torch.jit.ScriptModule):
    def __init__(self):
        super(TestMod, self).__init__()
        self.eb = torch.jit.trace(torch.nn.EmbeddingBag(nemb, dim, mode='sum', _weight=weight), (input, offsets))

    @torch.jit.script_method
    def forward(self, inp, ofs):
        return self.eb(inp, ofs)

tm = TestMod()

niter = 10000

print('time per iteration (us)', tm.__getattr__('forward').benchmark(niter, input, offsets) * 1e6)
```

Benchmarking patch: 

```
diff --git a/torch/csrc/jit/script/init.cpp b/torch/csrc/jit/script/init.cpp
index 904bc2535..46761697f 100644
--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -1033,6 +1033,27 @@ void initJitScriptBindings(PyObject* module) {
             return invokeScriptMethodFromPython(
                 method, tuple_slice(std::move(args), 1), std::move(kwargs));
           })
+      .def(
+          "benchmark",
+          [](py::args args, py::kwargs kwargs) {
+            // see: [pybind11 varargs]
+            int64_t niter = py::cast<int64_t>(args[1]);
+            Method& method = py::cast<Method&>(args[0]);
+            auto stack = createStackForSchema(
+                method.getSchema(), std::move(tuple_slice(std::move(args), 2)), std::move(kwargs));
+            AutoNoGIL no_gil_guard;
+            auto _stack = stack;
+            method.run(_stack);
+
+            auto start = std::chrono::high_resolution_clock::now();
+            for (int64_t i = 0; i < niter - 1; ++i) {
+              auto _stack = stack;
+              method.run(_stack);
+            }
+            auto end = std::chrono::high_resolution_clock::now();
+            return std::chrono::duration<double>(end - start).count() / (niter - 1);
+          }
+      )
       .def_property_readonly("graph", &Method::graph)
       .def(
           "initial_ivalues",
```

Results: 32 us/iter before this change, 26 us/iter after