### PR TITLE
Add some named tensor helper functions

### DIFF
--- a/aten/src/ATen/Dimname.h
+++ b/aten/src/ATen/Dimname.h
@@ -2,6 +2,7 @@
 #ifdef NAMEDTENSOR_ENABLED
 
 #include <ATen/core/interned_strings.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
 
 namespace at {
@@ -26,6 +27,8 @@ struct CAFFE2_API Dimname {
   NameType type_;
   // Will need more fields for other special name types.
 };
+
+using DimnameList = c10::ArrayRef<Dimname>;
 
 static Symbol kWildcard = Symbol::dimname("*");
 bool CAFFE2_API is_valid_identifier(const std::string& name);

--- a/aten/src/ATen/NamedTensor.cpp
+++ b/aten/src/ATen/NamedTensor.cpp
@@ -1,13 +1,36 @@
 #ifdef NAMEDTENSOR_ENABLED
 #include <ATen/NamedTensor.h>
+#include <ATen/core/Tensor.h>
+#include <torch/csrc/utils/memory.h>
 
 namespace at {
 
 bool NamedTensorMeta::has_names() const {
   return !std::all_of(
-      names.begin(), names.end(), [](const Dimname& n) {
+      names_.begin(), names_.end(), [](const Dimname& n) {
         return n.type() == NameType::WILDCARD;
       });
+}
+
+void internal_set_names_inplace(Tensor tensor, optional<DimnameList> names) {
+  if (!names) {
+    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
+    return;
+  }
+
+  auto ndim = tensor.dim();
+  TORCH_CHECK(ndim == names->size(),
+      "Number of names (", names->size(), ") and "
+      "number of dimensions in tensor (", ndim, ") ",
+      "do not match.");
+
+  auto* meta = tensor.get_named_tensor_meta();
+  if (meta == nullptr) {
+    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(
+        torch::make_unique<NamedTensorMeta>(*names));
+  } else {
+    meta->set_names_(*names);
+  }
 }
 
 }

--- a/aten/src/ATen/NamedTensor.cpp
+++ b/aten/src/ATen/NamedTensor.cpp
@@ -12,7 +12,7 @@ bool NamedTensorMeta::has_names() const {
       });
 }
 
