### PR TITLE
stop build spew on development

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -287,7 +287,7 @@ def build_caffe2(version,
             check_call(build_cmd, cwd=build_dir, env=my_env)
     else:
         if USE_NINJA:
-            ninja_cmd = ['ninja', 'install', '-v']
+            ninja_cmd = ['ninja', 'install']
             if max_jobs is not None:
                 ninja_cmd += ['-j', max_jobs]
             check_call(ninja_cmd, cwd=build_dir, env=my_env)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20508 stop build spew on development**

It is important when developing that trivial rebuilds do not blow away your terminal state. This reverts the addition of -v to ninja, which causes the build to spew.

Differential Revision: [D15343207](https://our.internmc.facebook.com/intern/diff/D15343207)