### PR TITLE
Failing assertions is unlikely

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -228,8 +228,8 @@ inline std::string if_empty_then(std::string x, std::string y) {
         "Expected " #cond " to be true, but got false.  "   \
         "(Could this error message be improved?  If so, "   \
         "please report an enhancement request to PyTorch.)" \
-      ) \
-    ); \
+      )                                                     \
+    );                                                      \
   }
 #endif
 // TODO: We're going to get a lot of similar looking string literals

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -171,7 +171,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 //
 #ifdef C10_MOBILE
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
-  if (!(cond)) {                              \
+  if (C10_UNLIKELY(!(cond))) {                \
     C10_THROW_ERROR(Error,                    \
         #cond " INTERNAL ASSERT FAILED at"    \
         __FILE__                              \
@@ -179,7 +179,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #else
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
-  if (!(cond)) {                              \
+  if (C10_UNLIKELY(!(cond))) {                \
     C10_THROW_ERROR(Error, ::c10::str(        \
         #cond " INTERNAL ASSERT FAILED at ",  \
         __FILE__,                             \
@@ -213,7 +213,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 //
 #ifdef C10_MOBILE
 #define TORCH_CHECK(cond, ...)                \
-  if (!(cond)) {                              \
+  if (C10_UNLIKELY(!(cond))) {                \
     C10_THROW_ERROR(Error,                    \
         #cond " CHECK FAILED at "             \
         __FILE__                              \
@@ -221,7 +221,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #else
 #define TORCH_CHECK(cond, ...)                              \
-  if (!(cond)) {                                            \
+  if (C10_UNLIKELY(!(cond))) {                              \
     C10_THROW_ERROR(Error,                                  \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
@@ -238,7 +238,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // Like TORCH_CHECK, but raises IndexErrors instead of Errors.
 #ifdef C10_MOBILE
 #define TORCH_CHECK_INDEX(cond, ...)          \
-  if (!(cond)) {                              \
+  if (C10_UNLIKELY(!(cond))) {                \
     C10_THROW_ERROR(Error,                    \
         #cond " INDEX CHECK FAILED at "       \
         __FILE__                              \
@@ -246,7 +246,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #else
 #define TORCH_CHECK_INDEX(cond, ...)                        \
-  if (!(cond)) {                                            \
+  if (C10_UNLIKELY(!(cond))) {                              \
     C10_THROW_ERROR(IndexError,                             \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -86,7 +86,7 @@ using EnforceNotMet = ::c10::Error;
 
 #define CAFFE_ENFORCE(condition, ...)                               \
   do {                                                              \
-    if (!(condition)) {                                             \
+    if (C10_UNLIKELY(!(condition))) {                               \
       ::c10::ThrowEnforceNotMet(                                    \
           __FILE__, __LINE__, #condition, ::c10::str(__VA_ARGS__)); \
     }                                                               \
@@ -94,7 +94,7 @@ using EnforceNotMet = ::c10::Error;
 
 #define CAFFE_ENFORCE_WITH_CALLER(condition, ...)                         \
   do {                                                                    \
-    if (!(condition)) {                                                   \
+    if (C10_UNLIKELY(!(condition))) {                                     \
       ::c10::ThrowEnforceNotMet(                                          \
           __FILE__, __LINE__, #condition, ::c10::str(__VA_ARGS__), this); \
     }                                                                     \
@@ -198,7 +198,7 @@ BINARY_COMP_HELPER(LessEquals, <=)
   do {                                                                  \
     using namespace ::c10::enforce_detail;                              \
     const EnforceFailMessage& CAFFE_ENFORCE_THAT_IMPL_r_ = (condition); \
-    if (CAFFE_ENFORCE_THAT_IMPL_r_.bad()) {                             \
+    if (C10_UNLIKELY(CAFFE_ENFORCE_THAT_IMPL_r_.bad())) {               \
       ::c10::ThrowEnforceNotMet(                                        \
           __FILE__,                                                     \
           __LINE__,                                                     \
@@ -213,7 +213,7 @@ BINARY_COMP_HELPER(LessEquals, <=)
     using namespace ::c10::enforce_detail;                             \
     const EnforceFailMessage& CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER_r_ = \
         (condition);                                                   \
-    if (CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER_r_.bad()) {                \
+    if (C10_UNLIKELY(CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER_r_.bad())) {   \
       ::c10::ThrowEnforceNotMet(                                       \
           __FILE__,                                                    \
           __LINE__,                                                    \

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -213,7 +213,7 @@ BINARY_COMP_HELPER(LessEquals, <=)
     using namespace ::c10::enforce_detail;                             \
     const EnforceFailMessage& CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER_r_ = \
         (condition);                                                   \
-    if (C10_UNLIKELY(CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER_r_.bad())) {   \
+    if (C10_UNLIKELY(CAFFE_ENFORCE_THAT_IMPL_WITH_CALLER_r_.bad())) {  \
       ::c10::ThrowEnforceNotMet(                                       \
           __FILE__,                                                    \
           __LINE__,                                                    \


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20876 Failing assertions is unlikely**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15480066/)

Tell the compiler that assertions are likely to succeed.
This allows the compiler to generate betterr code and optimize for the success case.

Differential Revision: [D15480066](https://our.internmc.facebook.com/intern/diff/D15480066/)