### PR TITLE
Move THCTensor_{random, clampedRandom, cappedRandom} to ATen

### DIFF
--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -22,6 +22,7 @@ struct AccumulateType { };
 #if defined(__CUDACC__) || defined(__HIPCC__)
 template <> struct AccumulateType<half, true> { using type = float; };
 #endif
+template <> struct AccumulateType<bool, true> { using type = bool; };
 template <> struct AccumulateType<Half, true> { using type = float; };
 template <> struct AccumulateType<float, true> { using type = float; };
 template <> struct AccumulateType<double, true> { using type = double; };
@@ -31,6 +32,7 @@ template <> struct AccumulateType<char, true> { using type = int64_t; };
 template <> struct AccumulateType<int16_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int32_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int64_t, true> { using type = int64_t; };
+template <> struct AccumulateType<bool, false> { using type = bool; };
 template <> struct AccumulateType<float, false> { using type = double; };
 template <> struct AccumulateType<double, false> { using type = double; };
 template <> struct AccumulateType<int8_t, false> { using type = int64_t; };

--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -22,7 +22,6 @@ struct AccumulateType { };
 #if defined(__CUDACC__) || defined(__HIPCC__)
 template <> struct AccumulateType<half, true> { using type = float; };
 #endif
-template <> struct AccumulateType<bool, true> { using type = bool; };
 template <> struct AccumulateType<Half, true> { using type = float; };
 template <> struct AccumulateType<float, true> { using type = float; };
 template <> struct AccumulateType<double, true> { using type = double; };
@@ -32,7 +31,6 @@ template <> struct AccumulateType<char, true> { using type = int64_t; };
 template <> struct AccumulateType<int16_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int32_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int64_t, true> { using type = int64_t; };
-template <> struct AccumulateType<bool, false> { using type = bool; };
 template <> struct AccumulateType<float, false> { using type = double; };
 template <> struct AccumulateType<double, false> { using type = double; };
 template <> struct AccumulateType<int8_t, false> { using type = int64_t; };

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2530,7 +2530,6 @@
   name: _th_random_
   backends:
     - CPU
-    - CUDA
   return: self
   variants: function
   cpu_bool: True

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2533,7 +2533,6 @@
   return: self
   variants: function
   cpu_bool: True
-  cuda_bool: True
   options:
     - cname: random
       arguments:

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -237,15 +237,15 @@ Tensor & addcdiv_(Tensor& self, const Tensor & tensor1, const Tensor & tensor2, 
   return at::legacy::th::_th_addcdiv_(self, tensor1, tensor2, value);
 }
 
-Tensor & random_(Tensor& self, int64_t from, int64_t to, Generator * generator) {
+Tensor & clamped_random_cpu_(Tensor& self, int64_t from, int64_t to, Generator * generator) {
   return at::legacy::th::_th_random_(self, from, to, generator);
 }
 
-Tensor & random_(Tensor& self, int64_t to, Generator * generator) {
+Tensor & capped_random_cpu_(Tensor& self, int64_t to, Generator * generator) {
   return at::legacy::th::_th_random_(self, to, generator);
 }
 
-Tensor & random_(Tensor& self, Generator * generator) {
+Tensor & random_cpu_(Tensor& self, Generator * generator) {
   return at::legacy::th::_th_random_(self, generator);
 }
 

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -3,6 +3,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/AccumulateType.h>
+#include <ATen/CUDAGenerator.h>
 
 #include <curand.h>
 #include <curand_kernel.h>
@@ -403,7 +404,8 @@ Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
   return self;
 }
 
-void uniform_kernel_cuda(TensorIterator& iter, double from_, double to_, Generator* gen) {
+void uniform_kernel_cuda(TensorIterator& iter, double from_, double to_, Generator* gen_) {
+  auto gen = check_generator<CUDAGenerator>(gen_, &globalContext().defaultGenerator(kCUDA));
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "uniform_cuda", [&] {
     auto from = static_cast<scalar_t>(from_);
     auto to = static_cast<scalar_t>(to_);
@@ -441,11 +443,77 @@ void uniform_kernel_cuda(TensorIterator& iter, double from_, double to_, Generat
    });
 }
 
+void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Generator* gen_) {
+  auto gen = check_generator<CUDAGenerator>(gen_, &globalContext().defaultGenerator(kCUDA));
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, iter.dtype(), "random_cuda", [&] {
+    using accscalar_t = at::acc_type<scalar_t, true>;
+    if (std::is_same<scalar_t, double>::value || std::is_same<scalar_t, int64_t>::value) {
+      // define lambda to mod with range and add base
+      auto random_func = [range, base] __device__ (uint64_t rand) {
+        return static_cast<scalar_t>(rand % range + base);
+      };
+      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls/2>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
+          ulonglong2 ret;
+          uint4 rand = curand4(state);
+          ret.x = (static_cast<uint64_t>(rand.x) << 32) | rand.y;
+          ret.y = (static_cast<uint64_t>(rand.z) << 32) | rand.w;
+          return ret;
+        },
+        random_func);
+    } else {
+      auto random_func = [range, base] __device__ (uint32_t rand) {
+        return static_cast<scalar_t>(rand % static_cast<uint32_t>(range) + static_cast<int32_t>(base));
+      };
+      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand4(state); },
+        random_func);
+    }
+   });
+}
+
 Tensor& uniform_cuda_(Tensor& self, double from, double to, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   uniform_kernel_cuda(*iter, from, to, gen);
   return self;
 }
 
