### PR TITLE
Enabled mul for bool tensors on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -59,7 +59,7 @@ void mul_kernel_cuda(TensorIterator& iter) {
       return a && b;
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND2(kHalf, iter.dtype(), "mul_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "mul_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a * b;
       });

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -53,11 +53,18 @@ void div_kernel_cuda(TensorIterator& iter) {
 }
 
 void mul_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "mul_cuda", [&]() {
-    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(), "mul_cuda", [&]() {
+    if (iter.dtype() == ScalarType::Bool) {
+      // Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
+        return a && b;
+      });
+    } else {
+      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
       return a * b;
-    });
-  });
+      });
+    }
+  }
 }
 
 REGISTER_DISPATCH(add_stub, &add_kernel_cuda);

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -64,7 +64,7 @@ void mul_kernel_cuda(TensorIterator& iter) {
       return a * b;
       });
     }
-  }
+  });
 }
 
 REGISTER_DISPATCH(add_stub, &add_kernel_cuda);

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -53,18 +53,18 @@ void div_kernel_cuda(TensorIterator& iter) {
 }
 
 void mul_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(), "mul_cuda", [&]() {
-    if (iter.dtype() == ScalarType::Bool) {
-      // Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
-        return a && b;
-      });
-    } else {
+  if (iter.dtype() == ScalarType::Bool) {
+    // Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(bool a, bool b) -> bool {
+      return a && b;
+    });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(), "mul_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a * b;
+        return a * b;
       });
-    }
-  });
+    });
+  }
 }
 
 REGISTER_DISPATCH(add_stub, &add_kernel_cuda);

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -59,7 +59,7 @@ void mul_kernel_cuda(TensorIterator& iter) {
       return a && b;
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(), "mul_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND2(kHalf, iter.dtype(), "mul_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         return a * b;
       });

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1765,17 +1765,18 @@ class _TestTorchMixin(object):
             self.assertEqual(res_reciprocal, res_div)
 
     def test_mul(self):
-        m1 = torch.randn(10, 10)
-        res1 = m1.clone()
-        res1[:, 3].mul_(2)
-        res2 = m1.clone()
-        for i in range(res1.size(0)):
-            res2[i, 3] = res2[i, 3] * 2
-        self.assertEqual(res1, res2)
+        for device in torch.testing.get_all_device_types():
+            m1 = torch.randn(10, 10, device=device)
+            res1 = m1.clone()
+            res1[:, 3].mul_(2)
+            res2 = m1.clone()
+            for i in range(res1.size(0)):
+                res2[i, 3] = res2[i, 3] * 2
+            self.assertEqual(res1, res2)
 
-        a1 = torch.tensor([True, False, False, True], dtype=torch.bool)
-        a2 = torch.tensor([True, False, True, False], dtype=torch.bool)
-        self.assertEqual(a1 * a2, torch.tensor([True, False, False, False], dtype=torch.bool))
+            a1 = torch.tensor([True, False, False, True], dtype=torch.bool, device=device)
+            a2 = torch.tensor([True, False, True, False], dtype=torch.bool, device=device)
+            self.assertEqual(a1 * a2, torch.tensor([True, False, False, False], dtype=torch.bool, device=device))
 
     def test_div(self):
         m1 = torch.randn(10, 10)


### PR DESCRIPTION
Enable mul_cuda for bool tensors. 
This is a helper PR to fix a [test failure](https://circleci.com/gh/pytorch/pytorch/1992191?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) in the other [PR](https://github.com/pytorch/pytorch/pull/21113).