### PR TITLE
Enable bool support for several index methods

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -211,6 +211,8 @@
 ]]
 [[
   name: _th_index_select
+  cpu_bool: True
+  cuda_bool: True
   cname: indexSelect
   variants:
     - function

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -228,6 +228,8 @@
 [[
   name: _th_index_copy_
   cname: indexCopy
+  cpu_bool: True
+  cuda_bool: True
   variants: function
   return: argument 0
   arguments:

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -241,6 +241,8 @@
 ]]
 [[
   name: _th_take
+  cpu_bool: True
+  cuda_bool: True
   cname: take
   variants:
     - function
@@ -254,6 +256,8 @@
 ]]
 [[
   name: _th_put_
+  cpu_bool: True
+  cuda_bool: True
   cname: put
   variants: function
   backends:

--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -285,6 +285,8 @@
 ]]
 [[
   name: _th_index_fill_
+  cpu_bool: True
+  cuda_bool: True
   cname: indexFill
   variants: function
   return: argument 0

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -184,6 +184,91 @@ scalar_t THTensor_(maxall)(THTensor *tensor)
   return theMax;
 }
 
+void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index)
+{
+  ptrdiff_t i, numel;
+  THTensor *tSlice, *sSlice;
+  int64_t *index_data;
+  scalar_t *tensor_data, *src_data;
+
+  THArgCheck(THTensor_nDimensionLegacyNoScalars(index) == 1, 3, "Index is supposed to be 1-dimensional");
+  THArgCheck(dim < THTensor_nDimensionLegacyNoScalars(src), 4, "Indexing dim %d is out of bounds of tensor", dim);
+
+  numel = THLongTensor_nElement(index);
+
+  std::vector<int64_t> newSize = THTensor_sizesLegacyNoScalars(src);
+#ifdef DEBUG
+  THAssert(numel <= LONG_MAX);
+#endif
+  newSize[dim] = numel;
+  THTensor_(resize)(tensor,newSize,{});
+
+  index = THLongTensor_newContiguous(index);
+  index_data = THLongTensor_data(index);
+
+  if (dim == 0 && THTensor_(isContiguous)(src) && THTensor_(isContiguous)(tensor))
+  {
+    tensor_data = tensor->data<scalar_t>();
+    src_data = src->data<scalar_t>();
+    auto src_size0 = THTensor_sizeLegacyNoScalars(src, 0);
+    ptrdiff_t rowsize = src_size0 == 0 ? 1 : THTensor_(nElement)(src) / src_size0;
+
+    // check that the indices are within range
+    int64_t max = src_size0 - 1;
+    for (i=0; i<numel; i++) {
+      if (index_data[i] < 0 || index_data[i] > max) {
+        THLongTensor_free(index);
+        THError("index out of range");
+      }
+    }
+
+    // When src is empty, tensor_data maybe nullptr, and the memcpy will trigger
+    // ubsan. So we skip copying at all when every slice to copy is empty.
+    if (rowsize > 0) {
+      if (src->dim() <= 1) {
+        at::parallel_for(0, numel, TH_OMP_OVERHEAD_THRESHOLD,
+            [&](int64_t start, int64_t end) {
+          for (auto i = start; i < end; i++) {
+            tensor_data[i] = src_data[index_data[i]];
+          }
+        });
+      } else {
+        at::parallel_for(0, numel, TH_OMP_OVERHEAD_THRESHOLD / rowsize,
+            [&](int64_t start, int64_t end) {
+          for (auto i = start; i < end; i++) {
+            memcpy(
+              tensor_data + i * rowsize,
+              src_data + index_data[i] * rowsize,
+              rowsize * sizeof(scalar_t));
+          }
+        });
+      }
+    }
+  }
+  else if (src->dim() <= 1)
+  {
+    for (i=0; i<numel; i++)
+      THTensor_(set1d)(tensor,i,THTensor_(get1d)(src,index_data[i]));
+  }
+  else
+  {
+    for (i=0; i<numel; i++)
+    {
+      tSlice = THTensor_(new)();
+      sSlice = THTensor_(new)();
+      THTensor_(select)(tSlice, tensor, dim, i);
+      THTensor_(select)(sSlice, src, dim, index_data[i]);
+      at::Tensor tSlice_wrap = THTensor_wrap(tSlice);
+      at::Tensor sSlice_wrap = THTensor_wrap(sSlice);
+      at::native::copy_(tSlice_wrap, sSlice_wrap);
+      c10::raw::intrusive_ptr::decref(tSlice);
+      c10::raw::intrusive_ptr::decref(sSlice);
+    }
+  }
+
+  THLongTensor_free(index);
+}
+
 #if !defined(TH_REAL_IS_BOOL)
 
 void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
@@ -293,91 +378,6 @@ void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* s
                      cntr++;
                    });
   c10::raw::intrusive_ptr::decref(srct);
