### PR TITLE
Export feature length information for onnxifi operator

### DIFF
--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -156,11 +156,9 @@ ShapeInfoMap BackendTransformerBase::inferShapes(
   return shape_map;
 }
 
-void BackendTransformerBase::dumpNet(
-    const NetDef& pred_net,
-    const ShapeInfoMap& shape_hints,
-    const std::string& fname) const {
-  NetDef shape_net(pred_net);
+void BackendTransformerBase::addShapeToNet(
+    NetDef& shape_net,
+    const ShapeInfoMap& shape_hints) const {
   auto* shape_arg = shape_net.add_arg();
   auto* qshape_arg = shape_net.add_arg();
   shape_arg->set_name("shape_info");
@@ -176,6 +174,14 @@ void BackendTransformerBase::dumpNet(
       qshape_arg->mutable_qtensors()->Add()->CopyFrom(t);
     }
   }
+}
+
+void BackendTransformerBase::dumpNet(
+    const NetDef& pred_net,
+    const ShapeInfoMap& shape_hints,
+    const std::string& fname) const {
+  NetDef shape_net(pred_net);
+  addShapeToNet(shape_net, shape_hints);
   WriteProtoToTextFile(shape_net, fname);
 }
 } // namespace caffe2

--- a/caffe2/opt/backend_transformer_base.h
+++ b/caffe2/opt/backend_transformer_base.h
@@ -56,6 +56,9 @@ class BackendTransformerBase {
   // Get model ID from the NetDef
   std::string getModelId(const NetDef& net);
 
+  // add shape info to the net
+  void addShapeToNet(NetDef& shape_net, const ShapeInfoMap& shape_hints) const;
+
   // Dump the net with shape info
   void dumpNet(
       const NetDef& pred_net,

--- a/caffe2/opt/onnxifi_transformer.cc
+++ b/caffe2/opt/onnxifi_transformer.cc
@@ -910,10 +910,12 @@ void OnnxifiTransformer::transform(
   // Need to figure out a proper place to handle device option
   net_opt.mutable_device_option()->CopyFrom(pred_net->device_option());
 
-  if (opts_.debug) {
-    dumpNet(*pred_net, shape_hints, "debug_full_opt_net.pb_txt");
-  }
   pred_net->Swap(&net_opt);
+
+  addShapeToNet(*pred_net, shape_hints);
+  if (opts_.debug) {
+    WriteProtoToTextFile(*pred_net, "debug_full_opt_net.pb_txt");
+  }
 }
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Export feature length information for onnxifi operator
recommit for D15548138
disable caffe2_extract_feature_length_for_shape_inference by default
change LOG(INFO) to VLOG(4)
change LOG(WARNING) to LOG_EVERY_N(WARNING, 1000)

Differential Revision: D15608620

