### PR TITLE
Method-only entries in native functions should have self as first argument

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1038,6 +1038,9 @@ def create_generic(top_env, declarations):
 
         is_method = 'method' in option['variants']
         is_namespace_function = 'function' in option['variants']
+        # For method-only entries, the first argument should be self
+        if is_method and not is_namespace_function:
+            assert formals[0]['name'] == 'self'
         is_factory_method = find_formal('TensorOptions', formals) and \
             not dispatch_options and 'method' not in option['variants']
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21549 Method-only entries in native functions should have self as first argument**

This is already true, I'd just like to enforce it.

Differential Revision: [D15724794](https://our.internmc.facebook.com/intern/diff/D15724794)