### PR TITLE
Fixes error with custom scalars, fixes #20579

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -378,7 +378,7 @@ def custom_scalars(layout):
         categories.append(layout_pb2.Category(title=k, chart=charts))
 
     layout = layout_pb2.Layout(category=categories)
-    PluginData = [SummaryMetadata.PluginData(plugin_name='custom_scalars')]
+    PluginData = SummaryMetadata.PluginData(plugin_name='custom_scalars')
     smd = SummaryMetadata(plugin_data=PluginData)
     tensor = TensorProto(dtype='DT_STRING',
                          string_val=[layout.SerializeToString()],


### PR DESCRIPTION
When adding custom scalars like this
```python
from torch.utils.tensorboard import SummaryWriter

with SummaryWriter() as writer:
    writer.add_custom_scalars({'Stuff': {
        'Losses': ['MultiLine', ['loss/(one|two)']],
        'Metrics': ['MultiLine', ['metric/(three|four)']],
    }})
```
This error is raised:
```
TypeError: Parameter to MergeFrom() must be instance of same class: expected tensorboard.SummaryMetadata.PluginData got list.
```

Removing the square brackets around `SummaryMetadata.PluginData(plugin_name='custom_scalars')` should be enough to fix it.

