### PR TITLE
Refactor core DistributedDataParallel tests

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1646,52 +1646,60 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     def world_size(self):
         return 2
 
-    def _prepare_single_device_module(self, process_group, gpus, global_batch_size):
+    def _prepare_single_device_module(self, process_group, devices, device_ids, global_batch_size):
         model = Net()
         ddp_model = DistributedDataParallel(
-            copy.deepcopy(model).cuda(gpus[0]),
-            device_ids=gpus,
+            copy.deepcopy(model).to(devices[0]),
+            device_ids=device_ids,
             process_group=process_group,
             bucket_cap_mb=0.001)
 
-        model.cuda(gpus[0])
+        model.to(devices[0])
 
-        input = torch.randn(global_batch_size, 2).cuda(gpus[0])
-        target = torch.randn(global_batch_size, 4).cuda(gpus[0])
+        input = torch.randn(global_batch_size, 2).to(devices[0])
+        target = torch.randn(global_batch_size, 4).to(devices[0])
 
         return model, ddp_model, input, target
 
-    def _prepare_multi_device_module(self, process_group, gpus, global_batch_size):
+    def _prepare_multi_device_module(self, process_group, devices, device_ids, global_batch_size):
         self.assertTrue(
-            len(gpus) == 2 or len(gpus) == 4,
-            "unexpected devices for ddp tests {}".format(gpus))
-        if len(gpus) == 2:
-            model = DoubleGpuNet(gpus)
-        elif len(gpus) == 4:
-            model = QuadraGpuNet(gpus)
+            len(devices) == 2 or len(devices) == 4,
+            "unexpected devices for ddp tests {}".format(devices))
+        if len(devices) == 2:
+            model = DoubleGpuNet(devices)
+        elif len(devices) == 4:
+            model = QuadraGpuNet(devices)
 
         ddp_model = DistributedDataParallel(
             copy.deepcopy(model),
+            device_ids=device_ids,
             process_group=process_group,
             bucket_cap_mb=0.001)
 
-        input = torch.randn(global_batch_size, 2).to(gpus[0])
+        input = torch.randn(global_batch_size, 2).cuda(devices[0])
         target = torch.randn(global_batch_size, 4)
 
         return model, ddp_model, input, target
 
-    def _test_ddp_with_process_group(self, process_group, gpus, multi_gpu=False):
-        local_batch_size = len(gpus)
+    def _test_ddp_with_process_group(self, process_group, devices, device_ids, multi_device=False):
+        """
+        Note: we pass down `device_ids` all the way to DistributedDataParallel
+        as part of the test. Below you find tests that either use a list of
+        integers, a list of `torch.Device` instances, or an empty list.
+        The `devices` argument is used to control placement of the model and
+        must always be specified as list of `torch.Device` instances.
+        """
+        local_batch_size = len(devices)
         global_batch_size = self.world_size * local_batch_size
 
-        if multi_gpu:
+        if multi_device:
             model, ddp_model, input, target = \
                 self._prepare_multi_device_module(
-                    process_group, gpus, global_batch_size)
+                    process_group, devices, device_ids, global_batch_size)
         else:
             model, ddp_model, input, target = \
                 self._prepare_single_device_module(
-                    process_group, gpus, global_batch_size)
+                    process_group, devices, device_ids, global_batch_size)
 
         def step_model(model, input, target):
             model.train()
@@ -1725,87 +1733,62 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             torch.manual_seed(1337 + iteration)
             input = input[torch.randperm(global_batch_size)]
 
