### PR TITLE
trace multiple methods

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3157,7 +3157,6 @@ class TestScript(JitTestCase):
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
-                print ("running Net")
                 self.conv = nn.Conv2d(1, 1, 3)
 
             def forward(self, x):
@@ -3169,8 +3168,8 @@ class TestScript(JitTestCase):
         example_weight = torch.rand(1, 1, 3, 3)
         example_forward_input = torch.rand(1, 1, 3, 3)
         n = Net()
-        inputs = {n.forward : example_forward_input, n.weighted_kernel_sum : example_weight}
-        module = torch.jit.trace(n, inputs)
+        inputs = {'forward' : example_forward_input, 'weighted_kernel_sum' : example_weight}
+        module = torch.jit.trace_module(n, inputs)
 
     def test_submodule_twice(self):
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3169,8 +3169,8 @@ class TestScript(JitTestCase):
         example_weight = torch.rand(1, 1, 3, 3)
         example_forward_input = torch.rand(1, 1, 3, 3)
         n = Net()
-        traced_methods = torch.jit.trace_dict({'forward' : example_forward_input, 'weighted_kernel_sum': example_weight})
-        module = torch.jit.trace(n, traced_methods)
+        inputs = {n.forward : example_forward_input, n.weighted_kernel_sum : example_weight}
+        module = torch.jit.trace(n, inputs)
 
     def test_submodule_twice(self):
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3167,12 +3167,18 @@ class TestScript(JitTestCase):
 
         example_weight = torch.rand(1, 1, 3, 3)
         example_forward_input = torch.rand(1, 1, 3, 3)
-        n = Net()
         inputs = {'forward' : example_forward_input, 'weighted_kernel_sum' : example_weight}
+        n = Net()
         module = torch.jit.trace_module(n, inputs)
 
-    def test_submodule_twice(self):
+        check_inputs = []
+        for i in range(2):
+            check_weight = torch.rand(1, 1, 3, 3)
+            check_forward_input = torch.rand(1, 1, 3, 3)
+            check_inputs.append({'forward' : check_forward_input, 'weighted_kernel_sum' : check_weight})
+        module = torch.jit.trace_module(n, inputs, True, True, check_inputs)
 
+    def test_submodule_twice(self):
         @torch.jit.script
         def foo(x):
             return x * x

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3153,6 +3153,25 @@ class TestScript(JitTestCase):
             ge = torch.jit.script(script, optimize)
             ge(*inputs)
 
+    def test_tracing_multiple_methods(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                print ("running Net")
+                self.conv = nn.Conv2d(1, 1, 3)
+
+            def forward(self, x):
+                return self.conv(x)
+
+            def weighted_kernel_sum(self, weight):
+                return weight * self.conv.weight
+
+        example_weight = torch.rand(1, 1, 3, 3)
+        example_forward_input = torch.rand(1, 1, 3, 3)
+        n = Net()
+        traced_methods = torch.jit.trace_dict({'forward' : example_forward_input, 'weighted_kernel_sum': example_weight})
+        module = torch.jit.trace(n, traced_methods)
+
     def test_submodule_twice(self):
 
         @torch.jit.script

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -478,6 +478,7 @@ void initJitScriptBindings(PyObject* module) {
             return tensors;
           })
       .def_property_readonly("schema", &Method::getSchema)
