### PR TITLE
Make is_contiguous checks generic in number of arguments

### DIFF
--- a/aten/src/ATen/native/cpu/IsContiguous.h
+++ b/aten/src/ATen/native/cpu/IsContiguous.h
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace at { namespace native { namespace {
+
+// n: number of function arguments (arity)
+// traits: function_traits (see FunctionTraits.h)
+// s: index of scalar argument or -1
+template <int n, typename traits, int s=-1>
+struct IsContiguous {
+  static bool eval(const int64_t* strides) {
+    using type = typename traits::template arg<n - 1>::type;
+    return strides[n] == (s == n ? 0 : sizeof(type)) &&
+        IsContiguous<n - 1, traits>::eval(strides);
+  }
+};
+
+template <typename traits, int s>
+struct IsContiguous<0, traits, s> {
+  static bool eval(const int64_t* strides) {
+    return strides[0] == sizeof(typename traits::result_type);
+  }
+};
+
+// output and all inputs are contiguous
+template <typename traits>
+static inline bool is_contiguous(const int64_t* strides) {
+  return IsContiguous<traits::arity, traits>::eval(strides);
+}
+
+// input at `s` is scalar (stride 0); output and other inputs are contiguous
+template <typename traits, int s>
+static inline bool is_contiguous_scalar(const int64_t* strides) {
+  static_assert(s < traits::arity, "scalar argument index out of bounds");
+  return IsContiguous<traits::arity, traits, s>::eval(strides);
+}
+
+}}}

--- a/aten/src/ATen/native/cpu/IsContiguous.h
+++ b/aten/src/ATen/native/cpu/IsContiguous.h
@@ -10,7 +10,7 @@ struct IsContiguous {
   static bool eval(const int64_t* strides) {
     using type = typename traits::template arg<n - 1>::type;
     return strides[n] == (s == n ? 0 : sizeof(type)) &&
-        IsContiguous<n - 1, traits>::eval(strides);
+        IsContiguous<n - 1, traits, s>::eval(strides);
   }
 };
 
@@ -28,9 +28,10 @@ static inline bool is_contiguous(const int64_t* strides) {
 }
 
 // input at `s` is scalar (stride 0); output and other inputs are contiguous
