### PR TITLE
Make rshift implementation consistent between pytorch and numpy

### DIFF
--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -831,7 +831,7 @@ void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value)
 #if defined(TH_REAL_IS_BYTE)
         rp[i] = ((scalar_t) tp[i]) >> value;
 #else
-        rp[i] = ((ureal) tp[i]) >> value;
+        rp[i] = ((accreal) tp[i]) >> value;
 #endif
       }
     });
@@ -839,7 +839,7 @@ void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value)
 #if defined(TH_REAL_IS_BYTE)
     TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((scalar_t) *t_data) >> value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
 #else
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((ureal) *t_data) >> value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
+    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (((accreal) *t_data) >> value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
 #endif
   }
 #endif

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -441,7 +441,7 @@ void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
 #elif defined(TH_REAL_IS_BYTE)
           rp[i] = ((scalar_t) tp[i]) >> sp[i];
 #else
-          rp[i] = ((ureal) tp[i]) >> sp[i];
+          rp[i] = ((accreal) tp[i]) >> sp[i];
 #endif
         }
       });
@@ -453,7 +453,7 @@ void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
 #elif defined(TH_REAL_IS_BYTE)
       TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((scalar_t)*t_data) >> *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
 #else
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((ureal)*t_data) >> *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
+      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((accreal)*t_data) >> *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
 #endif
     }
   } else {
@@ -464,7 +464,7 @@ void THTensor_(crshift)(THTensor *r_, THTensor *t, THTensor *src)
 #elif defined(TH_REAL_IS_BYTE)
       TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((scalar_t)*t_data) >> *src_data;);
 #else
-      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((ureal)*t_data) >> *src_data;);
+      TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = ((accreal)*t_data) >> *src_data;);
 #endif
   }
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1479,6 +1479,7 @@ class _TestTorchMixin(object):
         self.assertTrue(x.all())
         self.assertFalse(x.any())
 
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_rshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
             for shift in [-1000, -2, -1, 0, 1, 2, 100]:
@@ -1489,6 +1490,7 @@ class _TestTorchMixin(object):
                     r2 = y >> shift
                     self.assertTrue(np.allclose(r2, r1.cpu().numpy()))
 
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_irshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
             for shift in [-1000, -2, -1, 0, 1, 2, 100]:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1507,6 +1507,31 @@ class _TestTorchMixin(object):
                     y >>= shift
                     self.assertTrue(np.allclose(y, x.cpu().numpy()))
 
+    def test_rshift_same_for_all_devices(self):
+        for val in [-100, -2, -1, 0, 1, 2, 100]:
+            for shift in [-100, -10, 0, 1, 2, 10, 100]:
+                base = torch.tensor([val, val, val], device="cpu")
+                r1 = base >> shift
+                for device in torch.testing.get_all_device_types():
+                    if device == "cpu":
+                        continue
+                    other = torch.tensor([val, val, val], device=device)
+                    r2 = other >> shift
+                    self.assertTrue(torch.allclose(r1, r2.cpu()))
+
+    def test_irshift_same_for_all_devices(self):
+        for val in [-100, -2, -1, 0, 1, 2, 100]:
+            for shift in [-100, -10, 0, 1, 2, 10, 100]:
+                base = torch.tensor([val, val, val], device="cpu")
+                base >>= shift
+                for device in torch.testing.get_all_device_types():
+                    if device == "cpu":
+                        continue
+                    other = torch.tensor([val, val, val], device=device)
+                    other >>= shift
+                    self.assertTrue(torch.allclose(base, other.cpu()))
+
+
     def test_all_any_with_dim(self):
         def test(x):
             r1 = x.prod(dim=0, keepdim=False).byte()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1480,6 +1480,12 @@ class _TestTorchMixin(object):
         self.assertFalse(x.any())
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    #potentially >> can execute differently for shifts greater then number of bits for different OS
+    #for example:
+    #   Mac: np.array([-100]) >> 100 = array([-1])
+    #   Win: np.array([-100]) >> 100 = array([-7])
+    #Also >> can execute differently for shifts less then zero
+    #But the results should be same for "normal" shifts
     def test_rshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
             for shift in [0, 1, 2, 5, 10]:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1487,7 +1487,7 @@ class _TestTorchMixin(object):
                     y = np.array([val, val, val])
                     r1 = x >> shift
                     r2 = y >> shift
-                    self.assertTrue(np.allclose(r2, r1.numpy()))
+                    self.assertTrue(np.allclose(r2, r1.cpu().numpy()))
 
     def test_irshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
@@ -1497,7 +1497,7 @@ class _TestTorchMixin(object):
                     y = np.array([val, val, val])
                     x >>= shift
                     y >>= shift
-                    self.assertTrue(np.allclose(y, x.numpy()))
+                    self.assertTrue(np.allclose(y, x.cpu().numpy()))
 
     def test_all_any_with_dim(self):
         def test(x):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1479,6 +1479,26 @@ class _TestTorchMixin(object):
         self.assertTrue(x.all())
         self.assertFalse(x.any())
 
