### PR TITLE
Remove virtual keyword from most functions in TensorImpl

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -33,48 +33,8 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
     opaque_handle_ = {};
   }
 
-  IntArrayRef strides() const override {
-    AT_ERROR("opaque tensors do not have strides");
-  }
-
-  bool is_contiguous(c10::MemoryFormat memory_format=c10::MemoryFormat::Any) const override {
-    AT_ERROR("opaque tensors do not have is_contiguous");
-  }
-
-  int64_t stride(int64_t d) const override {
-    AT_ERROR("opaque tensors do not have strides");
-  }
-
-  void resize_dim(int64_t ndim) override {
-    AT_ERROR("opaque tensors do not have resize_dim");
-  }
-
-  void set_size(int64_t dim, int64_t new_size) override {
-    AT_ERROR("opaque tensors do not have set_size");
-  }
-
-  void set_stride(int64_t dim, int64_t new_stride) override {
-    AT_ERROR("opaque tensors do not have set_stride");
-  }
-
-  void set_storage_offset(int64_t storage_offset) override {
-    AT_ERROR("opaque tensors do not have set_storage_offset");
-  }
-
-  TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override {
-      AT_ERROR("opaque tensors do not support maybe_zero_dim");
-  }
-
   bool has_storage() const override {
     return false;
-    }
-
-  const Storage& storage() const override{
-    AT_ERROR("opaque tensors do not have storage");
-  }
-
-  int64_t storage_offset() const override {
-    AT_ERROR("opaque tensors do not have storage");
   }
 
   /**

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -33,10 +33,6 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
     opaque_handle_ = {};
   }
 
-  bool has_storage() const override {
-    return false;
-  }
-
   /**
    * Return a TensorImpl that is a shallow-copy of this TensorImpl.
    *

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -48,10 +48,6 @@ SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, const caffe2::TypeM
   AT_ASSERT(values_.device() == device());
 }
 
-// yf225 TODO: is this ok to remove??
-// int64_t SparseTensorImpl::dim() const {
-//   return sparse_dim_ + dense_dim_;
-// }
 bool SparseTensorImpl::has_storage() const {
   return false;
 }

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -48,46 +48,12 @@ SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, const caffe2::TypeM
   AT_ASSERT(values_.device() == device());
 }
 
-IntArrayRef SparseTensorImpl::strides() const {
-  AT_ERROR("sparse tensors do not have strides");
-}
-bool SparseTensorImpl::is_contiguous(at::MemoryFormat memory_format) const {
-  AT_ERROR("sparse tensors do not have is_contiguous");
-}
-int64_t SparseTensorImpl::stride(int64_t d) const {
-  AT_ERROR("sparse tensors do not have strides");
-}
-void SparseTensorImpl::resize_dim(int64_t ndim) {
-  AT_ERROR("sparse tensors do not have resize_dim");
-}
-void SparseTensorImpl::set_size(int64_t dim, int64_t new_size) {
-  AT_ERROR("sparse tensors do not have set_size");
-}
-void SparseTensorImpl::set_stride(int64_t dim, int64_t new_stride) {
-  AT_ERROR("sparse tensors do not have set_stride");
-}
-void SparseTensorImpl::set_storage_offset(int64_t storage_offset) {
-  AT_ERROR("sparse tensors do not have set_storage_offset");
-}
-
-int64_t SparseTensorImpl::dim() const {
-  return sparse_dim_ + dense_dim_;
-}
-TensorImpl* SparseTensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
-  TORCH_CHECK(condition_when_zero_dim == (dim() == 0),
-           "Attempted to maybe_zero_dim on a SparseTensorImpl to ", condition_when_zero_dim,
-           " but the SparseTensor's dim() is ", dim(), " and SparseTensors do not support"
-           " changing dimensionality via maybe_zero_dim");
-  return this;
-}
+// yf225 TODO: is this ok to remove??
+// int64_t SparseTensorImpl::dim() const {
+//   return sparse_dim_ + dense_dim_;
+// }
 bool SparseTensorImpl::has_storage() const {
   return false;
-}
-const Storage& SparseTensorImpl::storage() const {
-  AT_ERROR("sparse tensors do not have storage");
-}
-int64_t SparseTensorImpl::storage_offset() const {
-  AT_ERROR("sparse tensors do not have storage");
 }
 void SparseTensorImpl::set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values) {
   TORCH_CHECK(allow_tensor_metadata_change(), "set_indices_and_values_unsafe is not allowed on Tensor created from .data or .detach()");

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -48,9 +48,6 @@ SparseTensorImpl::SparseTensorImpl(at::TensorTypeId type_id, const caffe2::TypeM
   AT_ASSERT(values_.device() == device());
 }
 
-bool SparseTensorImpl::has_storage() const {
-  return false;
-}
 void SparseTensorImpl::set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values) {
   TORCH_CHECK(allow_tensor_metadata_change(), "set_indices_and_values_unsafe is not allowed on Tensor created from .data or .detach()");
   AT_ASSERT(!indices.is_variable() && !values.is_variable());  // They should be plain tensors!  // TODO: change this to check `.requires_grad()` and `GradMode::is_enabled()` when Variable and Tensor are merged

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -40,7 +40,6 @@ public:
   Tensor indices() const { return indices_; }
   Tensor values() const { return values_; }
 
-  // int64_t dim() const override;  // yf225 TODO: is this ok to remove??
   bool has_storage() const override;
 
   // WARNING: This function does NOT preserve invariants of sparse_dim/dense_dim with

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -40,8 +40,6 @@ public:
   Tensor indices() const { return indices_; }
   Tensor values() const { return values_; }
 
-  bool has_storage() const override;
-
   // WARNING: This function does NOT preserve invariants of sparse_dim/dense_dim with
   // respect to indices and values
   void raw_resize_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -40,19 +40,8 @@ public:
   Tensor indices() const { return indices_; }
   Tensor values() const { return values_; }
 
-  IntArrayRef strides() const override;
-  bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Any) const override;
-  int64_t stride(int64_t d) const override;
-  void resize_dim(int64_t ndim) override;
-  void set_size(int64_t dim, int64_t new_size) override;
-  void set_stride(int64_t dim, int64_t new_stride) override;
-  void set_storage_offset(int64_t storage_offset) override;
-
-  int64_t dim() const override;
-  TensorImpl* maybe_zero_dim(bool condition_when_zero_dim) override;
+  // int64_t dim() const override;  // yf225 TODO: is this ok to remove??
   bool has_storage() const override;
-  const Storage& storage() const override;
-  int64_t storage_offset() const override;
 
   // WARNING: This function does NOT preserve invariants of sparse_dim/dense_dim with
   // respect to indices and values

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -126,7 +126,8 @@ TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
 }
 
 bool TensorImpl::has_storage() const {
-  return storage_;
+  TORCH_CHECK(type_id_ != UndefinedTensorId(), type_id_, " does not have has_storage");
+  return !is_sparse() && !is_mkldnn() && storage_;
 }
 
 bool TensorImpl::is_contiguous(at::MemoryFormat memory_format) const {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -115,7 +115,7 @@ int64_t TensorImpl::stride(int64_t d) const {
 TensorImpl* TensorImpl::maybe_zero_dim(bool condition_when_zero_dim) {
   // We only allow this operation on dense tensors
   if (!(has_storage() && layout() == kStrided)) {
-    TORCH_CHECK(condition_when_zero_dim == (dim() == 0),
+    TORCH_INTERNAL_ASSERT(condition_when_zero_dim == (dim() == 0),
            type_id_, " does not support changing dimensionality via maybe_zero_dim");
   }
   bool set_zero_dim = condition_when_zero_dim && this->sizes().size() == 1 && this->size(0) == 1;

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -391,7 +391,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Any) const;
 
   bool is_sparse() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
     auto tid = type_id();
     // NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
@@ -399,7 +398,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_quantized() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
     auto tid = type_id();
     // NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
@@ -407,7 +405,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_cuda() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
     auto tid = type_id();
     // NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
@@ -415,7 +412,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_hip() const {
-    // NB: This method is not virtual and avoid dispatches for performance reasons.
     auto tid = type_id();
     // NB: At the moment, variables have the same TensorTypeId as their
     // corresponding tensor, but if this ever changes, we need to modify this.
@@ -445,7 +441,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   Layout layout() const {
-    // NB: This method is not virtual and avoid dispatches for perf.
     if (is_sparse()) {
       return kSparse;
     } else if (is_mkldnn()) {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -354,7 +354,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * True if this tensor has storage. See storage() for details.
    */
