### PR TITLE
replaces torch.Size() inside with a tuple

### DIFF
--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -135,7 +135,7 @@ class LayerNorm(Module):
         super(LayerNorm, self).__init__()
         if isinstance(normalized_shape, numbers.Integral):
             normalized_shape = (normalized_shape,)
-        self.normalized_shape = torch.Size(normalized_shape)
+        self.normalized_shape = normalized_shape
         self.eps = eps
         self.elementwise_affine = elementwise_affine
         if self.elementwise_affine:


### PR DESCRIPTION
Summary: replaces torch.Size() inside with a tuple

Differential Revision: D15460726

