### PR TITLE
Change magic grain sizes used in parallel_for/reduce to internal::GRAIN_SIZE

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -38,7 +38,8 @@ begin: index at which to start applying user function
 
 end: index at which to stop applying user function
 
-grain_size: number of elements per chunk. impacts the degree of parallelization
+grain_size: number of elements per chunk. impacts the degree of parallelization.
+  Normally should be set to internal::GRAIN_SIZE
 
 f: user function applied in parallel to the chunks, signature:
   void f(int64_t begin, int64_t end)
@@ -58,7 +59,8 @@ begin: index at which to start applying reduction
 end: index at which to stop applying reduction
 
 grain_size: number of elements per chunk. impacts number of elements in
-intermediate results tensor and degree of parallelization.
+  intermediate results tensor and degree of parallelization. Normally should be
+  set to internal::GRAIN_SIZE
 
 ident: identity for binary combination function sf. sf(ident, x) needs to return
 x.

--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -55,7 +55,8 @@ using namespace vec256;
 
 template <typename scalar_t>
 inline void vrsqrt(scalar_t* out, scalar_t* in, int64_t size) {
-  parallel_for(0, size, 2048, [out, in](int64_t begin, int64_t end) {
+  parallel_for(0, size, internal::GRAIN_SIZE,
+               [out, in](int64_t begin, int64_t end) {
     map(
         [](const Vec256<scalar_t>& x) {
           return Vec256<scalar_t>((scalar_t)(1)) / x.sqrt();
@@ -78,7 +79,8 @@ inline void vrsqrt(scalar_t* out, scalar_t* in, int64_t size) {
   template <typename scalar_t>                                          \
   inline void v##op(scalar_t* out, const scalar_t* in, int64_t size) {  \
     DL_RUNTIME_BUG(op, scalar_t)                                        \
-    parallel_for(0, size, 2048, [out, in](int64_t begin, int64_t end) { \
+    parallel_for(0, size, internal::GRAIN_SIZE,                         \
+                 [out, in](int64_t begin, int64_t end) {                \
       map([](const Vec256<scalar_t>& x) { return x.op(); },             \
           out + begin,                                                  \
           in + begin,                                                   \
@@ -89,7 +91,8 @@ inline void vrsqrt(scalar_t* out, scalar_t* in, int64_t size) {
 #define IMPLEMENT_VML(op)                                              \
   template <typename scalar_t>                                          \
   inline void v##op(scalar_t* out, const scalar_t* in, int64_t size) {  \
-    parallel_for(0, size, 2048, [out, in](int64_t begin, int64_t end) { \
+    parallel_for(0, size, internal::GRAIN_SIZE,                         \
+                 [out, in](int64_t begin, int64_t end) {                \
       map([](const Vec256<scalar_t>& x) { return x.op(); },             \
           out + begin,                                                  \
           in + begin,                                                   \

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -95,7 +95,8 @@ void inline prelu_cpu_kernel_share_weights(
   auto input_data = input.data<scalar_t>();
   auto weight_val = weight.data<scalar_t>()[0];
 
-  at::parallel_for(0, input_numel, 1000, [&](int64_t start, int64_t end) {
+  at::parallel_for(0, input_numel, internal::GRAIN_SIZE,
+                   [&](int64_t start, int64_t end) {
     for (auto i = start; i < end; i++) {
       scalar_t input_data_val = input_data[i];
       // to allow for compiler optimization, here splitting into two lines:
@@ -209,7 +210,8 @@ void inline prelu_cpu_backward_kernel_share_weights(
   auto input_grad_data = input_grad.data<scalar_t>();
   auto weight_grad_data = weight_grad.data<scalar_t>();
 
-  scalar_t sum = at::parallel_reduce(0, input_numel, 1000, scalar_t(0),
+  scalar_t sum = at::parallel_reduce(0, input_numel,
+                                     internal::GRAIN_SIZE, scalar_t(0),
       [&](int64_t start, int64_t end, scalar_t ident) -> scalar_t {
     scalar_t partial_sum = ident;
     for (auto i = start; i < end; i++) {

--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -144,7 +144,8 @@ Tensor & embedding_renorm_cpu_(
   auto sorted_indices = std::vector<int64_t>(data_ptr, data_ptr + num_indices);
   std::sort(sorted_indices.begin(), sorted_indices.end(), std::less<int64_t>());
 
-  at::parallel_for(0, num_indices, 1000, [&](int64_t start, int64_t end) {
+  at::parallel_for(0, num_indices, internal::GRAIN_SIZE,
+                   [&](int64_t start, int64_t end) {
     for (auto i = start; i < end; i++) {
       if (i > 0 && sorted_indices[i] == sorted_indices[i - 1]) {
         continue;

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -672,8 +672,8 @@ Tensor _embedding_bag_per_sample_weights_backward_cpu_template(
   auto output_data = output.data<scalar_t>();
   auto offset2bag_data = offset2bag_.data<int64_t>();
 
-  // XXX: 64 was arbitrarily chosen. There is probably a sweet spot for this number.
-  parallel_for(0, num_samples, 64, [&](int64_t begin, int64_t end) {
+  parallel_for(0, num_samples, internal::GRAIN_SIZE,
+               [&](int64_t begin, int64_t end) {
     for (int64_t sample_idx = begin; sample_idx < end; sample_idx++) {
       auto bag_idx = offset2bag_data[sample_idx];
       auto embedding_idx = indices_data[sample_idx];

--- a/aten/src/ATen/native/TensorTransformations.cpp
+++ b/aten/src/ATen/native/TensorTransformations.cpp
@@ -27,7 +27,8 @@ void inline flip_cpu_kernel(
   auto sizes_v = in_tensor.sizes().vec();
   auto strides_v = in_tensor.strides().vec();
 
-  at::parallel_for(0, numel, 1000, [&](int64_t start, int64_t end) {
+  at::parallel_for(0, numel, internal::GRAIN_SIZE,
+                   [&](int64_t start, int64_t end) {
     for (auto i = start; i < end; i++) {
       int64_t cur_indices = i;
       int64_t rem = 0;

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -164,7 +164,7 @@ void bernoulli_mkl_kernel(Tensor &self, const double p, Generator* gen) {
       }
     };
 
-    parallel_for(0, n, /* grain_size= */ 800, sample);
+    parallel_for(0, n, internal::GRAIN_SIZE, sample);
 
     // copy_ if using buffer and non contiguous
     if (!contig) {

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -136,7 +136,8 @@ static inline void _fft_fill_with_conjugate_symmetry_(Tensor& input,
     num *= input.size(d);
   }
 
-  at::parallel_for(0, num, 500, [&](int64_t start, int64_t end) {
+  at::parallel_for(0, num, internal::GRAIN_SIZE,
+                   [&](int64_t start, int64_t end) {
     AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "_fft_fill_with_conjugate_symmetry", [&] {
       _fft_fill_with_conjugate_symmetry_slice<scalar_t>(input, signal_ndim, size_last_dim,
           last_dim_start_slice, start, (end - start));

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -440,7 +440,8 @@ void inline sparse_mask_out_cpu_kernel(
   auto mask_indices_accessor = mask_indices.accessor<int64_t, 2>();
   scalar_t* t_ptr = t.data<scalar_t>();
 
-  at::parallel_for(0, r_nnz, 1000, [&](int64_t start, int64_t end) {
+  at::parallel_for(0, r_nnz, internal::GRAIN_SIZE,
+                   [&](int64_t start, int64_t end) {
     for (auto i = start; i < end; i++) {
       int64_t idx = 0;
       for (int64_t d = 0; d < sparse_dim; d++) {

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -24,7 +24,8 @@ namespace {
     if (nnz > 0) {
       auto csr_accessor = csr.accessor<int64_t, 1>();
       // Convert the sparse matrix to CSR format
-      at::parallel_for(0, nnz, 10000, [&](int64_t start, int64_t end) {
+      at::parallel_for(0, nnz, internal::GRAIN_SIZE,
+                       [&](int64_t start, int64_t end) {
         int64_t h, hp0, hp1;
         for (auto i = start; i < end; i++) {
           hp0 = indices[i];


### PR DESCRIPTION
Many grain sizes in magic numbers (e.g., 1000, 100) are currently used in various spots. This commit replaces them with internal::GRAIN_SIZE, a heuristically reasonable number.

---

This PR has only modified those calls of `parallel_for/reduce` that uses a magic grain size directly. A separate PR will be made for those with grain size set to `0` or `1`, as they require a closer scrutiny and there are many more of them. If we have a somewhat more uniform grain size, we can make it adjustable through build options or environment variable.