### PR TITLE
Auto-convert GPU arrays that support the __cuda_array_interface__ protocol

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -319,8 +319,8 @@ class TestNumbaIntegration(common.TestCase):
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
     @unittest.skipIf(not TEST_MULTIGPU, "No multigpu")
-    def test_active_device(self):
-        """'as_cuda_array' tensor device must match active numba context."""
+    def test_active_device_using_cuda_array_interface(self):
+        """'as_tensor()' tensor device must match active numba context."""
 
         # Both torch/numba default to device 0 and can interop freely
         numba_ary = numba.cuda.to_device(numpy.arange(6))

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -256,6 +256,83 @@ class TestNumbaIntegration(common.TestCase):
                 numba.cuda.as_cuda_array(cudat), numba.cuda.devicearray.DeviceNDArray
             )
 
+    @unittest.skipIf(not TEST_NUMPY, "No numpy")
+    @unittest.skipIf(not TEST_CUDA, "No cuda")
+    @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
+    def test_from_cuda_array_interface(self):
+        """torch.as_tensor() and torch.tensor() supports the __cuda_array_interface__ protocol.
+
+        If an object exposes the __cuda_array_interface__, .as_tensor() and .tensor()
+        will use the exposed device memory.
+
+        See:
+        https://numba.pydata.org/numba-doc/latest/cuda/cuda_array_interface.html
+        """
+
+        dtypes = [
+            numpy.float64,
+            numpy.float32,
+            numpy.int64,
+            numpy.int32,
+            numpy.int16,
+            numpy.int8,
+            numpy.uint8,
+        ]
+        for dtype in dtypes:
+            numpy_arys = [
+                numpy.arange(6).reshape(2, 3).astype(dtype),
+                numpy.arange(6).reshape(2, 3).astype(dtype)[1:],  # View offset should be ignored
+                numpy.arange(6).reshape(2, 3).astype(dtype)[:, None],  # change the strides but still contiguous
+            ]
+            # Zero-copy when using `torch.as_tensor()`
+            for numpy_ary in numpy_arys:
+                numba_ary = numba.cuda.to_device(numpy_ary)
+                torch_ary = torch.as_tensor(numba_ary, device="cuda")
+                self.assertEqual(numba_ary.__cuda_array_interface__, torch_ary.__cuda_array_interface__)
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+
+                # Check that `torch_ary` and `numba_ary` points to the same device memory
+                torch_ary += 42
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+
+            # Implicit-copy because `torch_ary` is a CPU array
+            for numpy_ary in numpy_arys:
+                numba_ary = numba.cuda.to_device(numpy_ary)
+                torch_ary = torch.as_tensor(numba_ary, device="cpu")
+                self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary))
+
+                # Check that `torch_ary` and `numba_ary` points to different memory
+                torch_ary += 42
+                self.assertEqual(torch_ary.data.numpy(), numpy.asarray(numba_ary) + 42)
+
+            # Explict-copy when using `torch.tensor()`
+            for numpy_ary in numpy_arys:
+                numba_ary = numba.cuda.to_device(numpy_ary)
+                torch_ary = torch.tensor(numba_ary, device="cuda")
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+
+                # Check that `torch_ary` and `numba_ary` points to different memory
+                torch_ary += 42
+                self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary) + 42)
+
+    @unittest.skipIf(not TEST_NUMPY, "No numpy")
+    @unittest.skipIf(not TEST_CUDA, "No cuda")
+    @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
+    @unittest.skipIf(not TEST_MULTIGPU, "No multigpu")
+    def test_active_device(self):
+        """'as_cuda_array' tensor device must match active numba context."""
+
+        # Both torch/numba default to device 0 and can interop freely
+        numba_ary = numba.cuda.to_device(numpy.arange(6))
+        torch_ary = torch.as_tensor(numba_ary, device="cuda")
+        self.assertEqual(torch_ary.cpu().data.numpy(), numpy.asarray(numba_ary))
+        self.assertEqual(torch_ary.__cuda_array_interface__, numba_ary.__cuda_array_interface__)
+
+        # Torch should raise `RuntimeError` when the Numba and Torch device differ
+        numba_ary = numba.cuda.to_device(numpy.arange(6))
+        with self.assertRaises(RuntimeError):
+            torch.as_tensor(numba_ary, device=torch.device("cuda", 1))
+
 
 if __name__ == "__main__":
     common.run_tests()

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -261,8 +261,8 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
 
     // Extract the `strides` attribute
     PyObject *py_strides = PyDict_GetItemString(cuda_dict, "strides");
