### PR TITLE
Mention issue number in the JIT workaround comments

### DIFF
--- a/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
@@ -142,7 +142,7 @@ void adaptive_max_pool2d_out_cpu_template(
   AT_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
     "non-empty 3D or 4D (batch mode) tensor expected for input");
 
-  // the jit sometimes passes output_size.size() == 1
+  // Issue #20215: the JIT sometimes passes output_size.size() == 1.
   AT_CHECK(output_size.size() == 1 || output_size.size() == 2,
     "adaptive_max_pool2d: internal error: output_size.size() must be 1 or 2");
 

--- a/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
@@ -164,7 +164,7 @@ void adaptive_max_pool3d_out_cpu_template(
   AT_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
 
-  // the jit sometimes passes output_size.size() == 1
+  // Issue #20215: the JIT sometimes passes output_size.size() == 1.
   AT_CHECK(output_size.size() == 1 || output_size.size() == 3,
     "adaptive_max_pool3d: internal error: output_size.size() must be 1 or 3");
 

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -213,7 +213,7 @@ void adaptive_max_pool2d_out_cuda_template(
   AT_CHECK((input.ndimension() == 3 || input.ndimension() == 4),
     "non-empty 3D or 4D (batch mode) tensor expected for input");
 
-  // the jit sometimes passes output_size.size() == 1
+  // Issue #20215: the JIT sometimes passes output_size.size() == 1.
   AT_CHECK(output_size.size() == 1 || output_size.size() == 2,
     "adaptive_max_pool2d: internal error: output_size.size() must be 1 or 2");
 

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -316,7 +316,7 @@ void adaptive_max_pool3d_out_cuda_template(
   AT_CHECK((input_.ndimension() == 4 || input_.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
 
-  // the jit sometimes passes output_size.size() == 1
+  // Issue #20215: the JIT sometimes passes output_size.size() == 1.
   AT_CHECK(output_size.size() == 1 || output_size.size() == 3,
     "adaptive_max_pool3d: internal error: output_size.size() must be 1 or 3");
 


### PR DESCRIPTION
This just updates the `JIT` comments with the issue number #20215.  Hopefully this will stop the proliferation of the workaround. :)