### PR TITLE
[JIT] Override print when python is present

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -416,6 +416,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/passes/utils/check_alias_annotation.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/utils/memory_dag.cpp
     ${TORCH_SRC_DIR}/csrc/jit/passes/quantization.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/print_handler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/fuser/interface.cpp
     ${TORCH_SRC_DIR}/csrc/jit/register_prim_ops.cpp
     ${TORCH_SRC_DIR}/csrc/jit/register_special_ops.cpp

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12929,6 +12929,22 @@ a")
                 .check_count(s2, 1, exactly=True) \
                 .check_count("BINGET", 2, exactly=True).run(out.getvalue())
 
+    def test_sys_stdout_override(self):
+        @torch.jit.script
+        def foo():
+            print('foo')
+
+        old_stdout = sys.stdout
+        with tempfile.TemporaryFile() as f:
+            try:
+                sys.stdout = f
+                foo()
+            finally:
+                sys.stdout = old_stdout
+
+            f.seek(0)
+            FileCheck().check('foo').run(f.read())
+
     def test_optional_tuple(self):
         def fn(x=None):
             # type: (Optional[Tuple[int, int]]) -> Tuple[int, int]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12934,16 +12934,22 @@ a")
         def foo():
             print('foo')
 
-        old_stdout = sys.stdout
-        with tempfile.TemporaryFile() as f:
-            try:
-                sys.stdout = f
-                foo()
-            finally:
-                sys.stdout = old_stdout
+        class Redirect(object):
+            def __init__(self):
+                self.s = ''
 
-            f.seek(0)
-            FileCheck().check('foo').run(f.read())
+            def write(self, s : str):
+                self.s += s
+
+        old_stdout = sys.stdout
+        redirect = Redirect()
+        try:
+            sys.stdout = redirect
+            foo()
+        finally:
+            sys.stdout = old_stdout
+
+        FileCheck().check('foo').run(redirect.s)
 
     def test_optional_tuple(self):
         def fn(x=None):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12938,7 +12938,7 @@ a")
             def __init__(self):
                 self.s = ''
 
-            def write(self, s : str):
+            def write(self, s):
                 self.s += s
 
         old_stdout = sys.stdout

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -103,6 +103,7 @@ libtorch_sources = [
     "torch/csrc/jit/passes/subgraph_rewrite.cpp",
     "torch/csrc/jit/passes/utils/subgraph_utils.cpp",
     "torch/csrc/jit/passes/utils/memory_dag.cpp",
+    "torch/csrc/jit/print_handler.cpp",
     "torch/csrc/jit/register_prim_ops.cpp",
     "torch/csrc/jit/register_special_ops.cpp",
     "torch/csrc/jit/register_quantized_ops.cpp",

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -569,8 +569,17 @@ void initJITBindings(PyObject* module) {
 
   setPrintHandler([](const std::string& str) {
     py::gil_scoped_acquire acquire;
-    auto _stdout = py::module::import("sys").attr("stdout");
-    _stdout.attr("write")(py::bytes(str));
+    try {
+      auto _stdout = py::module::import("sys").attr("stdout");
+      _stdout.attr("write")(str);
+    } catch (pybind11::error_already_set e) {
+      TORCH_WARN(
+          "Exception occured when printing to Python stdout: ",
+          e.what(),
+          ". Falling back to C++ stdout."
+          " Please report a bug to PyTorch");
+      std::cout << str << std::endl;
+    }
   });
 }
 } // namespace jit

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -572,13 +572,8 @@ void initJITBindings(PyObject* module) {
     try {
       auto _stdout = py::module::import("sys").attr("stdout");
       _stdout.attr("write")(str);
-    } catch (pybind11::error_already_set e) {
-      TORCH_WARN(
-          "Exception occured when printing to Python stdout: ",
-          e.what(),
-          ". Falling back to C++ stdout."
-          " Please report a bug to PyTorch");
-      std::cout << str << std::endl;
+    } catch (py::error_already_set& e) {
+      throw std::runtime_error(e.what());
     }
   });
 }

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -54,8 +54,8 @@
 
 #include <ATen/core/function_schema.h>
 
