### PR TITLE
Require passing version_counter and allow_tensor_metadata_change to shallow_copy_and_detach()

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -78,7 +78,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
 
 // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
 // 1. the AutogradMeta pointer, because it is unique for each Variable.
-// 2. the version counter, because although it lives in TensorImpl, the version counter is managed
+// 2. [yf225 TODO: fix comment here!] the version counter, because although it lives in TensorImpl, the version counter is managed
 // by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
 // the version counter should be for each new TensorImpl. See NOTE [ Version Counter Sharing ] for details.
 //
@@ -86,7 +86,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
 // to this function that need to change the shallow copy's size or storage afterwards, and setting
 // `allow_tensor_metadata_change_` to false would prevent those changes from happening and is
 // undesirable.
-c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach() const override {
+c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(ShallowCopyVersionCounterMode version_counter_mode) const override {
   //AT_ASSERT(false);
   auto impl = c10::make_intrusive<OpaqueTensorImpl<OpaqueHandle>>(
     type_id(), dtype(), device(), opaque_handle_, sizes_);
@@ -99,6 +99,16 @@ c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach() const override {
   impl->is_contiguous_ = is_contiguous_;
   impl->is_wrapped_number_ = is_wrapped_number_;
   impl->reserved_ = reserved_;
+  switch (version_counter_mode) {
+    case ShallowCopyVersionCounterMode::kShareVersionCounter:
+      impl->set_version_counter(version_counter());
+      break;
+    case ShallowCopyVersionCounterMode::kCreateNewVersionCounter:
+      impl->set_version_counter(0);
+      break;
+    default:
+      AT_ERROR("Unsupported version_counter_mode: ", version_counter_mode);
+  }
 
   // OpaqueTensorImpl-specific fields (none currently).
   return impl;

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -76,12 +76,12 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
     AT_ERROR("opaque tensors do not have storage");
   }
 
-// NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
-// for each Variable.
-//
-// yf225 TODO: fix comment!
-// NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
-// version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
+// NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
+// 1. the AutogradMeta pointer, because it is unique for each Variable.
+// 2. the version counter, because although it lives in TensorImpl, the version counter is managed
+// by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
+// the version counter should be for each new TensorImpl, by passing the correct version counter as
+// `version_counter` into this function. See NOTE [ Version Counter Sharing ] for details.
 //
 // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
 // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -77,7 +77,6 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
   }
 
 // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-//
 // 1. the AutogradMeta pointer, because it is unique for each Variable.
 // 2. the version counter, because it is set to the passed in `version_counter`.
 //    See NOTE [ Version Counter Sharing ] for details.

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -78,10 +78,8 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
 
 // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
 // 1. the AutogradMeta pointer, because it is unique for each Variable.
-// 2. the version counter, because although it lives in TensorImpl, the version counter is managed
-// by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
-// the version counter should be for each new TensorImpl, by passing the correct version counter as
-// `version_counter` into this function. See NOTE [ Version Counter Sharing ] for details.
+// 2. the version counter, because it is set to the passed in `version_counter`. See NOTE [ Version Counter Sharing ]
+// for details.
 //
 // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
 // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -76,11 +76,11 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
     AT_ERROR("opaque tensors do not have storage");
   }
 
-// NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-// 1. the AutogradMeta pointer, because it is unique for each Variable.
-// 2. [yf225 TODO: fix comment here!] the version counter, because although it lives in TensorImpl, the version counter is managed
-// by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
-// the version counter should be for each new TensorImpl. See NOTE [ Version Counter Sharing ] for details.
+// NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
+// for each Variable.
+//
+// NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
+// version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
 //
 // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
 // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -79,6 +79,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
 // NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
 // for each Variable.
 //
+// yf225 TODO: fix comment!
 // NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
 // version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
 //
@@ -86,7 +87,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
 // to this function that need to change the shallow copy's size or storage afterwards, and setting
 // `allow_tensor_metadata_change_` to false would prevent those changes from happening and is
 // undesirable.
