### PR TITLE
[easy] profiler: improve repr for averaged events

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -564,8 +564,16 @@ class FunctionEventAvg(FormattedTimesMixin):
         return self
 
     def __repr__(self):
-        return '<FunctionEventAvg cpu_time={} cuda_time={} key={}>'.format(
-            self.cpu_time_str, self.cuda_time_str, self.key)
+        return (
+            '<FunctionEventAvg key={} self_cpu_time={} cpu_time={} '
+            'cuda_time={} input_shapes={}>'.format(
+                self.key,
+                self.self_cpu_time_total_str,
+                self.cpu_time_str,
+                self.cuda_time_str,
+                str(self.input_shapes),
+            )
+        )
 
 
 ################################################################################


### PR DESCRIPTION
Summary:
This is how it looks like now:

```
<FunctionEventAvg key=mm self_cpu_time=11.404s cpu_time=2.895ms
cuda_time=0.000us input_shapes=[[26, 4096], [4096, 1024]]>
```

Before I forgot to update the repr for these when updated it for not
averaged events

Differential Revision: D15262862

