### PR TITLE
[RFC] Make SparseTensorRef the same as Tensor

### DIFF
--- a/aten/src/ATen/core/SparseTensorRef.h
+++ b/aten/src/ATen/core/SparseTensorRef.h
@@ -3,9 +3,6 @@
 namespace at {
 
 class Tensor;
-struct SparseTensorRef {
-  explicit SparseTensorRef(const Tensor& t): tref(t) {}
-  const Tensor& tref;
-};
+using SparseTensorRef = Tensor;
 
 }

--- a/aten/src/ATen/core/SparseTensorRef.h
+++ b/aten/src/ATen/core/SparseTensorRef.h
@@ -3,6 +3,6 @@
 namespace at {
 
 class Tensor;
-using SparseTensorRef = Tensor;
+using SparseTensorRef = const Tensor&;
 
 }

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -288,11 +288,6 @@ CHECKED_CAST = {
             'checked_tensor_unwrap('
             '${arg_name},"${arg_name}",${arg_pos}, ${null_okay}, '
             'Backend::${Backend}, ScalarType::${ScalarName})'),
-    'THSTensor*':
-        CodeTemplate(
-            'checked_tensor_unwrap('
-            '${arg_name},"${arg_name}",${arg_pos},false, '
-            'Backend::${Backend}, ScalarType::${ScalarName})'),
     'THByteTensor*':
         CodeTemplate(
             'checked_tensor_unwrap('

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -291,7 +291,7 @@ CHECKED_CAST = {
     'THSTensor*':
         CodeTemplate(
             'checked_tensor_unwrap('
-            '${arg_name}.tref,"${arg_name}",${arg_pos},false, '
+            '${arg_name},"${arg_name}",${arg_pos},false, '
             'Backend::${Backend}, ScalarType::${ScalarName})'),
     'THByteTensor*':
         CodeTemplate(

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -499,7 +499,7 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
 
 SparseTensor sparse_mask_cpu(const Tensor& t, SparseTensorRef mask) {
   SparseTensor r = at::empty({0}, t.options().layout(kSparse));
-  sparse_mask_out_cpu(r, t, mask.tref);
+  sparse_mask_out_cpu(r, t, mask);
   return r;
 }
 

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -329,7 +329,7 @@ void add_dense_sparse_worker_cpu(Tensor& r, Scalar value, const SparseTensor& sp
 }
 
 Tensor& add_out_dense_sparse_cpu(Tensor& r, const Tensor& dense, SparseTensorRef sparse__, Scalar value) {
-  const SparseTensor& sparse_ = sparse__.tref;
+  const SparseTensor& sparse_ = sparse__;
 
   AT_ASSERT(!r.is_sparse());
   AT_ASSERT(!dense.is_sparse());

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cpp
@@ -55,7 +55,7 @@ SparseTensor& sparse_mask_out_cuda(SparseTensor& r, const Tensor& t, const Spars
 
 SparseTensor sparse_mask_cuda(const Tensor& t, SparseTensorRef mask) {
   SparseTensor r = at::empty({0}, t.options().layout(kSparse));
-  sparse_mask_out_cuda(r, t, mask.tref);
+  sparse_mask_out_cuda(r, t, mask);
   return r;
 }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -249,7 +249,7 @@ SparseTensor hspmm_sparse_cuda(const SparseTensor& sparse, const Tensor& dense) 
 // --------------------------------------------------------------------
 
 Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, SparseTensorRef sparse_, at::Scalar value) {
-  const SparseTensor& sparse = sparse_.tref;
+  const SparseTensor& sparse = sparse_;
 
   AT_ASSERT(dense.is_cuda()); // dispatch argument
   AT_CHECK(sparse.is_cuda(), "add: expected 'other' to be CUDA, but got CPU");

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -671,7 +671,7 @@ def emit_body(declaration):
         res = []
         for arg in args:
             if arg['type'] == 'SparseTensorRef':
-                res.append('{}.tref'.format(arg['name']))
+                res.append('{}'.format(arg['name']))
             else:
                 res.append(arg['name'])
         return res

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -64,7 +64,6 @@ private:
   static Variable & checked_cast_variable(Tensor & t, const char * name, int pos);
   static at::Tensor & unpack(Tensor & t, const char * name, int pos);
   static const at::Tensor & unpack(const Tensor & t, const char * name, int pos);
-  static at::SparseTensorRef unpack(SparseTensorRef t, const char * name, int pos);
   static at::Tensor unpack_opt(const Tensor & t, const char * name, int pos);
   static std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos);
 

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -183,10 +183,6 @@ Tensor & VariableType::unpack(Tensor & t, const char * name, int pos) {
   return checked_cast_variable(t, name, pos).data();
 }
 
-SparseTensorRef VariableType::unpack(SparseTensorRef t, const char * name, int pos) {
-  return SparseTensorRef(checked_cast_variable(t.tref, name, pos).data());
-}
-
 Tensor VariableType::unpack_opt(const Tensor & t, const char * name, int pos) {
   if (!t.defined()) {
     return Tensor();

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -430,9 +430,6 @@ void addInputs(Node* n, const char* name, const std::string& value) {
 void addInputs(Node* n, const char* name, const at::Tensor& value) {
   n->addInput(getValueTrace(value));
 }
-void addInputs(Node* n, const char* name, const at::SparseTensorRef& value) {
-  detail::badArgType(value);
-}
 void addInputs(Node* n, const char* name, at::Generator* value) {
   if (value) {
     detail::badArgType(value);

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -136,10 +136,6 @@ TORCH_API void addInputs(Node* n, const char* name, const std::string& value);
 TORCH_API void addInputs(
     Node* n,
     const char* name,
-    const at::SparseTensorRef& value);
-TORCH_API void addInputs(
-    Node* n,
-    const char* name,
     const at::TensorOptions& value);
 TORCH_API void addInputs(Node* n, const char* name, at::Device value);
 TORCH_API void addInputs(Node* n, const char* name, at::Layout value);


### PR DESCRIPTION
As part of the Variable/Tensor merge, we will make VariableType `unpack()` call `var.tensor_data()` to get the equivalent Tensor of a Variable. Under the hood, `var.tensor_data()` return a temporary object which is a shallow copy of `var`. This causes problem with the sparse tensor version of `unpack()`:
```cpp
// torch/csrc/autograd/VariableTypeManual.cpp
SparseTensorRef VariableType::unpack(SparseTensorRef t, const char * name, int pos) {
  return SparseTensorRef(checked_cast_variable(t.tref, name, pos).tensor_data());
}
```
```cpp
// aten/src/ATen/core/SparseTensorRef.h
class Tensor;
struct SparseTensorRef {
  explicit SparseTensorRef(const Tensor& t): tref(t) {}
  const Tensor& tref;
};
```
In the first code block for `unpack()`, `.tensor_data()` returns a temporary object, but since SparseTensorRef only stores a const reference of Tensor `tref` (which doesn't extend the lifetime of a temporary according to https://stackoverflow.com/questions/2784262/does-a-const-reference-class-member-prolong-the-life-of-a-temporary), after `unpack()` is done, the tensor referenced by SparseTensorRef `tref` is gone, and accessing the returned value of `unpack()` will result in error. One example of such failure is in `VariableType::sparse_mask`:

```cpp
Tensor VariableType::sparse_mask(const Tensor & self, SparseTensorRef mask) const {
  ...
  auto mask_ = unpack(mask, "mask", 1);
  std::cout << "mask_: " << mask_.tref << std::endl;  // This segfaults! Because `tref` can't hold a temporary object
  ...
}
```

One solution to this is to make SparseTensorRef the same as Tensor, and allow sparse tensors to be passed around using the Tensor class. The reasoning is that since Tensor is just wrapper of TensorImpl, and copying a Tensor doesn't deep copy the underlying TensorImpl, there should be no need to have another SparseTensorRef wrapper class that wraps the Tensor, which will also solve the problem we encounter here.