### PR TITLE
Add Registry for Jit Module Exporter

### DIFF
--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/util/Registry.h>
+
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/script/module.h>
 #include <torch/csrc/onnx/onnx.h>
@@ -8,6 +10,20 @@
 
 namespace torch {
 namespace jit {
+
+struct TORCH_API JitExportByURI {
+  JitExportByURI() {}
+
+  virtual void write(const script::Module& module,
+      const std::string& filename,
+      const script::ExtraFilesMap& extra_files) = 0;
+
+  virtual ~JitExportByURI() {}
+};
+
+C10_DECLARE_REGISTRY(JitExportByURIRegistry, JitExportByURI);
+#define REGISTER_JIT_EXPORT_BY_PATH(clsname, key) \
+  C10_REGISTER_TYPED_CLASS(JitExportByURIRegistry, key, clsname)
 
 // This map is used to keep track of parameters that should be exported
 // externally. When `defer_weight_export` is true, the returned map contains


### PR DESCRIPTION
Summary:
besides writing to local files, we may also use path to specify different targets, such as manifold, etc
so far, we use xxx://yyy for path, if there is no ://, we consider it as a local file
xxx can be manifold, s3, so on

Differential Revision: D15637455

