### PR TITLE
Fix missing files for upload jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,6 +576,8 @@ binary_linux_upload: &binary_linux_upload
       <<: *setup_linux_system_environment
   - run:
       <<: *setup_ci_environment
+  - attach_workspace:
+      at: /home/circleci/project
   - run:
       <<: *binary_populate_env
   - run:

--- a/.circleci/verbatim-sources/linux-binary-build-defaults.yml
+++ b/.circleci/verbatim-sources/linux-binary-build-defaults.yml
@@ -73,6 +73,8 @@ binary_linux_upload: &binary_linux_upload
       <<: *setup_linux_system_environment
   - run:
       <<: *setup_ci_environment
+  - attach_workspace:
+      at: /home/circleci/project
   - run:
       <<: *binary_populate_env
   - run:


### PR DESCRIPTION
The earlier fix to extract scripts missed an attach_workspace which was used to make the built binaries available to the nightly build upload jobs.

