### PR TITLE
DOC: Update web documentation of geometric_ to be consistent with Tensor behaviour

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -996,7 +996,7 @@ Fills :attr:`self` tensor with elements drawn from the geometric distribution:
 
 .. math::
 
-    f(X=k) = (1 - p)^{k - 1} p
+    f(X=k) = p^{k - 1} (1 - p)
 
 """)
 


### PR DESCRIPTION
Fix #19940 by updating web doc to reflect Tensor behaviour which will reflect [here](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.geometric_)