### PR TITLE
Speed up RecordFunction with sampled callbacks

### DIFF
--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -708,10 +708,10 @@ void testRecordFunction() {
   auto jit_inputs = traced_inputs;
   traced_inputs.clear();
 
+  autograd::profiler::popCallback();
+
   checkTracedInputs(eager_inputs);
   checkTracedInputs(jit_inputs);
-
-  autograd::profiler::popCallback();
 }
 
 void testAutogradProfiler() {

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -691,7 +691,6 @@ void testRecordFunction() {
             std::make_tuple(std::string(getFullName(&fn)), sizes));
       }, [](const autograd::profiler::RecordFunction&) {}, true);
 
-  autograd::profiler::setSampledCallbacks(true);
   autograd::profiler::setSamplingProbability(1.0);
 
   auto t = torch::randn({1, 2, 3}, at::kCPU);

--- a/test/cpp/jit/test_misc.h
+++ b/test/cpp/jit/test_misc.h
@@ -691,26 +691,25 @@ void testRecordFunction() {
             std::make_tuple(std::string(getFullName(&fn)), sizes));
       }, [](const autograd::profiler::RecordFunction&) {}, true);
 
-  for (auto iter = 0; iter < 2; ++iter) {
-    autograd::profiler::setLazyInputsCopy(iter == 0);
+  autograd::profiler::setSampledCallbacks(true);
+  autograd::profiler::setSamplingProbability(1.0);
 
-    auto t = torch::randn({1, 2, 3}, at::kCPU);
-    t.set_requires_grad(true);
-    auto t2 = invokeTestRecordFunction(t);
-    t2.backward();
-    auto eager_inputs = traced_inputs;
-    traced_inputs.clear();
+  auto t = torch::randn({1, 2, 3}, at::kCPU);
+  t.set_requires_grad(true);
+  auto t2 = invokeTestRecordFunction(t);
+  t2.backward();
+  auto eager_inputs = traced_inputs;
+  traced_inputs.clear();
 
-    t = torch::randn({1, 2, 3}, at::kCPU);
-    t.set_requires_grad(true);
-    t2 = invokeTestRecordFunctionJIT(t);
-    t2.backward();
-    auto jit_inputs = traced_inputs;
-    traced_inputs.clear();
+  t = torch::randn({1, 2, 3}, at::kCPU);
+  t.set_requires_grad(true);
+  t2 = invokeTestRecordFunctionJIT(t);
+  t2.backward();
+  auto jit_inputs = traced_inputs;
+  traced_inputs.clear();
 
-    checkTracedInputs(eager_inputs);
-    checkTracedInputs(jit_inputs);
-  }
+  checkTracedInputs(eager_inputs);
+  checkTracedInputs(jit_inputs);
 
   autograd::profiler::popCallback();
 }

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -8,6 +8,7 @@ std::vector<RecordFunctionCallback> start_callbacks;
 std::vector<RecordFunctionCallback> end_callbacks;
 size_t callback_needs_inputs = 0;
 thread_local RecordFunction* thread_local_func_ = nullptr;
