### PR TITLE
Pass loop_over optional parameter for cached reader properly.

### DIFF
--- a/caffe2/python/cached_reader.py
+++ b/caffe2/python/cached_reader.py
@@ -44,6 +44,8 @@ class CachedReader(DBFileReader):
         original_reader: Reader.
             If provided, it's the original reader used to build the cache file.
         db_path: str.
+
+    Optional Args:
         db_type: str. DB type of file. A db_type is registed by
             `REGISTER_CAFFE2_DB(<db_type>, <DB Class>)`.
             Default to 'LevelDB'.
@@ -52,6 +54,10 @@ class CachedReader(DBFileReader):
             Default to '<db_name>_<default_name_suffix>'.
         batch_size: int.
             How many examples are read for each time the read_net is run.
+            Defaults to 100.
+        loop_over: bool.
+            If True given, will go through examples in random order endlessly.
+            Defaults to False.
     """
     def __init__(
         self,
@@ -60,6 +66,7 @@ class CachedReader(DBFileReader):
         db_type='LevelDB',
         name=None,
         batch_size=100,
+        loop_over=False,
     ):
         assert original_reader is not None, "original_reader can't be None"
         self.original_reader = original_reader
@@ -69,6 +76,7 @@ class CachedReader(DBFileReader):
             db_type,
             name,
             batch_size,
+            loop_over,
         )
 
     def _init_reader_schema(self, *args, **kwargs):

--- a/caffe2/python/dataio_test.py
+++ b/caffe2/python/dataio_test.py
@@ -364,7 +364,7 @@ class TestDBFileReader(TestCase):
 
         # Read data for the first time.
         cached_reader1 = CachedReader(
-            self._build_source_reader(ws, 100), db_path,
+            self._build_source_reader(ws, 100), db_path, loop_over=False,
         )
         build_cache_step = cached_reader1.build_cache_step()
         session.run(build_cache_step)


### PR DESCRIPTION
Summary: Just need to pass `loop_over` argument properly.

Differential Revision: D15885401

