### PR TITLE
Enable operator profiling via command line

### DIFF
--- a/caffe2/core/net_async_base.cc
+++ b/caffe2/core/net_async_base.cc
@@ -16,6 +16,11 @@ C10_DEFINE_bool(
     false,
     "If set, use one single chain containing all ops");
 
+C10_DEFINE_bool(
+    caffe2_net_async_profile_operators,
+    false,
+    "If set, profile operators of the net regardless of net being prof_dag.");
+
 C10_DEFINE_int(
     caffe2_net_async_max_gpus,
     16,
@@ -534,6 +539,9 @@ ExecutionOptions::ExecutionOptions(
     }
   }
 
+  if (FLAGS_caffe2_net_async_profile_operators) {
+    report_stats_ = true;
+  }
   run_root_tasks_inline_ = FLAGS_caffe2_net_async_run_root_tasks_inline;
 }
 

--- a/caffe2/core/net_async_base.h
+++ b/caffe2/core/net_async_base.h
@@ -22,6 +22,7 @@ C10_DECLARE_bool(caffe2_net_async_check_stream_status);
 C10_DECLARE_bool(caffe2_net_async_use_single_pool);
 C10_DECLARE_bool(caffe2_net_async_use_per_net_pools);
 C10_DECLARE_bool(caffe2_net_async_run_root_tasks_inline);
+C10_DECLARE_bool(caffe2_net_async_profile_operators);
 
 namespace caffe2 {
 


### PR DESCRIPTION
Summary:
Enabled op profiling even when net type is not dag or prof dag. Also added
engine type info to summary.

Differential Revision: D15177813

