### PR TITLE
ListPtr->List DictPtr->Dict step 3

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -8,13 +8,13 @@
 
 namespace c10 {
 struct IValue;
-template<class Key, class Value> class DictPtr;
+template<class Key, class Value> class Dict;
 
 /**
  * Creates an empty dict.
  */
 template<class Key, class Value>
-DictPtr<Key, Value> make_dict();
+Dict<Key, Value> make_dict();
 
 namespace impl {
 bool shallowEquals(const IValue& lhs, const IValue& rhs);
@@ -84,7 +84,7 @@ public:
 private:
   Iterator iterator_;
   friend class DictIterator<Key, Value, Iterator>;
-  friend class DictPtr<Key, Value>;
+  friend class Dict<Key, Value>;
   friend bool operator==<Key, Value, Iterator>(const DictIterator<Key, Value, Iterator>& lhs, const DictIterator<Key, Value, Iterator>& rhs);
 };
 
@@ -134,7 +134,7 @@ private:
   DictEntryRef<Key, Value, Iterator> entryRef_;
 
   friend class DictIterator<Key, Value, typename detail::DictImpl::dict_map_type::iterator>;
-  friend class DictPtr<Key, Value>;
+  friend class Dict<Key, Value>;
   friend bool operator==<Key, Value, Iterator>(const DictIterator& lhs, const DictIterator& rhs);
 
   // TODO We also need comparison operators <, >, <=, >=, see ListIterator.
@@ -150,19 +150,19 @@ inline bool operator!=(const DictIterator<Key, Value, Iterator>& lhs, const Dict
   return !(lhs == rhs);
 }
 
-template<class Key, class Value> DictPtr<Key, Value> toTypedDict(DictPtr<IValue, IValue> dict);
-template<class Key, class Value> DictPtr<IValue, IValue> toGenericDict(DictPtr<Key, Value> dict);
+template<class Key, class Value> Dict<Key, Value> toTypedDict(Dict<IValue, IValue> dict);
+template<class Key, class Value> Dict<IValue, IValue> toGenericDict(Dict<Key, Value> dict);
 }
 
 /**
  * An object of this class stores a map from Key to Value.
  * You can create instances using the make_dict<Key, Value>() function.
  *
- * This is a pointer type. After a copy, both DictPtrs
+ * This is a pointer type. After a copy, both Dicts
  * will share the same storage:
  *
- * > DictPtr<int, string> a = make_dict<int, string>();
- * > DictPtr<int, string> b = a;
+ * > Dict<int, string> a = make_dict<int, string>();
+ * > Dict<int, string> b = a;
  * > b.insert(3, "three");
  * > ASSERT("three" == a.at(3));
  *
@@ -172,7 +172,7 @@ template<class Key, class Value> DictPtr<IValue, IValue> toGenericDict(DictPtr<K
  * for the kernel API.
  */
 template<class Key, class Value>
