### PR TITLE
Add ONNX py3 CI cases

### DIFF
--- a/.circleci/cimodel/data/caffe2_build_data.py
+++ b/.circleci/cimodel/data/caffe2_build_data.py
@@ -22,7 +22,7 @@ CONFIG_TREE_DATA = [
         (Ver("gcc", "5"), [XImportant("onnx_py2")]),
         (Ver("clang", "3.8"), [X("py2")]),
         (Ver("clang", "3.9"), [X("py2")]),
-        (Ver("clang", "7"), [XImportant("py2")]),
+        (Ver("clang", "7"), [XImportant("py2"), XImportant("onnx_py3.6")]),
         (Ver("android"), [XImportant("py2")]),
     ]),
     (Ver("centos", "7"), [
@@ -54,6 +54,8 @@ class TreeConfigNode(ConfigNode):
         return [self.child_constructor()(self, k, v) for (k, v) in self.subtree]
 
     def is_build_only(self):
+        if str(self.find_prop("language_version")) == "onnx_py3.6":
+            return False
         return str(self.find_prop("compiler_version")) in [
             "gcc4.9",
             "clang3.8",

--- a/.circleci/cimodel/data/caffe2_build_definitions.py
+++ b/.circleci/cimodel/data/caffe2_build_definitions.py
@@ -30,6 +30,7 @@ class Conf:
     def get_cudnn_insertion(self):
 
         omit = self.language == "onnx_py2" \
+            or self.language == "onnx_py3.6" \
             or self.compiler.name in ["android", "mkl", "clang"] \
             or str(self.distro) in ["ubuntu14.04", "macos10.13"]
 
@@ -58,6 +59,7 @@ class Conf:
 
         lang_substitutions = {
             "onnx_py2": "py2",
+            "onnx_py3.6": "py3.6",
             "cmake": "py2",
         }
 
@@ -71,6 +73,7 @@ class Conf:
 
         lang_substitutions = {
             "onnx_py2": "onnx-py2",
+            "onnx_py3.6": "onnx-py3.6",
         }
 
         lang = miniutils.override(self.language, lang_substitutions)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1320,6 +1320,19 @@ jobs:
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
+  caffe2_onnx_py3_6_clang7_ubuntu16_04_build:
+    environment:
+      BUILD_ENVIRONMENT: "caffe2-onnx-py3.6-clang7-ubuntu16.04-build"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py3.6-clang7-ubuntu16.04:287"
+    <<: *caffe2_linux_build_defaults
+
+  caffe2_onnx_py3_6_clang7_ubuntu16_04_test:
+    environment:
+      BUILD_ENVIRONMENT: "caffe2-onnx-py3.6-clang7-ubuntu16.04-test"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py3.6-clang7-ubuntu16.04:287"
+    resource_class: large
+    <<: *caffe2_linux_test_defaults
+
   caffe2_py2_android_ubuntu16_04_build:
     environment:
       BUILD_ENVIRONMENT: "caffe2-py2-android-ubuntu16.04-build"
@@ -2560,6 +2573,13 @@ workflows:
       - caffe2_py2_clang7_ubuntu16_04_build:
           requires:
             - setup
+      - caffe2_onnx_py3_6_clang7_ubuntu16_04_build:
+          requires:
+            - setup
+      - caffe2_onnx_py3_6_clang7_ubuntu16_04_test:
+          requires:
+            - setup
+            - caffe2_onnx_py3_6_clang7_ubuntu16_04_build
       - caffe2_py2_android_ubuntu16_04_build:
           requires:
             - setup

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -25,6 +25,7 @@ default_set = [
     'caffe2-py2-cuda9.1-cudnn7-ubuntu16.04',
     # Caffe2 ONNX
     'caffe2-onnx-py2-gcc5-ubuntu16.04',
+    'caffe2-onnx-py3.6-clang7-ubuntu16.04',
     # Caffe2 Clang
     'caffe2-py2-clang7-ubuntu16.04',
     # Caffe2 CMake

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -101,6 +101,9 @@ fi
 # NB: Warnings are disabled because they make it harder to see what
 # the actual erroring test is
 echo "Running Python tests.."
+# locale setting is required by click package
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
 pip install --user pytest-sugar
 "$PYTHON" \
   -m pytest \
@@ -121,7 +124,5 @@ pip install --user pytest-sugar
 #####################
 if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   pip install -q --user git+https://github.com/pytorch/vision.git
-  export LC_ALL=C.UTF-8
-  export LANG=C.UTF-8
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -121,5 +121,7 @@ pip install --user pytest-sugar
 #####################
 if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   pip install -q --user git+https://github.com/pytorch/vision.git
+  export LC_ALL=C.UTF-8
+  export LANG=C.UTF-8
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi

--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -101,9 +101,11 @@ fi
 # NB: Warnings are disabled because they make it harder to see what
 # the actual erroring test is
 echo "Running Python tests.."
-# locale setting is required by click package
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
+if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
+  # locale setting is required by click package with py3
+  export LC_ALL=C.UTF-8
+  export LANG=C.UTF-8
+fi
 pip install --user pytest-sugar
 "$PYTHON" \
   -m pytest \

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -54,6 +54,6 @@ pytest "${args[@]}" \
 # onnxruntime only support py3
 if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
   pip install --user onnxruntime
-  pytest "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py"
+  pytest "${args[@]}" "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py"
 fi
 

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -48,4 +48,12 @@ fi
 pytest "${args[@]}" \
   -k \
   'not (TestOperators and test_full_like) and not (TestOperators and test_zeros_like) and not (TestOperators and test_ones_like) and not (TestModels and test_vgg16) and not (TestModels and test_vgg16_bn) and not (TestModels and test_vgg19) and not (TestModels and test_vgg19_bn)' \
+  --ignore "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py" \
   "${test_paths[@]}"
+
+# onnxruntime only support py3
+if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
+  pip install onnxruntime
+  pytest "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py"
+fi
+

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -53,7 +53,7 @@ pytest "${args[@]}" \
 
 # onnxruntime only support py3
 if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
-  pip install onnxruntime
+  pip install --user onnxruntime
   pytest "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py"
 fi
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import sys
+import onnxruntime  # noqa
+
+
+class TestONNXRuntime(unittest.TestCase):
+
+    def test_onnxruntime_installed(self):
+        self.assertTrue('onnxruntime' in sys.modules)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
So far, we only have py2 ci for onnx. I think py3 support is important. And we have the plan to add onnxruntime backend tests, which only supports py3.