### PR TITLE
generate tests based on op metadata

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_caffe2.py
+++ b/benchmarks/operator_benchmark/benchmark_caffe2.py
@@ -18,6 +18,7 @@ class Caffe2BenchmarkBase(object):
     """ This is a base class used to create Caffe2 operator benchmark
     """
     tensor_index = 0
+    test_index = 0
 
     def __init__(self):
         self.args = {}
@@ -52,17 +53,22 @@ class Caffe2BenchmarkBase(object):
             ret = int(value)
         return str(ret)
 
-    def test_name(self, **kargs):
+    def test_name(self, name_type, **kargs):
         """ this is a globally unique name which can be used to
             label a specific test
         """
-        test_name_str = []
-        for key in kargs:
-            value = kargs[key]
-            test_name_str.append(
-                key + self._value_to_str(value))
-        name = (self.module_name() + '_' +
-                '_'.join(test_name_str)).replace(" ", "")
+        if name_type == "long": 
+            test_name_str = []
+            for key in kargs:
+                value = kargs[key]
+                test_name_str.append(
+                    key + self._value_to_str(value))
+            name = (self.module_name() + '_' +
+                    '_'.join(test_name_str)).replace(" ", "")
+        elif name_type == "short":
+            # this is used to generate test name based on unique index
+            name = '_'.join([self.module_name(), 'test', str(Caffe2BenchmarkBase.test_index)])
+            Caffe2BenchmarkBase.test_index += 1
         return name
 
 

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-
+from collections import namedtuple
 from benchmark_core import TestConfig
 from benchmark_caffe2 import register_caffe2_op_test_case
 from benchmark_pytorch import register_pytorch_op_test_case
@@ -37,6 +37,52 @@ def generate_test(configs, bench_op, OperatorTestCase, run_backward):
         test_config = TestConfig(test_name, input_config, tags, run_backward)
         if op is not None:
             OperatorTestCase(
+                op,
+                test_config)
+
+
+OpMeta = namedtuple("OpMeta", "op_type num_inputs input_dims input_types \
+                    output_dims num_outputs args")
+
+def generate_c2_test_from_ops(ops_metadata, bench_op, tags):
+    """
+    This function is used to generate Caffe2 tests based on the meatdata
+    of operators. The metadata includes seven fields which are 1) op_type: 
+    the name of the operator. 2) num_inputs: the number of input blobs. 
+    3) input_dims: a dictionary which includes the shapes of the input blobs.
+    4) input_types: a list which includes the types of input blobs. 5) 
+    output_dims: a dictionary which includes the shapes of output blobs.
+    6) num_oupts: the number of output blobs. 7) args: a dictionary which
+    includes the args for th operator. 
+    Here is an example to show the metadata for the WeighedSum operator
+    op_type : WeightedSum
+    num_inputs: 4 
+    input_dims: {'0': [256], '1': [1], '2': [256], '3': [1]}
+    input_types: ['float', 'float', 'float', 'float']
+    output_dims:  {'0': [256]} 
+    num_outputs: 4 
+    args: {}
+    TODO(mingzhe0908): introduce device and add it to the benchmark name 
+    """
+    for op_metadata in ops_metadata:
+        tmp_attrs = OpMeta(op_metadata.op_type, 
+                           op_metadata.num_inputs, 
+                           op_metadata.input_dims,
+                           op_metadata.input_types, 
+                           op_metadata.output_dims, 
+                           op_metadata.num_outputs, 
+                           op_metadata.args)
+        test_attrs = tmp_attrs._asdict()
+        op = bench_op()
+        op.init(**test_attrs)
+        test_name = op.test_name("short")
+        input_config = "Shapes: {}, Type: {}, Args: {}".format(
+            op_metadata.input_dims, 
+            op_metadata.input_types,
+            str(op_metadata.args))
+        test_config = TestConfig(test_name, input_config, tags, run_backward=False)
+        if op is not None:
+            register_caffe2_op_test_case(
                 op,
                 test_config)
 


### PR DESCRIPTION
Summary: This diff introduce a new interface to generate tests based on the metadata of operators.

Differential Revision: D15675542

