### PR TITLE
[JIT] fix incorrect default on Graph::toString

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3705,8 +3705,9 @@ def foo(x):
         scripted = torch.jit.script(foobar)
 
         _, lineno = inspect.getsourcelines(foobar)
-        FileCheck().check('test_jit.py:{}:20'.format(lineno + 1))\
-                   .run(scripted.graph)
+        fc = FileCheck().check('test_jit.py:{}:20'.format(lineno + 1))
+        fc.run(scripted.graph)
+        fc.run(str(scripted.graph))
 
     def test_file_line_save_load(self):
         class Scripted(torch.jit.ScriptModule):
@@ -3723,7 +3724,9 @@ def foo(x):
         bytesio = io.BytesIO(buffer)
         scripted = torch.jit.load(bytesio)
 
-        FileCheck().check('code/archive.py:4:10').run(scripted.graph)
+        fc = FileCheck().check('code/archive.py:4:10')
+        fc.run(scripted.graph)
+        fc.run(str(scripted.graph))
 
     def test_file_line_string(self):
         scripted = torch.jit.CompilationUnit('''
@@ -3731,7 +3734,9 @@ def foo(xyz):
     return torch.neg(xyz)
         ''')
 
-        FileCheck().check('<string>:2:12').run(scripted.foo.graph)
+        fc = FileCheck().check('<string>:2:12')
+        fc.run(scripted.foo.graph)
+        fc.run(str(scripted.foo.graph))
 
     def test_file_line_trace(self):
         def foobar(xyz):
@@ -3740,8 +3745,9 @@ def foo(xyz):
         scripted = torch.jit.trace(foobar, (torch.rand(3, 4)))
 
         _, lineno = inspect.getsourcelines(foobar)
-        FileCheck().check('test_jit.py:{}:0'.format(lineno + 1))\
-                   .run(scripted.graph)
+        fc = FileCheck().check('test_jit.py:{}:0'.format(lineno + 1))
+        fc.run(scripted.graph)
+        fc.run(str(scripted.graph))
 
     def test_tensor_shape(self):
         x = torch.empty(34, 56, 78)

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1176,7 +1176,7 @@ struct Graph {
 
   TORCH_API ~Graph();
 
-  TORCH_API std::string toString(bool print_source_locations=false) const;
+  TORCH_API std::string toString(bool print_source_locations = true) const;
 
   TORCH_API std::ostream& print(
       std::ostream& out,


### PR DESCRIPTION
This default was incorrect and made printing in python not print file:line:col

This wasn't caught because FileCheck internally uses operator<< to print the graph, which has `true` hardcoded as the value. I've added more comprehensive tests to catch this