-void internal_set_names_inplace(Tensor tensor, optional<DimnameList> names) {
+void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
   if (!names) {
     tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
     return;

--- a/aten/src/ATen/NamedTensor.h
+++ b/aten/src/ATen/NamedTensor.h
@@ -11,16 +11,24 @@ namespace at {
 // that c10::Symbol isn't actually a part of the c10 lib (where TensorImpl is).
 // In the long term, we should decouple c10::Symbol from aten and toss it into c10.
 struct CAFFE2_API NamedTensorMeta : public c10::NamedTensorMetaInterface {
-  std::vector<Dimname> names;
-
   explicit NamedTensorMeta(int64_t num_names)
-    : names(std::vector<Dimname>(num_names, Dimname::wildcard())) {}
+    : names_(std::vector<Dimname>(num_names, Dimname::wildcard())) {}
 
-  explicit NamedTensorMeta(std::vector<Dimname> names)
-    : names(names) {}
+  explicit NamedTensorMeta(DimnameList names)
+    : names_(names.vec()) {}
 
   bool has_names() const;
+  DimnameList names() const { return names_; }
+
+  void set_names_(DimnameList new_names) {
+    TORCH_INTERNAL_ASSERT(new_names.size() == names_.size());
+    std::copy(new_names.begin(), new_names.end(), names_.begin());
+  }
+
+ private:
+  std::vector<Dimname> names_;
 };
 
+CAFFE2_API void internal_set_names_inplace(Tensor tensor, optional<DimnameList> names);
 }
 #endif

--- a/aten/src/ATen/NamedTensor.h
+++ b/aten/src/ATen/NamedTensor.h
@@ -29,6 +29,6 @@ struct CAFFE2_API NamedTensorMeta : public c10::NamedTensorMetaInterface {
   std::vector<Dimname> names_;
 };
 
-CAFFE2_API void internal_set_names_inplace(Tensor tensor, optional<DimnameList> names);
+CAFFE2_API void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names);
 }
 #endif

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -165,6 +165,16 @@ class CAFFE2_API Tensor {
   IntArrayRef strides() const {
     return impl_->strides();
   }
+#ifdef NAMEDTENSOR_ENABLED
+  optional<DimnameList> names() const {
+    const auto* meta = get_named_tensor_meta();
+    if (meta == nullptr) {
+      return nullopt;
+    } else {
+      return meta->names();
+    }
+  }
+#endif
   int64_t ndimension() const {
     return dim();
   }
@@ -257,6 +267,7 @@ class CAFFE2_API Tensor {
 
   /// Returns a `Tensor`'s dimension names data structure
   NamedTensorMeta* get_named_tensor_meta() const;
+  NamedTensorMeta* get_named_tensor_meta();
 #endif
 
   /// Returns the `TensorOptions` corresponding to this `Tensor`. Defined in

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -266,7 +266,7 @@ class CAFFE2_API Tensor {
   bool is_named() const;
 
   /// Returns a `Tensor`'s dimension names data structure
-  NamedTensorMeta* get_named_tensor_meta() const;
+  const NamedTensorMeta* get_named_tensor_meta() const;
   NamedTensorMeta* get_named_tensor_meta();
 #endif
 

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1334,6 +1334,10 @@ inline bool Tensor::is_cuda() const {
 }
 
 #ifdef NAMEDTENSOR_ENABLED
+inline NamedTensorMeta* Tensor::get_named_tensor_meta() {
+  return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
+}
+
 inline NamedTensorMeta* Tensor::get_named_tensor_meta() const {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1338,7 +1338,7 @@ inline NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }
 
-inline NamedTensorMeta* Tensor::get_named_tensor_meta() const {
+inline const NamedTensorMeta* Tensor::get_named_tensor_meta() const {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -165,6 +165,16 @@ class CAFFE2_API Tensor {
   IntArrayRef strides() const {
     return impl_->strides();
   }
+#ifdef NAMEDTENSOR_ENABLED
+  optional<DimnameList> names() const {
+    const auto* meta = get_named_tensor_meta();
+    if (meta == nullptr) {
+      return nullopt;
+    } else {
+      return meta->names();
+    }
+  }
+#endif
   int64_t ndimension() const {
     return dim();
   }
@@ -257,6 +267,7 @@ class CAFFE2_API Tensor {
 
   /// Returns a `Tensor`'s dimension names data structure
   NamedTensorMeta* get_named_tensor_meta() const;
+  NamedTensorMeta* get_named_tensor_meta();
 #endif
 
   /// Returns the `TensorOptions` corresponding to this `Tensor`. Defined in

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -266,7 +266,7 @@ class CAFFE2_API Tensor {
   bool is_named() const;
 
   /// Returns a `Tensor`'s dimension names data structure
-  NamedTensorMeta* get_named_tensor_meta() const;
+  const NamedTensorMeta* get_named_tensor_meta() const;
   NamedTensorMeta* get_named_tensor_meta();
 #endif
 

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -93,6 +93,10 @@ inline bool Tensor::is_cuda() const {
 }
 
 #ifdef NAMEDTENSOR_ENABLED
+inline NamedTensorMeta* Tensor::get_named_tensor_meta() {
+  return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
+}
+
 inline NamedTensorMeta* Tensor::get_named_tensor_meta() const {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -97,7 +97,7 @@ inline NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }
 
-inline NamedTensorMeta* Tensor::get_named_tensor_meta() const {
+inline const NamedTensorMeta* Tensor::get_named_tensor_meta() const {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }
 

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -14,7 +14,7 @@ using torch::make_unique;
 TEST(NamedTensorTest, defaultMetadata) {
   int num_names = 4;
   const auto meta = NamedTensorMeta(num_names);
-  for (const auto name : meta.names) {
+  for (const auto name : meta.names()) {
     ASSERT_EQ(name.type(), at::NameType::WILDCARD);
   }
 }
@@ -52,7 +52,7 @@ TEST(NamedTensorTest, attachMetadata) {
   
   const auto retrieved_meta = tensor.get_named_tensor_meta();
   for (int i = 0; i < tensor.dim(); ++i) {
-    const auto& retrieved_name = retrieved_meta->names[i];
+    const auto& retrieved_name = retrieved_meta->names()[i];
     const auto& expected_name = names[i];
 
     ASSERT_EQ(retrieved_name.type(), expected_name.type());
@@ -62,5 +62,31 @@ TEST(NamedTensorTest, attachMetadata) {
   // Test dropping metadata
   tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
   ASSERT_FALSE(tensor.is_named());
+}
+
+TEST(NamedTensorTest, internalSetNamesInplace) {
+  auto tensor = at::zeros({3, 2, 5, 7});
+  auto N = Dimname::fromSymbol(Symbol::dimname("N"));
+  auto C = Dimname::fromSymbol(Symbol::dimname("C"));
+  auto H = Dimname::fromSymbol(Symbol::dimname("H"));
+  auto W = Dimname::fromSymbol(Symbol::dimname("W"));
+  std::vector<Dimname> names = { N, C, H, W };
+  ASSERT_FALSE(tensor.is_named());
+
+  // Set names
+  at::internal_set_names_inplace(tensor, names);
+  const auto retrieved_names = tensor.names().value();
+  for (int i = 0; i < tensor.dim(); ++i) {
+    const auto& retrieved_name = retrieved_names[i];
+    const auto& expected_name = names[i];
+
+    ASSERT_EQ(retrieved_name.type(), expected_name.type());
+    ASSERT_EQ(retrieved_name.name(), expected_name.name());
+  }
+
+  // Drop names
+  at::internal_set_names_inplace(tensor, at::nullopt);
+  ASSERT_TRUE(tensor.get_named_tensor_meta() == nullptr);
+  ASSERT_TRUE(tensor.names() == at::nullopt);
 }
 #endif

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -19,6 +19,10 @@ TEST(NamedTensorTest, defaultMetadata) {
   }
 }
 
+static Dimname dimnameFromString(const std::string& str) {
+  return Dimname::fromSymbol(Symbol::dimname(str));
+}
+
 TEST(NamedTensorTest, isNamed) {
   auto tensor = at::zeros({3, 2, 5, 7});
   ASSERT_FALSE(tensor.is_named());
@@ -29,10 +33,10 @@ TEST(NamedTensorTest, isNamed) {
   ASSERT_FALSE(tensor.is_named());
 
   tensor = at::zeros({3, 2, 5, 7});
-  auto N = Dimname::fromSymbol(Symbol::dimname("N"));
-  auto C = Dimname::fromSymbol(Symbol::dimname("C"));
-  auto H = Dimname::fromSymbol(Symbol::dimname("H"));
-  auto W = Dimname::fromSymbol(Symbol::dimname("W"));
+  auto N = dimnameFromString("N");
+  auto C = dimnameFromString("C");
+  auto H = dimnameFromString("H");
+  auto W = dimnameFromString("W");
   std::vector<Dimname> names = { N, C, H, W };
   tensor.unsafeGetTensorImpl()->set_named_tensor_meta(
       make_unique<NamedTensorMeta>(names));
@@ -41,10 +45,10 @@ TEST(NamedTensorTest, isNamed) {
 
 TEST(NamedTensorTest, attachMetadata) {
   auto tensor = at::zeros({3, 2, 5, 7});
-  auto N = Dimname::fromSymbol(Symbol::dimname("N"));
-  auto C = Dimname::fromSymbol(Symbol::dimname("C"));
-  auto H = Dimname::fromSymbol(Symbol::dimname("H"));
-  auto W = Dimname::fromSymbol(Symbol::dimname("W"));
+  auto N = dimnameFromString("N");
+  auto C = dimnameFromString("C");
+  auto H = dimnameFromString("H");
+  auto W = dimnameFromString("W");
   std::vector<Dimname> names = { N, C, H, W };
 
   tensor.unsafeGetTensorImpl()->set_named_tensor_meta(
@@ -66,10 +70,10 @@ TEST(NamedTensorTest, attachMetadata) {
 
 TEST(NamedTensorTest, internalSetNamesInplace) {
   auto tensor = at::zeros({3, 2, 5, 7});
-  auto N = Dimname::fromSymbol(Symbol::dimname("N"));
-  auto C = Dimname::fromSymbol(Symbol::dimname("C"));
-  auto H = Dimname::fromSymbol(Symbol::dimname("H"));
-  auto W = Dimname::fromSymbol(Symbol::dimname("W"));
+  auto N = dimnameFromString("N");
+  auto C = dimnameFromString("C");
+  auto H = dimnameFromString("H");
+  auto W = dimnameFromString("W");
   std::vector<Dimname> names = { N, C, H, W };
   ASSERT_FALSE(tensor.is_named());
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -868,6 +868,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   c10::NamedTensorMetaInterface* named_tensor_meta() const {
     return named_tensor_meta_.get();
   }
+
+  c10::NamedTensorMetaInterface* named_tensor_meta() {
+    return named_tensor_meta_.get();
+  }
 #endif
 
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -865,7 +865,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Return the pointer to named tensor metadata.
    */
-  c10::NamedTensorMetaInterface* named_tensor_meta() const {
+  const c10::NamedTensorMetaInterface* named_tensor_meta() const {
     return named_tensor_meta_.get();
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21648 Expose torch.empty(sizes, *, names, ...) to Python
* #21647 Implement at::empty(IntArrayRef, DimnameList?, TensorOptions) in aten
* **#21636 Add some named tensor helper functions**
* #21632 Add some more namedtensor builds to the CI
* #21633 Add virtual dtor to NamedTensorMetaInterface

at::internal_set_names_inplace(Tensor, optional<DimnameList>)
- Used for setting the names of a tensor. This isn't a native function for
  performance reasons; it'll be used to implement tensor.set_names_,
  torch.empty(..., names=), and other functions.

optional<DimnameList> Tensor::names()
- Access names of a tensor.

Test Plan:
- New tests in [namedtensor ci]

gh-metadata: pytorch pytorch 21636 gh/zou3519/46/head

Differential Revision: [D15780269](https://our.internmc.facebook.com/intern/diff/D15780269)