### PR TITLE
[jit] Fix weak module cuda() _flat_weights bug

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6431,16 +6431,16 @@ a")
         y = torch.tensor(3)
 
         self.checkScript(tensor_test, (x, y))
-    
-    def test_number_all(self):	
-        def int1():	
-            return all(torch.tensor([1,2,3],dtype=torch.uint8))	
-        def int2():	
-            return all(torch.tensor([1,0,3],dtype=torch.uint8))	
 
-        self.checkScript(int1, ())	
+    def test_number_all(self):
+        def int1():
+            return all(torch.tensor([1,2,3],dtype=torch.uint8))
+        def int2():
+            return all(torch.tensor([1,0,3],dtype=torch.uint8))
+
+        self.checkScript(int1, ())
         self.checkScript(int2, ())
-        
+
     def test_number_math(self):
         ops_template = dedent('''
         def func():
@@ -11922,6 +11922,8 @@ a")
         weak_mod.weight = torch.nn.Parameter(torch.ones(5, 5) * 100)
         self.assertFalse(strong_mod(inp).allclose(weak_mod(inp)))
 
+    @unittest.skipIf(hasattr(torch.jit, 'WeakScriptModuleProxy'), "# TODO: re-enable"
+                                                                  "this when WeakScriptModuleProxy has been deleted")
     def test_weak_module_isinstance(self):
         tester = self
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1224,7 +1224,7 @@ graph(%x : Tensor,
   %2 : int = prim::Constant[value=1]()
   %3 : Tensor = aten::add(%x, %y, %2)
   %4 : int = aten::add(%2, %20)
-  %5 : bool = aten::Bool(%4)
+  %5 : bool = prim::Bool(%4)
   %z : int = prim::If(%5)
     # CHECK: block
     block0():
@@ -6431,7 +6431,16 @@ a")
         y = torch.tensor(3)
 
         self.checkScript(tensor_test, (x, y))
+    
+    def test_number_all(self):	
+        def int1():	
+            return all(torch.tensor([1,2,3],dtype=torch.uint8))	
+        def int2():	
+            return all(torch.tensor([1,0,3],dtype=torch.uint8))	
 
+        self.checkScript(int1, ())	
+        self.checkScript(int2, ())
+        
     def test_number_math(self):
         ops_template = dedent('''
         def func():
@@ -14877,16 +14886,22 @@ def add_nn_module_test(*args, **kwargs):
                 def __init__(self):
                     super(TheModule, self).__init__()
                     self.submodule = nn_module(*constructor_args)
+
+            def make_module(script):
+                module = TheModule()
+                # check __repr__
+                str(module)
+                module.define(script)
+                return module
+
             # module cannot be imported / exported
             if module_name in EXCLUDE_MODULE_EXPORT_IMPORT:
                 with self.disableEmitHook():
-                    module = TheModule()
-                    module.define(script)
+                    module = make_module(script)
                     create_script_module.last_graph = module.graph
                     mod = module(*args)
             else:
-                module = TheModule()
-                module.define(script)
+                module = make_module(script)
                 self.assertExportImportModule(module, tensors)
                 create_script_module.last_graph = module.graph
                 mod = module(*args)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6431,16 +6431,16 @@ a")
         y = torch.tensor(3)
 
         self.checkScript(tensor_test, (x, y))
-    
-    def test_number_all(self):	
-        def int1():	
-            return all(torch.tensor([1,2,3],dtype=torch.uint8))	
-        def int2():	
-            return all(torch.tensor([1,0,3],dtype=torch.uint8))	
 
-        self.checkScript(int1, ())	
+    def test_number_all(self):
+        def int1():
+            return all(torch.tensor([1,2,3],dtype=torch.uint8))
+        def int2():
+            return all(torch.tensor([1,0,3],dtype=torch.uint8))
+
+        self.checkScript(int1, ())
         self.checkScript(int2, ())
-        
+
     def test_number_math(self):
         ops_template = dedent('''
         def func():
@@ -12698,7 +12698,15 @@ a")
                 self.lstm = torch.nn.LSTM(5, 5)
                 self.lstm.cuda()
 
+            @torch.jit.script_method
+            def forward(self, x):
+                return self.lstm(x)
+
         m = M()
+        m.cuda()
+        out = m(torch.ones(5, 5, 5).cuda())
+        self.assertTrue(out[0].is_cuda)
+
 
     def test_ignore_decorator(self):
         class M(torch.jit.ScriptModule):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11925,7 +11925,6 @@ a")
     @unittest.skipIf(hasattr(torch.jit, 'WeakScriptModuleProxy'), "# TODO: re-enable"
                                                                   "this when WeakScriptModuleProxy has been deleted")
     def test_weak_module_isinstance(self):
-    def test_weak_module_isinstance(self):
         tester = self
 
         class M(torch.jit.ScriptModule):
@@ -12690,6 +12689,16 @@ a")
             return python_list_op(lst)
 
         self.checkScript(fn, ([torch.ones(2) + 2, torch.ones(2)],))
+
+    @unittest.skipIf(not RUN_CUDA, "no CUDA")
+    def test_weak_cuda(self):
+        class M(torch.jit.ScriptModule):
+            def __init__(self):
+                super(M, self).__init__()
+                self.lstm = torch.nn.LSTM(5, 5)
+                self.lstm.cuda()
+
+        m = M()
 
     def test_ignore_decorator(self):
         class M(torch.jit.ScriptModule):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1631,10 +1631,7 @@ def _make_strong(mod):
     # Create proxy with stubs
     original_type = type(mod)
 
-    # Construct a new type that inherits from both WeakScriptModuleProxy and
-    # original_type so that isinstance checks work correctly
-    weak_type = type(original_type.__name__, (WeakScriptModuleProxy, original_type), {})
-    proxy = weak_type(mod, stubs)
+    proxy = WeakScriptModuleProxy(mod, stubs)
 
     _jit_internal.weak_modules[mod] = proxy
 


### PR DESCRIPTION
Dynamically creating a type at runtime was messing up the MRO and has been causing many other problems. I think it's best to delete it, this causes a regression since
```python
self.linear = nn.Linear(10, 10)
isinstance(self.linear, nn.Linear)
```
will now be `False` again, but this will be fixed once recursive script mode is the default (#20939)

Differential Revision: [D15560549](https://our.internmc.facebook.com/intern/diff/15560549/)