### PR TITLE
identify important circleci builds

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -8,7 +8,7 @@ CONFIG_TREE_DATA = [
         (None, [
             X("2.7.9"),
             X("2.7"),
-            X("3.5"),
+            ("3.5", [("important", [X(True)])]),
             X("nightly"),
         ]),
         ("gcc", [
@@ -36,7 +36,7 @@ CONFIG_TREE_DATA = [
                 # and
                 # https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L153
                 # (from https://github.com/pytorch/pytorch/pull/17323#discussion_r259453144)
-                X("2.7"),
+                ("2.7", [("important", [X(True)])]),
                 X("3.6"),
             ]),
             ("9.2", [X("3.6")]),
@@ -135,6 +135,7 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
         next_nodes = {
             "xla": XlaConfigNode,
             "namedtensor": NamedTensorConfigNode,
+            "important": ImportantConfigNode,
         }
         return next_nodes[experimental_feature]
 
@@ -153,6 +154,14 @@ class NamedTensorConfigNode(TreeConfigNode):
 
     def init2(self, node_name):
         self.props["is_namedtensor"] = node_name
+
+
+class ImportantConfigNode(TreeConfigNode):
+    def modify_label(self, label):
+        return "IMPORTANT=" + str(label)
+
+    def init2(self, node_name):
+        self.props["is_important"] = node_name
 
 
 class XenialCompilerConfigNode(TreeConfigNode):

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -105,7 +105,7 @@ class Conf(object):
             resource_class = "large"
 
         if self.is_important:
-            resource_class = "xlarge"
+            resource_class = "large"
 
         if self.gpu_resource:
             resource_class = "gpu." + self.gpu_resource

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -25,7 +25,8 @@ class Conf(object):
                  gpu_resource=None,
                  dependent_tests=None,
                  parent_build=None,
-                 is_namedtensor=False):
+                 is_namedtensor=False,
+                 is_important=False):
 
         self.distro = distro
         self.pyver = pyver
@@ -37,6 +38,7 @@ class Conf(object):
         # (from https://github.com/pytorch/pytorch/pull/17323#discussion_r259453608)
         self.is_xla = is_xla
         self.is_namedtensor = is_namedtensor
+        self.is_important = is_important
 
         self.restrict_phases = restrict_phases
         self.gpu_resource = gpu_resource
@@ -46,7 +48,10 @@ class Conf(object):
     # TODO: Eliminate the special casing for docker paths
     # In the short term, we *will* need to support special casing as docker images are merged for caffe2 and pytorch
     def get_parms(self, for_docker):
-        leading = ["pytorch"]
+        leading = []
+        if self.is_important and not for_docker:
+            leading.append("AAA")
+        leading.append("pytorch")
         if self.is_xla and not for_docker:
             leading.append("xla")
         if self.is_namedtensor and not for_docker:
@@ -95,14 +100,19 @@ class Conf(object):
             "<<": "*" + "_".join(["pytorch", "linux", build_or_test, "defaults"]),
         }
 
+        resource_class = None
         if build_or_test == "test":
             resource_class = "large"
-            if self.gpu_resource:
-                resource_class = "gpu." + self.gpu_resource
 
-                if self.gpu_resource == "large":
-                    env_dict["MULTI_GPU"] = miniutils.quote("1")
+        if self.is_important:
+            resource_class = "vlarge"
 
+        if self.gpu_resource:
+            resource_class = "gpu." + self.gpu_resource
+            if self.gpu_resource == "large":
+                env_dict["MULTI_GPU"] = miniutils.quote("1")
+
+        if resource_class is not None:
             d["resource_class"] = resource_class
 
         return d
@@ -225,6 +235,7 @@ def instantiate_configs():
 
         is_xla = fc.find_prop("is_xla") or False
         is_namedtensor = fc.find_prop("is_namedtensor") or False
+        is_important = fc.find_prop("is_important") or False
 
         gpu_resource = None
         if cuda_version and cuda_version != "10":
@@ -239,6 +250,7 @@ def instantiate_configs():
             restrict_phases,
             gpu_resource,
             is_namedtensor=is_namedtensor,
+            is_important=is_important,
         )
 
         if cuda_version == "9" and python_version == "3.6":

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -100,19 +100,14 @@ class Conf(object):
             "<<": "*" + "_".join(["pytorch", "linux", build_or_test, "defaults"]),
         }
 
-        resource_class = None
-        if build_or_test == "test" or self.is_important:
+        if build_or_test == "test":
             resource_class = "large"
+            if self.gpu_resource:
+                resource_class = "gpu." + self.gpu_resource
 
-        if self.is_important:
-            resource_class = "large"
+                if self.gpu_resource == "large":
+                    env_dict["MULTI_GPU"] = miniutils.quote("1")
 
-        if self.gpu_resource:
-            resource_class = "gpu." + self.gpu_resource
-            if self.gpu_resource == "large":
-                env_dict["MULTI_GPU"] = miniutils.quote("1")
-
-        if resource_class is not None:
             d["resource_class"] = resource_class
 
         return d

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -101,11 +101,8 @@ class Conf(object):
         }
 
         resource_class = None
