### PR TITLE
Add warning about memory overhead when using multiple tiny tensors

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -120,6 +120,11 @@ view of a storage and defines numeric operations on it.
     To change an existing tensor's :class:`torch.device` and/or :class:`torch.dtype`, consider using
     :meth:`~torch.Tensor.to` method on the tensor.
 
+.. warning::
+   Current implementation of :class:`torch.Tensor` introduces memory overhead,
+   thus it might lead to unexpectedly high memory usage in the applications with many tiny tensors. 
+   If this is your case, consider using one large structure.
+
 .. class:: Tensor()
 
    There are a few main ways to create a tensor, depending on your use case.


### PR DESCRIPTION
added note in docs regarding #19408