### PR TITLE
Avoid dynamic dispatch inside the omp loop in AdaptiveAvgPool2d

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -18,7 +18,7 @@ namespace {
   }
 
   template <typename scalar_t>
-  static void adaptive_avg_pool2d_out_frame(
+  static void adaptive_avg_pool2d_single_out_frame(
             scalar_t *input_p,
             scalar_t *output_p,
             int64_t sizeD,
@@ -71,6 +71,38 @@ namespace {
     });
   }
 
+  template <typename scalar_t>
+  void adaptive_avg_pool2d_out_frame(
+    scalar_t *input_p,
+    scalar_t *output_p,
+    int64_t sizeB,
+    int64_t sizeD,
+    int64_t isizeH,
+    int64_t isizeW,
+    int64_t osizeH,
+    int64_t osizeW,
+    int64_t istrideB,
+    int64_t istrideD,
+    int64_t istrideH,
+    int64_t istrideW)
+  {
+    at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
+      for (auto b = start; b < end; b++)
+      {
+        auto input_data = input_p + b *istrideB;
+        auto output_data = output_p + b * sizeD * osizeH * osizeW;
+        adaptive_avg_pool2d_single_out_frame<scalar_t>(
+          input_data,
+          output_data,
+          sizeD,
+          isizeH, isizeW,
+          osizeH, osizeW,
+          istrideD,
+          istrideH, istrideW);
+      }
+    });
+  }
+
   void adaptive_avg_pool2d_out_cpu_template(
     at::Tensor& output,
     at::Tensor const& input,
@@ -106,7 +138,7 @@ namespace {
       AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
           auto input_data = input.data<scalar_t>();
           auto output_data = output.data<scalar_t>();
-          adaptive_avg_pool2d_out_frame<scalar_t>(input_data, output_data,
+          adaptive_avg_pool2d_single_out_frame<scalar_t>(input_data, output_data,
                                                   sizeD,
                                                   isizeH, isizeW,
                                                   osizeH, osizeW,
@@ -118,28 +150,24 @@ namespace {
     else
     {
       output.resize_({input.size(-4), sizeD, osizeH, osizeW});
+      int64_t sizeB = input.size(0);
+      int64_t istrideB = input.stride(0);
 
-      at::parallel_for(0, input.size(0), 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++)
-        {
-          AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
-              auto input_data = input.data<scalar_t>();
-              auto output_data = output.data<scalar_t>();
-              adaptive_avg_pool2d_out_frame<scalar_t>(input_data+b*input.stride(0), output_data+b*sizeD*osizeH*osizeW,
-                                                      sizeD,
-                                                      isizeH, isizeW,
-                                                      osizeH, osizeW,
-                                                      istrideD,
-                                                      istrideH, istrideW);
-            }
-          );
-        }
+      AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "adaptive_avg_pool2d_cpu", [&] {
+        auto input_data = input.data<scalar_t>();
+        auto output_data = output.data<scalar_t>();
+        adaptive_avg_pool2d_out_frame<scalar_t>(input_data, output_data,
+                                                sizeB, sizeD,
+                                                isizeH, isizeW,
+                                                osizeH, osizeW,
+                                                istrideB, istrideD,
+                                                istrideH, istrideW);
       });
     }
   }
 
   template <typename scalar_t>
-  static void adaptive_avg_pool2d_backward_out_frame(
+  static void adaptive_avg_pool2d_backward_single_out_frame(
     scalar_t *gradInput_p,
     scalar_t *gradOutput_p,
     int64_t sizeD,
@@ -186,6 +214,30 @@ namespace {
     });
   }
 
+  template <typename scalar_t>
+  void adaptive_avg_pool2d_backward_out_frame(
+    scalar_t *gradInput_p,
+    scalar_t *gradOutput_p,
+    int64_t sizeB,
+    int64_t sizeD,
+    int64_t isizeH,
+    int64_t isizeW,
+    int64_t osizeH,
+    int64_t osizeW)
+  {
+    at::parallel_for(0, sizeB, 0, [&](int64_t start, int64_t end) {
+      for (auto b = 0; b < end; b++)
+      {
+        scalar_t *gradInput_p = gradInput_p + d
+        adaptive_avg_pool2d_backward_single_out_frame(
+          gradInput_data+b*sizeD*isizeH*isizeW, gradOutput_data+b*sizeD*osizeH*osizeW,
+          sizeD,
+          isizeH, isizeW,
+          osizeH, osizeW);
+      }
+    });
+  }
+
   Tensor& adaptive_avg_pool2d_backward_out_cpu_template(
     Tensor& gradInput,
     const Tensor& gradOutput_,
@@ -210,7 +262,7 @@ namespace {
           scalar_t *gradInput_data = gradInput.data<scalar_t>();
           scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
 
-          adaptive_avg_pool2d_backward_out_frame<scalar_t>(
+          adaptive_avg_pool2d_backward_single_out_frame<scalar_t>(
             gradInput_data, gradOutput_data,
             sizeD,
             isizeH, isizeW,
@@ -220,24 +272,19 @@ namespace {
     }
     else
     {
-      at::parallel_for(0, input.size(0), 0, [&](int64_t start, int64_t end) {
-        for (auto b = start; b < end; b++)
-        {
-          AT_DISPATCH_FLOATING_TYPES(
-            input.scalar_type(), "adaptive_avg_pool2d_backward_cpu", [&] {
-              /* get raw pointers */
-              scalar_t *gradInput_data = gradInput.data<scalar_t>();
-              scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
+      AT_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "adaptive_avg_pool2d_backward_cpu", [&] {
+          /* get raw pointers */
+          scalar_t *gradInput_data = gradInput.data<scalar_t>();
+          scalar_t *gradOutput_data = gradOutput.data<scalar_t>();
 
-              adaptive_avg_pool2d_backward_out_frame<scalar_t>(
-                gradInput_data+b*sizeD*isizeH*isizeW, gradOutput_data+b*sizeD*osizeH*osizeW,
-                sizeD,
-                isizeH, isizeW,
-                osizeH, osizeW);
-            }
-          );
+          adaptive_avg_pool2d_backward_out_frame<scalar_t>(
+            gradInput_data, gradOutput_data,
+            sizeB, sizeD,
+            isizeH, isizeW,
+            osizeH, osizeW);
         }
-      });
+      );
     }
     return gradInput;
   }


### PR DESCRIPTION
This PR changes CPU implementation of `AdaptiveAveragePool2D` by
- move dispatch to outside the OpenMP loop
- support fp16