### PR TITLE
Forbid kernels from returning Scalar[]

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_functor.h
+++ b/aten/src/ATen/core/op_registration/kernel_functor.h
@@ -57,6 +57,7 @@ namespace detail {
     static ArrayRef<T> call(const IValue& v) {
       // TODO Do we want to support ArrayRef<optional<T>> ?
       static_assert(guts::typelist::contains<supported_primitive_arg_types, T>::value, "You tried to register a kernel with an unsupported argument type: c10::ArrayRef<T> and T is not one of the supported primitive types.");
+      static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported argument type: c10::ArrayRef<Scalar>. Please use c10::ArrayRef<int64_t>, c10::ArrayRef<double> or Tensor instead.");
       return v.to<intrusive_ptr<ivalue::List<T>>>()->elements();
     }
   };
@@ -118,6 +119,7 @@ namespace detail {
     static IValue call(std::vector<T>&& v) {
       // TODO Do we want to support vector<optional<T>> ?
       static_assert(guts::typelist::contains<supported_primitive_arg_types, T>::value, "You tried to register a kernel with an unsupported return type: vector<T> and T is not one of the supported primitive types.");
+      static_assert(!std::is_same<T, at::Scalar>::value, "You tried to register a kernel with an unsupported return type: vector<Scalar>. Please use vector<int64_t>, vector<double> or Tensor instead.");
       return IValue(std::move(v));
     }
   };


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19811 Forbid kernels from returning Scalar[]**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15101924/)

This does not immediately take effect for the custom op API but will break backwards compatibility once we switch to the new operator registration.

Differential Revision: [D15101924](https://our.internmc.facebook.com/intern/diff/D15101924/)