### PR TITLE
Support for non-contiguous tensors in PT benchmarks

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -60,7 +60,9 @@ def map_c2_config_add(M, N, K):
 map_pt_config_add = map_c2_config_add
 
 
-def map_c2_config_matmul(M, N, K, trans_a, trans_b):
+def map_c2_config_matmul(M, N, K, trans_a, trans_b, contig):
+    if not config:
+        return None
     input_one = (N, M) if trans_a else (M, N)
     input_two = (K, N) if trans_b else (N, K)
     input_shapes = [input_one, input_two]
@@ -68,11 +70,11 @@ def map_c2_config_matmul(M, N, K, trans_a, trans_b):
     return (input_shapes, args)
 
 
-def map_pt_config_matmul(M, N, K, trans_a, trans_b):
+def map_pt_config_matmul(M, N, K, trans_a, trans_b, contig):
     input_one = (N, M) if trans_a else (M, N)
     input_two = (K, N) if trans_b else (N, K)
     input_shapes = [input_one, input_two]
-    args = {}
+    args = {'contig': contig}
     if not trans_a and not trans_b:
         return (input_shapes, args)
     return None

--- a/benchmarks/operator_benchmark/ops/matmul_test.py
+++ b/benchmarks/operator_benchmark/ops/matmul_test.py
@@ -17,6 +17,7 @@ long_config = generate_configs(
     K=get_n_rand_nums(min_val=1, max_val=128, n=2),
     trans_a=[False, True],
     trans_b=[True, False],
+    contig=[True],
     mode=['long'],
     sample_func=cross_product
 )
@@ -28,6 +29,7 @@ short_config = generate_configs(
     K=[64, 128],
     trans_a=[False, True],
     trans_b=[True, False],
+    contig=[True, False],
     mode=['short'],
     sample_func=cross_product
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #19993 Support for non-contiguous tensors and arbitrary dtypes in PT benchmarks
* **#19992 Support for non-contiguous tensors in PT benchmarks**
* #19980 Initialize Caffe2 only when running Caffe2 benchmarks
* #19749 Allow a non-OpenMP based build

Summary:
Add an option to use non-contiguous tensors in PT benchmarks

Test Plan:
BUILD_BINARY=1 BLAS=MKL USE_MKLDNN=1 USE_OPENCV=1 USE_FFMPEG=1 python setup.py develop --cmake
cd benchmarks
python -m operator_benchmark.ops.matmul_test --framework PyTorch --run_mode long