### PR TITLE
Trace directly into first-class module form.

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -50,6 +50,10 @@ struct Argument {
     return alias_info_;
   }
 
+  Argument cloneWithType(TypePtr new_type) const {
+    return Argument(name_, new_type, N_, default_value_, kwarg_only_, alias_info_);
+  }
+
 private:
   std::string name_;
   TypePtr type_;
@@ -109,8 +113,7 @@ struct FunctionSchema {
       std::vector<Argument> arguments,
       std::vector<Argument> returns,
       bool is_vararg = false,
-      bool is_varret = false,
-      std::vector<std::string> writes = {})
+      bool is_varret = false)
       : FunctionSchema(
             name.toQualString(),
             std::move(overload_name),
@@ -178,6 +181,8 @@ public:
         is_vararg(),
         is_varret());
   }
+
+  FunctionSchema cloneWithRemappedTypes(const std::function<TypePtr(TypePtr)> type_map) const;
 
   // Check that inputs have the correct types and appends any missing default
   // values.

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -142,4 +142,23 @@ inline void FunctionSchema::checkAndNormalizeInputs(
   }
 }
 
+inline FunctionSchema FunctionSchema::cloneWithRemappedTypes(
+    const std::function<TypePtr(TypePtr)> type_map) const {
+  auto update_args = [&](const std::vector<Argument>& args) {
+    std::vector<Argument> new_args;
+    new_args.reserve(args.size());
+    for(const Argument& arg : args) {
+      new_args.emplace_back(arg.cloneWithType(type_map(arg.type())));
+    }
+    return new_args;
+  };
+  return FunctionSchema(
+      name(),
+      overload_name(),
+      update_args(arguments()),
+      update_args(returns()),
+      is_vararg(),
+      is_varret());
+}
+
 } // namespace c10

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -912,7 +912,7 @@ struct Block {
   // value_map is used whenever a node in src references a free variable
   // in src to look up its corresponding value
   TORCH_API void cloneFrom(Block* src, std::function<Value*(Value*)> value_map);
-
+  TORCH_API void remapTypes(const std::function<TypePtr(TypePtr)>& type_map);
  private:
   void reIndexTopology();
 
@@ -1169,6 +1169,7 @@ struct Graph {
   TORCH_API void dumpPretty();
 
   TORCH_API std::shared_ptr<Graph> copy();
+  TORCH_API void remapTypes(const std::function<TypePtr(TypePtr)>& type_map);
 
  private:
   TORCH_API void freeNode(Node* n);

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -41,9 +41,10 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
     TypedStack trace_inputs,
     const py::function& var_name_lookup_fn,
     bool force_outplace,
-    const c10::optional<size_t>& num_real_inputs) {
-  size_t num_func_inputs = num_real_inputs.value_or(trace_inputs.size());
-  auto enter_info = tracer::enter(std::move(trace_inputs));
+    const std::shared_ptr<script::Module>& self) {
+  auto enter_info = tracer::enter(std::move(trace_inputs), self);
+  auto graph = enter_info.first->graph;
+
   getTracingState()->lookup_var_name_fn =
       [var_name_lookup_fn](const Variable& var) -> std::string {
     AutoGIL ag;
@@ -51,6 +52,7 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
   };
   getTracingState()->force_outplace = force_outplace;
   try {
+    size_t num_func_inputs = enter_info.second.size();
     py::tuple py_inputs(num_func_inputs);
     for (size_t i = 0; i < num_func_inputs; ++i) {
       py_inputs[i] = py::cast(enter_info.second[i]);
@@ -62,7 +64,6 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
           "captured in traces, so it would be a no-op.");
     }
     tracer::exit({toIValue(out)});
-    auto graph = enter_info.first->graph;
     EliminateDeadCode(graph);
     LowerSimpleTuples(graph);
 

--- a/torch/csrc/jit/python_tracer.h
+++ b/torch/csrc/jit/python_tracer.h
@@ -9,6 +9,11 @@
 
 namespace torch {
 namespace jit {
+
+namespace script {
+  struct Module;
+}
+
 namespace tracer {
 void initPythonTracerBindings(PyObject* module);
 
@@ -24,7 +29,7 @@ std::shared_ptr<Graph> createGraphByTracing(
     TypedStack inputs,
     const py::function& var_name_lookup_fn,
     bool force_outplace,
-    const c10::optional<size_t>& num_real_inputs = c10::nullopt);
+    const std::shared_ptr<script::Module>& self = nullptr);
 } // namespace tracer
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -218,14 +218,11 @@ struct TORCH_API CompilationUnit {
       const ResolverPtr& resolver,
       const Self& self);
 
-  void clone_function(const Function& remote) {
-    create_function(remote.name(), remote.graph()->copy());
-  }
-
-  Function& create_function(std::string name, std::shared_ptr<Graph> graph) {
+  std::shared_ptr<Function> create_function(std::string name, std::shared_ptr<Graph> graph) {
     auto fn = std::make_shared<Function>(
         std::move(name), is_optimized(), std::move(graph), nullptr);
-    return register_function(std::move(fn));
+    register_function(fn);
+    return fn;
   }
 
   const std::vector<std::shared_ptr<Function>>& get_functions() const {

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -210,11 +210,14 @@ std::pair<std::shared_ptr<Graph>, std::vector<Slot>> lower_graph(
   return std::make_pair(std::move(g), std::move(extra_ivalues));
 }
 
-Method& Module::lower_first_class_method(Function* fn) {
+std::pair<std::shared_ptr<Function>, std::vector<Slot>> Module::
+    lower_first_class_method(Function* fn) {
   fn->ensure_defined();
   auto lowered = lower_graph(module_object(), *fn->graph());
-  Function& new_func =
-      lowered_methods_.create_function(fn->name(), lowered.first);
+  CompilationUnit cu;
+  cu.set_optimized(fn->is_optimized());
+  std::shared_ptr<Function> new_func =
+      cu.create_function(fn->name(), lowered.first);
 
   // generate the new schema
   // slice away the self argument
@@ -227,125 +230,107 @@ Method& Module::lower_first_class_method(Function* fn) {
     ss << "slot" << id++;
     args.emplace_back(ss.str(), slot.type());
   }
-  new_func.setSchema(fn->getSchema().cloneWithArguments(std::move(args)));
-  return _create_lowered_method(&new_func, std::move(lowered.second));
+  new_func->setSchema(fn->getSchema().cloneWithArguments(std::move(args)));
+  return std::make_pair(new_func, std::move(lowered.second));
 }
 
-static void createFirstClassValues(
-    Module* module,
-    Value* self,
-    std::unordered_map<Slot, Value*>& result) {
-  auto& g = *self->owningGraph();
-
-  std::vector<Node*> created;
-  struct ToScan {
-    Module* mod;
-    Value* v; // value representing module in the graph
-  };
-  std::vector<ToScan> to_scan = {{module, self}};
-
-  while (!to_scan.empty()) {
-    auto s = to_scan.back();
-    to_scan.pop_back();
-    size_t offset = 0;
-    for (const std::string& name :
-         s.mod->module_object()->type()->attributeNames()) {
-      Value* v = g.insertGetAttr(s.v, name);
-      result[Slot(s.mod->module_object(), offset++)] = v;
-      if (std::shared_ptr<Module> sub = s.mod->find_module(name)) {
-        to_scan.emplace_back(ToScan{sub.get(), v});
-      }
-    }
-  }
+static FunctionSchema sliceFirst(const FunctionSchema& schema) {
+  // we are required to slice out the self argument
+  // because it is not expected to appear in Module schema
+  // until the executor is made to be first-class
+  std::vector<Argument> sliced(
+      schema.arguments().begin() + 1, schema.arguments().end());
+  return schema.cloneWithArguments(std::move(sliced));
 }
 
-void Module::lift_lowered_method(Method& m) {
-  auto graph = m.graph()->copy();
-  Value* self = graph->insertInput(0, "self")->setType(module_object()->type());
-  std::unordered_map<Slot, Value*> slot_to_value;
-  if (!m.initial_ivalues().empty()) {
-    WithInsertPoint guard(*graph->nodes().begin());
-    createFirstClassValues(this, self, slot_to_value);
-  }
-
-  size_t orig_graph_inputs_size = graph->inputs().size();
-  for (size_t i = 0; i < m.initial_ivalues().size(); ++i) {
-    size_t input_offset = orig_graph_inputs_size - i - 1;
-    size_t ivalue_offset = m.initial_ivalues().size() - i - 1;
-    graph->inputs()
-        .at(input_offset)
-        ->replaceAllUsesWith(
-            slot_to_value.at(m.initial_ivalues().at(ivalue_offset)));
-    graph->eraseInput(input_offset);
-  }
-
-  if (!m.initial_ivalues().empty()) {
-    // we added _all_ the submodules as first-class values but maybe did not use
-    // them. So remove any dead attribute lookups
-    EliminateDeadCode(graph);
-  }
-
-  Function& new_fn = class_cu().create_function(m.name(), std::move(graph));
-  // created lifted schema
-  // self argument is named '$self' to prevent accidental name collisions
-  // with another input that the user named 'self'
-  std::vector<Argument> new_args = {Argument("$self", module_object()->type())};
-  const auto& lowered_args = m.function().getSchema().arguments();
-  new_args.insert(
-      new_args.end(),
-      lowered_args.begin(),
-      lowered_args.begin() + m.num_inputs());
-  new_fn.setSchema(m.function().getSchema().cloneWithArguments(std::move(new_args)));
-}
-
-Method& Module::_create_lowered_method(
-    Function* func,
-    std::vector<Slot> member_inputs) {
-  std::unique_ptr<Method> m(new Method(this, func, std::move(member_inputs)));
-  return *insert(func->name(), methods_, EntityType::METHOD, std::move(m));
-}
-
-void Module::lift_lowered_methods(size_t start) {
-  for (size_t i = start; i < lowered_methods_.get_functions().size(); ++i) {
-    Method& m = _create_lowered_method(
-        lowered_methods_.get_functions().at(i).get(), {});
-    lift_lowered_method(m);
-  }
-}
-
-void Module::_define_lowered(
-    const std::vector<Def>& definitions,
-    const std::vector<ResolverPtr>& resolvers) {
-  size_t start = lowered_methods_.get_functions().size();
-  lowered_methods_.define(definitions, resolvers, nullptr);
-  lift_lowered_methods(start);
-  // call lift_lowered_method for each definition
-}
-
-void Module::_define_lowered(
-    const std::string& src,
-    const ResolverPtr& resolver) {
-  size_t start = lowered_methods_.get_functions().size();
-  lowered_methods_.define(src, resolver, nullptr);
-  lift_lowered_methods(start);
-}
-
-Method& Module::_define_lowered(
-    std::string name,
-    std::shared_ptr<Graph> graph,
-    std::vector<Slot> slots) {
-  Method& m = _create_lowered_method(
-      &lowered_methods_.create_function(std::move(name), std::move(graph)),
-      std::move(slots));
-  lift_lowered_method(m);
-  return m;
+Method::Method(Module* owner, Function* first_class_function)
+    : owner_(owner), schema_(sliceFirst(first_class_function->getSchema())) {
+  std::tie(function_, initial_ivalues_) =
+      owner->lower_first_class_method(first_class_function);
 }
 
 void Module::define(const std::string& src, const ResolverPtr& resolver) {
-  class_cu().define(
+  class_compilation_unit().define(
       src,
       resolver ? resolver : script::nativeResolver(),
       simpleSelf(module_object()->type()));
+}
+
+void Module::copy_into(
+    const ModuleLookup& module_lookup,
+    // translate current module singleton type to new module
+    // singleton type.
+    std::unordered_map<TypePtr, TypePtr>& type_remap,
+    std::vector<std::string> names) const {
+  auto curr = module_lookup(names);
+  type_remap[module_object()->type()] = curr->module_object()->type();
+  for (auto& param : get_parameters()) {
+    curr->register_parameter(
+        param.name(),
+        param.value().toTensor(),
+        /*is_buffer=*/false);
+  }
+  for (auto& attr : get_attributes()) {
+    curr->register_attribute(attr.name(), attr.type(), attr.value());
+  }
+
+  for (auto& mod : get_modules()) {
+    names.push_back(mod->name());
+    // Submodules must be translated first, otherwise parameter_remap entries
+    // will not be filled in for methods of this module.
+    mod->copy_into(module_lookup, type_remap, names);
+    names.pop_back();
+  }
+
+  for (auto& fn : class_compilation_unit().get_functions()) {
+    curr->clone_method(*this, fn->name(), type_remap);
+  }
+}
+
+
+void Module::clone_method(
+    const Module& orig,
+    const std::string& name,
+    const std::unordered_map<TypePtr, TypePtr>& type_remap) {
+  // type remapping - when we copy method implementations from one module
+  // singleton to another, we need to update the types of the self arguments
+  // to match the new module.
+  // XXX - this only handles modules that occur as variables, not modules
+  // that appear in aggregate types. Currently this works fine because
+  // we restrict how modules can be used during the lowering step. Eventually,
+  // we will need to decide what it means for us to 'copy' a module.
+  // For instance, we can copy just the state (parameters, attributes),
+  // but share the code. Or we can copy the code. If we choose to copy the
+  // code, what should we do about aggregate types that contain a module?
+  auto type_remap_fn = [&](TypePtr in) {
+    auto it = type_remap.find(in);
+    if (it == type_remap.end())
+      return in;
+    return it->second;
+  };
+  const Function& fn = orig.class_compilation_unit().get_function(name);
+  auto graph = fn.graph()->copy();
+  graph->remapTypes(type_remap_fn);
+  auto schema = fn.getSchema().cloneWithRemappedTypes(type_remap_fn);
+  auto copied = class_compilation_unit().create_function(fn.name(), graph);
+  copied->setSchema(std::move(schema));
+}
+
+void Module::clone_method(const Module& orig, const std::string& name) {
+  std::unordered_map<TypePtr, TypePtr> type_remap;
+  std::vector<std::pair<const Module*, const Module*>> to_scan = {
+      {&orig, this}};
+  while (!to_scan.empty()) {
+    auto entry = to_scan.back();
+    to_scan.pop_back();
+    type_remap[entry.first->module_object()->type()] =
+        entry.second->module_object()->type();
+    for (const auto& sub : entry.first->get_modules()) {
+      to_scan.emplace_back(
+          sub.get(), entry.second->get_module(sub->name()).get());
+    }
+  }
+  return clone_method(orig, name, type_remap);
 }
 
 void Module::train(bool on) {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -55,12 +55,7 @@ using ModuleLookup =
     std::function<std::shared_ptr<Module>(const std::vector<std::string>&)>;
 
 struct TORCH_API Method {
-  Method(Module* owner, Function* function, std::vector<Slot> initial_members)
-      : owner_(owner),
-        function_(function),
-        initial_ivalues_(std::move(initial_members)) {
-    AT_ASSERT(function->num_inputs() >= initial_ivalues_.size());
-  }
+  Method(Module* owner, Function* function);
 
   // the module that contains this method.
   Module& owner() const {
@@ -105,13 +100,8 @@ struct TORCH_API Method {
     return function_->num_inputs() - initial_ivalues_.size();
   }
 
-  FunctionSchema getSchema() const {
-    // we are required to slice out the slot inputs from the schema
-    // we can't cache this because setSchema on the underlying function
-    // will change the underlying schema
-    auto sliced = ArrayRef<Argument>(function_->getSchema().arguments())
-                      .slice(0, num_inputs());
-    return function_->getSchema().cloneWithArguments(sliced.vec());
+  const FunctionSchema& getSchema() const {
+    return schema_;
   }
 
   GraphExecutor& get_executor() {
@@ -128,11 +118,14 @@ struct TORCH_API Method {
   Module* owner_;
 
   // Underlying unbound function
-  Function* function_;
+  // This is the _lowered_ function and is different than the
+  // first-class function in class_compilation_unit()
+  std::shared_ptr<Function> function_;
 
   // parameters and attributes loaded from the Module and appending
   // before calling function_
   std::vector<Slot> initial_ivalues_;
+  FunctionSchema schema_;
 };
 
 struct Module;
@@ -150,7 +143,7 @@ struct TORCH_API Module {
     // Function has a self argument which owns the ClassType, created a
     // referernce cycle. By dropping all the methods of the module's class
     // here we break the cycle.
-    class_cu().drop_all_functions();
+    class_compilation_unit().drop_all_functions();
   }
   const std::string& name() const {
     return name_;
@@ -159,12 +152,11 @@ struct TORCH_API Module {
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
   void set_optimized(bool o) {
-    lowered_methods().set_optimized(o);
-    class_cu().set_optimized(o);
+    class_compilation_unit().set_optimized(o);
   }
 
   bool is_optimized() const {
-    return class_cu().is_optimized();
+    return class_compilation_unit().is_optimized();
   }
 
   IValue forward(std::vector<IValue> inputs) {
@@ -283,8 +275,8 @@ struct TORCH_API Module {
   }
   const std::vector<std::unique_ptr<Method>>& get_methods() const {
     // force methods_ to be up to date by querying all
-    // methods. This will go away when lowered_methods_ is deleted
-    for (const auto& m : class_cu().get_functions()) {
+    // methods.
+    for (const auto& m : class_compilation_unit().get_functions()) {
       get_method(m->name());
     }
     return methods_;
@@ -315,13 +307,21 @@ struct TORCH_API Module {
       return methods_[*offset].get();
     }
 
-    if (Function* fn = class_cu().find_function(name).get()) {
-      // temporary lock because technically this is marked const,
+    if (Function* fn = class_compilation_unit().find_function(name).get()) {
+      // lock because technically this is marked const,
       // but we have to update the internal Method cache.
-      // This can be removed when class_cu() is the source of truth for
-      // methods.
-      std::lock_guard<std::recursive_mutex> guard(find_method_guard_);
-      return &const_cast<Module*>(this)->lower_first_class_method(fn);
+      // This can be removed when class_compilation_unit() is the source of
+      // truth for methods.
+      std::lock_guard<std::recursive_mutex> guard(create_method_guard_);
+      Module* mutable_this = const_cast<Module*>(this);
+      std::unique_ptr<Method> m(new Method(mutable_this, fn));
+      return mutable_this
+          ->insert(
+              fn->name(),
+              mutable_this->methods_,
+              EntityType::METHOD,
+              std::move(m))
+          .get();
     }
 
     return nullptr;
@@ -399,51 +399,31 @@ struct TORCH_API Module {
       const ExtraFilesMap& extra_files = ExtraFilesMap());
 
   void copy_into(
-      ModuleLookup module_lookup,
-      // parameter_remap is needed when a parent module uses a parameter of a
-      // submodule
-      std::unordered_map<Slot, Slot>& parameter_remap,
-      std::vector<std::string> names = {}) const {
-    auto curr = module_lookup(names);
-    for (auto& param : get_parameters()) {
-      curr->register_parameter(
-          param.name(),
-          param.value().toTensor(),
-          /*is_buffer=*/false);
-      parameter_remap[param] = curr->parameter_slot(param.name());
-    }
-    for (auto& attr : get_attributes()) {
-      if (attr.type()->isSubtypeOf(TensorType::get())) {
-        curr->register_buffer(attr.name(), attr.value().toTensor());
-        parameter_remap[attr] = *curr->find_buffer(attr.name());
-      } else {
-        curr->register_attribute(attr.name(), attr.type(), attr.value());
-        parameter_remap[attr] = *curr->find_attribute(attr.name());
-      }
-    }
-    for (auto& mod : get_modules()) {
-      names.push_back(mod->name());
-      // Submodules must be translated first, otherwise parameter_remap entries
-      // will not be filled in for methods of this module.
-      mod->copy_into(module_lookup, parameter_remap, names);
-      names.pop_back();
-    }
+      const ModuleLookup& module_lookup,
+      // translate current module singleton type to new module
+      // singleton type.
+      std::unordered_map<TypePtr, TypePtr>& type_remap,
+      std::vector<std::string> names = {}) const;
 
-    for (auto& fn : class_cu().get_functions()) {
-      curr->class_cu().clone_function(*fn);
-    }
-  }
+  void clone_method(
+      const Module& orig,
+      const std::string& name,
+      const std::unordered_map<TypePtr, TypePtr>& type_remap);
+
+  void clone_method(const Module& orig, const std::string& name);
 
   enum class EntityType { MODULE, PARAMETER, ATTRIBUTE, METHOD };
 
   at::optional<EntityType> kind_of(const std::string& name) const {
-    // force lazy creation of Method if needed
-    // remove once lowered_methods_ is removed.
-    find_method(name);
-
     auto it = dict_.find(name);
-    if (it == dict_.end())
+    if (it == dict_.end()) {
+      // methods are lazily created, see if this is, in face,
+      // a method that has not been created yet.
+      if (auto fn = class_compilation_unit().find_function(name)) {
+        return EntityType::METHOD;
+      }
       return at::nullopt;
+    }
     return it->second.type;
   }
 
@@ -453,31 +433,16 @@ struct TORCH_API Module {
   CompilationUnit& class_compilation_unit() {
     return module_object()->type()->compilation_unit();
   }
-  CompilationUnit& lowered_methods() const {
-    return lowered_methods_;
+  const CompilationUnit& class_compilation_unit() const {
+    return module_object()->type()->compilation_unit();
   }
 
   // so that C++ users can easily add methods
   void define(const std::string& src, const ResolverPtr& resolver = nullptr);
 
-  void _define_lowered(
-      const std::vector<Def>& definitions,
-      const std::vector<ResolverPtr>& resolvers);
-  void _define_lowered(const std::string& src, const ResolverPtr& resolver);
-
-  Method& _define_lowered(
-      std::string name,
-      std::shared_ptr<Graph> graph,
-      std::vector<Slot> slots);
-
  private:
-  Method& _create_lowered_method(
-      Function* func,
-      std::vector<Slot> member_inputs);
-
-  Method& lower_first_class_method(Function* fn);
-  void lift_lowered_method(Method& fn);
-  void lift_lowered_methods(size_t start);
+  std::pair<std::shared_ptr<Function>, std::vector<Slot>>
+  lower_first_class_method(Function* fn);
 
   void to_impl(
       const c10::optional<at::Device>& device,
@@ -566,13 +531,6 @@ struct TORCH_API Module {
     return Slot(module_value_, slot_index);
   }
 
-  CompilationUnit& class_cu() {
-    return module_value_->type()->compilation_unit();
-  }
-  const CompilationUnit& class_cu() const {
-    return module_value_->type()->compilation_unit();
-  }
-
   // modules have a single namespace, but spread over 4 different concepts:
   // parameters, attributes, methods, and sub-modules
   // we store individual lists of each concept, and a single map to
@@ -605,11 +563,8 @@ struct TORCH_API Module {
   // first-class: module_value_->type().compilation_unit() holds Functions that
   // treat modules as first class.
 
-  // lowered: In this lowered form, all the attributes/parameters are appended
-  // as additional inputs. lowered_methods_ holds this lowered form
-  // mutable because it is a cache for class_cu() methods
-  mutable CompilationUnit lowered_methods_;
-  mutable std::recursive_mutex find_method_guard_;
+  mutable std::recursive_mutex create_method_guard_;
+  friend struct Method;
 };
 
 } // namespace script

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -21,6 +21,11 @@
 
 namespace torch {
 namespace jit {
+
+namespace script {
+  struct Module;
+}
+
 namespace tracer {
 
 using ::c10::ivalue::List;
@@ -88,7 +93,7 @@ struct TypedStack : public std::pair<Stack, TupleTypePtr>
   }
 };
 
-TORCH_API std::pair<std::shared_ptr<TracingState>, Stack> enter(TypedStack inputs);
+TORCH_API std::pair<std::shared_ptr<TracingState>, Stack> enter(TypedStack inputs, const std::shared_ptr<script::Module>& self=nullptr);
 
 TORCH_API void exit(const Stack& outputs);
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -667,11 +667,11 @@ def trace(func,
             _module_class = TopLevelTracedModule
         traced = _module_class(func, **executor_options)
         traced._c._create_method_from_trace('forward', func, example_inputs,
-                                           var_lookup_fn, _force_outplace)
+                                            var_lookup_fn, _force_outplace)
     else:
         name = getattr(func, '__name__', 'forward')
         if name == '<lambda>':
-            name = '_lambda' # make name a valid identifier
+            name = '_lambda'  # make name a valid identifier
         traced = torch._C._create_function_from_trace(name, func, example_inputs,
                                                       var_lookup_fn,
                                                       _force_outplace)
@@ -1232,7 +1232,7 @@ if _enabled:
             # createResolutionCallback internally adds 1 to get us to our frame, then
             # we add 1 to get to the proper surrounding scope.
             rcb = _jit_internal.createResolutionCallback(frames_up=1)
-            self._c._define(self, lang, rcb, True)
+            self._c._define(self, lang, rcb)
 
         def copy(self):
             m = ScriptModule()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19724 Remove duplicate inlineCallToCode
* #19723 Serialize first-class version of functions
* **#19722 Trace directly into first-class module form.**
* #19721 @torch.jit.script(fn) now is a torch.jit.Function
* #19720 pybind CompilationUnit and Function directly

The trace logic now inserts a `self` argument rather than
additional inputs.

With this change, we no longer have to _define_ methods in
lowered form (with additional Slot inputs).

We still continue to lower methods before execution.

Now that we only execute methods in lowered form, it is possible
to remove the lowered_methods() table. Instead, each individual
method creates its lowered Function on creation.

Methods are still lazily created but there is no additional
need to keep lowered_methods() and the class methods in sync.

Differential Revision: [D15078535](https://our.internmc.facebook.com/intern/diff/D15078535)