### PR TITLE
Remove the misguided attempt at TORCH_STATIC.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -531,9 +531,6 @@ endif()
 add_library(caffe2 ${Caffe2_CPU_SRCS})
 
 
-option(TORCH_STATIC "Build libtorch.a rather than libtorch.so" OFF)
-
-
 # This is required for older versions of CMake, which don't allow
 # specifying add_library() without a list of source files
 set(DUMMY_EMPTY_FILE ${CMAKE_BINARY_DIR}/empty.cpp)
@@ -550,11 +547,7 @@ file(WRITE ${DUMMY_EMPTY_FILE} ${DUMMY_FILE_CONTENT})
 # Wrapper library for transition to merged libcaffe and libtorch.
 # Only necessary on Windows?
 # Contains "caffe2" and "caffe2_gpu".
-if (TORCH_STATIC)
-  add_library(torch STATIC ${DUMMY_EMPTY_FILE})
-else()
-  add_library(torch SHARED ${DUMMY_EMPTY_FILE})
-endif()
+add_library(torch ${DUMMY_EMPTY_FILE})
 
 
 target_link_libraries(torch caffe2)
@@ -966,7 +959,7 @@ install(TARGETS caffe2 EXPORT Caffe2Targets DESTINATION lib)
 
 install(TARGETS torch DESTINATION "${TORCH_INSTALL_LIB_DIR}")
 
-if (MSVC AND NOT TORCH_STATIC)
+if (MSVC)
   install(FILES $<TARGET_PDB_FILE:torch> DESTINATION "${TORCH_INSTALL_LIB_DIR}" OPTIONAL)
 endif()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21704 Remove the misguided attempt at TORCH_STATIC.**

TORCH_STATIC does something, but it's not what you want.  What the
TORCH_STATIC toggle does is cause libtorch to be generated as a static
library, rather than a dynamic library.  This sounds useful, until you
realize that it doesn't affect any of the *other* libraries we also
define in PyTorch, e.g., libcaffe2 or libc10, etc. etc.  So you end up
with one library that is static... that links to a pile of dynamic
libraries.  Not useful.

The proper way to build everything "static" is to set -DBUILD_SHARED_LIBS=OFF
which will turn the interpretation of any add_library() specifier to
generate a static library (assuming you didn't override it with SHARED
which is what happened here).

There is some attempt at building static libraries in builder, but it
doesn't seem to work, and in any case we don't seem to publish them.

Fixes #20742 (but it's not enough to make static linking work)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>