-c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(ShallowCopyVersionCounterMode version_counter_mode) const override {
+c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(const c10::VariableVersion& version_counter) const override {
   //AT_ASSERT(false);
   auto impl = c10::make_intrusive<OpaqueTensorImpl<OpaqueHandle>>(
     type_id(), dtype(), device(), opaque_handle_, sizes_);
@@ -99,16 +100,7 @@ c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(ShallowCopyVersionCounter
   impl->is_contiguous_ = is_contiguous_;
   impl->is_wrapped_number_ = is_wrapped_number_;
   impl->reserved_ = reserved_;
-  switch (version_counter_mode) {
-    case ShallowCopyVersionCounterMode::kShareVersionCounter:
-      impl->set_version_counter(version_counter());
-      break;
-    case ShallowCopyVersionCounterMode::kCreateNewVersionCounter:
-      impl->set_version_counter(0);
-      break;
-    default:
-      AT_ERROR("Unsupported version_counter_mode: ", version_counter_mode);
-  }
+  impl->set_version_counter(version_counter);
 
   // OpaqueTensorImpl-specific fields (none currently).
   return impl;

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -184,7 +184,6 @@ public:
   void set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values);
 
   // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-  //
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
   // 2. the version counter, because it is set to the passed in `version_counter`.
   //    See NOTE [ Version Counter Sharing ] for details.

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -185,10 +185,8 @@ public:
 
   // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
-  // 2. the version counter, because although it lives in TensorImpl, the version counter is managed
-  // by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
-  // the version counter should be for each new TensorImpl, by passing the correct version counter as
-  // `version_counter` into this function. See NOTE [ Version Counter Sharing ] for details.
+  // 2. the version counter, because it is set to the passed in `version_counter`. See NOTE [ Version Counter Sharing ]
+  // for details.
   //
   // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
   // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -183,11 +183,11 @@ public:
   // make it happen
   void set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values);
 
-  // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-  // 1. the AutogradMeta pointer, because it is unique for each Variable.
-  // 2. [yf225 TODO fix comment here!] the version counter, because although it lives in TensorImpl, the version counter is managed
-  // by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
-  // the version counter should be for each new TensorImpl. See NOTE [ Version Counter Sharing ] for details.
+  // NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
+  // for each Variable.
+  //
+  // NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
+  // version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
   //
   // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
   // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -186,6 +186,7 @@ public:
   // NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
   // for each Variable.
   //
+  // yf225 TODO: fix comment!
   // NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
   // version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
   //
@@ -193,7 +194,7 @@ public:
   // to this function that need to change the shallow copy's size or storage afterwards, and setting
   // `allow_tensor_metadata_change_` to false would prevent those changes from happening and is
   // undesirable.
-  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(ShallowCopyVersionCounterMode version_counter_mode) const override {
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(const c10::VariableVersion& version_counter) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(type_id(), dtype());
     // TensorImpl general fields
     // Note that these fields are not used in sparse tensor code, and we copy them here only for completeness.
@@ -203,16 +204,7 @@ public:
     impl->is_contiguous_ = is_contiguous_;
     impl->is_wrapped_number_ = is_wrapped_number_;
     impl->reserved_ = reserved_;
-    switch (version_counter_mode) {
-      case ShallowCopyVersionCounterMode::kShareVersionCounter:
-        impl->set_version_counter(version_counter());
-        break;
-      case ShallowCopyVersionCounterMode::kCreateNewVersionCounter:
-        impl->set_version_counter(0);
-        break;
-      default:
-        AT_ERROR("Unsupported version_counter_mode: ", version_counter_mode);
-    }
+    impl->set_version_counter(version_counter);
 
     // Sparse-specific fields
     impl->sparse_dim_ = sparse_dim();

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -184,15 +184,17 @@ public:
   void set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values);
 
   // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-  // 1. the AutogradMeta pointer, because it is unique for each Variable.
-  // 2. the version counter, because it is set to the passed in `version_counter`. See NOTE [ Version Counter Sharing ]
-  // for details.
   //
-  // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
-  // to this function that need to change the shallow copy's size or storage afterwards, and setting
-  // `allow_tensor_metadata_change_` to false would prevent those changes from happening and is
-  // undesirable.
-  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(const c10::VariableVersion& version_counter) const override {
+  // 1. the AutogradMeta pointer, because it is unique for each Variable.
+  // 2. the version counter, because it is set to the passed in `version_counter`.
+  //    See NOTE [ Version Counter Sharing ] for details.
+  //
+  // NOTE: `allow_tensor_metadata_change` determines whether the TensorImpl shallow-copy
+  // allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
+  // See NOTE [ Metadata Change for a Detached Tensor ] for details.
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      const c10::VariableVersion& version_counter,
+      bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(type_id(), dtype());
     // TensorImpl general fields
     // Note that these fields are not used in sparse tensor code, and we copy them here only for completeness.
@@ -203,6 +205,7 @@ public:
     impl->is_wrapped_number_ = is_wrapped_number_;
     impl->reserved_ = reserved_;
     impl->set_version_counter(version_counter);
+    impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
 
     // Sparse-specific fields
     impl->sparse_dim_ = sparse_dim();

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -183,12 +183,12 @@ public:
   // make it happen
   void set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values);
 
-  // NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
-  // for each Variable.
-  //
-  // yf225 TODO: fix comment!
-  // NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
-  // version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
+  // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
+  // 1. the AutogradMeta pointer, because it is unique for each Variable.
+  // 2. the version counter, because although it lives in TensorImpl, the version counter is managed
+  // by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
+  // the version counter should be for each new TensorImpl, by passing the correct version counter as
+  // `version_counter` into this function. See NOTE [ Version Counter Sharing ] for details.
   //
   // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
   // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -25,7 +25,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     return quantizer_;
   }
 
