### PR TITLE
Add a new method SummaryWriter.flush()

### DIFF
--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -837,6 +837,16 @@ class SummaryWriter(object):
         """
         self._get_file_writer().add_summary(custom_scalars(layout))
 
+    def flush(self):
+        """Flushes the event file to disk.
+        Call this method to make sure that all pending events have been written to
+        disk.
+        """
+        if self.all_writers is None:
+            return
+        for writer in self.all_writers.values():
+            writer.flush()
+
     def close(self):
         if self.all_writers is None:
             return  # ignore double close


### PR DESCRIPTION
Summary: Add a new method SummaryWriter.flush()  that iterates through all of the FileWriters and flushes them

Differential Revision: D15380124

