### PR TITLE
[jit] Make warnings be UserWarnings with source file info

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3138,13 +3138,20 @@ graph(%Ra, %Rb):
     def test_warnings(self):
         import warnings
 
-        @torch.jit.script
         def fn(x):
             if bool(x < 2):
                 warnings.warn("x is less than 2")
             return x
 
-        FileCheck().check("aten::warn").run(str(fn.graph))
+        scripted_fn = torch.jit.script(fn)
+
+        with warnings.catch_warnings(record=True) as warns:
+            fn(torch.ones(1))
+
+        with warnings.catch_warnings(record=True) as script_warns:
+            scripted_fn(torch.ones(1))
+
+        self.assertEqual(str(warns[0]), str(script_warns[0]))
 
     def test_no_erroneous_warnings(self):
         import warnings

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -564,7 +564,19 @@ static void warning_handler(
     const c10::SourceLocation& source_location,
     const char* msg) {
   AutoGIL gil;
-  if (PyErr_WarnEx(PyExc_RuntimeWarning, msg, 1) < 0) {
+  auto result = -1;
+  if (source_location.file == nullptr) {
+    result = PyErr_WarnEx(PyExc_RuntimeWarning, msg, 1);
+  } else {
+    result = PyErr_WarnExplicit(
+        /*category=*/PyExc_UserWarning,
+        /*message=*/msg,
+        /*filename=*/source_location.file,
+        /*lineno=*/source_location.line,
+        /*module=*/nullptr,
+        /*registry=*/nullptr);
+  }
+  if (result < 0) {
     throw python_error();
   }
 }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -555,7 +555,7 @@ RegisterOperators reg(
              return [=](Stack& stack) {
                drop(stack, 1);
                c10::SourceLocation location{
-                   "", range->filename()->c_str(), line};
+                   "", range->filename()->c_str(), uint32_t(line)};
                c10::Warning::warn(location,
                    pop(stack).toStringRef());
                return 0;

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -547,8 +547,22 @@ RegisterOperators reg(
              {Argument("message", StringType::get()),
               Argument("stacklevel", IntType::get(), c10::nullopt, 2, true)},
              {}),
-         [](const Node* node) {
-           return [](Stack& stack) {
+         [](const Node* node) -> std::function<int(Stack&)> {
+           auto range = node->sourceRange().source();
+           if (range->filename()) {
+             auto line = range->starting_line_no() +
+                 range->lineno_for_offset(node->sourceRange().start());
+             return [=](Stack& stack) {
+               drop(stack, 1);
+               c10::SourceLocation location{
+                   "", range->filename()->c_str(), line};
+               c10::Warning::warn(location,
+                   pop(stack).toStringRef());
+               return 0;
+             };
+           }
+
+           return [=](Stack& stack) {
              drop(stack, 1);
              AT_WARN(pop(stack).toStringRef());
              return 0;


### PR DESCRIPTION
Redo of #15201, this makes `warnings.warn` calls match their Python
behavior

Differential Revision: [D15605266](https://our.internmc.facebook.com/intern/diff/15605266/)