### PR TITLE
Deprecate torch::jit::RegisterOperators

### DIFF
--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -19,8 +19,7 @@
 // because we are C++11.  However, aspirationally, we would like
 // to use this version, because as of C++14 it is the correct and
 // portable way to declare something deprecated.
-#if (defined(__cplusplus) && __cplusplus >= 201402L) || \
-    (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#if (defined(__cplusplus) && __cplusplus >= 201402L)
 # define C10_DEPRECATED [[deprecated]]
 # define C10_DEPRECATED_MESSAGE(message) [[deprecated(message)]]
 #elif defined(__GNUC__)

--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -19,6 +19,10 @@
 // because we are C++11.  However, aspirationally, we would like
 // to use this version, because as of C++14 it is the correct and
 // portable way to declare something deprecated.
+// NB: __cplusplus doesn't work for MSVC, so for now MSVC always uses
+// the "__declspec(deprecated)" implementation and not the C++14 "[[deprecated]]"
+// attribute. We tried enabling "[[deprecated]]" for C++14 on MSVC, but
+// ran into issues with some older MSVC versions.
 #if (defined(__cplusplus) && __cplusplus >= 201402L)
 # define C10_DEPRECATED [[deprecated]]
 # define C10_DEPRECATED_MESSAGE(message) [[deprecated(message)]]

--- a/torch/csrc/jit/custom_operator.h
+++ b/torch/csrc/jit/custom_operator.h
@@ -24,11 +24,13 @@ struct TORCH_API RegisterOperators {
 
   /// Calls `op(...)` with the given operator name and implementation.
   template <typename Implementation>
+  C10_DEPRECATED_MESSAGE("torch::jit::RegisterOperators is deprecated. Please use torch::RegisterOperators instead.")
   RegisterOperators(const std::string& name, Implementation&& implementation) {
     op(name, std::forward<Implementation>(implementation));
   }
 
   template <typename Implementation>
+  C10_DEPRECATED_MESSAGE("torch::jit::RegisterOperators is deprecated. Please use torch::RegisterOperators instead.")
   RegisterOperators& op(
       const std::string& name,
       Implementation&& implementation) {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21552 Deprecate torch::jit::RegisterOperators**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15727526/)

Original commit changeset: a142c22be3fd

https://github.com/pytorch/pytorch/pull/21368 got reverted because of a MSVC issue. This commit re-introduces that change and fixes the MSVC issue.

Differential Revision: [D15727526](https://our.internmc.facebook.com/intern/diff/D15727526/)