### PR TITLE
Back out "[pytorch][PR] don't materialize constants"

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1,4 +1,3 @@
-#include <torch/csrc/jit/script/compiler.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
 #include <torch/csrc/jit/hooks_for_testing.h>
@@ -9,6 +8,7 @@
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/inliner.h>
 #include <torch/csrc/jit/passes/lower_tuples.h>
+#include <torch/csrc/jit/script/compiler.h>
 #include <torch/csrc/jit/script/final_returns.h>
 #include <torch/csrc/jit/script/parser.h>
 #include <torch/csrc/jit/script/schema_matching.h>
@@ -501,6 +501,24 @@ struct Environment {
   ValueTable value_table;
 };
 
+template <class T>
+static Value* materializeConstant(
+    T val,
+    Graph& graph,
+    const SourceRange& r,
+    std::unordered_map<T, Value*>& map) {
+  auto existing_constant = map.find(val);
+  if (existing_constant != map.end()) {
+    return existing_constant->second;
+  }
+
+  WithInsertPoint guard(graph.block()->nodes().front());
+  auto new_constant = graph.insertConstant(val, nullptr, r);
+  map[val] = new_constant;
+
+  return new_constant;
+}
+
 static Value* ensureInt(const SourceRange& range, Value* v) {
   if (!v->type()->isSubtypeOf(IntType::get())) {
     throw ErrorReport(range)
@@ -551,6 +569,8 @@ struct to_ir {
   Function& method;
   std::shared_ptr<Graph> graph;
   ResolverPtr resolver;
+  std::unordered_map<int64_t, Value*> integral_constants;
+  std::unordered_map<double, Value*> fp_constants;
   ScriptTypeParser typeParser_;
 
   // Singly-linked list of environments. This top element contains a member
@@ -1334,8 +1354,11 @@ struct to_ir {
     WithInsertPoint guard(n);
 
     if (!max_trip_count_val) {
-      max_trip_count_val = insertConstant(
-          *graph, std::numeric_limits<int64_t>::max(), nullptr, range);
+      max_trip_count_val = materializeConstant(
+          std::numeric_limits<int64_t>::max(),
+          *graph,
+          range,
+          integral_constants);
     }
 
     cond_val = (cond) ? emitCond(cond.value())
@@ -2651,9 +2674,11 @@ struct to_ir {
 
   Value* emitConst(const Const& c) {
     if (c.isFloatingPoint())
-      return insertConstant(*graph, c.asFloatingPoint(), nullptr, c.range());
+      return materializeConstant(
+          c.asFloatingPoint(), *graph, c.range(), fp_constants);
     else
-      return insertConstant(*graph, c.asIntegral(), nullptr, c.range());
+      return materializeConstant(
+          c.asIntegral(), *graph, c.range(), integral_constants);
   }
 
   Value* emitStringLiteral(const StringLiteral& c) {


### PR DESCRIPTION
Summary:
Original commit changeset: d5609b0a5697

Not materializing constants slows compilation time significantly

Differential Revision: D15630632

