### PR TITLE
shape inference for learning rate op

### DIFF
--- a/caffe2/python/operator_test/shape_inference_test.py
+++ b/caffe2/python/operator_test/shape_inference_test.py
@@ -539,6 +539,28 @@ class TestShapeInference(test_util.TestCase):
         # TODO: find a tighter bound
         assert(np.allclose(x, x_recovered, atol=1e-2))
 
+    def testLearningRateOp(self):
+        net = core.Net("lr_test")
+        iteration = net.ConstantFill(
+            [],
+            "iteration",
+            shape=[1],
+            value=0,
+            dtype=core.DataType.INT64,
+        )
+        lr = net.LearningRate(
+            [iteration],
+            net.NextScopedBlob("weight_decay"),
+            base_lr=0.5,
+            policy="constantWarmup",
+            multiplier=0.0,
+            num_iter=0,
+        )
+        (shapes, types) = workspace.InferShapesAndTypes(
+            [net],
+        )
+        self.assertEqual(shapes['weight_decay'], [1])
+
     def testShapeOp(self):
         model = model_helper.ModelHelper(name="shape_op_test")
         model.Shape('x', 'y')
@@ -567,6 +589,7 @@ class TestShapeInference(test_util.TestCase):
         correct_types = {}
         for b in workspace.Blobs():
             arr = workspace.FetchBlob(b)
+            print("arr is {}".format(arr))
             correct_shapes[b] = arr.shape
             if type(arr) is np.ndarray:
                 if arr.dtype == np.dtype('float32'):

--- a/caffe2/sgd/learning_rate_op.cc
+++ b/caffe2/sgd/learning_rate_op.cc
@@ -6,6 +6,12 @@ REGISTER_CPU_OPERATOR(LearningRate, LearningRateOp<float, CPUContext>);
 OPERATOR_SCHEMA(LearningRate)
     .NumInputs(1)
     .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef&,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out(1);
+      out[0] = in[0];
+      return out;
+    })
     .SetDoc(R"DOC(
 Learning rate is a decreasing function of time. With low learning rates the
 improvements will be linear. With high learning rates they will start to look
@@ -84,4 +90,4 @@ Example usage:
     });
 
 NO_GRADIENT(LearningRate);
-}  // namespace caffe2
+} // namespace caffe2


### PR DESCRIPTION
Summary: Add shape inference for LearningRate op. The output (lr) should have similar shape with input (iteration), but not the same type (float vs int).

Differential Revision: D15112300

