### PR TITLE
insert default parameters in binary cross entropy with logits

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -326,10 +326,10 @@
 
 - func: bilinear(Tensor input1, Tensor input2, Tensor weight, Tensor? bias) -> Tensor
 
-- func: binary_cross_entropy_with_logits(Tensor self, Tensor target, Tensor? weight, Tensor? pos_weight, int reduction) -> Tensor
+- func: binary_cross_entropy_with_logits(Tensor self, Tensor target, Tensor? weight=None, Tensor? pos_weight=None, int reduction=Mean) -> Tensor
   variants: function
 
-- func: binary_cross_entropy_with_logits_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, Tensor? pos_weight, int reduction) -> Tensor
+- func: binary_cross_entropy_with_logits_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight=None, Tensor? pos_weight=None, int reduction=Mean) -> Tensor
   variants: function
 
 - func: bincount(Tensor self, Tensor? weights=None, int minlength=0) -> Tensor

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -56,6 +56,7 @@ blacklist = [
     # defined in functional
     'einsum',
     # reduction argument; these bindings don't make sense
+    'binary_cross_entropy_with_logits'
     'ctc_loss',
     'cosine_embedding_loss',
     'hinge_embedding_loss',

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -56,7 +56,7 @@ blacklist = [
     # defined in functional
     'einsum',
     # reduction argument; these bindings don't make sense
-    'binary_cross_entropy_with_logits'
+    'binary_cross_entropy_with_logits',
     'ctc_loss',
     'cosine_embedding_loss',
     'hinge_embedding_loss',


### PR DESCRIPTION
I inserted default weight and reduction params in binary_cross_entropy_with_logits function . These default params exist in python and binary_cross_entropy function in cpp.