### PR TITLE
Expunge some more deprecated uses of AT_CHECK.

### DIFF
--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -67,7 +67,7 @@ Tensor contiguous(const Tensor& self, MemoryFormat memory_format) {
       break;
     }
     case MemoryFormat::ChannelsLast: {
-      AT_CHECK(
+      TORCH_CHECK(
           result.dim() == 4,
           " required rank 4 tensor to use channels_last format");
       std::vector<int64_t> newStrides(self.dim());
@@ -80,7 +80,7 @@ Tensor contiguous(const Tensor& self, MemoryFormat memory_format) {
       break;
     }
     default: {
-      AT_CHECK(false, " unsupported memory format");
+      TORCH_CHECK(false, " unsupported memory format");
     }
   }
   return result.copy_(self);

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -161,7 +161,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
     
     // tensor is not well formed as it has 0 sized dimensions
     if (self.size(dim) == 0){
-      AT_CHECK(
+      TORCH_CHECK(
           num_zero_dims == 1,
           "Number of zero sized dimensions is more than one, so unique cannot be applied ")
       Tensor output = at::empty({0}, self.options());
@@ -172,7 +172,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
       return std::make_tuple(output, inverse_indices, counts);
     }
     
-    AT_CHECK(num_zero_dims == 0,
+    TORCH_CHECK(num_zero_dims == 0,
     "There are 0 sized dimensions, and they aren't selected, so unique cannot be applied");
   
   // reshape tensor as [dim, -1]

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -145,7 +145,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_dim_cuda_template(
   
   // tensor is not well formed as it has 0 sized dimensions
   if (self.size(dim) == 0){
-    AT_CHECK(
+    TORCH_CHECK(
         num_zero_dims == 1,
         "Number of zero sized dimensions is more than one, so unique cannot be applied ")
     Tensor output = at::empty({0}, self.options());
@@ -156,7 +156,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_dim_cuda_template(
     return std::make_tuple(output, inverse_indices, counts);
   }
 
-  AT_CHECK(num_zero_dims == 0,
+  TORCH_CHECK(num_zero_dims == 0,
     "There are 0 sized dimensions, and they aren't selected, so unique cannot be applied");
 
   int64_t num_inp = self.size(dim);

--- a/aten/src/ATen/templates/LegacyTHFunctions.cpp
+++ b/aten/src/ATen/templates/LegacyTHFunctions.cpp
@@ -19,7 +19,7 @@ namespace {
     return t.scalar_type();
   }
   ScalarType infer_scalar_type(const TensorList & tl) {
-    AT_CHECK(tl.size() > 0, "expected a non-empty list of Tensors");
+    TORCH_CHECK(tl.size() > 0, "expected a non-empty list of Tensors");
     return tl[0].scalar_type();
   }
 

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -700,12 +700,12 @@ bool ScriptModuleSerializer::moduleHasValidGetSetState(
 
   // Check __getstate__
   //   __getstate__ is expected to be (self) -> T
-  AT_CHECK(
+  TORCH_CHECK(
       get_schema.arguments().size() == 1,
       "'__getstate__' must have 'self' as its only argument, but found ",
       get_schema.arguments().size(),
       " arguments");
-  AT_CHECK(
+  TORCH_CHECK(
       get_schema.returns().size() == 1,
       "'__getstate__' must return 1 value, but found ",
       get_schema.returns().size());
@@ -719,18 +719,18 @@ bool ScriptModuleSerializer::moduleHasValidGetSetState(
   }
   auto set_schema = setstate->getSchema();
 
-  AT_CHECK(
+  TORCH_CHECK(
       set_schema.arguments().size() == 2,
       "'__setstate__' must have 'self' and the state as its "
       "only arguments, but found ",
       set_schema.arguments().size(),
       " arguments");
-  AT_CHECK(
+  TORCH_CHECK(
       set_schema.returns().size() == 1,
       "'__setstate__' must return None, but found ",
       set_schema.returns().size(),
       " return values");
-  AT_CHECK(
+  TORCH_CHECK(
       set_schema.returns().at(0).type()->isSubtypeOf(NoneType::get()),
       "'__setstate__' must return None, but found value of type",
       set_schema.returns().at(0).type()->python_str());
@@ -740,7 +740,7 @@ bool ScriptModuleSerializer::moduleHasValidGetSetState(
   auto get_type = get_schema.returns().at(0).type();
   auto set_type = set_schema.arguments().at(1).type();
 
-  AT_CHECK(
+  TORCH_CHECK(
       set_type->isSubtypeOf(get_type),
       "'__getstate__'s return type (",
       get_type->python_str(),
@@ -754,7 +754,7 @@ bool ScriptModuleSerializer::moduleHasValidGetSetState(
 /// Run module.__getstate__() and return the result
 IValue ScriptModuleSerializer::moduleGetState(const script::Module& module) {
   auto getstate = module.find_method("__getstate__");
-  AT_CHECK(
+  TORCH_CHECK(
       getstate != nullptr,
       "Cannot call '__getstate__' method because"
       " it does not exist");

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -267,7 +267,7 @@ void ScriptModuleDeserializer::moduleSetState(
     IValue state) {
   auto setstate = module->class_compilation_unit().find_function("__setstate__");
 
-  AT_CHECK(
+  TORCH_CHECK(
       setstate != nullptr,
       "Cannot call '__setstate__' method because"
       " it does not exist");
@@ -341,7 +341,7 @@ void ScriptModuleDeserializer::convertModule(
     // Verify that all the non-optional attributes have been initialized
     // TODO: Issue #20497
     if (slot.type()->kind() != TypeKind::OptionalType) {
-      AT_CHECK(
+      TORCH_CHECK(
           !slot.value().isNone(),
           "The field '",
           slot.name(),

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1436,7 +1436,7 @@ struct to_ir {
           << "range expected at most 3 arguments, got " << args.size();
     }
     const auto& ident_name = target.name();
-    AT_CHECK(
+    TORCH_CHECK(
         end_val != nullptr && start_val != nullptr && step_val != nullptr,
         "Expected non-null pointers for range() arguments");
     auto addOp = [end_val, range](

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -392,7 +392,7 @@ inline c10::optional<at::Device> PythonArgs::deviceOptional(int i) {
 
 inline at::MemoryFormat PythonArgs::toMemoryFormat(int i) {
   if (!args[i]) return at::MemoryFormat::Any;
-  AT_CHECK(THPMemoryFormat_Check(args[i]), "memory_format arg must be an instance of the torch.memory_format");
+  TORCH_CHECK(THPMemoryFormat_Check(args[i]), "memory_format arg must be an instance of the torch.memory_format");
   const auto memory_format = reinterpret_cast<THPMemoryFormat*>(args[i]);
   return memory_format->memory_format;
 }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -221,7 +221,7 @@ Tensor internal_new_from_data(
 
 #ifdef USE_NUMPY
   if (PyObject_HasAttrString(data, "__cuda_array_interface__")) {
-    AT_CHECK(!pin_memory, "Can't pin tensor constructed from __cuda_array_interface__");
+    TORCH_CHECK(!pin_memory, "Can't pin tensor constructed from __cuda_array_interface__");
     auto tensor = autograd::make_variable(tensor_from_cuda_array_interface(data), /*requires_grad=*/false);
     const auto& inferred_scalar_type = type_inference ? tensor.scalar_type() : scalar_type;
     auto device = device_opt.has_value() ? *device_opt : at::Device(type.device_type());


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21195 Turn on Werror for deprecated-declarations.&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15576968/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21194 Expunge some more deprecated uses of AT_CHECK.**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15576898/)

Pull Request resolved: https://github.com/pytorch/pytorch/pull/21194

Differential Revision: [D15576898](https://our.internmc.facebook.com/intern/diff/D15576898/)