### PR TITLE
[pytorch] fix labs warning in THTensorMoreMath.cpp

### DIFF
--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1137,7 +1137,7 @@ void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k)
 LAB_IMPLEMENT_BASIC_FUNCTION(neg,-)
 
 #if defined(TH_REAL_IS_LONG)
-LAB_IMPLEMENT_BASIC_FUNCTION(abs,labs)
+LAB_IMPLEMENT_BASIC_FUNCTION(abs,std::abs)
 #endif /* int64_t only part */
 
 #if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_CHAR)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19734 [pytorch] CMakeLists changes to enable libtorch for Android
* #19733 [pytorch] add new macro TORCH_MOBILE for libtorch mobile build
* **#19732 [pytorch] fix labs warning in THTensorMoreMath.cpp**
* #19731 [pytorch] fix THAllocator.cpp
* #19730 [pytorch] remove C10_MOBILE from LegacyTypeDispatch.cpp

Summary:
Seems pretty innocent change copied from https://github.com/pytorch/pytorch/pull/16242

Test Plan:
Make sure the following warning is gone:
../aten/src/TH/generic/THTensorMoreMath.cpp:1140:34: note: use function 'std::abs' instead
LAB_IMPLEMENT_BASIC_FUNCTION(abs,labs)
                                 ^~~~
                                 std::abs

Differential Revision: [D15079086](https://our.internmc.facebook.com/intern/diff/D15079086)