### PR TITLE
Fixed Softmax doc to specify dimension to prevent warning in 1.1.0.

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1109,7 +1109,7 @@ class Softmax(Module):
 
     Examples::
 
-        >>> m = nn.Softmax()
+        >>> m = nn.Softmax(dim=1)
         >>> input = torch.randn(2, 3)
         >>> output = m(input)
     """


### PR DESCRIPTION
See Issue #20301

Specifying dim in docstring example to prevent UserWarning.
