### PR TITLE
Use "important" node to toggle whether or not to build on PR

### DIFF
--- a/.circleci/cimodel/data/caffe2_build_data.py
+++ b/.circleci/cimodel/data/caffe2_build_data.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
-from cimodel.lib.conf_tree import ConfigNode, X
+from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 from cimodel.lib.conf_tree import Ver
-import cimodel.data.dimensions as dimensions
 
 
 CONFIG_TREE_DATA = [
@@ -14,16 +13,17 @@ CONFIG_TREE_DATA = [
         (Ver("cuda", "9.0"), [
             # TODO make explicit that this is a "secret TensorRT build"
             #  (see https://github.com/pytorch/pytorch/pull/17323#discussion_r259446749)
+            # TODO Uh oh, were we supposed to make this one important?!
             X("py2"),
-            X("cmake"),
+            XImportant("cmake"),
         ]),
-        (Ver("cuda", "9.1"), [X("py2")]),
-        (Ver("mkl"), [X("py2")]),
-        (Ver("gcc", "5"), [X("onnx_py2")]),
+        (Ver("cuda", "9.1"), [XImportant("py2")]),
+        (Ver("mkl"), [XImportant("py2")]),
+        (Ver("gcc", "5"), [XImportant("onnx_py2")]),
         (Ver("clang", "3.8"), [X("py2")]),
         (Ver("clang", "3.9"), [X("py2")]),
-        (Ver("clang", "7"), [X("py2")]),
-        (Ver("android"), [X("py2")]),
+        (Ver("clang", "7"), [XImportant("py2")]),
+        (Ver("android"), [XImportant("py2")]),
     ]),
     (Ver("centos", "7"), [
         (Ver("cuda", "9.0"), [X("py2")]),
@@ -32,7 +32,7 @@ CONFIG_TREE_DATA = [
         # TODO ios and system aren't related. system qualifies where the python comes
         #  from (use the system python instead of homebrew or anaconda)
         (Ver("ios"), [X("py2")]),
-        (Ver("system"), [X("py2")]),
+        (Ver("system"), [XImportant("py2")]),
     ]),
 ]
 
@@ -95,16 +95,13 @@ class LanguageConfigNode(TreeConfigNode):
         self.props["language_version"] = node_name
         self.props["build_only"] = self.is_build_only()
 
-    def get_children(self):
-
-        children = []
-        for phase in dimensions.PHASES:
-            if phase == "build" or not self.props["build_only"]:
-                children.append(PhaseConfigNode(self, phase, []))
-
-        return children
+    def child_constructor(self):
+        return ImportantConfigNode
 
 
-class PhaseConfigNode(TreeConfigNode):
+class ImportantConfigNode(TreeConfigNode):
     def init2(self, node_name):
-        self.props["phase_name"] = node_name
+        self.props["important"] = True
+
+    def get_children(self):
+        return []

--- a/.circleci/cimodel/data/caffe2_build_definitions.py
+++ b/.circleci/cimodel/data/caffe2_build_definitions.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict
 
+import cimodel.data.dimensions as dimensions
 import cimodel.lib.conf_tree as conf_tree
 from cimodel.lib.conf_tree import Ver
 import cimodel.lib.miniutils as miniutils
@@ -22,8 +23,8 @@ class Conf:
     language: str
     distro: Ver
     compiler: Ver
-    phase: str
     build_only: bool
+    is_important: bool
 
     # TODO: Eventually we can probably just remove the cudnn7 everywhere.
     def get_cudnn_insertion(self):
@@ -47,9 +48,6 @@ class Conf:
         root_parts = self.get_build_name_root_parts()
         return "_".join(root_parts + [phase]).replace(".", "_")
 
-    def get_name(self):
-        return self.construct_phase_name(self.phase)
-
     def get_platform(self):
         platform = self.distro.name
         if self.distro.name != "macos":
