### PR TITLE
Fix init_thread calls in thread pool initialization

### DIFF
--- a/aten/src/ATen/Parallel.cpp
+++ b/aten/src/ATen/Parallel.cpp
@@ -137,12 +137,10 @@ std::string get_parallel_info() {
 PTThreadPool::PTThreadPool(
     int pool_size,
     int numa_node_id)
-    : c10::ThreadPool(pool_size, numa_node_id) {}
-
-void PTThreadPool::init_thread() {
-  c10::setThreadName("PTThreadPool");
-  at::init_num_threads();
-}
+    : c10::ThreadPool(pool_size, numa_node_id, [](){
+      c10::setThreadName("PTThreadPool");
+      at::init_num_threads();
+    }) {}
 
 C10_REGISTER_CREATOR(ThreadPoolRegistry, C10, create_c10_threadpool);
 

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -155,8 +155,6 @@ class CAFFE2_API PTThreadPool : public c10::ThreadPool {
   explicit PTThreadPool(
       int pool_size,
       int numa_node_id = -1);
-
-  void init_thread() override;
 };
 
 // Sets number of threads used for inter-op parallelism

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -76,8 +76,6 @@ void ThreadPool::waitWorkComplete() {
 }
 
 void ThreadPool::main_loop(std::size_t index) {
-  init_thread();
-
   std::unique_lock<std::mutex> lock(mutex_);
   while (running_) {
     // Wait on condition variable while the task is empty and

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -2,7 +2,10 @@
 
 namespace c10 {
 
-ThreadPool::ThreadPool(int pool_size, int numa_node_id)
+ThreadPool::ThreadPool(
+      int pool_size,
+      int numa_node_id,
+      std::function<void()> init_thread)
     : threads_(pool_size < 0 ? defaultNumThreads() : pool_size),
       running_(true),
       complete_(true),
@@ -10,7 +13,12 @@ ThreadPool::ThreadPool(int pool_size, int numa_node_id)
       total_(threads_.size()),
       numa_node_id_(numa_node_id) {
   for (std::size_t i = 0; i < threads_.size(); ++i) {
-    threads_[i] = std::thread(std::bind(&ThreadPool::main_loop, this, i));
+    threads_[i] = std::thread([this, i, init_thread](){
+      if (init_thread) {
+        init_thread();
+      }
+      this->main_loop(i);
+    });
   }
 }
 

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -109,9 +109,9 @@ class C10_API TaskThreadPool : public c10::ThreadPool {
   explicit TaskThreadPool(
       std::size_t pool_size,
       int numa_node_id = -1)
-      : ThreadPool(pool_size, numa_node_id, [](){
+      : ThreadPool(pool_size, numa_node_id, [numa_node_id](){
         setThreadName("CaffeTaskThread");
-        NUMABind(numa_node_id_);
+        NUMABind(numa_node_id);
       }) {}
 };
 

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -71,7 +71,8 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
 
   explicit ThreadPool(
       int pool_size,
-      int numa_node_id = -1);
+      int numa_node_id = -1,
+      std::function<void()> init_thread = nullptr);
 
   ~ThreadPool();
 
@@ -98,9 +99,6 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
   /// @brief Wait for queue to be empty
   void waitWorkComplete();
 
- protected:
-  virtual void init_thread() {}
-
  private:
   // @brief Entry point for pool threads.
   void main_loop(std::size_t index);
@@ -111,13 +109,10 @@ class C10_API TaskThreadPool : public c10::ThreadPool {
   explicit TaskThreadPool(
       std::size_t pool_size,
       int numa_node_id = -1)
-      : ThreadPool(pool_size, numa_node_id) {}
-
-  // TODO move this to ATen/core/thread_pool.h
-  void init_thread() override {
-    setThreadName("CaffeTaskThread");
-    NUMABind(numa_node_id_);
-  }
+      : ThreadPool(pool_size, numa_node_id, [](){
+        setThreadName("CaffeTaskThread");
+        NUMABind(numa_node_id_);
+      }) {}
 };
 
 C10_DECLARE_SHARED_REGISTRY(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #20157 Support for Eigen thread pool
* #20480 Native TBB parallel backend
* #20454 Restore TBB module
* #20087 Native ATen/Parallel backend
* #20825 Resend "Split ATen/Parallel into interface and backend"
* **#20848 Fix init_thread calls in thread pool initialization**

Summary:
When we create threads in ThreadPool constructor pointer to the
virtual function init_thread might not be initialized yet, so for
some threads we call parent's (empty) init_thread. This PR fixes this
by explicitly passing init_thread lambda in the constructor

Test Plan:
test_torch.py, test_jit.py

Reviewers: jamesreed, dzhulgakov, cpuhrsch, vitalyf

Differential Revision: [D15466918](https://our.internmc.facebook.com/intern/diff/D15466918)