### PR TITLE
better constant propagation through tuples

### DIFF
--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -16,6 +16,7 @@
 #include <test/cpp/jit/test_class_parser.h>
 #include <test/cpp/jit/test_code_template.h>
 #include <test/cpp/jit/test_constant_pooling.h>
+#include <test/cpp/jit/test_constant_propagation.h>
 #include <test/cpp/jit/test_create_autodiff_subgraphs.h>
 #include <test/cpp/jit/test_custom_operators.h>
 #include <test/cpp/jit/test_dynamic_dag.h>
@@ -71,6 +72,7 @@ namespace jit {
   _(MemoryDAG)                     \
   _(IRParser)                      \
   _(ConstantPooling)               \
+  _(ConstantPropagation)           \
   _(NetDefConverter)               \
   _(THNNConv)                      \
   _(ATenNativeBatchNorm)           \

--- a/test/cpp/jit/test_constant_propagation.h
+++ b/test/cpp/jit/test_constant_propagation.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/irparser.h>
+#include <torch/csrc/jit/passes/constant_pooling.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/testing/file_check.h>
+#include "test/cpp/jit/test_base.h"
+#include "torch/csrc/jit/custom_operator.h"
+
+#include <sstream>
+#include <string>
+
+namespace torch {
+namespace jit {
+
+void testConstantPropagation() {
+  {
+    auto graph = std::make_shared<Graph>();
+    script::parseIR(
+        R"IR(
+graph():
+  %1 : int = prim::Constant[value=1]()
+  %0 : int = prim::Constant[value=0]()
+  %x : (int, int) = prim::TupleConstruct(%0, %1)
+  %y : int = prim::TupleIndex(%x, %0)
+  %5 : int = aten::add(%y, %y)
+  return (%5)
+  )IR",
+        &*graph);
+    // optimize through tuple construct and indexing
+    ConstantPropagation(graph);
+    testing::FileCheck()
+        .check("graph")
+        ->check_next("prim::Constant[value=0]")
+        ->check_next("return")
+        ->run(*graph);
+  }
+  {
+    auto graph = std::make_shared<Graph>();
+    script::parseIR(
+        R"IR(
+graph():
+  %10 : None = prim::Constant()
+  %7 : int = prim::Constant[value=0]()
+  %1 : int = prim::Constant[value=1]()
+  %0 : int = prim::Constant[value=3]()
+  %x : (int, int) = prim::TupleConstruct(%0, %1)
+  %y : (int, (int, int)) = prim::TupleConstruct(%1, %x)
+  %6 : (int, int) = prim::TupleIndex(%y, %1)
+  %z : int = prim::TupleIndex(%6, %7)
+  %9 : int = aten::add(%z, %z)
+  %ign = prim::Print(%y, %9)
+  return (%10)  )IR",
+        &*graph);
+    ConstantPropagation(graph);
+    // The index should be optimized away, with a computed value of 6,
+    // and the TupleConstructs should still remain
+    testing::FileCheck()
+        .check_count("TupleConstruct", 2)
+        ->check_not("TupleIndex")
+        ->check("value=6")
+        ->run(*graph);
+  }
+  {
+    RegisterOperators reg({
+        Operator(
+            "prim::test_tuple() -> (float[])",
+            [](const Node* node) {
+              return [](Stack& stack) {
+                std::vector<double> list;
+                auto li = IValue(list);
+                std::vector<IValue> tup = {li};
+                push(stack, Tuple::create(tup));
+                return 0;
+              };
+            }),
+        Operator(
+            "prim::run_float_list(float[] a) -> (int)",
+            [](const Node* node) {
+              return [](Stack& stack) {
+                pop(stack);
+                push(stack, 1);
+                return 0;
+              };
+            }),
+    });
+    auto graph = std::make_shared<Graph>();
+    script::parseIR(
+        R"IR(
+  graph():
+    %2 : (float[]) = prim::test_tuple()
+    %1 : int = prim::Constant[value=0]()
+    %y : float[] = prim::TupleIndex(%2, %1)
+    %z : int = prim::run_float_list(%y)
+    return (%z)
+    )IR",
+        &*graph);
+    ConstantPropagation(graph);
+    // float[] are not embeddable as constants, so we should not
+    // run the run_float_list op.
+    // this logic prevents e.g. running a tensor with grad in constant prop
+    testing::FileCheck()
+        .check("test_tuple")
+        ->check("TupleIndex")
+        ->check("run_float_list")
+        ->run(*graph);
+  }
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -25,215 +25,226 @@ std::unordered_set<Symbol> skip_list = {
     // where the constant tensor would be large but cheap to create.
 };
 
-std::vector<IValue> runNode(Node* n) {
-  auto op = getOperation(n);
-  Stack stack;
-  for (auto input : n->inputs()) {
-    stack.push_back(*(toIValue(input)));
+struct ConstantPropagator {
+  ConstantPropagator(std::shared_ptr<Graph> graph)
+      : graph_(std::move(graph)), aliasDb(graph_){};
+
+  void run() {
+    ConstantPropagation(graph_->block());
   }
-  op(stack);
-  auto var_outputs = fmap(stack, [&](IValue v) -> IValue {
-    if (v.isTensor()) {
-      auto t = std::move(v).toTensor();
-      if (t.defined()) {
-        if (t.requires_grad()) {
-          // error gets caught within propagateNode()
-          throw c10::Error("Can't insert requires grad as constant", "");
+
+ private:
+  std::vector<IValue> runNode(Node* n) {
+    auto op = getOperation(n);
+    Stack stack;
+    for (auto input : n->inputs()) {
+      stack.push_back(*(toIValue(input)));
+    }
+    op(stack);
+    auto var_outputs = fmap(stack, [&](IValue v) -> IValue {
+      if (v.isTensor()) {
+        auto t = std::move(v).toTensor();
+        if (t.defined()) {
+          if (t.requires_grad()) {
+            // error gets caught within propagateNode()
+            throw c10::Error("Can't insert requires grad as constant", "");
+          }
+          return IValue(t);
+        } else {
+          return t;
         }
-        return IValue(t);
       } else {
-        return t;
+        return v;
       }
-    } else {
-      return v;
-    }
-  });
-  return var_outputs;
-}
-
-void propagateNode(Node* n) {
-  std::vector<IValue> outputs;
-  try {
-    outputs = runNode(n);
-  } catch (const c10::Error& e) {
-    // catch AT_ASSERT errors. This op may not be run reached,
-    // so catch the error here & leave the op in the graph
-    return;
+    });
+    return var_outputs;
   }
-  auto graph = n->owningGraph();
-  WithInsertPoint guard(n);
-  for (size_t i = 0; i < outputs.size(); ++i) {
 
-    auto new_output = tryInsertConstant(*graph, outputs[i]);
-    if (new_output) {
-      if (outputs[i].isNone()) {
-        (*new_output)->setType(n->outputs()[i]->type());
+  void propagateNode(Node* n) {
+    std::vector<IValue> outputs;
+    try {
+      outputs = runNode(n);
+    } catch (const c10::Error& e) {
+      // catch AT_ASSERT errors. This op may not be run reached,
+      // so catch the error here & leave the op in the graph
+      return;
+    }
+    auto graph = n->owningGraph();
+    WithInsertPoint guard(n);
+    for (size_t i = 0; i < outputs.size(); ++i) {
+      auto new_output = tryInsertConstant(*graph, outputs[i]);
+      if (new_output) {
+        if (outputs[i].isNone()) {
+          (*new_output)->setType(n->outputs()[i]->type());
+        }
+        n->outputs()[i]->replaceAllUsesWith(*new_output);
       }
-      n->outputs()[i]->replaceAllUsesWith(*new_output);
-    }
-    // If we cannot insert the IValue as a constant, give up replacing the node
-    // and let DCE remove it
-  }
-}
-
-void removeLoopNode(Node* n) {
-  auto loop_input_offset = 2; // offset of loop carried deps in input list
-  for (size_t i = 0; i < n->outputs().size(); ++i) {
-    n->outputs().at(i)->replaceAllUsesWith(
-        n->inputs().at(i + loop_input_offset));
-  }
-  n->destroy();
-}
-
-bool loopWillNotRun(Node* node) {
-  Value* trip_count = node->inputs().at(0);
-  int64_t iter_len = constant_as<int64_t>(trip_count).value_or(1);
-
-  Value* start_cond = node->inputs().at(1);
-  bool cond_val = constant_as<bool>(start_cond).value_or(true);
-
-  bool loop_might_run = cond_val && iter_len > 0;
-  return !loop_might_run;
-}
-
-void ConstantPropagation(Block* block, const AliasDb& aliasDb);
-
-void inlineIfBody(Block* body) {
-  Node* n = body->owningNode();
-  for (auto it = body->nodes().begin(); it != body->nodes().end();) {
-    Node* body_node = *it;
-    // advance iterator because after body_node is moved its next pointer will
-    // be to n
-    it++;
-    body_node->moveBefore(n);
-  }
-  for (size_t i = 0; i < n->outputs().size(); ++i) {
-    n->outputs().at(i)->replaceAllUsesWith(body->outputs().at(i));
-  }
-  // NB: destroy the node here, because it might contain side effects, like
-  // print
-  n->destroy();
-}
-
-void inlineIf(Node* n, const AliasDb& aliasDb) {
-  auto input_bool = constant_as<bool>(n->input());
-  AT_ASSERT(input_bool);
-  size_t block_index = *input_bool ? 0 : 1;
-  ConstantPropagation(n->blocks().at(block_index), aliasDb);
-  inlineIfBody(n->blocks().at(block_index));
-}
-
-void replaceAndRemoveIfOutput(Node* n, size_t i, Value* replacement) {
-  n->outputs().at(i)->replaceAllUsesWith(replacement);
-  n->eraseOutput(i);
-  n->blocks().at(0)->eraseOutput(i);
-  n->blocks().at(1)->eraseOutput(i);
-}
-
-// remove extra outputs from the node
-bool removeExtraIfOutputs(Node* n) {
-  TORCH_CHECK(n->kind() == prim::If, "Only supported for If nodes");
-  auto true_block = n->blocks()[0];
-  auto false_block = n->blocks()[1];
-  auto graph = n->owningGraph();
-  auto initial_outputs = true_block->outputs().size();
-  WithInsertPoint guard(n);
-  for (size_t i = 0; i < true_block->outputs().size();) {
-    auto t_out = true_block->outputs().at(i);
-    auto f_out = false_block->outputs().at(i);
-
-    // neither block changes the output value
-    if (true_block->outputs()[i] == false_block->outputs()[i]) {
-      replaceAndRemoveIfOutput(n, i, true_block->outputs()[i]);
-      continue;
-    }
-
-    // true block output is constant and constant matches false block output
-    auto maybe_const = toIValue(t_out);
-    auto eq = EqualNode();
-    if (maybe_const && eq(t_out->node(), f_out->node())) {
-      auto new_const = graph->insertConstant(*maybe_const, t_out->type());
-      replaceAndRemoveIfOutput(n, i, new_const);
-      continue;
-    }
-
-    i++; // increment bc we didn't remove current index
-  }
-  // an output was removed
-  return initial_outputs != true_block->outputs().size();
-}
-
-// remove extra outputs from the node
-void removeExtraLoopOutputs(Node* node) {
-  auto loop_body = node->blocks().at(0);
-  auto loop_input_offset = 2; // offset of loop carried deps in input list
-  auto loop_body_offset =
-      1; // offset to the loop carried dependencies in block inputs/outputs
-  for (size_t i_1 = node->outputs().size(); i_1 > 0; --i_1) {
-    size_t i = i_1 - 1;
-    // if the value is no longer changed remove output
-    if (loop_body->inputs().at(loop_body_offset + i) ==
-        loop_body->outputs().at(loop_body_offset + i)) {
-      auto node_input = node->inputs().at(loop_input_offset + i);
-      node->outputs().at(i)->replaceAllUsesWith(node_input);
-      loop_body->inputs()
-          .at(loop_body_offset + i)
-          ->replaceAllUsesWith(node_input);
-      node->eraseOutput(i);
-      node->removeInput(loop_input_offset + i);
-      loop_body->eraseInput(loop_body_offset + i);
-      loop_body->eraseOutput(loop_body_offset + i);
+      // If we cannot insert the IValue as a constant, give up replacing the
+      // node and let DCE remove it
     }
   }
-}
 
-void ConstantPropagation(Node* n, const AliasDb& aliasDb) {
-  bool constant_inputs =
-      std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
-        return v->node()->kind() == prim::Constant;
-      });
-  bool supported_node = !n->kind().is_onnx() &&
-      skip_list.count(n->kind()) == 0 && !n->isNondeterministic() &&
-      !n->hasSideEffects() && !aliasDb.hasWriters(n);
-  auto run_blocks = [&]() {
-    for (Block* block : n->blocks()) {
-      ConstantPropagation(block, aliasDb);
+  void removeLoopNode(Node* n) {
+    auto loop_input_offset = 2; // offset of loop carried deps in input list
+    for (size_t i = 0; i < n->outputs().size(); ++i) {
+      n->outputs().at(i)->replaceAllUsesWith(
+          n->inputs().at(i + loop_input_offset));
     }
-  };
-  if (n->kind() == prim::If) {
-    // inline node if we can, otherwise check for simplified outputs
-    if (constant_inputs) {
-      inlineIf(n, aliasDb);
+    n->destroy();
+  }
+
+  bool loopWillNotRun(Node* node) {
+    Value* trip_count = node->inputs().at(0);
+    int64_t iter_len = constant_as<int64_t>(trip_count).value_or(1);
+
+    Value* start_cond = node->inputs().at(1);
+    bool cond_val = constant_as<bool>(start_cond).value_or(true);
+
+    bool loop_might_run = cond_val && iter_len > 0;
+    return !loop_might_run;
+  }
+
+  void inlineIfBody(Block* body) {
+    Node* n = body->owningNode();
+    for (auto it = body->nodes().begin(); it != body->nodes().end();) {
+      Node* body_node = *it;
+      // advance iterator because after body_node is moved its next pointer will
+      // be to n
+      it++;
+      body_node->moveBefore(n);
+    }
+    for (size_t i = 0; i < n->outputs().size(); ++i) {
+      n->outputs().at(i)->replaceAllUsesWith(body->outputs().at(i));
+    }
+    // NB: destroy the node here, because it might contain side effects, like
+    // print
+    n->destroy();
+  }
+
+  void inlineIf(Node* n) {
+    auto input_bool = constant_as<bool>(n->input());
+    AT_ASSERT(input_bool);
+    size_t block_index = *input_bool ? 0 : 1;
+    ConstantPropagation(n->blocks().at(block_index));
+    inlineIfBody(n->blocks().at(block_index));
+  }
+
+  void replaceAndRemoveIfOutput(Node* n, size_t i, Value* replacement) {
+    n->outputs().at(i)->replaceAllUsesWith(replacement);
+    n->eraseOutput(i);
+    n->blocks().at(0)->eraseOutput(i);
+    n->blocks().at(1)->eraseOutput(i);
+  }
+
+  // remove extra outputs from the node
+  bool removeExtraIfOutputs(Node* n) {
+    TORCH_CHECK(n->kind() == prim::If, "Only supported for If nodes");
+    auto true_block = n->blocks()[0];
+    auto false_block = n->blocks()[1];
+    auto graph = n->owningGraph();
+    auto initial_outputs = true_block->outputs().size();
+    WithInsertPoint guard(n);
+    for (size_t i = 0; i < true_block->outputs().size();) {
+      auto t_out = true_block->outputs().at(i);
+      auto f_out = false_block->outputs().at(i);
+
+      // neither block changes the output value
+      if (true_block->outputs()[i] == false_block->outputs()[i]) {
+        replaceAndRemoveIfOutput(n, i, true_block->outputs()[i]);
+        continue;
+      }
+
+      // true block output is constant and constant matches false block output
+      auto maybe_const = toIValue(t_out);
+      auto eq = EqualNode();
+      if (maybe_const && eq(t_out->node(), f_out->node())) {
+        auto new_const = graph->insertConstant(*maybe_const, t_out->type());
+        replaceAndRemoveIfOutput(n, i, new_const);
+        continue;
+      }
+
+      i++; // increment bc we didn't remove current index
+    }
+    // an output was removed
+    return initial_outputs != true_block->outputs().size();
+  }
+
+  // remove extra outputs from the node
+  void removeExtraLoopOutputs(Node* node) {
+    auto loop_body = node->blocks().at(0);
+    auto loop_input_offset = 2; // offset of loop carried deps in input list
+    auto loop_body_offset =
+        1; // offset to the loop carried dependencies in block inputs/outputs
+    for (size_t i_1 = node->outputs().size(); i_1 > 0; --i_1) {
+      size_t i = i_1 - 1;
+      // if the value is no longer changed remove output
+      if (loop_body->inputs().at(loop_body_offset + i) ==
+          loop_body->outputs().at(loop_body_offset + i)) {
+        auto node_input = node->inputs().at(loop_input_offset + i);
+        node->outputs().at(i)->replaceAllUsesWith(node_input);
+        loop_body->inputs()
+            .at(loop_body_offset + i)
+            ->replaceAllUsesWith(node_input);
+        node->eraseOutput(i);
+        node->removeInput(loop_input_offset + i);
+        loop_body->eraseInput(loop_body_offset + i);
+        loop_body->eraseOutput(loop_body_offset + i);
+      }
+    }
+  }
+
+  void ConstantPropagation(Node* n) {
+    bool constant_inputs =
+        std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
+          return v->node()->kind() == prim::Constant;
+        });
+    bool supported_node = !n->kind().is_onnx() &&
+        skip_list.count(n->kind()) == 0 && !n->isNondeterministic() &&
+        !n->hasSideEffects() && !aliasDb.hasWriters(n);
+    auto run_blocks = [&]() {
+      for (Block* block : n->blocks()) {
+        ConstantPropagation(block);
+      }
+    };
+    if (n->kind() == prim::If) {
+      // inline node if we can, otherwise check for simplified outputs
+      if (constant_inputs) {
+        inlineIf(n);
+      } else {
+        run_blocks();
+        removeExtraIfOutputs(n);
+      }
+    } else if (n->kind() == prim::Loop) {
+      if (loopWillNotRun(n)) {
+        removeLoopNode(n);
+      } else {
+        run_blocks();
+        removeExtraLoopOutputs(n);
+      }
+    } else if (constant_inputs && supported_node) {
+      propagateNode(n);
     } else {
       run_blocks();
-      removeExtraIfOutputs(n);
     }
-  } else if (n->kind() == prim::Loop) {
-    if (loopWillNotRun(n)) {
-      removeLoopNode(n);
-    } else {
-      run_blocks();
-      removeExtraLoopOutputs(n);
-    }
-  } else if (constant_inputs && supported_node) {
-    propagateNode(n);
-  } else {
-    run_blocks();
   }
-}
 
-void ConstantPropagation(Block* block, const AliasDb& aliasDb) {
-  for (auto it = block->nodes().begin(); it != block->nodes().end();) {
-    Node* n = *it;
-    it++; // advance iterator bc the current node may be destroyed
-    ConstantPropagation(n, aliasDb);
+  void ConstantPropagation(Block* block) {
+    for (auto it = block->nodes().begin(); it != block->nodes().end();) {
+      Node* n = *it;
+      it++; // advance iterator bc the current node may be destroyed
+      ConstantPropagation(n);
+    }
   }
-}
+
+  std::shared_ptr<Graph> graph_;
+  AliasDb aliasDb;
+  std::unordered_map<Value*, IValue> tuples;
+};
 } // anonymous namespace
 
 void ConstantPropagation(std::shared_ptr<Graph>& graph) {
-  AliasDb aliasDb(graph);
-  ConstantPropagation(graph->block(), aliasDb);
+  ConstantPropagator cp(graph);
+  cp.run();
   EliminateDeadCode(graph);
 }
 } // namespace jit

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -25,6 +25,13 @@ std::unordered_set<Symbol> skip_list = {
     // where the constant tensor would be large but cheap to create.
 };
 
+std::unordered_set<Symbol> tuple_ops = {
+    prim::TupleSlice,
+    prim::TupleIndex,
+    prim::TupleUnpack,
+    prim::TupleConstruct,
+};
+
 struct ConstantPropagator {
   ConstantPropagator(std::shared_ptr<Graph> graph)
       : graph_(std::move(graph)), aliasDb(graph_){};
@@ -34,11 +41,20 @@ struct ConstantPropagator {
   }
 
  private:
+  void pushIValue(Value* v, Stack& stack) {
+    if (tuples.count(v)) {
+      const auto& ival = tuples[v];
+      stack.push_back(ival);
+    } else {
+      stack.push_back(*toIValue(v));
+    }
+  }
+
   std::vector<IValue> runNode(Node* n) {
     auto op = getOperation(n);
     Stack stack;
     for (auto input : n->inputs()) {
-      stack.push_back(*(toIValue(input)));
+      pushIValue(input, stack);
     }
     op(stack);
     auto var_outputs = fmap(stack, [&](IValue v) -> IValue {
@@ -60,6 +76,35 @@ struct ConstantPropagator {
     return var_outputs;
   }
 
+  // Tuples are not representable as constants, however
+  // we can try to insert each tuple element and then create a TupleConstruct
+  // from the elements
+  Value* tryInsertTuple(const IValue& tuple, Value* tuple_to_replace) {
+    auto type = tuple_to_replace->type();
+    TupleTypePtr tup_type;
+    if (auto opt = type->cast<OptionalType>()) {
+      tup_type = opt->getElementType()->expect<TupleType>();
+    } else {
+      tup_type = type->expect<TupleType>();
+    }
+    auto type_elements = tup_type->elements();
+    const auto& tuple_elements = tuple.toTuple()->elements();
+    std::vector<Value*> inputs;
+    for (size_t i = 0; i < type_elements.size(); ++i) {
+      auto inp =
+          tryInsertConstant(*graph_, tuple_elements[i], type_elements[i]);
+      if (inp) {
+        inputs.push_back(*inp);
+      } else {
+        return nullptr;
+      }
+    }
+    auto new_tuple = graph_->insertNode(graph_->createTuple(inputs));
+    tuple_to_replace->replaceAllUsesWith(new_tuple->output());
+    new_tuple->output()->copyMetadata(tuple_to_replace);
+    return new_tuple->output();
+  }
+
   void propagateNode(Node* n) {
     std::vector<IValue> outputs;
     try {
@@ -78,6 +123,14 @@ struct ConstantPropagator {
           (*new_output)->setType(n->outputs()[i]->type());
         }
         n->outputs()[i]->replaceAllUsesWith(*new_output);
+      } else if (outputs[i].isTuple()) {
+        // we save the new Tuple ivalue in case it is used in an op that
+        // forwards tuples later in the graph, such as a Tuple index
+        auto tuple_val = n->outputs()[i];
+        if (auto new_tup = tryInsertTuple(outputs[i], tuple_val)) {
+          tuple_val = new_tup;
+        }
+        tuples[tuple_val] = std::move(outputs[i]);
       }
       // If we cannot insert the IValue as a constant, give up replacing the
       // node and let DCE remove it
@@ -193,11 +246,29 @@ struct ConstantPropagator {
     }
   }
 
-  void ConstantPropagation(Node* n) {
-    bool constant_inputs =
-        std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
+  // An Op has runnable inputs if:
+  // - All inputs are constants.
+  // - It is an op that forwards tuples, and all inputs are constants
+  // or tuples that we know the ivalue for. We can't use known tuple ivalues
+  // for non-forwarding ops because that Tuple could contain an ivalue that is
+  // not allowed as a constant, for instance, a Tensor with a gradient.
+  bool runnableInputs(Node* n) {
+    if (std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
           return v->node()->kind() == prim::Constant;
-        });
+        })) {
+      return true;
+    }
+    if (tuple_ops.count(n->kind())) {
+      return (
+          std::all_of(n->inputs().begin(), n->inputs().end(), [&](Value* v) {
+            return v->node()->kind() == prim::Constant || tuples.count(v);
+          }));
+    }
+    return false;
+  };
+
+  void ConstantPropagation(Node* n) {
+    bool runnable_inputs = runnableInputs(n);
     bool supported_node = !n->kind().is_onnx() &&
         skip_list.count(n->kind()) == 0 && !n->isNondeterministic() &&
         !n->hasSideEffects() && !aliasDb.hasWriters(n);
@@ -208,7 +279,7 @@ struct ConstantPropagator {
     };
     if (n->kind() == prim::If) {
       // inline node if we can, otherwise check for simplified outputs
-      if (constant_inputs) {
+      if (runnable_inputs) {
         inlineIf(n);
       } else {
         run_blocks();
@@ -221,7 +292,7 @@ struct ConstantPropagator {
         run_blocks();
         removeExtraLoopOutputs(n);
       }
-    } else if (constant_inputs && supported_node) {
+    } else if (runnable_inputs && supported_node) {
       propagateNode(n);
     } else {
       run_blocks();
@@ -238,6 +309,7 @@ struct ConstantPropagator {
 
   std::shared_ptr<Graph> graph_;
   AliasDb aliasDb;
+  // these are tuples which we know the computed IValue for
   std::unordered_map<Value*, IValue> tuples;
 };
 } // anonymous namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21378 better constant propagation through tuples**
* #21377 move constant propagation to a class

This PR lets us constant prop through ops that forward tuples, & through builtins that return tuples.  Previously, tuples inhibited constant prop and combined with lower tuples pass caused jitter for running constant propagation on compilation.

