### PR TITLE
[WIP][RFC] Edit nn.Linear to take arbitrary in and out feature dimensions

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -13,10 +13,11 @@ namespace nn {
 /// Options for the `Linear` module.
 struct TORCH_API LinearOptions {
   LinearOptions(int64_t in, int64_t out);
+  LinearOptions(std::vector<int64_t> in, std::vector<int64_t> out);
   /// The number of input features (columns of the input matrix).
-  TORCH_ARG(int64_t, in);
+  TORCH_ARG(std::vector<int64_t>, in);
   /// The number of output features to produce (columns of the output matrix).
-  TORCH_ARG(int64_t, out);
+  TORCH_ARG(std::vector<int64_t>, out);
   /// Whether to learn and add a bias after the linear transformation.
   TORCH_ARG(bool, with_bias) = true;
 };
@@ -24,7 +25,18 @@ struct TORCH_API LinearOptions {
 /// Applies a linear transformation with optional bias.
 class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
  public:
-  LinearImpl(int64_t in, int64_t out) : LinearImpl(LinearOptions(in, out)) {}
+  LinearImpl(int64_t in, int64_t out)
+      : LinearImpl(LinearOptions(in, out)) {}
+
+  LinearImpl(std::vector<int64_t> in, int64_t out)
+      : LinearImpl(LinearOptions(in, {out})) {}
+
+  LinearImpl(int64_t in, std::vector<int64_t>  out)
+      : LinearImpl(LinearOptions({in}, out)) {}
+
+  LinearImpl(std::vector<int64_t> in, std::vector<int64_t> out)
+      : LinearImpl(LinearOptions(in, out)) {}
+
   explicit LinearImpl(LinearOptions options);
 
   void reset() override;
@@ -45,6 +57,9 @@ class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
   /// The learned bias. If `with_bias` is false in the `options`, this tensor is
   /// undefined.
   Tensor bias;
+
+ private:
+   int64_t in_prod_, out_prod_;
 };
 
 /// A `ModuleHolder` subclass for `LinearImpl`.

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -5,18 +5,34 @@
 
 #include <cmath>
 #include <cstdint>
+#include <numeric>
 
 namespace torch {
 namespace nn {
-LinearOptions::LinearOptions(int64_t in, int64_t out) : in_(in), out_(out) {}
+LinearOptions::LinearOptions(int64_t in, int64_t out)
+    : in_({in}), out_({out}) {}
 
-LinearImpl::LinearImpl(LinearOptions options) : options(options) {
+LinearOptions::LinearOptions(std::vector<int64_t> in, std::vector<int64_t> out)
+    : in_(std::move(in)), out_(std::move(out)) {}
+
+LinearImpl::LinearImpl(LinearOptions options)
+    : options(options),
+      in_prod_(std::accumulate(options.in_.begin(),
+                               options.in_.end(),
+                               1,
+                               std::multiplies<int64_t>())),
+      out_prod_(std::accumulate(options.out_.begin(),
+                                options.out_.end(),
+                                1,
+                                std::multiplies<int64_t>())) {
   reset();
 }
 
 void LinearImpl::reset() {
+  std::vector<int64_t> sizes(options.out_);
+  sizes.insert(sizes.end(), options.in_.begin(), options.in_.end());
   weight =
-      register_parameter("weight", torch::empty({options.out_, options.in_}));
+      register_parameter("weight", torch::empty(sizes));
   if (options.with_bias_) {
     bias = register_parameter("bias", torch::empty(options.out_));
   }
@@ -36,7 +52,29 @@ void LinearImpl::pretty_print(std::ostream& stream) const {
 
 Tensor LinearImpl::forward(const Tensor& input) {
   AT_ASSERT(!options.with_bias_ || bias.defined());
-  return torch::linear(input, weight, bias);
+  auto input_view = input.view_as(input);
+  if (options.in_.size() != 1) {
+    // reshape input
+    auto in_sizes = input.sizes().vec();
+    auto in_sizes_length = in_sizes.size() - options.in_.size() + 1;
+    in_sizes.resize(in_sizes_length);
+    in_sizes.back() = in_prod_;
+    input_view = input.view(in_sizes);
+  }
+
+  auto output = torch::linear(
+      input_view, weight.view({out_prod_, in_prod_}), bias.view({out_prod_}));
+
+  auto output_view = output.view_as(output);
+  if (options.out_.size() != 1) {
+    // reshape output
+    auto out_sizes = output.sizes().vec();
+    out_sizes.pop_back();
+    out_sizes.insert(out_sizes.end(), options.out_.begin(), options.out_.end());
+    output_view = output.view(out_sizes);
+  }
+
+  return output_view;
 }
 } // namespace nn
 } // namespace torch


### PR DESCRIPTION
### Current Behavior

Currently, `nn.Linear` takes two integer parameters `in_features` and `out_features` and creates a weight parameter of size `[out_features, in_features]`, and bias parameter of size `[out_features]`. This API is a little cumbersome if users would like to run higher-dimensional features through a linear layer. Say I have 2D input features of size `[2, 3]`, and provide an input batch of size `[4, 5, 2, 3]`. To use the existing linear layer, I will have to first reshape the the input into size `[4, 5, 6]`, and pass `6` as `in_features` arg for `nn.Linear`. 


### Proposed Behavior

It would be nice if `nn.Linear` can handle arbitrary feature dimensions. For example, if I have input feature size `[2, 3]`, and output feature size `4`, I should be able to do the following:

```python
m = Linear(in_features=[2, 3], out_features=4)
input = torch.rand(4, 5, 2, 3)
output = m(input) # get output of size [4, 5, 4]
```

Let `in_features=[in_1, in_2, ..., in_x]`, `out_features=[out_1, out_2, ..., out_y]`, and `input.size() == [d1, d2, ..., dz]`. The output dimensions should be `[d_1, ..., d_{z-x}, out_1, ..., out_y]`. 

It is allowed to set `in_features` and/or `out_features` to `[]` or `()`, and its behavior will stay consistent with `torch.matmul`.


### Implementation Alternatives

#### Option 1 [implemented in this PR]

Weights and bias dimensions respect `in_features` and `out_features` provided by users, where `weight.size() == [out_1, out_2, ..., out_y, in_1, in_2, ..., in_x]`  and `bias.size() == out_features`. In every `forward()` iteration, `weight` is reshaped to a 2D tensor of size `[prod(out_features), prod(in_features)]`, and `bias` of size `[prod(in_features)]`. Then, inputs are reshaped to `[d_1, ..., d_{z-x}, prod(in_features)]`. `F.linear` function creates an intermediate output of size `[d_1, ..., d_{z-x}, prod(out_features)]`, and are reshaped to `[d_1, ..., d_z, out_1, ..., out_y]`. 

The reason for not keeping weight and bias views as member var is to avoid showing them in `Linear.parameters()` 

Pro: Dimensions shown in `Linear.parameters()` will match users' expectation.
Con: Have to create multiple views in every `forward`.

#### Option 2

In constructor, directly create weight of size `[prod(out_features), prod(in_features)]` and bias of size `[prod(out_features)]`. And only reshape input and output in every `forward()` iteration. 

Pro: Avoid reshaping `weight` and `bias` in `forward()`
Con: Dimensions shown in `Linear.parameters()` won't match `in_features` and `out_features`

#### Option 3
Implement a new `linear` native function which address the dimensions internal, and modify both Python and C++ frontend to call it.

Will edit docs and add comments when we have consensus.

@gchanan @vishwakftw @yf225 

### Benchmark [Python API only]

before

```python
In [2]: l = torch.nn.Linear(10, 10)

In [3]: input = torch.rand(2, 10)

In [4]: %timeit l(input)
26.2 µs ± 5.17 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit l(input)
25.1 µs ± 1.57 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [6]: %timeit l(input)
25.6 µs ± 1.93 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

after

```python
In [2]: l = torch.nn.Linear(10, 10)

In [4]: input = torch.rand(2, 10)

In [5]: %timeit l(input)
24.4 µs ± 383 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [6]: %timeit l(input)
26.2 µs ± 4.25 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [7]: %timeit l(input)
24.8 µs ± 2.37 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```