### PR TITLE
Add gtest for TensorIterator

### DIFF
--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -23,7 +23,8 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/weakref_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/extension_backend_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/xla_tensor_test.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/xla_tensor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp)
 
 list(APPEND ATen_CUDA_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda_integer_divider_test.cu

--- a/aten/src/ATen/test/tensor_iterator_test.cpp
+++ b/aten/src/ATen/test/tensor_iterator_test.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/native/TensorIterator.h>
+
+using namespace at;
+
+// An operation with a CUDA tensor and CPU scalar should keep the scalar
+// on the CPU (and lift it to a parameter).
+TEST(TensorIteratorTest, CPUScalar) {
+  if (!at::hasCUDA()) return;
+  Tensor out;
+  auto x = at::randn({5, 5}, kCUDA);
+  auto y = at::ones(1, kCPU).squeeze();
+  auto iter = TensorIterator::binary_op(out, x, y);
+  EXPECT_TRUE(iter->device(0).is_cuda()) << "result should be CUDA";
+  EXPECT_TRUE(iter->device(1).is_cuda()) << "x should be CUDA";
+  EXPECT_TRUE(iter->device(2).is_cpu()) << "y should be CPU";
+}
+
+// Mixing CPU and CUDA tensors should raise an exception (if neither is a scalar)
+TEST(TensorIteratorTest, MixedDevices) {
+  if (!at::hasCUDA()) return;
+  Tensor out;
+  auto x = at::randn({5, 5}, kCUDA);
+  auto y = at::ones({5}, kCPU);
+  ASSERT_ANY_THROW(TensorIterator::binary_op(out, x, y));
+}
+

--- a/aten/tools/run_tests.sh
+++ b/aten/tools/run_tests.sh
@@ -19,6 +19,7 @@ VALGRIND=${VALGRIND:=ON}
 ./undefined_tensor_test
 ./extension_backend_test
 ./xla_tensor_test
+./tensor_iterator_test
 if [[ -x ./cudnn_test ]]; then
   ./cudnn_test
 fi


### PR DESCRIPTION
This adds a regression test for the bug fix in #21236. Operations
involving CUDA tensors an CPU scalars should not copy the CPU scalar to
the device (because that is slow). They should instead "lift" the scalar
to a kernel parameter.

