### PR TITLE
Speedup bernoulli_scalar_cuda_kernel with grid-stride loop

### DIFF
--- a/aten/src/ATen/native/cuda/Distributions.cu
+++ b/aten/src/ATen/native/cuda/Distributions.cu
@@ -308,45 +308,6 @@ void bernoulli_tensor_cuda_kernel(
 }
 
 template<typename scalar_t>
-void bernoulli_scalar_cuda_kernel(
-    at::Tensor& ret, double p_,
-    std::pair<uint64_t, uint64_t> seeds) {
-  float p = static_cast<float>(p_);
-  // The template argument `4` below indicates that we want to operate on four
-  // element at each time. See NOTE [ CUDA_tensor_applyN helpers ] for details.
-  at::cuda::CUDA_tensor_apply1<scalar_t, 4>(
-      ret, [seeds, p] __device__(
-        int n, scalar_t& v1, scalar_t& v2, scalar_t& v3, scalar_t& v4) {
-        curandStatePhilox4_32_10_t state;
-        curand_init(
-            seeds.first,
-            blockIdx.x * blockDim.x + threadIdx.x,
-            seeds.second,
-            &state);
-        // See Note [Register spilling in curand call for CUDA < 10]
-        float4 rand = curand_uniform4(&state);
-        switch (n) {
-          case 4: {
-            v4 = static_cast<scalar_t>(rand.w <= p);
-            // fallthrough
-          }
-          case 3: {
-            v3 = static_cast<scalar_t>(rand.z <= p);
-            // fallthrough
-          }
-          case 2: {
-            v2 = static_cast<scalar_t>(rand.y <= p);
-            // fallthrough
-          }
-          case 1: {
-            v1 = static_cast<scalar_t>(rand.x <= p);
-          }
-        }
-      }
-    );
-}
-
-template<typename scalar_t>
 void dirichlet_scalar_cuda_kernel(
     at::Tensor& ret,
     const at::Tensor& gamma) {
@@ -408,15 +369,6 @@ Tensor& bernoulli_tensor_cuda_(Tensor &self, const Tensor& p_, Generator* gen) {
         using p_t = scalar_t;
         return bernoulli_tensor_cuda_kernel<self_t, p_t>(self, p, seeds);
       });
-   });
-  return self;
-}
-
-Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
-  TORCH_CHECK(0 <= p && p <= 1, "bernoulli_ expects p to be in [0, 1], but got p=", p);
-  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, self.scalar_type(), "bernoulli_scalar_cuda_", [&] {
-    auto seeds = next_philox_seed(gen, 10);
-    bernoulli_scalar_cuda_kernel<scalar_t>(self, p, seeds);
    });
   return self;
 }
@@ -611,6 +563,31 @@ void log_normal_kernel_cuda(TensorIterator& iter, double mean_, double std_, Gen
    });
 }
 
