### PR TITLE
Cleanup includes in torch/csrc/jit/interpreter.cpp.

### DIFF
--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -4,17 +4,13 @@
 #include <c10/core/thread_pool.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/autograd/edge.h>
-#include <torch/csrc/autograd/function.h>
-#include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/autograd/grad_mode.h>
-#include <torch/csrc/autograd/profiler.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/script/jit_exception.h>
-#include <torch/csrc/jit/script/logging.h>
 
 #include <exception>
 #include <iostream>
@@ -475,7 +471,9 @@ struct CodeImpl {
           createJumpFalse(cond_branch, instructions.size());
           createJumpTrue(cond_branch_end, entry);
         } break;
-        default: { insertInstruction(node); } break;
+        default: {
+          insertInstruction(node);
+        } break;
       }
     }
   }
@@ -702,8 +700,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         // the current thread will continue running before it suspends.
         InterpreterState state(intrusive_from_this());
         e.future->addCallback([state]() {
-          c10::global_work_queue().run(InterpreterContinuation(state, Stack(),
-              autograd::GradMode::is_enabled()));
+          c10::global_work_queue().run(InterpreterContinuation(
+              state, Stack(), autograd::GradMode::is_enabled()));
         });
 
         return true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19894 Cleanup includes in torch/csrc/jit/register_prim_ops.cpp.
* #19893 Cleanup includes in torch/csrc/jit/passes/*.
* #19892 Cleanup includes in torch/csrc/jit/ir.cpp.
* **#19891 Cleanup includes in torch/csrc/jit/interpreter.cpp.**
* #19890 Cleanup includes in torch/csrc/jit/import.cpp.
* #19889 Cleanup includes in torch/csrc/jit/graph_executor.cpp.
* #19888 Cleanup includes in torch/csrc/jit/export.cpp.
* #19887 Cleanup includes in torch/csrc/autograd/*.
* #19886 Cleanup includes in torch/csrc/jit/script/python_tree_views.cpp.
* #19885 Cleanup includes in c10/core/CPUAllocator.cpp.
* #19884 Cleanup includes in torch/csrc/jit/script/script_type_parser.h.
* #19883 Cleanup includes in torch/csrc/jit/symbolic_script.h.
* #19882 Cleanup includes in torch/csrc/api/include/torch/ordered_dict.h.
* #19881 Cleanup includes in torch/csrc/jit/import_source.h.
* #19880 Cleanup includes in torch/csrc/jit/script/sugared_value.h.
* #19879 Cleanup includes in torch/csrc/jit/script/logging.h.
* #19878 Cleanup includes in torch/csrc/jit/passes/utils/check_alias_annotation.h.
* #19877 Cleanup includes in torch/csrc/jit/argument_spec.h.
* #19876 Cleanup includes in torch/csrc/autograd/functions/basic_ops.h.
* #19875 Cleanup includes in torch/csrc/utils/python_arg_parser.h.
* #19874 Cleanup includes in torch/csrc/jit/graph_executor.h.
* #19873 Cleanup includes in torch/csrc/autograd/saved_variable.h.
* #19872 Cleanup includes in torch/csrc/PtrWrapper.h.
* #19871 Cleanup includes in torch/csrc/autograd/python_engine.h.
* #19870 Cleanup includes in torch/csrc/autograd/profiler.h.
* #19869 Cleanup includes in torch/csrc/Exceptions.h.
* #19868 Remove redundant includes from torch/csrc/autograd/variable.h.
* #19867 Remove redundant includes from torch/csrc/jit/script/lexer.h.
* #19866 Remove redundant include from torch/csrc/jit/import_export_helpers.h.
* #19865 Remove redundant include from torch/csrc/jit/script/edit_distance.h.
* #19864 Remove redundant includes from torch/csrc/api/include/torch/jit.h.
* #19863 Remove redundant include from jit/fuser/cpu/dynamic_library.h.

Differential Revision: [D15118495](https://our.internmc.facebook.com/intern/diff/D15118495)