### PR TITLE
More stable computation of KL between two Bernoulli distributions

### DIFF
--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -176,10 +176,10 @@ _euler_gamma = 0.57721566490153286060
 
 @register_kl(Bernoulli, Bernoulli)
 def _kl_bernoulli_bernoulli(p, q):
-    t1 = p.probs * (p.probs / q.probs).log()
+    t1 = p.probs * (torch.nn.functional.softplus(-q.logits) - torch.nn.functional.softplus(-p.logits))
     t1[q.probs == 0] = inf
     t1[p.probs == 0] = 0
-    t2 = (1 - p.probs) * ((1 - p.probs) / (1 - q.probs)).log()
+    t2 = (1 - p.probs) * (torch.nn.functional.softplus(q.logits) - torch.nn.functional.softplus(p.logits))
     t2[q.probs == 1] = inf
     t2[p.probs == 1] = 0
     return t1 + t2


### PR DESCRIPTION
I propose to use `Bernoulli.logits` instead of `Bernoulli.probs` when computing the KL between two Bernoulli distributions. The two formulations are equivalent but since usually neural networks output logits, the second is more stable.