### PR TITLE
optimize topk on cpu using parallel and partial sort

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -216,6 +216,11 @@ std::tuple<Tensor&, Tensor&> topk_out_cpu(
       "selected index k out of range");
 
   _allocate_or_resize_output_with_indices(values, indices, self, dim_, k);
+  if (self.dim() == 0 && self.numel() == 1) {
+    values.copy_(self);
+    indices.zero_();
+    return std::forward_as_tuple(values, indices);
+  }
   auto tmp_values = self.clone();
   AT_DISPATCH_ALL_TYPES(self.scalar_type(), "topk_cpu", [&] {
     dim_apply(

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -211,7 +211,7 @@ std::tuple<Tensor&, Tensor&> topk_out_cpu(
     bool largest,
     bool sorted) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
-  AT_CHECK(
+  TORCH_CHECK(
       k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
       "selected index k out of range");
 

--- a/aten/src/ATen/native/Sorting.h
+++ b/aten/src/ATen/native/Sorting.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at { namespace native {
+
+using topk_fn = void(*)(Tensor&, Tensor&, const Tensor&, int64_t, int64_t, bool, bool);
+
+DECLARE_DISPATCH(topk_fn, topk_stub);
+
+}} // at::native

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -3,6 +3,41 @@
 namespace at {
 namespace native {
 
+template <typename Fn>
+void dim_apply(TensorList tensors, int64_t dim, Fn f) {
+  AT_ASSERT(tensors.size() > 0);
+  auto t = tensors[0];
+  auto sizes = t.sizes();
+  int64_t ndim = t.dim();
+  int64_t itersize = 1;
+  for (int64_t i = 0; i < ndim; i++) {
+    if (i != dim) {
+      itersize *= t.size(i);
+    }
+  }
+  parallel_for(0, itersize, 1, [&](int64_t i_begin, int64_t i_end) {
+    std::vector<Tensor> narrowed_tensors;
+    narrowed_tensors.reserve(tensors.size());
+    for (int64_t it = i_begin; it < i_end; it++) {
+      narrowed_tensors.clear();
+      for (auto ti : tensors) {
+        int64_t i = it;
+        Tensor nt = ti;
+        for (size_t d = 0; d < ndim; d++) {
+          if (d != dim) {
+            // this could be avoided for slower-changing dimensions if done
+            // better
+            nt = nt.select((d > dim ? 1 : 0), i % sizes[d]);
+            i = i / sizes[d];
+          }
+        }
+        narrowed_tensors.emplace_back(nt);
+      }
+      f(it, narrowed_tensors);
+    }
+  });
+}
+
 // ensure we get good values and indices for kthvalue, mode, median
 // this will always be with the reducing dim as 1-d
 static void _reduction_with_indices_allocate_or_resize_output(

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -57,7 +57,7 @@ static void _allocate_or_resize_output_with_indices(
     result_sizes[dim] = k;
   }
   if (values.defined()) {
-    AT_CHECK(
+    TORCH_CHECK(
         self.type() == values.type(),
         "output values must be of same type as input");
     values.resize_(result_sizes);
@@ -65,9 +65,9 @@ static void _allocate_or_resize_output_with_indices(
     values = at::empty(result_sizes, self.options());
   }
   if (indices.defined()) {
-    AT_CHECK(
+    TORCH_CHECK(
         indices.dtype() == kLong, "output indices must be of scalar type Long");
-    AT_CHECK(
+    TORCH_CHECK(
         indices.device() == self.device(),
         "output indices must be on same device as input");
     indices.resize_(result_sizes);

--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -44,5 +44,37 @@ static void _reduction_with_indices_allocate_or_resize_output(
   }
 }
 
+// ensure we get good values and indices for topk
+static void _allocate_or_resize_output_with_indices(
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& self,
+    int64_t dim_,
+    int64_t k) {
+  int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
+  auto result_sizes = self.sizes().vec();
+  if (result_sizes.size() > 0) {
+    result_sizes[dim] = k;
+  }
+  if (values.defined()) {
+    AT_CHECK(
+        self.type() == values.type(),
+        "output values must be of same type as input");
+    values.resize_(result_sizes);
+  } else {
+    values = at::empty(result_sizes, self.options());
+  }
+  if (indices.defined()) {
+    AT_CHECK(
+        indices.dtype() == kLong, "output indices must be of scalar type Long");
+    AT_CHECK(
+        indices.device() == self.device(),
+        "output indices must be on same device as input");
+    indices.resize_(result_sizes);
+  } else {
+    indices = at::empty(result_sizes, self.options().dtype(kLong));
+  }
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -1,0 +1,90 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/NumericUtils.h>
+#include <ATen/native/Sorting.h>
+#include <ATen/native/SortingUtils.h>
+
+namespace at { namespace native {
+
+namespace {
+
+static void topk_kernel(
+    Tensor& values,
+    Tensor& indices,
+    const Tensor& self,
+    int64_t k,
+    int64_t dim,
+    bool largest,
+    bool sorted) {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "topk_cpu", [&] {
+    dim_apply(
+        {self, values, indices},
+        dim,
+        [&](int64_t i, TensorList tl) {
+          auto tmp_values = tl[0].accessor<scalar_t, 1>();
+          auto mode_values = tl[1].accessor<scalar_t, 1>();
+          auto mode_indices = tl[2].accessor<int64_t, 1>();
+
+          auto n = tmp_values.size(0);
+          auto use_partial_sort = k * 64 <= n;
+
+          using elem_t = std::pair<scalar_t, int64_t>;
+          std::vector<elem_t> queue(n);
+          for (int64_t j = 0; j < n; j++) {
+            queue[j].first = tmp_values[j];
+            queue[j].second = j;
+          }
+
+          // we want NaN to be sorted as top for numpy compatibility
+          if (use_partial_sort) {
+            if (largest) {
+              std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
+                [](const elem_t& x, const elem_t& y) -> bool {
+                  return ((_isnan<scalar_t>(x.first) && !_isnan<scalar_t>(y.first)) || (x.first > y.first));
+                });
+            } else {
+              std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
+                [](const elem_t& x, const elem_t& y) -> bool {
+                  return ((!_isnan<scalar_t>(x.first) && _isnan<scalar_t>(y.first)) || (x.first < y.first));
+                });
+            }
+          } else {
+            if (largest) {
+              std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(),
+                [](const elem_t& x, const elem_t& y) -> bool {
+                  return ((_isnan<scalar_t>(x.first) && !_isnan<scalar_t>(y.first)) || (x.first > y.first));
+                });
+              if (sorted) {
+                std::sort(queue.begin(), queue.begin() + k - 1,
+                  [](const elem_t& x, const elem_t& y) -> bool {
+                    return ((_isnan<scalar_t>(x.first) && !_isnan<scalar_t>(y.first)) || (x.first > y.first));
+                  });
+              }
+            } else {
+              std::nth_element(queue.begin(), queue.begin() + k -1, queue.end(),
+                [](const elem_t& x, const elem_t& y) -> bool {
+                  return ((!_isnan<scalar_t>(x.first) && _isnan<scalar_t>(y.first)) || (x.first < y.first));
+                });
+              if (sorted) {
+                std::sort(queue.begin(), queue.begin() + k -1,
+                  [](const elem_t& x, const elem_t& y) -> bool {
+                    return ((!_isnan<scalar_t>(x.first) && _isnan<scalar_t>(y.first)) || (x.first < y.first));
+                  });
+              }
+            }
+          }
+
+          for (int64_t j = 0; j < k; j++) {
+            mode_values[j] = queue[j].first;
+            mode_indices[j] = queue[j].second;
+          }
+        });
+  });
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(topk_stub, &topk_kernel);
+
+}} //at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3976,14 +3976,11 @@
 
 - func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, *, Tensor(a!) values, Tensor(b!) indices) ->(Tensor(a!) values, Tensor(b!) indices)
   dispatch:
-    CPU: legacy::cpu::_th_topk_out
+    CPU: topk_out_cpu
     CUDA: legacy::cuda::_th_topk_out
 
 - func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
   variants: method, function
-  dispatch:
-    CPU: legacy::cpu::_th_topk
-    CUDA: legacy::cuda::_th_topk
 
 - func: all(Tensor self) -> Tensor
   variants: method, function


### PR DESCRIPTION
This PR aims at improving `topk()` performance on CPU. This is useful when computing **beam search** during `Transformer` and `BERT`.

Given a tensor x of size `[N, C]`, and we want to apply `x.topk(K)`, the current logic is **sequentially** loop on the dimension of `N` and do **quick select** on the dimension of `C` so as to find out top K elements.

Performance can be further improved from:

- On the dimension of `N`, it can be paralleled
- Maybe a faster sorting algorithm for `topk`. (After a bunch of experimenting, `std::partial_sort` seems to be the most promising)

So i compared 3 versions:

1. vanilla: sequential + quick select
2. reference PR #19737: parallel + quick select
3. this PR: parallel + partial sort

with the following benchmark, on `Xeon 8180, 2*28 cores@2.5 GHz`:
```python
import torch
from time import time

num_iters = 1000

def bench_topk(N=8, C=168560, k=10):
    a = torch.randn(N, C)
    # warm up
    for i in range(100):
        torch.topk(a, k)
    
    t = 0
    for i in range(num_iters):
        a = torch.randn(N, C)
        start = time()
        value, indice = torch.topk(a, k)
        t += time() - start
    print("#[%d, %d] times: %f ms" % (N, C, t / num_iters * 1000))

Ns = [10, 20, 30]
Cs = [10000, 20000, 40000, 80000, 160000, 320000]

for n in Ns:
    for c in Cs:
        bench_topk(N=n, C=c)

```
### vanilla: sequential + quick select
```
#[10, 10000] times: 0.746740 ms
#[10, 20000] times: 1.437399 ms
#[10, 40000] times: 2.832455 ms
#[10, 80000] times: 5.649426 ms
#[10, 160000] times: 11.309466 ms
#[10, 320000] times: 22.798765 ms
#[20, 10000] times: 1.511303 ms
#[20, 20000] times: 2.822024 ms
#[20, 40000] times: 5.564770 ms
#[20, 80000] times: 11.443044 ms
#[20, 160000] times: 22.747731 ms
#[20, 320000] times: 46.234449 ms
#[30, 10000] times: 2.214045 ms
#[30, 20000] times: 4.236179 ms
#[30, 40000] times: 8.418577 ms
#[30, 80000] times: 17.067578 ms
#[30, 160000] times: 33.826214 ms
#[30, 320000] times: 68.109420 ms
```
### reference PR: parallel + quick select
```
#[10, 10000] times: 0.271649 ms
#[10, 20000] times: 0.593016 ms
#[10, 40000] times: 1.133518 ms
#[10, 80000] times: 2.082355 ms
#[10, 160000] times: 4.049928 ms
#[10, 320000] times: 7.321285 ms
#[20, 10000] times: 0.315255 ms
#[20, 20000] times: 0.539054 ms
#[20, 40000] times: 1.000675 ms
#[20, 80000] times: 1.914586 ms
#[20, 160000] times: 4.437122 ms
#[20, 320000] times: 8.822445 ms
#[30, 10000] times: 0.347209 ms
#[30, 20000] times: 0.589947 ms
#[30, 40000] times: 1.102814 ms
#[30, 80000] times: 2.112201 ms
#[30, 160000] times: 5.186837 ms
#[30, 320000] times: 10.523023 ms
```
### this PR: parallel + partial sort
```
#[10, 10000] times: 0.150284 ms
#[10, 20000] times: 0.220089 ms
#[10, 40000] times: 0.521875 ms
#[10, 80000] times: 0.965593 ms
#[10, 160000] times: 2.312356 ms
#[10, 320000] times: 4.759422 ms
#[20, 10000] times: 0.167630 ms
#[20, 20000] times: 0.265607 ms
#[20, 40000] times: 0.471477 ms
#[20, 80000] times: 0.974572 ms
#[20, 160000] times: 3.269645 ms
#[20, 320000] times: 6.538608 ms
#[30, 10000] times: 0.204976 ms
#[30, 20000] times: 0.342833 ms
#[30, 40000] times: 0.589381 ms
#[30, 80000] times: 1.398579 ms
#[30, 160000] times: 3.904077 ms
#[30, 320000] times: 9.681224 ms
```
In summary, `2` is **5x** faster than `vanilla` on average and `3` is **8.6x** faster than `vanilla`.
On `Fairseq Transformer`, the default parameter on dataset `wmt14` would have a `topk` size of `[8, 168560]`, and this operator gets `3x` faster with this PR.