### PR TITLE
Don't concatenate string literals to reduce mobile binary size.

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -169,10 +169,18 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // simply raises an exception, it does NOT unceremoniously quit the process
 // (unlike assert()).
 //
+// NB: In the macros below, I've very carefully used comma instead of
+// string literal concatenation (which would also be a permissible
+// implementation) to reduce binary size on mobile (if you concatenate
+// string literals, you end up with a lot of duplicated strings in
+// the binary, one for each #cond).  It matters most on TORCH_CHECK but
+// I've applied it another cases.  Another reasonable strategy to just
+// reduce the error message size on mobile.
+//
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
   if (!(cond)) {                              \
     C10_THROW_ERROR(Error, ::c10::str(        \
-        #cond " INTERNAL ASSERT FAILED at ",  \
+        #cond, " INTERNAL ASSERT FAILED at ", \
         __FILE__,                             \
         ":",                                  \
         __LINE__,                             \
@@ -206,14 +214,12 @@ inline std::string if_empty_then(std::string x, std::string y) {
     C10_THROW_ERROR(Error,                                  \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
-        "Expected " #cond " to be true, but got false.  "   \
+        "Expected ", #cond, " to be true, but got false.  " \
         "(Could this error message be improved?  If so, "   \
         "please report an enhancement request to PyTorch.)" \
       ) \
     ); \
   }
-// TODO: We're going to get a lot of similar looking string literals
-// this way; check if this actually affects binary size.
 
 // Like TORCH_CHECK, but raises IndexErrors instead of Errors.
 #define TORCH_CHECK_INDEX(cond, ...)                        \
@@ -221,7 +227,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
     C10_THROW_ERROR(IndexError,                             \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
-        "Expected " #cond " to be true, but got false.  "   \
+        "Expected, " #cond, " to be true, but got false.  " \
         "(Could this error message be improved?  If so, "   \
         "please report an enhancement request to PyTorch.)" \
       )                                                     \

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -214,9 +214,9 @@ inline std::string if_empty_then(std::string x, std::string y) {
     C10_THROW_ERROR(Error,                                  \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
-        "Expected ", #cond, " to be true, but got false.  " \
+        ::c10::str("Expected ", #cond, " to be true, but got false.  " \
         "(Could this error message be improved?  If so, "   \
-        "please report an enhancement request to PyTorch.)" \
+        "please report an enhancement request to PyTorch.)") \
       ) \
     ); \
   }
@@ -227,9 +227,9 @@ inline std::string if_empty_then(std::string x, std::string y) {
     C10_THROW_ERROR(IndexError,                             \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
-        "Expected, " #cond, " to be true, but got false.  " \
+        ::c10::str("Expected, " #cond, " to be true, but got false.  " \
         "(Could this error message be improved?  If so, "   \
-        "please report an enhancement request to PyTorch.)" \
+        "please report an enhancement request to PyTorch.)") \
       )                                                     \
     );                                                      \
   }

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -212,12 +212,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 #define TORCH_CHECK(cond, ...)                              \
   if (!(cond)) {                                            \
     C10_THROW_ERROR(Error,                                  \
-      ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
-        ::c10::str("Expected ", #cond, " to be true, but got false.  " \
-        "(Could this error message be improved?  If so, "   \
-        "please report an enhancement request to PyTorch.)") \
-      ) \
     ); \
   }
 
@@ -225,12 +220,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 #define TORCH_CHECK_INDEX(cond, ...)                        \
   if (!(cond)) {                                            \
     C10_THROW_ERROR(IndexError,                             \
-      ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
-        ::c10::str("Expected, " #cond, " to be true, but got false.  " \
-        "(Could this error message be improved?  If so, "   \
-        "please report an enhancement request to PyTorch.)") \
-      )                                                     \
     );                                                      \
   }
 

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -212,7 +212,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 #define TORCH_CHECK(cond, ...)                              \
   if (!(cond)) {                                            \
     C10_THROW_ERROR(Error,                                  \
-        ::c10::str(__VA_ARGS__),                            \
+        ::c10::str(__VA_ARGS__)                             \
     ); \
   }
 
@@ -220,7 +220,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 #define TORCH_CHECK_INDEX(cond, ...)                        \
   if (!(cond)) {                                            \
     C10_THROW_ERROR(IndexError,                             \
-        ::c10::str(__VA_ARGS__),                            \
+        ::c10::str(__VA_ARGS__)                             \
     );                                                      \
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20487 Don't concatenate string literals to reduce mobile binary size.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D15334785](https://our.internmc.facebook.com/intern/diff/D15334785)