### PR TITLE
Change onnxifi workflow to support multi-group quantized & Add multi quantization info to caffe2.proto

### DIFF
--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -581,11 +581,18 @@ TensorShapes InferBlobShapesAndTypes(
   return tps;
 }
 
-void LoadInt8TensorInfoOfBlob(float* scale, float* offset, const Blob* b) {
-  const int8::Int8TensorCPU* i8tc =
+void LoadInt8TensorInfoOfBlob(
+    std::vector<float>* scale,
+    std::vector<float>* offset,
+    uint32_t* axis,
+    const Blob* b) {
+  const int8::Int8TensorCPU* int8_tensor =
       static_cast<const int8::Int8TensorCPU*>(b->GetRaw());
-  *scale = i8tc->scale;
-  *offset = i8tc->zero_point;
+  scale->clear();
+  offset->clear();
+  scale->push_back(int8_tensor->scale);
+  offset->push_back(int8_tensor->zero_point);
+  *axis = 1;
 }
 
 TensorShape GetTensorShapeOfBlob(const Blob* b) {

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -1392,8 +1392,11 @@ CAFFE2_API void SetOpEnginePref(
     const std::string& op_type,
     const CaffeMap<DeviceType, EnginePrefType>& op_pref);
 
-CAFFE2_API void
-LoadInt8TensorInfoOfBlob(float* scale, float* offset, const Blob* b);
+CAFFE2_API void LoadInt8TensorInfoOfBlob(
+    std::vector<float>* scale,
+    std::vector<float>* offset,
+    uint32_t* axis,
+    const Blob* b);
 
 CAFFE2_API TensorShape GetTensorShapeOfBlob(const Blob* b);
 

--- a/caffe2/core/tensor.cc
+++ b/caffe2/core/tensor.cc
@@ -58,8 +58,9 @@ TypeMeta GetTensorType(const void* c) {
   return tc->dtype();
 }
 TypeMeta GetInt8TensorType(const void* c) {
-  const int8::Int8TensorCPU* i8tc = static_cast<const int8::Int8TensorCPU*>(c);
-  return (i8tc->t).dtype();
+  const int8::Int8TensorCPU* int8_tensor =
+      static_cast<const int8::Int8TensorCPU*>(c);
+  return (int8_tensor->t).dtype();
 }
 
 // TODO(jerryzh): Remove
@@ -98,8 +99,9 @@ vector<int64_t> GetTensorInfo(
 
 vector<int64_t>
 GetInt8TensorInfo(const void* c, size_t* capacity, DeviceOption* device) {
-  const int8::Int8TensorCPU* i8tc = static_cast<const int8::Int8TensorCPU*>(c);
-  return GetTensorInfo(&(i8tc->t), capacity, device);
+  const int8::Int8TensorCPU* int8_tensor =
+      static_cast<const int8::Int8TensorCPU*>(c);
+  return GetTensorInfo(&(int8_tensor->t), capacity, device);
 }
 // since we only have one tensor, probably need to remove this at some point?
 static CaffeMap<TypeIdentifier, TensorInfoCall> tensor_info_call_registry_{

--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -54,8 +54,16 @@ QTensorProto BackendTransformerBase::wrapShapeInfoIntoQTensorProto(
       "Only quantized shapeinfo can be extracted into QTensor!");
   t.set_name(name);
   t.set_data_type(shape_info.shape.data_type());
-  t.set_scale(shape_info.q_info.scale);
-  t.set_bias(shape_info.q_info.offset);
+  t.set_axis(shape_info.q_info.axis);
+  t.set_is_multiparam(true);
+  for (const auto i : shape_info.q_info.scale) {
+    t.add_scales(i);
+  }
+  t.set_scale(1.0);
+  for (const auto i : shape_info.q_info.offset) {
+    t.add_biases(i);
+  }
+  t.set_bias(0.0);
   // precision and is_signed is not used in onnxifi workflow, but it is required
   // field
   t.set_precision(0);

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -123,8 +123,11 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorShapeAndType(
   TensorShape& shape = shape_info.shape;
   if (is_quantized) {
     shape_info.is_quantized = true;
-    shape_info.q_info.scale = 1;
-    shape_info.q_info.offset = 0;
+    shape_info.q_info.scale.clear();
+    shape_info.q_info.scale.push_back(1);
+    shape_info.q_info.offset.clear();
+    shape_info.q_info.offset.push_back(0);
+    shape_info.q_info.axis = 1;
   }
   if (!rt.second) {
     // Check shape consistency

--- a/caffe2/opt/shape_info.cc
+++ b/caffe2/opt/shape_info.cc
@@ -14,7 +14,10 @@ ShapeInfo getShapeInfoFromBlob(const Blob* blob) {
   if (blob->meta().id() == TypeMeta::Id<int8::Int8TensorCPU>()) {
     shape_info.is_quantized = true;
     LoadInt8TensorInfoOfBlob(
-        &shape_info.q_info.scale, &shape_info.q_info.offset, blob);
+        &shape_info.q_info.scale,
+        &shape_info.q_info.offset,
+        &shape_info.q_info.axis,
+        blob);
   }
   return shape_info;
 }

--- a/caffe2/opt/shape_info.h
+++ b/caffe2/opt/shape_info.h
@@ -5,11 +5,17 @@
 namespace caffe2 {
 
 struct CAFFE2_API QShapeInfo {
-  QShapeInfo(float o = 0, float s = 1) : offset(o), scale(s) {}
-  float offset;
-  float scale;
-  // TODO zrphercule
-  // Add multi offset/scale support here
+  QShapeInfo(float o = 0, float s = 1, uint32_t a = 1) {
+    offset.clear();
+    scale.clear();
+    offset.push_back(o);
+    scale.push_back(s);
+    axis = a;
+  }
+
+  uint32_t axis;
+  vector<float> offset;
+  vector<float> scale;
 };
 
 struct CAFFE2_API ShapeInfo {

--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -126,6 +126,17 @@ message QTensorProto {
   repeated int32 data = 6 [packed = true];
   optional string name = 7;
   optional TensorProto.DataType data_type = 8 [default = INT32];
+
+  // Multi-group quantization params
+  repeated double scales = 9;
+  repeated double biases = 10;
+
+  // Multi-group quantization needed, indicates in which dimension
+  // we do the "group wise quantization"
+  optional int32 axis = 11;
+
+  // It should be true if it is a multi-group quantization proto
+  optional bool is_multiparam = 12 [default = false];
 }
 
 // TensorProtos stores multiple TensorProto objects in one single proto. This


### PR DESCRIPTION
Summary:
This is the QTensorProto workflow for multi group quantization in C2 side.
No DNNLOWP Tensor related thing is included in this pr, so once we finished glow side, we should be able to test this pr using resnet50.

Differential Revision: D15096919

