### PR TITLE
[jit] make CU::define() take only a single resolver

### DIFF
--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -183,11 +183,9 @@ struct SourceImporter {
       parseImportsAndDoCallback();
 
       std::vector<Def> definitions;
-      std::vector<ResolverPtr> resolvers;
       auto class_def = ClassDef(p_.parseClass());
       for (const auto& method_def : class_def.defs()) {
         definitions.emplace_back(method_def);
-        resolvers.emplace_back(resolver_);
       }
 
       auto cu = std::make_shared<CompilationUnit>();
@@ -200,7 +198,7 @@ struct SourceImporter {
         v->setType(class_type);
         return std::make_shared<SimpleValue>(v);
       };
-      cu->define(definitions, resolvers, self);
+      cu->define(definitions, resolver_, self);
     }
   }
 
@@ -209,13 +207,11 @@ struct SourceImporter {
     parseImportsAndDoCallback();
 
     std::vector<Def> definitions;
-    std::vector<ResolverPtr> resolvers;
     while (p_.lexer().cur().kind != TK_EOF) {
       auto def = Def(p_.parseFunction(/*is_method=*/bool(self)));
       definitions.emplace_back(def);
-      resolvers.emplace_back(resolver_);
     }
-    cu.define(definitions, resolvers, self);
+    cu.define(definitions, resolver_, self);
   }
 
   size_t parseVersionNumber() {

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -68,9 +68,8 @@ struct TORCH_API CompilationUnit {
   // for historic reasons, these are defined in compiler.cpp
   void define(
       const std::vector<Def>& definitions,
-      const std::vector<ResolverPtr>&
-          resolvers, /* determines how we handle free
-                     variables in each definition*/
+      // determines how we handle free variables in each definition
+      const ResolverPtr& resolver,
       // if non-null, the first argument to each def, is bound to this value
       const Self& self);
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1715,7 +1715,7 @@ def _get_weak_stubs(cls):
         func = get_function_from_type(cls, name)
         if func in _jit_internal.weak_script_methods:
             entry = _jit_internal.weak_script_methods[func]
-            stub = script_method(entry["original_method"], entry["rcb"])
+            stub = script_method(entry["original_method"])
             stubs.append(stub)
     return stubs
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21920 [jit] make CU::define() take only a single resolver**
* #21886 [jit] fix bug in CompilationUnit::define

There isn't a use-case for making the resolvers different. The only
place where we do it is stub method compilation, but they should all
share a single closure environment

Differential Revision: [D15882059](https://our.internmc.facebook.com/intern/diff/D15882059)