### PR TITLE
Add flag to temporarily enable first class modules

### DIFF
--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -333,6 +333,9 @@ void initJITBindings(PyObject* module) {
           "_jit_set_profiling_mode",
           [](bool profiling_flag) { getProfilingMode() = profiling_flag; })
       .def(
+          "_jit_set_first_class_mode",
+          [](bool enabled) { script::setRunAsFirstClass(enabled); })
+      .def(
           "_jit_fuser_get_fused_kernel_code",
           [](Graph& g, std::vector<at::Tensor> inps) {
             return debugGetFusedKernelCode(g, inps);

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -12,6 +12,16 @@ namespace torch {
 namespace jit {
 namespace script {
 
+// first class mode runs models as first class objects,
+// and does not force inlining everywhere. This is experimental
+// as we bring up the system since it will degrade performance
+// and may introduce bugs. test_jit.py provides context managers
+// that enable it for specific tests.
+thread_local bool experimental_run_as_first_class = false;
+void setRunAsFirstClass(bool enabled) {
+  experimental_run_as_first_class = enabled;
+}
+
 struct RecursiveMethodCallError : public std::exception {};
 void placeholderCreator(Function&) {
   throw RecursiveMethodCallError();
@@ -213,10 +223,40 @@ static FunctionSchema sliceFirst(const FunctionSchema& schema) {
   return schema.cloneWithArguments(std::move(sliced));
 }
 
-Method::Method(Module* owner, Function* first_class_function)
+Method::Method(
+    Module* owner,
+    const std::shared_ptr<Function>& first_class_function)
     : owner_(owner), schema_(sliceFirst(first_class_function->getSchema())) {
-  std::tie(function_, initial_ivalues_) =
-      owner->lower_first_class_method(first_class_function);
+  if (experimental_run_as_first_class) {
+    function_ = first_class_function;
+    // initial_ivalues_ left blank
+  } else {
+    std::tie(function_, initial_ivalues_) =
+        owner->lower_first_class_method(first_class_function.get());
+  }
+}
+
+void Method::run(Stack& stack) {
+  if (experimental_run_as_first_class) {
+    stack.insert(stack.begin(), owner().module_object());
+  }
+  for (const auto& input : initial_ivalues_) {
+    push(stack, input.value());
+  }
+  function_->run(stack);
+}
+
+IValue Method::operator()(std::vector<IValue> stack, const Kwargs& kwargs) {
+  getSchema().checkAndNormalizeInputs(stack, kwargs);
+  if (experimental_run_as_first_class) {
+    stack.insert(stack.begin(), owner().module_object());
+  }
+  for (const auto& input : initial_ivalues_) {
+    push(stack, input.value());
+  }
+  // use run rather than operator() to skip the second schema check.
+  function_->run(stack);
+  return stack.front();
 }
 
 void Module::define(const std::string& src, const ResolverPtr& resolver) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21565 [WIP] make tests pass with enable_first_class_module() enabled.
* #21515 Add WeakIValue, use in tracer.
* #21564 clean up the TracingState API
* #21563 Collapse tracing_state.h into tracer.h
* #21562 Interpreter support for CallFunction/CallMethod
* #21561 Expose ExecutionPlan in prep for function calls
* **#21560 Add flag to temporarily enable first class modules**
* #21559 unfinished push/pop reduction
* #21558 Prepare interpreter for function calling

Summary: this flag is used in tests to enable first-class module
execution so that we can test things like invoking methods on
first-class modules and setting their properties before we implement
all the parts necessary to remove the old execution pattern.

Differential Revision: [D15729502](https://our.internmc.facebook.com/intern/diff/D15729502)