### PR TITLE
[pytorch] fix labs warning in THVectorDefault.cpp

### DIFF
--- a/aten/src/TH/generic/THVectorDefault.cpp
+++ b/aten/src/TH/generic/THVectorDefault.cpp
@@ -215,7 +215,7 @@ void THVector_(normal_fill_DEFAULT)(scalar_t *data,
   } \
 
 #if defined(TH_REAL_IS_LONG)
-VECTOR_IMPLEMENT_FUNCTION(abs,labs)
+VECTOR_IMPLEMENT_FUNCTION(abs,std::abs)
 #endif /* long only part */
 
 #if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_CHAR)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #20000 [pytorch] exclude some caffe2 modules from libtorch mobile build
* #19762 [pytorch] CMakeLists changes to enable libtorch for Android
* **#19999 [pytorch] fix labs warning in THVectorDefault.cpp**
* #19760 [pytorch] fix labs warning in THTensorMoreMath.cpp

Summary:
Similar to https://github.com/pytorch/pytorch/pull/19760

Test Plan:
- verified the warning is gone;

Differential Revision: [D15169025](https://our.internmc.facebook.com/intern/diff/D15169025)