### PR TITLE
Return device object instead of device index for torch.cuda.current_device

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -363,9 +363,9 @@ def device_count():
 
 
 def current_device():
-    r"""Returns the index of a currently selected device."""
+    r"""Returns the currently selected device."""
     _lazy_init()
-    return torch._C._cuda_getDevice()
+    return torch.device(torch._C._cuda_getDevice())
 
 
 def synchronize(device=None):


### PR DESCRIPTION
Semantically `current_device` should return a device object. It may break some backwards-compatibility BTW.