### PR TITLE
Add aten mkldnn backward ops: relu, linear and reshape

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -80,6 +80,9 @@ Tensor& threshold_out(Tensor& result, const Tensor& self, Scalar threshold, Scal
 }
 
 Tensor threshold_backward(const Tensor& grad, const Tensor& self, Scalar threshold) {
+  if (grad.is_mkldnn()) {
+    return at::mkldnn_relu_backward(grad, self);
+  }
   return threshold_out(nullopt, self, threshold, 0, grad);
 }
 

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -40,21 +40,6 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> mkldnn_convolution_backward(
 
 using namespace mkldnn;
 
-namespace {
-// Helper function for getting an ideep tensor out of an aten Tensor.
-// Note in case the aten Tensor is a dense tensor, the retured ideep
-// tensor is just a view of the storage of the aten dense tensor, so
-// caller needs to make sure the aten dense tensor's lifetime is
-// longer than the ideep tensor.
-inline ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor) {
-  if (tensor.is_mkldnn()) {
-    return at::native::itensor_from_mkldnn(tensor);
-  } else {
-    return at::native::itensor_view_from_dense(tensor);
-  }
-}
-}
-
 namespace at { namespace native {
 
 ideep::tensor _mkldnn_conv2d(
@@ -126,11 +111,11 @@ at::Tensor mkldnn_convolution(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups) {
-  const ideep::tensor mkldnn_input = get_mkldnn_tensor(input);
-  const ideep::tensor mkldnn_weight = get_mkldnn_tensor(weight);
+  const ideep::tensor mkldnn_input = itensor_from_tensor(input);
+  const ideep::tensor mkldnn_weight = itensor_from_tensor(weight);
   c10::optional<ideep::tensor> mkldnn_bias{c10::nullopt};
   if (bias.defined()) {
-    mkldnn_bias = get_mkldnn_tensor(bias);
+    mkldnn_bias = itensor_from_tensor(bias);
   }
 
   ideep::tensor mkldnn_output = _mkldnn_conv2d(

--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -11,7 +11,23 @@ Tensor mkldnn_linear(
     const Tensor& self,
     const Tensor& weight,
     const Tensor& bias) {
-  AT_ERROR("mkldnn_linear: ATen not compiled with MKLDNN support");
+  TORCH_CHECK(false, "mkldnn_linear: ATen not compiled with MKLDNN support");
+}
+
+Tensor mkldnn_linear_backward_input(
+    IntArrayRef input_size, const Tensor& grad_output, const Tensor& weight) {
+  TORCH_CHECK(false, "mkldnn_linear_backward_input: ATen not compiled with MKLDNN support");
+}
+
+std::tuple<Tensor, Tensor> mkldnn_linear_backward_weights(
+    const Tensor& grad_output, const Tensor& input, const Tensor& weight, bool bias_defined) {
+  TORCH_CHECK(false, "mkldnn_linear_backward_weights: ATen not compiled with MKLDNN support");
+}
+
+std::tuple<Tensor, Tensor, Tensor> mkldnn_linear_backward(
+    const Tensor& input, const Tensor& grad_output_t,
+    const Tensor& weight, std::array<bool,3> output_mask) {
+  TORCH_CHECK(false, "mkldnn_linear_backward: ATen not compiled with MKLDNN support");
 }
 
 } // namespace native
@@ -32,17 +48,15 @@ Tensor mkldnn_linear(
       "mkldnn_linear: input needs to has dim at least 2, input dim ", self.dim());
   TORCH_CHECK(self.is_mkldnn(),
       "mkldnn_linear: input needs to be mkldnn layout");
-  TORCH_CHECK(weight.is_mkldnn() && bias.is_mkldnn(),
-      "mkldnn_linear: weight and bias need to be mkldnn layout");
 
   // reshape first if input dim is greater than 2 and the reshape will cost a memory copy.
   auto self_reshaped = self.dim() > 2 ? self.reshape({-1, self.size(self.dim() - 1)}) : self;
   const ideep::tensor x = itensor_from_mkldnn(self_reshaped);
-  const ideep::tensor w = itensor_from_mkldnn(weight);
+  const ideep::tensor w = itensor_from_tensor(weight);
 
   ideep::tensor y;
   if (bias.defined()) {
-    const ideep::tensor b = itensor_from_mkldnn(bias);
+    const ideep::tensor b = itensor_from_tensor(bias);
     ideep::inner_product_forward::compute(x, w, b, y);
   } else {
     ideep::inner_product_forward::compute(x, w, y);
@@ -56,6 +70,65 @@ Tensor mkldnn_linear(
     return new_with_itensor_mkldnn(std::move(y), self.options()).reshape(output_size);
   }
   return new_with_itensor_mkldnn(std::move(y), self.options());
+}
+
+Tensor mkldnn_linear_backward_input(
+    IntArrayRef input_size, const Tensor& grad_output, const Tensor& weight){
+  auto grad_output_reshaped = grad_output.dim() > 2 ?
+    grad_output.reshape({-1, grad_output.size(grad_output.dim() - 1)}) : grad_output;
+  ideep::tensor& grady = itensor_from_mkldnn(grad_output_reshaped);
+  const ideep::tensor w = itensor_from_tensor(weight);
+
+  std::vector<int64_t> input_reshaped_size;
+  input_reshaped_size.push_back(grad_output_reshaped.size(0));
+  input_reshaped_size.push_back(weight.size(1));
+
+  ideep::tensor gradx;
+  ideep::inner_product_backward_data::compute(
+    grady, w, {input_reshaped_size.begin(), input_reshaped_size.end()}, gradx);
+
+  if (input_size.size() > 2) {
+    return new_with_itensor_mkldnn(std::move(gradx), grad_output.options()).reshape(input_size);
+  }
+  return new_with_itensor_mkldnn(std::move(gradx), grad_output.options());
+}
+
+std::tuple<Tensor, Tensor> mkldnn_linear_backward_weights(
+    const Tensor& grad_output, const Tensor& input, const Tensor& weight, bool bias_defined) {
+  auto grad_output_reshaped = grad_output.dim() > 2 ?
+    grad_output.reshape({-1, grad_output.size(grad_output.dim() - 1)}) : grad_output;
+  auto input_reshaped = input.dim() > 2 ? input.reshape({-1, input.size(input.dim() - 1)}) : input;
+
+  ideep::tensor& grady = itensor_from_mkldnn(grad_output_reshaped);
+  ideep::tensor& x = itensor_from_mkldnn(input_reshaped);
+  ideep::tensor gradw, gradb;
+  if (bias_defined) {
+    ideep::inner_product_backward_weights::compute(x, grady, gradw, gradb);
+  } else {
+    ideep::inner_product_backward_weights::compute(x, grady, gradw);
+  }
+
+  if (weight.is_mkldnn()) {
+    return std::tuple<Tensor, Tensor>{new_with_itensor_mkldnn(std::move(gradw), grad_output.options()),
+      new_with_itensor_mkldnn(std::move(gradb), grad_output.options())};
+  } else {
+    return std::tuple<Tensor, Tensor>{
+      mkldnn_to_dense(new_with_itensor_mkldnn(std::move(gradw), grad_output.options())),
+      mkldnn_to_dense(new_with_itensor_mkldnn(std::move(gradb), grad_output.options()))};
+  }
+}
+
+std::tuple<Tensor, Tensor, Tensor> mkldnn_linear_backward(
+    const Tensor& input, const Tensor& grad_output,
+    const Tensor& weight, std::array<bool,3> output_mask) {
+  Tensor grad_input, grad_weight, grad_bias;
+  if (output_mask[0]) {
+    grad_input = at::mkldnn_linear_backward_input(input.sizes(), grad_output, weight);
+  }
+  if (output_mask[1] || output_mask[2]) {
+    std::tie(grad_weight, grad_bias) = at::mkldnn_linear_backward_weights(grad_output, input, weight, output_mask[2]);
+  }
+  return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
 }
 
 } // namespace native

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -75,6 +75,19 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
            ideep::tensor::data_type::f32},
           tensor.template data_ptr<float>()};
 }
