### PR TITLE
Cleanup includes in torch/csrc/jit/script/logging.h.

### DIFF
--- a/torch/csrc/jit/script/logging.h
+++ b/torch/csrc/jit/script/logging.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -42,9 +41,7 @@ class TORCH_API LockingLogger : public LoggerBase {
   void addStatValue(const std::string& stat_name, int64_t val) override;
   virtual int64_t getCounterValue(const std::string& name) const;
   enum class AggregationType { SUM, AVG };
-  void setAggregationType(
-      const std::string& stat_name,
-      AggregationType type);
+  void setAggregationType(const std::string& stat_name, AggregationType type);
   ~LockingLogger() {}
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19894 Cleanup includes in torch/csrc/jit/register_prim_ops.cpp.
* #19893 Cleanup includes in torch/csrc/jit/passes/*.
* #19892 Cleanup includes in torch/csrc/jit/ir.cpp.
* #19891 Cleanup includes in torch/csrc/jit/interpreter.cpp.
* #19890 Cleanup includes in torch/csrc/jit/import.cpp.
* #19889 Cleanup includes in torch/csrc/jit/graph_executor.cpp.
* #19888 Cleanup includes in torch/csrc/jit/export.cpp.
* #19887 Cleanup includes in torch/csrc/autograd/*.
* #19886 Cleanup includes in torch/csrc/jit/script/python_tree_views.cpp.
* #19885 Cleanup includes in c10/core/CPUAllocator.cpp.
* #19884 Cleanup includes in torch/csrc/jit/script/script_type_parser.h.
* #19883 Cleanup includes in torch/csrc/jit/symbolic_script.h.
* #19882 Cleanup includes in torch/csrc/api/include/torch/ordered_dict.h.
* #19881 Cleanup includes in torch/csrc/jit/import_source.h.
* #19880 Cleanup includes in torch/csrc/jit/script/sugared_value.h.
* **#19879 Cleanup includes in torch/csrc/jit/script/logging.h.**
* #19878 Cleanup includes in torch/csrc/jit/passes/utils/check_alias_annotation.h.
* #19877 Cleanup includes in torch/csrc/jit/argument_spec.h.
* #19876 Cleanup includes in torch/csrc/autograd/functions/basic_ops.h.
* #19875 Cleanup includes in torch/csrc/utils/python_arg_parser.h.
* #19874 Cleanup includes in torch/csrc/jit/graph_executor.h.
* #19873 Cleanup includes in torch/csrc/autograd/saved_variable.h.
* #19872 Cleanup includes in torch/csrc/PtrWrapper.h.
* #19871 Cleanup includes in torch/csrc/autograd/python_engine.h.
* #19870 Cleanup includes in torch/csrc/autograd/profiler.h.
* #19869 Cleanup includes in torch/csrc/Exceptions.h.
* #19868 Remove redundant includes from torch/csrc/autograd/variable.h.
* #19867 Remove redundant includes from torch/csrc/jit/script/lexer.h.
* #19866 Remove redundant include from torch/csrc/jit/import_export_helpers.h.
* #19865 Remove redundant include from torch/csrc/jit/script/edit_distance.h.
* #19864 Remove redundant includes from torch/csrc/api/include/torch/jit.h.
* #19863 Remove redundant include from jit/fuser/cpu/dynamic_library.h.

Differential Revision: [D15118509](https://our.internmc.facebook.com/intern/diff/D15118509)