### PR TITLE
Fix memory leak in torch._dirichlet_grad()

### DIFF
--- a/aten/src/TH/generic/THTensorMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorMoreMath.cpp
@@ -1676,6 +1676,9 @@ void THTensor_(dirichlet_grad)(THTensor *self, THTensor *x, THTensor *alpha, THT
     grad_data[i] = THTensor_(dirichlet_grad_one)(x_data[i], alpha_data[i], total_data[i]);
   }
 
+  c10::raw::intrusive_ptr::decref(x);
+  c10::raw::intrusive_ptr::decref(alpha);
+  c10::raw::intrusive_ptr::decref(total);
   THTensor_(freeCopyTo)(grad, self);
 }
 


### PR DESCRIPTION
Fixes https://github.com/pyro-ppl/pyro/issues/1853

This fixes a memory leak in `torch._dirichlet_grad()`. This function is used for reparametrized gradients for the `Dirichlet` and `Beta` distributions.

## Questions for reviewiers

- [x] Could a reviewer please confirm that `freeCopyTo()` is being used correctly and doesn't need an additional `decref()`? The author is unfamiliar with PyTorch C++ memory utilities. Help appreciated.

## Tested
- ran locally and confirmed leak is fixed