### PR TITLE
Fix size of histc return on CPU when input is 0-dimensional and bins=1.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1758,6 +1758,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: false
   arguments:
     - arg: THTensor* result
       output: True

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2646,6 +2646,13 @@ class _TestTorchMixin(object):
                 torch.tensor([0, 2, 1, 0], dtype=torch.float, device=device),
                 actual)
             self.assertEqual(actual.dtype, torch.float)
+            # scalar input and 1 bin -- should return a 1-dimensional tensor, not a scalar.
+            actual = torch.histc(
+                torch.tensor(0, dtype=torch.float, device=device),
+                bins=1, min=0, max=3)
+            self.assertEqual(
+                torch.tensor([1], dtype=torch.float, device=device),
+                actual)
 
         # test against numpy.histogram()
         def test_against_np(tensor, bins=100, min=0, max=0):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21498 Set "scalar_check: false" for some LAPACK functions that can't return scalars.
* **#21497 Fix size of histc return on CPU when input is 0-dimensional and bins=1.**
* #21496 Set "scalar_check: false" for TH methods that can't return scalars.

This triggers the wrong scalar_check unless it is explicitly overridden (because the heuristic uses the shape of the input).
This wasn't an issue on CUDA because it didn't use TH, so doesn't have scalar checks.

Differential Revision: [D15715478](https://our.internmc.facebook.com/intern/diff/D15715478)