### PR TITLE
[RFC] Make sure sparse tensor smm works after making VariableType unpack() call tensor_data()

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -732,8 +732,6 @@ SparseTensor& _sspaddmm_out_cpu(
   int64_t dim_j = sparse.size(1);
   int64_t dim_k = dense.size(1);
 
-  // NB: This has to occur before the checks, because r may alias t.
-  // See test_saddmm
   get_sparse_impl(r)->raw_resize_(2, 0, {dim_i, dim_k});
 
   AT_CHECK(dense.size(0) == dim_j,
@@ -823,7 +821,7 @@ Tensor& _sspaddmm_out_only_sparse(Tensor& result, const Tensor& self,
 
 // sparse, dense -> sparse
 Tensor smm(const Tensor& self, const Tensor& mat2) {
-  auto result = at::empty({0}, self.options());
+  auto result = at::_sparse_coo_tensor_with_dims(2, 0, {self.size(0), mat2.size(1)}, self.options());
   at::sspaddmm_out(result, result, self, mat2, 0.0, 1.0);
   return result;
 }


### PR DESCRIPTION
As part of the Variable/Tensor merge, we will make VariableType `unpack()` call `var.tensor_data()` to get the equivalent Tensor of a Variable. However, `var.tensor_data()` makes a shallow copy of `var`, and size changes to the shallow copy will not be reflected back to the original tensor. This causes problem in the `smm()` path. Consider the following example (`TestSparse.test_saddmm`):

```cpp
// aten/src/ATen/native/sparse/SparseTensorMath.cpp:827
Tensor smm(const Tensor& self, const Tensor& mat2) {
  auto result = at::empty({0}, self.options());
  // [MY COMMENT] Here, we expect the first arg and the second arg share the same tensor
  at::sspaddmm_out(result, result, self, mat2, 0.0, 1.0);
  return result;
}
```

```cpp
// torch/csrc/autograd/generated/VariableType_1.cpp:17480
Tensor & VariableType::sspaddmm_out(Tensor & out, const Tensor & self, const Tensor & mat1, const Tensor & mat2, Scalar beta, Scalar alpha) const {
  ...
  // [MY COMMENT] Since unpack() makes shallow copy, `out_` and `self_` are not pointing to the same tensor anymore
  auto out_ = unpack(out, "out", 0);
  auto self_ = unpack(self, "self", 1);
  ...
  {
    ...
    baseType->sspaddmm_out(out_, self_, mat1_, mat2_, beta, alpha);
  }
}
```

```cpp
// aten/src/ATen/native/sparse/SparseTensorMath.cpp:741
SparseTensor& _sspaddmm_out_cpu(
    SparseTensor& r,
    const SparseTensor& t,
    const SparseTensor& sparse_,
    const Tensor& dense,
    Scalar beta,
    Scalar alpha
) {
  ...
  // [original comment] NB: This has to occur before the checks, because r may alias t.
  // [original comment] See test_saddmm
  // [MY COMMENT] : Since r doesn't alias t anymore, resizing r will not resize t, which causes the size check to fail in subsequent lines.
  get_sparse_impl(r)->raw_resize_(2, 0, {dim_i, dim_k});
  ...
  // [MY COMMENT] This fails, because t is not resized along with r.
  AT_CHECK(t.size(0) == dim_i,
      "sspaddmm: Argument #1: Expected dim 0 size ", dim_i, ", got ", t.size(0));
  ...
}
```

One solution is to resize the `result` tensor in `smm()` properly before going into `at::sspaddmm_out()`, so that we don't need to rely on the tensor aliasing to have both `r` and `t` resized properly.