-#include <Python.h>
 #include <pybind11/functional.h>
+#include <pybind11/iostream.h>
 
 #include <memory>
 #include <sstream>
@@ -570,7 +570,7 @@ void initJITBindings(PyObject* module) {
   setPrintHandler([](const std::string& str) {
     py::gil_scoped_acquire acquire;
     auto _stdout = py::module::import("sys").attr("stdout");
-    _stdout.attr("write")(str);
+    _stdout.attr("write")(py::bytes(str));
   });
 }
 } // namespace jit

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -568,13 +568,9 @@ void initJITBindings(PyObject* module) {
   script::initJitScriptBindings(module);
 
   setPrintHandler([](const std::string& str) {
-    AutoGIL ag;
-    // TODO: I can't get the below to work without crashing.
-    //       figure out how to make this work. Otherwise,
-    //       WriteStdout will truncate to 1000 bytes.
-    // auto _stdout = py::module::import("sys").attr("stdout");
-    // _stdout.attr("write")(_stdout, str);
-    PySys_WriteStdout("%s", str.c_str());
+    py::gil_scoped_acquire acquire;
+    auto _stdout = py::module::import("sys").attr("stdout");
+    _stdout.attr("write")(str);
   });
 }
 } // namespace jit

--- a/torch/csrc/jit/init.h
+++ b/torch/csrc/jit/init.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <iostream>
+
 namespace torch {
 namespace jit {
 

--- a/torch/csrc/jit/init.h
+++ b/torch/csrc/jit/init.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <functional>
-#include <iostream>
-
 namespace torch {
 namespace jit {
 

--- a/torch/csrc/jit/print_handler.cpp
+++ b/torch/csrc/jit/print_handler.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/print_handler.h>
 
 #include <iostream>
+#include <string>
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/print_handler.cpp
+++ b/torch/csrc/jit/print_handler.cpp
@@ -1,5 +1,7 @@
 #include <torch/csrc/jit/print_handler.h>
 
+#include <iostream>
+
 namespace torch {
 namespace jit {
 

--- a/torch/csrc/jit/print_handler.cpp
+++ b/torch/csrc/jit/print_handler.cpp
@@ -1,0 +1,19 @@
+#include <torch/csrc/jit/print_handler.h>
+
+namespace torch {
+namespace jit {
+
+std::atomic<PrintHandler> print_handler([](const std::string& str) {
+  std::cout << str;
+});
+
+PrintHandler getPrintHandler() {
+  return print_handler.load();
+}
+
+void setPrintHandler(PrintHandler ph) {
+  print_handler.store(ph);
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/print_handler.h
+++ b/torch/csrc/jit/print_handler.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+#include <atomic>
+#include <functional>
+#include <iostream>
+
+namespace torch {
+namespace jit {
+
+using PrintHandler = void (*)(const std::string&);
+
+TORCH_API void setPrintHandler(PrintHandler ph);
+TORCH_API PrintHandler getPrintHandler();
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/pickler.h>
+#include <torch/csrc/jit/print_handler.h>
 #include <torch/csrc/jit/profiling_record.h>
 #include <torch/csrc/jit/script/compilation_unit.h>
 #include <torch/csrc/jit/script/error_report.h>
@@ -544,15 +545,19 @@ RegisterOperators reg(
          [](const Node* node) {
            size_t num_inputs = node->inputs().size();
            return [num_inputs](Stack& stack) {
+             std::stringstream ss;
              bool first = true;
              for (const IValue& i : last(stack, num_inputs)) {
                if (!first)
-                 std::cout << " ";
+                 ss << " ";
                first = false;
-               std::cout << i;
+               ss << i;
              }
              drop(stack, num_inputs);
-             std::cout << std::endl;
+             ss << std::endl;
+             auto* handler = getPrintHandler();
+             TORCH_INTERNAL_ASSERT(handler);
+             handler(ss.str());
              return 0;
            };
          }),


### PR DESCRIPTION
This makes it so we can see the output of prim::Print in environments like iPython notebooks which override sys.stdout