### PR TITLE
Defer error string construction during schema matching

### DIFF
--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -131,7 +131,7 @@ struct TORCH_API Function : public std::enable_shared_from_this<Function> {
       c10::optional<NamedValue> self,
       ArrayRef<NamedValue> args,
       ArrayRef<NamedValue> kwargs,
-      std::stringstream& failure_messages,
+      std::function<void(std::ostream&)>& render_errors,
       bool conv_tensors_to_nums);
 
   Value* emit_call(

--- a/torch/csrc/jit/script/schema_matching.h
+++ b/torch/csrc/jit/script/schema_matching.h
@@ -28,7 +28,7 @@ TORCH_API c10::optional<MatchedSchema> tryMatchSchema(
     c10::optional<NamedValue> self,
     at::ArrayRef<NamedValue> inputs,
     at::ArrayRef<NamedValue> attributes,
-    std::ostream& failure_messages,
+    std::function<void(std::ostream&)>& failure_messages,
     bool allow_conversions);
 
 TORCH_API bool convertibleToList(


### PR DESCRIPTION
Defer error string construction during schema matching so that
we only construct the error string when an error will be reported
in the end.

This saves 20% (5.3s -> 4.3s) load time on DenseNet on my laptop.

