### PR TITLE
 [JIT] Record source/line info in SourceRange and report in highlight

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3667,6 +3667,14 @@ def foo(x):
             return [[4]] + [[4, 5]]
         self.checkScript(foo, ())
 
+    def test_file_line_error(self):
+        def foobar(x):
+            return torch.blargh(xyz)
+
+        _, lineno = inspect.getsourcelines(foobar)
+        with self.assertRaisesRegex(RuntimeError, "test_jit.py:{}".format(lineno + 1)):
+            scripted = torch.jit.script(foobar)
+
     def test_tensor_shape(self):
         x = torch.empty(34, 56, 78)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3668,12 +3668,21 @@ def foo(x):
         self.checkScript(foo, ())
 
     def test_file_line_error(self):
-        def foobar(x):
+        def foobar(xyz):
             return torch.blargh(xyz)
 
         _, lineno = inspect.getsourcelines(foobar)
         with self.assertRaisesRegex(RuntimeError, "test_jit.py:{}:20".format(lineno + 1)):
             scripted = torch.jit.script(foobar)
+
+    def test_file_line_error_class_defn(self):
+        class FooBar:
+            def baz(x):
+                return torch.blargh(xyz)
+
+        _, lineno = inspect.getsourcelines(FooBar)
+        with self.assertRaisesRegex(RuntimeError, "test_jit.py:{}:24".format(lineno + 2)):
+            torch.jit.script(FooBar)
 
     def test_tensor_shape(self):
         x = torch.empty(34, 56, 78)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3672,7 +3672,7 @@ def foo(x):
             return torch.blargh(xyz)
 
         _, lineno = inspect.getsourcelines(foobar)