-  virtual bool has_storage() const;
+  bool has_storage() const;
 
   /**
    * Return the underlying storage of a Tensor.  Multiple tensors may share

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -8,37 +8,10 @@ UndefinedTensorImpl::UndefinedTensorImpl()
 : TensorImpl(UndefinedTensorId(), caffe2::TypeMeta(), c10::nullopt) {
 }
 
-IntArrayRef UndefinedTensorImpl::sizes() const {
-  AT_ERROR("sizes() called on undefined Tensor");
-}
-
-int64_t UndefinedTensorImpl::size(int64_t d) const {
-  AT_ERROR("size(dim) called on an undefined Tensor");
-}
-
-int64_t UndefinedTensorImpl::stride(int64_t d) const {
-  AT_ERROR("stride(dim) called on an undefined Tensor");
-}
-
-int64_t UndefinedTensorImpl::dim() const {
-  AT_ERROR("dim() called on undefined Tensor");
-}
-
 bool UndefinedTensorImpl::has_storage() const {
   AT_ERROR("has_storage() called on undefined Tensor");
 }
 
-const Storage& UndefinedTensorImpl::storage() const {
-  AT_ERROR("storage() called on undefined Tensor");
-}
-
-int64_t UndefinedTensorImpl::storage_offset() const {
-  AT_ERROR("storage_offset() called on an undefined Tensor");
-}
-
-IntArrayRef UndefinedTensorImpl::strides() const {
-  AT_ERROR("strides() called on undefined Tensor");
-}
 UndefinedTensorImpl UndefinedTensorImpl::_singleton;
 
 }

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -8,10 +8,6 @@ UndefinedTensorImpl::UndefinedTensorImpl()
 : TensorImpl(UndefinedTensorId(), caffe2::TypeMeta(), c10::nullopt) {
 }
 
-bool UndefinedTensorImpl::has_storage() const {
-  AT_ERROR("has_storage() called on undefined Tensor");
-}
-
 UndefinedTensorImpl UndefinedTensorImpl::_singleton;
 
 }

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -17,7 +17,6 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 #endif
     return &_singleton;
   }
-  bool has_storage() const override;
 private:
   UndefinedTensorImpl();
   static UndefinedTensorImpl _singleton;

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -17,14 +17,7 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 #endif
     return &_singleton;
   }
-  IntArrayRef sizes() const override;
-  IntArrayRef strides() const override;
-  int64_t size(int64_t d) const override;
-  int64_t stride(int64_t d) const override;
-  int64_t dim() const override;
   bool has_storage() const override;
-  const Storage& storage() const override;
-  int64_t storage_offset() const override;
 private:
   UndefinedTensorImpl();
   static UndefinedTensorImpl _singleton;


### PR DESCRIPTION
As part of the Variable/Tensor merge, we want to de-virtualize TensorImpl as much as possible, to achieve performance gain for common Tensor functions such as `numel()` / `sizes()` / `dim()`.

This supersedes https://github.com/pytorch/pytorch/pull/11259.