### PR TITLE
Address precision matrix instability of MVN distribution

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1781,6 +1781,11 @@ class TestDistributions(TestCase):
         multivariate_normal_log_prob_gradcheck(mean, None, None, scale_tril)
         multivariate_normal_log_prob_gradcheck(mean_no_batch, None, None, scale_tril_batched)
 
+    def test_multivariate_normal_stable_with_precision_matrix(self):
+        x = torch.randn(10)
+        P = torch.exp(-(x - x.unsqueeze(-1)) ** 2)  # RBF kernel
+        MultivariateNormal(mean, precision_matrix=P)
+
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_multivariate_normal_log_prob(self):
         mean = torch.randn(3, requires_grad=True)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1784,7 +1784,7 @@ class TestDistributions(TestCase):
     def test_multivariate_normal_stable_with_precision_matrix(self):
         x = torch.randn(10)
         P = torch.exp(-(x - x.unsqueeze(-1)) ** 2)  # RBF kernel
-        MultivariateNormal(mean, precision_matrix=P)
+        MultivariateNormal(x.new_zeros(10), precision_matrix=P)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_multivariate_normal_log_prob(self):

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -69,8 +69,10 @@ def _batch_mahalanobis(bL, bx):
 def _precision_to_scale_tril(P):
     # Ref: https://nbviewer.jupyter.org/gist/fehiepsi/5ef8e09e61604f10607380467eb82006#Precision-to-scale_tril
     Lf = torch.cholesky(torch.flip(P, (-2, -1)))
-    L = torch.inverse(torch.transpose(torch.flip(Lf, (-2, -1)), -2, -1))
-    return L.tril()  # torch.inverse of a triangular is not a triangular due to precision
+    L_inv = torch.transpose(torch.flip(Lf, (-2, -1)), -2, -1)
+    L = torch.triangular_solve(torch.eye(P.shape[-1], dtype=P.dtype, device=P.device),
+                               L_inv, upper=False)[0]
+    return L
 
 
 class MultivariateNormal(Distribution):

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -67,6 +67,7 @@ def _batch_mahalanobis(bL, bx):
 
 
 def _precision_to_scale_tril(P):
+    # Ref: https://nbviewer.jupyter.org/gist/fehiepsi/5ef8e09e61604f10607380467eb82006#Precision-to-scale_tril
     Lf = torch.cholesky(torch.flip(P, (-2, -1)))
     L = torch.inverse(torch.transpose(torch.flip(Lf, (-2, -1)), -2, -1))
     return L.tril()  # torch.inverse of a triangular is not a triangular due to precision


### PR DESCRIPTION
Currently, when the input of MVN is precision matrix, we take inverse to convert the result to covariance matrix. This, however, will easily make the covariance matrix not positive definite, hence will trigger a cholesky error.

For example,
```
import torch
torch.manual_seed(0)
x = torch.randn(10)
P = torch.exp(-(x - x.unsqueeze(-1)) ** 2)
torch.distributions.MultivariateNormal(loc=torch.ones(10), precision_matrix=P)
```
will trigger `RuntimeError: cholesky_cpu: U(8,8) is zero, singular U.`

This PR uses some math tricks ([ref](https://nbviewer.jupyter.org/gist/fehiepsi/5ef8e09e61604f10607380467eb82006#Precision-to-scale_tril)) to only take inverse of a triangular matrix, hence increase the stability.

cc @fritzo, @neerajprad , @SsnL 