### PR TITLE
Emit Loop Condition as Separate Block

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -40,6 +40,8 @@ namespace c10 {
   _(prim, JumpZ) /* debug */       \
   _(prim, Load)                    \
   _(prim, Loop)                    \
+  _(prim, While)                   \
+  _(prim, For)                     \
   _(prim, Param)                   \
   _(prim, PackPadded) /* onnx */   \
   _(prim, PadPacked) /* onnx */    \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -40,8 +40,6 @@ namespace c10 {
   _(prim, JumpZ) /* debug */       \
   _(prim, Load)                    \
   _(prim, Loop)                    \
-  _(prim, While)                   \
-  _(prim, For)                     \
   _(prim, Param)                   \
   _(prim, PackPadded) /* onnx */   \
   _(prim, PadPacked) /* onnx */    \

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1236,21 +1236,20 @@ struct to_ir {
   }
 
   // *********************** Loop Operators ************************************
-  // Emits a loop operators conforming to the semantics specified at
+  // Emits a loop operator with the form:
+  // Loop(max_trip_count)
+  // block0(loop_counter) {
+  //   <body>
+  // }
+  // block1 {
+  //   <loop condition>
+  //   -> (condition)
+  // }
+  // For loops will have an empty loop condition block with condition set to
+  // true. In the convert to ssa pass, the loop condition will correctly
+  // inlined. and inputs and outputs added so that the loop conforms to the
+  // semantics specified at
   // https://github.com/onnx/onnx/blob/master/docs/Operators.md#experimental-loop
-  // TODO: implement scan_outputs
-
-  // the format of the Loop instruction is:
-  // loop_carried_outputs* = Loop(max_trip_count, start_condition,
-  //                              loop_carried_inputs*)
-  //                    block0(loop_counter, loop_carried_block*) {
-  //                       <body>
-  //                       -> (continue_condition, loop_carried_block_outputs*)
-  //                    }
-  // all loop_carried_... lists are the same length and represent the value of
-  // loop-carried variables whose definitions are updated as the loop executes
-  // in a way that ensure single static assignment.
-
   void emitLoopCommon(
       SourceRange range,
       const List<Stmt>& body,
@@ -1266,18 +1265,22 @@ struct to_ir {
           integral_constants);
     }
 
-    Value* cond_val = (cond) ? emitCond(cond.value())
-                             : graph->insertConstant(true, nullptr, range);
-
     Node* n = graph->insertNode(create(prim::Loop, range, 0));
-    WithInsertPoint guard(n);
-
-    n->addInput(max_trip_count_val);
-    n->addInput(cond_val);
     auto* body_block = n->addBlock();
+
+    {
+      Block* condition_block = n->addBlock();
+      pushFrame(condition_block);
+      WithInsertPoint insert(condition_block);
+      Value* out = cond ? emitCond(cond.value())
+                        : graph->insertConstant(true, nullptr, range);
+      condition_block->registerOutput(out);
+      popFrame();
+    }
+    n->addInput(max_trip_count_val);
+
     Value* trip_count =
         body_block->addInput()->setType(IntType::get()); // Iteration num
-
     {
       pushFrame(body_block);
       WithInsertPoint guard(body_block);
@@ -1289,12 +1292,6 @@ struct to_ir {
       }
 
       emitStatements(body);
-
-      Value* block_condition = (cond)
-          ? emitCond(cond.value())
-          : graph->insertConstant(true, nullptr, range);
-
-      body_block->registerOutput(block_condition);
 
       popFrame();
     }

--- a/torch/csrc/jit/script/convert_to_ssa.cpp
+++ b/torch/csrc/jit/script/convert_to_ssa.cpp
@@ -172,6 +172,62 @@ struct ControlFlowLoadStores {
   std::shared_ptr<TypeEnvironment> environment_stack = nullptr;
 };
 
+// The loop node is initially emitted as:
+// Loop(max_trip_count)
+//    block0(loop_counter) {
+//      <body>
+//    }
+//    block1 {
+//      <loop condition>
+//      -> (condition)
+//    }
+// Here, we inline the loop condition and convert the loop to the form:
+// Loop(max_trip_count, start_condition)
+//    block0(loop_counter, loop_carried_block*) {
+//      <body>
+//      -> (continue_condition)
+//    }
+
+void inlineLoopCondition(Node* n) {
+  Block* body_block = n->blocks().at(0);
+
+  auto pre_header = n->blocks().at(1);
+  auto header_block = n->addBlock();
+  header_block->cloneFrom(pre_header, [](Value* v) { return v; });
+  for (auto it = header_block->nodes().begin();
+       it != header_block->nodes().end();) {
+    auto block_node = *it++;
+    block_node->moveBefore(n);
+  }
+  n->addInput(header_block->outputs().at(0));
+  n->eraseBlock(2);
+
+  for (auto it = pre_header->nodes().begin();
+       it != pre_header->nodes().end();) {
+    auto block_node = *it++;
+    block_node->moveBefore(body_block->return_node());
+  }
+  body_block->insertOutput(0, pre_header->outputs().at(0));
+  n->eraseBlock(1);
+}
+
+void inlineLoopCondition(Block* block) {
+  for (Node* n : block->nodes()) {
+    switch (n->kind()) {
+      case prim::If:
+      case prim::Function: {
+        for (auto b : n->blocks()) {
+          inlineLoopCondition(b);
+        }
+      } break;
+      case prim::Loop: {
+        inlineLoopCondition(n->blocks().at(0));
+        inlineLoopCondition(n);
+      } break;
+    }
+  }
+}
+
 // Given a graph where outputs have been added to control flow nodes, and
 // loads and stores are represented in the graph, converts the graph to SSA
 struct SSATransformer {
@@ -223,9 +279,11 @@ struct SSATransformer {
   std::shared_ptr<ValueEnvironment> environment_stack = nullptr;
 };
 
-// Converting to SSA works in two parts. First we add outputs to control flow
+// Converting to SSA works in multiple parts. First we inline the loop condition
+// before and into the body of loops, then we add outputs to control flow
 // nodes, then we stitch together Loads & Stores into SSA form.
 void ConvertToSSA(std::shared_ptr<Graph>& graph) {
+  inlineLoopCondition(graph->block());
   ControlFlowLoadStores ctrl;
   ctrl.run(graph);
   SSATransformer ssa;


### PR DESCRIPTION
Emit loop condition as a separate block in loops, then inline them before conversion to SSA. This is needed for breaks & continues where we will inline the condition block after the continue pass and before the break pass. 

I also considered emitting a prim::For and a prim::While, but i think it's easier to just have one pathway.  