### PR TITLE
Kill apt-get even harder, and before we purge.

### DIFF
--- a/.circleci/scripts/setup_linux_system_environment.sh
+++ b/.circleci/scripts/setup_linux_system_environment.sh
@@ -29,12 +29,13 @@ done
 # See if we actually were successful
 systemctl list-units --all | cat
 
+# For good luck, try even harder to kill apt-get
+sudo pkill apt-get || true
+
+# For even better luck, purge unattended-upgrades
 sudo apt-get purge -y unattended-upgrades
 
 cat /etc/apt/sources.list
-
-# For good luck, try even harder to kill apt-get
-pkill apt-get || true
 
 # Bail out early if we detect apt/dpkg is stuck
 ps auxfww | (! grep '[a]pt')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21464 Kill apt-get even harder, and before we purge.**

In recent flaky builds https://circleci.com/gh/pytorch/pytorch/1929183?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link I observed:

* The `pkill apt-get` isn't actually doing anything because I didn't run it under sudo
* It's running too late, `apt-get purge` will fail if there's a straggling apt process (we kill after purging)

I don't know if this is a 100% fix, but rearrange the script to deal with  these things.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D15694828](https://our.internmc.facebook.com/intern/diff/D15694828)