### PR TITLE
Made a += b for lists do an in place add

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -350,6 +350,12 @@ public:
   void push_back(T&& value) const;
 
   /**
+   * Appends the given list to the end of the container. Uses at most one memory allocation.
+   * May invalidate any references, pointers, or iterators referring to contained elements. Any past-the-end iterators may also be invalidated.
+   */
+  void append(ListPtr<T> lst) const;
+
+  /**
    * Appends the given element value to the end of the container.
    * The new element is constructed with the given arguments.
    * May invalidate any references, pointers, or iterators referring to contained elements. Any past-the-end iterators may also be invalidated.

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -353,7 +353,7 @@ public:
    * Appends the given list to the end of the container. Uses at most one memory allocation.
    * May invalidate any references, pointers, or iterators referring to contained elements. Any past-the-end iterators may also be invalidated.
    */
-  void append(ListPtr<T> lst) const;
+  void append(List<T> lst) const;
 
   /**
    * Appends the given element value to the end of the container.

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -182,6 +182,21 @@ void List<T>::push_back(T&& value) const {
 }
 
 template<class T>
+void ListPtr<T>::append(ListPtr<T> b) const {
+  size_type neededSize = this->size() + b.size();
+  if (impl_->list.capacity() < neededSize) {
+    this->reserve(std::max(impl_->list.capacity() * 2, neededSize));
+  }
+  if (b.use_count() == 1) {
+    std::move(b.begin(), b.end(), this->begin());
+  } else {
+    for (const auto& el: b) {
+      this->push_back(el);
+    }
+  }
+}
+
+template<class T>
 template<class... Args>
 void List<T>::emplace_back(Args&&... args) const {
   // TODO Use list_element_from?

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -182,7 +182,7 @@ void List<T>::push_back(T&& value) const {
 }
 
 template<class T>
-void ListPtr<T>::append(ListPtr<T> b) const {
+void List<T>::append(List<T> b) const {
   if (b.use_count() == 1) {
     impl_->list.insert(impl_->list.end(), make_move_iterator(b.impl_->list.begin()), make_move_iterator(b.impl_->list.end()));
   } else {

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -183,16 +183,10 @@ void List<T>::push_back(T&& value) const {
 
 template<class T>
 void ListPtr<T>::append(ListPtr<T> b) const {
-  size_type neededSize = this->size() + b.size();
-  if (impl_->list.capacity() < neededSize) {
-    this->reserve(std::max(impl_->list.capacity() * 2, neededSize));
-  }
   if (b.use_count() == 1) {
-    std::move(b.begin(), b.end(), this->begin());
+    impl_->list.insert(impl_->list.end(), make_move_iterator(b.impl_->list.begin()), make_move_iterator(b.impl_->list.end()));
   } else {
-    for (const auto& el: b) {
-      this->push_back(el);
-    }
+    impl_->list.insert(impl_->list.end(), b.impl_->list.begin(), b.impl_->list.end());
   }
 }
 

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1534,6 +1534,15 @@ int listAdd(Stack& stack) {
   push(stack, std::move(ret));
   return 0;
 }
+template <class T>
+int listInplaceAdd(Stack& stack) {
+  c10::ListPtr<T> a = c10::make_list<T>();
+  c10::ListPtr<T> b = c10::make_list<T>();
+  pop(stack, a, b);
+  a.append(b);
+  push(stack, std::move(a));
+  return 0;
+}
 
 template <class T>
 int listMulIntLeft(Stack& stack) {
@@ -1915,6 +1924,10 @@ RegisterOperators reg2({
           "aten::add(" decl_type "[] a, " decl_type "[] b) -> " decl_type           \
           "[]",                                                                     \
           listAdd<c_type::value_type>),                                             \
+      Operator(                                                                     \
+          "aten::add_(" decl_type "[](a!) self, " decl_type "[] b) -> " decl_type           \
+          "[]",                                                                     \
+          listInplaceAdd<c_type::value_type>),                                             \
       Operator(                                                                     \
           "aten::slice(" decl_type                                                  \
           "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type \

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1536,9 +1536,8 @@ int listAdd(Stack& stack) {
 }
 template <class T>
 int listInplaceAdd(Stack& stack) {
-  c10::ListPtr<T> a = c10::make_list<T>();
-  c10::ListPtr<T> b = c10::make_list<T>();
-  pop(stack, a, b);
+  c10::List<T> b = pop(stack).to<List<T>>();
+  c10::List<T> a = pop(stack).to<List<T>>();
   a.append(std::move(b));
   push(stack, std::move(a));
   return 0;
@@ -1925,9 +1924,9 @@ RegisterOperators reg2({
           "[]",                                                                     \
           listAdd<c_type::value_type>),                                             \
       Operator(                                                                     \
-          "aten::add_(" decl_type "[](a!) self, " decl_type "[] b) -> " decl_type           \
+          "aten::add_(" decl_type "[](a!) self, " decl_type "[] b) -> " decl_type   \
           "[]",                                                                     \
-          listInplaceAdd<c_type::value_type>),                                             \
+          listInplaceAdd<c_type::value_type>),                                      \
       Operator(                                                                     \
           "aten::slice(" decl_type                                                  \
           "[] l, int start, int end=9223372036854775807, int step=1) -> " decl_type \
@@ -2081,7 +2080,7 @@ RegisterOperators reg2({
         "prim::min(int[] x) -> int",
         [](Stack& stack) {
           c10::List<int64_t> int_list = pop(stack).toIntList();
-          int64_t min_element = std::numeric_limits<int64_t>::max(); 
+          int64_t min_element = std::numeric_limits<int64_t>::max();
 
           for(int64_t ele: int_list) {
             if(ele < min_element) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1539,7 +1539,7 @@ int listInplaceAdd(Stack& stack) {
   c10::ListPtr<T> a = c10::make_list<T>();
   c10::ListPtr<T> b = c10::make_list<T>();
   pop(stack, a, b);
-  a.append(b);
+  a.append(std::move(b));
   push(stack, std::move(a));
   return 0;
 }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1462,7 +1462,6 @@ struct to_ir {
   // If it's a list of scalars, then return the corresponding list augment op
   Symbol getAugOp(const AugAssign& stmt, const TypePtr& type) {
     if (type->cast<ListType>()) { // Lists also have in-place ops.
-      std::cout<<"generating list op"<<std::endl;
       switch (stmt.aug_op()) {
         case '+':
           return aten::add_;

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1460,7 +1460,15 @@ struct to_ir {
   // Get the appropriate builtin op for this augmented assignment
   // If the RHS is a tensor, return the corresponding ATen in-place op
   // If it's a list of scalars, then return the corresponding list augment op
-  Symbol getAugOp(const AugAssign& stmt, bool isTensor) {
+  Symbol getAugOp(const AugAssign& stmt, TypePtr type) {
+    if (type->cast<ListType>()) { // Lists also have in-place ops.
+      std::cout<<"generating list op"<<std::endl;
+      switch (stmt.aug_op()) {
+        case '+':
+          return aten::add_;
+      }
+    }
+    bool isTensor = type->isSubtypeOf(TensorType::get());
     switch (stmt.aug_op()) {
       case '+':
         return isTensor ? aten::add_ : aten::add;
@@ -1524,7 +1532,7 @@ struct to_ir {
       emitBuiltinCall(
           stmt.range(),
           *method.graph(),
-          getAugOp(stmt, /*isTensor=*/true),
+          getAugOp(stmt, lhsValue->type()),
           self,
           {rhs},
           {},