+
+// Note in case the aten Tensor is a dense tensor, the retured ideep
+// tensor is just a view of the storage of the aten dense tensor, so
+// caller needs to make sure the aten dense tensor's lifetime is
+// longer than the ideep tensor.
+ideep::tensor itensor_from_tensor(const at::Tensor& tensor) {
+  if (tensor.is_mkldnn()) {
+    return at::native::itensor_from_mkldnn(tensor);
+  } else {
+  return at::native::itensor_view_from_dense(tensor);
+  }
+}
+
 }}
 
 #endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -30,6 +30,10 @@ ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 // Construct an `ideep::tensor` "view" from dense tensor, note the
 // ideep::tensor will share the underlying buffer
 ideep::tensor itensor_view_from_dense(const Tensor& tensor);
+
+// Helper function for getting an ideep tensor out of an aten Tensor.
+ideep::tensor itensor_from_tensor(const at::Tensor& tensor);
+
 }}
 
 #endif // AT_MKLDNN_ENABLED

--- a/aten/src/ATen/native/mkldnn/Relu.cpp
+++ b/aten/src/ATen/native/mkldnn/Relu.cpp
@@ -8,11 +8,15 @@
 namespace at { namespace native {
 
 Tensor mkldnn_relu(const Tensor& input) {
-  AT_ERROR("mkldnn_relu: ATen not compiled with MKLDNN support");
+  TORCH_CHECK(false, "mkldnn_relu: ATen not compiled with MKLDNN support");
 }
 
 Tensor& mkldnn_relu_(Tensor& input) {
-  AT_ERROR("mkldnn_relu_: ATen not compiled with MKLDNN support");
+  TORCH_CHECK(false, "mkldnn_relu_: ATen not compiled with MKLDNN support");
+}
+
+Tensor mkldnn_relu_backward(const Tensor& grad_output, const Tensor& input) {
+  TORCH_CHECK(false, "mkldnn_relu_backward: ATen not compiled with MKLDNN support");
 }
 
 }}
