### PR TITLE
Add mkldnn support for adaptive_avg_pool2d

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -262,9 +262,11 @@ namespace {
     return output;
   }
 
-  Tensor adaptive_avg_pool2d(
-    at::Tensor const& input,
-    IntArrayRef output_size){
+  Tensor adaptive_avg_pool2d(at::Tensor const& input, IntArrayRef output_size) {
+    if (input.is_mkldnn()) {
+      return at::mkldnn_adaptive_avg_pool2d(input, output_size);
+    }
+
     if (output_size[0] == 1 && output_size[1] == 1) {
 //in this case, adaptive pooling is just computing mean over hw dimensions, which can be done more efficiently
        int64_t mean_size = input.size(-1) * input.size(-2);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3634,9 +3634,15 @@
   dispatch:
     CPU: adaptive_avg_pool2d_out_cpu
     CUDA: adaptive_avg_pool2d_out_cuda
+    MkldnnCPU: mkldnn_adaptive_avg_pool2d_out
 
 - func: adaptive_avg_pool2d(Tensor self, int[2] output_size) -> Tensor
   python_module: nn
+
+- func: mkldnn_adaptive_avg_pool2d(Tensor self, int[2] output_size) -> Tensor
+  dispatch:
+    MkldnnCPU: mkldnn_adaptive_avg_pool2d
+  requires_tensor: True
 
 - func: _adaptive_avg_pool2d(Tensor self, int[2] output_size) -> Tensor
   dispatch:

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -148,6 +148,17 @@ class TestMkldnn(TestCase):
                 avg_pool2d(x),
                 avg_pool2d(x.to_mkldnn()).to_dense())
 
+    def test_adaptive_avg_pool2d(self):
+        N = torch.randint(3, 10, (1,)).item()
+        C = torch.randint(3, 10, (1,)).item()
+        x = torch.randn(N, C, 224, 224, dtype=torch.float32) * 100
+
+        adaptive_avg_pool2d = torch.nn.AdaptiveAvgPool2d(7)
+
+        self.assertEqual(
+            adaptive_avg_pool2d(x),
+            adaptive_avg_pool2d(x.to_mkldnn()).to_dense())
+
     def test_batch_norm2d(self):
         N = torch.randint(3, 10, (1,)).item()
         C = torch.randint(3, 100, (1,)).item()


### PR DESCRIPTION
AdaptiveAvgPool2d is used in torchvision resnet models https://github.com/pytorch/vision/blob/9a481d0/torchvision/models/resnet.py#L145

Fixes #19797