### PR TITLE
Followup cleanup in cmake.py and add a comment in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -367,7 +367,8 @@ def check_pydep(importname, module):
 
 class build_ext(setuptools.command.build_ext.build_ext):
     def run(self):
-        # report build options
+        # Report build options. This is run after the build completes so # `CMakeCache.txt` exists and we can get an
+        # accurate report on what is used and what is not.
         cmake_cache_vars = defaultdict(lambda: False, cmake.get_cmake_cache_variables())
         if cmake_cache_vars['USE_NUMPY']:
             report('-- Building with NumPy bindings')

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -67,6 +67,15 @@ class CMake:
         else:
             self._build_type = "Release"
 
+    @property
+    def _cmake_cache_file(self):
+        r"""Returns the path to CMakeCache.txt.
+
+        Returns:
+          string: The path to CMakeCache.txt.
+        """
+        return os.path.join(self.build_dir, 'CMakeCache.txt')
+
     @staticmethod
     def _get_cmake_command():
         "Returns cmake command."
@@ -362,10 +371,3 @@ class CMake:
         ninja_build_file = os.path.join(self.build_dir, 'build.ninja')
         if os.path.exists(ninja_build_file):
             os.utime(ninja_build_file, None)
-
-    def __setattr__(self, name, value):
-        if name == 'build_dir':
-            self.__dict__['build_dir'] = value
-            self._cmake_cache_file = os.path.join(self.build_dir, 'CMakeCache.txt')
-        else:
-            self.__dict__[name] = value


### PR DESCRIPTION
Following up b811b6d5c03596d789a33d7891b606842e01f7d2

* Use @property instead of __setattr__ in CMake.
* Add a comment clarifying when built_ext.run is called.

---

cc @ezyang 