### PR TITLE
fix optional type unification

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -226,6 +226,7 @@ using OptionalTypePtr = std::shared_ptr<OptionalType>;
 // with a particular type: v: Optional[int] = None()
 struct CAFFE2_API OptionalType: public SingleElementType<TypeKind::OptionalType, OptionalType> {
   static OptionalTypePtr create(TypePtr element) {
+    // Optional is a union of [None, T], so Optional[[Optional[T]]] -> Optional[T]
     if (auto opt_ptr = element->cast<OptionalType>()) {
       return opt_ptr;
     }

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -226,6 +226,9 @@ using OptionalTypePtr = std::shared_ptr<OptionalType>;
 // with a particular type: v: Optional[int] = None()
 struct CAFFE2_API OptionalType: public SingleElementType<TypeKind::OptionalType, OptionalType> {
   static OptionalTypePtr create(TypePtr element) {
+    if (auto opt_ptr = element->cast<OptionalType>()) {
+      return opt_ptr;
+    }
     return OptionalTypePtr(new OptionalType(std::move(element))); // NOLINT(modernize-make-shared)
   }
   DEFINE_IS_SUBCLASS(OptionalType);

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5139,6 +5139,20 @@ a")
                 return a + b
             ''')
 
+    def test_opt_opt_refinement(self):
+        @torch.jit.script
+        def test_unify(weight, bias):
+            # type: (Optional[int], Optional[int]) -> Optional[int]
+            if weight is not None:
+                opt = None
+            else:
+                if bias is not None:
+                    opt = 1
+                else:
+                    opt = None
+
+            return opt
+
     def test_optional_refinement(self):
         @torch.jit.script
         def test_if_none_assignment(x):


### PR DESCRIPTION
Previously in type unification when we encountered an Optional[T] and a None, we would unify it to Optional[Optional[T]]. If you think about Optionals as a union of [T, None], then a union of [Optional[T], None] -> [T, None]. We should just be never create an Optional of an Optional. 

The other fix is to change unify_types directly, but I think this is the more general fix, and would play more nicely with our optional type refinement, which also assumes we never encounter an Optional[Optional[T]].