### PR TITLE
Remove unused var (ws_) and use vars in undefined case for compile

### DIFF
--- a/caffe2/utils/signal_handler.cc
+++ b/caffe2/utils/signal_handler.cc
@@ -123,15 +123,13 @@ struct {
   const char* name;
   int signum;
   struct sigaction previous;
-} kSignalHandlers[] = {
-  { "SIGABRT",  SIGABRT,  {} },
-  { "SIGINT",   SIGINT,   {} },
-  { "SIGILL",   SIGILL,   {} },
-  { "SIGFPE",   SIGFPE,   {} },
-  { "SIGBUS",   SIGBUS,   {} },
-  { "SIGSEGV",  SIGSEGV,  {} },
-  { nullptr,    0,        {} }
-};
+} kSignalHandlers[] = {{"SIGABRT", SIGABRT, {}},
+                       {"SIGINT", SIGINT, {}},
+                       {"SIGILL", SIGILL, {}},
+                       {"SIGFPE", SIGFPE, {}},
+                       {"SIGBUS", SIGBUS, {}},
+                       {"SIGSEGV", SIGSEGV, {}},
+                       {nullptr, 0, {}}};
 
 struct sigaction* getPreviousSigaction(int signum) {
   for (auto handler = kSignalHandlers; handler->name != nullptr; handler++) {
@@ -433,7 +431,7 @@ REGISTER_CAFFE2_INIT_FUNCTION(
     "Inits signal handlers for fatal signals so we can see what if"
     " caffe2_print_stacktraces is set.");
 
-} // namepsace internal
+} // namespace internal
 #endif // defined(CAFFE2_SUPPORTS_FATAL_SIGNAL_HANDLERS)
 } // namespace caffe2
 