+Tensor& random_cuda_(Tensor& self, Generator* gen) {
+  auto iter = TensorIterator::nullary_op(self);
+  uint64_t range;
+  auto iter_scalar_type = iter->dtype();
+  if (isFloatingType(iter_scalar_type)) {
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter_scalar_type, "random_cuda_range_calc", [&] {
+      range = static_cast<uint64_t>((1ULL << std::numeric_limits<scalar_t>::digits) + 1);
+    });
+  } else {
+    AT_DISPATCH_INTEGRAL_TYPES(iter_scalar_type, "random_cuda_range_calc", [&] {
+      range = static_cast<uint64_t>(std::numeric_limits<scalar_t>::max()) + 1;
+    });
+  }
+  random_kernel_cuda(*iter, range, 0, gen);
+  return self;
+}
+
+Tensor& clamped_random_cuda_(Tensor& self, int64_t from, int64_t to, Generator* gen) {
+  AT_CHECK(from < to, "random_ expects 'from' to be less than 'to', but got from=", from, " >= to=", to);
+  auto iter = TensorIterator::nullary_op(self);
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, iter->dtype(), "range_check", [&] {
+    AT_CHECK(from >= std::numeric_limits<scalar_t>::min() && to <= std::numeric_limits<scalar_t>::max(),
+             "[from, to] is outside the range of the tensor data type: ", toString(iter->dtype()),
+             ". Expected [from, to] to be inside [", std::numeric_limits<scalar_t>::min(),
+             ", ", std::numeric_limits<scalar_t>::max(), "]",
+             " but found [from, to] to be [", from, ", ", to, "]");
+  });
+  auto range = static_cast<uint64_t>(to) - static_cast<uint64_t>(from);
+  random_kernel_cuda(*iter, range, from, gen);
+  return self;
+}
+
+Tensor& capped_random_cuda_(Tensor& self, int64_t to, Generator* gen) {
+  return clamped_random_cuda_(self, 0, to, gen);
+}
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -476,7 +476,19 @@ void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Gene
       };
       distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
         gen,