-        with self.assertRaisesRegex(RuntimeError, "test_jit.py:{}".format(lineno + 1)):
+        with self.assertRaisesRegex(RuntimeError, "test_jit.py:{}:20".format(lineno + 1)):
             scripted = torch.jit.script(foobar)
 
     def test_tensor_shape(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3676,7 +3676,7 @@ def foo(x):
             scripted = torch.jit.script(foobar)
 
     def test_file_line_error_class_defn(self):
-        class FooBar:
+        class FooBar(object):
             def baz(x):
                 return torch.blargh(xyz)
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1220,8 +1220,7 @@ void Node::removeFromList() {
 }
 
 inline const SourceRange& fakeRange() {
-  static SourceRange range(
-      std::make_shared<Source>(""), 0, 1);
+  static SourceRange range(std::make_shared<Source>(""), 0, 1);
   return range;
 }
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1221,7 +1221,7 @@ void Node::removeFromList() {
 
 inline const SourceRange& fakeRange() {
   static SourceRange range(
-      std::make_shared<std::string>("<internally-created-node>"), 0, 1);
+      std::make_shared<Source>(""), 0, 1);
   return range;
 }
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -219,6 +219,16 @@ std::ostream& Node::print(
     std::ostream& out,
     size_t level,
     std::vector<const Node*>* groups) const {
+  auto& source = sourceRange().source();
+  if (source->filename()) {
+    auto col_offset = (int)sourceRange().start() -
+        (int)source->offset_for_line(
+            source->lineno_for_offset(sourceRange().start()));
+    indent(out, level) << "# " << *source->filename() << ":"
+                       << source->source_lineno_for_offset(
+                              sourceRange().start())
+                       << ":" << col_offset << "\n";
+  }
   auto outs = outputs();
   indent(out, level) << const_value_list_with_types(outs);
   out << " = ";

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -220,15 +220,6 @@ std::ostream& Node::print(
     size_t level,
     std::vector<const Node*>* groups) const {
   auto& source = sourceRange().source();
-  if (source->filename()) {
-    auto col_offset = (int)sourceRange().start() -
-        (int)source->offset_for_line(
-            source->lineno_for_offset(sourceRange().start()));
-    indent(out, level) << "# " << *source->filename() << ":"
-                       << source->source_lineno_for_offset(
-                              sourceRange().start())
-                       << ":" << col_offset << "\n";
-  }
   auto outs = outputs();
   indent(out, level) << const_value_list_with_types(outs);
   out << " = ";

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -219,7 +219,6 @@ std::ostream& Node::print(
     std::ostream& out,
     size_t level,
     std::vector<const Node*>* groups) const {
-  auto& source = sourceRange().source();
   auto outs = outputs();
   indent(out, level) << const_value_list_with_types(outs);
   out << " = ";

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -368,7 +368,7 @@ struct Token {
 
 struct Lexer {
   explicit Lexer(const std::string& str)
-      : file(std::make_shared<std::string>(str)),
+      : source(std::make_shared<Source>(str)),
         pos(0),
         nesting(0),
         indent_stack(),
@@ -485,9 +485,9 @@ struct Lexer {
     int kind;
     size_t start;
     size_t length;
-    AT_ASSERT(file);
+    AT_ASSERT(source);
     if (!shared.match(
-            *file,
+            source->text(),
             pos,
             nesting > 0,
             whitespace_token,
@@ -496,14 +496,14 @@ struct Lexer {
             &length)) {
       expected(
           "a valid token",
-          Token((*file)[start], SourceRange(file, start, start + 1)));
+          Token((source->text())[start], SourceRange(source, start, start + 1)));
     }
-    auto t = Token(kind, SourceRange(file, start, start + length));
+    auto t = Token(kind, SourceRange(source, start, start + length));
     pos = start + length;
     return t;
   }
 
-  std::shared_ptr<std::string> file;
+  std::shared_ptr<Source> source;
   size_t pos;
   size_t nesting; // depth of ( [ { nesting...
   std::vector<int> indent_stack; // stack of identation level of blocks

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -496,7 +496,8 @@ struct Lexer {
             &length)) {
       expected(
           "a valid token",
-          Token((source->text())[start], SourceRange(source, start, start + 1)));
+          Token(
+              (source->text())[start], SourceRange(source, start, start + 1)));
     }
     auto t = Token(kind, SourceRange(source, start, start + length));
     pos = start + length;

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -14,11 +14,16 @@ namespace jit {
 namespace script {
 
 struct SourceRangeFactory {
-  SourceRangeFactory(std::string text, std::string filename, size_t file_lineno)
+  SourceRangeFactory(
+      std::string text,
+      std::string filename,
+      size_t file_lineno,
+      size_t leading_whitespace_chars)
       : source_(std::make_shared<Source>(
             std::move(text),
             std::move(filename),
-            file_lineno)) {}
+            file_lineno,
+            leading_whitespace_chars)) {}
   SourceRange create(int line, int start_col, int end_col) {
     size_t start_byte_offset, end_byte_offset;
     std::tie(start_byte_offset, end_byte_offset) =
@@ -58,7 +63,7 @@ void initTreeViewBindings(PyObject* module) {
       .def_property_readonly("start", &SourceRange::start)
       .def_property_readonly("end", &SourceRange::end);
   py::class_<SourceRangeFactory>(m, "SourceRangeFactory")
-      .def(py::init<std::string&&, std::string&&, size_t>())
+      .def(py::init<std::string&&, std::string&&, size_t, size_t>())
       .def("make_range", &SourceRangeFactory::create)
       .def(
           "make_raw_range",

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -27,11 +27,26 @@ struct SourceRangeFactory {
   SourceRange create(int line, int start_col, int end_col) {
     size_t start_byte_offset, end_byte_offset;
     std::tie(start_byte_offset, end_byte_offset) =
-        source_->line_col_to_byte_offs(
+        line_col_to_byte_offs(
             line,
             start_col + leading_whitespace_chars_,
             end_col + leading_whitespace_chars_);
     return SourceRange(source_, start_byte_offset, end_byte_offset);
+  }
+
+  std::tuple<size_t, size_t> line_col_to_byte_offs(
+      int line,
+      int start_col,
+      int end_col) {
+    // Python has a weird convention where col_offset points to the column
+    // *before* the token starts.
+    start_col++;
+    end_col++;
+    // Also, lines are counted from 1.
+    line--;
+    auto line_start = source_->offset_for_line(line);
+    return std::make_tuple<size_t, size_t>(
+        line_start + start_col, line_start + end_col);
   }
 
   std::shared_ptr<Source> source_;

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -14,26 +14,16 @@ namespace jit {
 namespace script {
 
 struct SourceRangeFactory {
-  SourceRangeFactory(std::string source)
-      : source_(std::make_shared<std::string>(std::move(source))) {
-    size_t pos = 0;
-    do {
-      line_len_prefix_sum_.push_back(pos);
-      pos++;
-    } while ((pos = source_->find('\n', pos)) != std::string::npos);
+  SourceRangeFactory(std::string text, std::string filename, size_t file_lineno)
+      : source_(std::make_shared<Source>(std::move(text), std::move(filename), file_lineno)) {
   }
   SourceRange create(int line, int start_col, int end_col) {
-    // Python has a weird convention where col_offset points to the column
-    // *before* the token starts.
-    start_col++;
-    end_col++;
-    // Also, lines are counted from 1.
-    line--;
-    auto line_start = line_len_prefix_sum_.at(line);
-    return SourceRange(source_, line_start + start_col, line_start + end_col);
+    size_t start_byte_offset, end_byte_offset;
+    std::tie(start_byte_offset, end_byte_offset) = source_->line_col_to_byte_offs(line, start_col, end_col);
+    return SourceRange(source_, start_byte_offset, end_byte_offset);
   }
 
-  std::shared_ptr<std::string> source_;
+  std::shared_ptr<Source> source_;
   std::vector<size_t> line_len_prefix_sum_;
 };
 
@@ -65,7 +55,7 @@ void initTreeViewBindings(PyObject* module) {
       .def_property_readonly("start", &SourceRange::start)
       .def_property_readonly("end", &SourceRange::end);
   py::class_<SourceRangeFactory>(m, "SourceRangeFactory")
-      .def(py::init<std::string&&>())
+      .def(py::init<std::string&&, std::string&&, size_t>())
       .def("make_range", &SourceRangeFactory::create)
       .def(
           "make_raw_range",
@@ -73,7 +63,7 @@ void initTreeViewBindings(PyObject* module) {
             return SourceRange(self.source_, start, end);
           })
       .def_property_readonly("source", [](const SourceRangeFactory& self) {
-        return *self.source_;
+        return self.source_->text();
       });
 
   py::class_<TreeView>(m, "TreeView")

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -22,17 +22,21 @@ struct SourceRangeFactory {
       : source_(std::make_shared<Source>(
             std::move(text),
             std::move(filename),
-            file_lineno,
-            leading_whitespace_chars)) {}
+            file_lineno)),
+        leading_whitespace_chars_(leading_whitespace_chars) {}
   SourceRange create(int line, int start_col, int end_col) {
     size_t start_byte_offset, end_byte_offset;
     std::tie(start_byte_offset, end_byte_offset) =
-        source_->line_col_to_byte_offs(line, start_col, end_col);
+        source_->line_col_to_byte_offs(
+            line,
+            start_col + leading_whitespace_chars_,
+            end_col + leading_whitespace_chars_);
     return SourceRange(source_, start_byte_offset, end_byte_offset);
   }
 
   std::shared_ptr<Source> source_;
   std::vector<size_t> line_len_prefix_sum_;
+  size_t leading_whitespace_chars_;
 };
 
 template <typename T>

--- a/torch/csrc/jit/script/python_tree_views.cpp
+++ b/torch/csrc/jit/script/python_tree_views.cpp
@@ -15,11 +15,14 @@ namespace script {
 
 struct SourceRangeFactory {
   SourceRangeFactory(std::string text, std::string filename, size_t file_lineno)
-      : source_(std::make_shared<Source>(std::move(text), std::move(filename), file_lineno)) {
-  }
+      : source_(std::make_shared<Source>(
+            std::move(text),
+            std::move(filename),
+            file_lineno)) {}
   SourceRange create(int line, int start_col, int end_col) {
     size_t start_byte_offset, end_byte_offset;
-    std::tie(start_byte_offset, end_byte_offset) = source_->line_col_to_byte_offs(line, start_col, end_col);
+    std::tie(start_byte_offset, end_byte_offset) =
+        source_->line_col_to_byte_offs(line, start_col, end_col);
     return SourceRange(source_, start_byte_offset, end_byte_offset);
   }
 

--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -123,7 +123,7 @@ static SourceRange mergeRanges(SourceRange c, const TreeList& others) {
       continue;
     size_t s = std::min(c.start(), t->range().start());
     size_t e = std::max(c.end(), t->range().end());
-    c = SourceRange(c.file_ptr(), s, e);
+    c = SourceRange(c.source(), s, e);
   }
   return c;
 }

--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -5,14 +5,14 @@ namespace jit {
 
 // a range of a shared string 'file_' with
 C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
-  if (size() == file_->size()) {
+  const std::string& str = source_->text();
+  if (size() == str.size()) {
     // this is just the entire file, not a subset, so print it out.
     // primarily used to print out python stack traces
-    out << *file_;
+    out << str;
     return;
   }
 
-  const std::string& str = file();
   size_t begin_line = start(); // beginning of line to highlight
   size_t end_line = start(); // end of line to highlight
   while (begin_line > 0 && str[begin_line - 1] != '\n')
@@ -42,6 +42,11 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
   }
   AT_ASSERT(end_highlight == str.size() || str[end_highlight] == '\n');
 
+  if (source_->filename()) {
+    auto col_offset = (int)start() - (int)source_->offset_for_line(source_->lineno_for_offset(start()));
+    out << "at " << *source_->filename() << ":"
+        << source_->source_lineno_for_offset(start()) << ":" << col_offset << "\n";
+  }
   out << str.substr(begin_highlight, end_line - begin_highlight) << "\n";
   out << std::string(start() - begin_line, ' ');
   size_t len = std::min(size(), end_line - start());

--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -43,10 +43,11 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
   AT_ASSERT(end_highlight == str.size() || str[end_highlight] == '\n');
 
   if (source_->filename()) {
+    auto lineno = source_->lineno_for_offset(start());
     auto col_offset = (int)start() -
-        (int)source_->offset_for_line(source_->lineno_for_offset(start()));
+        (int)source_->offset_for_line(lineno);
     out << "at " << *source_->filename() << ":"
-        << source_->source_lineno_for_offset(start()) << ":" << col_offset
+        << source_->lineno_to_source_lineno(lineno) << ":" << col_offset
         << "\n";
   }
   out << str.substr(begin_highlight, end_line - begin_highlight) << "\n";

--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -43,9 +43,11 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
   AT_ASSERT(end_highlight == str.size() || str[end_highlight] == '\n');
 
   if (source_->filename()) {
-    auto col_offset = (int)start() - (int)source_->offset_for_line(source_->lineno_for_offset(start()));
+    auto col_offset = (int)start() -
+        (int)source_->offset_for_line(source_->lineno_for_offset(start()));
     out << "at " << *source_->filename() << ":"
-        << source_->source_lineno_for_offset(start()) << ":" << col_offset << "\n";
+        << source_->source_lineno_for_offset(start()) << ":" << col_offset
+        << "\n";
   }
   out << str.substr(begin_highlight, end_line - begin_highlight) << "\n";
   out << std::string(start() - begin_line, ' ');

--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -44,8 +44,7 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
 
   if (source_->filename()) {
     auto col_offset = (int)start() -
-        (int)source_->offset_for_line(source_->lineno_for_offset(start())) +
-        source_->leading_whitespace_chars();
+        (int)source_->offset_for_line(source_->lineno_for_offset(start()));
     out << "at " << *source_->filename() << ":"
         << source_->source_lineno_for_offset(start()) << ":" << col_offset
         << "\n";

--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -44,7 +44,8 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
 
   if (source_->filename()) {
     auto col_offset = (int)start() -
-        (int)source_->offset_for_line(source_->lineno_for_offset(start()));
+        (int)source_->offset_for_line(source_->lineno_for_offset(start())) +
+        source_->leading_whitespace_chars();
     out << "at " << *source_->filename() << ":"
         << source_->source_lineno_for_offset(start()) << ":" << col_offset
         << "\n";

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -23,10 +23,12 @@ struct Source {
   Source(
       std::string text,
       c10::optional<std::string> filename,
-      size_t starting_line_no)
+      size_t starting_line_no,
+      size_t leading_whitespace_chars)
       : text_(std::move(text)),
         filename_(std::move(filename)),
-        starting_line_no_(starting_line_no) {
+        starting_line_no_(starting_line_no),
+        leading_whitespace_chars_(leading_whitespace_chars) {
     calc_line_start_offsets();
   }
 
@@ -83,6 +85,10 @@ struct Source {
     return starting_line_no_;
   }
 
+  size_t leading_whitespace_chars() const {
+    return leading_whitespace_chars_;
+  }
+
  private:
   void calc_line_start_offsets() {
     size_t pos = 0;
@@ -93,8 +99,9 @@ struct Source {
   }
   std::string text_;
   c10::optional<std::string> filename_;
-  // If filename_ is not present, starting_line_no_ is don't care.
+  // If filename_ is not present, these two fields are don't care
   size_t starting_line_no_;
+  size_t leading_whitespace_chars_;
   // Starting offsets for lines into the source. e.g. line 0 starts at
   // line_starting_offsets_[0], etc.
   std::vector<size_t> line_starting_offsets_;

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
 
 #include <algorithm>
 #include <memory>
@@ -7,30 +8,110 @@
 namespace torch {
 namespace jit {
 
-// a range of a shared string 'file_' with functions to help debug by highlight
-// that
-// range.
+// Source represents a code segment. It keeps track of:
+//  - text : the text of the code segment
+//  - filename (optional) : if present, represents the name of the file from
+//                          which the code semgemnt originated.
+//  - starting_line_no : represents the line in the original file where the
+//                       code segment started.
+struct Source {
+  explicit Source(std::string text)
+    : text_(std::move(text)),
+      filename_(c10::nullopt) {
+    calc_line_start_offsets();
+  }
+
+  Source(std::string text,
+         c10::optional<std::string> filename,
+         size_t starting_line_no)
+    : text_(std::move(text)),
+      filename_(std::move(filename)),
+      starting_line_no_(starting_line_no) {
+    calc_line_start_offsets();
+  }
+
+  // Given a line number (within source_), return the byte offset of the
+  // beginning of that line.
+  size_t offset_for_line(size_t line) const {
+    return line_starting_offsets_.at(line);
+  }
+
+  // Calculate the line (within the code segment) on which `offset` resides.
+  size_t lineno_for_offset(size_t offset) const {
+    return std::upper_bound(line_starting_offsets_.begin(), line_starting_offsets_.end(), offset) - line_starting_offsets_.begin() - 1;
+  }
+
+  // Calculate the line (within the original source file, if present) on which
+  // `offset` resides.
+  size_t source_lineno_for_offset(size_t offset) const {
+    auto segment_offset = lineno_for_offset(offset);
+    if (filename_) {
+      return segment_offset + starting_line_no_;
+    } else {
+      return segment_offset;
+    }
+  }
+
+  std::tuple<size_t, size_t> line_col_to_byte_offs(int line, int start_col, int end_col) {
+    // Python has a weird convention where col_offset points to the column
+    // *before* the token starts.
+    start_col++;
+    end_col++;
+    // Also, lines are counted from 1.
+    line--;
+    auto line_start = line_starting_offsets_.at(line);
+    return std::make_tuple<size_t, size_t>(line_start + start_col, line_start + end_col);
+  }
+
+  const std::string& text() const {
+    return text_;
+  }
+
+  const c10::optional<std::string>& filename() const {
+    return filename_;
+  }
+
+  size_t starting_line_no() const {
+    return starting_line_no_;
+  }
+
+ private:
+  void calc_line_start_offsets() {
+    size_t pos = 0;
+    do {
+      line_starting_offsets_.push_back(pos);
+      pos++;
+    } while ((pos = text_.find('\n', pos)) != std::string::npos);
+  }
+  std::string text_;
+  c10::optional<std::string> filename_;
+  // If filename_ is not present, starting_line_no_ is don't care.
+  size_t starting_line_no_;
+  // Starting offsets for lines into the source. e.g. line 0 starts at
+  // line_starting_offsets_[0], etc.
+  std::vector<size_t> line_starting_offsets_;
+};
+
+// A SourceRange is a view into a Source, that points to a subset of the source,
+// specified by `start` and `end` byte offsets into the source text.
 struct CAFFE2_API SourceRange {
-  SourceRange(std::shared_ptr<std::string> file_, size_t start_, size_t end_)
-      : file_(std::move(file_)), start_(start_), end_(end_) {}
+  SourceRange(std::shared_ptr<Source> source_, size_t start_, size_t end_)
+      : source_(std::move(source_)), start_(start_), end_(end_) {}
   explicit SourceRange(std::string string_range)
-      : file_(std::make_shared<std::string>(std::move(string_range))),
+      : source_(std::make_shared<Source>(std::move(string_range))),
         start_(0),
-        end_(file_->size()) {}
+        end_(source_->text().size()) {}
 
   const std::string text() const {
-    return file().substr(start(), end() - start());
+    return source_->text().substr(start(), end() - start());
   }
   size_t size() const {
     return end() - start();
   }
   static const size_t CONTEXT = 10;
   void highlight(std::ostream& out) const;
-  const std::string& file() const {
-    return *file_;
-  }
-  const std::shared_ptr<std::string>& file_ptr() const {
-    return file_;
+  const std::shared_ptr<Source>& source() const {
+    return source_;
   }
   size_t start() const {
     return start_;
@@ -61,7 +142,7 @@ struct CAFFE2_API SourceRange {
   }
 
  private:
-  std::shared_ptr<std::string> file_;
+  std::shared_ptr<Source> source_;
   size_t start_;
   size_t end_;
 };

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -23,12 +23,10 @@ struct Source {
   Source(
       std::string text,
       c10::optional<std::string> filename,
-      size_t starting_line_no,
-      size_t leading_whitespace_chars)
+      size_t starting_line_no)
       : text_(std::move(text)),
         filename_(std::move(filename)),
-        starting_line_no_(starting_line_no),
-        leading_whitespace_chars_(leading_whitespace_chars) {
+        starting_line_no_(starting_line_no) {
     calc_line_start_offsets();
   }
 
@@ -85,10 +83,6 @@ struct Source {
     return starting_line_no_;
   }
 
-  size_t leading_whitespace_chars() const {
-    return leading_whitespace_chars_;
-  }
-
  private:
   void calc_line_start_offsets() {
     size_t pos = 0;
@@ -99,9 +93,8 @@ struct Source {
   }
   std::string text_;
   c10::optional<std::string> filename_;
-  // If filename_ is not present, these two fields are don't care
+  // If filename_ is not present, starting_line_no_ is don't care
   size_t starting_line_no_;
-  size_t leading_whitespace_chars_;
   // Starting offsets for lines into the source. e.g. line 0 starts at
   // line_starting_offsets_[0], etc.
   std::vector<size_t> line_starting_offsets_;

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -16,17 +16,17 @@ namespace jit {
 //                       code segment started.
 struct Source {
   explicit Source(std::string text)
-    : text_(std::move(text)),
-      filename_(c10::nullopt) {
+      : text_(std::move(text)), filename_(c10::nullopt) {
     calc_line_start_offsets();
   }
 
-  Source(std::string text,
-         c10::optional<std::string> filename,
-         size_t starting_line_no)
-    : text_(std::move(text)),
-      filename_(std::move(filename)),
-      starting_line_no_(starting_line_no) {
+  Source(
+      std::string text,
+      c10::optional<std::string> filename,
+      size_t starting_line_no)
+      : text_(std::move(text)),
+        filename_(std::move(filename)),
+        starting_line_no_(starting_line_no) {
     calc_line_start_offsets();
   }
 
@@ -38,7 +38,11 @@ struct Source {
 
   // Calculate the line (within the code segment) on which `offset` resides.
   size_t lineno_for_offset(size_t offset) const {
-    return std::upper_bound(line_starting_offsets_.begin(), line_starting_offsets_.end(), offset) - line_starting_offsets_.begin() - 1;
+    return std::upper_bound(
+               line_starting_offsets_.begin(),
+               line_starting_offsets_.end(),
+               offset) -
+        line_starting_offsets_.begin() - 1;
   }
 
   // Calculate the line (within the original source file, if present) on which
@@ -52,7 +56,10 @@ struct Source {
     }
   }
 
-  std::tuple<size_t, size_t> line_col_to_byte_offs(int line, int start_col, int end_col) {
+  std::tuple<size_t, size_t> line_col_to_byte_offs(
+      int line,
+      int start_col,
+      int end_col) {
     // Python has a weird convention where col_offset points to the column
     // *before* the token starts.
     start_col++;
@@ -60,7 +67,8 @@ struct Source {
     // Also, lines are counted from 1.
     line--;
     auto line_start = line_starting_offsets_.at(line);
-    return std::make_tuple<size_t, size_t>(line_start + start_col, line_start + end_col);
+    return std::make_tuple<size_t, size_t>(
+        line_start + start_col, line_start + end_col);
   }
 
   const std::string& text() const {

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -46,29 +46,13 @@ struct Source {
   }
 
   // Calculate the line (within the original source file, if present) on which
-  // `offset` resides.
-  size_t source_lineno_for_offset(size_t offset) const {
-    auto segment_offset = lineno_for_offset(offset);
+  // `lineno` resides.
+  size_t lineno_to_source_lineno(size_t lineno) const {
     if (filename_) {
-      return segment_offset + starting_line_no_;
+      return lineno + starting_line_no_;
     } else {
-      return segment_offset;
+      return lineno;
     }
-  }
-
-  std::tuple<size_t, size_t> line_col_to_byte_offs(
-      int line,
-      int start_col,
-      int end_col) {
-    // Python has a weird convention where col_offset points to the column
-    // *before* the token starts.
-    start_col++;
-    end_col++;
-    // Also, lines are counted from 1.
-    line--;
-    auto line_start = line_starting_offsets_.at(line);
-    return std::make_tuple<size_t, size_t>(
-        line_start + start_col, line_start + end_col);
   }
 
   const std::string& text() const {

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -84,10 +84,10 @@ size_t assertFind(
     const SourceRange& search_range,
     const std::string& sub,
     std::function<void(std::ostream& out)> extra_msg = nullptr) {
-  auto pos = search_range.file_ptr()->find(sub, search_range.start());
+  auto pos = search_range.source()->text().find(sub, search_range.start());
   if (pos == std::string::npos || (pos + sub.size()) > search_range.end()) {
     auto found_range =
-        SourceRange(search_range.file_ptr(), search_range.start(), sub.size());
+        SourceRange(search_range.source(), search_range.start(), sub.size());
     std::stringstream ss;
     ss << "Expected to find ";
     printQuotedString(ss, sub);
@@ -111,21 +111,21 @@ size_t assertFind(
 }
 
 size_t assertFind(
-    const std::shared_ptr<std::string>& file,
+    std::shared_ptr<Source> source,
     const std::string& sub,
     size_t start,
     const Check& check) {
-  return assertFind(SourceRange(file, start, file->size()), sub, check);
+  return assertFind(SourceRange(source, start, source->text().size()), sub, check);
 }
 
 void assertNotFind(
     const SourceRange& search_range,
     const std::string& sub,
     const Check& check) {
-  auto pos = search_range.file_ptr()->find(sub, search_range.start());
+  auto pos = search_range.source()->text().find(sub, search_range.start());
   if (pos != std::string::npos && (pos + sub.size()) <= search_range.end()) {
     auto found_range =
-        SourceRange(search_range.file_ptr(), pos, sub.size() + pos);
+        SourceRange(search_range.source(), pos, sub.size() + pos);
     std::stringstream ss;
     ss << "Expected to not find ";
     printQuotedString(ss, sub);
@@ -150,14 +150,14 @@ struct FileCheckImpl {
           "Filecheck! Check for bad input.");
     }
 
-    doChecks(std::make_shared<std::string>(test_file));
+    doChecks(std::make_shared<Source>(test_file));
   }
 
   TORCH_API void run(
       const std::string& checks_file,
       const std::string& test_file) {
-    auto checks_ptr = std::make_shared<std::string>(checks_file);
-    parseStrings(checks_ptr);
+    auto source = std::make_shared<Source>(checks_file);
+    parseStrings(source);
     run(test_file);
   }
 
@@ -190,7 +190,7 @@ struct FileCheckImpl {
 
  private:
   bool parseSingleCheck(
-      const std::shared_ptr<std::string>& checks_file,
+      std::shared_ptr<Source> source,
       size_t* start) {
     const static std::vector<std::pair<CheckType, std::string>> check_pairs = {
         {CHECK, ": "},
@@ -203,30 +203,30 @@ struct FileCheckImpl {
 
     for (const auto& check_pair : check_pairs) {
       const std::string& check_suffix = check_pair.second;
-      auto suffix_pos = checks_file->find(check_suffix, *start);
+      auto suffix_pos = source->text().find(check_suffix, *start);
       if (suffix_pos != *start) {
         continue;
       }
       size_t end_check_string = suffix_pos + check_suffix.size();
       CheckType type = check_pair.first;
       c10::optional<size_t> count = c10::nullopt;
-      auto end_line = checks_file->find("\n", end_check_string);
+      auto end_line = source->text().find("\n", end_check_string);
       bool exactly = false;
       if (type == CHECK_COUNT) {
         const std::string exact = "EXACTLY-";
-        if (checks_file->find(exact, end_check_string) == end_check_string) {
+        if (source->text().find(exact, end_check_string) == end_check_string) {
           exactly = true;
           end_check_string += exact.size();
         }
         size_t end = assertFind(
-            SourceRange(checks_file, end_check_string, end_line), ":");
+            SourceRange(source, end_check_string, end_line), ":");
         count = std::stoll(
-            checks_file->substr(end_check_string, end - end_check_string));
+            source->text().substr(end_check_string, end - end_check_string));
         end_check_string = end + 2; // add ':' and the space
       }
       auto check = Check(
           type,
-          checks_file->substr(end_check_string, end_line - end_check_string),
+          source->text().substr(end_check_string, end_line - end_check_string),
           count);
       addCheck(check);
       if (exactly) {
@@ -239,50 +239,50 @@ struct FileCheckImpl {
   }
 
   size_t findNextStart(
-      const std::shared_ptr<std::string>& checks_file,
+      std::shared_ptr<Source> source,
       size_t prev_end) {
-    size_t start = checks_file->find("#", prev_end);
+    size_t start = source->text().find("#", prev_end);
     if (start == std::string::npos) {
       return start;
     }
     start += 1;
     static constexpr size_t max_whitespace = 6;
     size_t i = 0;
-    while (start + i < checks_file->size() && i < max_whitespace) {
-      auto c = checks_file->at(start + i);
+    while (start + i < source->text().size() && i < max_whitespace) {
+      auto c = source->text().at(start + i);
       if (c != ' ' && c != '\t') {
         break;
       }
       i++;
     }
     static const std::string check = "CHECK";
-    if (checks_file->substr(start + i, check.size()) == check) {
+    if (source->text().substr(start + i, check.size()) == check) {
       return start + i + check.size();
     } else {
-      return findNextStart(checks_file, start + i + 1);
+      return findNextStart(source, start + i + 1);
     }
   }
 
-  void parseStrings(const std::shared_ptr<std::string>& checks_file) {
+  void parseStrings(std::shared_ptr<Source> source) {
     size_t start = 0;
-    start = findNextStart(checks_file, 0);
+    start = findNextStart(source, 0);
     while (start != std::string::npos) {
-      bool found_match = parseSingleCheck(checks_file, &start);
+      bool found_match = parseSingleCheck(source, &start);
       if (!found_match) {
         std::ostringstream ss;
         ss << "Could not parse check at:\n";
-        SourceRange(checks_file, start, start + 1).highlight(ss);
+        SourceRange(source, start, start + 1).highlight(ss);
         ss << "Check for bad input.";
         has_run = true;
         throw std::runtime_error(ss.str());
       }
-      start = findNextStart(checks_file, start);
+      start = findNextStart(source, start);
     }
   }
 
   void doCheckNot(
       const std::vector<Check>& nots,
-      const std::shared_ptr<std::string>& file,
+      std::shared_ptr<Source> source,
       const SourceRange& prev,
       const SourceRange& next) {
     auto start = prev.end(); // inclusive
@@ -292,13 +292,13 @@ struct FileCheckImpl {
     }
     for (const auto& check : nots) {
       AT_ASSERT(check.type_ == CHECK_NOT);
-      assertNotFind(SourceRange(file, start, end), check.search_str_, check);
+      assertNotFind(SourceRange(source, start, end), check.search_str_, check);
     }
   }
 
   SourceRange matchDagGroup(
       const std::vector<Check>& group,
-      const std::shared_ptr<std::string>& test_file,
+      std::shared_ptr<Source> source,
       const SourceRange& prev) {
     size_t group_beg = std::string::npos;
     size_t group_end = 0;
@@ -306,23 +306,23 @@ struct FileCheckImpl {
     AT_ASSERT(groups.size() != 0);
     for (const auto& check : group) {
       AT_ASSERT(check.type_ == group[0].type_);
-      auto pos = assertFind(test_file, check.search_str_, prev.end(), check);
+      auto pos = assertFind(source, check.search_str_, prev.end(), check);
       group_beg = std::min(pos, group_beg);
       group_end = std::max(pos + check.search_str_.size(), group_end);
     }
 
-    return SourceRange(test_file, group_beg, group_end);
+    return SourceRange(source, group_beg, group_end);
   }
 
   SourceRange matchGroup(
       const std::vector<Check>& group,
-      const std::shared_ptr<std::string>& test_file,
+      std::shared_ptr<Source> source,
       const SourceRange& prev) {
     AT_ASSERT(group.size() != 0);
     CheckType type = group[0].type_;
 
     if (type == CHECK_DAG) {
-      return matchDagGroup(group, test_file, prev);
+      return matchDagGroup(group, source, prev);
     }
     AT_ASSERT(type != CHECK_NOT);
     AT_ASSERT(group.size() == 1);
@@ -334,20 +334,20 @@ struct FileCheckImpl {
     switch (check.type_) {
       case CHECK: {
         start_range =
-            assertFind(test_file, check.search_str_, start_range, check);
+            assertFind(source, check.search_str_, start_range, check);
         end_range = start_range + check.search_str_.size();
       } break;
       case CHECK_SAME: {
-        auto pos = assertFind(test_file, check.search_str_, start_range, check);
-        assertNotFind(SourceRange(test_file, prev.end(), pos), "\n", check);
+        auto pos = assertFind(source, check.search_str_, start_range, check);
+        assertNotFind(SourceRange(source, prev.end(), pos), "\n", check);
         start_range = pos;
         end_range = pos + check.search_str_.size();
       } break;
       case CHECK_NEXT: {
-        auto line_end = assertFind(test_file, "\n", start_range, check);
+        auto line_end = assertFind(source, "\n", start_range, check);
         auto pos =
-            assertFind(test_file, check.search_str_, line_end + 1, check);
-        assertNotFind(SourceRange(test_file, line_end + 1, pos), "\n", check);
+            assertFind(source, check.search_str_, line_end + 1, check);
+        assertNotFind(SourceRange(source, line_end + 1, pos), "\n", check);
         start_range = pos;
         end_range = pos + check.search_str_.size();
       } break;
@@ -356,7 +356,7 @@ struct FileCheckImpl {
         AT_ASSERT(check.count_ && *check.count_ != 0);
         for (size_t i = 0; i < *check.count_; ++i) {
           start_range =
-              assertFind(test_file, check.search_str_, start_range, check);
+              assertFind(source, check.search_str_, start_range, check);
           group_start_range = std::min(start_range, group_start_range);
           end_range = start_range + check.search_str_.size();
           start_range = end_range;
@@ -370,28 +370,28 @@ struct FileCheckImpl {
         AT_ERROR();
       } break;
     }
-    return SourceRange(test_file, start_range, end_range);
+    return SourceRange(source, start_range, end_range);
   }
 
-  void doChecks(const std::shared_ptr<std::string>& test_file) {
-    SourceRange prev(test_file, 0, 0);
+  void doChecks(std::shared_ptr<Source> source) {
+    SourceRange prev(source, 0, 0);
     for (size_t i = 0; i < groups.size(); i++) {
       const auto& curr_group = groups[i];
       CheckType type = curr_group.at(0).type_;
       if (type != CHECK_NOT) {
-        prev = matchGroup(curr_group, test_file, prev);
+        prev = matchGroup(curr_group, source, prev);
       } else {
         if (i + 1 < groups.size()) {
           const auto& next_group = groups[i + 1];
           AT_ASSERT(next_group.at(0).type_ != CHECK_NOT);
-          SourceRange after_not = matchGroup(next_group, test_file, prev);
-          doCheckNot(curr_group, test_file, prev, after_not);
+          SourceRange after_not = matchGroup(next_group, source, prev);
+          doCheckNot(curr_group, source, prev, after_not);
           prev = after_not;
           ++i; // already checked the group after
         } else {
           SourceRange end_of_file(
-              test_file, test_file->size() + 1, test_file->size() + 1);
-          doCheckNot(curr_group, test_file, prev, end_of_file);
+              source, source->text().size() + 1, source->text().size() + 1);
+          doCheckNot(curr_group, source, prev, end_of_file);
         }
       }
     }

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -115,7 +115,8 @@ size_t assertFind(
     const std::string& sub,
     size_t start,
     const Check& check) {
-  return assertFind(SourceRange(source, start, source->text().size()), sub, check);
+  return assertFind(
+      SourceRange(source, start, source->text().size()), sub, check);
 }
 
 void assertNotFind(
@@ -189,9 +190,7 @@ struct FileCheckImpl {
   friend std::ostream& operator<<(std::ostream& out, const FileCheckImpl& fc);
 
  private:
-  bool parseSingleCheck(
-      std::shared_ptr<Source> source,
-      size_t* start) {
+  bool parseSingleCheck(std::shared_ptr<Source> source, size_t* start) {
     const static std::vector<std::pair<CheckType, std::string>> check_pairs = {
         {CHECK, ": "},
         {CHECK_NEXT, "-NEXT: "},
@@ -218,8 +217,8 @@ struct FileCheckImpl {
           exactly = true;
           end_check_string += exact.size();
         }
-        size_t end = assertFind(
-            SourceRange(source, end_check_string, end_line), ":");
+        size_t end =
+            assertFind(SourceRange(source, end_check_string, end_line), ":");
         count = std::stoll(
             source->text().substr(end_check_string, end - end_check_string));
         end_check_string = end + 2; // add ':' and the space
@@ -238,9 +237,7 @@ struct FileCheckImpl {
     return false;
   }
 
-  size_t findNextStart(
-      std::shared_ptr<Source> source,
-      size_t prev_end) {
+  size_t findNextStart(std::shared_ptr<Source> source, size_t prev_end) {
     size_t start = source->text().find("#", prev_end);
     if (start == std::string::npos) {
       return start;
@@ -333,8 +330,7 @@ struct FileCheckImpl {
 
     switch (check.type_) {
       case CHECK: {
-        start_range =
-            assertFind(source, check.search_str_, start_range, check);
+        start_range = assertFind(source, check.search_str_, start_range, check);
         end_range = start_range + check.search_str_.size();
       } break;
       case CHECK_SAME: {
@@ -345,8 +341,7 @@ struct FileCheckImpl {
       } break;
       case CHECK_NEXT: {
         auto line_end = assertFind(source, "\n", start_range, check);
-        auto pos =
-            assertFind(source, check.search_str_, line_end + 1, check);
+        auto pos = assertFind(source, check.search_str_, line_end + 1, check);
         assertNotFind(SourceRange(source, line_end + 1, pos), "\n", check);
         start_range = pos;
         end_range = pos + check.search_str_.size();

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -111,7 +111,7 @@ size_t assertFind(
 }
 
 size_t assertFind(
-    std::shared_ptr<Source> source,
+    const std::shared_ptr<Source>& source,
     const std::string& sub,
     size_t start,
     const Check& check) {
@@ -190,7 +190,7 @@ struct FileCheckImpl {
   friend std::ostream& operator<<(std::ostream& out, const FileCheckImpl& fc);
 
  private:
-  bool parseSingleCheck(std::shared_ptr<Source> source, size_t* start) {
+  bool parseSingleCheck(const std::shared_ptr<Source>& source, size_t* start) {
     const static std::vector<std::pair<CheckType, std::string>> check_pairs = {
         {CHECK, ": "},
         {CHECK_NEXT, "-NEXT: "},
@@ -209,7 +209,7 @@ struct FileCheckImpl {
       size_t end_check_string = suffix_pos + check_suffix.size();
       CheckType type = check_pair.first;
       c10::optional<size_t> count = c10::nullopt;
-      auto end_line = source->text().find("\n", end_check_string);
+      auto end_line = source->text().find('\n', end_check_string);
       bool exactly = false;
       if (type == CHECK_COUNT) {
         const std::string exact = "EXACTLY-";
@@ -237,8 +237,8 @@ struct FileCheckImpl {
     return false;
   }
 
-  size_t findNextStart(std::shared_ptr<Source> source, size_t prev_end) {
-    size_t start = source->text().find("#", prev_end);
+  size_t findNextStart(const std::shared_ptr<Source>& source, size_t prev_end) {
+    size_t start = source->text().find('#', prev_end);
     if (start == std::string::npos) {
       return start;
     }
@@ -260,7 +260,7 @@ struct FileCheckImpl {
     }
   }
 
-  void parseStrings(std::shared_ptr<Source> source) {
+  void parseStrings(const std::shared_ptr<Source>& source) {
     size_t start = 0;
     start = findNextStart(source, 0);
     while (start != std::string::npos) {
@@ -279,7 +279,7 @@ struct FileCheckImpl {
 
   void doCheckNot(
       const std::vector<Check>& nots,
-      std::shared_ptr<Source> source,
+      const std::shared_ptr<Source>& source,
       const SourceRange& prev,
       const SourceRange& next) {
     auto start = prev.end(); // inclusive
@@ -295,7 +295,7 @@ struct FileCheckImpl {
 
   SourceRange matchDagGroup(
       const std::vector<Check>& group,
-      std::shared_ptr<Source> source,
+      const std::shared_ptr<Source>& source,
       const SourceRange& prev) {
     size_t group_beg = std::string::npos;
     size_t group_end = 0;
@@ -313,7 +313,7 @@ struct FileCheckImpl {
 
   SourceRange matchGroup(
       const std::vector<Check>& group,
-      std::shared_ptr<Source> source,
+      const std::shared_ptr<Source>& source,
       const SourceRange& prev) {
     AT_ASSERT(group.size() != 0);
     CheckType type = group[0].type_;
@@ -368,7 +368,7 @@ struct FileCheckImpl {
     return SourceRange(source, start_range, end_range);
   }
 
-  void doChecks(std::shared_ptr<Source> source) {
+  void doChecks(const std::shared_ptr<Source>& source) {
     SourceRange prev(source, 0, 0);
     for (size_t i = 0; i < groups.size(); i++) {
       const auto& curr_group = groups[i];

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -5,62 +5,12 @@ import ast
 import inspect
 import re
 import string
+from textwrap import dedent
 from torch._six import PY2
 from torch._C._jit_tree_views import *
 
 # Borrowed from cPython implementation 
 # https://github.com/python/cpython/blob/561612d8456cfab5672c9b445521113b847bd6b3/Lib/textwrap.py#L411# 
-
-_whitespace_only_re = re.compile('^[ \t]+$', re.MULTILINE)
-_leading_whitespace_re = re.compile('(^[ \t]*)(?:[^ \t\n])', re.MULTILINE)
-
-def _dedent(text):
-    """Remove any common leading whitespace from every line in `text`.
-    This can be used to make triple-quoted strings line up with the left
-    edge of the display, while still presenting them in the source code
-    in indented form.
-    Note that tabs and spaces are both treated as whitespace, but they
-    are not equal: the lines "  hello" and "\\thello" are
-    considered to have no common leading whitespace.  (This behaviour is
-    new in Python 2.5; older versions of this module incorrectly
-    expanded tabs before searching for common leading whitespace.)
-    """
-    # Look for the longest leading string of spaces and tabs common to
-    # all lines.
-    margin = None
-    text = _whitespace_only_re.sub('', text)
-    indents = _leading_whitespace_re.findall(text)
-    for indent in indents:
-        if margin is None:
-            margin = indent
-
-        # Current line more deeply indented than previous winner:
-        # no change (previous winner is still on top).
-        elif indent.startswith(margin):
-            pass
-
-        # Current line consistent with and no deeper than previous winner:
-        # it's the new winner.
-        elif margin.startswith(indent):
-            margin = indent
-
-        # Find the largest common whitespace between current line and previous
-        # winner.
-        else:
-            for i, (x, y) in enumerate(zip(margin, indent)):
-                if x != y:
-                    margin = margin[:i]
-                    break
-
-    # sanity check (testing/debugging only)
-    if 0 and margin:
-        for line in text.split("\n"):
-            assert not line or line.startswith(margin), \
-                   "line = %r, margin = %r" % (line, margin)
-
-    if margin:
-        text = re.sub(r'(?m)^' + margin, '', text)
-    return text, len(margin) if margin else 0
 
 _reserved_prefix = '__jit'
 _reserved_names = {'print'}
@@ -197,20 +147,23 @@ def get_jit_class_def(cls, self_name):
                    self_name=self_name) for method in methods]
 
     sourcelines, file_lineno = inspect.getsourcelines(cls)
-    source, leading_whitespace_len = _dedent(''.join(sourcelines))
+    source = ''.join(sourcelines)
     filename = inspect.getsourcefile(cls)
-    py_ast = ast.parse(source)
+    py_ast = ast.parse(dedent(source))
+    leading_whitespace_len = len(source.split('\n', 1)) - len(source.split('\n', 1))
     ctx = SourceContext(source, filename, file_lineno, leading_whitespace_len, False)
     return build_class_def(ctx, py_ast.body[0], method_defs, self_name)
 
 
 def get_jit_def(fn, self_name=None):
     sourcelines, file_lineno = inspect.getsourcelines(fn)
-    source, leading_whitespace_len = _dedent(''.join(sourcelines))
+    source = ''.join(sourcelines)
     filename = inspect.getsourcefile(fn)
-    py_ast = ast.parse(source)
+    dedent_src = dedent(source)
+    py_ast = ast.parse(dedent_src)
     if len(py_ast.body) != 1 or not isinstance(py_ast.body[0], ast.FunctionDef):
         raise RuntimeError("expected a single top-level function")
+    leading_whitespace_len = len(source.split('\n', 1)[0]) - len(dedent_src.split('\n', 1)[0])
     type_line = torch.jit.annotations.get_type_line(source)
     ctx = SourceContext(source, filename, file_lineno, leading_whitespace_len, _uses_true_division(fn))
     return build_def(ctx, py_ast.body[0], type_line, self_name)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -3,7 +3,6 @@ import torch
 import sys
 import ast
 import inspect
-import re
 import string
 from textwrap import dedent
 from torch._six import PY2

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -148,8 +148,9 @@ def get_jit_class_def(cls, self_name):
     sourcelines, file_lineno = inspect.getsourcelines(cls)
     source = ''.join(sourcelines)
     filename = inspect.getsourcefile(cls)
-    py_ast = ast.parse(dedent(source))
-    leading_whitespace_len = len(source.split('\n', 1)) - len(source.split('\n', 1))
+    dedent_src = dedent(source)
+    py_ast = ast.parse(dedent_src)
+    leading_whitespace_len = len(source.split('\n', 1)[0]) - len(dedent_src.split('\n', 1)[0])
     ctx = SourceContext(source, filename, file_lineno, leading_whitespace_len, False)
     return build_class_def(ctx, py_ast.body[0], method_defs, self_name)
 


### PR DESCRIPTION
Resolves https://github.com/pytorch/lockdown/issues/29

Examples:

```
import torch

@torch.jit.script
def foobar(x):
    return torch.blargh(xyz)

==

RuntimeError: 
object has no attribute blargh:
at compile.py:5:12
@torch.jit.script
def foo(x):
    return torch.blargh(x)
           ~~~~~~~~~~~~ <--- HERE
```

It also gets the correct column number in the case where the original source file has common leading whitespace in front of the callable:

```
import torch

with torch.no_grad():
            @torch.jit.script
            def foo(x):
                return torch.blargh(x)

==
RuntimeError: 
object has no attribute blargh:
at compile_leading.py:6:24
@torch.jit.script
def foo(x):
    return torch.blargh(x)
           ~~~~~~~~~~~~ <--- HERE
```
