### PR TITLE
Add aten mkldnn batchnorm backward operator

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -40,21 +40,6 @@ std::tuple<at::Tensor,at::Tensor,at::Tensor> mkldnn_convolution_backward(
 
 using namespace mkldnn;
 
-namespace {
-// Helper function for getting an ideep tensor out of an aten Tensor.
-// Note in case the aten Tensor is a dense tensor, the retured ideep
-// tensor is just a view of the storage of the aten dense tensor, so
-// caller needs to make sure the aten dense tensor's lifetime is
-// longer than the ideep tensor.
-inline ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor) {
-  if (tensor.is_mkldnn()) {
-    return at::native::itensor_from_mkldnn(tensor);
-  } else {
-    return at::native::itensor_view_from_dense(tensor);
-  }
-}
-}
-
 namespace at { namespace native {
 
 ideep::tensor _mkldnn_conv2d(
@@ -126,11 +111,11 @@ at::Tensor mkldnn_convolution(
     IntArrayRef stride,
     IntArrayRef dilation,
     int64_t groups) {
-  const ideep::tensor mkldnn_input = get_mkldnn_tensor(input);
-  const ideep::tensor mkldnn_weight = get_mkldnn_tensor(weight);
+  const ideep::tensor mkldnn_input = itensor_from_tensor(input);
+  const ideep::tensor mkldnn_weight = itensor_from_tensor(weight);
   c10::optional<ideep::tensor> mkldnn_bias{c10::nullopt};
   if (bias.defined()) {
-    mkldnn_bias = get_mkldnn_tensor(bias);
+    mkldnn_bias = itensor_from_tensor(bias);
   }
 
   ideep::tensor mkldnn_output = _mkldnn_conv2d(

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -73,6 +73,19 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
            ideep::tensor::data_type::f32},
           tensor.template data_ptr<float>()};
 }
+
+// Note in case the aten Tensor is a dense tensor, the retured ideep
+// tensor is just a view of the storage of the aten dense tensor, so
+// caller needs to make sure the aten dense tensor's lifetime is
+// longer than the ideep tensor.
+ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor) {
+  if (tensor.is_mkldnn()) {
+    return at::native::itensor_from_mkldnn(tensor);
+  } else {
+    return at::native::itensor_view_from_dense(tensor);
+  }
+}
+
 }}
 
 #endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -78,7 +78,7 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
 // tensor is just a view of the storage of the aten dense tensor, so
 // caller needs to make sure the aten dense tensor's lifetime is
 // longer than the ideep tensor.
-ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor) {
+ideep::tensor itensor_from_tensor(const at::Tensor& tensor) {
   if (tensor.is_mkldnn()) {
     return at::native::itensor_from_mkldnn(tensor);
   } else {

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -30,6 +30,10 @@ ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 // Construct an `ideep::tensor` "view" from dense tensor, note the
 // ideep::tensor will share the underlying buffer
 ideep::tensor itensor_view_from_dense(const Tensor& tensor);
+
+// Helper function for getting an ideep tensor out of an aten Tensor.
+ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor);
+
 }}
 
 #endif // AT_MKLDNN_ENABLED

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -32,7 +32,7 @@ ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 ideep::tensor itensor_view_from_dense(const Tensor& tensor);
 
 // Helper function for getting an ideep tensor out of an aten Tensor.
-ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor);
+ideep::tensor itensor_from_tensor(const at::Tensor& tensor);
 
 }}
 

--- a/aten/src/ATen/native/mkldnn/Normalization.cpp
+++ b/aten/src/ATen/native/mkldnn/Normalization.cpp
@@ -56,7 +56,7 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_batch_norm(
   AT_ASSERTM(input.dim() == 4 || input.dim() == 5,
              "mkldnn_batch_norm: currently mkldnn only support 2d and 3d batchnorm");
   AT_ASSERTM(weight.defined() && bias.defined(),
-             "mkldnn_batch_norm: currently mkldnn only support affine model")
+             "mkldnn_batch_norm: currently mkldnn only support affine model");
 
   ideep::tensor& x = itensor_from_mkldnn(input);
   const ideep::tensor w = get_mkldnn_tensor(weight);

