### PR TITLE
dont make alias for none value

### DIFF
--- a/test/cpp/jit/test_alias_analysis.h
+++ b/test/cpp/jit/test_alias_analysis.h
@@ -453,7 +453,7 @@ void testAliasAnalysis() {
     ASSERT_FALSE(aliasDb.moveBeforeTopologicallyValid(d->node(), wait));
   }
 
-  // test none value does not alias anything
+  // test none value does not have writers
   {
     {
       auto graph = std::make_shared<Graph>();
@@ -463,13 +463,14 @@ void testAliasAnalysis() {
     graph():
       %opt : Tensor? = prim::Constant()
       %out : Tensor = prim::unchecked_unwrap_optional(%opt)
-      return (%opt, %out)
+      %ret.2 : Tensor = aten::div(%out, %out, %out)
+      return (%opt, %out, %ret.2)
       )IR",
           &*graph,
           vmap);
 
       AliasDb aliasDb(graph);
-      AT_ASSERT(!aliasDb.mayAlias(vmap["opt"], vmap["out"]));
+      AT_ASSERT(!aliasDb.hasWriters(vmap["opt"]->node()));
     }
   }
 }

--- a/test/cpp/jit/test_alias_analysis.h
+++ b/test/cpp/jit/test_alias_analysis.h
@@ -452,6 +452,26 @@ void testAliasAnalysis() {
     AliasDb aliasDb(graph);
     ASSERT_FALSE(aliasDb.moveBeforeTopologicallyValid(d->node(), wait));
   }
+
+  // test none value does not alias anything
+  {
+    {
+      auto graph = std::make_shared<Graph>();
+      std::unordered_map<std::string, Value*> vmap;
+      script::parseIR(
+          R"IR(
+    graph():
+      %opt : Tensor? = prim::Constant()
+      %out : Tensor = prim::unchecked_unwrap_optional(%opt)
+      return (%opt, %out)
+      )IR",
+          &*graph,
+          vmap);
+
+      AliasDb aliasDb(graph);
+      AT_ASSERT(!aliasDb.mayAlias(vmap["opt"], vmap["out"]));
+    }
+  }
 }
 
 void testWriteTracking() {

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -20,7 +20,7 @@ bool AliasDb::shouldAnnotate(const TypePtr& type) {
 // We only need to annotate values that either are mutable or could contain
 // mutable types.
 bool AliasDb::shouldAnnotate(const Value* v) {
-  return shouldAnnotate(v->type());
+  return !v->mustBeNone() && shouldAnnotate(v->type());
 }
 
 bool AliasDb::isContainerType(const TypePtr& type) {

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -777,6 +777,13 @@ void AliasDb::makePointerTo(const Value* from, const Value* to) {
     return;
   }
 
+  // Special case: if `from` is an optional, `to` could be a None. Don't
+  // create a pointer in that case
+  if (from->type()->kind() == TypeKind::OptionalType &&
+      to->type()->kind() == TypeKind::NoneType) {
+    return;
+  }
+
   // At this point, we should be dealing with two mutable types.
   AT_ASSERT(shouldAnnotate(from) && shouldAnnotate(to));
 

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -60,8 +60,8 @@ bool AliasDb::isWildcard(const Value* v) const {
 }
 
 bool AliasDb::writesTo(Node* n, const Value* v) const {
-  if (!shouldAnnotate(v)) {
-    // This is a primitive type
+  if (!shouldAnnotate(v) || v->mustBeNone()) {
+    // This is a non-aliasing value
     return false;
   }
   if (isWildcard(v)) {
@@ -104,7 +104,7 @@ bool AliasDb::hasWriters(const Value* v) const {
     return numWrites_ != 0;
   }
 
-  if (!elementMap_.count(v)) {
+  if (!elementMap_.count(v) || v->mustBeNone()) {
     return false;
   }
 
@@ -763,11 +763,6 @@ void AliasDb::analyzeBroadcastingChunk(Node* node) {
 
 // Register the fact that `value` is a pointer to `to`
 void AliasDb::makePointerTo(const Value* from, const Value* to) {
-  // guaranteed to not alias
-  if (from->mustBeNone() || to->mustBeNone()) {
-    return;
-  }
-
   if (!shouldAnnotate(from)) {
     AT_ASSERT(!shouldAnnotate(to));
     return;


### PR DESCRIPTION
Don't make an alias value for a value that is known to be None. This was preventing constant propagation from running the `out is None` check in nn.functional.normalize, and thus preventing the if statement from being inlined. 