### PR TITLE
Rearrange stopping condition in CompositeReader

### DIFF
--- a/caffe2/python/dataio.py
+++ b/caffe2/python/dataio.py
@@ -542,18 +542,30 @@ class CompositeReader(Reader):
         """
         Stops when one of the reader finished
         """
-        local_should_stop = local_init_net.ConstantFill(
-            [], shape=[], dtype=core.DataType.BOOL, value=False)
-        read_nets = []
+        # First, instantiate all the reader nets
         fields = []
+        stop_blobs = []
+        all_sub_read_nets = []
         for name, reader in zip(self._names, self._readers):
             sub_read_nets, should_stop, record = reader.read_record_ex(
                 local_init_net, local_finish_net)
-            stop_net = core.Net("{}_stop".format(name))
-            stop_net.Copy(should_stop, local_should_stop)
-            sub_read_nets.append(stop_net)
-            read_nets.extend(sub_read_nets)
+            stop_blobs.append(should_stop)
+            all_sub_read_nets.append(sub_read_nets)
             fields.extend(record.field_blobs())
+
+        read_nets = []
+        # Use the stop blob of the last reader as stop blob of composite reader.
+        local_should_stop = stop_blobs[-1]
+        for name, sub_read_nets, stop_blob in zip(self._names, all_sub_read_nets, stop_blobs):
+            read_nets.extend(sub_read_nets)
+            if stop_blob == local_should_stop:
+                # Skip adding stop net because Or([A, A], A) doesn't pass operator
+                # schema check
+                continue
+            stop_net = core.Net("{}_stop".format(name))
+            stop_net.Or([local_should_stop, stop_blob], local_should_stop)
+            read_nets.append(stop_net)
+
         return read_nets, local_should_stop, fields
 
     def reset(self, net):
@@ -584,13 +596,27 @@ class CompositeReaderBuilder(ReaderBuilder):
         return self._schema
 
     def setup(self, **kwargs):
-        for reader_builder in self._reader_builders:
-            reader_builder.setup(**kwargs)
-            # limiter is stateful; it can only be used once. Since
-            # CompositeReader stops when one of the reader stops,
-            # this is fine.
-            if "limiter" in kwargs:
-                kwargs.pop("limiter")
+        data_finished_blobs = {}
+        # limiter is stateful; it can only be used once. Since
+        # CompositeReader stops when one of the reader stops,
+        # this is fine.
+        if "limiter" in kwargs:
+            limiter = kwargs.pop("limiter")
+        else:
+            limiter = None
+        for i, reader_builder in enumerate(self._reader_builders):
+            if i == len(self._reader_builders) - 1 and limiter is not None:
+                # The limiter must be applied to the last reader so that the
+                # batch counter is incremented only if every reader has data
+                kwargs["limiter"] = limiter
+            sub_reader_data_finished_blobs = reader_builder.setup(**kwargs)
+            overlapping_keys = set(data_finished_blobs.keys()) & set(sub_reader_data_finished_blobs.keys())
+            overlapping_values = set(data_finished_blobs.values()) & set(sub_reader_data_finished_blobs.values())
+            assert overlapping_keys == set(), "Overlapping keys: {}".format(overlapping_keys)
+            assert overlapping_values == set(), "Overlapping values: {}".format(overlapping_values)
+            data_finished_blobs.update(sub_reader_data_finished_blobs)
+
+        return data_finished_blobs
 
     def new_reader(self, **kwargs):
         readers = []

--- a/caffe2/python/dataio_test.py
+++ b/caffe2/python/dataio_test.py
@@ -70,6 +70,7 @@ class TestReaderBuilder(ReaderBuilder):
     def setup(self, ws):
         self._src_ds = make_source_dataset(ws, offset=self._offset, size=self._size,
                                     name=self._name)
+        return {}
 
     def new_reader(self, **kwargs):
         return self._src_ds


### PR DESCRIPTION
Summary:
Previously, the batch counter is incremented even if none of the readers has data. In this diff,
1) Limiter is applied to the last reader so that the batch counter is not incremented unless the first N-1 readers have data
2) The stop blob of the last reader as the stop blob of the task so that it's checked before the counter is incremented

Differential Revision: D15099761

