### PR TITLE
[pytorch] build torch for libtorch mobile build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,6 @@ endif()
 # TorchScript model, but doesn't contain not-yet-unified caffe2 ops;
 if (INTERN_BUILD_MOBILE AND NOT BUILD_CAFFE2_MOBILE)
   set(BUILD_PYTHON OFF)
-  set(BUILD_TORCH ON)
   set(BUILD_CAFFE2_OPS OFF)
   set(USE_DISTRIBUTED OFF)
   set(FEATURE_TORCH_MOBILE ON)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -228,7 +228,7 @@ endif()
 
 
 
-if (NOT INTERN_BUILD_MOBILE)
+if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
 
 
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
@@ -556,7 +556,7 @@ target_link_libraries(torch caffe2)
 # formerly-libtorch flags
 # ==========================================================
 
-if (NOT INTERN_BUILD_MOBILE)
+if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
 
   # Forces caffe2.pb.h to be generated before its dependents are compiled.
   # Adding the generated header file to the ${TORCH_SRCS} list is not sufficient


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21234 [pytorch] build torch for libtorch mobile build**

Summary:
Since recent unification of caffe2 and torch library we stop building
torch for mobile. This diff re-enables torch build for libtorch mobile
build unless BUILD_CAFFE2_MOBILE is set to TRUE.

BUILD_CAFFE2_MOBILE is used to build old libcaffe2 library which will
be deprecated. We can remove these conditions after the deprecation.

Test Plan:
Build mobile library and make sure it can run pytorch model on Android.

Differential Revision: [D15616540](https://our.internmc.facebook.com/intern/diff/D15616540)