-        if build_or_test == "test":
+        if build_or_test == "test" or self.is_important:
             resource_class = "large"
-
-        if self.is_important:
-            resource_class = "vlarge"
 
         if self.gpu_resource:
             resource_class = "gpu." + self.gpu_resource

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -104,6 +104,9 @@ class Conf(object):
         if build_or_test == "test" or self.is_important:
             resource_class = "large"
 
+        if self.is_important:
+            resource_class = "xlarge"
+
         if self.gpu_resource:
             resource_class = "gpu." + self.gpu_resource
             if self.gpu_resource == "large":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,14 +760,14 @@ jobs:
     environment:
       BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
-    resource_class: xlarge
+    resource_class: large
     <<: *pytorch_linux_build_defaults
 
   AAA_pytorch_linux_trusty_py3_5_test:
     environment:
       BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
-    resource_class: xlarge
+    resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_pynightly_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,7 +760,6 @@ jobs:
     environment:
       BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
-    resource_class: large
     <<: *pytorch_linux_build_defaults
 
   AAA_pytorch_linux_trusty_py3_5_test:
@@ -868,7 +867,6 @@ jobs:
       BUILD_ENVIRONMENT: AAA-pytorch-linux-xenial-cuda9-cudnn7-py2-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:300"
       PYTHON_VERSION: "2.7"
-    resource_class: gpu.medium
     <<: *pytorch_linux_build_defaults
 
   AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_test:
@@ -885,7 +883,6 @@ jobs:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:300"
       PYTHON_VERSION: "3.6"
-    resource_class: gpu.medium
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py3_test:
@@ -947,7 +944,6 @@ jobs:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:300"
       PYTHON_VERSION: "3.6"
-    resource_class: gpu.medium
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,14 +760,14 @@ jobs:
     environment:
       BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
-    resource_class: vlarge
+    resource_class: xlarge
     <<: *pytorch_linux_build_defaults
 
   AAA_pytorch_linux_trusty_py3_5_test:
     environment:
       BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
-    resource_class: vlarge
+    resource_class: xlarge
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_pynightly_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -756,17 +756,18 @@ jobs:
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
-  pytorch_linux_trusty_py3_5_build:
+  AAA_pytorch_linux_trusty_py3_5_build:
     environment:
-      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.5-build
+      BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
+    resource_class: vlarge
     <<: *pytorch_linux_build_defaults
 
-  pytorch_linux_trusty_py3_5_test:
+  AAA_pytorch_linux_trusty_py3_5_test:
     environment:
-      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.5-test
+      BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
-    resource_class: large
+    resource_class: vlarge
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_trusty_pynightly_build:
@@ -862,16 +863,17 @@ jobs:
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
-  pytorch_linux_xenial_cuda9_cudnn7_py2_build:
+  AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_build:
     environment:
-      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-build
+      BUILD_ENVIRONMENT: AAA-pytorch-linux-xenial-cuda9-cudnn7-py2-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:300"
       PYTHON_VERSION: "2.7"
+    resource_class: gpu.medium
     <<: *pytorch_linux_build_defaults
 
-  pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+  AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_test:
     environment:
-      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-test
+      BUILD_ENVIRONMENT: AAA-pytorch-linux-xenial-cuda9-cudnn7-py2-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:300"
       PYTHON_VERSION: "2.7"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -883,6 +885,7 @@ jobs:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:300"
       PYTHON_VERSION: "3.6"
+    resource_class: gpu.medium
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py3_test:
@@ -944,6 +947,7 @@ jobs:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:300"
       PYTHON_VERSION: "3.6"
+    resource_class: gpu.medium
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
@@ -2821,13 +2825,13 @@ workflows:
           requires:
             - setup
             - pytorch_linux_trusty_py2_7_build
-      - pytorch_linux_trusty_py3_5_build:
+      - AAA_pytorch_linux_trusty_py3_5_build:
           requires:
             - setup
-      - pytorch_linux_trusty_py3_5_test:
+      - AAA_pytorch_linux_trusty_py3_5_test:
           requires:
             - setup
-            - pytorch_linux_trusty_py3_5_build
+            - AAA_pytorch_linux_trusty_py3_5_build
       - pytorch_linux_trusty_pynightly_build:
           requires:
             - setup
@@ -2877,13 +2881,13 @@ workflows:
           requires:
             - setup
             - pytorch_linux_xenial_py3_clang5_asan_build
-      - pytorch_linux_xenial_cuda9_cudnn7_py2_build:
+      - AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_build:
           requires:
             - setup
-      - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+      - AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_test:
           requires:
             - setup
-            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+            - AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_build
       - pytorch_linux_xenial_cuda9_cudnn7_py3_build:
           requires:
             - setup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20498 identify important circleci builds**

We want to move toward running only dev-blocking builds on PRs and the
rest on continuous. This saves tons of capacity and reduces noise for
developers.

The first step is trying to identify the minimal set of builds that can
be considered "important". The hope is that if all important builds
pass, the likelihood that the change is good is super high.

This PR also gives important builds more juice so that we get signal
faster.

Differential Revision: [D15342506](https://our.internmc.facebook.com/intern/diff/D15342506)