### PR TITLE
When building extensions, honor options set in CMake.

### DIFF
--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -12,6 +12,7 @@ sys.path.append(pytorch_root)
 # building torch, you should do it in tools/setup_helpers/configure.py.
 # Please don't add it here unless it's only used in LibTorch.
 from tools.build_pytorch_libs import build_caffe2
+from tools.setup_helpers.cmake import CMake
 
 if __name__ == '__main__':
     # Placeholder for future interface. For now just gives a nice -h.
@@ -19,4 +20,4 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     build_caffe2(version=None, cmake_python_library=None, build_python=False,
-                 rerun_cmake=True, cmake_only=False, build_dir='.')
+                 rerun_cmake=True, cmake_only=False, cmake=CMake('.'))

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -5,7 +5,7 @@ import shutil
 
 from .setup_helpers import escape_path
 from .setup_helpers.env import IS_64BIT, IS_WINDOWS, check_negative_env_flag
-from .setup_helpers.cmake import CMake, USE_NINJA
+from .setup_helpers.cmake import USE_NINJA
 from .setup_helpers.cuda import USE_CUDA, CUDA_HOME
 from .setup_helpers.cudnn import CUDNN_INCLUDE_DIR, CUDNN_LIBRARY, USE_CUDNN
 
@@ -50,15 +50,9 @@ def _create_build_env():
     return my_env
 
 
-def build_caffe2(version,
-                 cmake_python_library,
-                 build_python,
-                 rerun_cmake,
-                 cmake_only,
-                 build_dir):
+def build_caffe2(version, cmake_python_library, build_python, rerun_cmake, cmake_only, cmake):
     my_env = _create_build_env()
     build_test = not check_negative_env_flag('BUILD_TEST')
-    cmake = CMake(build_dir)
     cmake.generate(version,
                    cmake_python_library,
                    build_python,
@@ -69,7 +63,7 @@ def build_caffe2(version,
         return
     cmake.build(my_env)
     if build_python:
-        caffe2_proto_dir = os.path.join(build_dir, 'caffe2', 'proto')
+        caffe2_proto_dir = os.path.join(cmake.build_dir, 'caffe2', 'proto')
         for proto_file in glob(os.path.join(caffe2_proto_dir, '*.py')):
             if proto_file != os.path.join(caffe2_proto_dir, '__init__.py'):
                 shutil.copy(proto_file, os.path.join('caffe2', 'proto'))


### PR DESCRIPTION
Currently when building extensions, variables such as USE_CUDA, USE_CUDNN are used to determine what libraries should be linked. But we should use what CMake has detected, because:

1. If CMake found them unavailable but the variables say some libraries should be linked, the build would fail.
2. If the first build is made using a set of non-default build options, rebuild must have these option passed to setup.py again, otherwise the extension build process is inconsistent with CMake. For example,

```bash
# First build
USE_CUDA=0 python setup.py install
# Subsequent builds like this would fail, unless "build/" is deleted
python setup.py install
```

This commit addresses the above issues by using variables from CMakeCache.txt when building the extensions.

---

The changes in `setup.py` may look lengthy, but the biggest changed block is mostly moving them into a function `configure_extension_build` (along with some variable names changed to `cmake_cache_vars['variable name']` and other minor changes), because it must be called after CMake has been called (and thus the options used and system environment detected by CMake become available).