### PR TITLE
Refactored math tests to iterate over all math ops

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6138,32 +6138,38 @@ a")
                     msg = ("Failed on {func_name} with inputs {a} {b}. Python: {res_python}, Script: {res_script}"
                            .format(func_name=func_name, a=a, b=b, res_python=res_python, res_script=res_script))
                     self.assertEqual(res_python, res_script, message=msg, prec=(1e-4) * max(abs(res_python), res_script))
-
-        unary_float_ops = ["log", "log1p", "log10", "exp", "sqrt", "gamma", "lgamma", "erf",
-                           "erfc", "expm1", "fabs", "acos", "asin", "atan", "cos", "sin", "tan",
-                           "asinh", "atanh", "acosh", "sinh", "cosh", "tanh", "degrees", "radians"]
-        binary_float_ops = ["atan2", "fmod", "copysign"]
-        for op in unary_float_ops:
-            checkMathWrap(op, 1)
-        for op in binary_float_ops:
-            checkMathWrap(op, 2)
-
-        checkMath("modf", 1, ret_type="Tuple[float, float]")
-        checkMath("frexp", 1, ret_type="Tuple[float, int]")
-        checkMath("isnan", 1, ret_type="bool")
-        checkMath("isinf", 1, ret_type="bool")
-        checkMath("ldexp", 2, is_float=False, ret_type="float", args_type="(float, int)",
-                  vals=[(i, j) for i in float_vals for j in range(-10, 10)])
-        checkMath("pow", 2, is_float=False, ret_type="int")
-        checkMath("pow", 2, is_float=True, ret_type="float")
-        if not PY2:
-            checkMathWrap("floor", ret_type="int")
-            checkMathWrap("ceil", ret_type="int")
-            checkMathWrap("gcd", 2, is_float=False, ret_type="int")
-            checkMath("isfinite", 1, ret_type="bool")
-        if PY37:
-            checkMathWrap("remainder", 2)
-        checkMathWrap("factorial", 1, is_float=False, ret_type="int", vals=[(i, 0) for i in range(-2, 10)])
+        unimplemented = ["fsum", "hypot", "isclose", "log2", "trunc"]
+        ops = [x for x in dir(math) if callable(getattr(math, x))]
+        for op in ops:
+            if op in unimplemented:
+                continue
+            if op == "modf":
+                checkMath("modf", 1, ret_type="Tuple[float, float]")
+            elif op in ["isnan", "isinf", "isfinite"]:
+                checkMath(op, 1, ret_type="bool")
+            elif op in ["floor", "ceil"]:
+                checkMathWrap(op, ret_type="int")
+            elif op == "factorial":
+                checkMathWrap("factorial", 1, is_float=False, ret_type="int", vals=[(i, 0) for i in range(-2, 10)])
+            elif op == "frexp":
+                checkMath("frexp", 1, ret_type="Tuple[float, int]")
+            elif op == "gcd":
+                checkMathWrap("gcd", 2, is_float=False, ret_type="int")
+            elif op == "ldexp":
+                checkMath("ldexp", 2, is_float=False, ret_type="float", args_type="(float, int)",
+                            vals=[(i, j) for i in float_vals for j in range(-10, 10)])
+            elif op == "log":
+                checkMathWrap("log", 1)
+            elif op == "pow":
+                checkMath("pow", 2, is_float=False, ret_type="int")
+                checkMath("pow", 2, is_float=True, ret_type="float")
+            else:
+                func = getattr(math, op)
+                sig = inspect.signature(func)
+                if len(sig.parameters) == 1:
+                    checkMathWrap(op, 1)
+                else:
+                    checkMathWrap(op, 2)
 
     def test_if_nest_while(self):
         def func(a, b):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15,7 +15,7 @@ import torch.jit.frontend
 from torch.autograd import Variable, Function
 from torch.autograd.function import _nested_map
 from torch.onnx import OperatorExportTypes
-from torch._six import inf, PY2, PY37, builtins, StringIO
+from torch._six import inf, PY2, builtins, StringIO
 from common_utils import TestCase, run_tests, IS_WINDOWS, TEST_WITH_UBSAN, \
     skipIfRocm, skipIfNoLapack, suppress_warnings, load_tests, IS_SANDCASTLE, \
     freeze_rng_state, set_rng_seed, slowTest, TemporaryFileName
@@ -6157,7 +6157,7 @@ a")
                 checkMathWrap("gcd", 2, is_float=False, ret_type="int")
             elif op == "ldexp":
                 checkMath("ldexp", 2, is_float=False, ret_type="float", args_type="(float, int)",
-                            vals=[(i, j) for i in float_vals for j in range(-10, 10)])
+                          vals=[(i, j) for i in float_vals for j in range(-10, 10)])
             elif op == "log":
                 checkMathWrap("log", 1)
             elif op == "pow":

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6165,8 +6165,16 @@ a")
                 checkMath("pow", 2, is_float=True, ret_type="float")
             else:
                 func = getattr(math, op)
