### PR TITLE
ensure version_counter gets incremented for non-differentiable outputs

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -850,7 +850,7 @@ def emit_body(declaration):
     def emit_increment_version():
         if not modifies_arguments:
             return []
-        return ['increment_version({});'.format(arg['name']) for arg in candidate_differentiable_outputs]
+        return ['increment_version({});'.format(arg['name']) for arg in differentiable_outputs]
 
     def check_record_function_input_type(simple_type):
         return simple_type in ['Tensor', 'Scalar']
@@ -924,7 +924,6 @@ def unpack_args(env, declaration):
             # although it's stll getting the non-variable from the variable
             # (in this case via TensorOptions rather than Variable/Tensor).
             body.append(UNPACK_OPTIONS.substitute(arg_name=arg['name']))
-
 
         unpacked_args.append(arg['name'] + '_')
         unpacked_args_simple_type[arg['name'] + '_'] = arg['simple_type']

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -515,18 +515,19 @@ def emit_body(declaration):
     if declaration['output_differentiability'] is not None:
         differentiable_outputs = []
         output_differentiability = declaration['output_differentiability']
+        if False in output_differentiability and inplace:
+            raise RuntimeError("output_differentiability=False for inplace operation (version_counter won't get updated)")
         for differentiable, output in zip(output_differentiability, returns):
             if differentiable:
                 differentiable_outputs.append(output)
     elif uses_single_grad(func):
-        candidate_differentiable_outputs = candidate_differentiable_outputs[:1]
-        differentiable_outputs = candidate_differentiable_outputs
+        differentiable_outputs = candidate_differentiable_outputs[:1]
     else:
         differentiable_outputs = candidate_differentiable_outputs
 
     requires_derivative = (
         base_name not in DONT_REQUIRE_DERIVATIVE and name not in DONT_REQUIRE_DERIVATIVE and
-        len(differentiable_inputs) > 0 and len(candidate_differentiable_outputs) > 0 and
+        len(differentiable_inputs) > 0 and len(differentiable_outputs) > 0 and
         strategy == 'use_derived')
 
     if func is not None and not requires_derivative:

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -520,13 +520,13 @@ def emit_body(declaration):
                 differentiable_outputs.append(output)
     elif uses_single_grad(func):
         candidate_differentiable_outputs = candidate_differentiable_outputs[:1]
-        differentiable_outputs = candidate_differentiable_outputs[:1]
+        differentiable_outputs = candidate_differentiable_outputs
     else:
         differentiable_outputs = candidate_differentiable_outputs
 
     requires_derivative = (
         base_name not in DONT_REQUIRE_DERIVATIVE and name not in DONT_REQUIRE_DERIVATIVE and
-        len(differentiable_inputs) > 0 and len(differentiable_outputs) > 0 and
+        len(differentiable_inputs) > 0 and len(candidate_differentiable_outputs) > 0 and
         strategy == 'use_derived')
 
     if func is not None and not requires_derivative:
@@ -878,10 +878,10 @@ def emit_body(declaration):
 
     body.append(pre_record_trace)
     body.append(emit_call(env))
-    body.extend(emit_increment_version())
     if requires_derivative:
         # set_flags has to appear after version_counter, because rebase_history
         # requires that the counter is incremented before it is called
+        body.extend(emit_increment_version())
         body.append(emit_history())
     # post_record_trace must appear before save_outputs so that saved outputs
     # have their tracing state saved (that is setup by recordTrace)


### PR DESCRIPTION
issue:
https://github.com/pytorch/pytorch/issues/14571

To reproduce I:
1) added these lines to derivatives.yaml:
```
- name: add_(Tensor self, Scalar other, Scalar alpha)
  output_differentiability: [False, False, False]
- name: add_(Tensor self, Tensor other, Scalar alpha)
  output_differentiability: [False, False, False]
```

2) Ran this code:
```
import torch

scalar = torch.tensor(5)
var1 = torch.randn(4,2,requires_grad=True)
var2 = var1.detach().requires_grad_()
output1 = var1 * scalar
output2 = var2 * scalar
output1.sum().backward()
scalar.add_(5, 1)
output2.sum().backward()
print(var1.grad)
print(var2.grad)
```
Observed modified var2.grad in the output:
```
tensor([[5., 5.],
        [5., 5.],
        [5., 5.],
        [5., 5.]])
tensor([[10., 10.],
        [10., 10.],
        [10., 10.],
        [10., 10.]])
```

After making this change, re-running the above code produces the expected error:
```
Traceback (most recent call last):
  File "test.py", line 18, in <module>
    output2.sum().backward()
  File "/home/bvaughan/anaconda3/lib/python3.7/site-packages/torch/tensor.py", line 107, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "/home/bvaughan/anaconda3/lib/python3.7/site-packages/torch/autograd/__init__.py", line 93, in backward
    allow_unreachable=True)  # allow_unreachable flag
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.LongTensor []] is at version 1; expected version 0 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```


