### PR TITLE
[pt1][quant] Replace AT_ASSERTM with TORCH_CHECK

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -14,7 +14,8 @@ class QAddInt8 final : public c10::OperatorKernel {
  public:
   Tensor operator()(at::Tensor qa, at::Tensor qb,
                     double scale, int64_t zero_point) {
-    AT_ASSERTM(qa.numel() == qb.numel(), "Add operands must be the same size!");
+    TORCH_CHECK(
+        qa.numel() == qb.numel(), "Add operands must be the same size!");
     TORCH_CHECK(qa.scalar_type() == qb.scalar_type(), "Add operands should have same data type.");
     auto a = qa.dequantize();
     auto b = qb.dequantize();

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -26,7 +26,7 @@ class QFCInt8 final : public c10::OperatorKernel {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.
-    AT_ASSERTM(
+    TORCH_CHECK(
         fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
 
     // TODO: contiguous is called for further jit optimizations.
@@ -145,7 +145,7 @@ class QFCInt8 final : public c10::OperatorKernel {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.
-    AT_ASSERTM(
+    TORCH_CHECK(
         false, "This PyTorch installation was not built with FBGEMM operators");
   }
 #endif // USE_FBGEMM

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -84,7 +84,7 @@ class QFCPackWeightInt8 final : public c10::OperatorKernel {
     // We make a strong guarantee that models using these operators will have
     // the same numerics across different machines. Therefore, we do not provide
     // a fallback path and rather fail loudly if we cannot run FBGEMM.
-    AT_ASSERTM(
+    TORCH_CHECK(
         false, "This PyTorch installation was not built with FBGEMM operators");
   }
 #endif // USE_FBGEMM


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21267 [pt1][quant] Replace AT_ASSERTM with TORCH_CHECK**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15599242/)

Replace AT_ASSERTM with TORCH_CHECK: AT_ASSERTM is deprecated.

Not sure when ```AT_ASSERT``` is dprecated with some new TORCH ASSERT function.

Differential Revision: [D15599242](https://our.internmc.facebook.com/intern/diff/D15599242/)