### PR TITLE
introduce a new interface to add op [core changes]

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -8,7 +8,8 @@ import argparse
 
 from caffe2.python import workspace
 
-from operator_benchmark import benchmark_core, benchmark_utils
+import benchmark_core
+import benchmark_utils
 
 """Performance microbenchmarks's main binary.
 
@@ -26,28 +27,24 @@ def main():
     )
 
     parser.add_argument(
-        '--run_mode',
-        help='Run mode. '
-        'short: run all operators with few shapes'
-        'long: run all operators with all shapes',
-        choices=benchmark_core.RUN_MODES.keys(),
+        '--tag_filter',
+        help='tag_filter can be used to run the benchmarks which matches the tag',
         default='short')
 
     # This option is used to filter test cases to run.
-    # Currently, the matching is sub-string but we can consider support regex.
-    # For example, if test_case_filter = 'matmul', in will match these test
-    # cases:
-    # matmul_benchmark.Caffe2OperatorTestCase.matmul_512_128_512_transa_transb
-    # matmul_benchmark.PyTorchOperatorTestCase.matmul_100_200_150
-    # ...
     parser.add_argument(
         '--operator',
-        help='Only run the test cases that contain the provided operator'
+        help='Run the test cases that contain the provided operator'
         ' as a substring of their names',
         default=None)
 
     parser.add_argument(
-        '--list_tests',
+        '--test_name',
+        help='Run tests that have the provided test_name',
+        default=None)
+
+    parser.add_argument(
+        '--list_ops',
         help='List all test cases without running them',
         action='store_true')
 
@@ -55,6 +52,13 @@ def main():
         "--iterations",
         help="Repeat each operator for the number of iterations",
         type=int
+    )
+
+    parser.add_argument(
+        "--min_time_per_test",
+        help="Set the minimum time (unit: seconds) to run each test",
+        type=int,
+        default=0,
     )
 
     parser.add_argument(
@@ -69,6 +73,12 @@ def main():
         help="Print result when running on AI-PEP",
         default=False,
         type=bool
+    )
+
+    parser.add_argument(
+        "--forward_only",
+        help="Only run the forward path of operators",
+        action='store_true'
     )
 
     parser.add_argument(

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -4,80 +4,65 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from operator_benchmark.benchmark_caffe2 import Caffe2OperatorTestCase
-from operator_benchmark.benchmark_pytorch import PyTorchOperatorTestCase
-from operator_benchmark.benchmark_utils import * # noqa
-
-import torch
+from benchmark_core import TestConfig
+from benchmark_caffe2 import register_caffe2_op_test_case
+from benchmark_pytorch import register_pytorch_op_test_case
 
 
-def generate_test(configs, map_config, ops, OperatorTestCase):
+def generate_test(configs, bench_op, OperatorTestCase, run_backward):
     """
