### PR TITLE
Support multi-dim reduce op

### DIFF
--- a/test/onnx/expect/TestOperators.test_reduced_mean_multidim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_multidim.expect
@@ -1,0 +1,63 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "1.1"
+graph {
+  node {
+    input: "0"
+    output: "1"
+    op_type: "ReduceMean"
+    attribute {
+      name: "axes"
+      ints: 2
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 0
+      type: INT
+    }
+  }
+  name: "torch-jit-export"
+  input {
+    name: "0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -330,6 +330,10 @@ class TestOperators(TestCase):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: torch.mean(x, dim=2), x)
 
+    def test_reduced_mean_multidim(self):
+        x = torch.randn(1, 2, 3, 4, requires_grad=True)
+        self.assertONNX(lambda x: torch.mean(x, dim=[2, 3]), x)
+
     def test_reduced_mean_keepdim(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: torch.mean(x, dim=2, keepdim=True), x)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1029,6 +1029,24 @@ class TestCaffe2Backend(unittest.TestCase):
             x = torch.randn(*shape)
             self.run_model_test(MyModel(), train=False, input=(x), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_mean_multidim(self):
+        class MyModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.mean(x, [1, 2])
+
+        shape = (3, 4, 5)
+        x = torch.randn(*shape)
+        self.run_model_test(MyModel(), train=False, input=(x), batch_size=BATCH_SIZE, use_gpu=False)
+
+    def test_norm_multidim(self):
+        class MyModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.norm(x, dim=[1, 2])
+
+        shape = (3, 4, 5)
+        x = torch.randn(*shape)
+        self.run_model_test(MyModel(), train=False, input=(x), batch_size=BATCH_SIZE, use_gpu=False)
+
     # TODO: Add test cases for prod once Caffe2 has support for ReduceProd
     def test_softmax(self):
         for i in range(2, 8):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -78,7 +78,13 @@ def _parse_arg(value, desc):
         elif desc == 't':
             return tval
         elif desc == 'is':
-            return [int(v) for v in tval]
+            try:
+                return [int(v) for v in tval]
+            except TypeError:
+                if tval.dim():
+                    raise
+            # scalar tensors are not iterable
+            return [int(tval)]
         else:
             raise RuntimeError("ONNX symbolic doesn't know to interpret Constant node")
     elif value.node().kind() == 'prim::ListConstruct':

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -208,8 +208,9 @@ def _reduce_op_symbolic(onnx_op_name):
             return g.op(onnx_op_name, self, keepdims_i=0)
         else:
             # dim-reduce path
-            dim, keepdim = sym_help._get_const(dim, 'i', 'dim'), sym_help._get_const(keepdim, 'i', 'keepdim')
-            return g.op(onnx_op_name, self, axes_i=[dim], keepdims_i=keepdim)
+            return g.op(onnx_op_name, self,
+                        axes_i=sym_help._get_const(dim, 'is', 'dim'),
+                        keepdims_i=sym_help._get_const(keepdim, 'i', 'keepdim'))
     return symbolic
 
 mean = _reduce_op_symbolic('ReduceMean')
@@ -1061,7 +1062,7 @@ alpha_dropout_ = alpha_dropout
 feature_alpha_dropout_ = feature_alpha_dropout
 
 
-@parse_args('v', 't', 'i', 'i')
+@parse_args('v', 't', 'is', 'i')
 def norm(g, self, p, dim, keepdim):
     if p == 1:
         f = _reduce_op_symbolic("ReduceL1")


### PR DESCRIPTION
Prior to the patch, networks that apply reduce operation on
multiple dimensions have failed on ONNX JIT pass during
graph optimization.
e.g. torch.mean(tensor, [dim1, dim2])

This patch adds support for iterable dim argument.

Resolves issue #20942