-  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(ShallowCopyVersionCounterMode version_counter_mode) const override {
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(const c10::VariableVersion& version_counter) const override {
     auto impl = c10::make_intrusive<QTensorImpl>(
         Storage(storage()), type_id(), quantizer_);
     impl->set_sizes_and_strides(sizes(), strides());
@@ -34,16 +34,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     impl->reserved_ = reserved_;
     impl->refresh_numel();
     impl->refresh_contiguous();
-    switch (version_counter_mode) {
-      case ShallowCopyVersionCounterMode::kShareVersionCounter:
-        impl->set_version_counter(version_counter());
-        break;
-      case ShallowCopyVersionCounterMode::kCreateNewVersionCounter:
-        impl->set_version_counter(0);
-        break;
-      default:
-        AT_ERROR("Unsupported version_counter_mode: ", version_counter_mode);
-    }
+    impl->set_version_counter(version_counter);
 
     return impl;
   }

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -25,7 +25,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     return quantizer_;
   }
 
-  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach() const override {
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(ShallowCopyVersionCounterMode version_counter_mode) const override {
     auto impl = c10::make_intrusive<QTensorImpl>(
         Storage(storage()), type_id(), quantizer_);
     impl->set_sizes_and_strides(sizes(), strides());
@@ -34,6 +34,17 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     impl->reserved_ = reserved_;
     impl->refresh_numel();
     impl->refresh_contiguous();
+    switch (version_counter_mode) {
+      case ShallowCopyVersionCounterMode::kShareVersionCounter:
+        impl->set_version_counter(version_counter());
+        break;
+      case ShallowCopyVersionCounterMode::kCreateNewVersionCounter:
+        impl->set_version_counter(0);
+        break;
+      default:
+        AT_ERROR("Unsupported version_counter_mode: ", version_counter_mode);
+    }
+
     return impl;
   }
 

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -35,7 +35,6 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     impl->refresh_numel();
     impl->refresh_contiguous();
     impl->set_version_counter(version_counter);
-
     return impl;
   }
 

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -25,7 +25,9 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     return quantizer_;
   }
 
-  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(const c10::VariableVersion& version_counter) const override {
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      const c10::VariableVersion& version_counter,
+      bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<QTensorImpl>(
         Storage(storage()), type_id(), quantizer_);
     impl->set_sizes_and_strides(sizes(), strides());
@@ -35,6 +37,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
     impl->refresh_numel();
     impl->refresh_contiguous();
     impl->set_version_counter(version_counter);
+    impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     return impl;
   }
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -915,12 +915,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return std::move(autograd_meta_);
   }
 
