### PR TITLE
Make DistributedDataParallel usable with CPU models

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -1740,6 +1740,9 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
         self._test_ddp_with_process_group(process_group, devices, device_ids, multi_device)
 
+    def test_gloo_backend_cpu_module(self):
+        self._test_gloo_backend([torch.device('cpu')], [])
+
     @skip_if_not_multigpu
     def test_gloo_backend_1gpu_module(self):
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -282,8 +282,8 @@ class DistributedDataParallel(Module):
         # Sync params and buffers
         module_states = list(self.module.state_dict().values())
         if len(module_states) > 0:
-            self._dist_broadcast_coalesced(module_states,
-                                           self.broadcast_bucket_size)
+            self._broadcast_coalesced(module_states,
+                                      self.broadcast_bucket_size)
 
         self._ddp_init_helper()
 
@@ -406,8 +406,8 @@ class DistributedDataParallel(Module):
         for module in self._module_copies[1:]:
             module.train(mode)
 
-    def _dist_broadcast_coalesced(self, tensors, buffer_size):
-        dist._dist_broadcast_coalesced(self.process_group, tensors, buffer_size, False)
+    def _broadcast_coalesced(self, tensors, buffer_size):
+        dist._broadcast_coalesced(self.process_group, tensors, buffer_size)
 
     def _sync_params(self):
         with torch.no_grad():
@@ -432,9 +432,10 @@ class DistributedDataParallel(Module):
 
             # module buffer sync
             if self.broadcast_buffers and len(self.modules_buffers[0]) > 0:
-                # cross-node buffer sync
-                self._dist_broadcast_coalesced(self.modules_buffers[0],
-                                               self.broadcast_bucket_size)
+                # Synchronize buffers across processes.
+                # The process with rank 0 is considered the authoritative copy.
+                self._broadcast_coalesced(self.modules_buffers[0],
+                                          self.broadcast_bucket_size)
                 # only do intra-node buffer sync for replicated single-device
                 # CUDA modules
                 if self.device_ids and len(self.device_ids) > 1:


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20236 Make DistributedDataParallel usable with CPU models**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15245428/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20235 Refactor core DistributedDataParallel tests&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15245429/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20234 Add c10d::broadcast_coalesced and tests&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15228099/)

Use the new version of broadcast_coalesced that deals with both CPU
and CUDA models. Add tests that evaluate correctness of
DistributedDataParallel for CPU models.

Closes #17757.

Differential Revision: [D15245428](https://our.internmc.facebook.com/intern/diff/D15245428/)