### PR TITLE
[jit] Remove WeakScriptModuleProxy caching

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12012,9 +12012,8 @@ a")
         other_strong_mod = OtherStrong()
 
         self.assertIsNot(other_strong_mod.weak, other_strong_mod.weak2)
-
-        with self.assertRaisesRegex(RuntimeError, "Cannot call a ScriptModule that is not a submodule of the caller"):
-            strong_mod = Strong()
+        strong_mod = Strong()
+        FileCheck().check("python_value").run(strong_mod.graph)
 
     def test_weak_module_copying(self):
         class Submodule(torch.nn.Module):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -14,9 +14,6 @@ compiled_weak_fns = weakref.WeakKeyDictionary()  # noqa: T484
 # Tracks which methods should be converted to strong methods
 weak_script_methods = weakref.WeakKeyDictionary()  # noqa: T484
 
-# Converted modules and their corresponding WeakScriptModuleProxy objects
-weak_modules = weakref.WeakKeyDictionary()  # noqa: T484
-
 # Types that have been declared as weak modules
 weak_types = weakref.WeakKeyDictionary()  # noqa: T484
 

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -461,11 +461,6 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     }
   }
 
-  auto weak_obj =
-      py::module::import("torch.jit").attr("_try_get_weak_module")(obj);
-  if (!weak_obj.is_none()) {
-    obj = weak_obj;
-  }
   if (auto callee = as_function(obj)) {
     return std::make_shared<FunctionValue>(callee);
   } else if (py::isinstance<py::module>(obj)) {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1077,15 +1077,6 @@ def script_method(fn, _rcb=None):
     return ScriptMethodStub(_rcb, ast, fn)
 
 
-def _try_get_weak_module(mod):
-    """
-    Get the WeakScriptModuleProxy corresponding to mod if it exists
-    """
-    if not isinstance(mod, Module):
-        return None
-    return _jit_internal.weak_modules.get(mod)
-
-
 def _is_weak_type(cls):
     """
     Check if a type has been annotated with `weak_module`
@@ -1674,9 +1665,6 @@ def _make_strong(mod):
     Converts a weak module into a subclass of ScriptModule. If `_methods` is
     provided, only these methods are treated as @script_methods.
     """
-    if mod in _jit_internal.weak_modules:
-        return _jit_internal.weak_modules[mod]
-
     cls = type(mod)
     # Explicitly annotated weak script
     stubs = _jit_internal.weak_types.get(cls)["method_stubs"]
@@ -1686,11 +1674,7 @@ def _make_strong(mod):
         stubs = _get_weak_stubs(cls)
         _jit_internal.weak_types[cls]["method_stubs"] = stubs
 
-    proxy = WeakScriptModuleProxy(mod, stubs)
-
-    _jit_internal.weak_modules[mod] = proxy
-
-    return proxy
+    return WeakScriptModuleProxy(mod, stubs)
 
 
 def _get_methods(cls):


### PR DESCRIPTION
Slightly changes semantics in that weak script modules that are not submodules of a caller but are submodules of some other `ScriptModule` now are inserted as Python values instead of raising an error, but this should be fine since this is all going away soon anyways.