### PR TITLE
Add slot_list/slot_iterator

### DIFF
--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -923,12 +923,9 @@ void ScriptModuleSerializer::convertModule(
     record->set_key(filename.str());
   }
 
-  for (size_t i = 0; i < module.num_slots(); ++i) {
-    script::Slot s = module.get_slot(i);
-    if (s.is_module()) {
-      torch::ModuleDef* sub_def = module_def->add_submodules();
-      convertModule(s.to_module(), module_name.str(), s.name(), sub_def);
-    }
+  for (script::Slot s : module.get_module_slots()) {
+    torch::ModuleDef* sub_def = module_def->add_submodules();
+    convertModule(s.to_module(), module_name.str(), s.name(), sub_def);
   }
 }
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -412,11 +412,8 @@ void initJitScriptBindings(PyObject* module) {
           "_get_modules",
           [](Module& self) {
             std::vector<std::pair<std::string, Module>> modules;
-            for (size_t i = 0; i < self.num_slots(); ++i) {
-              Slot s = self.get_slot(i);
-              if (s.is_module()) {
-                modules.emplace_back(s.name(), s.to_module());
-              }
+            for (Slot s : self.get_module_slots()) {
+              modules.emplace_back(s.name(), s.to_module());
             }
             return modules;
           })
@@ -425,10 +422,10 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& self) -> py::tuple {
             auto parameters = self.get_parameters();
             py::tuple result(parameters.size());
-            for (size_t i = 0; i < parameters.size(); ++i) {
-              auto& p = parameters[i];
+            auto i = 0;
+            for (Slot p : parameters) {
               py::tuple r(2);
-              result[i] = std::make_tuple(
+              result[i++] = std::make_tuple(
                   p.name(), autograd::as_variable_ref(p.value().toTensor()));
             }
             return result;
@@ -438,11 +435,11 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& self) -> py::tuple {
             auto attributes = self.get_attributes();
             py::tuple result(attributes.size());
-            for (size_t i = 0; i < attributes.size(); ++i) {
-              auto& buffer = attributes[i];
+            size_t i = 0;
+            for (Slot buffer : attributes) {
               py::tuple r(3);
               IValue v = buffer.value();
-              result[i] = std::make_tuple(
+              result[i++] = std::make_tuple(
                   buffer.name(), buffer.type(), toPyObject(std::move(v)));
             }
             return result;

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -68,11 +68,11 @@ void Module::to_impl(
     child->to_impl(device, dtype, non_blocking);
   }
   // Then convert every of our parameters.
-  for (auto& parameter : get_parameters()) {
+  for (Slot parameter : get_parameters()) {
     module_state_to(parameter, device, dtype, non_blocking);
   }
   // Then convert every tensor attributes (buffers).
-  for (auto& attr : get_attributes()) {
+  for (Slot attr : get_attributes()) {
     if (attr.type()->isSubtypeOf(TensorType::get())) {
       module_state_to(attr, device, dtype, non_blocking);
     }
@@ -209,8 +209,7 @@ void Module::copy_into(
   auto curr = module_lookup(names);
   type_remap[module_object()->type()] = curr->module_object()->type();
 
-  for (size_t i = 0; i < curr->num_slots(); ++i) {
-    Slot s = curr->get_slot(i);
+  for (Slot s : curr->get_slots()) {
     if (s.is_module()) {
       names.push_back(s.name());
       // Submodules must be translated first, otherwise parameter_remap entries
@@ -263,11 +262,8 @@ void Module::clone_method(const Module& orig, const std::string& name) {
     to_scan.pop_back();
     type_remap[entry.first.module_object()->type()] =
         entry.second.module_object()->type();
-    for (size_t i = 0; i < entry.first.num_slots(); ++i) {
-      Slot s = entry.first.get_slot(i);
-      if (s.is_module()) {
-        to_scan.emplace_back(s.to_module(), *entry.second.get_module(s.name()));
-      }
+    for (Slot s : entry.first.get_module_slots()) {
+      to_scan.emplace_back(s.to_module(), *entry.second.get_module(s.name()));
     }
   }
   return clone_method(orig, name, type_remap);
@@ -309,6 +305,32 @@ IValue Module::create_class(const c10::QualifiedName& name, Stack stack) const {
   classType->getMethod("__init__")->operator()(std::move(stackWithSelf));
 
   return obj;
+}
+
+slot_list Module::get_parameters() const {
+  return slot_list(*this, EntityType::PARAMETER);
+}
+
+slot_list Module::get_attributes() const {
+  return slot_list(*this, EntityType::ATTRIBUTE);
+}
+
+slot_list Module::get_module_slots() const {
+  return slot_list(*this, EntityType::MODULE);
+}
+
+slot_list Module::get_slots() const {
+  return slot_list(*this, c10::nullopt);
+}
+
+std::vector<std::shared_ptr<Module>> Module::get_modules() const {
+  std::vector<std::shared_ptr<Module>> result;
+  for (Slot s : get_slots()) {
+    if (s.is_module()) {
+      result.push_back(std::make_shared<Module>(s.to_module()));
+    }
+  }
+  return result;
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -364,11 +364,8 @@ std::vector<std::shared_ptr<SugaredValue>> ModuleValue::asTuple(
   // and script Modules. If we need to load a Module, we need its field
   // name so we can emit 'self.field_name'.
   std::unordered_map<at::ivalue::Object*, std::string> obj_to_field;
-  for (size_t i = 0; i < module_->num_slots(); ++i) {
-    Slot s = module_->get_slot(i);
-    if (s.is_module()) {
-      obj_to_field[s.value().toObject().get()] = s.name();
-    }
+  for (Slot s : module_->get_module_slots()) {
+    obj_to_field[s.value().toObject().get()] = s.name();
   }
 
   std::vector<std::shared_ptr<SugaredValue>> result;

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -287,8 +287,7 @@ static void gatherParametersAndBuffers(
   
   state->setValue(self.module_object(), self_value);
 
-  for (size_t i = 0; i < self.num_slots(); ++i) {
-    script::Slot s = self.get_slot(i);
+  for (script::Slot s : self.get_slots()) {
     if (s.type()->isSubtypeOf(TensorType::get())) {
       addInput(
           state, s.value(), s.type(), g.insertGetAttr(self_value, s.name()));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #21853 Add interface declarations to JIT
* **#21874 Add slot_list/slot_iterator**
* #21814 script::Module as a view.
* #21675 Make script::Method a value type

Summary: we've change  implementation of iterating over parameters/attributes/modules
many times, and each time we've had to slightly break backward compatibility.
This changes the api to use a class to encapsulate iteration of parameters/attributes/modules.
This should allow us to make implementation changes without affecting the user API.

Differential Revision: [D15864719](https://our.internmc.facebook.com/intern/diff/D15864719)