### PR TITLE
Changes to detect unsupported shapes and cut graph accordingly.

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -10,6 +10,11 @@
 #include <unordered_set>
 
 namespace caffe2 {
+
+namespace {
+constexpr char kShapeNotSupported[] = "shape_not_supported";
+}
+
 // This struct stores the max bound size for batch in the general sense. We have
 // the conventioal batch size and the look-up sequence, which is also batch in a
 // sense.
@@ -37,7 +42,7 @@ class BoundShapeInferencerBase {
   virtual ~BoundShapeInferencerBase() {}
 
   virtual void InferBoundShapeAndType(
-      const NetDef& net,
+      NetDef& net,
       const std::unordered_map<std::string, ShapeInfo>& info,
       caffe2::Workspace* ws) = 0;
 
@@ -71,7 +76,7 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
 
   virtual ~BoundShapeInferencer() override {}
   void InferBoundShapeAndType(
-      const NetDef& net,
+      NetDef& net,
       const std::unordered_map<std::string, ShapeInfo>& info,
       caffe2::Workspace* ws) override;
 


### PR DESCRIPTION
Summary:
This diff introduces changes to catch any exceptions during shape inference
while attempting graph lowering. Op's on which exceptions occur are recorded
such and are used during graph cutting.
Furthermore during creation of TVMJitOp if we catch any error the compilation
status is set to failed so that we run the original net.

Differential Revision: D15545271

