### PR TITLE
[ONNX] Update logic for folding onnx::Constant nodes.

### DIFF
--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -186,11 +186,15 @@ bool areNodeInputsConstant(
       [&valsToParamsMap](Value* v) { return isConstant(v, valsToParamsMap); });
 }
 
-std::vector<Node*> getOnnxConstParents(Node* node) {
+std::vector<Node*> getOnnxConstParentsToRemove(Node* node) {
   std::vector<Node*> parentNodes;
   for (auto val : node->inputs()) {
-    if (val->node()->kind() == onnx::Constant) {
-      parentNodes.push_back(val->node());
+    // If the parent of 'node' is an onnx::Constant node, 
+    // and 'node' is the only downstream node it serves (this
+    // is important), then push it in the list to remove.
+    if (val->node()->kind() == onnx::Constant &&
+        val->uses().size() == 1) {
+          parentNodes.push_back(val->node());
     }
   }
   return parentNodes;
@@ -245,7 +249,7 @@ void ConstantFoldONNX(Block* b, ParamMap& paramsDict) {
     // below), and then remove the current node. If the parent was
     // an initializer (not onnx::Constant) then they are all removed
     // by eraseUnusedBlockInputs() call (below) outside the loop.
-    auto onnxConstParents = getOnnxConstParents(node);
+    auto onnxConstParents = getOnnxConstParentsToRemove(node);
     node->removeAllInputs();
     for (auto* n : onnxConstParents) {
       n->destroy();


### PR DESCRIPTION
Currently, constant folding pass during ONNX conversion removes all onnx::Constant nodes that are parents of nodes that are folded. In situations where the parent onnx::Constant node is other subscribers downstream this could be a problem. This change updates the removal logic to remove to only those onnx::Constant nodes that do not have other subscribers downstream