### PR TITLE
Allow tensors with requires_grad=True in c10 ops

### DIFF
--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -8,9 +8,6 @@ namespace jit {
 namespace {
 
 at::Tensor unwrap_tensor(at::Tensor&& tensor) {
-  if (tensor.requires_grad()) {
-    throw std::runtime_error("Autograd not yet supported for c10 ops.");
-  }
   if (tensor.is_variable()) {
     return torch::autograd::Variable(std::move(tensor)).tensor_data();
   } else {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21599 Allow tensors with requires_grad=True in c10 ops**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15744692/)

We prevented this because c10 ops can't have a backwards yet and calling them with requires_grad=True would do the wrong thing
if the c10 op is not purely implemented by calling other autograd-able ops.

However, it is a valid use case to have c10 ops that just call other autograd-aware ops, and these ops should be callable with requires_grad=True.

This should fix https://github.com/pytorch/pytorch/issues/21584.

Differential Revision: [D15744692](https://our.internmc.facebook.com/intern/diff/D15744692/)