### PR TITLE
improve regex so that alternative nvcc path can be hit

### DIFF
--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -42,8 +42,8 @@ def find_cuda_version(cuda_home):
             if os.path.exists(cuda_lib_path):
                 break
         # get a list of candidates for the version number
-        # which are files containing cudart
-        candidate_names = list(glob.glob(os.path.join(cuda_lib_path, '*cudart*')))
+        # which are files containing *cudart.so.9.2.88 or *cudart.9.2.88.dylib
+        candidate_names = list(glob.glob(os.path.join(cuda_lib_path, '*cudart*.[0-9]*.[0-9]*.[0-9]**')))
         candidate_names = [os.path.basename(c) for c in candidate_names]
         # if we didn't find any cudart, ask nvcc
         if len(candidate_names) == 0:


### PR DESCRIPTION
if a custom CUDA install didn't have `libcudart.so.9.2.88` but only `libcudart.so` for example, then `torch.version.cuda` was `None` because https://github.com/pytorch/pytorch/blob/6480d3f1406cff80ab7b63c62bd08144fc88efbd/tools/setup_helpers/cuda.py#L49-L52 was never being hit.

Fixes https://github.com/pytorch/pytorch/issues/19128