### PR TITLE
add cancelAsyncCallback method to OperatorBase

### DIFF
--- a/caffe2/core/net_async_scheduling.cc
+++ b/caffe2/core/net_async_scheduling.cc
@@ -156,6 +156,7 @@ void AsyncSchedulingNet::schedule(int task_id, bool run_inline) noexcept {
             // SetFinished may throw, e.g. when we call it on already finished
             // event, and in some other cases (CUDA)
             try {
+              lastTaskOp(tid)->CancelAsyncCallback();
               event(tid).SetFinished("Cancelled");
             } catch (const EnforceNotMet&) {
               // ignore

--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -478,6 +478,8 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     return false;
   }
 
+  virtual void CancelAsyncCallback() {}
+
   // RunAsync, if implemenented by the specific operators, will schedule the
   // computation on the corresponding context and record the event in its
   // event_ member object. If the specific operator does not support RunAsync,


### PR DESCRIPTION
Summary:
If one async operator failed, async_scheduling net currently only marks all scheduled async operators as finished without cancelling the callbacks.

The new behavior is to cancel the callbacks first, then set event status to finished.

Differential Revision: D15702475

