### PR TITLE
Fix wrong type hints for Tensor.is_cuda, is_leaf

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -431,8 +431,8 @@ def gen_pyi(declarations_path, out):
                  ' -> Union[str, Tensor]: ...'],
         'get_device': ['def get_device(self) -> _int: ...'],
         'is_contiguous': ['def is_contiguous(self) -> bool: ...'],
-        'is_cuda': ['def is_cuda(self) -> bool: ...'],
-        'is_leaf': ['def is_leaf(self) -> bool: ...'],
+        'is_cuda': ['is_cuda: bool'],
+        'is_leaf': ['is_leaf: bool'],
         'storage_offset': ['def storage_offset(self) -> _int: ...'],
         'to': ['def to(self, dtype: _dtype, non_blocking: bool=False, copy: bool=False) -> Tensor: ...',
                'def to(self, device: Optional[Union[_device, str]]=None, dtype: Optional[_dtype]=None, '


### PR DESCRIPTION
`Tensor.is_cuda` and `is_leaf` is not a predicate function but a `bool` attribute. This patch fixes the type hints in `torch/__init__.pyi` for those attributes.

```diff
- def is_cuda(self) -> bool: ...
+ is_cuda: bool
- def is_leaf(self) -> bool: ...
+ is_leaf: bool
```