### PR TITLE
Fix C10_MOBILE macro for ios

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -158,6 +158,10 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #define C10_HIP_HOST_DEVICE
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #if defined(__ANDROID__)
 #define C10_ANDROID 1
 #define C10_MOBILE 1


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19967 Remove torch/jit from xplat build**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15150843/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19779 Fix C10_MOBILE macro for ios&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15090427/)

This macro wasn't set correctly because the target macros weren't included from Apple's header.

Differential Revision: [D15090427](https://our.internmc.facebook.com/intern/diff/D15090427/)