### PR TITLE
[jit] Support recursive ModuleList / Sequential

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7753,7 +7753,7 @@ a")
         input = torch.randn(1, 5, 5)
         o = m(input)
         self.assertEqual(o, m.sub(input))
-        with self.assertRaisesRegex(RuntimeError, "cannot re-assign"):
+        with self.assertRaisesRegex(RuntimeError, "Cannot re-assign"):
             m.sub = nn.Linear(5, 5)
 
     def test_script_inline_trace_multiple_args(self):

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -275,7 +275,6 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
 
   // This can also be a call to a non-script module, or a plain
   // python method. If so return this as a python value.
-
   py::object overloads =
       py_module_.attr("_overloads").attr("get")(field, py::none());
   if (!overloads.is_none()) {
@@ -327,7 +326,7 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
         module_->register_module(field, submodule);
         auto v = module_->find_module(field);
         return std::make_shared<ModuleValue>(
-            m.graph()->insertGetAttr(self_, field), v, attr);
+            m.graph()->insertGetAttr(self_, field), v, result);
       }
     } else if (py::isinstance<py::function>(attr)) {
       auto stub = py::module::import("torch.jit")

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -971,6 +971,8 @@ def _try_compile_fn(fn):
         return None
 
     if isinstance(fn, torch.nn.Module):
+        # Since modules are callable pybind recognizes them as functions, but
+        # don't do anything for them
         return None
 
     # We don't have the actual scope where the function was defined, but we can

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -945,6 +945,8 @@ def _create_constant_iterable_module(module):
         if isinstance(submodule, (ModuleList, Sequential)):
             # Make each item in the module a constant
             module[i] = _create_constant_iterable_module(submodule)
+        else:
+            module[i] = _convert_to_script_module(submodule)
 
     if isinstance(module, Sequential):
         return _ConstSequential(module)
@@ -1278,7 +1280,6 @@ class ScriptMeta(type):
                 cls._methods[v.original_method.__name__] = v
 
         original_init = getattr(cls, '__init__', lambda self: None)
-        print("set overloads", cls, name)
         cls._overloads = dict(getattr(cls, '__overloads__', {}))
 
         # after the user's __init__ register all the script methods

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1255,6 +1255,8 @@ def _create_methods_from_stubs(self, stubs):
 # has run. This has to occur after the user-defined __init__ so that
 # submodules and parameters are initialized _before_ the script compiler
 # resolve references to `self.param` or `self.module`.
+
+
 class ScriptMeta(type):
     # this has to inherit from pybind11's metaclass otherwise we get
     # issues because ScriptModule inherits from torch._C.ScriptModule,


### PR DESCRIPTION
Adds support for recursively compiling `nn.Sequential` and
`nn.ModuleList`. When either is used, it is converted to a
`jit._ConstModuleList` or `jit._ConstSequential` as necessary. Due to
this, we don't need to add it to `__constants__` since it's made
constant on demand.

This PR also moves the recursive script tests out to their own class
`TestRecursiveScript` (the added test is called `test_iterable_modules`)

Differential Revision: [D15611738](https://our.internmc.facebook.com/intern/diff/15611738/)