### PR TITLE
Fix infinite loop in del_post_hook

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -261,7 +261,7 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
 
   // delete a post hook matching the key
   bool del_post_hook(const uintptr_t& key) {
-    for (auto it = post_hooks_.begin(); it != post_hooks_.end();) {
+    for (auto it = post_hooks_.begin(); it != post_hooks_.end(); ++it) {
       if (key == reinterpret_cast<std::uintptr_t>(it->get())) {
         post_hooks_.erase(it);
         return true;


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21914 Fix infinite loop in del_post_hook**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15878884/)

https://github.com/pytorch/pytorch/pull/21591 added a needed feature to clean up grad accumulator post hooks when the DistributedDataParallel model object is cleaned up. There's a minor typo that causes it to loop infinitely over the first element.

Differential Revision: [D15878884](https://our.internmc.facebook.com/intern/diff/D15878884/)