### PR TITLE
Fix crash issue in conv+sum fusion for MKLDNN on caffe2

### DIFF
--- a/caffe2/opt/optimize_ideep.cc
+++ b/caffe2/opt/optimize_ideep.cc
@@ -79,6 +79,11 @@ bool isOnIdeepDevice(const repr::NeuralNetOperator& nnOp) {
 }
 
 bool isConvFusion(repr::NNGraph::NodeRef convNode, int fusion_type) {
+  // Here we only check the type of ConvFusion op (for FP32 only)
+  if (!repr::nn::is<repr::Conv>(convNode)) {
+    return false;
+  }
+
   auto conv = repr::nn::get<repr::Conv>(convNode);
   auto& op = getOpDef(*conv);
 


### PR DESCRIPTION
The isConvFusion(...) is only for Conv op.
If non-Conv op, the crash takes place.
