### PR TITLE
Per-callback sampling

### DIFF
--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -8,20 +8,22 @@ namespace torch { namespace autograd { namespace profiler {
 namespace {
 std::vector<RecordFunctionCallback> start_callbacks;
 std::vector<RecordFunctionCallback> end_callbacks;
+std::vector<bool> is_callback_sampled;
+size_t num_sampled_callbacks = 0;
 size_t callback_needs_inputs = 0;
 thread_local RecordFunction* thread_local_func_ = nullptr;
 
-bool is_sampled_callbacks = false;
+bool sampling_prop_set = false;
 double sampling_prob = 1.0;
 constexpr double kEps = 1e-10;
 }
 
 void setSamplingProbability(double prob) {
   if (std::abs(prob - 1.0) < kEps) {
-    is_sampled_callbacks = false;
+    sampling_prop_set = false;
   } else {
     TORCH_CHECK(prob > -kEps && prob < 1.0);
-    is_sampled_callbacks = true;
+    sampling_prop_set = true;
   }
   sampling_prob = prob;
 }
@@ -30,18 +32,25 @@ double getSamplingProbability() {
   return sampling_prob;
 }
 
-bool checkCallbacksSampled() {
-  return is_sampled_callbacks;
+bool shouldRunSampledCallbacks() {
+  return (num_sampled_callbacks > 0) &&
+      (!sampling_prop_set ||
+      (((double) std::rand() / RAND_MAX) < sampling_prob));
 }
 
 void pushCallback(
     RecordFunctionCallback start,
     RecordFunctionCallback end,
-    bool needs_inputs) {
+    bool needs_inputs,
+    bool sampled) {
   start_callbacks.push_back(start);
   end_callbacks.push_back(end);
   if (callback_needs_inputs > 0 || needs_inputs) {
     ++callback_needs_inputs;
+  }
+  is_callback_sampled.push_back(sampled);
+  if (sampled) {
+    ++num_sampled_callbacks;
   }
 }
 
@@ -54,6 +63,10 @@ void popCallback() {
   if (callback_needs_inputs > 0) {
     --callback_needs_inputs;
   }
+  if (is_callback_sampled.back()) {
+    --num_sampled_callbacks;
+  }
+  is_callback_sampled.pop_back();
 }
 
 bool hasCallbacks() {
@@ -62,6 +75,10 @@ bool hasCallbacks() {
 
 bool needsInputs() {
   return callback_needs_inputs > 0;
+}
+
+bool hasNonSampledCallbacks() {
+  return num_sampled_callbacks < start_callbacks.size();
 }
 
 void RecordFunction::before(const char* name, int64_t sequence_nr) {
@@ -105,15 +122,19 @@ void RecordFunction::processCallbacks() {
   parent_ = thread_local_func_;
   thread_local_func_ = this;
 
-  for (const auto& cb : start_callbacks) {
-    cb(*this);
+  for (size_t idx = 0; idx < start_callbacks.size(); ++idx) {
+    if (!is_callback_sampled[idx] || run_sampled_) {
+      start_callbacks[idx](*this);
+    }
   }
 }
 
 RecordFunction::~RecordFunction() {
   if (initialized_) {
-    for (const auto& cb : end_callbacks) {
-      cb(*this);
+    for (size_t idx = 0; idx < end_callbacks.size(); ++idx) {
+      if (!is_callback_sampled[idx] || run_sampled_) {
+        end_callbacks[idx](*this);
+      }
     }
     thread_local_func_ = parent_;
   }

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/autograd/function.h>
 
 #include <cstdlib>
+#include <random>
 
 namespace torch { namespace autograd { namespace profiler {
 
@@ -15,6 +16,12 @@ thread_local RecordFunction* thread_local_func_ = nullptr;
 
 bool sampling_prop_set = false;
 double sampling_prob = 1.0;
+
+double sample_zero_one() {
+  static thread_local auto gen = std::mt19937(std::random_device()());
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  return dist(gen);
+}
 }
 
 void setSamplingProbability(double prob) {
@@ -34,7 +41,7 @@ double getSamplingProbability() {
 bool shouldRunSampledCallbacks() {
   return (num_sampled_callbacks > 0) &&
       (!sampling_prop_set ||
-      (((double) std::rand() / RAND_MAX) < sampling_prob));
+      (sample_zero_one() < sampling_prob));
 }
 
 void pushCallback(

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -15,14 +15,13 @@ thread_local RecordFunction* thread_local_func_ = nullptr;
 
 bool sampling_prop_set = false;
 double sampling_prob = 1.0;
-constexpr double kEps = 1e-10;
 }
 
 void setSamplingProbability(double prob) {
-  if (std::abs(prob - 1.0) < kEps) {
+  if (prob == 1.0) {
     sampling_prop_set = false;
   } else {
-    TORCH_CHECK(prob > -kEps && prob < 1.0);
+    TORCH_CHECK(prob >= 0.0 && prob < 1.0);
     sampling_prop_set = true;
   }
   sampling_prob = prob;

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -77,6 +77,10 @@ struct TORCH_API RecordFunction {
     return parent_;
   }
 
+  void setRunSampled(bool run_sampled) {
+    run_sampled_ = run_sampled;
+  }
+
  private:
   void processCallbacks();
 
@@ -87,25 +91,25 @@ struct TORCH_API RecordFunction {
   RecordFunction* parent_ = nullptr;
 
   bool initialized_ = false;
+  bool run_sampled_ = true;
 };
 
 TORCH_API bool hasCallbacks();
 TORCH_API bool needsInputs();
+TORCH_API bool hasNonSampledCallbacks();
 
 TORCH_API void setSamplingProbability(double);
 TORCH_API double getSamplingProbability();
-TORCH_API bool checkCallbacksSampled();
 
-inline bool checkCallbacksEnabled() {
-  return !checkCallbacksSampled() ||
-      (((double) std::rand() / RAND_MAX) < getSamplingProbability());
-}
+TORCH_API bool shouldRunSampledCallbacks();
 
 // optional argument - function's seq_no
 #define RECORD_FUNCTION(fn, inputs, ...) \
   torch::autograd::profiler::RecordFunction guard; \
   if (torch::autograd::profiler::hasCallbacks()) { \
-    if (torch::autograd::profiler::checkCallbacksEnabled()) { \
+    auto run_sampled = torch::autograd::profiler::shouldRunSampledCallbacks(); \
+    if (run_sampled || torch::autograd::profiler::hasNonSampledCallbacks()) { \
+      guard.setRunSampled(run_sampled); \
       if (torch::autograd::profiler::needsInputs()) { \
         guard.before(fn, inputs, ##__VA_ARGS__); \
       } else { \
@@ -120,7 +124,8 @@ using RecordFunctionCallback = std::function<void(const RecordFunction&)>;
 TORCH_API void pushCallback(
     RecordFunctionCallback start,
     RecordFunctionCallback end = [](const RecordFunction&){},
-    bool needs_inputs = false);
+    bool needs_inputs = false,
+    bool sampled = false);
 TORCH_API void popCallback();
 
 } // namespace profiler

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -91,7 +91,7 @@ struct TORCH_API RecordFunction {
   RecordFunction* parent_ = nullptr;
 
   bool initialized_ = false;
-  bool run_sampled_ = true;
+  bool run_sampled_ = false;
 };
 
 TORCH_API bool hasCallbacks();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21394 Per-callback sampling**

Summary:
Make it possible to use continuous logging (sampled callbacks) and
on-demand profiling (non-sampled callback) at the same time.

Test Plan:
BLAS=MKL USE_MKLDNN=1 USE_OPENCV=1 USE_FFMPEG=1 python setup.py develop
--cmake
./build/bin/test_jit --gtest_filter=JitTest.RecordFunction

Differential Revision: [D15639723](https://our.internmc.facebook.com/intern/diff/D15639723)