### PR TITLE
[jit] make containedElements a vector

### DIFF
--- a/test/cpp/jit/test_alias_analysis.h
+++ b/test/cpp/jit/test_alias_analysis.h
@@ -948,10 +948,10 @@ void testMemoryDAG() {
     MemoryDAG t;
     auto a = t.makeFreshValue(aValue);
     auto b = t.makeFreshValue(bValue);
-    t.addToContainedElements(a, b);
+    t.appendToContainedElements(a, b);
 
     auto c = t.makeFreshValue(cValue);
-    t.addToContainedElements(a, c);
+    t.appendToContainedElements(a, c);
 
     AT_ASSERT(t.mayContainAlias(a, b));
     AT_ASSERT(t.mayContainAlias(b, a));
@@ -972,7 +972,7 @@ void testMemoryDAG() {
     // b(a)
     // c(a)
     // d(b(a))
-    t.addToContainedElements(b, d);
+    t.appendToContainedElements(b, d);
     AT_ASSERT(t.mayContainAlias(b, d));
     AT_ASSERT(t.mayContainAlias(d, b));
 
@@ -985,7 +985,7 @@ void testMemoryDAG() {
     auto f = t.makeFreshValue(aValue);
     auto e = t.makeFreshValue(bValue);
 
-    t.addToContainedElements(f, e);
+    t.appendToContainedElements(f, e);
 
     for (auto elem : {a, b, c, d}) {
       AT_ASSERT(!t.mayContainAlias(f, elem));

--- a/torch/csrc/jit/passes/alias_analysis.h
+++ b/torch/csrc/jit/passes/alias_analysis.h
@@ -147,9 +147,6 @@ class AliasDb {
    */
   void makeAllAlias(const std::vector<Value*>& values);
   void makePointerTo(const Value* value, const Value* to);
-  TORCH_API void addToContainedElements(
-      const Value* element,
-      const Value* container);
   void assignWildcardToContained(Element* e, const TypePtr& type);
   void assignWildcardToContained(const Value* v);
   void mapAliases(at::ArrayRef<Value*> to, at::ArrayRef<Value*> from);

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -46,7 +46,7 @@ class TORCH_API MemoryDAG {
   // `to`'s contained elements.
   void makePointerTo(Element* from, Element* to);
 
-  void addToContainedElements(Element* contained, Element* container);
+  void appendToContainedElements(Element* contained, Element* container);
 
   // Make a fresh element (i.e. an element that doesn't point to anything) and
   // return it.
@@ -97,7 +97,11 @@ struct Element {
   MemoryLocations pointedFrom;
 
   // Elements can contain other elements (e.g. List[Tensor])
-  MemoryLocations containedElements;
+  // This is a vector instead of bitset because index matters.
+  //
+  // NOTE: elements MAY BE nullptr; this represents that they are non-aliasing
+  // types.
+  std::vector<Element*> containedElements;
 
   // Return the unique memory locations that `Element` might represent.
   TORCH_API const MemoryLocations& getMemoryLocations() const;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21450 [jit] fix tuple index and slicing
* **#21445 [jit] make containedElements a vector**
* #21431 [jit] Track contained elements in alias analysis.
* #21430 [jit] cleanups to memory_dag
* #21397 [jit] cleanups to alias analysis interfaces
* #21396 [jit] avoid calling front() on empty working set

The bitset doesn't preserve ordering, which will be important for doing
contained element analysis on tuples/classes.

One annoying thing: If we have a tuple like `(Tensor, int, Tensor)`, we
want the contained elements to match, so that indexing into
`type->containedTypes()` is the same as indexing into
`el->containedElements()`. But since `int` is not mutable, we need to
make the vector `(Element*, nullptr, Element*)`. Open to suggestions how
to avoid.