### PR TITLE
fix build with python-2.7.5

### DIFF
--- a/aten/src/ATen/code_template.py
+++ b/aten/src/ATen/code_template.py
@@ -11,7 +11,7 @@ import re
 
 
 class CodeTemplate(object):
-    substitution_str = r'(^[^\n\S]*)?\$([^\d\W]\w*|\{,?[^\d\W]\w*\,?})'
+    substitution_str = r'(^[^\n\S]*[^\n\S]?)?\$([^\d\W]\w*|\{,?[^\d\W]\w*\,?})'
 
     # older versions of Python have a bug where \w* does not work,
     # so we need to replace with the non-shortened version [a-zA-Z0-9_]*

--- a/aten/src/ATen/code_template.py
+++ b/aten/src/ATen/code_template.py
@@ -11,6 +11,9 @@ import re
 
 
 class CodeTemplate(object):
+    # Python 2.7.5 has a bug where the leading (^[^\n\S]*)? does not work,
+    # workaround via appending another [^\n\S]? inside
+
     substitution_str = r'(^[^\n\S]*[^\n\S]?)?\$([^\d\W]\w*|\{,?[^\d\W]\w*\,?})'
 
     # older versions of Python have a bug where \w* does not work,


### PR DESCRIPTION
pytorch failed to build with the following error, complaining about the first regex match
It may be caused by a bug in python 2.7.5
This change proposed is a workaround for building pytorch with python 2.7.5
Since the '*' star notation is greedy in python regex, the new expression shall produce the identical result with the old one.

```
Traceback (most recent call last):
  File "/data2/nihuini/pytorch/cmake/../aten/src/ATen/gen.py", line 14, in <module>
    import preprocess_declarations
  File "/data2/nihuini/pytorch/aten/src/ATen/preprocess_declarations.py", line 3, in <module>
    from function_wrapper import TYPE_FORMAL_GENERIC
  File "/data2/nihuini/pytorch/aten/src/ATen/function_wrapper.py", line 5, in <module>
    from code_template import CodeTemplate
  File "/data2/nihuini/pytorch/aten/src/ATen/code_template.py", line 13, in <module>
    class CodeTemplate(object):
  File "/data2/nihuini/pytorch/aten/src/ATen/code_template.py", line 23, in CodeTemplate
    subtitution = re.compile(substitution_str, re.MULTILINE)
  File "/usr/lib64/python2.7/re.py", line 190, in compile
    return _compile(pattern, flags)
  File "/usr/lib64/python2.7/re.py", line 242, in _compile
    raise error, v # invalid expression
sre_constants.error: nothing to repeat
-- 
CMake Error at cmake/Codegen.cmake:162 (message):
  Failed to get generated_cpp list
Call Stack (most recent call first):
  caffe2/CMakeLists.txt:2 (include)


```