### PR TITLE
Update cuSPARSE namespace collision w/ CUDA 10.1 Update 1

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -56,7 +56,7 @@ std::string cusparseGetErrorString(cusparseStatus_t status) {
 inline void CUSPARSE_CHECK(cusparseStatus_t status)
 {
   if (status != CUSPARSE_STATUS_SUCCESS) {
-    AT_ERROR("cusparse runtime error: ", getCusparseErrorString(status));
+    AT_ERROR("cusparse runtime error: ", cusparseGetErrorString(status));
   }
 }
 

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDABlas.cu
@@ -9,8 +9,8 @@
 
 namespace at { namespace native { namespace sparse { namespace cuda {
 
-
-std::string getCusparseErrorString(cusparseStatus_t status) {
+#if (!((CUSPARSE_VER_MAJOR >= 10) && (CUSPARSE_VER_MINOR >= 2)))
+std::string cusparseGetErrorString(cusparseStatus_t status) {
   switch(status)
   {
     case CUSPARSE_STATUS_SUCCESS:
@@ -51,6 +51,7 @@ std::string getCusparseErrorString(cusparseStatus_t status) {
       }
   }
 }
+#endif
 
 inline void CUSPARSE_CHECK(cusparseStatus_t status)
 {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#20889 Update cuSPARSE namespace collision w/ CUDA 10.1 Update 1**

cuSPARSE 10.1.157 and later give us CUSPARSE_VER_* symbols so that we can detect and avoid the conflict.  We should prefer cuSPARSE's own implementation of this function when it's available since it will be aware of all the latest cuSPARSE error codes.

Differential Revision: [D15495545](https://our.internmc.facebook.com/intern/diff/D15495545)