### PR TITLE
[jit] pretty print generic list

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3123,6 +3123,14 @@ graph(%Ra, %Rb):
                 # type: (Tensor, float, int) -> Tensor
                 return x + a + b
 
+        @torch.jit.script
+        def list_str_fn(x, a=['world']):
+            # type: (str, List[str]) -> str
+            return x + a[0]
+
+        self.assertEqual(list_str_fn("hello "), "hello world")
+
+
     def test_module_default_values(self):
         four = torch.tensor(4)
 

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -800,6 +800,15 @@ struct PythonPrintPass {
     } else if (v.isDoubleList()) {
       printMaybeAnnotatedConstantList(
           stmt, "float", v.toDoubleListRef().size(), v);
+    } else if (v.isGenericList()) {
+      stmt << "[";
+      const char* delim = "";
+      for (const auto& g : v.toGenericListRef()) {
+        stmt << delim;
+        printConstant(stmt, g);
+        delim = ", ";
+      }
+      stmt << "]";
     } else {
       stmt << v;
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21046 [jit] bake constants into the traced graph, get rid of getNestedValueTrace
* **#21245 [jit] pretty print generic list**