+      .def_property_readonly("name", &Method::name)
       .def_property_readonly("code", [](Method& self) {
         std::ostringstream ss;
         std::vector<at::Tensor> tensors;

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -472,7 +472,6 @@ class TracingCheckError(Exception):
 def _check_trace(check_inputs, func, executor_options, traced_func, check_tolerance, force_outplace, is_trace_module):
     # Note: tracing is independent of optimizations, which consume the trace
     executor_options['optimize'] = False
-    func_name = traced_func.name
     for inputs in check_inputs:
         if isinstance(inputs, torch.Tensor):
             inputs = (inputs,)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -612,6 +612,10 @@ torch._C._tracer_warn_use_python()
 
 
 class trace_dict(dict):
+    """
+    A tagging interface to differentiate when inputs to trace is a dictionary
+    of methods-inputs pairs or dictionary of regular inputs
+    """
     def __init__(self, methods_inputs):
         super(trace_dict, self).__init__()
         if not isinstance(methods_inputs, dict):
@@ -699,10 +703,6 @@ def trace(mod,
     else:
         methods_inputs[mod] = (getattr(mod, '__name__', 'forward'), inputs)
         if hasattr(mod, '__self__') and isinstance(mod.__self__, torch.nn.Module):
-                # override the default name for nn.Module's methods
-                # `forward` will stay `forward` and any other
-                # method will keep its original name
-                # make sure we capture module's parameters in TopLevelTracedModule
                 mod = mod.__self__
 
     executor_options = {'optimize': bool(optimize)}
@@ -718,7 +718,6 @@ def trace(mod,
     for func, name_inputs in methods_inputs.items():
         method_name = name_inputs[0]
         example_inputs = name_inputs[1]
-        # Special case for common case of passing a single Tensor
         if isinstance(example_inputs, (torch.Tensor, dict)):
             example_inputs = (example_inputs,)
         # done primarily so that weird iterables fail here and not pybind11 code

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -703,26 +703,26 @@ def trace(mod,
         len(inputs.keys()) > 0 and
             isinstance(inputs.keys()[0], types.MethodType)):
 
-            if not isinstance(mod, torch.nn.Module):
-                raise AttributeError("expected torch.nn.Module as the first argument")
+        if not isinstance(mod, torch.nn.Module):
+            raise AttributeError("expected torch.nn.Module as the first argument")
 
-            module = make_module(mod, _module_class, executor_options)
+        module = make_module(mod, _module_class, executor_options)
 
-            for func, example_inputs in inputs.items():
+        for func, example_inputs in inputs.items():
 
-                if func.__self__ is not mod:
-                    raise AttributeError("function's __self__ should be equal to module")
-                method_name = func.__name__
-                example_inputs = make_tuple(example_inputs)
-                module._c._create_method_from_trace(method_name, func, example_inputs, var_lookup_fn, _force_outplace)
-                check_trace_method = module._c._get_method(method_name)
+            if func.__self__ is not mod:
+                raise AttributeError("function's __self__ should be equal to module")
+            method_name = func.__name__
+            example_inputs = make_tuple(example_inputs)
+            module._c._create_method_from_trace(method_name, func, example_inputs, var_lookup_fn, _force_outplace)
+            check_trace_method = module._c._get_method(method_name)
 
-                # Check the trace against new traces created from user-specified inputs
-                if check_trace:
-                    if check_inputs is not None:
-                        _check_trace(check_inputs, func, executor_options, check_trace_method, check_tolerance, _force_outplace)
-                    else:
-                        _check_trace([example_inputs], func, executor_options, check_trace_method, check_tolerance, _force_outplace)
+            # Check the trace against new traces created from user-specified inputs
+            if check_trace:
+                if check_inputs is not None:
+                    _check_trace(check_inputs, func, executor_options, check_trace_method, check_tolerance, _force_outplace)
+                else:
+                    _check_trace([example_inputs], func, executor_options, check_trace_method, check_tolerance, _force_outplace)
 
             return module
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -703,7 +703,7 @@ def trace(mod,
     else:
         methods_inputs[mod] = (getattr(mod, '__name__', 'forward'), inputs)
         if hasattr(mod, '__self__') and isinstance(mod.__self__, torch.nn.Module):
-                mod = mod.__self__
+            mod = mod.__self__
 
     executor_options = {'optimize': bool(optimize)}
 


### PR DESCRIPTION
This PR adds a new trace API `trace_module` that will allow us to trace multiple methods as a part of a single `ScriptModule`

See the example below.

```python
        class Net(nn.Module):
            def __init__(self):
                super(Net, self).__init__()
                self.conv = nn.Conv2d(1, 1, 3)

            def forward(self, x):
                return self.conv(x)

            def weighted_kernel_sum(self, weight):
                return weight * self.conv.weight

        example_weight = torch.rand(1, 1, 3, 3)
        example_forward_input = torch.rand(1, 1, 3, 3)
        n = Net()
        inputs = {'forward' : example_forward_input, 'weighted_kernel_sum' : example_weight}
        module = torch.jit.trace_module(n, inputs)
```