### PR TITLE
[jit] avoid multiple writes to files on export

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -365,6 +365,8 @@ class JitTestCase(TestCase):
 
                 # crack open the zip format to get at the main module code
                 archive = zipfile.ZipFile(buffer)
+                # check that we have no duplicate names
+                self.assertEqual(len(set(archive.namelist())), len(archive.namelist()))
                 main_module = archive.open('archive/code/archive.py')
                 main_module_code = ""
                 for line in main_module:

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -607,10 +607,16 @@ void ScriptModuleSerializer::writeLibs(torch::ModelDef* model_def) {
 
   // Write out the files. We still have to do this in converted_classes_ order,
   // to maintain dependency order.
+  std::unordered_set<std::string> written_files;
   for (const auto& item : converted_classes_) {
     const ClassTypePtr& class_type = item.key();
     const std::string filename =
         ImportExportHelpers::qualifierToPath(class_type->qualifier());
+    if (written_files.count(filename)) {
+      continue;
+    }
+    written_files.insert(filename);
+
     const std::string& src = fileToSrc.at(filename).str();
 
     std::ostringstream lib_stream;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21186 [jit] avoid multiple writes to files on export**

Don't write the same file multiple times. This doesn't have any
observable effect on model loading, but it makes running unzip manually
confusing (since it will try to unzip multiple files with the same name
and ask whether to overwrite them).

Differential Revision: [D15581527](https://our.internmc.facebook.com/intern/diff/D15581527)