### PR TITLE
Lite JIT executor, the high level save flow.

### DIFF
--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -30,6 +30,7 @@
 #include <test/cpp/jit/test_qualified_name.h>
 #include <test/cpp/jit/test_subgraph_matcher.h>
 #include <test/cpp/jit/test_subgraph_utils.h>
+#include <test/cpp/jit/test_lite_executor.h>
 
 using namespace torch::jit::script;
 using namespace torch::jit::test;
@@ -37,6 +38,7 @@ using namespace torch::jit::test;
 namespace torch {
 namespace jit {
 #define TH_FORALL_TESTS(_)         \
+  _(LiteExecutor)                  \
   _(ADFormulas)                    \
   _(Attributes)                    \
   _(Blocks)                        \

--- a/test/cpp/jit/test_lite_executor.h
+++ b/test/cpp/jit/test_lite_executor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "test/cpp/jit/test_base.h"
+#include "test/cpp/jit/test_utils.h"
+
+#include "torch/csrc/autograd/generated/variable_factories.h"
+#include "torch/jit.h"
+#include "torch/csrc/jit/script/module.h"
+#include "torch/script.h"
+
+#include <ATen/ATen.h>
+
+namespace torch {
+namespace jit {
+namespace test {
+
+void testLiteExecutor() {
+  auto m = std::make_shared<script::Module>();
+  m->register_parameter("foo", torch::ones({}), false);
+  m->define(R"(
+    def add_it(self, x, b : int = 4):
+      return self.foo + x + b
+  )");
+  std::vector<IValue> inputs;
+  inputs.emplace_back(torch::ones({}));
+  std::stringstream ss;
+  m->save_method("add_it", inputs, ss);
+
+  // TODO:
+  // 1. Load ss to a InstructionList
+  // 2. Execute InstructionList
+  // 3. Compare the result to n->run_method("add_it", torch::ones({})).toTensor()
+  AT_ASSERT(!ss.str().empty());
+}
+
+} // namespace test
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -31,6 +31,9 @@ struct TORCH_API GraphExecutor {
   GraphExecutor() = default;
   GraphExecutor(std::shared_ptr<Graph> graph, bool optimize = true);
   void run(Stack& inputs);
+  // Save optimized instructions to fileName. Inputs are required for optimization.
+  void saveInstructions(Stack& inputs, const std::string& fileName);
+  void saveInstructions(Stack& inputs, std::ostream& os);
   explicit operator bool() const {
     return pImpl != nullptr;
   }

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -534,6 +534,12 @@ struct CodeImpl {
     return inst;
   }
 
+  void exportInstructions(std::ostream& os) {
+    // Demonstration only.
+    // TODO: Implement the serializer and deserializer.
+    dump(os);
+  }
+
   // helpers to build/access RegList objects
   int get(const ListHandle<int>& list, int i) const {
     return int_data[list.start + i];
@@ -831,6 +837,10 @@ Code::~Code() = default;
 
 const std::vector<GraphExecutor*>& Code::grad_executors() {
   return pImpl->grad_executors();
+}
+
+void Code::exportInstructions(std::ostream& os) const {
+  pImpl->exportInstructions(os);
 }
 
 InterpreterState::InterpreterState(const Code& code)

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -40,6 +40,8 @@ struct TORCH_API Code {
     return pImpl != nullptr;
   }
 
+  void exportInstructions(std::ostream& os) const;
+
  private:
   std::shared_ptr<CodeImpl> pImpl;
   friend struct InterpreterStateImpl;

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -56,6 +56,14 @@ struct TORCH_API Function {
     run(stack);
   }
 
+  void saveInstructions(Stack& stack, std::ostream& out) {
+    get_executor().saveInstructions(stack, out);
+  }
+
+  void saveInstructions(Stack&& stack, std::ostream& out) {
+    saveInstructions(stack, out);
+  }
+
   IValue operator()(
       std::vector<IValue> stack,
       const Kwargs& kwargs = Kwargs()) {

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -101,6 +101,12 @@ void Module::save(
   ExportModule(*this, filename, extra_files);
 }
 
+void Module::save_method(const std::string &method_name,
+                         const std::vector<IValue>& inputs,
+                         std::ostream &out) {
+  return get_method(method_name).saveInstructions(inputs, out);
+}
+
 void module_state_to(
     const Slot& s,
     const c10::optional<at::Device>& device,


### PR DESCRIPTION
This first diff of the lite JIT executor project. It's focused on the high-level save flow: from script::module, how could we save the instructions compiled in JIT. 
The user-facing idea in this pull is that for PyTorch script, we provide the option for users to dump instruction-level byte codes. If the user wants to have inference on a method, they could dump instructions using this feature. On device the light executor could load and execute them. 
The unit test is in src/pytorch/test/cpp/jit/test_lite_executor.h. 
The two major TODO parts:
1) A parser to serialize/deserialize the instructions
2) A lite executor to load and execute the instructions

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20227 Lite JIT executor, the high level save flow.**

Differential Revision: [D15244231](https://our.internmc.facebook.com/intern/diff/D15244231)