### PR TITLE
[tensorboard] Add logging import and failing MLP

### DIFF
--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import time
 from collections import OrderedDict


### PR DESCRIPTION
Add logging import and a failed MLP model that confirms that we don't fail `add_graph` when graph optimization fails.

This addresses part of https://github.com/pytorch/pytorch/issues/18903

cc @lanpa @ezyang @natalialunova 