@@ -67,7 +65,7 @@ class Conf:
         parts = [lang] + self.get_build_name_middle_parts()
         return miniutils.quote(DOCKER_IMAGE_PATH_BASE + "-".join(parts) + ":" + str(DOCKER_IMAGE_VERSION))
 
-    def gen_yaml_tree(self):
+    def gen_yaml_tree(self, phase):
 
         tuples = []
 
@@ -80,7 +78,7 @@ class Conf:
         parts = [
             "caffe2",
             lang,
-        ] + self.get_build_name_middle_parts() + [self.phase]
+        ] + self.get_build_name_middle_parts() + [phase]
 
         build_env = "-".join(parts)
         if not self.distro.name == "macos":
@@ -91,7 +89,7 @@ class Conf:
         if self.compiler.name == "ios":
             tuples.append(("BUILD_IOS", miniutils.quote("1")))
 
-        if self.phase == "test":
+        if phase == "test":
             # TODO cuda should not be considered a compiler
             if self.compiler.name == "cuda":
                 tuples.append(("USE_CUDA_DOCKER_RUNTIME", miniutils.quote("1")))
@@ -106,11 +104,11 @@ class Conf:
 
         d = OrderedDict({"environment": OrderedDict(tuples)})
 
-        if self.phase == "test":
+        if phase == "test":
             resource_class = "large" if self.compiler.name != "cuda" else "gpu.medium"
             d["resource_class"] = resource_class
 
-        d["<<"] = "*" + "_".join(["caffe2", self.get_platform(), self.phase, "defaults"])
+        d["<<"] = "*" + "_".join(["caffe2", self.get_platform(), phase, "defaults"])
 
         return d
 
@@ -128,11 +126,11 @@ def instantiate_configs():
     for fc in found_configs:
 
         c = Conf(
-            fc.find_prop("language_version"),
-            fc.find_prop("distro_version"),
-            fc.find_prop("compiler_version"),
-            fc.find_prop("phase_name"),
-            fc.find_prop("build_only"),
+            language=fc.find_prop("language_version"),
+            distro=fc.find_prop("distro_version"),
+            compiler=fc.find_prop("compiler_version"),
+            build_only=fc.find_prop("build_only"),
+            is_important=fc.find_prop("important"),
         )
 
         config_list.append(c)
@@ -141,10 +139,13 @@ def instantiate_configs():
 
 
 def add_caffe2_builds(jobs_dict):
-
     configs = instantiate_configs()
     for conf_options in configs:
-        jobs_dict[conf_options.get_name()] = conf_options.gen_yaml_tree()
+        phases = ["build"]
+        if not conf_options.build_only:
+            phases = dimensions.PHASES
+        for phase in phases:
+            jobs_dict[conf_options.construct_phase_name(phase)] = conf_options.gen_yaml_tree(phase)
 
     graph = visualization.generate_graph(get_root())
     graph.draw("caffe2-config-dimensions.png", prog="twopi")
@@ -161,11 +162,21 @@ def get_caffe2_workflows():
     x = []
     for conf_options in filtered_configs:
 
-        requires = ["setup"]
+        phases = ["build"]
+        if not conf_options.build_only:
+            phases = dimensions.PHASES
 
-        if conf_options.phase == "test":
-            requires.append(conf_options.construct_phase_name("build"))
+        for phase in phases:
 
-        x.append({conf_options.get_name(): {"requires": requires}})
+            requires = ["setup"]
+            sub_d = {"requires": requires}
+
+            if phase == "test":
+                requires.append(conf_options.construct_phase_name("build"))
+
+            if not conf_options.is_important:
+                sub_d["filters"] = {"branches": {"only": "master"}}
+
+            x.append({conf_options.construct_phase_name(phase): sub_d})
 
     return x

