### PR TITLE
Implement various AliasAnalysis operations directly on top of MemoryLocations.

### DIFF
--- a/test/cpp/jit/test_alias_analysis.h
+++ b/test/cpp/jit/test_alias_analysis.h
@@ -826,16 +826,6 @@ void testMemoryDAG() {
     ASSERT_TRUE(t.mayAlias(e, f));
     // But a and f don't alias
     ASSERT_FALSE(t.mayAlias(a, f));
-
-    /**
-     * Test mayAlias() set interface
-     */
-    std::multiset<const Element*> foo{c, c, d};
-    std::multiset<const Element*> bar{e, f};
-    std::unordered_set<const Element*> baz{f, g};
-    ASSERT_TRUE(t.mayAlias(foo, bar));
-    ASSERT_TRUE(t.mayAlias(bar, baz));
-    ASSERT_FALSE(t.mayAlias(foo, baz));
   }
 
   {

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -162,14 +162,14 @@ void AliasDb::dump() const {
     if (!element->pointsTo.empty()) {
       std::cout << getElementName(element) << " points to: ";
       for (const auto pointedTo : element->pointsTo) {
-        std::cout << getElementName(Element::fromIndex(pointedTo)) << ", ";
+        std::cout << getElementName(memoryDAG_->fromIndex(pointedTo)) << ", ";
       }
       std::cout << "\n";
     }
     if (!element->contained_elements.empty()) {
       std::cout << getElementName(element) << " contains: ";
       for (const auto contained : element->contained_elements) {
-        std::cout << getElementName(Element::fromIndex(contained)) << ", ";
+        std::cout << getElementName(memoryDAG_->fromIndex(contained)) << ", ";
       }
       std::cout << "\n";
     }
@@ -532,7 +532,7 @@ void AliasDb::analyzeWait(Node* node) {
     const auto el = pr.second;
     const auto& pointedFrom = el->pointedFrom;
     TORCH_INTERNAL_ASSERT(!pointedFrom.empty());
-    const auto wildcardValue = Element::fromIndex(*pointedFrom.begin())->value;
+    const auto wildcardValue = memoryDAG_->fromIndex(*pointedFrom.begin())->value;
     TORCH_INTERNAL_ASSERT(wildcardValue);
     registerWrite(wildcardValue, node);
   }

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -110,8 +110,54 @@ void AliasDb::getWritesImpl(Node* n, ValueSet& ret, bool recurseBlocks) const {
 // Does `n` write to an alias of one of the values in `vs`?
 bool AliasDb::writesToAlias(Node* n, const ValueSet& vs, bool recurseBlocks)
     const {
-  const auto writtenTo = getWrites(n, recurseBlocks);
-  return mayAlias(vs, writtenTo);
+  c10::SmallVector<Node*, 4> stack;
+  stack.push_back(n);
+
+  // Depth-first search to accumulate memory locations aliased
+  // by `n`.
+  MemoryLocations nMemLocs;
+  while (!stack.empty()) {
+    auto node = stack.back();
+    stack.pop_back();
+
+    // Accumulate memory locations
+    auto I = writeIndex_.find(node);
+    if (I != writeIndex_.end()) {
+      const auto& writes = I->second;
+      for (const auto write : writes) {
+        if (elementMap_.count(write)) {
+          auto element = elementMap_.at(write);
+          nMemLocs |= element->getMemoryLocations();
+        }
+      }
+    }
+
+    // Explore sub-blocks
+    if (recurseBlocks) {
+      for (auto block : n->blocks()) {
+        for (auto subnode : block->nodes()) {
+          stack.push_back(subnode);
+        }
+      }
+    }
+  }
+
+  // Bail if the intersection will be trivially false.
+  if (nMemLocs.empty()) {
+    return false;
+  }
+
+  // Test against each member of vs
+  for (auto value : vs) {
+    if (elementMap_.count(value)) {
+      auto element = elementMap_.at(value);
+      if (nMemLocs.intersects(element->getMemoryLocations())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 std::unordered_set<const Value*> AliasDb::getWrites(Node* n, bool recurseBlocks)

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -105,7 +105,7 @@ class AliasDb {
 
       do {
         ++it;
-      } while (it != a.cend() && *it == value);
+      } while (it != b.cend() && *it == value);
     }
     // No overlap, so group `a` and `b` do not share a memory location
     return false;

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -78,21 +78,37 @@ class AliasDb {
       return false;
     }
 
-    T<Element*> aElements;
-    for (const Value* v : a) {
-      if (elementMap_.count(v)) {
-        aElements.insert(elementMap_.at(v));
+    // Record all memory locations from group `a`
+    MemoryLocations memoryLocations;
+    for (auto it = a.cbegin(); it != a.cend();) {
+      const auto value = *it;
+      if (elementMap_.count(value)) {
+        auto element = elementMap_.at(value);
+        memoryLocations |= element->getMemoryLocations();
       }
+
+      do {
+        ++it;
+      } while (it != a.cend() && *it == value);
     }
 
-    U<Element*> bElements;
-    for (const Value* v : b) {
-      if (elementMap_.count(v)) {
-        bElements.insert(elementMap_.at(v));
-      }
-    }
+    // If any of group `b`s memory locations overlap, return true.
+    for (auto it = b.cbegin(); it != b.cend();) {
+      const auto value = *it;
+      if (elementMap_.count(value)) {
+        auto element = elementMap_.at(value);
 
-    return memoryDAG_->mayAlias(aElements, bElements);
+        if (memoryLocations.intersects(element->getMemoryLocations())) {
+          return true;
+        }
+      }
+
+      do {
+        ++it;
+      } while (it != a.cend() && *it == value);
+    }
+    // No overlap, so group `a` and `b` do not share a memory location
+    return false;
   }
 
   // Do any nodes write to an alias set inputed/outputed by `n`?

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -7,18 +7,13 @@
 
 namespace torch {
 namespace jit {
-namespace {
-std::vector<const Element*> indexToElementMap;
-} // namespace
-unsigned Element::indexCount = 0;
-Element::Element(const Value* value_) : value(value_), index(indexCount++) {
-  indexToElementMap.push_back(this);
-}
 
-const Element* Element::fromIndex(unsigned x) {
+Element::Element(MemoryDAG& dag_, const Value* value_, int index_)
+  : dag(dag_), value(value_), index(index_) { }
+
+const Element* MemoryDAG::fromIndex(int x) const {
   TORCH_INTERNAL_ASSERT(x < indexToElementMap.size());
-  auto res = indexToElementMap[x];
-  return res;
+  return indexToElementMap[x].get();
 }
 
 bool MemoryDAG::mayAlias(Element* a, Element* b) const {
@@ -44,9 +39,9 @@ bool MemoryDAG::mayContainAlias(Element* a, Element* b) const {
   return mayContainAliasImpl(a, b);
 }
 
-void collectAllContainedMemoryLocations(
+void MemoryDAG::collectAllContainedMemoryLocations(
     const Element* elem,
-    MemoryLocations& cont) {
+    MemoryLocations& cont) const {
   // we have already recursed on this element
   unsigned compIdx = elem->index;
   if (cont.test(compIdx)) {
@@ -55,11 +50,11 @@ void collectAllContainedMemoryLocations(
   cont.set(compIdx);
 
   for (const auto& mem_loc : elem->getMemoryLocations()) {
-    collectAllContainedMemoryLocations(Element::fromIndex(mem_loc), cont);
+    collectAllContainedMemoryLocations(fromIndex(mem_loc), cont);
   }
 
   for (const auto& contained : elem->contained_elements) {
-    collectAllContainedMemoryLocations(Element::fromIndex(contained), cont);
+    collectAllContainedMemoryLocations(fromIndex(contained), cont);
   }
 }
 
@@ -105,11 +100,9 @@ void MemoryDAG::addToContainedElements(Element* elem, Element* container) {
 
 // Give `v` a fresh alias (i.e. it does not point to any value)
 Element* MemoryDAG::makeFreshValue(const Value* v) {
-  auto el = torch::make_unique<Element>(v);
-
-  auto rawPtr = el.get();
-  elements_.emplace(rawPtr, std::move(el));
-  return rawPtr;
+  indexToElementMap.emplace_back(
+    torch::make_unique<Element>(*this, v, indexToElementMap.size()));
+  return indexToElementMap.back().get();
 }
 
 const MemoryLocations& Element::getMemoryLocations() const {
@@ -134,7 +127,7 @@ void Element::bfs(BfsDirection dir, MemoryLocations& res) const {
     const auto index = queue.front();
     queue.pop();
     seen.insert(index);
-    auto el = Element::fromIndex(index);
+    auto el = dag.fromIndex(index);
     if (el->pointsTo.empty()) {
       res.set(index);
     }

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -8,10 +8,10 @@
 namespace torch {
 namespace jit {
 
-Element::Element(MemoryDAG& dag_, const Value* value_, int index_)
+Element::Element(MemoryDAG& dag_, const Value* value_, unsigned index_)
   : dag(dag_), value(value_), index(index_) { }
 
-const Element* MemoryDAG::fromIndex(int x) const {
+const Element* MemoryDAG::fromIndex(unsigned x) const {
   TORCH_INTERNAL_ASSERT(x < indexToElementMap.size());
   return indexToElementMap[x].get();
 }

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -10,7 +10,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 // Uses a compressed index representation for faster comparisons
-typedef c10::SparseBitVector<128> MemoryLocations;
+typedef c10::SparseBitVector<256> MemoryLocations;
 namespace torch {
 namespace jit {
 
@@ -62,48 +62,19 @@ class TORCH_API MemoryDAG {
       const at::ArrayRef<Element*>& a,
       const at::ArrayRef<Element*>& b) const;
 
-  // Do any values in group `a` potentially share a memory location with any
-  // value in group `b`?
-  //
-  // This is written so that either of the inputs could be a multiset
-  template <typename T, typename U>
-  bool mayAlias(const T& a, const U& b) const {
-    if (a.empty() || b.empty()) {
-      return false;
-    }
-
-    // Record all memory locations from group `a`
-    MemoryLocations memoryLocations;
-    for (auto it = a.cbegin(); it != a.cend();) {
-      const auto element = *it;
-
-      memoryLocations |= element->getMemoryLocations();
-
-      const auto cnt = a.count(*it);
-      std::advance(it, cnt);
-    }
-
-    // If any of group `b`s memory locations overlap, return true.
-    for (auto it = b.cbegin(); it != b.cend();) {
-      const auto element = *it;
-      if (memoryLocations.intersects(element->getMemoryLocations())) {
-        return true;
-      }
-
-      const auto cnt = b.count(*it);
-      std::advance(it, cnt);
-    }
-    // No overlap, so group `a` and `b` do not share a memory location
-    return false;
-  }
+  // Converts from the compressed index representation
+  const Element* fromIndex(int x) const;
 
  private:
   bool mayAliasImpl(const Element* a, const Element* b) const;
   bool mayContainAliasImpl(const Element* contained, const Element* container)
       const;
-  // Structure that owns all the element pointers. It's a map of
-  //  raw pointer -> unique_ptr to facilitate easy queries
-  std::unordered_map<Element*, std::unique_ptr<Element>> elements_;
+  void collectAllContainedMemoryLocations(
+    const Element* elem, MemoryLocations& cont) const;
+
+  std::vector<std::unique_ptr<Element>> indexToElementMap;
+
+  friend class AliasDB;
 };
 
 enum class BfsDirection {
@@ -115,6 +86,8 @@ enum class BfsDirection {
 // anything that could have an aliasing relationship, mostly IR `Value`s, but
 // also the "inside of a list", or wildcards.
 struct Element {
+  MemoryDAG& dag;
+
   // The value that this element corresponds to. May be null if this element
   // doesn't represent a first-class value.
   const Value* value = nullptr;
@@ -126,9 +99,8 @@ struct Element {
   MemoryLocations pointedFrom;
 
   MemoryLocations contained_elements;
-  static unsigned indexCount;
-  signed index;
-  Element(const Value* value_);
+  int index;
+  Element(MemoryDAG& dag_, const Value* value_, int index_);
 
   // Return the unique memory locations that `Element` might represent.
   TORCH_API const MemoryLocations& getMemoryLocations() const;
@@ -140,9 +112,6 @@ struct Element {
   // Do a breadth-first search over the graph, starting at `this` and
   // traversing in the direction `dir`.`fn` will be run on each element.
   void bfs(BfsDirection dir, MemoryLocations& res) const;
-
-  // Converts from the compressed index representation
-  static const Element* fromIndex(unsigned x);
 };
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -63,7 +63,7 @@ class TORCH_API MemoryDAG {
       const at::ArrayRef<Element*>& b) const;
 
   // Converts from the compressed index representation
-  const Element* fromIndex(int x) const;
+  const Element* fromIndex(unsigned x) const;
 
  private:
   bool mayAliasImpl(const Element* a, const Element* b) const;
@@ -99,8 +99,8 @@ struct Element {
   MemoryLocations pointedFrom;
 
   MemoryLocations contained_elements;
-  int index;
-  Element(MemoryDAG& dag_, const Value* value_, int index_);
+  unsigned index;
+  Element(MemoryDAG& dag_, const Value* value_, unsigned index_);
 
   // Return the unique memory locations that `Element` might represent.
   TORCH_API const MemoryLocations& getMemoryLocations() const;


### PR DESCRIPTION
This reduces DenseNet load time by about 25% (down to 5.3s on my laptop) and gets AliasAnalysis out of the profile top hits entirely.