### PR TITLE
Only call into reducer if torch.is_grad_enabled()

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2308,6 +2308,65 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             self.assertTrue(torch.is_tensor(p.grad))
             self.assertEqual(p.size(), p.grad.size())
 
+    @skip_if_not_nccl
+    @skip_if_not_multigpu
+    def test_no_grad(self):
+        """
+        Note: this test can be sped up by only running it on a CPU module
+        once DistributedDataParallel supports them.
+        """
+        store = c10d.FileStore(self.file.name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        class NoUsedParameters(nn.Module):
+            def __init__(self):
+                super(NoUsedParameters, self).__init__()
+                self.fc1 = nn.Linear(2, 10, bias=False)
+                self.fc2 = nn.Linear(10, 4, bias=False)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.relu(self.fc1(x))
+                x = self.relu(self.fc2(x))
+                return F.softmax(x, dim=1)
+
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        model = DistributedDataParallel(
+            NoUsedParameters().float().to(device_id),
+            device_ids=[device_id],
+            process_group=process_group,
+        )
+
+        batch_size = 4
+        input = torch.rand([batch_size, 2], dtype=torch.float)
+
+        def check_no_grads():
+            for p in model.parameters():
+                self.assertTrue(p.requires_grad)
+                self.assertIsNone(p.grad)
+
+        # After initialization, no parameter has their gradient set.
+        check_no_grads()
+
+        # Run `forward` function in eval mode
+        model.eval()
+        output = model(input)
+        self.assertTrue(torch.is_tensor(output))
+        model.train()
+
+        # No parameter should have their gradient set.
+        check_no_grads()
+
+        # Run `forward` function with torch.no_grad()
+        with torch.no_grad():
+            output = model(input)
+            self.assertTrue(torch.is_tensor(output))
+
+        # No parameter should have their gradient set.
+        check_no_grads()
+
+
+
 
 class ReducerModule(nn.Module):
     def __init__(self):

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2318,9 +2318,9 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         store = c10d.FileStore(self.file.name, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
-        class NoUsedParameters(nn.Module):
+        class NoGradModule(nn.Module):
             def __init__(self):
-                super(NoUsedParameters, self).__init__()
+                super(NoGradModule, self).__init__()
                 self.fc1 = nn.Linear(2, 10, bias=False)
                 self.fc2 = nn.Linear(10, 4, bias=False)
                 self.relu = nn.ReLU()
@@ -2332,7 +2332,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
         device_id = gpus_for_rank(self.world_size)[self.rank][0]
         model = DistributedDataParallel(
-            NoUsedParameters().float().to(device_id),
+            NoGradModule().float().to(device_id),
             device_ids=[device_id],
             process_group=process_group,
         )

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2366,8 +2366,6 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         check_no_grads()
 
 
-
-
 class ReducerModule(nn.Module):
     def __init__(self):
         super(ReducerModule, self).__init__()

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2348,15 +2348,6 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         # After initialization, no parameter has their gradient set.
         check_no_grads()
 
-        # Run `forward` function in eval mode
-        model.eval()
-        output = model(input)
-        self.assertTrue(torch.is_tensor(output))
-        model.train()
-
-        # No parameter should have their gradient set.
-        check_no_grads()
-
         # Run `forward` function with torch.no_grad()
         with torch.no_grad():
             output = model(input)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -380,14 +380,16 @@ class DistributedDataParallel(Module):
         else:
             output = self.module(*inputs, **kwargs)
 
-        # We'll return the output object verbatim since it is a freeform object.
-        # We need to find any tensors in this object, though, because we need to
-        # figure out which parameters were used during this forward pass,
-        # to ensure we short circuit reduction for any unused parameters.
-        if self.find_unused_parameters:
-            self.reducer.prepare_for_backward(list(_find_tensors(output)))
-        else:
-            self.reducer.prepare_for_backward([])
+        if self.training and torch.is_grad_enabled():
+            # We'll return the output object verbatim since it is a freeform
+            # object. We need to find any tensors in this object, though,
+            # because we need to figure out which parameters were used during
+            # this forward pass, to ensure we short circuit reduction for any
+            # unused parameters. Only if `find_unused_parameters` is set.
+            if self.find_unused_parameters:
+                self.reducer.prepare_for_backward(list(_find_tensors(output)))
+            else:
+                self.reducer.prepare_for_backward([])
         return output
 
     def scatter(self, inputs, kwargs, device_ids):

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -380,7 +380,7 @@ class DistributedDataParallel(Module):
         else:
             output = self.module(*inputs, **kwargs)
 
-        if self.training and torch.is_grad_enabled():
+        if torch.is_grad_enabled():
             # We'll return the output object verbatim since it is a freeform
             # object. We need to find any tensors in this object, though,
             # because we need to figure out which parameters were used during


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19901 Finer grained consistency check in reducer**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15118871/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19897 Only call into reducer if torch.is_grad_enabled()&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15118726/)

During validation, gradient reduction is not needed, and autograd is
never called. The model output will always be a detached tensor. After
the new reducer was merged, this meant that it would find all model
parameters unused, and kick off reduction for them. When #19799 and
#19821 were merged it looked like model output during validation is an
output where no parameters are used and it tries to kick off reduction
of zeroed gradients. Test for `torch.is_grad_enabled()` and
`self.training` before calling into the reducer.

Differential Revision: [D15118726](https://our.internmc.facebook.com/intern/diff/D15118726/)