### PR TITLE
[jit] Add `Final[T]` annotated members to `__constants__`

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13142,6 +13142,7 @@ class TestRecursiveScript(JitTestCase):
 
         return sm
 
+    @skipIf(PY2, "Class annotations are a thing in > 3.5")
     def test_constants_with_final(self):
         class M(torch.nn.Module):
             # TODO: Use this (see below)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13142,7 +13142,7 @@ class TestRecursiveScript(JitTestCase):
 
         return sm
 
-    @skipIf(PY2, "Class annotations are a thing in > 3.5")
+    @unittest.skipIf(PY2, "Class annotations are a thing in > 3.5")
     def test_constants_with_final(self):
         class M(torch.nn.Module):
             # TODO: Use this (see below)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13155,13 +13155,13 @@ class TestRecursiveScript(JitTestCase):
             def forward(self, t):
                 return t + self.x
 
-        m = M()
 
         # TODO: Fix this test so that we can actually define the class like
         #   class M(torch.nn.Module):
         #       x : torch.jit.Final[int]
-        m.__annotations__ = {'x': torch.jit.Final[int]}
+        M.__annotations__ = {'x': torch.jit.Final[int]}
 
+        m = M()
 
         self.checkModule(M(), (torch.randn(2, 2),))
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -43,6 +43,7 @@ from functools import wraps
 from itertools import product, chain
 from textwrap import dedent
 from typing import List, Dict, Optional, Tuple
+import typing_extensions
 import copy
 import inspect
 import math
@@ -13084,6 +13085,20 @@ class TestRecursiveScript(JitTestCase):
         self.assertExportImportModule(sm, args)
 
         return sm
+
+    def test_constants_with_final(self):
+        class M(torch.nn.Module):
+            x : torch.jit.Final[int]
+
+            def __init__(self):
+                super(M, self).__init__()
+                self.x = 2
+
+            def forward(self, t):
+                return t + self.x
+
+        self.checkModule(M(), (torch.randn(2, 2),))
+
 
     def test_script_basic(self):
         def a_python_fn(a, b, c):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -43,7 +43,6 @@ from functools import wraps
 from itertools import product, chain
 from textwrap import dedent
 from typing import List, Dict, Optional, Tuple
-import typing_extensions
 import copy
 import inspect
 import math
@@ -13145,7 +13144,8 @@ class TestRecursiveScript(JitTestCase):
 
     def test_constants_with_final(self):
         class M(torch.nn.Module):
-            x : torch.jit.Final[int]
+            # TODO: Use this (see below)
+            # x : torch.jit.Final[int]
 
             def __init__(self):
                 super(M, self).__init__()
@@ -13153,6 +13153,14 @@ class TestRecursiveScript(JitTestCase):
 
             def forward(self, t):
                 return t + self.x
+
+        m = M()
+
+        # TODO: Fix this test so that we can actually define the class like
+        #   class M(torch.nn.Module):
+        #       x : torch.jit.Final[int]
+        m.__annotations__ = {'x': torch.jit.Final[int]}
+
 
         self.checkModule(M(), (torch.randn(2, 2),))
 

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -347,6 +347,31 @@ except ImportError:
         return isinstance(ann, OptionalInstance)
 
 
+try:
+    import typing_extensions
+    from typing_extensions import Final
+
+    def is_final(ann):
+        return ann.__module__ == 'typing_extensions' and \
+            (getattr(ann, '__origin__', None) is typing_extensions.Final)
+except ImportError:
+    # Same as above, this polyfill is only for `typing_extensions`
+    class FinalInstance(object):
+        __slots__ = ['__args__']
+
+        def __init__(self, types):
+            self.__args__ = types
+
+    class FinalCls(object):
+        def __getitem__(self, types):
+            return FinalInstance(types)
+
+    Final = FinalCls()  # noqa: T484
+
+    def is_final(ann):
+        return isinstance(ann, FinalInstance)
+
+
 # allows BroadcastingList instance to be subscriptable
 class BroadcastingListCls(object):
     def __getitem__(self, types):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -6,6 +6,7 @@ from torch.jit.frontend import get_jit_class_def, get_jit_def, get_default_args
 import torch.backends.cudnn as cudnn
 import torch.jit.annotations
 import torch._jit_internal as _jit_internal
+from torch._jit_internal import Final
 from torch._six import PY2, PY37, with_metaclass, get_function_from_type, \
     string_classes, builtins
 from torch._jit_internal import ignore, export  # noqa: F401
@@ -1618,6 +1619,11 @@ if _enabled:
                     object.__setattr__(self, name, None)
                 else:
                     self.register_buffer(name, original._buffers[name])
+
+            # Constants annotated via `Final[T]` rather than being added to `__constants__`
+            for name, ann in getattr(original, '__annotations__', {}).items():
+                if torch._jit_internal.is_final(ann):
+                    constants_set.add(name)
 
             # Copy constants
             self.__dict__["_constants_set"] = constants_set

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -6,10 +6,8 @@ from torch.jit.frontend import get_jit_class_def, get_jit_def, get_default_args
 import torch.backends.cudnn as cudnn
 import torch.jit.annotations
 import torch._jit_internal as _jit_internal
-from torch._jit_internal import Final
 from torch._six import PY2, PY37, with_metaclass, get_function_from_type, \
     string_classes, builtins
-from torch._jit_internal import ignore, export  # noqa: F401
 from ..nn.modules.utils import _single, _pair, _triple, _quadruple, \
     _list_with_default
 import torch.testing
@@ -28,6 +26,11 @@ import copy
 import collections
 import inspect
 import pickle
+
+# These are imported so users can access them from the `torch.jit` module
+from torch._jit_internal import Final  # noqa: F401
+from torch._jit_internal import ignore, export  # noqa: F401
+
 if sys.version_info[0] > 2:
     import pathlib
 


### PR DESCRIPTION
Class member annotations can be marked with `Final[T]` instead of adding them to `__constants__`. `Final` comes from the `typing_extensions` module (which will be used if it is present). If not, the polyfill from `_jit_internal` is exposed as `torch.jit.Final` for users that don't want to install `typing_extensions`.

This keeps around `__constants__` since a lot of code is still using it, but in documentation follow ups we should change the examples to all to use `Final`.

TODO: install typing_extensions on CI, move tests to a Python3 only file when #21489 lands

Differential Revision: [D15746274](https://our.internmc.facebook.com/intern/diff/15746274/)