### PR TITLE
caffe2 | Use _aligned_free in WorkerPool destruction

### DIFF
--- a/caffe2/utils/threadpool/WorkersPool.h
+++ b/caffe2/utils/threadpool/WorkersPool.h
@@ -53,7 +53,11 @@ struct AllocAligned {
   static void release(T* p) {
     if (p) {
       p->~T();
+#if defined(_MSC_VER)
+      _aligned_free((void*)p);
+#else
       free((void*)p);
+#endif
     }
   }
 };


### PR DESCRIPTION
Summary: This has probably never been tested on Windows but destruction of WorkersPool crashes because it uses _aligned_malloc to allocate and 'free' to deallocate, which is not symmetric. Fix is to use _aligned_free in deallocation

Differential Revision: D15083472

