### PR TITLE
Break circular dependency between Type.h, Tensor.h and TensorMethods.h

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -13,7 +13,6 @@
 #include <ATen/Tensor.h>
 #include <ATen/TensorGeometry.h>
 #include <ATen/TensorOperators.h>
-#include <ATen/Type.h>
 #include <ATen/Version.h>
 #include <ATen/core/ATenGeneral.h>
 #include <ATen/core/Generator.h>

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ATen/core/ATenGeneral.h>
-#include <ATen/Type.h>
+#include <ATen/Tensor.h>
 #include <ATen/TypeExtendedInterface.h>
 #include <ATen/Utils.h>
 #include <ATen/LegacyTHDispatch.h>

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ATen/Type.h>
+#include <ATen/core/Tensor.h>
 #include <c10/util/Half.h>
 #include <c10/util/Exception.h>
 #include <ATen/core/DeprecatedTypeProperties.h>

--- a/aten/src/ATen/Type.h
+++ b/aten/src/ATen/Type.h
@@ -1,2 +1,2 @@
 #pragma once
-#include <ATen/core/Type.h>
+#include <ATen/core/Tensor.h>

--- a/aten/src/ATen/core/DeprecatedTypeProperties.cpp
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.cpp
@@ -1,7 +1,7 @@
 #include <ATen/core/DeprecatedTypeProperties.h>
 
 #include <ATen/core/LegacyTypeDispatch.h>
-#include <ATen/core/Type.h>
+#include <ATen/core/Tensor.h>
 
 namespace at {
 

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/Type.h>
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/Scalar.h>

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <ATen/core/Tensor.h>
 #include <c10/core/Scalar.h>
 #include <c10/macros/Macros.h>
 #include <ATen/core/SparseTensorRef.h>
-#include <ATen/core/Type.h>
 #include <c10/core/TensorOptions.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
 

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -565,5 +565,3 @@ protected:
 };
 
 } // namespace at
-
-#include <ATen/core/Tensor.h>

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <ATen/core/TensorMethods.h>
-#include <ATen/core/Type.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/core/functional.h>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>

--- a/aten/src/ATen/templates/RegisterCPU.cpp
+++ b/aten/src/ATen/templates/RegisterCPU.cpp
@@ -2,7 +2,7 @@
 
 // ${generated_comment}
 
-#include <ATen/Type.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/Context.h>
 #include <ATen/UndefinedType.h>
 #include <ATen/core/VariableHooksInterface.h>

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/Type.h>
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/Scalar.h>

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <ATen/core/Tensor.h>
 #include <c10/core/Scalar.h>
 #include <c10/macros/Macros.h>
 #include <ATen/core/SparseTensorRef.h>
-#include <ATen/core/Type.h>
 #include <c10/core/TensorOptions.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
 

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -143,5 +143,3 @@ protected:
 };
 
 } // namespace at
-
-#include <ATen/core/Tensor.h>

--- a/aten/src/ATen/templates/TypeExtendedInterface.h
+++ b/aten/src/ATen/templates/TypeExtendedInterface.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ATen/Type.h>
+#include <ATen/core/Tensor.h>
 
 namespace at {
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19833 Remove self-include.
* #19831 Don't include TensorMethods.h - it's already included by Tensor.h anyway.
* **#19830 Break circular dependency between Type.h, Tensor.h and TensorMethods.h**

Currently these headers always include each other. Not only it creates a
different behavior depending on which header was included first, it also creates
a false sense of selective including - i.e. one might think they only include
Type-related code, but in fact they also always include Tensor.h and
TensorMethods.h.

Differential Revision: [D15115631](https://our.internmc.facebook.com/intern/diff/D15115631)