-  // NOTE: `shallow_copy_and_detach()` does not copy the AutogradMeta pointer, because it is unique
-  // for each Variable.
-  //
-  // yf225 TODO: fix comment!
-  // NOTE: `version_counter_mode` determines the source of value for the TensorImpl shallow-copy's
-  // version counter. See NOTE [ Version Counter Behavior in TensorImpl Shallow-Copy ] for more details.
+  // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
+  // 1. the AutogradMeta pointer, because it is unique for each Variable.
+  // 2. the version counter, because although it lives in TensorImpl, the version counter is managed
+  // by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
+  // the version counter should be for each new TensorImpl, by passing the correct version counter as
+  // `version_counter` into this function. See NOTE [ Version Counter Sharing ] for details.
   //
   // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
   // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -917,10 +917,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
-  // 2. the version counter, because although it lives in TensorImpl, the version counter is managed
-  // by autograd, and the call sites of `shallow_copy_and_detach()` (from autograd) should decide what
-  // the version counter should be for each new TensorImpl, by passing the correct version counter as
-  // `version_counter` into this function. See NOTE [ Version Counter Sharing ] for details.
+  // 2. the version counter, because it is set to the passed in `version_counter`. See NOTE [ Version Counter Sharing ]
+  // for details.
   //
   // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
   // to this function that need to change the shallow copy's size or storage afterwards, and setting

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -882,6 +882,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   /**
    * Set whether a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
+   * See NOTE [ Metadata Change for a Detached Tensor ] for details.
    */
   virtual void set_allow_tensor_metadata_change(bool value) {
     allow_tensor_metadata_change_ = value;
@@ -889,6 +890,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   /**
    * True if a tensor allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
+   * See NOTE [ Metadata Change for a Detached Tensor ] for details.
    */
   virtual bool allow_tensor_metadata_change() const {
     return allow_tensor_metadata_change_;
@@ -916,15 +918,17 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-  // 1. the AutogradMeta pointer, because it is unique for each Variable.
-  // 2. the version counter, because it is set to the passed in `version_counter`. See NOTE [ Version Counter Sharing ]
-  // for details.
   //
-  // NOTE: We don't set `allow_tensor_metadata_change_` to false here, because there are call sites
-  // to this function that need to change the shallow copy's size or storage afterwards, and setting
-  // `allow_tensor_metadata_change_` to false would prevent those changes from happening and is
-  // undesirable.
-  virtual c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(const c10::VariableVersion& version_counter) const {
+  // 1. the AutogradMeta pointer, because it is unique for each Variable.
+  // 2. the version counter, because it is set to the passed in `version_counter`.
+  //    See NOTE [ Version Counter Sharing ] for details.
+  //
+  // NOTE: `allow_tensor_metadata_change` determines whether the TensorImpl shallow-copy
+  // allows changes to its metadata (e.g. sizes / strides / storage / storage_offset).
+  // See NOTE [ Metadata Change for a Detached Tensor ] for details.
+  virtual c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      const c10::VariableVersion& version_counter,
+      bool allow_tensor_metadata_change) const {
     AT_ASSERT(!is_variable());  // TODO: remove this when Variable and Tensor are merged
     auto impl = c10::make_intrusive<TensorImpl>(Storage(storage()), type_id());
     impl->set_sizes_and_strides(sizes(), strides());
@@ -934,6 +938,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     impl->refresh_numel();
     impl->refresh_contiguous();
     impl->set_version_counter(version_counter);
+    impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     return impl;
   }
 
@@ -1502,15 +1507,21 @@ protected:
   bool is_contiguous_ = true;
   bool is_wrapped_number_ = false;
 
-  // Previously, if we change the tensor metadata (e.g. sizes / strides / storage / storage_offset)
-  // of a derived tensor (i.e. tensors created from Python `tensor.data` or Python/C++ `tensor.detach()`),
-  // those metadata in the original tensor will also be updated. However, the new behavior is that
-  // those metadata changes to a derived tensor will not update the original tensor anymore, and we
-  // need this flag to make such changes explicitly illegal, to prevent users from changing metadata of
-  // the derived tensor and expecting the original tensor to also be updated.
+  // NOTE [ Metadata Change for a Detached Tensor ]
   //
-  // NOTE: For a full list of tensor metadata fields, please see `shallow_copy_and_detach()` in TensorImpl
-  // and its subclasses to find which fields are copied by value.
+  // Normally, a user is allowed to change the tensor metadata
+  // (e.g. sizes / strides / storage / storage_offset) of a tensor.
+  // However, if the tensor is created by `t1_detached = t1.data` in Python
+  // or `t1_detached = t1.detach()` in Python/C++, those changes to the
+  // tensor metadata of `t1_detached` will not be propagated back to the
+  // original tensor `t1`. In order to make such changes explicitly illegal,
+  // we created the `allow_tensor_metadata_change_` flag, to prevent users
+  // from changing metadata of the detached tensor and expecting the original
+  // tensor to also be updated.
+  //
+  // NOTE: For a full list of tensor metadata fields, please see
+  // `shallow_copy_and_detach()` in TensorImpl and its subclasses to find
+  // which fields are copied by value.
   bool allow_tensor_metadata_change_ = true;
 
   // we decide to keep reserved_ and it will

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -918,7 +918,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   // NOTE: `shallow_copy_and_detach()` does not copy the following TensorImpl fields:
-  //
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
   // 2. the version counter, because it is set to the passed in `version_counter`.
   //    See NOTE [ Version Counter Sharing ] for details.

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -174,7 +174,8 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   // by calling `set_data(...)`. The original version of the `Variable` is always preserved.
   // See NOTE [ Version Counter Sharing ] for details.
   auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(
-    /*version_counter=*/data_.unsafeGetTensorImpl()->version_counter());
+    /*version_counter=*/data_.unsafeGetTensorImpl()->version_counter(),
+    /*allow_tensor_metadata_change=*/true);
   data_ = std::move(at::Tensor(new_data_impl_copy));
 }
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -170,7 +170,8 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   device_opt_ = new_data.device();
   type_id_ = new_data.dispatch_type().type_id();
 
