### PR TITLE
Move THCTensor_(exponential) to ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2721,7 +2721,6 @@
     - floating_point
   backends:
     - CPU
-    - CUDA
   cname: exponential
   variants: function
   return: self

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3223,7 +3223,7 @@
   variants: method
   dispatch:
     CPU: legacy::cpu::_th_exponential_
-    CUDA: legacy::cuda::_th_exponential_
+    CUDA: exponential_cuda_
 
 - func: geometric_(Tensor(a!) self, float p, *, Generator? generator=None) -> Tensor(a!)
   variants: method

--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -129,13 +129,9 @@ __global__ void NAME(curandStateMtgp32 *state, int size, T *result, ARG1, ARG2) 
   }                                                                                  \
 }
 
-GENERATE_KERNEL1(generate_exponential, float, double lambda, float, curand_uniform, (float)(-1. / lambda * log(x)))
-GENERATE_KERNEL1(generate_exponential, double, double lambda, double, curand_uniform_double, (double)(-1. / lambda * log(x)))
-
 GENERATE_KERNEL2(generate_cauchy, float, double median, double sigma, float, curand_uniform, (float)(median + sigma * tan(M_PI*(x-0.5))))
 GENERATE_KERNEL2(generate_cauchy, double, double median, double sigma, double, curand_uniform_double, (double)(median + sigma * tan(M_PI*(x-0.5))))
 
-GENERATE_KERNEL1(generate_exponential, at::Half, double lambda, float, curand_uniform, (ScalarConvert<float, at::Half>::to((float)(-1. / lambda * log(x)))))
 GENERATE_KERNEL2(generate_cauchy, at::Half, double median, double sigma, float, curand_uniform, (ScalarConvert<float, at::Half>::to((float)(median + sigma * tan(M_PI*(x-0.5))))))
 
 #include <THC/generic/THCTensorRandom.cu>

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -26,22 +26,6 @@ void THCTensor_(logNormal)(THCState* state, THCTensor *self_, double mean, doubl
   THCTensor_(freeCopyTo)(state, self, self_);
 };
 
-void THCTensor_(exponential)(THCState* state, THCTensor *self_, double lambda)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
-  ptrdiff_t size = THCTensor_(nElement)(state, self_);
-  if (size == 0) return;
-  THCGenerator* gen = THCRandom_getGenerator(state);
-
-  THCTensor *self = THCTensor_(newContiguous)(state, self_);
-  scalar_t *data = THCTensor_(data)(state, self);
-
-  generate_exponential<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, lambda);
-
-  THCTensor_(freeCopyTo)(state, self, self_);
-};
-
 void THCTensor_(cauchy)(THCState* state, THCTensor *self_, double median, double sigma)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -5,7 +5,6 @@
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
 THC_API void THCTensor_(logNormal)(struct THCState *state, THCTensor *self, double mean, double stdv);
-THC_API void THCTensor_(exponential)(struct THCState *state, THCTensor *self, double lambda);
 THC_API void THCTensor_(cauchy)(struct THCState *state, THCTensor *self, double median, double sigma);
 THC_API void THCTensor_(multinomial)(struct THCState *state, THCudaLongTensor *self, THCTensor *prob_dist, int n_sample, int with_replacement);
 THC_API void THCTensor_(multinomialAliasSetup)(struct THCState *state, THCTensor *probs, THCudaLongTensor *J, THCTensor *q);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21301 Remove curandStateMTGP32 usage
* #21300 Speedup bernoulli_scalar_cuda_kernel with grid-stride loop
* #21299 Move THCTensor_(lognormal) to ATen
* #21298 Move THCTensor_(geometric) to ATen
* **#21297 Move THCTensor_(exponential) to ATen**

Resubmit of https://github.com/pytorch/pytorch/pull/20623