@@ -36,6 +40,15 @@ Tensor& mkldnn_relu_(Tensor& input) {
   ideep::eltwise_forward::compute<AllocForMKLDNN>(
       x, x, ideep::algorithm::eltwise_relu, ideep::prop_kind::forward_training, /*alpha*/ 0.0);
   return input;
+}
+
+Tensor mkldnn_relu_backward(const Tensor& grad_output, const Tensor& input) {
+  ideep::tensor& x = itensor_from_mkldnn(input);
+  ideep::tensor grady = itensor_from_mkldnn(grad_output);
+  ideep::tensor gradx;
+  ideep::eltwise_backward::compute<AllocForMKLDNN>(x, grady, gradx,
+      ideep::algorithm::eltwise_relu, /*alpha*/ 0.0);
+  return new_with_itensor_mkldnn(std::move(gradx), grad_output.options());
 }
 
 }}

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1463,6 +1463,15 @@
 
 - func: fbgemm_linear_int8_weight_fp32_activation(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor
 
+- func: mkldnn_linear_backward_input(int[] input_size, Tensor grad_output, Tensor weight) -> Tensor
+
+- func: mkldnn_linear_backward_weights(Tensor grad_output, Tensor input, Tensor weight, bool bias_defined) -> (Tensor, Tensor)
+
+- func: mkldnn_linear_backward(Tensor input, Tensor grad_output, Tensor weight, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+  python_module: nn
+  dispatch:
+    MkldnnCPU: mkldnn_linear_backward
+
 - func: fbgemm_linear_int8_weight(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor
   use_c10_dispatcher: full
 
@@ -2236,6 +2245,8 @@
     CUDA: relu_
     MkldnnCPU: mkldnn_relu_
     QuantizedCPU: quantized_relu_
+
+- func: mkldnn_relu_backward(Tensor grad_output, Tensor input) -> Tensor
 
 - func: prelu(Tensor self, Tensor weight) -> Tensor
   use_c10_dispatcher: full

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1516,6 +1516,12 @@
 - name: mkldnn_convolution_backward(Tensor self, Tensor grad_output, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   grad_output, self, weight: _convolution_double_backward(grads[0], grads[1], grads[2], grad_output, weight, self, stride, padding, dilation, false, std::vector<int64_t>(padding.size(), 0), groups, false, false, false, grad_input_mask)
 
+- name: mkldnn_linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
+  input, weight, bias: mkldnn_linear_backward(input, grad, weight, grad_input_mask)
+
+- name: _mkldnn_reshape(Tensor self, int[] shape) -> Tensor
+  self: grad.reshape(self.sizes())
+
 # fft
 - name: _fft_with_size(Tensor self, int signal_ndim, bool complex_input, bool complex_output, bool inverse, int[] checked_signal_sizes, bool normalized, bool onesided, int[] output_sizes) -> Tensor
   self: fft_backward(self, grad, signal_ndim, complex_input, complex_output, inverse, checked_signal_sizes, normalized, onesided, output_sizes)

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -43,6 +43,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
     // under following condition, we can avoid clone()
     if (!GradMode::is_enabled()
         && !new_grad.is_sparse()
+        && !new_grad.is_mkldnn()
         && new_grad.is_contiguous()
         && new_grad.use_count() <= 1 + !post_hooks().empty()) {
       // first check it is in first-order grad only mode


### PR DESCRIPTION
### mkldnn backward ops list:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20567) Add aten mkldnn conv2d backward operator :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20570) Add aten mkldnn backward ops: relu, linear and reshape :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20571) Add aten mkldnn backward ops: max_pool2d, avg_pool2d and adaptive_avg_poo2d :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20572) Add aten mkldnn batchnorm backward operator :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20573) Add aten mkldnn zero_ operator💚 
- [ ] \(https://github.com/pytorch/pytorch/pull/20575) Add mkldnn mul operator 💚 