### PR TITLE
Operator Metadata

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorMetadata.h
+++ b/aten/src/ATen/core/dispatch/OperatorMetadata.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+
+namespace c10 {
+namespace detail {
+
+template<class Data> class OperatorMetadataType;
+
+template<class Data>
+class OpRegistrationListenerForMetadata final : public OpRegistrationListener {
+public:
+  explicit OpRegistrationListenerForMetadata(OperatorMetadataType<Data>* metadataType)
+  : metadataType_(metadataType) {}
+
+  void onOperatorRegistered(const OperatorHandle& op) override {
+    // no-op
+  }
+
+  void onOperatorDeregistered(const OperatorHandle& op) override {
+    metadataType_->removeOperator(op);
+  }
+
+private:
+  OperatorMetadataType<Data>* metadataType_;
+};
+
+/**
+ * OperatorMetadataType is an extensible way to store metadata for an operator
+ * without the c10 dispatcher needing to know about the metadata.
+ * New kinds of metadata can easily be added externally.
+ */
+
+template<class Data>
+class CAFFE2_API OperatorMetadataType final {
+public:
+  explicit OperatorMetadataType()
+  : metadataForOperators_()
+  , listenerRegistrationHandle_(
+      Dispatcher::singleton().addRegistrationListener(
+        guts::make_unique<detail::OpRegistrationListenerForMetadata<Data>>(this))
+    ) {}
+
+  void set(OperatorHandle op, Data&& metadata) {
+    metadataForOperators_.insert_or_assign(op, std::move(metadata));
+  }
+
+  c10::optional<const Data*> get(OperatorHandle op) {
+    auto found = metadataForOperators_.find(op);
+    if (found == metadataForOperators_.end()) {
+      return c10::nullopt;
+    }
+    return &found->second;
+  }
+
+  void removeOperator(OperatorHandle op) {
+    metadataForOperators_.erase(op);
+  }
+
+private:
+  ska::flat_hash_map<OperatorHandle, Data> metadataForOperators_;
+  RegistrationHandleRAII listenerRegistrationHandle_;
+};
+
+template<class Data> CAFFE2_API OperatorMetadataType<Data>& operatorMetadataTypeSingleton() {
+  static_assert(guts::false_t<Data>::value, "Please define TORCH_DEFINE_OPERATOR_METADATA_TYPE");
+}
+
+}
+
+/**
+ * Call this macro to register a new metadata type for operators.
+ * After calling this on a type T, you can use get_op_metadata<T>(op)
+ * and set_op_metadata<T>(op, data) to load and store metadata.
+ *
+ * Please use your own custom types (e.g. structs) for storing metadata,
+ * instead of commonly used types like std::string or int, otherwise you're
+ * likely to clash with other code registering metadata for std::string.
+ *
+ * This macro must be called from the top level namespace, i.e. outside
+ * of any namespaces.
+ */
+#define TORCH_DEFINE_OPERATOR_METADATA_TYPE(Type)                             \
+  namespace c10 { namespace detail {                                          \
+    template<>                                                                \
+    C10_EXPORT OperatorMetadataType<Type>&                                    \
+        operatorMetadataTypeSingleton<Type>() {                               \
+      static OperatorMetadataType<Type> singleton;                            \
+      return singleton;                                                       \
+    }                                                                         \
+  }}
+
+/**
+ * Get the metadata of type Data from the operator op.
+ * If metadata of this type was registered for this operator before
+ * using set_op_metadata<Data>(op, data), then this will return that metadata.
+ * Otherwise, returns c10::nullopt.
+ */
+template<class Data>
+inline c10::optional<const Data*> get_op_metadata(OperatorHandle op) {
+  return detail::operatorMetadataTypeSingleton<Data>().get(op);
+}
+
+/**
+ * Set the metadata of type Data from the operator op.
+ * After setting the metadata for an operator using
+ * set_op_metadata<Data>(op, data), it can be retrieved using
+ * get_op_metadata<Data>(op).
+ */
+template<class Data>
+inline void set_op_metadata(OperatorHandle op, Data data) {
+  detail::operatorMetadataTypeSingleton<Data>().set(op, std::move(data));
+}
+
+}

