### PR TITLE
[jit] Add support for LONG_BINGET pickler op

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -417,6 +417,9 @@ OpCode Unpickler::readInstruction() {
     case OpCode::BINGET: {
       stack_.push_back(memo_table_.at(read<uint8_t>()));
     } break;
+    case OpCode::LONG_BINGET: {
+      stack_.push_back(memo_table_.at(read<uint32_t>()));
+    } break;
     case OpCode::STOP:
       break;
     case OpCode::GLOBAL: {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19815 [jit] Add support for LONG_BINGET pickler op**

This was missing in the earlier patch, as a follow up we should ensure
that all emitted OpCodes can be decoded

Differential Revision: [D15109969](https://our.internmc.facebook.com/intern/diff/D15109969)