### PR TITLE
[JIT] Add file:line:graph to graph printout

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -138,7 +138,7 @@ def MiLSTMCell(x, hx, cx, w_ih, w_hh, alpha, beta_i, beta_h, bias):
 
 
 def canonical(graph):
-    return str(torch._C._jit_pass_canonicalize(graph))
+    return torch._C._jit_pass_canonicalize(graph).str(False)
 
 
 def get_lstm_inputs(device, training=False, seq_length=None):
@@ -3704,7 +3704,7 @@ def foo(x):
 
         _, lineno = inspect.getsourcelines(foobar)
         FileCheck().check('test_jit.py:{}:20'.format(lineno + 1))\
-                   .run(scripted.graph.debug_str())
+                   .run(scripted.graph)
 
     def test_tensor_shape(self):
         x = torch.empty(34, 56, 78)
@@ -13636,11 +13636,6 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
         if quantized:
             snli = SNLIClassifier(Config()).cpu()
             torch.jit.quantized.quantize_linear_modules(snli)
-            traced = torch.jit.trace(snli, (premise, hypothesis))
-            traced.save('/tmp/foo')
-            traced = torch.jit.load('/tmp/foo')
-            print(traced.graph.debug_str())
-            import pdb; pdb.set_trace()
             # we don't do export/import checks because we would need to call
             # _pack/_unpack
             self.checkTrace(snli, (premise, hypothesis), inputs_require_grads=False,

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3703,7 +3703,7 @@ def foo(x):
         scripted = torch.jit.script(foobar)
 
         _, lineno = inspect.getsourcelines(foobar)
-        FileCheck().check('test_jit.py:{}:20'.format(lineno+1))\
+        FileCheck().check('test_jit.py:{}:20'.format(lineno + 1))\
                    .run(scripted.graph.debug_str())
 
     def test_tensor_shape(self):
@@ -13636,6 +13636,11 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
         if quantized:
             snli = SNLIClassifier(Config()).cpu()
             torch.jit.quantized.quantize_linear_modules(snli)
+            traced = torch.jit.trace(snli, (premise, hypothesis))
+            traced.save('/tmp/foo')
+            traced = torch.jit.load('/tmp/foo')
+            print(traced.graph.debug_str())
+            import pdb; pdb.set_trace()
             # we don't do export/import checks because we would need to call
             # _pack/_unpack
             self.checkTrace(snli, (premise, hypothesis), inputs_require_grads=False,

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3696,6 +3696,16 @@ def foo(x):
         with self.assertRaisesRegex(RuntimeError, "test_jit.py:{}:24".format(lineno + 2)):
             torch.jit.script(FooBar)
 
+    def test_file_line_graph(self):
+        def foobar(xyz):
+            return torch.neg(xyz)
+
+        scripted = torch.jit.script(foobar)
+
+        _, lineno = inspect.getsourcelines(foobar)
+        FileCheck().check('test_jit.py:{}:20'.format(lineno+1))\
+                   .run(scripted.graph.debug_str())
+
     def test_tensor_shape(self):
         x = torch.empty(34, 56, 78)
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -254,7 +254,7 @@ std::ostream& Node::print(
   // In debug print, append file:line:col as a comment after each node
   if (print_source_locations && source_range_ &&
       source_range_->source()->filename()) {
-    auto range = sourceRange();
+    const auto& range = sourceRange();
     auto source = range.source();
     auto lineno = source->lineno_for_offset(range.start());
     auto col_offset = (int)range.start() - (int)source->offset_for_line(lineno);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -252,12 +252,12 @@ std::ostream& Node::print(
   }
 
   // In debug print, append file:line:col as a comment after each node
-  if (print_source_locations && source_range_ && source_range_->source()->filename()) {
+  if (print_source_locations && source_range_ &&
+      source_range_->source()->filename()) {
     auto range = sourceRange();
     auto source = range.source();
     auto lineno = source->lineno_for_offset(range.start());
-    auto col_offset = (int)range.start() -
-        (int)source->offset_for_line(lineno);
+    auto col_offset = (int)range.start() - (int)source->offset_for_line(lineno);
     out << " # " << source->filename().value() << ":"
         << source->lineno_to_source_lineno(lineno) << ":" << col_offset;
   }
@@ -282,7 +282,8 @@ std::ostream& operator<<(std::ostream& out, const Node& n) {
   return n.print(out, 0, nullptr);
 }
 
-std::ostream& Graph::print(std::ostream& out, bool print_source_locations) const {
+std::ostream& Graph::print(std::ostream& out, bool print_source_locations)
+    const {
   out << "graph(" << const_value_list_with_types(inputs(), ",\n      ")
       << "):\n";
   std::vector<const Node*> groups;

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -255,7 +255,7 @@ std::ostream& Node::print(
   if (print_source_locations && source_range_ &&
       source_range_->source()->filename()) {
     const auto& range = sourceRange();
-    auto source = range.source();
+    const auto& source = range.source();
     auto lineno = source->lineno_for_offset(range.start());
     auto col_offset = (int)range.start() - (int)source->offset_for_line(lineno);
     out << " # " << source->filename().value() << ":"

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -218,7 +218,8 @@ static std::ostream& indent(std::ostream& out, size_t level) {
 std::ostream& Node::print(
     std::ostream& out,
     size_t level,
-    std::vector<const Node*>* groups) const {
+    std::vector<const Node*>* groups,
+    bool debug) const {
   auto outs = outputs();
   indent(out, level) << const_value_list_with_types(outs);
   out << " = ";
@@ -245,12 +246,23 @@ std::ostream& Node::print(
 
   out << "(" << inputs() << ")";
   std::string scName = scopeName();
-  if (scName.empty()) {
-    out << "\n";
-  } else {
+  if (!scName.empty()) {
     out << ", ";
-    out << "scope: " << scName << "\n";
+    out << "scope: " << scName;
   }
+
+  // In debug print, append file:line:col as a comment after each node
+  if (debug && source_range_ && source_range_->source()->filename()) {
+    auto range = sourceRange();
+    auto source = range.source();
+    auto lineno = source->lineno_for_offset(range.start());
+    auto col_offset = (int)range.start() -
+        (int)source->offset_for_line(lineno);
+    out << " # " << source->filename().value() << ":"
+        << source->lineno_to_source_lineno(lineno) << ":" << col_offset;
+  }
+
+  out << "\n";
 
   for (size_t i = 0; i < blocks().size(); ++i) {
     auto b = blocks()[i];
@@ -270,14 +282,14 @@ std::ostream& operator<<(std::ostream& out, const Node& n) {
   return n.print(out, 0, nullptr);
 }
 
-std::ostream& operator<<(std::ostream& out, const Graph& g) {
-  out << "graph(" << const_value_list_with_types(g.inputs(), ",\n      ")
+std::ostream& Graph::print(std::ostream& out, bool debug) const {
+  out << "graph(" << const_value_list_with_types(inputs(), ",\n      ")
       << "):\n";
   std::vector<const Node*> groups;
-  for (auto n : g.nodes()) {
-    n->print(out, 1, &groups);
+  for (auto n : nodes()) {
+    n->print(out, 1, &groups, debug);
   }
-  out << "  return (" << g.outputs() << ")\n";
+  out << "  return (" << outputs() << ")\n";
   size_t i = 0;
   for (auto fg : groups) {
     out << "with " << fg->kind().toQualString() << "_" << i++ << " = "
@@ -288,12 +300,16 @@ std::ostream& operator<<(std::ostream& out, const Graph& g) {
   {
     out << "\n";
     out << "all_nodes:\n";
-    for (auto& n : g.all_nodes) {
+    for (auto& n : all_nodes) {
       printNode(out, const_cast<Node*>(n), nullptr);
     }
   }
   */
   return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const Graph& g) {
+  return g.print(out, false);
 }
 
 static void checkSameDevice(const Node* node) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -310,7 +310,7 @@ std::ostream& Graph::print(std::ostream& out, bool print_source_locations)
 }
 
 std::ostream& operator<<(std::ostream& out, const Graph& g) {
-  return g.print(out, false);
+  return g.print(out, true);
 }
 
 static void checkSameDevice(const Node* node) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -219,7 +219,7 @@ std::ostream& Node::print(
     std::ostream& out,
     size_t level,
     std::vector<const Node*>* groups,
-    bool debug) const {
+    bool print_source_locations) const {
   auto outs = outputs();
   indent(out, level) << const_value_list_with_types(outs);
   out << " = ";
@@ -252,7 +252,7 @@ std::ostream& Node::print(
   }
 
   // In debug print, append file:line:col as a comment after each node
-  if (debug && source_range_ && source_range_->source()->filename()) {
+  if (print_source_locations && source_range_ && source_range_->source()->filename()) {
     auto range = sourceRange();
     auto source = range.source();
     auto lineno = source->lineno_for_offset(range.start());
@@ -282,12 +282,12 @@ std::ostream& operator<<(std::ostream& out, const Node& n) {
   return n.print(out, 0, nullptr);
 }
 
-std::ostream& Graph::print(std::ostream& out, bool debug) const {
+std::ostream& Graph::print(std::ostream& out, bool print_source_locations) const {
   out << "graph(" << const_value_list_with_types(inputs(), ",\n      ")
       << "):\n";
   std::vector<const Node*> groups;
   for (auto n : nodes()) {
-    n->print(out, 1, &groups, debug);
+    n->print(out, 1, &groups, print_source_locations);
   }
   out << "  return (" << outputs() << ")\n";
   size_t i = 0;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -633,7 +633,7 @@ struct TORCH_API Node {
       std::ostream& out,
       size_t level,
       std::vector<const Node*>* groups,
-      bool print_source_locations=false) const;
+      bool print_source_locations = false) const;
 
   virtual ~Node() = default;
 
@@ -1178,7 +1178,8 @@ struct Graph {
 
   TORCH_API std::string toString() const;
 
-  TORCH_API std::ostream& print(std::ostream& out, bool print_source_locations) const;
+  TORCH_API std::ostream& print(std::ostream& out, bool print_source_locations)
+      const;
 
   friend TORCH_API std::ostream& operator<<(std::ostream& out, const Graph& g);
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -632,7 +632,8 @@ struct TORCH_API Node {
   std::ostream& print(
       std::ostream& out,
       size_t level,
-      std::vector<const Node*>* groups) const;
+      std::vector<const Node*>* groups,
+      bool debug=false) const;
 
   virtual ~Node() = default;
 
@@ -1176,6 +1177,8 @@ struct Graph {
   TORCH_API ~Graph();
 
   TORCH_API std::string toString() const;
+
+  TORCH_API std::ostream& print(std::ostream& out, bool debug) const;
 
   friend TORCH_API std::ostream& operator<<(std::ostream& out, const Graph& g);
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -633,7 +633,7 @@ struct TORCH_API Node {
       std::ostream& out,
       size_t level,
       std::vector<const Node*>* groups,
-      bool print_source_locations = false) const;
+      bool print_source_locations = true) const;
 
   virtual ~Node() = default;
 
@@ -1178,8 +1178,9 @@ struct Graph {
 
   TORCH_API std::string toString() const;
 
-  TORCH_API std::ostream& print(std::ostream& out, bool print_source_locations)
-      const;
+  TORCH_API std::ostream& print(
+      std::ostream& out,
+      bool print_source_locations = true) const;
 
   friend TORCH_API std::ostream& operator<<(std::ostream& out, const Graph& g);
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -633,7 +633,7 @@ struct TORCH_API Node {
       std::ostream& out,
       size_t level,
       std::vector<const Node*>* groups,
-      bool debug=false) const;
+      bool print_source_locations=false) const;
 
   virtual ~Node() = default;
 
@@ -1178,7 +1178,7 @@ struct Graph {
 
   TORCH_API std::string toString() const;
 
-  TORCH_API std::ostream& print(std::ostream& out, bool debug) const;
+  TORCH_API std::ostream& print(std::ostream& out, bool print_source_locations) const;
 
   friend TORCH_API std::ostream& operator<<(std::ostream& out, const Graph& g);
 

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -219,10 +219,10 @@ void initPythonIRBindings(PyObject* module_) {
             return ss.str();
           })
       .def(
-          "debug_str",
-          [](Graph& g) -> std::string {
+          "str",
+          [](Graph& g, bool print_source_ranges) {
             std::stringstream ss;
-            g.print(ss, true);
+            g.print(ss, print_source_ranges);
             return ss.str();
           })
       .def(

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -224,8 +224,7 @@ void initPythonIRBindings(PyObject* module_) {
             std::stringstream ss;
             g.print(ss, true);
             return ss.str();
-          }
-      )
+          })
       .def(
           "dump_alias_db",
           [](std::shared_ptr<Graph> g) {

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -224,7 +224,8 @@ void initPythonIRBindings(PyObject* module_) {
             std::stringstream ss;
             g.print(ss, print_source_ranges);
             return ss.str();
-          })
+          },
+          py::arg("print_source_ranges") = true)
       .def(
           "dump_alias_db",
           [](std::shared_ptr<Graph> g) {

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -219,6 +219,14 @@ void initPythonIRBindings(PyObject* module_) {
             return ss.str();
           })
       .def(
+          "debug_str",
+          [](Graph& g) -> std::string {
+            std::stringstream ss;
+            g.print(ss, true);
+            return ss.str();
+          }
+      )
+      .def(
           "dump_alias_db",
           [](std::shared_ptr<Graph> g) {
             AliasDb db(g);


### PR DESCRIPTION
Example:

```
import torch

@torch.jit.script
def foo(x):
    y = torch.neg(x)
    return x - y

print(foo.graph.debug_str())
```

```
graph(%x : Tensor):
  %2 : int = prim::Constant[value=1]()
  %y : Tensor = aten::neg(%x) # demo.py:5:9
  %3 : Tensor = aten::sub(%x, %y, %2) # demo.py:6:12
  return (%3)
```