### PR TITLE
[pytorch] fix THAllocator.cpp

### DIFF
--- a/aten/src/TH/THAllocator.cpp
+++ b/aten/src/TH/THAllocator.cpp
@@ -25,9 +25,9 @@ at::Allocator* getTHDefaultAllocator() {
   return c10::GetCPUAllocator();
 }
 
-#if defined(_WIN32) || defined(HAVE_MMAP)
-
 #define TH_ALLOC_ALIGNMENT 64
+
+#if defined(_WIN32) || defined(HAVE_MMAP)
 
 typedef struct {
   std::atomic<int> refcount;
@@ -496,16 +496,23 @@ int THRefcountedMapAllocator::decref()
 
 THRefcountedMapAllocatorArgCheck::THRefcountedMapAllocatorArgCheck(int flags) {}
 
-THRefcountedMapAllocator::THRefcountedMapAllocator(const char *filename, int flags, size_t size) {
+THRefcountedMapAllocator::THRefcountedMapAllocator(const char *filename, int flags, size_t size)
+  : THRefcountedMapAllocatorArgCheck(flags),
+    THMapAllocator(filename, flags, size + TH_ALLOC_ALIGNMENT)
+{
   AT_ERROR("refcounted file mapping not supported on your system");
 }
 
-THRefcountedMapAllocator::THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size) {
+THRefcountedMapAllocator::THRefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size)
+  : THRefcountedMapAllocatorArgCheck(flags),
+    THMapAllocator(WITH_FD, filename, flags, fd, size + TH_ALLOC_ALIGNMENT)
+{
   AT_ERROR("refcounted file mapping not supported on your system");
 }
 
 void THRefcountedMapAllocator::initializeAlloc() {}
-THRefcountedMapAllocator::~THRefcountedMapAllocator() {}
+
+void THRefcountedMapAllocator::close() {}
 
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19734 [pytorch] CMakeLists changes to enable libtorch for Android
* #19733 [pytorch] add new macro TORCH_MOBILE for libtorch mobile build
* #19732 [pytorch] fix labs warning in THTensorMoreMath.cpp
* **#19731 [pytorch] fix THAllocator.cpp**
* #19730 [pytorch] remove C10_MOBILE from LegacyTypeDispatch.cpp

Summary:
Update THRefcountedMapAllocator constructor/close() to fix build error
when _WIN32 and HAVE_MMAP are undefined - which case doesn't seem to be
covered by any CI.

Discovered by Thomas in https://github.com/pytorch/pytorch/pull/16242
Seems to be a good fix regardless of android build.

Test Plan:
Build with stacked diffs

Differential Revision: [D15079088](https://our.internmc.facebook.com/intern/diff/D15079088)