### PR TITLE
Fix "warning: missing return statement at end of non-void function"

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -145,6 +145,26 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
 #define C10_EXPAND_MSVC_WORKAROUND(x) x
 
+// On nvcc, C10_UNLIKELY thwarts missing return statement analysis.  In cases
+// where the unlikely expression may be a constant, use this macro to ensure
+// return statement analysis keeps working (at the cost of not getting the
+// likely/unlikely annotation on nvcc). https://github.com/pytorch/pytorch/issues/21418
+//
+// Currently, this is only used in the error reporting macros below.  If you
+// want to use it more generally, move me to Macros.h
+//
+// TODO: Brian Vaughan observed that we might be able to get this to work on nvcc
+// by writing some sort of C++ overload that distinguishes constexpr inputs
+// from non-constexpr.  Since there isn't any evidence that losing C10_UNLIKELY
+// in nvcc is causing us perf problems, this is not yet implemented, but this
+// might be an interesting piece of C++ code for an intrepid bootcamper to
+// write.
+#if defined(__CUDACC__)
+#define C10_UNLIKELY_OR_CONST(e) e
+#else
+#define C10_UNLIKELY_OR_CONST(e) C10_UNLIKELY(e)
+#endif
+
 
 // ----------------------------------------------------------------------------
 // Error reporting macros
@@ -171,7 +191,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 //
 #ifdef C10_MOBILE
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
-  if (C10_UNLIKELY(!(cond))) {                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " INTERNAL ASSERT FAILED at"    \
         __FILE__                              \
@@ -179,7 +199,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #else
 #define TORCH_INTERNAL_ASSERT(cond, ...)      \
-  if (C10_UNLIKELY(!(cond))) {                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error, ::c10::str(        \
         #cond " INTERNAL ASSERT FAILED at ",  \
         __FILE__,                             \
@@ -213,7 +233,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 //
 #ifdef C10_MOBILE
 #define TORCH_CHECK(cond, ...)                \
-  if (C10_UNLIKELY(!(cond))) {                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " CHECK FAILED at "             \
         __FILE__                              \
@@ -221,7 +241,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #else
 #define TORCH_CHECK(cond, ...)                              \
-  if (C10_UNLIKELY(!(cond))) {                              \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
     C10_THROW_ERROR(Error,                                  \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \
@@ -238,7 +258,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // Like TORCH_CHECK, but raises IndexErrors instead of Errors.
 #ifdef C10_MOBILE
 #define TORCH_CHECK_INDEX(cond, ...)          \
-  if (C10_UNLIKELY(!(cond))) {                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {       \
     C10_THROW_ERROR(Error,                    \
         #cond " INDEX CHECK FAILED at "       \
         __FILE__                              \
@@ -246,7 +266,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
   }
 #else
 #define TORCH_CHECK_INDEX(cond, ...)                        \
-  if (C10_UNLIKELY(!(cond))) {                              \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                     \
     C10_THROW_ERROR(IndexError,                             \
       ::c10::detail::if_empty_then(                         \
         ::c10::str(__VA_ARGS__),                            \


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21424 Fix "warning: missing return statement at end of non-void function"**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15676140/)

Fixes #21418

Differential Revision: [D15676140](https://our.internmc.facebook.com/intern/diff/D15676140/)