### PR TITLE
Fixes the tests after introduction of `qint8`

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -10,7 +10,7 @@
 namespace at { namespace native {
 namespace {
 
-class QReluInt8 final : public c10::OperatorKernel {
+class QReluUInt8 final : public c10::OperatorKernel {
  public:
   Tensor operator()(Tensor qx) {
     Tensor qy = at::_empty_affine_quantized(qx.sizes(),
@@ -28,7 +28,7 @@ class QReluInt8 final : public c10::OperatorKernel {
 
 static auto registry = c10::RegisterOperators().op(
     "quantized::relu(Tensor qx) -> Tensor",
-    c10::kernel<QReluInt8>(),
+    c10::kernel<QReluUInt8>(),
     c10::dispatchKey(QuantizedCPUTensorId()));
 
 }  // namespace

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -122,7 +122,7 @@ class TestQuantizedOps(unittest.TestCase):
         X = torch.arange(-5, 5, dtype=torch.float)
         scale = 2.0
         zero_point = 1
-        qX = X.quantize_linear(scale=scale, zero_point=zero_point, dtype=torch.qint8)
+        qX = X.quantize_linear(scale=scale, zero_point=zero_point, dtype=torch.quint8)
 
         Y = X.numpy().copy()
         Y[Y < 0] = 0
@@ -139,8 +139,8 @@ class TestQuantizedOps(unittest.TestCase):
         B = torch.arange(-25, 25, dtype=torch.float)
         scale = 2.0
         zero_point = 127
-        qA = A.quantize_linear(scale=scale, zero_point=zero_point, dtype=torch.qint8)
-        qB = A.quantize_linear(scale=scale, zero_point=zero_point, dtype=torch.qint8)
+        qA = A.quantize_linear(scale=scale, zero_point=zero_point, dtype=torch.quint8)
+        qB = A.quantize_linear(scale=scale, zero_point=zero_point, dtype=torch.quint8)
 
         # Add ReLU ground truth
         C = (qA.dequantize() + qB.dequantize()).numpy()
@@ -172,8 +172,8 @@ class TestQuantizedOps(unittest.TestCase):
         scale_C = 0.5
         zero_point_C = 5
 
-        qA = A.quantize_linear(scale=scale_A, zero_point=zero_point_A, dtype=torch.qint8)
-        qB = A.quantize_linear(scale=scale_B, zero_point=zero_point_B, dtype=torch.qint8)
+        qA = A.quantize_linear(scale=scale_A, zero_point=zero_point_A, dtype=torch.quint8)
+        qB = A.quantize_linear(scale=scale_B, zero_point=zero_point_B, dtype=torch.quint8)
 
         # Add ground truth
         C = (qA.dequantize() + qB.dequantize()).numpy()


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20474 [RFC] Quantized Max Pool op&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15327923/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20473 Fixes the tests after introduction of `qint8`**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15332106/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19984 [pt1][quant] Add qint8 type (int8_t)&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15150715/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19932 [pt1][quant] Rename qint8 data type&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15137838/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #19816 [pt1][quant] Add QInt32 ScalarType and qint32 data type&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15094174/)

The initial assumption was that `qint8` would be unsigned. After introduction of `quint8` and `qint8`, some tests break.

Differential Revision: [D15332106](https://our.internmc.facebook.com/intern/diff/D15332106/)