### PR TITLE
pybind CompilationUnit and Function directly

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3041,7 +3041,7 @@ class TestScript(JitTestCase):
             def bar(x):
                 return foo(x, y=x)
         ''')
-        self.assertTrue('*' in str(cu.module._get_method('foo').schema))
+        self.assertTrue('*' in str(cu.foo.schema))
         with self.assertRaisesRegex(RuntimeError, "not provided"):
             torch.jit.CompilationUnit('''
                 def foo(x, *, y) -> Tuple[Tensor, Tensor]:

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1197,6 +1197,18 @@ TORCH_API void PythonPrint(
 
 TORCH_API void PythonPrint(
     std::ostream& out,
+    const script::Function& callee,
+    std::vector<at::Tensor>& tensor_table,
+    std::vector<ClassTypePtr>& class_table,
+    bool enforce_importable) {
+  PythonPrintPass pp(tensor_table, class_table, enforce_importable);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  pp.printFunction(const_cast<script::Function&>(callee), /*is_class=*/false);
+  pp.print(out);
+}
+
+TORCH_API void PythonPrint(
+    std::ostream& out,
     const script::Module& module,
     std::vector<at::Tensor>& tensor_table,
     std::vector<ClassTypePtr>& class_table,

--- a/torch/csrc/jit/passes/python_print.h
+++ b/torch/csrc/jit/passes/python_print.h
@@ -18,18 +18,28 @@ TORCH_API void PythonPrint(
     std::vector<at::Tensor>& tensor_table,
     std::vector<ClassTypePtr>& class_table,
     bool enforce_importable = false);
+
 TORCH_API void PythonPrint(
     std::ostream& out,
     const script::Method& graph,
     std::vector<at::Tensor>& tensor_table,
     std::vector<ClassTypePtr>& class_table,
     bool enforce_importable = false);
+
+TORCH_API void PythonPrint(
+    std::ostream& out,
+    const script::Function& callee,
+    std::vector<at::Tensor>& tensor_table,
+    std::vector<ClassTypePtr>& class_table,
+    bool enforce_importable = false);
+
 TORCH_API void PythonPrint(
     std::ostream& out,
     const script::Module& module,
     std::vector<at::Tensor>& tensor_table,
     std::vector<ClassTypePtr>& class_table,
     bool enforce_importable = false);
+
 TORCH_API void PythonPrint(
     std::ostream& out,
     const ClassTypePtr& classType,

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -514,15 +514,16 @@ inline Stack evilDeprecatedBadCreateStackDoNotUse(
   return result;
 }
 
+template<typename MethodOrFunction>
 inline py::object invokeScriptMethodFromPython(
-    script::Method& method,
+    MethodOrFunction& callee,
     tuple_slice args,
     py::kwargs kwargs) {
   auto stack = createStackForSchema(
-      method.getSchema(), std::move(args), std::move(kwargs));
+      callee.getSchema(), std::move(args), std::move(kwargs));
   {
     AutoNoGIL no_gil_guard;
-    method.run(stack);
+    callee.run(stack);
   }
   return toPyObject(std::move(stack.back()));
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19724 Remove duplicate inlineCallToCode
* #19723 Serialize first-class version of functions
* #19722 Trace directly into first-class module form.
* #19721 @torch.jit.script(fn) now is a torch.jit.Function
* **#19720 pybind CompilationUnit and Function directly**

This exposes CompilationUnit and Function in python rather
than indirectly through modules.

For context, currently script functions are actually modules with
a forward method defined. A future patch will replace them with
a Function object. This is needed because when first-class
script modules land, they will all have an initial 'self' argument.
@script functions do not have this argument, and hence can no
longer be punned onto ScriptModule.

Differential Revision: [D15078536](https://our.internmc.facebook.com/intern/diff/D15078536)