### PR TITLE
When detecting numpy, assign relavant variables outside the try block

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -594,10 +594,11 @@ main_link_args.extend(CAFFE2_LIBS)
 
 try:
     import numpy as np
-    NUMPY_INCLUDE_DIR = np.get_include()
-    USE_NUMPY = True
 except ImportError:
     USE_NUMPY = False
+else:
+    NUMPY_INCLUDE_DIR = np.get_include()
+    USE_NUMPY = True
 
 if USE_CUDA:
     if IS_WINDOWS:


### PR DESCRIPTION
When detecting the presence of NumPy using import, move numpy-related variable assignments outside the try block (i.e., to an else block) to improve readability.

