### PR TITLE
[WIP][JIT] Support for rudimentary f-strings

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6283,19 +6283,6 @@ a")
         x = torch.arange(4., requires_grad=True)
         self.checkScript(func, [x], optimize=True, capture_output=True)
 
-    def test_joined_str(self):
-        def func(x):
-            hello, test = "Hello", "test"
-            print(f"{hello + ' ' + test}, I'm a {test}")
-            print(f"format blank")
-            hi = 'hi'
-            print(f"stuff before {hi}")
-            print(f"{hi} stuff after")
-            return x + 1
-
-        x = torch.arange(4., requires_grad=True)
-        self.checkScript(func, [x], optimize=True, capture_output=True)
-
     def test_logical_short_circuit(self):
         @torch.jit.script
         def testNoThrows(t):
@@ -16189,3 +16176,7 @@ for test in criterion_tests:
 
 if __name__ == '__main__':
     run_tests()
+    if not PY2:
+        import test_jit_py3
+        suite = unittest.findTestCases(test_jit_py3)
+        unittest.TextTestRunner().run(suite)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6283,6 +6283,19 @@ a")
         x = torch.arange(4., requires_grad=True)
         self.checkScript(func, [x], optimize=True, capture_output=True)
 
+    def test_joined_str(self):
+        def func(x):
+            hello, test = "Hello", "test"
+            print(f"{hello + ' ' + test}, I'm a {test}")
+            print(f"format blank")
+            hi = 'hi'
+            print(f"stuff before {hi}")
+            print(f"{hi} stuff after")
+            return x + 1
+
+        x = torch.arange(4., requires_grad=True)
+        self.checkScript(func, [x], optimize=True, capture_output=True)
+
     def test_logical_short_circuit(self):
         @torch.jit.script
         def testNoThrows(t):

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -47,25 +47,25 @@ class TestScriptPy3(TestCase):
             os.close(w)
 
     def test_joined_str(self):
-      def func(x):
-          hello, test = "Hello", "test"
-          print(f"{hello + ' ' + test}, I'm a {test}")
-          print(f"format blank")
-          hi = 'hi'
-          print(f"stuff before {hi}")
-          print(f"{hi} stuff after")
-          return x + 1
+        def func(x):
+            hello, test = "Hello", "test"
+            print(f"{hello + ' ' + test}, I'm a {test}") # noqa E999
+            print(f"format blank")
+            hi = 'hi'
+            print(f"stuff before {hi}")
+            print(f"{hi} stuff after")
+            return x + 1
 
-      x = torch.arange(4., requires_grad=True)
-      # TODO: Add support for f-strings in string parser frontend
-      # self.checkScript(func, [x], optimize=True, capture_output=True)
+        x = torch.arange(4., requires_grad=True)
+        # TODO: Add support for f-strings in string parser frontend
+        # self.checkScript(func, [x], optimize=True, capture_output=True)
 
-      with self.capture_stdout() as captured:
-          out = func(x)
+        with self.capture_stdout() as captured:
+            out = func(x)
 
-      scripted = torch.jit.script(func)
-      with self.capture_stdout() as captured_script:
-          out_script = func(x)
+        scripted = torch.jit.script(func)
+        with self.capture_stdout() as captured_script:
+            out_script = func(x)
 
