### PR TITLE
Move THCTensor_(lognormal) to ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2703,7 +2703,6 @@
     - floating_point
   backends:
     - CPU
-    - CUDA
   return: self
   arguments:
     - THTensor* self

--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -583,6 +583,34 @@ void geometric_kernel_cuda(TensorIterator& iter, double p_, Generator* gen_) {
    });
 }
 
+void log_normal_kernel_cuda(TensorIterator& iter, double mean_, double std_, Generator* gen_) {
+  auto gen = check_generator<CUDAGenerator>(gen_, &globalContext().defaultGenerator(kCUDA));
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "log_normal_cuda", [&] {
+    using accscalar_t = at::acc_type<scalar_t, true>;
+    auto mean = static_cast<accscalar_t>(mean_);
+    auto std = static_cast<accscalar_t>(std_);
+    if (std::is_same<scalar_t, double>::value) {
+      // define lambda for log_normal transformation
+      auto log_normal_func = [mean, std] __device__ (accscalar_t rand) {
+        return static_cast<scalar_t>(::exp(rand * std + mean));
+      };
+      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls/2>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_normal2_double(state); },
+        log_normal_func);
+    } else {
+      auto log_normal_func = [mean, std] __device__ (accscalar_t rand) {
+        // use __expf fast approximation for peak bandwidth
+        return static_cast<scalar_t>(__expf(rand * std + mean));
+      };
+      distribution_nullary_kernel<scalar_t, accscalar_t, curand4_engine_calls>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_normal4(state); },
+        log_normal_func);
+    }
+   });
+}
+
 Tensor& uniform_cuda_(Tensor& self, double from, double to, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   uniform_kernel_cuda(*iter, from, to, gen);
@@ -672,6 +700,13 @@ Tensor& geometric_cuda_(Tensor& self, double p, Generator* gen) {
   TORCH_CHECK(0 < p && p < 1, "geometric_ expects p to be in (0, 1), but got p=", p);
   auto iter = TensorIterator::nullary_op(self);
   geometric_kernel_cuda(*iter, p, gen);
+  return self;
+}
+
+Tensor& log_normal_cuda_(Tensor& self, double mean, double std, Generator* gen) {
+  TORCH_CHECK(std > 0.0, "log_normal_ expects std > 0.0, but found std=", std);
+  auto iter = TensorIterator::nullary_op(self);
+  log_normal_kernel_cuda(*iter, mean, std, gen);
   return self;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3217,7 +3217,7 @@
   variants: method
   dispatch:
     CPU: legacy::cpu::_th_log_normal_
-    CUDA: legacy::cuda::_th_log_normal_
+    CUDA: log_normal_cuda_
 
 - func: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)
   variants: method

--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -9,33 +9,6 @@
 
 #define MAX_NUM_BLOCKS 200
 #define BLOCK_SIZE 256
-/* Separate kernel because curand_log_normal gets extra parameters. */
-
-template <typename T>
-__global__ void generateLogNormal(curandStateMtgp32 *state, int size, T *result, double mean, double stddev)
-{
-  int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;
-  int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;
-  for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {
-    float x = curand_log_normal(&state[blockIdx.x], mean, stddev);
-    if (i < size) {
-      result[i] = ScalarConvert<float, T>::to(x);
-    }
-  }
-}
-
-template <>
-__global__ void generateLogNormal<double>(curandStateMtgp32 *state, int size, double *result, double mean, double stddev)
-{
-  int idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;
-  int rounded_size = THCCeilDiv(size, BLOCK_SIZE) * BLOCK_SIZE;
-  for (int i = idx; i < rounded_size; i += BLOCK_SIZE * MAX_NUM_BLOCKS) {
-    double x = curand_log_normal_double(&state[blockIdx.x], mean, stddev);
-    if (i < size) {
-      result[i] = x;
-    }
-  }
-}
 
 template <typename T>
 __global__ void

--- a/aten/src/THC/generic/THCTensorRandom.cu
+++ b/aten/src/THC/generic/THCTensorRandom.cu
@@ -4,27 +4,7 @@
 
 #include "ATen/cuda/CUDAContext.h"
 
-#define NUM_BLOCKS min((int)THCCeilDiv(size, (ptrdiff_t) BLOCK_SIZE), MAX_NUM_BLOCKS)
-
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
-
-
-void THCTensor_(logNormal)(THCState* state, THCTensor *self_, double mean, double stdv)
-{
-
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self_));
-  ptrdiff_t size = THCTensor_(nElement)(state, self_);
-  if (size == 0) return;
-  THCGenerator* gen = THCRandom_getGenerator(state);
-
-  THCTensor *self = THCTensor_(newContiguous)(state, self_);
-  scalar_t *data = THCTensor_(data)(state, self);
-
-  generateLogNormal<scalar_t><<<NUM_BLOCKS, BLOCK_SIZE, 0, THCState_getCurrentStream(state)>>>(
-      gen->state.gen_states, size, data, mean, stdv);
-
-  THCTensor_(freeCopyTo)(state, self, self_);
-};
 
 void THCTensor_(cauchy)(THCState* state, THCTensor *self_, double median, double sigma)
 {
@@ -334,7 +314,4 @@ void THCTensor_(multinomialAliasDraw)(THCState *state, THCudaLongTensor *self, T
 }
 
 #endif
-
-#undef NUM_BLOCKS
-
 #endif

--- a/aten/src/THC/generic/THCTensorRandom.h
+++ b/aten/src/THC/generic/THCTensorRandom.h
@@ -4,7 +4,6 @@
 
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
-THC_API void THCTensor_(logNormal)(struct THCState *state, THCTensor *self, double mean, double stdv);
 THC_API void THCTensor_(cauchy)(struct THCState *state, THCTensor *self, double median, double sigma);
 THC_API void THCTensor_(multinomial)(struct THCState *state, THCudaLongTensor *self, THCTensor *prob_dist, int n_sample, int with_replacement);
 THC_API void THCTensor_(multinomialAliasSetup)(struct THCState *state, THCTensor *probs, THCudaLongTensor *J, THCTensor *q);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21301 Remove curandStateMTGP32 usage
* #21300 Speedup bernoulli_scalar_cuda_kernel with grid-stride loop
* **#21299 Move THCTensor_(lognormal) to ATen**
* #21298 Move THCTensor_(geometric) to ATen
* #21297 Move THCTensor_(exponential) to ATen

Resubmit of https://github.com/pytorch/pytorch/pull/20624

## Effective Bandwidth Benchmark
- using https://gist.github.com/syed-ahmed/f8b7384d642f4bce484228b508b4bc68
- on V100
### Float Type
#### Before:
```
log_normal, size, elements 65536 forward 4.84466552734375e-06 bandwidth (GB/s) 54.1098242015748
log_normal, size, elements 131072 forward 5.0425529479980465e-06 bandwidth (GB/s) 103.97273075895983
log_normal, size, elements 262144 forward 7.326602935791016e-06 bandwidth (GB/s) 143.11898832098927
log_normal, size, elements 524288 forward 1.1749267578125e-05 bandwidth (GB/s) 178.49214736623378
log_normal, size, elements 1048576 forward 2.05230712890625e-05 bandwidth (GB/s) 204.37019103643124
log_normal, size, elements 2097152 forward 3.9284229278564456e-05 bandwidth (GB/s) 213.53627534643442
log_normal, size, elements 4194304 forward 7.281541824340821e-05 bandwidth (GB/s) 230.40746595613766
log_normal, size, elements 8388608 forward 0.00013544559478759766 bandwidth (GB/s) 247.7336531514311
log_normal, size, elements 16777216 forward 0.0002670741081237793 bandwidth (GB/s) 251.27431659866272
log_normal, size, elements 33554432 forward 0.0005250406265258789 bandwidth (GB/s) 255.63303336753222
```
#### After:
```
log_normal, size, elements 65536 forward 5.47647476196289e-06 bandwidth (GB/s) 47.86728897588159
log_normal, size, elements 131072 forward 6.859302520751953e-06 bandwidth (GB/s) 76.43459351936045
log_normal, size, elements 262144 forward 7.7056884765625e-06 bandwidth (GB/s) 136.07817175445544
log_normal, size, elements 524288 forward 8.029937744140625e-06 bandwidth (GB/s) 261.1666574289786
log_normal, size, elements 1048576 forward 1.1892318725585938e-05 bandwidth (GB/s) 352.6901773138733
log_normal, size, elements 2097152 forward 1.9683837890625e-05 bandwidth (GB/s) 426.1672975875969
log_normal, size, elements 4194304 forward 3.241539001464844e-05 bandwidth (GB/s) 517.5694629130921
log_normal, size, elements 8388608 forward 5.803346633911133e-05 bandwidth (GB/s) 578.1910700272298
log_normal, size, elements 16777216 forward 0.00011091709136962891 bandwidth (GB/s) 605.0362768381755
log_normal, size, elements 33554432 forward 0.00021491527557373046 bandwidth (GB/s) 624.5146029834174
```
### Double Type
#### Before:
```
log_normal, size, elements 65536 forward 5.793571472167969e-06 bandwidth (GB/s) 45.247392089547326
log_normal, size, elements 131072 forward 8.199214935302735e-06 bandwidth (GB/s) 63.943682918057576
log_normal, size, elements 262144 forward 1.3582706451416015e-05 bandwidth (GB/s) 77.19934195373004
log_normal, size, elements 524288 forward 2.3326873779296876e-05 bandwidth (GB/s) 89.90283137988553
log_normal, size, elements 1048576 forward 4.379749298095703e-05 bandwidth (GB/s) 95.76584673062604
log_normal, size, elements 2097152 forward 8.105754852294922e-05 bandwidth (GB/s) 103.48953493979646
log_normal, size, elements 4194304 forward 0.0001421213150024414 bandwidth (GB/s) 118.04855590951854
log_normal, size, elements 8388608 forward 0.00027796506881713865 bandwidth (GB/s) 120.71456367804988
log_normal, size, elements 16777216 forward 0.0005494546890258789 bandwidth (GB/s) 122.13721229493271
log_normal, size, elements 33554432 forward 0.0010767412185668946 bandwidth (GB/s) 124.65179718729368
```
#### After:
```
log_normal, size, elements 65536 forward 5.91278076171875e-06 bandwidth (GB/s) 44.33514628129032
log_normal, size, elements 131072 forward 7.789134979248047e-06 bandwidth (GB/s) 67.31017005056627
log_normal, size, elements 262144 forward 9.219646453857422e-06 bandwidth (GB/s) 113.73277763392811
log_normal, size, elements 524288 forward 1.5113353729248047e-05 bandwidth (GB/s) 138.7615242500079
log_normal, size, elements 1048576 forward 2.7089118957519532e-05 bandwidth (GB/s) 154.83353321964444
log_normal, size, elements 2097152 forward 4.64177131652832e-05 bandwidth (GB/s) 180.71997580169503
log_normal, size, elements 4194304 forward 8.719682693481446e-05 bandwidth (GB/s) 192.40626740399748
log_normal, size, elements 8388608 forward 0.0001693272590637207 bandwidth (GB/s) 198.16320293339717
log_normal, size, elements 16777216 forward 0.00033437252044677735 bandwidth (GB/s) 200.70089464986953
log_normal, size, elements 33554432 forward 0.0006206154823303223 bandwidth (GB/s) 216.26551676737367
```

Differential Revision: [D15632930](https://our.internmc.facebook.com/intern/diff/D15632930)