### PR TITLE
Fix advanced indexing on "huge" Tensors

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -28,6 +28,13 @@ void gpu_index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
     return;
   }
 
+  if (!iter.can_use_32bit_indexing()) {
+    for (auto& sub_iter : iter.with_32bit_indexing()) {
+      gpu_index_kernel(sub_iter, index_size, index_stride, f);
+    }
+    return;
+  }
+
   auto sizes = cuda::Array<int64_t, 25>(0);
   auto strides = cuda::Array<int64_t, 25>(0);
   auto index_ptrs = cuda::Array<char*, 25>(nullptr);

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -62,6 +62,7 @@ static OffsetCalculator<N> make_offset_calculator(const TensorIterator& iter) {
 
 template<int nt, int vt, typename func_t>
 static void launch_kernel(int64_t N, const func_t& f) {
+  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }

--- a/aten/src/THC/THCIntegerDivider.cuh
+++ b/aten/src/THC/THCIntegerDivider.cuh
@@ -1,7 +1,6 @@
-#ifndef THC_INTEGER_DIVIDER_INC
-#define THC_INTEGER_DIVIDER_INC
+#pragma once
 
-#include <assert.h>
+#include <c10/util/Exception.h>
 
 // A utility class to implement integer division by muliplication, given a fixed
 // divisor.
@@ -78,8 +77,8 @@ struct IntDivider<unsigned int> {
 
   IntDivider() { }  // Dummy constructor for arrays.
 
-  IntDivider(unsigned int d) : divisor(d) {
-    assert(divisor >= 1 && divisor <= INT32_MAX);
+  IntDivider(int64_t d) : divisor(static_cast<unsigned int>(d)) {
+    TORCH_INTERNAL_ASSERT(d >= 1 && d <= INT32_MAX);
 
     // TODO: gcc/clang has __builtin_clz() but it's not portable.
     for (shift = 0; shift < 32; shift++) if ((1U << shift) >= divisor) break;
@@ -87,7 +86,7 @@ struct IntDivider<unsigned int> {
     uint64_t one = 1;
     uint64_t magic = ((one << 32) * ((one << shift) - divisor)) / divisor + 1;
     m1 = magic;
-    assert(m1 > 0 && m1 == magic);  // m1 must fit in 32 bits.
+    TORCH_INTERNAL_ASSERT(m1 > 0 && m1 == magic);  // m1 must fit in 32 bits.
   }
 
   __host__ __device__ inline unsigned int div(unsigned int n) const {
@@ -116,5 +115,3 @@ struct IntDivider<unsigned int> {
   unsigned int m1;  // Magic number: m' above.
   unsigned int shift;  // Shift amounts.
 };
-
-#endif // THC_INTEGER_DIVIDER_INC

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -19,7 +19,8 @@ from test_torch import _TestTorchMixin
 from common_methods_invocations import tri_tests_args, tri_large_tests_args, \
     _compare_trilu_indices, _compare_large_trilu_indices
 from common_utils import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
-    PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_NUMPY, TEST_WITH_ROCM, load_tests
+    PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_NUMPY, TEST_WITH_ROCM, \
+    load_tests, slowTest
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -2456,6 +2457,7 @@ class TestCuda(TestCase):
     def test_advancedindex_big(self):
         _TestTorchMixin._test_advancedindex_big(self, lambda t: t.cuda())
 
+    @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     def test_huge_index(self):
         src = torch.empty(15000000, 45, device='cuda', dtype=torch.long).random_(0, 2**22)


### PR DESCRIPTION
This fixes advanced indexing in cases where there's more than 2^31-1
bytes in the output. The `gpu_index_kernel` was missing the
`can_use_32bit_indexing`/`with_32bit_indexing` check.

This also adds a number of TORCH_INTERNAL_ASSERTS in Loops.cuh,
OffsetCalculator, and IntDivider that sizes are fit in a signed 32-bit
integer.

More comprehensive tests that require a 32 GB GPU are here:
https://gist.github.com/colesbury/e29387f5851521256dff562be07b981e

Fixes #20888