### PR TITLE
[jit] Use AT_INTERNAL_ASSERT in test_base

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -269,16 +269,16 @@ inline void deprecated_AT_CHECK() {}
 /*
 // Deprecation disabled until we fix sites in our codebase
 C10_DEPRECATED_MESSAGE("AT_ASSERT is deprecated, if you mean to indicate an internal invariant failure, use " \
-                       "AT_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
-                       "AT_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
+                       "TORCH_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
+                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
 */
 inline void deprecated_AT_ASSERT() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
 C10_DEPRECATED_MESSAGE("AT_ASSERTM is deprecated, if you mean to indicate an internal invariant failure, use " \
-                       "AT_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
-                       "AT_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
+                       "TORCH_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
+                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
 */
 inline void deprecated_AT_ASSERTM() {}
 

--- a/test/cpp/jit/test_base.h
+++ b/test/cpp/jit/test_base.h
@@ -10,9 +10,9 @@
 #include <test/cpp/common/support.h>
 #else
 #include "c10/util/Exception.h"
-#define ASSERT_EQ(x, y) AT_ASSERT((x) == (y))
-#define ASSERT_NE(x, y) AT_ASSERT((x) != (y))
-#define ASSERT_TRUE AT_ASSERT
+#define ASSERT_EQ(x, y) AT_INTERNAL_ASSERT((x) == (y))
+#define ASSERT_NE(x, y) AT_INTERNAL_ASSERT((x) != (y))
+#define ASSERT_TRUE AT_INTERNAL_ASSERT
 #define ASSERT_FALSE(x) ASSERT_TRUE(!(x))
 #define ASSERT_THROWS_WITH(statement, substring)                         \
   try {                                                                  \

--- a/test/cpp/jit/test_base.h
+++ b/test/cpp/jit/test_base.h
@@ -10,9 +10,9 @@
 #include <test/cpp/common/support.h>
 #else
 #include "c10/util/Exception.h"
-#define ASSERT_EQ(x, y) AT_INTERNAL_ASSERT((x) == (y))
-#define ASSERT_NE(x, y) AT_INTERNAL_ASSERT((x) != (y))
-#define ASSERT_TRUE AT_INTERNAL_ASSERT
+#define ASSERT_EQ(x, y) TORCH_INTERNAL_ASSERT((x) == (y))
+#define ASSERT_NE(x, y) TORCH_INTERNAL_ASSERT((x) != (y))
+#define ASSERT_TRUE TORCH_INTERNAL_ASSERT
 #define ASSERT_FALSE(x) ASSERT_TRUE(!(x))
 #define ASSERT_THROWS_WITH(statement, substring)                         \
   try {                                                                  \


### PR DESCRIPTION
as title. We were using AT_ASSERT, which is newly deprecated. In this case, we do in fact want an internal assertion since this is used in testing code to describe expected behavior.