### PR TITLE
zero out possible NaN in pytorch.ctc_loss

### DIFF
--- a/aten/src/ATen/native/cuda/LossCTC.cu
+++ b/aten/src/ATen/native/cuda/LossCTC.cu
@@ -571,6 +571,8 @@ Tensor ctc_loss_backward_gpu_template(const Tensor& grad_out, const Tensor& log_
     grad *= grad_out.view({1, batch_size, 1});
     if (zero_infinity) {
       grad = at::where(neg_log_likelihood.view({1, batch_size, 1}) == Scalar(INFINITY), at::zeros({}, grad.options()), grad);
+      grad = at::where(grad != grad, at::zeros({}, grad.options()), grad);
+      // to filter out NaN value
     }
 
     // For the non-blank characters, we use a kernel to compute the subtrahend.


### PR DESCRIPTION
When use ATen version of CTCLoss, we observe indeterminstically having NaN in the output gradient. Initial examination reveal that  1) those NaN happens rarely and only at BLANK position. 2) if we disable large batch handling (https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/LossCTC.cu#L552), NaN disappears.
Based on the above observation, I believe this line (https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/LossCTC.cu#L560) might incur NaN indeterminstically.
Unfortunately, due to the indeterminstic behavior, I am not able to provide a repo thus pinpoint the exact root cause. Before we find it, we'd like to place a stopgap here to zero out any NaN in gradient.

Note there is a previous PR which zero out infinity only (https://github.com/pytorch/pytorch/pull/16199), unfortunately, NaN is not infinity. so it won't help if there is a NaN in gradient. This PR overloads the zero_infinity option to zero out both infinity and NaN. Considering they are used for the same purpose, I think it is fine to just use "zero_infinity" option at the moment. 

Differential Revision: D15591296

