### PR TITLE
Update submodule URL based on redirection.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "third_party/protobuf"]
     ignore = dirty
     path = third_party/protobuf
-    url = https://github.com/google/protobuf.git
+    url = https://github.com/protocolbuffers/protobuf.git
 [submodule "third_party/ios-cmake"]
     ignore = dirty
     path = third_party/ios-cmake
@@ -57,7 +57,7 @@
 [submodule "third-party/cpuinfo"]
     ignore = dirty
     path = third_party/cpuinfo
-    url = https://github.com/Maratyszcza/cpuinfo.git
+    url = https://github.com/pytorch/cpuinfo.git
 [submodule "third_party/python-enum"]
     ignore = dirty
     path = third_party/python-enum


### PR DESCRIPTION
Changes:
  - protobuf has been moved to protocolbuffers/protobuf a while ago.
  - cpuinfo has been moved to pytorch/cpuinfo and updated in FBGEMM recently.

