### PR TITLE
[BC-breaking] Fix version counter sharing in set_data()

### DIFF
--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -174,8 +174,8 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   // Version counter is not shared when we replace a `Variable`'s underlying `Tensor`
   // by calling `set_data(...)`. The original version of the `Variable` is always preserved.
   // See NOTE [ Version Counter Sharing ] for details.
-  auto saved_version_ = data_.unsafeGetTensorImpl()->version_counter().current_version();
-  new_data_impl_copy->set_version_counter(saved_version_);
+  auto saved_version_counter = data_.unsafeGetTensorImpl()->version_counter();
+  new_data_impl_copy->set_version_counter(saved_version_counter);
   data_ = std::move(at::Tensor(new_data_impl_copy));
 }
 


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/18223/files#diff-77a6f3462f2233b921d3042412fed6d3R178, we used `auto saved_version_ = data_.unsafeGetTensorImpl()->version_counter().current_version()` and then `new_data_impl_copy->set_version_counter(saved_version_)`, which actually doesn't preserve the original semantics that `var.set_data(tensor)` should keep `var`'s version counter object intact. This PR fixes the bug and adds test to make sure it doesn't happen again.

This PR is BC-breaking for v1.1.0, because v1.1.0 contains https://github.com/pytorch/pytorch/pull/18223 which introduces the bug. As an example, the following test passes on v1.0.1 and will pass on master after this PR is merged, but doesn't pass on v1.1.0:
```python
x = torch.randn(2, 3)
xz = x[:]
assert x._version == xz._version
x.add_(1)
assert x._version == xz._version  # We can confirm that `x` and `xz` have the same version counter

x.data = torch.randn(3, 4)
x.add_(1)
assert x._version == xz._version  # We can confirm that `x` and `xz` still have the same version counter
```