### PR TITLE
[jit] fix tuple index and slicing

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10959,6 +10959,30 @@ a")
         self.checkScriptRaisesRegex(test_indexing_out_of_bounds_pos, (), Exception,
                                     "out of range")
 
+        def negative_index():
+            tup = (1, 2, 3, 4)
+            return tup[-1]
+
+        self.checkScript(negative_index, [])
+
+        def really_negative_index():
+            tup = (1, 2, 3, 4)
+            return tup[-100]
+
+        self.checkScriptRaisesRegex(really_negative_index, [], Exception, "index out of range")
+
+        def negative_slice():
+            tup = (1, 2, 3, 4)
+            return tup[-3:4]
+
+        self.checkScript(negative_slice, [])
+
+        def really_slice_out_of_bounds():
+            tup = (1, 2, 3, 4)
+            return tup[-300:4000]
+
+        self.checkScript(really_slice_out_of_bounds, [])
+
     def test_namedtuple_attr(self):
         def f(x):
             return x.max(dim=1).indices + torch.max(x, dim=1).indices

--- a/torch/csrc/jit/range_utils.h
+++ b/torch/csrc/jit/range_utils.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace torch {
+namespace jit {
+// Convert an python index (which may be negative) into an index usable for a
+// C++ container
+inline size_t normalizeIndex(int64_t idx, size_t list_size) {
+  if (idx < 0) {
+    // Handle negative indexing
+    idx = list_size + idx;
+  }
+  return idx;
+}
+
+// Clamp `start` and `end` in the way Python does for iterable slicing.
+inline std::pair<size_t, size_t> clamp_bounds(
+    int64_t start,
+    int64_t end,
+    size_t list_size) {
+  const size_t normalized_start =
+      std::max((size_t)0, normalizeIndex(start, list_size));
+  const size_t normalized_end =
+      std::min(list_size, normalizeIndex(end, list_size));
+  return std::pair<size_t, size_t>(normalized_start, normalized_end);
+}
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21450 [jit] fix tuple index and slicing**
* #21445 [jit] make containedElements a vector
* #21431 [jit] Track contained elements in alias analysis.
* #21430 [jit] cleanups to memory_dag
* #21397 [jit] cleanups to alias analysis interfaces
* #21396 [jit] avoid calling front() on empty working set

Previously, we were not correctly normalizing slices/indexes.
Closes https://github.com/pytorch/lockdown/issues/102