### PR TITLE
[BC-BREAKING] Add scalar type info to tensor print

### DIFF
--- a/aten/src/ATen/core/DeprecatedTypeProperties.h
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.h
@@ -65,6 +65,10 @@ class CAFFE2_API DeprecatedTypeProperties {
 
   std::string toString() const {
     std::stringstream ss;
+    if (is_variable_) {
+      ss << "Variable[" << at::toString(backend()) << at::toString(scalarType()) << "Type" << "]";
+      return ss.str();
+    }
     ss << at::toString(backend()) << at::toString(scalarType()) << "Type";
     return ss.str();
   }

--- a/aten/src/ATen/core/DeprecatedTypeProperties.h
+++ b/aten/src/ATen/core/DeprecatedTypeProperties.h
@@ -64,13 +64,16 @@ class CAFFE2_API DeprecatedTypeProperties {
   }
 
   std::string toString() const {
-    std::stringstream ss;
-    if (is_variable_) {
-      ss << "Variable[" << at::toString(backend()) << at::toString(scalarType()) << "Type" << "]";
-      return ss.str();
+    std::string base_str;
+    if (backend_ == Backend::Undefined || scalar_type_ == ScalarType::Undefined) {
+      base_str = "UndefinedType";
+    } else {
+      base_str = std::string(at::toString(backend_)) + at::toString(scalar_type_) + "Type";
     }
-    ss << at::toString(backend()) << at::toString(scalarType()) << "Type";
-    return ss.str();
+    if (is_variable_) {
+      return "Variable[" + base_str + "]";
+    }
+    return base_str;
   }
 
   DeprecatedTypeProperties & toBackend(Backend b) const {

--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -35,14 +35,14 @@ void Tensor::enforce_invariants() {
 
 void Tensor::print() const {
   if (defined()) {
-    std::cerr << "[" << dispatch_type().toString() << " " << sizes() << "]" << std::endl;
+    std::cerr << "[" << type().toString() << " " << sizes() << "]" << std::endl;
   } else {
     std::cerr << "[UndefinedTensor]" << std::endl;
   }
 }
 
-const char * Tensor::toString() const {
-  return dispatch_type().toString();
+std::string Tensor::toString() const {
+  return type().toString();
 }
 
 } // namespace at

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -154,7 +154,7 @@ class CAFFE2_API Tensor {
     return impl_.weak_use_count();
   }
 
-  const char * toString() const;
+  std::string toString() const;
 
   IntArrayRef sizes() const {
     return impl_->sizes();

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -154,7 +154,7 @@ class CAFFE2_API Tensor {
     return impl_.weak_use_count();
   }
 
-  const char * toString() const;
+  std::string toString() const;
 
   IntArrayRef sizes() const {
     return impl_->sizes();

--- a/test/expect/TestScript.test_print-stdout.expect
+++ b/test/expect/TestScript.test_print-stdout.expect
@@ -2,4 +2,4 @@
  0.9526
  0.9975
  0.9999
-[ Variable[CPUType]{4} ] 1 2 [1, 2] [1., 2.]
+[ Variable[CPUDoubleType]{4} ] 1 2 [1, 2] [1., 2.]

--- a/test/expect/TestScript.test_string_print-stdout.expect
+++ b/test/expect/TestScript.test_string_print-stdout.expect
@@ -1,2 +1,2 @@
 1
-[ Variable[CPUType]{} ] abcd 2 1.5
+[ Variable[CPULongType]{} ] abcd 2 1.5


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20483 Add scalar type info to tensor print**

This got taken out when Type became scalar type agnostic. Adding it back. closes #20320

Differential Revision: [D15334010](https://our.internmc.facebook.com/intern/diff/D15334010)