### PR TITLE
[JIT] Support for NamedTuple

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -31,6 +31,20 @@ std::ostream& printList(std::ostream & out, const c10::ListPtr<T> &v,
   return out;
 }
 
+template<class T>
+std::ostream& printList(std::ostream & out, const std::vector<T> &v,
+  const std::string start, const std::string finish) {
+  out << start;
+  for(size_t i = 0; i < v.size(); ++i) {
+    if(i > 0)
+      out << ", ";
+    // make sure we use ivalue printing, and not default printing for the element type
+    out << IValue(v[i]);
+  }
+  out << finish;
+  return out;
+}
+
 template<typename Dict>
 std::ostream& printDict(std::ostream& out, const Dict& v) {
   out << "{";
@@ -75,7 +89,7 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
     case IValue::Tag::Bool:
       return out << (v.toBool() ? "True" : "False");
     case IValue::Tag::Tuple:
-      return printList(out, v.toTuple().elements(), "(", ")");
+      return printList(out, v.toTuple()->elements(), "(", ")");
     case IValue::Tag::IntList:
       return printList(out, v.toIntList(), "[", "]");
     case IValue::Tag::DoubleList:

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -14,7 +14,7 @@ template<class Key, class Value> class DictPtr;
 template<class T> class ListPtr;
 struct IValue;
 namespace ivalue {
-struct TuplePtr;
+struct Tuple;
 struct Future;
 struct ConstantString;
 struct GenericDict;
@@ -145,11 +145,10 @@ struct CAFFE2_API IValue final {
   c10::intrusive_ptr<caffe2::Blob> toBlob() const &;
 
   // Tuple
-  IValue(ivalue::TuplePtr v);
+  IValue(c10::intrusive_ptr<ivalue::Tuple> v);
   bool isTuple() const { return Tag::Tuple == tag; }
-  ivalue::TuplePtr toTuple() &&;
-  ivalue::TuplePtr toTuple() const &;
-  c10::ArrayRef<IValue> toTupleRef() const;
+  c10::intrusive_ptr<ivalue::Tuple> toTuple() &&;
+  c10::intrusive_ptr<ivalue::Tuple> toTuple() const &;
 
   // Double
   IValue(double d)

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -19,6 +19,7 @@ struct Function;
 namespace c10 {
 struct IValue;
 struct ClassType;
+struct TupleType;
 
 template<class T, class NullType>
 c10::intrusive_ptr<T, NullType> IValue::moveToIntrusivePtr() {
@@ -101,34 +102,42 @@ struct CAFFE2_API ConstantString final : c10::intrusive_ptr_target {
 
 struct Future;
 
-struct CAFFE2_API TuplePtr final {
-private:
-  c10::ListPtr<IValue> elements_;
+struct CAFFE2_API Tuple : c10::intrusive_ptr_target {
+ private:
+   std::vector<IValue> elements_;
 
-  TuplePtr(c10::ListPtr<IValue> elements): elements_(std::move(elements)) {}
-
-public:
-  static TuplePtr create(c10::ListPtr<IValue> elements) {
-    return TuplePtr { std::move(elements) };
+ public:
+  static c10::intrusive_ptr<Tuple> create(std::vector<IValue> elements_, std::shared_ptr<TupleType> type_) {
+    return c10::make_intrusive<Tuple>(std::move(elements_), type_);
   }
-  static TuplePtr create(std::initializer_list<IValue> elements_) {
-    return create(c10::impl::make_generic_list(std::move(elements_)));
-  }
-  static TuplePtr create(std::vector<IValue> elements_) {
-    return create(c10::impl::make_generic_list(std::move(elements_)));
+  static c10::intrusive_ptr<Tuple> create(std::vector<IValue> elements_) {
+    return c10::make_intrusive<Tuple>(std::move(elements_), nullptr);
   }
 
-  c10::ListPtr<IValue> elements() && {
+ const std::vector<IValue>& elements() const & {
+    return elements_;
+  }
+  operator const std::vector<IValue>&() const {
+    return elements();
+  }
+
+  std::vector<IValue>& elements() & {
+    return elements_;
+  }
+  operator std::vector<IValue>&() {
+    return elements();
+  }
+
+  std::vector<IValue>&& elements() && {
     return std::move(elements_);
   }
 
-  const c10::ListPtr<IValue>& elements() const & {
-    return elements_;
-  }
+  std::shared_ptr<TupleType> type;
+ private:
+  Tuple(std::vector<IValue> elements, std::shared_ptr<TupleType> type)
+    : elements_(std::move(elements)), type(std::move(type)) {}
 
-  c10::ListPtr<IValue>& elements() & {
-    return elements_;
-  }
+  friend class c10::intrusive_ptr<Tuple>;
 };
 
 struct Object;
@@ -391,7 +400,7 @@ DEFINE_TO(c10::ListPtr<bool>, toBoolList)
 DEFINE_TO(c10::ListPtr<at::Tensor>, toTensorList)
 DEFINE_TO(c10::impl::GenericListPtr, toGenericList)
 DEFINE_TO(c10::impl::GenericDictPtr, toGenericDict)
-DEFINE_TO(c10::ivalue::TuplePtr, toTuple)
+DEFINE_TO(c10::intrusive_ptr<ivalue::Tuple>, toTuple)
 DEFINE_TO(std::string, toStringRef)
 DEFINE_TO(c10::intrusive_ptr<ivalue::Future>, toFuture)
 DEFINE_TO(IValue, toIValue)
@@ -540,22 +549,18 @@ inline c10::DictPtr<IValue, IValue> IValue::toGenericDict() const & {
   AT_ASSERT(isGenericDict(), "Expected GenericDict but got ", tagKind());
   return c10::DictPtr<IValue, IValue>(toIntrusivePtr<c10::detail::DictImpl>());
 }
-inline ivalue::TuplePtr IValue::toTuple() && {
+inline c10::intrusive_ptr<ivalue::Tuple> IValue::toTuple() && {
   AT_ASSERT(isTuple(), "Expected Tuple but got ", tagKind());
-  return ivalue::TuplePtr::create(c10::ListPtr<IValue>(moveToIntrusivePtr<c10::detail::ListImpl<IValue>>()));
+  return moveToIntrusivePtr<ivalue::Tuple>();
 }
-inline ivalue::TuplePtr IValue::toTuple() const & {
+inline c10::intrusive_ptr<ivalue::Tuple> IValue::toTuple() const & {
   AT_ASSERT(isTuple(), "Expected Tuple but got ", tagKind());
-  return ivalue::TuplePtr::create(c10::ListPtr<IValue>(toIntrusivePtr<c10::detail::ListImpl<IValue>>()));
-}
-inline c10::ArrayRef<IValue> IValue::toTupleRef() const {
-  AT_ASSERT(isTuple(), "Expected Tuple but got ", tagKind());
-  return static_cast<const c10::detail::ListImpl<IValue>*>(payload.as_intrusive_ptr)->list;
+  return toIntrusivePtr<ivalue::Tuple>();
 }
 
-inline IValue::IValue(ivalue::TuplePtr v)
+inline IValue::IValue(c10::intrusive_ptr<ivalue::Tuple> v)
 : tag(Tag::Tuple), is_intrusive_ptr(true) {
-  payload.as_intrusive_ptr = std::move(v).elements().impl_.release();
+  payload.as_intrusive_ptr = v.release();
 }
 inline IValue::IValue(c10::ListPtr<int64_t> v)
 : tag(Tag::IntList), is_intrusive_ptr(true) {

--- a/caffe2/contrib/pytorch/script_module_op.cc
+++ b/caffe2/contrib/pytorch/script_module_op.cc
@@ -103,9 +103,9 @@ class ScriptModuleOp final : public Operator<Context> {
     IValue output = method(inputs);
     if (output.isTuple()) {
       auto elems = std::move(output).toTuple();
-      CAFFE_ENFORCE_EQ(elems.elements().size(), OutputSize());
-      for (int i = 0; i < elems.elements().size(); ++i) {
-        this->SetOutputTensor(i, castIValueToTensor(elems.elements()[i]));
+      CAFFE_ENFORCE_EQ(elems->elements().size(), OutputSize());
+      for (int i = 0; i < elems->elements().size(); ++i) {
+        this->SetOutputTensor(i, castIValueToTensor(elems->elements()[i]));
       }
     } else if (output.isTensor()) {
       CAFFE_ENFORCE_EQ(1, OutputSize());

--- a/test/cpp/api/jit.cpp
+++ b/test/cpp/api/jit.cpp
@@ -106,7 +106,7 @@ TEST(TorchScriptTest, TestTupleArgMatching) {
     )JIT");
 
   std::vector<int64_t> int_list = {1};
-  auto tuple_generic_list = c10::ivalue::TuplePtr::create({ int_list });
+  auto tuple_generic_list = c10::ivalue::Tuple::create({ int_list });
 
   // doesn't fail on arg matching
   module->run_method("tuple_op", tuple_generic_list);
@@ -122,7 +122,7 @@ TEST(TorchScriptTest, TestOptionalArgMatching) {
           return a[0]
     )JIT");
 
-  auto optional_tuple = c10::ivalue::TuplePtr::create({2, std::string("hi")});
+  auto optional_tuple = c10::ivalue::Tuple::create({2, std::string("hi")});
 
   ASSERT_EQ(2, module->run_method("optional_tuple_op", optional_tuple).toInt());
   ASSERT_EQ(

--- a/test/cpp/jit/test_ivalue.h
+++ b/test/cpp/jit/test_ivalue.h
@@ -44,10 +44,10 @@ void testIValue() {
   ASSERT_TRUE(dlist.isNone());
   dlist = IValue(c10::make_list<double>({3.4}));
   ASSERT_TRUE(dlist.toDoubleListRef().equals({3.4}));
-  IValue the_list(ivalue::TuplePtr::create({IValue(3.4), IValue(4), IValue(foo)}));
+  IValue the_list(ivalue::Tuple::create({IValue(3.4), IValue(4), IValue(foo)}));
   ASSERT_EQ(foo.use_count(), 3);
   ASSERT_TRUE(the_list.isTuple());
-  auto first = the_list.toTupleRef()[1];
+  auto first = the_list.toTuple()->elements()[1];
   ASSERT_EQ(first.toInt(), 4);
   at::Tensor tv = at::rand({3, 4});
   IValue ten(tv);

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13066,14 +13066,31 @@ a")
         self.checkScript(fn, ((3, 4),))
         self.checkScript(fn, ())
 
-    def test_named_tuple_error(self):
-        _GoogLeNetOutputs = namedtuple('GoogLeNetOuputs', ['logits', 'aux_logits2', 'aux_logits1'])
+    def test_named_tuple_py2(self):
+        _GoogLeNetOutputs = namedtuple('GoogLeNetOutputs', ['logits', 'aux_logits2', 'aux_logits1'])
 
-        with self.assertRaisesRegex(RuntimeError, 'NamedTuple is currently not supported'):
-            @torch.jit.script
-            def foo(x):
-                return _GoogLeNetOutputs(x, x, x)
+        @torch.jit.script
+        def foo(x):
+            # type: (_GoogLeNetOutputs) -> _GoogLeNetOutputs
+            return x
 
+        vals = torch.rand(3), torch.rand(4), torch.rand(5)
+        out = foo(_GoogLeNetOutputs(logits=vals[0], aux_logits2=vals[1], aux_logits1=vals[2]))
+        self.assertEqual(out.logits, vals[0])
+        self.assertEqual(out.aux_logits2, vals[1])
+        self.assertEqual(out.aux_logits1, vals[2])
+
+    def test_named_tuple_good_error(self):
+        _GoogLeNetOutputs = namedtuple('GoogLeNetOutputs', ['logits', 'aux_logits2', 'aux_logits1'])
+
+        @torch.jit.script
+        def foo(x):
+            # type: (_GoogLeNetOutputs) -> _GoogLeNetOutputs
+            return x
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    r'aka NamedTuple\(logits, aux_logits2, aux_logits1\)'):
+            out = foo(_GoogLeNetOutputs(logits=3, aux_logits2=4, aux_logits1=5))
 
     def _test_pickle_checkpoint(self, device):
         with TemporaryFileName() as fname:

--- a/torch/csrc/jit/argument_spec.cpp
+++ b/torch/csrc/jit/argument_spec.cpp
@@ -156,7 +156,8 @@ ArgumentSpec ArgumentSpecCreator::create(bool with_grad, const Stack& input)
         // consume tuple
         const IValue* iv = stack[stack_top]++;
         AT_ASSERT(iv->isTuple(), "Expected Tuple but got ", iv->tagKind());
-        auto* tup_ptr = &iv->toTupleRef()[0];
+        auto p = *reinterpret_cast<const at::ivalue::Tuple* const*>(iv);
+        auto tup_ptr = &p->elements()[0];
         // push list of tuple elements to the stack
         stack[++stack_top] = tup_ptr;
       } break;

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -827,8 +827,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
               if (num_outputs == 1) {
                 future_->markCompleted(stack.back());
               } else {
-                future_->markCompleted(
-                    c10::ivalue::TuplePtr::create(jit::last(stack, num_outputs).vec()));
+                future_->markCompleted(c10::ivalue::Tuple::create(
+                    jit::last(stack, num_outputs).vec()));
               }
             }
             return false;
@@ -940,8 +940,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       if (num_outputs == 1) {
         push(stack, future_->value());
       } else {
-        auto tuple = future_->value().toTupleRef();
-        for (const IValue& value : tuple) {
+        auto tuple = future_->value().toTuple();
+        for (const IValue& value : tuple->elements()) {
           push(stack, value);
         }
       }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1311,9 +1311,11 @@ Node* Graph::createWithSubgraph(Symbol kind) {
 
 Node* Graph::createTuple(
     at::ArrayRef<Value*> values,
-    c10::OptNameList field_names) {
+    c10::OptNameList field_names,
+    c10::optional<std::string> unqualName) {
   auto types = fmap(values, [](Value* v) { return v->type(); });
-  auto tt = TupleType::create(std::move(types), std::move(field_names));
+  auto tt = TupleType::create(
+      std::move(types), std::move(field_names), std::move(unqualName));
   auto n = create(prim::TupleConstruct, values);
   n->output()->setType(tt);
   return n;

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1063,7 +1063,8 @@ struct Graph {
   TORCH_API Node* createDifferentiableSubgraph();
   TORCH_API Node* createTuple(
       at::ArrayRef<Value*> values,
-      c10::OptNameList field_names = c10::nullopt);
+      c10::OptNameList field_names = c10::nullopt,
+      c10::optional<std::string> unqualName = c10::nullopt);
   TORCH_API Node* createTupleUnpack(Value* v);
   TORCH_API Node* createTupleIndex(
       Value* tup,

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -533,8 +533,12 @@ class ShapePropagator {
       case prim::TupleConstruct: {
         // We refresh the tuple type, because the input types could have been
         // refined.
+        auto orig_type = node->output()->type()->expect<TupleType>();
         node->output()->setType(TupleType::create(
-            fmap(node->inputs(), [](Value* v) { return v->type(); })));
+            fmap(node->inputs(), [](Value* v) { return v->type(); }),
+            orig_type->hasNames() ? c10::make_optional(orig_type->names())
+                                  : c10::nullopt,
+            orig_type->unqualName()));
         return;
       }
       case prim::TupleUnpack: {

--- a/torch/csrc/jit/register_quantized_ops.cpp
+++ b/torch/csrc/jit/register_quantized_ops.cpp
@@ -32,7 +32,7 @@ caffe2::Tensor from_at_tensor(const c10::IValue& v) {
 }
 
 Int8TensorCPU from_proxy(const c10::IValue& proxy) {
-  auto t = proxy.toTupleRef();
+  auto t = proxy.toTuple()->elements();
   Int8TensorCPU r;
   r.t = from_at_tensor(t[0]);
   r.scale = t[1].toDouble();
@@ -44,8 +44,8 @@ at::Tensor to_proxy(const caffe2::Tensor& t) {
   return autograd::make_variable(at::Tensor(t.UnsafeSharedInstance()), false);
 }
 
-c10::ivalue::TuplePtr to_proxy(const Int8TensorCPU& t) {
-  return c10::ivalue::TuplePtr::create({to_proxy(t.t), t.scale, t.zero_point});
+c10::intrusive_ptr<c10::ivalue::Tuple> to_proxy(const Int8TensorCPU& t) {
+  return c10::ivalue::Tuple::create({to_proxy(t.t), t.scale, t.zero_point});
 }
 
 // TODO: replace this with c10 registration when it's ready

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -516,15 +516,6 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     if (auto classType = pyCu.get_class(c10::QualifiedName(qualifiedName))) {
       return std::make_shared<ClassValue>(classType);
     }
-    // Use a heuristic here to identify NamedTuple instances:
-    // 1) must be a subclass of tuple
-    // 2) Has an attribute "_fields"
-    auto tuple_type = reinterpret_cast<PyObject*>(&PyTuple_Type);
-    if (PyObject_IsSubclass(obj.ptr(), tuple_type) &&
-        py::hasattr(obj, "_fields")) {
-      throw ErrorReport(loc)
-          << "NamedTuple is currently not supported in TorchScript";
-    }
   }
 
   if (getRecursiveScriptMode() && py::isinstance<py::function>(obj)) {

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -436,7 +436,9 @@ static Value* packOutputs(
   if (values.size() == 1) {
     return values[0];
   }
-  return g.insertNode(g.createTuple(values, std::move(field_names)))->output();
+  return g
+      .insertNode(g.createTuple(values, std::move(field_names), c10::nullopt))
+      ->output();
 }
 
 // Given a successful match between operator schema and symbol, emit a node

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -215,6 +215,23 @@ struct TORCH_API ClassValue : public SugaredValue {
   ClassTypePtr type_;
 };
 
+struct TORCH_API NamedTupleConstructor : public SugaredValue {
+  explicit NamedTupleConstructor(TupleTypePtr type) : type_(std::move(type)) {}
+
+  std::shared_ptr<SugaredValue> call(
+      const SourceRange& loc,
+      Function& m,
+      at::ArrayRef<NamedValue> inputs,
+      at::ArrayRef<NamedValue> attributes,
+      size_t n_binders) override;
+
+  std::string kind() const override {
+    return type_->str();
+  }
+
+  TupleTypePtr type_;
+};
+
 struct FunctionValue : public SugaredValue {
   FunctionValue(std::shared_ptr<Function> callee)
       : callee_(std::move(callee)) {}

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -96,9 +96,9 @@ Value* TracingState::getValue(const IValue& var) {
   } else if (var.isTuple()) {
     return graph
         ->insertNode(graph->createTuple(fmap(
-            var.toTupleRef(),
+            var.toTuple()->elements(),
             [&](const IValue& val) { return getValue(val); })))
-        ->output(); 
+        ->output();
   } if (var.isTensor()) {
     auto ten = var.toTensor();
     if (!ten.defined()) {
@@ -198,11 +198,9 @@ Value* TracingState::getOutput(const IValue& iv) {
      }
      return it->second;
   } else if (iv.isTuple()) {
-    auto tuple = iv.toTupleRef();
-    auto tuple_node =
-        graph->createTuple(fmap(tuple, [&](const IValue& ival) {
-          return getOutput(ival);
-        }));
+    auto tuple = iv.toTuple()->elements();
+    auto tuple_node = graph->createTuple(
+        fmap(tuple, [&](const IValue& ival) { return getOutput(ival); }));
     graph->insertNode(tuple_node);
     return tuple_node->output();
   } else {
@@ -228,13 +226,13 @@ static IValue addInput(const std::shared_ptr<TracingState> & state, const IValue
         state->graph->insertNode(state->graph->createTupleUnpack(value));
     auto elem_values = unpack_node->outputs();
     auto elem_types = tuple_type->elements();
-    c10::ivalue::TuplePtr tuple = input.toTuple();
-    c10::ListPtr<IValue>& elems = tuple.elements();
+    auto tuple = input.toTuple();
+    auto elems = tuple->elements();
     size_t num_elems = elems.size();
     AT_ASSERT(
         elem_values.size() == num_elems && elem_types.size() == num_elems);
     for (size_t i = 0; i < num_elems; ++i) {
-      elems[i] = addInput(state, elems.get(i), elem_types[i], elem_values[i]);
+      elems[i] = addInput(state, elems.at(i), elem_types[i], elem_values[i]);
     }
     return std::move(tuple);
   } else if (auto dict_type = type->cast<DictType>()) {
@@ -364,7 +362,7 @@ void TracingState::setValue(const IValue& v, Value* value) {
       setValue(outputs.get(i), unpack_node->outputs()[i]);
     }
   } else if (v.isTuple()) {
-    auto outputs = v.toTupleRef();
+    auto outputs = v.toTuple()->elements();
     Node* unpack_node = graph->insertNode(graph->createTupleUnpack(value));
     for (size_t i = 0; i < outputs.size(); ++i) {
       setValue(outputs[i], unpack_node->outputs()[i]);

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -2025,6 +2025,21 @@ def _get_script_class(name):
 # torch.jit.Error
 Error = torch._C.JITException
 
+def _get_named_tuple_properties(obj):
+    assert issubclass(obj, tuple) and hasattr(obj, '_fields')
+    fields = list(obj._fields)
+    annotations = []
+    has_annotations = hasattr(obj, '__annotations__')
+    for field in fields:
+        if has_annotations and field in obj.__annotations__:
+            annotations.append(torch.jit.annotations.ann_to_type(obj.__annotations__[field]))
+        else:
+            annotations.append(torch._C.TensorType.get())
+    return type(obj).__name__, fields, annotations
+
+def _create_named_tuple(t, names, unqual_name):
+    TupleType = collections.namedtuple(unqual_name, names)
+    return TupleType(*t)
 
 class _disable_tracing(object):
     def __enter__(self):


### PR DESCRIPTION
Resolves https://github.com/pytorch/lockdown/issues/18

This implements NamedTuple by taking advantage of the existing `names` field in `TupleType`. 

TODO: This currently doesn't retain the NamedTuple-ness through serialization. Discussed with @suo offline, we can probably make a way to define an anonymous NamedTuple in script (e.g. `NamedTuple('Foo', [('a', int), ('b', float), ('c', List[float])])` and serialize that
TODO: implement support for calling the constructor with kwargs