+// NB: output is typically at strides[0] so first input corresponds to s=1
 template <typename traits, int s>
 static inline bool is_contiguous_scalar(const int64_t* strides) {
-  static_assert(s < traits::arity, "scalar argument index out of bounds");
+  static_assert(s > 0 && s <= traits::arity, "scalar argument index out of bounds");
   return IsContiguous<traits::arity, traits, s>::eval(strides);
 }
 

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -303,7 +303,7 @@ void unary_kernel(TensorIterator& iter, func_t op) {
     // Specializations to encourage auto-vectorization (trick from Numpy's loops.c.src)
     if (is_contiguous<traits>(strides)) {
       unary_loop(data, strides, 0, n, op);
-    } else if (is_contiguous_scalar<traits, 0>(strides)) {
+    } else if (is_contiguous_scalar<traits, 1>(strides)) {
       unary_loop(data, strides, 0, n, op);
     } else {
       unary_loop(data, strides, 0, n, op);
@@ -323,7 +323,7 @@ void unary_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
       [&](int ntensor, char** data, const int64_t* strides, int64_t n) {
         if (is_contiguous<traits>(strides)) {
           vectorized_unary_loop(data, n, op, vop);
-        } else if (is_contiguous_scalar<traits, 0>(strides)) {
+        } else if (is_contiguous_scalar<traits, 1>(strides)) {
           unary_loop(data, strides, 0, n, op);
         } else {
           unary_loop(data, strides, 0, n, op);
@@ -339,9 +339,9 @@ void binary_kernel(TensorIterator& iter, func_t op) {
     // Specializations to encourage auto-vectorization (trick from Numpy's loops.c.src)
     if (is_contiguous<traits>(strides)) {
       binary_loop(data, strides, 0, n, op);
-    } else if (is_contiguous_scalar<traits, 0>(strides)) {
-      binary_loop(data, strides, 0, n, op);
     } else if (is_contiguous_scalar<traits, 1>(strides)) {
+      binary_loop(data, strides, 0, n, op);
+    } else if (is_contiguous_scalar<traits, 2>(strides)) {
       binary_loop(data, strides, 0, n, op);
     } else {
       binary_loop(data, strides, 0, n, op);
@@ -364,9 +364,9 @@ void binary_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
   iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
     if (is_contiguous<traits>(strides)) {
       vectorized_binary_loop(data, n, op, vop);
-    } else if (is_contiguous_scalar<traits, 0>(strides)) {
-      vectorized_binary_loop_s1(data, n, op, vop);
     } else if (is_contiguous_scalar<traits, 1>(strides)) {
+      vectorized_binary_loop_s1(data, n, op, vop);
+    } else if (is_contiguous_scalar<traits, 2>(strides)) {
       vectorized_binary_loop_s2(data, n, op, vop);
     } else {
       binary_loop(data, strides, 0, n, op);

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -2,62 +2,13 @@
 
 #include <stdint.h>
 #include <ATen/detail/FunctionTraits.h>
+#include <ATen/native/cpu/IsContiguous.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/cpu/vec256/vec256.h>
 
 namespace at { namespace native { namespace {
 
 using namespace vec256;
-
-// all three operands contiguous
-template <typename traits>
-static inline bool is_binary_contiguous(const int64_t* strides) {
-  return strides[0] == sizeof(typename traits::result_type) &&
-         strides[1] == sizeof(typename traits::arg1_t) &&
-         strides[2] == sizeof(typename traits::arg2_t);
-}
-
-// arg1 is a scalar, output and arg2 are contiguous
-template <typename traits>
-static inline bool is_binary_contiguous_s1(const int64_t* strides) {
-  return strides[0] == sizeof(typename traits::result_type) &&
-         strides[1] == 0 &&
-         strides[2] == sizeof(typename traits::arg2_t);
-}
-
-// arg2 is a scalar, output and arg1 are contiguous
-template <typename traits>
-static inline bool is_binary_contiguous_s2(const int64_t* strides) {
-  return strides[0] == sizeof(typename traits::result_type) &&
-         strides[1] == sizeof(typename traits::arg1_t) &&
-         strides[2] == 0;
-}
-
-// all two operands contiguous
-template <typename traits>
-static inline bool is_unary_contiguous(const int64_t* strides) {
-  return strides[0] == sizeof(typename traits::result_type) &&
-         strides[1] == sizeof(typename traits::arg1_t);
-}
-
-// output is contiguous, arg1 is scalar
-template <typename traits>
-static inline bool is_unary_contiguous_s1(const int64_t* strides) {
-  return strides[0] == sizeof(typename traits::result_type) &&
-         strides[1] == 0;
-}
-
-template <typename traits>
-static inline bool is_nullary_contiguous(const int64_t* strides) {
-  return strides[0] == sizeof(typename traits::result_type);
-}
-
-// result is
-static inline bool is_reduction(char** data, const int64_t* strides) {
-  return strides[0] == 0 &&
-         strides[1] == 0 &&
-         data[0] == data[1];
-}
 
 #define UNARY_LOOP_HEADER(func_t, data, strides) \
   using traits = unary_function_traits<func_t>; \
@@ -142,12 +93,12 @@ static inline void vectorized_nullary_loop(char** data, int64_t n, func_t op, ve
 
 template <typename func_t>
 void nullary_kernel(TensorIterator& iter, func_t op) {
-  AT_ASSERT(iter.ntensors() > 0)
-  using traits = nullary_function_traits<func_t>;
+  TORCH_INTERNAL_ASSERT(iter.ntensors() > 0);
+  using traits = function_traits<func_t>;
 
-   iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
+  iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
     // Specializations to encourage auto-vectorization (trick from Numpy's loops.c.src)
-    if (is_nullary_contiguous<traits>(strides)) {
+    if (is_contiguous<traits>(strides)) {
       nullary_loop(data, strides, 0, n, op);
     } else {
       nullary_loop(data, strides, 0, n, op);
@@ -155,13 +106,13 @@ void nullary_kernel(TensorIterator& iter, func_t op) {
   });
 }
 
- template <typename func_t, typename vec_func_t>
+template <typename func_t, typename vec_func_t>
 void nullary_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
-  AT_ASSERT(iter.ntensors() > 0)
-  using traits = nullary_function_traits<func_t>;
+  TORCH_INTERNAL_ASSERT(iter.ntensors() > 0);
+  using traits = function_traits<func_t>;
 
-   iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
-    if (is_nullary_contiguous<traits>(strides)) {
+  iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
+    if (is_contiguous<traits>(strides)) {
       vectorized_nullary_loop(data, n, op, vop);
     } else {
       nullary_loop(data, strides, 0, n, op);
@@ -346,13 +297,13 @@ static inline void vectorized_outer_reduction(char** data, int64_t inner_stride,
 
 template <typename func_t>
 void unary_kernel(TensorIterator& iter, func_t op) {
-  using traits = unary_function_traits<func_t>;
+  using traits = function_traits<func_t>;
 
   iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
     // Specializations to encourage auto-vectorization (trick from Numpy's loops.c.src)
-    if (is_unary_contiguous<traits>(strides)) {
+    if (is_contiguous<traits>(strides)) {
       unary_loop(data, strides, 0, n, op);
-    } else if (is_unary_contiguous_s1<traits>(strides)) {
+    } else if (is_contiguous_scalar<traits, 0>(strides)) {
       unary_loop(data, strides, 0, n, op);
     } else {
       unary_loop(data, strides, 0, n, op);
@@ -362,16 +313,17 @@ void unary_kernel(TensorIterator& iter, func_t op) {
 
 template <typename func_t, typename vec_func_t>
 void unary_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
-  using traits = unary_function_traits<func_t>;
+  using traits = function_traits<func_t>;
   static_assert(
-    std::is_same<typename traits::result_type, typename traits::arg1_t>::value,
+    std::is_same<typename traits::result_type,
+                 typename traits::template arg<0>::type>::value,
     "all types must match");
 
   iter.for_each(
       [&](int ntensor, char** data, const int64_t* strides, int64_t n) {
-        if (is_unary_contiguous<traits>(strides)) {
+        if (is_contiguous<traits>(strides)) {
           vectorized_unary_loop(data, n, op, vop);
-        } else if (is_unary_contiguous_s1<traits>(strides)) {
+        } else if (is_contiguous_scalar<traits, 0>(strides)) {
           unary_loop(data, strides, 0, n, op);
         } else {
           unary_loop(data, strides, 0, n, op);
@@ -381,15 +333,15 @@ void unary_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
 
 template <typename func_t>
 void binary_kernel(TensorIterator& iter, func_t op) {
-  using traits = binary_function_traits<func_t>;
+  using traits = function_traits<func_t>;
 
   iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
     // Specializations to encourage auto-vectorization (trick from Numpy's loops.c.src)
-    if (is_binary_contiguous<traits>(strides)) {
+    if (is_contiguous<traits>(strides)) {
       binary_loop(data, strides, 0, n, op);
-    } else if (is_binary_contiguous_s1<traits>(strides)) {
+    } else if (is_contiguous_scalar<traits, 0>(strides)) {
       binary_loop(data, strides, 0, n, op);
-    } else if (is_binary_contiguous_s2<traits>(strides)) {
+    } else if (is_contiguous_scalar<traits, 1>(strides)) {
       binary_loop(data, strides, 0, n, op);
     } else {
       binary_loop(data, strides, 0, n, op);
@@ -399,20 +351,22 @@ void binary_kernel(TensorIterator& iter, func_t op) {
 
 template <typename func_t, typename vec_func_t>
 void binary_kernel_vec(TensorIterator& iter, func_t op, vec_func_t vop) {
-  using traits = binary_function_traits<func_t>;
+  using traits = function_traits<func_t>;
   static_assert(
-    std::is_same<typename traits::result_type, typename traits::arg1_t>::value,
+    std::is_same<typename traits::result_type,
+                 typename traits::template arg<0>::type>::value,
     "all types must match");
   static_assert(
-    std::is_same<typename traits::result_type, typename traits::arg2_t>::value,
+    std::is_same<typename traits::result_type,
+                 typename traits::template arg<1>::type>::value,
     "all types must match");
 
   iter.for_each([&](int ntensor, char** data, const int64_t* strides, int64_t n) {
-    if (is_binary_contiguous<traits>(strides)) {
+    if (is_contiguous<traits>(strides)) {
       vectorized_binary_loop(data, n, op, vop);
-    } else if (is_binary_contiguous_s1<traits>(strides)) {
+    } else if (is_contiguous_scalar<traits, 0>(strides)) {
       vectorized_binary_loop_s1(data, n, op, vop);
-    } else if (is_binary_contiguous_s2<traits>(strides)) {
+    } else if (is_contiguous_scalar<traits, 1>(strides)) {
       vectorized_binary_loop_s2(data, n, op, vop);
     } else {
       binary_loop(data, strides, 0, n, op);


### PR DESCRIPTION
Loops.h has contains specializations for cases where all the inputs are
contiguous as well as cases where one input is a scalar and all other
inputs are contiguous.

Previously, there were separate checks for each functions that take
zero, one, or two input arguments. This is getting unwieldy, especially
once we add support for functions that take three inputs (#21025).

This requires the use of recursive templates (which have their own
downsides), but this seems better than the alternative.