-class DictPtr final {
+class Dict final {
 private:
   static_assert((std::is_same<IValue, Key>::value && std::is_same<IValue, Value>::value) || guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "Invalid Key type for Dict. We only support int64_t, double, bool, and string.");
 
@@ -181,15 +181,15 @@ private:
   // ska::flat_hash_map, return references to it or something like that,
   // because such operations would get expensive if we switch out
   // the actual map implementation.
-  // This is an intrusive_ptr because DictPtr is a pointer type.
+  // This is an intrusive_ptr because Dict is a pointer type.
   // Invariant: This will never be a nullptr, there will always be a valid
   // DictImpl.
   c10::intrusive_ptr<detail::DictImpl> impl_;
 
-  explicit DictPtr(c10::intrusive_ptr<detail::DictImpl>&& impl);
+  explicit Dict(c10::intrusive_ptr<detail::DictImpl>&& impl);
   friend struct IValue;
-  template<class K, class V> friend DictPtr<K, V> impl::toTypedDict(DictPtr<IValue, IValue>);
-  template<class K, class V> friend DictPtr<IValue, IValue> impl::toGenericDict(DictPtr<K, V>);
+  template<class K, class V> friend Dict<K, V> impl::toTypedDict(Dict<IValue, IValue>);
+  template<class K, class V> friend Dict<IValue, IValue> impl::toGenericDict(Dict<K, V>);
 
 public:
   using key_type = Key;
@@ -201,24 +201,24 @@ public:
   /**
    * Creates an empty dict.
    */
-  friend DictPtr make_dict<Key, Value>();
+  friend Dict make_dict<Key, Value>();
 
   // please use make_dict instead
-  DictPtr() = delete;
+  Dict() = delete;
 
-  ~DictPtr() = default;
+  ~Dict() = default;
 
-  DictPtr(const DictPtr&) = default;
-  DictPtr& operator=(const DictPtr&) = default;
-  DictPtr(DictPtr&&) noexcept;
-  DictPtr& operator=(DictPtr&&) noexcept;
+  Dict(const Dict&) = default;
+  Dict& operator=(const Dict&) = default;
+  Dict(Dict&&) noexcept;
+  Dict& operator=(Dict&&) noexcept;
 
   /**
-   * Create a new DictPtr pointing to a deep copy of the same data.
-   * The DictPtr returned is a new dict with separate storage.
+   * Create a new Dict pointing to a deep copy of the same data.
+   * The Dict returned is a new dict with separate storage.
    * Changes in it are not reflected in the original dict or vice versa.
    */
-  DictPtr copy() const;
+  Dict copy() const;
 
   /**
    * Returns an iterator to the first element of the container.
@@ -343,33 +343,29 @@ public:
 };
 
 namespace impl {
-// GenericDictPtr is how IValue stores dicts. It is, however, not part of the
+// GenericDict is how IValue stores dicts. It is, however, not part of the
 // public API. Kernels should use Dicts with concrete Key, Value types instead
 // (maybe except for some internal prim ops).
-using GenericDictPtr = DictPtr<IValue, IValue>;
+using GenericDict = Dict<IValue, IValue>;
 
-inline GenericDictPtr make_generic_dict() {
+inline GenericDict make_generic_dict() {
   return make_dict<IValue, IValue>();
 }
 
 template<class Key, class Value>
-DictPtr<Key, Value> toTypedDict(GenericDictPtr dict) {
-  return DictPtr<Key, Value>(std::move(dict.impl_));
+Dict<Key, Value> toTypedDict(GenericDict dict) {
+  return Dict<Key, Value>(std::move(dict.impl_));
 }
 
 template<class Key, class Value>
-GenericDictPtr toGenericDict(DictPtr<Key, Value> dict) {
-  return GenericDictPtr(std::move(dict.impl_));
+GenericDict toGenericDict(Dict<Key, Value> dict) {
+  return GenericDict(std::move(dict.impl_));
 }
 }
-
-template<class Key, class Value> using Dict = DictPtr<Key, Value>;
-
 }
 
 namespace torch {
-  template<class Key, class Value> using DictPtr = c10::DictPtr<Key, Value>;
-  template<class Key, class Value> using Dict = DictPtr<Key, Value>;
+  template<class Key, class Value> using Dict = c10::Dict<Key, Value>;
 }
 
 #include <ATen/core/Dict_inl.h>

--- a/aten/src/ATen/core/Dict_inl.h
+++ b/aten/src/ATen/core/Dict_inl.h
@@ -46,80 +46,80 @@ inline intrusive_ptr<DictImpl> DictImpl::copy() const {
 }
 
 template<class Key, class Value>
-DictPtr<Key, Value> make_dict() {
-  return DictPtr<Key, Value>(make_intrusive<detail::DictImpl>());
+Dict<Key, Value> make_dict() {
+  return Dict<Key, Value>(make_intrusive<detail::DictImpl>());
 }
 
 template<class Key, class Value>
-DictPtr<Key, Value>::DictPtr(DictPtr&& rhs) noexcept: impl_(std::move(rhs.impl_)) {
+Dict<Key, Value>::Dict(Dict&& rhs) noexcept: impl_(std::move(rhs.impl_)) {
   rhs.impl_ = make_intrusive<detail::DictImpl>();
 }
 
 template<class Key, class Value>
-DictPtr<Key, Value>::DictPtr(c10::intrusive_ptr<detail::DictImpl>&& impl): impl_(std::move(impl)) {}
+Dict<Key, Value>::Dict(c10::intrusive_ptr<detail::DictImpl>&& impl): impl_(std::move(impl)) {}
 
 template<class Key, class Value>
-DictPtr<Key, Value>& DictPtr<Key, Value>::operator=(DictPtr&& rhs) noexcept {
+Dict<Key, Value>& Dict<Key, Value>::operator=(Dict&& rhs) noexcept {
   impl_ = std::move(rhs.impl_);
   rhs.impl_ = make_intrusive<detail::DictImpl>();
   return *this;
 }
 
 template<class Key, class Value>
-DictPtr<Key, Value> DictPtr<Key, Value>::copy() const {
-  return DictPtr<Key, Value>(impl_->copy());
+Dict<Key, Value> Dict<Key, Value>::copy() const {
+  return Dict<Key, Value>(impl_->copy());
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::iterator DictPtr<Key, Value>::begin() {
+typename Dict<Key, Value>::iterator Dict<Key, Value>::begin() {
   return iterator{impl_->dict.begin()};
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::const_iterator DictPtr<Key, Value>::begin() const {
+typename Dict<Key, Value>::const_iterator Dict<Key, Value>::begin() const {
   return const_iterator{impl_->dict.begin()};
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::const_iterator DictPtr<Key, Value>::cbegin() const {
+typename Dict<Key, Value>::const_iterator Dict<Key, Value>::cbegin() const {
   return const_iterator{impl_->dict.cbegin()};
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::iterator DictPtr<Key, Value>::end() {
+typename Dict<Key, Value>::iterator Dict<Key, Value>::end() {
   return iterator{impl_->dict.end()};
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::const_iterator DictPtr<Key, Value>::end() const {
+typename Dict<Key, Value>::const_iterator Dict<Key, Value>::end() const {
   return const_iterator{impl_->dict.end()};
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::const_iterator DictPtr<Key, Value>::cend() const {
+typename Dict<Key, Value>::const_iterator Dict<Key, Value>::cend() const {
   return const_iterator{impl_->dict.cend()};
 }
 
 template<class Key, class Value>
-bool DictPtr<Key, Value>::empty() const {
+bool Dict<Key, Value>::empty() const {
   return impl_->dict.empty();
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::size_type DictPtr<Key, Value>::size() const {
+typename Dict<Key, Value>::size_type Dict<Key, Value>::size() const {
   return impl_->dict.size();
 }
 
 template<class Key, class Value>
-void DictPtr<Key, Value>::clear() {
+void Dict<Key, Value>::clear() {
   impl_->dict.clear();
 }
 
 template<class Key, class Value>
 template<class Key_, class Value_>
-std::pair<typename DictPtr<Key, Value>::iterator, bool> DictPtr<Key, Value>::insert(Key_&& key, Value_&& value) {
-  static_assert(std::is_constructible<Key, Key_>::value, "Wrong type for the key argument of DictPtr::insert");
-  static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of DictPtr::insert");
+std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert(Key_&& key, Value_&& value) {
+  static_assert(std::is_constructible<Key, Key_>::value, "Wrong type for the key argument of Dict::insert");
+  static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of Dict::insert");
   auto inserted = impl_->dict.insert(std::pair<IValue, IValue>{
     Key(std::forward<Key_>(key)),
     Value(std::forward<Value_>(value))});
@@ -128,9 +128,9 @@ std::pair<typename DictPtr<Key, Value>::iterator, bool> DictPtr<Key, Value>::ins
 
 template<class Key, class Value>
 template<class Key_, class Value_>
-std::pair<typename DictPtr<Key, Value>::iterator, bool> DictPtr<Key, Value>::insert_or_assign(Key_&& key, Value_&& value) {
-  static_assert(std::is_constructible<Key, Key_>::value, "Wrong type for the key argument of DictPtr::insert_or_assign");
-  static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of DictPtr::insert_or_assign");
+std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert_or_assign(Key_&& key, Value_&& value) {
+  static_assert(std::is_constructible<Key, Key_>::value, "Wrong type for the key argument of Dict::insert_or_assign");
+  static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of Dict::insert_or_assign");
   auto inserted = impl_->dict.insert_or_assign(
     Key(std::forward<Key_>(key)),
     Value(std::forward<Value_>(value)));
@@ -138,37 +138,37 @@ std::pair<typename DictPtr<Key, Value>::iterator, bool> DictPtr<Key, Value>::ins
 }
 
 template<class Key, class Value>
-void DictPtr<Key, Value>::erase(const_iterator iter) {
+void Dict<Key, Value>::erase(const_iterator iter) {
   impl_->dict.erase(iter.entryRef_.iterator_);
 }
 
 template<class Key, class Value>
-C10_NODISCARD size_t DictPtr<Key, Value>::erase(const Key& key) {
+C10_NODISCARD size_t Dict<Key, Value>::erase(const Key& key) {
   return impl_->dict.erase(key);
 }
 
 template<class Key, class Value>
-Value DictPtr<Key, Value>::at(const Key& key) const {
+Value Dict<Key, Value>::at(const Key& key) const {
   return impl_->dict.at(key).template to<Value>();
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::iterator DictPtr<Key, Value>::find(const Key& key) {
+typename Dict<Key, Value>::iterator Dict<Key, Value>::find(const Key& key) {
   return iterator{impl_->dict.find(key)};
 }
 
 template<class Key, class Value>
-typename DictPtr<Key, Value>::const_iterator DictPtr<Key, Value>::find(const Key& key) const {
+typename Dict<Key, Value>::const_iterator Dict<Key, Value>::find(const Key& key) const {
   return const_iterator{impl_->dict.find(key)};
 }
 
 template<class Key, class Value>
-bool DictPtr<Key, Value>::contains(const Key& key) const {
+bool Dict<Key, Value>::contains(const Key& key) const {
   return end() != find(key);
 }
 
 template<class Key, class Value>
-void DictPtr<Key, Value>::reserve(size_type count) {
+void Dict<Key, Value>::reserve(size_type count) {
   impl_->dict.reserve(count);
 }
 

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -12,9 +12,9 @@ class Tensor;
 }
 namespace c10 {
 struct IValue;
-template<class T> class ListPtr;
-template<class T> ListPtr<T> make_list();
-template<class T> ListPtr<T> make_list(ArrayRef<T> values);
+template<class T> class List;
+template<class T> List<T> make_list();
+template<class T> List<T> make_list(ArrayRef<T> values);
 
 namespace detail {
 
@@ -61,14 +61,14 @@ private:
   ListElementReference(const ListElementReference&) = delete;
   ListElementReference& operator=(const ListElementReference&) = delete;
 
-  // allow moving, but only our friends (i.e. the ListPtr class) can move us
+  // allow moving, but only our friends (i.e. the List class) can move us
   ListElementReference(ListElementReference&&) noexcept = default;
   ListElementReference& operator=(ListElementReference&& rhs) & noexcept {
     iterator_ = std::move(rhs.iterator_);
     return *this;
   }
 
-  friend class ListPtr<T>;
+  friend class List<T>;
   friend class ListIterator<T, Iterator, StorageT>;
 
   Iterator iterator_;
@@ -109,21 +109,21 @@ public:
       return copy;
   }
 
-  ListIterator& operator+=(typename ListPtr<T>::size_type offset) {
+  ListIterator& operator+=(typename List<T>::size_type offset) {
       iterator_ += offset;
       return *this;
   }
 
-  ListIterator& operator-=(typename ListPtr<T>::size_type offset) {
+  ListIterator& operator-=(typename List<T>::size_type offset) {
       iterator_ -= offset;
       return *this;
   }
 
-  ListIterator operator+(typename ListPtr<T>::size_type offset) const {
+  ListIterator operator+(typename List<T>::size_type offset) const {
     return ListIterator{iterator_ + offset};
   }
 
-  ListIterator operator-(typename ListPtr<T>::size_type offset) const {
+  ListIterator operator-(typename List<T>::size_type offset) const {
     return ListIterator{iterator_ - offset};
   }
 
@@ -165,25 +165,25 @@ private:
   }
 
   friend class ListIterator<T, typename detail::ListImpl<StorageT>::list_type::iterator, StorageT>;
-  friend class ListPtr<T>;
+  friend class List<T>;
 };
 
-template<class T> ListPtr<T> toTypedList(ListPtr<IValue> list);
-template<class T> ListPtr<IValue> toGenericList(ListPtr<T> list);
-const IValue* ptr_to_first_element(const ListPtr<IValue>& list);
-template<class T> ListPtr<T> toList(std::vector<T> list);
-template<class T> const std::vector<T>& toVector(const ListPtr<T>& list);
+template<class T> List<T> toTypedList(List<IValue> list);
+template<class T> List<IValue> toGenericList(List<T> list);
+const IValue* ptr_to_first_element(const List<IValue>& list);
+template<class T> List<T> toList(std::vector<T> list);
+template<class T> const std::vector<T>& toVector(const List<T>& list);
 }
-template<class T> bool list_is_equal(const ListPtr<T>& lhs, const ListPtr<T>& rhs);
+template<class T> bool list_is_equal(const List<T>& lhs, const List<T>& rhs);
 
 /**
  * An object of this class stores a list of values of type T.
  *
- * This is a pointer type. After a copy, both ListPtrs
+ * This is a pointer type. After a copy, both Lists
  * will share the same storage:
  *
- * > ListPtr<int> a = make_list<string>();
- * > ListPtr<int> b = a;
+ * > List<int> a = make_list<string>();
+ * > List<int> b = a;
  * > b.push_back("three");
  * > ASSERT("three" == a.get(0));
  *
@@ -193,7 +193,7 @@ template<class T> bool list_is_equal(const ListPtr<T>& lhs, const ListPtr<T>& rh
  * breaking backwards compatibility for the kernel API.
  */
 template<class T>
-class ListPtr final {
+class List final {
 private:
   // List of types that don't use IValue based lists
   using types_with_direct_list_implementation = guts::typelist::typelist<
@@ -209,12 +209,12 @@ private:
     IValue  // All other types store the list as std::vector<IValue>
   >;
 
-  // This is an intrusive_ptr because ListPtr is a pointer type.
+  // This is an intrusive_ptr because List is a pointer type.
   // Invariant: This will never be a nullptr, there will always be a valid
   // ListImpl.
   c10::intrusive_ptr<detail::ListImpl<StorageT>> impl_;
 
-  using internal_reference_type = impl::ListElementReference<T, typename detail::ListImpl<typename ListPtr<T>::StorageT>::list_type::iterator, typename ListPtr<T>::StorageT>;
+  using internal_reference_type = impl::ListElementReference<T, typename detail::ListImpl<typename List<T>::StorageT>::list_type::iterator, typename List<T>::StorageT>;
 
 public:
   using value_type = T;
@@ -226,27 +226,27 @@ public:
   /**
    * Constructs an empty list.
    */
-  friend ListPtr make_list<T>();
+  friend List make_list<T>();
 
   /**
    * Constructs a list with some initial values
    */
-  friend ListPtr make_list<T>(ArrayRef<T>);
+  friend List make_list<T>(ArrayRef<T>);
 
   // please use make_list instead.
-  ListPtr() = delete;
+  List() = delete;
 
-  ListPtr(const ListPtr&) = default;
-  ListPtr& operator=(const ListPtr&) = default;
-  ListPtr(ListPtr&&) noexcept;
-  ListPtr& operator=(ListPtr&&) noexcept;
+  List(const List&) = default;
+  List& operator=(const List&) = default;
+  List(List&&) noexcept;
+  List& operator=(List&&) noexcept;
 
   /**
-   * Create a new ListPtr pointing to a deep copy of the same data.
-   * The ListPtr returned is a new list with separate storage.
+   * Create a new List pointing to a deep copy of the same data.
+   * The List returned is a new list with separate storage.
    * Changes in it are not reflected in the original list or vice versa.
    */
-  ListPtr copy() const;
+  List copy() const;
 
   /**
    * Returns the element at specified location pos, with bounds checking.
@@ -268,7 +268,7 @@ public:
    *
    * You cannot store the reference, but you can read it and assign new values to it:
    *
-   *   ListPtr<int64_t> list = ...;
+   *   List<int64_t> list = ...;
    *   list[2] = 5;
    *   int64_t v = list[1];
    */
@@ -395,79 +395,75 @@ public:
    * same number of elements and for each list position the elements at
    * that position are equal.
    */
-  friend bool list_is_equal<T>(const ListPtr& lhs, const ListPtr& rhs);
+  friend bool list_is_equal<T>(const List& lhs, const List& rhs);
 
   /**
-   * Returns the number of ListPtrs currently pointing to this same list.
+   * Returns the number of Lists currently pointing to this same list.
    * If this is the only instance pointing to this list, returns 1.
    */
   // TODO Test use_count
   size_t use_count() const;
 
 private:
-  explicit ListPtr(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements);
+  explicit List(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements);
   friend struct IValue;
-  template<class T_> friend ListPtr<T_> impl::toTypedList(ListPtr<IValue>);
-  template<class T_> friend ListPtr<IValue> impl::toGenericList(ListPtr<T_>);
-  friend const IValue* impl::ptr_to_first_element(const ListPtr<IValue>& list);
-  template<class T_> friend ListPtr<T_> impl::toList(std::vector<T_> list);
-  template<class T_> friend const std::vector<T_>& impl::toVector(const ListPtr<T_>& list);
+  template<class T_> friend List<T_> impl::toTypedList(List<IValue>);
+  template<class T_> friend List<IValue> impl::toGenericList(List<T_>);
+  friend const IValue* impl::ptr_to_first_element(const List<IValue>& list);
+  template<class T_> friend List<T_> impl::toList(std::vector<T_> list);
+  template<class T_> friend const std::vector<T_>& impl::toVector(const List<T_>& list);
 };
 
 namespace impl {
-// GenericListPtr is how IValue stores lists. It is, however, not part of the
+// GenericList is how IValue stores lists. It is, however, not part of the
 // public API. Kernels should use Lists with concrete types instead
 // (maybe except for some internal prim ops).
-using GenericListPtr = ListPtr<IValue>;
+using GenericList = List<IValue>;
 
-inline GenericListPtr make_generic_list() {
+inline GenericList make_generic_list() {
   return make_list<IValue>();
 }
 
-inline GenericListPtr make_generic_list(ArrayRef<IValue> values) {
+inline GenericList make_generic_list(ArrayRef<IValue> values) {
   return make_list<IValue>(values);
 }
 
 template<class T>
-ListPtr<T> toTypedList(GenericListPtr list) {
-  static_assert(std::is_same<IValue, typename ListPtr<T>::StorageT>::value, "Can only call toTypedList with lists that store their elements as IValues.");
-  return ListPtr<T>(std::move(list.impl_));
+List<T> toTypedList(GenericList list) {
+  static_assert(std::is_same<IValue, typename List<T>::StorageT>::value, "Can only call toTypedList with lists that store their elements as IValues.");
+  return List<T>(std::move(list.impl_));
 }
 
 template<class T>
-GenericListPtr toGenericList(ListPtr<T> list) {
-  static_assert(std::is_same<IValue, typename ListPtr<T>::StorageT>::value, "Can only call toGenericList with lists that store their elements as IValues.");
-  return GenericListPtr(std::move(list.impl_));
+GenericList toGenericList(List<T> list) {
+  static_assert(std::is_same<IValue, typename List<T>::StorageT>::value, "Can only call toGenericList with lists that store their elements as IValues.");
+  return GenericList(std::move(list.impl_));
 }
 
-inline const IValue* ptr_to_first_element(const GenericListPtr& list) {
+inline const IValue* ptr_to_first_element(const GenericList& list) {
   return &list.impl_->list[0];
 }
 
 template<class T>
-const std::vector<T>& toVector(const ListPtr<T>& list) {
-  static_assert(std::is_same<T, IValue>::value || std::is_same<T, typename ListPtr<T>::StorageT>::value, "toVector only works for lists that store their elements as std::vector<T>. You tried to call it for a list that stores its elements as std::vector<IValue>.");
+const std::vector<T>& toVector(const List<T>& list) {
+  static_assert(std::is_same<T, IValue>::value || std::is_same<T, typename List<T>::StorageT>::value, "toVector only works for lists that store their elements as std::vector<T>. You tried to call it for a list that stores its elements as std::vector<IValue>.");
 
   return list.impl_->list;
 }
 
 template<class T>
-ListPtr<T> toList(std::vector<T> list) {
-  static_assert(std::is_same<T, IValue>::value || std::is_same<T, typename ListPtr<T>::StorageT>::value, "toList only works for lists that store their elements as std::vector<T>. You tried to call it for a list that stores its elements as std::vector<IValue>.");
-  ListPtr<T> result = make_list<T>();
+List<T> toList(std::vector<T> list) {
+  static_assert(std::is_same<T, IValue>::value || std::is_same<T, typename List<T>::StorageT>::value, "toList only works for lists that store their elements as std::vector<T>. You tried to call it for a list that stores its elements as std::vector<IValue>.");
+  List<T> result = make_list<T>();
   result.impl_->list = std::move(list);
   return result;
 }
 
 }
-
-template<class T> using List = ListPtr<T>;
-
 }
 
 namespace torch {
-  template<class T> using ListPtr = c10::ListPtr<T>;
-  template<class T> using List = ListPtr<T>;
+  template<class T> using List = c10::List<T>;
 }
 
 #include <ATen/core/List_inl.h>

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -5,12 +5,12 @@
 namespace c10 {
 
 template<class T>
-ListPtr<T> make_list() {
-  return ListPtr<T>(make_intrusive<detail::ListImpl<typename ListPtr<T>::StorageT>>());
+List<T> make_list() {
+  return List<T>(make_intrusive<detail::ListImpl<typename List<T>::StorageT>>());
 }
 
-template<class T> ListPtr<T> make_list(ArrayRef<T> values) {
-  ListPtr<T> result = make_list<T>();
+template<class T> List<T> make_list(ArrayRef<T> values) {
+  List<T> result = make_list<T>();
   result.reserve(values.size());
   for (const T& element : values) {
     result.push_back(element);
@@ -19,23 +19,23 @@ template<class T> ListPtr<T> make_list(ArrayRef<T> values) {
 }
 
 template<class T>
-ListPtr<T>::ListPtr(ListPtr&& rhs) noexcept: impl_(std::move(rhs.impl_)) {
+List<T>::List(List&& rhs) noexcept: impl_(std::move(rhs.impl_)) {
   rhs.impl_ = make_intrusive<detail::ListImpl<StorageT>>();
 }
 
 template<class T>
-ListPtr<T>& ListPtr<T>::operator=(ListPtr&& rhs) noexcept {
+List<T>& List<T>::operator=(List&& rhs) noexcept {
   impl_ = std::move(rhs.impl_);
   rhs.impl_ = make_intrusive<detail::ListImpl<StorageT>>();
   return *this;
 }
 
 template<class T>
-ListPtr<T>::ListPtr(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements): impl_(std::move(elements)) {}
+List<T>::List(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements): impl_(std::move(elements)) {}
 
 template<class T>
-ListPtr<T> ListPtr<T>::copy() const {
-  return ListPtr<T>(impl_->copy());
+List<T> List<T>::copy() const {
+  return List<T>(impl_->copy());
 }
 
 namespace detail {
@@ -93,28 +93,28 @@ void swap(ListElementReference<T, Iterator, StorageT>&& lhs, ListElementReferenc
 }
 
 template<class T>
-void ListPtr<T>::set(size_type pos, const value_type& value) const {
+void List<T>::set(size_type pos, const value_type& value) const {
   impl_->list.at(pos) = detail::list_element_from<T, StorageT>(value);
 }
 
 template<class T>
-void ListPtr<T>::set(size_type pos, value_type&& value) const {
+void List<T>::set(size_type pos, value_type&& value) const {
   impl_->list.at(pos) = detail::list_element_from<T, StorageT>(std::move(value));
 }
 
 template<class T>
-typename ListPtr<T>::value_type ListPtr<T>::get(size_type pos) const {
+typename List<T>::value_type List<T>::get(size_type pos) const {
   return detail::list_element_to<T>(impl_->list.at(pos));
 }
 
 template<class T>
-typename ListPtr<T>::internal_reference_type ListPtr<T>::operator[](size_type pos) const {
+typename List<T>::internal_reference_type List<T>::operator[](size_type pos) const {
   impl_->list.at(pos); // Throw the exception if it is out of range.
   return {impl_->list.begin() + pos};
 }
 
 template<class T>
-typename ListPtr<T>::value_type ListPtr<T>::extract(size_type pos) const {
+typename List<T>::value_type List<T>::extract(size_type pos) const {
   auto& elem = impl_->list.at(pos);
   auto result = detail::list_element_to<T>(std::move(elem));
   elem = detail::list_element_from<T, StorageT>(T{});
@@ -122,96 +122,96 @@ typename ListPtr<T>::value_type ListPtr<T>::extract(size_type pos) const {
 }
 
 template<class T>
-typename ListPtr<T>::iterator ListPtr<T>::begin() const {
+typename List<T>::iterator List<T>::begin() const {
   return iterator(impl_->list.begin());
 }
 
 template<class T>
-typename ListPtr<T>::iterator ListPtr<T>::end() const {
+typename List<T>::iterator List<T>::end() const {
   return iterator(impl_->list.end());
 }
 
 template<class T>
-bool ListPtr<T>::empty() const {
+bool List<T>::empty() const {
   return impl_->list.empty();
 }
 
 template<class T>
-typename ListPtr<T>::size_type ListPtr<T>::size() const {
+typename List<T>::size_type List<T>::size() const {
   return impl_->list.size();
 }
 
 template<class T>
-void ListPtr<T>::reserve(size_type new_cap) const {
+void List<T>::reserve(size_type new_cap) const {
   impl_->list.reserve(new_cap);
 }
 
 template<class T>
-void ListPtr<T>::clear() const {
+void List<T>::clear() const {
   impl_->list.clear();
 }
 
 template<class T>
-typename ListPtr<T>::iterator ListPtr<T>::insert(iterator pos, const T& value) const {
+typename List<T>::iterator List<T>::insert(iterator pos, const T& value) const {
   return iterator { impl_->list.insert(pos.iterator_, detail::list_element_from<T, StorageT>(value)) };
 }
 
 template<class T>
-typename ListPtr<T>::iterator ListPtr<T>::insert(iterator pos, T&& value) const {
+typename List<T>::iterator List<T>::insert(iterator pos, T&& value) const {
   return iterator { impl_->list.insert(pos.iterator_, detail::list_element_from<T, StorageT>(std::move(value))) };
 }
 
 template<class T>
 template<class... Args>
-typename ListPtr<T>::iterator ListPtr<T>::emplace(iterator pos, Args&&... value) const {
+typename List<T>::iterator List<T>::emplace(iterator pos, Args&&... value) const {
   // TODO Use list_element_from?
   return iterator { impl_->list.emplace(pos.iterator_, std::forward<Args>(value)...) };
 }
 
 template<class T>
-void ListPtr<T>::push_back(const T& value) const {
+void List<T>::push_back(const T& value) const {
   impl_->list.push_back(detail::list_element_from<T, StorageT>(value));
 }
 
 template<class T>
-void ListPtr<T>::push_back(T&& value) const {
+void List<T>::push_back(T&& value) const {
   impl_->list.push_back(detail::list_element_from<T, StorageT>(std::move(value)));
 }
 
 template<class T>
 template<class... Args>
-void ListPtr<T>::emplace_back(Args&&... args) const {
+void List<T>::emplace_back(Args&&... args) const {
   // TODO Use list_element_from?
   impl_->list.emplace_back(std::forward<Args>(args)...);
 }
 
 template<class T>
-typename ListPtr<T>::iterator ListPtr<T>::erase(iterator pos) const {
+typename List<T>::iterator List<T>::erase(iterator pos) const {
   return iterator { impl_->list.erase(pos.iterator_) };
 }
 
 template<class T>
-typename ListPtr<T>::iterator ListPtr<T>::erase(iterator first, iterator last) const {
+typename List<T>::iterator List<T>::erase(iterator first, iterator last) const {
   return iterator { impl_->list.erase(first.iterator_, last.iterator_) };
 }
 
 template<class T>
-void ListPtr<T>::pop_back() const {
+void List<T>::pop_back() const {
   impl_->list.pop_back();
 }
 
 template<class T>
-void ListPtr<T>::resize(size_type count) const {
+void List<T>::resize(size_type count) const {
   impl_->list.resize(count, T{});
 }
 
 template<class T>
-void ListPtr<T>::resize(size_type count, const T& value) const {
+void List<T>::resize(size_type count, const T& value) const {
   impl_->list.resize(count, value);
 }
 
 template<class T>
-bool list_is_equal(const ListPtr<T>& lhs, const ListPtr<T>& rhs) {
+bool list_is_equal(const List<T>& lhs, const List<T>& rhs) {
   if (lhs.size() != rhs.size()) {
     return false;
   }
@@ -224,7 +224,7 @@ bool list_is_equal(const ListPtr<T>& lhs, const ListPtr<T>& rhs) {
 }
 
 template<class T>
-size_t ListPtr<T>::use_count() const {
+size_t List<T>::use_count() const {
   return impl_.use_count();
 }
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#21938 ListPtr->List DictPtr->Dict step 3**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15892402/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21937 ListPtr->List DictPtr->Dict step 2&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15892404/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #21936 ListPtr->List DictPtr->Dict step 1&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D15892405/)

After having changed all call sites, we can now remove the old naming scheme.

Differential Revision: [D15892402](https://our.internmc.facebook.com/intern/diff/D15892402/)