### PR TITLE
[jit] Convenience APIs for script objects

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -114,6 +114,16 @@ std::string ivalue::Object::name() const {
   return this->type_->qualname();
 }
 
+IValue ivalue::Object::getAttr(const std::string& name) const {
+  const size_t slot = type_->getAttributeSlot(name);
+  return getSlot(slot);
+}
+
+void ivalue::Object::setAttr(const std::string& name, IValue v) {
+  const size_t slot = type_->getAttributeSlot(name);
+  setSlot(slot, std::move(v));
+}
+
 void ivalue::Object::resizeObject(size_t slot) {
   AT_ASSERT(slot < type()->numAttributes());
   slots_.resize(type()->numAttributes());

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -157,6 +157,8 @@ TypePtr incompleteInferTypeFrom(const IValue& value) {
     return TupleType::create(fmap(value.toTuple()->elements(), incompleteInferTypeFrom));
   } else if (value.isDevice()) {
     return DeviceObjType::get();
+  } else if (value.isObject()) {
+    return value.toObject()->type();
   }
   AT_ERROR("Type cannot be accurately recovered from this IValue.");
 }

--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -80,7 +80,8 @@ namespace jit {
   _(SubgraphMatching)              \
   _(ModuleDefine)                  \
   _(QualifiedName)                 \
-  _(ClassImport)
+  _(ClassImport)                   \
+  _(ScriptObject)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/test_class_import.h
+++ b/test/cpp/jit/test_class_import.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <ATen/core/qualified_name.h>
 #include <test/cpp/jit/test_base.h>
+#include <test/cpp/jit/test_utils.h>
+
+#include <ATen/core/qualified_name.h>
 #include <torch/csrc/jit/import_source.h>
+#include <torch/torch.h>
 
 namespace torch {
 namespace jit {
@@ -13,10 +16,12 @@ op_version_set = 1
 class FooNestedTest:
     def __init__(self, y):
         self.y = y
+
 class FooNestedTest2:
     def __init__(self, y):
         self.y = y
         self.nested = __torch__.FooNestedTest(y)
+
 class FooTest:
     def __init__(self, x):
         self.class_attr = __torch__.FooNestedTest(x)
@@ -56,6 +61,36 @@ void testClassImport() {
 
   c = cu2.get_class(c10::QualifiedName(base, "FooNestedTest"));
   ASSERT_FALSE(c);
+}
+
+void testScriptObject() {
+  Module m1;
+  Module m2;
+  std::vector<at::Tensor> constantTable;
+  import_libs(
+      m1.class_compilation_unit(),
+      "__torch__",
+      classSrcs1,
+      constantTable,
+      nullptr);
+  import_libs(
+      m2.class_compilation_unit(),
+      "__torch__",
+      classSrcs2,
+      constantTable,
+      nullptr);
+
+  // Incorrect arguments for constructor should throw
+  c10::QualifiedName base("__torch__");
+  ASSERT_ANY_THROW(m1.create_class(c10::QualifiedName(base, "FooTest"), {1}));
+  auto x = torch::ones({2, 3});
+  auto obj = m2.create_class(c10::QualifiedName(base, "FooTest"), x).toObject();
+  ASSERT_TRUE(test::almostEqual(x, dx.toTensor()));
+
+  auto new_x = torch::rand({2, 3});
+  obj->setAttr("dx", new_x);
+  auto new_dx = obj->getAttr("dx");
+  ASSERT_TRUE(test::almostEqual(new_x, new_dx.toTensor()));
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -442,6 +442,14 @@ struct TORCH_API Module {
   // so that C++ users can easily add methods
   void define(const std::string& src, const ResolverPtr& resolver = nullptr);
 
+  template <typename... Types>
+  IValue create_class(const c10::QualifiedName& name, Types&&... args)
+      const {
+    return create_class(name, {IValue(std::forward<Types>(args))...});
+  }
+
+  IValue create_class(const c10::QualifiedName& name, Stack stack) const;
+
  private:
   std::pair<std::shared_ptr<Function>, std::vector<Slot>>
   lower_first_class_method(Function* fn);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20352 [jit] Convenience APIs for script objects**

The compiler should be emitting static lookups to object slots, but
people using the C++ API should have some sugar for doing attribute
lookup.