### PR TITLE
BatchSampler now uses list.clear() instead of creating new objects

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -173,7 +173,7 @@ class BatchSampler(Sampler):
             batch.append(idx)
             if len(batch) == self.batch_size:
                 yield batch
-                batch = []
+                batch.clear()
         if len(batch) > 0 and not self.drop_last:
             yield batch
 


### PR DESCRIPTION
[soumith]: PR reverted