@@ -444,7 +442,12 @@ REGISTER_CAFFE2_INIT_FUNCTION(
 namespace caffe2 {
 SignalHandler::SignalHandler(
     SignalHandler::Action SIGINT_action,
-    SignalHandler::Action SIGHUP_action) {}
+    SignalHandler::Action SIGHUP_action) {
+  SIGINT_action_ = SIGINT_action;
+  SIGHUP_action_ = SIGHUP_action;
+  my_sigint_count_ = 0;
+  my_sighup_count_ = 0;
+}
 SignalHandler::~SignalHandler() {}
 bool SignalHandler::GotSIGINT() {
   return false;


### PR DESCRIPTION
Summary:
I'm trying to get xplat/caffe2 compiling in ovrsource. I was running into undefined and unused private field compiler warnings and decided it would be easier to fix these then to add Wno equivalents of those flags into the caffe2 buck file.

```
 ✘ dxy@dxy-mbp  ~/ovrsource  buck build mode/android32/coretech/mac/dev-release //xplat/caffe2:caffe2
In file included from xplat/caffe2/caffe2/utils/signal_handler.cc:1:
xplat/caffe2/caffe2/utils/signal_handler.h:31:10: error: private field 'SIGINT_action_' is not used [-Werror,-Wunused-private-field]
  Action SIGINT_action_;
         ^
xplat/caffe2/caffe2/utils/signal_handler.h:32:10: error: private field 'SIGHUP_action_' is not used [-Werror,-Wunused-private-field]
  Action SIGHUP_action_;
         ^
xplat/caffe2/caffe2/utils/signal_handler.h:33:17: error: private field 'my_sigint_count_' is not used [-Werror,-Wunused-private-field]
  unsigned long my_sigint_count_;
                ^
xplat/caffe2/caffe2/utils/signal_handler.h:34:17: error: private field 'my_sighup_count_' is not used [-Werror,-Wunused-private-field]
  unsigned long my_sighup_count_;
                ^
4 errors generated.
command exited with code 1: third-party/toolchains/android-ndk/r18b/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=armv7-none-linux-android --sysroot third-party/toolchains/android-ndk/r18b/sysroot --gcc-toolchain=third-party/toolchains/android-ndk/r18b/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64 -D__ANDROID_API__=24 @/Users/dxy/ovrsource/buck-out/bin/xplat/caffe2/caffe2#compile-signal_handler.cc.oe8090f90,default/ppandcompile.argsfile -isystem third-party/toolchains/android-ndk/r18b/sysroot/usr/include/arm-linux-androideabi -isystem third-party/toolchains/android-ndk/r18b/sources/cxx-stl/llvm-libc++/include -isystem third-party/toolchains/android-ndk/r18b/sources/cxx-stl/llvm-libc++abi/include -isystem third-party/toolchains/android-ndk/r18b/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi
xplat/caffe2/caffe2/share/fb/stylizer/median_blur_ops.cc:593:14: error: private field 'ws_' is not used [-Werror,-Wunused-private-field]
  Workspace* ws_;
             ^
1 error generated.
command exited with code 1: third-party/toolchains/android-ndk/r18b/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=armv7-none-linux-android --sysroot third-party/toolchains/android-ndk/r18b/sysroot --gcc-toolchain=third-party/toolchains/android-ndk/r18b/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64 -D__ANDROID_API__=24 @/Users/dxy/ovrsource/buck-out/bin/xplat/caffe2/caffe2#compile-median_blur_ops.cc.o0cb98141,default/ppandcompile.argsfile -isystem third-party/toolchains/android-ndk/r18b/sysroot/usr/include/arm-linux-androideabi -isystem third-party/toolchains/android-ndk/r18b/sources/cxx-stl/llvm-libc++/include -isystem third-party/toolchains/android-ndk/r18b/sources/cxx-stl/llvm-libc++abi/include -isystem third-party/toolchains/android-ndk/r18b/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi
Building: finished in 4.9 sec (100%) 211/210 jobs, 2 updated
  Total time: 4.9 sec
More details at https://our.intern.facebook.com/intern/buck/build/774d0dc6-8e29-437f-97af-31a6f341991a
Command failed with exit code 1.
stderr: In file included from xplat/caffe2/caffe2/utils/signal_handler.cc:1:
xplat/caffe2/caffe2/utils/signal_handler.h:31:10: error: private field 'SIGINT_action_' is not used [-Werror,-Wunused-private-field]
  Action SIGINT_action_;
         ^
xplat/caffe2/caffe2/utils/signal_handler.h:32:10: error: private field 'SIGHUP_action_' is not used [-Werror,-Wunused-private-field]
  Action SIGHUP_action_;
         ^
xplat/caffe2/caffe2/utils/signal_handler.h:33:17: error: private field 'my_sigint_count_' is not used [-Werror,-Wunused-private-field]
  unsigned long my_sigint_count_;
                ^
xplat/caffe2/caffe2/utils/signal_handler.h:34:17: error: private field 'my_sighup_count_' is not used [-Werror,-Wunused-private-field]
  unsigned long my_sighup_count_;
                ^
4 errors generated.
command exited with code 1: third-party/toolchains/android-ndk/r18b/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=armv7-none-linux-android --sysroot third-party/toolchains/android-ndk/r18b/sysroot --gcc-toolchain=third-party/toolchains/android-ndk/r18b/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64 -D__ANDROID_API__=24 @/Users/dxy/ovrsource/buck-out/bin/xplat/caffe2/caffe2#compile-signal_handler.cc.oe8090f90,default/ppandcompile.argsfile -isystem third-party/toolchains/android-ndk/r18b/sysroot/usr/include/arm-linux-androideabi -isystem third-party/toolchains/android-ndk/r18b/sources/cxx-stl/llvm-libc++/include -isystem third-party/toolchains/android-ndk/r18b/sources/cxx-stl/llvm-libc++abi/include -isystem third-party/toolchains/android-ndk/r18b/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi
    When running <c++ preprocess_and_compile>.
    When building rule //xplat/caffe2:caffe2#compile-signal_handler.cc.oe8090f90,default.
```

Differential Revision: D15402928

