### PR TITLE
Disallow creation of tensors with duplicate names

### DIFF
--- a/aten/src/ATen/Dimname.cpp
+++ b/aten/src/ATen/Dimname.cpp
@@ -4,6 +4,15 @@
 
 namespace at {
 
+std::ostream& operator<<(std::ostream& out, const Dimname& dimname) {
+  if (dimname.type() == NameType::WILDCARD) {
+    out << "None";
+  } else {
+    out << "'" << dimname.name().toUnqualString() << "'";
+  }
+  return out;
+}
+
 bool is_valid_identifier(const std::string& name) {
   std::locale loc;
   if (name.length() == 0) {

--- a/aten/src/ATen/Dimname.h
+++ b/aten/src/ATen/Dimname.h
@@ -4,6 +4,7 @@
 #include <ATen/core/interned_strings.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
+#include <iostream>
 
 namespace at {
 
@@ -35,6 +36,8 @@ bool CAFFE2_API is_valid_identifier(const std::string& name);
 
 CAFFE2_API c10::optional<Dimname> unify(Dimname dimname, Dimname other);
 CAFFE2_API bool match(Dimname dimname, Dimname other);
+
+std::ostream& operator<<(std::ostream& out, const Dimname& dimname);
 
 } // namespace at
 #endif

--- a/aten/src/ATen/NamedTensor.cpp
+++ b/aten/src/ATen/NamedTensor.cpp
@@ -12,6 +12,37 @@ bool NamedTensorMeta::has_names() const {
       });
 }
 
+static DimnameList::const_iterator find_untagged_name(
+    DimnameList::const_iterator begin,
+    DimnameList::const_iterator end,
+    Symbol target) {
+  return std::find_if(begin, end,
+      [&target](const Dimname& candidate) { return candidate.untagged_name() == target; });
+}
+
+static void check_unique_names(DimnameList names) {
+  // Strategy: Compare each element with the ones that come after it.
+  // Although this is O(N^2), in practice N is small (no more than 25).
+  for (auto it = names.begin(); it != names.end(); ++it) {
+    if (it->type() == NameType::WILDCARD) {
+      continue;
+    }
+    auto dup = find_untagged_name(it + 1, names.end(), it->untagged_name());
+    while (dup != names.end()) {
+      TORCH_CHECK(it->name() != dup->name(),
+          "Cannot construct a tensor with duplicate names. Got names: ",
+          names, ".");
+
+      // "C.in" and "C" are not allowed, but "C.in" and "C.out" are.
+      TORCH_CHECK(it->type() == NameType::TAGGED && dup->type() == NameType::TAGGED,
+          "Cannot construct a tensor with duplicate names unless they are tagged ",
+          "and have different tags. Got names: ", names, ", offending names: (",
+          *it, " and ", *dup, ").");
+      dup = find_untagged_name(dup + 1, names.end(), it->untagged_name());
+    }
+  }
+}
+
 void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
   if (!names) {
     tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
@@ -23,6 +54,7 @@ void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
       "Number of names (", names->size(), ") and "
       "number of dimensions in tensor (", ndim, ") ",
       "do not match.");
+  check_unique_names(*names);
 
   auto* meta = tensor.get_named_tensor_meta();
   if (meta == nullptr) {

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -47,6 +47,21 @@ class TestNamedTensor(TestCase):
         with self.assertRaisesRegex(TypeError, 'invalid combination of arguments'):
             x = factory(2, 1, names='N', device=device)
 
+        with self.assertRaisesRegex(RuntimeError, 'construct a tensor with duplicate names'):
+            x = factory(2, 1, 1, names=('N', 'C', 'N'), device=device)
+
+        # Tests for tagged names
+        x = factory(2, 3, 1, names=('C.in', 'H', 'C.out'), device=device)
+        self.assertEqual(x.names, ('C.in', 'H', 'C.out'))
+
+        with self.assertRaisesRegex(RuntimeError, 'construct a tensor with duplicate names'):
+            x = factory(2, 1, 1, names=('C.in', 'H', 'C.in'), device=device)
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                'with duplicate names unless they are tagged and have different tags'):
+            x = factory(2, 1, 1, names=('C.in', 'H', 'C'), device=device)
+
 
     @skipIfNamedTensorDisabled
     def test_empty(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21795 Implement tensor.select(Dimname,int)
* #21789 Add at::dimname_to_position helper.
* #21752 named inference rule for tensor.select
* **#21781 Disallow creation of tensors with duplicate names**
* #21803 Rename Dimname::name to Dimname::full_name
* #21735 Copy NamedTensorMeta in TensorImpl::copy_tensor_data()
* #21648 Expose torch.empty(sizes, *, names, ...) to Python

Duplicate names must have tags and their tags must be different.
i.e., ("C.in", "C") is not allowed, but ("C.in", "C.out") is.

Test Plan:
- `python test/test_namedtensor.py -v` [namedtensor ci]

gh-metadata: pytorch pytorch 21781 gh/zou3519/51/head

Differential Revision: [D15833454](https://our.internmc.facebook.com/intern/diff/D15833454)