### PR TITLE
Add Gate Policy GateLearningRateOp

### DIFF
--- a/caffe2/python/operator_test/learning_rate_op_test.py
+++ b/caffe2/python/operator_test/learning_rate_op_test.py
@@ -82,6 +82,36 @@ class TestLearningRate(serial.SerializedTestCase):
         )
         self.assertReferenceChecks(gc, op, [iter], ref)
 
+    @given(
+        **hu.gcs_cpu_only
+    )
+    def test_gate_learningrate(self, gc, dc):
+        iter = np.random.randint(low=1, high=1e5, size=1)
+        num_iter = int(np.random.randint(low=1e2, high=1e3, size=1))
+        base_lr = float(np.random.uniform(-1, 1))
+        multiplier_1 = float(np.random.uniform(-1, 1))
+        multiplier_2 = float(np.random.uniform(-1, 1))
+
+        def ref(iter):
+            iter = float(iter)
+            if iter < num_iter:
+                return (np.array(multiplier_1 * base_lr), )
+            else:
+                return (np.array(multiplier_2 * base_lr), )
+
+        op = core.CreateOperator(
+            'LearningRate',
+            'data',
+            'out',
+            policy="gate",
+            num_iter=num_iter,
+            multiplier_1=multiplier_1,
+            multiplier_2=multiplier_2,
+            base_lr=base_lr,
+        )
+
+        self.assertReferenceChecks(gc, op, [iter], ref)
+
     @given(gc=hu.gcs['gc'],
             min_num_iter=st.integers(min_value=10, max_value=20),
             max_num_iter=st.integers(min_value=50, max_value=100))

--- a/caffe2/sgd/learning_rate_functors.h
+++ b/caffe2/sgd/learning_rate_functors.h
@@ -80,6 +80,28 @@ class ExpLearningRate : public LearningRateFunctor<T> {
   T gamma_;
 };
 
