### PR TITLE
Run test_c10d.py in multi-gpu environment

### DIFF
--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -28,4 +28,5 @@ if [ -n "${IN_CIRCLECI}" ]; then
 fi
 
 time python test/run_test.py --verbose -i distributed
+time python test/run_test.py --verbose -i c10d
 assert_git_not_dirty


### PR DESCRIPTION
@yf225 helped me discovered that our CI does not run multi-gpu tests in `test_c10d.py`. There are quite a few multi-gpu c10d tests. This PR tries to enable those tests. 