-  auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach();
+  auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(
+    at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
   // Version counter is not shared when we replace a `Variable`'s underlying `Tensor`
   // by calling `set_data(...)`. The original version of the `Variable` is always preserved.
   // See NOTE [ Version Counter Sharing ] for details.

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -171,7 +171,7 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   type_id_ = new_data.dispatch_type().type_id();
 
   auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(
-    at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
+    /*version_counter=*/0);
   // Version counter is not shared when we replace a `Variable`'s underlying `Tensor`
   // by calling `set_data(...)`. The original version of the `Variable` is always preserved.
   // See NOTE [ Version Counter Sharing ] for details.

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -170,12 +170,11 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   device_opt_ = new_data.device();
   type_id_ = new_data.dispatch_type().type_id();
 
-  auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
   // Version counter is not shared when we replace a `Variable`'s underlying `Tensor`
   // by calling `set_data(...)`. The original version of the `Variable` is always preserved.
   // See NOTE [ Version Counter Sharing ] for details.
-  auto saved_version_counter = data_.unsafeGetTensorImpl()->version_counter();
-  new_data_impl_copy->set_version_counter(saved_version_counter);
+  auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(
+    /*version_counter=*/data_.unsafeGetTensorImpl()->version_counter());
   data_ = std::move(at::Tensor(new_data_impl_copy));
 }
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -170,8 +170,7 @@ void Variable::Impl::set_data(const at::Tensor &new_data) {
   device_opt_ = new_data.device();
   type_id_ = new_data.dispatch_type().type_id();
 
-  auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(
-    /*version_counter=*/0);
+  auto new_data_impl_copy = new_data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
   // Version counter is not shared when we replace a `Variable`'s underlying `Tensor`
   // by calling `set_data(...)`. The original version of the `Variable` is always preserved.
   // See NOTE [ Version Counter Sharing ] for details.

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -546,7 +546,7 @@ inline Variable make_variable_view(
   if (data.defined()) {
     if (is_differentiable) {
       /// Differentiable view. Track history with DifferentiableViewImpl.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
       data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto diff_view_meta = c10::guts::make_unique<Variable::DifferentiableViewMeta>();
@@ -554,7 +554,7 @@ inline Variable make_variable_view(
               std::move(base), std::move(data_copy), std::move(gradient_edge), std::move(diff_view_meta)));
     } else {
       /// Non-differentiable view. Just share version counter.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
       data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
@@ -575,7 +575,7 @@ inline Variable make_variable(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
-    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
+    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
     data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     auto data_copy = at::Tensor(data_impl_copy);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
@@ -608,7 +608,7 @@ inline Variable make_variable(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
-    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
+    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
     data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     auto data_copy = at::Tensor(data_impl_copy);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -546,7 +546,7 @@ inline Variable make_variable_view(
   if (data.defined()) {
     if (is_differentiable) {
       /// Differentiable view. Track history with DifferentiableViewImpl.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach();
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
       data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto diff_view_meta = c10::guts::make_unique<Variable::DifferentiableViewMeta>();
@@ -554,7 +554,7 @@ inline Variable make_variable_view(
               std::move(base), std::move(data_copy), std::move(gradient_edge), std::move(diff_view_meta)));
     } else {
       /// Non-differentiable view. Just share version counter.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach();
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
       data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
@@ -575,7 +575,7 @@ inline Variable make_variable(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
-    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach();
+    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
     data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     auto data_copy = at::Tensor(data_impl_copy);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
@@ -608,7 +608,7 @@ inline Variable make_variable(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
-    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach();
+    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(at::ShallowCopyVersionCounterMode::kCreateNewVersionCounter);
     data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
     auto data_copy = at::Tensor(data_impl_copy);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -554,13 +554,12 @@ inline Variable make_variable_view(
               std::move(base), std::move(data_copy), std::move(gradient_edge), std::move(diff_view_meta)));
     } else {
       /// Non-differentiable view. Just share version counter.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/base.version_counter());
       data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
       auto var = Variable(c10::make_intrusive<Variable::Impl>(
               std::move(data_copy), std::move(autograd_meta), false, std::move(gradient_edge)));
-      var.set_version_counter(base.version_counter());
       return var;
     }
   }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -546,16 +546,18 @@ inline Variable make_variable_view(
   if (data.defined()) {
     if (is_differentiable) {
       /// Differentiable view. Track history with DifferentiableViewImpl.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
-      data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
+        /*version_counter=*/0,
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto diff_view_meta = c10::guts::make_unique<Variable::DifferentiableViewMeta>();
       return Variable(c10::make_intrusive<Variable::DifferentiableViewImpl>(
               std::move(base), std::move(data_copy), std::move(gradient_edge), std::move(diff_view_meta)));
     } else {
       /// Non-differentiable view. Just share version counter.
-      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/base.version_counter());
-      data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+      auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
+        /*version_counter=*/base.version_counter(),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
       auto data_copy = at::Tensor(data_impl_copy);
       auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
       auto var = Variable(c10::make_intrusive<Variable::Impl>(
@@ -574,8 +576,9 @@ inline Variable make_variable(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
-    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
-    data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
+      /*version_counter=*/0,
+      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     auto data_copy = at::Tensor(data_impl_copy);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
     return Variable(c10::make_intrusive<Variable::Impl>(data_copy, std::move(autograd_meta), requires_grad));
@@ -607,8 +610,9 @@ inline Variable make_variable(
       !data.is_variable(),
       "Must not create a new variable from a variable, use its .data()");
   if (data.defined()) {
-    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(/*version_counter=*/0);
-    data_impl_copy->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+    auto data_impl_copy = data.getIntrusivePtr()->shallow_copy_and_detach(
+      /*version_counter=*/0,
+      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     auto data_copy = at::Tensor(data_impl_copy);
     auto autograd_meta = c10::guts::make_unique<Variable::AutogradMeta>();
     return Variable(c10::make_intrusive<Variable::Impl>(data_copy, std::move(autograd_meta), false, std::move(gradient_edge)));


### PR DESCRIPTION
Previously, the caller of `shallow_copy_and_detach()` is responsible for deciding whether the shallow-copy should share the source TensorImpl's version counter, or have its own new version counter. However, since this decision is crucial for ensuring the correctness of the shallow-copy's version counter, we want to enforce users of `shallow_copy_and_detach()` to pass a version counter to the function call, so that they are required to make the decision at the time of API usage, not as an afterthought.

For similar reasons, we want to enforce users of `shallow_copy_and_detach()` to pass `allow_tensor_metadata_change` to the function call, so that they are required to decide "whether the TensorImpl shallow-copy should allow tensor metadata change" at the time of API usage, not as an afterthought.