### PR TITLE
use feenableexcept when glibc is available

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -29,8 +29,14 @@ C10_DEFINE_bool(
 C10_DEFINE_bool(
     caffe2_operator_throw_if_fp_exceptions,
     false,
-    "If set, throws if floating point exceptions (FE_DIVBYZERO, FE_INVALID, "
-    "FE_OVERFLOW) are detected when running any operator.");
+    "If set, throws if floating point exceptions (FE_DIVBYZERO, FE_INVALID) "
+    "are detected when running any operator. FE_OVERFLOW is handled separately "
+    "by caffe2_operator_throw_if_fp_overflow_exceptions option.");
+C10_DEFINE_bool(
+    caffe2_operator_throw_if_fp_overflow_exceptions,
+    false,
+    "If set, throws if floating point exception FE_OVERFLOW is detected when "
+    "running any operator.");
 
 namespace caffe2 {
 

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -29,6 +29,7 @@
 #include <ATen/core/ivalue.h>
 
 C10_DECLARE_bool(caffe2_operator_throw_if_fp_exceptions);
+C10_DECLARE_bool(caffe2_operator_throw_if_fp_overflow_exceptions);
 
 namespace c10 {
 struct FunctionSchema;
@@ -844,6 +845,8 @@ class Operator : public OperatorBase {
         CAFFE_ENFORCE(
             !std::fetestexcept(FE_INVALID),
             "Invalid floating point exception (FE_INVALID) reported.");
+      }
+      if (FLAGS_caffe2_operator_throw_if_fp_overflow_exceptions) {
         CAFFE_ENFORCE(
             !std::fetestexcept(FE_OVERFLOW),
             "Overflow floating point exception (FE_OVERFLOW) reported.");

--- a/caffe2/python/operator_test/adadelta_test.py
+++ b/caffe2/python/operator_test/adadelta_test.py
@@ -55,6 +55,8 @@ class TestAdadelta(serial.SerializedTestCase):
            **hu.gcs)
     def test_adadelta(self, inputs, lr, epsilon, decay, gc, dc):
         param, moment, moment_delta, grad = inputs
+        moment = np.abs(moment)
+        moment_delta = np.abs(moment_delta)
         lr = np.array([lr], dtype=np.float32)
 
         op = core.CreateOperator(
@@ -85,6 +87,7 @@ class TestAdadelta(serial.SerializedTestCase):
     def test_sparse_adadelta(self, inputs, lr, epsilon, decay, gc, dc):
         param, moment, moment_delta, grad = inputs
         moment = np.abs(moment)
+        moment_delta = np.abs(moment_delta)
         lr = np.array([lr], dtype=np.float32)
 
         # Create an indexing array containing values that are lists of indices,

--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -60,6 +60,7 @@ class TestAdam(hu.HypothesisTestCase):
            **hu.gcs)
     def test_adam(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):
         param, mom1, mom2, grad = inputs
+        mom2 = np.abs(mom2)
         ITER = np.array([ITER], dtype=np.int64)
         LR = np.array([LR], dtype=np.float32)
 
@@ -93,6 +94,7 @@ class TestAdam(hu.HypothesisTestCase):
            **hu.gcs_cpu_only)
     def test_adam_output_grad(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):
         param, mom1, mom2, grad = inputs
+        mom2 = np.abs(mom2)
         ITER = np.array([ITER], dtype=np.int64)
         LR = np.array([LR], dtype=np.float32)
 

--- a/caffe2/python/operator_test/math_ops_test.py
+++ b/caffe2/python/operator_test/math_ops_test.py
@@ -19,6 +19,8 @@ class TestMathOps(serial.SerializedTestCase):
            exponent=st.floats(min_value=2.0, max_value=3.0),
            **hu.gcs)
     def test_elementwise_power(self, X, exponent, gc, dc):
+        # negative integer raised with non-integer exponent is domain error
+        X = np.abs(X)
         def powf(X):
             return (X ** exponent,)
 


### PR DESCRIPTION
Summary: glibc has a non-standard function, feenableexcept, that triggers floating-point exception handler . Compared to feclearexcept + fetestexcept , this approach allows us to see precisely where the exception is raised from the stack trace.

Differential Revision: D15301095

