### PR TITLE
Install TensorBoard for doc generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,14 @@ install_doc_push_script: &install_doc_push_script
 
     rm -rf pytorch || true
 
+    # Install TensorBoard so torch.utils.tensorboard classes render
+    PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())'|cut -c1)
+    if [[ $PYTHON_VERSION == "2" ]]; then
+      pip install -q https://s3.amazonaws.com/ossci-linux/wheels/tensorboard-1.14.0a0-py2-none-any.whl
+    else
+      pip install -q https://s3.amazonaws.com/ossci-linux/wheels/tensorboard-1.14.0a0-py3-none-any.whl
+    fi
+
     # Get all the documentation sources, put them in one place
     pushd "\$pt_checkout"
     git clone https://github.com/pytorch/vision

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -110,6 +110,14 @@ install_doc_push_script: &install_doc_push_script
 
     rm -rf pytorch || true
 
+    # Install TensorBoard so torch.utils.tensorboard classes render
+    PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())'|cut -c1)
+    if [[ $PYTHON_VERSION == "2" ]]; then
+      pip install -q https://s3.amazonaws.com/ossci-linux/wheels/tensorboard-1.14.0a0-py2-none-any.whl
+    else
+      pip install -q https://s3.amazonaws.com/ossci-linux/wheels/tensorboard-1.14.0a0-py3-none-any.whl
+    fi
+
     # Get all the documentation sources, put them in one place
     pushd "\$pt_checkout"
     git clone https://github.com/pytorch/vision


### PR DESCRIPTION
In order to have `torch.utils.tensorboard.SummaryWriter` rendered in the documentation at the bottom of https://pytorch.org/docs/master/tensorboard.html we need to have TensorBoard installed.

This change makes it so our pinned version of `tb-nightly` is used for doc generation same as it is used for running tests at https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/test.sh#L45-L52

Eventually we'll use a pinned version of `pip install tensorboard`, but it's not on the release channel yet.

cc @kostmo @soumith @ezyang 