### PR TITLE
Rename hubconf.conf to hubconf.py in docs

### DIFF
--- a/docs/source/hub.rst
+++ b/docs/source/hub.rst
@@ -20,8 +20,8 @@ to a github repository by adding a simple ``hubconf.py`` file;
 How to implement an entrypoint?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Here is a code snippet specifies an entrypoint for ``resnet18`` model if we expand
-the implementation in ``pytorch/vision/hubconf.conf``.
-In most case importing the right function in ``hubconf.conf`` is sufficient. Here we
+the implementation in ``pytorch/vision/hubconf.py``.
+In most case importing the right function in ``hubconf.py`` is sufficient. Here we
 just want to use the expanded version as an example to show how it works.
 You can see the full script in
 `pytorch/vision repo <https://github.com/pytorch/vision/blob/master/hubconf.py>`_


### PR DESCRIPTION
It's a typo I guess. cc @fmassa 