### PR TITLE
tracing for intra_op_parallel

### DIFF
--- a/caffe2/core/net_async_tracing.h
+++ b/caffe2/core/net_async_tracing.h
@@ -128,6 +128,9 @@ class CAFFE2_API TracerGuard {
 
   virtual ~TracerGuard();
 
+  static TracerGuard* getCurrentTracerGuard();
+  void disable();
+
  private:
   bool enabled_ = false;
   TracerEvent event_;


### PR DESCRIPTION
Summary:
When we use intra_op_parallel operators, Caffe2 tracing was generating trace only for the master task giving a false impression that a lot of threads are underutilized.
This diff also traces child tasks.

Differential Revision: D14820008

