### PR TITLE
Fix an incorrect implementation of celu

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -33,12 +33,12 @@ Tensor & selu_(Tensor & self) {
 
 Tensor celu(const Tensor & self, Scalar alpha) {
   double inv_alpha = 1. / alpha.to<double>();
-  return at::elu(self, 1.0, alpha, Scalar(inv_alpha));
+  return at::elu(self, alpha, Scalar(1.0), Scalar(inv_alpha));
 }
 
 Tensor & celu_(Tensor & self, Scalar alpha) {
   double inv_alpha = 1. / alpha.to<double>();
-  return at::elu_(self, 1.0, alpha, Scalar(inv_alpha));
+  return at::elu_(self, alpha, Scalar(1.0), Scalar(inv_alpha));
 }
 
 Tensor rrelu(const Tensor & self, Scalar lower, Scalar upper, bool training, Generator* generator) {

--- a/aten/src/THCUNN/generic/ELU.cu
+++ b/aten/src/THCUNN/generic/ELU.cu
@@ -15,7 +15,7 @@ void THNN_(ELU_updateOutput)(
            bool inplace)
 {
   scalar_t negcoef = ScalarConvert<accreal, scalar_t>::to(alpha * scale);
-  scalar_t poscoef = ScalarConvert<accreal, scalar_t>::to(scale * input_scale);
+  scalar_t poscoef = ScalarConvert<accreal, scalar_t>::to(scale);
   scalar_t negiptcoef = ScalarConvert<accreal, scalar_t>::to(input_scale);
   THCUNN_assertSameGPU(state, 2, input, output);
 
@@ -31,7 +31,6 @@ void THNN_(ELU_updateOutput)(
   }
 }
 
-
 void THNN_(ELU_updateGradInput)(
            THCState *state,
            THCTensor *gradOutput,
@@ -42,7 +41,7 @@ void THNN_(ELU_updateGradInput)(
            accreal input_scale)
 {
   scalar_t negcoef = ScalarConvert<accreal, scalar_t>::to(alpha * scale);
-  scalar_t poscoef = ScalarConvert<accreal, scalar_t>::to(scale * input_scale);
+  scalar_t poscoef = ScalarConvert<accreal, scalar_t>::to(scale);
   scalar_t negiptcoef = ScalarConvert<accreal, scalar_t>::to(input_scale);
   THCUNN_check_nElement(state, output, gradOutput);
   THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);

--- a/aten/src/THNN/generic/ELU.c
+++ b/aten/src/THNN/generic/ELU.c
@@ -11,8 +11,17 @@ void THNN_(ELU_updateOutput)(
           accreal input_scale,
           bool inplace)
 {
+  // https://pytorch.org/docs/stable/nn.html#id30
+  // This elu function is used to implement selu and celu.
+  // elu(x, alpha, scale, input_scale) =
+  //    x <= 0:        (exp(input * input_scale)-1) * alpha * scale
+  //     x > 0:        x * scale
+  // elu: scale = 1, input_scale = 1. default alpha = 1
+  // selu: input scale = 1. default alpha=1.6732.., scale=1.0507...
+  // celu: scale = 1, input_scale = 1/alpha. default alpha = 1
+
   scalar_t negcoef = TH_CONVERT_ACCREAL_TO_REAL(alpha_ * scale);
-  scalar_t poscoef = TH_CONVERT_ACCREAL_TO_REAL(scale * input_scale);
+  scalar_t poscoef = TH_CONVERT_ACCREAL_TO_REAL(scale);
   scalar_t negiptcoef = TH_CONVERT_ACCREAL_TO_REAL(input_scale);
   if (inplace) {
     TH_TENSOR_APPLY(scalar_t, input,
@@ -37,7 +46,7 @@ void THNN_(ELU_updateGradInput)(
           accreal input_scale)
 {
   scalar_t negcoef = TH_CONVERT_ACCREAL_TO_REAL(alpha_ * scale);
-  scalar_t poscoef = TH_CONVERT_ACCREAL_TO_REAL(scale * input_scale);
+  scalar_t poscoef = TH_CONVERT_ACCREAL_TO_REAL(scale);
   scalar_t negiptcoef = TH_CONVERT_ACCREAL_TO_REAL(input_scale);
   THNN_CHECK_NELEMENT(output, gradOutput);
   THTensor_(resizeAs)(gradInput, output);


### PR DESCRIPTION
Fixing an incorrect implementation of the CELU activation function. The existing implementation works by a chance combination of errors that seem to cancel each other out. This change makes the code more readable, aligns the parameter names correctly, and is consistent with the cuda implementation.

I came across this issue while working on version counters... I attempted to specify a gradient in derivatives.yaml for CELU due to a failed test, but the derivative couldn't be specified correctly without fixing the celu implementation.
https://github.com/pytorch/pytorch/pull/20612
