### PR TITLE
Use latest stable flake8-bugbear in CI and fix B011 flake8 error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,7 @@ matrix:
         dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
         sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
         install:
-          - pip install flake8 flake8-mypy flake8-comprehensions flake8-pyi mccabe pycodestyle pyflakes
-          # Apparently Facebook runs master of this one
-          # https://github.com/PyCQA/flake8-bugbear/issues/53
-          - pip install git+https://github.com/PyCQA/flake8-bugbear.git@d9444713a51a9fb6ee8cd2d88fca85e9ff0c2d58
+          - pip install flake8 flake8-bugbear flake8-mypy flake8-comprehensions flake8-pyi mccabe pycodestyle pyflakes
         script: flake8
       - name: "MyPy typecheck"
         python: "3.6"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -548,7 +548,8 @@ which is in PyTorch's `requirements.txt`.
 
 ### Pre-commit Tidy/Linting Hook
 
-We use clang-tidy and flake8 (installed with flake-mypy) to perform additional
+We use clang-tidy and flake8 (installed with flake8-bugbear,
+flake8-comprehensions, flake8-mypy, and flake8-pyi) to perform additional
 formatting and semantic checking of code. We provide a pre-commit git hook for
 performing these checks, before a commit is created:
 

--- a/aten/src/ATen/common_with_cwrap.py
+++ b/aten/src/ATen/common_with_cwrap.py
@@ -18,7 +18,7 @@ def parse_arguments(args):
                 del arg['arg']
             new_args.append(arg)
         else:
-            assert False
+            raise AssertionError()
     return new_args
 
 

--- a/test/error_messages/storage.py
+++ b/test/error_messages/storage.py
@@ -14,7 +14,7 @@ def check_error(desc, fn, *required_substrings):
         for sub in required_substrings:
             assert sub in error_message
         return
-    assert False, "given function ({}) didn't raise an error".format(desc)
+    raise AssertionError("given function ({}) didn't raise an error".format(desc))
 
 check_error(
     'Wrong argument types',

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -218,7 +218,7 @@ class TestOperators(TestCase):
             def symbolic(g, x):
                 # The inside of this function should never be invoked, because
                 # we will fail due to an argument mismatch first.
-                assert False
+                raise AssertionError()
 
             @staticmethod
             def forward(ctx, x, y):

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -431,7 +431,7 @@ def verify(model, args, backend, verbose=False, training=False, rtol=1e-3, atol=
                     # that is a bug in verify
                     errs.requireEqual(proto, alt_proto)
                     errs.requireEqual(proto_bytes.getvalue(), alt_proto_bytes.getvalue())
-                    assert False
+                    raise AssertionError()
 
             # TODO: test that the traced model also returns the same thing...
             run_helper(torch_out, args)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7335,7 +7335,7 @@ class TestNN(NNTestCase):
                             [[3.4500, 6.0000000000, 5.0000, 4.8340, 9.0000],
                              [2.2500, 6.3332500450, 5.0000, 5.1000, 7.7500]]).view(1, 1, 2, 5)
                     else:
-                        assert False, "missing groundtruth test for padding mode '{}'".format(padding_mode)
+                        raise AssertionError("missing groundtruth test for padding mode '{}'".format(padding_mode))
                 elif mode == 'nearest':
                     if padding_mode == 'zeros':
                         groundtruth = torch.tensor(
@@ -7350,9 +7350,9 @@ class TestNN(NNTestCase):
                             [[1., 8., 5., 7., 9.],
                              [1., 8., 5., 8., 9.]]).view(1, 1, 2, 5)
                     else:
-                        assert False, "missing groundtruth test for padding mode '{}'".format(padding_mode)
+                        raise AssertionError("missing groundtruth test for padding mode '{}'".format(padding_mode))
                 else:
-                    assert False, "missing groundtruth test for interpolation mode '{}'".format(mode)
+                    raise AssertionError("missing groundtruth test for interpolation mode '{}'".format(mode))
                 output = F.grid_sample(input, grid, mode=mode, padding_mode=padding_mode)
                 self.assertEqual(output, groundtruth,
                                  "groundtruth comparison failed for mode={}, "

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -588,7 +588,7 @@ def emit_body(declaration):
                 if arg['name'] == derivative_var_name:
                     break
             else:
-                assert False
+                raise AssertionError()
 
             return 'grad_fn->should_compute_output({})'.format(edge_off)
 

--- a/tools/cwrap/cwrap.py
+++ b/tools/cwrap/cwrap.py
@@ -130,7 +130,7 @@ class cwrap(object):
                     del arg['arg']
                 new_args.append(arg)
             else:
-                assert False
+                raise AssertionError()
         return new_args
 
     def search_plugins(self, fnname, args, fallback):


### PR DESCRIPTION
- PyCQA/flake8-bugbear#53 has been fixed (but not yet closed on their side) and a new version of flake8-bugbear has been released on Mar 28, 2019. Switch CI to use the latest stable version.
- Fix the new B011 errors that flake8-bugbear catches in the current codebase.

---

B011: Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().