### PR TITLE
[C++ API] Ignore `nn::Functional` submodules in `nn::Module` serialization

### DIFF
--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -382,9 +382,16 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   const ModuleType* as() const noexcept;
 
   /// Serializes the `Module` into the given `OutputArchive`.
+  ///
+  /// If the `Module` contains unserializable submodules (e.g. `nn::Functional`),
+  /// those submodules are skipped when serializing.
   virtual void save(serialize::OutputArchive& archive) const;
 
   /// Deserializes the `Module` from the given `InputArchive`.
+  ///
+  /// If the `Module` contains unserializable submodules (e.g. `nn::Functional`),
+  /// we don't check the existence of those submodules in the `InputArchive` when
+  /// deserializing.
   virtual void load(serialize::InputArchive& archive);
 
   /// Streams a pretty representation of the `Module` into the given `stream`.
@@ -395,6 +402,9 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   /// Override this method to change the pretty print. The input
   /// `stream` should be returned from the method, to allow easy chaining.
   virtual void pretty_print(std::ostream& stream) const;
+
+  /// Returns whether the `Module` is serializable.
+  virtual bool is_serializable() const;
 
  protected:
   /// Registers a parameter with this `Module`.

--- a/torch/csrc/api/include/torch/nn/modules/functional.h
+++ b/torch/csrc/api/include/torch/nn/modules/functional.h
@@ -88,6 +88,8 @@ class TORCH_API FunctionalImpl : public torch::nn::Cloneable<FunctionalImpl> {
   /// Calls forward(input).
   Tensor operator()(Tensor input);
 
+  bool is_serializable() const override;
+
  private:
   Function function_;
 };

--- a/torch/csrc/api/include/torch/serialize/input-archive.h
+++ b/torch/csrc/api/include/torch/serialize/input-archive.h
@@ -44,8 +44,8 @@ class TORCH_API InputArchive final {
 
   ~InputArchive() = default;
 
-  /// Reads a `tensor` associated with a given `key`. If the `InputArchive` doesn't
-  /// contain `key`, this function returns false, otherwise it returns true.
+  /// Reads a `tensor` associated with a given `key`. If there is no `tensor`
+  /// associated with the `key`, this returns false, otherwise it returns true.
   /// If the tensor is expected to be a buffer (not differentiable), `is_buffer`
   /// must be `true`.
   bool try_read(const std::string& key, Tensor& tensor, bool is_buffer = false);
@@ -54,6 +54,11 @@ class TORCH_API InputArchive final {
   /// If the tensor is expected to be a buffer (not differentiable), `is_buffer`
   /// must be `true`.
   void read(const std::string& key, Tensor& tensor, bool is_buffer = false);
+
+  /// Reads a `InputArchive` associated with a given `key`. If there is no
+  /// `InputArchive` associated with the `key`, this returns false, otherwise
+  /// it returns true.
+  bool try_read(const std::string& key, InputArchive& archive);
 
   /// Reads an `InputArchive` associated with a given `key`.
   /// The archive can thereafter be used for further deserialization of the

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -278,9 +278,11 @@ void Module::save(serialize::OutputArchive& archive) const {
     archive.write(buffer.key(), buffer.value(), /*is_buffer=*/true);
   }
   for (const auto& child : children_) {
-    serialize::OutputArchive child_archive;
-    child.value()->save(child_archive);
-    archive.write(child.key(), child_archive);
+    if (child.value()->is_serializable()) {
+      serialize::OutputArchive child_archive;
+      child.value()->save(child_archive);
+      archive.write(child.key(), child_archive);
+    }
   }
 }
 
@@ -292,10 +294,16 @@ void Module::load(serialize::InputArchive& archive) {
     archive.read(buffer.key(), buffer.value(), /*is_buffer=*/true);
   }
   for (const auto& child : children_) {
-    serialize::InputArchive child_archive;
-    archive.read(child.key(), child_archive);
-    child.value()->load(child_archive);
+    if (child.value()->is_serializable()) {
+      serialize::InputArchive child_archive;
+      archive.read(child.key(), child_archive);
+      child.value()->load(child_archive);
+    }
   }
+}
+
+bool Module::is_serializable() const {
+  return true;
 }
 
 Tensor& Module::register_parameter(

--- a/torch/csrc/api/src/nn/modules/functional.cpp
+++ b/torch/csrc/api/src/nn/modules/functional.cpp
@@ -23,5 +23,9 @@ Tensor FunctionalImpl::forward(Tensor input) {
 Tensor FunctionalImpl::operator()(Tensor input) {
   return forward(std::move(input));
 }
+
+bool FunctionalImpl::is_serializable() const {
+  return false;
+}
 } // namespace nn
 } // namespace torch

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -59,12 +59,19 @@ void InputArchive::read(
     "'");
 }
 
-void InputArchive::read(const std::string& key, InputArchive& archive) {
+bool InputArchive::try_read(const std::string& key, InputArchive& archive) {
   if (auto named_module = module_->find_module(key)) {
     archive.module_ = std::move(named_module);
+    return true;
   } else {
-    AT_ERROR("No such serialized submodule: '", key, "'");
+    return false;
   }
+}
+
+void InputArchive::read(const std::string& key, InputArchive& archive) {
+  AT_CHECK(
+    try_read(key, archive),
+    "No such serialized submodule: '", key, "'");
 }
 
 void InputArchive::load_from(const std::string& filename,


### PR DESCRIPTION
Currently, the Python API doesn't serialize layers that don't have weights (such as `nn.ReLU` and `nn.MaxPool2d`e.g. in https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py#L80-L81). If one saves a model that contains weight-less layers in Python and tries to load it into C++, the C++ module loading code (`torch::load(...)`) will throw an error complaining that the expected layers are not found in the serialized file (e.g. https://github.com/pytorch/vision/pull/728#issuecomment-480974175). This PR solves the problem by ignoring layers that are not serializable (which currently only include `nn::Functional`) in the C++ module serialization code (`torch::save(...)` and `torch::load(...)`), and the user is expected to use `nn::Functional` to wrap the weight-less layers so that they can be ignored when serializing / deserializing.