### PR TITLE
Re-land "Fix advanced indexing on "huge" Tensors"

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -28,6 +28,13 @@ void gpu_index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef 
     return;
   }
 
+  if (!iter.can_use_32bit_indexing()) {
+    for (auto& sub_iter : iter.with_32bit_indexing()) {
+      gpu_index_kernel(sub_iter, index_size, index_stride, f);
+    }
+    return;
+  }
+
   auto sizes = cuda::Array<int64_t, 25>(0);
   auto strides = cuda::Array<int64_t, 25>(0);
   auto index_ptrs = cuda::Array<char*, 25>(nullptr);

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -62,6 +62,7 @@ static OffsetCalculator<N> make_offset_calculator(const TensorIterator& iter) {
 
 template<int nt, int vt, typename func_t>
 static void launch_kernel(int64_t N, const func_t& f) {
+  TORCH_INTERNAL_ASSERT(N >= 0 && N <= std::numeric_limits<int32_t>::max());
   if (N == 0) {
     return;
   }


### PR DESCRIPTION
This is #20919 without the changes to aten/src/THC/THCIntegerDivider.cuh
that broke the ROCm build.

cc @bddppq 

Original summary:

This fixes advanced indexing in cases where there's more than 2^31-1
bytes in the output. The `gpu_index_kernel` was missing the
`can_use_32bit_indexing`/`with_32bit_indexing` check.

This also adds a number of TORCH_INTERNAL_ASSERTS in Loops.cuh,
OffsetCalculator, and IntDivider that sizes are fit in a signed 32-bit
integer.

More comprehensive tests that require a 32 GB GPU are here:
https://gist.github.com/colesbury/e29387f5851521256dff562be07b981e

