### PR TITLE
[ONNX] Support tuples in ScriptModule inputs/outputs

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1655,7 +1655,7 @@ class TestCaffe2Backend(unittest.TestCase):
         class TupleModel(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, a):
-                # type: (Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor])
+                # type: (Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]
                 return a
 
         x = (torch.randn(3, 4), torch.randn(4, 3))

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1651,6 +1651,29 @@ class TestCaffe2Backend(unittest.TestCase):
 
         self.run_model_test(MyModel(), train=False, input=lstm_in, batch_size=3, use_gpu=False)
 
+    def test_tuple_input_output(self):
+        class TupleModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, a):
+                # type: (Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor])
+                return a
+
+        x = (torch.randn(3, 4), torch.randn(4, 3))
+        self.run_model_test(TupleModel(), train=False, input=(x,), batch_size=BATCH_SIZE,
+                            example_outputs=(x,))
+
+    def test_nested_tuple_input_output(self):
+        class NestedTupleModel(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, a, b):
+                # type: (Tensor, Tuple[Tensor, Tuple[Tensor, Tensor]]) -> Tensor
+                return a + b[0] + b[1][0] + b[1][1]
+
+        x = torch.randn(4, 5)
+        y = (torch.randn(4, 5), (torch.randn(4, 5), torch.randn(4, 5)))
+        self.run_model_test(NestedTupleModel(), train=False, input=(x, y), batch_size=BATCH_SIZE,
+                            example_outputs=x + y[0] + y[1][0] + y[1][1])
+
     def test_topk(self):
         class TopKModel(torch.nn.Module):
             def forward(self, input):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -198,7 +198,7 @@ static TupleTypePtr getTupleTensorType(
   AT_ASSERT(s_iter != s_iter_end);
 
   std::vector<TypePtr> types;
-  for (auto subType : tupleType->containedTypes()) {
+  for (const auto& subType : tupleType->containedTypes()) {
     if (subType->kind() == TupleType::Kind) {
       types.push_back(getTupleTensorType(s_iter+1, s_iter_end, subType, isDimensionedTensor));
     } else {
@@ -237,7 +237,7 @@ static std::shared_ptr<Graph> _propagate_shapes(
 
 static std::shared_ptr<Graph> _propagate_and_assign_input_shapes(
     Graph& graph,
-    std::vector<at::Tensor> inputs,
+    const std::vector<at::Tensor>& inputs,
     bool with_grad = false,
     bool propagate = true) {
   auto retval = graph.copy();

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -181,14 +181,17 @@ static Self moduleSelf(
 static TypePtr getTensorType(
     const at::Tensor& t,
     const TypeKind type_kind) {
-  AT_ASSERT(type_kind == TypeKind::DimensionedTensorType || type_kind == TypeKind::CompleteTensorType);
   switch (type_kind) {
     case TypeKind::DimensionedTensorType:
       return DimensionedTensorType::create(t);
-    case TypeKind::CompleteTensorType:
+    case TypeKind::CompleteTensorType: {
       auto scalar_type = t.scalar_type();
       auto sizes = t.sizes();
       return CompleteTensorType::create(scalar_type, at::kCPU, sizes);
+    }
+    default:
+      throw std::runtime_error(
+          "Attempted to call getTensorType for type kind other than DimensionedTensorType or CompleteTensorType.");
   }
 }
 


### PR DESCRIPTION
- [x] Add tests after https://github.com/pytorch/pytorch/pull/20256 is merged

- Support exporting ScriptModule with inputs/outputs of arbitrarily constructed tuples.

- Moved the assigning of output shapes to after graph conversion to ONNX is completed. By then all tuples in the IR has already been lowered by the pass ```_jit_pass_lower_all_tuples```. If assigning output shapes is required to happen before that, we'll need to hand parse the tuple structures in the graph, and repeat the same logic in ```_jit_pass_lower_all_tuples```. Handling inputs is easier because all tuple information is encoded within the input tensor type.

- Swap the order of ```_jit_pass_lower_all_tuples``` and ```_jit_pass_erase_number_types```. Ops like ```prim::TupleIndex``` relies on index being a scalar. ```_jit_pass_erase_number_types``` will convert these kind of scalars to tensors.