+bool lazy_inputs_copy = false;
 }
 
 void pushCallback(
@@ -38,6 +39,14 @@ bool hasCallbacks() {
 
 bool needsInputs() {
   return callback_needs_inputs > 0;
+}
+
+bool isLazyInputsCopy() {
+  return lazy_inputs_copy;
+}
+
+void setLazyInputsCopy(bool is_lazy) {
+  lazy_inputs_copy = is_lazy;
 }
 
 void RecordFunction::before(const char* name, int64_t sequence_nr) {
@@ -84,6 +93,9 @@ void RecordFunction::processCallbacks() {
   for (const auto& cb : start_callbacks) {
     cb(*this);
   }
+
+  // inputs callback is unavailable after start callbacks are called
+  inputs_cb_ = nullptr;
 }
 
 RecordFunction::~RecordFunction() {

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -16,11 +16,6 @@ double sampling_prob = 1.0;
 constexpr double kEps = 1e-10;
 }
 
-bool checkCallbacksEnabled() {
-  return !is_sampled_callbacks ||
-      (((double) std::rand() / RAND_MAX) < sampling_prob);
-}
-
 void setSamplingProbability(double prob) {
   if (std::abs(prob - 1.0) < kEps) {
     is_sampled_callbacks = false;
@@ -29,6 +24,14 @@ void setSamplingProbability(double prob) {
     is_sampled_callbacks = true;
   }
   sampling_prob = prob;
+}
+
+double getSamplingProbability() {
+  return sampling_prob;
+}
+
+bool checkCallbacksSampled() {
+  return is_sampled_callbacks;
 }
 
 void pushCallback(

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -8,7 +8,9 @@ std::vector<RecordFunctionCallback> start_callbacks;
 std::vector<RecordFunctionCallback> end_callbacks;
 size_t callback_needs_inputs = 0;
 thread_local RecordFunction* thread_local_func_ = nullptr;
-bool lazy_inputs_copy = false;
+
+bool is_sampled_callbacks = false;
+double sampling_prob = 1.0;
 }
 
 void pushCallback(
@@ -41,12 +43,20 @@ bool needsInputs() {
   return callback_needs_inputs > 0;
 }
 
-bool isLazyInputsCopy() {
-  return lazy_inputs_copy;
+bool isSampledCallbacks() {
+  return is_sampled_callbacks;
 }
 
-void setLazyInputsCopy(bool is_lazy) {
-  lazy_inputs_copy = is_lazy;
+void setSampledCallbacks(bool is_sampled) {
+  is_sampled_callbacks = is_sampled;
+}
+
+double getSamplingProbability() {
+  return sampling_prob;
+}
+
+void setSamplingProbability(double prob) {
+  sampling_prob = prob;
 }
 
 void RecordFunction::before(const char* name, int64_t sequence_nr) {
@@ -93,9 +103,6 @@ void RecordFunction::processCallbacks() {
   for (const auto& cb : start_callbacks) {
     cb(*this);
   }
-
-  // inputs callback is unavailable after start callbacks are called
-  inputs_cb_ = nullptr;
 }
 
 RecordFunction::~RecordFunction() {

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -11,6 +11,22 @@ thread_local RecordFunction* thread_local_func_ = nullptr;
 
 bool is_sampled_callbacks = false;
 double sampling_prob = 1.0;
+constexpr double kEps = 1e-10;
+}
+
+bool checkCallbacksEnabled() {
+  return !is_sampled_callbacks ||
+      (((double) std::rand() / RAND_MAX) < sampling_prob);
+}
+
+void setSamplingProbability(double prob) {
+  if (std::abs(prob - 1.0) < kEps) {
+    is_sampled_callbacks = false;
+  } else {
+    AT_CHECK(prob > -kEps && prob < 1.0);
+    is_sampled_callbacks = true;
+  }
+  sampling_prob = prob;
 }
 
 void pushCallback(
@@ -41,22 +57,6 @@ bool hasCallbacks() {
 
 bool needsInputs() {
   return callback_needs_inputs > 0;
-}
-
-bool isSampledCallbacks() {
-  return is_sampled_callbacks;
-}
-
-void setSampledCallbacks(bool is_sampled) {
-  is_sampled_callbacks = is_sampled;
-}
-
-double getSamplingProbability() {
-  return sampling_prob;
-}
-
-void setSamplingProbability(double prob) {
-  sampling_prob = prob;
 }
 
 void RecordFunction::before(const char* name, int64_t sequence_nr) {

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/autograd/record_function.h>
 #include <torch/csrc/autograd/function.h>
 
+#include <cstdlib>
+
 namespace torch { namespace autograd { namespace profiler {
 
 namespace {

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -4,8 +4,6 @@
 #include <c10/util/SmallVector.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
-#include <cstdlib>
-
 namespace torch { namespace autograd {
 
 struct Function;

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -111,7 +111,7 @@ TORCH_API bool isLazyInputsCopy();
 TORCH_API void setLazyInputsCopy(bool);
 
 inline std::vector<c10::IValue> toVec(std::vector<c10::IValue>&& vec) {
-  return vec;
+  return std::move(vec);
 }
 
 inline std::vector<c10::IValue> toVec(c10::ArrayRef<c10::IValue> vec_ref) {
@@ -124,7 +124,7 @@ inline std::vector<c10::IValue> toVec(c10::ArrayRef<c10::IValue> vec_ref) {
   if (torch::autograd::profiler::hasCallbacks()) { \
     if (torch::autograd::profiler::needsInputs()) { \
       if (torch::autograd::profiler::isLazyInputsCopy()) { \
-        guard.before(fn, [&](){ return torch::autograd::profiler::toVec(inputs); }, ##__VA_ARGS__); \
+        guard.before(fn, [&](){ return torch::autograd::profiler::toVec(std::move(inputs)); }, ##__VA_ARGS__); \
       } else { \
         guard.before(fn, inputs, ##__VA_ARGS__); \
       } \

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -94,17 +94,14 @@ struct TORCH_API RecordFunction {
 TORCH_API bool hasCallbacks();
 TORCH_API bool needsInputs();
 
-TORCH_API bool isSampledCallbacks();
-TORCH_API void setSampledCallbacks(bool);
-TORCH_API double getSamplingProbability();
 TORCH_API void setSamplingProbability(double);
+TORCH_API bool checkCallbacksEnabled();
 
 // optional argument - function's seq_no
 #define RECORD_FUNCTION(fn, inputs, ...) \
   torch::autograd::profiler::RecordFunction guard; \
   if (torch::autograd::profiler::hasCallbacks()) { \
-    if (!torch::autograd::profiler::isSampledCallbacks() || \
-        (((double) std::rand() / RAND_MAX) < torch::autograd::profiler::getSamplingProbability())) { \
+    if (torch::autograd::profiler::checkCallbacksEnabled()) { \
       if (torch::autograd::profiler::needsInputs()) { \
         guard.before(fn, inputs, ##__VA_ARGS__); \
       } else { \

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -93,7 +93,7 @@ TORCH_API bool hasCallbacks();
 TORCH_API bool needsInputs();
 
 TORCH_API void setSamplingProbability(double);
-TORCH_API bool checkCallbacksEnabled();
+bool checkCallbacksEnabled();
 
 // optional argument - function's seq_no
 #define RECORD_FUNCTION(fn, inputs, ...) \

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -93,7 +93,7 @@ TORCH_API bool hasCallbacks();
 TORCH_API bool needsInputs();
 
 TORCH_API void setSamplingProbability(double);
-bool checkCallbacksEnabled();
+TORCH_API bool checkCallbacksEnabled();
 
 // optional argument - function's seq_no
 #define RECORD_FUNCTION(fn, inputs, ...) \

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -93,7 +93,13 @@ TORCH_API bool hasCallbacks();
 TORCH_API bool needsInputs();
 
 TORCH_API void setSamplingProbability(double);
-TORCH_API bool checkCallbacksEnabled();
+TORCH_API double getSamplingProbability();
+TORCH_API bool checkCallbacksSampled();
+
+inline bool checkCallbacksEnabled() {
+  return !checkCallbacksSampled() ||
+      (((double) std::rand() / RAND_MAX) < getSamplingProbability());
+}
 
 // optional argument - function's seq_no
 #define RECORD_FUNCTION(fn, inputs, ...) \

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -4,6 +4,8 @@
 #include <c10/util/SmallVector.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
+#include <cstdlib>
+
 namespace torch { namespace autograd {
 
 struct Function;
@@ -54,15 +56,6 @@ struct TORCH_API RecordFunction {
     before(fn, current_sequence_nr);
   }
 
-  template<typename F>
-  void before(
-      F fn,
-      std::function<std::vector<c10::IValue>()> inputs_cb,
-      int64_t current_sequence_nr = -1) {
-    inputs_cb_ = inputs_cb;
-    before(fn, current_sequence_nr);
-  }
-
   // Destructor calls end callbacks
   virtual ~RecordFunction();
 
@@ -79,10 +72,6 @@ struct TORCH_API RecordFunction {
   }
 
   const std::vector<c10::IValue>& inputs() const {
-    if (inputs_cb_) {
-      inputs_ = inputs_cb_();
-      inputs_cb_ = nullptr;
-    }
     return inputs_;
   }
 
@@ -96,40 +85,31 @@ struct TORCH_API RecordFunction {
   Function* fn_ = nullptr;
   StringView name_;
   int64_t sequence_nr_ = -1;
+  std::vector<c10::IValue> inputs_;
   RecordFunction* parent_ = nullptr;
-
-  // lazy initialization
-  mutable std::vector<c10::IValue> inputs_;
-  mutable std::function<std::vector<c10::IValue>()> inputs_cb_;
 
   bool initialized_ = false;
 };
 
 TORCH_API bool hasCallbacks();
 TORCH_API bool needsInputs();
-TORCH_API bool isLazyInputsCopy();
-TORCH_API void setLazyInputsCopy(bool);
 
-inline std::vector<c10::IValue> toVec(std::vector<c10::IValue> vec) {
-  return vec;
-}
-
-inline std::vector<c10::IValue> toVec(c10::ArrayRef<c10::IValue> vec_ref) {
-  return vec_ref.vec();
-}
+TORCH_API bool isSampledCallbacks();
+TORCH_API void setSampledCallbacks(bool);
+TORCH_API double getSamplingProbability();
+TORCH_API void setSamplingProbability(double);
 
 // optional argument - function's seq_no
 #define RECORD_FUNCTION(fn, inputs, ...) \
   torch::autograd::profiler::RecordFunction guard; \
   if (torch::autograd::profiler::hasCallbacks()) { \
-    if (torch::autograd::profiler::needsInputs()) { \
-      if (torch::autograd::profiler::isLazyInputsCopy()) { \
-        guard.before(fn, [&](){ return torch::autograd::profiler::toVec(std::move(inputs)); }, ##__VA_ARGS__); \
-      } else { \
+    if (!torch::autograd::profiler::isSampledCallbacks() || \
+        (((double) std::rand() / RAND_MAX) < torch::autograd::profiler::getSamplingProbability())) { \
+      if (torch::autograd::profiler::needsInputs()) { \
         guard.before(fn, inputs, ##__VA_ARGS__); \
+      } else { \
+        guard.before(fn, ##__VA_ARGS__); \
       } \
-    } else { \
-      guard.before(fn, ##__VA_ARGS__); \
     } \
   }
 

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -110,8 +110,8 @@ TORCH_API bool needsInputs();
 TORCH_API bool isLazyInputsCopy();
 TORCH_API void setLazyInputsCopy(bool);
 
-inline std::vector<c10::IValue> toVec(std::vector<c10::IValue>&& vec) {
-  return std::move(vec);
+inline std::vector<c10::IValue> toVec(std::vector<c10::IValue> vec) {
+  return vec;
 }
 
 inline std::vector<c10::IValue> toVec(c10::ArrayRef<c10::IValue> vec_ref) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20307 Allow lazy initialization of inputs in RecordFunction**

Summary:
In production environment we typically use sampling and don't
require expensive input copying on every function call, this PR
enables lazy inputs copying, when actual RecordFunction callback
calls inputs()

Test Plan:
BLAS=MKL USE_MKLDNN=1 USE_OPENCV=1 USE_FFMPEG=1 python setup.py develop --cmake
./build/bin/test_jit --gtest_filter=JitTest.RecordFunction

Differential Revision: [D15276308](https://our.internmc.facebook.com/intern/diff/D15276308)