### PR TITLE
Add USE_CUDA macro in THD DataChannelGloo for non-GPU use case

### DIFF
--- a/torch/lib/THD/base/data_channels/GlooCache.hpp
+++ b/torch/lib/THD/base/data_channels/GlooCache.hpp
@@ -321,10 +321,12 @@ struct algorithm_spec<CollectiveType::ALL_REDUCE, T> {
       size_t unused_count,
       THDReduceOp op) {
     int stream = UNUSED_STREAM;
+#ifdef USE_CUDA
     if (device == DeviceType::CUDA) {
       auto cuda_stream = THCState_getCurrentStream(THDGetCudaState());
       stream = THDGetStreamId(cuda_stream);
     }
+#endif
     return std::make_tuple(
         CollectiveType::ALL_REDUCE,
         group_id,
@@ -406,10 +408,12 @@ struct algorithm_spec<CollectiveType::BROADCAST, T> {
       size_t unused_count,
       rank_type src_rank) {
     int stream = UNUSED_STREAM;
+#ifdef USE_CUDA
     if (device == DeviceType::CUDA) {
       auto cuda_stream = THCState_getCurrentStream(THDGetCudaState());
       stream = THDGetStreamId(cuda_stream);
     }
+#endif
     return std::make_tuple(
         CollectiveType::BROADCAST,
         group_id,


### PR DESCRIPTION
Summary:
We're missing two USE_CUDA macro for GPU-related code in THD's DataChannelGloo.
Also adding GlooCache back to compilation.

Differential Revision: D15227502

