### PR TITLE
Make `nn.Sequential` forward function more flexible

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -87,9 +87,9 @@ class Sequential(Module):
         keys = [key for key in keys if not key.isdigit()]
         return keys
 
-    def forward(self, input):
+    def forward(self, *input):
         for module in self._modules.values():
-            input = module(input)
+            input = module(*input)
         return input
 
 


### PR DESCRIPTION
Use `*input` instead of `input` to allow an arbitrary number of positional arguments to module forward functions, especially for custom modules with multiple forward input arguments.

