### PR TITLE
Interpreter support for CallFunction/CallMethod

### DIFF
--- a/test/jit_utils.py
+++ b/test/jit_utils.py
@@ -59,9 +59,18 @@ class JitTestCase(TestCase):
         yield None
         self.setHooks()
 
+    def _isHookExceptionOk(self, e):
+        se = str(e)
+        allowed = ("Could not export Python function",
+                   "closures are not exportable")
+        for a in allowed:
+            if a in se:
+                return True
+        return False
+
     def emitFunctionHook(self, func):
         # func has invalid names for export, skip the jitter check
-        if func.name == "<lambda>" or "aten::" in func.name:
+        if func.name == "<lambda>" or "aten::" in func.name or _in_first_class_mode:
             return
         # disable the hook while we parse code, otherwise we will re-enter the hook
         with self.disableEmitHook():
@@ -72,9 +81,7 @@ class JitTestCase(TestCase):
                 src2, constants2 = _jit_python_print(func2)
                 self.assertMultiLineEqual(src, src2)
             except RuntimeError as e:
-                se = str(e)
-                if "Could not export Python function" not in se and \
-                   "closures are not exportable" not in se:
+                if not self._isHookExceptionOk(e):
                     raise
 
     def emitModuleHook(self, module):
@@ -113,9 +120,7 @@ class JitTestCase(TestCase):
                 for line in main_module:
                     main_module_code += line.decode()
             except RuntimeError as e:
-                se = str(e)
-                if "Could not export Python function" not in se and \
-                   "closures are not exportable" not in se:
+                if not self._isHookExceptionOk(e):
                     raise
                 else:
                     return
@@ -427,6 +432,18 @@ def enable_profiling_mode():
     torch._C._jit_set_profiling_mode(True)
     yield
     torch._C._jit_set_profiling_mode(False)
+
+
+_in_first_class_mode = False
+@contextmanager
+def enable_first_class_mode():
+    global _in_first_class_mode
+    torch._C._jit_set_first_class_mode(True)
+    _in_first_class_mode = True
+    yield
+    torch._C._jit_set_first_class_mode(False)
+    _in_first_class_mode = False
+
 
 # note: not re-entrant, use unnested only
 @contextmanager

--- a/torch/csrc/jit/argument_spec.cpp
+++ b/torch/csrc/jit/argument_spec.cpp
@@ -166,7 +166,6 @@ ArgumentSpec ArgumentSpecCreator::create(bool with_grad, const Stack& input)
         // consume object
         const IValue* iv = stack[stack_top]++;
         AT_ASSERT(iv->isObject());
-        iv->toObject();
         // see [argspec refcounting]
         auto p = *reinterpret_cast<const at::ivalue::Object* const*>(iv);
         auto obj_ptr = &p->slots()[0];

