### PR TITLE
Remove operator.h's dependency on function_schema.h

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -735,4 +735,11 @@ std::function<void(const OperatorDef&)> GetOperatorLogger() {
   return OperatorLogger;
 }
 
+
+c10::optional<int> OperatorBase::argumentIndexWithName(const std::string& name) const {
+  return getFunctionSchema().argumentIndexWithName(name);
+}
+
+OperatorBase::~OperatorBase() noexcept = default;
+
 }  // namespace caffe2

--- a/caffe2/core/operator_c10wrapper.h
+++ b/caffe2/core/operator_c10wrapper.h
@@ -6,6 +6,7 @@
 #include <c10/util/C++17.h>
 #include <c10/util/Metaprogramming.h>
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
 
 namespace caffe2 {
 

--- a/caffe2/operators/bbox_transform_op.h
+++ b/caffe2/operators/bbox_transform_op.h
@@ -7,6 +7,7 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+#include "caffe2/core/c10_operator.h"
 
 C10_DECLARE_CAFFE2_OPERATOR(BBoxTransform)
 

--- a/caffe2/operators/box_with_nms_limit_op.h
+++ b/caffe2/operators/box_with_nms_limit_op.h
@@ -5,6 +5,8 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
+
 
 C10_DECLARE_CAFFE2_OPERATOR(BoxWithNMSLimit)
 

--- a/caffe2/operators/gelu_op.h
+++ b/caffe2/operators/gelu_op.h
@@ -4,6 +4,7 @@
 #include "caffe2/core/common.h"
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
 #include "caffe2/operators/elementwise_ops.h"
 
 C10_DECLARE_CAFFE2_OPERATOR(Gelu);

--- a/caffe2/operators/generate_proposals_op.h
+++ b/caffe2/operators/generate_proposals_op.h
@@ -3,6 +3,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"
 

--- a/caffe2/operators/inference_lstm_op.h
+++ b/caffe2/operators/inference_lstm_op.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include "caffe2/core/blob_serialization.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
 #include "caffe2/core/tensor.h"
 #include "caffe2/utils/eigen_utils.h"
 #include "caffe2/utils/math.h"

--- a/caffe2/operators/layer_norm_op.h
+++ b/caffe2/operators/layer_norm_op.h
@@ -6,6 +6,7 @@
 
 #include "caffe2/core/context.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
 

--- a/caffe2/operators/roi_align_op.h
+++ b/caffe2/operators/roi_align_op.h
@@ -6,6 +6,7 @@
 #include "caffe2/core/context.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
+#include "caffe2/core/c10_operator.h"
 
 C10_DECLARE_CAFFE2_OPERATOR(RoIAlign)
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19817 Remove operator.h's dependency on function_schema.h**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15112247/)

A lot of files were depending on the JIT's typesystem
because operator.h depends on function_schema.h. However,
this isn't fundamental to the design. This diff tries to
remove the direct depenency and only includes the c10
wrapper helpers in files where it is required.

Differential Revision: [D15112247](https://our.internmc.facebook.com/intern/diff/D15112247/)