### PR TITLE
Only record grad_fn in C++ Scatter and Gather when required so

### DIFF
--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -59,8 +59,9 @@ variable_list Scatter::apply(variable_list&& inputs) {
     }
   }
 
-  if (grad_fn)
+  if (grad_fn) {
     set_history(variables, grad_fn);
+  }
 
   return variables;
 }
@@ -121,8 +122,9 @@ variable_list Gather::apply(variable_list&& inputs) {
   const auto destination_index =
       destination_device_.is_cpu() ? -1 : destination_device_.index();
   auto variable = torch::cuda::gather(tensors, dim_, destination_index);
-  if (grad_fn)
+  if (grad_fn) {
     set_history(variable, grad_fn);
+  }
   return {variable};
 }
 

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -59,7 +59,8 @@ variable_list Scatter::apply(variable_list&& inputs) {
     }
   }
 
-  set_history(variables, grad_fn);
+  if (grad_fn)
+    set_history(variables, grad_fn);
 
   return variables;
 }
@@ -120,7 +121,8 @@ variable_list Gather::apply(variable_list&& inputs) {
   const auto destination_index =
       destination_device_.is_cpu() ? -1 : destination_device_.index();
   auto variable = torch::cuda::gather(tensors, dim_, destination_index);
-  set_history(variable, grad_fn);
+  if (grad_fn)
+    set_history(variable, grad_fn);
   return {variable};
 }
 


### PR DESCRIPTION
C++ `Scatter` and `Gather` always set autograd history for input data tensors regardless whether they require grad. This hits assertion failure in `set_history(Tensor, shared_ptr<Function> grad_fn)`
where `grad_fn` cannot be nullptr. After this PR, C++ `Scatter` and `Gather` only record `grad_fn` when required.

