### PR TITLE
[cuda] faster kernelTransformReduceInnermostDimIndex using cub

### DIFF
--- a/aten/src/THC/THCReduce.cuh
+++ b/aten/src/THC/THCReduce.cuh
@@ -15,6 +15,7 @@
 
 // Threads per thread block
 #define THC_NONCONTIG_REDUCE_BLOCK_SIZE 32 * 16
+#define THC_ONEDIM_REDUCE_NUM_THREADS 256
 #define CHUNKPERBLOCK 256
 
 template <typename IndexType>

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -934,6 +934,16 @@ class _TestTorchMixin(object):
     def test_min(self):
         self._testSelection(torch.min, min)
 
+    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
+    def test_large_reduction_inner(self):
+        # This test stresses THC_transformReduceInnermostDimIndex
+        for n, m in [(4, 1001), (1001, 4)]:
+            a = torch.tensor((np.random.rand(n, m) * 10000).astype(np.int32))
+            min_ref = torch.min(a, 1)
+            cuda_min = torch.min(a.cuda(), 1)
+            self.assertEqual(min_ref[0].numpy(), cuda_min[0].cpu().numpy())
+            self.assertEqual(min_ref[1].numpy(), cuda_min[1].cpu().numpy())
+
     @staticmethod
     def _test_min_with_inf(self, dtypes=(torch.float, torch.double), device='cpu'):
         for dtype in dtypes:


### PR DESCRIPTION
When optimizing sparse tensor coalesce, I recognized that this kernel was taking bulk of the time (see PR #21214). It is used (at least) in the sparse tensor constructor to validate that the index tensor min/max indices are valid.

This PR rewrites the kernel by using CUB reduction ,achieving about 16x speedup. With my benchmark for coalesce, before nvprof showed:
```
#  GPU activities:   45.47%  2.42669s       101  24.027ms  23.862ms  28.968ms  void kernelTransformReduceInnermostDimIndex<long, long, MinValuePair<long, long>>(long*, long*, long*, unsigned int, unsigned int, thrust::pair<long, long>, long)
#                    45.41%  2.42386s       101  23.999ms  23.857ms  28.944ms  void kernelTransformReduceInnermostDimIndex<long, long, MaxValuePair<long, long>>(long*, long*, long*, unsigned int, unsigned int, thrust::pair<long, long>, long)
```

... after this:

```
 GPU activities:   19.50%  154.92ms       101  1.5338ms  1.5285ms  1.5987ms  void kernelTransformReduceInnermostDimIndex<long, long, MinValuePair<long, long>>(long*, long*, long*, unsigned int, unsigned int, thrust::pair<long, long>, long)
                   19.45%  154.52ms       101  1.5299ms  1.5247ms  1.5933ms  void kernelTransformReduceInnermostDimIndex<long, long, MaxValuePair<long, long>>(long*, long*, long*, unsigned int, unsigned int, thrust::pair<long, long>, long)
``` 

Test: test/torch.py and test/sparse.py pass. 