### PR TITLE
[mkldnn][pooling] support ceil mode by padding changes

### DIFF
--- a/aten/src/ATen/native/mkldnn/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/Utils.cpp
@@ -25,7 +25,8 @@ std::vector<int64_t> pool_output_sizes(
     IntArrayRef input_size,
     IntArrayRef kernel_size,
     IntArrayRef stride,
-    IntArrayRef padding,
+    IntArrayRef padding_l,
+    IntArrayRef padding_r,
     IntArrayRef dilation,
     bool ceil_mode) {
   std::vector<int64_t> output_size(input_size.size());
@@ -33,11 +34,12 @@ std::vector<int64_t> pool_output_sizes(
   output_size[0] = input_size[0];
   output_size[1] = input_size[1];
 
-  for (int i = 2; i < input_size.size(); ++i) {
-    output_size[i] = pooling_output_shape<int64_t>(
+  for (size_t i = 2; i < input_size.size(); ++i) {
+    output_size[i] = pooling_output_shape_pad_lr<int64_t>(
       input_size[i],
       kernel_size[i - 2],
-      padding[i - 2],
+      padding_l[i - 2],
+      padding_r[i - 2],
       stride[i - 2],
       dilation[i - 2],
       ceil_mode

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -16,7 +16,8 @@ std::vector<int64_t> pool_output_sizes(
     IntArrayRef input_size,
     IntArrayRef kernel_size,
     IntArrayRef stride,
-    IntArrayRef padding,
+    IntArrayRef padding_l,
+    IntArrayRef padding_r,
     IntArrayRef dilation,
     bool ceil_mode);
 }}

--- a/aten/src/THNN/generic/pooling_shape.h
+++ b/aten/src/THNN/generic/pooling_shape.h
@@ -2,16 +2,26 @@
 #define THNN_POOLING_SHAPE_H
 
 template<typename T>
-static inline T pooling_output_shape(
-        T inputSize, T kernelSize, T pad, T stride, T dilation, bool ceil_mode) {
-    T outputSize = ((inputSize + 2 * pad - dilation * (kernelSize - 1) - 1 + (ceil_mode ? stride - 1 : 0)) / stride + 1);
-    if (pad) {
+static inline T pooling_output_shape_pad_lr(
+    T inputSize, T kernelSize, T pad_l, T pad_r, T stride, T dilation,
+    bool ceil_mode
+  ) {
+    T outputSize = ((inputSize + pad_l + pad_r - dilation * (kernelSize - 1)
+        - 1 + (ceil_mode ? stride - 1 : 0)) / stride + 1);
+    if (pad_l) {
         // ensure that the last pooling starts inside the image
         // needed to avoid problems in ceil mode
-        if ((outputSize - 1) * stride >= inputSize + pad)
+        if ((outputSize - 1) * stride >= inputSize + pad_l)
           --outputSize;
     }
     return outputSize;
+}
+
+template<typename T>
+static inline T pooling_output_shape(
+      T inputSize, T kernelSize, T pad, T stride, T dilation, bool ceil_mode) {
+    return pooling_output_shape_pad_lr(
+        inputSize, kernelSize, pad, pad, stride, dilation, ceil_mode);
 }
 
 #endif

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -126,16 +126,21 @@ class TestMkldnn(TestCase):
     def test_max_pool2d(self):
         N = torch.randint(3, 10, (1,)).item()
         C = torch.randint(3, 10, (1,)).item()
-        x = torch.randn(N, C, 64, 64, dtype=torch.float32) * 10
 
-        max_pool2d = torch.nn.MaxPool2d(
-            kernel_size=3,
-            stride=2,
-            padding=1)
+        for stride in [1, 2, 3]:
+            for H, W in [(64, 64), (35, 39), (16, 19), [7, 8]]:
+                x = torch.randn(N, C, H, W, dtype=torch.float32) * 10
 
-        self.assertEqual(
-            max_pool2d(x),
-            max_pool2d(x.to_mkldnn()).to_dense())
+                for ceil_mode in [False, True]:
+                    max_pool2d = torch.nn.MaxPool2d(
+                        kernel_size=3 if not ceil_mode else 7,
+                        stride=stride,
+                        padding=1,
+                        ceil_mode=ceil_mode)
+
+                    self.assertEqual(
+                        max_pool2d(x),
+                        max_pool2d(x.to_mkldnn()).to_dense())
 
     def test_avg_pool2d(self):
         N = torch.randint(3, 10, (1,)).item()


### PR DESCRIPTION
Modify MKLDNN pooling operation to support ceil mode by adjusting the right/bottom padding accordingly. This is done similarly as in Caffe (see discussion https://github.com/pytorch/pytorch/pull/19205#discussion_r276903751).

To make this possible, I split the padding to left and right (top / bottom). This naming is confusing but actually follows mkldnn's own naming for pooling::compute(). We increase the r paddings so that it matches the ceiling mode expected output size. 

Strengthened the test case.