### PR TITLE
Move IValues from stack into kernels

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -41,20 +41,21 @@ namespace detail {
   // cast it to the type that should be passed to the kernel function.
   // Examples: If the IValue contains a plain type like an int, return that.
   //           If the IValue contains an IntList, return it as ArrayRef<int>.
-  // TODO Should we move the IValue so we can avoid bumping the Tensor refcount?
   template<class T, class Enable = void> struct ivalue_to_arg_type {
     // This base case is hit whenever a type does not have a specialisation below.
     static_assert(guts::false_t<T>::value, "You tried to register a kernel with an unsupported argument type.");
   };
   template<class T>
   struct ivalue_to_arg_type<T, guts::enable_if_t<guts::typelist::contains<supported_primitive_arg_types, T>::value>> {
-    static T call(const IValue& v) {
+    static T call(IValue&& v) {
       return std::move(v).to<T>();
     }
   };
   template<class T>
   struct ivalue_to_arg_type<ArrayRef<T>> {
     static ArrayRef<T> call(const IValue& v) {
+      // Note: This takes a `const IValue&` argument and not `IValue&&`, because the
+      //        returned ArrayRef is non-owning, so the call site needs to keep ownership
       // TODO Do we want to support ArrayRef<optional<T>> ?
       static_assert(guts::typelist::contains<supported_primitive_arg_types, T>::value, "You tried to register a kernel with an unsupported argument type: c10::ArrayRef<T> and T is not one of the supported primitive types.");
       return v.to<intrusive_ptr<ivalue::List<T>>>()->elements();
@@ -62,11 +63,11 @@ namespace detail {
   };
   template<class T>
   struct ivalue_to_arg_type<optional<T>> {
-    static optional<T> call(const IValue& v) {
+    static optional<T> call(IValue&& v) {
       if (v.isNone()) {
         return nullopt;
       }
-      return ivalue_to_arg_type<T>::call(v);
+      return ivalue_to_arg_type<T>::call(std::move(v));
     }
   };
   // The following specialisations of ivalue_to_arg_type are technically not
@@ -116,7 +117,6 @@ namespace detail {
   template<class T>
   struct return_type_to_ivalue_<std::vector<T>> {
     static IValue call(std::vector<T>&& v) {
-      // TODO Do we want to support vector<optional<T>> ?
       static_assert(guts::typelist::contains<supported_primitive_arg_types, T>::value, "You tried to register a kernel with an unsupported return type: vector<T> and T is not one of the supported primitive types.");
       return IValue(std::move(v));
     }
@@ -148,17 +148,21 @@ namespace detail {
   }
 
   template<class Functor, size_t... ivalue_arg_indices>
-  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_ivalue_args_(Functor* functor, ArrayRef<IValue> ivalue_args, guts::index_sequence<ivalue_arg_indices...>) {
-    (void)(ivalue_args); // when sizeof...(ivalue_arg_indices) == 0, this argument would be unused and we have to silence the compiler warning.
+  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_args_from_stack_(Functor* functor, Stack* stack, guts::index_sequence<ivalue_arg_indices...>) {
+    (void)(stack); // when sizeof...(ivalue_arg_indices) == 0, this argument would be unused and we have to silence the compiler warning.
+
+    constexpr size_t num_ivalue_args = sizeof...(ivalue_arg_indices);
+
     using IValueArgTypes = typename guts::infer_function_traits_t<Functor>::parameter_types;
-    return (*functor)(ivalue_to_arg_type<guts::remove_cv_t<guts::remove_reference_t<guts::typelist::element_t<ivalue_arg_indices, IValueArgTypes>>>>::call(ivalue_args[ivalue_arg_indices])...);
+    return (*functor)(ivalue_to_arg_type<guts::remove_cv_t<guts::remove_reference_t<guts::typelist::element_t<ivalue_arg_indices, IValueArgTypes>>>>::call(
+      std::move(torch::jit::peek(*stack, ivalue_arg_indices, num_ivalue_args))
+    )...);
   }
 
   template<class Functor>
-  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_ivalue_args(Functor* functor, ArrayRef<IValue> ivalue_args) {
+  typename guts::infer_function_traits_t<Functor>::return_type call_functor_with_args_from_stack(Functor* functor, Stack* stack) {
     constexpr size_t num_ivalue_args = guts::infer_function_traits_t<Functor>::number_of_parameters;
-    AT_ASSERTM(num_ivalue_args == ivalue_args.size(), "Wrong number of ivalue arguments");
-    return call_functor_with_ivalue_args_<Functor>(functor, ivalue_args, guts::make_index_sequence<num_ivalue_args>());
+    return call_functor_with_args_from_stack_<Functor>(functor, stack, guts::make_index_sequence<num_ivalue_args>());
   }
 
   template<class OutputType>
@@ -176,11 +180,7 @@ namespace detail {
   private:
     template<size_t... indices>
     static void call_(std::tuple<OutputTypes...>&& output, Stack* stack, guts::index_sequence<indices...>) {
-      (void)(stack); // when sizeof...(indices) == 0, this argument would be unused and we have to silence the compiler warning.
-      // iterate over all outputs and push them
-      (void)std::initializer_list<int>{(
-        torch::jit::push(*stack, return_type_to_ivalue(std::move(std::get<indices>(output))))
-      , 0)...};
+      torch::jit::push(*stack, return_type_to_ivalue(std::move(std::get<indices>(output)))...);
     }
   };
 
@@ -194,7 +194,7 @@ namespace detail {
     static void call(Stack* stack, KernelCache* cache) {
       constexpr size_t num_inputs = guts::infer_function_traits_t<KernelFunctor>::number_of_parameters;
       KernelFunctor* functor = static_cast<KernelFunctor*>(cache);
-      auto output = call_functor_with_ivalue_args<KernelFunctor>(functor, torch::jit::last(*stack, num_inputs));
+      auto output = call_functor_with_args_from_stack<KernelFunctor>(functor, stack);
       torch::jit::drop(*stack, num_inputs);
       push_outputs<typename guts::infer_function_traits_t<KernelFunctor>::return_type>::call(std::move(output), stack);
     }
@@ -208,7 +208,7 @@ namespace detail {
     static void call(Stack* stack, KernelCache* cache) {
       constexpr size_t num_inputs = guts::infer_function_traits_t<KernelFunctor>::number_of_parameters;
       KernelFunctor* functor = static_cast<KernelFunctor*>(cache);
-      call_functor_with_ivalue_args<KernelFunctor>(functor, torch::jit::last(*stack, num_inputs));
+      call_functor_with_args_from_stack<KernelFunctor>(functor, stack);
       torch::jit::pop(*stack, num_inputs);
     }
   };


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19784 The deprecated API allows std::vector arguments**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15091972/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19783 Move IValues from stack into kernels&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15091973/)

Previously, the IValues were copied into the kernel arguments, which caused a refcount bump if Tensor was taken by value.
Now, a kernel can take Tensor by value without any refcount bump because it is moved in.

Differential Revision: [D15091973](https://our.internmc.facebook.com/intern/diff/D15091973/)