### PR TITLE
rename Half.x to be clearer

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -56,8 +56,8 @@ static void abs_kernel(TensorIterator& iter) {
 
 static void fill_kernel(TensorIterator& iter, Scalar value_scalar) {
   if( iter.dtype() == ScalarType::Half ) {
-    auto value = value_scalar.to<at::Half>().x;
-    using H = decltype(value);
+    auto value = value_scalar.to<at::Half>().raw_bytes;
+    using H = at::Half::UnderlyingType;
     nullary_kernel_vec(
         iter,
         [=]() -> H { return value; },

--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -105,9 +105,9 @@ static inline  __device__ void atomicAdd(at::Half *address, at::Half val) {
     do {
       assumed = old;
       at::Half hsum;
-      hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+      hsum.raw_bytes = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
       hsum = THCNumerics<at::Half>::add(hsum, val);
-      old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
+      old = (size_t)address & 2 ? (old & 0xffff) | (hsum.raw_bytes << 16) : (old & 0xffff0000) | hsum.raw_bytes;
       old = atomicCAS(address_as_ui, assumed, old);
     } while (assumed != old);
   #else

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -18,9 +18,9 @@ namespace c10 {
 
 inline C10_HOST_DEVICE Half::Half(float value) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  x = __half_as_short(__float2half(value));
+  raw_bytes = __half_as_short(__float2half(value));
 #else
-  x = detail::fp16_ieee_from_fp32_value(value);
+  raw_bytes = detail::fp16_ieee_from_fp32_value(value);
 #endif
 }
 
@@ -28,18 +28,18 @@ inline C10_HOST_DEVICE Half::Half(float value) {
 
 inline C10_HOST_DEVICE Half::operator float() const {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  return __half2float(*reinterpret_cast<const __half*>(&x));
+  return __half2float(*reinterpret_cast<const __half*>(&raw_bytes));
 #else
-  return detail::fp16_ieee_to_fp32_value(x);
+  return detail::fp16_ieee_to_fp32_value(raw_bytes);
 #endif
 }
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 inline C10_HOST_DEVICE Half::Half(const __half& value) {
-  x = *reinterpret_cast<const unsigned short*>(&value);
+  raw_bytes = *reinterpret_cast<const unsigned short*>(&value);
 }
 inline C10_HOST_DEVICE Half::operator __half() const {
-  return *reinterpret_cast<const __half*>(&x);
+  return *reinterpret_cast<const __half*>(&raw_bytes);
 }
 #endif
 

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -322,7 +322,8 @@ namespace detail {
 } // namespace detail
 
 struct alignas(2) Half {
-  unsigned short x;
+  unsigned short raw_bytes;
+  using UnderlyingType = decltype(raw_bytes);
 
   struct from_bits_t {};
   static constexpr from_bits_t from_bits() {
@@ -336,7 +337,7 @@ struct alignas(2) Half {
   Half() = default;
 #endif
 
-  constexpr C10_HOST_DEVICE Half(unsigned short bits, from_bits_t) : x(bits){};
+  constexpr C10_HOST_DEVICE Half(unsigned short bits, from_bits_t) : raw_bytes(bits){};
   inline C10_HOST_DEVICE Half(float value);
   inline C10_HOST_DEVICE operator float() const;
 

--- a/caffe2/contrib/aten/aten_op.cc
+++ b/caffe2/contrib/aten/aten_op.cc
@@ -19,7 +19,7 @@ void Set<at::Half, CPUContext>(
     const at::Half h,
     at::Half* v,
     CPUContext* c) {
-  Set(0, h.x, (uint16_t*)v, c);
+  Set(0, h.raw_bytes, (uint16_t*)v, c);
 }
 
 } // namespace math

--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -699,7 +699,7 @@ TEST(TensorTest, Half) {
   TensorCPU* tensor = BlobGetMutableTensor(&blob, CPU);
   tensor->Resize(kSize);
   for (int i = 0; i < tensor->numel(); ++i) {
-    tensor->mutable_data<at::Half>()[i].x = i % 10000;
+    tensor->mutable_data<at::Half>()[i].raw_bytes = i % 10000;
   }
   string serialized = SerializeBlob(blob, "test");
   BlobProto proto;
@@ -713,7 +713,7 @@ TEST(TensorTest, Half) {
   if (FLAGS_caffe2_serialize_fp16_as_bytes) {
     EXPECT_EQ(tensor_proto.byte_data().size(), 2 * kSize);
     for (int i = 0; i < kSize; ++i) {
-      auto value = tensor->mutable_data<at::Half>()[i].x;
+      auto value = tensor->mutable_data<at::Half>()[i].raw_bytes;
       auto low_bits = static_cast<char>(value & 0xff);
       auto high_bits = static_cast<char>(value >> 8);
       EXPECT_EQ(tensor_proto.byte_data()[2 * i], low_bits);
@@ -729,7 +729,7 @@ TEST(TensorTest, Half) {
   EXPECT_EQ(new_tensor.dim(), 1);
   EXPECT_EQ(new_tensor.size(0), kSize);
   for (int i = 0; i < kSize; ++i) {
-    EXPECT_EQ(new_tensor.data<at::Half>()[i].x, i % 10000);
+    EXPECT_EQ(new_tensor.data<at::Half>()[i].raw_bytes, i % 10000);
   }
 }
 

--- a/caffe2/perfkernels/typed_axpy.cc
+++ b/caffe2/perfkernels/typed_axpy.cc
@@ -24,9 +24,9 @@ void TypedAxpyHalffloat__base(
       float floatval;
     } t1;
     uint32_t t2, t3;
-    t1.intval = x[i].x & 0x7fff; // Non-sign bits
-    t2 = x[i].x & 0x8000; // Sign bit
-    t3 = x[i].x & 0x7c00; // Exponent
+    t1.intval = x[i].raw_bytes & 0x7fff; // Non-sign bits
+    t2 = x[i].raw_bytes & 0x8000; // Sign bit
+    t3 = x[i].raw_bytes & 0x7c00; // Exponent
     t1.intval <<= 13; // Align mantissa on MSB
     t2 <<= 16; // Shift sign bit into position
     t1.intval += 0x38000000; // Adjust bias

--- a/caffe2/perfkernels/typed_axpy_avx.cc
+++ b/caffe2/perfkernels/typed_axpy_avx.cc
@@ -14,7 +14,7 @@ void TypedAxpyHalffloat__avx_f16c(
   // if x does not start at the 16 byte boundary, we will process the first few.
   // before we get to a real one.
   while ((reinterpret_cast<unsigned long>(x) % 16) && N) {
-    *(y++) += _cvtsh_ss((*(x++)).x) * a;
+    *(y++) += _cvtsh_ss((*(x++)).raw_bytes) * a;
     --N;
   }
 
@@ -36,7 +36,7 @@ void TypedAxpyHalffloat__avx_f16c(
 
   if (bound != N) {
     while (current < N) {
-      y[current] += _cvtsh_ss(x[current].x) * a;
+      y[current] += _cvtsh_ss(x[current].raw_bytes) * a;
       ++current;
     }
   }

--- a/caffe2/perfkernels/typed_axpy_avx2.cc
+++ b/caffe2/perfkernels/typed_axpy_avx2.cc
@@ -14,7 +14,7 @@ void TypedAxpyHalffloat__avx2_fma(
   // if x does not start at the 16 byte boundary, we will process the first few.
   // before we get to a real one.
   while ((reinterpret_cast<unsigned long>(x) % 16) && N) {
-    *(y++) += _cvtsh_ss((*(x++)).x) * a;
+    *(y++) += _cvtsh_ss((*(x++)).raw_bytes) * a;
     --N;
   }
 
@@ -35,7 +35,7 @@ void TypedAxpyHalffloat__avx2_fma(
 
   if (bound != N) {
     while (current < N) {
-      y[current] += _cvtsh_ss(x[current].x) * a;
+      y[current] += _cvtsh_ss(x[current].raw_bytes) * a;
       ++current;
     }
   }


### PR DESCRIPTION
Seems like it would be clearer to use a more descriptive name for the variable holding the underlying data in Half.h. Open to other suggestions.