--- a/aten/src/ATen/native/mkldnn/Normalization.cpp
+++ b/aten/src/ATen/native/mkldnn/Normalization.cpp
@@ -20,6 +20,20 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_batch_norm(
   AT_ERROR("mkldnn_batch_norm: ATen not compiled with MKLDNN support");
 }
 
+std::tuple<Tensor, Tensor, Tensor> mkldnn_batch_norm_backward(
+    const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& running_mean,
+    const Tensor& running_var,
+    const Tensor& save_mean,
+    const Tensor& save_invstd,
+    bool train,
+    double eps,
+    std::array<bool,3> grad_input_mask) {
+  AT_ERROR("mkldnn_batch_norm_backward: ATen not compiled with MKLDNN support");
+}
+
 } // namespace native
 } // namespace at
 
@@ -39,35 +53,83 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_batch_norm(
     bool train,
     double momentum,
     double eps) {
-  ideep::tensor& x = itensor_from_mkldnn(input);
-  ideep::tensor& w = itensor_from_mkldnn(weight);
-  ideep::tensor& b = itensor_from_mkldnn(bias);
-  ideep::tensor& m = itensor_from_mkldnn(running_mean);
-  ideep::tensor& v = itensor_from_mkldnn(running_var);
+  AT_ASSERTM(input.dim() == 4 || input.dim() == 5,
+             "mkldnn_batch_norm: currently mkldnn only support 2d and 3d batchnorm");
+  AT_ASSERTM(weight.defined() && bias.defined(),
+             "mkldnn_batch_norm: currently mkldnn only support affine model")
 
+  ideep::tensor& x = itensor_from_mkldnn(input);
+  const ideep::tensor w = get_mkldnn_tensor(weight);
+  const ideep::tensor b = get_mkldnn_tensor(bias);
+
+  bool use_running_stat = (running_mean.defined() && running_var.defined());
   ideep::tensor y;
 
   if (train) {
-    // TODO: support training
-    AT_ERROR("mkldnn_batch_norm: mkldnn training is not supported in yet.");
-
-    // ideep::tensor saved_mean;
-    // ideep::tensor saved_var;
-    // ideep::batch_normalization_forward_training::compute<AllocForMKLDNN>(
-    //     x, w, b, y, saved_mean, saved_var, m, v, momentum, eps);
-    // return std::make_tuple(
-    //     new_with_itensor_mkldnn(std::move(y), input.options()),
-    //     new_with_itensor_mkldnn(std::move(saved_mean), input.options()),
-    //     new_with_itensor_mkldnn(std::move(saved_var), input.options()));
+    ideep::tensor saved_mean;
+    ideep::tensor saved_var;
+    if (use_running_stat) {
+      ideep::tensor m = itensor_view_from_dense(running_mean);
+      ideep::tensor v = itensor_view_from_dense(running_var);
+      ideep::batch_normalization_forward_training::compute<AllocForMKLDNN>(
+          x, w, b, y, saved_mean, saved_var, m, v, momentum, eps);
+    } else {
+      ideep::batch_normalization_forward_training::compute<AllocForMKLDNN>(
+          x, w, b, y, saved_mean, saved_var, momentum, eps);
+    }
+    return std::make_tuple(
+        new_with_itensor_mkldnn(std::move(y), input.options()),
+        new_with_itensor_mkldnn(std::move(saved_mean), input.options()),
+        new_with_itensor_mkldnn(std::move(saved_var), input.options()));
   } else {
-    AT_ASSERTM(input.dim() == 4 || input.dim() == 5,
-               "mkldnn_batch_norm: currently mkldnn only support 2d and 3d batchnorm");
-    ideep::batch_normalization_forward_inference::compute<AllocForMKLDNN>(
-        x, m, v, w, b, y, eps);
+    if (use_running_stat) {
+      ideep::tensor m = get_mkldnn_tensor(running_mean);
+      ideep::tensor v = get_mkldnn_tensor(running_var);
+      ideep::batch_normalization_forward_inference::compute<AllocForMKLDNN>(
+          x, m, v, w, b, y, eps);
+    } else {
+      ideep::batch_normalization_forward_inference::compute<AllocForMKLDNN>(
+          x, w, b, y, eps);
+    }
     return std::make_tuple(
         new_with_itensor_mkldnn(std::move(y), input.options()),
         new_with_itensor_mkldnn(ideep::tensor{}, input.options()),
         new_with_itensor_mkldnn(ideep::tensor{}, input.options()));
+  }
+}
+
+std::tuple<Tensor, Tensor, Tensor> mkldnn_batch_norm_backward(const Tensor& grad_output,
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& running_mean,
+    const Tensor& running_var,
+    const Tensor& save_mean,
+    const Tensor& save_invstd,
+    bool train,
+    double eps,
+    std::array<bool,3> grad_input_mask) {
+  AT_ASSERTM(train, "mkldnn_batch_norm_backward: currently mkldnn only support train model");
+
+  ideep::tensor& grady = itensor_from_mkldnn(grad_output);
+  ideep::tensor& x = itensor_from_mkldnn(input);
+  ideep::tensor w = itensor_view_from_dense(weight);
+  ideep::tensor& m = itensor_from_mkldnn(save_mean);
+  ideep::tensor& v = itensor_from_mkldnn(save_invstd);
+
+  ideep::tensor gradx, gradw, gradb;
+  ideep::batch_normalization_backward::compute<AllocForMKLDNN>(
+      x, m, v, grady, w, gradx, gradw, gradb, eps);
+
+  if (weight.is_mkldnn()) {
+    return std::make_tuple(
+        new_with_itensor_mkldnn(std::move(gradx), input.options()),
+        new_with_itensor_mkldnn(std::move(gradw), input.options()),
+        new_with_itensor_mkldnn(std::move(gradb), input.options()));
+  } else {
+    return std::make_tuple(
+        new_with_itensor_mkldnn(std::move(gradx), input.options()),
+        mkldnn_to_dense(new_with_itensor_mkldnn(std::move(gradw), input.options())),
+        mkldnn_to_dense(new_with_itensor_mkldnn(std::move(gradb), input.options())));
   }
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1920,6 +1920,7 @@
   dispatch:
     CPU: batch_norm_backward_cpu
     CUDA: batch_norm_backward_cuda
+    MkldnnCPU: mkldnn_batch_norm_backward
 
 - func: batch_norm_backward_reduce(Tensor grad_out, Tensor input, Tensor mean, Tensor invstd, Tensor? weight, bool input_g, bool weight_g, bool bias_g) -> (Tensor, Tensor, Tensor, Tensor)
   dispatch:

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -198,8 +198,8 @@ class TestMkldnn(TestCase):
                         bn(x),
                         mkldnn_bn(x.to_mkldnn()).to_dense())
                     if (not train and track_running_stats):