-        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand4(state); },
+        [] __device__ (curandStatePhilox4_32_10_t* state) {
+        #ifndef __HIP_PLATFORM_HCC__
+          return curand4(state);
+        #else
+          // HIP doesn't have curand4
+          uint4 rand;
+          rand.x = curand(state);
+          rand.y = curand(state);
+          rand.z = curand(state);
+          rand.w = curand(state);
+          return rand;
+        #endif
+        },
         random_func);
     }
    });

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -446,17 +446,25 @@ void uniform_kernel_cuda(TensorIterator& iter, double from_, double to_, Generat
 void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Generator* gen_) {
   auto gen = check_generator<CUDAGenerator>(gen_, &globalContext().defaultGenerator(kCUDA));
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half, iter.dtype(), "random_cuda", [&] {
-    using accscalar_t = at::acc_type<scalar_t, true>;
     if (std::is_same<scalar_t, double>::value || std::is_same<scalar_t, int64_t>::value) {
       // define lambda to mod with range and add base
       auto random_func = [range, base] __device__ (uint64_t rand) {
-        return static_cast<scalar_t>(rand % range + base);
+        return static_cast<int64_t>(rand % range + base);
       };
-      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls/2>(iter,
+      distribution_nullary_kernel<scalar_t, uint64_t, curand4_engine_calls/2>(iter,
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
           ulonglong2 ret;
+        #ifndef __HIP_PLATFORM_HCC__
           uint4 rand = curand4(state);
+        #else
+          // HIP doesn't have curand4
+          uint4 rand;
+          rand.x = curand(state);
+          rand.y = curand(state);
+          rand.z = curand(state);
+          rand.w = curand(state);
+        #endif
           ret.x = (static_cast<uint64_t>(rand.x) << 32) | rand.y;
           ret.y = (static_cast<uint64_t>(rand.z) << 32) | rand.w;
           return ret;
@@ -464,9 +472,9 @@ void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Gene
         random_func);
     } else {
       auto random_func = [range, base] __device__ (uint32_t rand) {
-        return static_cast<scalar_t>(rand % static_cast<uint32_t>(range) + static_cast<int32_t>(base));
+        return static_cast<int32_t>(rand % static_cast<uint32_t>(range) + static_cast<int32_t>(base));
       };
-      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls>(iter,
+      distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) { return curand4(state); },
         random_func);

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -455,18 +455,18 @@ void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Gene
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
           ulonglong2 ret;
+          uint4 rand_val;
         #ifndef __HIP_PLATFORM_HCC__
-          uint4 rand = curand4(state);
+          rand_val = curand4(state);
         #else
           // HIP doesn't have curand4
-          uint4 rand;
-          rand.x = curand(state);
-          rand.y = curand(state);
-          rand.z = curand(state);
-          rand.w = curand(state);
+          rand_val.x = curand(state);
+          rand_val.y = curand(state);
+          rand_val.z = curand(state);
+          rand_val.w = curand(state);
         #endif
-          ret.x = (static_cast<uint64_t>(rand.x) << 32) | rand.y;
-          ret.y = (static_cast<uint64_t>(rand.z) << 32) | rand.w;
+          ret.x = (static_cast<uint64_t>(rand_val.x) << 32) | rand_val.y;
+          ret.y = (static_cast<uint64_t>(rand_val.z) << 32) | rand_val.w;
           return ret;
         },
         random_func);
@@ -477,17 +477,17 @@ void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Gene
       distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) {
+          uint4 rand_val;
         #ifndef __HIP_PLATFORM_HCC__
-          return curand4(state);
+          rand_val = curand4(state);
         #else
           // HIP doesn't have curand4
-          uint4 rand;
-          rand.x = curand(state);
-          rand.y = curand(state);
-          rand.z = curand(state);
-          rand.w = curand(state);
-          return rand;
+          rand_val.x = curand(state);
+          rand_val.y = curand(state);
+          rand_val.z = curand(state);
+          rand_val.w = curand(state);
         #endif
+          return rand_val;
         },
         random_func);
     }

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -455,16 +455,7 @@ void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Gene
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) -> ulonglong2 {
           ulonglong2 ret;
-          uint4 rand_val;
-        #ifndef __HIP_PLATFORM_HCC__
-          rand_val = curand4(state);
-        #else
-          // HIP doesn't have curand4
-          rand_val.x = curand(state);
-          rand_val.y = curand(state);
-          rand_val.z = curand(state);
-          rand_val.w = curand(state);
-        #endif
+          uint4 rand_val = curand4(state);
           ret.x = (static_cast<uint64_t>(rand_val.x) << 32) | rand_val.y;
           ret.y = (static_cast<uint64_t>(rand_val.z) << 32) | rand_val.w;
           return ret;
@@ -477,17 +468,7 @@ void random_kernel_cuda(TensorIterator& iter, uint64_t range, int64_t base, Gene
       distribution_nullary_kernel<scalar_t, uint32_t, curand4_engine_calls>(iter,
         gen,
         [] __device__ (curandStatePhilox4_32_10_t* state) {
-          uint4 rand_val;
-        #ifndef __HIP_PLATFORM_HCC__
-          rand_val = curand4(state);
-        #else
-          // HIP doesn't have curand4
-          rand_val.x = curand(state);
-          rand_val.y = curand(state);
-          rand_val.z = curand(state);
-          rand_val.w = curand(state);
-        #endif
-          return rand_val;
+          return curand4(state);
         },
         random_func);
     }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2959,12 +2959,21 @@
 
 - func: random_(Tensor(a!) self, int from, int to, *, Generator? generator=None) -> Tensor(a!)
   variants: method
+  dispatch:
+    CPU: clamped_random_cpu_
+    CUDA: clamped_random_cuda_
 
 - func: random_(Tensor(a!) self, int to, *, Generator? generator=None) -> Tensor(a!)
   variants: method
+  dispatch:
+    CPU: capped_random_cpu_
+    CUDA: capped_random_cuda_
 
 - func: random_(Tensor(a!) self, *, Generator? generator=None) -> Tensor(a!)
   variants: method
+  dispatch:
+    CPU: random_cpu_
+    CUDA: random_cuda_
 
 - func: uniform_(Tensor(a!) self, float from=0, float to=1, *, Generator? generator=None) -> Tensor(a!)
   variants: method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2959,18 +2959,24 @@
 
 - func: random_(Tensor(a!) self, int from, int to, *, Generator? generator=None) -> Tensor(a!)
   variants: method
+  cpu_bool: True
+  cuda_bool: True
   dispatch:
     CPU: clamped_random_cpu_
     CUDA: clamped_random_cuda_
 
 - func: random_(Tensor(a!) self, int to, *, Generator? generator=None) -> Tensor(a!)
   variants: method
+  cpu_bool: True
+  cuda_bool: True
   dispatch:
     CPU: capped_random_cpu_
     CUDA: capped_random_cuda_
 
 - func: random_(Tensor(a!) self, *, Generator? generator=None) -> Tensor(a!)
   variants: method
+  cpu_bool: True
+  cuda_bool: True
   dispatch:
     CPU: random_cpu_
     CUDA: random_cuda_

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -17,9 +17,6 @@ THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor 
 
 #endif
 
-THC_API void THCTensor_(random)(struct THCState *state, THCTensor *self);
-THC_API void THCTensor_(clampedRandom)(struct THCState *state, THCTensor *self, int64_t min, int64_t max);
-THC_API void THCTensor_(cappedRandom)(struct THCState *state, THCTensor *self, int64_t max);
 THC_API void THCTensor_(geometric)(struct THCState *state, THCTensor *self, double p);
 
 #endif

--- a/tools/amd_build/pyHIPIFY/cuda_to_hip_mappings.py
+++ b/tools/amd_build/pyHIPIFY/cuda_to_hip_mappings.py
@@ -2073,6 +2073,7 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict([
     ("curandSetQuasiRandomGeneratorDimensions", ("hiprandSetQuasiRandomGeneratorDimensions", CONV_MATH_FUNC, API_RAND)),
     ("curandSetStream", ("hiprandSetStream", CONV_MATH_FUNC, API_RAND)),
     ("curand", ("hiprand", CONV_DEVICE_FUNC, API_RAND)),
+    ("curand4", ("hiprand4", CONV_DEVICE_FUNC, API_RAND)),
     ("curand_init", ("hiprand_init", CONV_DEVICE_FUNC, API_RAND)),
     ("curand_log_normal", ("hiprand_log_normal", CONV_DEVICE_FUNC, API_RAND)),
     ("curand_log_normal_double", ("hiprand_log_normal_double", CONV_DEVICE_FUNC, API_RAND)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #20626 Speedup bernoulli_scalar_cuda_kernel with grid-stride loop
* #20625 Move THCTensor_(geometric) to ATen
* #20624 Move THCTensor_(lognormal) to ATen
* #20623 Move THCTensor_(exponential) to ATen
* #20622 Move THCTensor_(cauchy) to ATen
* #20621 Move THCTensor_{normal, normal_means, normal_stddevs, normal_means_stddevs} to ATen
* **#20620 Move THCTensor_{random, clampedRandom, cappedRandom} to ATen**

Differential Revision: [D15454050](https://our.internmc.facebook.com/intern/diff/D15454050)

## Effective Bandwidth Benchmark
- using https://gist.github.com/syed-ahmed/f8b7384d642f4bce484228b508b4bc68
- on V100
### Float Type
#### Before:
```
random, size, elements 65536 forward 5.106925964355469e-06 bandwidth (GB/s) 51.331075059570495
random, size, elements 131072 forward 5.497932434082031e-06 bandwidth (GB/s) 95.36093909592368
random, size, elements 262144 forward 7.791519165039062e-06 bandwidth (GB/s) 134.57914660660956
random, size, elements 524288 forward 1.2221336364746093e-05 bandwidth (GB/s) 171.59760090144363
random, size, elements 1048576 forward 2.0668506622314453e-05 bandwidth (GB/s) 202.93212647844044
random, size, elements 2097152 forward 3.9124488830566405e-05 bandwidth (GB/s) 214.40811754315664
random, size, elements 4194304 forward 7.290840148925782e-05 bandwidth (GB/s) 230.1136173239503
random, size, elements 8388608 forward 0.00013821840286254883 bandwidth (GB/s) 242.76385275098409
random, size, elements 16777216 forward 0.0002722597122192383 bandwidth (GB/s) 246.48841157211064
random, size, elements 33554432 forward 0.0005396437644958496 bandwidth (GB/s) 248.71542456418447
```
#### After:
```
random, size, elements 65536 forward 5.841255187988281e-06 bandwidth (GB/s) 44.878025623510204
random, size, elements 131072 forward 5.857944488525391e-06 bandwidth (GB/s) 89.5003360013024
random, size, elements 262144 forward 6.563663482666016e-06 bandwidth (GB/s) 159.75468620065382
random, size, elements 524288 forward 7.276535034179687e-06 bandwidth (GB/s) 288.207504004194
random, size, elements 1048576 forward 1.0349750518798827e-05 bandwidth (GB/s) 405.2565317764571
random, size, elements 2097152 forward 1.6405582427978516e-05 bandwidth (GB/s) 511.3264364021509
random, size, elements 4194304 forward 2.7208328247070314e-05 bandwidth (GB/s) 616.6206114411497
random, size, elements 8388608 forward 4.884481430053711e-05 bandwidth (GB/s) 686.9599665901694
random, size, elements 16777216 forward 9.639024734497071e-05 bandwidth (GB/s) 696.2204771591086
random, size, elements 33554432 forward 0.00017502307891845704 bandwidth (GB/s) 766.8573129291814
```
### Double Type
#### Before:
```
random, size, elements 65536 forward 6.1082839965820315e-06 bandwidth (GB/s) 42.916144721935986
random, size, elements 131072 forward 8.215904235839844e-06 bandwidth (GB/s) 63.81379151340685
random, size, elements 262144 forward 1.3575553894042968e-05 bandwidth (GB/s) 77.240016001124
random, size, elements 524288 forward 2.3760795593261718e-05 bandwidth (GB/s) 88.26101768219948
random, size, elements 1048576 forward 4.4798851013183595e-05 bandwidth (GB/s) 93.62525835240021
random, size, elements 2097152 forward 8.335113525390626e-05 bandwidth (GB/s) 100.64179659276888
random, size, elements 4194304 forward 0.00015572309494018554 bandwidth (GB/s) 107.7374939564633
random, size, elements 8388608 forward 0.0003071308135986328 bandwidth (GB/s) 109.25127181751903
random, size, elements 16777216 forward 0.0006092119216918945 bandwidth (GB/s) 110.15684626398355
random, size, elements 33554432 forward 0.0011054635047912597 bandwidth (GB/s) 121.41307914578674
```
#### After:
```
random, size, elements 65536 forward 5.834102630615234e-06 bandwidth (GB/s) 44.93304567944422
random, size, elements 131072 forward 6.258487701416016e-06 bandwidth (GB/s) 83.77231449721906
random, size, elements 262144 forward 7.848739624023438e-06 bandwidth (GB/s) 133.5980106653706
random, size, elements 524288 forward 1.185894012451172e-05 bandwidth (GB/s) 176.84143591089668
random, size, elements 1048576 forward 2.0167827606201173e-05 bandwidth (GB/s) 207.97004426546874
random, size, elements 2097152 forward 3.463029861450195e-05 bandwidth (GB/s) 242.23319854617557
random, size, elements 4194304 forward 6.528139114379883e-05 bandwidth (GB/s) 256.9984448254775
random, size, elements 8388608 forward 0.00012089729309082031 bandwidth (GB/s) 277.544940355226
random, size, elements 16777216 forward 0.00023464202880859374 bandwidth (GB/s) 286.0053006733214
random, size, elements 33554432 forward 0.00044272661209106447 bandwidth (GB/s) 303.1616449846316
```