@@ -1541,14 +1549,15 @@ struct to_ir {
     const auto lhs = Var(stmt.lhs());
     const auto lhsValue = environment_stack->getSugaredVar(lhs.name())
                               ->asValue(lhs.range(), method);
-    if (lhsValue->type()->isSubtypeOf(TensorType::get())) {
+    auto lhsType = lhsValue->type();
+    if (lhsType->isSubtypeOf(TensorType::get()) || lhsType->cast<c10::ListType>()) {
       // for tensors, emit the corresponding in-place op
       const auto rhs = NamedValue(stmt.rhs().range(), emitExpr(stmt.rhs()));
       const auto self = NamedValue(stmt.lhs().range(), "self", lhsValue);
       const auto output = emitBuiltinCall(
           stmt.range(),
           *method.graph(),
-          getAugOp(stmt, /*isTensor=*/true),
+          getAugOp(stmt, lhsValue->type()),
           self,
           {rhs},
           {},
@@ -1589,7 +1598,7 @@ struct to_ir {
         emitBuiltinCall(
             stmt.range(),
             *method.graph(),
-            getAugOp(stmt, /*isTensor=*/true),
+            getAugOp(stmt, sliceable->type()),
             slicedArg,
             {rhs},
             {},
@@ -1606,7 +1615,7 @@ struct to_ir {
         const auto augmented = emitBuiltinCall(
             stmt.range(),
             *method.graph(),
-            getAugOp(stmt, /*isTensor=*/true),
+            getAugOp(stmt, sliceable->type()),
             indexed,
             {rhs},
             {},
@@ -1624,8 +1633,7 @@ struct to_ir {
       const auto listType = sliceable->type()->cast<ListType>();
       AT_ASSERT(listType != nullptr);
 
-      bool isTensorList =
-          listType->getElementType()->isSubtypeOf(TensorType::get());
+      auto elementType = listType->getElementType();
 
       // Get the idx to augment
       const auto subscriptExprs = lhs.subscript_exprs();
@@ -1645,7 +1653,7 @@ struct to_ir {
       const auto getItem =
           graph->insert(aten::select, {listArg, idxArg}, {}, stmt.range());
       const auto augmentedItem = graph->insert(
-          getAugOp(stmt, isTensorList), {getItem, valueArg}, {}, stmt.range());
+          getAugOp(stmt, elementType), {getItem, valueArg}, {}, stmt.range());
       graph->insert(
           aten::_set_item, {listArg, idxArg, augmentedItem}, {}, stmt.range());
     }

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1460,7 +1460,7 @@ struct to_ir {
   // Get the appropriate builtin op for this augmented assignment
   // If the RHS is a tensor, return the corresponding ATen in-place op
   // If it's a list of scalars, then return the corresponding list augment op
-  Symbol getAugOp(const AugAssign& stmt, TypePtr type) {
+  Symbol getAugOp(const AugAssign& stmt, const TypePtr& type) {
     if (type->cast<ListType>()) { // Lists also have in-place ops.
       std::cout<<"generating list op"<<std::endl;
       switch (stmt.aug_op()) {


### PR DESCRIPTION
In talks with @smessmer, we decided that it'd be better to put the logic in `list`, as optimal behavior requires knowing `.capacity()`

Results on my cpu (for the benchmark here: https://twitter.com/VahidK/status/1138674536679821312) now look like this:
```
Pytorch batch_gather took 0.018311 seconds.
Pytorch batch_gather jit took 0.013921 seconds.
Pytorch vectorized batch_gather took 0.001384 seconds.
```
Previously, `batch_gather jit` took 3x as long as `batch_gather`.

Some logic taken from https://github.com/pytorch/pytorch/pull/21690. Note that these two PR's are somewhat orthogonal. That PR handles this benchmark by looking at the alias analysis, while this PR specializes for `+=`. 

Note that we can't jit the vectorized version as we think `torch.arange` returns a float tensor.