### PR TITLE
Add use_rocm flag to detect AMD build in the runtime

### DIFF
--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1032,7 +1032,18 @@ void addGlobalMethods(py::module& m) {
 #else // CAFFE2_USE_MKLDNN
       false
 #endif // CAFFE2_USE_MKLDNN
-      );
+  );
+
+  // if the binary is built with __HIP_PLATFORM_HCC__, this is a ROCm build
+  // and therefore we need to ignore dyndep failures (because the the module
+  // may not have a ROCm equivalent yet e.g. nccl)
+  m.attr("use_rocm") = py::bool_(
+#if __HIP_PLATFORM_HCC__
+      true
+#else // __HIP_PLATFORM_HCC__
+      false
+#endif // __HIP_PLATFORM_HCC__
+  );
 
   m.attr("use_trt") = py::bool_(
 #ifdef CAFFE2_USE_TRT


### PR DESCRIPTION
Summary:
dyndep for AMD gpu needs some special treatment. The component module may not be available because it doesn't have a CUDA-equivalent (e.g., nccl).

Currently we detect whether there is AMD GPU that is visible to the system (has_hip_support) to decide whether to loose the condition. However, we still want packages to run on the host which doesn't have AMD GPU installed (because it doesn't need GPU, but run from the same package, e.g., reader process). Therefore, adding a detection method on whether the package is built for AMD.

Differential Revision: D15795893