--- a/aten/src/ATen/core/dispatch/OperatorMetadata_test.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorMetadata_test.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/core/dispatch/OperatorMetadata.h>
+
+using c10::RegisterOperators;
+using c10::Dispatcher;
+using c10::set_op_metadata;
+using c10::get_op_metadata;
+
+namespace {
+
+struct MyMetadata final {
+  int value;
+};
+struct MyMetadata2 final {
+  int value;
+};
+}
+
+TORCH_DEFINE_OPERATOR_METADATA_TYPE(MyMetadata);
+TORCH_DEFINE_OPERATOR_METADATA_TYPE(MyMetadata2);
+
+namespace {
+
+TEST(OperatorMetadataTest, givenOp_whenSettingAndGettingMetadata_thenValueIsCorrect) {
+  auto registry = RegisterOperators().op("my::op() -> ()");
+
+  auto op = Dispatcher::singleton().findSchema("my::op", "").value();
+
+  set_op_metadata<MyMetadata>(op, MyMetadata{1});
+
+  EXPECT_EQ(1, get_op_metadata<MyMetadata>(op).value()->value);
+}
+
+TEST(OperatorMetadataTest, givenOp_whenGettingMetadata_thenValueIsEmpty) {
+  auto registry = RegisterOperators().op("my::op() -> ()");
+
+  auto op = Dispatcher::singleton().findSchema("my::op", "").value();
+
+  EXPECT_FALSE(get_op_metadata<MyMetadata>(op).has_value());
+}
+
+TEST(OperatorMetadataTest, givenOp_whenGettingSettingAndGettingMetadata_thenValueIsEmpty) {
+  auto registry = RegisterOperators().op("my::op() -> ()");
+
+  auto op = Dispatcher::singleton().findSchema("my::op", "").value();
+
+  EXPECT_FALSE(get_op_metadata<MyMetadata>(op).has_value());
+  set_op_metadata<MyMetadata>(op, MyMetadata{1});
+  EXPECT_EQ(1, get_op_metadata<MyMetadata>(op).value()->value);
+}
+
+TEST(OperatorMetadataTest, givenMultipleOps_whenSettingAndGettingMetadata_thenValueIsCorrect) {
+  auto registry = RegisterOperators()
+    .op("my::op1() -> ()")
+    .op("my::op2() -> ()")
+    .op("my::op3() -> ()");
+
+  auto op1 = Dispatcher::singleton().findSchema("my::op1", "").value();
+  auto op2 = Dispatcher::singleton().findSchema("my::op2", "").value();
+  auto op3 = Dispatcher::singleton().findSchema("my::op3", "").value();
+
+  set_op_metadata<MyMetadata>(op1, MyMetadata{1});
+  set_op_metadata<MyMetadata>(op2, MyMetadata{2});
+
+  EXPECT_EQ(1, get_op_metadata<MyMetadata>(op1).value()->value);
+  EXPECT_EQ(2, get_op_metadata<MyMetadata>(op2).value()->value);
+  EXPECT_FALSE(get_op_metadata<MyMetadata>(op3).has_value());
+}
+
+TEST(OperatorMetadataTest, whenOpGoesOutOfScope_thenMetadataIsDeleted) {
+  auto registry = c10::guts::make_unique<RegisterOperators>(RegisterOperators().op("my::op() -> ()"));
+  auto op = Dispatcher::singleton().findSchema("my::op", "").value();
+  set_op_metadata<MyMetadata>(op, MyMetadata{1});
+
+  EXPECT_TRUE(get_op_metadata<MyMetadata>(op).has_value());
+
+  registry.reset();
+  EXPECT_FALSE(get_op_metadata<MyMetadata>(op).has_value());
+}
+
+TEST(OperatorMetadataTest, givenMultipleMetadatas_whenSettingAndGettingMetadata_thenValueIsCorrect) {
+  auto registry = RegisterOperators()
+    .op("my::op() -> ()");
+
+  auto op = Dispatcher::singleton().findSchema("my::op", "").value();
+
+  set_op_metadata<MyMetadata>(op, MyMetadata{1});
+  set_op_metadata<MyMetadata2>(op, MyMetadata2{2});
+
+  EXPECT_EQ(1, get_op_metadata<MyMetadata>(op).value()->value);
+  EXPECT_EQ(2, get_op_metadata<MyMetadata2>(op).value()->value);
+}
+
+}

--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -224,7 +224,7 @@ struct Registerer final {
   Registerer() {
     // this immediately calls the listener on all existing ops,
     // and calls it in future whenever a new op is registered
-    c10::Dispatcher::singleton().addRegistrationListener(
+    static auto registrationHandle = c10::Dispatcher::singleton().addRegistrationListener(
       c10::guts::make_unique<RegistrationListener>()
     );
   }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21085 Remove old custom op implementation&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15542261/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21084 Add aliasAnalysis to torch::RegisterOperators()&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15542097/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21083 Operator Metadata**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15542096/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21079 registration options should only be callable on rvalues&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15541583/)

Add a mechanism to store metadata for operators. This is used in a diff stacked on top to store AliasAnalysisKind for c10 operators.

Differential Revision: [D15542096](https://our.internmc.facebook.com/intern/diff/D15542096/)