### PR TITLE
compare scalar device with common device

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -127,7 +127,7 @@ void TensorIterator::compute_types() {
       } else if (compute_common_dtype_ &&
                  (op.device != common_device || op.dtype != common_dtype)) {
         if (allow_cpu_scalars_ && op.tensor.defined() && op.tensor.dim() == 0 &&
-            op.device.is_cuda() && op.tensor.device().is_cpu()) {
+            common_device.is_cuda() && op.tensor.device().is_cpu()) {
           // don't cast CPU scalars in CUDA ops that directly support them
           op.device = op.tensor.device();
           op.dtype = op.tensor.scalar_type();


### PR DESCRIPTION
I think there was a typo in #20690 here https://github.com/pytorch/pytorch/pull/20690/files#diff-b47a50873394e38a005b4c1acd151957R130. 
Original conditional was ` common_backend == Backend::CUDA && op.tensor.type().backend() == Backend::CPU)`, now it is `op.device.is_cuda() && op.tensor.device().is_cpu()`. It seems that `op.device` and `op.tensor.device()` should be the same, so this conditional is never true. This leads to spurious h2d copies for operations between cuda tensors and cpu scalars, because cpu scalars are now sent to gpu, instead of being passed to lambdas directly. 
Unfortunately, I don't know how to test this change, because functionally everything was fine after #20690, it was just a performance regression. 

cc @colesbury 