### PR TITLE
schema_matching.cpp: mark internal functions as static.

### DIFF
--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -8,7 +8,7 @@ namespace torch {
 namespace jit {
 namespace script {
 
-inline TypePtr unwrapOptional(TypePtr opt_type) {
+static inline TypePtr unwrapOptional(TypePtr opt_type) {
   if (auto unwrap_list_type = opt_type->cast<OptionalType>()) {
     return unwrap_list_type->getElementType();
   }
@@ -122,7 +122,7 @@ Value* tryConvertToType(
 // VarType, it will be added to the type_env through `matchTypeVariables` as
 // the corresponding actual type. If `allow_conversions` is true, implicit
 // conversions to the `arg` type may be performed through `tryConvertToType`.
-Value* tryMatchArgument(
+static Value* tryMatchArgument(
     const Argument& arg,
     Graph& graph,
     const SourceRange& loc,
@@ -195,7 +195,7 @@ c10::optional<size_t> findInputWithName(
 /// `elem_type`, nullptr is returned. This is used for creating lists from
 /// varargs so that calls like torch.zeros(1, 2, 3) will be matched to
 /// aten::zeros(int[]).
-Value* tryCreateList(
+static Value* tryCreateList(
     const TypePtr& elem_type,
     Graph& graph,
     const SourceRange& loc,
@@ -227,7 +227,7 @@ Value* tryCreateList(
 // Check if it is possible to convert all the remaining non-kwarg arguments
 // to a list. This allows zeros(IntArrayRef sizes) to work with zeros(1, 2) or
 // zeros(1)
-bool varargsCanBeUsedAsList(
+static bool varargsCanBeUsedAsList(
     const FunctionSchema& schema,
     size_t arg_index,
     const Argument& arg) {
@@ -389,7 +389,7 @@ c10::optional<MatchedSchema> tryMatchSchema(
 
 // pack outputs of a function following python rules. If there is a single value
 // return a SimpleValue, otherwise pack all the values into a Tuple.
-Value* packOutputs(
+static Value* packOutputs(
     Graph& g,
     at::ArrayRef<Value*> values,
     c10::OptNameList field_names) {


### PR DESCRIPTION
Some of the functions are only used in this file - mark them `static`.