### PR TITLE
Improve bmm performance on CPU by applying TensorAccessor

### DIFF
--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -52,30 +52,36 @@ static inline void gemm_batched(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANS
 
 template <typename scalar_t>
 static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, const Tensor& mat2, Scalar beta_, Scalar alpha_) {
-  auto is_transposed = [&](const Tensor& t) {
+  auto is_transposed = [&](const TensorAccessor<scalar_t, 2>& t) {
     return t.stride(0) == 1 && t.stride(1) >= t.size(0);
   };
-  const CBLAS_TRANSPOSE trans_A = is_transposed(mat1[0]) ? CblasTrans : CblasNoTrans;
-  const CBLAS_TRANSPOSE trans_B = is_transposed(mat2[0]) ? CblasTrans : CblasNoTrans;
 
-  const int batch_size = mat1.size(0);
-  const int M = mat1.size(1);
-  const int N = mat2.size(2);
-  const int K = mat1.size(2);
+  auto mat1_acc = mat1.accessor<scalar_t, 3>();
+  auto mat2_acc = mat2.accessor<scalar_t, 3>();
+  auto res_acc = res.accessor<scalar_t, 3>();
+
+  const CBLAS_TRANSPOSE trans_A = is_transposed(mat1_acc[0]) ? CblasTrans : CblasNoTrans;
+  const CBLAS_TRANSPOSE trans_B = is_transposed(mat2_acc[0]) ? CblasTrans : CblasNoTrans;
+
+  const int batch_size = mat1_acc.size(0);
+  const int M = mat1_acc.size(1);
+  const int N = mat2_acc.size(2);
+  const int K = mat1_acc.size(2);
   scalar_t alpha = alpha_.to<scalar_t>();
   scalar_t beta = beta_.to<scalar_t>();
 
-  const int lda = is_transposed(mat1[0]) ? mat1[0].stride(1) : mat1[0].stride(0);
-  const int ldb = is_transposed(mat2[0]) ? mat2[0].stride(1) : mat2[0].stride(0);
+  const int lda = is_transposed(mat1_acc[0]) ? mat1_acc[0].stride(1) : mat1_acc[0].stride(0);
+  const int ldb = is_transposed(mat2_acc[0]) ? mat2_acc[0].stride(1) : mat2_acc[0].stride(0);
   const int ldc = res[0].stride(0);
 
   std::vector<const scalar_t*> A(batch_size);
   std::vector<const scalar_t*> B(batch_size);
   std::vector<scalar_t*> C(batch_size);
+
   for (int64_t batch = 0; batch < batch_size; batch++) {
-    A[batch] = mat1[batch].data<scalar_t>();
-    B[batch] = mat2[batch].data<scalar_t>();
-    C[batch] = res[batch].data<scalar_t>();
+    A[batch] = mat1_acc[batch].data();
+    B[batch] = mat2_acc[batch].data();
+    C[batch] = res_acc[batch].data();
   }
 
   gemm_batched(trans_A, trans_B, batch_size, M, N, K, alpha, A.data(), lda, B.data(), ldb, beta, C.data(), ldc);


### PR DESCRIPTION
Currently `bmm()` has very heavy performance overhead on CPU due to construction/deconstruction of `TensorImpl`. Applying `TensorAccessor` when indexing tensor data can greatly improve the performance.

I tested this on `fairseq` Transformer model. Results on Xeon 6148 (20*2 cores @2.5GHz) indicate this PR improves Transformer training performance by approximately **10%** (seconds per iteration reduced from **3.60** to **3.21**). Considering the fact that `bmm()` takes only **14%** of the total time, 10% overall improvement indicates `bmm()` itself improves by roughly **3x**.

Before:
```
| epoch 001:   0%| | 43/25337 [02:34<25:17:11,  3.60s/it, loss=16.179, nll_loss=16.137, ppl=72045.59, wps=1320, ups=0, wpb=4758.767, bsz=136.558, num_updates=43, lr=6.45e-06, gnorm=6.88
```

After:
```
| epoch 001:   0%| | 23/25337 [01:13<22:32:48,  3.21s/it, loss=17.072, nll_loss=17.068, ppl=137419.42, wps=1478, ups=0, wpb=4746.870, bsz=128.348, num_updates=23, lr=3.45e-06, gnorm=10.
```