-    if (py_strides != nullptr and py_strides != Py_None) {
-      if (PySequence_Length(py_shape) == -1 or PySequence_Length(py_shape) != ndim) {
+    if (py_strides != nullptr && py_strides != Py_None) {
+      if (PySequence_Length(py_shape) == -1 || PySequence_Length(py_shape) != ndim) {
         throw TypeError("strides must be a sequence of the same length as shape");
       }
       std::vector<npy_intp> npy_strides(ndim);

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -263,13 +263,12 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
     if(!PyTuple_Check(py_data) || PyTuple_GET_SIZE(py_data) != 2) {
       throw TypeError("`data` must be a 2-tuple of (int, bool)");
     }
-    PyTuple_GET_ITEM(py_data, 0);
     data_ptr = PyLong_AsVoidPtr(PyTuple_GET_ITEM(py_data, 0));
     if (data_ptr == nullptr && PyErr_Occurred()) {
       throw python_error();
     }
     int read_only = PyObject_IsTrue(PyTuple_GET_ITEM(py_data, 1));
-    if (PyErr_Occurred() || read_only == -1) {
+    if (read_only == -1) {
       throw python_error();
     }
     if (read_only) {

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -204,9 +204,7 @@ bool is_numpy_scalar(PyObject* obj) {
 
 at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
   PyObject *cuda_dict = PyObject_GetAttrString(obj, "__cuda_array_interface__");
-  if (cuda_dict == nullptr) {
-    throw TypeError("attribute `__cuda_array_interface__` must exist");
-  }
+  TORCH_INTERNAL_ASSERT(cuda_dict != nullptr);
 
   // In the following code block, we extract the values of `__cuda_array_interface__`
   std::vector<int64_t> sizes;
@@ -242,7 +240,7 @@ at::Tensor tensor_from_cuda_array_interface(PyObject* obj) {
       }
       dtype = numpy_dtype_to_aten(descr->type_num);
       dtype_size_in_bytes = descr->elsize;
-      assert(dtype_size_in_bytes > 0);
+      TORCH_INTERNAL_ASSERT(dtype_size_in_bytes > 0);
     }
 
     // Extract the `data` attribute

--- a/torch/csrc/utils/tensor_numpy.h
+++ b/torch/csrc/utils/tensor_numpy.h
@@ -12,4 +12,6 @@ at::ScalarType numpy_dtype_to_aten(int dtype);
 
 bool is_numpy_scalar(PyObject* obj);
 
+at::Tensor tensor_from_cuda_array_interface(PyObject* obj);
+
 }} // namespace torch::utils


### PR DESCRIPTION
This PR implements auto-conversion of GPU arrays that support the `__cuda_array_interface__` protocol (fixes #15601).

If an object exposes the `__cuda_array_interface__` attribute, `touch.as_tensor()` and `touch.tensor()` will use the exposed device memory.

#### Zero-copy 
When using `touch.as_tensor(...,device=D)` where `D` is the same device as the one used in `__cuda_array_interface__`.

#### Implicit copy 
When using `touch.as_tensor(...,device=D)` where `D` is the CPU or another non-CUDA device.

#### Explicit copy 
When using `torch.tensor()`.

#### Exception
When using `touch.as_tensor(...,device=D)` where `D` is a CUDA device not used in `__cuda_array_interface__`.

#### Lifetime 
`torch.as_tensor(obj)` tensor grabs a reference to `obj` so that the lifetime of `obj` exceeds the tensor

