### PR TITLE
Add batch id to tracer event

### DIFF
--- a/caffe2/core/net_async_base.cc
+++ b/caffe2/core/net_async_base.cc
@@ -399,6 +399,10 @@ bool AsyncNetBase::run(int task_id, int stream_id) noexcept {
     if (!options_.finish_chain_) {
       asyncWait(task_id, stream_id, parents(task_id));
     }
+    int iter_id = -1;
+    if (tracer_) {
+      iter_id = tracer_->getIter();
+    }
     for (auto& op_id : chains_[task_id]) {
       op = operators_[op_id];
       bool success = false;
@@ -409,7 +413,9 @@ bool AsyncNetBase::run(int task_id, int stream_id) noexcept {
             tracing::TRACE_TASK,
             task_id,
             tracing::TRACE_STREAM,
-            stream_id);
+            stream_id,
+            tracing::TRACE_ITER,
+            iter_id);
         success = op->RunAsync(stream_id);
       } else {
         counters_.AddPerOpStartTime(op_id);

--- a/caffe2/core/net_async_tracing.cc
+++ b/caffe2/core/net_async_tracing.cc
@@ -145,6 +145,10 @@ std::string Tracer::serializeEvent(const TracerEvent& event) {
       int_args["task_id"] = event.task_id_;
     }
 
+    if (event.iter_ >= 0) {
+      int_args["iter_id"] = event.iter_;
+    }
+
     if (event.stream_id_ >= 0) {
       int_args["stream_id"] = event.stream_id_;
     }
@@ -258,6 +262,10 @@ int Tracer::bumpIter() {
   return iter_++;
 }
 
+int Tracer::getIter() {
+  return iter_;
+}
+
 int Tracer::bumpDumpingIter() {
   return dumping_iter_++;
 }
@@ -332,6 +340,10 @@ void TracerGuard::addArgument(TracingField field, int value) {
     }
     case TRACE_THREAD: {
       event_.thread_label_ = value;
+      break;
+    }
+    case TRACE_ITER: {
+      event_.iter_ = value;
       break;
     }
     default: {

--- a/caffe2/core/net_async_tracing.h
+++ b/caffe2/core/net_async_tracing.h
@@ -39,6 +39,7 @@ struct CAFFE2_API TracerEvent {
   bool is_beginning_ = false;
   long thread_label_ = -1;
   std::thread::id tid_;
+  int iter_ = -1;
 };
 
 enum TracingField {
@@ -48,6 +49,7 @@ enum TracingField {
   TRACE_THREAD,
   TRACE_NAME,
   TRACE_CATEGORY,
+  TRACE_ITER,
 };
 
 enum class TracingMode {
@@ -87,6 +89,7 @@ class CAFFE2_API Tracer {
     return config_;
   }
   int bumpIter();
+  int getIter();
   int bumpDumpingIter();
   // Dump the tracing result to file with given suffix, and then
   // clear current events.


### PR DESCRIPTION
Summary: this is used for easier tracing of iter id when looking at trace diagram

Differential Revision: D15628950

