### PR TITLE
Quick fix for #18215, the CPU case

### DIFF
--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -147,12 +147,16 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
         }
       }
       // the likelihood is the the sum of the last two alphas, eq (8), the loss is the negative log likelihood
-      scalar_t l1 = log_alpha_a[input_length-1][target_length*2];
-      scalar_t l2 = log_alpha_a[input_length-1][target_length*2-1];
-      scalar_t m = std::max(l1, l2);
-      m = ((m == neginf) ? 0 : m);
-      scalar_t log_likelihood = std::log(std::exp(l1-m)+std::exp(l2-m))+m;
-      neg_log_likelihood_a[b] = -log_likelihood;
+      if (target_length == 0) {
+        neg_log_likelihood_a[b] = -log_alpha_a[input_length-1][0];
+      } else {
+        scalar_t l1 = log_alpha_a[input_length-1][target_length*2];
+        scalar_t l2 = log_alpha_a[input_length-1][target_length*2-1];
+        scalar_t m = std::max(l1, l2);
+        m = ((m == neginf) ? 0 : m);
+        scalar_t log_likelihood = std::log(std::exp(l1-m)+std::exp(l2-m))+m;
+        neg_log_likelihood_a[b] = -log_likelihood;
+      }
     }
   });
 

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -148,6 +148,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
       }
       // the likelihood is the the sum of the last two alphas, eq (8), the loss is the negative log likelihood
       if (target_length == 0) {
+        // if the target is empty then there is no preceding BLANK state and hence there is no path to merge
         neg_log_likelihood_a[b] = -log_alpha_a[input_length-1][0];
       } else {
         scalar_t l1 = log_alpha_a[input_length-1][target_length*2];

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5111,6 +5111,21 @@ class TestNN(NNTestCase):
         with self.assertRaises(RuntimeError):
             torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths)
 
+    def test_CTCLoss_empty_target_cpu(self):
+        target_lengths = [0, 0, 0]
+        input_lengths = [50, 50, 50]
+        targets = torch.randint(1, 15, (0,), dtype=torch.int)
+        log_probs = torch.randn(50, 3, 15, dtype=torch.float).log_softmax(2)
+        loss = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
+        self.assertTrue((loss >= 0).all().item())
+
+        target_lengths = [0, 9, 0]
+        input_lengths = [50, 50, 50]
+        targets = torch.randint(1, 15, (9,), dtype=torch.int)
+        log_probs = torch.randn(50, 3, 15, dtype=torch.float).log_softmax(2)
+        loss = torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
+        self.assertTrue((loss >= 0).all().item())
+
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_CTCLoss_zero_infinity(self):
         target_lengths = [60, 25, 20]


### PR DESCRIPTION
The bug is that when target_length == 0, there is no preceding BLANK state and the original implementation will lead to out of bound pointer access.