### PR TITLE
Set "scalar_check: false" for some LAPACK functions that can't return scalars.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -2412,6 +2412,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: false
   arguments:
     - arg: THTensor* output
       output: True
@@ -2460,6 +2461,7 @@
   variants:
     - function
   return: argument 0,1
+  scalar_check: false
   arguments:
     - arg: THTensor* res1
       output: True
@@ -2478,6 +2480,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: false
   arguments:
     - arg: THTensor* result
       output: True
@@ -2521,6 +2524,7 @@
   variants:
     - function
   return: argument 0
+  scalar_check: false
   arguments:
     - arg: THTensor* result
       output: True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21498 Set "scalar_check: false" for some LAPACK functions that can't return scalars.**
* #21497 Fix size of histc return on CPU when input is 0-dimensional and bins=1.
* #21496 Set "scalar_check: false" for TH methods that can't return scalars.

Differential Revision: [D15715477](https://our.internmc.facebook.com/intern/diff/D15715477)