### PR TITLE
[WIP] Move set_requires_grad(bool) to VariableType

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -309,10 +309,7 @@ class CAFFE2_API Tensor {
 
   // ~~~~~ Autograd API ~~~~~
 
-  Tensor& set_requires_grad(bool requires_grad) {
-    impl_->set_requires_grad(requires_grad);
-    return *this;
-  }
+  Tensor& set_requires_grad(bool requires_grad);
   bool requires_grad() const {
     return impl_->requires_grad();
   }

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -44,6 +44,10 @@ inline TensorOptions Tensor::options() const {
                         .is_variable(is_variable());
 }
 
+inline Tensor & Tensor::set_requires_grad(bool requires_grad) {
+  return dispatch_type().set_requires_grad(*this, requires_grad);
+}
+
 inline void Tensor::backward(
     c10::optional<Tensor> gradient,
     bool keep_graph,

--- a/aten/src/ATen/core/Type.h
+++ b/aten/src/ATen/core/Type.h
@@ -107,6 +107,8 @@ struct CAFFE2_API Type {
     return backendToDeviceType(backend());
   }
 
+  virtual Tensor & set_requires_grad(Tensor & self, bool requires_grad) const = 0;
+
   virtual void backward(
       Tensor& self,
       c10::optional<Tensor> gradient,

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -309,10 +309,7 @@ class CAFFE2_API Tensor {
 
   // ~~~~~ Autograd API ~~~~~
 
-  Tensor& set_requires_grad(bool requires_grad) {
-    impl_->set_requires_grad(requires_grad);
-    return *this;
-  }
+  Tensor& set_requires_grad(bool requires_grad);
   bool requires_grad() const {
     return impl_->requires_grad();
   }

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -44,6 +44,10 @@ inline TensorOptions Tensor::options() const {
                         .is_variable(is_variable());
 }
 
+inline Tensor & Tensor::set_requires_grad(bool requires_grad) {
+  return dispatch_type().set_requires_grad(*this, requires_grad);
+}
+
 inline void Tensor::backward(
     c10::optional<Tensor> gradient,
     bool keep_graph,

--- a/aten/src/ATen/templates/Type.h
+++ b/aten/src/ATen/templates/Type.h
@@ -100,6 +100,8 @@ struct CAFFE2_API Type {
     return backendToDeviceType(backend());
   }
 
+  virtual Tensor & set_requires_grad(Tensor & self, bool requires_grad) const = 0;
+
   virtual void backward(
       Tensor& self,
       c10::optional<Tensor> gradient,

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -15,6 +15,10 @@
 
 namespace at {
 
+Tensor & TypeDefault::set_requires_grad(Tensor & self, bool requires_grad) const {
+  AT_ERROR("set_requires_grad is not implemented for Tensor");
+}
+
 void TypeDefault::backward(
     Tensor& self,
     c10::optional<Tensor> gradient,

--- a/aten/src/ATen/templates/TypeDefault.h
+++ b/aten/src/ATen/templates/TypeDefault.h
@@ -31,6 +31,8 @@ struct CAFFE2_API TypeDefault : public TypeExtendedInterface {
   Type & toBackend(Backend b) const override;
   Type & toScalarType(ScalarType s) const override;
 
+  Tensor & set_requires_grad(Tensor & self, bool requires_grad) const override;
+
   void backward(
       Tensor& self,
       c10::optional<Tensor> gradient,

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -518,17 +518,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // autograd metadata).
 
   /**
-   * Set whether or not a tensor requires gradient.
-   *
-   * It is only valid to call this method on a Variable.
-   * See Note [Tensor versus Variable in C++].
-   */
-  void set_requires_grad(bool requires_grad) {
-    TORCH_INTERNAL_ASSERT(autograd_meta(), "set_requires_grad is not implemented for Tensor");
-    autograd_meta()->set_requires_grad(requires_grad, this);
-  }
-
-  /**
    * True if a tensor requires gradient.  Tensors which require gradient
    * have history tracked for any operations performed on them, so that
    * we can automatically differentiate back to them.  A tensor that

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -29,7 +29,8 @@ from .gen_autograd_functions import uses_single_grad
 
 # These functions are written manually in templates/VariableType.cpp
 MANUAL_IMPLEMENTATIONS = {
-    'resize_', 'resize_as_', 'detach', 'detach_', 'copy_'
+    'resize_', 'resize_as_', 'detach', 'detach_', 'copy_',
+    'set_requires_grad'
 }
 
 # These functions we don't want to record for tracing, because we always want

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -49,6 +49,8 @@ struct TORCH_API VariableType final : public at::TypeDefault {
   static std::vector<at::Type*> allCUDATypes();
   static std::vector<at::Type*> allCPUTypes();
 
+  Tensor & set_requires_grad(Tensor & self, bool requires_grad) const override;
+
   void backward(
       Tensor& self,
       c10::optional<Tensor> gradient,

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -206,6 +206,13 @@ std::vector<at::Tensor> VariableType::unpack(at::TensorList tl, const char *name
   return ret;
 }
 
+Tensor & VariableType::set_requires_grad(Tensor & self, bool requires_grad) const {
+  auto self_impl = self.unsafeGetTensorImpl();
+  TORCH_INTERNAL_ASSERT(self_impl->autograd_meta(), "set_requires_grad is not implemented for Tensor");
+  self_impl->autograd_meta()->set_requires_grad(requires_grad, self_impl);
+  return self;
+}
+
 void VariableType::backward(
     Tensor& self,
     c10::optional<Tensor> gradient,


### PR DESCRIPTION
As part of the Variable/Tensor merge, we'd like to have the optimization that only requires-grad tensors have AutogradMeta. To enable this optimization, when `.set_requires_grad(true)` is called on a non-requires-grad tensor, we need to be able to create AutogradMeta for that tensor on the fly. This is currently not possible, because TensorImpl's `set_requires_grad(bool)` method dispatches to `autograd_meta()->set_requires_grad(requires_grad, this)`, and `autograd_meta()` is null when the tensor doesn't have AutogradMeta. There are two possible ways to solve this issue:

1. Create AutogradMeta in TensorImpl's `set_requires_grad(bool)` method, then call `autograd_meta()->set_requires_grad(requires_grad, this)`
Problem with this approach: AutogradMeta is an autograd concept, and its creation logic doesn't exist in ATen. One way to solve this is to populate an AutogradMeta creation function pointer in `AutogradMetaInterface` and call it in TensorImpl's `set_requires_grad(bool)`, but this ...

TODO: finish this up
