### PR TITLE
Prepare interpreter for function calling

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12537,6 +12537,18 @@ a")
 
         self.assertEqual(fn(), {'ok': 10})
 
+    def test_dict_loop(self):
+        @torch.jit.script
+        def fn(x):
+            # type: (int) -> Dict[str, int]
+            a = torch.jit.annotate(Dict[str, int], {})
+            for i in range(x):
+                a['ok'] = i
+            return a
+
+        self.assertEqual(fn(10), {'ok': 9})
+
+
     def test_dict_membership(self):
         def fn(x, y):
             # type: (Dict[int, int], int) -> int

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -1,7 +1,7 @@
 #include <torch/csrc/jit/interpreter.h>
 
-#include <ATen/core/ivalue.h>
 #include <ATen/Parallel.h>
+#include <ATen/core/ivalue.h>
 #include <c10/core/thread_pool.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/autograd/edge.h>
@@ -32,16 +32,15 @@ namespace jit {
 // some preprocessing of the graph to turn it into a form that is closer
 // to what the instructions will look like.
 // In particular we:
-// * (TODO) desugar Loop trip counts into c = 0, c += 1 instructions in the loop
-// * Turn inputs/outputs into Load/Store instruction
-// *. computes move_flags (see Outputs), and inserts
+// *  Computes whether a input to a node is the last use, so we can issue MOVE
+//    rather than LOAD instructions.
 // *  Drop nodes are inserted for any node that is unused to create a dummy use
 //    that will cause the interpreter to free the node.
-//    A drop node is just a node with no outputs that just pops its inputs off
-//    the stack, to ensure the interpreter release references to nodes that are
-//    never used. Drop nodes are also inserted when the last use of a node is in
-//    some conditionally run control flow (e.g. one side of an If) and the
-//    interpreter must free the node only after the control flow has reconverged
+//    A drop node just pops its input off the stack to  ensure the interpreter
+//    releases references to nodes that are never used. Drop nodes are also
+//    inserted when the last use of a node is in some conditionally run control
+//    flow (e.g. one side of an If) and the interpreter must free the node only
+//    after the control flow has reconverged
 // Outputs are:
 // * graph - the post processed copy of g
 // * move_flags[n] - a list of booleans, one for each input,
@@ -49,102 +48,6 @@ namespace jit {
 //   should generate a move rather than a copy in this case.
 
 namespace {
-
-// new_cond = (i < max_trip_count) && cond
-Value* createTripCountConjunctiveCondition(
-    Graph* g,
-    Value* cur_trip_count,
-    Value* max_trip_count,
-    Value* cond) {
-  // Emit initial comparison -- initial_trip_count < max_trip_count
-  Value* initial_comparison_value =
-      g->insertNode(g->create(aten::lt, {cur_trip_count, max_trip_count}, 1))
-          ->output()
-          ->setType(BoolType::get());
-
-  // Replace initial condition with logical `and` of trip count and
-  // initial condition
-  Value* new_cond =
-      g->insertNode(
-           g->create(aten::__and__, {initial_comparison_value, cond}, 1))
-          ->output()
-          ->setType(BoolType::get());
-  return new_cond;
-}
-
-// this currently just _removes_ the trip count inputs and checks they are
-// unused. In the future they will be desugared into normal arithmetic to
-// provide a loop counter
-void desugarTripCounts(Block* b) {
-  for (auto n : b->nodes()) {
-    if (n->kind() == prim::Loop) {
-      auto g = n->owningGraph();
-      auto body_block = n->blocks()[0];
-
-      Value* block_trip_count_input = body_block->inputs()[0];
-      // Treat loop iteration number as a loop-carried dependency. We emit an
-      // increment at the end of the body block.
-      n->insertOutput(0);
-
-      Value* max_trip_count_value = n->input(0);
-      {
-        WithInsertPoint guard(n);
-        // int i = 0
-        Value* initial_trip_count = g->insertConstant(0);
-        // Set up initial iteration number value for loop-carried dependency
-        n->removeInput(0);
-        // Input 0 is now initial termination condition, insert this after that.
-        // LCD's start at index 1.
-        n->insertInput(1, initial_trip_count);
-
-        Value* new_cond = createTripCountConjunctiveCondition(
-            g, initial_trip_count, max_trip_count_value, n->input(0));
-        n->replaceInput(0, new_cond);
-      }
-
-      {
-        WithInsertPoint guard(body_block);
-        // Trip count is now a loop carried dependency. We emit an op to
-        // increment the trip count at the end of the body. Then, emit the same
-        // conjunctive stopping condition as above.
-
-        Value* const_one = g->insertConstant(1);
-
-        Value* inc_trip_count =
-            g->insertNode(
-                 g->create(aten::add, {block_trip_count_input, const_one}, 1))
-                ->output()
-                ->setType(IntType::get());
-        body_block->insertOutput(1, inc_trip_count);
-
-        Value* body_cond = createTripCountConjunctiveCondition(
-            g, inc_trip_count, max_trip_count_value, body_block->outputs()[0]);
-        body_block->eraseOutput(0);
-        body_block->insertOutput(0, body_cond);
-      }
-    }
-    for (auto sb : n->blocks()) {
-      desugarTripCounts(sb);
-    }
-  }
-}
-
-// removes all inputs and outputs to a graph, replacing them with Load Store
-// nodes
-static void flattenIO(Graph& graph) {
-  auto load = graph.prependNode(graph.create(prim::Load, 0));
-  for (auto old_input : graph.inputs()) {
-    auto nv = load->addOutput();
-    nv->setType(old_input->type());
-    old_input->replaceAllUsesWith(nv);
-  }
-  graph.appendNode(graph.create(prim::Store, graph.outputs(), 0));
-
-  while (graph.inputs().size() > 0)
-    graph.eraseInput(graph.inputs().size() - 1);
-  while (graph.outputs().size() > 0)
-    graph.eraseOutput(graph.outputs().size() - 1);
-}
 
 // insert Drop nodes to kill references for anything unused:
 // this can happen in a few places, e.g. when a node returns
@@ -155,7 +58,7 @@ void dropUnused(Block* b) {
   auto createDropIfUnused = [&](ArrayRef<Value*> values) -> Node* {
     std::vector<Value*> to_drop;
     for (auto v : values) {
-      if (v->uses().size() == 0)
+      if (v->uses().size() == 0 && v->node()->kind() != prim::Constant)
         to_drop.push_back(v);
     }
     if (to_drop.size() == 0)
@@ -273,6 +176,9 @@ std::unordered_map<Node*, std::vector<uint8_t>> findLastUses(Graph& g) {
     }
 
     void addToDropIfNotExists(Node* drop, Value* v) {
+      if (v->node()->kind() == prim::Constant) {
+        return;
+      }
       for (auto i : drop->inputs()) {
         // we already accounted for this use
         if (i == v)
@@ -290,308 +196,290 @@ std::unordered_map<Node*, std::vector<uint8_t>> findLastUses(Graph& g) {
 // pre-processing that happens once per graph
 struct PreprocessGraph {
   PreprocessGraph(Graph& g) : graph(g.copy()) {
-    n_outputs = graph->outputs().size();
-    desugarTripCounts(graph->block());
-    flattenIO(*graph);
     dropUnused(graph->block());
     // fill in move_flags by scanning blocks;
     move_flags = findLastUses(*graph);
-    // TODO: desugar Loop trip counts, for now we drop trip counts
   }
   // Outputs of the preprocessing:
   std::shared_ptr<Graph> graph;
   // for each input, should we move rather than copy the inputs
   std::unordered_map<Node*, std::vector<uint8_t>> move_flags;
-  // Record number of outputs before flattenIO()
-  size_t n_outputs;
 };
 
-// We need some lists for inputs and outputs. To keep all the memory
-// contiguous we allocate a single vector and use offsets into the vector
-// which are stored in the ListHandle struct
-// start is an offset into int_data of Code for ListHandle<int>
-// and bool_data of Code for ListHandle<bool>
-template <typename T>
-struct ListHandle {
-  int start;
-  int size;
+// instructs look like:
+// op_code X, N
+// meaning of X, N depend on the op:
+// O - index into operator table
+// R - index into register table
+// I - literal integer
+// C - index into constant table
+// P - jump offset relative to beginning of current instruction
+
+#define FORALL_OPCODES(_)                                                   \
+  _(OP, "O") /* invoke operator X */                                        \
+  _(LOAD, "R") /* push a value from a register X */                         \
+  _(MOVE, "R") /* push a value from register X, clearing the register */    \
+  _(STOREN, "RI") /* store N values to registers [X, X+N) */                \
+  _(STORE, "R") /* store 1 value to registers X */                          \
+  _(DROP, "") /* drop 1 value from the top of the stack */                  \
+  _(DROPR, "R") /* clear register X */                                      \
+  _(LOADC, "C") /* push the constant X */                                   \
+  _(JF, "P") /* pop the top of the stack, if false, branch to P */          \
+  _(JMP, "P") /* unconditional branch to X */                               \
+  _(LOOP, "PI") /* perform a loop, X is where to branch if cond is false */ \
+  _(RET, "") /* exit execution */                                           \
+  _(WAIT, "") /* wait for a future to be complete */
+
+enum OpCode : uint8_t {
+#define DEFINE_OP(op, _) op,
+  FORALL_OPCODES(DEFINE_OP)
+#undef DEFINE_OP
 };
 
-struct UseList {
-  // values to be used
-  ListHandle<int> values;
-  // boolean flags indicating whether to free the Tensor after this use
-  ListHandle<bool> free_flags;
-};
-
-// one instruction plus meta-data
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct Instruction {
-  Operation callback;
-  UseList inputs;
-  ListHandle<int> outputs;
-  Symbol debug_name; // used in dump to understand the generated code
-  c10::optional<SourceRange> debug_location; // for error reporting
-};
-
-int relativeJump(int from_inst, int to_inst) {
-  return to_inst - (from_inst + 1);
+std::ostream& operator<<(std::ostream& out, OpCode op) {
+  switch (op) {
+#define OP_STRING(x, _) \
+  case x:               \
+    return out << #x;
+    FORALL_OPCODES(OP_STRING)
+#undef OP_STRING
+  }
+  return out;
 }
 
+const char* OpInfo(OpCode op) {
+  switch (op) {
+#define OP_INFO(x, info) \
+  case x:                \
+    return info;
+    FORALL_OPCODES(OP_INFO)
+#undef OP_INFO
+  }
+  return nullptr;
+}
+
+struct Instruction {
+  OpCode op;
+  uint8_t padding; // currently unused
+  uint16_t N;
+  int32_t X;
+  // TODO: check for overflow
+  Instruction(OpCode op, int32_t X, uint16_t N)
+      : op(op), padding(0), N(N), X(X) {}
+};
+
+static_assert(sizeof(Instruction) == 8, "Instructions should be 8 bytes");
+std::ostream& operator<<(std::ostream& out, Instruction inst) {
+  // TODO: use op info to print out the op in a more user-friendly way
+  int nargs = strlen(OpInfo(inst.op));
+  out << inst.op;
+  if (nargs > 0) {
+    out << " " << inst.X;
+  }
+  if (nargs > 1) {
+    out << " " << inst.N;
+  }
+  return out;
+}
+
+// for keeping track of the current node
+struct WithCurrentNode {
+  WithCurrentNode(Node** loc, Node* new_value) : loc_(loc), old_value_(*loc_) {
+    *loc = new_value;
+  }
+  ~WithCurrentNode() {
+    *loc_ = old_value_;
+  }
+
+ private:
+  Node** loc_;
+  Node* old_value_;
+};
+
 struct CodeImpl {
-  CodeImpl(const std::shared_ptr<Graph>& graph_) : preprocess(*graph_) {
-    graph = preprocess.graph;
-    insertNodesFromBlock(graph->block());
+  friend struct InterpreterState;
+  std::vector<Instruction> instructions_;
+
+  // same length as instructions.
+  // what node in the graph cause this
+  // instruction to be emitted?
+  std::vector<Node*> instructions_source_;
+
+  std::vector<IValue> constant_table_;
+  std::vector<Operation> operator_table_;
+  int register_size_ = 0;
+  size_t n_outputs;
+  size_t n_inputs;
+
+  // We MUST hold onto graph here because some Operators stored in the
+  // instruction lists have dependencies on meta-data stored in the graph
+  // that would be dead otherwise.
+  // It is also very useful for debugging interpreter problems to
+  // keep this around.
+  std::shared_ptr<Graph> graph_;
+  c10::optional<std::vector<GraphExecutor*>> grad_executors_;
+  PreprocessGraph preprocess_;
+
+  std::unordered_map<Value*, int>
+      value_to_reg_; // map from unique of nodes to register in register table
+  Node* current_node_; // used in creation of code to keep track
+                       // of node being emitted
+
+  CodeImpl(const std::shared_ptr<Graph>& graph)
+      : preprocess_(*graph), current_node_(preprocess_.graph->return_node()) {
+    graph_ = preprocess_.graph;
+    n_outputs = graph_->outputs().size();
+    n_inputs = graph_->inputs().size();
+    // std::cout << *graph_ << "\n";
+    emitCodeForBlock(graph_->block());
+    insertInstruction(RET);
   }
 
-  // jump when input is false
-  void createJumpFalse(int from_inst, int to_inst) {
-    auto& inst = instructions[from_inst];
-    AT_ASSERT(inst.debug_name == prim::Placeholder);
-    auto offset = relativeJump(from_inst, to_inst);
-    inst.callback = [offset](Stack& stack) {
-      auto t = pop(stack).toBool();
-      return t ? 0 : offset;
-    };
-    inst.debug_name = prim::JumpZ;
+  void insertInstruction(OpCode op, int64_t X = 0, uint64_t N = 0) {
+    instructions_.emplace_back(op, X, N);
+    instructions_source_.emplace_back(current_node_);
   }
 
-  // jump when input is true
-  void createJumpTrue(int from_inst, int to_inst) {
-    auto& inst = instructions[from_inst];
-    AT_ASSERT(inst.debug_name == prim::Placeholder);
-    auto offset = relativeJump(from_inst, to_inst);
-    inst.callback = [offset](Stack& stack) {
-      auto t = pop(stack).toBool();
-      return t ? offset : 0;
-    };
-    inst.debug_name = prim::JumpNZ;
+  int allocRegs(at::ArrayRef<Value*> vs) {
+    int result = register_size_;
+    for (Value* v : vs) {
+      AT_ASSERT(value_to_reg_.count(v) == 0);
+      value_to_reg_[v] = register_size_++;
+    }
+    return result;
   }
 
-  void createJump(int from_inst, int to_inst) {
-    auto& inst = instructions[from_inst];
-    AT_ASSERT(inst.debug_name == prim::Placeholder);
-    auto offset = relativeJump(from_inst, to_inst);
-    inst.callback = [=](Stack& stack) { return offset; };
-    inst.debug_name = prim::Jump;
+  int registerFor(Value* v) {
+    return value_to_reg_.at(v);
   }
 
-  void insertNodesFromBlock(Block* block) {
-    for (auto node : block->nodes()) {
-      SourceRange source_location = node->sourceRange();
-      switch (node->kind()) {
-        case prim::If: {
-          // x = if c:
-          //   <then_block>
-          //   -> (vt)
-          // else:
-          //    <else_block>
-          //   -> (vf)
-
-          // turns into:
-          //   JumpNZ c, then
-          //   <else_block>
-          //   x = vf
-          //   Jump end
-          // then:
-          //   <then_block>
-          //   x = vt
-          // end:
-
-          // prim::Placeholder instructions are replaced with branch
-          // instructions when the branch target locations are known
-          auto cond_branch = insertInstruction(
-              prim::Placeholder,
-              source_location,
-              node->inputs(),
-              moveFlags(node),
-              {});
-          auto then_block = node->blocks()[0];
-          auto else_block = node->blocks()[1];
-          insertNodesFromBlock(else_block);
-          insertAssign(
-              source_location,
-              else_block->outputs(),
-              moveFlags(else_block),
-              node->outputs());
-          auto jump =
-              insertInstruction(prim::Placeholder, source_location, {}, {}, {});
-          auto then_block_start = instructions.size();
-          insertNodesFromBlock(then_block);
-          insertAssign(
-              source_location,
-              then_block->outputs(),
-              moveFlags(then_block),
-              node->outputs());
-          createJump(jump, instructions.size());
-          createJumpTrue(cond_branch, then_block_start);
-        } break;
-        case prim::Loop: {
-          // o0 = while c i0
-          //        block 0: l0
-          //          <body>
-          //          -> (v0, v1)
-
-          // turns into:
-          // l0 = i0
-          // JumpZ c, end
-          // begin:
-          //   <body>
-          //   c, l0 = v0, v1
-          //   JumpNZ c, begin
-          // end:
-
-          auto body_block = node->blocks()[0];
-
-          // before assign op: stack: ... <cond> <loop-carried-depdencies>
-          insertAssign(
-              source_location,
-              node->inputs(),
-              moveFlags(node),
-              body_block->inputs());
-          // after assign op: stack: ... <cond>
-          // cond_branch consumes <cond> from top of the stack
-          auto cond_branch =
-              insertInstruction(prim::Placeholder, source_location, {}, {}, {});
-          // after branch: stack: ...
-
-          auto entry = instructions.size();
-          insertNodesFromBlock(body_block);
-          // before assign op: stack: ... <cond> <loop-carried-depdencies>
-          insertAssign(
-              source_location,
-              body_block->outputs(),
-              moveFlags(body_block),
-              body_block->inputs());
-          // after assign op: stack: ... <cond>
-          auto cond_branch_end =
-              insertInstruction(prim::Placeholder, source_location, {}, {}, {});
-          // after branch: stack: ...
-
-          aliasRegistersTo(node->outputs(), body_block->inputs());
-          createJumpFalse(cond_branch, instructions.size());
-          createJumpTrue(cond_branch_end, entry);
-        } break;
-        default: {
-          insertInstruction(node);
-        } break;
+  void emitLoadInputs(Node* node) {
+    auto move_flag_it = preprocess_.move_flags.at(node).begin();
+    for (Value* input : node->inputs()) {
+      int reg = registerFor(input);
+      bool moved = (*move_flag_it++);
+      OpCode op;
+      if (input->node()->kind() == prim::Constant) {
+        op = LOADC;
+      } else if (moved) {
+        op = MOVE;
+      } else {
+        op = LOAD;
       }
+      insertInstruction(op, reg);
     }
   }
 
-  size_t insertInstruction(Node* n) {
-    auto inst = insertInstruction(
-        n->kind(),
-        n->sourceRange(),
-        n->inputs(),
-        moveFlags(n),
-        n->outputs());
-    instructions[inst].callback = getOperation(n);
-    return inst;
-  }
-  size_t insertInstruction(
-      Symbol sym,
-      const SourceRange& debug_location,
-      ArrayRef<Value*> inputs,
-      ArrayRef<uint8_t> move_flags,
-      ArrayRef<Value*> outputs) {
-    instructions.emplace_back();
-    auto& inst = instructions.back();
-    inst.debug_name = sym;
-    inst.debug_location = std::move(debug_location);
-    listBegin(inst.inputs.values);
-    for (auto input : inputs) {
-      listInsert(inst.inputs.values, getOrAllocateRegister(input, true));
-    }
-    listBegin(inst.inputs.free_flags);
-    for (auto flag : move_flags) {
-      listInsert(inst.inputs.free_flags, flag);
-    }
-    listBegin(inst.outputs);
-    for (auto output : outputs) {
-      listInsert(inst.outputs, getOrAllocateRegister(output));
-    }
-    return instructions.size() - 1;
-  }
-  ArrayRef<uint8_t> moveFlags(Node* n) {
-    return preprocess.move_flags.at(n);
-  }
-  ArrayRef<uint8_t> moveFlags(Block* b) {
-    return moveFlags(b->return_node());
+  void emitOperator(Node* node) {
+    emitLoadInputs(node);
+    insertInstruction(OP, operator_table_.size());
+    operator_table_.emplace_back(getOperation(node));
+    emitStoreOutputs(node);
   }
 
-  size_t insertAssign(
-      const SourceRange& debug_location,
-      ArrayRef<Value*> inputs,
-      ArrayRef<uint8_t> move_flags,
-      ArrayRef<Value*> outputs) {
-    auto inst = insertInstruction(
-        prim::Assign, std::move(debug_location), inputs, move_flags, outputs);
-    // This node effectively forwards its inputs into different places in a
-    // register list. We don't need to manipulate the stack in any way, because
-    // all inputs are also outputs, and the interpreter will take care of
-    // putting them in correct places.
-    instructions[inst].callback = [](Stack& stack) { return 0; };
-    return inst;
+  void emitWait(Node* node) {
+    emitLoadInputs(node);
+    insertInstruction(WAIT);
+    emitStoreOutputs(node);
   }
 
-  // helpers to build/access RegList objects
-  int get(const ListHandle<int>& list, int i) const {
-    return int_data[list.start + i];
-  }
-  bool get(const ListHandle<bool>& list, int i) const {
-    return bool_data[list.start + i];
-  }
-  void listBegin(ListHandle<int>& list) {
-    list.start = int_data.size();
-    list.size = 0;
-  }
-  void listInsert(ListHandle<int>& list, int value) {
-    TORCH_CHECK(
-        list.start + list.size == (int)int_data.size(),
-        "another list already started");
-    int_data.push_back(value);
-    list.size++;
-  }
-  void listBegin(ListHandle<bool>& list) {
-    list.start = bool_data.size();
-    list.size = 0;
-  }
-  void listInsert(ListHandle<bool>& list, int value) {
-    TORCH_CHECK(
-        list.start + list.size == (int)bool_data.size(),
-        "another list already started");
-    bool_data.push_back(value);
-    list.size++;
-  }
-  // must be called before any new_allocations are used, otherwise they will
-  // already have registers assigned
-  void aliasRegistersTo(
-      ArrayRef<Value*> new_allocations,
-      ArrayRef<Value*> existing_allocations) {
-    AT_ASSERT(new_allocations.size() == existing_allocations.size());
-    for (size_t i = 0; i < new_allocations.size(); ++i) {
-      auto n = new_allocations[i]->unique();
-      auto e = existing_allocations[i]->unique();
-      AT_ASSERT(unique_to_reg.count(e) > 0 && unique_to_reg.count(n) == 0);
-      unique_to_reg[n] = unique_to_reg[e];
+  void emitDrop(at::ArrayRef<Value*> to_drop) {
+    for (Value* input : to_drop) {
+      insertInstruction(DROPR, registerFor(input));
     }
   }
-  int getOrAllocateRegister(Value* n, bool required = false) {
-    size_t u = n->unique();
-    if (unique_to_reg.count(u) > 0)
-      return unique_to_reg[u];
-    AT_ASSERT(!required);
-    int r = register_size++;
-    unique_to_reg[u] = r;
-    return r;
+
+  void emitStoreOutputs(Node* node) {
+    size_t N = node->outputs().size();
+    if (N == 0)
+      return;
+    int regs = allocRegs(node->outputs());
+    if (N == 1) {
+      insertInstruction(STORE, regs);
+    } else {
+      insertInstruction(STOREN, regs, node->outputs().size());
+    }
+  }
+
+  int insertConstant(IValue value) {
+    int result = constant_table_.size();
+    constant_table_.emplace_back(std::move(value));
+    return result;
+  }
+
+  void emitConstant(Node* node) {
+    // constants are just put in the constant table
+    value_to_reg_[node->output()] =
+        insertConstant(toIValue(node->output()).value());
+  }
+
+  void emitIf(Node* node) {
+    emitLoadInputs(node);
+    size_t start_if = instructions_.size();
+    insertInstruction(JF, 0); // dummy offset to be filled in
+    emitCodeForBlock(node->blocks().at(0));
+    insertInstruction(JMP, 0); // dummy offset
+    size_t start_else = instructions_.size();
+    instructions_[start_if].X = start_else - start_if;
+    emitCodeForBlock(node->blocks().at(1));
+    instructions_[start_else - 1].X = instructions_.size() - (start_else - 1);
+    emitStoreOutputs(node);
+  }
+
+  void emitLoop(Node* loop) {
+    insertInstruction(LOADC, insertConstant(0));
+    emitLoadInputs(loop);
+    size_t start = instructions_.size();
+    insertInstruction(LOOP, 0, loop->inputs().size()); // dummy offset
+    emitCodeForBlock(loop->blocks().at(0));
+    insertInstruction(JMP, start - instructions_.size());
+    instructions_[start].X = instructions_.size() - start;
+    emitStoreOutputs(loop);
+  }
+
+  void emitNode(Node* node) {
+    WithCurrentNode guard(&current_node_, node);
+    switch (node->kind()) {
+      default:
+        emitOperator(node);
+        break;
+      case prim::Drop:
+        emitDrop(node->inputs());
+        break;
+      case prim::Constant:
+        emitConstant(node);
+        break;
+      case prim::If:
+        emitIf(node);
+        break;
+      case prim::Loop:
+        emitLoop(node);
+        break;
+      case aten::wait:
+        emitWait(node);
+        break;
+      case prim::Param:
+        emitStoreOutputs(node);
+        break;
+      case prim::Return:
+        emitLoadInputs(node);
+        break;
+    }
+  }
+
+  void emitCodeForBlock(Block* block) {
+    emitNode(block->param_node());
+    for (auto node : block->nodes()) {
+      emitNode(node);
+    }
+    emitNode(block->return_node());
   }
 
   const std::vector<GraphExecutor*>& grad_executors() {
     if (!grad_executors_) {
       grad_executors_.emplace();
-      for (Instruction& instr : instructions) {
-        if (auto executor = detail::getGradExecutor(instr.callback)) {
+      for (Operation& op : operator_table_) {
+        if (auto executor = detail::getGradExecutor(op)) {
           grad_executors_->push_back(executor);
         }
       }
@@ -599,139 +487,208 @@ struct CodeImpl {
     return *grad_executors_;
   }
 
-  void dumpInstruction(std::ostream& out, size_t pc) const {
-    auto writeList = [&](const ListHandle<int>& list) {
-      for (int i = 0; i < list.size; i++) {
-        if (i > 0)
-          out << ", ";
-        out << get(list, i);
-      }
-    };
-    auto writeUseList = [&](const UseList& list) {
-      for (int i = 0; i < list.values.size; i++) {
-        if (i > 0)
-          out << ", ";
-        if (get(list.free_flags, i))
-          out << "move(" << get(list.values, i) << ")";
-        else
-          out << get(list.values, i);
-      }
-    };
-    auto& inst = instructions.at(pc);
-    writeList(inst.outputs);
-    // NB: debug names are the kind of operator used to select
-    // dispatch
-    out << " = " << inst.debug_name.toUnqualString() << " ";
-    writeUseList(inst.inputs);
-  }
-  void dump(std::ostream& out) const {
-    for (size_t i = 0; i < instructions.size(); ++i) {
-      dumpInstruction(out, i);
+  void dump(std::ostream& out, size_t i) const {
+    out << i << " " << instructions_[i];
+    if (instructions_[i].op == OP) {
+      out << " # " << *instructions_source_[i];
+    } else {
       out << "\n";
     }
   }
 
-  // We MUST hold onto graph here because some Operators stored in the
-  // instruction lists have dependencies on meta-data stored in the graph
-  // that would be dead otherwise.
-  // It is also very useful for debugging interpreter problems to
-  // keep this around.
-  std::shared_ptr<Graph> graph;
-  c10::optional<std::vector<GraphExecutor*>> grad_executors_;
-  PreprocessGraph preprocess;
-
-  std::unordered_map<size_t, int>
-      unique_to_reg; // map from unique of nodes to register in register table
-
-  friend struct InterpreterState;
-  std::vector<Instruction> instructions;
-  int register_size = 0;
-
-  // all memory ArrayRef<int> are slices of this, to make sure
-  // the interpreter is mostly linearly scanning through memory
-  std::vector<int> int_data;
-  std::vector<bool> bool_data;
+  void dump(std::ostream& out) const {
+    out << *graph_ << "\n";
+    for (size_t i = 0; i < instructions_.size(); ++i) {
+      dump(out, i);
+    }
+  }
 };
 
 // InterpreterState state that and used to compute a Code
 struct InterpreterStateImpl : c10::intrusive_ptr_target {
   InterpreterStateImpl(const Code& code)
-      : function(code.pImpl),
-        int_data(function->int_data.data()),
-        bool_data(function->bool_data),
-        registers(function->register_size) {}
+      : function(code.pImpl), registers(function->register_size_) {}
 
  private:
+  // pc is critical for the interperter to pick up the progress from suspend
+  size_t pc = 0;
+
+  // if we need to suspend, where do we reset the stack?
+  // answer: to where it was when we were called, not
+  // including any inputs to this function
+  int64_t stack_start_ = -1;
+  c10::intrusive_ptr<Future> future;
+  std::shared_ptr<CodeImpl> function; // keep function alive
+
+  // this holds all the tensors for this interpreter run
+  // we don't bother minimizing the size of this vector, since the extra
+  // memory used by the pointers in this will be small
+  // instead we are very aggresive about releasing tensors when they become dead
+  // to make sure memory management happens efficiently.
+  // We optimize for the case where derivatives are run with retain_graph=False
+  // in the case where it is true, then the interpreter and this array get
+  // copied if this every becomes a bottleneck then we _should_ consider
+  // minimizing the total number or register
+  std::vector<IValue> registers;
+
   c10::intrusive_ptr<InterpreterStateImpl> intrusive_from_this() {
     c10::raw::intrusive_ptr::incref(this);
     return c10::intrusive_ptr<InterpreterStateImpl>::reclaim(this);
   }
 
   bool runImpl(Stack& stack) {
-    auto& instructions = function->instructions;
-    size_t last = instructions.size();
+    // if we have never run before, then we might have to return the
+    // stack when we suspend, record where it starts so we return the right
+    // stack
+    if (stack_start_ == -1) {
+      TORCH_INTERNAL_ASSERT(stack.size() >= function->n_inputs);
+      stack_start_ = stack.size() - function->n_inputs;
+    } else {
+      // during restarts, all of the stack is always our own, so we leave
+      // nothing
+      stack_start_ = 0;
+    }
+    try {
+      return runInterpreterLoop(stack);
+    } catch (std::exception& e) {
+      // Error from the current thread
+      bool is_jit_exception = dynamic_cast<JITException*>(&e);
+      handleError(
+          function->instructions_source_[pc]->sourceRange().wrapException(
+              e, "operation failed in interpreter"),
+          is_jit_exception);
+      return false;
+    }
+  }
 
-    while (pc < last) {
-      // std::cout << "executing " << pc << ": ";
-      // function->dumpInstruction(std::cout, pc);
-      // std::cout << "\n";
-      auto& inst = instructions[pc];
-      try {
-        loadTensorsFromRegisters(inst.inputs, stack);
-        size_t new_pc = pc + 1 + inst.callback(stack);
-        for (int i = inst.outputs.size - 1; i >= 0; --i) {
-          int reg = get(inst.outputs, i);
-          registers[reg] = pop(stack);
-          // std::cout << "pop reg[" << reg << "];\n" << registers[reg] << "\n";
-        }
-        pc = new_pc;
-      } catch (Suspend& e) {
-        // wait() expects a single input
-        AT_ASSERT(inst.inputs.values.size == 1);
+  bool runInterpreterLoop(Stack& stack) {
+    // function->dump(std::cout);
+    Instruction* instructions = function->instructions_.data();
+    IValue* constants = function->constant_table_.data();
+    Operation* operators = function->operator_table_.data();
+    while (true) {
+      // std::cout << "RUNNING ";
+      // function->dump(std::cout, pc);
+      Instruction inst = instructions[pc];
+      switch (inst.op) {
+        case OP:
+          operators[inst.X](stack);
+          ++pc;
+          break;
+        case LOAD:
+          stack.emplace_back(registers[inst.X]);
+          ++pc;
+          break;
+        case MOVE:
+          stack.emplace_back(std::move(registers[inst.X]));
+          ++pc;
+          break;
+        case STORE:
+          registers[inst.X] = pop(stack);
+          ++pc;
+          break;
+        case STOREN:
+          for (size_t i = inst.N; i > 0; --i) {
+            registers[inst.X + i - 1] = pop(stack);
+          }
+          ++pc;
+          break;
+        case DROP:
+          pop(stack);
+          ++pc;
+          break;
+        case DROPR:
+          registers[inst.X] = IValue();
+          ++pc;
+          break;
+        case LOADC:
+          stack.emplace_back(constants[inst.X]);
+          ++pc;
+          break;
+        case JF:
+          pc += (pop(stack).toBool()) ? 1 : inst.X;
+          break;
+        case JMP:
+          pc += inst.X;
+          break;
+        case LOOP: {
+          // stack: iteration_count, max_iter, cond, loop_carried_deps...
+          auto frame = stack.end() - (inst.N + 1);
+          int64_t trip_count = frame[0].toInt();
+          int64_t max_trip_count = frame[1].toInt();
+          bool cond = frame[2].toBool();
+          if (trip_count < max_trip_count && cond) {
+            frame[2] = trip_count;
+            frame[0] = trip_count + 1;
+            ++pc;
+          } else {
+            size_t n_loop_carried = inst.N - 2;
+            for (size_t i = 0; i < n_loop_carried; ++i) {
+              frame[i] = std::move(frame[i + 3]);
+            }
+            drop(stack, 3); // iteration_count, max_iter, cond
+            pc += inst.X;
+          }
+        } break;
+        case RET:
+          if (future) {
+            auto num_outputs = function->n_outputs;
+            if (num_outputs == 1) {
+              future->markCompleted(stack.back());
+            } else {
+              future->markCompleted(
+                  Tuple::create(jit::last(stack, num_outputs).vec()));
+            }
+          }
+          return false;
+        case WAIT:
+          auto future = stack.back().toFuture();
+          if (!future->completed()) {
+            getOrCreateFuture();
 
-        getOrCreateFuture();
+            // callback needs to be a struct rather than a lambda so that
+            // we can move the stack to the other thread
+            struct Callback {
+              Callback(
+                  c10::intrusive_ptr<InterpreterStateImpl> state,
+                  Stack stack)
+                  : state_(std::move(state)), stack_(std::move(stack)) {}
+              void operator()() {
+                at::launch(InterpreterContinuation(
+                    state_,
+                    std::move(stack_),
+                    autograd::GradMode::is_enabled()));
+              }
 
-        if (get(inst.inputs.free_flags, 0)) {
-          // make sure the register is not freed once we are waked up
-          registers[get(inst.inputs.values, 0)] = e.future;
-        }
+             private:
+              InterpreterState state_;
+              Stack stack_;
+            };
 
-        // Make sure adding callback is the last step.
-        // Otherwise if e.future has completed,
-        // the current thread will continue running before it suspends.
-        InterpreterState state(intrusive_from_this());
-        e.future->addCallback([state]() {
-          at::launch(InterpreterContinuation(state, Stack(),
-              autograd::GradMode::is_enabled()));
-        });
+            // we are suspending, so we need to reset the stack to where we
+            // started if it started empty, except for the inputs we can avoid a
+            // true copy by swapping, which leaves the original stack empty.
+            Stack copied;
+            if (stack_start_ == 0) {
+              copied.swap(stack);
+            } else {
+              copied.insert(
+                  copied.begin(),
+                  std::make_move_iterator(stack.begin() + stack_start_),
+                  std::make_move_iterator(stack.end()));
+              stack.resize(stack_start_);
+            }
+            future->addCallback(
+                Callback(intrusive_from_this(), std::move(copied)));
 
-        return true;
-      } catch (Future::FutureError& e) {
-        // Error from the forked thread.
-        auto msg = e.error_msg; // copy the error for each callback
-        handleError(std::move(msg), false);
-        return false;
-      } catch (std::exception& e) {
-        // Error from the current thread
-        bool is_jit_exception = dynamic_cast<JITException*>(&e);
-        handleError(
-            instructions[pc].debug_location->wrapException(
-                e, "operation failed in interpreter"),
-            is_jit_exception);
-        return false;
+            return true;
+          }
+          stack.pop_back();
+          stack.emplace_back(future->value());
+          ++pc;
+          break;
       }
     }
-    if (future) {
-      auto num_outputs = function->preprocess.n_outputs;
-      if (num_outputs == 1) {
-        future->markCompleted(stack.back());
-      } else {
-        future->markCompleted(
-            Tuple::create(jit::last(stack, num_outputs).vec()));
-      }
-    }
-
-    return false;
   }
 
   void handleError(std::string&& error_msg, bool is_jit_exception) {
@@ -762,7 +719,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
     if (runImpl(stack)) {
       future->wait();
 
-      auto num_outputs = function->preprocess.n_outputs;
+      auto num_outputs = function->n_outputs;
       if (num_outputs == 1) {
         push(stack, future->value());
       } else {
@@ -773,52 +730,10 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
       }
     }
   }
-
-  int get(const ListHandle<int>& list, int i) {
-    return int_data[list.start + i];
-  };
-  bool get(const ListHandle<bool>& list, int i) {
-    return bool_data[list.start + i];
-  }
-  void loadTensorsFromRegisters(const UseList& uses, Stack& stack) {
-    for (int i = 0; i < uses.values.size; i++) {
-      int reg = get(uses.values, i);
-      // std::cout << "push reg[" << reg << "];\n" << registers[reg] << "\n\n";
-      if (get(uses.free_flags, i)) {
-        stack.push_back(std::move(registers[reg]));
-      } else {
-        stack.push_back(registers[reg]);
-      }
-    }
-  }
-
-  // pc is critical for the interperter to pick up the progress from suspend
-  size_t pc = 0;
-  c10::intrusive_ptr<Future> future;
-  std::shared_ptr<CodeImpl> function; // keep function alive
-  // these are just copies of function to prevent indirections in interpreter
-  int* int_data;
-  const std::vector<bool>& bool_data;
-
-  // this holds all the tensors for this interpreter run
-  // we don't bother minimizing the size of this vector, since the extra
-  // memory used by the pointers in this will be small
-  // instead we are very aggresive about releasing tensors when they become dead
-  // to make sure memory management happens efficiently.
-
-  // We optimize for the case where derivatives are run with retain_graph=False
-  // in the case where it is true, then the interpreter and this array get
-  // copied if this every becomes a bottleneck then we _should_ consider
-  // minimizing the total number or register
-  std::vector<IValue> registers;
-
-  // single buffer for input/output calls to ATen functions, so that we do not
-  // reallocate
-  Stack stack;
 };
 
 std::ostream& operator<<(std::ostream& out, const Code& code) {
-  out << *code.pImpl->graph << "\n";
+  out << *code.pImpl->graph_ << "\n";
   code.pImpl->dump(out);
   return out;
 }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1016,12 +1016,8 @@ RegisterOperators reg(
      Operator(
          "aten::wait(Future(t) self) -> t",
          [](Stack& stack) {
-           auto future = pop(stack).toFuture();
-           if (future->completed()) {
-             push(stack, future->value());
-           } else {
-             throw Suspend(future);
-           }
+           TORCH_CHECK(
+               false, "wait is implemented directly in the interpreter");
            return 0;
          }),
      Operator(
@@ -1723,7 +1719,6 @@ int dictSetItem(Stack& stack) {
   auto idx = pop(stack);
   auto dict = pop(stack).toGenericDict();
   dict->elements().insert_or_assign(std::move(idx), std::move(value));
-  push(stack, std::move(dict));
   return 0;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21565 [WIP] make tests pass with enable_first_class_module() enabled.
* #21515 Add WeakIValue, use in tracer.
* #21564 clean up the TracingState API
* #21563 Collapse tracing_state.h into tracer.h
* #21562 Interpreter support for CallFunction/CallMethod
* #21561 Expose ExecutionPlan in prep for function calls
* #21560 Add flag to temporarily enable first class modules
* #21559 unfinished push/pop reduction
* **#21558 Prepare interpreter for function calling**

Summary: In order to support calling functions without inlining,
the interpreter will need to push another function 'frame' somewhere
when we invoke the call operator. This behavior is not easily expressible
in the current interpreter since ops can only push/pop to the stack.

Furthermore, we have accumulated several other warts because of the design:

* every Operation needs to return an int because a few ops branch
* aten::wait has to communicate with the core interpreter loop via exceptions.
* The way we encode Loop is a complicated desugaring because implementing
  it as an operator that can only push/pop the stack is hard.

To enable an easy implementation of the call instruction, and to fix the
above warts this patch changes the format of the interpreter instructions
to make it easier to encode arbitrary functionality.

Notes:
* Instructions are now 64-bit words with an opcode, and two arguments
* The var-arg register push/pop/move parts of the instructions are gone.
  Explicit instructions LOAD/STORE/MOVE now encode this logic.
* LOOP/WAIT are directly implemented as operators. We no longer desugar.
* We no longer need to lower Param and Return nodes, avoiding one
  preprocessing pass.
* Debug info is stored off to the side since now multiple Instructions
  may correspond to one node in the graph.

Future:
* This patch should not be merged on its own. A followup will add a
  pass that optimizes the register push/pop logic to cut down the
  number of raw instructions. The pretty printer already does something
  similar to inline instructions.
* The follow up patch will require performance testing before merging
  to make sure this does not regress interpreter overhead.

Test Plan: test_jit.py

Differential Revision: [D15729491](https://our.internmc.facebook.com/intern/diff/D15729491)