### PR TITLE
Query caffe2 operator stats for detailed execution info

### DIFF
--- a/caffe2/python/utils.py
+++ b/caffe2/python/utils.py
@@ -205,7 +205,7 @@ def TryReadProtoWithClass(cls, s):
     try:
         text_format.Parse(s, obj)
         return obj
-    except text_format.ParseError:
+    except (text_format.ParseError, UnicodeDecodeError):
         obj.ParseFromString(s)
         return obj
 


### PR DESCRIPTION
Summary: I found a python3 bug for deserializing caffe2 code. The exception thrown is Unicode related error instead of just decode error, and we need to catch that as well

Reviewed By: ipiszy

Differential Revision: D15293221