-                      self._test_serialization(mkldnn_bn, (x.to_mkldnn(),))
-                      self._test_tracing(mkldnn_bn, (x.to_mkldnn(),))
+                        self._test_serialization(mkldnn_bn, (x.to_mkldnn(),))
+                        self._test_tracing(mkldnn_bn, (x.to_mkldnn(),))
 
     def test_batch_norm2d_backward(self):
         N = torch.randint(3, 10, (1,)).item()

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -182,16 +182,45 @@ class TestMkldnn(TestCase):
         C = torch.randint(3, 100, (1,)).item()
         x = torch.randn(N, C, 35, 45, dtype=torch.float32) * 10
 
-        # TODO: support training
-        for train in [False]:
-            bn = torch.nn.BatchNorm2d(C).float().train(train)
-            mkldnn_bn = mkldnn_utils.to_mkldnn(copy.deepcopy(bn))
-            self.assertEqual(
-                bn(x),
-                mkldnn_bn(x.to_mkldnn()).to_dense())
+        for train in [True, False]:
+            # TODO: support none affine
+            for affine in [True]:
+                for track_running_stats in [True, False]:
+                    bn = torch.nn.BatchNorm2d(
+                        C,
+                        affine=affine,
+                        track_running_stats=track_running_stats).float().train(train)
+                    if (train or not track_running_stats):
+                        mkldnn_bn = copy.deepcopy(bn)
+                    else:
+                        mkldnn_bn = mkldnn_utils.to_mkldnn(copy.deepcopy(bn))
+                    self.assertEqual(
+                        bn(x),
+                        mkldnn_bn(x.to_mkldnn()).to_dense())
+                    if (not train and track_running_stats):
+                      self._test_serialization(mkldnn_bn, (x.to_mkldnn(),))
+                      self._test_tracing(mkldnn_bn, (x.to_mkldnn(),))
 
