### PR TITLE
Finer grained consistency check in reducer

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2386,11 +2386,20 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         )
 
         batch_size = 4
+        criterion = nn.CrossEntropyLoss()
         input = torch.rand([batch_size, 2], dtype=torch.float)
+        target = torch.LongTensor([random.randrange(4) for _ in range(batch_size)]).to(device_id)
 
+        # Run a few iterations where we ignore the output.
         for _ in range(4):
             output = model(input)
             del output
+
+        # Run a few iterations where we use the output.
+        for _ in range(4):
+            output = model(input)
+            loss = criterion(output, target)
+            loss.backward()
 
 
 class ReducerModule(nn.Module):

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2356,6 +2356,42 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         # No parameter should have their gradient set.
         check_no_grads()
 
+    @skip_if_not_nccl
+    @skip_if_not_multigpu
+    def test_ignored_output(self):
+        """
+        Note: this test can be sped up by only running it on a CPU module
+        once DistributedDataParallel supports them.
+        """
+        store = c10d.FileStore(self.file.name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+
+        class IgnoredOutput(nn.Module):
+            def __init__(self):
+                super(IgnoredOutput, self).__init__()
+                self.fc1 = nn.Linear(2, 10, bias=False)
+                self.fc2 = nn.Linear(10, 4, bias=False)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.relu(self.fc1(x))
+                x = self.relu(self.fc2(x))
+                return F.softmax(x, dim=1)
+
+        device_id = gpus_for_rank(self.world_size)[self.rank][0]
+        model = DistributedDataParallel(
+            IgnoredOutput().float().to(device_id),
+            device_ids=[device_id],
+            process_group=process_group,
+        )
+
+        batch_size = 4
+        input = torch.rand([batch_size, 2], dtype=torch.float)
+
+        for _ in range(4):
+            output = model(input)
+            del output
+
 
 class ReducerModule(nn.Module):
     def __init__(self):

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -45,6 +45,7 @@ Reducer::Reducer(
     : replicas_(std::move(replicas)),
       process_group_(std::move(process_group)),
       expect_autograd_hooks_(false),
+      require_finalize_(false),
       has_marked_unused_parameters_(false),
       next_bucket_(0),
       backward_stats_base_(0) {
@@ -159,6 +160,12 @@ void Reducer::mark_variable_ready(
       "Out of range variable index.");
   backward_stats_[replica_index][variable_index] =
       current_time_in_nanos() - backward_stats_base_;
+
+  // Any time we mark a variable ready (be it in line due to unused parameters,
+  // or via an autograd hook), we require a call to the finalize function. If
+  // this doesn't happen before the next iteration (or call to
+  // `prepare_for_backwards`), we know something is wrong.
+  require_finalize_ = true;
 
   const auto& bucket_index = variable_locators_[variable_index];
   auto& bucket = buckets_[bucket_index.bucket_index];
@@ -382,7 +389,7 @@ void Reducer::prepare_for_backward(
   // Check that any prior reduction has finished.
   // The variable `expect_autograd_hooks` is true until gradients for all
   // parameters have been received and all buckets are ready.
-  if (expect_autograd_hooks_) {
+  if (require_finalize_) {
     AT_ERROR(
         "Expected to have finished reduction in the prior iteration before ",
         "starting a new one. ",
@@ -462,6 +469,10 @@ void Reducer::finalize_backward() {
   // No longer expect autograd hooks to fire after this function returns.
   AT_ASSERT(expect_autograd_hooks_);
   expect_autograd_hooks_ = false;
+
+  // No longer require call to finalize after this function returns.
+  AT_ASSERT(expect_autograd_hooks_);
+  require_finalize_ = false;
 
   // Check that all buckets were completed and had their work kicked off.
   AT_ASSERT(next_bucket_ == buckets_.size());

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -471,7 +471,7 @@ void Reducer::finalize_backward() {
   expect_autograd_hooks_ = false;
 
   // No longer require call to finalize after this function returns.
-  AT_ASSERT(expect_autograd_hooks_);
+  AT_ASSERT(require_finalize_);
   require_finalize_ = false;
 
   // Check that all buckets were completed and had their work kicked off.

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -54,6 +54,7 @@ class Reducer {
   std::unordered_map<torch::autograd::Function*, std::tuple<int, int>> func_;
 
   bool expect_autograd_hooks_;
+  bool require_finalize_;
   bool has_marked_unused_parameters_;
   size_t next_bucket_;
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19901 Finer grained consistency check in reducer&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15118871/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#19897 Only call into reducer if torch.is_grad_enabled()**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15118726/)

The existing code used `expect_autograd_hooks_` as a proxy for the
situation where finalization of the previous iteration is needed. This
is not correct, however, since you may decide to completely ignore the
output of a DDP wrapped module. If this is the case, and no gradients
have been passed to the reducer, it is fine to keep going. This commit
adds a new variable `require_finalize_` that tracks whether the
finalization is really needed.

Differential Revision: [D15118871](https://our.internmc.facebook.com/intern/diff/D15118871/)