### PR TITLE
fix bug of not using get_score_cls_index in BoxWithNMSLimitOp

### DIFF
--- a/caffe2/python/operator_test/box_with_nms_limit_op_test.py
+++ b/caffe2/python/operator_test/box_with_nms_limit_op_test.py
@@ -122,6 +122,7 @@ class TestBoxWithNMSLimitOp(serial.SerializedTestCase):
 
     @given(
         num_classes=st.integers(2, 10),
+        det_per_im=st.integers(1, 4),
         cls_agnostic_bbox_reg=st.booleans(),
         input_boxes_include_bg_cls=st.booleans(),
         output_classes_include_bg_cls=st.booleans(),
@@ -130,6 +131,7 @@ class TestBoxWithNMSLimitOp(serial.SerializedTestCase):
     def test_multiclass(
         self,
         num_classes,
+        det_per_im,
         cls_agnostic_bbox_reg,
         input_boxes_include_bg_cls,
         output_classes_include_bg_cls,
@@ -145,9 +147,12 @@ class TestBoxWithNMSLimitOp(serial.SerializedTestCase):
         if cls_agnostic_bbox_reg:
             # only leave one class
             boxes = boxes[:, :4]
+        # randomize un-used scores for background class
+        scores_bg_class_id = 0 if input_boxes_include_bg_cls else -1
+        scores[:, scores_bg_class_id] = np.random.rand(scores.shape[0]).astype(np.float32)
 
-        gt_centers = [(20, 20), (0, 0), (50, 50)]
-        gt_scores = [0.85, 0.7, 0.6]
+        gt_centers = [(20, 20), (0, 0), (50, 50)][:det_per_im]
+        gt_scores = [0.85, 0.7, 0.6][:det_per_im]
         gt_boxes, gt_scores = gen_multiple_boxes(gt_centers, gt_scores, 1, 1)
         # [1, 1, 1, 2, 2, 2, 3, 3, 3, ...]
         gt_classes = np.tile(
@@ -164,7 +169,7 @@ class TestBoxWithNMSLimitOp(serial.SerializedTestCase):
             {
                 "score_thresh": 0.5,
                 "nms": 0.9,
-                "detections_per_im": 100,
+                "detections_per_im": (num_classes - 1) * det_per_im,
                 "cls_agnostic_bbox_reg": cls_agnostic_bbox_reg,
                 "input_boxes_include_bg_cls": input_boxes_include_bg_cls,
                 "output_classes_include_bg_cls": output_classes_include_bg_cls


### PR DESCRIPTION
Summary: When `input_boxes_include_bg_cls` is false (which means `input_scores_fg_cls_starting_id` is 0), It doesn't map the class index of score currectly when sorting and limiting the detections over all classes after nms.

Differential Revision: D15472706

