### PR TITLE
[jit] change ClassType::compilation_unit to return owning ptr

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -105,7 +105,7 @@ public:
     return kind_;
   }
 
-  virtual bool requires_grad() const { 
+  virtual bool requires_grad() const {
     for(const auto& ct : containedTypes()) {
       if (ct->requires_grad()) {
         return true;
@@ -877,7 +877,7 @@ struct CAFFE2_API TupleType : public Type {
       return a->isSubtypeOf(b);
     });
   }
-  
+
   std::string str() const override {
     std::stringstream ss;
     ss << "(";
@@ -1435,9 +1435,9 @@ struct CAFFE2_API ClassType : public Type {
   }
 
   std::shared_ptr<Function> getMethod(const std::string& name) const;
-  CompilationUnit& compilation_unit();
-  const CompilationUnit& compilation_unit() const;
   std::vector<Function*> methods() const;
+  std::shared_ptr<CompilationUnit> compilation_unit();
+  std::shared_ptr<const CompilationUnit> compilation_unit() const;
 
 
   size_t numAttributes() const {

--- a/test/cpp/jit/test_class_import.h
+++ b/test/cpp/jit/test_class_import.h
@@ -78,13 +78,13 @@ void testScriptObject() {
   Module m2;
   std::vector<at::Tensor> constantTable;
   import_libs(
-      m1.class_compilation_unit(),
+      *m1.class_compilation_unit(),
       "__torch__",
       std::make_shared<Source>(classSrcs1),
       constantTable,
       nullptr);
   import_libs(
-      m2.class_compilation_unit(),
+      *m2.class_compilation_unit(),
       "__torch__",
       std::make_shared<Source>(classSrcs2),
       constantTable,

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -130,7 +130,7 @@ class EncoderBase {
       const std::shared_ptr<Graph>& graph,
       const std::map<std::string, at::Tensor>& initializers =
         std::map<std::string, at::Tensor>(),
-      const std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>& dynamic_axes = 
+      const std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>& dynamic_axes =
         std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>());
 
   void EncodeBlock(
@@ -138,7 +138,7 @@ class EncoderBase {
       const Block* block,
       const std::map<std::string, at::Tensor>& initializers =
         std::map<std::string, at::Tensor>(),
-      const std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>& dynamic_axes = 
+      const std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>& dynamic_axes =
         std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>());
 
   virtual void EncodeTensor(
@@ -154,7 +154,7 @@ class EncoderBase {
       onnx::GraphProto* graph_proto,
       onnx::ValueInfoProto* v,
       const Value* n,
-      const std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>& dynamic_axes = 
+      const std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>& dynamic_axes =
         std::unordered_map<std::string, std::unordered_map<int64_t, std::string>>());
 
   void AddAttribute(
@@ -740,7 +740,7 @@ bool ScriptModuleSerializer::moduleHasValidGetSetState(
   // Check __setstate__ if the method exists
   //   __setstate__ is expected to be (self, T) -> None
   // TODO: use getMethod("__getstate__") once methods are not lowered
-  auto setstate = module.class_compilation_unit().find_function("__setstate__");
+  auto setstate = module.class_compilation_unit()->find_function("__setstate__");
   if (setstate == nullptr) {
     return false;
   }
@@ -911,12 +911,12 @@ void ScriptModuleSerializer::convertModule(
     module_name << prefix << "_";
   module_name << name;
 
-  if (module.class_compilation_unit().get_functions().size() > 0) {
+  if (module.class_compilation_unit()->get_functions().size() > 0) {
     std::ostringstream methods;
     methods << "op_version_set = " << CURRENT_OP_VERSION_SET << "\n";
     PythonPrint(
         methods,
-        module.class_compilation_unit(),
+        *module.class_compilation_unit(),
         /*is_method=*/true,
         tensor_table_,
         class_table_,

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -256,7 +256,7 @@ void ScriptModuleDeserializer::importCallback(const std::string& qualifier) {
   auto src = std::make_shared<Source>(
       std::string(static_cast<const char*>(data.get()), size), path, 0);
   script::import_libs(
-      main_module_->class_compilation_unit(),
+      *main_module_->class_compilation_unit(),
       qualifier,
       src,
       tensor_table_,
@@ -266,7 +266,7 @@ void ScriptModuleDeserializer::importCallback(const std::string& qualifier) {
 void ScriptModuleDeserializer::moduleSetState(
     const std::shared_ptr<script::Module>& module,
     IValue state) {
-  auto setstate = module->class_compilation_unit().find_function("__setstate__");
+  auto setstate = module->class_compilation_unit()->find_function("__setstate__");
 
   TORCH_CHECK(
       setstate != nullptr,
@@ -330,7 +330,7 @@ void ScriptModuleDeserializer::convertModule(
     std::function<void(const std::string&)> import_callback =
         [this](const std::string& qualifier) { importCallback(qualifier); };
     script::import_methods(
-        main_module_->class_compilation_unit(),
+        *main_module_->class_compilation_unit(),
         module,
         src,
         tensor_table_,

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -290,7 +290,7 @@ void import_methods(
   };
   import_functions(
       lib_cu,
-      mod->module_object()->type()->compilation_unit(),
+      *mod->module_object()->type()->compilation_unit(),
       src,
       constant_table,
       self,

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -9,16 +9,16 @@ std::shared_ptr<Function> ClassType::getMethod(const std::string& name) const {
   return compilation_unit_->find_function(name);
 }
 
-CompilationUnit& ClassType::compilation_unit() {
-  return *compilation_unit_;
+std::shared_ptr<CompilationUnit> ClassType::compilation_unit() {
+  return compilation_unit_;
 }
-const CompilationUnit& ClassType::compilation_unit() const {
-  return *compilation_unit_;
+std::shared_ptr<const CompilationUnit> ClassType::compilation_unit() const {
+  return compilation_unit_;
 }
 
 std::vector<Function*> ClassType::methods() const {
   std::vector<Function*> ret;
-  for (const auto& pr : compilation_unit().get_functions()) {
+  for (const auto& pr : compilation_unit()->get_functions()) {
     ret.push_back(pr.get());
   }
   return ret;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -281,7 +281,7 @@ void addFunctionToModule(
   auto graph = func->graph()->copy();
   auto v = graph->insertInput(0, "self");
   v->setType(module.module_object()->type());
-  module.module_object()->type()->compilation_unit().create_function(
+  module.module_object()->type()->compilation_unit()->create_function(
       "forward", graph);
 }
 
@@ -323,7 +323,7 @@ void initJitScriptBindings(PyObject* module) {
              const std::string& script,
              ResolutionCallback rcb) {
             c10::optional<Self> self;
-            m->class_compilation_unit().define(
+            m->class_compilation_unit()->define(
                 script, pythonResolver(rcb), moduleSelf(m, py_m));
             didFinishEmitModule(m);
           })
@@ -339,13 +339,13 @@ void initJitScriptBindings(PyObject* module) {
             for (auto& callback : rcbs) {
               resolvers.push_back(pythonResolver(callback));
             }
-            m->class_compilation_unit().define(
+            m->class_compilation_unit()->define(
                 defs, resolvers, moduleSelf(m, py_m));
             // Stitch in default arguments for each Def if provided
             auto defaults_it = defaults.begin();
             auto defs_it = defs.begin();
             while (defs_it != defs.end()) {
-              auto& method = m->class_compilation_unit().get_function(
+              auto& method = m->class_compilation_unit()->get_function(
                   (*defs_it).name().name());
               method.setSchema(getSchemaWithNameAndDefaults(
                   defs_it->range(),
@@ -367,7 +367,7 @@ void initJitScriptBindings(PyObject* module) {
       .def(
           "_get_functions",
           [](Module& self) {
-            return self.class_compilation_unit().get_functions();
+            return self.class_compilation_unit()->get_functions();
           })
       .def(
           "_register_attribute",
@@ -473,7 +473,7 @@ void initJitScriptBindings(PyObject* module) {
             auto typed_inputs = toTypedStack(input_tuple);
             auto graph = tracer::createGraphByTracing(
                 func, typed_inputs, var_lookup_fn, force_outplace, self);
-            self->module_object()->type()->compilation_unit().create_function(
+            self->module_object()->type()->compilation_unit()->create_function(
                 name, graph);
             didFinishEmitModule(self);
           })
@@ -495,7 +495,7 @@ void initJitScriptBindings(PyObject* module) {
             std::vector<ClassTypePtr> classes;
             PythonPrint(
                 ss,
-                self.class_compilation_unit(),
+                *self.class_compilation_unit(),
                 true,
                 tensors,
                 classes,
@@ -731,7 +731,7 @@ void initJitScriptBindings(PyObject* module) {
     std::vector<ClassTypePtr> classes;
     if (auto self = as_module(obj)) {
       PythonPrint(
-          ss, self->class_compilation_unit(), true, constants, classes, true);
+          ss, *self->class_compilation_unit(), true, constants, classes, true);
     } else if (auto self = as_function(obj)) {
       PythonPrint(ss, *self, false, constants, classes, true);
     } else {

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -256,7 +256,7 @@ std::pair<std::shared_ptr<Graph>, std::vector<at::Tensor>> Method::_lowered_grap
 }
 
 void Module::define(const std::string& src, const ResolverPtr& resolver) {
-  class_compilation_unit().define(
+  class_compilation_unit()->define(
       src,
       resolver ? resolver : script::nativeResolver(),
       simpleSelf(module_object()->type()));
@@ -288,7 +288,7 @@ void Module::copy_into(
     names.pop_back();
   }
 
-  for (auto& fn : class_compilation_unit().get_functions()) {
+  for (auto& fn : class_compilation_unit()->get_functions()) {
     curr->clone_method(*this, fn->name(), type_remap);
   }
 }
@@ -313,11 +313,11 @@ void Module::clone_method(
       return in;
     return it->second;
   };
-  const Function& fn = orig.class_compilation_unit().get_function(name);
+  const Function& fn = orig.class_compilation_unit()->get_function(name);
   auto graph = fn.graph()->copy();
   graph->remapTypes(type_remap_fn);
   auto schema = fn.getSchema().cloneWithRemappedTypes(type_remap_fn);
-  auto copied = class_compilation_unit().create_function(fn.name(), graph);
+  auto copied = class_compilation_unit()->create_function(fn.name(), graph);
   copied->setSchema(std::move(schema));
 }
 
@@ -352,7 +352,7 @@ void Module::train(bool on) {
 IValue Module::create_class(const c10::QualifiedName& name, Stack stack) const {
   // Look up the class
   const auto classType =
-      class_compilation_unit().get_class(c10::QualifiedName(name));
+      class_compilation_unit()->get_class(c10::QualifiedName(name));
   if (!classType) {
     AT_ERROR(
         "Could not find class with name: '",

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -99,7 +99,7 @@ struct TORCH_API Method {
     return *function_;
   }
 
-  // Used for ONNX export. Return a tuple (graph, parameters) where 
+  // Used for ONNX export. Return a tuple (graph, parameters) where
   // the last parameters.size() inputs to the graph are the trainable parameters
   // used in this method. The remaining inputs are the true inputs to the function.
   std::pair<std::shared_ptr<Graph>, std::vector<at::Tensor>> _lowered_graph();
@@ -135,7 +135,7 @@ struct TORCH_API Module {
     // Function has a self argument which owns the ClassType, created a
     // reference cycle. By dropping all the methods of the module's class
     // here we break the cycle.
-    class_compilation_unit().drop_all_functions();
+    class_compilation_unit()->drop_all_functions();
   }
   const std::string& name() const {
     return name_;
@@ -144,11 +144,11 @@ struct TORCH_API Module {
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
   void set_optimized(bool o) {
-    class_compilation_unit().set_optimized(o);
+    class_compilation_unit()->set_optimized(o);
   }
 
   bool is_optimized() const {
-    return class_compilation_unit().is_optimized();
+    return class_compilation_unit()->is_optimized();
   }
 
   IValue forward(std::vector<IValue> inputs) {
@@ -253,7 +253,7 @@ struct TORCH_API Module {
   const std::vector<std::unique_ptr<Method>>& get_methods() const {
     // force methods_ to be up to date by querying all
     // methods.
-    for (const auto& m : class_compilation_unit().get_functions()) {
+    for (const auto& m : class_compilation_unit()->get_functions()) {
       get_method(m->name());
     }
     return methods_;
@@ -291,7 +291,7 @@ struct TORCH_API Module {
     }
 
     if (const std::shared_ptr<Function>& fn =
-            class_compilation_unit().find_function(name)) {
+            class_compilation_unit()->find_function(name)) {
       // lock because technically this is marked const,
       // but we have to update the internal Method cache.
       // This can be removed when class_compilation_unit() is the source of
@@ -402,7 +402,7 @@ struct TORCH_API Module {
     if (it == dict_.end()) {
       // methods are lazily created, see if this is, in face,
       // a method that has not been created yet.
-      if (auto fn = class_compilation_unit().find_function(name)) {
+      if (auto fn = class_compilation_unit()->find_function(name)) {
         return EntityType::METHOD;
       }
       return at::nullopt;
@@ -413,10 +413,10 @@ struct TORCH_API Module {
   ModulePtr module_object() const {
     return module_value_;
   }
-  CompilationUnit& class_compilation_unit() {
+  std::shared_ptr<CompilationUnit> class_compilation_unit() {
     return module_object()->type()->compilation_unit();
   }
-  const CompilationUnit& class_compilation_unit() const {
+  std::shared_ptr<const CompilationUnit> class_compilation_unit() const {
     return module_object()->type()->compilation_unit();
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21787 [jit] change ClassType::compilation_unit to return owning ptr**

As title. Mechanical changes only.

We need this because I am making it so that only CompilationUnit owns Function. But sometimes we will need to create a StrongFunctionPtr (just a pair of Function and it's owning CompilationUnit), for example when we pass things into Python.

Differential Revision: [D15831353](https://our.internmc.facebook.com/intern/diff/D15831353)