### PR TITLE
Run constant prop on compilation

### DIFF
--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -63,7 +63,6 @@ void propagateNode(Node* n) {
   auto graph = n->owningGraph();
   WithInsertPoint guard(n);
   for (size_t i = 0; i < outputs.size(); ++i) {
-
     auto new_output = tryInsertConstant(*graph, outputs[i]);
     if (new_output) {
       if (outputs[i].isNone()) {
@@ -172,8 +171,10 @@ void removeExtraLoopOutputs(Node* node) {
   for (size_t i_1 = node->outputs().size(); i_1 > 0; --i_1) {
     size_t i = i_1 - 1;
     // if the value is no longer changed remove output
-    if (loop_body->inputs().at(loop_body_offset + i) ==
-        loop_body->outputs().at(loop_body_offset + i)) {
+    if ((loop_body->inputs().at(loop_body_offset + i) ==
+         loop_body->outputs().at(loop_body_offset + i)) ||
+        (node->inputs().at(loop_input_offset + i)) ==
+            loop_body->outputs().at(loop_body_offset + i)) {
       auto node_input = node->inputs().at(loop_input_offset + i);
       node->outputs().at(i)->replaceAllUsesWith(node_input);
       loop_body->inputs()

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -170,7 +170,9 @@ void removeExtraLoopOutputs(Node* node) {
       1; // offset to the loop carried dependencies in block inputs/outputs
   for (size_t i_1 = node->outputs().size(); i_1 > 0; --i_1) {
     size_t i = i_1 - 1;
-    // if the value is no longer changed remove output
+    // if the value of the loop block output equals its node input or its block
+    // input, than the value was not modified during the loop body,
+    // and we can remove it as a loop output
     if ((loop_body->inputs().at(loop_body_offset + i) ==
          loop_body->outputs().at(loop_body_offset + i)) ||
         (node->inputs().at(loop_input_offset + i)) ==

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -18,6 +18,7 @@ namespace {
 std::unordered_set<Symbol> skip_list = {
     prim::If,
     prim::Loop,
+    prim::Function,
     prim::Constant,
     prim::AutogradZero,
     prim::unchecked_unwrap_optional, // TODO remove

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/script/compiler.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/hooks_for_testing.h>
 #include <torch/csrc/jit/interpreter.h>
@@ -5,8 +6,8 @@
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/lower_tuples.h>
-#include <torch/csrc/jit/script/compiler.h>
 #include <torch/csrc/jit/script/final_returns.h>
 #include <torch/csrc/jit/script/parser.h>
 #include <torch/csrc/jit/script/schema_matching.h>
@@ -596,6 +597,7 @@ struct to_ir {
     // remove any uses of tuples that we inserted that are not needed
     LowerSimpleTuples(to_clean);
     ConstantPooling(to_clean);
+    ConstantPropagation(to_clean);
     // For jitter
     CanonicalizeOutputs(to_clean);
   }


### PR DESCRIPTION
This helps clean up our graphs significantly, and will also put less pressure on upcoming compilation passes (Breaks, Continues, Returns) to generate nice graphs in their initial pass. 

Additionally, it solves jitter issues in Load/Store PR i am working on.

here is a count of the number of ifs in our nn/functional.py tests with and without compilation (graphs that have no ifs to begin with are omitted). In many cases it has a large difference. 

func_name, unoptimized ifs, ifs with constant prop
test_nn_affine_grid, 5, 5
test_nn_alpha_dropout, 3, 0
test_nn_batch_norm, 2, 0
test_nn_binary_cross_entropy, 19, 3
test_nn_binary_cross_entropy_size_average, 19, 3
test_nn_binary_cross_entropy_with_logits, 17, 1
test_nn_celu, 1, 0
test_nn_celu_inplace, 1, 0
test_nn_cosine_embedding_loss, 16, 0
test_nn_cross_entropy, 39, 5
test_nn_dropout, 3, 0
test_nn_dropout2d, 3, 0
test_nn_dropout3d, 3, 0
test_nn_elu, 1, 0
test_nn_elu_inplace, 1, 0
test_nn_embedding, 6, 0
test_nn_embedding_bag, 19, 9
test_nn_feature_alpha_dropout, 3, 0
test_nn_fractional_max_pool2d, 4, 0
test_nn_glu, 1, 1
test_nn_grid_sample, 8, 0
test_nn_gumbel_softmax, 2, 0
test_nn_gumbel_softmax_hard, 2, 0
test_nn_hardtanh, 1, 0
test_nn_hardtanh_inplace, 1, 0
test_nn_hinge_embedding_loss, 16, 0
test_nn_kl_div, 24, 0
test_nn_l1_loss, 16, 2
test_nn_l1_loss_with_grad, 16, 2
test_nn_layer_norm, 0, 0
test_nn_layer_norm_with_only_bias, 0, 0
test_nn_layer_norm_with_only_weight, 0, 0
test_nn_layer_norm_with_weight_and_bias, 0, 0
test_nn_leaky_relu, 1, 0
test_nn_leaky_relu_inplace, 1, 0
test_nn_linear, 3, 0
test_nn_linear_addmm, 3, 3
test_nn_local_response_norm, 52, 4
test_nn_log_softmax, 5, 0
test_nn_lp_pool1d, 2, 0
test_nn_lp_pool2d, 2, 0
test_nn_margin_ranking_loss, 19, 3
test_nn_max_pool1d, 1, 0
test_nn_max_pool1d_with_indices, 1, 0
test_nn_max_pool2d, 1, 0
test_nn_max_pool2d_with_indices, 1, 0
test_nn_max_pool3d, 1, 0
test_nn_max_unpool1d, 7, 0
test_nn_max_unpool2d, 6, 0
test_nn_max_unpool3d, 6, 0
test_nn_mse_loss, 16, 2
test_nn_mse_loss_with_grad, 16, 2
test_nn_multi_margin_loss, 20, 2
test_nn_multilabel_margin_loss, 16, 0
test_nn_multilabel_soft_margin_loss, 12, 0
test_nn_nll_loss, 26, 5
test_nn_normalize, 1, 1
test_nn_pad, 25, 1
test_nn_poisson_nll_loss, 13, 0
test_nn_poisson_nll_loss_full, 13, 0
test_nn_relu, 1, 0
test_nn_relu6, 1, 0
test_nn_relu6_inplace, 1, 0
test_nn_relu_inplace, 1, 0
test_nn_rrelu, 1, 0
test_nn_rrelu_inplace, 1, 0
test_nn_selu, 1, 0
test_nn_selu_inplace, 1, 0
test_nn_sigmoid, 0, 0
test_nn_smooth_l1_loss, 16, 2
test_nn_smooth_l1_loss_with_grad, 16, 2
test_nn_soft_margin_loss, 16, 0
test_nn_softmax, 5, 0
test_nn_softmax_with_all_args, 5, 0
test_nn_softmin, 5, 0
test_nn_threshold, 1, 0
test_nn_threshold_inplace, 1, 0
test_nn_triplet_margin_loss, 16, 0
