### PR TITLE
[JIT] Exclude file:line from graphs used for fuser kernel cache

### DIFF
--- a/torch/csrc/jit/fuser/kernel_cache.cpp
+++ b/torch/csrc/jit/fuser/kernel_cache.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<Graph> normalizeGraphForCache(
 // precondition: graph has been normalized via normalizeGraphForCache
 int64_t store(std::shared_ptr<Graph> graph) {
   auto& cache = getKernelCache();
-  std::string repr = graph->toString();
+  std::string repr = graph->toString(false);
 
   std::lock_guard<std::mutex> guard{cache.mutex_};
   const auto key = cache.kernel_counter++;
@@ -78,7 +78,7 @@ at::optional<KernelSpec*> retrieve(const int64_t key) {
 // precondition: graph has been normalized via normalizeGraphForCache
 at::optional<KernelSpec*> lookupGraph(std::shared_ptr<Graph> graph) {
   auto& cache = getKernelCache();
-  std::string repr = graph->toString();
+  std::string repr = graph->toString(false);
 
   std::lock_guard<std::mutex> guard{cache.mutex_};
   auto it = cache.graphToKey_.find(repr);

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1459,9 +1459,9 @@ Value* Graph::insertConstant(
       *this, std::move(val), result_type, std::move(loc), std::move(scope));
 }
 
-std::string Graph::toString() const {
+std::string Graph::toString(bool print_source_locations) const {
   std::ostringstream oss;
-  oss << *this;
+  print(oss, print_source_locations);
   return oss.str();
 }
 

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1176,7 +1176,7 @@ struct Graph {
 
   TORCH_API ~Graph();
 
-  TORCH_API std::string toString() const;
+  TORCH_API std::string toString(bool print_source_locations=false) const;
 
   TORCH_API std::ostream& print(
       std::ostream& out,

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -214,17 +214,11 @@ void initPythonIRBindings(PyObject* module_) {
       .def(
           "__repr__",
           [](Graph& g) {
-            std::stringstream ss;
-            ss << g;
-            return ss.str();
+            return g.toString();
           })
       .def(
           "str",
-          [](Graph& g, bool print_source_ranges) {
-            std::stringstream ss;
-            g.print(ss, print_source_ranges);
-            return ss.str();
-          },
+          &Graph::toString,
           py::arg("print_source_ranges") = true)
       .def(
           "dump_alias_db",


### PR DESCRIPTION
cc @ezyang this is meant to fix the fuser failures on master