-}
-
-void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index)
-{
-  ptrdiff_t i, numel;
-  THTensor *tSlice, *sSlice;
-  int64_t *index_data;
-  scalar_t *tensor_data, *src_data;
-
-  THArgCheck(THTensor_nDimensionLegacyNoScalars(index) == 1, 3, "Index is supposed to be 1-dimensional");
-  THArgCheck(dim < THTensor_nDimensionLegacyNoScalars(src), 4, "Indexing dim %d is out of bounds of tensor", dim);
-
-  numel = THLongTensor_nElement(index);
-
-  std::vector<int64_t> newSize = THTensor_sizesLegacyNoScalars(src);
-#ifdef DEBUG
-  THAssert(numel <= LONG_MAX);
-#endif
-  newSize[dim] = numel;
-  THTensor_(resize)(tensor,newSize,{});
-
-  index = THLongTensor_newContiguous(index);
-  index_data = THLongTensor_data(index);
-
-  if (dim == 0 && THTensor_(isContiguous)(src) && THTensor_(isContiguous)(tensor))
-  {
-    tensor_data = tensor->data<scalar_t>();
-    src_data = src->data<scalar_t>();
-    auto src_size0 = THTensor_sizeLegacyNoScalars(src, 0);
-    ptrdiff_t rowsize = src_size0 == 0 ? 1 : THTensor_(nElement)(src) / src_size0;
-
-    // check that the indices are within range
-    int64_t max = src_size0 - 1;
-    for (i=0; i<numel; i++) {
-      if (index_data[i] < 0 || index_data[i] > max) {
-        THLongTensor_free(index);
-        THError("index out of range");
-      }
-    }
-
-    // When src is empty, tensor_data maybe nullptr, and the memcpy will trigger
-    // ubsan. So we skip copying at all when every slice to copy is empty.
-    if (rowsize > 0) {
-      if (src->dim() <= 1) {
-        at::parallel_for(0, numel, TH_OMP_OVERHEAD_THRESHOLD,
-            [&](int64_t start, int64_t end) {
-          for (auto i = start; i < end; i++) {
-            tensor_data[i] = src_data[index_data[i]];
-          }
-        });
-      } else {
-        at::parallel_for(0, numel, TH_OMP_OVERHEAD_THRESHOLD / rowsize,
-            [&](int64_t start, int64_t end) {
-          for (auto i = start; i < end; i++) {
-            memcpy(
-              tensor_data + i * rowsize,
-              src_data + index_data[i] * rowsize,
-              rowsize * sizeof(scalar_t));
-          }
-        });
-      }
-    }
-  }
-  else if (src->dim() <= 1)
-  {
-    for (i=0; i<numel; i++)
-      THTensor_(set1d)(tensor,i,THTensor_(get1d)(src,index_data[i]));
-  }
-  else
-  {
-    for (i=0; i<numel; i++)
-    {
-      tSlice = THTensor_(new)();
-      sSlice = THTensor_(new)();
-      THTensor_(select)(tSlice, tensor, dim, i);
-      THTensor_(select)(sSlice, src, dim, index_data[i]);
-      at::Tensor tSlice_wrap = THTensor_wrap(tSlice);
-      at::Tensor sSlice_wrap = THTensor_wrap(sSlice);
-      at::native::copy_(tSlice_wrap, sSlice_wrap);
-      c10::raw::intrusive_ptr::decref(tSlice);
-      c10::raw::intrusive_ptr::decref(sSlice);
-    }
-  }
-
-  THLongTensor_free(index);
 }
 
 void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -179,29 +179,6 @@ void THTensor_(bitor)(THTensor *r_, THTensor *t, scalar_t value)
 
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
-void THTensor_(cadd)(THTensor *r_, THTensor *t, scalar_t value, THTensor *src)
-{
-  THTensor_(resizeAs)(r_, t);
-  int64_t r_Size = THTensor_(nElement)(r_);
-  int64_t srcSize = THTensor_(nElement)(src);
-  int r_Contig = THTensor_(isContiguous)(r_);
-  int tContig = THTensor_(isContiguous)(t);
-  int srcContig = THTensor_(isContiguous)(src);
-  if (srcSize == r_Size) {
-    if (r_Contig && tContig && srcContig) {
-      if(r_ == t) {
-        THBlas_(axpy)(THTensor_(nElement)(t), value, src->data<scalar_t>(), 1, r_->data<scalar_t>(), 1);
-      } else {
-        TH_TENSOR_APPLY3_CONTIG(scalar_t, r_, scalar_t, t, scalar_t, src, THVector_(cadd)(r__data, t_data, src_data, value, r__len););
-      }
-    } else {
-      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data + value * *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-    }
-  } else {
-    TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data + value * *src_data;);
-  }
-}
-
 // Should wrap if the value (a) has a different sign than the divisor (b), but is not 0.
 static inline bool modulo_wrap(scalar_t a, scalar_t b) {
   return (a != 0) && (a < 0) != (b < 0);
@@ -225,6 +202,29 @@ void THTensor_(clamp)(THTensor *r_, THTensor *t, scalar_t min_value, scalar_t ma
     });
   } else {
     TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (*t_data < min_value) ? min_value : (*t_data > max_value ? max_value : *t_data);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
+  }
+}
+
+void THTensor_(cadd)(THTensor *r_, THTensor *t, scalar_t value, THTensor *src)
+{
+  THTensor_(resizeAs)(r_, t);
+  int64_t r_Size = THTensor_(nElement)(r_);
+  int64_t srcSize = THTensor_(nElement)(src);
+  int r_Contig = THTensor_(isContiguous)(r_);
+  int tContig = THTensor_(isContiguous)(t);
+  int srcContig = THTensor_(isContiguous)(src);
+  if (srcSize == r_Size) {
+    if (r_Contig && tContig && srcContig) {
+      if(r_ == t) {
+        THBlas_(axpy)(THTensor_(nElement)(t), value, src->data<scalar_t>(), 1, r_->data<scalar_t>(), 1);
+      } else {
+        TH_TENSOR_APPLY3_CONTIG(scalar_t, r_, scalar_t, t, scalar_t, src, THVector_(cadd)(r__data, t_data, src_data, value, r__len););
+      }
+    } else {
+      TH_TENSOR_APPLY3_PARALLEL(r_Size, r_Contig, tContig, srcContig, scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data + value * *src_data;, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
+    }
+  } else {
+    TH_TENSOR_APPLY3(scalar_t, r_, scalar_t, t, scalar_t, src, *r__data = *t_data + value * *src_data;);
   }
 }
 

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -64,6 +64,8 @@ TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, scalar_t value);
 
 TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
