### PR TITLE
[Caffe2] Expose test utils

### DIFF
--- a/caffe2/core/test_utils.h
+++ b/caffe2/core/test_utils.h
@@ -5,6 +5,8 @@
 #include "caffe2/core/workspace.h"
 #include "caffe2/utils/proto_utils.h"
 
+#include <c10/macros/Macros.h>
+
 #include <cmath>
 #include <string>
 #include <vector>
@@ -16,10 +18,10 @@ namespace caffe2 {
 namespace testing {
 
 // Asserts that the values of two tensors are the same.
-void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2);
+CAFFE2_API void assertTensorEquals(const TensorCPU& tensor1, const TensorCPU& tensor2);
 
 // Asserts that two float values are close within epsilon.
-void assertNear(float value1, float value2, float epsilon);
+CAFFE2_API void assertNear(float value1, float value2, float epsilon);
 
 // Asserts that the numeric values of a tensor is equal to a data vector.
 template <typename T>
@@ -50,7 +52,7 @@ void assertTensor(
 }
 
 // Asserts a list of tensors presented in two workspaces are equal.
-void assertTensorListEquals(
+CAFFE2_API void assertTensorListEquals(
     const std::vector<std::string>& tensorNames,
     const Workspace& workspace1,
     const Workspace& workspace2);
@@ -61,12 +63,12 @@ CAFFE2_API const caffe2::Tensor& getTensor(
     const std::string& name);
 
 // Create a new tensor in the workspace.
-caffe2::Tensor* createTensor(
+CAFFE2_API caffe2::Tensor* createTensor(
     const std::string& name,
     caffe2::Workspace* workspace);
 
 // Create a new operator in the net.
-caffe2::OperatorDef* createOperator(
+CAFFE2_API caffe2::OperatorDef* createOperator(
     const std::string& type,
     const std::vector<std::string>& inputs,
     const std::vector<std::string>& outputs,
@@ -163,7 +165,7 @@ class CAFFE2_API NetMutator {
 };
 
 // Concise util class to mutate a workspace in a chaining fashion.
-class WorkspaceMutator {
+class CAFFE2_API WorkspaceMutator {
  public:
   explicit WorkspaceMutator(caffe2::Workspace* workspace)
       : workspace_(workspace) {}


### PR DESCRIPTION
Some functions were not decorated with `CAFFE2_API`, makes them unusable when creating unit tests for custom ops outside Caffe2 repo.