### PR TITLE
Autograd profile recording in c10 custom ops

### DIFF
--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <torch/csrc/autograd/record_function.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/tracer.h>
 
@@ -17,6 +18,8 @@ at::Tensor unwrap(at::Tensor&& tensor) {
 //      It should also handle autograd.
 Operator createOperatorFromC10(const c10::OperatorHandle& op) {
   return Operator(op.schema(), [op](Stack& stack) {
+      RECORD_FUNCTION(op.schema().name(), stack);
+
       const auto input_size = op.schema().arguments().size();
       const auto output_size = op.schema().returns().size();
 


### PR DESCRIPTION
Summary: This ensures that custom operators registered through c10::RegisterOperators are recorded in autograd profile traces.

Differential Revision: D15221311

