### PR TITLE
Add the missing scale in the forward of SpatialSoftmaxWithLossOp

### DIFF
--- a/caffe2/operators/spatial_softmax_with_loss_op.h
+++ b/caffe2/operators/spatial_softmax_with_loss_op.h
@@ -67,4 +67,4 @@ class SpatialSoftmaxWithLossGradientOp final : public Operator<Context> {
 
 } // namespace caffe2
 
-#endif // SOFTMAX_WITH_LOSS_OP_H_
+#endif // SPATIAL_SOFTMAX_WITH_LOSS_OP_H_


### PR DESCRIPTION
Add the missing `scale_` for computing the averaged loss in the final part of `SpatialSoftmaxWithLossOp`. Docs and some variables' names are also refined to be consistent with `SoftmaxWithLossOp`.