-    This function is used to create PyTorch/Caffe2 operators based on configs.
-    configs usually include both long_config and short_config and they will be
-    mapped to input_shapes and args which are ready to be digested by an operator.
-    OperatorTestCase is used to create an operator with inputs/outputs and args.
+    This function is used to generate PyTorch/Caffe2 tests based on 
+    the configs and operators.
+    TODO(mingzhe0908): introduce device and add it to the benchmark name 
     """
     for config in configs:
-        for case in config:
-            shapes = {}
-            for item in case:
-                if 'mode' in item:
-                    run_mode = item['mode']
-                    continue
-                shapes.update(item)
-            assert run_mode is not None, "Missing mode in configs"
-            for op in ops:
-                shapes_args = map_config(test_name=op[0], **shapes)
-                if shapes_args is not None:
-                    OperatorTestCase(
-                        test_name=op[0],
-                        op_type=op[1],
-                        input_shapes=shapes_args[0],
-                        op_args=shapes_args[1],
-                        run_mode=run_mode)
+        test_attrs = {}
+        tags = None
+        for attr in config:
+            # tags is only used in our benchmark backend to filter tests and
+            # it will be removed from config which is then passed to the init function 
+            # an example of config and atrr is: 
+            # config: [{'M': 16}, {'N': 16}, {'K': 64}, {'tags': 'short'}]
+            # attr: {'tags': 'short'} 
+            if "tags" in attr:
+                tags = attr["tags"]
+                continue
+            test_attrs.update(attr)
+        if tags is None:
+            raise ValueError("Missing tags in configs")
+        op = bench_op()
+        op.init(**test_attrs)
+        test_name = op.test_name(**test_attrs)
+        input_config = str(test_attrs)[1:-1].replace('\'', '')
+        test_config = TestConfig(test_name, input_config, tags, run_backward)
+        if op is not None:
+            OperatorTestCase(
+                op,
+                test_config)
 
 
-def generate_pt_test(configs, pt_map_func, pt_ops):
+def generate_pt_test(configs, pt_bench_op):
+    """ This function creates PyTorch op test based on the given operator
     """
-    This function creates PyTorch operators which will be benchmarked.
+    generate_test(configs, pt_bench_op, register_pytorch_op_test_case, run_backward=False)
+
+
+def generate_c2_test(configs, c2_bench_op):
+    """ This function creates Caffe2 op test based on the given operator 
     """
-    generate_test(configs, pt_map_func, pt_ops, PyTorchOperatorTestCase)
+    generate_test(configs, c2_bench_op, register_caffe2_op_test_case, run_backward=False)
 
 
-def generate_c2_test(configs, c2_map_func, c2_ops):
+def generate_pt_gradient_test(configs, pt_bench_op):
+    """ This function creates PyTorch op test based on the given operator
     """
-    This function creates Caffe2 operators which will be benchmarked.
+    generate_test(configs, pt_bench_op, register_pytorch_op_test_case, run_backward=True)
+
+
+def generate_c2_gradient_test(configs, c2_bench_op):
+    """ This function creates Caffe2 op test based on the given operator 
     """
-    generate_test(configs, c2_map_func, c2_ops, Caffe2OperatorTestCase)
-
-
-def map_c2_config_add(test_name, M, N, K):
-    input_one = (M, N, K)
-    input_two = (M, N, K)
-    input_shapes = [input_one, input_two]
-    args = {}
-    return (input_shapes, args)
-
-map_pt_config_add = map_c2_config_add
-
-
-def map_c2_config_matmul(test_name, M, N, K, trans_a, trans_b, contig, dtype):
-    if not contig or dtype != torch.float32:
-        return None
-    input_one = (N, M) if trans_a else (M, N)
-    input_two = (K, N) if trans_b else (N, K)
-    input_shapes = [input_one, input_two]
-    args = {'trans_a': trans_a, 'trans_b': trans_b}
-    return (input_shapes, args)
-
-
-def map_pt_config_matmul(test_name, M, N, K, trans_a, trans_b, contig, dtype):
-    if trans_a or trans_b:
-        return None
-    input_shapes = [(M, N), (N, K)]
-    args = {'contig': contig, 'dtype': dtype}
-    return (input_shapes, args)
+    generate_test(configs, c2_bench_op, register_caffe2_op_test_case, run_backward=True)
 
 
 def map_pt_config_intraop(test_name, N, M, contig, dtype):

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -63,6 +63,55 @@ def generate_configs(**configs):
     return results
 
 
+def cross_product_configs(**configs):
+    """
+    Given configs from users, we want to generate different combinations of
+    those configs
+    For example, given M = ((1, 2), N = (4, 5)),
+    we will generate (({'M': 1}, {'N' : 4}),
+                      ({'M': 1}, {'N' : 5}),
+                      ({'M': 2}, {'N' : 4}),
+                      ({'M': 2}, {'N' : 5}))
+    """
+    configs_attrs_list = []
+    for key, values in configs.items():
+        tmp_results = [{key : value} for value in values]
+        configs_attrs_list.append(tmp_results)
+
+    # TODO(mingzhe0908) remove the conversion to list. 
+    # itertools.product produces an iterator that produces element on the fly
+    # while converting to a list produces everything at the same time.
+    generated_configs = list(itertools.product(*configs_attrs_list))
+    return generated_configs
+
+
+def config_list(**configs):
+    """
+    Take specific inputs from users
+    For example, given 
+    attrs = [
+        [1, 2],
+        [4, 5],
+    ]
+    attr_names = ["M", "N"]
+    we will generate (({'M': 1}, {'N' : 2}),
+                      ({'M': 4}, {'N' : 5}))
+    """
+    generated_configs = []
+    if "attrs" not in configs:
+        raise ValueError("Missing attrs in configs")
+    for inputs in configs["attrs"]:
+        tmp_result = [{configs["attr_names"][i] : input_value} 
+                      for i, input_value in enumerate(inputs)]
+        # TODO(mingzhe0908): 
+        # If multiple "tags" were provided, do they get concat?
+        # If a config has both ["short", "medium"], it should match 
+        # both "short" and "medium" tag-filter?
+        tmp_result.append({"tags" : '_'.join(configs["tags"])})
+        generated_configs.append(tmp_result)
+    return generated_configs
+
+
 def is_caffe2_enabled(framework_arg):
     return 'Caffe2' in framework_arg
 

--- a/benchmarks/operator_benchmark/operator_benchmark.py
+++ b/benchmarks/operator_benchmark/operator_benchmark.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+# TODO (mingzhe09088): get rid of noqa
+import benchmark_runner # noqa
+from benchmark_pytorch import TorchBenchmarkBase # noqa
+from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
+from benchmark_test_generator import * # noqa
+from benchmark_utils import * # noqa


### PR DESCRIPTION
Summary:
This diff introduces a new interface to add PT/C2 operators to the benchmark suite.

The following steps are needed to add a new operator:
1. Specify the input shapes, args to an operator in configs
2. Create a PT/C2 benchmark class which includes ```init``` (create tensors),  ```forward``` (specify the operator to be tested.), and ```backward```(gradient of an op.) methods
3. call generate_pt_test/generate_c2_test to create test cases based on configs

Differential Revision: D15250380

