### PR TITLE
[jit] Mark test_snli as a slow test

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13742,6 +13742,7 @@ class TestEndToEndHybridFrontendModels(JitTestCase):
             self.checkTrace(SNLIClassifier(Config()).to(device), (premise, hypothesis),
                             inputs_require_grads=False, export_import=check_export_import)
 
+    @slowTest
     def test_snli(self):
         self._test_snli(self, device='cpu')
 


### PR DESCRIPTION
It takes way longer than the other CPU tests:

`pytest -n 30 -q test/test_jit.py -p no:warnings --durations=15`
```
68.99s call     test/test_jit.py::TestEndToEndHybridFrontendModels::test_snli
19.47s call     test/test_jit.py::TestEndToEndHybridFrontendModels::test_dcgan_models
18.88s call     test/test_jit.py::TestJit::test_export_batchnorm
16.71s call     test/test_jit.py::TestEndToEndHybridFrontendModels::test_neural_style
16.44s call     test/test_jit.py::TestScript::test_fuser_double_float_codegen
11.11s call     test/test_jit.py::TestJit::test_alexnet
9.28s call     test/test_jit.py::TestJitGeneratedAutograd::test_logsumexp
7.56s call     test/test_jit.py::TestJitGeneratedModule::test_nn_Conv3d_stride_pad1circular
```

Differential Revision: [D15875846](https://our.internmc.facebook.com/intern/diff/15875846/)