### PR TITLE
Populate profiling events with source info.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -355,6 +355,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/autograd/grad_mode.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/input_buffer.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/profiler.cpp
+    ${TORCH_SRC_DIR}/csrc/autograd/source_debug_info.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/record_function.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/saved_variable.cpp
     ${TORCH_SRC_DIR}/csrc/autograd/variable.cpp

--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -28,6 +28,7 @@
 #include <test/cpp/jit/test_misc.h>
 #include <test/cpp/jit/test_netdef_converter.h>
 #include <test/cpp/jit/test_peephole_optimize.h>
+#include <test/cpp/jit/test_profile_source_debug.h>
 #include <test/cpp/jit/test_qualified_name.h>
 #include <test/cpp/jit/test_save_load.h>
 #include <test/cpp/jit/test_subgraph_matcher.h>
@@ -39,54 +40,56 @@ using namespace torch::jit::test;
 
 namespace torch {
 namespace jit {
-#define TH_FORALL_TESTS(_)             \
-  _(ADFormulas)                        \
-  _(Attributes)                        \
-  _(Blocks)                            \
-  _(CodeTemplate)                      \
-  _(ControlFlow)                       \
-  _(CreateAutodiffSubgraphs)           \
-  _(CustomOperators)                   \
-  _(CustomOperatorAliasing)            \
-  _(IValueKWargs)                      \
-  _(CustomFusion)                      \
-  _(Differentiate)                     \
-  _(DifferentiateWithRequiresGrad)     \
-  _(DynamicDAG)                        \
-  _(FromQualString)                    \
-  _(InternedStrings)                   \
-  _(IValue)                            \
-  _(PassManagement)                    \
-  _(Proto)                             \
-  _(RegisterFusionCachesKernel)        \
-  _(SchemaParser)                      \
-  _(TopologicalIndex)                  \
-  _(TopologicalMove)                   \
-  _(SubgraphUtils)                     \
-  _(AliasAnalysis)                     \
-  _(ContainerAliasing)                 \
-  _(AliasRegistration)                 \
-  _(WriteTracking)                     \
-  _(Wildcards)                         \
-  _(MemoryDAG)                         \
-  _(IRParser)                          \
-  _(ConstantPooling)                   \
-  _(NetDefConverter)                   \
-  _(THNNConv)                          \
-  _(ATenNativeBatchNorm)               \
-  _(NoneSchemaMatch)                   \
-  _(ClassParser)                       \
-  _(Profiler)                          \
-  _(InsertAndEliminateRedundantGuards) \
-  _(InsertBailOuts)                    \
-  _(PeepholeOptimize)                  \
-  _(RecordFunction)                    \
-  _(SubgraphMatching)                  \
-  _(ModuleDefine)                      \
-  _(QualifiedName)                     \
-  _(ClassImport)                       \
-  _(ScriptObject)                      \
-  _(SaveExtraFilesHook)
+#define TH_FORALL_TESTS(_)                \
+  _(ADFormulas)                           \
+  _(Attributes)                           \
+  _(Blocks)                               \
+  _(CodeTemplate)                         \
+  _(ControlFlow)                          \
+  _(CreateAutodiffSubgraphs)              \
+  _(CustomOperators)                      \
+  _(CustomOperatorAliasing)               \
+  _(IValueKWargs)                         \
+  _(CustomFusion)                         \
+  _(Differentiate)                        \
+  _(DifferentiateWithRequiresGrad)        \
+  _(DynamicDAG)                           \
+  _(FromQualString)                       \
+  _(InternedStrings)                      \
+  _(IValue)                               \
+  _(PassManagement)                       \
+  _(Proto)                                \
+  _(RegisterFusionCachesKernel)           \
+  _(SchemaParser)                         \
+  _(TopologicalIndex)                     \
+  _(TopologicalMove)                      \
+  _(SubgraphUtils)                        \
+  _(AliasAnalysis)                        \
+  _(ContainerAliasing)                    \
+  _(AliasRegistration)                    \
+  _(WriteTracking)                        \
+  _(Wildcards)                            \
+  _(MemoryDAG)                            \
+  _(IRParser)                             \
+  _(ConstantPooling)                      \
+  _(NetDefConverter)                      \
+  _(THNNConv)                             \
+  _(ATenNativeBatchNorm)                  \
+  _(NoneSchemaMatch)                      \
+  _(ClassParser)                          \
+  _(Profiler)                             \
+  _(InsertAndEliminateRedundantGuards)    \
+  _(InsertBailOuts)                       \
+  _(PeepholeOptimize)                     \
+  _(RecordFunction)                       \
+  _(SubgraphMatching)                     \
+  _(ModuleDefine)                         \
+  _(QualifiedName)                        \
+  _(ClassImport)                          \
+  _(ScriptObject)                         \
+  _(SaveExtraFilesHook)                   \
+  _(ProfileSourceDebugInfoSingleThread)   \
+  _(ProfileSourceDebugInfoMultiThreaded)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/test/cpp/jit/test_profile_source_debug.h
+++ b/test/cpp/jit/test_profile_source_debug.h
@@ -1,0 +1,114 @@
+#include <thread>
+
+#include "test/cpp/jit/test_utils.h"
+#include "caffe2/torch/csrc/autograd/profiler.h"
+#include "torch/torch.h"
+
+namespace torch {
+namespace jit {
+namespace test {
+
+using namespace torch::autograd::profiler;
+using namespace torch::jit;
+using namespace torch::autograd;
+using Var = SymbolicVariable;
+
+const std::string kDEBUGINFO = "TEST_SOURCE_DEBUG_PROFILING";
+constexpr int kNumThreads = 4;
+constexpr int batch_size = 4;
+constexpr int input_size = 256;
+constexpr int w_k_n = 256;
+
+namespace {
+Var build_fc_body(Var input, Var w) {
+  auto out = input.mm(w);
+  return out;
+}
+
+std::shared_ptr<Graph> build_fc() {
+  auto graph_ptr = std::make_shared<Graph>();
+  auto& g = *graph_ptr;
+  Value* input = g.addInput();
+  Value* w = g.addInput();
+
+  Var out;
+  out = build_fc_body(input, w);
+
+  out.addAsOutput();
+  g.lint();
+
+  return graph_ptr;
+}
+
+int64_t add_source_debug_info(std::shared_ptr<Graph> graph_ptr) {
+  int64_t num_nodes = 0;
+  for (auto n : graph_ptr->nodes()) {
+    SourceRange range(kDEBUGINFO);
+    n->setSourceRange(range);
+    num_nodes++;
+  }
+  return num_nodes;
+}
+
+int64_t num_events_annotated_with_source_debug(thread_event_lists& event_lists) {
+  int64_t num_annotated{0};
+  std::unique_lock<std::mutex> source_debug_info_lock(module_source_debug_info_lock);
+  for (const auto& event_list : event_lists) {
+    for (const auto& event : event_list) {
+      auto info = event.inst_info();
+      std::string source_debug_info = unsafeGetInstructionDebugInfo(event.inst_info());
+      std::cout << "debug info:" << info.code_id << ":" << info.instruction_pc << ":" <<  source_debug_info << std::endl;
+      if (source_debug_info == kDEBUGINFO) {
+        num_annotated++;
+      }
+    }
+  }
+  return num_annotated;
+}
+
+void run_graph(const std::shared_ptr<Graph> graph_ptr, const std::vector<Variable>& inputs) {
+  Code function(graph_ptr);
+  InterpreterState interp(function);
+  std::vector<IValue> stack(inputs.begin(), inputs.end());
+  interp.run(stack);
+  auto output = fmap(stack, [](const IValue& i) { return i.toTensor(); });
+}
+
+} // namespace
+
+void testProfileSourceDebugInfoSingleThread() {
+  auto input = torch::randn({batch_size, input_size}, at::kCPU);
+  auto weight = torch::randn({input_size, input_size}, at::kCPU);
+
+  enableProfiler(ProfilerConfig(ProfilerState::CPU, false));
+  auto fc_graph_ptr = build_fc();
+  int64_t num_nodes = add_source_debug_info(fc_graph_ptr);
+  run_graph(fc_graph_ptr, {input, weight});
+  auto event_list = disableProfiler();
+  int64_t num_annotated = num_events_annotated_with_source_debug(event_list);
+  ASSERT_TRUE(num_annotated > num_nodes);
+}
+
+void testProfileSourceDebugInfoMultiThreaded() {
+
+  auto input = torch::randn({batch_size, input_size}, at::kCPU);
+  auto weight = torch::randn({input_size, input_size}, at::kCPU);
+
+  enableProfiler(ProfilerConfig(ProfilerState::CPU, false));
+  auto fc_graph_ptr = build_fc();
+  int64_t num_nodes = add_source_debug_info(fc_graph_ptr);
+  std::vector<std::thread> interpreter_threads;
+  for (int64_t i = 0; i < kNumThreads; ++i) {
+    interpreter_threads.emplace_back(std::thread(run_graph, fc_graph_ptr, std::vector<Variable>{input, weight}));
+  }
+  for (int64_t i = 0; i < kNumThreads; ++i) {
+    interpreter_threads[i].join();
+  }
+  auto event_list = disableProfiler();
+  int64_t num_annotated = num_events_annotated_with_source_debug(event_list);
+  ASSERT_TRUE(num_annotated > (num_nodes * kNumThreads));
+}
+
+} // namespace test
+} // namespace jit
+} // namespace torch

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -46,6 +46,7 @@ libtorch_sources = [
     "torch/csrc/autograd/grad_mode.cpp",
     "torch/csrc/autograd/input_buffer.cpp",
     "torch/csrc/autograd/profiler.cpp",
+    "torch/csrc/autograd/source_debug_info.cpp",
     "torch/csrc/autograd/record_function.cpp",
     "torch/csrc/autograd/saved_variable.cpp",
     "torch/csrc/autograd/variable.cpp",

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -46,7 +46,8 @@ PyObject* THPAutograd_initExtension(PyObject* _unused) {
       .def("cpu_elapsed_us", &Event::cpu_elapsed_us)
       .def("cuda_elapsed_us", &Event::cuda_elapsed_us)
       .def("has_cuda", &Event::has_cuda)
-      .def("shapes", &Event::shapes);
+      .def("shapes", &Event::shapes)
+      .def("source_debug_info", &Event::source_debug_info);
 
   m.def("_enable_profiler", enableProfiler);
   m.def("_disable_profiler", disableProfiler);

--- a/torch/csrc/autograd/source_debug_info.cpp
+++ b/torch/csrc/autograd/source_debug_info.cpp
@@ -1,0 +1,57 @@
+#include  <torch/csrc/autograd/source_debug_info.h>
+
+namespace torch { namespace autograd { namespace profiler {
+
+std::mutex module_source_debug_info_lock;
+
+thread_local InstructionInfo inst_info;
+
+void setInstructionInfo(int64_t code_id, size_t pc) {
+  inst_info = InstructionInfo(code_id, pc);
+}
+
+InstructionInfo getInstructionInfo() {
+  return inst_info;
+}
+
+// For nodes of JIT graph, InstructionDebufInfo stores instruction/node's
+// debug information. Since instructions are serially
+// executed from instruction buffer (each node is an instruction)
+// we can use a vector and index into it using instruction's pc,
+// which should be unique for each instruction of a graph.
+using InstructionDebugInfo = std::vector<std::string>;
+// Maps from thread_id to a scope of instructions for interpreter running
+// on that thread.
+std::vector<InstructionDebugInfo> module_source_debug_info;
+
+int64_t createNextCodeId() {
+  std::unique_lock<std::mutex> lock(module_source_debug_info_lock);
+  module_source_debug_info.emplace_back(InstructionDebugInfo());
+  return module_source_debug_info.size() - 1;
+}
+
+void setInstructionDebugInfo(const InstructionInfo& info , std::string&& inst_debug_info) {
+  const int64_t code_id = info.code_id;
+  if (code_id < 0 || code_id >= module_source_debug_info.size()) {
+    TORCH_WARN("Found wrong code_id, found:", code_id);
+    return;
+  }
+  std::unique_lock<std::mutex> lock(module_source_debug_info_lock);
+  module_source_debug_info[code_id].emplace_back(inst_debug_info);
+}
+
+std::string unsafeGetInstructionDebugInfo(const InstructionInfo& info) {
+  int64_t code_id = info.code_id;
+  size_t inst_pc = info.instruction_pc;
+  if (code_id < 0 || code_id >= module_source_debug_info.size()) {
+    TORCH_WARN("Found wrong code_id, found:", code_id);
+    return "";
+  }
+  if (inst_pc < 0 || inst_pc >= module_source_debug_info[code_id].size()) {
+    TORCH_WARN("Instruction PC out of range, found:", inst_pc);
+    return "";
+  }
+  return module_source_debug_info[code_id][inst_pc];
+}
+
+}}}

--- a/torch/csrc/autograd/source_debug_info.h
+++ b/torch/csrc/autograd/source_debug_info.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <c10/util/Exception.h>
+
+#include <mutex>
+#include <vector>
+#include <unordered_map>
+#include <thread>
+
+namespace torch { namespace autograd { namespace profiler {
+
+extern std::mutex module_source_debug_info_lock;
+
+int64_t createNextCodeId();
+
+struct InstructionInfo {
+  InstructionInfo() : code_id(-1), instruction_pc(0) {}
+  InstructionInfo(int64_t id, size_t pc) :
+    code_id(id), instruction_pc(pc) {}
+  int64_t code_id;
+  size_t instruction_pc;
+};
+
+void setInstructionInfo(int64_t code_id, size_t pc);
+
+InstructionInfo getInstructionInfo();
+
+// Insert instructions' debug info in DebugInfo structure.
+// There is one such instance for every instance of a Graph in a process.
+// Thus graph_id uniquely identifies it.
+// Furthermore it assumes that source_debug info is inserted in GraphebugInfo
+// when the instructions are created. Therefore if we set the source_debug info
+// at the time of instruction creation we do not need instruction_pc as
+// it will always be, at the point of insertion, instruction_buffer.size() - 1.
+// Thus instruction buffer and GraphSourceDebugInfo size shall be equal.
+void setInstructionDebugInfo(const InstructionInfo& info, std::string&& inst_debug_info);
+
+// Accessing module_source_debug_info requires locking the mutex.
+// This function accesses without locking, assuming the caller
+// acquires the lock. Hence the unsafe prefix.
+std::string unsafeGetInstructionDebugInfo(const InstructionInfo& info);
+}}}


### PR DESCRIPTION
Summary:
This changelist adds:
1) Information about where the operators are in the model source.
2) Populates this information in chrome trace.
3) Enables use of python interface for profiler to get source debug info.

Differential Revision: D15772906