+TH_API void THTensor_(take)(THTensor *tensor, THTensor *src, THLongTensor *index);
+TH_API void THTensor_(put)(THTensor *tensor, THLongTensor *index, THTensor *src, int accumulate);
 
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
@@ -74,8 +76,6 @@ TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTe
 
 TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
-TH_API void THTensor_(take)(THTensor *tensor, THTensor *src, THLongTensor *index);
-TH_API void THTensor_(put)(THTensor *tensor, THLongTensor *index, THTensor *src, int accumulate);
 
 TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -66,6 +66,7 @@ TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THL
 TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(take)(THTensor *tensor, THTensor *src, THLongTensor *index);
 TH_API void THTensor_(put)(THTensor *tensor, THLongTensor *index, THTensor *src, int accumulate);
+TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
@@ -73,9 +74,6 @@ TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t
 TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
 TH_API void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* src);
-
-TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
-TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 
 TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
@@ -86,6 +84,8 @@ TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 
 TH_API void THTensor_(neg)(THTensor *self, THTensor *src);
 TH_API void THTensor_(cinv)(THTensor *self, THTensor *src);
+
+TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 
 TH_API void THTensor_(add)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(sub)(THTensor *r_, THTensor *t, scalar_t value);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -62,6 +62,8 @@ TH_API void THTensor_(cmin)(THTensor *r, THTensor *t, THTensor *src);
 TH_API void THTensor_(cmaxValue)(THTensor *r, THTensor *t, scalar_t value);
 TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, scalar_t value);
 
+TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
+
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
 TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value);
@@ -69,7 +71,6 @@ TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor
 TH_API void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* src);
 
-TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -63,6 +63,7 @@ TH_API void THTensor_(cmaxValue)(THTensor *r, THTensor *t, scalar_t value);
 TH_API void THTensor_(cminValue)(THTensor *r, THTensor *t, scalar_t value);
 
 TH_API void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
+TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 
 #if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
@@ -71,7 +72,6 @@ TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor
 TH_API void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* src);
 
-TH_API void THTensor_(indexCopy)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(indexFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 TH_API void THTensor_(take)(THTensor *tensor, THTensor *src, THLongTensor *index);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -75,6 +75,8 @@ TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor
 TH_API void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* src);
 
+TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
+
 TH_API void THTensor_(gather)(THTensor *tensor, THTensor *src, int dim, THLongTensor *index);
 TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
@@ -84,8 +86,6 @@ TH_API accreal THTensor_(dot)(THTensor *t, THTensor *src);
 
 TH_API void THTensor_(neg)(THTensor *self, THTensor *src);
 TH_API void THTensor_(cinv)(THTensor *self, THTensor *src);
-
-TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 
 TH_API void THTensor_(add)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(sub)(THTensor *r_, THTensor *t, scalar_t value);

--- a/aten/src/THC/THCTensorIndex.cu
+++ b/aten/src/THC/THCTensorIndex.cu
@@ -480,3 +480,7 @@ void dispatchTakePut(THCState *state, TensorType *a, TensorType *b, THCudaLongTe
 
 #include <THC/generic/THCTensorIndex.cu>
 #include <THC/THCGenerateAllTypes.h>
+
+
+#include <THC/generic/THCTensorIndex.cu>
+#include <THC/THCGenerateBoolType.h>

--- a/aten/src/THC/THCTensorMath.h
+++ b/aten/src/THC/THCTensorMath.h
@@ -61,6 +61,9 @@
 #include <THC/generic/THCTensorIndex.h>
 #include <THC/THCGenerateAllTypes.h>
 
+#include <THC/generic/THCTensorIndex.h>
+#include <THC/THCGenerateBoolType.h>
+
 #include <THC/generic/THCTensorSort.h>
 #include <THC/THCGenerateAllTypes.h>
 

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -175,8 +175,6 @@ void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, in
 #undef LARGE_INDEX
 }
 
-#if !defined(THC_REAL_IS_BOOL) /* non bool only part */
-
 // Check tensor dimensions for index operations, and return the slice size.
 // src can be nullptr in case of indexFill: in that case it is ignored.
 static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
@@ -357,6 +355,8 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
 #undef SMALL_INDEX
 #undef LARGE_INDEX
 }
