### PR TITLE
handle exit from init method

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -176,3 +176,8 @@ def is_pytorch_enabled(framework_arg):
 
 def get_requested_frameworks(framework_arg):
     return [fr.strip() for fr in framework_arg.split(',') if len(fr.strip()) > 0]
+
+
+class SkipInputShape(Exception):
+    """Used when a test case should be skipped"""
+    pass

--- a/benchmarks/operator_benchmark/pt/intraop_test.py
+++ b/benchmarks/operator_benchmark/pt/intraop_test.py
@@ -61,7 +61,7 @@ def tensor_init_helper(N, M, dtype, is_contig):
 class TorchOrTensorBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, M, dtype, contig): 
         if dtype.is_floating_point:
-            raise op_bench.InputShapeError
+            raise op_bench.SkipInputShape
 
         self.input_one = tensor_init_helper(N, M, dtype, contig)
         self.input_two = tensor_init_helper(N, M, dtype, contig)
@@ -97,7 +97,7 @@ def forward(self, a, iterations):
 class TorchTanhBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, M, dtype, contig): 
         if not dtype.is_floating_point:
-            raise op_bench.InputShapeError
+            raise op_bench.SkipInputShape
         self.input_one = tensor_init_helper(N, M, dtype, contig)
         self.set_module_name("tanh_")
         self.tanh_jit = torch_unary('tanh_')
@@ -111,7 +111,7 @@ class TorchSigmoidBenchmark(TorchTanhBenchmark):
     def init(self, N, M, dtype, contig): 
         super(TorchSigmoidBenchmark, self).init(N, M, dtype, contig)
         if not dtype.is_floating_point:
-            raise op_bench.InputShapeError
+            raise op_bench.SkipInputShape
         self.set_module_name("sigmoid_")
         self.sigmoid_jit = torch_unary('sigmoid_')
 
@@ -133,7 +133,7 @@ def torch_sumall(a, iterations):
 class TorchSumBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, N, M, dtype, contig): 
         if not dtype.is_floating_point:
-            raise op_bench.InputShapeError
+            raise op_bench.SkipInputShape
         self.input_one = tensor_init_helper(N, M, dtype, contig)
         self.set_module_name("sum")
 


### PR DESCRIPTION
Summary: There are cases where the `init` method used to create inputs can exit with error. When this happens, that specific input should be skipped.

Differential Revision: D15466410

