### PR TITLE
Add get/set_num_interop_threads into torch.h include

### DIFF
--- a/test/cpp/api/torch_include.cpp
+++ b/test/cpp/api/torch_include.cpp
@@ -9,4 +9,6 @@ TEST(TorchIncludeTest, GetSetNumThreads) {
   torch::init_num_threads();
   torch::set_num_threads(2);
   ASSERT_EQ(torch::get_num_threads(), 2);
+  torch::set_num_interop_threads(2);
+  ASSERT_EQ(torch::get_num_interop_threads(), 2);
 }

--- a/torch/csrc/api/include/torch/utils.h
+++ b/torch/csrc/api/include/torch/utils.h
@@ -26,4 +26,10 @@ using at::get_num_threads;
 // Sets the number of threads to be used in parallel region.
 using at::set_num_threads;
 
+// Returns the number of threads used for inter-op parallelism.
+using at::get_num_interop_threads;
+
+// Sets the number of threads to be used for inter-op parallelism.
+using at::set_num_interop_threads;
+
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20659 Add get/set_num_interop_threads into torch.h include**

Summary:
Adding these functions into torch namespace

Test Plan:
test/cpp/api/torch_include
./build/bin/test_api
Reviewers:cpuhrsch, vitalyf, soumith, dzhulgakov


Differential Revision: [D15399780](https://our.internmc.facebook.com/intern/diff/D15399780)