### PR TITLE
[WIP] Swap thread state before forwarding to Python apply

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -90,6 +90,7 @@ set(TORCH_PYTHON_SRCS
     ${TORCH_SRC_DIR}/csrc/utils/object_ptr.cpp
     ${TORCH_SRC_DIR}/csrc/utils/python_arg_parser.cpp
     ${TORCH_SRC_DIR}/csrc/utils/structseq.cpp
+    ${TORCH_SRC_DIR}/csrc/utils/swap_thread_state.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tensor_apply.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tensor_dtypes.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tensor_layouts.cpp

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -21,7 +21,7 @@
 #include <torch/csrc/jit/python_tracer.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/utils/auto_gil.h>
-#include <torch/csrc/utils/swap_thread_states.h>
+#include <torch/csrc/utils/swap_thread_state.h>
 #include <torch/csrc/Exceptions.h>
 
 #include <exception>

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -21,6 +21,7 @@
 #include <torch/csrc/jit/python_tracer.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/utils/auto_gil.h>
+#include <torch/csrc/utils/swap_thread_states.h>
 #include <torch/csrc/Exceptions.h>
 
 #include <exception>
@@ -107,11 +108,6 @@ auto PyFunction::legacy_apply(const variable_list& inputs) -> variable_list {
 // C++'s Function::apply to a Python method "apply".
 auto PyFunction::apply(variable_list&& inputs) -> variable_list {
   AutoGIL gil;
-  auto old_tstate = PyThreadState_Get();
-  auto interp = old_tstate->interp;
-  PyThreadState* new_tstate = PyThreadState_New(interp);
-  PyThreadState_Swap(new_tstate);
-
   at::OptionalDeviceGuard _device_guard;
   THPFunction* py_fn = (THPFunction*)obj;
 
@@ -138,7 +134,13 @@ auto PyFunction::apply(variable_list&& inputs) -> variable_list {
 
   THPObjectPtr apply_fn(PyObject_GetAttrString(obj, "apply"));
   if (!apply_fn) throw python_error();
-  THPObjectPtr r(PyObject_CallObject(apply_fn, pyInputs.get()));
+
+  PyObject* callRes;
+  {
+    SwapPyThreadState swapThreadState;
+    callRes = PyObject_CallObject(apply_fn, pyInputs.get());
+  }
+  THPObjectPtr r(callRes);
   if (!r) throw python_error();
   ensure_tuple(r);
 
@@ -202,9 +204,6 @@ auto PyFunction::apply(variable_list&& inputs) -> variable_list {
     }
   }
 
-  PyThreadState_Swap(old_tstate);
-  PyThreadState_Clear(new_tstate);
-  PyThreadState_Delete(new_tstate);
   return results;
 }
 
@@ -1087,8 +1086,12 @@ bool THPFunction_initModule(PyObject *module)
 
 struct Decref {
   void operator()(PyFunction* p) const {
-    AutoGIL gil;
-    Py_DECREF(p->obj);
+    if (swappedThreadState) {
+      Py_DECREF(p->obj);
+    } else {
+      AutoGIL gil;
+      Py_DECREF(p->obj);
+    }
   }
 };
 

--- a/torch/csrc/utils/cuda_lazy_init.cpp
+++ b/torch/csrc/utils/cuda_lazy_init.cpp
@@ -5,24 +5,37 @@
 
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/utils/swap_thread_state.h>
 
 namespace torch {
 namespace utils {
 
 void cuda_lazy_init() {
-  AutoGIL g;
-  // Protected by the GIL.  We don't use call_once because under ASAN it
-  // has a buggy implementation that deadlocks if an instance throws an
-  // exception.  In any case, call_once isn't necessary, because we
-  // have taken a lock.
-  static bool run_yet = false;
-  if (!run_yet) {
-    auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
-    if (!module) throw python_error();
-    auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
-    if (!res) throw python_error();
-    run_yet = true;
-  }
+  if (swappedThreadState) {
+    // Don't acquired GIL because it is already held by this thread
+    static bool run_yet = false;
+    if (!run_yet) {
+      auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
+      if (!module) throw python_error();
+      auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
+      if (!res) throw python_error();
+      run_yet = true;
+    }
+  } else {
+    AutoGIL g;
+    // Protected by the GIL.  We don't use call_once because under ASAN it
+    // has a buggy implementation that deadlocks if an instance throws an
+    // exception.  In any case, call_once isn't necessary, because we
+    // have taken a lock.
+    static bool run_yet = false;
+    if (!run_yet) {
+      auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
+      if (!module) throw python_error();
+      auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
+      if (!res) throw python_error();
+      run_yet = true;
+    }
+ }
 }
 
 }

--- a/torch/csrc/utils/swap_thread_state.cpp
+++ b/torch/csrc/utils/swap_thread_state.cpp
@@ -1,0 +1,23 @@
+#include <torch/csrc/utils/swap_thread_state.h>
+
+thread_local bool swappedThreadState = false;
+
+SwapPyThreadState::SwapPyThreadState() : old_tstate(PyThreadState_Get()),
+ new_tstate(PyThreadState_New(old_tstate->interp)) {
+   PyThreadState_Swap(new_tstate);
+   swappedThreadState = true;
+ }
+
+SwapPyThreadState::~SwapPyThreadState() {
+  // Copy exception to the old thread state
+  PyObject *type, *value, *traceback;
+  PyErr_Fetch(&type, &value, &traceback);
+
+  PyThreadState_Swap(old_tstate);
+  PyErr_Restore(type, value, traceback);
+
+  PyThreadState_Clear(new_tstate);
+  PyThreadState_Delete(new_tstate);
+  swappedThreadState = false;
+
+}

--- a/torch/csrc/utils/swap_thread_state.h
+++ b/torch/csrc/utils/swap_thread_state.h
@@ -7,21 +7,12 @@
 // Check this thread local before trying to acqure the GIL using
 // PyGILStateEnsure recursively. If the ThreadState has been swapped and the GIL
 // hasn't been released, do not try to acquire it again from the same thread
-static thread_local bool swappedThreadState = false;
+extern thread_local bool swappedThreadState;
 
 struct SwapPyThreadState {
-  SwapPyThreadState() : old_tstate(PyThreadState_Get()),
-   new_tstate(PyThreadState_New(old_tstate->interp)) {
-     PyThreadState_Swap(new_tstate);
-     swappedThreadState = true;
-   }
+  SwapPyThreadState();
 
-  ~SwapPyThreadState() {
-      PyThreadState_Swap(old_tstate);
-      PyThreadState_Clear(new_tstate);
-      PyThreadState_Delete(new_tstate);
-      swappedThreadState = false;
-  }
+  ~SwapPyThreadState();
 
   PyThreadState* old_tstate;
   PyThreadState* new_tstate;

--- a/torch/csrc/utils/swap_thread_states.h
+++ b/torch/csrc/utils/swap_thread_states.h
@@ -20,6 +20,7 @@ struct SwapPyThreadState {
       PyThreadState_Swap(old_tstate);
       PyThreadState_Clear(new_tstate);
       PyThreadState_Delete(new_tstate);
+      swappedThreadState = false;
   }
 
   PyThreadState* old_tstate;

--- a/torch/csrc/utils/swap_thread_states.h
+++ b/torch/csrc/utils/swap_thread_states.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// RAII struct to change the current PyThreadState to a new PyThreadState
+
+#include <torch/csrc/python_headers.h>
+
+// Check this thread local before trying to acqure the GIL using
+// PyGILStateEnsure recursively. If the ThreadState has been swapped and the GIL
+// hasn't been released, do not try to acquire it again from the same thread
+static thread_local bool swappedThreadState = false;
+
+struct SwapPyThreadState {
+  SwapPyThreadState() : old_tstate(PyThreadState_Get()),
+   new_tstate(PyThreadState_New(old_tstate->interp)) {
+     PyThreadState_Swap(new_tstate);
+     swappedThreadState = true;
+   }
+
+  ~SwapPyThreadState() {
+      PyThreadState_Swap(old_tstate);
+      PyThreadState_Clear(new_tstate);
+      PyThreadState_Delete(new_tstate);
+  }
+
+  PyThreadState* old_tstate;
+  PyThreadState* new_tstate;
+};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21634 Swap thread state before forwarding to Python apply**

Summary:
Before calling into the python apply_fn from PyFunction::apply, swap to a new PyThreadState to prevent recursion error in python in the cases of reentrant backwards.

TODO : Do not swap thread state for non reentrant backward calls. 

Test Plan:
Tested with https://github.com/pytorch/pytorch/issues/6959 to ensure no Recursion Error