### PR TITLE
Significantly simplify the spawning of pytorch libs building process.

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -79,6 +79,9 @@ if not "%USE_CUDA%"=="1" (
 )
 
 if not "%USE_CUDA%"=="0" (
+  :: sccache will fail for CUDA builds if all cores are used for compiling
+  if not defined MAX_JOBS set /A MAX_JOBS=%NUMBER_OF_PROCESSORS%-1
+
   if "%REBUILD%"=="" (
     sccache --show-stats
     sccache --zero-stats

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -118,13 +118,12 @@ def create_build_env():
     if USE_CUDA:
         my_env['CUDA_BIN_PATH'] = escape_path(CUDA_HOME)
 
-    if IS_WINDOWS:
-        # When using Ninja under Windows, the gcc toolchain will be chosen as default.
-        # But it should be set to MSVC as the user's first choice.
-        if USE_NINJA:
-            my_env = overlay_windows_vcvars(my_env)
-            my_env.setdefault('CC', 'cl')
-            my_env.setdefault('CXX', 'cl')
+    if IS_WINDOWS and USE_NINJA:
+        # When using Ninja under Windows, the gcc toolchain will be chosen as
+        # default. But it should be set to MSVC as the user's first choice.
+        my_env = overlay_windows_vcvars(my_env)
+        my_env.setdefault('CC', 'cl')
+        my_env.setdefault('CXX', 'cl')
     return my_env
 
 


### PR DESCRIPTION
Instead of attempting to hardcode calls to "ninja" or "make", we should always let cmake do it. This better integrates build configurations (DEBUG or REL_WITH_DEB_INFO) and better handles the case in which the native build tool is not in PATH (cmake has some capacity to find them and has options for users to specify their locations).

