### PR TITLE
Remove setting logger level in caffe2.python.checkpoint

### DIFF
--- a/caffe2/python/checkpoint.py
+++ b/caffe2/python/checkpoint.py
@@ -19,7 +19,6 @@ from caffe2.python.task import (
 )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 


### PR DESCRIPTION
Summary: There is no reason to set a specific logging level for this module. Removing it to just use the default logging level.

Differential Revision: D15098834

