### PR TITLE
Add c10d::broadcast_coalesced and tests

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2597,7 +2597,7 @@ class ComputeBucketAssignmentTest(TestCase):
 
 class CommTest(MultiProcessTestCase):
     def tearDown(self):
-        super()
+        super(CommTest, self).tearDown()
         try:
             os.remove(self.file.name)
         except OSError:

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2595,6 +2595,72 @@ class ComputeBucketAssignmentTest(TestCase):
         self.assertEqual([[0], [1], [2, 4], [3, 5]], result)
 
 
+class CommTest(MultiProcessTestCase):
+    def tearDown(self):
+        super()
+        try:
+            os.remove(self.file.name)
+        except OSError:
+            pass
+
+    @property
+    def world_size(self):
+        return 2
+
+    def _test_broadcast_coalesced(self, process_group, device):
+        half = torch.float16
+
+        # No support for float16 for CPU tensors
+        if device == torch.device('cpu'):
+            half = torch.float32
+
+        target = torch.arange(60, dtype=half, device=device).chunk(5)
+        target += torch.arange(60, dtype=torch.float32, device=device).chunk(5)
+        target += torch.arange(60, dtype=half, device=device).chunk(5)
+        target += torch.arange(60, dtype=torch.float64, device=device).chunk(5)
+        target += torch.arange(60, dtype=half, device=device).chunk(5)
+        target += torch.arange(60, dtype=torch.float32, device=device).chunk(5)
+
+        # The tensors to pass to broadcast are idential to the target
+        # only on the process that is the root of the broadcast.
+        if self.rank == 0:
+            tensors = list(tensor.clone() for tensor in target)
+        else:
+            tensors = list(torch.empty_like(tensor) for tensor in target)
+
+        c10d._broadcast_coalesced(
+            process_group,
+            tensors,
+            buffer_size=256)
+
+        self.assertEqual(tensors, target)
+
+    @skip_if_not_multigpu
+    @skip_if_not_nccl
+    def test_broadcast_coalesced_nccl(self):
+        store = c10d.FileStore(self.file.name, self.world_size)
+        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
+        device = torch.device('cuda:%d' % self.rank)
+        self._test_broadcast_coalesced(process_group, device)
+
+    @skip_if_not_multigpu
+    def test_broadcast_coalesced_gloo_cuda(self):
+        store = c10d.FileStore(self.file.name, self.world_size)
+        options = c10d.ProcessGroupGloo.Options()
+        options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
+        process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
+        device = torch.device('cuda:%d' % self.rank)
+        self._test_broadcast_coalesced(process_group, device)
+
+    def test_broadcast_coalesced_gloo_cpu(self):
+        store = c10d.FileStore(self.file.name, self.world_size)
+        options = c10d.ProcessGroupGloo.Options()
+        options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
+        process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
+        device = torch.device('cpu')
+        self._test_broadcast_coalesced(process_group, device)
+
+
 if __name__ == '__main__':
     assert not torch.cuda._initialized, "test_distributed must not have initialized CUDA context on main process"
 

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -199,6 +199,7 @@ def add_torch_libs():
         "torch/csrc/autograd/python_variable_indexing.cpp",
         "torch/csrc/byte_order.cpp",
         "torch/csrc/distributed/Module.cpp",
+        "torch/csrc/distributed/c10d/comm.cpp",
         "torch/csrc/distributed/c10d/init.cpp",
         "torch/csrc/distributed/c10d/reducer.cpp",
         "torch/csrc/jit/init.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -690,8 +690,11 @@ if (BUILD_PYTHON)
     list(APPEND TORCH_PYTHON_LINK_LIBRARIES THD)
     list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_DISTRIBUTED)
     if (NOT MSVC AND NOT APPLE)
-      list(APPEND TORCH_PYTHON_SRCS ${TORCH_SRC_DIR}/csrc/distributed/c10d/init.cpp)
-      list(APPEND TORCH_PYTHON_SRCS ${TORCH_SRC_DIR}/csrc/distributed/c10d/reducer.cpp)
+      list(APPEND TORCH_PYTHON_SRCS
+        ${TORCH_SRC_DIR}/csrc/distributed/c10d/comm.cpp
+        ${TORCH_SRC_DIR}/csrc/distributed/c10d/init.cpp
+        ${TORCH_SRC_DIR}/csrc/distributed/c10d/reducer.cpp
+        )
       list(APPEND TORCH_PYTHON_LINK_LIBRARIES c10d)
       list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_C10D)
       if (USE_CUDA)

