### PR TITLE
Rename Dimname::name to Dimname::full_name

### DIFF
--- a/aten/src/ATen/Dimname.cpp
+++ b/aten/src/ATen/Dimname.cpp
@@ -25,19 +25,19 @@ static void check_valid_identifier(const std::string& name) {
       name, "'.");
 }
 
-Dimname Dimname::fromSymbol(Symbol name) {
-  TORCH_INTERNAL_ASSERT(name.is_dimname());
-  if (name == kWildcard) {
+Dimname Dimname::fromSymbol(Symbol full_name) {
+  TORCH_INTERNAL_ASSERT(full_name.is_dimname());
+  if (full_name == kWildcard) {
     return Dimname::wildcard();
   }
   const std::string delimiter = ".";
-  const std::string str(name.toUnqualString());
+  const std::string str(full_name.toUnqualString());
   auto it = str.find(delimiter);
 
   // Check for normal name
   if (it == std::string::npos) {
     check_valid_identifier(str);
-    return Dimname(name);
+    return Dimname(full_name);
   }
 
   // Check for tagged name
@@ -49,7 +49,7 @@ Dimname Dimname::fromSymbol(Symbol name) {
   auto tag = str.substr(it + 1);
   check_valid_identifier(untagged_name); 
   check_valid_identifier(tag);
-  return Dimname(NameType::TAGGED, name, Symbol::dimname(untagged_name));
+  return Dimname(NameType::TAGGED, full_name, Symbol::dimname(untagged_name));
 }
 
 Dimname Dimname::wildcard() {
@@ -64,7 +64,7 @@ optional<Dimname> unify(Dimname dimname, Dimname other) {
   if (dimname.type() == NameType::WILDCARD) {
     return other;
   }
-  if (dimname.name() == other.name()) {
+  if (dimname.full_name() == other.full_name()) {
     return dimname;
   }
   if (dimname.untagged_name() == other.untagged_name()) {

--- a/aten/src/ATen/Dimname.h
+++ b/aten/src/ATen/Dimname.h
@@ -14,16 +14,23 @@ struct CAFFE2_API Dimname {
   static Dimname wildcard();
 
   NameType type() const { return type_; }
-  Symbol name() const { return name_; }
+  Symbol full_name() const { return full_name_; }
   Symbol untagged_name() const { return untagged_name_; }
 
  private:
   Dimname(Symbol name)
-    : untagged_name_(name), name_(name), type_(NameType::NORMAL) {}
-  Dimname(NameType type, Symbol name, Symbol untagged_name)
-    : untagged_name_(untagged_name), name_(name), type_(type) {}
+    : untagged_name_(name), full_name_(name), type_(NameType::NORMAL) {}
+  Dimname(NameType type, Symbol full_name, Symbol untagged_name)
+    : untagged_name_(untagged_name), full_name_(full_name), type_(type) {}
+
+  // [Dimname Terminology]
+  //
+  // For "C.in":
+  // - "C.in" is the "full name"
+  // - "C" is the "name"
+  // - "in" is the "tag"
   Symbol untagged_name_;
-  Symbol name_;
+  Symbol full_name_;
   NameType type_;
   // Will need more fields for other special name types.
 };

--- a/aten/src/ATen/Dimname.h
+++ b/aten/src/ATen/Dimname.h
@@ -27,7 +27,7 @@ struct CAFFE2_API Dimname {
   //
   // For "C.in":
   // - "C.in" is the "full name"
-  // - "C" is the "name"
+  // - "C" is the "untagged name"
   // - "in" is the "tag"
   Symbol untagged_name_;
   Symbol full_name_;

--- a/aten/src/ATen/test/Dimname_test.cpp
+++ b/aten/src/ATen/test/Dimname_test.cpp
@@ -29,7 +29,7 @@ TEST(DimnameTest, isValidIdentifier) {
 TEST(DimnameTest, wildcardName) {
   Dimname wildcard = Dimname::wildcard();
   ASSERT_EQ(wildcard.type(), NameType::WILDCARD);
-  ASSERT_EQ(wildcard.name(), Symbol::dimname("*"));
+  ASSERT_EQ(wildcard.full_name(), Symbol::dimname("*"));
   ASSERT_EQ(wildcard.untagged_name(), Symbol::dimname("*"));
 }
 
@@ -37,7 +37,7 @@ TEST(DimnameTest, createNormalName) {
   auto foo = Symbol::dimname("foo");
   auto dimname = Dimname::fromSymbol(foo);
   ASSERT_EQ(dimname.type(), NameType::NORMAL);
-  ASSERT_EQ(dimname.name(), foo);
+  ASSERT_EQ(dimname.full_name(), foo);
   ASSERT_EQ(dimname.untagged_name(), foo);
 
   ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname("invalid1")), c10::Error);
@@ -48,7 +48,7 @@ TEST(DimnameTest, createTaggedName) {
   auto foo = Symbol::dimname("foo");
   auto dimname = Dimname::fromSymbol(foo_bar);
   ASSERT_EQ(dimname.type(), NameType::TAGGED);
-  ASSERT_EQ(dimname.name(), foo_bar);
+  ASSERT_EQ(dimname.full_name(), foo_bar);
   ASSERT_EQ(dimname.untagged_name(), foo);
 
   ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname(".bar")), c10::Error);
@@ -65,7 +65,7 @@ static void check_unify_and_match(
   auto result = at::unify(dimname1, dimname2);
   if (expected) {
     auto expected_result = Dimname::fromSymbol(Symbol::dimname(*expected));
-    ASSERT_EQ(result->name(), expected_result.name());
+    ASSERT_EQ(result->full_name(), expected_result.full_name());
     ASSERT_EQ(result->type(), expected_result.type());
     ASSERT_EQ(result->untagged_name(), expected_result.untagged_name());
     ASSERT_TRUE(match(dimname1, dimname2));

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -50,7 +50,7 @@ static bool dimnames_equal(at::DimnameList names, at::DimnameList other) {
   for (auto i = 0; i < names.size(); i++) {
     const auto& name = names[i];
     const auto& other_name = other[i];
-    if (name.type() != other_name.type() || name.name() != other_name.name()) {
+    if (name.type() != other_name.type() || name.full_name() != other_name.full_name()) {
       return false;
     }
   }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -332,7 +332,7 @@ PyObject *THPVariable_get_names(THPVariable *self)
   for (size_t i = 0; i < size; ++i) {
     PyObject* str = Py_None;
     if (dimnames[i].type() != at::NameType::WILDCARD) {
-      str = THPUtils_packString(dimnames[i].name().toUnqualString());
+      str = THPUtils_packString(dimnames[i].full_name().toUnqualString());
       if (!str) throw python_error();
     }
     PyTuple_SET_ITEM(tuple.get(), i, str);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21795 Implement tensor.select(Dimname,int)
* #21789 Add at::dimname_to_position helper.
* #21752 named inference rule for tensor.select
* #21781 Disallow creation of tensors with duplicate names
* **#21803 Rename Dimname::name to Dimname::full_name**
* #21735 Copy NamedTensorMeta in TensorImpl::copy_tensor_data()
* #21648 Expose torch.empty(sizes, *, names, ...) to Python

This makes it clearer: the name field is the full name (untagged_name + tag).

Test Plan:
- [namedtensor ci]

Differential Revision: [D15833452](https://our.internmc.facebook.com/intern/diff/D15833452)