### PR TITLE
Fix with emit_nvtx, also allow shape information to appear in nvtx ranges.

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15,7 +15,7 @@ from functools import reduce
 from torch._six import inf, nan, istuple
 from torch.autograd.gradcheck import gradgradcheck, gradcheck
 from torch.autograd.function import once_differentiable
-from torch.autograd.profiler import profile, format_time, EventList, FunctionEvent
+from torch.autograd.profiler import profile, format_time, EventList, FunctionEvent, emit_nvtx
 from torch.utils.checkpoint import checkpoint
 from common_utils import (TEST_MKL, TestCase, run_tests, skipIfNoLapack,
                           suppress_warnings, skipIfRocm,
@@ -2563,6 +2563,17 @@ class TestAutograd(TestCase):
         if sys.platform != "win32":
             with tempfile.NamedTemporaryFile() as trace_file:
                 prof.export_chrome_trace(trace_file.name)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
+    def test_profiler_emit_nvtx(self):
+        # This test is not intended to ensure correctness of nvtx ranges.
+        # That would require something a great deal more complex (you'd have to create a
+        # profile in a subprocess, open it, and parse the sql somehow).
+        # This test is merely intended to catch if emit_nvtx breaks on construction.
+        a = torch.tensor([1, 2, 3], dtype=torch.float32, device='cuda')
+        with torch.cuda.profiler.profile():
+            with emit_nvtx():
+                a.add(1.0)
 
     def test_dir(self):
         x = torch.randn(10, 10)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2564,6 +2564,7 @@ class TestAutograd(TestCase):
             with tempfile.NamedTemporaryFile() as trace_file:
                 prof.export_chrome_trace(trace_file.name)
 
+    @skipIfRocm
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA unavailable")
     def test_profiler_emit_nvtx(self):
         # This test is not intended to ensure correctness of nvtx ranges.

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -202,15 +202,15 @@ class profile(object):
             Default: ``False``
 
         record_shapes (bool, optional): If shapes recording is set, information
-        about input dimensions will be collected. This allows one to see which
-        dimensions have been used under the hood and further group by them
-        using prof.key_averages(group_by_input_shape=True). Please note that
-        shape recording might skew your profiling data. It is recommended to
-        use separate runs with and without shape recording to validate the timing.
-        Most likely the skew will be negligible for bottom most events (in a case
-        of nested function calls). But for higher level functions the total
-        self cpu time might be artificially increased because of the shape
-        collection.
+            about input dimensions will be collected. This allows one to see which
+            dimensions have been used under the hood and further group by them
+            using prof.key_averages(group_by_input_shape=True). Please note that
+            shape recording might skew your profiling data. It is recommended to
+            use separate runs with and without shape recording to validate the timing.
+            Most likely the skew will be negligible for bottom most events (in a case
+            of nested function calls). But for higher level functions the total
+            self cpu time might be artificially increased because of the shape
+            collection.
 
     .. warning:
         This context managers should not be called recursively, i.e. at most one
@@ -327,8 +327,16 @@ class emit_nvtx(object):
         instance should be enabled at any given time.
 
     Arguments:
-        enabled (bool, optional): Setting this to False makes this context manager a no-op.
+        enabled (bool, optional, default=True): Setting ``enabled=False`` makes this context manager a no-op.
             Default: ``True``.
+        record_shapes (bool, optional, default=False): If ``record_shapes=True``, the nvtx range wrapping
+            each autograd op will append information about the sizes of Tensor arguments received
+            by that op, in the following format:
+            ``[[arg0.size(0), arg0.size(1), ...], [arg1.size(0), arg1.size(1), ...], ...]``
+            Non-tensor arguments will be represented by ``[]``.
+            Arguments will be listed in the order they are received by the backend op.
+            Please note that this order may not match the order in which those arguments were passed
+            on the Python side.  Also note that shape recording may increase the overhead of nvtx range creation.
 
     Example:
         >>> with torch.cuda.profiler.profile():
@@ -345,7 +353,7 @@ class emit_nvtx(object):
 
     During the forward pass, each function range is decorated with ``seq=<N>``.  ``seq`` is a running
     counter, incremented each time a new backward Function object is created and stashed for backward.
-    Thus, the `seq=<N>` annotation associated with each forward function range tells you that
+    Thus, the ``seq=<N>`` annotation associated with each forward function range tells you that
     if a backward Function object is created by this forward function,
     the backward object will receive sequence number N.
     During the backward pass, the top-level range wrapping each C++ backward Function's
@@ -381,9 +389,10 @@ class emit_nvtx(object):
         backward Function object.  You may need to make a judgment based on analytic knowledge of what
         the expected correspondence should be.
     """
-    def __init__(self, enabled=True):
+    def __init__(self, enabled=True, record_shapes=False):
         self.enabled = enabled
         self.entered = False
+        self.record_shapes = record_shapes
 
     def __enter__(self):
         if not self.enabled:

--- a/torch/csrc/autograd/profiler.cpp
+++ b/torch/csrc/autograd/profiler.cpp
@@ -63,9 +63,29 @@ void pushRangeImpl(
     return;
   }
   if (state == ProfilerState::NVTX) {
-    if(sequence_nr >= 0) {
+    if(sequence_nr >= 0 || shapes.size() > 0) {
       std::stringstream s;
-      s << name.str() << msg << sequence_nr;
+      if(sequence_nr >= 0)
+        s << name.str() << msg << sequence_nr;
+      if(shapes.size() > 0) {
+        s << ", sizes = [";
+        for(int i = 0; i < shapes.size(); i++) {
+          if(shapes[i].size() > 0) {
+            s << "[";
+            for(int dim = 0; dim < shapes[i].size(); dim++) {
+              s << shapes[i][dim];
+              if(dim < shapes[i].size() - 1)
+                s << ", ";
+            }
+            s << "]";
+          }
+          else
+            s << "[]";
+          if(i < shapes.size() - 1)
+            s << ", ";
+        }
+        s << "]";
+      }
       cuda_stubs->nvtxRangePushA(s.str().c_str());
     } else {
       cuda_stubs->nvtxRangePushA(name.str());


### PR DESCRIPTION
This PR is intended as a fix for https://github.com/pytorch/pytorch/issues/21644.

It allows the `with emit_nvtx` context manager to take an additional `record_shapes` argument. `record_shapes` is False by default, but if True, the nvtx ranges generated for each autograd op will append additional information about the sizes of Tensors received by that op.

The format of shape information is equivalent to what the CPU-side profiler spits out.  For example,
```
M = torch.randn(2, 3)
mat1 = torch.randn(2, 3)
mat2 = torch.randn(3, 3)

with torch.cuda.profiler.profile():
    with torch.autograd.profiler.emit_nvtx(record_shapes=True):
        torch.addmm(M, mat1, mat2)
```
produces the following nvtx range label for addmm:
![Screenshot from 2019-06-12 10-48-01](https://user-images.githubusercontent.com/7799218/59374008-b7d13100-8cff-11e9-9245-58410073d965.png)
(cf the "Input Shapes" shown in https://github.com/pytorch/pytorch/commit/864cfbc2162a874fd67b50414205483cb9ac6b5d#diff-115b6d48fa8c0ff33fa94b8fce8877b6)

I also took the opportunity to do some minor docstring cleanup.