### PR TITLE
@torch.jit.script(fn) now is a torch.jit.Function

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1369,7 +1369,7 @@ struct CAFFE2_API ClassType : public Type {
     return attributeNames_[slot];
   }
 
-  Function* getMethod(const std::string& name) const;
+  std::shared_ptr<Function> getMethod(const std::string& name) const;
   CompilationUnit& compilation_unit();
   const CompilationUnit& compilation_unit() const;
   std::vector<Function*> methods() const;

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -222,8 +222,6 @@ def get_grad_executor(plan_state, diff_graph_idx=None):
 
 
 def backward_graph(script_module, diff_graph_idx=None):
-    if not isinstance(script_module, torch.jit.ScriptModule):
-        raise RuntimeError('Expected ScriptModule')
     ge_state = script_module.get_debug_state()
     fwd_plan = get_execution_plan(ge_state)
     grad_executor_state = get_grad_executor(fwd_plan, diff_graph_idx=diff_graph_idx)
@@ -281,6 +279,12 @@ class JitTestCase(TestCase):
     _do_cuda_memory_leak_check = True
     _restored_warnings = False
 
+    def setHooks(self):
+        torch._C._jit_set_emit_hooks(self.emitModuleHook, self.emitFunctionHook)
+
+    def clearHooks(self):
+        torch._C._jit_set_emit_hooks(None, None)
+
     def setUp(self):
         super(JitTestCase, self).setUp()
         # unittest overrides all warning filters and forces all of them to show up
@@ -289,20 +293,37 @@ class JitTestCase(TestCase):
         if not JitTestCase._restored_warnings:
             torch.jit.TracerWarning.ignore_lib_warnings()
             JitTestCase._restored_warnings = True
-        torch._C._jit_set_emit_module_hook(self.emitModuleHook)
+        self.setHooks()
 
     def tearDown(self):
         super(JitTestCase, self).tearDown()
         # needs to be cleared because python might be unloaded before
         # the callback gets destucted
-        torch._C._jit_set_emit_module_hook(None)
+        self.clearHooks()
         torch._C._jit_clear_class_registry()
 
     @contextmanager
-    def disableModuleHook(self):
-        torch._C._jit_set_emit_module_hook(None)
+    def disableEmitHook(self):
+        self.clearHooks()
         yield None
-        torch._C._jit_set_emit_module_hook(self.emitModuleHook)
+        self.setHooks()
+
+    def emitFunctionHook(self, func):
+        # func has invalid names for export, skip the jitter check
+        if func.name == "<lambda>" or "aten::" in func.name:
+            return
+        # disable the hook while we parse code, otherwise we will re-enter the hook
+        with self.disableEmitHook():
+            try:
+                src, constants = _jit_python_print(func)
+                cu = torch.jit.CompilationUnit()._import(src, constants)
+                src2, constants2 = _jit_python_print(getattr(cu, func.name))
+                self.assertMultiLineEqual(src, src2)
+            except RuntimeError as e:
+                se = str(e)
+                if "could not export python function" not in se and \
+                   "closures are not exportable" not in se:
+                    raise
 
     def emitModuleHook(self, module):
         import zipfile
@@ -318,7 +339,7 @@ class JitTestCase(TestCase):
             return c
 
         # disable the hook while we parse code, otherwise we will re-enter the hook
-        with self.disableModuleHook():
+        with self.disableEmitHook():
             try:
                 if len(module.code) == 0:
                     # short-circuit if this is an empty module
@@ -365,6 +386,11 @@ class JitTestCase(TestCase):
             self.assertMultiLineEqual(main_module_code, main_module_2_code)
 
     def getExportImportCopy(self, m, also_test_file=True, map_location=None):
+        if isinstance(m, torch._C.Function):
+            src, constants = _jit_python_print(m)
+            cu = torch.jit.CompilationUnit()._import(src, constants)
+            return getattr(cu, m.name)
+
         buffer = io.BytesIO()
         torch.jit.save(m, buffer)
         buffer.seek(0)
