### PR TITLE
Break reference cycle in load_state_dict

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4308,8 +4308,9 @@ class TestNN(NNTestCase):
         self.assertEqual(bn.num_batches_tracked.dtype, torch.long)
         self.assertEqual(bn.num_batches_tracked.item(), 0)
 
+    @unittest.skipIf(not PY3, 'Python 2.7 generates cyclic trash')
     def test_load_state_dict_ref_cycle(self):
-        # m.load_state_dict(m.state_dict()) shouldn't cause a reference cycle
+        # load_state_dict shouldn't cause a reference cycle involving Tensors
         import gc
 
         m = torch.nn.LSTM(16, 16, bidirectional=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4308,6 +4308,18 @@ class TestNN(NNTestCase):
         self.assertEqual(bn.num_batches_tracked.dtype, torch.long)
         self.assertEqual(bn.num_batches_tracked.item(), 0)
 
+    def test_load_state_dict_ref_cycle(self):
+        # m.load_state_dict(m.state_dict()) shouldn't cause a reference cycle
+        import gc
+
+        m = torch.nn.LSTM(16, 16, bidirectional=True)
+
+        gc.collect()
+        m.load_state_dict(deepcopy(m).state_dict())
+        refcycles = gc.collect()
+
+        self.assertEqual(refcycles, 0)
+
     def test_parameter_assignment(self):
         l = nn.Linear(5, 5)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -761,6 +761,7 @@ class Module(object):
                     load(child, prefix + name + '.')
 
         load(self)
+        del load  # break load->load reference cycle
 
         if strict:
             if len(unexpected_keys) > 0:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -761,7 +761,7 @@ class Module(object):
                     load(child, prefix + name + '.')
 
         load(self)
-        del load  # break load->load reference cycle
+        load = None  # break load->load reference cycle
 
         if strict:
             if len(unexpected_keys) > 0:


### PR DESCRIPTION
load_state_dict includes a recursive inner function `load` that captures
Tensors through the close-over variable `state_dict`. Because it's
recursive, it also captures itself leading to a reference cycle.

This breaks the reference cycle so that any Tensors in state_dict can be
collected immediately instead of waiting until the next GC cycle.

Alternatively, we could have passed `state_dict` and `metadata` as
arguments to load to prevent capture of Tensors. (That would still
result in cyclic garbage, but not any cyclic garbage of Tensors).

See:
https://github.com/pytorch/pytorch/issues/20199#issuecomment-491089004

