### PR TITLE
Enabled _th_ixor_ and _th_equal for bool

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -374,9 +374,9 @@
 ]]
 [[
   name: _th_equal
-  cpu_bool: True
   cname: equal
   cpu_bool: True
+  cuda_bool: True
   variants:
     - function
   return: bool
@@ -498,6 +498,8 @@
 [[
   name: _th_ixor_
   cname: __ixor__
+  cpu_bool: True
+  cuda_bool: True
   variants:
     - function
   return: argument 0


### PR DESCRIPTION
Following up on the feedback in this [PR](https://github.com/pytorch/pytorch/pull/21113/files?file-filters%5B%5D=.cwrap&owned-by%5B%5D=) 

Changes: enabled `xor` and `equal` for bool tensors.