### PR TITLE
Make sure advanced pooling is not used when fp16 training is enabled

### DIFF
--- a/caffe2/python/layers/sparse_lookup.py
+++ b/caffe2/python/layers/sparse_lookup.py
@@ -58,6 +58,10 @@ class SparseLookup(ModelLayer):
         'Float16UniformFill'
     ]
 
+    _fp16_compatible_reducers = [
+        'Sum', 'Mean', 'Sqrt', 'PositionWeighted'
+    ]
+
     def __init__(self, model, input_record, inner_shape, reducer,
                  weight_init=None, weight_optim=None,
                  name='sparse_lookup', regularizer=None, **kwargs):
@@ -105,6 +109,14 @@ class SparseLookup(ModelLayer):
 
         # If fp16 is used, make sure fp16 init op is used
         if self.trainer_version == "fp16":
+            assert self.reducer in self._fp16_compatible_reducers, (
+                "Fp16 training is enabled. The reducer specified is not supported. "
+                "Got {}. Supported reducers: {}. Right now, in general, sum, mean, "
+                "positional pooling are supported. Attention is not. Please check "
+                "if there is fp16 trained sparse features using advanced pooling.".format(
+                    self.reducer, self._fp16_compatible_reducers)
+            )
+
             # if init op is UniformFill, we replace it directly
             if self.weight_init[0] == "UniformFill":
                 self.weight_init = ("Float16UniformFill", self.weight_init[1])


### PR DESCRIPTION


Differential Revision: D15291545

