### PR TITLE
Use std::set to track wildcard nodes so that "last" queries are fast.

### DIFF
--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -1283,12 +1283,8 @@ bool AliasDb::isBeforeSameGraph(const Node* a, const Node* b) const {
 }
 
 c10::optional<const Node*> AliasDb::getLastWildcard() const {
-  auto it = std::max_element(
-      wildcardNodes_.cbegin(),
-      wildcardNodes_.cend(),
-      [this](const Node* a, const Node* b) { return isBeforeSameGraph(a, b); });
-  if (it != wildcardNodes_.end()) {
-    return *it;
+  if (!wildcardNodes_.empty()) {
+    return *std::prev(wildcardNodes_.end());
   } else {
     return c10::nullopt;
   }

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -239,8 +239,9 @@ class AliasDb {
   ValueSet wildcards_;
   // All nodes that write to a wildcard
   std::unordered_set<Node*> wildcardWriters_;
-  // All nodes that contain a wildcard
-  std::unordered_set<const Node*> wildcardNodes_;
+  // All nodes that contain a wildcard, sorted to make queries for the last fast.
+  std::set<const Node*, std::function<bool (const Node*, const Node*)>> wildcardNodes_
+    { [this](const Node* a, const Node* b) { return isBeforeSameGraph(a, b); } };
 
   // State for tracking write info
   size_t numWrites_ = 0;


### PR DESCRIPTION
Cuts load time on ResNet18 by 40%.

