### PR TITLE
[jit] Made floor/ceil return ints (yay Python 3!)

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5954,11 +5954,11 @@ a")
     def test_math_ops(self):
 
         def test_floor(x):
-            # type: (float) -> float
+            # type: (float) -> int
             return math.floor(x)
 
         def test_ceil(x):
-            # type: (float) -> float
+            # type: (float) -> int
             return math.ceil(x)
 
         def test_log_int(x):
@@ -6431,16 +6431,17 @@ a")
         y = torch.tensor(3)
 
         self.checkScript(tensor_test, (x, y))
-    
-    def test_number_all(self):	
-        def int1():	
-            return all(torch.tensor([1,2,3],dtype=torch.uint8))	
-        def int2():	
-            return all(torch.tensor([1,0,3],dtype=torch.uint8))	
 
-        self.checkScript(int1, ())	
+    def test_number_all(self):
+        def int1():
+            return all(torch.tensor([1, 2, 3], dtype=torch.uint8))
+
+        def int2():
+            return all(torch.tensor([1, 0, 3], dtype=torch.uint8))
+
+        self.checkScript(int1, ())
         self.checkScript(int2, ())
-        
+
     def test_number_math(self):
         ops_template = dedent('''
         def func():

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -96,6 +96,23 @@ static int64_t floordiv(int64_t a, int64_t b) {
     return (r.rem) ? r.quot - 1 : r.quot;
   }
 }
+void checkDoubleInRange(double a) {
+  if (std::isnan(a) || std::isinf(a) ||
+      a > double(std::numeric_limits<int64_t>::max()) ||
+      a < double(std::numeric_limits<int64_t>::min())) {
+    throw std::runtime_error(
+        "Cannot convert float " + std::to_string(a) + " to integer");
+    return;
+  }
+}
+static int64_t floor(double a) {
+  checkDoubleInRange(a);
+  return std::floor(a);
+}
+static int64_t ceil(double a) {
+  checkDoubleInRange(a);
+  return std::ceil(a);
+}
 
 static int64_t gcd(int64_t a, int64_t b) {
   while (b != 0) {
@@ -2123,8 +2140,8 @@ RegisterOperators reg2({
     DEFINE_INT_OP(aten::__or__, a | b),
     DEFINE_INT_OP(aten::__xor__, a ^ b),
 
-    DEFINE_UNARY_OP(aten::floor, (int64_t)std::floor(a), int, int),
-    DEFINE_UNARY_OP(aten::ceil, (int64_t)std::ceil(a), int, int),
+    DEFINE_UNARY_OP(aten::floor, floor(a), int, int),
+    DEFINE_UNARY_OP(aten::ceil, ceil(a), int, int),
     DEFINE_UNARY_OP(aten::log, std::log(a), float, float),
     DEFINE_UNARY_OP(aten::log1p, std::log1p(a), float, float),
     DEFINE_UNARY_OP(aten::log10, std::log10(a), float, float),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1083,18 +1083,20 @@ RegisterOperators logging_operators(
       DEFINE_INT_FLOAT_OP(aten_op, op, bool), DEFINE_STR_CMP_OP(aten_op, op)
 
 #define DEFINE_UNARY_OP(aten_op, op, int_result, float_result)            \
-  Operator(#aten_op "(int a) -> " #int_result, [](Stack& stack) {         \
-    int64_t a;                                                            \
-    pop(stack, a);                                                        \
-    push(stack, op);                                                      \
-    return 0;                                                             \
-  }),                                                                     \
-  Operator(#aten_op "(float a) -> " #float_result, [](Stack& stack) {     \
-    double a;                                                             \
-    pop(stack, a);                                                        \
-    push(stack, op);                                                      \
-    return 0;                                                             \
-  })
+  Operator(                                                               \
+      #aten_op "(int a) -> " #int_result,                                 \
+      [](Stack& stack) {                                                  \
+        int64_t a;                                                        \
+        pop(stack, a);                                                    \
+        push(stack, op);                                                  \
+        return 0;                                                         \
+      }),                                                                 \
+      Operator(#aten_op "(float a) -> " #float_result, [](Stack& stack) { \
+        double a;                                                         \
+        pop(stack, a);                                                    \
+        push(stack, op);                                                  \
+        return 0;                                                         \
+      })
 
 #define DEFINE_BOOL_OP(aten_op, op)                                \
   Operator(#aten_op "(bool a, bool b) -> bool", [](Stack& stack) { \
@@ -2121,8 +2123,8 @@ RegisterOperators reg2({
     DEFINE_INT_OP(aten::__or__, a | b),
     DEFINE_INT_OP(aten::__xor__, a ^ b),
 
-    DEFINE_UNARY_OP(aten::floor, std::floor(a), float, float),
-    DEFINE_UNARY_OP(aten::ceil, std::ceil(a), float, float),
+    DEFINE_UNARY_OP(aten::floor, (int64_t)std::floor(a), int, int),
+    DEFINE_UNARY_OP(aten::ceil, (int64_t)std::ceil(a), int, int),
     DEFINE_UNARY_OP(aten::log, std::log(a), float, float),
     DEFINE_UNARY_OP(aten::log1p, std::log1p(a), float, float),
     DEFINE_UNARY_OP(aten::log10, std::log10(a), float, float),


### PR DESCRIPTION
In particular, I think `flooor/ceil` should have special handling (even if we silently fail for other functions) as they're returning integers. Having `pow(0, -2)` return `inf` is somewhat reasonable, having `floor(NaN)` return -951347564385 (or something like that) is less so.