### PR TITLE
remove dependency to caffe2::math and eigen

### DIFF
--- a/caffe2/perfkernels/embedding_lookup.cc
+++ b/caffe2/perfkernels/embedding_lookup.cc
@@ -2,9 +2,6 @@
 
 #include "caffe2/core/types.h"
 #include "caffe2/perfkernels/common.h"
-#include "caffe2/perfkernels/typed_axpy.h"
-#include "caffe2/utils/eigen_utils.h"
-#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 
@@ -32,7 +29,6 @@ static bool EmbeddingLookupGenericSlow(
   int64_t current = 0;
   for (int m = 0; m < output_size; ++m) {
     memset(out, 0, sizeof(OutType) * block_size);
-    EigenVectorArrayMap<OutType> out_vector(out, block_size);
     if (current + lengths[m] > index_size) {
       return false;
     }
@@ -56,19 +52,17 @@ static bool EmbeddingLookupGenericSlow(
         w = w * scale_bias[2 * indices[current]];
       }
 
-      TypedAxpy<InType, OutType>(
-          block_size, w, input + block_size * indices[current], out);
-
-      if (scale_bias) {
-        out_vector = out_vector + b;
+      for (int j = 0; j < block_size; ++j) {
+        out[j] += w * input[block_size * indices[current] + j] + b;
       }
 
       ++current;
     }
     if (normalize_by_lengths && lengths[m]) {
-      // hack: context is not really used
-      math::Scale<float, OutType, CPUContext>(
-          block_size, 1.f / lengths[m], out, out, nullptr);
+      float scale = 1.f / lengths[m];
+      for (int j = 0; j < block_size; ++j) {
+        out[j] *= scale;
+      }
     }
     out += block_size;
   }

--- a/caffe2/perfkernels/typed_axpy.cc
+++ b/caffe2/perfkernels/typed_axpy.cc
@@ -2,15 +2,22 @@
 #include "caffe2/core/types.h"
 #include "caffe2/perfkernels/common.h"
 #include "caffe2/utils/cpuid.h"
-#include "caffe2/utils/math.h"
 
 namespace caffe2 {
 
+void TypedAxpy__base(int N, const float a, const float* x, float* y) {
+  for (int i = 0; i < N; ++i) {
+    y[i] += a * x[i];
+  }
+}
+
+decltype(TypedAxpy__base) TypedAxpy__avx2_fma;
+decltype(TypedAxpy__base) TypedAxpy__avx_f16c;
 template <>
 void TypedAxpy<float, float>(int N, const float a, const float* x, float* y) {
-  // This uses a hack that axpy implementation actually does not use the
-  // CPUContext, so passing in a nullpointer works.
-  math::Axpy<float, float, CPUContext>(N, a, x, y, nullptr);
+  AVX2_FMA_DO(TypedAxpy, N, a, x, y);
+  AVX_F16C_DO(TypedAxpy, N, a, x, y);
+  BASE_DO(TypedAxpy, N, a, x, y);
 }
 
 void TypedAxpyHalffloat__base(

--- a/caffe2/perfkernels/typed_axpy_avx.cc
+++ b/caffe2/perfkernels/typed_axpy_avx.cc
@@ -6,6 +6,26 @@
 
 namespace caffe2 {
 
+void TypedAxpy__avx_f16c(int N, const float a, const float* x, float* y) {
+  int current = 0;
+  const int bound = (N % 8) ? N - 8 : N;
+  __m256 mma = _mm256_set1_ps(a);
+  for (; current < bound; current += 8) {
+    _mm256_storeu_ps(
+        y + current,
+        _mm256_add_ps(
+            _mm256_mul_ps(mma, _mm256_loadu_ps(x + current)),
+            _mm256_loadu_ps(y + current)));
+  }
+
+  if (bound != N) {
+    while (current < N) {
+      y[current] += x[current] * a;
+      ++current;
+    }
+  }
+}
+
 void TypedAxpyHalffloat__avx_f16c(
     int N,
     const float a,

--- a/caffe2/perfkernels/typed_axpy_avx2.cc
+++ b/caffe2/perfkernels/typed_axpy_avx2.cc
@@ -6,6 +6,25 @@
 
 namespace caffe2 {
 
+void TypedAxpy__avx2_fma(int N, const float a, const float* x, float* y) {
+  int current = 0;
+  const int bound = (N % 8) ? N - 8 : N;
+  __m256 mma = _mm256_set1_ps(a);
+  for (; current < bound; current += 8) {
+    _mm256_storeu_ps(
+        y + current,
+        _mm256_fmadd_ps(
+            mma, _mm256_loadu_ps(x + current), _mm256_loadu_ps(y + current)));
+  }
+
+  if (bound != N) {
+    while (current < N) {
+      y[current] += x[current] * a;
+      ++current;
+    }
+  }
+}
+
 void TypedAxpyHalffloat__avx2_fma(
     int N,
     const float a,


### PR DESCRIPTION
Summary: We should minimize dependency from perfkernels to avoid illegal instruction errors

Differential Revision: D15563839

