### PR TITLE
Remove double indirection for storing lists and dicts

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -190,6 +190,7 @@ private:
   c10::intrusive_ptr<detail::DictImpl> impl_;
 
   explicit DictPtr(c10::intrusive_ptr<detail::DictImpl>&& impl);
+  friend struct IValue;
   template<class K, class V> friend DictPtr<K, V> impl::toTypedDict(DictPtr<IValue, IValue>);
   template<class K, class V> friend DictPtr<IValue, IValue> impl::toGenericDict(DictPtr<K, V>);
 

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -406,7 +406,7 @@ public:
   // TODO Test use_count
   size_t use_count() const;
 
-protected:
+private:
   explicit ListPtr(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements);
   friend class IValue;
   template<class T_> friend ListPtr<T_> impl::toTypedList(ListPtr<IValue>);

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -392,10 +392,23 @@ public:
    */
   void resize(size_type count, const T& value) const;
 
+  /**
+   * Compares two lists for equality. Two lists are equal if they have the
+   * same number of elements and for each list position the elements at
+   * that position are equal.
+   */
   friend bool list_is_equal<T>(const ListPtr& lhs, const ListPtr& rhs);
+
+  /**
+   * Returns the number of ListPtrs currently pointing to this same list.
+   * If this is the only instance pointing to this list, returns 1.
+   */
+  // TODO Test use_count
+  size_t use_count() const;
 
 protected:
   explicit ListPtr(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements);
+  friend class IValue;
   template<class T_> friend ListPtr<T_> impl::toTypedList(ListPtr<IValue>);
   template<class T_> friend ListPtr<IValue> impl::toGenericList(ListPtr<T_>);
   friend const IValue* impl::ptr_to_first_element(const ListPtr<IValue>& list);

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -232,4 +232,9 @@ bool list_is_equal(const ListPtr<T>& lhs, const ListPtr<T>& rhs) {
   return true;
 }
 
+template<class T>
+size_t ListPtr<T>::use_count() const {
+  return impl_.use_count();
+}
+
 }

--- a/aten/src/ATen/core/dispatch/DispatchTable.h
+++ b/aten/src/ATen/core/dispatch/DispatchTable.h
@@ -233,7 +233,7 @@ private:
         reverse_index_of_first_tensor_arg_
       );
       if (C10_UNLIKELY(first_tensor_arg_is_tensor_list_)) {
-        const auto& tensor_list = first_tensor_arg.toTensorListRef();
+        auto tensor_list = first_tensor_arg.toTensorList(); // TODO avoid refcount bump?
         if (tensor_list.size() == 0) {
           throw std::runtime_error("Tried to dispatch operator " + operator_name + " based on an empty tensor list. When the first tensor argument of an operator is a tensor list, then it must not be empty.");
         }

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -17,15 +17,15 @@ CAFFE2_API c10::intrusive_ptr<ConstantString> ConstantString::create(
 
 namespace {
 
-template<typename List>
-std::ostream& printList(std::ostream & out, const List &v,
+template<class T>
+std::ostream& printList(std::ostream & out, const c10::ListPtr<T> &v,
   const std::string start, const std::string finish) {
   out << start;
-  for(size_t i = 0; i < v->elements().size(); ++i) {
+  for(size_t i = 0; i < v.size(); ++i) {
     if(i > 0)
       out << ", ";
     // make sure we use ivalue printing, and not default printing for the element type
-    out << IValue(v->elements()[i]);
+    out << IValue(v.get(i));
   }
   out << finish;
   return out;
@@ -36,7 +36,7 @@ std::ostream& printDict(std::ostream& out, const Dict& v) {
   out << "{";
 
   bool first = true;
-  for (const auto& pair : v->elements()) {
+  for (const auto& pair : v) {
     if (!first) {
       out << ", ";
     }
@@ -75,7 +75,7 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
     case IValue::Tag::Bool:
       return out << (v.toBool() ? "True" : "False");
     case IValue::Tag::Tuple:
-      return printList(out, v.toTuple(), "(", ")");
+      return printList(out, v.toTuple().elements(), "(", ")");
     case IValue::Tag::IntList:
       return printList(out, v.toIntList(), "[", "]");
     case IValue::Tag::DoubleList:
@@ -144,9 +144,9 @@ static bool CompareIValue(const std::pair<IValue, IValue>& aWrap,
   AT_ERROR("Illegal dict key");
 }
 
-const ivalue::GenericDict::IterationOrder ivalue::GenericDict::iterationOrder() const {
-  IterationOrder ordered;
-  for (auto element : elements()) {
+std::vector<std::pair<IValue, IValue>> iterationOrder(const c10::DictPtr<IValue, IValue>& dict) {
+  std::vector<std::pair<IValue, IValue>> ordered;
+  for (auto& element : dict) {
     ordered.emplace_back(element.key(), element.value());
   }
   std::sort(ordered.begin(), ordered.end(), CompareIValue);

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -16,13 +16,7 @@ template<class Key, class Value> class DictPtr;
 template<class T> class ListPtr;
 struct IValue;
 namespace ivalue {
-struct Tuple;
-template<class Elem> struct List;
-using IntList = List<int64_t>;
-using TensorList = List<at::Tensor>;
-using DoubleList = List<double>;
-using BoolList = List<bool>;
-using GenericList = List<IValue>;
+struct TuplePtr;
 struct Future;
 struct ConstantString;
 struct GenericDict;
@@ -157,10 +151,10 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<caffe2::Blob> toBlob() const &;
 
   // Tuple
-  IValue(c10::intrusive_ptr<ivalue::Tuple> v);
+  IValue(ivalue::TuplePtr v);
   bool isTuple() const { return Tag::Tuple == tag; }
-  c10::intrusive_ptr<ivalue::Tuple> toTuple() &&;
-  c10::intrusive_ptr<ivalue::Tuple> toTuple() const &;
+  ivalue::TuplePtr toTuple() &&;
+  ivalue::TuplePtr toTuple() const &;
 
   // Double
   IValue(double d)
@@ -208,26 +202,13 @@ struct CAFFE2_API IValue final {
   }
 
   // IntList
-  IValue(c10::intrusive_ptr<ivalue::IntList> v);
   IValue(c10::ListPtr<int64_t> v);
   IValue(c10::ArrayRef<int64_t> v);
   IValue(std::vector<int64_t> v);
   bool isIntList() const { return Tag::IntList == tag; }
-  c10::intrusive_ptr<ivalue::IntList> toIntList() &&;
-  c10::intrusive_ptr<ivalue::IntList> toIntList() const &;
+  c10::ListPtr<int64_t> toIntList() &&;
+  c10::ListPtr<int64_t> toIntList() const &;
 
-  const c10::ListPtr<int64_t>& toIntListRef() const &;
-  c10::ListPtr<int64_t> toIntListRef() &&;
-  const c10::ListPtr<double>& toDoubleListRef() const &;
-  c10::ListPtr<double> toDoubleListRef() &&;
-  const c10::ListPtr<bool>& toBoolListRef() const &;
-  c10::ListPtr<bool> toBoolListRef() &&;
-  const c10::ListPtr<at::Tensor>& toTensorListRef() const &;
-  c10::ListPtr<at::Tensor> toTensorListRef() &&;
-  const c10::ListPtr<IValue>& toGenericListRef() const &;
-  c10::ListPtr<IValue> toGenericListRef() &&;
-  const c10::DictPtr<IValue, IValue>& toGenericDictRef() const &;
-  c10::DictPtr<IValue, IValue> toGenericDictRef() &&;
   const std::string& toStringRef() const;
 
   // ConstantString
@@ -239,36 +220,32 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<ivalue::ConstantString> toString() const &;
 
   // DoubleList
-  IValue(c10::intrusive_ptr<ivalue::DoubleList> v);
   IValue(c10::ListPtr<double> v);
   IValue(std::vector<double> v);
   bool isDoubleList() const { return Tag::DoubleList == tag; }
-  c10::intrusive_ptr<ivalue::DoubleList> toDoubleList() &&;
-  c10::intrusive_ptr<ivalue::DoubleList> toDoubleList() const &;
+  c10::ListPtr<double> toDoubleList() &&;
+  c10::ListPtr<double> toDoubleList() const &;
 
   // BoolList
-  IValue(c10::intrusive_ptr<ivalue::BoolList> v);
   IValue(c10::ListPtr<bool> v);
   IValue(std::vector<bool> v);
   bool isBoolList() const { return Tag::BoolList == tag; }
-  c10::intrusive_ptr<ivalue::BoolList> toBoolList() &&;
-  c10::intrusive_ptr<ivalue::BoolList> toBoolList() const &;
+  c10::ListPtr<bool> toBoolList() &&;
+  c10::ListPtr<bool> toBoolList() const &;
 
   //TensorList
-  IValue(c10::intrusive_ptr<ivalue::TensorList> v);
   IValue(c10::ListPtr<at::Tensor> v);
   IValue(std::vector<at::Tensor> v);
   bool isTensorList() const { return Tag::TensorList == tag; }
-  c10::intrusive_ptr<ivalue::TensorList> toTensorList() &&;
-  c10::intrusive_ptr<ivalue::TensorList> toTensorList() const &;
+  c10::ListPtr<at::Tensor> toTensorList() &&;
+  c10::ListPtr<at::Tensor> toTensorList() const &;
 
   //GenericList
-  IValue(c10::intrusive_ptr<ivalue::GenericList> v);
   IValue(std::vector<IValue> v);
   IValue(c10::ListPtr<IValue> v);
   bool isGenericList() const { return Tag::GenericList == tag; }
-  c10::intrusive_ptr<ivalue::GenericList> toGenericList() &&;
-  c10::intrusive_ptr<ivalue::GenericList> toGenericList() const &;
+  c10::ListPtr<IValue> toGenericList() &&;
+  c10::ListPtr<IValue> toGenericList() const &;
 
   template<class T>
   IValue(c10::ListPtr<T> v);
@@ -276,11 +253,10 @@ struct CAFFE2_API IValue final {
   IValue(std::vector<T> v);
 
   // GenericDict
-  IValue(c10::intrusive_ptr<ivalue::GenericDict> v);
   IValue(c10::DictPtr<IValue, IValue> v);
   bool isGenericDict() const { return Tag::GenericDict == tag; }
-  c10::intrusive_ptr<ivalue::GenericDict> toGenericDict() &&;
-  c10::intrusive_ptr<ivalue::GenericDict> toGenericDict() const &;
+  c10::DictPtr<IValue, IValue> toGenericDict() &&;
+  c10::DictPtr<IValue, IValue> toGenericDict() const &;
 
   template<class Key, class Value>
   IValue(c10::DictPtr<Key, Value> v);
@@ -390,6 +366,11 @@ struct CAFFE2_API IValue final {
 
   bool isPtrType() const {
     return is_intrusive_ptr;
+  }
+
+  const void* toPointer() const {
+    TORCH_INTERNAL_ASSERT(isPtrType(), "Can only call toPointer() for pointer types");
+    return payload.as_intrusive_ptr;
   }
 
  private:

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -368,8 +368,8 @@ struct CAFFE2_API IValue final {
     return is_intrusive_ptr;
   }
 
-  const void* toPointer() const {
-    TORCH_INTERNAL_ASSERT(isPtrType(), "Can only call toPointer() for pointer types");
+  const void* internalToPointer() const {
+    TORCH_INTERNAL_ASSERT(isPtrType(), "Can only call internalToPointer() for pointer types");
     return payload.as_intrusive_ptr;
   }
 

--- a/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_function_legacy_test.cpp
@@ -22,8 +22,6 @@ using c10::TensorTypeId;
 using c10::KernelCache;
 using c10::Stack;
 using c10::guts::make_unique;
-using c10::ivalue::TensorList;
-using c10::ivalue::IntList;
 using c10::intrusive_ptr;
 using c10::DictPtr;
 using c10::make_dict;
@@ -185,10 +183,10 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithTensorLi
 
   auto result = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), dummyTensor(TensorType1()));
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[0].toTensorListRef().get(1).type_id());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(2).type_id());
+  EXPECT_EQ(3, result[0].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[0].toTensorList().get(1).type_id());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(2).type_id());
 }
 
 std::vector<int64_t> kernelWithIntListOutput(const Tensor&, int64_t input1, int64_t input2, int64_t input3) {
@@ -204,10 +202,10 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithIntListO
 
   auto result = callOp(*op, dummyTensor(TensorType1()), 2, 4, 6);
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toIntListRef().size());
-  EXPECT_EQ(2, result[0].toIntListRef().get(0));
-  EXPECT_EQ(4, result[0].toIntListRef().get(1));
-  EXPECT_EQ(6, result[0].toIntListRef().get(2));
+  EXPECT_EQ(3, result[0].toIntList().size());
+  EXPECT_EQ(2, result[0].toIntList().get(0));
+  EXPECT_EQ(4, result[0].toIntList().get(1));
+  EXPECT_EQ(6, result[0].toIntList().get(2));
 }
 
 std::tuple<Tensor, int64_t, std::vector<Tensor>, c10::optional<int64_t>, DictPtr<string, Tensor>> kernelWithMultipleOutputs(Tensor) {
@@ -234,11 +232,11 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithMultiple
   EXPECT_EQ(5, result.size());
   EXPECT_EQ(TensorType2(), result[0].toTensor().type_id());
   EXPECT_EQ(5, result[1].toInt());
-  EXPECT_EQ(2, result[2].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[2].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[2].toTensorListRef().get(1).type_id());
+  EXPECT_EQ(2, result[2].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[2].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[2].toTensorList().get(1).type_id());
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(std::move(result[4].toGenericDict()->elements()));
+  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(TensorType1(), result_dict.at("first").type_id());
   EXPECT_EQ(TensorType2(), result_dict.at("second").type_id());
@@ -374,7 +372,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithIntListI
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
@@ -390,7 +388,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithIntListI
   auto op = c10::Dispatcher::singleton().findSchema("_test::int_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
@@ -407,7 +405,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithTensorLi
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -423,7 +421,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithTensorLi
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -440,7 +438,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithLegacyTe
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -456,7 +454,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithLegacyTe
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -473,7 +471,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithLegacyTe
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -489,7 +487,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithLegacyTe
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -508,7 +506,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithStringLi
   c10::ListPtr<std::string> list = c10::make_list<std::string>({"value1", "value2"});
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
-  auto output = std::move(outputs[0].toGenericList()->elements());
+  auto output = std::move(outputs[0]).toGenericList();
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.get(0).toString()->string());
@@ -572,7 +570,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithDictOutp
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
@@ -634,7 +632,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithUnordere
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
@@ -657,7 +655,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithMapOfLis
   dict.insert("key2", c10::make_list<int64_t>({30, 40}));
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, c10::ListPtr<int64_t>>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, c10::ListPtr<int64_t>>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(2, output.at("key1").size());
@@ -690,7 +688,7 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithMapOfLis
   dict.insert("key2", c10::make_list<c10::DictPtr<int64_t, string>>({dict2}));
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, c10::ListPtr<c10::DictPtr<int64_t, string>>>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, c10::ListPtr<c10::DictPtr<int64_t, string>>>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(1, output.at("key1").size());
@@ -722,15 +720,15 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithListOfMa
   c10::ListPtr<c10::DictPtr<string, int64_t>> list = c10::make_list<c10::DictPtr<string, int64_t>>({dict1, dict2});
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
-  c10::impl::GenericListPtr output = std::move(outputs[0].toGenericList()->elements());
+  c10::impl::GenericListPtr output = std::move(outputs[0]).toGenericList();
 
   EXPECT_EQ(2, output.size());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().size());
-  EXPECT_EQ(1, output.get(0).toGenericDictRef().at("1").toInt());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("2").toInt());
-  EXPECT_EQ(2, output.get(1).toGenericDictRef().size());
-  EXPECT_EQ(3, output.get(1).toGenericDictRef().at("3").toInt());
-  EXPECT_EQ(4, output.get(1).toGenericDictRef().at("4").toInt());
+  EXPECT_EQ(2, output.get(0).toGenericDict().size());
+  EXPECT_EQ(1, output.get(0).toGenericDict().at("1").toInt());
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("2").toInt());
+  EXPECT_EQ(2, output.get(1).toGenericDict().size());
+  EXPECT_EQ(3, output.get(1).toGenericDict().at("3").toInt());
+  EXPECT_EQ(4, output.get(1).toGenericDict().at("4").toInt());
 }
 
 std::vector<std::unordered_map<string, std::vector<int64_t>>> kernelWithListOfMapOfIntList(std::vector<std::unordered_map<string, std::vector<int64_t>>> input) {
@@ -754,22 +752,22 @@ TEST(OperatorRegistrationTest_LegacyFunctionBasedKernel, givenKernelWithListOfMa
       c10::make_list<c10::DictPtr<string, c10::ListPtr<int64_t>>>({ dict1, dict2 });
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
-  c10::impl::GenericListPtr output = std::move(outputs[0].toGenericList()->elements());
+  c10::impl::GenericListPtr output = std::move(outputs[0]).toGenericList();
 
   EXPECT_EQ(2, output.size());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().size());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("1").toIntListRef().size());
-  EXPECT_EQ(1, output.get(0).toGenericDictRef().at("1").toIntListRef().get(0));
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("1").toIntListRef().get(1));
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("3").toIntListRef().size());
-  EXPECT_EQ(3, output.get(0).toGenericDictRef().at("3").toIntListRef().get(0));
-  EXPECT_EQ(4, output.get(0).toGenericDictRef().at("3").toIntListRef().get(1));
-  EXPECT_EQ(2, output.get(1).toGenericDictRef().at("5").toIntListRef().size());
-  EXPECT_EQ(5, output.get(1).toGenericDictRef().at("5").toIntListRef().get(0));
-  EXPECT_EQ(6, output.get(1).toGenericDictRef().at("5").toIntListRef().get(1));
-  EXPECT_EQ(2, output.get(1).toGenericDictRef().at("7").toIntListRef().size());
-  EXPECT_EQ(7, output.get(1).toGenericDictRef().at("7").toIntListRef().get(0));
-  EXPECT_EQ(8, output.get(1).toGenericDictRef().at("7").toIntListRef().get(1));
+  EXPECT_EQ(2, output.get(0).toGenericDict().size());
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("1").toIntList().size());
+  EXPECT_EQ(1, output.get(0).toGenericDict().at("1").toIntList().get(0));
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("1").toIntList().get(1));
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("3").toIntList().size());
+  EXPECT_EQ(3, output.get(0).toGenericDict().at("3").toIntList().get(0));
+  EXPECT_EQ(4, output.get(0).toGenericDict().at("3").toIntList().get(1));
+  EXPECT_EQ(2, output.get(1).toGenericDict().at("5").toIntList().size());
+  EXPECT_EQ(5, output.get(1).toGenericDict().at("5").toIntList().get(0));
+  EXPECT_EQ(6, output.get(1).toGenericDict().at("5").toIntList().get(1));
+  EXPECT_EQ(2, output.get(1).toGenericDict().at("7").toIntList().size());
+  EXPECT_EQ(7, output.get(1).toGenericDict().at("7").toIntList().get(0));
+  EXPECT_EQ(8, output.get(1).toGenericDict().at("7").toIntList().get(1));
 }
 
 bool called = false;

