### PR TITLE
BERT CPU performance optimization: use mkldnn for nn.Linear() when input is dense layout

### DIFF
--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -52,8 +52,8 @@ Tensor mkldnn_linear(
   TORCH_CHECK(self.dim() >= 2,
       "mkldnn_linear: input needs to has dim at least 2, input dim ", self.dim());
 
-  const ideep::tensor& x = get_mkldnn_tensor(self);
-  const ideep::tensor& w = itensor_from_mkldnn(weight);
+  const ideep::tensor x = get_mkldnn_tensor(self);
+  const ideep::tensor w = itensor_from_mkldnn(weight);
 
   ideep::tensor y;
   if (bias.defined()) {

--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -25,15 +25,23 @@ namespace at {
 namespace native {
 
 // Helper function for getting an ideep tensor out of an aten Tensor.
-// Note in case the aten Tensor is a dense tensor, make sure:
+// In case the aten Tensor is a mkldnn tensor,
+//   1. reshape first if input dim is greater than 2 and the reshape will cost a memory copy.
+//   2. directly return the ideep tensor if the input dim is 2.
+// In case the aten Tensor is a dense tensor, make sure:
 //   1. the aten tensor is 2d, so that 3d*2d Linear is viewed as 2d*2d.
 //   2. the aten tensor is contiguous.
 inline ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor) {
   if (tensor.is_mkldnn()) {
-    return at::native::itensor_from_mkldnn(tensor);
+    if (tensor.dim() > 2) {
+      // use reshape for mkldnn tensor
+      auto x = tensor.reshape({-1, tensor.size(tensor.dim() - 1)});
+      return itensor_from_mkldnn(x);
+    }
+    return itensor_from_mkldnn(tensor);
   } else {
     auto x = tensor.contiguous().view({-1, tensor.size(tensor.dim() - 1)});
-    return at::native::itensor_view_from_dense(x);
+    return itensor_view_from_dense(x);
   }
 }
 
@@ -41,25 +49,31 @@ Tensor mkldnn_linear(
     const Tensor& self,
     const Tensor& weight,
     const Tensor& bias) {
-  const ideep::tensor x = get_mkldnn_tensor(self);
-  const ideep::tensor w = get_mkldnn_tensor(weight);
+  TORCH_CHECK(self.dim() >= 2,
+      "mkldnn_linear: input needs to has dim at least 2, input dim ", self.dim());
+
+  const ideep::tensor& x = get_mkldnn_tensor(self);
+  const ideep::tensor& w = itensor_from_mkldnn(weight);
 
   ideep::tensor y;
   if (bias.defined()) {
-    const ideep::tensor b = get_mkldnn_tensor(bias);
+    const ideep::tensor b = itensor_from_mkldnn(bias);
     ideep::inner_product_forward::compute(x, w, b, y);
   } else {
     ideep::inner_product_forward::compute(x, w, y);
   }
 
+  auto input_size = self.sizes();
+  auto weight_size = weight.sizes();
+  std::vector<int64_t> output_size(input_size.begin(), input_size.end() - 1);
+  output_size.push_back(weight.size(0));
+
   if (self.is_mkldnn()) {
+    if (self.dim() > 2) {
+      return new_with_itensor_mkldnn(std::move(y), self.options()).reshape(output_size);
+    }
     return new_with_itensor_mkldnn(std::move(y), self.options());
   } else {
-    auto input_size = self.sizes();
-    auto weight_size = weight.sizes();
-    std::vector<int64_t> output_size;
-    output_size.insert(output_size.end(), input_size.begin(), input_size.end() - 1);
-    output_size.push_back(weight.size(0));
     return mkldnn_to_dense(
         new_with_itensor_mkldnn(std::move(y), self.options())).view(output_size);
   }

--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -24,22 +24,45 @@ Tensor mkldnn_linear(
 namespace at {
 namespace native {
 
+// Helper function for getting an ideep tensor out of an aten Tensor.
+// Note in case the aten Tensor is a dense tensor, make sure:
+//   1. the aten tensor is 2d, so that 3d*2d Linear is viewed as 2d*2d.
+//   2. the aten tensor is contiguous.
+inline ideep::tensor get_mkldnn_tensor(const at::Tensor& tensor) {
+  if (tensor.is_mkldnn()) {
+    return at::native::itensor_from_mkldnn(tensor);
+  } else {
+    auto x = tensor.contiguous().view({-1, tensor.size(tensor.dim() - 1)});
+    return at::native::itensor_view_from_dense(x);
+  }
+}
+
 Tensor mkldnn_linear(
     const Tensor& self,
     const Tensor& weight,
     const Tensor& bias) {
-  ideep::tensor& x = itensor_from_mkldnn(self);
-  ideep::tensor& w = itensor_from_mkldnn(weight);
+  const ideep::tensor x = get_mkldnn_tensor(self);
+  const ideep::tensor w = get_mkldnn_tensor(weight);
 
   ideep::tensor y;
   if (bias.defined()) {
-    ideep::tensor& b = itensor_from_mkldnn(bias);
+    const ideep::tensor b = get_mkldnn_tensor(bias);
     ideep::inner_product_forward::compute(x, w, b, y);
   } else {
     ideep::inner_product_forward::compute(x, w, y);
   }
 
-  return new_with_itensor_mkldnn(std::move(y), self.options());
+  if (self.is_mkldnn()) {
+    return new_with_itensor_mkldnn(std::move(y), self.options());
+  } else {
+    auto input_size = self.sizes();
+    auto weight_size = weight.sizes();
+    std::vector<int64_t> output_size;
+    output_size.insert(output_size.end(), input_size.begin(), input_size.end() - 1);
+    output_size.push_back(weight.size(0));
+    return mkldnn_to_dense(
+        new_with_itensor_mkldnn(std::move(y), self.options())).view(output_size);
+  }
 }
 
 } // namespace native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1093,6 +1093,7 @@
 - func: mkldnn_linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
   python_module: nn
   dispatch:
+    CPU: mkldnn_linear
     MkldnnCPU: mkldnn_linear
 
 - func: fbgemm_linear_int8_weight(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1093,7 +1093,6 @@
 - func: mkldnn_linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
   python_module: nn
   dispatch:
-    CPU: mkldnn_linear
     MkldnnCPU: mkldnn_linear
 
 - func: fbgemm_linear_int8_weight(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor

--- a/torch/utils/mkldnn.py
+++ b/torch/utils/mkldnn.py
@@ -27,7 +27,10 @@ class MkldnnLinear(torch.jit.ScriptModule):
 
     @torch.jit.script_method
     def forward(self, x):
-        return torch._C._nn.mkldnn_linear(x, self.weight, self.bias)
+        x_mkldnn = x if x.is_mkldnn else x.to_mkldnn()
+        y_mkldnn = torch._C._nn.mkldnn_linear(x_mkldnn, self.weight, self.bias)
+        y = y_mkldnn if x.is_mkldnn else y_mkldnn.to_dense()
+        return y
 
 
 class MkldnnConv2d(torch.jit.ScriptModule):


### PR DESCRIPTION
This PR aims at improving BERT performance on CPU by using `mkldnn` inner product for `nn.Linear()`.
The current logic is to use `mkldnn` only when `input` tensor is of mkldnn layout. This PR loosens this condition, `mkldnn` will be used for `nn.Linear()` when `input` tensor is of dense layout. The aten tensor is viewed inplace in `mkldnn` without additional memory copy.
1. when `input.dim() >= 3` , it is viewed as 2d tensor. e.g. `[T, N, C]` is treated as `[TN, C]`;
2. when `input` is not contiguous, it is copied so as to be contiguous. `mkldnn` inner product can't handle non-contiguous memory.

With this PR, BERT on `glue/MRPC` inference (batch size = 1) on Xeon 6148 single socket (20 cores@2.5GHz) improves by `44%`:

1. before (unit: iterations/sec):
```bash
408/408 [00:24<00:00, 16.69it/s]
```
2. after (unit: iterations/sec):
```bash
408/408 [00:16<00:00, 24.06it/s]
```

The latency reduces from `59.92 ms` to `41.56ms` correspondingly.