### PR TITLE
Make IValue("string") do the right thing

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -324,6 +324,7 @@ struct CAFFE2_API IValue final {
   // ConstantString
   IValue(c10::intrusive_ptr<ivalue::ConstantString> v);
   IValue(std::string v);
+  IValue(const char* v): IValue(std::string(v)) {}
   bool isString() const { return Tag::String == tag; }
   c10::intrusive_ptr<ivalue::ConstantString> toString() && {
     AT_ASSERT(isString());


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20027 Make IValue("string") do the right thing**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15172409/)

Before this change, any pointer was converted to bool, i.e.

    IValue("string") == IValue(true)

After this change, it does the right thing and creates a string.

Differential Revision: [D15172409](https://our.internmc.facebook.com/intern/diff/D15172409/)