## Effective Bandwidth Benchmark
- using https://gist.github.com/syed-ahmed/f8b7384d642f4bce484228b508b4bc68
- on V100
### Float Type
#### Before:
```
exponential, size, elements 65536 forward 4.951953887939453e-06 bandwidth (GB/s) 52.937488097063074
exponential, size, elements 131072 forward 5.1164627075195315e-06 bandwidth (GB/s) 102.47079476011184
exponential, size, elements 262144 forward 7.412433624267578e-06 bandwidth (GB/s) 141.46177263119975
exponential, size, elements 524288 forward 1.1911392211914063e-05 bandwidth (GB/s) 176.06271061265014
exponential, size, elements 1048576 forward 2.077341079711914e-05 bandwidth (GB/s) 201.90733437869852
exponential, size, elements 2097152 forward 3.968000411987305e-05 bandwidth (GB/s) 211.4064296631136
exponential, size, elements 4194304 forward 7.367134094238281e-05 bandwidth (GB/s) 227.73056368176054
exponential, size, elements 8388608 forward 0.0001375126838684082 bandwidth (GB/s) 244.00972372926472
exponential, size, elements 16777216 forward 0.0002710747718811035 bandwidth (GB/s) 247.5658783526883
exponential, size, elements 33554432 forward 0.0005277013778686524 bandwidth (GB/s) 254.34409237682056
```
#### After:
```
exponential, size, elements 65536 forward 5.60760498046875e-06 bandwidth (GB/s) 46.74794335782313
exponential, size, elements 131072 forward 7.700920104980468e-06 bandwidth (GB/s) 68.0812153421672
exponential, size, elements 262144 forward 6.551742553710938e-06 bandwidth (GB/s) 160.04536066608443
exponential, size, elements 524288 forward 6.9427490234375e-06 bandwidth (GB/s) 302.0636340043956
exponential, size, elements 1048576 forward 9.472370147705077e-06 bandwidth (GB/s) 442.7935072845709
exponential, size, elements 2097152 forward 1.4712810516357422e-05 bandwidth (GB/s) 570.1567345459731
exponential, size, elements 4194304 forward 2.4566650390625e-05 bandwidth (GB/s) 682.9264768795031
exponential, size, elements 8388608 forward 4.60505485534668e-05 bandwidth (GB/s) 728.6434810009216
exponential, size, elements 16777216 forward 9.00864601135254e-05 bandwidth (GB/s) 744.9384060094111
exponential, size, elements 33554432 forward 0.00017408370971679687 bandwidth (GB/s) 770.9953344764326
```
### Double Type
#### Before:
```
exponential, size, elements 65536 forward 4.985332489013672e-06 bandwidth (GB/s) 52.58305250004783
exponential, size, elements 131072 forward 6.051063537597656e-06 bandwidth (GB/s) 86.64394229913319
exponential, size, elements 262144 forward 9.377002716064453e-06 bandwidth (GB/s) 111.82421843640988
exponential, size, elements 524288 forward 1.549959182739258e-05 bandwidth (GB/s) 135.30369208134132
exponential, size, elements 1048576 forward 2.866983413696289e-05 bandwidth (GB/s) 146.2967654421289
exponential, size, elements 2097152 forward 5.302190780639648e-05 bandwidth (GB/s) 158.2102256793561
exponential, size, elements 4194304 forward 9.615898132324219e-05 bandwidth (GB/s) 174.47372849762968
exponential, size, elements 8388608 forward 0.00018301725387573242 bandwidth (GB/s) 183.34026595537955
exponential, size, elements 16777216 forward 0.0003589057922363281 bandwidth (GB/s) 186.98183604629858
exponential, size, elements 33554432 forward 0.000672616958618164 bandwidth (GB/s) 199.5455604862227
```
#### After:
```
exponential, size, elements 65536 forward 5.755424499511719e-06 bandwidth (GB/s) 45.547291954266775
exponential, size, elements 131072 forward 6.275177001953125e-06 bandwidth (GB/s) 83.54951578844985
exponential, size, elements 262144 forward 7.97271728515625e-06 bandwidth (GB/s) 131.52052963827754
exponential, size, elements 524288 forward 1.2047290802001953e-05 bandwidth (GB/s) 174.07664797561844
exponential, size, elements 1048576 forward 2.0439624786376954e-05 bandwidth (GB/s) 205.20454968407793
exponential, size, elements 2097152 forward 3.5920143127441405e-05 bandwidth (GB/s) 233.53492691379267
exponential, size, elements 4194304 forward 6.896495819091797e-05 bandwidth (GB/s) 243.27160401598564
exponential, size, elements 8388608 forward 0.00012843608856201173 bandwidth (GB/s) 261.2539230653945
exponential, size, elements 16777216 forward 0.0002438235282897949 bandwidth (GB/s) 275.23539041005995
exponential, size, elements 33554432 forward 0.00046614646911621096 bandwidth (GB/s) 287.93037573462635
```

Differential Revision: [D15632931](https://our.internmc.facebook.com/intern/diff/D15632931)