### PR TITLE
Improving Categorical Distribution Docs' (#16291)

### DIFF
--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -35,7 +35,7 @@ class Categorical(Distribution):
 
     Args:
         probs (Tensor): event probabilities
-        logits (Tensor): event log probabilities
+        logits (Tensor): event log-odds
     """
     arg_constraints = {'probs': constraints.simplex,
                        'logits': constraints.real}


### PR DESCRIPTION
**Closes:** Confusing documentation with distributions.Categorical about logits. Closes #16291

**Solution**: Changes documentation on the Categorical distribution from `log probabilities` to `event log-odds`. This makes should reduce confusion as raised by this issue, and is consistent with other distributions such as `torch.Binomial`. 

More than happy to make any other changes if they fit :).