### PR TITLE
eliminate FE_INVALID in optimizer related operators and tests

### DIFF
--- a/caffe2/python/operator_test/adadelta_test.py
+++ b/caffe2/python/operator_test/adadelta_test.py
@@ -55,6 +55,8 @@ class TestAdadelta(serial.SerializedTestCase):
            **hu.gcs)
     def test_adadelta(self, inputs, lr, epsilon, decay, gc, dc):
         param, moment, moment_delta, grad = inputs
+        moment = np.abs(moment)
+        moment_delta = np.abs(moment_delta)
         lr = np.array([lr], dtype=np.float32)
 
         op = core.CreateOperator(
@@ -85,6 +87,7 @@ class TestAdadelta(serial.SerializedTestCase):
     def test_sparse_adadelta(self, inputs, lr, epsilon, decay, gc, dc):
         param, moment, moment_delta, grad = inputs
         moment = np.abs(moment)
+        moment_delta = np.abs(moment_delta)
         lr = np.array([lr], dtype=np.float32)
 
         # Create an indexing array containing values that are lists of indices,

--- a/caffe2/python/operator_test/adam_test.py
+++ b/caffe2/python/operator_test/adam_test.py
@@ -60,6 +60,7 @@ class TestAdam(hu.HypothesisTestCase):
            **hu.gcs)
     def test_adam(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):
         param, mom1, mom2, grad = inputs
+        mom2 = np.abs(mom2)
         ITER = np.array([ITER], dtype=np.int64)
         LR = np.array([LR], dtype=np.float32)
 
@@ -93,6 +94,7 @@ class TestAdam(hu.HypothesisTestCase):
            **hu.gcs_cpu_only)
     def test_adam_output_grad(self, inputs, ITER, LR, beta1, beta2, epsilon, gc, dc):
         param, mom1, mom2, grad = inputs
+        mom2 = np.abs(mom2)
         ITER = np.array([ITER], dtype=np.int64)
         LR = np.array([LR], dtype=np.float32)
 


### PR DESCRIPTION
Summary: Fixing unit tests related to optimizer related operators and tests

Differential Revision: D15307410

