### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ conda install -c pytorch magma-cuda90 # or [magma-cuda80 | magma-cuda92 | magma-
 git clone --recursive https://github.com/pytorch/pytorch
 cd pytorch
 git submodule sync 
-git submodule update --init
+git submodule update --init --recursive
 ```
 
 #### Install PyTorch

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ conda install -c pytorch magma-cuda90 # or [magma-cuda80 | magma-cuda92 | magma-
 ```bash
 git clone --recursive https://github.com/pytorch/pytorch
 cd pytorch
+# if you are updating an existing checkout
 git submodule sync 
 git submodule update --init --recursive
 ```

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ conda install -c pytorch magma-cuda90 # or [magma-cuda80 | magma-cuda92 | magma-
 ```bash
 git clone --recursive https://github.com/pytorch/pytorch
 cd pytorch
+git submodule sync 
+git submodule update --init
 ```
 
 #### Install PyTorch


### PR DESCRIPTION
Sometimes people need to checkout an older version and build PyTorch. In that case, they need to do `git submodule sync` and maybe `git submodule update --init` as mentioned [here](https://github.com/pytorch/pytorch/issues/20074).