### PR TITLE
Make nn functions configurable for different scalar types

### DIFF
--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -5,9 +5,9 @@
   scalar_check:
     output: 'false'
     grad_input: 'false'
-  # This section provides scalar types to be generated for each backend
-  # If backend is not specified, ['Float', 'Double', 'Half'] will be used
-  # If forward_scalar_types or backward_scalar_types is not specified, ['Float', 'Double', 'Half'] will be used
+  # Using this section you can specify what scalar types should be used for each backend
+  # to generate backward and forward methods
+  # If not specified, ['Float', 'Double', 'Half'] will be used
   CPU:
     forward_scalar_types: ['Float', 'Double', 'Half']
     backward_scalar_types: ['Float', 'Double', 'Half']

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -5,10 +5,13 @@
   scalar_check:
     output: 'false'
     grad_input: 'false'
+  # This section provides scalar types to be generated for each backend
+  # If backend is not specified, ['Float', 'Double', 'Half'] will be used
+  # If forward_scalar_types or backward_scalar_types is not specified, ['Float', 'Double', 'Half'] will be used
   CPU:
     forward_scalar_types: ['Float', 'Double', 'Half']
     backward_scalar_types: ['Float', 'Double', 'Half']
-  GPU:
+  CUDA:
     forward_scalar_types: ['Float', 'Double', 'Half']
     backward_scalar_types: ['Float', 'Double', 'Half']
 

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -5,6 +5,12 @@
   scalar_check:
     output: 'false'
     grad_input: 'false'
+  CPU:
+    forward_scalar_types: ['Float', 'Double', 'Half']
+    backward_scalar_types: ['Float', 'Double', 'Half']
+  GPU:
+    forward_scalar_types: ['Float', 'Double', 'Half']
+    backward_scalar_types: ['Float', 'Double', 'Half']
 
 - name: _thnn_l1_loss(Tensor self, Tensor target, int64_t reduction=Reduction::Mean)
   cname: AbsCriterion

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -415,15 +415,15 @@ def run(paths):
                 if cname + suffix in header_functions:
                     bwd_functions.append(header_functions[cname + suffix])
 
-            defualt_scalar_types = ['Float', 'Double', 'Half']
+            default_scalar_types = ['Float', 'Double', 'Half']  # Half will be stripped for CPU backend
             forward_backend_types = {}
             backward_backend_types = {}
             for backend in backends:
                 backend_props = func.get(backend, {})
-                forward_backend_types[backend] = backend_props.get('forward_scalar_types', defualt_scalar_types)
-                backward_backend_types[backend] = backend_props.get('backward_backend_types', defualt_scalar_types)
+                forward_backend_types[backend] = backend_props.get('forward_scalar_types', default_scalar_types)
+                backward_backend_types[backend] = backend_props.get('backward_backend_types', default_scalar_types)
 
-            base = base_declaration(func, fwd_function, backends, defualt_scalar_types)
+            base = base_declaration(func, fwd_function, backends, default_scalar_types)
             declarations.append(forward_declaration(base, fwd_function, forward_backend_types))
             if bwd_functions:
                 declarations.append(backward_declaration(base, bwd_functions, backward_backend_types))

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -421,7 +421,7 @@ def run(paths):
             for backend in backends:
                 backend_props = func.get(backend, {})
                 forward_backend_types[backend] = backend_props.get('forward_scalar_types', default_scalar_types)
-                backward_backend_types[backend] = backend_props.get('backward_backend_types', default_scalar_types)
+                backward_backend_types[backend] = backend_props.get('backward_scalar_types', default_scalar_types)
 
             base = base_declaration(func, fwd_function, backends, default_scalar_types)
             declarations.append(forward_declaration(base, fwd_function, forward_backend_types))

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -423,7 +423,7 @@ def run(paths):
                 forward_backend_types[backend] = backend_props.get('forward_scalar_types', default_scalar_types)
                 backward_backend_types[backend] = backend_props.get('backward_scalar_types', default_scalar_types)
 
-            base = base_declaration(func, fwd_function, backends, default_scalar_types)
+            base = base_declaration(func, fwd_function, backends, None)
             declarations.append(forward_declaration(base, fwd_function, forward_backend_types))
             if bwd_functions:
                 declarations.append(backward_declaration(base, bwd_functions, backward_backend_types))

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -225,7 +225,7 @@ def unique_args(argslist):
     return result
 
 
