### PR TITLE
add logging in sparse_to_dense_mask when skipping

### DIFF
--- a/caffe2/operators/sparse_to_dense_mask_op.h
+++ b/caffe2/operators/sparse_to_dense_mask_op.h
@@ -155,6 +155,7 @@ class SparseToDenseMaskOp : public SparseToDenseMaskBase<Context> {
         const auto sparse_index = sparse_indices_vec[offset + c];
         if (sparse_index < 0 ||
             sparse_index >= std::numeric_limits<TInd>::max()) {
+          LOG(WARNING) << "Skipping invalid sparse index: " << sparse_index;
           CAFFE_ENFORCE_LT(
               ++skippedSparseIndices_,
               maxSkippedSparseIndices_,


### PR DESCRIPTION
Summary: this logging was removed in D6888977, but i think it could be useful to debug upstream data issue to check the violating index

Differential Revision: D15127887

