### PR TITLE
Change PyTorch tests to use non-default CUDA stream

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -309,7 +309,7 @@ class CudaMemoryLeakCheck():
         self.beforeStreams = []
         for d in range(torch.cuda.device_count()):
             self.beforeStreams.append(torch.cuda.current_stream(d))
-            deviceStream = torch.cuda.Stream(device = d)
+            deviceStream = torch.cuda.Stream(device=d)
             torch._C._cuda_setStream(deviceStream._cdata)
         torch._C._cuda_setDevice(beforeDevice)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -20,7 +20,7 @@ from common_methods_invocations import tri_tests_args, tri_large_tests_args, \
     _compare_trilu_indices, _compare_large_trilu_indices
 from common_utils import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
     PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_NUMPY, TEST_WITH_ROCM, \
-    load_tests, slowTest
+    load_tests, slowTest, skipCUDAMemoryLeakCheckIf
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -1575,6 +1575,7 @@ class TestCuda(TestCase):
             torch.cuda.current_stream(torch.device('cpu'))
 
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
+    @skipCUDAMemoryLeakCheckIf(True)
     def test_default_stream(self):
         d0 = torch.device('cuda:0')
         d1 = torch.device('cuda:1')
@@ -1605,6 +1606,7 @@ class TestCuda(TestCase):
                                     "Expected a cuda device, but got: cpu"):
             torch.cuda.default_stream(torch.device('cpu'))
 
+    @skipCUDAMemoryLeakCheckIf(True)
     def test_streams(self):
         default_stream = torch.cuda.current_stream()
         user_stream = torch.cuda.Stream()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21420 Change PyTorch tests to use non-default CUDA stream**

Summary: Before test starts CUDA memory leak checker replaces
current streams for each CUDA device with new stream and after
test ends restores current streams to their previous values.

Note that some tests rely on a particular CUDA device to be
selected hence it also preserves the currently selected device.

Note that on two CUDA tests the check was disabled because they
are testing streams behavior and replacing streams interfers with
that logic.

Test Plan: Run unit tests (python test/test_cuda.py)

Reviewers: ezyang

Subscribers:

Tasks: T40579608

Tags:

Differential Revision: [D15674292](https://our.internmc.facebook.com/intern/diff/D15674292)