### PR TITLE
c10::OperatorOptions

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/dispatch/DispatchTable.h>
+#include <ATen/core/dispatch/OperatorOptions.h>
 #include <ATen/core/dispatch/RegistrationHandleRAII.h>
 #include <list>
 
@@ -8,7 +9,7 @@ namespace c10 {
 namespace impl {
 
 // This is a private class used inside the Dispatcher to represent an operator
-// and it's dispatch table. This is not part of the public API.
+// and its dispatch table. This is not part of the public API.
 class OperatorEntry final {
 public:
   explicit OperatorEntry(FunctionSchema&& schema);
@@ -32,6 +33,10 @@ public:
 
   RegistrationHandleRAII registerKernel(TensorTypeId dispatch_key, DispatchTableEntry kernel);
   RegistrationHandleRAII registerCatchallKernel(DispatchTableEntry kernel);
+
+  OperatorOptions& options() {
+    return options_;
+  }
 
 private:
   void deregisterKernel_(TensorTypeId dispatch_key, std::list<DispatchTableEntry>::iterator kernel);
@@ -75,6 +80,9 @@ private:
     std::list<DispatchTableEntry> // catch-all kernels
   > kernels_;
   std::mutex kernelsMutex_; // protects kernels_
+
+  // Some metadata about the operator
+  OperatorOptions options_;
 
   // This function re-establishes the invariant that dispatchTable
   // contains the front element from the kernels list for a given dispatch key.

--- a/aten/src/ATen/core/dispatch/OperatorOptions.h
+++ b/aten/src/ATen/core/dispatch/OperatorOptions.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+
+namespace c10 {
+namespace impl {
+class OperatorEntry;
+}
+
+enum class AliasAnalysisKind : uint8_t {
+  DEFAULT, // The most conservative alias analysis type, assumes side-effects
+  PURE
+};
+
+struct OperatorOptions final {
+public:
+  AliasAnalysisKind aliasAnalysis() const {
+    return aliasAnalysisKind_;
+  }
+
+  void setAliasAnalysis(AliasAnalysisKind v) {
+    aliasAnalysisKind_ = v;
+  }
+
+private:
+  AliasAnalysisKind aliasAnalysisKind_ = AliasAnalysisKind::DEFAULT;
+};
+
+} // namespace c10


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21085 Remove old custom op implementation&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15542261/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21084 Add aliasAnalysis to torch::RegisterOperators()&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15542097/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21181 c10::OperatorOptions**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15569897/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21079 registration options should only be callable on rvalues&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15541583/)

Implement c10::OperatorOptions as a class to store metadata about operators.
This is meant to replace torch::jit::OperatorOptions.

Differential Revision: [D15569897](https://our.internmc.facebook.com/intern/diff/D15569897/)