### PR TITLE
Import fast tanh impl from eigen

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -399,6 +399,38 @@ inline T fmadd(const T& a, const T& b, const T& c) {
   return a * b + c;
 }
 
+// Implement fast tanh from Eigen.
+// https://github.com/eigenteam/eigen-git-mirror/blob/master/Eigen/src/Core/MathFunctionsImpl.h#L26
+template <typename T>
+inline T FastTanh(const T& x) {
+  const T kL = T(-9.0);
+  const T kR = T(9.0);
+  const T kAlpha1 = T(4.89352455891786e-03);
+  const T kAlpha3 = T(6.37261928875436e-04);
+  const T kAlpha5 = T(1.48572235717979e-05);
+  const T kAlpha7 = T(5.12229709037114e-08);
+  const T kAlpha9 = T(-8.60467152213735e-11);
+  const T kAlpha11 = T(2.00018790482477e-13);
+  const T kAlpha13 = T(-2.76076847742355e-16);
+  const T kBeta0 = T(4.89352518554385e-03);
+  const T kBeta2 = T(2.26843463243900e-03);
+  const T kBeta4 = T(1.18534705686654e-04);
+  const T kBeta6 = T(1.19825839466702e-06);
+  const T x1 = minimum(maximum(x, kL), kR);
+  const T x2 = x1 * x1;
+  T p = fmadd(x2, kAlpha13, kAlpha11);
+  p = fmadd(x2, p, kAlpha9);
+  p = fmadd(x2, p, kAlpha7);
+  p = fmadd(x2, p, kAlpha5);
+  p = fmadd(x2, p, kAlpha3);
+  p = fmadd(x2, p, kAlpha1);
+  p = p * x1;
+  T q = fmadd(x2, kBeta6, kBeta4);
+  q = fmadd(x2, q, kBeta2);
+  q = fmadd(x2, q, kBeta0);
+  return p / q;
+}
+
 template <int64_t scale = 1, typename T = void>
 c10::guts::enable_if_t<scale == 1 || scale == 2 || scale == 4 || scale == 8, Vec256<T>>
 inline gather(T const* base_addr, const Vec256<int_same_size_t<T>>& vindex) {

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -275,7 +275,7 @@ template <>
 Vec256<double> inline fmadd(const Vec256<double>& a, const Vec256<double>& b, const Vec256<double>& c) {
   return _mm256_fmadd_pd(a, b, c);
 }
-#endif
+#endif // __AVX2__
 
 #endif
 

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -159,9 +159,7 @@ public:
   Vec256<float> tan() const {
     return map(std::tan);
   }
-  Vec256<float> tanh() const {
-    return Vec256<float>(Sleef_tanhf8_u10(values));
-  }
+  Vec256<float> tanh() const;
   Vec256<float> trunc() const {
     return _mm256_round_ps(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC));
   }
@@ -280,10 +278,17 @@ void convert(const float* src, float* dst, int64_t n) {
 
 #ifdef __AVX2__
 template <>
-Vec256<float> inline fmadd(const Vec256<float>& a, const Vec256<float>& b, const Vec256<float>& c) {
+Vec256<float> inline fmadd(
+    const Vec256<float>& a,
+    const Vec256<float>& b,
+    const Vec256<float>& c) {
   return _mm256_fmadd_ps(a, b, c);
 }
-#endif
+#endif // __AVX2__
+
+Vec256<float> Vec256<float>::tanh() const {
+  return FastTanh<Vec256<float>>(*this);
+}
 
 #endif
 

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -116,6 +116,15 @@ static void cosh_kernel(TensorIterator& iter) {
   });
 }
 
+void tanh_kernel(TensorIterator& it) {
+  AT_DISPATCH_FLOATING_TYPES(it.dtype(), "tanh_cpu", [&]() {
+    unary_kernel_vec(
+        it,
+        [](scalar_t x) { return std::tanh(x); },
+        [](const Vec256<scalar_t>& x) { return x.tanh(); });
+  });
+}
+
 #if !AT_MKL_ENABLED()
 void bernoulli_mkl_kernel(Tensor &output, const double p, Generator* gen) {
   // Use AT_ASSERTM because this should never be reached, and AT_ASSERTM tells
@@ -230,6 +239,7 @@ REGISTER_DISPATCH(neg_stub, &neg_kernel);
 REGISTER_DISPATCH(fill_stub, &fill_kernel);
 REGISTER_DISPATCH(sinh_stub, &sinh_kernel);
 REGISTER_DISPATCH(cosh_stub, &cosh_kernel);
+REGISTER_DISPATCH(tanh_stub, &tanh_kernel);
 
 // IMPLEMENT_FLOAT_KERNEL(ALL, abs)
 IMPLEMENT_FLOAT_KERNEL(FLOATING, acos)
@@ -252,7 +262,7 @@ IMPLEMENT_FLOAT_KERNEL(FLOATING, sin)
 // IMPLEMENT_FLOAT_KERNEL(FLOATING, sinh)
 IMPLEMENT_FLOAT_KERNEL(FLOATING, sqrt)
 IMPLEMENT_FLOAT_KERNEL(FLOATING, tan)
-IMPLEMENT_FLOAT_KERNEL(FLOATING, tanh)
+// IMPLEMENT_FLOAT_KERNEL(FLOATING, tanh)
 IMPLEMENT_FLOAT_KERNEL(FLOATING, trunc)
 
 }} // namespace at::native


### PR DESCRIPTION
Summary:
Import fast tanh impl from eigen.

This approach is about 30% faster than MKL v?Tanh and ouver 50% faster than previous Vec256::tanh().

Differential Revision: D15632834

