### PR TITLE
[tensorboard] Remove duplicated _optimize_trace

### DIFF
--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -36,7 +36,7 @@ void RemoveInplaceOps(Block* block) {
       // create a replacement out of place op
       auto newNode = graph->create(inPlaceToOutOfPlace.at(node->kind()));
       newNode->insertBefore(node);
-
+      newNode->setScope(node->scope());
       // copy inputs
       for (auto input : node->inputs()) {
         newNode->addInput(input);


### PR DESCRIPTION
The duplicated code of `_optimize_trace` in _pytorch_graph.py is used to bypass some optimization step which causes missing scope.

It seems that most of the problematic steps have been fixed recently. Standard models implemented in torchvision are visually inspected before the commit. However, the `+=` in https://github.com/pytorch/vision/blob/50d54a82d1479ffb6dd7469ed05fccdf290a1d84/torchvision/models/resnet.py#L63 will let https://github.com/pytorch/pytorch/blob/f4d9bfaa4dd983288518a310bb900756ee3c6046/torch/onnx/utils.py#L159 produce a bad result. It can be fixed by replacing it with `out += identity`. This also implies that `+=` has non-intuitive behavior.

cc @orionr @ezyang 