### PR TITLE
Move THCTensor_(geometric) to ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2736,7 +2736,6 @@
   name: _th_geometric_
   backends:
     - CPU
-    - CUDA
   cname: geometric
   variants: function
   return: self

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -557,6 +557,32 @@ void exponential_kernel_cuda(TensorIterator& iter, double lambda_, Generator* ge
    });
 }
 
+void geometric_kernel_cuda(TensorIterator& iter, double p_, Generator* gen_) {
+  auto gen = check_generator<CUDAGenerator>(gen_, &globalContext().defaultGenerator(kCUDA));
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, iter.dtype(), "geometric_cuda", [&] {
+    if (std::is_same<scalar_t, double>::value) {
+      // define lambda for geometric transformation
+      auto geometric_func = [p_] __device__ (double rand) {
+        return static_cast<scalar_t>(::ceil(::log(rand) / ::log(static_cast<double>(1.0)-p_)));
+      };
+      distribution_nullary_kernel<scalar_t, double, curand4_engine_calls/2>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform2_double(state); },
+        geometric_func);
+    } else {
+      auto p = static_cast<float>(p_);
+      auto geometric_func = [p] __device__ (float rand) {
+        // use __logf fast approximation for peak bandwidth
+        return static_cast<scalar_t>(::ceil(__logf(rand) / __logf(static_cast<float>(1.0)-p)));
+      };
+      distribution_nullary_kernel<scalar_t, float, curand4_engine_calls>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform4(state); },
+        geometric_func);
+    }
+   });
+}
+
 Tensor& uniform_cuda_(Tensor& self, double from, double to, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   uniform_kernel_cuda(*iter, from, to, gen);
@@ -639,6 +665,13 @@ Tensor normal_cuda(const Tensor& mean, const Tensor& std, Generator* gen) {
 Tensor& exponential_cuda_(Tensor& self, double lambda, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   exponential_kernel_cuda(*iter, lambda, gen);
+  return self;
+}
+
+Tensor& geometric_cuda_(Tensor& self, double p, Generator* gen) {
+  TORCH_CHECK(0 < p && p < 1, "geometric_ expects p to be in (0, 1), but got p=", p);
+  auto iter = TensorIterator::nullary_op(self);
+  geometric_kernel_cuda(*iter, p, gen);
   return self;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3229,7 +3229,7 @@
   variants: method
   dispatch:
     CPU: legacy::cpu::_th_geometric_
-    CUDA: legacy::cuda::_th_geometric_
+    CUDA: geometric_cuda_
 
 # wrappers for TH functions
 

--- a/aten/src/THC/THCTensorRandom.cu
+++ b/aten/src/THC/THCTensorRandom.cu
@@ -101,20 +101,6 @@ THC_API __host__ void THCRandom_setRNGState(THCState* state, THByteTensor *rng_s
   }
 }
 
-#define GENERATE_KERNEL1(NAME, T, ARG1, CURAND_T, CURAND_FUNC, TRANSFORM)      \
-__global__ void NAME(curandStateMtgp32 *state, int size, T *result, ARG1)    \
-{                                                                              \
-  int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;                             \
-  int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;                \
-  for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {      \
-    CURAND_T x = CURAND_FUNC(&state[blockIdx.x]);                              \
-    if (i < size) {                                                            \
-      T y = TRANSFORM;                                                         \
-      result[i] = y;                                                           \
-    }                                                                          \
-  }                                                                            \
-}
-
 #define GENERATE_KERNEL2(NAME, T, ARG1, ARG2, CURAND_T, CURAND_FUNC, TRANSFORM)      \
 __global__ void NAME(curandStateMtgp32 *state, int size, T *result, ARG1, ARG2)    \
 {                                                                                    \
@@ -140,5 +126,4 @@ GENERATE_KERNEL2(generate_cauchy, at::Half, double median, double sigma, float, 
 #include <THC/generic/THCTensorRandom.cu>
 #include <THC/THCGenerateBoolType.h>
 
-#undef GENERATE_KERNEL1
 #undef GENERATE_KERNEL2

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -335,28 +335,6 @@ void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor *self, T
 
 #endif
 
-#if defined(THC_REAL_IS_DOUBLE)
-GENERATE_KERNEL1(generate_geometric, double, double p, double, curand_uniform_double, ceil(log(x) / log(1-p)))
-#else
-GENERATE_KERNEL1(generate_geometric, scalar_t, double p, float, curand_uniform, (ScalarConvert<float, scalar_t>::to(ceilf(logf(x) / log(1-p)))))
-#endif
-
-void THCTensor_(geometric)(THCState* state, THCTensor *self_, double p)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
-  ptrdiff_t size = THCTensor_(nElement)(state, self_);
-  if (size == 0) return;
-  THCGenerator* gen = THCRandom_getGenerator(state);
-
-  THCTensor *self = THCTensor_(newContiguous)(state, self_);
-  scalar_t *data = THCTensor_(data)(state, self);
-
-  generate_geometric<<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, p);
-
-  THCTensor_(freeCopyTo)(state, self, self_);
-};
-
 #undef NUM_BLOCKS
 
 #endif

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -11,7 +11,4 @@ THC_API void THCTensor_(multinomialAliasSetup)(struct THCState *state, THCTensor
 THC_API void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor *self, THCTensor *_q, THCudaLongTensor *_J, int n_sample);
 
 #endif
-
-THC_API void THCTensor_(geometric)(struct THCState *state, THCTensor *self, double p);
-
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21301 Remove curandStateMTGP32 usage
* #21300 Speedup bernoulli_scalar_cuda_kernel with grid-stride loop
* #21299 Move THCTensor_(lognormal) to ATen
* **#21298 Move THCTensor_(geometric) to ATen**
* #21297 Move THCTensor_(exponential) to ATen

Resubmit of https://github.com/pytorch/pytorch/pull/20625

## Effective Bandwidth Benchmark
- using https://gist.github.com/syed-ahmed/f8b7384d642f4bce484228b508b4bc68
- on V100
### Float Type
#### Before:
```
geometric, size, elements 65536 forward 4.827976226806641e-06 bandwidth (GB/s) 54.296870507456795
geometric, size, elements 131072 forward 5.9986114501953125e-06 bandwidth (GB/s) 87.40156023656598
geometric, size, elements 262144 forward 9.603500366210938e-06 bandwidth (GB/s) 109.18685479404171
geometric, size, elements 524288 forward 1.6007423400878906e-05 bandwidth (GB/s) 131.01121570163838
geometric, size, elements 1048576 forward 2.911090850830078e-05 bandwidth (GB/s) 144.08014778391484
geometric, size, elements 2097152 forward 5.525588989257812e-05 bandwidth (GB/s) 151.81382502947878
geometric, size, elements 4194304 forward 0.00010294198989868164 bandwidth (GB/s) 162.9773818877273
geometric, size, elements 8388608 forward 0.0001985597610473633 bandwidth (GB/s) 168.98908330170744
geometric, size, elements 16777216 forward 0.00038609743118286135 bandwidth (GB/s) 173.8132879941806
geometric, size, elements 33554432 forward 0.0007671475410461426 bandwidth (GB/s) 174.9568639912085
```
#### After:
```
geometric, size, elements 65536 forward 5.98907470703125e-06 bandwidth (GB/s) 43.7703673477707
geometric, size, elements 131072 forward 5.676746368408203e-06 bandwidth (GB/s) 92.3571295905922
geometric, size, elements 262144 forward 6.127357482910156e-06 bandwidth (GB/s) 171.13021443984437
geometric, size, elements 524288 forward 7.076263427734375e-06 bandwidth (GB/s) 296.3643201552561
geometric, size, elements 1048576 forward 1.0535717010498046e-05 bandwidth (GB/s) 398.1033275495814
geometric, size, elements 2097152 forward 1.7604827880859376e-05 bandwidth (GB/s) 476.49474659848323
geometric, size, elements 4194304 forward 2.9888153076171875e-05 bandwidth (GB/s) 561.333313478494
geometric, size, elements 8388608 forward 5.422115325927734e-05 bandwidth (GB/s) 618.8439378916895
geometric, size, elements 16777216 forward 0.00010248422622680665 bandwidth (GB/s) 654.8213951626288
geometric, size, elements 33554432 forward 0.00019872665405273437 bandwidth (GB/s) 675.388657046396
```
### Double Type
#### Before:
```
geometric, size, elements 65536 forward 7.531642913818359e-06 bandwidth (GB/s) 34.80568622272872
geometric, size, elements 131072 forward 7.486343383789062e-06 bandwidth (GB/s) 70.03258775643313
geometric, size, elements 262144 forward 1.2500286102294922e-05 bandwidth (GB/s) 83.8841600439443
geometric, size, elements 524288 forward 2.1970272064208986e-05 bandwidth (GB/s) 95.45407511891482
geometric, size, elements 1048576 forward 4.1151046752929686e-05 bandwidth (GB/s) 101.9246004890846
geometric, size, elements 2097152 forward 7.607698440551757e-05 bandwidth (GB/s) 110.26472809812907
geometric, size, elements 4194304 forward 0.00013311147689819335 bandwidth (GB/s) 126.03883895625013
geometric, size, elements 8388608 forward 0.00026131629943847655 bandwidth (GB/s) 128.40543078293493
geometric, size, elements 16777216 forward 0.0005186843872070312 bandwidth (GB/s) 129.38284948456277
geometric, size, elements 33554432 forward 0.0010293865203857423 bandwidth (GB/s) 130.38613323759532
```
#### After:
```
geometric, size, elements 65536 forward 6.048679351806641e-06 bandwidth (GB/s) 43.33904721229799
geometric, size, elements 131072 forward 7.328987121582031e-06 bandwidth (GB/s) 71.5362152098894
geometric, size, elements 262144 forward 1.009225845336914e-05 bandwidth (GB/s) 103.89904349407041
geometric, size, elements 524288 forward 1.6951560974121092e-05 bandwidth (GB/s) 123.71438849800283
geometric, size, elements 1048576 forward 3.087997436523438e-05 bandwidth (GB/s) 135.82601949054973
geometric, size, elements 2097152 forward 5.675792694091797e-05 bandwidth (GB/s) 147.7962366161136
geometric, size, elements 4194304 forward 0.00010924100875854492 bandwidth (GB/s) 153.57983408119776
geometric, size, elements 8388608 forward 0.0002037382125854492 bandwidth (GB/s) 164.69385675957594
geometric, size, elements 16777216 forward 0.0003897523880004883 bandwidth (GB/s) 172.18332989384
geometric, size, elements 33554432 forward 0.0007770538330078125 bandwidth (GB/s) 172.72642164375063
```

Differential Revision: [D15632932](https://our.internmc.facebook.com/intern/diff/D15632932)