### PR TITLE
quantize_rnn_modules in ensemble_export

### DIFF
--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -378,7 +378,7 @@ class QuantizedLSTM(QuantizedRNNBase):
         self.check_forward_args(input, hx, batch_sizes)
         assert batch_sizes is None
         result = _VF.quantized_lstm(input, hx, self._get_all_weights(), self.bias, self.num_layers,
-                                    self.dropout, self.training, self.bidirectional,
+                                    float(self.dropout), self.training, self.bidirectional,
                                     self.batch_first)
 
         output = result[0]


### PR DESCRIPTION
Summary: Enable quantization of `torch.nn.LSTM` module in the decoder of PyTorch natively exported beam search models.

Differential Revision: D15260631