+void bernoulli_scalar_cuda_kernel(TensorIterator& iter, double p_, Generator* gen_) {
+  auto gen = check_generator<CUDAGenerator>(gen_, &globalContext().defaultGenerator(kCUDA));
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, iter.dtype(), "bernoulli_scalar_cuda_", [&] {
+      if (std::is_same<scalar_t, double>::value) {
+      // define lambda for bernoulli transformation
+      auto bernoulli_func = [p_] __device__ (double rand) {
+        return static_cast<scalar_t>(rand <= p_);
+      };
+      distribution_nullary_kernel<scalar_t, double, curand4_engine_calls/2>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform2_double(state); },
+        bernoulli_func);
+    } else {
+      auto p = static_cast<float>(p_);
+      auto bernoulli_func = [p] __device__ (float rand) {
+        return static_cast<scalar_t>(rand <= p);
+      };
+      distribution_nullary_kernel<scalar_t, float, curand4_engine_calls>(iter,
+        gen,
+        [] __device__ (curandStatePhilox4_32_10_t* state) { return curand_uniform4(state); },
+        bernoulli_func);
+    }
+   });
+}
+
 Tensor& uniform_cuda_(Tensor& self, double from, double to, Generator* gen) {
   auto iter = TensorIterator::nullary_op(self);
   uniform_kernel_cuda(*iter, from, to, gen);
@@ -707,6 +684,13 @@ Tensor& log_normal_cuda_(Tensor& self, double mean, double std, Generator* gen) 
   TORCH_CHECK(std > 0.0, "log_normal_ expects std > 0.0, but found std=", std);
   auto iter = TensorIterator::nullary_op(self);
   log_normal_kernel_cuda(*iter, mean, std, gen);
+  return self;
+}
+
+Tensor& bernoulli_scalar_cuda_(Tensor &self, double p, Generator* gen) {
+  TORCH_CHECK(0 <= p && p <= 1, "bernoulli_ expects p to be in [0, 1], but got p=", p);
+  auto iter = TensorIterator::nullary_op(self);
+  bernoulli_scalar_cuda_kernel(*iter, p, gen);
   return self;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21301 Remove curandStateMTGP32 usage
* **#21300 Speedup bernoulli_scalar_cuda_kernel with grid-stride loop**
* #21299 Move THCTensor_(lognormal) to ATen
* #21298 Move THCTensor_(geometric) to ATen
* #21297 Move THCTensor_(exponential) to ATen

Resubmit of https://github.com/pytorch/pytorch/pull/20626

## Effective Bandwidth Benchmark
- using https://gist.github.com/syed-ahmed/f8b7384d642f4bce484228b508b4bc68
- on V100
### Float Type
#### Before:
```
bernoulli, size, elements 65536 forward 5.810260772705078e-06 bandwidth (GB/s) 45.117424200902754
bernoulli, size, elements 131072 forward 5.700588226318359e-06 bandwidth (GB/s) 91.97085970522794
bernoulli, size, elements 262144 forward 7.650852203369141e-06 bandwidth (GB/s) 137.0534905298847
bernoulli, size, elements 524288 forward 1.1038780212402343e-05 bandwidth (GB/s) 189.98041084682507
bernoulli, size, elements 1048576 forward 1.817464828491211e-05 bandwidth (GB/s) 230.77772588765578
bernoulli, size, elements 2097152 forward 3.152847290039063e-05 bandwidth (GB/s) 266.06451972800966
bernoulli, size, elements 4194304 forward 5.8722496032714846e-05 bandwidth (GB/s) 285.7033868358262
bernoulli, size, elements 8388608 forward 0.0001120924949645996 bandwidth (GB/s) 299.3459286511284
bernoulli, size, elements 16777216 forward 0.0002196049690246582 bandwidth (GB/s) 305.58900510336235
bernoulli, size, elements 33554432 forward 0.0004137754440307617 bandwidth (GB/s) 324.3733525907877
```
#### After:
```
bernoulli, size, elements 65536 forward 5.7387351989746094e-06 bandwidth (GB/s) 45.679751881013715
bernoulli, size, elements 131072 forward 5.600452423095703e-06 bandwidth (GB/s) 93.61529397837378
bernoulli, size, elements 262144 forward 6.201267242431641e-06 bandwidth (GB/s) 169.09060019623223
bernoulli, size, elements 524288 forward 6.272792816162109e-06 bandwidth (GB/s) 334.3250863629039
bernoulli, size, elements 1048576 forward 8.275508880615235e-06 bandwidth (GB/s) 506.83336342310577
bernoulli, size, elements 2097152 forward 1.2857913970947266e-05 bandwidth (GB/s) 652.4081603714445
bernoulli, size, elements 4194304 forward 2.348184585571289e-05 bandwidth (GB/s) 714.4760298270282
bernoulli, size, elements 8388608 forward 4.356622695922851e-05 bandwidth (GB/s) 770.1936647257047
bernoulli, size, elements 16777216 forward 8.656024932861328e-05 bandwidth (GB/s) 775.2850126994326
bernoulli, size, elements 33554432 forward 0.0001675891876220703 bandwidth (GB/s) 800.8734328534002
```
### Double Type
#### Before:
```
bernoulli, size, elements 65536 forward 5.733966827392578e-06 bandwidth (GB/s) 45.717739200665285
bernoulli, size, elements 131072 forward 6.6208839416503905e-06 bandwidth (GB/s) 79.18700956254952
bernoulli, size, elements 262144 forward 1.0859966278076171e-05 bandwidth (GB/s) 96.55425929975851
bernoulli, size, elements 524288 forward 1.7333030700683594e-05 bandwidth (GB/s) 120.99165092445668
bernoulli, size, elements 1048576 forward 3.1557083129882816e-05 bandwidth (GB/s) 132.91165038090057
bernoulli, size, elements 2097152 forward 5.902767181396485e-05 bandwidth (GB/s) 142.11314358523305
bernoulli, size, elements 4194304 forward 0.00011337995529174805 bandwidth (GB/s) 147.9733869785806
bernoulli, size, elements 8388608 forward 0.00022054195404052734 bandwidth (GB/s) 152.14534643070206
bernoulli, size, elements 16777216 forward 0.0004380941390991211 bandwidth (GB/s) 153.18366079491483
bernoulli, size, elements 33554432 forward 0.0008704972267150879 bandwidth (GB/s) 154.1851299245198
```
#### After:
```
bernoulli, size, elements 65536 forward 5.877017974853515e-06 bandwidth (GB/s) 44.60493418969575
bernoulli, size, elements 131072 forward 5.819797515869141e-06 bandwidth (GB/s) 90.08698302138468
bernoulli, size, elements 262144 forward 6.091594696044922e-06 bandwidth (GB/s) 172.1348928025049
bernoulli, size, elements 524288 forward 8.232593536376953e-06 bandwidth (GB/s) 254.73770698546193
bernoulli, size, elements 1048576 forward 1.3000965118408203e-05 bandwidth (GB/s) 322.6148183461581
bernoulli, size, elements 2097152 forward 2.2871494293212892e-05 bandwidth (GB/s) 366.7713133413114
bernoulli, size, elements 4194304 forward 4.316329956054687e-05 bandwidth (GB/s) 388.69169342501107
bernoulli, size, elements 8388608 forward 8.46099853515625e-05 bandwidth (GB/s) 396.5776835981966
bernoulli, size, elements 16777216 forward 0.00016601085662841796 bandwidth (GB/s) 404.2438269577137
bernoulli, size, elements 33554432 forward 0.00031869888305664063 bandwidth (GB/s) 421.14276244936264
```

Differential Revision: [D15632935](https://our.internmc.facebook.com/intern/diff/D15632935)