### PR TITLE
Fixes a bug when incorrect number of bytes are copied.

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -55,7 +55,7 @@ Tensor int_repr_quant(const Tensor& self) {
         underlying_t* self_data = reinterpret_cast<underlying_t *>(self.data<scalar_t>());
         underlying_t* dst_data = dst.data<underlying_t>();
         if (self.numel() > 0) {
-          memcpy(dst_data, self_data, self.numel());
+          memcpy(dst_data, self_data, self.numel() * sizeof(underlying_t));
         }});
   return dst;
 }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20780 Fixes a bug when incorrect number of bytes are copied.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15440923/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20656 [pt1][quant] int_repr for different quantized types&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15398134/)

`memcpy`'s third argument is a count of bytes to copy. When using non-byte length data, it might cause an error.

Differential Revision: [D15440923](https://our.internmc.facebook.com/intern/diff/D15440923/)