### PR TITLE
error instead of crashing on attempt to subclass typed tensors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11334,7 +11334,7 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         class Foo2(torch.Tensor):
             def foo(self):
                 return 5
-        f = Foo()
+        f = Foo2()
         self.assertEqual(f.foo(), 5)
 
 # Functions to test negative dimension wrapping

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11324,6 +11324,18 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
                 weight), torch.tensor(bias), 1, epsilon, True)
         torch.testing.assert_allclose(expected_norm, actual_norm)
 
+    def test_subclass_tensors(self):
+        # raise an error when trying to subclass FloatTensor
+        with self.assertRaisesRegex(TypeError, "type 'torch.FloatTensor' is not an acceptable base type"):
+            class Foo(torch.FloatTensor):
+                pass
+        # but allow subclassing Tensor:
+        class Foo(torch.Tensor):
+            def foo(self):
+                return 5
+        f=Foo()
+        self.assertEqual(f.foo(), 5)
+
 # Functions to test negative dimension wrapping
 METHOD = 1
 INPLACE_METHOD = 2

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11327,13 +11327,14 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
     def test_subclass_tensors(self):
         # raise an error when trying to subclass FloatTensor
         with self.assertRaisesRegex(TypeError, "type 'torch.FloatTensor' is not an acceptable base type"):
-            class Foo(torch.FloatTensor):
+            class Foo1(torch.FloatTensor):
                 pass
+
         # but allow subclassing Tensor:
-        class Foo(torch.Tensor):
+        class Foo2(torch.Tensor):
             def foo(self):
                 return 5
-        f=Foo()
+        f = Foo()
         self.assertEqual(f.foo(), 5)
 
 # Functions to test negative dimension wrapping

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -159,7 +159,9 @@ static void py_initialize_tensor_type(PyTypeObject& type, const char* name, PyOb
   ((PyObject*)&type)->ob_refcnt = 1;
   ((PyObject*)&type)->ob_type = &metaclass;
   type.tp_basicsize = sizeof(PyTensorType);
-  type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+  // Subclassing from torch.<ScalarType>Tensor isn't supported.
+  // (Py_TPFLAGS_BASETYPE omitted). Subclassing torch.Tensor still allowed.
+  type.tp_flags = Py_TPFLAGS_DEFAULT;
   type.tp_name = name;
   type.tp_new = Tensor_new;
   if (PyType_Ready(&type) < 0) {


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/20052

typed tensors (e.g. torch.FloatTensor) can't be subclassed. Was causing
crashes and other errors.

