### PR TITLE
Fix NameError with PYTORCH_JIT=0

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3084,6 +3084,15 @@ graph(%a, %b, %c, %d):
                 self.assertTrue(type(block.paramNode()) == torch._C.Node)
         self.assertTrue(tested_blocks)
 
+    def test_pytorch_jit_env_off(self):
+        import subprocess
+        env = os.environ.copy()
+        env['PYTORCH_JIT'] = '0'
+        try:
+            subprocess.check_output([sys.executable, '-c', 'import torch'], env=env)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("Could not 'import torch' with PYTORCH_JIT=0")
+
 
 def execWrapper(code, glob, loc):
     if PY2:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1630,8 +1630,9 @@ class TracedModule(ScriptModule):
         raise RuntimeError("Cannot set new properties on a traced module.")
 
 
-class TopLevelTracedModule(TracedModule):
-    forward = _CachedForward()
+if _enabled:
+    class TopLevelTracedModule(TracedModule):
+        forward = _CachedForward()
 
 
 class _ConstModuleList(ScriptModule):


### PR DESCRIPTION
Right now using `PYTORCH_JIT=0` gives this error:

`NameError: name '_CachedForward' is not defined`
Differential Revision: [D15210046](https://our.internmc.facebook.com/intern/diff/15210046/)