### PR TITLE
Change InferLengthsRangeFill & InferGatherRanges, add more tests

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -9,8 +9,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-C10_DECLARE_bool(caffe2_extract_feature_length_for_shape_inference);
-
 namespace caffe2 {
 // This struct stores the max bound size for batch in the general sense. We have
 // the conventioal batch size and the look-up sequence, which is also batch in a
@@ -72,7 +70,6 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
       : BoundShapeInferencerBase(spec) {}
 
   virtual ~BoundShapeInferencer() override {}
-
   void InferBoundShapeAndType(
       const NetDef& net,
       const std::unordered_map<std::string, ShapeInfo>& info,
@@ -93,6 +90,8 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
       std::vector<int64_t> bound_dims,
       TensorProto::DataType type,
       bool is_quantized);
+
+  virtual void InferOps(const OperatorDef& op, caffe2::Workspace* ws);
 
   void InferConcatInputs(const OperatorDef& op);
 


### PR DESCRIPTION
Summary:
Change InferLengthsRangeFill
Add InferGatherRanges
add tests from ClipRangesGatherSigridHash all the way to SparseLengthsWeightedSum
add tests from SigridTransforms all the way to SparseLengthsWeightedSum
move the infer stage (for values, ids, scores, multiply inferred seq length by max_batch_size) from ClipRangesGatherSigridHash/SparseLengthsWeightedSum to GatherRanges, i.e. do the multiplication in InferGatherRanges

e2e test will be added in the following diff

Differential Revision: D15382730

