### PR TITLE
ListPtr->List DictPtr->Dict step 1

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -363,10 +363,13 @@ GenericDictPtr toGenericDict(DictPtr<Key, Value> dict) {
 }
 }
 
+template<class Key, class Value> using Dict = DictPtr<Key, Value>;
+
 }
 
 namespace torch {
   template<class Key, class Value> using DictPtr = c10::DictPtr<Key, Value>;
+  template<class Key, class Value> using Dict = DictPtr<Key, Value>;
 }
 
 #include <ATen/core/Dict_inl.h>

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -461,10 +461,13 @@ ListPtr<T> toList(std::vector<T> list) {
 
 }
 
+template<class T> using List = ListPtr<T>;
+
 }
 
 namespace torch {
   template<class T> using ListPtr = c10::ListPtr<T>;
+  template<class T> using List = ListPtr<T>;
 }
 
 #include <ATen/core/List_inl.h>


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21938 ListPtr->List DictPtr->Dict step 3&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15892402/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21937 ListPtr->List DictPtr->Dict step 2&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15892404/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21936 ListPtr->List DictPtr->Dict step 1**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15892405/)

This introduces torch::List and torch::Dict as aliases to ListPtr/DictPtr.
After this lands, we can step by step change the call sites to the new naming
and finally remove the old spellings.

Differential Revision: [D15892405](https://our.internmc.facebook.com/intern/diff/D15892405/)