### PR TITLE
Make strtod_c compatible with different gcc abi

### DIFF
--- a/torch/csrc/jit/script/strtod.cpp
+++ b/torch/csrc/jit/script/strtod.cpp
@@ -82,7 +82,7 @@ C10_EXPORT double strtod_c(const char *nptr, char **endptr)
     static _locale_t loc = _create_locale(LC_ALL, "C");
     return _strtod_l(nptr, endptr, loc);
 }
-#else
+#elif defined(__ANDROID__)
 C10_EXPORT double strtod_c(const char *nptr, char **endptr)
 {
     char *fail_pos;
@@ -246,6 +246,12 @@ invalid_string:
     *endptr = (char*)nptr;
     errno = EINVAL;
     return -1.0;
+}
+#else
+C10_EXPORT double strtod_c(const char* nptr, char** endptr) {
+  /// NOLINTNEXTLINE(hicpp-signed-bitwise)
+  static locale_t loc = newlocale(LC_ALL_MASK, "C", nullptr);
+  return strtod_l(nptr, endptr, loc);
 }
 #endif
 


### PR DESCRIPTION
We have encountered `std::bad_cast` error when running PyTorch binary built with cxx11 abi on CentOS7, stack trace:
```
#0  0x00007fec10160207 in raise () from /lib64/libc.so.6
#1  0x00007fec101618f8 in abort () from /lib64/libc.so.6
#2  0x00007fec015767d5 in __gnu_cxx::__verbose_terminate_handler() () from /lib64/libstdc++.so.6
#3  0x00007fec01574746 in ?? () from /lib64/libstdc++.so.6
#4  0x00007fec01574773 in std::terminate() () from /lib64/libstdc++.so.6
#5  0x00007fec01574993 in __cxa_throw () from /lib64/libstdc++.so.6
#6  0x00007fec015c94d2 in std::__throw_bad_cast() () from /lib64/libstdc++.so.6
#7  0x00007feb2ab3c2d7 in std::__cxx11::numpunct<char> const& std::use_facet<std::__cxx11::numpunct<char> >(std::locale const&) ()
   from /root/.local/lib/python2.7/site-packages/torch/lib/libcaffe2.so
#8  0x00007feb28643d62 in torch::jit::script::strtod_c(char const*, char**) () from /root/.local/lib/python2.7/site-packages/torch/lib/libcaffe2.so
```

We are suspecting this line will get compiled to gcc abi dependent symbol:
```
char decimal_point = std::use_facet<std::numpunct<char>>(std::locale()).decimal_point();
```