+
+#if !defined(THC_REAL_IS_BOOL) /* non bool only part */
 
 void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLongTensor *index)
 {

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -4,6 +4,179 @@
 
 #include "ATen/cuda/CUDAContext.h"
 
+// Compare the stride between adjacent slices (sliceStride) with strides in the
+// other dimensions (i.e., strides *inside* each slice).
+//
+// - Returns true if some dimension inside the slice has lower stride than
+//   sliceStride.  The simplest example is a 2-D contiguous tensor with sliceDim
+//   == 0 (that is, each slice is a row).
+//
+//   In this case, we choose the CUDA kernel that processes the data in
+//   "index-major order".  For example, if thread count equals slice size, then
+//   all threads process slice #0 in lockstep, and then slice #1, and so on.
+//
+// - Otherwise (i.e., sliceStride has the lowest value), this function returns
+//   false.  The simplest example is a 2-D contiguous tensor with sliceDim == 1
+//   (each slice is a column).
+//
+//   In this case, we choose the CUDA kernel that processes the data in
+//   "elementInSlice-major order".  For example, each thread can process element
+//   #0 of every slice, and then element #1 of every slice, and so on.
+bool THCTensor_(indexShouldBeMajor)(TensorInfo<scalar_t, unsigned int> &info,
+                                    int sliceDim)
+{
+  // The stride between adjacent slices (e.g., between element #0 of slice #100
+  // and element #0 of slice #101).
+  unsigned int sliceStride = info.strides[sliceDim];
+
+  for (int i = 0; i < info.dims; ++i) {
+    if (i != sliceDim && info.sizes[i] > 1 && info.strides[i] < sliceStride) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, int dim, THCudaLongTensor *indices)
+{
+  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, dst, src, indices));
+
+  int dims = THCTensor_(nDimensionLegacyNoScalars)(state, dst);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
+  dims = THCTensor_(nDimensionLegacyNoScalars)(state, src);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
+  dims = THCudaLongTensor_nDimensionLegacyNoScalars(state, indices);
+  THArgCheck(dims <= MAX_CUTORCH_DIMS, 5, CUTORCH_DIM_WARNING);
+
+  ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
+
+  int srcDims = THCTensor_(nDimensionLegacyNoScalars)(state, src);
+  cudaStream_t stream = THCState_getCurrentStream(state);
+
+  THArgCheck(THCudaLongTensor_nDimensionLegacyNoScalars(state, indices) <= 1, 3,
+             "Index is supposed to be an empty tensor or a vector");
+  THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
+  THArgCheck(srcDims > 0, 2, "Source tensor is empty");
+
+  std::vector<int64_t> newSize = THTensor_sizesLegacyNoScalars(src);
+  newSize[dim] = numIndices;
+  THCTensor_(resize)(state, dst, newSize, {});
+
+  ptrdiff_t dstTotalSize = THCTensor_(nElement)(state, dst);
+  if (dstTotalSize == 0) {
+    return;
+  }
+
+  int indContig = THCudaLongTensor_isContiguous(state, indices);
+
+  // The `src` is partitioned into two parts:
+  // -the size of each slice we are indexing, which is the
+  // total size of the tensor ignoring dimension `dim`;
+  // -the number of indices we are choosing, which is the total size
+  // of the tensor `indices`.
+  int64_t srcSelectDimSize = THCTensor_(sizeLegacyNoScalars)(state, src, dim);
+  ptrdiff_t sliceSize = dstTotalSize / numIndices;
+
+  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+
+#define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM) \
+  indexSelectSmallIndex<TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM>     \
+    <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(           \
+      dstInfo, srcInfo, indicesInfo,                            \
+      dstSelectDim, srcSelectDim, static_cast<TYPE>(sliceSize), \
+      srcSelectDimSize);
+
+#define LARGE_INDEX(TENSOR_TYPE, TYPE,                           \
+                    DST_DIM, SRC_DIM, IDX_DIM, IDX_IS_MAJOR)     \
+  indexSelectLargeIndex<TENSOR_TYPE, TYPE,                       \
+                        DST_DIM, SRC_DIM, IDX_DIM, IDX_IS_MAJOR> \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(            \
+      dstInfo, srcInfo, indicesInfo,                             \
+      dstSelectDim, srcSelectDim, static_cast<TYPE>(dstTotalSize), \
+      static_cast<TYPE>((IDX_IS_MAJOR) ? sliceSize : numIndices),  \
+      srcSelectDimSize);
+
+  dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, (ptrdiff_t)128), (ptrdiff_t)(mpc * 8)));
+  dim3 smallIndexBlock(std::min(sliceSize, (ptrdiff_t)128));
+
+  dim3 largeIndexGrid(std::min(THCCeilDiv(dstTotalSize, (ptrdiff_t)128), (ptrdiff_t)(mpc * 8)));
+  dim3 largeIndexBlock(std::min(dstTotalSize, (ptrdiff_t)128));
+
+  if (THCTensor_canUse32BitIndexMath(state, dst) &&
+      THCTensor_canUse32BitIndexMath(state, src) &&
+      THCTensor_canUse32BitIndexMath(state, indices)) {
+    TensorInfo<scalar_t, unsigned int> dstInfo =
+      getTensorInfo<scalar_t, THCTensor, unsigned int>(state, dst);
+    int dstSelectDim = dstInfo.collapseDims(dim);
+    dstInfo.reduceDim(dstSelectDim);
+
+    TensorInfo<scalar_t, unsigned int> srcInfo =
+      getTensorInfo<scalar_t, THCTensor, unsigned int>(state, src);
+    int srcSelectDim = srcInfo.collapseDims(dim);
+    srcInfo.reduceDim(srcSelectDim);
+
+    TensorInfo<int64_t, unsigned int> indicesInfo =
+      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
+    indicesInfo.collapseDims();
+
+    // A reasonable choice for when to have each thread iterate over
+    // indices to choose
+    if (numIndices <= 16) {
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        SMALL_INDEX(scalar_t, unsigned int, 1, 1, -2);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        SMALL_INDEX(scalar_t, unsigned int, 2, 2, -2);
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        SMALL_INDEX(scalar_t, unsigned int, 3, 3, -2);
+      } else {
+        SMALL_INDEX(scalar_t, unsigned int, -1, -1, -1);
+      }
+    } else {
+      bool indexIsMajor = THCTensor_(indexShouldBeMajor)(dstInfo, dstSelectDim);
+
+      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
+        LARGE_INDEX(scalar_t, unsigned int, 1, 1, -2, true);
+      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
+        if (indexIsMajor) {
+          LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, true);
+        } else {
+          LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, false);
+        }
+      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
+        if (indexIsMajor) {
+          LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, true);
+        } else {
+          LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, false);
+        }
+      } else {
+        LARGE_INDEX(scalar_t, unsigned int, -1, -1, -1, true);
+      }
+    }
+  } else {
+    TensorInfo<scalar_t, uint64_t> dstInfo =
+      getTensorInfo<scalar_t, THCTensor, uint64_t>(state, dst);
+    int dstSelectDim = dstInfo.collapseDims(dim);
+    dstInfo.reduceDim(dstSelectDim);
+
+    TensorInfo<scalar_t, uint64_t> srcInfo =
+      getTensorInfo<scalar_t, THCTensor, uint64_t>(state, src);
+    int srcSelectDim = srcInfo.collapseDims(dim);
+    srcInfo.reduceDim(srcSelectDim);
+
+    TensorInfo<int64_t, uint64_t> indicesInfo =
+      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
+    indicesInfo.collapseDims();
+
+    LARGE_INDEX(scalar_t, uint64_t, -1, -1, -1, true);
+  }
+
+#undef SMALL_INDEX
+#undef LARGE_INDEX
+}
+
+#if !defined(THC_REAL_IS_BOOL) /* non bool only part */
+
 // Check tensor dimensions for index operations, and return the slice size.
 // src can be nullptr in case of indexFill: in that case it is ignored.
 static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