@@ -1219,7 +1245,7 @@ graph(%x : Tensor,
         torch._C._jit_pass_insert_observers(m.graph, observe)
 
         # Collect statistics
-        m.forward(x1, y1)
+        m(x1, y1)
 
         # Check what we collected
         self.assertTrue('p' in value_stats and 'z' in value_stats)
@@ -1229,7 +1255,7 @@ graph(%x : Tensor,
         self.assertEqual(value_stats['z'][0], x1 - y1)
 
         # Run one more time and check the updated statistics
-        m.forward(x2, y2)
+        m(x2, y2)
         self.assertEqual(len(value_stats['p']), 2)
         self.assertEqual(len(value_stats['z']), 2)
         self.assertEqual(value_stats['p'][1], x2 + y2)
@@ -2753,9 +2779,8 @@ graph(%x : Tensor,
             return 2 * x + y
 
         r, _ = _jit_python_print(foo)
-        mod = torch.jit.ScriptModule()
-        torch._C._jit_import_methods(mod._c, "op_version_set = 0\n{}".format(r), [])
-        self.assertExpected(mod.graph.pretty_print())
+        cu = torch.jit.CompilationUnit()._import(r, [])
+        self.assertExpected(cu.foo.graph.pretty_print())
 
     def test_function_default_values(self):
         outer_var = torch.tensor(20)
@@ -3056,17 +3081,15 @@ class TestScript(JitTestCase):
         mod.ninf = float("-inf")
         mod.nan = float("nan")
 
-        with self.disableModuleHook():
+        with self.disableEmitHook():
             @torch.jit.script
             def foo():
                 return math.pi, 0.1, mod.inf, mod.ninf, 2.225073858507201e-308, mod.nan
 
             pp, table = _jit_python_print(foo)
-            ppv = "op_version_set = 0\n{}".format(pp)
-            sm = torch.jit.ScriptModule()
-            torch._C._jit_import_methods(sm._c, ppv, table)
+            sm = torch.jit.CompilationUnit()._import(pp, table)
             r = foo()
-            r2 = sm()
+            r2 = sm.foo()
             # use precise assert, we are checking floating point details
             self.assertTrue(r[:-1] == r2[:-1])
             self.assertTrue(math.isnan(r[-1]) and math.isnan(r2[-1]))
@@ -8708,7 +8731,7 @@ a")
                 return x, x
         ''')
 
-        self.assertExpected(str(cu.__getattr__('foo').schema))
+        self.assertExpected(str(cu.foo.schema))
 
     def test_parser_type_annotations_comment(self):
         cu = torch.jit.CompilationUnit('''
@@ -8717,7 +8740,7 @@ a")
                 return x, x
         ''')
 
-        self.assertExpected(str(cu.__getattr__('foo').schema))
+        self.assertExpected(str(cu.foo.schema))
 
     def test_parser_type_annotations_unknown_type(self):
         with self.assertRaisesRegex(RuntimeError, r'Unknown type name Foo'):
@@ -9306,7 +9329,7 @@ a")
         FileCheck().check("aten::neg").check("aten::add").run(str(traced_fn.graph))
 
     def test_call_script_mod_from_tracing_fn(self):
-        with self.disableModuleHook():
+        with self.disableEmitHook():
             class ScriptMod(torch.jit.ScriptModule):
                 def __init__(self):
                     super(ScriptMod, self).__init__()
@@ -9388,6 +9411,7 @@ a")
                 return traced_fn(torch.mm(x, self.param))
 
         tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
+
         # Note: neg op from the traced function should be properly inlined
         FileCheck().check("aten::mm").check_same("scope: TracedModule") \
             .check_next("aten::neg").check("scope: TracedModule/traced_fn") \
@@ -9600,21 +9624,19 @@ a")
         FileCheck().check("aten::neg").check("aten::add").run(str(script_fn.graph))
 
     def test_call_traced_mod_from_script_fn(self):
-        class TracedModule(torch.nn.Module):
-            def __init__(self):
-                super(TracedModule, self).__init__()
+        with self.assertRaisesRegex(RuntimeError, "Cannot call a ScriptModule that is not a submodule of the caller"):
+            class TracedModule(torch.nn.Module):
+                def __init__(self):
+                    super(TracedModule, self).__init__()
 
-            def forward(self, x):
-                return torch.mm(x, torch.zeros(4, 3))
+                def forward(self, x):
+                    return torch.mm(x, torch.zeros(4, 3))
 
-        tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
+            tm = torch.jit.trace(TracedModule(), torch.rand(3, 4))
 
-        @torch.jit.script
-        def script_fn(x):
-            return tm(x) + 1
-
-        FileCheck().check("aten::zeros").check_same("scope: TracedModule").check("aten::mm") \
-            .check("aten::add").run(str(script_fn.graph))
+            @torch.jit.script
+            def script_fn(x):
+                return tm(x) + 1
 
     def test_call_script_fn_from_script_fn(self):
         @torch.jit.script
@@ -9630,21 +9652,20 @@ a")
         FileCheck().check("aten::neg").run(str(script_fn.graph))
 
     def test_call_script_mod_from_script_fn(self):
-        class ScriptMod(torch.jit.ScriptModule):
-            def __init__(self):
-                super(ScriptMod, self).__init__()
+        with self.assertRaisesRegex(RuntimeError, "Cannot call a ScriptModule that is not a submodule of the caller"):
+            class ScriptMod(torch.jit.ScriptModule):
+                def __init__(self):
+                    super(ScriptMod, self).__init__()
 
-            @torch.jit.script_method
-            def forward(self, x):
-                return torch.mm(x, torch.zeros([4, 3]))
+                @torch.jit.script_method
+                def forward(self, x):
+                    return torch.mm(x, torch.zeros([4, 3]))
 
-        sm = ScriptMod()
+            sm = ScriptMod()
 
-        @torch.jit.script
-        def script_fn(x):
-            return sm(x) + 1
-
-        FileCheck().check("zeros").check("aten::mm").check("add").run(str(script_fn.graph))
+            @torch.jit.script
+            def script_fn(x):
+                return sm(x) + 1
 
     def test_call_python_fn_from_script_module(self):
         def python_fn(x):
@@ -9661,7 +9682,7 @@ a")
 
         sm = ScriptMod()
         FileCheck().check("aten::mm").check("python_fn") \
-            .run(str(sm.__getattr__('forward').graph))
+            .run(str(sm.forward.graph))
 
     def test_call_python_mod_from_script_module(self):
         class PythonMod(torch.nn.Module):
@@ -9702,7 +9723,7 @@ a")
                 return traced_fn(torch.mm(x, self.param))
 
         sm = ScriptMod()
-        FileCheck().check("aten::mm").check("aten::neg").run(str(sm.__getattr__('forward').graph))
+        FileCheck().check("aten::mm").check("aten::neg").run(str(sm.forward.graph))
 
     def test_call_tracing_mod_from_script_module(self):
         class TracedMod(torch.nn.Module):
@@ -9745,7 +9766,7 @@ a")
                 return script_fn(torch.mm(x, self.param))
 
         sm = ScriptMod()
-        graph = (sm.__getattr__('forward').graph)
+        graph = (sm.forward.graph)
         FileCheck().check("aten::mm").check("aten::neg").run(str(graph))
 
     def test_call_script_mod_from_script_module(self):
@@ -9776,8 +9797,7 @@ a")
         FileCheck().check_count('%', 3).check(":").check_count("mm", 2).run(str(sm.graph))
 
     def test_module_with_params_called_fails(self):
-        with self.assertRaisesRegex(RuntimeError, "Attempted to inline a Module with parameters. Stateful "
-                                                  "modules to be inlined must be submodules of the callee."):
+        with self.assertRaisesRegex(RuntimeError, "Cannot call a ScriptModule that is not a submodule of the caller"):
             class ScriptMod(torch.jit.ScriptModule):
                 def __init__(self):
                     super(ScriptMod, self).__init__()
@@ -9937,7 +9957,7 @@ a")
             # type: (Tensor, Tuple[Tensor, Tensor, Tensor], Tuple[Tensor, Tuple[Tensor, Tensor]]) -> Tensor
             return x
 
-        self.assertExpected(str(foo.__getattr__('forward').schema))
+        self.assertExpected(str(foo.schema))
 
     def test_annotated_script_method(self):
         class SM(torch.jit.ScriptModule):
@@ -9948,7 +9968,7 @@ a")
 
         sm = SM()
 
-        self.assertExpected(str(sm.__getattr__('forward').schema))
+        self.assertExpected(str(sm.forward.schema))
 
     def test_annotated_script_fn_return_mismatch(self):
         with self.assertRaisesRegex(RuntimeError, "but is actually of type"):
@@ -10042,7 +10062,7 @@ a")
         test_str = []
         for pair in self.type_input_return_pairs():
             cu = torch.jit.CompilationUnit(self.format_code(code, pair))
-            test_str.append(str(cu.__getattr__('foo').schema))
+            test_str.append(str(cu.foo.schema))
         self.assertExpected("\n".join(test_str))
 
     #  String frontend , Python 3-style type annotations , Script method
@@ -10059,7 +10079,7 @@ a")
         for pair in self.type_input_return_pairs():
             tm = TestModule()
             tm.define(self.format_code(code, pair))
-            test_str.append(str(tm.__getattr__('foo').schema))
+            test_str.append(str(tm.foo.schema))
         self.assertExpected("\n".join(test_str))
 
     #  String frontend , MyPy-style type comments , Script function
@@ -10072,7 +10092,7 @@ a")
         test_str = []
         for pair in self.type_input_return_pairs():
             cu = torch.jit.CompilationUnit(self.format_code(code, pair))
-            test_str.append(str(cu.__getattr__('foo').schema))
+            test_str.append(str(cu.foo.schema))
         self.assertExpected("\n".join(test_str))
 
     #  String frontend , MyPy-style type comments , Script method
@@ -10091,7 +10111,7 @@ a")
         for pair in self.type_input_return_pairs():
             tm = TestModule()
             tm.define(self.format_code(code, pair))
-            test_str.append(str(tm.__getattr__('foo').schema))
+            test_str.append(str(tm.foo.schema))
         self.assertExpected("\n".join(test_str))
 
     # Helper function to eval Python3 code without causing a syntax error for
@@ -10123,7 +10143,7 @@ a")
         test_str = []
         for pair in self.type_input_return_pairs():
             fn = self._get_py3_code(self.format_code(code, pair), 'foo')
-            test_str.append(str(fn.__getattr__('forward').schema))
+            test_str.append(str(fn.schema))
         self.assertExpected("\n".join(test_str))
 
     #  Python AST Frontend , Python 3-style type annotations , Script method
@@ -10145,7 +10165,7 @@ a")
         test_str = []
         for pair in self.type_input_return_pairs():
             fn = self._get_py3_code(self.format_code(code, pair), 'instance')
-            test_str.append(str(fn.__getattr__('foo').schema))
+            test_str.append(str(fn.foo.schema))
         self.assertExpected("\n".join(test_str))
 
     #  Python AST Frontend , MyPy-style type comments , Script function
@@ -10162,7 +10182,7 @@ a")
         test_str = []
         for pair in self.type_input_return_pairs():
             fn = self._get_py3_code(self.format_code(code, pair), 'foo')
-            test_str.append(str(fn.__getattr__('forward').schema))
+            test_str.append(str(fn.schema))
         self.assertExpected("\n".join(test_str))
 
     #  Python AST Frontend , MyPy-style type comments , Script method
@@ -10181,7 +10201,7 @@ a")
         test_str = []
         for pair in self.type_input_return_pairs():
             fn = self._get_py3_code(self.format_code(code, pair), 'instance')
-            test_str.append(str(fn.__getattr__('foo').schema))
+            test_str.append(str(fn.foo.schema))
         self.assertExpected("\n".join(test_str))
 
     def test_method_casts_script(self):
@@ -10782,7 +10802,7 @@ a")
 
         self.assertIsNot(other_strong_mod.weak, other_strong_mod.weak2)
 
-        with self.assertRaisesRegex(RuntimeError, "Attempted to inline a Module with param"):
+        with self.assertRaisesRegex(RuntimeError, "Cannot call a ScriptModule that is not a submodule of the caller"):
             strong_mod = Strong()
 
     def test_weak_module_copying(self):
@@ -10994,7 +11014,7 @@ a")
         self.checkScript(foo, (torch.rand(2, 3), torch.rand(3)))
 
     def test_bool_dispatch(self):
-        with self.disableModuleHook():  # TODO: Python print broadcasting list
+        with self.disableEmitHook():  # TODO: Python print broadcasting list
             def kwarg_false(x):
                 # type: (Tensor) -> Tensor
                 return F.max_pool1d(x, 1, 1, return_indices=False)
@@ -11436,14 +11456,12 @@ a")
 
         # Export and ensure ignored code not present
         pp, constants = _jit_python_print(m.forward)
-        printed = torch.jit.ScriptModule()
-        ppv = "op_version_set = 0\n{}".format(pp)
-        torch._C._jit_import_methods(printed._c, ppv, constants)
-        self.assertIn('IgnoredPythonOp', ppv)
-        self.assertNotIn('ignored_code', ppv)
+        printed = torch.jit.CompilationUnit()._import(pp, constants)
+        self.assertIn('IgnoredPythonOp', pp)
+        self.assertNotIn('ignored_code', pp)
 
         with self.assertRaisesRegex(torch.jit.Error, "This Python function is annotated to be ignored"):
-            printed(torch.ones(1))
+            printed.forward(torch.ones(1))
 
     def test_view_write(self):
         def fn(x, y):
@@ -11595,7 +11613,7 @@ a")
                 # type: (str) -> Tensor
                 return self.table[key] + self.x
 
-        with self.disableModuleHook():
+        with self.disableEmitHook():
             # TODO: re-enable module hook when Python printing of attributes is
             # supported
             m = M({char : torch.ones(1) + ord(char) - ord("a") for char in "abcdefg"})
@@ -13424,7 +13442,7 @@ def add_nn_functional_test(name, self_size, args, variant_name='', check_ad=(), 
                     self.assertAutodiffNode(script_fn.last_graph, should_autodiff_node, autodiff_nodes, fusible_nodes)
 
             if test_name in EXCLUDE_PYTHON_PRINT:
-                with self.disableModuleHook():
+                with self.disableEmitHook():
                     run_test()
             else:
                 run_test()
@@ -13497,7 +13515,7 @@ def add_nn_module_test(*args, **kwargs):
                     self.submodule = nn_module(*constructor_args)
             # module cannot be imported / exported
             if module_name in EXCLUDE_MODULE_EXPORT_IMPORT:
-                with self.disableModuleHook():
+                with self.disableEmitHook():
                     module = TheModule()
                     module.define(script)
                     create_script_module.last_graph = module.graph

--- a/torch/csrc/jit/hooks_for_testing.cpp
+++ b/torch/csrc/jit/hooks_for_testing.cpp
@@ -11,9 +11,19 @@ TORCH_API void didFinishEmitModule(std::shared_ptr<script::Module> module) {
     emit_module_callback(std::move(module));
   }
 }
-TORCH_API void setEmitModuleHook(
-    std::function<void(std::shared_ptr<script::Module> module)> cb) {
-  emit_module_callback = std::move(cb);
+static std::function<void(std::shared_ptr<script::Function> fn)>
+    emit_function_callback;
+TORCH_API void didFinishEmitFunction(std::shared_ptr<script::Function> fn) {
+  if (emit_function_callback) {
+    emit_function_callback(fn);
+  }
 }
+TORCH_API void setEmitHooks(
+    std::function<void(std::shared_ptr<script::Module> module)> for_mod,
+    std::function<void(std::shared_ptr<script::Function> for_fn)> for_fn) {
+  emit_module_callback = std::move(for_mod);
+  emit_function_callback = std::move(for_fn);
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/hooks_for_testing.h
+++ b/torch/csrc/jit/hooks_for_testing.h
@@ -7,9 +7,12 @@ namespace torch {
 namespace jit {
 namespace script {
 struct Module;
+struct Function;
 }
 TORCH_API void didFinishEmitModule(std::shared_ptr<script::Module> module);
-TORCH_API void setEmitModuleHook(
-    std::function<void(std::shared_ptr<script::Module> module)> cb);
+TORCH_API void didFinishEmitFunction(std::shared_ptr<script::Function> defined);
+TORCH_API void setEmitHooks(
+    std::function<void(std::shared_ptr<script::Module> module)> for_module,
+    std::function<void(std::shared_ptr<script::Function> fn)> for_fn);
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -21,6 +21,16 @@ TORCH_API void import_libs(
     const std::string& src,
     const std::vector<at::Tensor>& constant_table);
 
+// Add the functions defined in `src` to the module `mod`.
+// self is passed through the CompilationUnit's define function.
+// If present, it determines the SugaredValue for the first argument
+// and that argument is no longer expected to have type annotations.
+TORCH_API void import_functions(
+    CompilationUnit& cu,
+    const std::string& src,
+    const std::vector<at::Tensor>& constant_table,
+    const Self& self=nullptr);
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -5,8 +5,8 @@ namespace c10 {
 
 // This file exists because we need to reference module.h, which we can't from
 // c10. Sigh...
-Function* ClassType::getMethod(const std::string& name) const {
-  return compilation_unit_->find_function(name).get();
+std::shared_ptr<Function> ClassType::getMethod(const std::string& name) const {
+  return compilation_unit_->find_function(name);
 }
 
 CompilationUnit& ClassType::compilation_unit() {

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -116,7 +116,7 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
   if (auto classType = value_->type()->cast<ClassType>()) {
     // This is a class, emit the proper attribute lookup
     if (auto method = classType->getMethod(field)) {
-      return std::make_shared<MethodValue>(getValue(), *method);
+      return std::make_shared<MethodValue>(getValue(), method);
     }
 
     if (!classType->hasAttribute(field)) {
@@ -232,7 +232,7 @@ std::shared_ptr<SugaredValue> ClassValue::call(
   AT_ASSERT(initMethod);
 
   // Call the init function
-  MethodValue(self, *initMethod).call(loc, m, inputs, attributes, n_binders);
+  MethodValue(self, initMethod).call(loc, m, inputs, attributes, n_binders);
 
   return std::make_shared<SimpleValue>(self);
 }

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -208,8 +208,8 @@ struct TORCH_API ClassValue : public SugaredValue {
 
 // defines how a method obtained from a module behaves in script
 struct MethodValue : public SugaredValue {
-  MethodValue(c10::optional<NamedValue> self, Function& method)
-      : self_(std::move(self)), method(method) {}
+  MethodValue(c10::optional<NamedValue> self, std::shared_ptr<Function> method)
+      : self_(std::move(self)), method_(std::move(method)) {}
   std::string kind() const override {
     return "method";
   }
@@ -225,16 +225,16 @@ struct MethodValue : public SugaredValue {
       inputsWithSelf.emplace_back(loc, self_->value(graph));
       inputsWithSelf.insert(inputsWithSelf.end(), inputs.begin(), inputs.end());
       return std::make_shared<SimpleValue>(
-          method.emit_call(graph, loc, inputsWithSelf, attributes));
+          method_->emit_call(graph, loc, inputsWithSelf, attributes));
     }
 
     return std::make_shared<SimpleValue>(
-        method.emit_call(graph, loc, inputs, attributes));
+        method_->emit_call(graph, loc, inputs, attributes));
   }
 
  private:
   c10::optional<NamedValue> self_;
-  Function& method;
+  std::shared_ptr<Function> method_;
 };
 
 struct TORCH_API PrintValue : public SugaredValue {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -52,7 +52,6 @@ def _parse_env(name, default, true_message, false_message):
 _enabled = _parse_env('PYTORCH_JIT', True, "> Using PyTorch JIT", "> PyTorch JIT DISABLED")
 _flatten = torch._C._jit_flatten
 _unflatten = torch._C._jit_unflatten
-_jit_script_compile = torch._C._jit_script_compile
 _jit_script_class_compile = torch._C._jit_script_class_compile
 
 Future = torch._C.Future
@@ -661,22 +660,30 @@ def trace(func,
     # done primarily so that weird iterables fail here and not pybind11 code
     elif not isinstance(example_inputs, tuple):
         example_inputs = tuple(example_inputs)
-    if _module_class:
-        module = _module_class(func, **executor_options)
-    else:
-        module = TopLevelTracedModule(func, **executor_options)
     var_lookup_fn = _create_interpreter_name_lookup_fn(0)
-    module._c._create_method_from_trace('forward', func, example_inputs,
-                                        var_lookup_fn, _force_outplace)
+
+    if isinstance(func, torch.nn.Module):
+        if _module_class is None:
+            _module_class = TopLevelTracedModule
+        traced = _module_class(func, **executor_options)
+        traced._c._create_method_from_trace('forward', func, example_inputs,
+                                           var_lookup_fn, _force_outplace)
+    else:
+        name = getattr(func, '__name__', 'forward')
+        if name == '<lambda>':
+            name = '_lambda' # make name a valid identifier
+        traced = torch._C._create_function_from_trace(name, func, example_inputs,
+                                                      var_lookup_fn,
+                                                      _force_outplace)
 
     # Check the trace against new traces created from user-specified inputs
     if check_trace:
         if check_inputs is not None:
-            _check_trace(check_inputs, func, executor_options, module, check_tolerance, _force_outplace)
+            _check_trace(check_inputs, func, executor_options, traced, check_tolerance, _force_outplace)
         else:
-            _check_trace([example_inputs], func, executor_options, module, check_tolerance, _force_outplace)
+            _check_trace([example_inputs], func, executor_options, traced, check_tolerance, _force_outplace)
 
-    return module
+    return traced
 
 
 class CompilationUnit(object):
@@ -696,6 +703,21 @@ class CompilationUnit(object):
         if r is None:
             raise AttributeError("'CompilationUnit' has no attribute '{}'".format(attr))
         return r
+
+    def _import(self, src, constants):
+        """ test import logic for single function, use only for testing """
+        src = "op_version_set = 0\n{}".format(src)
+        # HACK: export always adds a self argument
+        # even if the thing is a pure function,
+        # we just delete it here
+        # Once the serialization outputs the first-class
+        # functions and not the lowered functions,
+        # we can change this behavior
+        src = (src.replace('self,\n', '')
+                  .replace('(self)', '()')
+                  .replace('self.__forked_function', '__forked_function'))
+        torch._C._jit_import_functions(self._c, src, constants, None)
+        return self
 
 
 def _try_get_dispatched_fn(fn):
@@ -742,12 +764,11 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
         _add_script_class(obj, obj.__name__)
         return obj
     else:
-        mod = ScriptModule()
         ast = get_jit_def(obj)
-        _jit_script_compile(mod._c, ast, _rcb, get_default_args(obj))
+        fn = torch._C._jit_script_compile(ast, _rcb, get_default_args(obj))
         # Forward docstrings
-        mod.__doc__ = obj.__doc__
-        return mod
+        fn.__doc__ = obj.__doc__
+        return fn
 
 
 ScriptMethodStub = namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))
@@ -1378,11 +1399,8 @@ class TracedModule(ScriptModule):
         if id_set is None:
             id_set = set()
 
-        if not isinstance(orig, torch.nn.Module):
-            self._name = orig.__name__
-            orig = torch.nn.Module()
-        else:
-            self._name = 'TracedModule[' + type(orig).__name__ + ']'
+        assert(isinstance(orig, torch.nn.Module))
+        self._name = 'TracedModule[' + type(orig).__name__ + ']'
 
         def check_unique(param):
             if param in id_set:
@@ -1595,6 +1613,7 @@ def _graph_for(self, *args, **kwargs):
 
 torch._C.ScriptMethod.graph_for = _graph_for
 torch._C.Function.graph_for = _graph_for
+Function = torch._C.Function
 
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19724 Remove duplicate inlineCallToCode
* #19723 Serialize first-class version of functions
* #19722 Trace directly into first-class module form.
* **#19721 @torch.jit.script(fn) now is a torch.jit.Function**
* #19720 pybind CompilationUnit and Function directly

Differential Revision: [D15078534](https://our.internmc.facebook.com/intern/diff/D15078534)