### PR TITLE
Update multiprocessing note now that shared CUDA tensors are refcounted

### DIFF
--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -31,8 +31,13 @@ Python 2 can only create subprocesses using ``fork``, and it's not supported
 by the CUDA runtime.
 
 Unlike CPU tensors, the sending process is required to keep the original tensor
-as long as the receiving process retains a copy of the tensor. It is implemented
-under the hood but requires users to follow the next best practices.
+as long as the receiving process retains a copy of the tensor. The refcounting is
+implemented under the hood but requires users to follow the next best practices.
+
+.. warning::
+    If the consumer process dies abnormally to a fatal signal, the shared tensor
+    could be forever kept in memory as long as the sending process is running.
+
 
 1. Release memory ASAP in the consumer.
 

--- a/docs/source/multiprocessing.rst
+++ b/docs/source/multiprocessing.rst
@@ -19,6 +19,9 @@ Strategy management
 .. autofunction:: get_sharing_strategy
 .. autofunction:: set_sharing_strategy
 
+
+.. _multiprocessing-cuda-sharing-details:
+
 Sharing CUDA tensors
 --------------------
 

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -35,7 +35,10 @@ required to use CUDA in subprocesses.
 
 Unlike CPU tensors, the sending process is required to keep the original tensor
 as long as the receiving process retains a copy of the tensor. It is implemented
-under the hood but requires users to follow the best practices described in
+under the hood but requires users to follow the best practices for the program
+to run correctly. For example, the sending process must stay alive as long as
+the consumer process has references to the tensor, and the refcounting can not
+save you if the consumer process exits abnormally via a fatal signal. See
 :ref:`this section <multiprocessing-cuda-sharing-details>`.
 
 See also: :ref:`cuda-nn-dataparallel-instead`

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -25,7 +25,7 @@ CUDA in multiprocessing
 
 The CUDA runtime does not support the ``fork`` start method. However,
 :mod:`python:multiprocessing` in Python 2 can only create subprocesses using
-``fork``. So Python 3 and either ``spawn`` or ``forkserver`` start method is
+``fork``. So Python 3 and either ``spawn`` or ``forkserver`` start method are
 required to use CUDA in subprocesses.
 
 .. note::

--- a/docs/source/notes/multiprocessing.rst
+++ b/docs/source/notes/multiprocessing.rst
@@ -20,22 +20,23 @@ memory and will only send a handle to another process.
 This allows to implement various training methods, like Hogwild, A3C, or any
 others that require asynchronous operation.
 
-Sharing CUDA tensors
---------------------
+CUDA in multiprocessing
+-----------------------
 
-Sharing CUDA tensors between processes is supported only in Python 3, using
-a ``spawn`` or ``forkserver`` start methods. :mod:`python:multiprocessing` in
-Python 2 can only create subprocesses using ``fork``, and it's not supported
-by the CUDA runtime.
+The CUDA runtime does not support the ``fork`` start method. However,
+:mod:`python:multiprocessing` in Python 2 can only create subprocesses using
+``fork``. So Python 3 and either ``spawn`` or ``forkserver`` start method is
+required to use CUDA in subprocesses.
 
-.. warning::
+.. note::
+  The start method can be set via either creating a context with
+  ``multiprocessing.get_context(...)`` or directly using
+  ``multiprocessing.set_start_method(...)``.
 
-    CUDA API requires that the allocation exported to other processes remains
-    valid as long as it's used by them. You should be careful and ensure that
-    CUDA tensors you shared don't go out of scope as long as it's necessary.
-    This shouldn't be a problem for sharing model parameters, but passing other
-    kinds of data should be done with care. Note that this restriction doesn't
-    apply to shared CPU memory.
+Unlike CPU tensors, the sending process is required to keep the original tensor
+as long as the receiving process retains a copy of the tensor. It is implemented
+under the hood but requires users to follow the best practices described in
+:ref:`this section <multiprocessing-cuda-sharing-details>`.
 
 See also: :ref:`cuda-nn-dataparallel-instead`
 


### PR DESCRIPTION
The mp notes are not updated after https://github.com/pytorch/pytorch/pull/16854. (The torch.multiprocessing page is.)