### PR TITLE
Add support for CMake switches for VS 2019

### DIFF
--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -137,11 +137,10 @@ def run_cmake(version,
     if USE_NINJA:
         cmake_args.append('-GNinja')
     elif IS_WINDOWS:
+        cmake_args.append('-GVisual Studio 15 2017')
         if IS_64BIT:
-            cmake_args.append('-GVisual Studio 15 2017 Win64')
+            cmake_args.append('-Ax64')
             cmake_args.append('-Thost=x64')
-        else:
-            cmake_args.append('-GVisual Studio 15 2017')
     try:
         import numpy as np
         NUMPY_INCLUDE_DIR = np.get_include()


### PR DESCRIPTION
Appending `arch` to the generator name is not supported for VS starting from VS 2019.