### PR TITLE
[BC-breaking] Use fn(param) instead of fn(param.data) in nn.Module._apply

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1585,10 +1585,9 @@ class TestNN(NNTestCase):
         # the module's parameters' version counter.
         m = nn.Linear(20, 10)
         pvm = m.weight.mul(m.weight)
-        weight_ref = m.weight
-        m_weight_version_saved = weight_ref._version
+        m_weight_version_saved = m.weight._version
         m = m._apply(add_one_inplace)
-        self.assertGreater(weight_ref._version, m_weight_version_saved)
+        self.assertGreater(m.weight._version, m_weight_version_saved)
         with self.assertRaisesRegex(RuntimeError, "modified by an inplace operation"):
             pvm.backward(torch.randn(10, 20))
 
@@ -1597,10 +1596,9 @@ class TestNN(NNTestCase):
         m = nn.Linear(20, 10)
         m.weight.grad = torch.randn(10, 20).requires_grad_()
         pgm = m.weight.grad.mul(m.weight.grad)
-        weight_grad_ref = m.weight.grad
-        m_weight_grad_version_saved = weight_grad_ref._version
+        m_weight_grad_version_saved = m.weight.grad._version
         m = m._apply(add_one_inplace)
-        self.assertGreater(weight_grad_ref._version, m_weight_grad_version_saved)
+        self.assertGreater(m.weight.grad._version, m_weight_grad_version_saved)
         with self.assertRaisesRegex(RuntimeError, "modified by an inplace operation"):
             pgm.backward(torch.randn(10, 20))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1577,6 +1577,33 @@ class TestNN(NNTestCase):
         with self.assertRaises(TypeError):
             net.to(cpu, torch.tensor(3, dtype=torch.long), non_blocking=True)
 
+    def test_module_apply_inplace_op(self):
+        def add_one_inplace(t):
+            return t.add_(1.0)
+
+        # Test that applying an in-place operation to a module would bump
+        # the module's parameters' version counter.
+        m = nn.Linear(20, 10)
+        pvm = m.weight.mul(m.weight)
+        weight_ref = m.weight
+        m_weight_version_saved = weight_ref._version
+        m = m._apply(add_one_inplace)
+        self.assertGreater(weight_ref._version, m_weight_version_saved)
+        with self.assertRaisesRegex(RuntimeError, "modified by an inplace operation"):
+            pvm.backward(torch.randn(10, 20))
+
+        # Test that applying an in-place operation to a module would bump
+        # the module's parameters' gradients' version counter.
+        m = nn.Linear(20, 10)
+        m.weight.grad = torch.randn(10, 20).requires_grad_()
+        pgm = m.weight.grad.mul(m.weight.grad)
+        weight_grad_ref = m.weight.grad
+        m_weight_grad_version_saved = weight_grad_ref._version
+        m = m._apply(add_one_inplace)
+        self.assertGreater(weight_grad_ref._version, m_weight_grad_version_saved)
+        with self.assertRaisesRegex(RuntimeError, "modified by an inplace operation"):
+            pgm.backward(torch.randn(10, 20))
+
     def test_type(self):
         l = nn.Linear(10, 20)
         net = nn.Module()

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -195,8 +195,6 @@ class Module(object):
 
         for param in self._parameters.values():
             if param is not None:
-                # Tensors stored in modules are graph leaves, and we don't
-                # want to create copy nodes, so we have to unpack the data.
                 with torch.no_grad():
                     param_applied = fn(param)
                 param.data = param_applied

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -197,9 +197,13 @@ class Module(object):
             if param is not None:
                 # Tensors stored in modules are graph leaves, and we don't
                 # want to create copy nodes, so we have to unpack the data.
-                param.data = fn(param.data)
+                with torch.no_grad():
+                    param_applied = fn(param)
+                param.data = param_applied
                 if param._grad is not None:
-                    param._grad.data = fn(param._grad.data)
+                    with torch.no_grad():
+                        grad_applied = fn(param._grad)
+                    param._grad.data = grad_applied
 
         for key, buf in self._buffers.items():
             if buf is not None:


### PR DESCRIPTION
When we pass `fn` to `nn.Module._apply()` and `fn` is an in-place operation, the correct behavior should also include bumping the parameters' and their gradients' version counters. This PR fixes the old incorrect behavior and makes sure the new behavior is right.

Note that this PR is BC-breaking in the following way:

Previously, passing an in-place operation to `nn.Module._apply()` does not bump the module's parameters' and their gradients' version counters. After this PR, the module's parameters' and their gradients' version counters will be correctly bumped by the in-place operation, which will invalidate them in any autograd graph they previously participate in.