### PR TITLE
[jit] Don't print backtrace for interpreter errors

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12900,6 +12900,16 @@ a")
         y = torch.randn(3, 6)
         self.checkScript(split_two, [(x + y)])
 
+    def test_conv_error(self):
+        @torch.jit.script
+        def fn(x, y):
+            return F.conv2d(x, y)
+
+        try:
+            fn(torch.ones(2, 2), torch.ones(4, 4))
+        except RuntimeError as e:
+            self.assertFalse('frame' in str(e))
+
     def test_python_op_name(self):
         import random
 

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -47,7 +47,14 @@ struct CAFFE2_API SourceRange {
       const std::exception& e,
       const std::string& additional = "") {
     std::stringstream msg;
-    msg << "\n" << e.what() << ":\n";
+    std::string what;
+    auto c10_error = dynamic_cast<const c10::Error*>(&e);
+    if (c10_error) {
+      what = c10_error->msg_without_backtrace();
+    } else {
+      what = e.what();
+    }
+    msg << "\n" << what << ":\n";
     if (!additional.empty()) {
       msg << additional << ":\n";
     }


### PR DESCRIPTION
Eager Python errors don't include a backtrace so script shouldn't either


Differential Revision: [D15499952](https://our.internmc.facebook.com/intern/diff/15499952/)