### PR TITLE
upgrade mkldnn-bridge

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -10,13 +10,11 @@ namespace at { namespace native {
 
 // Custom allocator using c10 CPU allocator for `ideep::tensor`
 struct AllocForMKLDNN {
-  template<class computation_t = void>
   static char* malloc(size_t size) {
     auto allocator = c10::GetAllocator(c10::DeviceType::CPU);
     return (char*)allocator->raw_allocate(size);
   }
 
-  template<class computation_t = void>
   static void free(void* p) {
     auto allocator = c10::GetAllocator(c10::DeviceType::CPU);
     allocator->raw_deallocate(p);

--- a/aten/src/ATen/native/mkldnn/SoftMax.cpp
+++ b/aten/src/ATen/native/mkldnn/SoftMax.cpp
@@ -24,41 +24,6 @@ Tensor mkldnn_softmax(
 namespace at {
 namespace native {
 
-namespace {
-// TODO: move this to ideep
-struct ideep_softmax_forward
-    : public ideep::softmax_forward,
-      public ideep::utils::computation_cache<ideep_softmax_forward> {
-  template <typename... Ts>
-  ideep_softmax_forward(
-      const ideep::tensor::descriptor& src_desc,
-      const ideep::tensor::descriptor& dst_desc,
-      Ts&&... args) {
-    init(src_desc, dst_desc, std::forward<Ts>(args)...);
-  }
-
-  template <class alloc>
-  static void compute(
-      const ideep::tensor& src,
-      ideep::tensor& dst,
-      int softmax_axis) {
-    if (dst.get_descriptor() != src.get_descriptor()) {
-      dst.reinit<alloc, ideep_softmax_forward>(src.get_descriptor());
-    }
-    ideep::key_t key;
-    ideep::utils::create_key(
-        key,
-        src.get_data_type(),
-        src.get_dims(),
-        src.get_internal_format(),
-        softmax_axis);
-    fetch_or_create_m(
-        comp, key, src.get_descriptor(), dst.get_descriptor(), softmax_axis);
-    comp.execute(src, dst);
-  }
-};
-} // namespace
-
 Tensor mkldnn_softmax(
     const Tensor& self,
     const int64_t dim,
@@ -69,7 +34,7 @@ Tensor mkldnn_softmax(
   const int64_t wrapped_dim = maybe_wrap_dim(dim, self.dim());
   ideep::tensor& x = itensor_from_mkldnn(self);
   ideep::tensor y;
-  ideep_softmax_forward::compute<AllocForMKLDNN>(x, y, wrapped_dim);
+  ideep::softmax_forward::compute<AllocForMKLDNN>(x, y, wrapped_dim);
   return new_with_itensor_mkldnn(std::move(y), self.options());
 }
 

--- a/caffe2/opt/optimize_ideep.cc
+++ b/caffe2/opt/optimize_ideep.cc
@@ -892,10 +892,11 @@ void preConvertFiltersFormat(repr::NNModule* nn, caffe2::Workspace* ws) {
 
       if (filter->get_descriptor() != expectedDesc) {
         filter->set_public_format(ideep::format::iohw);
-        itensor&& newFilter(expectedDesc);
+        itensor newFilter;
+        newFilter.init(expectedDesc);
         newFilter.feed_from(*filter);
         newFilter.set_public_format(ideep::format::iohw);
-        filterBlob->Reset<itensor>(new itensor(newFilter));
+        filterBlob->Reset<itensor>(new itensor(std::move(newFilter)));
       }
     } else if (repr::nn::is<repr::Conv>(node)) {
       auto conv = repr::nn::get<repr::Conv>(node);
@@ -932,9 +933,10 @@ void preConvertFiltersFormat(repr::NNModule* nn, caffe2::Workspace* ws) {
           aalgorithm);
 
       if (filter->get_descriptor() != expectedDesc) {
-        itensor&& newFilter(expectedDesc);
+        itensor newFilter;
+        newFilter.init(expectedDesc);
         newFilter.feed_from(*filter);
-        filterBlob->Reset<itensor>(new itensor(newFilter));
+        filterBlob->Reset<itensor>(new itensor(std::move(newFilter)));
       }
       // convert weights for FC
     } else if (repr::nn::is<repr::FC>(node)) {
@@ -959,9 +961,10 @@ void preConvertFiltersFormat(repr::NNModule* nn, caffe2::Workspace* ws) {
           filter->get_dims());
 
       if (filter->get_descriptor() != expectedDesc) {
-        itensor&& newFilter(expectedDesc);
+        itensor newFilter;
+        newFilter.init(expectedDesc);
         newFilter.feed_from(filter->as_weights());
-        filterBlob->Reset<itensor>(new itensor(newFilter));
+        filterBlob->Reset<itensor>(new itensor(std::move(newFilter)));
       }
     }
   }


### PR DESCRIPTION
1. reduce the overhead of mkldnn-bridge itself
2. remove redundant code and useless APIs
3. provide new operators, including int8 inner_product,  ND permute/transpose, elem_add/mul, and etc.
4. improve inner_product to support io format weights without implicit reorder
5. add SoftMax support

