### PR TITLE
added CUDA tensor to numpy compability

### DIFF
--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -455,9 +455,9 @@ class Tensor(torch._C._TensorBase):
 
     def __array__(self, dtype=None):
         if dtype is None:
-            return self.numpy()
+            return self.cpu().numpy()
         else:
-            return self.numpy().astype(dtype, copy=False)
+            return self.cpu().numpy().astype(dtype, copy=False)
 
     # Wrap Numpy array again in a suitable tensor when done, to support e.g.
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`


### PR DESCRIPTION
Edit on line 458 and 460.
Copying tensor to host memory before performing numpy operation.