+// Gate: return multiplier_1 if before num_iter, else multiplier_2
+template <typename T>
+class GateLearningRate : public LearningRateFunctor<T> {
+ public:
+  GateLearningRate(
+      const T multiplier_1,
+      const T multiplier_2,
+      const int64_t num_iter)
+      : multiplier_1_(multiplier_1),
+        multiplier_2_(multiplier_2),
+        num_iter_(num_iter) {}
+  T operator()(const int64_t iter) const override {
+    if (iter >= num_iter_) {
+      return T(multiplier_2_);
+    }
+    return T(multiplier_1_);
+  }
+  T multiplier_1_;
+  T multiplier_2_;
+  uint64_t num_iter_;
+};
+
 // Inv: return (1 + gamma * iter) ^ (-power)
 template <typename T>
 class InvLearningRate : public LearningRateFunctor<T> {
@@ -116,7 +138,8 @@ class LinearWarmupLearningRate : public LearningRateFunctor<T> {
     if (iter >= num_iter_) {
       return 1.;
     }
-    return start_multiplier_ + (1. - start_multiplier_) * T(iter) / T(num_iter_);
+    return start_multiplier_ +
+        (1. - start_multiplier_) * T(iter) / T(num_iter_);
   }
   T start_multiplier_;
   uint64_t num_iter_;

--- a/caffe2/sgd/learning_rate_op.cc
+++ b/caffe2/sgd/learning_rate_op.cc
@@ -19,6 +19,7 @@ Required:
    `fixed`
    `step`: uses `stepsize`, `gamma`
    `exp`: uses `gamma`
+   `gate`: uses 'multiplier_1', 'multiplier_2', `num_iter``
    `inv`: uses `gamma`, `power`
    `linearWarmup`: uses `start_multiplier`, `num_iter`
    `constantWarmup`: uses `multiplier`, `num_iter`
@@ -38,6 +39,8 @@ Optional:
   `num_iter`: defaults to 0
   `start_multiplier`: defaults to 0
   `multiplier`: defaults to 0.5
+  `multiplier_1`: defaults to 1
+  `multiplier_2`: defaults to 1
 
 
 Usage:
@@ -72,6 +75,10 @@ Example usage:
     .Arg(
         "multiplier",
         "(float, default 0.5) constant multiplier for learning rate")
+    .Arg(
+        "multiplier_1",
+        "(float, default 1) start multiplier for learning rate")
+    .Arg("multiplier_2", "(float, default 1) end multiplier for learning rate")
     .Arg(
         "sub_policy_num_iters",
         "(int array, default empty) number of iterations for each sub learning rate policy in composite policy")

--- a/caffe2/sgd/learning_rate_op.h
+++ b/caffe2/sgd/learning_rate_op.h
@@ -15,11 +15,10 @@ class LearningRateOp final : public Operator<Context> {
   LearningRateOp(const OperatorDef& operator_def, Workspace* ws)
       : Operator<Context>(operator_def, ws),
         functor_(nullptr),
-        base_lr_(this->template GetSingleArgument<float>(
-            "base_lr",
-            FLT_MAX)) {
+        base_lr_(this->template GetSingleArgument<float>("base_lr", FLT_MAX)) {
     CAFFE_ENFORCE_NE(base_lr_, FLT_MAX, "Base learning rate must be set.");
-    const string policy = this->template GetSingleArgument<string>("policy", "");
+    const string policy =
+        this->template GetSingleArgument<string>("policy", "");
     CAFFE_ENFORCE(policy.size(), "Must specify a learning rate policy.");
     functor_.reset(createLearningRateFunctor(policy));
   }
@@ -58,26 +57,25 @@ class LearningRateOp final : public Operator<Context> {
           arg_prefix + "active_first", true);
       int64_t active_period = this->template GetSingleArgument<int64_t>(
           arg_prefix + "active_period", -1);
-      int64_t inactive_period =
-          this->template GetSingleArgument<int64_t>(
-              arg_prefix + "inactive_period", -1);
+      int64_t inactive_period = this->template GetSingleArgument<int64_t>(
+          arg_prefix + "inactive_period", -1);
       DCHECK_GE(active_period, 0);
       DCHECK_GE(inactive_period, 0);
       return new AlternateLearningRate<T>(
           active_period, inactive_period, active_first);
     } else if (policy == "hill") {
-      int64_t num_iter = this->template GetSingleArgument<int>(
-          arg_prefix + "num_iter", 0);
+      int64_t num_iter =
+          this->template GetSingleArgument<int>(arg_prefix + "num_iter", 0);
       DCHECK_GT(num_iter, 0);
       T start_multiplier = this->template GetSingleArgument<float>(
           arg_prefix + "start_multiplier", 0.);
       DCHECK_GE(start_multiplier, 0); // start_multiplier in range [0, 1]
       DCHECK_LE(start_multiplier, 1);
-      T gamma = this->template GetSingleArgument<float>(
-          arg_prefix + "gamma", 0);
+      T gamma =
+          this->template GetSingleArgument<float>(arg_prefix + "gamma", 0);
       DCHECK_GT(gamma, 0);
-      T power = this->template GetSingleArgument<float>(
-          arg_prefix + "power", 0);
+      T power =
+          this->template GetSingleArgument<float>(arg_prefix + "power", 0);
       DCHECK_GT(power, 0);
       T end_multiplier = this->template GetSingleArgument<float>(
           arg_prefix + "end_multiplier", 0);
@@ -86,51 +84,59 @@ class LearningRateOp final : public Operator<Context> {
       return new HillLearningRate<T>(
           num_iter, start_multiplier, gamma, power, end_multiplier);
     } else if (policy == "step") {
-      int stepsize = this->template GetSingleArgument<int>(
-          arg_prefix + "stepsize", 0);
-      T gamma = this->template GetSingleArgument<float>(
-          arg_prefix + "gamma", 0);
+      int stepsize =
+          this->template GetSingleArgument<int>(arg_prefix + "stepsize", 0);
+      T gamma =
+          this->template GetSingleArgument<float>(arg_prefix + "gamma", 0);
       DCHECK_GT(stepsize, 0);
       DCHECK_GT(gamma, 0);
       return new StepLearningRate<T>(stepsize, gamma);
     } else if (policy == "exp") {
-      T gamma = this->template GetSingleArgument<float>(
-          arg_prefix + "gamma", 0);
+      T gamma =
+          this->template GetSingleArgument<float>(arg_prefix + "gamma", 0);
       DCHECK_GT(gamma, 0);
       return new ExpLearningRate<T>(gamma);
+    } else if (policy == "gate") {
+      T multiplier_1 = this->template GetSingleArgument<float>(
+          arg_prefix + "multiplier_1", 1);
+      T multiplier_2 = this->template GetSingleArgument<float>(
+          arg_prefix + "multiplier_2", 1);
+      int num_iter =
+          this->template GetSingleArgument<int>(arg_prefix + "num_iter", 0);
+      // no constraint on the range of multiplier_1 and multiplier_2
+      return new GateLearningRate<T>(multiplier_1, multiplier_2, num_iter);
     } else if (policy == "inv") {
-      T gamma = this->template GetSingleArgument<float>(
-          arg_prefix + "gamma", 0);
-      T power = this->template GetSingleArgument<float>(
-          arg_prefix + "power", 0);
+      T gamma =
+          this->template GetSingleArgument<float>(arg_prefix + "gamma", 0);
+      T power =
+          this->template GetSingleArgument<float>(arg_prefix + "power", 0);
       DCHECK_GT(gamma, 0);
       DCHECK_GT(power, 0);
       return new InvLearningRate<T>(gamma, power);
     } else if (policy == "poly") {
-      int max_iter = this->template GetSingleArgument<int>(
-          arg_prefix + "max_iter", -1);
-      T power = this->template GetSingleArgument<float>(
-          arg_prefix + "power", 0);
+      int max_iter =
+          this->template GetSingleArgument<int>(arg_prefix + "max_iter", -1);
+      T power =
+          this->template GetSingleArgument<float>(arg_prefix + "power", 0);
       DCHECK_GT(power, 0);
       return new PolyLearningRate<T>(power, max_iter);
     } else if (policy == "linearWarmup") {
       T start_multiplier = this->template GetSingleArgument<float>(
           arg_prefix + "start_multiplier", 0.);
-      int num_iter = this->template GetSingleArgument<int>(
-          arg_prefix + "num_iter", 0);
+      int num_iter =
+          this->template GetSingleArgument<int>(arg_prefix + "num_iter", 0);
       DCHECK_GE(start_multiplier, 0);
       return new LinearWarmupLearningRate<T>(start_multiplier, num_iter);
     } else if (policy == "constantWarmup") {
       T multiplier = this->template GetSingleArgument<float>(
           arg_prefix + "multiplier", 0.5);
-      int num_iter = this->template GetSingleArgument<int>(
-          arg_prefix + "num_iter", 0);
+      int num_iter =
+          this->template GetSingleArgument<int>(arg_prefix + "num_iter", 0);
       DCHECK_GT(multiplier, 0);
       return new ConstantWarmupLearningRate<T>(multiplier, num_iter);
     } else if (policy == "composite") {
       std::vector<int> sub_policy_num_iters =
-          this->template GetRepeatedArgument<int>(
-              "sub_policy_num_iters");
+          this->template GetRepeatedArgument<int>("sub_policy_num_iters");
       std::list<CompositeLearningRateItem<T>> sub_policies;
       CAFFE_ENFORCE_GT(
           sub_policy_num_iters.size(),


### PR DESCRIPTION
Summary:
We do not have a gating functor. This diff adds it.
* Since there are other policy in LearningRateOp which will be used as a union, I chose to add it as a LearningRateOp.

* There are multiple uses for it,
    * e.g. as a gating blob generator that is useful for turning off.
   * e.g. as a learning rate switcher at certain iteration.
* For generalizability, no regulation or constraint is applied on the range of value, nor on the range of base_lr.

* see figure below for illustration

{F157292712}

Differential Revision: D15178229

