### PR TITLE
Move at::internal_set_names_inplace to ATen/NamedTensorUtils.h

### DIFF
--- a/aten/src/ATen/NamedTensor.cpp
+++ b/aten/src/ATen/NamedTensor.cpp
@@ -12,58 +12,5 @@ bool NamedTensorMeta::has_names() const {
       });
 }
 
-static DimnameList::const_iterator find_untagged_name(
-    DimnameList::const_iterator begin,
-    DimnameList::const_iterator end,
-    Symbol target) {
-  return std::find_if(begin, end,
-      [&target](const Dimname& candidate) { return candidate.untagged_name() == target; });
-}
-
-static void check_unique_names(DimnameList names) {
-  // Strategy: Compare each element with the ones that come after it.
-  // Although this is O(N^2), in practice N is small (no more than 25).
-  for (auto it = names.begin(); it != names.end(); ++it) {
-    if (it->type() == NameType::WILDCARD) {
-      continue;
-    }
-    auto dup = find_untagged_name(it + 1, names.end(), it->untagged_name());
-    while (dup != names.end()) {
-      TORCH_CHECK(it->name() != dup->name(),
-          "Cannot construct a tensor with duplicate names. Got names: ",
-          names, ".");
-
-      // "C.in" and "C" are not allowed, but "C.in" and "C.out" are.
-      TORCH_CHECK(it->type() == NameType::TAGGED && dup->type() == NameType::TAGGED,
-          "Cannot construct a tensor with duplicate names unless they are tagged ",
-          "and have different tags. Got names: ", names, ", offending names: (",
-          *it, " and ", *dup, ").");
-      dup = find_untagged_name(dup + 1, names.end(), it->untagged_name());
-    }
-  }
-}
-
-void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
-  if (!names) {
-    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
-    return;
-  }
-
-  auto ndim = tensor.dim();
-  TORCH_CHECK(ndim == names->size(),
-      "Number of names (", names->size(), ") and "
-      "number of dimensions in tensor (", ndim, ") ",
-      "do not match.");
-  check_unique_names(*names);
-
-  auto* meta = tensor.get_named_tensor_meta();
-  if (meta == nullptr) {
-    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(
-        torch::make_unique<NamedTensorMeta>(*names));
-  } else {
-    meta->set_names_(*names);
-  }
-}
-
 } // namespace at
 #endif

--- a/aten/src/ATen/NamedTensor.h
+++ b/aten/src/ATen/NamedTensor.h
@@ -34,6 +34,5 @@ struct CAFFE2_API NamedTensorMeta : public c10::NamedTensorMetaInterface {
   std::vector<Dimname> names_;
 };
 
-CAFFE2_API void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names);
 }
 #endif

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -3,6 +3,61 @@
 #include <ATen/NamedTensorUtils.h>
 
 namespace at {
+
+static DimnameList::const_iterator find_untagged_name(
+    DimnameList::const_iterator begin,
+    DimnameList::const_iterator end,
+    Symbol target) {
+  return std::find_if(begin, end,
+      [&target](const Dimname& candidate) { return candidate.untagged_name() == target; });
+}
+
+static void check_unique_names(DimnameList names) {
+  // Strategy: Compare each element with the ones that come after it.
+  // Although this is O(N^2), in practice N is small (no more than 25).
+  for (auto it = names.begin(); it != names.end(); ++it) {
+    if (it->type() == NameType::WILDCARD) {
+      continue;
+    }
+    auto dup = find_untagged_name(it + 1, names.end(), it->untagged_name());
+    while (dup != names.end()) {
+      TORCH_CHECK(it->name() != dup->name(),
+          "Cannot construct a tensor with duplicate names. Got names: ",
+          names, ".");
+
+      // "C.in" and "C" are not allowed, but "C.in" and "C.out" are.
+      TORCH_CHECK(it->type() == NameType::TAGGED && dup->type() == NameType::TAGGED,
+          "Cannot construct a tensor with duplicate names unless they are tagged ",
+          "and have different tags. Got names: ", names, ", offending names: (",
+          *it, " and ", *dup, ").");
+      dup = find_untagged_name(dup + 1, names.end(), it->untagged_name());
+    }
+  }
+}
+
+void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
+  if (!names) {
+    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
+    return;
+  }
+
+  auto ndim = tensor.dim();
+  TORCH_CHECK(ndim == names->size(),
+      "Number of names (", names->size(), ") and "
+      "number of dimensions in tensor (", ndim, ") ",
+      "do not match.");
+  check_unique_names(*names);
+
+  auto* meta = tensor.get_named_tensor_meta();
+  if (meta == nullptr) {
+    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(
+        torch::make_unique<NamedTensorMeta>(*names));
+  } else {
+    meta->set_names_(*names);
+  }
+}
+
+
 namespace namedinference {
 
 optional<std::vector<Dimname>> erase_name(optional<DimnameList> self_names, int64_t dim) {

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -11,6 +11,9 @@ inline bool has_names(TensorList tensors) {
       tensors.begin(), tensors.end(), [](const Tensor& t) { return t.is_named(); });
 }
 
+// Sets the names of `tensor` to be `names`.
+CAFFE2_API void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names);
+
 namespace namedinference {
 
 optional<std::vector<Dimname>> erase_name(optional<DimnameList> self_names, int64_t dim);

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -19,7 +19,7 @@
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/Exception.h>
 #ifdef NAMEDTENSOR_ENABLED
-#include <ATen/NamedTensor.h>
+#include <ATen/NamedTensorUtils.h>
 #endif
 
 #include <algorithm>

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
-#include <ATen/NamedTensor.h>
+#include <ATen/NamedTensorUtils.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/utils/memory.h>
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21795 Implement tensor.select(Dimname,int)
* #21789 Add at::dimname_to_position helper.
* **#21784 Move at::internal_set_names_inplace to ATen/NamedTensorUtils.h**
* #21752 named inference rule for tensor.select
* #21781 Disallow creation of tensors with duplicate names
* #21803 Rename Dimname::name to Dimname::full_name
* #21735 Copy NamedTensorMeta in TensorImpl::copy_tensor_data()
* #21648 Expose torch.empty(sizes, *, names, ...) to Python

I'm planning on dumping helper functions here in the near future.

Test Plan:
- [namedtensor ci]