### PR TITLE
Temporarily disable caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test

### DIFF
--- a/.circleci/cimodel/data/caffe2_build_data.py
+++ b/.circleci/cimodel/data/caffe2_build_data.py
@@ -14,7 +14,7 @@ CONFIG_TREE_DATA = [
             # TODO make explicit that this is a "secret TensorRT build"
             #  (see https://github.com/pytorch/pytorch/pull/17323#discussion_r259446749)
             # TODO Uh oh, were we supposed to make this one important?!
-            X("py2"),
+            # X("py2"),
             XImportant("cmake"),
         ]),
         (Ver("cuda", "9.1"), [XImportant("py2")]),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1231,20 +1231,6 @@ jobs:
       BUILD_ONLY: "1"
     <<: *caffe2_linux_build_defaults
 
-  caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build:
-    environment:
-      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.0-cudnn7-ubuntu16.04-build"
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-ubuntu16.04:287"
-    <<: *caffe2_linux_build_defaults
-
-  caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
-    environment:
-      BUILD_ENVIRONMENT: "caffe2-py2-cuda9.0-cudnn7-ubuntu16.04-test"
-      USE_CUDA_DOCKER_RUNTIME: "1"
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-cuda9.0-cudnn7-ubuntu16.04:287"
-    resource_class: gpu.medium
-    <<: *caffe2_linux_test_defaults
-
   caffe2_cmake_cuda9_0_cudnn7_ubuntu16_04_build:
     environment:
       BUILD_ENVIRONMENT: "caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04-build"
@@ -2504,19 +2490,6 @@ workflows:
           requires:
             - setup
             - caffe2_py2_gcc4_8_ubuntu14_04_build
-      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build:
-          filters:
-            branches:
-              only: master
-          requires:
-            - setup
-      - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test:
-          filters:
-            branches:
-              only: master
-          requires:
-            - setup
-            - caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_build
       - caffe2_cmake_cuda9_0_cudnn7_ubuntu16_04_build:
           requires:
             - setup


### PR DESCRIPTION
Disabling caffe2_py2_cuda9_0_cudnn7_ubuntu16_04_test (and corresponding build) will restore good CI signal to the project while that build is being worked on.