### PR TITLE
[jit] fix optional type promotion for classes

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1380,12 +1380,6 @@ struct CAFFE2_API ClassType : public Type {
     return false;
   }
 
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    // XXX: We do not have inheritance implemented, only types that are the
-    // same can subtype from each other.
-    return *this == *rhs;
-  }
-
   std::string str() const override {
     return std::string("ClassType<") + name_.name() + ">";
   }

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16050,6 +16050,17 @@ class TestClassType(JitTestCase):
                 other.stack = list(self.stack)
                 return other
 
+    def test_optional_type_promotion(self):
+        # should not throw
+        @torch.jit.script  # noqa: B903
+        class Tree(object):
+            def __init__(self):
+                self.parent = torch.jit.annotate(Optional[Tree], None)
+
+            def add_child(self, child):
+                # type: (Tree) -> None
+                child.parent = torch.jit.annotate(Optional[Tree], self)
+
 
 class TestLogging(JitTestCase):
     def test_bump_numeric_counter(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21593 [jit] fix optional type promotion for classes**
Fixes https://github.com/pytorch/lockdown/issues/106
Differential Revision: [D15741471](https://our.internmc.facebook.com/intern/diff/D15741471)