### PR TITLE
Add ShapeInference for AtomicIter Op

### DIFF
--- a/caffe2/sgd/iter_op.cc
+++ b/caffe2/sgd/iter_op.cc
@@ -50,6 +50,7 @@ OPERATOR_SCHEMA(AtomicIter)
     .NumInputs(2)
     .NumOutputs(1)
     .EnforceInplace({{1, 0}})
+    .IdenticalTypeAndShapeOfInput(1)
     .SetDoc(R"DOC(
 Similar to Iter, but takes a mutex as the first input to make sure that
 updates are carried out atomically. This can be used in e.g. Hogwild sgd
@@ -60,4 +61,4 @@ algorithms.
 
 NO_GRADIENT(Iter);
 NO_GRADIENT(AtomicIter);
-}  // namespace caffe2
+} // namespace caffe2


### PR DESCRIPTION
Summary: Add shape inference for AtomicIter operator. The operator takes two blobs iteration and iter_mutex as input and outputs iteration, which should have the same type and shape as the input.

Differential Revision: D15111643

