### PR TITLE
Updated scalar type to onnx mapping

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -248,6 +248,9 @@ cast_pytorch_to_onnx = {
     'Long': torch.onnx.TensorProtoDataType.INT64,
     'Short': torch.onnx.TensorProtoDataType.INT16,
     'Bool': torch.onnx.TensorProtoDataType.BOOL,
+    'ComplexFloat': torch.onnx.TensorProtoDataType.COMPLEX64,
+    'ComplexDouble': torch.onnx.TensorProtoDataType.COMPLEX128,
+    'Undefined': torch.onnx.TensorProtoDataType.UNDEFINED,
 }
 
 scalar_name_to_pytorch = {
@@ -259,6 +262,9 @@ scalar_name_to_pytorch = {
     'int': 'Int',
     'int64_t': 'Long',
     'int16_t': 'Short',
+    'bool': 'Bool',
+    'complex64': '',
+    'complex128': ''
 }
 
 
@@ -266,14 +272,17 @@ scalar_name_to_pytorch = {
 # torch type. Related source:
 # https://github.com/pytorch/pytorch/blob/da7468853ae322252270bbb58032668bd21b7457/c10/core/ScalarType.h
 scalar_type_to_pytorch_type = [
-    torch.uint8,    # 0
-    torch.int8,     # 1
-    torch.short,    # 2
-    torch.int,      # 3
-    torch.int64,    # 4
-    torch.half,     # 5
-    torch.float,    # 6
-    torch.double,   # 7
+    torch.uint8,        # 0
+    torch.int8,         # 1
+    torch.short,        # 2
+    torch.int,          # 3
+    torch.int64,        # 4
+    torch.half,         # 5
+    torch.float,        # 6
+    torch.double,       # 7
+    torch.complex64,    # 9
+    torch.complex128,   # 10
+    torch.bool,         # 11
 ]
 
 
@@ -290,4 +299,8 @@ scalar_type_to_onnx = [
     cast_pytorch_to_onnx["Half"],
     cast_pytorch_to_onnx["Float"],
     cast_pytorch_to_onnx["Double"],
+    cast_pytorch_to_onnx["Undefined"],
+    cast_pytorch_to_onnx["ComplexFloat"],
+    cast_pytorch_to_onnx["ComplexDouble"],
+    cast_pytorch_to_onnx["Bool"],
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21096 Minor preparational JIT changes
* **#21095 Updated scalar type to onnx mapping**
* #21033 Enable all and any for bool tensors
* #21032 [WIP] Enabled add, sum and mul for bool tensor

This PR is a part of a stack which will change result tensor type of comparison ops from uint8 to bool. As this change is rather big and a lot of prep work is needed, im breaking it into a stack.

Changes in this PR:
- Updated scalar type to onnx mapping

Differential Revision: [D15546175](https://our.internmc.facebook.com/intern/diff/D15546175)