### PR TITLE
Don't include TensorMethods.h - it's already included by Tensor.h anyway.

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -19,6 +19,5 @@
 #include <c10/core/Layout.h>
 #include <ATen/core/Scalar.h>
 #include <c10/core/Storage.h>
-#include <ATen/core/TensorMethods.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/Exception.h>

--- a/aten/src/ATen/core/Formatting.h
+++ b/aten/src/ATen/core/Formatting.h
@@ -2,7 +2,6 @@
 
 #include <c10/core/Scalar.h>
 #include <ATen/core/Tensor.h>
-#include <ATen/core/TensorMethods.h>
 #include <ATen/core/Type.h>
 #include <iostream>
 

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -4,7 +4,6 @@
 
 #include <ATen/Context.h>
 #include <c10/core/ScalarType.h>
-#include <ATen/core/TensorMethods.h>
 #include <c10/core/TensorOptions.h>
 
 #include <array>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19833 Remove self-include.
* **#19831 Don't include TensorMethods.h - it's already included by Tensor.h anyway.**
* #19830 Break circular dependency between Type.h, Tensor.h and TensorMethods.h

Differential Revision: [D15115630](https://our.internmc.facebook.com/intern/diff/D15115630)