### PR TITLE
[tensorboard] replace LegacyTracedModule with torchscript used in add_graph

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -467,11 +467,7 @@ if TEST_TENSORBOARD:
             for model_name, input_shape in model_input_shapes.items():
                 with SummaryWriter(comment=model_name) as w:
                     model = getattr(torchvision.models, model_name)()
-                    # ValueError: only one element tensors can be converted to Python scalars
-                    if model_name == 'mobilenet_v2':
-                        w.add_graph(model, torch.zeros(input_shape), operator_export_type="RAW")
-                    else:
-                        w.add_graph(model, torch.zeros(input_shape))
+                    w.add_graph(model, torch.zeros(input_shape))
 
     class TestTensorBoardFigure(BaseTestCase):
         @skipIfNoMatplotlib

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -462,7 +462,7 @@ if TEST_TENSORBOARD:
                 'vgg19': (2, 3, 224, 224),
                 'vgg16_bn': (2, 3, 224, 224),
                 'vgg19_bn': (2, 3, 224, 224),
-                'mobilenet_v2': (2, 3, 224, 224),  # will fail optimize_graph
+                'mobilenet_v2': (2, 3, 224, 224),
             }
             for model_name, input_shape in model_input_shapes.items():
                 with SummaryWriter(comment=model_name) as w:

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -218,7 +218,7 @@ def parse(graph, args=None, omit_useless_nodes=True):
     return nodes_py.to_proto()
 
 
-def graph(model, args, verbose=False, operator_export_type='ONNX', omit_useless_nodes=True):
+def graph(model, args, verbose=False):
     """
     This method processes a PyTorch model and produces a `GraphDef` proto
     that can be logged to TensorBoard.
@@ -228,12 +228,7 @@ def graph(model, args, verbose=False, operator_export_type='ONNX', omit_useless_
       args (tuple): input tensor[s] for the model.
       verbose (bool): Whether to print out verbose information while
         processing.
-      operator_export_type (str): One of 'ONNX', 'ONNX_ATEN', or 'RAW'.
-        Defaults to 'ONNX' format  because it outputs the most visually
-        understandable format.
-      omit_useless_nodes (boolean): Whether to remove nodes from the graph.
     """
-    operator_export_type = getattr(OperatorExportTypes, operator_export_type)
 
 
     with torch.onnx.set_training(model, False):  # TODO: move outside of torch.onnx?
@@ -244,7 +239,6 @@ def graph(model, args, verbose=False, operator_export_type='ONNX', omit_useless_
             print(e)
             print('Error occurs, No graph saved')
             raise e
-
 
     if verbose:
         print(graph)

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -151,8 +151,6 @@ class GraphPy(object):
                 self.unique_name_to_scoped_name[input_node_id] = node.scopeName + '/' + input_node_id
 
         for key, node in self.nodes_io.items():
-            if hasattr(node, 'input_or_output'):
-                self.unique_name_to_scoped_name[key] = node.input_or_output + '/' + node.uniqueName
             if hasattr(node, 'scope') and node.scope is not None:
                 self.unique_name_to_scoped_name[key] = node.scope + '/' + node.uniqueName
                 if node.scope == '' and self.shallowest_scope_name:
@@ -239,7 +237,7 @@ def graph(model, args, verbose=False):
 
     if verbose:
         print(graph)
-    list_of_nodes = parse(graph, args, omit_useless_nodes)
+    list_of_nodes = parse(graph, args)
     # We are hardcoding that this was run on CPU even though it might have actually
     # run on GPU. Note this is what is shown in TensorBoard and has no bearing
     # on actual execution.

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -236,37 +236,16 @@ def graph(model, args, verbose=False, operator_export_type='ONNX', omit_useless_
     operator_export_type = getattr(OperatorExportTypes, operator_export_type)
 
 
-    with torch.onnx.set_training(model, False):
+    with torch.onnx.set_training(model, False):  # TODO: move outside of torch.onnx?
         try:
-            trace, _ = torch.jit.get_trace_graph(model, args)
-        except RuntimeError:
+            trace = torch.jit.trace(model, args)
+            graph = trace.graph
+        except RuntimeError as e:
+            print(e)
             print('Error occurs, No graph saved')
-            _ = model(*args)  # don't catch, just print the error message
-            print("Checking if it's onnx problem...")
-            try:
-                import tempfile
-                torch.onnx.export(
-                    model, args, tempfile.TemporaryFile(), verbose=True)
-            except RuntimeError:
-                print("Your model cannot be exported by onnx, please report to onnx team")
-            # Create an object matching
-            # https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/graph.proto
-            # The producer version has been reverse engineered from standard
-            # TensorBoard logged data.
-            return GraphDef(versions=VersionDef(producer=22))
+            raise e
 
-    try:
-        # An optimized graph helps debug at a higher level. Users can focus
-        # on connections between big modules such as Linear instead of W, x,
-        # bias, matmul, etc. Honestly, most users don't care about those
-        # detailed nodes information.
-        _optimize_trace(trace, operator_export_type)
-    except RuntimeError as e:
-        # Optimize trace might fail (due to bad scopes in some cases we've seen)
-        # and we don't want graph visualization to fail in this case. In this
-        # case we'll log the warning and display the non-optimized graph.
-        logging.warn(ImportError(e))
-    graph = trace.graph()
+
     if verbose:
         print(graph)
     list_of_nodes = parse(graph, args, omit_useless_nodes)
@@ -282,3 +261,5 @@ def graph(model, args, verbose=False, operator_export_type='ONNX', omit_useless_
     # https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/step_stats.proto
     stepstats = RunMetadata(step_stats=StepStats(dev_stats=[DeviceStepStats(device="/device:CPU:0")]))
     return GraphDef(node=list_of_nodes, versions=VersionDef(producer=22)), stepstats
+    # The producer version has been reverse engineered from standard
+    # TensorBoard logged data.

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -1,4 +1,3 @@
-import logging
 from collections import OrderedDict
 
 from tensorboard.compat.proto.config_pb2 import RunMetadata
@@ -8,8 +7,6 @@ from tensorboard.compat.proto.versions_pb2 import VersionDef
 
 import torch
 from ._proto_graph import node_proto
-from torch.onnx.utils import OperatorExportTypes
-from torch.onnx import _optimize_trace
 
 methods_OP = ['attributeNames', 'hasMultipleOutputs', 'hasUses', 'inputs',
               'kind', 'outputs', 'outputsSize', 'scopeName']


### PR DESCRIPTION
The new implementation of tracing supports more module. So many error-handling code can be removed by placing the old one (LegacyTracedModule).

cc @orionr