### PR TITLE
Zero slice bug

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -10,7 +10,7 @@ namespace at { namespace native {
 // to benchmark than TH; I can't get gbenchmark to call fns from THTensor.cpp
 
 static inline void maybe_resize_storage_cpu(TensorImpl* self, int64_t new_size) {
-  if (new_size + self->storage_offset() > 0) {
+  if (new_size > 0) {
     if (!THTensor_getStoragePtr(self)) {
       THTensor_stealAndSetStoragePtr(self, THStorage_new(self->dtype()));
     }

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -10,6 +10,11 @@ namespace at { namespace native {
 // to benchmark than TH; I can't get gbenchmark to call fns from THTensor.cpp
 
 static inline void maybe_resize_storage_cpu(TensorImpl* self, int64_t new_size) {
+  // It does not make sense to try to resize a storage
+  // to hold 0 elements, and this can break
+  // if storage_offset is positive but
+  // new_size is 0, so just bail in that case
+  // (same comment is in Resize.cuh)
   if (new_size > 0) {
     if (!THTensor_getStoragePtr(self)) {
       THTensor_stealAndSetStoragePtr(self, THStorage_new(self->dtype()));

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -12,6 +12,11 @@ namespace at { namespace native {
 // to benchmark than THC; I can't get gbenchmark to call fns from THTensor.cpp
 
 static inline void maybe_resize_storage_cuda(TensorImpl* self, int64_t new_size) {
+  // It does not make sense to try to resize a storage
+  // to hold 0 elements, and this can break
+  // if storage_offset is positive but
+  // new_size is 0, so just bail in that case
+  // (same comment is in Resize.h)
   if (new_size > 0) {
     if (!THTensor_getStoragePtr(self)) {
       AT_ERROR("Tensor: invalid null storage");

--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -12,7 +12,7 @@ namespace at { namespace native {
 // to benchmark than THC; I can't get gbenchmark to call fns from THTensor.cpp
 
 static inline void maybe_resize_storage_cuda(TensorImpl* self, int64_t new_size) {
-  if (new_size + self->storage_offset() > 0) {
+  if (new_size > 0) {
     if (!THTensor_getStoragePtr(self)) {
       AT_ERROR("Tensor: invalid null storage");
     }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7254,6 +7254,14 @@ class _TestTorchMixin(object):
         self._test_advancedindex_big(self, lambda x: x)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_empty_storage_view(self):
+        # we should be able to "modify" slices of a 0-element
+        # array without an error being raised due to
+        # trying to resize its storage
+        t = torch.from_numpy(np.empty((0,4)))
+        t[:,1::2] *= 1
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_newaxis_numpy_comparison(self):
         def run_test(tensor, *idx):
             npt = tensor.numpy()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7258,8 +7258,8 @@ class _TestTorchMixin(object):
         # we should be able to "modify" slices of a 0-element
         # array without an error being raised due to
         # trying to resize its storage
-        t = torch.from_numpy(np.empty((0,4)))
-        t[:,1::2] *= 1
+        t = torch.from_numpy(np.empty((0, 4)))
+        t[:, 1::2] *= 1
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_newaxis_numpy_comparison(self):


### PR DESCRIPTION
Bug reported internally at FB:

```python
>>> t=torch.from_numpy(np.empty((0,4)))
>>> t[:,1::2]*=1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Trying to resize storage that is not resizable at ../aten/src/TH/THStorageFunctions.cpp:76
```

This happens because the storage offset of `t[:, 1::2]` is 1, and it has 0 elements. We can fix this by avoiding resizing the storage for no-element arrays.

(We could *also* have avoided it by not modifying the storage index in this case, but I felt this way was more semantically correct -- in general, we should not be assuming it's okay to do anything to the storage when it has zero elements).