### PR TITLE
[jit][errors] Throw error when super().__init__() hasn't been called

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1696,6 +1696,10 @@ def _convert_to_script_module(mod, methods=None):
         # Create constant versions for the iterable modules
         return _create_constant_iterable_module(mod)
 
+    if not hasattr(mod, '_parameters'):
+        raise RuntimeError("'{}' has not been initialized, did you forget to call 'super()'?"
+            .format(type(mod).__name__))
+
     if methods is None:
         methods = ('forward',)
     exported = []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21646 [jit][errors] Throw error when super().__init__() hasn't been called**
* #21541 [jit][errors] Describe the location of a failed script attempt (to be improved when stack traces land)
* #21540 [jit][errors] Improve quality of error for non-implemented forward pass

