### PR TITLE
introduce a new interface to add a list of operators

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -135,6 +135,37 @@ def config_list(**configs):
     return generated_configs
 
 
+def op_list(**configs):
+    """Generate a list of ops organized in a specific format.
+       It takes two parameters which are "attr_names" and "attr". 
+       attrs stores the name and function of operators. 
+       Args: 
+           configs: key-value pairs including the name and function of 
+           operators. attrs and attr_names must be present in configs. 
+       Return: 
+           a sequence of dictionaries which stores the name and function 
+           of ops in a specifal format
+       Example:
+       attrs = [
+           ["abs", torch.abs],
+           ["abs_", torch.abs_],
+       ]
+       attr_names = ["op_name", "op"].
+
+       With those two examples, 
+       we will generate (({"op_name": "abs"}, {"op" : torch.abs}),
+                         ({"op_name": "abs_"}, {"op" : torch.abs_}))
+    """
+    generated_configs = []
+    if "attrs" not in configs:
+        raise ValueError("Missing attrs in configs")
+    for inputs in configs["attrs"]:
+        tmp_result = {configs["attr_names"][i] : input_value
+                      for i, input_value in enumerate(inputs)}
+        generated_configs.append(tmp_result)
+    return generated_configs
+
+
 def is_caffe2_enabled(framework_arg):
     return 'Caffe2' in framework_arg
 

--- a/benchmarks/operator_benchmark/ops/tests/add_ops_list_test.py
+++ b/benchmarks/operator_benchmark/ops/tests/add_ops_list_test.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import operator_benchmark as op_bench
+import torch
+
+
+# Configs for pointwise unary ops
+unary_ops_configs = op_bench.config_list(
+    attrs=[
+        [128, 128],
+    ],
+    attr_names=["M", "N"],
+    tags=["short"]
+)
+
+
+unary_ops_list = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["abs", torch.abs],
+        ["acos", torch.acos],
+    ],
+)
+
+
+class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, op_func): 
+        self.input_one = torch.rand(M, N)
+        self.op_func = op_func
+
+    def forward(self):
+        return self.op_func(self.input_one)
+
+
+op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary:
This diff introduces a new interface to add a list of operators. Here are the steps to add ops using this interface:

- create op_list:
```unary_ops_list = op_bench.op_list(
    attr_names=["op_name", "op"],
    attrs=[
         ["abs", torch.abs],
         ["abs_", torch.abs_],
   ],
)
```
-  create a bench class:
```
class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
    def init(self, M, N):
        self.input_one = torch.rand(M, N)

    def set_op(self, op_name, op):
        self.set_module_name(op_name)
        self.op = op

    def forward(self):
        return self.op(self.input_one)
```
- 3. register those ops
``` op_bench.generate_pt_tests_from_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
 ```

Differential Revision: D15514188