@@ -58,40 +231,6 @@ static ptrdiff_t THCTensor_(getSliceSize)(THCState *state, THCTensor *dst,
   }
 
   return dstSliceSize;
-}
-
-// Compare the stride between adjacent slices (sliceStride) with strides in the
-// other dimensions (i.e., strides *inside* each slice).
-//
-// - Returns true if some dimension inside the slice has lower stride than
-//   sliceStride.  The simplest example is a 2-D contiguous tensor with sliceDim
-//   == 0 (that is, each slice is a row).
-//
-//   In this case, we choose the CUDA kernel that processes the data in
-//   "index-major order".  For example, if thread count equals slice size, then
-//   all threads process slice #0 in lockstep, and then slice #1, and so on.
-//
-// - Otherwise (i.e., sliceStride has the lowest value), this function returns
-//   false.  The simplest example is a 2-D contiguous tensor with sliceDim == 1
-//   (each slice is a column).
-//
-//   In this case, we choose the CUDA kernel that processes the data in
-//   "elementInSlice-major order".  For example, each thread can process element
-//   #0 of every slice, and then element #1 of every slice, and so on.
-bool THCTensor_(indexShouldBeMajor)(TensorInfo<scalar_t, unsigned int> &info,
-                                    int sliceDim)
-{
-  // The stride between adjacent slices (e.g., between element #0 of slice #100
-  // and element #0 of slice #101).
-  unsigned int sliceStride = info.strides[sliceDim];
-
-  for (int i = 0; i < info.dims; ++i) {
-    if (i != sliceDim && info.sizes[i] > 1 && info.strides[i] < sliceStride) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongTensor *indices, THCTensor *src)
@@ -516,141 +655,5 @@ void THCTensor_(indexFill)(THCState *state, THCTensor *dst, int dim, THCudaLongT
 #undef LARGE_INDEX
 }
 
-void THCTensor_(indexSelect)(THCState *state, THCTensor *dst, THCTensor *src, int dim, THCudaLongTensor *indices)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, dst, src, indices));
-
-  int dims = THCTensor_(nDimensionLegacyNoScalars)(state, dst);
-  THArgCheck(dims <= MAX_CUTORCH_DIMS, 2, CUTORCH_DIM_WARNING);
-  dims = THCTensor_(nDimensionLegacyNoScalars)(state, src);
-  THArgCheck(dims <= MAX_CUTORCH_DIMS, 3, CUTORCH_DIM_WARNING);
-  dims = THCudaLongTensor_nDimensionLegacyNoScalars(state, indices);
-  THArgCheck(dims <= MAX_CUTORCH_DIMS, 5, CUTORCH_DIM_WARNING);
-
-  ptrdiff_t numIndices = THCudaLongTensor_nElement(state, indices);
-
-  int srcDims = THCTensor_(nDimensionLegacyNoScalars)(state, src);
-  cudaStream_t stream = THCState_getCurrentStream(state);
-
-  THArgCheck(THCudaLongTensor_nDimensionLegacyNoScalars(state, indices) <= 1, 3,
-             "Index is supposed to be an empty tensor or a vector");
-  THArgCheck(dim < srcDims, 4, "Indexing dim is out of bounds");
-  THArgCheck(srcDims > 0, 2, "Source tensor is empty");
-
-  std::vector<int64_t> newSize = THTensor_sizesLegacyNoScalars(src);
-  newSize[dim] = numIndices;
-  THCTensor_(resize)(state, dst, newSize, {});
-
-  ptrdiff_t dstTotalSize = THCTensor_(nElement)(state, dst);
-  if (dstTotalSize == 0) {
-    return;
-  }
-
-  int indContig = THCudaLongTensor_isContiguous(state, indices);
-
-  // The `src` is partitioned into two parts:
-  // -the size of each slice we are indexing, which is the
-  // total size of the tensor ignoring dimension `dim`;
-  // -the number of indices we are choosing, which is the total size
-  // of the tensor `indices`.
-  int64_t srcSelectDimSize = THCTensor_(sizeLegacyNoScalars)(state, src, dim);
-  ptrdiff_t sliceSize = dstTotalSize / numIndices;
-
-  int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-
-#define SMALL_INDEX(TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM) \
-  indexSelectSmallIndex<TENSOR_TYPE, TYPE, DST_DIM, SRC_DIM, IDX_DIM>     \
-    <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(           \
-      dstInfo, srcInfo, indicesInfo,                            \
-      dstSelectDim, srcSelectDim, static_cast<TYPE>(sliceSize), \
-      srcSelectDimSize);
-
-#define LARGE_INDEX(TENSOR_TYPE, TYPE,                           \
-                    DST_DIM, SRC_DIM, IDX_DIM, IDX_IS_MAJOR)     \
-  indexSelectLargeIndex<TENSOR_TYPE, TYPE,                       \
-                        DST_DIM, SRC_DIM, IDX_DIM, IDX_IS_MAJOR> \
-    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(            \
-      dstInfo, srcInfo, indicesInfo,                             \
-      dstSelectDim, srcSelectDim, static_cast<TYPE>(dstTotalSize), \
-      static_cast<TYPE>((IDX_IS_MAJOR) ? sliceSize : numIndices),  \
-      srcSelectDimSize);
-
-  dim3 smallIndexGrid(std::min(THCCeilDiv(sliceSize, (ptrdiff_t)128), (ptrdiff_t)(mpc * 8)));
-  dim3 smallIndexBlock(std::min(sliceSize, (ptrdiff_t)128));
-
-  dim3 largeIndexGrid(std::min(THCCeilDiv(dstTotalSize, (ptrdiff_t)128), (ptrdiff_t)(mpc * 8)));
-  dim3 largeIndexBlock(std::min(dstTotalSize, (ptrdiff_t)128));
-
-  if (THCTensor_canUse32BitIndexMath(state, dst) &&
-      THCTensor_canUse32BitIndexMath(state, src) &&
-      THCTensor_canUse32BitIndexMath(state, indices)) {
-    TensorInfo<scalar_t, unsigned int> dstInfo =
-      getTensorInfo<scalar_t, THCTensor, unsigned int>(state, dst);
-    int dstSelectDim = dstInfo.collapseDims(dim);
-    dstInfo.reduceDim(dstSelectDim);
-
-    TensorInfo<scalar_t, unsigned int> srcInfo =
-      getTensorInfo<scalar_t, THCTensor, unsigned int>(state, src);
-    int srcSelectDim = srcInfo.collapseDims(dim);
-    srcInfo.reduceDim(srcSelectDim);
-
-    TensorInfo<int64_t, unsigned int> indicesInfo =
-      getTensorInfo<int64_t, THCudaLongTensor, unsigned int>(state, indices);
-    indicesInfo.collapseDims();
-
-    // A reasonable choice for when to have each thread iterate over
-    // indices to choose
-    if (numIndices <= 16) {
-      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
-        SMALL_INDEX(scalar_t, unsigned int, 1, 1, -2);
-      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
-        SMALL_INDEX(scalar_t, unsigned int, 2, 2, -2);
-      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
-        SMALL_INDEX(scalar_t, unsigned int, 3, 3, -2);
-      } else {
-        SMALL_INDEX(scalar_t, unsigned int, -1, -1, -1);
-      }
-    } else {
-      bool indexIsMajor = THCTensor_(indexShouldBeMajor)(dstInfo, dstSelectDim);
-
-      if (dstInfo.dims == 1 && srcInfo.dims == 1 && indContig) {
-        LARGE_INDEX(scalar_t, unsigned int, 1, 1, -2, true);
-      } else if (dstInfo.dims == 2 && srcInfo.dims == 2 && indContig) {
-        if (indexIsMajor) {
-          LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, true);
-        } else {
-          LARGE_INDEX(scalar_t, unsigned int, 2, 2, -2, false);
-        }
-      } else if (dstInfo.dims == 3 && srcInfo.dims == 3 && indContig) {
-        if (indexIsMajor) {
-          LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, true);
-        } else {
-          LARGE_INDEX(scalar_t, unsigned int, 3, 3, -2, false);
-        }
-      } else {
-        LARGE_INDEX(scalar_t, unsigned int, -1, -1, -1, true);
-      }
-    }
-  } else {
-    TensorInfo<scalar_t, uint64_t> dstInfo =
-      getTensorInfo<scalar_t, THCTensor, uint64_t>(state, dst);
-    int dstSelectDim = dstInfo.collapseDims(dim);
-    dstInfo.reduceDim(dstSelectDim);
-
-    TensorInfo<scalar_t, uint64_t> srcInfo =
-      getTensorInfo<scalar_t, THCTensor, uint64_t>(state, src);
-    int srcSelectDim = srcInfo.collapseDims(dim);
-    srcInfo.reduceDim(srcSelectDim);
-
-    TensorInfo<int64_t, uint64_t> indicesInfo =
-      getTensorInfo<int64_t, THCudaLongTensor, uint64_t>(state, indices);
-    indicesInfo.collapseDims();
-
-    LARGE_INDEX(scalar_t, uint64_t, -1, -1, -1, true);
-  }
-
-#undef SMALL_INDEX
-#undef LARGE_INDEX
-}
-
+#endif
 #endif