-            self._test_serialization(mkldnn_bn, (x.to_mkldnn(),))
-            self._test_tracing(mkldnn_bn, (x.to_mkldnn(),))
+    def test_batch_norm2d_backward(self):
+        N = torch.randint(3, 10, (1,)).item()
+        C = torch.randint(3, 100, (1,)).item()
+        x = torch.randn(N, C, 35, 45, dtype=torch.float32) * 10
+
+        # TODO: support none affine
+        for affine in [True]:
+            for track_running_stats in [True, False]:
+                x1 = x.clone().requires_grad_()
+                x2 = x.clone().to_mkldnn().requires_grad_()
+                bn = torch.nn.BatchNorm2d(
+                    C,
+                    affine=affine,
+                    track_running_stats=track_running_stats).float().train(True)
+                mkldnn_bn = copy.deepcopy(bn)
+                y1 = bn(x1).sum()
+                y2 = mkldnn_bn(x2).to_dense().sum()
+                y1.backward()
+                y2.backward()
+                self.assertEqual(x1.grad, x2.grad.to_dense())
 
     def test_add(self):
         N = torch.randint(3, 10, (1,)).item()

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -43,6 +43,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
     // under following condition, we can avoid clone()
     if (!GradMode::is_enabled()
         && !new_grad.is_sparse()
+        && !new_grad.is_mkldnn()
         && new_grad.is_contiguous()
         && new_grad.use_count() <= 1 + !post_hooks().empty()) {
       // first check it is in first-order grad only mode

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -55,7 +55,7 @@ auto AccumulateGrad::apply(variable_list&& grads) -> variable_list {
       // addition of !post_hooks().empty().
       variable.grad() = new_grad.detach();
     } else {
-      if (new_grad.is_sparse()) {
+      if (new_grad.is_sparse() || new_grad.is_mkldnn()) {
         variable.grad() = new_grad.clone();
       } else {
         variable.grad() = new_grad.clone(at::MemoryFormat::Contiguous);


### PR DESCRIPTION
### mkldnn backward ops list:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20567) Add aten mkldnn conv2d backward operator :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20570) Add aten mkldnn backward ops: relu, linear and reshape :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20571) Add aten mkldnn backward ops: max_pool2d, avg_pool2d and adaptive_avg_poo2d :yellow_heart:
 - [ ] \(https://github.com/pytorch/pytorch/pull/20572) Add aten mkldnn batchnorm backward operator :yellow_heart:
 - [x] \(https://github.com/pytorch/pytorch/pull/20573) Add aten mkldnn zero_ operator💚 
- [x] \(https://github.com/pytorch/pytorch/pull/20575) Add mkldnn mul operator 💚 