### PR TITLE
[pytorch] remove C10_MOBILE from LegacyTypeDispatch.cpp

### DIFF
--- a/aten/src/ATen/core/LegacyTypeDispatch.cpp
+++ b/aten/src/ATen/core/LegacyTypeDispatch.cpp
@@ -26,7 +26,7 @@ namespace at {
 /// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
 /// thread_local is not supported. In that case, we don't provide
 /// `at::NonVariableTypeMode`.
-#if !defined(C10_MOBILE) && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
 
 thread_local bool NonVariableTypeMode_enabled = false;
 
@@ -38,7 +38,7 @@ void NonVariableTypeMode::set_enabled(bool enabled) {
   NonVariableTypeMode_enabled = enabled;
 }
 
-#else // defined(C10_MOBILE) || defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
 
 bool NonVariableTypeMode::is_enabled() {
   throw std::runtime_error("NonVariableTypeMode is not supported on mobile");


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19727 [pytorch] remove C10_MOBILE from LegacyTypeDispatch.cpp**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15076482/)

According to the comments and original diff D13640980, it seems CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
itself is enough - we simply want to disable thread_local when it's not supported.

Removing C10_MOBILE will allow us to NOT add another macro here for libtorch mobile build which further
complicates the logic.

See more discussion: https://fburl.com/7iup5x09

Differential Revision: [D15076482](https://our.internmc.facebook.com/intern/diff/D15076482/)