### PR TITLE
When converting to NumPy, throw TypeError when type is not supported

### DIFF
--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -69,7 +69,7 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
   return result;
 }
 
-static int aten_to_dtype(const ScalarType scalar_type);
+static int aten_to_numpy_dtype(const ScalarType scalar_type);
 
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   if (tensor.is_cuda()) {
@@ -85,7 +85,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   if (tensor.type().backend() != Backend::CPU) {
     throw TypeError("NumPy conversion for %s is not supported", tensor.type().toString().c_str());
   }
-  auto dtype = aten_to_dtype(tensor.scalar_type());
+  auto dtype = aten_to_numpy_dtype(tensor.scalar_type());
   auto sizes = to_numpy_shape(tensor.sizes());
   auto strides = to_numpy_shape(tensor.strides());
   // NumPy strides use bytes. Torch strides use element counts.
@@ -171,7 +171,7 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
   );
 }
 
-static int aten_to_dtype(const ScalarType scalar_type) {
+static int aten_to_numpy_dtype(const ScalarType scalar_type) {
   switch (scalar_type) {
     case kDouble: return NPY_DOUBLE;
     case kFloat: return NPY_FLOAT;
@@ -183,7 +183,7 @@ static int aten_to_dtype(const ScalarType scalar_type) {
     case kByte: return NPY_UINT8;
     case kBool: return NPY_BOOL;
     default:
-      throw ValueError("Got unsupported ScalarType ", toString(scalar_type));
+      throw TypeError("Got unsupported ScalarType ", toString(scalar_type));
   }
 }
 


### PR DESCRIPTION
This makes the error thrown in aten_to_numpy_dtype consistent with that in numpy_dtype_to_aten.