### PR TITLE
Use ignore=dirty in submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,84 +1,112 @@
 [submodule "third_party/pybind11"]
-	path = third_party/pybind11
-	url = https://github.com/pybind/pybind11.git
+    ignore = dirty
+    path = third_party/pybind11
+    url = https://github.com/pybind/pybind11.git
 [submodule "third_party/cub"]
-	path = third_party/cub
-	url = https://github.com/NVlabs/cub.git
+    ignore = dirty
+    path = third_party/cub
+    url = https://github.com/NVlabs/cub.git
 [submodule "third_party/eigen"]
-	path = third_party/eigen
-	url = https://github.com/eigenteam/eigen-git-mirror.git
+    ignore = dirty
+    path = third_party/eigen
+    url = https://github.com/eigenteam/eigen-git-mirror.git
 [submodule "third_party/googletest"]
-	path = third_party/googletest
-	url = https://github.com/google/googletest.git
+    ignore = dirty
+    path = third_party/googletest
+    url = https://github.com/google/googletest.git
 [submodule "third_party/benchmark"]
-	path = third_party/benchmark
-	url = https://github.com/google/benchmark.git
+    ignore = dirty
+    path = third_party/benchmark
+    url = https://github.com/google/benchmark.git
 [submodule "third_party/protobuf"]
-	path = third_party/protobuf
-	url = https://github.com/google/protobuf.git
+    ignore = dirty
+    path = third_party/protobuf
+    url = https://github.com/google/protobuf.git
 [submodule "third_party/ios-cmake"]
-	path = third_party/ios-cmake
-	url = https://github.com/Yangqing/ios-cmake.git
+    ignore = dirty
+    path = third_party/ios-cmake
+    url = https://github.com/Yangqing/ios-cmake.git
 [submodule "third_party/NNPACK"]
-	path = third_party/NNPACK
-	url = https://github.com/Maratyszcza/NNPACK.git
+    ignore = dirty
+    path = third_party/NNPACK
+    url = https://github.com/Maratyszcza/NNPACK.git
 [submodule "third_party/gloo"]
-	path = third_party/gloo
-	url = https://github.com/facebookincubator/gloo
+    ignore = dirty
+    path = third_party/gloo
+    url = https://github.com/facebookincubator/gloo
 [submodule "third_party/NNPACK_deps/pthreadpool"]
-	path = third_party/pthreadpool
-	url = https://github.com/Maratyszcza/pthreadpool.git
+    ignore = dirty
+    path = third_party/pthreadpool
+    url = https://github.com/Maratyszcza/pthreadpool.git
 [submodule "third_party/NNPACK_deps/FXdiv"]
-	path = third_party/FXdiv
-	url = https://github.com/Maratyszcza/FXdiv.git
+    ignore = dirty
+    path = third_party/FXdiv
+    url = https://github.com/Maratyszcza/FXdiv.git
 [submodule "third_party/NNPACK_deps/FP16"]
-	path = third_party/FP16
-	url = https://github.com/Maratyszcza/FP16.git
+    ignore = dirty
+    path = third_party/FP16
+    url = https://github.com/Maratyszcza/FP16.git
 [submodule "third_party/NNPACK_deps/psimd"]
-	path = third_party/psimd
-	url = https://github.com/Maratyszcza/psimd.git
+    ignore = dirty
+    path = third_party/psimd
+    url = https://github.com/Maratyszcza/psimd.git
 [submodule "third_party/zstd"]
-	path = third_party/zstd
-	url = https://github.com/facebook/zstd.git
+    ignore = dirty
+    path = third_party/zstd
+    url = https://github.com/facebook/zstd.git
 [submodule "third-party/cpuinfo"]
-	path = third_party/cpuinfo
-	url = https://github.com/Maratyszcza/cpuinfo.git
+    ignore = dirty
+    path = third_party/cpuinfo
+    url = https://github.com/Maratyszcza/cpuinfo.git
 [submodule "third_party/python-enum"]
-	path = third_party/python-enum
-	url = https://github.com/PeachPy/enum34.git
+    ignore = dirty
+    path = third_party/python-enum
+    url = https://github.com/PeachPy/enum34.git
 [submodule "third_party/python-peachpy"]
-	path = third_party/python-peachpy
-	url = https://github.com/Maratyszcza/PeachPy.git
+    ignore = dirty
+    path = third_party/python-peachpy
+    url = https://github.com/Maratyszcza/PeachPy.git
 [submodule "third_party/python-six"]
-	path = third_party/python-six
-	url = https://github.com/benjaminp/six.git
+    ignore = dirty
+    path = third_party/python-six
+    url = https://github.com/benjaminp/six.git
 [submodule "third_party/onnx"]
-	path = third_party/onnx
-	url = https://github.com/onnx/onnx.git
+    ignore = dirty
+    path = third_party/onnx
+    url = https://github.com/onnx/onnx.git
 [submodule "third_party/onnx-tensorrt"]
-	path = third_party/onnx-tensorrt
-	url = https://github.com/onnx/onnx-tensorrt
+    ignore = dirty
+    path = third_party/onnx-tensorrt
+    url = https://github.com/onnx/onnx-tensorrt
 [submodule "third_party/sleef"]
-	path = third_party/sleef
-	url = https://github.com/zdevito/sleef
+    ignore = dirty
+    path = third_party/sleef
+    url = https://github.com/zdevito/sleef
 [submodule "third_party/ideep"]
-	path = third_party/ideep
-	url = https://github.com/intel/ideep
+    ignore = dirty
+    path = third_party/ideep
+    url = https://github.com/intel/ideep
 [submodule "third_party/nccl/nccl"]
-	path = third_party/nccl/nccl
-	url = https://github.com/NVIDIA/nccl
+    ignore = dirty
+    path = third_party/nccl/nccl
+    url = https://github.com/NVIDIA/nccl
 [submodule "third_party/gemmlowp/gemmlowp"]
-	path = third_party/gemmlowp/gemmlowp
-	url = https://github.com/google/gemmlowp.git
+    ignore = dirty
+    path = third_party/gemmlowp/gemmlowp
+    url = https://github.com/google/gemmlowp.git
 [submodule "third_party/QNNPACK"]
-	path = third_party/QNNPACK
-	url = https://github.com/pytorch/QNNPACK
+    ignore = dirty
+    path = third_party/QNNPACK
+    url = https://github.com/pytorch/QNNPACK
 [submodule "third_party/neon2sse"]
-	path = third_party/neon2sse
-	url = https://github.com/intel/ARM_NEON_2_x86_SSE.git
+    ignore = dirty
+    path = third_party/neon2sse
+    url = https://github.com/intel/ARM_NEON_2_x86_SSE.git
 [submodule "third_party/fbgemm"]
-	path = third_party/fbgemm
-	url = https://github.com/pytorch/fbgemm
+    ignore = dirty
+    path = third_party/fbgemm
+    url = https://github.com/pytorch/fbgemm
 [submodule "third_party/foxi"]
-	path = third_party/foxi
-	url = https://github.com/houseroad/foxi.git
+    ignore = dirty
+    path = third_party/foxi
+    url = https://github.com/houseroad/foxi.git


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20135 Use ignore=dirty in submodules.**

Summary: This makes it so that leaving build files in submodule
folders not longer show '-dirty' in the diffs, which makes it hard
to see if you are about to commit accidental submodule changes.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D15214187](https://our.internmc.facebook.com/intern/diff/D15214187)