### PR TITLE
[ONNX] Support exporting optional args from scripting

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1196,19 +1196,22 @@ class TestCaffe2Backend(unittest.TestCase):
                 return torch.zeros(x.shape, dtype=torch.float) + torch.ones(x.shape)
 
         x = torch.randn(2, 3, 4)
-        self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False, example_outputs=(torch.ones(x.size()),))
+        self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE,
+                            use_gpu=False, example_outputs=(torch.ones(x.size()),))
 
     def test_tensor_like_factories_script(self):
         class TensorFactory(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, x):
-                # NOTE: issue #17932, scripting requires dtype, layout, device to be either provided together, or not provided at all.
+                # NOTE: issue #17932, scripting requires dtype, layout, device to be either provided together,
+                # or not provided at all.
                 zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
                 ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
                 return zeros + ones
 
         x = torch.randn(2, 3, 4)
-        self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False, example_outputs=(torch.ones(x.size()),))
+        self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE,
+                            use_gpu=False, example_outputs=(torch.ones(x.size()),))
 
     def test_where_functional(self):
         class WhereFunctional(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -77,6 +77,8 @@ def skipIfEmbed(func):
 def do_export(model, inputs, *args, **kwargs):
     f = io.BytesIO()
     out = torch.onnx._export(model, inputs, f, *args, **kwargs)
+    if isinstance(model, torch.jit.ScriptModule):
+        out = model(*inputs)
     return f.getvalue(), out
 
 
@@ -1186,6 +1188,27 @@ class TestCaffe2Backend(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
+
+    def test_tensor_factories_script(self):
+        class TensorFactory(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                return torch.zeros(x.shape, dtype=torch.float) + torch.ones(x.shape)
+
+        x = torch.randn(2, 3, 4)
+        self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False, example_outputs=(torch.ones(x.size()),))
+
+    def test_tensor_like_factories_script(self):
+        class TensorFactory(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, x):
+                # NOTE: issue #17932, scripting requires dtype, layout, device to be either provided together, or not provided at all.
+                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                return zeros + ones
+
+        x = torch.randn(2, 3, 4)
+        self.run_model_test(TensorFactory(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False, example_outputs=(torch.ones(x.size()),))
 
     def test_where_functional(self):
         class WhereFunctional(torch.nn.Module):

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -128,7 +128,10 @@ def parse_args(*arg_descriptors):
         def wrapper(g, *args):
             # some args may be optional, so the length may be smaller
             assert len(arg_descriptors) >= len(args)
-            argspec = inspect.getfullargspec(fn)
+            try:
+                argspec = inspect.getfullargspec(fn)
+            except:
+                argspec = inspect.getargspec(fn)
             args_names = argspec.args if argspec.args else []
             args_defaults = argspec.defaults if argspec.defaults else []
             default_args_dict = dict(zip(args_names[-len(args_defaults):], args_defaults))

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -130,7 +130,7 @@ def parse_args(*arg_descriptors):
             assert len(arg_descriptors) >= len(args)
             try:
                 argspec = inspect.getfullargspec(fn)
-            except:
+            except AttributeError:
                 argspec = inspect.getargspec(fn)
             args_names = argspec.args if argspec.args else []
             args_defaults = argspec.defaults if argspec.defaults else []
@@ -143,7 +143,7 @@ def parse_args(*arg_descriptors):
                 arg_name = args_names[i + 1]
 
                 # NOTE: Unprovided optional args become prim::Constant() in scripting.
-                is_arg_required = not arg_name in default_args_dict
+                is_arg_required = arg_name not in default_args_dict
                 if not _is_prim_constant(arg):
                     if is_arg_required:
                         fn_args.append(arg)
@@ -1354,7 +1354,8 @@ def ones_like(g, input, dtype, layout=None, device=None, pin_memory=False):
                 value_t=torch.tensor([1], dtype=scalar_type_to_pytorch_type[dtype]))
 
 
-def full(g, sizes, value, dtype=scalar_type_to_pytorch_type.index(torch.get_default_dtype()), layout=None, device=None, pin_memory=False):
+def full(g, sizes, value, dtype=scalar_type_to_pytorch_type.index(torch.get_default_dtype()),
+         layout=None, device=None, pin_memory=False):
     if pin_memory and _parse_arg(pin_memory, 'b'):
         raise RuntimeError("onnx pin_memory support is not implemented")
     const_value = _maybe_get_const(value, 't')

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -129,8 +129,8 @@ def parse_args(*arg_descriptors):
             # some args may be optional, so the length may be smaller
             assert len(arg_descriptors) >= len(args)
             argspec = inspect.getfullargspec(fn)
-            args_names = argspec.args
-            args_defaults = argspec.defaults
+            args_names = argspec.args if argspec.args else []
+            args_defaults = argspec.defaults if argspec.defaults else []
             default_args_dict = dict(zip(args_names[-len(args_defaults):], args_defaults))
 
             fn_args = []

--- a/torch/onnx/symbolic.py
+++ b/torch/onnx/symbolic.py
@@ -68,7 +68,7 @@ _sum = sum
 def _parse_arg(value, desc):
     if desc == 'none':
         return value
-    if desc == 'v' or not _is_value(value) or value.node().kind() == 'prim::Constant':
+    if desc == 'v' or not _is_value(value) or _is_prim_constant(value):
         return value
     if value.node().kind() == 'onnx::Constant':
         tval = value.node()['value']


### PR DESCRIPTION
Unlike tracing, which records the default argument inside the trace. Scripting inserts `prim::Constant()` for each unprovided optional argument. The ONNX exporter has no idea that this actually stands for argument not provided.

This PR is the first step of adding the support for exporting these optional arguments. 