### PR TITLE
option to thrash cache in BenchmarkNet

### DIFF
--- a/caffe2/core/net.cc
+++ b/caffe2/core/net.cc
@@ -203,7 +203,8 @@ float NetBase::TEST_Benchmark_One_Run() {
 std::vector<float> NetBase::TEST_Benchmark(
     const int warmup_runs,
     const int main_runs,
-    const bool run_individual) {
+    const bool run_individual,
+    const BenchmarkCacheWipe wipe_cache = BenchmarkCacheWipe::NONE) {
   LOG(INFO) << "Starting benchmark, running warmup runs";
   CAFFE_ENFORCE(
       warmup_runs >= 0,
@@ -228,7 +229,7 @@ std::vector<float> NetBase::TEST_Benchmark(
             << millis / main_runs
             << ". Iters per second: " << 1000.0 * main_runs / millis;
 
-  if (run_individual) {
+  if (run_individual || wipe_cache) {
     LOG(INFO) << "Net does not support per-op benchmark; "
                  "to run it, switch to a simple net type";
   }

--- a/caffe2/core/net.h
+++ b/caffe2/core/net.h
@@ -32,6 +32,13 @@ typedef std::function<std::unique_ptr<NetObserver>(NetBase*)>
 class OperatorBase;
 class Workspace;
 
+/* During benchmarking, options for wiping the cache
+ * NONE -> No wiping cache
+ * OP -> Wipe before each operator profiling main run
+ * BENCH -> Wipe before each benchmark main run
+ */
+enum BenchmarkCacheWipe { NONE, OP, BENCH };
+
 // Net is a thin struct that owns all the operators together with the operator
 // contexts.
 class CAFFE2_API NetBase : public Observable<NetBase> {
@@ -81,7 +88,8 @@ class CAFFE2_API NetBase : public Observable<NetBase> {
   virtual vector<float> TEST_Benchmark(
       const int /*warmup_runs*/,
       const int /*main_runs*/,
-      const bool /*run_individual*/);
+      const bool /*run_individual*/,
+      const BenchmarkCacheWipe /*wipe_cache*/);
 
   inline const vector<string>& external_output() const {
     return external_output_;

--- a/caffe2/core/net_simple.h
+++ b/caffe2/core/net_simple.h
@@ -26,7 +26,8 @@ class CAFFE2_API SimpleNet : public NetBase {
   vector<float> TEST_Benchmark(
       const int warmup_runs,
       const int main_runs,
-      const bool run_individual) override;
+      const bool run_individual,
+      const BenchmarkCacheWipe wipe_cache = BenchmarkCacheWipe::NONE) override;
 
   /*
    * This returns a list of pointers to objects stored in unique_ptrs.

--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -37,6 +37,7 @@ RootFolder = C.root_folder
 Workspaces = C.workspaces
 BenchmarkNet = C.benchmark_net
 BenchmarkNetOnce = C.benchmark_net_once
+BenchmarkCacheWipe = C.BenchmarkCacheWipe
 GetStats = C.get_stats
 
 operator_tracebacks = defaultdict(dict)


### PR DESCRIPTION
Summary: Allocate memory before each run for op profiling in TEST_Benchmark to invalidate cache

Differential Revision: D15090886

