### PR TITLE
Reuse common options between ONNXIFI and TVM transformations

### DIFF
--- a/caffe2/opt/backend_transformer_base.h
+++ b/caffe2/opt/backend_transformer_base.h
@@ -15,6 +15,20 @@ constexpr char kNetPos[] = "net_pos";
 constexpr char kModelId[] = "model_id";
 } // namespace
 
+struct BackendTransformOptions {
+  explicit BackendTransformOptions() : bound_shape_spec(0, 0) {}
+
+  // Enable debugging by dumping more intermediate graphs
+  bool debug{false};
+
+  // Minimum number of ops to create a backend op. If the subgraph is too
+  // small, it doesn't make sense to lower it to backend.
+  size_t min_ops{1};
+
+  // Bound shape spec
+  BoundShapeSpec bound_shape_spec;
+};
+
 // This class contains some common functions for backend lowering and graph
 // cutting
 class BackendTransformerBase {

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -16,24 +16,14 @@ namespace onnx {
 class OnnxExporter;
 }
 
-struct OnnxifiTransformerOptions {
-  explicit OnnxifiTransformerOptions() : bound_shape_spec(0, 0) {}
-
-  // Dump onnx model for debugging
-  bool debug{false};
+struct OnnxifiTransformerOptions final : public BackendTransformOptions {
+  explicit OnnxifiTransformerOptions() : BackendTransformOptions() {}
 
   // Pass serialized onnx model if true, otherwise pass serialized c2 model
   bool use_onnx{false};
 
   // Whether to adjust batch at the ouptuts or not
   bool adjust_batch{true};
-
-  // Minimum number of ops to create an onnxifi op. If the subgraph is too
-  // small, it doesn't make sense to lower it to backend.
-  size_t min_ops{1};
-
-  // Bound shape spec
-  BoundShapeSpec bound_shape_spec;
 };
 
 class CAFFE2_API OnnxifiTransformer final : public BackendTransformerBase {


### PR DESCRIPTION
Summary: These two backend transformation share some common traits. Therefore we want to reuse the data struct/code as much as possible.

Differential Revision: D15561177

