### PR TITLE
[jit] delete brodcasting ops from shape analysis resize aliasing

### DIFF
--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -456,7 +456,6 @@ class ShapePropagator {
     bool in_resize = false;
     for (auto v : vs) {
       if (aliasDb_.mayAlias(ValueSet{v}, resized_alias_set)) {
-        setUnshapedType(v);
         in_resize = true;
       }
     }
@@ -467,6 +466,9 @@ class ShapePropagator {
     // Certain ops like resize_ change the input tensors size. Because our
     // analysis is flow invariant, we set any Tensor that can alias a resized
     // Tensor to the base Tensor Type without size information.
+    // NB: We don't erase the input shape information for in-place operations
+    // since in-place operations do not allow the in-place tensor to change
+    // shape as a result of the broadcast.
     if (mayAliasResizedSet(node->inputs())) {
       return setUnshapedType(node);
     }


### PR DESCRIPTION
According to https://pytorch.org/docs/stable/notes/broadcasting.html, in-place operations do not allow the in-place tensor to change shape as a result of the broadcast. Therefore our shape analysis could keep the shape information on inputs.