### PR TITLE
Remove unneeded headers

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <fbgemm/Fbgemm.h>
-#include <fbgemm/src/FbgemmI8DepthwiseAvx2.h>
 #include "caffe2/operators/conv_op.h"
 #include "caffe2/operators/conv_pool_op_base.h"
 #include "caffe2/quantization/server/caffe2_dnnlowp_utils.h"

--- a/caffe2/quantization/server/fbgemm_pack_blob.h
+++ b/caffe2/quantization/server/fbgemm_pack_blob.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include <fbgemm/Fbgemm.h>
-#include <fbgemm/src/FbgemmI8DepthwiseAvx2.h>
 
 #include "caffe2/quantization/server/dnnlowp.h"
 


### PR DESCRIPTION
Summary: Result of splitting the base diff. We moved a header from src/* to include/fbgemm/*

Differential Revision: D15635188