--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 
-from cimodel.lib.conf_tree import ConfigNode, X
+from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 
 
 CONFIG_TREE_DATA = [
     ("trusty", [
         (None, [
-            X("2.7.9"),
+            XImportant("2.7.9"),
             X("2.7"),
-            ("3.5", [("important", [X(True)])]),
+            X("3.5"),
             X("nightly"),
         ]),
         ("gcc", [
             ("4.8", [X("3.6")]),
             ("5.4", [
-                X("3.6"),
+                XImportant("3.6"),
                 ("3.6", [
                     ("xla", [X(True)]),
                     ("namedtensor", [X(True)]),
@@ -25,7 +25,7 @@ CONFIG_TREE_DATA = [
     ]),
     ("xenial", [
         ("clang", [
-            ("5", [X("3.6")]),
+            ("5", [XImportant("3.6")]),  # This is actually the ASAN build
         ]),
         ("cuda", [
             ("9", [
@@ -36,14 +36,14 @@ CONFIG_TREE_DATA = [
                 # and
                 # https://github.com/pytorch/pytorch/blob/master/.jenkins/pytorch/build.sh#L153
                 # (from https://github.com/pytorch/pytorch/pull/17323#discussion_r259453144)
-                ("2.7", [("important", [X(True)])]),
-                X("3.6"),
+                X("2.7"),
+                XImportant("3.6"),
             ]),
             ("9.2", [X("3.6")]),
             ("10", [X("3.6")]),
         ]),
         ("android", [
-            ("r19c", [X("3.6")]),
+            ("r19c", [XImportant("3.6")]),
         ]),
     ]),
 ]

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -38,8 +38,10 @@ class Conf:
     # In the short term, we *will* need to support special casing as docker images are merged for caffe2 and pytorch
     def get_parms(self, for_docker):
         leading = []
-        if self.is_important and not for_docker:
-            leading.append("AAA")
+        # We just don't run non-important jobs on pull requests;
+        # previously we also named them in a way to make it obvious
+        #if self.is_important and not for_docker:
+        #    leading.append("AAA")
         leading.append("pytorch")
         if self.is_xla and not for_docker:
             leading.append("xla")
@@ -116,6 +118,9 @@ class Conf:
             dependency_build = self.parent_build or self
             parameters["requires"].append(dependency_build.gen_build_name("build"))
 
+        if not self.is_important:
+            parameters["filters"] = {"branches": {"only": "master"}}
+
         return {self.gen_build_name(phase): parameters}
 
 
@@ -155,6 +160,7 @@ def gen_dependent_configs(xenial_parent_config):
             restrict_phases=["test"],
             gpu_resource=gpu,
             parent_build=xenial_parent_config,
+            is_important=xenial_parent_config.is_important,
         )
 
         configs.append(c)
@@ -210,6 +216,7 @@ def instantiate_configs():
             gcc_version = compiler_name + (fc.find_prop("compiler_version") or "")
             parms_list.append(gcc_version)
 
+            # TODO: This is a nasty special case
             if compiler_name == "clang":
                 parms_list.append("asan")
 

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -40,7 +40,7 @@ class Conf:
         leading = []
         # We just don't run non-important jobs on pull requests;
         # previously we also named them in a way to make it obvious
-        #if self.is_important and not for_docker:
+        # if self.is_important and not for_docker:
         #    leading.append("AAA")
         leading.append("pytorch")
         if self.is_xla and not for_docker:

--- a/.circleci/cimodel/lib/conf_tree.py
+++ b/.circleci/cimodel/lib/conf_tree.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Optional, Dict
 
 
 def X(val):
@@ -9,6 +10,11 @@ def X(val):
     Compact way to write a leaf node
     """
     return val, []
+
+
+def XImportant(name):
+    """Compact way to write an important (run on PRs) leaf node"""
+    return (name, [("important", [X(True)])])
 
 
 @dataclass
@@ -23,11 +29,11 @@ class Ver:
         return self.name + self.version
 
 
-class ConfigNode(object):
-    def __init__(self, parent, node_name):
-        self.parent = parent
-        self.node_name = node_name
-        self.props = {}
+@dataclass
+class ConfigNode:
+    parent: Optional['ConfigNode']
+    node_name: str
+    props: Dict[str, str] = field(default_factory=dict)
 
     def get_label(self):
         return self.node_name

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,15 +823,15 @@ jobs:
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
-  AAA_pytorch_linux_trusty_py3_5_build:
+  pytorch_linux_trusty_py3_5_build:
     environment:
-      BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-build
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.5-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
     <<: *pytorch_linux_build_defaults
 
-  AAA_pytorch_linux_trusty_py3_5_test:
+  pytorch_linux_trusty_py3_5_test:
     environment:
-      BUILD_ENVIRONMENT: AAA-pytorch-linux-trusty-py3.5-test
+      BUILD_ENVIRONMENT: pytorch-linux-trusty-py3.5-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-trusty-py3.5:300"
     resource_class: large
     <<: *pytorch_linux_test_defaults
@@ -929,16 +929,16 @@ jobs:
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
-  AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_build:
+  pytorch_linux_xenial_cuda9_cudnn7_py2_build:
     environment:
-      BUILD_ENVIRONMENT: AAA-pytorch-linux-xenial-cuda9-cudnn7-py2-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:300"
       PYTHON_VERSION: "2.7"
     <<: *pytorch_linux_build_defaults
 
-  AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+  pytorch_linux_xenial_cuda9_cudnn7_py2_test:
     environment:
-      BUILD_ENVIRONMENT: AAA-pytorch-linux-xenial-cuda9-cudnn7-py2-test
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:300"
       PYTHON_VERSION: "2.7"
       USE_CUDA_DOCKER_RUNTIME: "1"
@@ -2579,31 +2579,55 @@ workflows:
       - pytorch_linux_trusty_py2_7_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_py2_7_test:
           requires:
             - setup
             - pytorch_linux_trusty_py2_7_build
-      - AAA_pytorch_linux_trusty_py3_5_build:
+          filters:
+            branches:
+              only: master
+      - pytorch_linux_trusty_py3_5_build:
           requires:
             - setup
-      - AAA_pytorch_linux_trusty_py3_5_test:
+          filters:
+            branches:
+              only: master
+      - pytorch_linux_trusty_py3_5_test:
           requires:
             - setup
-            - AAA_pytorch_linux_trusty_py3_5_build
+            - pytorch_linux_trusty_py3_5_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_pynightly_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_pynightly_test:
           requires:
             - setup
             - pytorch_linux_trusty_pynightly_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_py3_6_gcc4_8_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_py3_6_gcc4_8_test:
           requires:
             - setup
             - pytorch_linux_trusty_py3_6_gcc4_8_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_py3_6_gcc5_4_build:
           requires:
             - setup
@@ -2614,24 +2638,42 @@ workflows:
       - pytorch_xla_linux_trusty_py3_6_gcc5_4_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_xla_linux_trusty_py3_6_gcc5_4_test:
           requires:
             - setup
             - pytorch_xla_linux_trusty_py3_6_gcc5_4_build
+          filters:
+            branches:
+              only: master
       - pytorch_namedtensor_linux_trusty_py3_6_gcc5_4_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_namedtensor_linux_trusty_py3_6_gcc5_4_test:
           requires:
             - setup
             - pytorch_namedtensor_linux_trusty_py3_6_gcc5_4_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_py3_6_gcc7_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_linux_trusty_py3_6_gcc7_test:
           requires:
             - setup
             - pytorch_linux_trusty_py3_6_gcc7_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_xenial_py3_clang5_asan_build:
           requires:
             - setup
@@ -2639,13 +2681,19 @@ workflows:
           requires:
             - setup
             - pytorch_linux_xenial_py3_clang5_asan_build
-      - AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_build:
+      - pytorch_linux_xenial_cuda9_cudnn7_py2_build:
           requires:
             - setup
-      - AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_test:
+          filters:
+            branches:
+              only: master
+      - pytorch_linux_xenial_cuda9_cudnn7_py2_test:
           requires:
             - setup
-            - AAA_pytorch_linux_xenial_cuda9_cudnn7_py2_build
+            - pytorch_linux_xenial_cuda9_cudnn7_py2_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_xenial_cuda9_cudnn7_py3_build:
           requires:
             - setup
@@ -2682,40 +2730,67 @@ workflows:
       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
           requires:
             - setup
             - pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build
+          filters:
+            branches:
+              only: master
       - pytorch_linux_xenial_cuda10_cudnn7_py3_gcc7_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_build:
           requires:
             - setup
+      # Warning: indentation here matters!
 
       # Pytorch MacOS builds
       - pytorch_macos_10_13_py3_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_macos_10_13_py3_test:
           requires:
             - setup
             - pytorch_macos_10_13_py3_build
+          filters:
+            branches:
+              only: master
       - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build:
           requires:
             - setup
-            
       - caffe2_py2_gcc4_8_ubuntu14_04_build:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
       - caffe2_py2_gcc4_8_ubuntu14_04_test:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
             - caffe2_py2_gcc4_8_ubuntu14_04_build
       - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
       - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
             - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
@@ -2748,9 +2823,15 @@ workflows:
             - setup
             - caffe2_onnx_py2_gcc5_ubuntu16_04_build
       - caffe2_py2_clang3_8_ubuntu16_04_build:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
       - caffe2_py2_clang3_9_ubuntu16_04_build:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
       - caffe2_py2_clang7_ubuntu16_04_build:
@@ -2760,13 +2841,22 @@ workflows:
           requires:
             - setup
       - caffe2_py2_cuda9_0_cudnn7_centos7_build:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
       - caffe2_py2_cuda9_0_cudnn7_centos7_test:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
             - caffe2_py2_cuda9_0_cudnn7_centos7_build
       - caffe2_py2_ios_macos10_13_build:
+          filters:
+            branches:
+              only: master
           requires:
             - setup
       - caffe2_py2_system_macos10_13_build:

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -4,6 +4,9 @@ import sys
 
 # Modify this variable if you want to change the set of default jobs
 # which are run on all pull requests.
+#
+# WARNING: Actually, this is a lie; we're currently also controlling
+# the set of jobs to run via the Workflows filters in CircleCI config.
 
 default_set = [
     # PyTorch CPU

--- a/.circleci/scripts/should_run_job.sh
+++ b/.circleci/scripts/should_run_job.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -exu -o pipefail
 
+echo "This check is currently disabled in favor of branch-based filtering"
+exit 0
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Check if we should actually run

--- a/.circleci/verbatim-sources/workflows-pytorch-macos-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-macos-builds.yml
@@ -1,13 +1,19 @@
+      # Warning: indentation here matters!
 
       # Pytorch MacOS builds
       - pytorch_macos_10_13_py3_build:
           requires:
             - setup
+          filters:
+            branches:
+              only: master
       - pytorch_macos_10_13_py3_test:
           requires:
             - setup
             - pytorch_macos_10_13_py3_build
+          filters:
+            branches:
+              only: master
       - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build:
           requires:
             - setup
-            


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21308 Use "important" node to toggle whether or not to build on PR**
* #21284 Make .circleci Conf class uses dataclasses; use types.

- Previously, the "important" tag was used to determine if you should
  prefix AAA_ in job name.  Now I get rid of that prefix, but instead
  if your job is not important, we filter it to only run on master.

- To do this, I rewrote the Caffe2 build data to stop generating
  explicit Phase nodes (this probably wasn't strictly necessary, but
  I don't really understand how the tree logic works, but I know
  that PyTorch build data works without explicit phase nodes, so
  I just lined these two up.)

- ConfigNode is a dataclass now too.

TODO:
- Extend filter so that there are other branch names you can push to
  to trigger these jobs.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D15621909](https://our.internmc.facebook.com/intern/diff/D15621909)