### PR TITLE
[jit] on import, register class before defining it

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15673,6 +15673,39 @@ class TestClassType(JitTestCase):
         output = m_loaded(input)
         self.assertEqual(input, output)
 
+    def test_save_load_with_classes_returned(self):
+        @torch.jit.script
+        class FooTest(object):
+            def __init__(self, x):
+                self.x = x
+
+            def clone(self):
+                clone = FooTest(self.x)
+                return clone
+
+        class MyMod(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, a):
+                foo = FooTest(a)
+                foo_clone = foo.clone()
+                return foo_clone.x
+
+        m = MyMod()
+
+        buffer = io.BytesIO()
+        torch.jit.save(m, buffer)
+
+        # classes are globally registered for now, so we need to clear the JIT
+        # registry to simulate loading a new model
+        torch._C._jit_clear_class_registry()
+
+        buffer.seek(0)
+        m_loaded = torch.jit.load(buffer)
+
+        input = torch.rand(2, 3)
+        output = m_loaded(input)
+        self.assertEqual(input, output)
+
     def test_save_load_with_classes_nested(self):
         @torch.jit.script  # noqa: B903
         class FooNestedTest(object):

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -194,12 +194,12 @@ struct SourceImporter {
           class_qualifier + "." + class_def.name().name();
       auto class_type =
           ClassType::create(c10::QualifiedName(qualified_classname), cu);
+      owner.register_class(class_type);
       auto self = [&](Value* v) {
         v->setType(class_type);
         return std::make_shared<SimpleValue>(v);
       };
       cu->define(definitions, resolvers, self);
-      owner.register_class(class_type);
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21182 [jit] on import, register class before defining it**

This allows classes to refer to themselves in the serialized model
format.

Differential Revision: [D15571334](https://our.internmc.facebook.com/intern/diff/D15571334)