### PR TITLE
Fix lint error

### DIFF
--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -164,7 +164,7 @@ def add_torch_libs():
     torch_cpp_headers["script.h"] = "torch/script.h"
 
     torch_cpp_srcs = [
-        "torch/csrc/api/src/cuda.cpp", # this just forwards stuff, no real CUDA
+        "torch/csrc/api/src/cuda.cpp",  # this just forwards stuff, no real CUDA
         "torch/csrc/api/src/data/datasets/mnist.cpp",
         "torch/csrc/api/src/data/samplers/distributed.cpp",
         "torch/csrc/api/src/data/samplers/random.cpp",
@@ -376,39 +376,38 @@ def add_torch_libs():
     # torch-cpp is still conditionally compiled based on USE_CUDA. Ideally we'd
     # separate it out as an additive library instead.
     gpu_library_selector(
-        name = "torch-cpp",
-        deps_cpu = [":torch-cpp-cpu"],
-        deps_cuda = [":torch-cpp-cuda"],
-        merge_cpu_deps = False,
+        name="torch-cpp",
+        deps_cpu=[":torch-cpp-cpu"],
+        deps_cuda=[":torch-cpp-cuda"],
+        merge_cpu_deps=False,
     )
 
     # USE_CUDA flag is propagated through propagated_pp_flags on libtorch
     cpp_library(
-        name = "torch-cpp-cuda",
-        srcs = torch_cpp_srcs,
-        headers = torch_cpp_headers,
-        header_namespace = "torch",
-        deps = [
+        name="torch-cpp-cuda",
+        srcs=torch_cpp_srcs,
+        headers=torch_cpp_headers,
+        header_namespace="torch",
+        deps=[
             ":libtorch_cuda",
             "//caffe2/torch/fb/init:init",
         ],
-        external_deps = [
+        external_deps=[
             ("cuda", None, "cuda-lazy"),
             ("cudnn", None, "cudnn-lazy"),
         ],
     )
 
     cpp_library(
-        name = "torch-cpp-cpu",
-        srcs = torch_cpp_srcs,
-        headers = torch_cpp_headers,
-        header_namespace = "torch",
-        deps = [
+        name="torch-cpp-cpu",
+        srcs=torch_cpp_srcs,
+        headers=torch_cpp_headers,
+        header_namespace="torch",
+        deps=[
             ":libtorch",
             "//caffe2/torch/fb/init:init",
         ],
     )
-
 
     # _C_impl is still conditionally compiled based on USE_CUDA. Ideally we'd
     # separate it out as an additive library instead.


### PR DESCRIPTION
#21916 has broken python lint on master
https://travis-ci.org/pytorch/pytorch/jobs/547354937
```
./tools/build_variables.py:167:39: E261 at least two spaces before inline comment
./tools/build_variables.py:379:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:379:15: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:380:17: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:380:19: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:381:18: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:381:20: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:382:23: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:382:25: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:387:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:387:15: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:388:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:388:15: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:389:16: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:389:18: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:390:25: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:390:27: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:391:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:391:15: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:395:22: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:395:24: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:402:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:402:15: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:403:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:403:15: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:404:16: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:404:18: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:405:25: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:405:27: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:406:13: E251 unexpected spaces around keyword / parameter equals
./tools/build_variables.py:406:15: E251 unexpected spaces around keyword / parameter equals
```