### PR TITLE
[jit][errors] Describe the location of a failed script attempt (to be improved when stack traces land)

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1711,7 +1711,11 @@ def _convert_to_script_module(mod, methods=None):
 
     def make_stub(method):
         func = get_function_from_type(type(mod), method)
-        return script_method(func, createResolutionCallbackFromClosure(func))
+        try:
+            sm = script_method(func, createResolutionCallbackFromClosure(func))
+        except Exception as e:
+            raise Exception(f"Error scripting method {func.__name__} in module {mod.__class__.__name__}: {str(e)}")
+        return sm
 
     stubs = list(map(make_stub, methods))
     return WeakScriptModuleProxy(mod, stubs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21646 [jit][errors] Throw error when super().__init__() hasn't been called
* **#21541 [jit][errors] Describe the location of a failed script attempt (to be improved when stack traces land)**
* #21540 [jit][errors] Improve quality of error for non-implemented forward pass

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)