### PR TITLE
[jit] CompilationArena

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -362,6 +362,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/autodiff.cpp
     ${TORCH_SRC_DIR}/csrc/jit/attributes.cpp
     ${TORCH_SRC_DIR}/csrc/jit/argument_spec.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/compilation_arena.cpp
     ${TORCH_SRC_DIR}/csrc/jit/export.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pass_manager.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pickler.cpp

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -53,6 +53,7 @@ libtorch_sources = [
     "torch/csrc/jit/autodiff.cpp",
     "torch/csrc/jit/attributes.cpp",
     "torch/csrc/jit/argument_spec.cpp",
+    "torch/csrc/jit/compilation_arena.cpp",
     "torch/csrc/jit/constants.cpp",
     "torch/csrc/jit/node_hashing.cpp",
     "torch/csrc/jit/export.cpp",

--- a/torch/csrc/jit/compilation_arena.cpp
+++ b/torch/csrc/jit/compilation_arena.cpp
@@ -1,0 +1,32 @@
+#include <torch/csrc/jit/compilation_arena.h>
+
+namespace torch {
+namespace jit {
+void CompilationArena::unionWith(CompilationArena* other) {
+  // Merge the smaller blob into the bigger one
+  CompilationArena* src;
+  CompilationArena* dst;
+  if (other->blob_->size() > blob_->size()) {
+    src = this;
+    dst = other;
+  } else {
+    src = other;
+    dst = this;
+  }
+  auto& srcClasses = src->blob_->classes_;
+  auto& dstClasses = dst->blob_->classes_;
+  dstClasses.insert(
+      std::make_move_iterator(srcClasses.begin()),
+      std::make_move_iterator(srcClasses.end()));
+
+  auto& srcFunctions = src->blob_->functions_;
+  auto& dstFunctions = dst->blob_->functions_;
+  dstFunctions.insert(
+      std::make_move_iterator(srcFunctions.begin()),
+      std::make_move_iterator(srcFunctions.end()));
+
+  // The two arenas now point to the same blob
+  src->blob_ = dst->blob_;
+}
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/compilation_arena.h
+++ b/torch/csrc/jit/compilation_arena.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <ATen/core/jit_type.h>
+#include <torch/csrc/jit/function.h>
+
+namespace torch {
+namespace jit {
+/**
+ * class CompilationArena
+ *
+ * Every Arena is owned by a CompilationUnit, which is the publically-visible
+ * way to access classes and functions.
+ *
+ * So this class is pretty dumb; it's just supposed to keep unique pointers to
+ * the classes/functions so that they don't get freed. We should never be
+ * actually asking an Arena what it owns.
+ */
+class CompilationArena {
+ public:
+  /**
+   * Union this Arena with another one. After this now both Arenas own the same
+   * stuff, and as long as one of the arenas is alive, that stuff will stay
+   * alive.
+   */
+  void unionWith(CompilationArena* other);
+
+ private:
+  // The actual owner of the classes/functions. We have a layer of indirection
+  // here so that we can union Arenas transparently.
+  struct OwnerBlob {
+    // TODO: these are shared ptrs today, but eventually arenas will have unique
+    // ptrs when they become the sole owners of classes/functions
+    std::unordered_set<c10::ClassTypePtr> classes_;
+    std::unordered_set<std::shared_ptr<Function>> functions_;
+    size_t size() const {
+      return classes_.size() + functions_.size();
+    }
+  };
+  std::shared_ptr<OwnerBlob> blob_;
+};
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/function.h>
-#include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/source_range.h>
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21661 [wip] function ownership changes
* **#21621 [jit] CompilationArena**
* #21539 [jit] Split out Function into its own file

First steps toward overhauling the ownership model. See the code
comments for details

Differential Revision: [D15770893](https://our.internmc.facebook.com/intern/diff/D15770893)