### PR TITLE
Fall back to asking nvcc for detecting cuda version if no *cudaart* is found

### DIFF
--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -45,6 +45,11 @@ def find_cuda_version(cuda_home):
         # which are files containing cudart
         candidate_names = list(glob.glob(os.path.join(cuda_lib_path, '*cudart*')))
         candidate_names = [os.path.basename(c) for c in candidate_names]
+        # if we didn't find any cudart, ask nvcc
+        if len(candidate_names) == 0:
+            proc = Popen(['nvcc', '--version'], stdout=PIPE, stderr=PIPE)
+            out, err = proc.communicate()
+            candidate_names = [out.decode().rsplit('V')[-1]]
 
     # suppose version is MAJOR.MINOR.PATCH, all numbers
     version_regex = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+')


### PR DESCRIPTION
This happens on Debian/Ubuntu with distribution-provided cuda repackaging.
