### PR TITLE
add separate path for op with JIT

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -22,7 +22,7 @@ An example input is:
 TestConfig(test_name='add_M8_N2_K1', input_config='M: 8, N: 2, K: 1', 
     tag='long', run_backward=False)
 """
-TestConfig = namedtuple("TestConfig", "test_name input_config tag run_backward")
+TestConfig = namedtuple("TestConfig", "test_name input_config tag use_jit run_backward")
 
 
 BENCHMARK_TESTER = {}
@@ -111,8 +111,8 @@ class BenchmarkRunner(object):
                      "# Input: {}\n" \
                      "{} Execution Time (us) : {:.3f}\n"
             if test_case.framework == "PyTorch":
-                # FIXME: add JIT 
-                output = "# Mode: Eager\n" + output
+                output = "# Mode: {}\n". \
+                    format("JIT" if test_case.test_config.use_jit else "Eager") + output
             print(output.format(
                 test_case.test_config.test_name,
                 test_case.test_config.input_config,
@@ -135,6 +135,9 @@ class BenchmarkRunner(object):
     def _launch_forward(self, test_case, iters):
         """ Use Python's timeit module to measure execution time (unit: second).
         """
+        func = test_case.run_forward
+        if test_case.test_config.use_jit:
+            func = test_case.run_jit_forward
         forward_time = timeit.timeit(functools.partial(test_case.run_forward, iters), number=1)
         return forward_time
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -63,6 +63,12 @@ class PyTorchOperatorTestCase(object):
         self.op_bench = op_bench
         self.framework = "PyTorch"
 
+    def run_jit_forward(self, num_runs):
+        """ This is a temp solution and will be removed later 
+            Run the forward op with JIT 
+        """
+        self.op_bench.jit_forward(num_runs)
+
     def run_forward(self, num_runs):
         """ TODO (mingzhe): when JIT is ready, switch this to JIT 
             Run the forward path of an op in many iterations

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -33,8 +33,11 @@ def generate_test(configs, bench_op, OperatorTestCase, run_backward):
         op = bench_op()
         op.init(**test_attrs)
         test_name = op.test_name(**test_attrs)
+        use_jit = False
+        if hasattr(op, "jit_forward") and callable(op.jit_forward):
+            use_jit = True
         input_config = str(test_attrs)[1:-1].replace('\'', '')
-        test_config = TestConfig(test_name, input_config, tags, run_backward)
+        test_config = TestConfig(test_name, input_config, tags, use_jit, run_backward)
         if op is not None:
             OperatorTestCase(
                 op,

--- a/benchmarks/operator_benchmark/common/tests/jit_forward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/jit_forward_test.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import operator_benchmark as op_bench
+import torch
+
+intraop_bench_configs = op_bench.config_list(
+    attrs=[
+        [8, 16],
+    ],
+    attr_names=["M", "N"], 
+    tags=["short"], 
+)
+
+@torch.jit.script
+def torch_sumall(a, iterations):
+    # type: (Tensor, int)
+    result = 0.0
+    for _ in range(iterations):
+        result += float(torch.sum(a))
+        a[0][0] += 0.01
+    return result
+
+
+class TorchSumBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N):
+        self.input_one = torch.rand(M, N)
+        self.set_module_name("sum")
+
+    # This is a very temporary method and will be removed soon, so 
+    # don't use this method in your benchmark
+    # TODO(mingzhe): use one forward method for both JIT and Eager 
+    def jit_forward(self, iters):
+        return torch_sumall(self.input_one, iters)
+
+op_bench.generate_pt_test(intraop_bench_configs, TorchSumBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary:
This diff introduces a new path to run op with JIT. There are two steps involved here:
1. Users need to script the op. This should happen in the `init` method.
2. The generated graph from step1 is passed to `jit_forward` which will be executed by the benchmark backend

Differential Revision: D15460831

