### PR TITLE
Defining object destructor in c10

### DIFF
--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -5,11 +5,13 @@
 #include <c10/macros/Macros.h>
 namespace c10 {
 
-#ifdef C10_ANDROID
 namespace ivalue {
-Object::~Object() {}
+Object::~Object() {
+  if (on_delete_) {
+    on_delete_(this);
+  }
+}
 } // namespace ivalue
-#endif
 
 std::ostream& operator<<(std::ostream & out, const Type & t) {
   if(auto value = t.cast<CompleteTensorType>()) {

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -7,16 +7,6 @@ namespace c10 {
 // This file exists because we need to reference module.h, which we can't from
 // c10. Sigh...
 
-#ifndef C10_ANDROID
-namespace ivalue {
-Object::~Object() {
-  if (type_->is_module()) {
-    type_->compilation_unit()->drop_all_functions();
-  }
-}
-} // namespace ivalue
-#endif
-
 std::shared_ptr<Function> ClassType::getMethod(const std::string& name) const {
   return compilation_unit_->find_function(name);
 }

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -104,6 +104,9 @@ struct TORCH_API Method {
   // first-class function in class_compilation_unit()
   std::shared_ptr<Function> function_;
 };
+static void clearMethods(c10::ivalue::Object* self) {
+  self->type()->compilation_unit()->drop_all_functions();
+}
 
 struct TORCH_API Module {
   Module(std::string class_name)
@@ -112,7 +115,8 @@ struct TORCH_API Module {
                 QualifiedName(std::move(class_name)),
                 std::make_shared<CompilationUnit>(),
                 /*is_module=*/true),
-            0)) {}
+            0,
+            clearMethods)) {}
   Module() : Module("$Module") {}
   Module(ModulePtr module_value) : module_value_(std::move(module_value)) {}
   ~Module() {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#21984 Defining object destructor in c10**

This makes sure object's destructr is defined in c10 to prevent
fbcode linking issues. It temporarily adds on_delete to Object so
that we can dynamically get deletion to run for modules.

Differential Revision: [D15906530](https://our.internmc.facebook.com/intern/diff/D15906530)