+    def test_rshift_same_as_numpy(self):
+        for val in [-100, -2, -1, 0, 1, 2, 100]:
+            for shift in [-1000, -2, -1, 0, 1, 2, 100]:
+                for device in torch.testing.get_all_device_types():
+                    x = torch.tensor([val, val, val], device=device)
+                    y = np.array([val, val, val])
+                    r1 = x >> shift
+                    r2 = y >> shift
+                    self.assertTrue(np.allclose(r2, r1.numpy()))
+
+    def test_irshift_same_as_numpy(self):
+        for val in [-100, -2, -1, 0, 1, 2, 100]:
+            for shift in [-1000, -2, -1, 0, 1, 2, 100]:
+                for device in torch.testing.get_all_device_types():
+                    x = torch.tensor([val, val, val], device=device)
+                    y = np.array([val, val, val])
+                    x >>= shift
+                    y >>= shift
+                    self.assertTrue(np.allclose(y, x.numpy()))
+
     def test_all_any_with_dim(self):
         def test(x):
             r1 = x.prod(dim=0, keepdim=False).byte()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1482,7 +1482,7 @@ class _TestTorchMixin(object):
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_rshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
-            for shift in [-1000, -2, -1, 0, 1, 2, 100]:
+            for shift in [0, 1, 2, 100]:
                 for device in torch.testing.get_all_device_types():
                     x = torch.tensor([val, val, val], device=device)
                     y = np.array([val, val, val])
@@ -1493,7 +1493,7 @@ class _TestTorchMixin(object):
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_irshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
-            for shift in [-1000, -2, -1, 0, 1, 2, 100]:
+            for shift in [0, 1, 2, 100]:
                 for device in torch.testing.get_all_device_types():
                     x = torch.tensor([val, val, val], device=device)
                     y = np.array([val, val, val])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1482,7 +1482,7 @@ class _TestTorchMixin(object):
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_rshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
-            for shift in [0, 1, 2, 100]:
+            for shift in [0, 1, 2, 5, 10]:
                 for device in torch.testing.get_all_device_types():
                     x = torch.tensor([val, val, val], device=device)
                     y = np.array([val, val, val])

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1507,31 +1507,6 @@ class _TestTorchMixin(object):
                     y >>= shift
                     self.assertTrue(np.allclose(y, x.cpu().numpy()))
 
-    def test_rshift_same_for_all_devices(self):
-        for val in [-100, -2, -1, 0, 1, 2, 100]:
-            for shift in [-100, -10, 0, 1, 2, 10, 100]:
-                base = torch.tensor([val, val, val], device="cpu")
-                r1 = base >> shift
-                for device in torch.testing.get_all_device_types():
-                    if device == "cpu":
-                        continue
-                    other = torch.tensor([val, val, val], device=device)
-                    r2 = other >> shift
-                    self.assertTrue(torch.allclose(r1, r2.cpu()))
-
-    def test_irshift_same_for_all_devices(self):
-        for val in [-100, -2, -1, 0, 1, 2, 100]:
-            for shift in [-100, -10, 0, 1, 2, 10, 100]:
-                base = torch.tensor([val, val, val], device="cpu")
-                base >>= shift
-                for device in torch.testing.get_all_device_types():
-                    if device == "cpu":
-                        continue
-                    other = torch.tensor([val, val, val], device=device)
-                    other >>= shift
-                    self.assertTrue(torch.allclose(base, other.cpu()))
-
-
     def test_all_any_with_dim(self):
         def test(x):
             r1 = x.prod(dim=0, keepdim=False).byte()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1480,12 +1480,12 @@ class _TestTorchMixin(object):
         self.assertFalse(x.any())
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    #potentially >> can execute differently for shifts greater then number of bits for different OS
-    #for example:
+    # potentially >> can execute differently for shifts greater then number of bits for different OS
+    # for example:
     #   Mac: np.array([-100]) >> 100 = array([-1])
     #   Win: np.array([-100]) >> 100 = array([-7])
-    #Also >> can execute differently for shifts less then zero
-    #But the results should be same for "normal" shifts
+    # Also >> can execute differently for shifts less then zero
+    # But the results should be same for "normal" shifts
     def test_rshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
             for shift in [0, 1, 2, 5, 10]:
@@ -1499,7 +1499,7 @@ class _TestTorchMixin(object):
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_irshift_same_as_numpy(self):
         for val in [-100, -2, -1, 0, 1, 2, 100]:
-            for shift in [0, 1, 2, 100]:
+            for shift in [0, 1, 2, 5, 10]:
                 for device in torch.testing.get_all_device_types():
                     x = torch.tensor([val, val, val], device=device)
                     y = np.array([val, val, val])


### PR DESCRIPTION
Currently rshift function is inconsistent between numpy and pytorch:
```
>>> import torch
>>> import numpy as np
>>> a = torch.tensor([-1], dtype=torch.int, device="cpu")
>>> a >> 1
tensor([2147483647], dtype=torch.int32)
>>> a = torch.tensor([-1], dtype=torch.int, device="cuda")
>>> a >> 1
tensor([-1], device='cuda:0', dtype=torch.int32)
>>> a = np.array([-1])
>>> a >> 1
array([-1])
```