### PR TITLE
Keep Reducer hooks in a vector instead of an unordered_map

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -54,7 +54,7 @@ class Reducer {
   std::vector<std::vector<std::shared_ptr<torch::autograd::Function>>>
       grad_accumulators_;
   std::unordered_map<torch::autograd::Function*, std::tuple<int, int>> func_;
-  std::unordered_map<uintptr_t, std::shared_ptr<torch::autograd::Function>>
+  std::vector<std::pair<uintptr_t, std::shared_ptr<torch::autograd::Function>>>
       hooks_;
 
   bool expect_autograd_hooks_;


### PR DESCRIPTION
@kuttas pointed out that the DDP Reducer only needs to remember `uintptr, Function` pairs, and hence does not need a nunordered map as added by #21591. Using a vector should speed it up a bit. 