### PR TITLE
[JIT] Move NamedType method definitions into cpp file

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -854,25 +854,10 @@ struct CAFFE2_API NamedType : public Type {
     : Type(tk)
     , name_(std::move(qualifiedName)) {}
 
-  std::string python_str() const {
-    TORCH_INTERNAL_ASSERT(name_);
-    return name_->qualifiedName();
-  }
-
-  std::string qualname() const {
-    TORCH_INTERNAL_ASSERT(name_);
-    return name_->qualifiedName();
-  }
-
-  std::string qualifier() const {
-    TORCH_INTERNAL_ASSERT(name_);
-    return name_->prefix();
-  }
-
-  std::string basename() const {
-    TORCH_INTERNAL_ASSERT(name_);
-    return name_->name();
-  }
+  std::string python_str() const;
+  std::string qualname() const;
+  std::string qualifier() const;
+  std::string basename() const;
 
   const c10::optional<QualifiedName>& qualified_name_obj() const {
     return name_;

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -519,6 +519,26 @@ std::ostream& operator<<(std::ostream & out, const VaryingShape & vs) {
     return out;
 }
 
+std::string NamedType::python_str() const {
+  TORCH_INTERNAL_ASSERT(name_);
+  return name_->qualifiedName();
+}
+
+std::string NamedType::qualname() const {
+  TORCH_INTERNAL_ASSERT(name_);
+  return name_->qualifiedName();
+}
+
+std::string NamedType::qualifier() const {
+  TORCH_INTERNAL_ASSERT(name_);
+  return name_->prefix();
+}
+
+std::string NamedType::basename() const {
+  TORCH_INTERNAL_ASSERT(name_);
+  return name_->name();
+}
+
 std::shared_ptr<FunctionSchema> TupleType::namedTupleSchemaFromNamesAndTypes(c10::QualifiedName qualName, std::vector<std::string> field_names, std::vector<TypePtr> field_types) {
   TORCH_INTERNAL_ASSERT(field_names.size() == field_types.size());
   std::vector<Argument> arguments;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21983 [JIT] Move NamedType method definitions into cpp file**
* #21839 [JIT] NamedTuple serialization
* #21836 [JIT] Refactor TupleType to take a FunctionSchema
* #21835 [JIT] Introduce NamedType
* #21813 [JIT] Some small fixes for NamedTuple

This may possibly fix the windows CUDA build breakage introduced by the previous PRs

Differential Revision: [D15907633](https://our.internmc.facebook.com/intern/diff/D15907633)