--- a/aten/src/ATen/core/op_registration/kernel_functor_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_functor_test.cpp
@@ -11,8 +11,6 @@ using c10::TensorTypeId;
 using c10::KernelCache;
 using c10::Stack;
 using c10::guts::make_unique;
-using c10::ivalue::TensorList;
-using c10::ivalue::IntList;
 using c10::intrusive_ptr;
 using c10::DictPtr;
 using c10::make_dict;
@@ -199,10 +197,10 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithTensorListOutpu
 
   auto result = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), dummyTensor(TensorType1()));
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[0].toTensorListRef().get(1).type_id());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(2).type_id());
+  EXPECT_EQ(3, result[0].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[0].toTensorList().get(1).type_id());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(2).type_id());
 }
 
 struct KernelWithIntListOutput final : OperatorKernel {
@@ -220,10 +218,10 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithIntListOutput_w
 
   auto result = callOp(*op, dummyTensor(TensorType1()), 2, 4, 6);
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toIntListRef().size());
-  EXPECT_EQ(2, result[0].toIntListRef().get(0));
-  EXPECT_EQ(4, result[0].toIntListRef().get(1));
-  EXPECT_EQ(6, result[0].toIntListRef().get(2));
+  EXPECT_EQ(3, result[0].toIntList().size());
+  EXPECT_EQ(2, result[0].toIntList().get(0));
+  EXPECT_EQ(4, result[0].toIntList().get(1));
+  EXPECT_EQ(6, result[0].toIntList().get(2));
 }
 
 struct KernelWithMultipleOutputs final : OperatorKernel {
@@ -252,11 +250,11 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithMultipleOutputs
   EXPECT_EQ(5, result.size());
   EXPECT_EQ(TensorType2(), result[0].toTensor().type_id());
   EXPECT_EQ(5, result[1].toInt());
-  EXPECT_EQ(2, result[2].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[2].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[2].toTensorListRef().get(1).type_id());
+  EXPECT_EQ(2, result[2].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[2].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[2].toTensorList().get(1).type_id());
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(std::move(result[4].toGenericDict()->elements()));
+  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(TensorType1(), result_dict.at("first").type_id());
   EXPECT_EQ(TensorType2(), result_dict.at("second").type_id());
@@ -411,7 +409,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithIntListInput_wi
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
@@ -429,7 +427,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithIntListInput_wi
   auto op = c10::Dispatcher::singleton().findSchema("_test::int_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
@@ -448,7 +446,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithTensorListInput
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -466,7 +464,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithTensorListInput
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -534,7 +532,7 @@ TEST(OperatorRegistrationTest_FunctorBasedKernel, givenKernelWithDictOutput_when
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));

--- a/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_legacy_test.cpp
@@ -21,8 +21,6 @@ using c10::TensorTypeId;
 using c10::KernelCache;
 using c10::Stack;
 using c10::guts::make_unique;
-using c10::ivalue::TensorList;
-using c10::ivalue::IntList;
 using c10::intrusive_ptr;
 using c10::DictPtr;
 using c10::make_dict;
@@ -168,10 +166,10 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithTensorList
 
   auto result = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), dummyTensor(TensorType1()));
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[0].toTensorListRef().get(1).type_id());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(2).type_id());
+  EXPECT_EQ(3, result[0].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[0].toTensorList().get(1).type_id());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(2).type_id());
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
@@ -185,10 +183,10 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithIntListOut
 
   auto result = callOp(*op, dummyTensor(TensorType1()), 2, 4, 6);
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toIntListRef().size());
-  EXPECT_EQ(2, result[0].toIntListRef().get(0));
-  EXPECT_EQ(4, result[0].toIntListRef().get(1));
-  EXPECT_EQ(6, result[0].toIntListRef().get(2));
+  EXPECT_EQ(3, result[0].toIntList().size());
+  EXPECT_EQ(2, result[0].toIntList().get(0));
+  EXPECT_EQ(4, result[0].toIntList().get(1));
+  EXPECT_EQ(6, result[0].toIntList().get(2));
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
@@ -213,11 +211,11 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithMultipleOu
   EXPECT_EQ(5, result.size());
   EXPECT_EQ(TensorType2(), result[0].toTensor().type_id());
   EXPECT_EQ(5, result[1].toInt());
-  EXPECT_EQ(2, result[2].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[2].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[2].toTensorListRef().get(1).type_id());
+  EXPECT_EQ(2, result[2].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[2].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[2].toTensorList().get(1).type_id());
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(std::move(result[4].toGenericDict()->elements()));
+  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(TensorType1(), result_dict.at("first").type_id());
   EXPECT_EQ(TensorType2(), result_dict.at("second").type_id());
@@ -340,7 +338,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithIntListInp
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
@@ -354,7 +352,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithIntListInp
   auto op = c10::Dispatcher::singleton().findSchema("_test::int_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
@@ -369,7 +367,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithTensorList
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -383,7 +381,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithTensorList
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -398,7 +396,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithLegacyTens
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -412,7 +410,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithLegacyTens
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -427,7 +425,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithLegacyTens
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -441,7 +439,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithLegacyTens
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -458,7 +456,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithStringList
   c10::ListPtr<std::string> list = c10::make_list<std::string>({"value1", "value2"});
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
-  auto output = std::move(outputs[0].toGenericList()->elements());
+  auto output = std::move(outputs[0]).toGenericList();
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.get(0).toString()->string());
@@ -516,7 +514,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithDictOutput
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
@@ -574,7 +572,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithUnorderedM
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));
@@ -595,7 +593,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithMapOfList_
   dict.insert("key2", c10::make_list<int64_t>({30, 40}));
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, c10::ListPtr<int64_t>>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, c10::ListPtr<int64_t>>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(2, output.at("key1").size());
@@ -627,7 +625,7 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithMapOfListO
   dict.insert("key2", c10::make_list<c10::DictPtr<int64_t, string>>({dict2}));
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, c10::ListPtr<std::unordered_map<int64_t, string>>>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, c10::ListPtr<std::unordered_map<int64_t, string>>>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(1, output.at("key1").size());
@@ -657,15 +655,15 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithListOfMap_
   c10::ListPtr<c10::DictPtr<string, int64_t>> list = c10::make_list<c10::DictPtr<string, int64_t>>({dict1, dict2});
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
-  c10::impl::GenericListPtr output = std::move(outputs[0].toGenericList()->elements());
+  c10::impl::GenericListPtr output = std::move(outputs[0]).toGenericList();
 
   EXPECT_EQ(2, output.size());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().size());
-  EXPECT_EQ(1, output.get(0).toGenericDictRef().at("1").toInt());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("2").toInt());
-  EXPECT_EQ(2, output.get(1).toGenericDictRef().size());
-  EXPECT_EQ(3, output.get(1).toGenericDictRef().at("3").toInt());
-  EXPECT_EQ(4, output.get(1).toGenericDictRef().at("4").toInt());
+  EXPECT_EQ(2, output.get(0).toGenericDict().size());
+  EXPECT_EQ(1, output.get(0).toGenericDict().at("1").toInt());
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("2").toInt());
+  EXPECT_EQ(2, output.get(1).toGenericDict().size());
+  EXPECT_EQ(3, output.get(1).toGenericDict().at("3").toInt());
+  EXPECT_EQ(4, output.get(1).toGenericDict().at("4").toInt());
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithListOfMapOfIntList_whenRegistered_thenCanBeCalled) {
@@ -687,22 +685,22 @@ TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenKernelWithListOfMapO
       c10::make_list<c10::DictPtr<string, c10::ListPtr<int64_t>>>({ dict1, dict2 });
   auto outputs = callOp(*op, list);
   EXPECT_EQ(1, outputs.size());
-  c10::impl::GenericListPtr output = std::move(outputs[0].toGenericList()->elements());
+  c10::impl::GenericListPtr output = std::move(outputs[0]).toGenericList();
 
   EXPECT_EQ(2, output.size());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().size());
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("1").toIntListRef().size());
-  EXPECT_EQ(1, output.get(0).toGenericDictRef().at("1").toIntListRef().get(0));
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("1").toIntListRef().get(1));
-  EXPECT_EQ(2, output.get(0).toGenericDictRef().at("3").toIntListRef().size());
-  EXPECT_EQ(3, output.get(0).toGenericDictRef().at("3").toIntListRef().get(0));
-  EXPECT_EQ(4, output.get(0).toGenericDictRef().at("3").toIntListRef().get(1));
-  EXPECT_EQ(2, output.get(1).toGenericDictRef().at("5").toIntListRef().size());
-  EXPECT_EQ(5, output.get(1).toGenericDictRef().at("5").toIntListRef().get(0));
-  EXPECT_EQ(6, output.get(1).toGenericDictRef().at("5").toIntListRef().get(1));
-  EXPECT_EQ(2, output.get(1).toGenericDictRef().at("7").toIntListRef().size());
-  EXPECT_EQ(7, output.get(1).toGenericDictRef().at("7").toIntListRef().get(0));
-  EXPECT_EQ(8, output.get(1).toGenericDictRef().at("7").toIntListRef().get(1));
+  EXPECT_EQ(2, output.get(0).toGenericDict().size());
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("1").toIntList().size());
+  EXPECT_EQ(1, output.get(0).toGenericDict().at("1").toIntList().get(0));
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("1").toIntList().get(1));
+  EXPECT_EQ(2, output.get(0).toGenericDict().at("3").toIntList().size());
+  EXPECT_EQ(3, output.get(0).toGenericDict().at("3").toIntList().get(0));
+  EXPECT_EQ(4, output.get(0).toGenericDict().at("3").toIntList().get(1));
+  EXPECT_EQ(2, output.get(1).toGenericDict().at("5").toIntList().size());
+  EXPECT_EQ(5, output.get(1).toGenericDict().at("5").toIntList().get(0));
+  EXPECT_EQ(6, output.get(1).toGenericDict().at("5").toIntList().get(1));
+  EXPECT_EQ(2, output.get(1).toGenericDict().at("7").toIntList().size());
+  EXPECT_EQ(7, output.get(1).toGenericDict().at("7").toIntList().get(0));
+  EXPECT_EQ(8, output.get(1).toGenericDict().at("7").toIntList().get(1));
 }
 
 TEST(OperatorRegistrationTest_LegacyLambdaBasedKernel, givenFallbackKernelWithoutAnyArguments_whenRegistered_thenCanBeCalled) {

--- a/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
+++ b/aten/src/ATen/core/op_registration/kernel_lambda_test.cpp
@@ -10,8 +10,6 @@ using c10::TensorTypeId;
 using c10::KernelCache;
 using c10::Stack;
 using c10::guts::make_unique;
-using c10::ivalue::TensorList;
-using c10::ivalue::IntList;
 using c10::intrusive_ptr;
 using c10::DictPtr;
 using c10::make_dict;
@@ -161,10 +159,10 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithTensorListOutput
 
   auto result = callOp(*op, dummyTensor(TensorType1()), dummyTensor(TensorType2()), dummyTensor(TensorType1()));
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[0].toTensorListRef().get(1).type_id());
-  EXPECT_EQ(TensorType1(), result[0].toTensorListRef().get(2).type_id());
+  EXPECT_EQ(3, result[0].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[0].toTensorList().get(1).type_id());
+  EXPECT_EQ(TensorType1(), result[0].toTensorList().get(2).type_id());
 }
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithIntListOutput_whenRegistered_thenCanBeCalled) {
@@ -177,10 +175,10 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithIntListOutput_wh
 
   auto result = callOp(*op, dummyTensor(TensorType1()), 2, 4, 6);
   EXPECT_EQ(1, result.size());
-  EXPECT_EQ(3, result[0].toIntListRef().size());
-  EXPECT_EQ(2, result[0].toIntListRef().get(0));
-  EXPECT_EQ(4, result[0].toIntListRef().get(1));
-  EXPECT_EQ(6, result[0].toIntListRef().get(2));
+  EXPECT_EQ(3, result[0].toIntList().size());
+  EXPECT_EQ(2, result[0].toIntList().get(0));
+  EXPECT_EQ(4, result[0].toIntList().get(1));
+  EXPECT_EQ(6, result[0].toIntList().get(2));
 }
 
 TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithMultipleOutputs_whenRegistered_thenCanBeCalled) {
@@ -206,11 +204,11 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithMultipleOutputs_
   EXPECT_EQ(5, result.size());
   EXPECT_EQ(TensorType2(), result[0].toTensor().type_id());
   EXPECT_EQ(5, result[1].toInt());
-  EXPECT_EQ(2, result[2].toTensorListRef().size());
-  EXPECT_EQ(TensorType1(), result[2].toTensorListRef().get(0).type_id());
-  EXPECT_EQ(TensorType2(), result[2].toTensorListRef().get(1).type_id());
+  EXPECT_EQ(2, result[2].toTensorList().size());
+  EXPECT_EQ(TensorType1(), result[2].toTensorList().get(0).type_id());
+  EXPECT_EQ(TensorType2(), result[2].toTensorList().get(1).type_id());
   EXPECT_EQ(0, result[3].toInt());
-  auto result_dict = c10::impl::toTypedDict<string, Tensor>(std::move(result[4].toGenericDict()->elements()));
+  auto result_dict = c10::impl::toTypedDict<string, Tensor>(result[4].toGenericDict());
   EXPECT_EQ(2, result_dict.size());
   EXPECT_EQ(TensorType1(), result_dict.at("first").type_id());
   EXPECT_EQ(TensorType2(), result_dict.at("second").type_id());
@@ -334,7 +332,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithIntListInput_wit
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(3, captured_input_list_size);
 }
