### PR TITLE
[ROCm] enable ROCm 2.4 for the CI docker images

### DIFF
--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -76,8 +76,8 @@ install_centos() {
                    rocsparse \
                    hipsparse \
                    rocrand \
-                   rccl \
-                   Thrust
+                   hip-thrust \
+                   rccl
 }
  
 # Install Python packages depending on the base OS


### PR DESCRIPTION
With ROCm 2.4, the yum package name for hip-thrust is consistent with the deb one.

