### PR TITLE
Change the quantizer to match the behavior of the FBGEMM implementation

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -112,13 +112,13 @@ T quantize_val(float scale, int32_t zero_point, float value) {
   // cases away from zero, and can be consistent with SIMD implementations for
   // example in x86 using _mm512_cvtps_epi32 or mm512_round_ps with
   // _MM_FROUND_CUR_DIRECTION option that also follow the current rounding mode.
-  int32_t qvalue;
+  int64_t qvalue;
   constexpr int32_t qmin = std::numeric_limits<typename T::underlying>::min();
   constexpr int32_t qmax = std::numeric_limits<typename T::underlying>::max();
   checkZeroPoint<typename T::underlying>("quantize_val", zero_point);
-  qvalue = static_cast<int32_t>(std::nearbyint(value / scale + zero_point));
-  qvalue = std::max(qvalue, qmin);
-  qvalue = std::min(qvalue, qmax);
+  qvalue = static_cast<int64_t>(std::nearbyint(value / scale + zero_point));
+  qvalue = std::max<int64_t>(qvalue, qmin);
+  qvalue = std::min<int64_t>(qvalue, qmax);
   return static_cast<T>(qvalue);
 }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20474 Quantized Max Pool op&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15327923/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #20647 Renaming the relu kernel and adding hypothesis tests&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15332106/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#20892 Change the quantizer to match the behavior of the FBGEMM implementation**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15487664/)

FBGEMM uses 64 bit values. Need to change our implementation to match

Differential Revision: [D15487664](https://our.internmc.facebook.com/intern/diff/D15487664/)