### PR TITLE
[JIT] Fix slow unpickling

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -600,7 +600,7 @@ OpCode Unpickler::readInstruction() {
     } break;
     case OpCode::BINPUT: {
       size_t memo_id = read<uint8_t>();
-      if (memo_table_.size() <= memo_id) {
+      if (memo_table_.capacity() <= memo_id) {
         memo_table_.reserve(1 + 2 * memo_id);
       }
       memo_table_.push_back(stack_.back());
@@ -612,7 +612,7 @@ OpCode Unpickler::readInstruction() {
           "Found a LONG_BINPUT opcode, but size_t on this system is "
           "not big enough to decode it");
       size_t memo_id = read<uint32_t>();
-      if (memo_table_.size() <= memo_id) {
+      if (memo_table_.capacity() <= memo_id) {
         memo_table_.reserve(1 + 2 * memo_id);
       }
       memo_table_.push_back(stack_.back());


### PR DESCRIPTION
This was looking at the number of elements in the memo table, not the total capacity, and was thus calling reserve() a lot more than it should have

This makes loading in a language model with a big str->long table MUCH faster. Whereas before it took so long i never let it run to completion, now that model loads in in ~4 seconds