-                sig = inspect.signature(func)
-                if len(sig.parameters) == 1:
+                param_count = 0
+                def num_args(f):  # Parses the docstring for builtin functions
+                    spec = f.__doc__.split('\n')[0]
+                    args = spec[spec.find('(')+1:spec.find(')')]
+                    return args.count(',')+1 if args else 0
+                if PY2:
+                    param_count = num_args(func)
+                else:
+                    param_count = len(inspect.signature(func).parameters)
+                if param_count == 1:
                     checkMathWrap(op, 1)
                 else:
                     checkMathWrap(op, 2)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -6,7 +6,7 @@ from torch.jit.frontend import get_jit_class_def, get_jit_def, get_default_args
 import torch.backends.cudnn as cudnn
 import torch.jit.annotations
 import torch._jit_internal as _jit_internal
-from torch._six import PY2, PY37, with_metaclass, get_function_from_type, \
+from torch._six import PY37, with_metaclass, get_function_from_type, \
     string_classes, builtins
 from torch._jit_internal import ignore, export  # noqa: F401
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple, \
@@ -1937,8 +1937,8 @@ def _get_builtin_table():
         _builtin_table[id(builtin)] = aten_op
     math_ops = [x for x in dir(math) if callable(getattr(math, x))]
     unimplemented_math_ops = ["fsum", "hypot", "isclose", "log2", "trunc"]
-    special_math_ops = ["remainder"] # We bound this to aten::mathremainder, as there already exists
-                                     # aten::remainder used for other purposes
+    special_math_ops = ["remainder"]    # We bound this to aten::mathremainder, as there already exists
+                                        # aten::remainder used for other purposes
     for op in math_ops:
         if op in unimplemented_math_ops + special_math_ops:
             continue

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1918,49 +1918,6 @@ def _get_builtin_table():
         (_unwrap_optional, "aten::_unwrap_optional"),
         (_wait, 'aten::wait'),
         (cudnn.is_acceptable, "aten::cudnn_is_acceptable"),
-        (math.ceil, "aten::ceil"),
-        (math.copysign, "aten::copysign"),
-        (math.erf, "aten::erf"),
-        (math.erfc, "aten::erfc"),
-        (math.exp, "aten::exp"),
-        (math.expm1, "aten::expm1"),
-        (math.fabs, "aten::fabs"),
-        (math.floor, "aten::floor"),
-        (math.gamma, "aten::gamma"),
-        (math.lgamma, "aten::lgamma"),
-        (math.log, "aten::log"),
-        (math.log10, "aten::log10"),
-        (math.log1p, "aten::log1p"),
-        (math.pow, "aten::pow"),
-        (math.sqrt, "aten::sqrt"),
-        (math.isnan, "aten::isnan"),
-        (math.asinh, "aten::asinh"),
-        (math.atanh, "aten::atanh"),
-        (math.cosh, "aten::cosh"),
-        (math.sinh, "aten::sinh"),
-        (math.tanh, "aten::tanh"),
-        (math.acos, "aten::acos"),
-        (math.asin, "aten::asin"),
-        (math.atan, "aten::atan"),
-        (math.atan2, "aten::atan2"),
-        (math.cos, "aten::cos"),
-        (math.sin, "aten::sin"),
-        (math.tan, "aten::tan"),
-        (math.asinh, "aten::asinh"),
-        (math.atanh, "aten::atanh"),
-        (math.acosh, "aten::acosh"),
-        (math.sinh, "aten::sinh"),
-        (math.cosh, "aten::cosh"),
-        (math.tanh, "aten::tanh"),
-        (math.fmod, "aten::fmod"),
-        (math.modf, "aten::modf"),
-        (math.factorial, "aten::factorial"),
-        (math.frexp, "aten::frexp"),
-        (math.isnan, "aten::isnan"),
-        (math.isinf, "aten::isinf"),
-        (math.degrees, "aten::degrees"),
-        (math.radians, "aten::radians"),
-        (math.ldexp, "aten::ldexp"),
         (torch._C._infer_size, "aten::_infer_size"),
         (torch.nn.functional._no_grad_embedding_renorm_, "aten::_no_grad_embedding_renorm_"),
         (torch.nn.functional.assert_int_or_pair, "aten::_assert_int_or_pair"),
@@ -1978,9 +1935,14 @@ def _get_builtin_table():
 
     for builtin, aten_op in builtin_ops:
         _builtin_table[id(builtin)] = aten_op
-    if not PY2:
-        _builtin_table[id(math.gcd)] = "aten::gcd"
-        _builtin_table[id(math.isfinite)] = "aten::isfinite"
+    math_ops = [x for x in dir(math) if callable(getattr(math, x))]
+    unimplemented_math_ops = ["fsum", "hypot", "isclose", "log2", "trunc"]
+    special_math_ops = ["remainder"] # We bound this to aten::mathremainder, as there already exists
+                                     # aten::remainder used for other purposes
+    for op in math_ops:
+        if op in unimplemented_math_ops + special_math_ops:
+            continue
+        _builtin_table[id(getattr(math, op))] = "aten::" + op
     if PY37:
         _builtin_table[id(math.remainder)] = "aten::mathremainder"
 


### PR DESCRIPTION
The previous method where we specify all the math ops we can think of to test them is somewhat unwieldy. 

Following @driazati 's suggestion here: https://github.com/pytorch/pytorch/pull/21125#discussion_r289504794