--- a/aten/src/THC/generic/THCTensorIndex.cu
+++ b/aten/src/THC/generic/THCTensorIndex.cu
@@ -356,8 +356,6 @@ void THCTensor_(indexCopy)(THCState *state, THCTensor *dst, int dim, THCudaLongT
 #undef LARGE_INDEX
 }
 
-#if !defined(THC_REAL_IS_BOOL) /* non bool only part */
-
 void THCTensor_(take)(THCState *state, THCTensor *dst, THCTensor *src, THCudaLongTensor *index)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, dst, src));
@@ -421,6 +419,8 @@ void THCTensor_(put)(THCState *state, THCTensor *dst, THCudaLongTensor *index, T
     dispatchTakePut<scalar_t, TensorPutOp>(state, dst, src, index);
   }
 }
+
+#if !defined(THC_REAL_IS_BOOL) /* non bool only part */
 
 void THCTensor_(indexAdd)(THCState *state, THCTensor *dst, int dim, THCudaLongTensor *indices, THCTensor *src)
 {

--- a/aten/src/THC/generic/THCTensorIndex.h
+++ b/aten/src/THC/generic/THCTensorIndex.h
@@ -3,10 +3,10 @@
 #else
 
 THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
+THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 
 #if !defined(THC_REAL_IS_BOOL) /* non bool only part */
 
-THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 THC_API void THCTensor_(indexAdd)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
 THC_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);

