### PR TITLE
In Dockerfile, do not install unecessary packages, use conda to install ninja (saving one layer), and use "." to refer to WORKDIR to reduce redundancy.

### DIFF
--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -31,4 +31,4 @@ RUN TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX" TORCH_NVCC_FLAGS="-Xfatbin -c
 RUN git clone https://github.com/pytorch/vision.git && cd vision && pip install -v .
 
 WORKDIR /workspace
-RUN chmod -R a+w /workspace
+RUN chmod -R a+w .

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -15,11 +15,10 @@ RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-la
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy pyyaml scipy ipython mkl mkl-include cython typing && \
+     /opt/conda/bin/conda install -y python=$PYTHON_VERSION numpy pyyaml scipy ipython mkl mkl-include ninja cython typing && \
      /opt/conda/bin/conda install -y -c pytorch magma-cuda100 && \
      /opt/conda/bin/conda clean -ya
 ENV PATH /opt/conda/bin:$PATH
-RUN pip install ninja
 # This must be done before pip so that requirements.txt is available
 WORKDIR /opt/pytorch
 COPY . .

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -5,10 +5,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          cmake \
          git \
          curl \
-         vim \
          ca-certificates \
          libjpeg-dev \
-         libpng-dev &&\
+         libpng-dev && \
      rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
- Do not install unecessary packages in the Docker image.
- In the Docker image, use conda to install ninja (saving one layer)
- When workdir is set, use "." to refer to it to reduce redundancy.