### PR TITLE
Add empty check for InferenceLSTM

### DIFF
--- a/caffe2/operators/inference_lstm_op.cc
+++ b/caffe2/operators/inference_lstm_op.cc
@@ -11,9 +11,9 @@ bool InferenceLSTMOp::RunOnDevice() {
   for (int i = 3; i < InputSize(); i++) {
     params.push_back(Input(i).UnsafeSharedInstance());
   }
+  CAFFE_ENFORCE(_input.numel() > 0, "Can't run LSTM with empty sequences");
   auto input = batch_first_ ? transpose(_input, 0, 1, &context_)
                             : _input.UnsafeSharedInstance();
-
   auto cell_params = gather_params(params, has_biases_, &context_);
   auto results = _lstm_impl(
       input,
@@ -52,10 +52,10 @@ NO_GRADIENT(InferenceLSTM);
 C10_REGISTER_CAFFE2_OPERATOR_CPU(
     InferenceLSTM,
     "_caffe2::InferenceLSTM("
-      "Tensor[] input_list, "
-      "int num_layers, "
-      "bool has_biases, "
-      "bool batch_first, "
-      "bool bidirectional"
+    "Tensor[] input_list, "
+    "int num_layers, "
+    "bool has_biases, "
+    "bool batch_first, "
+    "bool bidirectional"
     ") -> (Tensor output, Tensor hidden, Tensor cell)",
     caffe2::InferenceLSTMOp);

--- a/caffe2/python/test/inference_lstm_op_test.py
+++ b/caffe2/python/test/inference_lstm_op_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-import inspect
-
 import hypothesis.strategies as st
 import numpy as np
 import torch
@@ -60,7 +58,6 @@ class TestC2LSTM(TestCase):
         c2_results = torch.ops._caffe2.InferenceLSTM(
             lstm_in, num_layers, has_biases, batch_first, is_bidirectional
         )
-
         np.testing.assert_array_almost_equal(
             py_results[0].detach().numpy(), c2_results[0].detach().numpy()
         )
@@ -70,3 +67,37 @@ class TestC2LSTM(TestCase):
         np.testing.assert_array_almost_equal(
             py_results[1][1].detach().numpy(), c2_results[2].detach().numpy()
         )
+
+    def test_c2_lstm_empty_input(self):
+        seq_lens = 0
+        bsz = 1
+        emb_lens = 200
+        hidden_size = 128
+        num_layers = 2
+        is_bidirectional = True
+        num_directions = 2
+
+        net = core.Net("test_net")
+        py_lstm = nn.LSTM(emb_lens, hidden_size, num_layers=num_layers)
+        hx = np.zeros((num_layers * num_directions, bsz, hidden_size), dtype=np.float32)
+        params = py_lstm._flat_weights
+        inputs = np.random.randn(seq_lens, bsz, emb_lens).astype(np.float32)
+
+        inputs_blob = net.AddExternalInput("inputs")
+        workspace.FeedBlob(str(inputs_blob), inputs)
+        hx_blob = net.AddExternalInput("hx")
+        workspace.FeedBlob(str(hx_blob), hx)
+        lstm_in_blobs = [inputs_blob, hx_blob, hx_blob]
+        for i, param in enumerate(params):
+            param_blob = net.AddExternalInput("param_{}".format(i))
+            workspace.FeedBlob(str(param_blob), param.detach().numpy())
+            lstm_in_blobs.append(param_blob)
+        outputs, hidden, cell = net.InferenceLSTM(
+            lstm_in_blobs,
+            bidirectional=is_bidirectional,
+            num_layers=num_layers,
+            outputs=3,
+        )
+        workspace.CreateNet(net)
+        with self.assertRaises(RuntimeError):
+            workspace.RunNet(net)


### PR DESCRIPTION
Summary: Throw an exception when the input to the InferenceLSTM layer is empty instead of crashing

Differential Revision: D15448784

