### PR TITLE
Add linear learning rate schedule

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -147,3 +147,5 @@ allows dynamic learning rate reducing based on some validation measurements.
     :members:
 .. autoclass:: torch.optim.lr_scheduler.CyclicLR
     :members:
+.. autoclass:: torch.optim.lr_scheduler.LinearLR
+    :members:

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -12,7 +12,7 @@ from torch.autograd import Variable
 from torch import sparse
 from torch.optim.lr_scheduler import LambdaLR, StepLR, MultiStepLR, \
     ExponentialLR, CosineAnnealingLR, ReduceLROnPlateau, _LRScheduler, \
-    CyclicLR, CosineAnnealingWarmRestarts
+    CyclicLR, CosineAnnealingWarmRestarts, LinearLR
 from common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests, \
     skipIfRocm
 
@@ -562,6 +562,13 @@ class TestLRScheduler(TestCase):
                           for x in range(epochs)]
         targets = [single_targets, list(map(lambda x: x * epochs, single_targets))]
         scheduler = CosineAnnealingLR(self.opt, T_max=epochs, eta_min=eta_min)
+        self._test(scheduler, targets, epochs)
+
+    def test_linear_lr(self):
+        epochs = 10
+        single_targets = [0.05 * (1 - x/float(epochs)) for x in range(epochs)]
+        targets = [single_targets, list(map(lambda x: x * epochs, single_targets))]
+        scheduler = LinearLR(self.opt, T=epochs)
         self._test(scheduler, targets, epochs)
 
     def test_legacy_step_lr(self):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -729,3 +729,37 @@ class CosineAnnealingWarmRestarts(_LRScheduler):
         self.last_epoch = math.floor(epoch)
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = lr
+
+
+class LinearLR(_LRScheduler):
+    r"""Set the learning rate of each parameter group with a linear
+    schedule: :math:`\eta_{t} = \eta_0*(1 - t/T)`, where :math:`\eta_0` is the
+    initial lr, :math:`t` is the current epoch or iteration (zero-based) and
+    :math:`T` is the total training epochs or iterations. It is recommended to
+    use the iteration based calculation if the total number of epochs is small,
+    in which case, the scheduler needs to be stepped after each iteration.
+    When last_epoch=-1, sets initial lr as lr.
+
+    It has been proposed in
+    `Budgeted Training: Rethinking Deep Neural Network Training Under Resource
+     Constraints`_.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        T (int): Total number of training epochs or iterations.
+        last_epoch (int): The index of last epoch or iteration. Default: -1.
+
+    .. _Budgeted Training\: Rethinking Deep Neural Network Training Under
+    Resource Constraints:
+        https://arxiv.org/abs/1905.04753
+    """
+
+    def __init__(self, optimizer, T, last_epoch=-1):
+        self.T = float(T)
+        super(LinearLR, self).__init__(optimizer, last_epoch)
+
+    def get_lr(self):
+        if self.last_epoch == 0:
+            return self.base_lrs
+        rate = 1 - self.last_epoch/self.T
+        return [base_lr * rate for base_lr in self.base_lrs]

--- a/torch/optim/lr_scheduler.pyi
+++ b/torch/optim/lr_scheduler.pyi
@@ -23,6 +23,9 @@ class ExponentialLR(_LRScheduler):
 class CosineAnnealingLr(_LRScheduler):
     def __init__(self, optimizer: Optimizer, T_max: int, eta_min: float, last_epoch: int=...) -> None: ...
 
+class LinearLR(_LRScheduler):
+    def __init__(self, optimizer: Optimizer, T: int, last_epoch: int=...) -> None: ...
+
 class ReduceLROnPlateau:
     in_cooldown: bool
 


### PR DESCRIPTION
The linear learning rate schedule is: base_lr * (1 - t/T), where t is the current iteration and T is the total training iterations. Although this simple schedule is literally parameter-free, it has been show [here](https://arxiv.org/abs/1905.04753) that linear learning rate schedule can often surpass existing schedules on various computer vision benchmarks, especially in the case with a small training budget (measured in the number of iterations).