### PR TITLE
Hotfix for caffe2 windows build

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -114,10 +114,10 @@ def create_build_env():
         my_env['CUDA_BIN_PATH'] = escape_path(CUDA_HOME)
 
     if IS_WINDOWS:
-        my_env = overlay_windows_vcvars(my_env)
         # When using Ninja under Windows, the gcc toolchain will be chosen as default.
         # But it should be set to MSVC as the user's first choice.
         if USE_NINJA:
+            my_env = overlay_windows_vcvars(my_env)
             cc = my_env.get('CC', 'cl')
             cxx = my_env.get('CXX', 'cl')
             my_env['CC'] = cc


### PR DESCRIPTION
We don't need to overlay vc env when not using ninja. CMake will deal with it automatically. Overlaying is a no-op when the env is the same with the generator specified but will generate the error "Cannot find CMAKE_CXX_COMPILER" when they are different.