-def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_check):
+def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_check, backend_types):
     """
     cimpls contains information use to call into THNN:
         cname: THNN function name
@@ -235,7 +235,7 @@ def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_ch
     return {
         'mode': 'NN',
         'name': name,
-        'types': ['Float', 'Double', 'Half'],  # Half will be stripped for CPU backend
+        'backend_types': backend_types,
         'arguments': arguments,
         'return': 'argument 0' if inplace else get_return(arguments),
         'buffers': buffers,
@@ -245,8 +245,7 @@ def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_ch
         'variants': ['function'],
     }
 
-
-def base_declaration(func, thnn_function, backends, inplace=False):
+def base_declaration(func, thnn_function, backends, backend_types, inplace=False):
     """Creates the NN function without any buffers in it's signature"""
     name, params = re.match(NAME_PARAM_REGEX, func['name']).groups()
     if inplace:
@@ -258,10 +257,9 @@ def base_declaration(func, thnn_function, backends, inplace=False):
     buffers = [argument_to_declaration('Tensor ' + buf)
                for buf in func.get('buffers', [])]
 
-    return function_info(name, arguments, None, buffers, backends, inplace, func.get('scalar_check'))
+    return function_info(name, arguments, None, buffers, backends, inplace, func.get('scalar_check'), backend_types)
 
-
-def forward_declaration(base, thnn_function, inplace=False):
+def forward_declaration(base, thnn_function, backend_types, inplace=False):
     name = '{}_forward'.format(base['name'])
     if inplace:
         name += '_'
@@ -284,10 +282,9 @@ def forward_declaration(base, thnn_function, inplace=False):
         output_arg_names = [arg['name'] for arg in arguments if arg.get('output', False)]
         scalar_check = {k: v for (k, v) in scalar_check.items() if k in output_arg_names}
 
-    return function_info(name, arguments, [cimpl], [], base['backends'], inplace, scalar_check)
+    return function_info(name, arguments, [cimpl], [], base['backends'], inplace, scalar_check, backend_types)
 
-
-def backward_declaration(base, thnn_functions):
+def backward_declaration(base, thnn_functions, backend_types):
     name = '{}_backward'.format(base['name'])
 
     arguments = []
@@ -376,7 +373,7 @@ def backward_declaration(base, thnn_functions):
                                   "does not exist.  Please explicitly specify scalar_check."
                                   .format(arg['name'], name, base_name)))
 
-    return function_info(name, arguments, cimpls, [], base['backends'], False, scalar_check)
+    return function_info(name, arguments, cimpls, [], base['backends'], False, scalar_check, backend_types)
 
 
 def parse_nn_yaml(filename):
@@ -418,12 +415,22 @@ def run(paths):
                 if cname + suffix in header_functions:
                     bwd_functions.append(header_functions[cname + suffix])
 
-            base = base_declaration(func, fwd_function, backends)
-            declarations.append(forward_declaration(base, fwd_function))
-            declarations.append(backward_declaration(base, bwd_functions))
+            defualt_scalar_types = ['Float', 'Double', 'Half']
+            forward_backend_types = {}
+            backward_backend_types = {}
+            for backend in backends:
+                backend_props = func.get(backend, {})
+                forward_backend_types[backend] = backend_props.get('forward_scalar_types', defualt_scalar_types)
+                backward_backend_types[backend] = backend_props.get('backward_backend_types', defualt_scalar_types)
+
+            base = base_declaration(func, fwd_function, backends, defualt_scalar_types)
+            declarations.append(forward_declaration(base, fwd_function, forward_backend_types))
+            if bwd_functions:
+                declarations.append(backward_declaration(base, bwd_functions, backward_backend_types))
+
 
             if func.get('has_inplace', False):
-                declarations.append(base_declaration(func, fwd_function, backends, True))
-                declarations.append(forward_declaration(base, fwd_function, True))
+                declarations.append(base_declaration(func, fwd_function, backends, forward_backend_types, True))
+                declarations.append(forward_declaration(base, fwd_function, forward_backend_types, True))
 
     return declarations


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20729 Make nn functions configurable for different scalar types**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15423752/)

Currently there is no way to specify what scalar types each nn function will support.

This change will allow to specify supported scalar types for each function/backward function and device. By default each function will support Float, Double, Half.

If you want to scpecify any extra supported scalar types, other then default, you will need to change nn.yalm:

- name: _some_func(Tensor self)
  cname: SomeFunction
  CPU:
    forward_scalar_types: ['Float', 'Double', 'Long']
    backward_scalar_types: ['Float', 'Double']

Differential Revision: [D15423752](https://our.internmc.facebook.com/intern/diff/D15423752/)