--- a/aten/src/THC/generic/THCTensorIndex.h
+++ b/aten/src/THC/generic/THCTensorIndex.h
@@ -2,15 +2,14 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorIndex.h"
 #else
 
-THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
 THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
+THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
+THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
 THC_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);
 THC_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor *indices, THCTensor *src, int accumulate);
 
 #if !defined(THC_REAL_IS_BOOL) /* non bool only part */
-
 THC_API void THCTensor_(indexAdd)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
-THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
-
 #endif
+
 #endif

--- a/aten/src/THC/generic/THCTensorIndex.h
+++ b/aten/src/THC/generic/THCTensorIndex.h
@@ -4,13 +4,13 @@
 
 THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
 THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
+THC_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);
+THC_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor *indices, THCTensor *src, int accumulate);
 
 #if !defined(THC_REAL_IS_BOOL) /* non bool only part */
 
 THC_API void THCTensor_(indexAdd)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
-THC_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);
-THC_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor *indices, THCTensor *src, int accumulate);
 
 #endif
 #endif

--- a/aten/src/THC/generic/THCTensorIndex.h
+++ b/aten/src/THC/generic/THCTensorIndex.h
@@ -2,11 +2,15 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorIndex.h"
 #else
 
+THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
+
+#if !defined(THC_REAL_IS_BOOL) /* non bool only part */
+
 THC_API void THCTensor_(indexCopy)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 THC_API void THCTensor_(indexAdd)(THCState *state, THCTensor *res_, int dim, THCudaLongTensor *indices, THCTensor *src);
 THC_API void THCTensor_(indexFill)(THCState *state, THCTensor *tensor, int dim, THCudaLongTensor *index, scalar_t val);
-THC_API void THCTensor_(indexSelect)(THCState *state, THCTensor *tensor, THCTensor *src, int dim, THCudaLongTensor *index);
 THC_API void THCTensor_(take)(THCState *state, THCTensor *res_, THCTensor *src, THCudaLongTensor *index);
 THC_API void THCTensor_(put)(THCState *state, THCTensor *res_, THCudaLongTensor *indices, THCTensor *src, int accumulate);
 
+#endif
 #endif

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2286,7 +2286,6 @@ class _TestTorchMixin(object):
         check_sum_all(torch.tensor([1, 2, 3, 4, 5]))
         check_sum_all(torch.randn(200000))
         check_sum_all(torch.randn(2000, 2)[:, 0])
