### PR TITLE
[jit] Add dictionary iteration

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -134,6 +134,7 @@ namespace c10 {
   _(aten, list)                    \
   _(aten, wait)                    \
   _(aten, save)                    \
+  _(aten, keys)                    \
   _(aten, ord)                     \
   _(prim, unchecked_unwrap_optional)\
   FORALL_ATEN_BASE_SYMBOLS(_)      \

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12773,6 +12773,16 @@ a")
 
         self.checkScript(length, (d,))
 
+    def test_dict_iteration(self):
+        def fn(x):
+            # type: (Dict[str, int]) -> int
+            sum = 0
+            for key in x:
+                sum += x[key]
+            return sum
+
+        self.checkScript(fn, ({"a": 1, "b": 2, "c": 3},))
+
     def test_dict(self):
         def simple(x):
             # type: (Dict[str, int]) -> Dict[str, int]

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1656,7 +1656,7 @@ int dictKeys(Stack& stack) {
   auto dict = pop(stack).toGenericDict();
   std::vector<IValue> keys;
   keys.reserve(dict->elements().size());
-  for (auto item : dict->elements()) {
+  for (auto item : dict->iterationOrder()) {
     keys.push_back(item.key());
   }
   push(stack, IValue(keys));


### PR DESCRIPTION
This adds for-in for dicts which under the hood calls `dict.keys()` and
iterates over that list.

* Modifying the dictionary while iterating won't change the list (since
it's all coming from the earlier `keys()` call. Maybe this needs to be
discussed more, see #21173
* The iteration order is not the same as Python 3.8 since we don't do
ordered dicts, but this PR changes `keys()` so it should at least be
stable

Differential Revision: [D15567917](https://our.internmc.facebook.com/intern/diff/15567917/)