### PR TITLE
backend.py: _getattr__ must raise AttributeError

### DIFF
--- a/torch/nn/backends/backend.py
+++ b/torch/nn/backends/backend.py
@@ -7,7 +7,7 @@ class FunctionBackend(object):
     def __getattr__(self, name):
         fn = self.function_classes.get(name)
         if fn is None:
-            raise NotImplementedError(
+            raise AttributeError(
                 "Could not find function class for [{}]".format(name))
         return fn
 


### PR DESCRIPTION
Summary: Custom __getattr__ functions can only raise AttributeError. This code throwed NotImplementedError which caused upstream troubles when hasattr() was called.

Differential Revision: D15815176

