### PR TITLE
Redesign the output shape adjustment of OnnxifiOp

### DIFF
--- a/caffe2/operators/slice_op.h
+++ b/caffe2/operators/slice_op.h
@@ -7,8 +7,6 @@
 
 namespace caffe2 {
 
-namespace {
-
 template <class SIndex, class Context>
 bool SliceImpl(
     Tensor* output,
@@ -195,8 +193,6 @@ bool SliceImpl(
   }
   return true;
 }
-
-} // namespace
 
 template <class Context>
 class SliceOp : public Operator<Context> {

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -28,10 +28,6 @@ struct OnnxifiTransformerOptions {
   // Whether to adjust batch at the ouptuts or not
   bool adjust_batch{true};
 
-  // Whether we allow unknown output batch size. This is often needed when
-  // we explicitly blacklist operators out of the onnxifi op.
-  bool permit_unknown_output_batch_size{false};
-
   // Minimum number of ops to create an onnxifi op. If the subgraph is too
   // small, it doesn't make sense to lower it to backend.
   size_t min_ops{1};
@@ -72,13 +68,13 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       const ShapeInfoMap& shape_hints);
 
   // We already have all the ops and external inputs and outputs!
-  OperatorDef BuildOnnxifiOp(
+  OperatorDef buildOnnxifiOp(
       const std::string& onnx_model_str,
       const std::unordered_map<std::string, TensorShape>& output_size_hints,
       const std::unordered_set<std::string>& initialization_list,
       const std::vector<std::string>& external_inputs,
       const std::vector<std::string>& external_outputs,
-      const std::unordered_map<int, std::string>& batch_pos_map);
+      const std::unordered_map<std::string, ShapeInfo>& shape_hints);
 
   // Transform by passing C2 proto to backend
   NetDef TransformViaC2(
@@ -108,17 +104,6 @@ class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {
       onnx::OnnxExporter* exporter,
       const std::unordered_set<int>& blacklisted_ops,
       onnxBackendID backend_id) const;
-
-  // Go through the inputs of the onnxifi subgraph and extract their batch size.
-  // And use this info to hint how we can cut output batch size from
-  // max_batch_size. The returning key/value is max_batch_size/input_name. For
-  // example, when OnnxifiOp sees an output with batch size 100, it will lookup
-  // the map with key=100. And if we then look into the batch size of the
-  // corresponding input for its real batch size, say 50, and use that to shrink
-  // the output tensor to real batch size.
-  std::unordered_map<int, std::string> generateBatchPaddingHints(
-      const NetDef& onnxifi_net,
-      const ShapeInfoMap& shape_hints);
 
   // Tie the output of Gather to the scalar weight input of the
   // SparseLengthsWeighted* op. If the latter is disabled, disable the former


### PR DESCRIPTION
Summary:
Previously, we are only able to adjust batch size when output shape has batch size conditioned at its first dim. Although not common, there are cases where we want to slice back the output whose batch size is conditioned on non-first dim, or whose output shape doesn't really has batch size in it but rather is an expression of it. Examples are shapes at the output of `Transpose` or `Tile`. This diff redesigns how we handle the output size. The key is when we run OnnxifiOp, the input shapes are given, and we can actually do a shape inference to derive the real output shapes, no matter how they got transformed. And then we compare the real output shape with max batch sized output shape, dim by dim and use a `Slice` op to cut the max output back to real output shape.

Notice that general `Slice` op is slow and in most of the cases, we still prefer adjusting batch size by shrinking its first dim, which is just an operation on meta info without data allocation/manipulation. Therefore, we add a flag `fast_path` to detect this situation and operate accordingly.

Differential Revision: D15515189