-        check_sum_all(torch.tensor([True, False, True], dtype=torch.bool))
 
     def _assert_matches_numpy(self, t, n):
         self.assertEqual(n.shape, t.shape)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7578,6 +7578,17 @@ class _TestTorchMixin(object):
             dest2[idx[i]] = dest2[idx[i]] + src[i]
         self.assertEqual(dest, dest2)
 
+    def test_index_fill(self):
+        for device in torch.testing.get_all_device_types():
+            for dt in torch.testing.get_all_dtypes():
+                if dt == torch.half:
+                    continue
+
+                x = torch.tensor([[1, 2], [4, 5]], dtype=dt, device=device)
+                index = torch.tensor([0], device=device)
+                x.index_fill_(1, index, 0)
+                self.assertEqual(x, torch.tensor([[0, 2], [0, 5]], dtype=dt, device=device))
+
     def test_index_select(self):
         for device in torch.testing.get_all_device_types():
             src = torch.randn(3, 4, 5, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2382,7 +2382,6 @@ class _TestTorchMixin(object):
         res2 = torch.Tensor()
         torch.sum(x, 1, out=res2)
         self.assertEqual(res1, res2)
-
         x = torch.rand(100, 100, 100)
         res1 = x.sum(2).sum(1)
         res2 = torch.Tensor()
@@ -3274,7 +3273,7 @@ class _TestTorchMixin(object):
             self.assertIs(default_dtype, torch.tensor(()).dtype)
             self.assertIs(default_dtype, torch.tensor(5.).dtype)
             self.assertIs(torch.int64, torch.tensor(5).dtype)
-            self.assertIs(torch.uint8, torch.tensor(True).dtype)
+            self.assertIs(torch.bool, torch.tensor(True).dtype)
             self.assertIs(torch.int32, torch.tensor(5, dtype=torch.int32).dtype)
             self.assertIs(default_dtype, torch.tensor(((7, 5), (9, 5.))).dtype)
             self.assertIs(default_dtype, torch.tensor(((5., 5), (3, 5))).dtype)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7531,24 +7531,32 @@ class _TestTorchMixin(object):
             reference[0.0, :, 0.0] = 1
 
     def test_index_copy(self):
-        num_copy, num_dest = 3, 20
-        dest = torch.randn(num_dest, 4, 5)
-        src = torch.randn(num_copy, 4, 5)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
-        dest2 = dest.clone()
-        dest.index_copy_(0, idx, src)
-        for i in range(idx.size(0)):
-            dest2[idx[i]] = src[i]
-        self.assertEqual(dest, dest2, 0)
+        for device in torch.testing.get_all_device_types():
+            num_copy, num_dest = 3, 20
+            dest = torch.randn(num_dest, 4, 5, device=device)
+            src = torch.randn(num_copy, 4, 5, device=device)
+            idx = torch.randperm(num_dest, device=device).narrow(0, 0, num_copy)
+            dest2 = dest.clone()
+            dest.index_copy_(0, idx, src)
+            for i in range(idx.size(0)):
+                dest2[idx[i]] = src[i]
+            self.assertEqual(dest, dest2, 0)
 
-        dest = torch.randn(num_dest)
-        src = torch.randn(num_copy)
-        idx = torch.randperm(num_dest).narrow(0, 0, num_copy)
-        dest2 = dest.clone()
-        dest.index_copy_(0, idx, src)
-        for i in range(idx.size(0)):
-            dest2[idx[i]] = src[i]
-        self.assertEqual(dest, dest2, 0)
+            dest = torch.randn(num_dest, device=device)
+            src = torch.randn(num_copy, device=device)
+            idx = torch.randperm(num_dest, device=device).narrow(0, 0, num_copy)
+            dest2 = dest.clone()
+            dest.index_copy_(0, idx, src)
+            for i in range(idx.size(0)):
+                dest2[idx[i]] = src[i]
+            self.assertEqual(dest, dest2, 0)
+
+            # Bool tensor
+            dest = torch.zeros(2, 2, dtype=torch.bool, device=device)
+            src = torch.tensor([[True, True], [True, True]], device=device)
+            index = torch.tensor([0, 1], device=device)
+            dest.index_copy_(0, index, src)
+            self.assertEqual(dest, torch.tensor([[True, True], [True, True]], device=device))
 
     def test_index_add(self):
         num_copy, num_dest = 3, 3

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7642,6 +7642,7 @@ class _TestTorchMixin(object):
         idx = torch.LongTensor([[0, 2], [3, 4]])
         check(src, idx)
         check(src.transpose(1, 2), idx)
+        check(src.bool(), idx)
 
     def test_take_empty(self):
         for device in torch.testing.get_all_device_types():
@@ -7664,6 +7665,9 @@ class _TestTorchMixin(object):
         values = torch.randn(2, 2)
         check(dst, idx, values)
         check(dst.transpose(1, 2), idx, values)
+
+        values = torch.tensor([[False, False], [False, False]])
+        check(dst.bool(), idx, values)
 
     def test_put_accumulate(self):
         dst = torch.ones(2, 2)


### PR DESCRIPTION
Enable bool tensors for these index methods: 
- index_select
- index_copy
- put
- take
- index_fill

Tested via unit tests


TODO: 
Enable index_add in a separate PR as it requires more "side" changes.