### PR TITLE
Enable promotion of tensor types in TensorIterator operations.

### DIFF
--- a/aten/src/ATen/detail/ScalarTypeConversions.h
+++ b/aten/src/ATen/detail/ScalarTypeConversions.h
@@ -9,7 +9,7 @@ namespace at { namespace detail {
 
 template <typename T>
 inline T load(const void* data, ScalarType src_type) {
-  return AT_DISPATCH_ALL_TYPES(src_type, "load", [&]() {
+  return AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, src_type, "load", [&]() {
     return at::convert<T>(*(scalar_t*)data);
   });
 }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -72,8 +72,13 @@ compute_result_type(at::ArrayRef<OperandInfo> operands, const F& predicate) {
   ScalarType dtype = ScalarType::Undefined;
   for (auto& op : operands) {
     if (!op.tensor.defined()) continue;
-    if (!predicate(op.tensor)) continue;
-    auto tensor_dtype = op.tensor.scalar_type();
+    if (!predicate(op)) continue;
+    ScalarType tensor_dtype;
+    if( op.tensor.unsafeGetTensorImpl()->is_wrapped_number() && isFloatingType(op.tensor.scalar_type())) {
+      tensor_dtype = typeMetaToScalarType(caffe2::get_default_dtype());
+    } else {
+      tensor_dtype = op.tensor.scalar_type();
+    }
     if (dtype == ScalarType::Undefined) {
       dtype = tensor_dtype;
       device = op.tensor.device();
@@ -98,11 +103,36 @@ compute_result_type(at::ArrayRef<OperandInfo> operands,
 
 std::tuple<Device, ScalarType> TensorIterator::compute_common_type() {
   // See [Result type computation] in TensorIterator.h
+
+  // in case of in-place operations, result type will be defined and needs to
+  // be preserved. Not an additional predicate becaue doesn't participate in
+  // zero-dim floating point promotion.
+  auto output = compute_result_type(operands_,
+    [](const OperandInfo& op) { return op.is_output; }
+  );
+  if( std::get<1>(output) != ScalarType::Undefined ) {
+    return output;
+  }
+
   auto result_type =
       compute_result_type(operands_,
-        [](const Tensor& t) { return t.dim() > 0; },
-        [](const Tensor& t) { return !t.unsafeGetTensorImpl()->is_wrapped_number(); },
-        [](const Tensor& t) { return true; });
+        [](const OperandInfo& op) { return op.tensor.dim() > 0; },
+        [](const OperandInfo& op) { return !op.tensor.unsafeGetTensorImpl()->is_wrapped_number(); },
+        [](const OperandInfo& op) { return true; });
+
+  // if non-zero-dim tensor result is an integral type and there's a zero-dim
+  // floating point operand, we'll promote the the floating point type.
+  if( isIntegralType(std::get<1>(result_type)) ) {
+    auto alternate = compute_result_type(operands_,
+        [](const OperandInfo& op) {
+          return isFloatingType(op.tensor.scalar_type()) && op.tensor.dim() == 0;
+        }
+    );
+    if( std::get<1>(alternate) != ScalarType::Undefined) {
+      // preserve device from original result
+      return std::make_tuple(std::get<0>(result_type), std::get<1>(alternate));
+    }
+  }
 
   TORCH_INTERNAL_ASSERT(std::get<1>(result_type) != ScalarType::Undefined);
   return result_type;
@@ -110,6 +140,7 @@ std::tuple<Device, ScalarType> TensorIterator::compute_common_type() {
 
 void TensorIterator::compute_types() {
   bool missing_dtypes = false;
+  ScalarType common_dtype = dtype();
   for (auto& op : operands_) {
     if (!op.tensor.defined() && !op.is_type_defined()) {
       missing_dtypes = true;
@@ -119,7 +150,7 @@ void TensorIterator::compute_types() {
   if (missing_dtypes || compute_common_dtype_) {
     auto common_type = compute_common_type();
     auto common_device = std::get<0>(common_type);
-    auto common_dtype = std::get<1>(common_type);
+    common_dtype = std::get<1>(common_type);
     bool has_cpu_scalar = false;
     for (auto& op : operands_) {
       if (!op.is_type_defined()) {
@@ -147,23 +178,32 @@ void TensorIterator::compute_types() {
           op.dtype = common_dtype;
         }
       }
-    }
-  }
 
-  for (auto& op : operands_) {
-    auto& tensor = op.tensor;
-    if (!tensor.defined()) {
-      continue;
-    }
-    if (op.device != tensor.device() || op.dtype != tensor.scalar_type()) {
-      if (op.is_output) {
-        AT_ERROR("output with device ", tensor.device(), " and dtype ", tensor.scalar_type(),
-                 " doesn't match the desired device ", op.device, " and dtype ", op.dtype);
-      } else if (tensor.dim() == 0) {
-        tensor = tensor.to(op.options());
-      } else {
-        AT_ERROR("expected device ", op.device, " and dtype ", op.dtype,
-                 " but got device ", tensor.device(), " and dtype ", tensor.scalar_type());
+      if( op.tensor.defined() && op.tensor.scalar_type() != common_dtype )
+      {
+        auto tensor = op.tensor;
+        op.tensor = tensor.to(common_dtype);
+        op.dtype = op.tensor.scalar_type();
+        auto original_element_size = tensor.element_size();
+        auto new_element_size = op.tensor.element_size();
+        // stride size (in bytes) can change if we change the dtype.
+        if( original_element_size != new_element_size ) {
+          for( size_t i=0; i < op.stride_bytes.size(); i++ ) {
+            auto stride = op.stride_bytes[i] / original_element_size;
+            op.stride_bytes[i] = stride * new_element_size;
+          }
+        }
+      }
+      if( op.tensor.defined() && op.device != op.tensor.device()) {
+        if (op.is_output) {
+          AT_ERROR("output with device ", op.tensor.device(),
+                   " doesn't match the desired device ", op.device);
+        } else if (op.tensor.dim() == 0) {
+          op.tensor = op.tensor.to(op.options());
+        } else {
+          AT_ERROR("expected device ", op.device,
+                   " but got device ", op.tensor.device());
+        }
       }
     }
   }

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -299,7 +299,7 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   // corrent values for the type promotions in complex type cases.
   static constexpr ScalarType _promoteTypesLookup[static_cast<int>(
       ScalarType::NumOptions)][static_cast<int>(ScalarType::NumOptions)] = {
-      /* u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1 */
+      /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1 */
       /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, ud, ud, ud, u1},
       /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, ud, ud, ud, i1},
       /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, ud, ud, ud, i2},

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -51,6 +51,7 @@ TESTS = [
     'jit_fuser',
     'tensorboard',
     'namedtensor',
+    'type_promotion',
 ]
 
 WINDOWS_BLACKLIST = [

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1069,8 +1069,13 @@ class TestCuda(TestCase):
 
             self.assertEqual(x * y, 4.5)
             self.assertEqual(y * x, 4.5)
-            with self.assertRaisesRegex(RuntimeError, "doesn't match the desired"):
-                y *= x
+
+            # *= is an in-place operation equivalent to prod_(). Doesn't modify
+            # dtype, instead casts x to int.
+            y *= x
+            self.assertEqual(y, 3)
+            y = torch.tensor(3, dtype=torch.int32, device='cuda')
+
             x *= y
             self.assertEqual(x, 4.5)
 
@@ -2131,12 +2136,12 @@ class TestCuda(TestCase):
         x = torch.randn(20, dtype=torch.float32, device='cuda:0')
         y = torch.randn(1, dtype=torch.float32)
         with self.assertRaisesRegex(RuntimeError,
-                                    'expected device cpu and dtype Float but got device cuda:0 and dtype Float'):
+                                    'expected device cpu but got device cuda:0'):
             torch.sum(x, dim=[0], dtype=torch.float32, out=y)
         # makeing sure half to float promotion is also properly working.
         x = x.half()
         with self.assertRaisesRegex(RuntimeError,
-                                    'expected device cpu and dtype Float but got device cuda:0 and dtype Half'):
+                                    'expected device cpu but got device cuda:0'):
             torch.sum(x, dim=[0], dtype=torch.float32, out=y)
 
     @skipIfRocm

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -1,0 +1,129 @@
+import torch
+import unittest
+
+from common_utils import TestCase, run_tests, TEST_NUMPY, load_tests
+
+# load_tests from common_utils is used to automatically filter tests for
+# sharding on sandcastle. This line silences flake warnings
+load_tests = load_tests
+
+class TestTypePromotion(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        torch.set_default_dtype(torch.float32)
+        self.device='cpu'
+
+    # In-place operations don't promote.
+    # int+float==float but int.add_(float)==int.
+    # Promoting inplace would require re-allocating and copying the memory of the
+    # tensor data, since element size could change.
+    def test_inplace(self):
+        int_tensor=torch.ones([4, 4, 4], dtype=torch.int32, device=self.device)
+        int_tensor.add_(1.5)
+        expected = torch.ones([4, 4, 4], device=self.device) + 1
+        expected = expected.to(torch.int32)
+        self.assertEqual(int_tensor, expected)
+
+        long_tensor=torch.ones([4, 4, 4], dtype=torch.int64, device=self.device)
+        int_tensor.add_(long_tensor)
+        self.assertEqual(int_tensor, expected + 1)
+
+    # some basic examples
+
+    def test_int_promotion(self):
+        a=torch.ones([4, 4, 4], dtype=torch.int32, device=self.device)
+        b=torch.ones([4, 4, 4], dtype=torch.int64, device=self.device)
+        c = a + b
+        self.assertEqual(c, b + b)
+        self.assertEqual(c.dtype, torch.int64)
+
+    def test_float_promotion(self):
+        a=torch.ones([4, 4, 4], dtype=torch.float, device=self.device)
+        b=torch.ones([4, 4, 4], dtype=torch.double, device=self.device)
+        c = a + b
+        self.assertEqual(c, b + b)
+        self.assertEqual(c.dtype, torch.double)
+        c = b + a
+        self.assertEqual(c, b + b)
+        self.assertEqual(c.dtype, torch.double)
+
+    def test_add_wrapped(self):
+        a=torch.ones([4, 4, 4], dtype=torch.int, device=self.device)
+        b=1
+        c = a + b
+        self.assertEqual(c, a + a)
+        self.assertEqual(c.dtype, torch.int)
+
+    def test_int_to_float(self):
+        a = torch.ones([4,4,4], dtype=torch.int32, device=self.device)
+        b = torch.ones([4,4,4], dtype=torch.float, device=self.device)
+        c = a + b
+        self.assertEqual(c.dtype, torch.float32)
+
+    # some examples from:
+    # https://github.com/pytorch/pytorch/issues/9515
+
+    def test_from_issue(self):
+        a = torch.rand(3, dtype=torch.float32, device=self.device)
+        u = torch.tensor([0, 0, 1], dtype=torch.uint8, device=self.device)
+        self.assertEqual( (a * 5).dtype, torch.float32)
+        self.assertEqual((u + 1).dtype, torch.uint8)
+        self.assertEqual((u + 1000).dtype, torch.uint8) # integer overflow
+
+        # not a "wrapped number"
+        other = torch.tensor(5.5, dtype=torch.double, device=self.device)
+
+        self.assertEqual((u + 5.5).dtype, torch.get_default_dtype())
+        self.assertEqual((u + other).dtype, torch.double)
+        # adding a 0-dim tensor to a float doesn't promote to double unless first
+        # type was integral.
+        self.assertEqual((a + other).dtype, torch.float32)
+
+    def test_half(self):
+        if( self.device=='cpu' ):
+            raise unittest.SkipTest('add_cpu not implemented for Half')
+        half = torch.tensor(5.5, dtype=torch.float16, device=self.device)
+        self.assertEqual( (half + 2.2).dtype, torch.float16 )
+        self.assertEqual( (half + 100000).dtype, torch.float16 ) # inf
+        default_tensor = torch.tensor(100000.0, device=self.device)
+        self.assertEqual( (half + default_tensor).dtype, torch.get_default_dtype())
+
+    # verifies that a.add(b) is the same as a.to(b.dtype).add(b) in cases
+    # where that should hold.
+    def test_many_promotions(self):
+        from_to = {
+            torch.float16:  torch.float32,
+            torch.half:     torch.float16,
+            torch.int:      torch.long,
+            torch.uint8:    torch.long,
+            torch.uint8:    torch.float,
+            torch.int:      torch.float,
+            torch.int:      torch.double,
+            torch.int16:    torch.long,
+            torch.float16:  torch.double
+        }
+
+        for k, v in from_to.items():
+            a = torch.rand([3, 3], device=self.device).to(k) # not _th_uniform for half on cpu.
+            b = torch.rand([3, 3], device=self.device).to(v)
+            c = a.add(b)
+            d = a.to(v).add(b)
+            self.assertEqual(c.dtype, d.dtype, message='from {} to {}'.format(k, v))
+            self.assertEqual(c, d, message='from {} to {}'.format(k, v))
+
+@unittest.skipIf(not torch.cuda.is_available(), "no cuda")
+class TestTypePromotionCuda(TestTypePromotion):
+    def setUp(self):
+        super().setUp()
+        self.device='cuda'
+
+# ensure type promotion logic properly handles an alternate default dtype.
+class TestTypePromotionDefaultDouble(TestTypePromotion):
+    def setUp(self):
+        super().setUp()
+        torch.set_default_dtype(torch.double)
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Enable type promotion for tensor operations handled by TensorIterator when dims of input tensors > 0. See test cases for examples.

Issue:
https://github.com/pytorch/pytorch/issues/9515

Backwards incompatible:

Previously int_tensor + float returns an int tensor. With this change we promote to a float tensor (see tests for examples).

Note that this does _not_ promote for the in-place case, so int_tensor.add_(float) leaves the in-place int tensor (in-place retains existing BC behavior). Changing in-place operations to promote would require re-allocating and copying memory of the modified tensor, since element size could change. We could also choose to raise an error on attempts to in-place modify a tensor with an incompatible type, but this would be an additional BC-incompatible change.

Todo / Not included:

* We may also need to change shape_analysis to handle type promotion cases. Will discuss with jit team.
* Additional test cases?
* We would like to expose a torch.result_type function. May add a separate PR.
* Fine-grained control over casting behavior via "casting API" described in ticket.
* Operators not implemented via TensorIterator