--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -1,0 +1,82 @@
+#include <torch/csrc/distributed/c10d/comm.h>
+
+#include <deque>
+
+#include <ATen/core/functional.h>
+#include <torch/csrc/distributed/c10d/reducer.h>
+#include <torch/csrc/utils/tensor_flatten.h>
+
+namespace c10d {
+namespace {
+
+class BroadcastWork {
+ public:
+  BroadcastWork(
+      std::shared_ptr<c10d::ProcessGroup> process_group,
+      std::vector<at::Tensor> bucket_tensors)
+      : bucket_tensors_(std::move(bucket_tensors)),
+        flat_tensor_({torch::utils::flatten_dense_tensors(bucket_tensors_)}),
+        work_(process_group->broadcast(flat_tensor_)) {}
+
+  void finish() {
+    work_->wait();
+
+    // Copy the output of the broadcast operation back.
+    auto output_tensors = torch::utils::unflatten_dense_tensors(
+        flat_tensor_.front(), bucket_tensors_);
+    AT_ASSERT(output_tensors.size() == bucket_tensors_.size());
+    for (size_t i = 0; i < output_tensors.size(); i++) {
+      bucket_tensors_[i].copy_(output_tensors[i], /*non_blocking=*/true);
+    }
+  }
+
+ protected:
+  // The list of tensors to broadcast. They are guaranteed to be
+  // placed on the same device and have the same dtype.
+  std::vector<at::Tensor> bucket_tensors_;
+
+  // The vector with a single flattened tensor containing the contents
+  // of the tensors in bucket_tensors_. It must be stored in a vector
+  // because c10d::ProcessGroup::broadcast takes a vector argument.
+  std::vector<at::Tensor> flat_tensor_;
+
+  // The broadcast work that is kicked off upon construction.
+  std::shared_ptr<c10d::ProcessGroup::Work> work_;
+};
+
+} // namespace
+
+// Broadcast many tensors to all processes in the process group.
+void broadcast_coalesced(
+    std::shared_ptr<c10d::ProcessGroup> process_group,
+    at::TensorList tensors,
+    size_t buffer_size) {
+  // Coalesce tensors into buckets taking into account the maximum buffer size.
+  // This routine is multi-device aware, so the tensors can be split across
+  // multiple devices and can contain a mix of CPU and CUDA tensors.
+  const auto buckets =
+      compute_bucket_assignment_by_size(tensors.vec(), {buffer_size});
+
+  // Returns tensor at specified index in input tensor list.
+  const auto lookup = [&tensors](size_t index) { return tensors[index]; };
+
+  // We maintain a maximum of 2 in flight broadcast operations to avoid
+  // allocating too much memory (in case the specified tensors are very large).
+  std::deque<BroadcastWork> in_flight;
+  constexpr auto max_in_flight = 2;
+  for (const auto& bucket : buckets) {
+    if (in_flight.size() >= max_in_flight) {
+      in_flight.front().finish();
+      in_flight.pop_front();
+    }
+
+    in_flight.emplace_back(process_group, c10::fmap(bucket, lookup));
+  }
+
+  while (!in_flight.empty()) {
+    in_flight.front().finish();
+    in_flight.pop_front();
+  }
+}
+
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -12,7 +12,7 @@ namespace {
 class BroadcastWork {
  public:
   BroadcastWork(
-      std::shared_ptr<c10d::ProcessGroup> process_group,
+      const std::shared_ptr<c10d::ProcessGroup>& process_group,
       std::vector<at::Tensor> bucket_tensors)
       : bucket_tensors_(std::move(bucket_tensors)),
         flat_tensor_({torch::utils::flatten_dense_tensors(bucket_tensors_)}),

--- a/torch/csrc/distributed/c10d/comm.h
+++ b/torch/csrc/distributed/c10d/comm.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+
+#include <ATen/ATen.h>
+#include <c10d/ProcessGroup.hpp>
+
+namespace c10d {
+
+// Broadcast many tensors to all processes in the process group.
+void broadcast_coalesced(
+    std::shared_ptr<c10d::ProcessGroup> process_group,
+    at::TensorList tensors,
+    size_t buffer_size);
+
+} // namespace c10d


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20236 Make DistributedDataParallel usable with CPU models&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15245428/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20235 Refactor core DistributedDataParallel tests&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15245429/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20234 Add c10d::broadcast_coalesced and tests**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15228099/)

The differences with the existing function _dist_broadcast_coalesced
is that this one works for both CPU and CUDA tensors and that it has a
maximum number of in flight operations.

This should be the final change needed to have only a single version
of DistributedDataParallel that both supports CPU and CUDA models, or
even a mix of both.

See #17757 for more information.

Differential Revision: [D15228099](https://our.internmc.facebook.com/intern/diff/D15228099/)