### PR TITLE
Allow tuples for scale_factor argument in nn.Upsample

### DIFF
--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -122,7 +122,12 @@ class Upsample(Module):
         super(Upsample, self).__init__()
         self.name = type(self).__name__
         self.size = size
-        self.scale_factor = float(scale_factor) if scale_factor else None
+        if isinstance(scale_factor, tuple):
+            self.scale_factor = ()
+            for factor in scale_factor:
+                self.scale_factor += (float(factor),)
+        else:
+            self.scale_factor = float(scale_factor) if scale_factor else None
         self.mode = mode
         self.align_corners = align_corners
 

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -123,9 +123,7 @@ class Upsample(Module):
         self.name = type(self).__name__
         self.size = size
         if isinstance(scale_factor, tuple):
-            self.scale_factor = ()
-            for factor in scale_factor:
-                self.scale_factor += (float(factor),)
+            self.scale_factor = tuple(float(factor) for factor in scale_factor)
         else:
             self.scale_factor = float(scale_factor) if scale_factor else None
         self.mode = mode


### PR DESCRIPTION
Fixes #20523 .

nn.Upsample was unable to accept tuple inputs for the scale_factor argument due to direct casting to float, which was done in #17732.