--- a/torch/csrc/jit/exception_message.h
+++ b/torch/csrc/jit/exception_message.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <c10/util/Exception.h>
+#include <stdexcept>
+
+namespace torch {
+namespace jit {
+
+struct ExceptionMessage {
+  ExceptionMessage(const std::exception& e) : e_(e) {}
+
+ private:
+  const std::exception& e_;
+  friend std::ostream& operator<<(
+      std::ostream& out,
+      const ExceptionMessage& msg);
+};
+
+inline std::ostream& operator<<(
+    std::ostream& out,
+    const ExceptionMessage& msg) {
+  auto c10_error = dynamic_cast<const c10::Error*>(&msg.e_);
+  if (c10_error) {
+    out << c10_error->msg_without_backtrace();
+  } else {
+    out << msg.e_.what();
+  }
+  return out;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -679,6 +679,10 @@ void GraphExecutor::run(Stack& inputs) {
   return pImpl->run(inputs);
 }
 
+ExecutionPlan GraphExecutor::getPlanFor(Stack& inputs) {
+  return pImpl->getPlanFor(inputs);
+}
+
 std::shared_ptr<Graph> GraphExecutor::graph() const {
   return pImpl->graph;
 }

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -40,6 +40,7 @@ struct TORCH_API GraphExecutor {
   GraphExecutor() = default;
   GraphExecutor(std::shared_ptr<Graph> graph, bool optimize = true);
   void run(Stack& inputs);
+  ExecutionPlan getPlanFor(Stack& inputs);
   explicit operator bool() const {
     return pImpl != nullptr;
   }

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -334,7 +334,7 @@ void initJITBindings(PyObject* module) {
           [](bool profiling_flag) { getProfilingMode() = profiling_flag; })
       .def(
           "_jit_set_first_class_mode",
-          [](bool enabled) { script::setRunAsFirstClass(enabled); })
+          [](bool enabled) { script::getFirstClassMode() = enabled; })
       .def(
           "_jit_fuser_get_fused_kernel_code",
           [](Graph& g, std::vector<at::Tensor> inps) {

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -8,9 +8,11 @@
 #include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/constants.h>
+#include <torch/csrc/jit/exception_message.h>
 #include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/operator.h>
+#include <torch/csrc/jit/script/compilation_unit.h>
 #include <torch/csrc/jit/script/jit_exception.h>
 
 #include <exception>
@@ -298,6 +300,7 @@ struct PreprocessGraph {
 // I - literal integer
 // C - index into constant table
 // P - jump offset relative to beginning of current instruction
+// F - index into function table
 
 #define FORALL_OPCODES(_)                                                   \
   _(OP, "O") /* invoke operator X */                                        \
@@ -312,7 +315,8 @@ struct PreprocessGraph {
   _(JMP, "P") /* unconditional branch to X */                               \
   _(LOOP, "PI") /* perform a loop, X is where to branch if cond is false */ \
   _(RET, "") /* exit execution */                                           \
-  _(WAIT, "") /* wait for a future to be complete */
+  _(WAIT, "") /* wait for a future to be complete */                        \
+  _(CALL, "F") /* call function X */
 
 enum OpCode : uint8_t {
 #define DEFINE_OP(op, _) op,
@@ -391,6 +395,7 @@ struct CodeImpl {
 
   std::vector<IValue> constant_table_;
   std::vector<Operation> operator_table_;
+  std::vector<std::shared_ptr<script::Function>> function_table_;
   int register_size_ = 0;
   size_t n_outputs;
   size_t n_inputs;
@@ -445,10 +450,10 @@ struct CodeImpl {
   }
 
   int allocRegs(at::ArrayRef<Value*> vs) {
-    int result = register_size_;
+    int result = register_size_ + 1;
     for (Value* v : vs) {
       AT_ASSERT(value_to_reg_.count(v) == 0);
-      value_to_reg_[v] = register_size_++;
+      value_to_reg_[v] = ++register_size_;
     }
     return result;
   }
@@ -485,20 +490,20 @@ struct CodeImpl {
     }
   }
 
-  void emitLoadInputs(Node* node) {
-    for (Value* input : node->inputs()) {
+  void emitLoadInputs(at::ArrayRef<Value*> inputs) {
+    for (Value* input : inputs) {
       emitUse(input, false);
     }
   }
 
   void emitOperator(Node* node) {
-    emitLoadInputs(node);
+    emitLoadInputs(node->inputs());
     insertInstruction(OP, operator_table_.size());
     operator_table_.emplace_back(getOperation(node));
   }
 
   void emitWait(Node* node) {
-    emitLoadInputs(node);
+    emitLoadInputs(node->inputs());
     insertInstruction(WAIT);
   }
 
@@ -527,13 +532,16 @@ struct CodeImpl {
   }
 
   void emitConstant(Node* node) {
+    if (node->output()->type()->kind() == FunctionType::Kind) {
+      return;
+    }
     // constants are just put in the constant table
     value_to_reg_[node->output()] =
         insertConstant(toIValue(node->output()).value());
   }
 
   void emitIf(Node* node) {
-    emitLoadInputs(node);
+    emitLoadInputs(node->inputs());
     size_t start_if = instructions_.size();
     insertInstruction(JF, 0); // dummy offset to be filled in
     emitCodeForBlock(node->blocks().at(0));
@@ -546,12 +554,20 @@ struct CodeImpl {
 
   void emitLoop(Node* loop) {
     insertInstruction(LOADC, insertConstant(0));
-    emitLoadInputs(loop);
+    emitLoadInputs(loop->inputs());
     size_t start = instructions_.size();
     insertInstruction(LOOP, 0, loop->inputs().size()); // dummy offset
     emitCodeForBlock(loop->blocks().at(0));
     insertInstruction(JMP, start - instructions_.size());
     instructions_[start].X = instructions_.size() - start;
+  }
+
+  void emitCall(
+      std::shared_ptr<script::Function> func,
+      at::ArrayRef<Value*> inputs) {
+    emitLoadInputs(inputs);
+    insertInstruction(CALL, function_table_.size());
+    function_table_.emplace_back(std::move(func));
   }
 
   void emitNodeAtBlockLevel(Node* node) {
@@ -561,7 +577,7 @@ struct CodeImpl {
         emitConstant(node);
         break;
       case prim::Return:
-        emitLoadInputs(node);
+        emitLoadInputs(node->inputs());
         break;
       default:
         if (!preprocess_.can_emit_inline[node]) {
@@ -594,6 +610,17 @@ struct CodeImpl {
         break;
       case prim::Param:
         break;
+      case prim::CallFunction:
+        emitCall(
+            node->inputs().at(0)->type()->expect<FunctionType>()->function(),
+            node->inputs().slice(1));
+        break;
+      case prim::CallMethod:
+        emitCall(
+            node->inputs().at(0)->type()->expect<ClassType>()->getMethod(
+                node->s(attr::name)),
+            node->inputs());
+        break;
     }
   }
 
@@ -619,7 +646,7 @@ struct CodeImpl {
 
   void dump(std::ostream& out, size_t i) const {
     out << i << " " << instructions_[i];
-    if (instructions_[i].op == OP) {
+    if (instructions_[i].op == OP || instructions_[i].op == CALL) {
       out << " # " << *instructions_source_[i];
     } else {
       out << "\n";
@@ -636,19 +663,16 @@ struct CodeImpl {
 
 // InterpreterState state that and used to compute a Code
 struct InterpreterStateImpl : c10::intrusive_ptr_target {
-  InterpreterStateImpl(const Code& code)
-      : function(code.pImpl), registers(function->register_size_) {}
+  InterpreterStateImpl(const Code& code) {
+    enterFrame(code);
+  }
 
  private:
-  // pc is critical for the interperter to pick up the progress from suspend
-  size_t pc = 0;
-
   // if we need to suspend, where do we reset the stack?
   // answer: to where it was when we were called, not
   // including any inputs to this function
   int64_t stack_start_ = -1;
   c10::intrusive_ptr<Future> future_;
-  std::shared_ptr<CodeImpl> function; // keep function alive
 
   // this holds all the tensors for this interpreter run
   // we don't bother minimizing the size of this vector, since the extra
@@ -661,9 +685,49 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
   // minimizing the total number or register
   std::vector<IValue> registers;
 
+  struct Frame {
+    std::shared_ptr<CodeImpl> function;
+    size_t pc;
+  };
+
+  // saved-by-value stuff that can exist on the stack inside runInterpreter
+  struct ActiveFrame {
+    size_t pc;
+    Instruction* instructions;
+    IValue* constants;
+    Operation* operators;
+    std::shared_ptr<script::Function>* functions;
+    ActiveFrame(const Frame& frame)
+        : pc(frame.pc),
+          instructions(frame.function->instructions_.data()),
+          constants(frame.function->constant_table_.data()),
+          operators(frame.function->operator_table_.data()),
+          functions(frame.function->function_table_.data()) {}
+  };
+
+  std::vector<Frame> frames;
+
   c10::intrusive_ptr<InterpreterStateImpl> intrusive_from_this() {
     c10::raw::intrusive_ptr::incref(this);
     return c10::intrusive_ptr<InterpreterStateImpl>::reclaim(this);
+  }
+
+  void enterFrame(const Code& code) {
+    frames.emplace_back(Frame{code.pImpl, 0});
+    registers.resize(registers.size() + code.pImpl->register_size_);
+    // frames.back().function->dump(std::cout);
+  }
+
+  void leaveFrame() {
+    registers.resize(registers.size() - frames.back().function->register_size_);
+    frames.pop_back();
+  }
+
+  // relative to the end of the register list so that when we call
+  // functions we are referring to the registers of the currenly executing
+  // function.
+  IValue& reg(size_t reg) {
+    return *(registers.end() - reg);
   }
 
   bool runImpl(Stack& stack) {
@@ -671,163 +735,189 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
     // stack when we suspend, record where it starts so we return the right
     // stack
     if (stack_start_ == -1) {
-      TORCH_INTERNAL_ASSERT(stack.size() >= function->n_inputs);
-      stack_start_ = stack.size() - function->n_inputs;
+      TORCH_INTERNAL_ASSERT(stack.size() >= frames.back().function->n_inputs);
+      stack_start_ = stack.size() - frames.back().function->n_inputs;
     } else {
       // during restarts, all of the stack is always our own, so we leave
       // nothing
       stack_start_ = 0;
     }
+
+    ActiveFrame af(frames.back());
     try {
-      return runInterpreterLoop(stack);
+      while (true) {
+        // std::cout << "RUNNING ";
+        // frames.back().function->dump(std::cout, af.pc);
+        Instruction inst = af.instructions[af.pc];
+        switch (inst.op) {
+          case OP:
+            af.operators[inst.X](stack);
+            ++af.pc;
+            break;
+          case LOAD:
+            stack.emplace_back(reg(inst.X));
+            ++af.pc;
+            break;
+          case MOVE:
+            stack.emplace_back(std::move(reg(inst.X)));
+            ++af.pc;
+            break;
+          case STORE:
+            reg(inst.X) = pop(stack);
+            ++af.pc;
+            break;
+          case STOREN:
+            for (size_t i = inst.N; i > 0; --i) {
+              reg(inst.X + i - 1) = pop(stack);
+            }
+            ++af.pc;
+            break;
+          case DROP:
+            pop(stack);
+            ++af.pc;
+            break;
+          case DROPR:
+            reg(inst.X) = IValue();
+            ++af.pc;
+            break;
+          case LOADC:
+            stack.emplace_back(af.constants[inst.X]);
+            ++af.pc;
+            break;
+          case JF:
+            af.pc += (pop(stack).toBool()) ? 1 : inst.X;
+            break;
+          case JMP:
+            af.pc += inst.X;
+            break;
+          case LOOP: {
+            // stack: iteration_count, max_iter, cond, loop_carried_deps...
+            auto frame = stack.end() - (inst.N + 1);
+            int64_t trip_count = frame[0].toInt();
+            int64_t max_trip_count = frame[1].toInt();
+            bool cond = frame[2].toBool();
+            if (trip_count < max_trip_count && cond) {
+              frame[2] = trip_count;
+              frame[0] = trip_count + 1;
+              ++af.pc;
+            } else {
+              size_t n_loop_carried = inst.N - 2;
+              for (size_t i = 0; i < n_loop_carried; ++i) {
+                frame[i] = std::move(frame[i + 3]);
+              }
+              drop(stack, 3); // iteration_count, max_iter, cond
+              af.pc += inst.X;
+            }
+          } break;
+          case CALL: {
+            const Code& code =
+                af.functions[inst.X]->get_executor().getPlanFor(stack).code;
+            frames.back().pc = af.pc + 1;
+            enterFrame(code);
+            af = ActiveFrame(frames.back());
+          } break;
+          case RET:
+            if (frames.size() > 1) {
+              leaveFrame();
+              af = ActiveFrame(frames.back());
+              break;
+            }
+            if (future_) {
+              auto num_outputs = frames.back().function->n_outputs;
+              if (num_outputs == 1) {
+                future_->markCompleted(stack.back());
+              } else {
+                future_->markCompleted(
+                    Tuple::create(jit::last(stack, num_outputs).vec()));
+              }
+            }
+            return false;
+          case WAIT:
+            auto future = stack.back().toFuture();
+            if (!future->completed()) {
+              getOrCreateFuture();
+
+              // callback needs to be a struct rather than a lambda so that
+              // we can move the stack to the other thread
+              struct Callback {
+                Callback(
+                    c10::intrusive_ptr<InterpreterStateImpl> state,
+                    Stack stack)
+                    : state_(std::move(state)), stack_(std::move(stack)) {}
+                void operator()() {
+                  at::launch(InterpreterContinuation(
+                      state_,
+                      std::move(stack_),
+                      autograd::GradMode::is_enabled()));
+                }
+
+               private:
+                InterpreterState state_;
+                Stack stack_;
+              };
+
+              // we are suspending, so we need to reset the stack to where we
+              // started if it started empty, except for the inputs we can avoid
+              // a true copy by swapping, which leaves the original stack empty.
+              Stack copied;
+              if (stack_start_ == 0) {
+                copied.swap(stack);
+              } else {
+                copied.insert(
+                    copied.begin(),
+                    std::make_move_iterator(stack.begin() + stack_start_),
+                    std::make_move_iterator(stack.end()));
+                stack.resize(stack_start_);
+              }
+              // save pc into the frame so we continue here when restored
+              frames.back().pc = af.pc;
+              future->addCallback(
+                  Callback(intrusive_from_this(), std::move(copied)));
+
+              return true;
+            }
+            stack.pop_back();
+            stack.emplace_back(future->value());
+            ++af.pc;
+            break;
+        }
+      }
     } catch (std::exception& e) {
+      frames.back().pc = af.pc;
       // Error from the current thread
       bool is_jit_exception = dynamic_cast<JITException*>(&e);
-      handleError(
-          function->instructions_source_[pc]->sourceRange().wrapException(
-              e, "operation failed in interpreter"),
-          is_jit_exception);
+      // TODO: stack trace
+      handleError(ExceptionMessage(e), is_jit_exception);
+      //    is_jit_exception);
       return false;
     }
   }
 
-  bool runInterpreterLoop(Stack& stack) {
-    // function->dump(std::cout);
-    Instruction* instructions = function->instructions_.data();
-    IValue* constants = function->constant_table_.data();
-    Operation* operators = function->operator_table_.data();
-    while (true) {
-      // std::cout << "RUNNING ";
-      // function->dump(std::cout, pc);
-      Instruction inst = instructions[pc];
-      switch (inst.op) {
-        case OP:
-          operators[inst.X](stack);
-          ++pc;
-          break;
-        case LOAD:
-          stack.emplace_back(registers[inst.X]);
-          ++pc;
-          break;
-        case MOVE:
-          stack.emplace_back(std::move(registers[inst.X]));
-          ++pc;
-          break;
-        case STORE:
-          registers[inst.X] = pop(stack);
-          ++pc;
-          break;
-        case STOREN:
-          for (size_t i = inst.N; i > 0; --i) {
-            registers[inst.X + i - 1] = pop(stack);
-          }
-          ++pc;
-          break;
-        case DROP:
-          pop(stack);
-          ++pc;
-          break;
-        case DROPR:
-          registers[inst.X] = IValue();
-          ++pc;
-          break;
-        case LOADC:
-          stack.emplace_back(constants[inst.X]);
-          ++pc;
-          break;
-        case JF:
-          pc += (pop(stack).toBool()) ? 1 : inst.X;
-          break;
-        case JMP:
-          pc += inst.X;
-          break;
-        case LOOP: {
-          // stack: iteration_count, max_iter, cond, loop_carried_deps...
-          auto frame = stack.end() - (inst.N + 1);
-          int64_t trip_count = frame[0].toInt();
-          int64_t max_trip_count = frame[1].toInt();
-          bool cond = frame[2].toBool();
-          if (trip_count < max_trip_count && cond) {
-            frame[2] = trip_count;
-            frame[0] = trip_count + 1;
-            ++pc;
-          } else {
-            size_t n_loop_carried = inst.N - 2;
-            for (size_t i = 0; i < n_loop_carried; ++i) {
-              frame[i] = std::move(frame[i + 3]);
-            }
-            drop(stack, 3); // iteration_count, max_iter, cond
-            pc += inst.X;
-          }
-        } break;
-        case RET:
-          if (future_) {
-            auto num_outputs = function->n_outputs;
-            if (num_outputs == 1) {
-              future_->markCompleted(stack.back());
-            } else {
-              future_->markCompleted(
-                  Tuple::create(jit::last(stack, num_outputs).vec()));
-            }
-          }
-          return false;
-        case WAIT:
-          auto future = stack.back().toFuture();
-          if (!future->completed()) {
-            getOrCreateFuture();
-
-            // callback needs to be a struct rather than a lambda so that
-            // we can move the stack to the other thread
-            struct Callback {
-              Callback(
-                  c10::intrusive_ptr<InterpreterStateImpl> state,
-                  Stack stack)
-                  : state_(std::move(state)), stack_(std::move(stack)) {}
-              void operator()() {
-                at::launch(InterpreterContinuation(
-                    state_,
-                    std::move(stack_),
-                    autograd::GradMode::is_enabled()));
-              }
-
-             private:
-              InterpreterState state_;
-              Stack stack_;
-            };
-
-            // we are suspending, so we need to reset the stack to where we
-            // started if it started empty, except for the inputs we can avoid a
-            // true copy by swapping, which leaves the original stack empty.
-            Stack copied;
-            if (stack_start_ == 0) {
-              copied.swap(stack);
-            } else {
-              copied.insert(
-                  copied.begin(),
-                  std::make_move_iterator(stack.begin() + stack_start_),
-                  std::make_move_iterator(stack.end()));
-              stack.resize(stack_start_);
-            }
-            future->addCallback(
-                Callback(intrusive_from_this(), std::move(copied)));
-
-            return true;
-          }
-          stack.pop_back();
-          stack.emplace_back(future->value());
-          ++pc;
-          break;
+  void formatStackTrace(std::ostream& out) {
+    for (size_t i = 0; i < frames.size(); ++i) {
+      const Frame& frame = frames[frames.size() - 1 - i];
+      size_t pc = (i == 0) ? frame.pc
+                           : frame.pc -
+              1; // make sure we report the call node, not the node after it
+      Node* node = frame.function->instructions_source_[pc];
+      if (i > 0) {
+        out << "during call ";
       }
+      node->sourceRange().highlight(out);
     }
   }
 
-  void handleError(std::string&& error_msg, bool is_jit_exception) {
+  void handleError(const ExceptionMessage& msg, bool is_jit_exception) {
+    std::stringstream ss;
+    ss << msg << "\n";
+    ss << "The above operation failed in interpreter, with the following stack trace:\n";
+    formatStackTrace(ss);
     if (future_) {
-      future_->markCompleted(Future::FutureError(std::move(error_msg)));
+      future_->markCompleted(Future::FutureError(ss.str()));
     } else if (is_jit_exception) {
-      throw JITException(std::move(error_msg));
+      throw JITException(ss.str());
     } else {
-      throw std::runtime_error(std::move(error_msg));
+      throw std::runtime_error(ss.str());
     }
   }
 
@@ -849,7 +939,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
     if (runImpl(stack)) {
       future_->wait();
 
-      auto num_outputs = function->n_outputs;
+      auto num_outputs = frames.front().function->n_outputs;
       if (num_outputs == 1) {
         push(stack, future_->value());
       } else {

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -91,5 +91,6 @@ struct InterpreterContinuation {
   bool grad_mode_enabled;
 };
 
+TORCH_API std::shared_ptr<Graph> lastExecutedOptimizedGraph();
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -891,6 +891,7 @@ bool Node::hasSideEffects() const {
     case prim::AddStatValue:
     case prim::TimePoint:
     case prim::CallFunction:
+    case prim::CallMethod:
       return true;
   }
   // All other builtin ops are known to be safe.

--- a/torch/csrc/jit/operator.cpp
+++ b/torch/csrc/jit/operator.cpp
@@ -1,6 +1,6 @@
-#include <torch/csrc/jit/operator.h>
 #include <ATen/ATen.h>
 #include <torch/csrc/jit/alias_info.h>
+#include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/passes/alias_analysis.h>
 #include <torch/csrc/jit/passes/python_print.h>
 #include <torch/csrc/jit/script/edit_distance.h>
@@ -246,11 +246,16 @@ const Operator& getOperatorFor(const Node* node) {
       er << ", ";
     er << *node->inputs()[i]->type();
   }
-  er << "\ncandidates were:\n";
   const auto& candidates = getAllOperatorsFor(node->kind());
-  for (auto& candidate : candidates) {
-    er << "  " << candidate->schema() << "\n";
+  if (candidates.size() > 0) {
+    er << "\ncandidates were:\n";
+    for (auto& candidate : candidates) {
+      er << "  " << candidate->schema() << "\n";
+    }
+  } else {
+    er << "\nno candidates found\n";
   }
+  er << "within the graph:\n";
   er << *node->owningGraph() << "\n";
   throw er;
 }

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -79,7 +79,9 @@ std::shared_ptr<torch::jit::Graph> createGraphByTracing(
           "captured in traces, so it would be a no-op.");
     }
     tracer::exit({toIValue(out)});
-    Inline(*graph);
+    if (!script::getFirstClassMode()) {
+      Inline(*graph);
+    }
     LowerSimpleTuples(graph);
     EliminateDeadCode(graph);
     return graph;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -596,7 +596,9 @@ struct to_ir {
 
   void runCleanupPasses(std::shared_ptr<Graph>& to_clean) {
     // remove any uses of tuples that we inserted that are not needed
-    Inline(*to_clean);
+    if (!script::getFirstClassMode()) {
+      Inline(*to_clean);
+    }
     LowerSimpleTuples(to_clean);
     ConstantPooling(to_clean);
     // For jitter

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -18,8 +18,8 @@ namespace script {
 // and may introduce bugs. test_jit.py provides context managers
 // that enable it for specific tests.
 thread_local bool experimental_run_as_first_class = false;
-void setRunAsFirstClass(bool enabled) {
-  experimental_run_as_first_class = enabled;
+bool& getFirstClassMode() {
+  return experimental_run_as_first_class;
 }
 
 struct RecursiveMethodCallError : public std::exception {};

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -567,7 +567,7 @@ struct TORCH_API Module {
   friend struct Method;
 };
 
-TORCH_API void setRunAsFirstClass(bool enabled);
+TORCH_API bool& getFirstClassMode();
 
 } // namespace script
 } // namespace jit

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -232,8 +232,9 @@ struct FunctionValue : public SugaredValue {
     callee_->ensure_defined();
     MatchedSchema match =
         matchSchema(callee_->getSchema(), loc, *f.graph(), inputs, attributes);
-    return std::make_shared<SimpleValue>(
-        f.graph()->insertFunctionCall(callee_, match));
+    Value* output = f.graph()->insertFunctionCall(callee_, match);
+    output->node()->setSourceRange(loc);
+    return std::make_shared<SimpleValue>(output);
   }
 
  private:
@@ -262,8 +263,9 @@ struct MethodValue : public SugaredValue {
     method->ensure_defined();
     MatchedSchema match = matchSchema(
         method->getSchema(), loc, *f.graph(), inputsWithSelf, attributes);
-    return std::make_shared<SimpleValue>(
-        f.graph()->insertMethodCall(method_name_, match));
+    Value* output = f.graph()->insertMethodCall(method_name_, match);
+    output->node()->setSourceRange(loc);
+    return std::make_shared<SimpleValue>(output);
   }
 
  private:

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -3,8 +3,8 @@
 #include <c10/util/Optional.h>
 
 #include <algorithm>
-#include <memory>
 #include <iostream>
+#include <memory>
 namespace torch {
 namespace jit {
 
@@ -115,29 +115,6 @@ struct CAFFE2_API SourceRange {
     std::stringstream ss;
     highlight(ss);
     return ss.str();
-  }
-  std::string wrapException(
-      const std::exception& e,
-      const std::string& additional = "") {
-    std::stringstream msg;
-    std::string what;
-    auto c10_error = dynamic_cast<const c10::Error*>(&e);
-    if (c10_error) {
-      what = c10_error->msg_without_backtrace();
-    } else {
-      what = e.what();
-    }
-    msg << "\n" << what << ":\n";
-    if (!additional.empty()) {
-      msg << additional << ":\n";
-    }
-    highlight(msg);
-    return msg.str();
-  }
-  void wrapAndRethrowException(
-      const std::exception& e,
-      const std::string& additional = "") {
-    throw std::runtime_error(wrapException(e, additional));
   }
 
  private:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21565 [WIP] make tests pass with enable_first_class_module() enabled.
* #21515 Add WeakIValue, use in tracer.
* #21564 clean up the TracingState API
* #21563 Collapse tracing_state.h into tracer.h
* **#21562 Interpreter support for CallFunction/CallMethod**
* #21561 Expose ExecutionPlan in prep for function calls
* #21560 Add flag to temporarily enable first class modules
* #21559 unfinished push/pop reduction
* #21558 Prepare interpreter for function calling

Summary: Adds CALL instruction, and function_table to interpreter state.
Interpreter state now has a list of Frame objects to keep track of
active call frames.

Nodes:
* Re-did how exception wrapping works so that call stacks can be printed
  by the interpreter.
* Change the order of error reporting so that it is more clear what
  part of a printout is attributable to the interpreter or shape prop
  adding additional context to an error.
* The first-class functions are only enabled under a guard because
  serialization does not work and more tests need to be added for
  the funnctionality.

Differential Revision: [D15729500](https://our.internmc.facebook.com/intern/diff/D15729500)