### PR TITLE
Revert "Fix the caffe2_gpu linkage with torch on Windows"

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -693,13 +693,6 @@ ENDIF()
   set_property(TARGET caffe2 PROPERTY CXX_STANDARD 11)
 
 
-  # Prevent the unused functions being optimized away
-  # Otherwise torch.dll will be linked without caffe2_gpu.dll
-  if (MSVC)
-    # TODO What to do with this line?
-    set_target_properties(caffe2 PROPERTIES LINK_FLAGS "/OPT:NOREF")
-  endif()
-
   install(DIRECTORY "${TORCH_SRC_DIR}/csrc"
     DESTINATION ${TORCH_INSTALL_INCLUDE_DIR}/torch
     FILES_MATCHING PATTERN "*.h")

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -16,18 +16,6 @@
 #include <cstddef>
 #include <vector>
 
-
-// The following code is used to ensure torch is linked against caffe2_gpu.
-#ifdef _MSC_VER
-namespace {
-#pragma optimize("", off)
-  int warp_size() {
-    return at::cuda::warp_size();
-  }
-#pragma optimize("", on)
-}
-#endif
-
 namespace torch { namespace cuda {
 using namespace at;
 using namespace torch::autograd;


### PR DESCRIPTION
The original PR (#16071) is not working anymore after `caffe2` and `torch` is unified. What's more, It is making the binary big since the optimizing flag is disabled on a very big project(the `torch` library used to be small, but it now applies on the whole `caffe2` and `caffe2_gpu` library). We need to get it reverted.