### PR TITLE
Remove self-include.

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -8,8 +8,6 @@
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
 
-#include <ATen/native/cuda/Normalization.cuh>
-
 namespace at { namespace native {
 
 #if defined(__HIP_PLATFORM_HCC__)

--- a/torch/csrc/jit/testing/file_check.h
+++ b/torch/csrc/jit/testing/file_check.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#include <torch/csrc/jit/testing/file_check.h>
 
 namespace torch {
 namespace jit {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#19833 Remove self-include.**
* #19831 Don't include TensorMethods.h - it's already included by Tensor.h anyway.
* #19830 Break circular dependency between Type.h, Tensor.h and TensorMethods.h

Differential Revision: [D15115726](https://our.internmc.facebook.com/intern/diff/D15115726)