-      self.assertAlmostEqual(out, out_script)
-      self.assertEqual(captured, captured_script)
+        self.assertAlmostEqual(out, out_script)
+        self.assertEqual(captured, captured_script)

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -1,0 +1,71 @@
+import sys
+import torch
+from common_utils import TestCase
+from contextlib import contextmanager
+
+WINDOWS = sys.platform == 'win32'
+
+class TestScriptPy3(TestCase):
+    @contextmanager
+    def capture_stdout(self):
+        # No idea how to capture stdout from C++ on Windows
+        if WINDOWS:
+            yield ['']
+            return
+        import os
+        import fcntl
+        import errno
+        sys.stdout.flush()
+        stdout_fd = os.dup(1)
+        r, w = os.pipe()
+        try:
+            # Override stdout with r - dup is guaranteed to return the lowest free fd
+            os.close(1)
+            os.dup(w)
+
+            captured_stdout = ['']
+            yield captured_stdout
+            sys.stdout.flush()  # Make sure that Python hasn't buffered anything
+
+            # Do the ugly dance to read all the data that was written into the pipe
+            fcntl.fcntl(r, fcntl.F_SETFL, os.O_NONBLOCK)
+            total_stdout = ''
+            while True:
+                try:
+                    total_stdout += os.read(r, 1000).decode('ascii')
+                except OSError as e:
+                    if e.errno != errno.EAGAIN:
+                        raise
+                    break
+            captured_stdout[0] = total_stdout
+        finally:
+            # Revert the change, and clean up all fds
+            os.close(1)
+            os.dup(stdout_fd)
+            os.close(stdout_fd)
+            os.close(r)
+            os.close(w)
+
+    def test_joined_str(self):
+      def func(x):
+          hello, test = "Hello", "test"
+          print(f"{hello + ' ' + test}, I'm a {test}")
+          print(f"format blank")
+          hi = 'hi'
+          print(f"stuff before {hi}")
+          print(f"{hi} stuff after")
+          return x + 1
+
+      x = torch.arange(4., requires_grad=True)
+      # TODO: Add support for f-strings in string parser frontend
+      # self.checkScript(func, [x], optimize=True, capture_output=True)
+
+      with self.capture_stdout() as captured:
+          out = func(x)
+
+      scripted = torch.jit.script(func)
+      with self.capture_stdout() as captured_script:
+          out_script = func(x)
+
+      self.assertAlmostEqual(out, out_script)
+      self.assertEqual(captured, captured_script)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -640,4 +640,3 @@ def find_after(ctx, pos, substr, offsets=(0, 0)):
 def find_before(ctx, pos, substr, offsets=(0, 0)):
     new_pos = ctx.source[:pos].rindex(substr)
     return ctx.make_raw_range(new_pos + offsets[0], new_pos + len(substr) + offsets[1])
-

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -589,6 +589,27 @@ class ExprBuilder(Builder):
         return StringLiteral(r, value)
 
     @staticmethod
+    def build_JoinedStr(ctx, expr):
+        s = ''
+        args = []
+        for value in expr.values:
+            r = ctx.make_range(value.lineno, value.col_offset, value.col_offset + 1)
+            if isinstance(value, ast.FormattedValue):
+                if value.conversion != -1:
+                    raise NotSupportedError(r, 'Don\'t support conversion in JoinedStr')
+                if value.format_spec is not None:
+                    raise NotSupportedError(r, 'Don\'t support formatting in JoinedStr')
+                s += '{}'
+                args.append(build_expr(ctx, value.value))
+            elif isinstance(value, ast.Str):
+                s += value.s
+            else:
+                raise NotSupportedError(r, 'Unsupported value in JoinedStr')
+
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + 1)
+        return Apply(Select(StringLiteral(r, s), Ident(r, 'format')), args, [])
+
+    @staticmethod
     def build_ListComp(ctx, stmt):
         r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset)
         if (len(stmt.generators) > 1):
@@ -619,3 +640,4 @@ def find_after(ctx, pos, substr, offsets=(0, 0)):
 def find_before(ctx, pos, substr, offsets=(0, 0)):
     new_pos = ctx.source[:pos].rindex(substr)
     return ctx.make_raw_range(new_pos + offsets[0], new_pos + len(substr) + offsets[1])
+


### PR DESCRIPTION
Resolves https://github.com/pytorch/lockdown/issues/51

This adds support for converting simple f-string literals to calls to `string.format()`. It does not support conversion specifiers or format strings.

This also does not support the string parser frontend, since that implementation would be more involved and likely would require modifying our TorchScript AST 