### PR TITLE
Avoid unnecessary refcount bump in unary operators.

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -136,7 +136,8 @@ Tensor& _sigmoid_out_cpu(Tensor& result, const Tensor& self) {
 #define IMPLEMENT_UNARY_OP_VEC(op)                              \
   Tensor op(const Tensor& self) {                               \
     Tensor result = at::empty({0}, self.options());             \
-    return at::op##_out(result, self);                          \
+    at::op##_out(result, self);                                 \
+    return result;                                              \
   }                                                             \
   Tensor& _##op##__cpu(Tensor& self) {                          \
     return at::op##_out(self, self);                            \
@@ -152,7 +153,8 @@ Tensor& _sigmoid_out_cpu(Tensor& result, const Tensor& self) {
 #define IMPLEMENT_UNARY_OP_TH(op)                               \
   Tensor op(const Tensor& self) {                               \
     Tensor result = at::empty({0}, self.options());             \
-    return at::op##_out(result, self);                          \
+    at::op##_out(result, self);                                 \
+    return result;                                              \
   }                                                             \
   Tensor& _##op##__cpu(Tensor& self) {                          \
     return at::op##_out(self, self);                            \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20331 Avoid unnecessary refcount bump in unary operators.**

If you convert a Tensor& to a Tensor, a copy-construction occurs
and you require a refcount bump.  If you just return the Tensor
on the stack, RVO applies and no refcount bump is necessary.

Signed-off-by: Edward Z. Yang <ezyang@mit.edu>

Differential Revision: [D15295193](https://our.internmc.facebook.com/intern/diff/D15295193)