### PR TITLE
replace `num_bits` with `quant_min` and `quant_max` (#21097)

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_per_tensor_affine.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_per_tensor_affine.cu
@@ -11,7 +11,8 @@ Args:
   X: Forward input tensor.
   scale: scale of per tensor affine quantization
   zero_point: zero_point of per tensor affine quantization
-  num_bits: Number of quantization bits.
+  quant_min: minimum quantized value
+  quant_max: maximum quantized value
   quant_delay: Count of global steps for which to delay the quantization.
                See note below.
   iter: The current quantization iteration used for `quant_delay`.
@@ -21,7 +22,7 @@ Returns:
 Notes:
   - quant_delay might be set to non-zero to help weights stabilize in the
     beginning of the training.
-  - quantization range [0, 2^bits - 1]
+  - quantization range [quant_min, quant_max]
 */
 class FakeQuantizePerTensorAffineOp_forward : public c10::OperatorKernel {
  public:
@@ -29,15 +30,16 @@ class FakeQuantizePerTensorAffineOp_forward : public c10::OperatorKernel {
       at::Tensor X,
       double scale,
       int64_t zero_point,
-      int64_t num_bits = 8,
+      int64_t quant_min = 0,
+      int64_t quant_max = 255,
       int64_t quant_delay = 0,
       int64_t iter = 0
     ) {
     // Sanity checks.
     TORCH_CHECK(X.is_cuda());
     TORCH_CHECK(X.scalar_type() == ScalarType::Float);
-    if (num_bits > 32 || num_bits < 1) {
-      throw std::invalid_argument("`num_bits` should be in the [1, 32] range.");
+    if (quant_min > quant_max) {
+      throw std::invalid_argument("`quant_min` should be less than or equal to `quant_max`.");
     }
     if (zero_point < 0) {
       throw std::invalid_argument("`zero_point` must be a positive integer.");
@@ -59,8 +61,6 @@ class FakeQuantizePerTensorAffineOp_forward : public c10::OperatorKernel {
     }
 
     float inv_scale = 1.0f / scale;
-    const float quant_min = 0;
-    const float quant_max = (1 << num_bits) - 1;
     at::cuda::CUDA_tensor_apply2<float, float>(
         X,
         Y,
@@ -80,7 +80,8 @@ Args:
   dY: Backward input tensor.
   scale: scale of per tensor affine quantization
   zero_point: zero_point of per tensor affine quantization
-  num_bits: Number of quantization bits.
+  quant_min: minimum quantized value
+  quant_max: maximum quantized value
   quant_delay: Count of global steps for which to delay the quantization.
                See note in forward.
   iter: The current quantization iteration used for `quant_delay`.
@@ -90,7 +91,7 @@ Returns:
 Notes:
   - quant_delay might be set to non-zero to help weights stabilize in the
     beginning of the training.
-  - quantization range [0, 2^bits - 1]
+  - quantization range [quant_min, quant_max]
 */
 class FakeQuantizePerTensorAffineOp_backward : public c10::OperatorKernel {
  public:
@@ -99,14 +100,15 @@ class FakeQuantizePerTensorAffineOp_backward : public c10::OperatorKernel {
       at::Tensor dY,
       double scale,
       int64_t zero_point,
-      int64_t num_bits = 8,
+      int64_t quant_min = 0,
+      int64_t quant_max = 255,
       int64_t quant_delay = 0,
       int64_t iter = 0) {
     // Sanity checks.
     TORCH_CHECK(X.is_cuda());
     TORCH_CHECK(X.scalar_type() == ScalarType::Float);
-    if (num_bits > 32 || num_bits < 1) {
-      throw std::invalid_argument("`num_bits` should be in the [1, 32] range.");
+    if (quant_min > quant_max) {
+      throw std::invalid_argument("`quant_min` should be less than or equal to `quant_max`.");
     }
     if (zero_point < 0) {
       throw std::invalid_argument("`zero_point` must be a positive integer.");
@@ -133,8 +135,6 @@ class FakeQuantizePerTensorAffineOp_backward : public c10::OperatorKernel {
     }
 
     float inv_scale = 1.0f / scale;
-    const float quant_min = 0;
-    const float quant_max = (1 << num_bits) - 1;
     auto mask = at::empty_like(dY);
     at::cuda::CUDA_tensor_apply2<float, float>(
         X,
@@ -152,10 +152,10 @@ class FakeQuantizePerTensorAffineOp_backward : public c10::OperatorKernel {
 
 static auto registry =
   c10::RegisterOperators()
-  .op("quantized::fake_quantize_per_tensor_affine_forward(Tensor X, float scale, int zero_point, int num_bits = 8, int quant_delay = 0, int iter = 0) -> Tensor",
+  .op("quantized::fake_quantize_per_tensor_affine_forward(Tensor X, float scale, int zero_point, int quant_min = 0, int quant_max = 255, int quant_delay = 0, int iter = 0) -> Tensor",
       c10::RegisterOperators::options()
       .kernel<FakeQuantizePerTensorAffineOp_forward>(CUDATensorId()))
-  .op("quantized::fake_quantize_per_tensor_affine_backward(Tensor X, Tensor dY, float scale, int zero_point, int num_bits=8, int quant_delay=0, int iter = 0) -> Tensor",
+  .op("quantized::fake_quantize_per_tensor_affine_backward(Tensor X, Tensor dY, float scale, int zero_point, int quant_min = 0, int quant_max = 255, int quant_delay = 0, int iter = 0) -> Tensor",
       c10::RegisterOperators::options()
       .kernel<FakeQuantizePerTensorAffineOp_backward>(CUDATensorId()));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21189 Honor OMP/MKL environment variables in AT_PARALLEL_NATIVE case
* **#21188 replace `num_bits` with `quant_min` and `quant_max` (#21097)**

Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/21097

att

Differential Revision: D15547166

fbshipit-source-id: 60bc7f7d82c424558b67881627fb74f1eff515af