### PR TITLE
Hook to store additional metadata about environment

### DIFF
--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -29,6 +29,7 @@
 #include <test/cpp/jit/test_netdef_converter.h>
 #include <test/cpp/jit/test_peephole_optimize.h>
 #include <test/cpp/jit/test_qualified_name.h>
+#include <test/cpp/jit/test_save_load.h>
 #include <test/cpp/jit/test_subgraph_matcher.h>
 #include <test/cpp/jit/test_subgraph_utils.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
@@ -83,7 +84,8 @@ namespace jit {
   _(ModuleDefine)                  \
   _(QualifiedName)                 \
   _(ClassImport)                   \
-  _(ScriptObject)
+  _(ScriptObject)                  \
+  _(SaveExtraFilesHook)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/test_save_load.h
+++ b/test/cpp/jit/test_save_load.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <test/cpp/jit/test_base.h>
+#include <test/cpp/jit/test_utils.h>
+
+#include <sstream>
+
+#include <torch/csrc/jit/export.h>
+#include <torch/csrc/jit/import.h>
+#include <torch/torch.h>
+
+namespace torch {
+namespace jit {
+namespace script {
+
+void testSaveExtraFilesHook() {
+  // no secrets
+  {
+    std::stringstream ss;
+    {
+      Module m;
+      ExtraFilesMap extra;
+      extra["metadata.json"] = "abc";
+      m.save(ss, extra);
+    }
+    ss.seekg(0);
+    {
+      ExtraFilesMap extra;
+      extra["metadata.json"] = "";
+      extra["secret.json"] = "";
+      jit::load(ss, c10::nullopt, extra);
+      ASSERT_EQ(extra["metadata.json"], "abc");
+      ASSERT_EQ(extra["secret.json"], "");
+    }
+  }
+  // some secret
+  {
+    std::stringstream ss;
+    {
+      SetExportModuleExtraFilesHook([](const Module&) -> ExtraFilesMap {
+        return {{"secret.json", "topsecret"}};
+      });
+      Module m;
+      ExtraFilesMap extra;
+      extra["metadata.json"] = "abc";
+      m.save(ss, extra);
+      SetExportModuleExtraFilesHook(nullptr);
+    }
+    ss.seekg(0);
+    {
+      ExtraFilesMap extra;
+      extra["metadata.json"] = "";
+      extra["secret.json"] = "";
+      jit::load(ss, c10::nullopt, extra);
+      ASSERT_EQ(extra["metadata.json"], "abc");
+      ASSERT_EQ(extra["secret.json"], "topsecret");
+    }
+  }
+}
+
+} // namespace script
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -35,6 +35,13 @@ namespace {
 namespace onnx_torch = ::torch::onnx;
 namespace onnx = ::ONNX_NAMESPACE;
 
+namespace {
+ExportModuleExtraFilesHook& GetExtraFilesHook() {
+  static ExportModuleExtraFilesHook func = nullptr;
+  return func;
+};
+}
+
 class ScriptModuleSerializer;
 
 std::string getNodeStackTraceString(const Node* n) {
@@ -670,6 +677,14 @@ void ScriptModuleSerializer::convertModel(
     const std::string key = "extra/" + kv.first;
     writer_.writeRecord(key, kv.second.data(), kv.second.size());
   }
+  auto hook = GetExtraFilesHook();
+  if (hook) {
+    script::ExtraFilesMap hook_files = hook(module);
+    for (const auto& kv : hook_files) {
+      const std::string key = "extra/" + kv.first;
+      writer_.writeRecord(key, kv.second.data(), kv.second.size());
+    }
+  }
 }
 
 bool ScriptModuleSerializer::moduleHasValidGetSetState(
@@ -1070,6 +1085,10 @@ std::string prettyPrint(const onnx::ModelProto& model) {
 }
 
 } // namespace
+
+void SetExportModuleExtraFilesHook(ExportModuleExtraFilesHook hook) {
+  GetExtraFilesHook() = hook;
+}
 
 std::string pretty_print_onnx(
     const std::shared_ptr<Graph>& graph,

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -50,5 +50,11 @@ TORCH_API void ExportModule(
     const std::string& filename,
     const script::ExtraFilesMap& metadata = script::ExtraFilesMap());
 
+// Surrounding system can install an additional hook to produce extra files
+// with metadata based on environment every time a module is serialized.
+using ExportModuleExtraFilesHook =
+    std::function<script::ExtraFilesMap(const script::Module&)>;
+TORCH_API void SetExportModuleExtraFilesHook(ExportModuleExtraFilesHook hook);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
In larger system environment, there's usually a need to store some information about how the model was created (e.g. from which process, workflow, by which user, etc). It's almost like JPEG metadata written by camera.

This PR adds a low-level c++ hook to allow population of additional files in zip container based on environment. The reason to have it a low-level hook instead of top-level API wrapper (e.g. `m.save_with_metadata`) is to capture all usages of the saving API transparently for user.

Let me know if there are concerns.