### PR TITLE
Modify quant-dequant node api to take module object and method name

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1309,7 +1309,8 @@ graph(%x : Tensor,
         torch._C._jit_pass_constant_propagation(scriptM.graph)
         # TODO: Build the qparam_dict from parse_ir directly for this pass
         qparam_dict = _helper_generate_qparam(scriptM, input_data)
-        torch._C._jit_pass_insert_quantdequant(scriptM.graph, qparam_dict)
+        torch._C._jit_pass_insert_quantdequant(scriptM._c, "forward",
+                                               qparam_dict)
 
         # We expect to see quant-dequant node before and after
         # both conv and relu nodes and at external output since relu
@@ -1340,7 +1341,8 @@ graph(%x : Tensor,
         qparam_dict = _helper_generate_qparam(scriptM, input_data)
         if not len(qparam_dict):
             return
-        torch._C._jit_pass_insert_quantdequant(scriptM.graph, qparam_dict)
+        torch._C._jit_pass_insert_quantdequant(scriptM._c, "forward",
+                                               qparam_dict)
 
         # We expect to see quant-dequant node before and after
         # both conv and relu nodes and at external output since relu
@@ -1376,7 +1378,8 @@ graph(%x : Tensor,
         torch._C._jit_pass_constant_propagation(scriptM.graph)
 
         qparam_dict = _helper_generate_qparam(scriptM, input_data)
-        torch._C._jit_pass_insert_quantdequant(scriptM.graph, qparam_dict)
+        torch._C._jit_pass_insert_quantdequant(scriptM._c, "forward",
+                                               qparam_dict)
 
         # We expect to see quant-dequant node before and after
         # both conv and no quant-dequant after add. Constant nodes correspond
@@ -1410,7 +1413,8 @@ graph(%x : Tensor,
         torch._C._jit_pass_constant_propagation(scriptM.graph)
 
         qparam_dict = _helper_generate_qparam(scriptM, input_data)
-        torch._C._jit_pass_insert_quantdequant(scriptM.graph, qparam_dict)
+        torch._C._jit_pass_insert_quantdequant(scriptM._c, "forward",
+                                               qparam_dict)
 
         # We expect to see quant-dequant node before and after
         # conv, relu and add. Constant nodes correspond to params for the

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -159,7 +159,9 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_pass_insert_quantdequant",
-          [](std::shared_ptr<Graph>& g, py::dict& pyQParamDict) {
+          [](std::shared_ptr<script::Module>& moduleObj,
+             const std::string& methodName,
+             py::dict& pyQParamDict) {
             if (!pyQParamDict.size()) {
               return;
             }
@@ -167,7 +169,7 @@ void initJITBindings(PyObject* module) {
             auto qparam_dict = py::cast<std::unordered_map<
                 std::string,
                 std::tuple<std::string, float, int>>>(pyQParamDict);
-            return InsertQuantDequantNodes(g, qparam_dict);
+            return InsertQuantDequantNodes(moduleObj, methodName, qparam_dict);
           })
       .def(
           "_jit_pass_insert_quantdequant_for_weight_bias",

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -340,7 +340,7 @@ void InsertObserverNodes(
 }
 
 void InsertQuantDequantNodes(
-    std::shared_ptr<Graph>& graph,
+    const std::shared_ptr<Graph>& graph,
     const std::unordered_map<std::string, std::tuple<std::string, float, int>>&
         qparam_dict) {
   std::stack<Block*> blocks_to_visit;
@@ -466,6 +466,15 @@ void InsertQuantDequantNodes(
       param_info.n->replaceInputWith(param_info.v, dq->output());
     }
   }
+}
+
+void InsertQuantDequantNodes(
+    std::shared_ptr<script::Module>& moduleObj,
+    const std::string& method_name,
+    const std::unordered_map<std::string, std::tuple<std::string, float, int>>&
+        qparam_dict) {
+  const auto& method = moduleObj->get_method(method_name);
+  InsertQuantDequantNodes(method.graph(), qparam_dict);
 }
 
 void QuantLinting(std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/passes/quantization.h
+++ b/torch/csrc/jit/passes/quantization.h
@@ -53,12 +53,14 @@ TORCH_API void InsertObserverNodes(
  * performs quantization of the model by inserting quant-dequant node pairs for
  * quantizatable tensors - later passes only cleanup the IR and
  * make sure the model runs faster/consumes less memory.
- * \param graph which is instrumented for quant-dequant nodes.
+ * \moduleObj is the module object whose containing methods are modified.
+ * \param method_name whose graph is instrumented for quant-dequant nodes.
  * \param qparam_dict dictionary of tensor unique names to qparams.
  *
  */
 TORCH_API void InsertQuantDequantNodes(
-    std::shared_ptr<Graph>& graph,
+    std::shared_ptr<script::Module>& moduleObj,
+    const std::string& methodName,
     const std::unordered_map<std::string, std::tuple<std::string, float, int>>&
         qparam_dict);
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21407 Modify quant-dequant node api to take module object and method name**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15651624/)

Modify api takes module object and method whose graph is
instrumented to insert the quant dequant nodes

Differential Revision: [D15651624](https://our.internmc.facebook.com/intern/diff/D15651624/)