### PR TITLE
Update randomness.rst

### DIFF
--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -45,7 +45,7 @@ When running on the CuDNN backend, two further options must be set::
 
 .. warning::
 
-    Deterministic mode can have a performance impact, depending on your model.
+    Deterministic mode can have a performance impact, depending on your model. This means that due to the deterministic nature of the model, the processing speed (i.e. processed batch items per second) can be lower than when the model is non-deterministic.
 
 Numpy
 .....


### PR DESCRIPTION
Following [this question on the forums](https://discuss.pytorch.org/t/reproducibility-and-performance/46504), I propose the following doc change. It clarifies that 'performance reduction' concerns the processing speed (and not the training accuracy).

Related website commit: https://github.com/pytorch/pytorch.github.io/pull/211

