### PR TITLE
[pytorch] add new macro TORCH_MOBILE for libtorch mobile build

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -8,7 +8,7 @@
 // To explicitly use interned strings as symbols in your code, you must add
 // them to this list.
 
-#ifndef C10_MOBILE
+#if !defined(C10_MOBILE) || defined(TORCH_MOBILE)
 #define FORALL_ATEN_BASE_SYMBOLS(_) \
 _(aten, __and__) \
 _(aten, __iand__) \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -10,7 +10,7 @@
 
 namespace c10 {
 
-#ifndef C10_MOBILE
+#if !defined(C10_MOBILE) || defined(TORCH_MOBILE)
 #define FORALL_NS_SYMBOLS(_)       \
   _(namespaces, prim)              \
   _(namespaces, aten)              \

--- a/c10/macros/cmake_macros.h.in
+++ b/c10/macros/cmake_macros.h.in
@@ -8,5 +8,6 @@
 #cmakedefine C10_USE_GLOG
 #cmakedefine C10_USE_GFLAGS
 #cmakedefine C10_DISABLE_NUMA
+#cmakedefine TORCH_MOBILE
 
 #endif // C10_MACROS_CMAKE_MACROS_H_


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19734 [pytorch] CMakeLists changes to enable libtorch for Android
* **#19733 [pytorch] add new macro TORCH_MOBILE for libtorch mobile build**
* #19732 [pytorch] fix labs warning in THTensorMoreMath.cpp
* #19731 [pytorch] fix THAllocator.cpp
* #19730 [pytorch] remove C10_MOBILE from LegacyTypeDispatch.cpp

Summary:
Libtorch mobile build needs (aten_)interned_strings to support all aten operators, which
is currently disabled by C10_MOBILE macro.

C10_MOBILE macro is defined for all mobile builds, including caffe2 mobile build used in
facebook production and libtorch mobile build we are currently working on, so choices are:
1. Remove C10_MOBILE macro from (aten_)interned_strings, which might regress production build size;
2. Add a new macro to override C10_MOBILE in this specific case, which will increase codebase complexity;

We decided to take #2 for now and commit to limit its uses and eventually remove it when things
like interned_strings can be modularized.

Test Plan:
- Make sure this diff doesn't regress any internal build size;
- Build with stacked diffs;

Differential Revision: [D15079089](https://our.internmc.facebook.com/intern/diff/D15079089)