### PR TITLE
eliminate FE_INVALID exceptions related to fp16 conversion

### DIFF
--- a/caffe2/perfkernels/embedding_lookup_avx2.cc
+++ b/caffe2/perfkernels/embedding_lookup_avx2.cc
@@ -1291,6 +1291,7 @@ static bool EmbeddingLookup_int32_t_half_float__avx2_fma(
     }
   } else {
     // generic code
+    alignas(64) at::Half vtmp1[8] = {0};
     for (int rangeIndex = 0; rangeIndex < output_size; ++rangeIndex) {
       float* op = &out[rangeIndex * block_size];
       int64_t j = 0;
@@ -1335,10 +1336,10 @@ static bool EmbeddingLookup_int32_t_half_float__avx2_fma(
           _mm_prefetch(
               reinterpret_cast<const char*>(&ip_next_T0[j]), _MM_HINT_T0);
         }
-        alignas(64) at::Half vtmp1[8];
         for (; j < block_size; j++) {
           vtmp1[0] = ip[j];
-          __m256 vtmp2 = _mm256_cvtph_ps(*((__m128i*)vtmp1));
+          __m256 vtmp2 =
+              _mm256_cvtph_ps(*(reinterpret_cast<const __m128i*>(vtmp1)));
           op[j] += wgt * ((float*)(&vtmp2))[0];
         }
       }
@@ -1837,6 +1838,7 @@ static bool EmbeddingLookup_int64_t_half_float__avx2_fma(
     }
   } else {
     // generic code
+    alignas(64) at::Half vtmp1[8] = {0};
     for (int64_t rangeIndex = 0; rangeIndex < output_size; ++rangeIndex) {
       float* op = &out[rangeIndex * block_size];
       int64_t j = 0;
@@ -1881,10 +1883,10 @@ static bool EmbeddingLookup_int64_t_half_float__avx2_fma(
           _mm_prefetch(
               reinterpret_cast<const char*>(&ip_next_T0[j]), _MM_HINT_T0);
         }
-        alignas(64) at::Half vtmp1[8];
         for (; j < block_size; j++) {
           vtmp1[0] = ip[j];
-          __m256 vtmp2 = _mm256_cvtph_ps(*((__m128i*)vtmp1));
+          __m256 vtmp2 =
+              _mm256_cvtph_ps(*(reinterpret_cast<const __m128i*>(vtmp1)));
           op[j] += wgt * ((float*)(&vtmp2))[0];
         }
       }

--- a/caffe2/perfkernels/embedding_lookup_fused_8bit_rowwise_avx2.cc
+++ b/caffe2/perfkernels/embedding_lookup_fused_8bit_rowwise_avx2.cc
@@ -1280,6 +1280,7 @@ static bool Fused8BitRowwiseEmbeddingLookup_int32_t_half_float__avx2_fma(
     }
   } else {
     // generic code
+    alignas(64) at::Half vtmp1[8] = {0};
     for (int rangeIndex = 0; rangeIndex < output_size; ++rangeIndex) {
       float* op = &out[rangeIndex * block_size];
       int64_t j = 0;
@@ -1324,10 +1325,10 @@ static bool Fused8BitRowwiseEmbeddingLookup_int32_t_half_float__avx2_fma(
           _mm_prefetch(
               reinterpret_cast<const char*>(&ip_next_T0[j]), _MM_HINT_T0);
         }
-        alignas(64) at::Half vtmp1[8];
         for (; j < block_size; j++) {
           vtmp1[0] = ip[j];
-          __m256 vtmp2 = _mm256_cvtph_ps(*((__m128i*)vtmp1));
+          __m256 vtmp2 =
+              _mm256_cvtph_ps(*(reinterpret_cast<const __m128i*>(vtmp1)));
           op[j] += wgt * ((float*)(&vtmp2))[0];
         }
       }
@@ -1821,6 +1822,7 @@ static bool Fused8BitRowwiseEmbeddingLookup_int64_t_half_float__avx2_fma(
     }
   } else {
     // generic code
+    alignas(64) at::Half vtmp1[8] = {0};
     for (int64_t rangeIndex = 0; rangeIndex < output_size; ++rangeIndex) {
       float* op = &out[rangeIndex * block_size];
       int64_t j = 0;
@@ -1865,10 +1867,10 @@ static bool Fused8BitRowwiseEmbeddingLookup_int64_t_half_float__avx2_fma(
           _mm_prefetch(
               reinterpret_cast<const char*>(&ip_next_T0[j]), _MM_HINT_T0);
         }
-        alignas(64) at::Half vtmp1[8];
         for (; j < block_size; j++) {
           vtmp1[0] = ip[j];
-          __m256 vtmp2 = _mm256_cvtph_ps(*((__m128i*)vtmp1));
+          __m256 vtmp2 =
+              _mm256_cvtph_ps(*(reinterpret_cast<const __m128i*>(vtmp1)));
           op[j] += wgt * ((float*)(&vtmp2))[0];
         }
       }

--- a/caffe2/quantization/server/fully_connected_fake_lowp_op_avx2.cc
+++ b/caffe2/quantization/server/fully_connected_fake_lowp_op_avx2.cc
@@ -2,21 +2,39 @@
 
 namespace caffe2 {
 
+namespace {
+
+// NOTE: clang-format wants to use a different formatting but the
+// current formatting should be easier to read.
+alignas(64) const int ld_st_masks[8][8] = {
+  {  0,  0,  0,  0,  0,  0,  0,  0, },
+  { -1,  0,  0,  0,  0,  0,  0,  0, },
+  { -1, -1,  0,  0,  0,  0,  0,  0, },
+  { -1, -1, -1,  0,  0,  0,  0,  0, },
+  { -1, -1, -1, -1,  0,  0,  0,  0, },
+  { -1, -1, -1, -1, -1,  0,  0,  0, },
+  { -1, -1, -1, -1, -1, -1,  0,  0, },
+  { -1, -1, -1, -1, -1, -1, -1,  0, },
+};
+
+} // anonymous namespace
+
 // convert to float16 reducing mantissa, preserving exponent
 void fp32_to_bfp16(const float* source, size_t size, float* dest) {
   // Results on a 1 sign, 8 exponent, 7 mantissa
   constexpr int mask = 0xFFFF0000;
   __m256 wmask = _mm256_broadcast_ss(reinterpret_cast<const float*>(&mask));
 
-  for (auto i = 0; i < (size / 8) * 8; i += 8) {
+  size_t i = 0;
+  for (; i < (size / 8) * 8; i += 8) {
     __m256 data = _mm256_loadu_ps(&source[i]);
     _mm256_storeu_ps(&dest[i], _mm256_and_ps(wmask, data));
   }
-  for (auto i = (size / 8) * 8; i < size; i++) {
-    alignas(64) float tmp[8];
-    __m256 data = _mm256_and_ps(wmask, _mm256_set1_ps(source[i]));
-    _mm256_store_ps(tmp, data);
-    dest[i] = tmp[0];
+  if (i < size) {
+    __m256i ld_st_mask = _mm256_load_si256(
+        reinterpret_cast<const __m256i*>(ld_st_masks[size - i]));
+    __m256 data = _mm256_maskload_ps(&source[i], ld_st_mask);
+    _mm256_maskstore_ps(&dest[i], ld_st_mask, _mm256_and_ps(wmask, data));
   }
 }
 
@@ -26,15 +44,16 @@ void fp32_to_bfp24(const float* source, size_t size, float* dest) {
   constexpr int mask = 0xFFFFFF00;
   __m256 wmask = _mm256_broadcast_ss(reinterpret_cast<const float*>(&mask));
 
-  for (auto i = 0; i < (size / 8) * 8; i += 8) {
+  size_t i = 0;
+  for (; i < (size / 8) * 8; i += 8) {
     __m256 data = _mm256_loadu_ps(&source[i]);
     _mm256_storeu_ps(&dest[i], _mm256_and_ps(wmask, data));
   }
-  for (auto i = (size / 8) * 8; i < size; i++) {
-    alignas(64) float tmp[8];
-    __m256 data = _mm256_and_ps(wmask, _mm256_set1_ps(source[i]));
-    _mm256_store_ps(tmp, data);
-    dest[i] = tmp[0];
+  if (i < size) {
+    __m256i ld_st_mask = _mm256_load_si256(
+        reinterpret_cast<const __m256i*>(ld_st_masks[size - i]));
+    __m256 data = _mm256_maskload_ps(&source[i], ld_st_mask);
+    _mm256_maskstore_ps(&dest[i], ld_st_mask, _mm256_and_ps(wmask, data));
   }
 }
 
@@ -44,15 +63,16 @@ void fp32_to_bfp14(const float* source, size_t size, float* dest) {
   constexpr int mask = 0xFFFC0000;
   __m256 wmask = _mm256_broadcast_ss((float*)(&mask));
 
-  for (auto i = 0; i < (size / 8) * 8; i += 8) {
+  size_t i = 0;
+  for (; i < (size / 8) * 8; i += 8) {
     __m256 data = _mm256_loadu_ps(&source[i]);
     _mm256_storeu_ps(&dest[i], _mm256_and_ps(wmask, data));
   }
-  for (auto i = (size / 8) * 8; i < size; i++) {
-    alignas(64) float tmp[8];
-    __m256 data = _mm256_and_ps(wmask, _mm256_set1_ps(source[i]));
-    _mm256_store_ps(tmp, data);
-    dest[i] = tmp[0];
+  if (i < size) {
+    __m256i ld_st_mask = _mm256_load_si256(
+        reinterpret_cast<const __m256i*>(ld_st_masks[size - i]));
+    __m256 data = _mm256_maskload_ps(&source[i], ld_st_mask);
+    _mm256_maskstore_ps(&dest[i], ld_st_mask, _mm256_and_ps(wmask, data));
   }
 }
 
@@ -65,15 +85,17 @@ void fp32_to_bfp16_scalar(const float* source, size_t size, float* dest) {
 
 // convert to IEEE float16
 void fp32_to_fp16(const float* source, size_t size, float* dest) {
-  for (auto i = 0; i < (size / 8) * 8; i += 8) {
+  size_t i = 0;
+  for (; i < (size / 8) * 8; i += 8) {
     __m128i vin_fp16 = _mm256_cvtps_ph(_mm256_loadu_ps(&source[i]), 0);
     _mm256_storeu_ps(&dest[i], _mm256_cvtph_ps(vin_fp16));
   }
-  for (auto i = (size / 8) * 8; i < size; i++) {
-    alignas(64) float tmp[8];
-    __m128i vin_fp16 = _mm256_cvtps_ph(_mm256_set1_ps(source[i]), 0);
-    _mm256_store_ps(tmp, _mm256_cvtph_ps(vin_fp16));
-    dest[i] = tmp[0];
+  if (i < size) {
+    __m256i ld_st_mask = _mm256_load_si256(
+        reinterpret_cast<const __m256i*>(ld_st_masks[size - i]));
+    __m128i vin_fp16 =
+        _mm256_cvtps_ph(_mm256_maskload_ps(&source[i], ld_st_mask), 0);
+    _mm256_maskstore_ps(&dest[i], ld_st_mask, _mm256_cvtph_ps(vin_fp16));
   }
 }
 
@@ -85,20 +107,25 @@ void fp32_to_bfp16_round(const float* source, size_t size, float* dest) {
   __m256i woffset = _mm256_set1_epi32(offset);
   __m256i wmask = _mm256_set1_epi32(mask);
 
-  for (auto i = 0; i < (size / 8) * 8; i += 8) {
+  size_t i = 0;
+  for (; i < (size / 8) * 8; i += 8) {
     __m256i v32int = _mm256_add_epi32(
         _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&source[i])),
         woffset);
     _mm256_storeu_si256(
         reinterpret_cast<__m256i*>(&dest[i]), _mm256_and_si256(wmask, v32int));
   }
-  for (auto i = (size / 8) * 8; i < size; i++) {
-    alignas(64) float tmp[8];
+  if (i < size) {
+    __m256i ld_st_mask = _mm256_load_si256(
+        reinterpret_cast<const __m256i*>(ld_st_masks[size - i]));
     __m256i v32int = _mm256_add_epi32(
-        _mm256_set1_epi32(*reinterpret_cast<const int*>(&source[i])), woffset);
-    _mm256_store_si256(
-        reinterpret_cast<__m256i*>(tmp), _mm256_and_si256(wmask, v32int));
-    dest[i] = tmp[0];
+        _mm256_maskload_epi32(
+            reinterpret_cast<const int*>(&source[i]), ld_st_mask),
+        woffset);
+    _mm256_maskstore_epi32(
+        reinterpret_cast<int*>(&dest[i]),
+        ld_st_mask,
+        _mm256_and_si256(wmask, v32int));
   }
 }
 


### PR DESCRIPTION
Summary: duc0 Ngo implemented observing floating point exceptions but there were a couple of places where we have "benign" floating point exceptions leading to false positives. This diff eliminates one source of such false positives, namely using _mm256_cvtph_ps and _mm256_cvtps_ph for partially uninitialized array for the remainder loop.

Differential Revision: D15307358

