### PR TITLE
StoreMatrixInMatrixMarketFormat can store both integer and float tensors

### DIFF
--- a/caffe2/quantization/server/mmio.h
+++ b/caffe2/quantization/server/mmio.h
@@ -14,10 +14,6 @@ void StoreMatrixInMatrixMarketFormat(
     const T* a,
     const std::string& matrix_name) {
   using namespace std;
-  static_assert(
-      is_integral<T>::value,
-      "StoreMatrixInMatrixMarket only works with integer types");
-
   static set<string> dumped_matrix_names;
 
   string name(matrix_name);
@@ -28,17 +24,25 @@ void StoreMatrixInMatrixMarketFormat(
   if (dumped_matrix_names.find(name) == dumped_matrix_names.end()) {
     dumped_matrix_names.insert(name);
 
-    FILE* fp = fopen((name + ".mtx").c_str(), "w");
+    FILE* fp = fopen((matrix_name + ".mtx").c_str(), "w");
     if (!fp) {
       return;
     }
 
-    fprintf(fp, "%%%%MatrixMarket matrix array integer general\n");
+    if (is_integral<T>::value) {
+      fprintf(fp, "%%%%MatrixMarket matrix array integer general\n");
+    } else {
+      fprintf(fp, "%%%%MatrixMarket matrix array real general\n");
+    }
     fprintf(fp, "%d %d\n", m, n);
     // matrix market array format uses column-major order
     for (int j = 0; j < n; ++j) {
       for (int i = 0; i < m; ++i) {
-        fprintf(fp, "%d\n", a[j * m + i]);
+        if (is_integral<T>::value) {
+          fprintf(fp, "%d\n", static_cast<int>(a[j * m + i]));
+        } else {
+          fprintf(fp, "%f\n", static_cast<float>(a[j * m + i]));
+        }
       }
     }
 


### PR DESCRIPTION
Summary: StoreMatrixInMatrixMarketFormat was able to dump quantized tensors only but sometimes we want to dump float tensors.

Differential Revision: D15741611