-    def _test_gloo_backend(self, gpus, multi_gpu=False, use_str=False):
-        if use_str:
-            gpus = list(map(lambda i: torch.device('cuda:' + str(i)), gpus))
+    def _test_gloo_backend(self, devices, device_ids, multi_device=False):
         store = c10d.FileStore(self.file.name, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
-        self._test_ddp_with_process_group(process_group, gpus, multi_gpu)
+        self._test_ddp_with_process_group(process_group, devices, device_ids, multi_device)
 
     @skip_if_not_multigpu
-    def test_gloo_backend(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_gloo_backend(gpus)
-
-    @skip_if_not_multigpu
-    def test_gloo_backend_str(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_gloo_backend(gpus, use_str=True)
+    def test_gloo_backend_1gpu_module(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_gloo_backend(devices, int_devices, multi_device=False)
+        self._test_gloo_backend(devices, devices, multi_device=False)
 
     @skip_if_lt_x_gpu(4)
     def test_gloo_backend_2gpu_module(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_gloo_backend(gpus[:2], multi_gpu=True)
-
-    @skip_if_lt_x_gpu(4)
-    def test_gloo_backend_2gpu_module_str(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_gloo_backend(gpus[:2], multi_gpu=True, use_str=True)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_gloo_backend(devices, int_devices, multi_device=True)
+        self._test_gloo_backend(devices, devices, multi_device=True)
 
     @skip_if_lt_x_gpu(8)
     def test_gloo_backend_4gpu_module(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_gloo_backend(gpus[:4], multi_gpu=True)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_gloo_backend(devices, int_devices, multi_device=True)
+        self._test_gloo_backend(devices, devices, multi_device=True)
 
-    @skip_if_lt_x_gpu(8)
-    def test_gloo_backend_4gpu_module_str(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_gloo_backend(gpus[:4], multi_gpu=True, use_str=True)
-
-    def _test_nccl_backend(self, gpus, multi_gpu=False, use_str=False):
-        if use_str:
-            gpus = list(map(lambda i: torch.device('cuda:' + str(i)), gpus))
+    def _test_nccl_backend(self, devices, device_ids, multi_device=False):
         store = c10d.FileStore(self.file.name, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
-        self._test_ddp_with_process_group(process_group, gpus, multi_gpu)
+        self._test_ddp_with_process_group(process_group, devices, device_ids, multi_device)
 
     @skip_if_not_multigpu
     @skip_if_not_nccl
-    def test_nccl_backend(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_nccl_backend(gpus)
-
-    @skip_if_not_multigpu
-    @skip_if_not_nccl
-    def test_nccl_backend_str(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_nccl_backend(gpus, use_str=True)
+    def test_nccl_backend_1gpu_module(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_nccl_backend(devices, int_devices, multi_device=False)
+        self._test_nccl_backend(devices, devices, multi_device=False)
 
     @skip_if_lt_x_gpu(4)
     @skip_if_not_nccl
     def test_nccl_backend_2gpu_module(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_nccl_backend(gpus[:2], multi_gpu=True)
-
-    @skip_if_lt_x_gpu(4)
-    @skip_if_not_nccl
-    def test_nccl_backend_2gpu_module_str(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_nccl_backend(gpus[:2], multi_gpu=True, use_str=True)
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_nccl_backend(devices, int_devices, multi_device=True)
+        self._test_nccl_backend(devices, devices, multi_device=True)
 
     @skip_if_lt_x_gpu(8)
     @skip_if_not_nccl
-    def test_nccl_backend_4gpu_module(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_nccl_backend(gpus[:4], multi_gpu=True)
-
-    @skip_if_lt_x_gpu(8)
-    @skip_if_not_nccl
-    def test_nccl_backend_4gpu_module_str(self):
-        gpus = gpus_for_rank(self.world_size)[self.rank]
-        self._test_nccl_backend(gpus[:4], multi_gpu=True, use_str=True)
+    def test_nccl_backend_2gpu_module(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_nccl_backend(devices, int_devices, multi_device=True)
+        self._test_nccl_backend(devices, devices, multi_device=True)
 
     @skip_if_lt_x_gpu(4)
     @skip_if_not_nccl

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1741,25 +1741,28 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         self._test_ddp_with_process_group(process_group, devices, device_ids, multi_device)
 
     @skip_if_not_multigpu
-    def test_gloo_backend_1gpu_module(self):
+    def test_gloo_backend_1gpu_module_device_ids_integer_list(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        self._test_gloo_backend(devices, int_devices, multi_device=False)
-        self._test_gloo_backend(devices, devices, multi_device=False)
+        self._test_gloo_backend(devices, int_devices)
+
+    @skip_if_not_multigpu
+    def test_gloo_backend_1gpu_module_device_ids_torch_device_list(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_gloo_backend(devices, devices)
 
     @skip_if_lt_x_gpu(4)
     def test_gloo_backend_2gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        self._test_gloo_backend(devices, int_devices, multi_device=True)
-        self._test_gloo_backend(devices, devices, multi_device=True)
+        self._test_gloo_backend(devices, [], multi_device=True)
 
     @skip_if_lt_x_gpu(8)
     def test_gloo_backend_4gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        self._test_gloo_backend(devices, int_devices, multi_device=True)
-        self._test_gloo_backend(devices, devices, multi_device=True)
+        self._test_gloo_backend(devices, [], multi_device=True)
 
     def _test_nccl_backend(self, devices, device_ids, multi_device=False):
         store = c10d.FileStore(self.file.name, self.world_size)
@@ -1768,27 +1771,31 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @skip_if_not_multigpu
     @skip_if_not_nccl
-    def test_nccl_backend_1gpu_module(self):
+    def test_nccl_backend_1gpu_module_device_ids_integer_list(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        self._test_nccl_backend(devices, int_devices, multi_device=False)
-        self._test_nccl_backend(devices, devices, multi_device=False)
+        self._test_nccl_backend(devices, int_devices)
+
+    @skip_if_not_multigpu
+    @skip_if_not_nccl
+    def test_nccl_backend_1gpu_module_device_ids_torch_device_list(self):
+        int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
+        devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
+        self._test_nccl_backend(devices, devices)
 
     @skip_if_lt_x_gpu(4)
     @skip_if_not_nccl
     def test_nccl_backend_2gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:2]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        self._test_nccl_backend(devices, int_devices, multi_device=True)
-        self._test_nccl_backend(devices, devices, multi_device=True)
+        self._test_nccl_backend(devices, [], multi_device=True)
 
     @skip_if_lt_x_gpu(8)
     @skip_if_not_nccl
-    def test_nccl_backend_2gpu_module(self):
+    def test_nccl_backend_4gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:4]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        self._test_nccl_backend(devices, int_devices, multi_device=True)
-        self._test_nccl_backend(devices, devices, multi_device=True)
+        self._test_nccl_backend(devices, [], multi_device=True)
 
     @skip_if_lt_x_gpu(4)
     @skip_if_not_nccl


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20236 Make DistributedDataParallel usable with CPU models&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15245428/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20235 Refactor core DistributedDataParallel tests**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15245429/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20234 Add c10d::broadcast_coalesced and tests&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15228099/)

The tests expected to only run for CUDA models. In a future commit we
need to update this to work for CPU models as well. Therefore, we can
no longer rely on only integers being passed for device identifiers.
With this change we pass both the materialized list of devices to use
(as `torch.Device` objects), as well as an optional list of integers.
The latter is specified to exercise the code in the
DistributedDataParallel constructor that turns a list of integers into
CUDA devices, IFF it is used to wrap a single-device CUDA module.

This commit also groups together the 'str' and non-'str' tests. These
used to test passing the list of devices as integers or as
`torch.Device` instances. These are now executed from the same test.

Differential Revision: [D15245429](https://our.internmc.facebook.com/intern/diff/D15245429/)