### PR TITLE
tweak scripts/build_android.sh for ABI and header install

### DIFF
--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -22,7 +22,9 @@
 set -e
 
 # Android specific flags
-ANDROID_ABI="armeabi-v7a with NEON"
+if [ -z "$ANDROID_ABI" ]; then
+  ANDROID_ABI="armeabi-v7a with NEON"
+fi
 ANDROID_NATIVE_API_LEVEL="21"
 echo "Build with ANDROID_ABI[$ANDROID_ABI], ANDROID_NATIVE_API_LEVEL[$ANDROID_NATIVE_API_LEVEL]"
 
@@ -114,7 +116,7 @@ if [ -z "$MAX_JOBS" ]; then
     MAX_JOBS=$(nproc)
   fi
 fi
-cmake --build . -- "-j${MAX_JOBS}"
+cmake --build . --target install -- "-j${MAX_JOBS}"
 
 # copy headers and libs to install directory
 echo "Will install headers and libs to $INSTALL_PREFIX for further Android project usage."

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -116,9 +116,7 @@ if [ -z "$MAX_JOBS" ]; then
     MAX_JOBS=$(nproc)
   fi
 fi
-cmake --build . --target install -- "-j${MAX_JOBS}"
 
-# copy headers and libs to install directory
 echo "Will install headers and libs to $INSTALL_PREFIX for further Android project usage."
-make install
+cmake --build . --target install -- "-j${MAX_JOBS}"
 echo "Installation completed, now you can copy the headers/libs from $INSTALL_PREFIX to your Android project directory."


### PR DESCRIPTION
We now can build libtorch for Android.
This patch aims to provide two improvements to the build
- Make the architecture overridable by providing an environment variable `ANDROID_ABI`.
- Use `--target install` when calling cmake to actually get the header files nicely in one place.

I ran the script without options to see if the caffe2 builds are affected (in particularly by the install), but they seem to run OK and probably only produce a few files in build_android/install.