@@ -347,7 +345,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithIntListInput_wit
   auto op = c10::Dispatcher::singleton().findSchema("_test::int_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, dummyTensor(TensorType1()), IntList::create(c10::make_list<int64_t>({2, 4, 6})));
+  auto outputs = callOp(*op, dummyTensor(TensorType1()), c10::make_list<int64_t>({2, 4, 6}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(3, outputs[0].toInt());
 }
@@ -361,7 +359,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithTensorListInput_
   ASSERT_TRUE(op.has_value());
 
   captured_input_list_size = 0;
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(0, outputs.size());
   EXPECT_EQ(2, captured_input_list_size);
 }
@@ -374,7 +372,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithTensorListInput_
   auto op = c10::Dispatcher::singleton().findSchema("_test::tensor_list_input", "");
   ASSERT_TRUE(op.has_value());
 
-  auto outputs = callOp(*op, TensorList::create(c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())})));
+  auto outputs = callOp(*op, c10::make_list<Tensor>({dummyTensor(TensorType1()), dummyTensor(TensorType1())}));
   EXPECT_EQ(1, outputs.size());
   EXPECT_EQ(2, outputs[0].toInt());
 }
@@ -430,7 +428,7 @@ TEST(OperatorRegistrationTest_LambdaBasedKernel, givenKernelWithDictOutput_whenR
   dict.insert("key2", "value2");
   auto outputs = callOp(*op, dict);
   EXPECT_EQ(1, outputs.size());
-  auto output = c10::impl::toTypedDict<string, string>(std::move(outputs[0].toGenericDict()->elements()));
+  auto output = c10::impl::toTypedDict<string, string>(outputs[0].toGenericDict());
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ("value1", output.at("key1"));

--- a/aten/src/ATen/core/op_registration/op_registration_test.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration_test.cpp
@@ -762,7 +762,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
     "(bool[] a) -> bool[]");
   testArgTypes<c10::ListPtr<std::string>>::test(
     c10::make_list<std::string>(), [] (const c10::ListPtr<std::string>& v) {EXPECT_EQ(0, v.size());},
-    c10::make_list<std::string>(), [] (const IValue& v) {EXPECT_EQ(0, v.toGenericListRef().size());},
+    c10::make_list<std::string>(), [] (const IValue& v) {EXPECT_EQ(0, v.toGenericList().size());},
     "(str[] a) -> str[]");
   testArgTypes<c10::ListPtr<Tensor>>::test(
     c10::make_list<Tensor>({}), [] (const c10::ListPtr<Tensor>& v) {EXPECT_EQ(0, v.size());},
@@ -786,9 +786,9 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
   testArgTypes<c10::ListPtr<std::string>>::test(
     c10::make_list<std::string>({"first", "second"}), [] (const c10::ListPtr<std::string>& v) {expectListEquals({"first", "second"}, v);},
     c10::make_list<std::string>({"first", "second"}), [] (const IValue& v) {
-      EXPECT_EQ(2, v.toGenericListRef().size());
-      EXPECT_EQ("first", v.toGenericListRef().get(0).toStringRef());
-      EXPECT_EQ("second", v.toGenericListRef().get(1).toStringRef());
+      EXPECT_EQ(2, v.toGenericList().size());
+      EXPECT_EQ("first", v.toGenericList().get(0).toStringRef());
+      EXPECT_EQ("second", v.toGenericList().get(1).toStringRef());
     },
     "(str[] a) -> str[]");
   testArgTypes<c10::ListPtr<Tensor>>::test(
@@ -816,7 +816,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
   //Note: vector<bool> is not supported, use ListPtr<bool> instead.
   testArgTypes<std::vector<std::string>>::test<TestLegacyAPI>(
     std::vector<std::string>(), [] (const std::vector<std::string>& v) {EXPECT_EQ(0, v.size());},
-    std::vector<std::string>(), [] (const IValue& v) {EXPECT_EQ(0, v.toGenericListRef().size());},
+    std::vector<std::string>(), [] (const IValue& v) {EXPECT_EQ(0, v.toGenericList().size());},
     "(str[] a) -> str[]");
   testArgTypes<std::vector<Tensor>>::test<TestLegacyAPI>(
     std::vector<Tensor>({}), [] (const std::vector<Tensor>& v) {EXPECT_EQ(0, v.size());},
@@ -837,9 +837,9 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
   testArgTypes<std::vector<std::string>>::test<TestLegacyAPI>(
     std::vector<std::string>({"first", "second"}), [] (const std::vector<std::string>& v) {expectListEquals({"first", "second"}, v);},
     std::vector<std::string>({"first", "second"}), [] (const IValue& v) {
-      EXPECT_EQ(2, v.toGenericListRef().size());
-      EXPECT_EQ("first", v.toGenericListRef().get(0).toStringRef());
-      EXPECT_EQ("second", v.toGenericListRef().get(1).toStringRef());
+      EXPECT_EQ(2, v.toGenericList().size());
+      EXPECT_EQ("first", v.toGenericList().get(0).toStringRef());
+      EXPECT_EQ("second", v.toGenericList().get(1).toStringRef());
     },
     "(str[] a) -> str[]");
   testArgTypes<std::vector<Tensor>>::test<TestLegacyAPI>(
@@ -896,7 +896,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
       EXPECT_EQ("value2", v.at("key2"));
     },
     str_dict, [] (const IValue& v) {
-      c10::DictPtr<std::string, std::string> dict = c10::impl::toTypedDict<std::string, std::string>(std::move(v.toGenericDict()->elements()));
+      c10::DictPtr<std::string, std::string> dict = c10::impl::toTypedDict<std::string, std::string>(v.toGenericDict());
       EXPECT_EQ(2, dict.size());
       EXPECT_EQ("value1", dict.at("key1"));
       EXPECT_EQ("value2", dict.at("key2"));
@@ -912,7 +912,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
       EXPECT_EQ(TensorType2(), v.at(2).type_id());
     },
     tensor_dict, [] (const IValue& v) {
-      c10::DictPtr<int64_t, Tensor> dict = c10::impl::toTypedDict<int64_t, Tensor>(std::move(v.toGenericDict()->elements()));
+      c10::DictPtr<int64_t, Tensor> dict = c10::impl::toTypedDict<int64_t, Tensor>(v.toGenericDict());
       EXPECT_EQ(2, dict.size());
       EXPECT_EQ(TensorType1(), dict.at(1).type_id());
       EXPECT_EQ(TensorType2(), dict.at(2).type_id());
@@ -930,7 +930,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
       EXPECT_EQ("value2", v.at("key2"));
     },
     str_map, [] (const IValue& v) {
-      c10::DictPtr<std::string, std::string> dict = c10::impl::toTypedDict<std::string, std::string>(std::move(v.toGenericDict()->elements()));
+      c10::DictPtr<std::string, std::string> dict = c10::impl::toTypedDict<std::string, std::string>(v.toGenericDict());
       EXPECT_EQ(2, dict.size());
       EXPECT_EQ("value1", dict.at("key1"));
       EXPECT_EQ("value2", dict.at("key2"));
@@ -946,7 +946,7 @@ TEST(OperatorRegistrationTest, testAvailableArgTypes) {
       EXPECT_EQ(TensorType2(), v.at(2).type_id());
     },
     tensor_map, [] (const IValue& v) {
-      c10::DictPtr<int64_t, Tensor> dict = c10::impl::toTypedDict<int64_t, Tensor>(std::move(v.toGenericDict()->elements()));
+      c10::DictPtr<int64_t, Tensor> dict = c10::impl::toTypedDict<int64_t, Tensor>(v.toGenericDict());
       EXPECT_EQ(2, dict.size());
       EXPECT_EQ(TensorType1(), dict.at(1).type_id());
       EXPECT_EQ(TensorType2(), dict.at(2).type_id());

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -155,7 +155,7 @@ TypePtr incompleteInferTypeFrom(const IValue& value) {
   } else if (value.isDoubleList()) {
     return ListType::ofFloats();
   } else if (value.isTuple()) {
-    return TupleType::create(fmap(value.toTuple()->elements(), incompleteInferTypeFrom));
+    return TupleType::create(fmap(value.toTuple().elements(), incompleteInferTypeFrom));
   } else if (value.isDevice()) {
     return DeviceObjType::get();
   } else if (value.isObject()) {
@@ -171,14 +171,14 @@ TypePtr incompleteInferTypeFrom(const IValue& value) {
 // XXX: only used for better error messages, should not be used elsewhere
 TypePtr attemptToRecoverType(const IValue& ivalue) {
   if (ivalue.isGenericList()) {
-    auto& ivalue_list = ivalue.toGenericListRef();
+    auto ivalue_list = ivalue.toGenericList();
     if (ivalue_list.size() == 0) {
       return ListType::create(VarType::create("t"));
     }
     return ListType::create(attemptToRecoverType(ivalue_list[0]));
   }
   if (ivalue.isGenericDict()) {
-    const auto& dict = ivalue.toGenericDictRef();
+    const auto& dict = ivalue.toGenericDict();
     if (dict.size() == 0) {
       return DictType::create(VarType::create("t"), VarType::create("t"));
     }
@@ -201,15 +201,16 @@ bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
   }
 
   if (ivalue.isTuple()) {
-    const auto& ivalue_elem = ivalue.toTuple()->elements();
+    const auto& ivalue_elem = ivalue.toTuple();
+    auto& elems = ivalue_elem.elements();
     auto tuple_type = type->cast<TupleType>();
-    if (!tuple_type || tuple_type->elements().size() != ivalue_elem.size()) {
+    if (!tuple_type || tuple_type->elements().size() != elems.size()) {
       return false;
     }
     auto type_elem = tuple_type->elements();
     bool is_subvalue = true;
     for (size_t i = 0; i < type_elem.size() && is_subvalue; ++i) {
-      is_subvalue = isSubvalueOf(ivalue_elem[i], type_elem[i]);
+      is_subvalue = isSubvalueOf(elems[i], type_elem[i]);
     }
     return is_subvalue;
   }
@@ -218,7 +219,7 @@ bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
     if (!list_type) {
       return false;
     }
-    auto& ivalue_list = ivalue.toGenericListRef();
+    auto ivalue_list = ivalue.toGenericList();
     auto element_type = list_type->getElementType();
     return std::all_of(ivalue_list.begin(), ivalue_list.end(), [&](const IValue& list_elem) {
       return isSubvalueOf(list_elem, element_type);
@@ -226,7 +227,7 @@ bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
   }
   if (ivalue.isGenericDict()) {
     auto dict_type = type->expect<DictType>();
-    const auto& dict = ivalue.toGenericDictRef();
+    const auto& dict = ivalue.toGenericDict();
     return std::all_of(
         dict.begin(), dict.end(), [=](const c10::impl::GenericDictPtr::const_iterator::value_type& item) {
           return isSubvalueOf(item.key(), dict_type->getKeyType()) &&

--- a/caffe2/contrib/pytorch/script_module_op.cc
+++ b/caffe2/contrib/pytorch/script_module_op.cc
@@ -82,8 +82,8 @@ class ScriptModuleOp final : public Operator<Context> {
     // for that.
   }
 
-  static caffe2::Tensor castIValueToTensor(const IValue& v) {
-    return caffe2::Tensor(torch::autograd::Variable(v.toTensor()).tensor_data());
+  static caffe2::Tensor castIValueToTensor(IValue v) {
+    return caffe2::Tensor(torch::autograd::Variable(std::move(v).toTensor()).tensor_data());
   }
 
   bool RunOnDevice() override {
@@ -102,14 +102,14 @@ class ScriptModuleOp final : public Operator<Context> {
     // don't have default values, method::operator() is going to complain.
     IValue output = method(inputs);
     if (output.isTuple()) {
-      const std::vector<IValue>& elems = output.toTuple()->elements();
+      auto elems = std::move(output).toTuple();
       CAFFE_ENFORCE_EQ(elems.size(), OutputSize());
       for (int i = 0; i < elems.size(); ++i) {
         this->SetOutputTensor(i, castIValueToTensor(elems[i]));
       }
     } else if (output.isTensor()) {
       CAFFE_ENFORCE_EQ(1, OutputSize());
-      this->SetOutputTensor(0, castIValueToTensor(output));
+      this->SetOutputTensor(0, castIValueToTensor(std::move(output)));
     } else {
       CAFFE_THROW("Unexpected return type: ", output.tagKind());
     }

--- a/caffe2/core/c10_operator.h
+++ b/caffe2/core/c10_operator.h
@@ -62,8 +62,7 @@ inline void _call_caffe2_op_from_c10(
     outputs.resize(num_outputs);
   } else {
     AT_ASSERT(preallocated_outputs.isTensorList());
-    outputs =
-        std::move(*std::move(preallocated_outputs).toTensorList()).elements();
+    outputs = std::move(preallocated_outputs).toTensorList();
   }
 
   // TODO Avoid vector allocation. One idea would be to keep the std::vector

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -85,7 +85,7 @@ compute_input_size_(const std::vector<c10::IValue>& inputs) {
     // into that list. currently, this means that only tensors from that list
     // are accessible as inputs. any hypothetical input tensors that come after
     // the list are not accessible.
-    return inputs[0].toTensorListRef().size();
+    return inputs[0].toTensorList().size();
   }
   // it's not a tensor list. Count the number of tensor inputs and return them.
   size_t num_tensor_inputs = 0;

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -198,7 +198,7 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
       // if the first input is a tensor list, we get input tensors by indexing into that list.
       // currently, this means that only tensors from that list are accessible as inputs.
       // any hypothetical input tensors that come after the list are not accessible.
-      const auto& tensorList = newstyle_inputs_[0].toTensorListRef();
+      const auto& tensorList = newstyle_inputs_[0].toTensorList();
       DCHECK_LT(idx, tensorList.size());
       ival = tensorList.get(idx);
     } else {
@@ -719,10 +719,10 @@ inline NetDef OperatorBase::GetSingleArgument<NetDef>(
 template <>
 inline vector<int> OperatorBase::GetVectorFromIValueList<int>(
     const c10::IValue& value) const {
-  const auto& vs = value.toIntListRef();
+  auto vs = value.toIntList();
   vector<int> out;
   out.reserve(vs.size());
-  for (const int64_t& v : vs) {
+  for (int64_t v : vs) {
     out.emplace_back(v);
   }
   return out;
@@ -731,7 +731,7 @@ inline vector<int> OperatorBase::GetVectorFromIValueList<int>(
 template <>
 inline vector<float> OperatorBase::GetVectorFromIValueList<float>(
     const c10::IValue& value) const {
-  const auto& vs = value.toDoubleListRef();
+  const auto& vs = value.toDoubleList();
   vector<float> out;
   out.reserve(vs.size());
   for (const double& v : vs) {

--- a/caffe2/core/operator_c10wrapper.h
+++ b/caffe2/core/operator_c10wrapper.h
@@ -105,7 +105,7 @@ class C10OperatorWrapper final : public Operator<Context> {
         AT_ASSERTM(
             input_tensor_index == 0,
             "Error in caffe2->c10 wrapper: Schema can only have either one or more Tensor inputs or one TensorList input.");
-        stack_.emplace_back(ivalue::TensorList::create(array_inputs_()));
+        stack_.emplace_back(array_inputs_());
         input_tensor_index = InputSize();
 
       } else {

--- a/caffe2/operators/experimental/c10/cpu/filler_cpu.cc
+++ b/caffe2/operators/experimental/c10/cpu/filler_cpu.cc
@@ -7,7 +7,6 @@ using caffe2::CPUContext;
 using caffe2::Tensor;
 using caffe2::TensorCPU;
 using std::vector;
-using c10::ivalue::TensorList;
 
 namespace caffe2 {
 namespace {

--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -106,7 +106,7 @@ TEST(TorchScriptTest, TestTupleArgMatching) {
     )JIT");
 
   std::vector<int64_t> int_list = {1};
-  auto tuple_generic_list = torch::jit::Tuple::create({ int_list });
+  auto tuple_generic_list = torch::jit::TuplePtr::create({ int_list });
 
   // doesn't fail on arg matching
   module->run_method("tuple_op", tuple_generic_list);
@@ -122,7 +122,7 @@ TEST(TorchScriptTest, TestOptionalArgMatching) {
           return a[0]
     )JIT");
 
-  auto optional_tuple = torch::jit::Tuple::create({2, std::string("hi")});
+  auto optional_tuple = torch::jit::TuplePtr::create({2, std::string("hi")});
 
   ASSERT_EQ(2, module->run_method("optional_tuple_op", optional_tuple).toInt());
   ASSERT_EQ(

--- a/test/cpp/jit/test_ivalue.h
+++ b/test/cpp/jit/test_ivalue.h
@@ -14,7 +14,7 @@ using Var = SymbolicVariable;
 using namespace torch::autograd;
 
 void testIValue() {
-  Shared<IntList> foo = IntList::create({3, 4, 5});
+  c10::ListPtr<int64_t> foo = c10::make_list<int64_t>({3, 4, 5});
   ASSERT_EQ(foo.use_count(), 1);
   IValue bar{foo};
   ASSERT_EQ(foo.use_count(), 2);
@@ -28,7 +28,7 @@ void testIValue() {
   ASSERT_TRUE(foo2.isDouble());
   ASSERT_EQ(foo2.toDouble(), 4.0);
   ASSERT_EQ(foo.use_count(), 2);
-  ASSERT_TRUE(c10::impl::toArrayRef(baz.toIntList()->elements()).equals({3, 4, 5}));
+  ASSERT_TRUE(c10::impl::toArrayRef(baz.toIntList()).equals({3, 4, 5}));
 
   auto move_it = std::move(baz).toIntList();
   ASSERT_EQ(foo.use_count(), 2);
@@ -36,17 +36,17 @@ void testIValue() {
   IValue i(4);
   ASSERT_TRUE(i.isInt());
   ASSERT_EQ(i.toInt(), 4);
-  IValue dlist(DoubleList::create({3.5}));
+  IValue dlist(c10::make_list<double>({3.5}));
   ASSERT_TRUE(dlist.isDoubleList());
-  ASSERT_TRUE(c10::impl::toArrayRef(std::move(dlist).toDoubleList()->elements())
+  ASSERT_TRUE(c10::impl::toArrayRef(std::move(dlist).toDoubleList())
                   .equals({3.5}));
   ASSERT_TRUE(dlist.isNone());
-  dlist = IValue(DoubleList::create({3.4}));
-  ASSERT_TRUE(c10::impl::toArrayRef(dlist.toDoubleList()->elements()).equals({3.4}));
-  IValue the_list(Tuple::create({IValue(3.4), IValue(4), IValue(foo)}));
+  dlist = IValue(c10::make_list<double>({3.4}));
+  ASSERT_TRUE(c10::impl::toArrayRef(dlist.toDoubleList()).equals({3.4}));
+  IValue the_list(ivalue::TuplePtr::create({IValue(3.4), IValue(4), IValue(foo)}));
   ASSERT_EQ(foo.use_count(), 3);
   ASSERT_TRUE(the_list.isTuple());
-  auto first = std::move(the_list).toTuple()->elements().get(1);
+  auto first = std::move(the_list).toTuple().elements().get(1);
   ASSERT_EQ(first.toInt(), 4);
   at::Tensor tv = at::rand({3, 4});
   IValue ten(tv);

--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -94,7 +94,7 @@ def jit_type_of(arg):
 FROM_IVALUE = {
     'Device': '{}.toDevice()',
     'Device?': '{}.toOptional<c10::Device>()',
-    'IntArrayRef': 'c10::impl::toArrayRef({}.toIntList()->elements())',
+    'IntArrayRef': 'c10::impl::toArrayRef({}.toIntList())',
     'Layout': '{}.toLayout()',
     'Layout?': '{}.toOptional<c10::Layout>()',
     'MemoryFormat': '{}.toMemoryFormat()',
@@ -105,7 +105,7 @@ FROM_IVALUE = {
     'Tensor': '{}.toTensor()',
     'Tensor?': 'toOptionalTensor({})',
     'Tensor?[]': 'toListOfOptionalTensor({})',
-    'TensorList': 'c10::impl::toArrayRef({}.toTensorList()->elements())',
+    'TensorList': 'c10::impl::toArrayRef({}.toTensorList())',
     'bool': '{}.toBool()',
     'bool?': '{}.toOptional<bool>()',
     'double': '{}.toDouble()',
@@ -113,9 +113,9 @@ FROM_IVALUE = {
     'int64_t?': '{}.toOptional<int64_t>()',
     'std::string': '{}.toString()->string()',
     'Generator': 'nullptr',
-    'std::array<bool,2>': 'as_bool_array<2>({}.toBoolListRef())',
-    'std::array<bool,3>': 'as_bool_array<3>({}.toBoolListRef())',
-    'std::array<bool,4>': 'as_bool_array<4>({}.toBoolListRef())',
+    'std::array<bool,2>': 'as_bool_array<2>({}.toBoolList())',
+    'std::array<bool,3>': 'as_bool_array<3>({}.toBoolList())',
+    'std::array<bool,4>': 'as_bool_array<4>({}.toBoolList())',
 }
 
 

--- a/tools/jit/templates/register_aten_ops.cpp
+++ b/tools/jit/templates/register_aten_ops.cpp
@@ -60,9 +60,9 @@ at::Tensor toOptionalTensor(const IValue& v) {
 
 // XXX: This function is to specialize IValue for list of optional
 // tensor type in interpreter, it should only be used in this file
-std::vector<Tensor> toListOfOptionalTensor(const IValue& v) {
+std::vector<Tensor> toListOfOptionalTensor(IValue v) {
   // v is a list of optional tensor, loop over as generic list
-  auto vlist = v.toGenericListRef();
+  auto vlist = std::move(v).toGenericList();
   std::vector<Tensor> res;
 
   for (const IValue &v: vlist) {

--- a/torch/csrc/jit/argument_spec.cpp
+++ b/torch/csrc/jit/argument_spec.cpp
@@ -157,7 +157,7 @@ ArgumentSpec ArgumentSpecCreator::create(bool with_grad, const Stack& input)
         const IValue* iv = stack[stack_top]++;
         AT_ASSERT(iv->isTuple());
         // see [argspec refcounting]
-        auto p = *reinterpret_cast<const at::ivalue::Tuple* const*>(iv);
+        auto p = *reinterpret_cast<const at::ivalue::TuplePtr* const*>(iv);
         auto tup_ptr = c10::impl::ptr_to_first_element(p->elements());
         // push list of tuple elements to the stack
         stack[++stack_top] = tup_ptr;

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -55,17 +55,17 @@ c10::optional<Value*> tryInsertConstant(
     n->i_(attr::value, val.toBool());
     n->output()->setType(BoolType::get());
   } else if (val.isBoolList()) {
-    auto bool_list = val.toBoolList()->elements();
+    auto bool_list = val.toBoolList();
     n->is_(
         attr::value, std::vector<int64_t>(bool_list.begin(), bool_list.end()));
     n->output()->setType(ListType::ofBools());
   } else if (val.isIntList()) {
-    n->is_(attr::value, c10::impl::toVector(val.toIntList()->elements()));
+    n->is_(attr::value, c10::impl::toVector(val.toIntList()));
     n->output()->setType(ListType::ofInts());
   } else if (val.isTensorList()) {
     n->ts_(
         attr::value,
-        fmap(val.toTensorList()->elements(), [](const at::Tensor& t) {
+        fmap(val.toTensorList(), [](const at::Tensor& t) {
           AT_ASSERT(t.is_variable() && !t.requires_grad());
           return t;
         }));

--- a/torch/csrc/jit/fuser/executor.cpp
+++ b/torch/csrc/jit/fuser/executor.cpp
@@ -385,7 +385,7 @@ bool runFusion(const int64_t key, Stack& stack, std::string* code_out) {
     if (omap.needsSumToSize()) {
       return at::sum_to(
           raw_outputs[omap.offset()],
-          c10::impl::toArrayRef(all_inputs[omap.sizeInput()].toIntList()->elements()));
+          c10::impl::toArrayRef(all_inputs[omap.sizeInput()].toIntList()));
     } else {
       return raw_outputs[omap.offset()];
     }

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -100,7 +100,7 @@ struct CaptureList {
       //  This is to avoid any implicit mutation to TensorList happened
       //  between forward & backward.
       capture_types_.emplace_back(CAPTURE_LIST);
-      const c10::ListPtr<at::Tensor>& tensors = val.toTensorListRef();
+      const c10::ListPtr<at::Tensor>& tensors = val.toTensorList();
       sizes_.push_back(tensors.size());
 
       for (const at::Tensor& tensor : tensors) {
@@ -129,13 +129,13 @@ struct CaptureList {
           ++var_capture_it;
         } break;
         case CAPTURE_LIST: {
-          std::vector<at::Tensor> lst;
+          c10::ListPtr<at::Tensor> lst = c10::make_list<at::Tensor>();
           auto size = *size_it++;
           for (size_t i = 0; i < size; i++) {
             lst.emplace_back(var_capture_it->unpack(saved_for));
             var_capture_it++;
           }
-          stack.emplace_back(TensorList::create(std::move(lst)));
+          stack.emplace_back(std::move(lst));
         } break;
         case CAPTURE_IVALUE: {
           stack.push_back(*ivalue_capture_it++);
@@ -181,7 +181,7 @@ struct UnpackInstructions {
         } break;
         case PUSH_LIST: {
           std::vector<at::Tensor> lst(input_it, input_it + *sizes_it++);
-          stack.emplace_back(TensorList::create(std::move(lst)));
+          stack.emplace_back(c10::impl::toList(std::move(lst)));
         } break;
       }
     }
@@ -229,7 +229,7 @@ struct DifferentiableGraphBackward : public autograd::Function {
     size_t output_index = 0;
     for (IValue& v : stack) {
       if (v.isTensorList()) {
-        for (at::Tensor tensor : v.toTensorListRef()) {
+        for (at::Tensor tensor : v.toTensorList()) {
           produceOutput(output_index++, std::move(tensor), outputs);
         }
       } else if (v.isTensor()) {
@@ -253,7 +253,7 @@ struct DifferentiableGraphBackward : public autograd::Function {
   }
   void addOutputForIValue(const IValue& value) {
     if (value.isTensorList()) {
-      for (const at::Tensor& tensor : value.toTensorListRef()) {
+      for (const at::Tensor& tensor : value.toTensorList()) {
         addOutputForTensor(tensor);
       }
     } else {
@@ -275,7 +275,7 @@ struct DifferentiableGraphBackward : public autograd::Function {
 
   void addInputIValue(const IValue& v) {
     if (v.isTensorList()) {
-      const c10::ListPtr<at::Tensor>& tensors = v.toTensorListRef();
+      const c10::ListPtr<at::Tensor>& tensors = v.toTensorList();
       input_instructions_.pushTensorList(tensors.size());
       for (const at::Tensor& tensor : tensors) {
         addInputVariable(tensor);
@@ -380,11 +380,11 @@ struct DifferentiableGraphOp {
       t = detach(std::move(t));
       v = IValue(std::move(t));
     } else if (v.isTensorList()) {
-      c10::ListPtr<at::Tensor> lst = v.toTensorListRef();
+      c10::ListPtr<at::Tensor> lst = v.toTensorList();
       for (size_t i = 0; i < lst.size(); ++i) {
         lst.set(i, detach(lst.extract(i)));
       }
-      v = TensorList::create(std::move(lst));
+      v = std::move(lst);
     }
   }
 

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -727,7 +727,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         future->markCompleted(stack.back());
       } else {
         future->markCompleted(
-            Tuple::create(jit::last(stack, num_outputs).vec()));
+            c10::ivalue::TuplePtr::create(jit::last(stack, num_outputs).vec()));
       }
     }
 
@@ -767,7 +767,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         push(stack, future->value());
       } else {
         auto tuple = future->value().toTuple();
-        for (const IValue& value : tuple->elements()) {
+        for (const IValue& value : tuple.elements()) {
           push(stack, value);
         }
       }

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -27,7 +27,6 @@ struct Graph;
 struct Node;
 using Stack = std::vector<c10::IValue>;
 using c10::ivalue::Future;
-using c10::ivalue::Tuple;
 
 struct TORCH_API Code {
   Code() : pImpl(nullptr) {}

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -36,18 +36,10 @@ using ::c10::Argument;
 using ::c10::FunctionSchema;
 using ::c10::Symbol;
 
-using ::c10::ivalue::List;
 using ::c10::ivalue::Shared;
 
 using ::c10::IValue;
 using ::c10::ivalue::Future;
-using ::c10::ivalue::Tuple;
-
-using ::c10::ivalue::BoolList;
-using ::c10::ivalue::DoubleList;
-using ::c10::ivalue::GenericList;
-using ::c10::ivalue::IntList;
-using ::c10::ivalue::TensorList;
 
 using ::c10::ivalue::ConstantString;
 

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -64,7 +64,7 @@ RegisterOperators reg_ln_view({Operator(
     [](const Node* node) {
       return [](Stack& stack) {
         const int64_t normalized_ndim = pop(stack).toInt();
-        auto input_shape = pop(stack).toIntListRef();
+        auto input_shape = pop(stack).toIntList();
         auto self = pop(stack).toTensor();
         const int64_t input_ndim = input_shape.size();
         c10::SmallVector<int64_t, 8> sizes(input_ndim, 1);

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -787,19 +787,19 @@ struct PythonPrintPass {
     } else if (v.isTensorList()) {
       stmt << "[";
       const char* delim = "";
-      for (const at::Tensor& t : v.toTensorListRef()) {
+      for (const at::Tensor& t : v.toTensorList()) {
         stmt << delim << "CONSTANTS.c" << getOrAddTensorConstant(t);
         delim = ", ";
       }
       stmt << "]";
     } else if (v.isBoolList()) {
       printMaybeAnnotatedConstantList(
-          stmt, "bool", v.toBoolListRef().size(), v);
+          stmt, "bool", v.toBoolList().size(), v);
     } else if (v.isIntList()) {
-      printMaybeAnnotatedConstantList(stmt, "int", v.toIntListRef().size(), v);
+      printMaybeAnnotatedConstantList(stmt, "int", v.toIntList().size(), v);
     } else if (v.isDoubleList()) {
       printMaybeAnnotatedConstantList(
-          stmt, "float", v.toDoubleListRef().size(), v);
+          stmt, "float", v.toDoubleList().size(), v);
     } else {
       stmt << v;
     }

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
@@ -17,7 +17,7 @@ IValue deepCopy(const IValue& self) {
   }
   if (self.isTensorList()) {
     std::vector<at::Tensor> newList;
-    for (const at::Tensor& oldTensor : self.toTensorListRef()) {
+    for (const at::Tensor& oldTensor : self.toTensorList()) {
       newList.push_back(oldTensor.clone());
     }
     return newList;
@@ -26,7 +26,7 @@ IValue deepCopy(const IValue& self) {
   // Lists of ivalues should recursively deep copy their contents
   if (self.isGenericList()) {
     std::vector<IValue> newList;
-    for (const IValue& value : self.toGenericListRef()) {
+    for (const IValue& value : self.toGenericList()) {
       newList.push_back(deepCopy(value));
     }
     return newList;
@@ -34,11 +34,11 @@ IValue deepCopy(const IValue& self) {
 
   // Regular lists can copy assign
   if (self.isIntList()) {
-    return IValue(self.toIntListRef());
+    return IValue(self.toIntList());
   } else if (self.isDoubleList()) {
-    return IValue(self.toDoubleListRef());
+    return IValue(self.toDoubleList());
   } else if (self.isBoolList()) {
-    return IValue(self.toBoolListRef());
+    return IValue(self.toBoolList());
   } else if (self.isString()) {
     return IValue(self.toStringRef());
   }
@@ -65,7 +65,7 @@ bool deepEquals(const IValue& lhs, const IValue& rhs) {
   } else if (lhs.isNone() && rhs.isNone()) {
     return true;
   } else if (lhs.isIntList() && rhs.isIntList()) {
-    return list_is_equal(lhs.toIntList()->elements(), rhs.toIntList()->elements());
+    return list_is_equal(lhs.toIntList(), rhs.toIntList());
   } else if (lhs.isTensor() && rhs.isTensor()) {
     return lhs.toTensor().equal(rhs.toTensor());
   }

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -220,7 +220,7 @@ const void* Pickler::getPointer(const IValue& ivalue) {
   if (ivalue.isGenericDict() || ivalue.isGenericList() || ivalue.isTuple()
     || ivalue.isString() || ivalue.isTensorList() || ivalue.isDoubleList()
     || ivalue.isBoolList()) {
-      return ivalue.toPointer();
+      return ivalue.internalToPointer();
   }
 
   return nullptr;

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -182,28 +182,28 @@ void Pickler::addIValue(const IValue& ivalue) {
   } else if (ivalue.isIntList()) {
     pushSpecializedList(
         ivalue, PicklerClass::INTLIST, [=](const IValue& ivalue) {
-          for (const int64_t item : ivalue.toIntListRef()) {
+          for (const int64_t item : ivalue.toIntList()) {
             addIValue(item);
           }
         });
   } else if (ivalue.isTensorList()) {
     pushSpecializedList(
         ivalue, PicklerClass::TENSORLIST, [=](const IValue& ivalue) {
-          for (const at::Tensor& item : ivalue.toTensorListRef()) {
+          for (const at::Tensor& item : ivalue.toTensorList()) {
             addIValue(item);
           }
         });
   } else if (ivalue.isDoubleList()) {
     pushSpecializedList(
         ivalue, PicklerClass::DOUBLELIST, [=](const IValue& ivalue) {
-          for (double item : ivalue.toDoubleListRef()) {
+          for (double item : ivalue.toDoubleList()) {
             addIValue(item);
           }
         });
   } else if (ivalue.isBoolList()) {
     pushSpecializedList(
         ivalue, PicklerClass::BOOLLIST, [=](const IValue& ivalue) {
-          for (bool item : ivalue.toBoolListRef()) {
+          for (bool item : ivalue.toBoolList()) {
             addIValue(item);
           }
         });
@@ -217,22 +217,10 @@ void Pickler::addIValue(const IValue& ivalue) {
 /// IValues so the pointers are guaranteed to be valid for the Pickler's
 /// lifetime.
 const void* Pickler::getPointer(const IValue& ivalue) {
-  if (ivalue.isGenericDict()) {
-    return ivalue.toGenericDict().get();
-  } else if (ivalue.isGenericList()) {
-    return ivalue.toGenericList().get();
-  } else if (ivalue.isTuple()) {
-    return ivalue.toTuple().get();
-  } else if (ivalue.isString()) {
-    return ivalue.toString().get();
-  } else if (ivalue.isIntList()) {
-    return ivalue.toIntList().get();
-  } else if (ivalue.isTensorList()) {
-    return ivalue.toTensorList().get();
-  } else if (ivalue.isDoubleList()) {
-    return ivalue.toDoubleList().get();
-  } else if (ivalue.isBoolList()) {
-    return ivalue.toBoolList().get();
+  if (ivalue.isGenericDict() || ivalue.isGenericList() || ivalue.isTuple()
+    || ivalue.isString() || ivalue.isTensorList() || ivalue.isDoubleList()
+    || ivalue.isBoolList()) {
+      return ivalue.toPointer();
   }
 
   return nullptr;
@@ -436,7 +424,7 @@ void Pickler::pushDict(const IValue& ivalue) {
   push<OpCode>(OpCode::MARK);
 
   // Sort the dict for deterministic keys
-  auto dict_items = ivalue.toGenericDict()->iterationOrder();
+  auto dict_items = iterationOrder(ivalue.toGenericDict());
   for (const auto& pair : dict_items) {
     addIValue(pair.first);
     addIValue(pair.second);
@@ -477,7 +465,7 @@ void Pickler::pushMemoization(const IValue& ivalue) {
 }
 
 void Pickler::pushGenericList(const IValue& ivalue) {
-  auto list = ivalue.toGenericListRef();
+  auto list = ivalue.toGenericList();
   push<OpCode>(OpCode::EMPTY_LIST);
   pushMemoization(ivalue);
 
@@ -493,9 +481,9 @@ void Pickler::pushGenericList(const IValue& ivalue) {
 void Pickler::pushTuple(const IValue& ivalue) {
   // TODO: Small tuple unrolling (e.g. TUPLE3)
   push<OpCode>(OpCode::MARK);
-  auto tuple = ivalue.toTuple()->elements();
+  auto tuple = ivalue.toTuple();
 
-  for (const IValue& item : tuple) {
+  for (const IValue& item : tuple.elements()) {
     addIValue(item);
   }
 
@@ -513,9 +501,9 @@ std::vector<IValue> Unpickler::parse_ivalue_list() {
   auto value = stack_[0].ivalue();
   if (value.isGenericList()) {
     // TODO [unpickler refactor]
-    return c10::impl::toVector(value.toGenericListRef());
+    return c10::impl::toVector(value.toGenericList());
   }
-  return c10::impl::toVector(value.toTuple()->elements());
+  return c10::impl::toVector(value.toTuple().elements());
 }
 
 double Unpickler::readFloat() {
@@ -596,7 +584,7 @@ OpCode Unpickler::readInstruction() {
       }
     } break;
     case OpCode::EMPTY_TUPLE: {
-      stack_.emplace_back(c10::ivalue::Tuple::create({}));
+      stack_.emplace_back(c10::ivalue::TuplePtr::create({}));
     } break;
     case OpCode::BINPUT: {
       size_t memo_id = read<uint8_t>();
@@ -657,11 +645,11 @@ OpCode Unpickler::readInstruction() {
     case OpCode::TUPLE: {
       size_t start = marks_.back();
       marks_.pop_back();
-      auto tuple = c10::ivalue::Tuple::create({});
-      tuple->elements().reserve(stack_.size() - start);
+      c10::ListPtr<IValue> tuple = c10::make_list<IValue>();
+      tuple.reserve(stack_.size() - start);
       auto start_it = stack_.begin() + start;
       for (auto it = start_it; it != stack_.end(); ++it) {
-        tuple->elements().emplace_back(it->ivalue());
+        tuple.emplace_back(it->ivalue());
       }
       stack_.erase(start_it, stack_.end());
       stack_.emplace_back(IValue(tuple));
@@ -677,7 +665,7 @@ OpCode Unpickler::readInstruction() {
       marks_.pop_back();
       auto dict = stack_.at(start - 1).ivalue().toGenericDict();
       for (size_t i = start; i < stack_.size(); i += 2) {
-        dict->elements().insert_or_assign(stack_[i].ivalue(), stack_[i + 1].ivalue());
+        dict.insert_or_assign(stack_[i].ivalue(), stack_[i + 1].ivalue());
       }
       stack_.erase(stack_.begin() + start, stack_.end());
     } break;
@@ -736,19 +724,19 @@ OpCode Unpickler::readInstruction() {
       switch (class_name) {
         case PicklerClass::TENSOR:
           stack_.emplace_back(
-              tensor_table_->at(data->elements().get(0).toInt()));
+              tensor_table_->at(data.elements().get(0).toInt()));
           break;
         case PicklerClass::INTLIST:
-          stack_.emplace_back(data->elements().get(0).toIntListRef());
+          stack_.emplace_back(data.elements().get(0).toIntList());
           break;
         case PicklerClass::TENSORLIST:
-          stack_.emplace_back(data->elements().get(0).toTensorListRef());
+          stack_.emplace_back(data.elements().get(0).toTensorList());
           break;
         case PicklerClass::DOUBLELIST:
-          stack_.emplace_back(data->elements().get(0).toDoubleListRef());
+          stack_.emplace_back(data.elements().get(0).toDoubleList());
           break;
         case PicklerClass::BOOLLIST:
-          stack_.emplace_back(data->elements().get(0).toBoolListRef());
+          stack_.emplace_back(data.elements().get(0).toBoolList());
           break;
         default:
           AT_ERROR("Unknown pickler class id");
@@ -773,31 +761,31 @@ void Unpickler::readList() {
   auto num_elements = stack_.size() - start;
   auto elements = at::ArrayRef<StackItem>(stack_).slice(start);
   if (list_ivalue.isIntList()) {
-    auto& list = list_ivalue.toIntList()->elements();
+    auto list = list_ivalue.toIntList();
     list.reserve(num_elements);
     for (const auto& elem : elements) {
       list.emplace_back(elem.ivalue().toInt());
     }
   } else if (list_ivalue.isTensorList()) {
-    auto& list = list_ivalue.toTensorList()->elements();
+    auto list = list_ivalue.toTensorList();
     list.reserve(num_elements);
     for (const auto& elem : elements) {
       list.emplace_back(elem.ivalue().toTensor());
     }
   } else if (list_ivalue.isDoubleList()) {
-    auto& list = list_ivalue.toDoubleList()->elements();
+    auto list = list_ivalue.toDoubleList();
     list.reserve(num_elements);
     for (const auto& elem : elements) {
       list.emplace_back(elem.ivalue().toDouble());
     }
   } else if (list_ivalue.isBoolList()) {
-    auto& list = list_ivalue.toBoolList()->elements();
+    auto list = list_ivalue.toBoolList();
     list.reserve(num_elements);
     for (const auto& elem : elements) {
       list.push_back(elem.ivalue().toBool());
     }
   } else if (list_ivalue.isGenericList()) {
-    auto& list = list_ivalue.toGenericList()->elements();
+    auto list = list_ivalue.toGenericList();
     list.reserve(num_elements);
     for (const auto& elem : elements) {
       list.emplace_back(elem.ivalue());

--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -23,19 +23,19 @@ IValue unwrap(IValue&& ivalue) {
   if (ivalue.isTensor() && ivalue.toTensor().defined()) {
     return unwrap_tensor(std::move(ivalue).toTensor());
   } else if (ivalue.isTensorList()) {
-    c10::ListPtr<at::Tensor> list = ivalue.toTensorList()->elements();
+    c10::ListPtr<at::Tensor> list = ivalue.toTensorList();
     for (size_t i = 0; i < list.size(); ++i) {
       list[i] = unwrap_tensor(list.extract(i));
     }
     return std::move(ivalue);
   } else if (ivalue.isGenericList()) {
-    c10::impl::GenericListPtr list = ivalue.toGenericList()->elements();
+    c10::impl::GenericListPtr list = ivalue.toGenericList();
     for (size_t i = 0; i < list.size(); ++i) {
       list[i] = unwrap(list.extract(i));
     }
     return std::move(ivalue);
   } else if (ivalue.isGenericDict()) {
-    for (auto& item : ivalue.toGenericDict()->elements()) {
+    for (auto& item : ivalue.toGenericDict()) {
       item.setValue(unwrap(item.value()));
     }
     return std::move(ivalue);
@@ -56,19 +56,19 @@ IValue wrap(IValue&& ivalue) {
   if (ivalue.isTensor()) {
     return wrap_tensor(std::move(ivalue).toTensor());
   } else if (ivalue.isTensorList()) {
-    c10::ListPtr<at::Tensor> list = ivalue.toTensorList()->elements();
+    c10::ListPtr<at::Tensor> list = ivalue.toTensorList();
     for (size_t i = 0; i < list.size(); ++i) {
       list[i] = wrap_tensor(list.extract(i));
     }
     return std::move(ivalue);
   } else if (ivalue.isGenericList()) {
-    c10::impl::GenericListPtr list = ivalue.toGenericList()->elements();
+    c10::impl::GenericListPtr list = ivalue.toGenericList();
     for (size_t i = 0; i < list.size(); ++i) {
       list[i] = wrap(list.extract(i));
     }
     return std::move(ivalue);
   } else if (ivalue.isGenericDict()) {
-    for (auto& item : ivalue.toGenericDict()->elements()) {
+    for (auto& item : ivalue.toGenericDict()) {
       item.setValue(wrap(item.value()));
     }
     return std::move(ivalue);
@@ -139,14 +139,14 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
                 reinterpret_cast<ListType*>(type.get())->getElementType();
             if (elem_type->isSubclass(TypeKind::TensorType)) {
               AT_ASSERT(iter->isTensorList());
-              const auto& list = iter->toTensorListRef();
+              const auto& list = iter->toTensorList();
               tracer::addInputs(node, args[i].name().c_str(), c10::impl::toArrayRef(list));
             } else if (elem_type->kind() == TypeKind::FloatType) {
               AT_ASSERT(iter->isDoubleList());
               // NB: now, tracer doesn't support tracing double list. We add special
               // handling here, since in our case, we assume that all the doubles
               // in the list are constants
-              const auto& value = iter->toDoubleListRef();
+              auto value = iter->toDoubleList();
               std::vector<Value*> info(value.size());
               for (size_t value_index = 0; value_index < value.size(); ++value_index) {
                 info[value_index] = graph->insertConstant(value.get(value_index));
@@ -157,11 +157,11 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
             } else if (elem_type->kind() == TypeKind::IntType) {
               AT_ASSERT(iter->isIntList());
               tracer::addInputs(
-                  node, args[i].name().c_str(), c10::impl::toArrayRef(iter->toIntListRef()));
+                  node, args[i].name().c_str(), c10::impl::toArrayRef(iter->toIntList()));
             } else if (elem_type->kind() == TypeKind::BoolType) {
               AT_ASSERT(iter->isBoolList());
               tracer::addInputs(
-                  node, args[i].name().c_str(), c10::impl::toVector(iter->toBoolListRef()));
+                  node, args[i].name().c_str(), c10::impl::toVector(iter->toBoolList()));
             } else {
               throw std::runtime_error(
                   "unsupported input list type: " + elem_type->str());
@@ -198,7 +198,7 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
                 reinterpret_cast<ListType*>(type.get())->getElementType();
             if (elem_type->isSubclass(TypeKind::TensorType)) {
               AT_ASSERT(iter->isTensorList());
-              tracer::addOutput(node, iter->toTensorList()->elements());
+              tracer::addOutput(node, iter->toTensorList());
             } else {
               throw std::runtime_error(
                   "unsupported ouptut list type: " + elem_type->str());

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -188,7 +188,7 @@ RegisterOperators reg(
            for (int i = 0; i < n; i++) {
              elems.push_back(i);
            }
-           push(stack, jit::IntList::create(std::move(elems)));
+           push(stack, std::move(elems));
            return 0;
          }),
      Operator(
@@ -515,7 +515,7 @@ RegisterOperators reg(
              size.reserve(8);
              for (size_t i = 0; i < num_inputs; ++i) {
                size = at::infer_size(
-                   size, c10::impl::toArrayRef(peek(stack, i, num_inputs).toIntList()->elements()));
+                   size, c10::impl::toArrayRef(peek(stack, i, num_inputs).toIntList()));
              }
              drop(stack, num_inputs);
              push(stack, std::move(size));
@@ -528,9 +528,8 @@ RegisterOperators reg(
            int64_t raw_dim = node->i(attr::dim);
            int64_t chunks = node->i(attr::chunks);
            return [raw_dim, chunks](Stack& stack) {
-             Shared<IntList> sizes_l;
-             pop(stack, sizes_l);
-             const auto& shape = sizes_l->elements();
+             c10::ListPtr<int64_t> shape = c10::make_list<int64_t>();
+             pop(stack, shape);
              c10::ListPtr<int64_t> regular_shape = shape.copy();
              c10::ListPtr<int64_t> last_shape = shape.copy();
              int64_t dim = at::maybe_wrap_dim(raw_dim, shape.size());
@@ -676,7 +675,7 @@ RegisterOperators reg(
            } else {
              push(
                  stack,
-                 at::sum_to(self.toTensor(), c10::impl::toArrayRef(size.toIntList()->elements())));
+                 at::sum_to(self.toTensor(), c10::impl::toArrayRef(size.toIntList())));
            }
            return 0;
          }),
@@ -685,8 +684,8 @@ RegisterOperators reg(
          [](Stack& stack) {
            IValue self_size, other_size;
            pop(stack, self_size, other_size);
-           const auto s = self_size.toIntList()->elements();
-           if (is_equal(s, other_size.toIntList()->elements())) {
+           const auto s = self_size.toIntList();
+           if (is_equal(s, other_size.toIntList())) {
              push(stack, IValue());
            } else {
              push(stack, s);
@@ -698,8 +697,8 @@ RegisterOperators reg(
          [](const Node* node) {
            size_t num_elems = node->outputs().size();
            return [=](Stack& stack) {
-             auto t = pop(stack).toTuple();
-             const auto& elems = t->elements();
+             auto tuple = pop(stack).toTuple();
+             auto& elems = tuple.elements();
              if (elems.size() != num_elems) {
                AT_ERROR(
                    "Expected a tuple of ",
@@ -717,13 +716,13 @@ RegisterOperators reg(
            int64_t beg_ind = node->i(attr::beg);
            int64_t end_ind = node->i(attr::end);
            return [=](Stack& stack) {
-             auto t = pop(stack).toTuple();
-             const auto& elems = t->elements();
+             auto tuple = pop(stack).toTuple();
+             auto& elems = tuple.elements();
              c10::impl::GenericListPtr output_elems = c10::impl::make_generic_list();
              for (int64_t i = beg_ind; i < end_ind; ++i) {
                output_elems.emplace_back(elems.get(i));
              }
-             push(stack, Tuple::create(std::move(output_elems)));
+             push(stack, c10::ivalue::TuplePtr::create(std::move(output_elems)));
              return 0;
            };
          }),
@@ -732,8 +731,8 @@ RegisterOperators reg(
          [](const Node* node) {
            return [](Stack& stack) {
              int64_t index = pop(stack).toInt();
-             auto tup = pop(stack).toTuple();
-             const auto& elems = tup->elements();
+             auto tuple = pop(stack).toTuple();
+             auto& elems = tuple.elements();
              auto norm_index = normalizeIndex(index, elems.size());
              if (norm_index < 0 ||
                  norm_index > static_cast<int64_t>(elems.size())) {
@@ -752,7 +751,7 @@ RegisterOperators reg(
                  std::make_move_iterator(stack.end() - num_inputs),
                  std::make_move_iterator(stack.end())};
              drop(stack, num_inputs);
-             push(stack, Tuple::create(c10::impl::toList(std::move(elems))));
+             push(stack, c10::ivalue::TuplePtr::create(c10::impl::toList(std::move(elems))));
              return 0;
            };
          }),
@@ -808,7 +807,7 @@ RegisterOperators reg(
            if (lt->getElementType() == IntType::get()) {
              return [=](Stack& stack) {
                auto ilist = pop(stack);
-               const auto& list = ilist.toIntList()->elements();
+               const auto& list = ilist.toIntList();
                TORCH_CHECK(
                    list.size() == num_outputs,
                    "Expected ",
@@ -821,7 +820,7 @@ RegisterOperators reg(
            } else if (lt->getElementType() == FloatType::get()) {
              return [=](Stack& stack) {
                auto ilist = pop(stack);
-               const auto& list = ilist.toDoubleList()->elements();
+               auto list = ilist.toDoubleList();
                TORCH_CHECK(
                    list.size() == num_outputs,
                    "Expected ",
@@ -834,7 +833,7 @@ RegisterOperators reg(
            } else if (lt->getElementType() == TensorType::get()) {
              return [=](Stack& stack) {
                auto ilist = pop(stack);
-               const auto& list = ilist.toTensorList()->elements();
+               const auto& list = ilist.toTensorList();
                TORCH_CHECK(
                    list.size() == num_outputs,
                    "Expected ",
@@ -847,7 +846,7 @@ RegisterOperators reg(
            } else {
              return [=](Stack& stack) {
                auto glist = pop(stack);
-               const auto& list = glist.toGenericList()->elements();
+               const auto& list = glist.toGenericList();
                TORCH_CHECK(
                    list.size() == num_outputs,
                    "Expected ",
@@ -1149,67 +1148,55 @@ int stringSlice(Stack& stack) {
 }
 
 // Equivalent to list.at(idx)
-template <typename TList> // something like Shared<IntList>
-typename TList::element_type::ElemType getItem(TList& list, int64_t idx) {
-  const int64_t list_size = list->elements().size();
-  const int64_t normalized_idx = normalizeIndex(idx, list_size);
-  if (normalized_idx < 0 || normalized_idx >= list_size) {
-    throw std::out_of_range("list index out of range");
-  }
-  return list->elements().get(normalized_idx);
-}
-
-template <typename TList> // something like Shared<IntList>
-void setItem(TList& list, int64_t idx, typename TList::element_type::ElemType&& value) {
-  const int64_t list_size = list->elements().size();
-  const int64_t normalized_idx = normalizeIndex(idx, list_size);
-  if (normalized_idx < 0 || normalized_idx >= list_size) {
-    throw std::out_of_range("list index out of range");
-  }
-  list->elements().set(normalized_idx, std::move(value));
-}
-
-// cannot return a reference to an element in a bool vector
-bool getBoolItem(const c10::ListPtr<bool>& list, int64_t idx) {
+template <typename T>
+T getItem(const c10::ListPtr<T>& list, int64_t idx) {
   const int64_t list_size = list.size();
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
   if (normalized_idx < 0 || normalized_idx >= list_size) {
     throw std::out_of_range("list index out of range");
   }
-  return list[normalized_idx];
+  return list.get(normalized_idx);
 }
 
-template <typename TList, typename TElement>
+template <typename T>
+void setItem(const c10::ListPtr<T>& list, int64_t idx, T&& value) {
+  const int64_t list_size = list.size();
+  const int64_t normalized_idx = normalizeIndex(idx, list_size);
+  if (normalized_idx < 0 || normalized_idx >= list_size) {
+    throw std::out_of_range("list index out of range");
+  }
+  list.set(normalized_idx, std::move(value));
+}
+
+template <typename T>
 int listAppend(Stack& stack) {
-  TList a;
-  TElement el;
-  pop(stack, a, el);
+  c10::ListPtr<T> list = c10::make_list<T>();
+  T el;
+  pop(stack, list, el);
 
-  a->elements().push_back(el);
-  push(stack, a);
+  list.push_back(std::move(el));
+  push(stack, std::move(list));
 
   return 0;
 }
 
-template <typename TList>
+template <typename T>
 int listReverse(Stack& stack) {
-  TList a;
-  pop(stack, a);
+  c10::ListPtr<T> list = c10::make_list<T>();
+  pop(stack, list);
 
-  auto& elements = a->elements();
-  std::reverse(elements.begin(), elements.end());
+  std::reverse(list.begin(), list.end());
 
   return 0;
 }
 
-template <typename TList>
+template <typename T>
 int listPop(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t idx;
   pop(stack, list, idx);
 
-  auto& elements = list->elements();
-  const int64_t list_size = elements.size();
+  const int64_t list_size = list.size();
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
 
   if (list_size == 0) {
@@ -1217,75 +1204,53 @@ int listPop(Stack& stack) {
   }
 
   push(stack, getItem(list, idx));
-  elements.erase(elements.begin() + normalized_idx);
+  list.erase(list.begin() + normalized_idx);
 
   return 0;
 }
 
-template <>
-int listPop<Shared<BoolList>>(Stack& stack) {
-  Shared<BoolList> list;
-  int64_t idx;
-  pop(stack, list, idx);
-
-  auto& elements = list->elements();
-  const int64_t list_size = elements.size();
-  const int64_t normalized_idx = normalizeIndex(idx, list_size);
-
-  if (list_size == 0) {
-    AT_ERROR("pop from empty list");
-  }
-
-  push(stack, getBoolItem(elements, idx));
-  elements.erase(elements.begin() + normalized_idx);
-
-  return 0;
-}
-
-template <typename TList>
+template <typename T>
 int listClear(Stack& stack) {
-  TList a;
-  pop(stack, a);
+  c10::ListPtr<T> list = c10::make_list<T>();
+  pop(stack, list);
 
-  a->elements().clear();
+  list.clear();
   return 0;
 }
 
-template <typename TList, typename TElement>
+template <typename T>
 int listInsert(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t idx;
-  TElement elem;
+  T elem;
   pop(stack, list, idx, elem);
 
-  auto& elements = list->elements();
-  const int64_t list_size = elements.size();
+  const int64_t list_size = list.size();
   const int64_t normalized_idx = normalizeIndex(idx, list_size);
 
   if (normalized_idx < 0 || normalized_idx >= list_size) {
     if (normalized_idx < 0) {
-      elements.insert(elements.begin(), elem);
+      list.insert(list.begin(), elem);
     } else {
-      elements.push_back(elem);
+      list.push_back(elem);
     }
   } else {
-    elements.insert(elements.begin() + normalized_idx, elem);
+    list.insert(list.begin() + normalized_idx, elem);
   }
 
   return 0;
 }
 
-template <typename TList, typename TElement>
+template <typename T>
 int listRemove(Stack& stack) {
-  TList list;
-  TElement elem;
+  c10::ListPtr<T> list = c10::make_list<T>();
+  T elem;
   pop(stack, list, elem);
 
-  auto& elements = list->elements();
-  auto pos = std::find(elements.begin(), elements.end(), elem);
+  auto pos = std::find(list.begin(), list.end(), elem);
 
-  if (pos != elements.end()) {
-    elements.erase(pos);
+  if (pos != list.end()) {
+    list.erase(pos);
   } else {
     AT_ERROR("list.remove(x): x not in list");
   }
@@ -1294,20 +1259,19 @@ int listRemove(Stack& stack) {
 }
 
 template <>
-int listRemove<Shared<TensorList>, at::Tensor>(Stack& stack) {
-  Shared<TensorList> list;
+int listRemove<at::Tensor>(Stack& stack) {
+  c10::ListPtr<at::Tensor> list = c10::make_list<at::Tensor>();
   at::Tensor elem;
   pop(stack, list, elem);
 
-  auto& elements = list->elements();
   auto pos = std::find_if(
-      elements.begin(), elements.end(), [elem](const at::Tensor& b) {
+      list.begin(), list.end(), [&](const at::Tensor& b) {
         const auto cmp_result = elem.eq(b);
         return cmp_result.is_nonzero();
       });
 
-  if (pos != elements.end()) {
-    elements.erase(pos);
+  if (pos != list.end()) {
+    list.erase(pos);
   } else {
     AT_ERROR("list.remove(x): x not in list");
   }
@@ -1315,17 +1279,16 @@ int listRemove<Shared<TensorList>, at::Tensor>(Stack& stack) {
   return 0;
 }
 
-template <typename TList, typename TElement>
+template <typename T>
 int listIndex(Stack& stack) {
-  TList list;
-  TElement elem;
+  c10::ListPtr<T> list = c10::make_list<T>();
+  T elem;
   pop(stack, list, elem);
 
-  auto& elements = list->elements();
-  auto pos = std::find(elements.begin(), elements.end(), elem);
+  auto pos = std::find(list.begin(), list.end(), elem);
 
-  if (pos != elements.end()) {
-    push(stack, static_cast<int64_t>(std::distance(elements.begin(), pos)));
+  if (pos != list.end()) {
+    push(stack, static_cast<int64_t>(std::distance(list.begin(), pos)));
   } else {
     AT_ERROR("'", elem, "' is not in list");
   }
@@ -1334,20 +1297,19 @@ int listIndex(Stack& stack) {
 }
 
 template <>
-int listIndex<Shared<TensorList>, at::Tensor>(Stack& stack) {
-  Shared<TensorList> list;
+int listIndex<at::Tensor>(Stack& stack) {
+  c10::ListPtr<at::Tensor> list = c10::make_list<at::Tensor>();
   at::Tensor elem;
   pop(stack, list, elem);
 
-  auto& elements = list->elements();
   auto pos = std::find_if(
-      elements.begin(), elements.end(), [elem](const at::Tensor& b) {
+      list.begin(), list.end(), [elem](const at::Tensor& b) {
         const auto cmp_result = elem.eq(b);
         return cmp_result.is_nonzero();
       });
 
-  if (pos != elements.end()) {
-    push(stack, static_cast<int64_t>(std::distance(elements.begin(), pos)));
+  if (pos != list.end()) {
+    push(stack, static_cast<int64_t>(std::distance(list.begin(), pos)));
   } else {
     AT_ERROR("'", elem, "' is not in list");
   }
@@ -1355,28 +1317,26 @@ int listIndex<Shared<TensorList>, at::Tensor>(Stack& stack) {
   return 0;
 }
 
-template <typename TList, typename TElement>
+template <typename T>
 int listCount(Stack& stack) {
-  TList list;
-  TElement elem;
+  c10::ListPtr<T> list = c10::make_list<T>();
+  T elem;
   pop(stack, list, elem);
 
-  auto& elements = list->elements();
-  const int64_t count = std::count(elements.begin(), elements.end(), elem);
+  const int64_t count = std::count(list.begin(), list.end(), elem);
   push(stack, count);
 
   return 0;
 }
 
 template <>
-int listCount<Shared<TensorList>, at::Tensor>(Stack& stack) {
-  Shared<TensorList> list;
+int listCount<at::Tensor>(Stack& stack) {
+  c10::ListPtr<at::Tensor> list = c10::make_list<at::Tensor>();
   at::Tensor elem;
   pop(stack, list, elem);
 
-  auto& elements = list->elements();
   const int64_t count = std::count_if(
-      elements.begin(), elements.end(), [elem](const at::Tensor& b) {
+      list.begin(), list.end(), [&](const at::Tensor& b) {
         const auto cmp_result = elem.eq(b);
         return cmp_result.is_nonzero();
       });
@@ -1385,39 +1345,34 @@ int listCount<Shared<TensorList>, at::Tensor>(Stack& stack) {
   return 0;
 }
 
-template <typename TList>
+template <typename T>
 Operation listExtend(const Node* node) {
   return [](Stack& stack) {
-    TList a;
-    TList b;
+    c10::ListPtr<T> a = c10::make_list<T>();
+    c10::ListPtr<T> b = c10::make_list<T>();
     pop(stack, a, b);
 
-    auto& vec_a = a->elements();
-    const auto& vec_b = b->elements();
-    vec_a.reserve(vec_a.size() + vec_b.size());
-    for (size_t i = 0; i < vec_b.size(); ++i) {
-      vec_a.push_back(vec_b.get(i));
+    a.reserve(a.size() + b.size());
+    for (size_t i = 0; i < b.size(); ++i) {
+      a.push_back(b.get(i));
     }
     return 0;
   };
 }
 
-template <typename TList>
+template <typename T>
 Operation listCopy(const Node* node) {
   return [](Stack& stack) {
-    TList list;
+    c10::ListPtr<T> list = c10::make_list<T>();
     pop(stack, list);
-
-    const auto& vec = list->elements();
-    auto out = vec.copy();
-    push(stack, out);
+    push(stack, list.copy());
     return 0;
   };
 }
 
 template <typename T>
 int listSelect(Stack& stack) {
-  T list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t idx;
   pop(stack, list, idx);
 
@@ -1426,54 +1381,42 @@ int listSelect(Stack& stack) {
   return 0;
 }
 
-// needs specialization because cannot return a pointer to a bool in an array
-template <>
-int listSelect<Shared<BoolList>>(Stack& stack) {
-  Shared<BoolList> list;
-  int64_t idx;
-  pop(stack, list, idx);
-
-  auto element = getBoolItem(list->elements(), idx);
-  push(stack, element);
-  return 0;
-}
-
 template <typename T>
 int listLen(Stack& stack) {
-  T a;
+  c10::ListPtr<T> a = c10::make_list<T>();
   pop(stack, a);
 
-  const int64_t size = a->elements().size();
+  const int64_t size = a.size();
   push(stack, size);
   return 0;
 }
 
 template <typename T>
 int listEq(Stack& stack) {
-  T a;
-  T b;
+  c10::ListPtr<T> a = c10::make_list<T>();
+  c10::ListPtr<T> b = c10::make_list<T>();
   pop(stack, a, b);
-  push(stack, list_is_equal(a->elements(), b->elements()));
+  push(stack, list_is_equal(a, b));
   return 0;
 }
 
 template <typename T>
 int listNe(Stack& stack) {
-  T a;
-  T b;
+  c10::ListPtr<T> a = c10::make_list<T>();
+  c10::ListPtr<T> b = c10::make_list<T>();
   pop(stack, a, b);
-  push(stack, !list_is_equal(a->elements(), b->elements()));
+  push(stack, !list_is_equal(a, b));
   return 0;
 }
 
-inline bool tensor_list_equal(Shared<TensorList> a, Shared<TensorList> b) {
-  if (a->elements().size() != b->elements().size()) {
+inline bool tensor_list_equal(const c10::ListPtr<at::Tensor>& a, const c10::ListPtr<at::Tensor>& b) {
+  if (a.size() != b.size()) {
     return false;
   }
 
-  for (size_t i = 0; i < a->elements().size(); ++i) {
-    at::Tensor a_element = a->elements()[i];
-    at::Tensor b_element = b->elements()[i];
+  for (size_t i = 0; i < a.size(); ++i) {
+    at::Tensor a_element = a[i];
+    at::Tensor b_element = b[i];
     // This preserves Python's semantics, which uses eq() to compare two
     // elements, then passes the result to bool().
     // see: https://docs.python.org/3.4/reference/datamodel.html#object.__ge__
@@ -1488,9 +1431,9 @@ inline bool tensor_list_equal(Shared<TensorList> a, Shared<TensorList> b) {
 
 // Specialization for at::Tensor, since it doesn't define operator==
 template <>
-int listEq<Shared<TensorList>>(Stack& stack) {
-  Shared<TensorList> a;
-  Shared<TensorList> b;
+int listEq<at::Tensor>(Stack& stack) {
+  c10::ListPtr<at::Tensor> a = c10::make_list<at::Tensor>();
+  c10::ListPtr<at::Tensor> b = c10::make_list<at::Tensor>();
   pop(stack, a, b);
   push(stack, tensor_list_equal(a, b));
   return 0;
@@ -1498,9 +1441,9 @@ int listEq<Shared<TensorList>>(Stack& stack) {
 
 // Specialization for at::Tensor, since it doesn't define operator==
 template <>
-int listNe<Shared<TensorList>>(Stack& stack) {
-  Shared<TensorList> a;
-  Shared<TensorList> b;
+int listNe<at::Tensor>(Stack& stack) {
+  c10::ListPtr<at::Tensor> a = c10::make_list<at::Tensor>();
+  c10::ListPtr<at::Tensor> b = c10::make_list<at::Tensor>();
   pop(stack, a, b);
   push(stack, !tensor_list_equal(a, b));
   return 0;
@@ -1514,75 +1457,75 @@ Operation listList(const Node* node) {
   };
 }
 
-template <class TList, class TElement>
+template <class T>
 int listAdd(Stack& stack) {
-  TList a;
-  TList b;
+  c10::ListPtr<T> a = c10::make_list<T>();
+  c10::ListPtr<T> b = c10::make_list<T>();
   pop(stack, a, b);
 
-  c10::ListPtr<TElement> ret = c10::make_list<TElement>();
-  const auto total_size = a->elements().size() + b->elements().size();
+  c10::ListPtr<T> ret = c10::make_list<T>();
+  const auto total_size = a.size() + b.size();
   ret.reserve(total_size);
-  for (const TElement& a_element : a->elements()) {
+  for (const T& a_element : a) {
     ret.push_back(a_element);
   }
-  for (const TElement& b_element : b->elements()) {
+  for (const T& b_element : b) {
     ret.push_back(b_element);
   }
 
-  push(stack, ret);
+  push(stack, std::move(ret));
   return 0;
 }
 
-template <class TList, class TElement>
+template <class T>
 int listMulIntLeft(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t n;
   pop(stack, list, n);
 
-  c10::ListPtr<TElement> ret = c10::make_list<TElement>();
-  const auto size = list->elements().size() * n;
+  c10::ListPtr<T> ret = c10::make_list<T>();
+  const auto size = list.size() * n;
   ret.reserve(size);
 
   for (auto i = 0; i < n; i++) {
-    for (const TElement& e : list->elements()) {
-      ret.push_back(e);
+    for (T e : list) {
+      ret.push_back(std::move(e));
     }
   }
 
-  push(stack, ret);
+  push(stack, std::move(ret));
   return 0;
 }
 
-template <class TList, class TElement>
+template <class T>
 int listMulIntRight(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t n;
   pop(stack, n, list);
 
-  c10::ListPtr<TElement> ret = c10::make_list<TElement>();
-  const auto size = list->elements().size() * n;
+  c10::ListPtr<T> ret = c10::make_list<T>();
+  const auto size = list.size() * n;
   ret.reserve(size);
 
   for (auto i = 0; i < n; i++) {
-    for (const TElement& e : list->elements()) {
-      ret.push_back(e);
+    for (T e : list) {
+      ret.push_back(std::move(e));
     }
   }
 
-  push(stack, ret);
+  push(stack, std::move(ret));
   return 0;
 }
 
-template <typename TList, typename TElement>
+template <typename T>
 int listSlice(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t start;
   int64_t end;
   int64_t step;
 
   pop(stack, list, start, end, step);
-  const int64_t list_size = list->elements().size();
+  const int64_t list_size = list.size();
 
   // clamp start and end to the bounds of the list
   const auto normalized_start =
@@ -1590,74 +1533,55 @@ int listSlice(Stack& stack) {
   const auto normalized_end =
       std::min(list_size, normalizeIndex(end, list_size));
 
-  c10::ListPtr<TElement> sliced_list = c10::make_list<TElement>();
+  c10::ListPtr<T> sliced_list = c10::make_list<T>();
   if (normalized_end <= normalized_start) {
     // early exit if the slice is trivially empty
-    push(stack, sliced_list);
+    push(stack, std::move(sliced_list));
     return 0;
   }
 
   sliced_list.reserve(normalized_end - normalized_start);
 
   for (auto i = normalized_start; i < normalized_end;) {
-    sliced_list.push_back(list->elements()[i]);
+    sliced_list.push_back(list.get(i));
     i += step;
   }
 
-  push(stack, sliced_list);
+  push(stack, std::move(sliced_list));
   return 0;
 }
 
-template <typename TList>
+template <typename T>
 int listSort(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
 
   pop(stack, list);
-  std::sort(list->elements().begin(), list->elements().end());
+  std::sort(list.begin(), list.end());
   return 0;
 }
 
 // Specialization for at::Tensor
 template <>
-int listSort<Shared<TensorList>>(Stack& stack) {
-  Shared<TensorList> list;
+int listSort<at::Tensor>(Stack& stack) {
+  c10::ListPtr<at::Tensor> list = c10::make_list<at::Tensor>();
   pop(stack, list);
   std::sort(
-      list->elements().begin(),
-      list->elements().end(),
+      list.begin(),
+      list.end(),
       [](const at::Tensor& a, const at::Tensor& b) {
         return a.lt(b).is_nonzero();
       });
   return 0;
 }
 
-template <typename TList, typename TElement>
+template <typename T>
 int listSetItem(Stack& stack) {
-  TList list;
+  c10::ListPtr<T> list = c10::make_list<T>();
   int64_t idx;
-  TElement value;
+  T value;
 
   pop(stack, list, idx, value);
   setItem(list, idx, std::move(value));
-
-  push(stack, list);
-  return 0;
-}
-
-template <>
-int listSetItem<Shared<BoolList>, bool>(Stack& stack) {
-  Shared<BoolList> list;
-  int64_t idx;
-  bool value;
-
-  pop(stack, list, idx, value);
-
-  int64_t list_size = list->elements().size();
-  auto normalized_idx = normalizeIndex(idx, list_size);
-  if (normalized_idx < 0 || normalized_idx >= list_size) {
-    throw std::out_of_range("list index out of range");
-  }
-  list->elements()[normalized_idx] = value;
 
   push(stack, list);
   return 0;
@@ -1667,22 +1591,22 @@ int dictSetItem(Stack& stack) {
   auto value = pop(stack);
   auto idx = pop(stack);
   auto dict = pop(stack).toGenericDict();
-  dict->elements().insert_or_assign(std::move(idx), std::move(value));
+  dict.insert_or_assign(std::move(idx), std::move(value));
   push(stack, std::move(dict));
   return 0;
 }
 
 int dictLen(Stack& stack) {
   auto dict = pop(stack).toGenericDict();
-  push(stack, int64_t(dict->elements().size()));
+  push(stack, int64_t(dict.size()));
   return 0;
 }
 
 int dictKeys(Stack& stack) {
   auto dict = pop(stack).toGenericDict();
   c10::impl::GenericListPtr keys = c10::impl::make_generic_list();
-  keys.reserve(dict->elements().size());
-  for (auto item : dict->elements()) {
+  keys.reserve(dict.size());
+  for (auto& item : dict) {
     keys.push_back(item.key());
   }
   push(stack, IValue(keys));
@@ -1691,7 +1615,7 @@ int dictKeys(Stack& stack) {
 
 template <typename Elem>
 c10::impl::GenericListPtr makeListForDictValues(
-    const c10::ivalue::GenericDict::IterationOrder& order) {
+    const std::vector<std::pair<IValue, IValue>>& order) {
   c10::impl::GenericListPtr values = c10::impl::make_generic_list();
   values.reserve(order.size());
   for (auto item : order) {
@@ -1703,7 +1627,7 @@ c10::impl::GenericListPtr makeListForDictValues(
 Operation dictValues(const Node* n) {
   auto outputType = n->output()->type()->expect<ListType>();
   return [=](Stack& stack) -> int {
-    const auto& order = pop(stack).toGenericDict()->iterationOrder();
+    const auto& order = iterationOrder(pop(stack).toGenericDict());
     if (outputType->getElementType()->isSubtypeOf(TensorType::get())) {
       push(stack, makeListForDictValues<at::Tensor>(order));
     } else if (outputType->getElementType() == IntType::get()) {
@@ -1722,9 +1646,8 @@ Operation dictValues(const Node* n) {
 int dictIndex(Stack& stack) {
   auto index = pop(stack);
   auto dict = pop(stack).toGenericDict();
-  const auto& elems = dict->elements();
-  auto value = elems.find(index);
-  if (value == elems.end()) {
+  auto value = dict.find(index);
+  if (value == dict.end()) {
     AT_ERROR("KeyError: '", index, "'");
   }
   push(stack, value->value());
@@ -1734,9 +1657,8 @@ int dictIndex(Stack& stack) {
 int dictGet(Stack& stack) {
   auto index = pop(stack);
   auto dict = pop(stack).toGenericDict();
-  const auto& elems = dict->elements();
-  auto value = elems.find(index);
-  if (value == elems.end()) {
+  auto value = dict.find(index);
+  if (value == dict.end()) {
     push(stack, IValue());
   } else {
     push(stack, value->value());
@@ -1748,9 +1670,8 @@ int dictGetDefault(Stack& stack) {
   auto default_value = pop(stack);
   auto index = pop(stack);
   auto dict = pop(stack).toGenericDict();
-  const auto& elems = dict->elements();
-  auto value = elems.find(index);
-  if (value == elems.end()) {
+  auto value = dict.find(index);
+  if (value == dict.end()) {
     push(stack, default_value);
   } else {
     push(stack, value->value());
@@ -1811,170 +1732,170 @@ RegisterOperators reg2({
           return 0;
         }),
 // Mutable ops for lists containing mutable types.
-#define CREATE_MUTABLE_LIST_OPS(decl_type, c_type)                          \
+#define CREATE_MUTABLE_LIST_OPS(decl_type, value_type)                      \
   Operator(                                                                 \
       "aten::select(" decl_type "[](a) list, int idx) -> " decl_type "(*)", \
-      listSelect<Shared<c_type>>),                                          \
+      listSelect<value_type>),                                              \
       Operator(                                                             \
           "aten::append( " decl_type "[](a!) self, " decl_type              \
           "(c -> *) el) -> " decl_type "[](a!)",                            \
-          listAppend<Shared<c_type>, c_type::ElemType>),                    \
+          listAppend<value_type>),                                          \
       Operator(                                                             \
           "aten::reverse( " decl_type "[](a!) self) -> ()",                 \
-          listReverse<Shared<c_type>>),                                     \
+          listReverse<value_type>),                                         \
       Operator(                                                             \
           "aten::extend(" decl_type "[](a!) self, " decl_type               \
           " [] other) -> ()",                                               \
-          listExtend<Shared<c_type>>),                                      \
+          listExtend<value_type>),                                          \
       Operator(                                                             \
           "aten::copy(" decl_type                                           \
           "[](a) self)"                                                     \
           " -> " decl_type "[]",                                            \
-          listCopy<Shared<c_type>>),                                        \
+          listCopy<value_type>),                                            \
       Operator(                                                             \
           "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type      \
           "(b -> *) el) -> " decl_type "[](a!)",                            \
-          listSetItem<Shared<c_type>, c_type::ElemType>),                   \
+          listSetItem<value_type>),                                         \
       Operator(                                                             \
           "aten::clear( " decl_type "[](a!) self) -> ()",                   \
-          listClear<Shared<c_type>>),                                       \
+          listClear<value_type>),                                           \
       Operator(                                                             \
           "aten::insert( " decl_type                                        \
-          "[](a!) self, int idx,                 \
+          "[](a!) self, int idx,                                            \
           " decl_type "(b -> *) el) -> ()",                                 \
-          listInsert<Shared<c_type>, c_type::ElemType>),                    \
+          listInsert<value_type>),                                          \
       Operator(                                                             \
           "aten::pop(" decl_type                                            \
-          "[](a!) self, int idx=-1)                    \
+          "[](a!) self, int idx=-1)                                         \
         -> " decl_type "(*)",                                               \
-          listPop<Shared<c_type>>)
+          listPop<value_type>)
 
-    CREATE_MUTABLE_LIST_OPS("Tensor", TensorList),
+    CREATE_MUTABLE_LIST_OPS("Tensor", at::Tensor),
 
     Operator(
         "aten::remove(Tensor[](a!) self, Tensor el) -> ()",
-        listRemove<Shared<TensorList>, at::Tensor>),
+        listRemove<at::Tensor>),
     Operator(
         "aten::index(Tensor[] self, Tensor el) -> int",
-        listIndex<Shared<TensorList>, at::Tensor>),
+        listIndex<at::Tensor>),
     Operator(
         "aten::count(Tensor[] self, Tensor el) -> int",
-        listCount<Shared<TensorList>, at::Tensor>),
+        listCount<at::Tensor>),
 
 // Mutable ops for lists containing immutable types.
-#define CREATE_IMMUTABLE_LIST_OPS(decl_type, c_type)                   \
+#define CREATE_IMMUTABLE_LIST_OPS(decl_type, value_type)               \
   Operator(                                                            \
       "aten::select(" decl_type "[] a, int b) -> " decl_type,          \
-      listSelect<Shared<c_type>>),                                     \
+      listSelect<value_type>),                                         \
       Operator(                                                        \
           "aten::append(" decl_type "[](a!) self, " decl_type          \
           " el) -> " decl_type "[](a!)",                               \
-          listAppend<Shared<c_type>, c_type::ElemType>),               \
+          listAppend<value_type>),                                     \
       Operator(                                                        \
           "aten::reverse(" decl_type "[](a!) self) -> ()",             \
-          listReverse<Shared<c_type>>),                                \
+          listReverse<value_type>),                                    \
       Operator(                                                        \
           "aten::extend(" decl_type "[](a!) self, " decl_type          \
           " [] other) -> ()",                                          \
-          listExtend<Shared<c_type>>),                                 \
+          listExtend<value_type>),                                     \
       Operator(                                                        \
           "aten::copy(" decl_type                                      \
           "[](a) self)"                                                \
           " -> " decl_type "[]",                                       \
-          listCopy<Shared<c_type>>),                                   \
+          listCopy<value_type>),                                       \
       Operator(                                                        \
           "aten::_set_item(" decl_type "[](a!) l, int idx, " decl_type \
           " el) -> " decl_type "[](a!)",                               \
-          listSetItem<Shared<c_type>, c_type::ElemType>),              \
+          listSetItem<value_type>),                                    \
       Operator(                                                        \
           "aten::clear( " decl_type "[](a!) self) -> ()",              \
-          listClear<Shared<c_type>>),                                  \
+          listClear<value_type>),                                      \
       Operator(                                                        \
           "aten::insert( " decl_type                                   \
-          "[](a!) self, int idx,            \
+          "[](a!) self, int idx,                                       \
           " decl_type " el) -> ()",                                    \
-          listInsert<Shared<c_type>, c_type::ElemType>),               \
+          listInsert<value_type>),                                     \
       Operator(                                                        \
           "aten::remove(" decl_type                                    \
-          "[](a!) self,                      \
+          "[](a!) self,                                                \
           " decl_type " el) -> ()",                                    \
-          listRemove<Shared<c_type>, c_type::ElemType>),               \
+          listRemove<value_type>),                                     \
       Operator(                                                        \
           "aten::index(" decl_type                                     \
-          "[] self,                           \
+          "[] self,                                                    \
           " decl_type " el) -> int",                                   \
-          listIndex<Shared<c_type>, c_type::ElemType>),                \
+          listIndex<value_type>),                                      \
       Operator(                                                        \
           "aten::count(" decl_type                                     \
-          "[] self,                           \
+          "[] self,                                                    \
           " decl_type " el) -> int",                                   \
-          listCount<Shared<c_type>, c_type::ElemType>),                \
+          listCount<value_type>),                                      \
       Operator(                                                        \
           "aten::pop(" decl_type                                       \
-          "[](a!) self, int idx=-1)             \
+          "[](a!) self, int idx=-1)                                    \
           -> " decl_type,                                              \
-          listPop<Shared<c_type>>)
+          listPop<value_type>)
 
-    CREATE_IMMUTABLE_LIST_OPS("int", IntList),
-    CREATE_IMMUTABLE_LIST_OPS("float", DoubleList),
-    CREATE_IMMUTABLE_LIST_OPS("bool", BoolList),
+    CREATE_IMMUTABLE_LIST_OPS("int", int64_t),
+    CREATE_IMMUTABLE_LIST_OPS("float", double),
+    CREATE_IMMUTABLE_LIST_OPS("bool", bool),
 
     // NOTE: this must be after the other list specializations so that operator
     // resolution doesn't pick this up first
-    CREATE_MUTABLE_LIST_OPS("t", GenericList),
+    CREATE_MUTABLE_LIST_OPS("t", IValue),
 #undef CREATE_IMMUTABLE_LIST_OPS
 #undef CREATE_MUTABLE_LIST_OPS
 
 #define CREATE_LIST_OPS(decl_type, c_type)                                          \
-  Operator("aten::len(" decl_type "[] a) -> int", listLen<Shared<c_type>>),         \
+  Operator("aten::len(" decl_type "[] a) -> int", listLen<c_type::value_type>),     \
       Operator(                                                                     \
           "aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type           \
           "[]",                                                                     \
-          listAdd<Shared<c_type>, c_type::ElemType>),                               \
+          listAdd<c_type::value_type>),                                             \
       Operator(                                                                     \
           "aten::slice(" decl_type                                                  \
           "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type \
           "[]",                                                                     \
-          listSlice<Shared<c_type>, c_type::ElemType>),                             \
+          listSlice<c_type::value_type>),                                           \
       Operator("aten::list(" decl_type "[] l) -> " decl_type "[]", listList),       \
       Operator(                                                                     \
           "aten::mul(" decl_type "[] l, int n) -> " decl_type "[]",                 \
-          listMulIntLeft<Shared<c_type>, c_type::ElemType>),                        \
+          listMulIntLeft<c_type::value_type>),                                      \
       Operator(                                                                     \
           "aten::mul(int n, " decl_type "[] l) -> " decl_type "[]",                 \
-          listMulIntRight<Shared<c_type>, c_type::ElemType>)
+          listMulIntRight<c_type::value_type>)
 
-    CREATE_LIST_OPS("int", IntList),
-    CREATE_LIST_OPS("float", DoubleList),
-    CREATE_LIST_OPS("bool", BoolList),
-    CREATE_LIST_OPS("Tensor", TensorList),
-    CREATE_LIST_OPS("t", GenericList),
+    CREATE_LIST_OPS("int", c10::ListPtr<int64_t>),
+    CREATE_LIST_OPS("float", c10::ListPtr<double>),
+    CREATE_LIST_OPS("bool", c10::ListPtr<bool>),
+    CREATE_LIST_OPS("Tensor", c10::ListPtr<at::Tensor>),
+    CREATE_LIST_OPS("t", c10::ListPtr<IValue>),
 #undef CREATE_LIST_OPS
-    Operator("aten::sort(int[](a!) self) -> ()", listSort<Shared<IntList>>),
+    Operator("aten::sort(int[](a!) self) -> ()", listSort<int64_t>),
     Operator(
         "aten::sort(float[](a!) self) -> ()",
-        listSort<Shared<DoubleList>>),
+        listSort<double>),
     Operator(
         "aten::sort(Tensor[](a!) self) -> ()",
-        listSort<Shared<TensorList>>),
-    Operator("aten::sort(bool[](a!) self) -> ()", listSort<Shared<BoolList>>),
+        listSort<at::Tensor>),
+    Operator("aten::sort(bool[](a!) self) -> ()", listSort<bool>),
 
-    Operator("aten::eq(int[] a, int[] b) -> bool", listEq<Shared<IntList>>),
+    Operator("aten::eq(int[] a, int[] b) -> bool", listEq<int64_t>),
     Operator(
         "aten::eq(float[] a, float[] b) -> bool",
-        listEq<Shared<DoubleList>>),
+        listEq<double>),
     Operator(
         "aten::eq(Tensor[] a, Tensor[] b) -> bool",
-        listEq<Shared<TensorList>>),
-    Operator("aten::eq(bool[] a, bool[] b) -> bool", listEq<Shared<BoolList>>),
-    Operator("aten::ne(int[] a, int[] b) -> bool", listNe<Shared<IntList>>),
+        listEq<at::Tensor>),
+    Operator("aten::eq(bool[] a, bool[] b) -> bool", listEq<bool>),
+    Operator("aten::ne(int[] a, int[] b) -> bool", listNe<int64_t>),
     Operator(
         "aten::ne(float[] a, float[] b) -> bool",
-        listNe<Shared<DoubleList>>),
+        listNe<double>),
     Operator(
         "aten::ne(Tensor[] a, Tensor[] b) -> bool",
-        listNe<Shared<TensorList>>),
-    Operator("aten::ne(bool[] a, bool[] b) -> bool", listNe<Shared<BoolList>>),
+        listNe<at::Tensor>),
+    Operator("aten::ne(bool[] a, bool[] b) -> bool", listNe<bool>),
     Operator(
         "aten::slice(str string, int start, int end=9223372036854775807, int step=1) -> str",
         stringSlice),
@@ -2234,7 +2155,7 @@ RegisterOperators reg2({
           for (int i = 0; i < t.size(0); i++) {
             elems.push_back(*t[i].data<int32_t>());
           }
-          push(stack, jit::IntList::create(std::move(elems)));
+          push(stack, std::move(elems));
           return 0;
         }),
     Operator(
@@ -2335,8 +2256,8 @@ RegisterOperators regSort({
             auto g_list = pop(stack).toGenericList();
             Stack sort_stack;
             std::sort(
-                g_list->elements().begin(),
-                g_list->elements().end(),
+                g_list.begin(),
+                g_list.end(),
                 [func, reverse, &sort_stack](
                     const IValue& a, const IValue& b) -> bool {
                   // FBCode errors without this check - "strict weak ordering"
@@ -2368,14 +2289,14 @@ std::vector<int64_t> _output_size(
       std::vector<int64_t> repeated(dim, size.toInt());
       return repeated;
     } else {
-      return c10::impl::toVector(size.toIntListRef());
+      return c10::impl::toVector(size.toIntList());
     }
   }
   std::vector<double> scale_repeated;
   if (scale_factors.isDouble()) {
     scale_repeated = std::vector<double>(dim, scale_factors.toDouble());
   } else {
-    scale_repeated = c10::impl::toVector(scale_factors.toDoubleListRef());
+    scale_repeated = c10::impl::toVector(scale_factors.toDoubleList());
   }
   std::vector<int64_t> ret;
   for (size_t i = 0; i < dim; ++i) {
@@ -2492,7 +2413,7 @@ IValue convert_scale_factor_to_double(const IValue& int_ivalue) {
   if (int_ivalue.isInt()) {
     scale_factor_double = static_cast<double>(int_ivalue.toInt());
   } else if (int_ivalue.isIntList()) {
-    auto int_list = int_ivalue.toIntListRef();
+    auto int_list = int_ivalue.toIntList();
     std::vector<double> double_vec(int_list.begin(), int_list.end());
     scale_factor_double = c10::impl::toList(double_vec);
   } else if (int_ivalue.isNone()) {

--- a/torch/csrc/jit/register_quantized_ops.cpp
+++ b/torch/csrc/jit/register_quantized_ops.cpp
@@ -34,9 +34,9 @@ caffe2::Tensor from_at_tensor(const c10::IValue& v) {
 Int8TensorCPU from_proxy(const c10::IValue& proxy) {
   auto t = std::move(proxy).toTuple();
   Int8TensorCPU r;
-  r.t = from_at_tensor(t->elements().get(0));
-  r.scale = t->elements().get(1).toDouble();
-  r.zero_point = t->elements().get(2).toInt();
+  r.t = from_at_tensor(t.elements().get(0));
+  r.scale = t.elements().get(1).toDouble();
+  r.zero_point = t.elements().get(2).toInt();
   return r;
 }
 
@@ -44,8 +44,8 @@ at::Tensor to_proxy(const caffe2::Tensor& t) {
   return autograd::make_variable(at::Tensor(t.UnsafeSharedInstance()), false);
 }
 
-c10::intrusive_ptr<c10::ivalue::Tuple> to_proxy(const Int8TensorCPU& t) {
-  return c10::ivalue::Tuple::create({to_proxy(t.t), t.scale, t.zero_point});
+c10::ivalue::TuplePtr to_proxy(const Int8TensorCPU& t) {
+  return c10::ivalue::TuplePtr::create({to_proxy(t.t), t.scale, t.zero_point});
 }
 
 // TODO: replace this with c10 registration when it's ready

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -42,13 +42,13 @@ void checkListInputType(const c10::TypePtr& elem_type, const Node* node) {
 
 int64_t list_size(const IValue& list) {
   if (list.isGenericList()) {
-    return list.toGenericListRef().size();
+    return list.toGenericList().size();
   } else if (list.isIntList()) {
-    return list.toIntListRef().size();
+    return list.toIntList().size();
   } else if (list.isDoubleList()) {
-    return list.toDoubleListRef().size();
+    return list.toDoubleList().size();
   } else if (list.isBoolList()) {
-    return list.toBoolListRef().size();
+    return list.toBoolList().size();
   }
   AT_ASSERTM(0, "Unexpected list type", list);
 }
@@ -59,7 +59,7 @@ std::vector<int64_t> compute_sizes(const IValue& seq) {
   // will not be generic list
   auto seq_recur = seq;
   while (seq_recur.isGenericList()) {
-    auto seq_list = seq_recur.toGenericListRef();
+    auto seq_list = seq_recur.toGenericList();
     auto length = seq_list.size();
     AT_ASSERT(length != 0);
     sizes.push_back(length);
@@ -131,7 +131,7 @@ void recursiveStore(
   auto seq_size = list_size(obj);
   checkSequenceSize(n, dim, seq_size);
   if (dim + 1 < static_cast<long>(ndim)) {
-    auto items = obj.toGenericListRef();
+    auto items = obj.toGenericList();
     for (int64_t i = 0; i < n; i++) {
       recursiveStore(data, sizes, strides, dim + 1, elementSize, items[i]);
       data += strides[dim] * elementSize;
@@ -140,13 +140,13 @@ void recursiveStore(
     AT_ASSERT(obj.isIntList() || obj.isDoubleList() || obj.isBoolList());
     if (obj.isIntList()) {
       storeLastDimension<int64_t>(
-          data, sizes, strides, dim, elementSize, obj.toIntListRef());
+          data, sizes, strides, dim, elementSize, obj.toIntList());
     } else if (obj.isDoubleList()) {
       storeLastDimension<double>(
-          data, sizes, strides, dim, elementSize, obj.toDoubleListRef());
+          data, sizes, strides, dim, elementSize, obj.toDoubleList());
     } else {
       storeLastDimension<bool>(
-          data, sizes, strides, dim, elementSize, obj.toBoolListRef());
+          data, sizes, strides, dim, elementSize, obj.toBoolList());
     }
   }
 }
@@ -159,7 +159,7 @@ RegisterOperators reg({
 
           auto result = at::split_with_sizes(
               (std::move(peek(stack, 0, 3))).toTensor(),
-              c10::impl::toArrayRef((std::move(peek(stack, 1, 3))).toIntList()->elements()),
+              c10::impl::toArrayRef((std::move(peek(stack, 1, 3))).toIntList()),
               (std::move(peek(stack, 2, 3))).toInt());
           drop(stack, 3);
           pack(stack, c10::impl::toList(std::move(result)));
@@ -182,8 +182,8 @@ RegisterOperators reg({
         [](Stack& stack) {
           RECORD_FUNCTION("sizes", last(stack, 2));
 
-          auto list = peek(stack, 0, 2).toIntListRef();
-          auto defaults = peek(stack, 1, 2).toIntListRef();
+          auto list = peek(stack, 0, 2).toIntList();
+          auto defaults = peek(stack, 1, 2).toIntList();
           drop(stack, 2);
 
           AT_ASSERT(defaults.size() > list.size());
@@ -198,8 +198,8 @@ RegisterOperators reg({
         "aten::_infer_size(int[] a, int[] b) -> int[]",
         [](const Node* node) {
           return [](Stack& stack) {
-            auto a = pop(stack).toIntList()->elements();
-            auto b = pop(stack).toIntList()->elements();
+            auto a = pop(stack).toIntList();
+            auto b = pop(stack).toIntList();
             push(stack, at::infer_size(c10::impl::toArrayRef(a), c10::impl::toArrayRef(b)));
             return 0;
           };
@@ -299,8 +299,8 @@ RegisterOperators reg({
         "aten::_infer_size(int[] a, int[] b) -> int[]",
         [](const Node* node) {
           return [](Stack& stack) {
-            auto a = pop(stack).toIntList()->elements();
-            auto b = pop(stack).toIntList()->elements();
+            auto a = pop(stack).toIntList();
+            auto b = pop(stack).toIntList();
             push(stack, at::infer_size(c10::impl::toArrayRef(a), c10::impl::toArrayRef(b)));
             return 0;
           };

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -655,7 +655,7 @@ struct to_ir {
     cu.define({def}, {resolver}, nullptr);
     Stack stack;
     cu.get_function("defaults").run(stack);
-    return c10::impl::toVector(std::move(std::move(stack.at(0)).toTuple()->elements()));
+    return c10::impl::toVector(std::move(stack.at(0)).toTuple().elements());
   }
 
   std::vector<Argument> parseArgsFromDecl(const Decl& decl, const Self& self) {

--- a/torch/csrc/jit/tracer.h
+++ b/torch/csrc/jit/tracer.h
@@ -28,18 +28,10 @@ namespace script {
 
 namespace tracer {
 
-using ::c10::ivalue::List;
 using ::c10::ivalue::Shared;
 
 using ::c10::IValue;
 using ::c10::ivalue::Future;
-using ::c10::ivalue::Tuple;
-
-using ::c10::ivalue::BoolList;
-using ::c10::ivalue::DoubleList;
-using ::c10::ivalue::GenericList;
-using ::c10::ivalue::IntList;
-using ::c10::ivalue::TensorList;
 
 using ::c10::ivalue::ConstantString;
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21317 Remove double indirection for storing lists and dicts**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15615077/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21228 Streamline conversion to/from IValue&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15585806/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21177 Use c10::List&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15476433/)

Now, IValue stores ListPtr/DictPtr directly, without the additional indirection of ivalue::List or ivalue::GenericDict.

Differential Revision: [D15615077](https://our.internmc.facebook.com/intern/diff/D15615077/)