### PR TITLE
Updated sum() logic to properly deal with bool tensor

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -230,7 +230,7 @@ static ScalarType get_dtype(Tensor& result, const Tensor& self, optional<ScalarT
     return result.scalar_type();
   }
   ScalarType src_type = self.scalar_type();
-  if (promote_integers && at::isIntegralType(src_type)) {
+  if (promote_integers && (at::isIntegralType(src_type) || src_type == ScalarType::Bool)) {
     return kLong;
   }
   return src_type;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2286,6 +2286,7 @@ class _TestTorchMixin(object):
         check_sum_all(torch.tensor([1, 2, 3, 4, 5]))
         check_sum_all(torch.randn(200000))
         check_sum_all(torch.randn(2000, 2)[:, 0])
+        check_sum_all(torch.tensor([True, False, True], dtype=torch.bool))
 
     def _assert_matches_numpy(self, t, n):
         self.assertEqual(n.shape, t.shape)


### PR DESCRIPTION
`torch.tensor([True, False, True], dtype=torch.bool).sum()` should return **2** instead of **True** as it does now. 

Tested via unit tests