### PR TITLE
Expose ExecutionPlan in prep for function calls

### DIFF
--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -12,18 +12,27 @@ namespace jit {
 struct GraphExecutorState;
 struct Code;
 
+struct ExecutionPlan {
+  ExecutionPlan() = default;
+  ExecutionPlan(std::shared_ptr<Graph> graph)
+      : code(graph), graph(std::move(graph)) {}
+
+  operator bool() const {
+    return static_cast<bool>(graph);
+  }
+
+  Code code;
+  std::shared_ptr<Graph> graph;
+};
+
 // Notice that those structs don't manage lifetime of their members.
 // They is only valid only right after you call getDebugState() and should never
 // be used again once another GraphExecutor function is called.
-struct ExecutionPlanState {
-  Code* code = nullptr;
-  const Graph* graph = nullptr;
-};
 
 struct GraphExecutorState {
   const Graph* graph = nullptr;
-  ExecutionPlanState fallback; // XXX: members of this field are optional
-  std::unordered_map<ArgumentSpec, ExecutionPlanState> execution_plans;
+  ExecutionPlan fallback; // XXX: members of this field are optional
+  std::unordered_map<ArgumentSpec, ExecutionPlan> execution_plans;
 };
 
 struct GraphExecutorImplBase;

--- a/torch/csrc/jit/graph_executor_impl.h
+++ b/torch/csrc/jit/graph_executor_impl.h
@@ -30,28 +30,6 @@
 namespace torch {
 namespace jit {
 
-struct ExecutionPlan {
-  ExecutionPlan() = default;
-  ExecutionPlan(std::shared_ptr<Graph> graph)
-      : code(graph), graph(std::move(graph)) {}
-
-  void run(Stack& stack) const;
-
-  operator bool() const {
-    return static_cast<bool>(graph);
-  }
-
-  ExecutionPlanState getDebugState() {
-    ExecutionPlanState state;
-    state.code = &code;
-    state.graph = graph.get();
-    return state;
-  }
-
-  Code code;
-  std::shared_ptr<Graph> graph;
-};
-
 // a Graph can be created via tracing, or via a language-based frontend
 // GraphExecutor runs it. It can run the same graph on many different sizes
 // and different requires_grad states, and handles specializations for each
@@ -74,7 +52,44 @@ struct GraphExecutorImplBase {
         num_outputs(this->graph->outputs().size()) {}
 
   // entry point where execution begins
-  virtual void run(Stack& stack) = 0;
+  void run(Stack& stack);
+
+  void runTraced(Stack& stack) {
+    const auto& state = tracer::getTracingState();
+    auto inputs = last(stack, num_inputs);
+    auto input_values = fmap(
+        inputs, [](const IValue& v) { return tracer::getValueTrace(v); });
+
+    // NB: we could just run the fallback in here and call it a day, but that
+    // would loose all the control flow information we have in the graph. Thus,
+    // we run the fallback to get the correct output values, but we will
+    // override the tracing states later.
+    {
+      // No need to trace a script module.
+      ResourceGuard guard(tracer::pauseTracing());
+      run(stack);
+    }
+
+    // Traces always have types propagated through them, so we make sure to
+    // also propagate types through the graph we are inserting here.
+    // However, this->graph itself may already have been generated with
+    // tracing and so we only do the type propgation if no concrete types have
+    // been set.
+    auto local_graph = this->graph->copy();
+    for (size_t i = 0; i < input_values.size(); ++i) {
+      local_graph->inputs().at(i)->setType(input_values.at(i)->type());
+    }
+    PropagateInputShapes(local_graph);
+    auto output_values =
+        inlineCallTo(*state->graph, *local_graph, input_values);
+
+    auto outputs = last(stack, num_outputs);
+    for (size_t i = 0; i < outputs.size(); ++i) {
+      tracer::setValueTrace(outputs[i], output_values[i]);
+    }
+  }
+
+  virtual ExecutionPlan getPlanFor(Stack& stack) = 0;
   virtual GraphExecutorState getDebugState() = 0;
   virtual ~GraphExecutorImplBase() = default;
 

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -358,11 +358,9 @@ void initJITBindings(PyObject* module) {
     return states;
   });
 
-  py::class_<ExecutionPlanState>(m, "ExecutionPlanState")
-      .def_property_readonly(
-          "graph", [](ExecutionPlanState& s) { return s.graph; })
-      .def_property_readonly(
-          "code", [](ExecutionPlanState& s) { return s.code; });
+  py::class_<ExecutionPlan>(m, "ExecutionPlan")
+      .def_property_readonly("graph", [](ExecutionPlan& s) { return s.graph; })
+      .def_property_readonly("code", [](ExecutionPlan& s) { return s.code; });
 
   py::class_<Gradient>(m, "Gradient")
       .def_property_readonly("f", [](Gradient& m) { return m.f; })

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -3,8 +3,8 @@
 #include <memory>
 #include <vector>
 
-#include <torch/csrc/WindowsTorchApiMacro.h>
 #include <ATen/core/ivalue.h>
+#include <torch/csrc/WindowsTorchApiMacro.h>
 
 namespace at {
 class Tensor;
@@ -75,8 +75,13 @@ struct Suspend : public std::exception {
 };
 
 struct InterpreterContinuation {
-  InterpreterContinuation(InterpreterState state_, Stack stack_, bool grad_mode_enabled_)
-      : state(state_), stack(std::move(stack_)), grad_mode_enabled(grad_mode_enabled_) {}
+  InterpreterContinuation(
+      InterpreterState state_,
+      Stack stack_,
+      bool grad_mode_enabled_)
+      : state(state_),
+        stack(std::move(stack_)),
+        grad_mode_enabled(grad_mode_enabled_) {}
 
   void operator()();
 
@@ -85,5 +90,6 @@ struct InterpreterContinuation {
   Stack stack;
   bool grad_mode_enabled;
 };
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -8,14 +8,7 @@ bool& getProfilingMode() {
   return profiling_mode;
 }
 
-void ProfilingGraphExecutorImpl::run(Stack& stack) {
-  TORCH_CHECK(
-      stack.size() >= num_inputs,
-      "expected ",
-      num_inputs,
-      " inputs, but got only ",
-      stack.size());
-
+ExecutionPlan ProfilingGraphExecutorImpl::getPlanFor(Stack& stack) {
   {
     std::lock_guard<std::mutex> lock(compile_mutex);
     if (!pr_) {
@@ -25,13 +18,10 @@ void ProfilingGraphExecutorImpl::run(Stack& stack) {
       exec_plan_ = caffe2::make_unique<ExecutionPlan>(pr_->profiled_graph_);
     }
   }
-
   if (pr_->profiling_count_ > 0) {
-    exec_plan_->run(stack);
-  } else {
-    AT_ERROR("Not yet implemented");
+    return *exec_plan_;
   }
-  return;
+  AT_ERROR("Not yet implemented");
 }
 
 GraphExecutorState ProfilingGraphExecutorImpl::getDebugState() {

--- a/torch/csrc/jit/profiling_graph_executor_impl.h
+++ b/torch/csrc/jit/profiling_graph_executor_impl.h
@@ -7,7 +7,7 @@ namespace jit {
 struct ProfilingGraphExecutorImpl : public GraphExecutorImplBase {
   using GraphExecutorImplBase::GraphExecutorImplBase;
 
-  void run(Stack& stack) override;
+  ExecutionPlan getPlanFor(Stack& stack) override;
   GraphExecutorState getDebugState() override;
   ~ProfilingGraphExecutorImpl() override = default;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21565 [WIP] make tests pass with enable_first_class_module() enabled.
* #21515 Add WeakIValue, use in tracer.
* #21564 clean up the TracingState API
* #21563 Collapse tracing_state.h into tracer.h
* #21562 Interpreter support for CallFunction/CallMethod
* **#21561 Expose ExecutionPlan in prep for function calls**
* #21560 Add flag to temporarily enable first class modules
* #21559 unfinished push/pop reduction
* #21558 Prepare interpreter for function calling

Summary: This reorganizes GraphExecutor into a stage that looks up
the execution plan getPlanFor, and a stage that runs the plan. This
separation is necessary for first-class functions since the interpreter
will call getPlanFor to look up the Code for the function it will be
calling rather than recursively calling run on the graph executor.

Test Plan: test_jit.py

Differential Revision: [D15729498](https://our.internmc.facebook.com/intern/diff/D15729498)