### PR TITLE
Improve build docs and process for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,17 +212,39 @@ If the version of Visual Studio 2017 is higher than 15.4.5, installing of "VC++ 
 NVTX is a part of CUDA distributive, where it is called "Nsight Compute". For installing it onto already installed CUDA run CUDA installation once again and check the corresponding checkbox.
 Be sure that CUDA with Nsight Compute is installed after Visual Studio 2017.
 
+Currently VS 2017, VS 2019 and Ninja are supported as the generator of CMake. If `ninja.exe` is detected in `PATH`, then Ninja will be used as the default generator, otherwise it will use VS 2017.
+<br/> If Ninja is selected as the generator, the latest MSVC which is newer than VS 2015 (14.0) will get selected as the underlying toolchain if you have Python > 3.5, otherwise VS 2015 will be selected so you'll have to activate the environment. If you use CMake <= 3.14.2 and has VS 2019 installed, then even if you specify VS 2017 as the generator, VS 2019 will get selected as the generator.
+
+CUDA and MSVC has strong version dependencies, so even if you use VS 2017 / 2019, you will get build errors like `nvcc fatal : Host compiler targets unsupported OS`. For this kind of problem, please install the corresponding VS toolchain in the table below and then you can either specify the toolset during activation (recommended) or set `CUDAHOSTCXX` to override the cuda host compiler (not recommended if there are big version differences).
+
+| CUDA version | Newest supported VS version                             |
+| ------------ | ------------------------------------------------------- |
+| 9.0 / 9.1    | Visual Studio 2017 Update 4 (15.4) (`_MSC_VER` <= 1911) |
+| 9.2          | Visual Studio 2017 Update 5 (15.5) (`_MSC_VER` <= 1912) |
+| 10.0         | Visual Studio 2017 (15.X) (`_MSC_VER` < 1920)           |
+| 10.1         | Visual Studio 2019 (16.X) (`_MSC_VER` < 1930)           |
+
 ```cmd
 cmd
-REM [Optional] The following two lines are needed for Python 2.7, but the support for it is very experimental.
+:: [Optional] Only add the next two lines if you need Python 2.7. If you use Python 3, ignore these two lines.
 set MSSdk=1
 set FORCE_PY27_BUILD=1
 
-set CMAKE_GENERATOR=Visual Studio 15 2017 Win64
-set DISTUTILS_USE_SDK=1
+:: [Optional] If you want to build with VS 2019 generator, please change the value in the next line to `Visual Studio 16 2019`.
+:: Note: This value is useless if Ninja is detected. However, you can force that by using `set USE_NINJA=OFF`.
+set CMAKE_GENERATOR=Visual Studio 15 2017
 
-REM Run "Visual Studio 2017 Developer Command Prompt"
-for /f "usebackq tokens=*" %i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version [15^,16^) -products * -latest -property installationPath`) do call "%i\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.11
+:: Read the content in the previous section carefully before you preceed.
+:: [Optional] If you want to override the underlying toolset used by Ninja and Visual Studio with CUDA, please run the following script block.
+:: "Visual Studio 2017 Developer Command Prompt" will be run automatically.
+:: Make sure you have CMake >= 3.12 before you do this when you use the Visual Studio generator.
+:: It's an essential step if you use Python 3.5.
+set CMAKE_GENERATOR_TOOLSET_VERSION=14.11
+set DISTUTILS_USE_SDK=1
+for /f "usebackq tokens=*" %i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version [15^,16^) -products * -latest -property installationPath`) do call "%i\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=%CMAKE_GENERATOR_TOOLSET_VERSION%
+
+:: [Optional] If you want to override the cuda host compiler
+set CUDAHOSTCXX=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.11.25503\bin\HostX64\x64\cl.exe
 
 python setup.py install
 

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -15,7 +15,11 @@ if NOT DEFINED BUILD_BINARY (
 )
 
 if NOT DEFINED BUILD_SHARED_LIBS (
-  set BUILD_SHARED_LIBS=OFF
+  :: On CI, we test with BUILD_SHARED_LIBS=OFF.
+  :: By default, it will be BUILD_SHARED_LIBS=ON.
+  if NOT DEFINED BUILD_ENVIRONMENT (
+    set BUILD_SHARED_LIBS=OFF
+  )
 )
 
 IF NOT DEFINED BUILDING_WITH_TORCH_LIBS (
@@ -51,22 +55,7 @@ if NOT DEFINED MSVC_Z7_OVERRIDE (
 )
 
 if NOT DEFINED CMAKE_GENERATOR (
-  if DEFINED APPVEYOR_BUILD_WORKER_IMAGE (
-    if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" (
-      set CMAKE_GENERATOR="Visual Studio 15 2017 Win64"
-    ) else if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" (
-      set CMAKE_GENERATOR="Visual Studio 14 2015 Win64"
-    ) else (
-      echo "You made a programming error: unknown APPVEYOR_BUILD_WORKER_IMAGE:"
-      echo %APPVEYOR_BUILD_WORKER_IMAGE%
-      exit /b
-    )
-  ) else (
-    :: In default we use win64 VS 2015.
-    :: Main reason is that currently, cuda 9 does not support VS 2017 newest
-    :: version. To use cuda you will have to use 2015.
-    set CMAKE_GENERATOR="Visual Studio 15 2017 Win64"
-  )
+  set CMAKE_GENERATOR=Visual Studio 15 2017
 )
 
 :: Install pyyaml for Aten codegen


### PR DESCRIPTION
Fixes #21026.
1. Improve build docs for Windows
2. Change `BUILD_SHARED_LIBS=ON` for Caffe2 local builds
3. Change to out-source builds for LibTorch and Caffe2 (transferred to #21452)