### PR TITLE
Optimization of the Embedding and Embedding-Bag CUDA Kernel

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -323,8 +323,8 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
     );
   }
 
-  return embedding_backward_cuda_kernel(grad, orig_indices, sorted_indices,
-      count, num_weights, padding_idx);
+  return embedding_backward_cuda_kernel(grad, orig_indices,
+      sorted_indices, count, num_weights, padding_idx);
 }
 
 Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -12,7 +12,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/unique.h>
 
-#include "EmbeddingBackwardKernel.cuh"
+#include <ATen/native/cuda/EmbeddingBackwardKernel.cuh>
 
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -12,6 +12,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/unique.h>
 
+#include "EmbeddingBackwardKernel.cuh"
+
 
 namespace at { namespace native {
 
@@ -231,14 +233,12 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
 
   auto num_indices = indices.numel();
   auto grad = grad_.contiguous().view({num_indices, grad_.size(-1)});
-  auto grad_weight = at::zeros({num_weights, grad_.size(-1)}, grad_.options());
-
-  int64_t stride = grad_weight.stride(0);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (num_indices <= 768 && !scale_grad_by_freq) {
     auto indices_contig = indices.contiguous();
-
+    auto grad_weight = at::zeros({num_weights, grad_.size(-1)}, grad_.options());
+    int64_t stride = grad_weight.stride(0);
     dim3 grid(THCCeilDiv(stride, (int64_t)WARP_SIZE));
     dim3 block(WARP_SIZE, BLOCKDIMY);
 
@@ -323,23 +323,8 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
     );
   }
 
-  dim3 grid(THCCeilDiv(num_indices, (int64_t) 4), THCCeilDiv(stride, (int64_t) 128));
-  dim3 block(WARP_SIZE, 4);
-
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "embedding_backward", [&] {
-    embedding_backward_kernel<<<grid, block, 0, stream>>>(
-      sorted_indices.data<int64_t>(),
-      orig_indices.data<int64_t>(),
-      grad.data<scalar_t>(),
-      grad_weight.data<scalar_t>(),
-      count.defined() ? count.data<int64_t>() : nullptr,
-      num_indices,
-      stride,
-      padding_idx);
-  });
-  THCudaCheck(cudaGetLastError());
-
-  return grad_weight;
+  return embedding_backward_cuda_kernel(grad, orig_indices, sorted_indices,
+      count, num_weights, padding_idx);
 }
 
 Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -211,7 +211,8 @@ Tensor embedding_backward_cuda_kernel(
   // Compute the number of segments and their start position so that we do not have to
   // spawn a warp per index. In this context, a segment is a number of rows that should
   // be summarized.
-  thrust::device_vector<int64_t> segment_offsets(numel); // Unit: index in `sorted_indices`
+  // Unit: index in `sorted_indices` and `orig_indices`
+  thrust::device_vector<int64_t> segment_offsets(numel);
   int64_t num_of_segments;
   {
     auto sorted_indices_dev = thrust::device_ptr<int64_t>(sorted_indices.data<int64_t>());
@@ -255,7 +256,7 @@ Tensor embedding_backward_cuda_kernel(
           partials_per_segment_offset[num_of_segments-1];
 
   // Now we can compute the start position of each partial-segment
-  // Unit: index in `sorted_indices`
+  // Unit: index in `sorted_indices` and `orig_indices`
   thrust::device_vector<int64_t> partial_segment_offset(num_of_partial_segments);
   {
     krn_partial_segment_offset<<<ceil_div(num_of_segments, 32), 32, 0, stream>>> (

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -24,7 +24,7 @@ namespace {
 constexpr int MAX_BLOCK_SIZE = 1024;
 /* This code computes the sum of the weights in two-steps:
   1) Each GPU warp sums `NROWS_PER_THREAD` number of row given by `indeces`
-  2) Each partial-sum from 1) a than summed and scatter into `grad_weight`
+  2) Each partial-sum from 1) are summed and scatter into `grad_weight`
 
   Notice, `NROWS_PER_THREAD` impacts the Achieved Occupancy of the
   kernel execution. If it is high, the size of the thread blocks will be

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -1,0 +1,371 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/NativeFunctions.h>
+
+#include <ATen/AccumulateType.h>
+
+#include <THC/THCDeviceUtils.cuh>
+#include <THC/THCTensorMathReduce.cuh>
+#include <THC/THCTensorSort.cuh>
+#include <THC/THCThrustAllocator.cuh>
+#include <THC/THCAtomics.cuh>
+
+#include <thrust/execution_policy.h>
+#include <thrust/unique.h>
+#include <thrust/device_vector.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+constexpr int MAX_BLOCK_SIZE = 1024;
+constexpr int NROWS_PER_THREAD = 10;
+
+#ifdef __HIP_PLATFORM_HCC__
+    constexpr int WARP_SIZE = 64;
+#else
+    constexpr int WARP_SIZE = 32;
+#endif
+
+
+__global__
+void segment_sizes_kernel(int64_t *ret, const int64_t *segment_offsets,
+                          int64_t num_of_segments, int64_t blocksize, int64_t numel) {
+  const int id = blockIdx.x * blockDim.x + threadIdx.x;
+  if(id < num_of_segments) {
+    const int64_t idx_start = segment_offsets[id];
+    const int64_t idx_end = (id == num_of_segments-1)?numel:segment_offsets[id+1];
+    const int64_t size = idx_end - idx_start;
+    ret[id] = (size + blocksize - 1) / blocksize;
+  }
+}
+
+__global__
+void split_segment_offsets_kernel(
+        int64_t *ret,
+        const int64_t *segment_sizes,
+        const int64_t *segment_sizes_offsets,
+        const int64_t *segment_offsets,
+        int64_t num_of_segments,
+        int64_t blocksize) {
+  const int id = blockIdx.x * blockDim.x + threadIdx.x;
+  if(id < num_of_segments) {
+    int64_t idx = segment_sizes_offsets[id];
+    const int64_t segment_size = segment_sizes[id];
+    const int64_t segment_offset = segment_offsets[id];
+    for (int64_t i=0; i<segment_size; ++i) {
+      ret[idx++] = segment_offset + i * blocksize;
+    }
+  }
+}
+
+
+// This kernel assumes that all input tensors are contiguous.
+template <typename scalar_t>
+__global__ void compute_grad_weight_bags(
+    int64_t *indices, scalar_t *gradOutput,
+    int64_t *offset2bag, int64_t *count, ptrdiff_t numel,
+    int64_t stride, int mode_mean, const int64_t *bag_size,
+    scalar_t* per_sample_weights, int64_t per_sample_weights_stride,
+    int64_t* segment_offsets, int64_t num_of_segments, scalar_t *grad_weight_per_segment,
+    const int64_t stride_warped) {
+
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int id = gid / stride_warped;
+  const int startFeature = gid % stride_warped;
+  if (startFeature >= stride) {
+    return;
+  }
+  if (id >= num_of_segments) {
+    return;
+  }
+  const int idx_begin = segment_offsets[id];
+  const int idx_end = (id == num_of_segments-1)?numel:segment_offsets[id+1];
+
+  acc_type<scalar_t, true> weight = 0;
+  for (int idx=idx_begin; idx < idx_end; ++idx) {
+    const int origRow = indices[idx];
+    const int seq_number = offset2bag[origRow];
+    const int gradOutputRow = seq_number * stride;
+
+    acc_type<scalar_t, true> scale = count ? 1.0 / count[idx] : 1.0;
+    if (per_sample_weights) {
+      scale *= per_sample_weights[origRow * per_sample_weights_stride];
+    }
+
+    acc_type<scalar_t, true> gradient = gradOutput[gradOutputRow + startFeature];
+    if (mode_mean) {
+      gradient /= bag_size[seq_number];
+    }
+    weight += gradient * scale;
+  }
+  grad_weight_per_segment[id * stride + startFeature] = weight;
+}
+
+template <typename scalar_t>
+__global__ void compute_grad_weight(
+    int64_t *indices,
+    scalar_t *gradOutput,
+    int64_t *count,
+    ptrdiff_t numel,
+    int64_t stride,
+    int64_t* segment_offsets,
+    int64_t num_of_segments,
+    scalar_t *grad_weight_per_segment,
+    int padding_idx,
+    const int64_t stride_warped) {
+
+  using accscalar_t = acc_type<scalar_t, true>;
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int id = gid / stride_warped;
+  const int startFeature = gid % stride_warped;
+  if (startFeature >= stride) {
+    return;
+  }
+  if (id >= num_of_segments) {
+    return;
+  }
+  const int idx_begin = segment_offsets[id];
+  const int idx_end = (id == num_of_segments-1)?numel:segment_offsets[id+1];
+  if (idx_begin == padding_idx) {
+    return;
+  }
+
+  accscalar_t weight = 0;
+  for (int idx=idx_begin; idx < idx_end; ++idx) {
+    const accscalar_t scale = count ? (accscalar_t)1.0 / count[idx] : 1.0;
+    const int gradOutputRow = indices[idx] * stride;
+
+    weight += gradOutput[gradOutputRow + startFeature] * scale;
+  }
+  grad_weight_per_segment[id * stride + startFeature] = weight;
+}
+
+// This kernel assumes that all input tensors are contiguous.
+template <typename scalar_t>
+__global__ void sum_and_scatter(
+    int64_t *input, scalar_t *gradWeight, int64_t stride,
+    int64_t* segment_offsets, int64_t num_of_segments, const scalar_t *grad_weight_per_segment,
+    const int64_t *segment_sizes_offsets, int64_t num_of_split_segments,
+    const int64_t stride_warped) {
+
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int id = gid / stride_warped;
+  const int startFeature = gid % stride_warped;
+  if (startFeature >= stride) {
+    return;
+  }
+  if (id >= num_of_segments) {
+    return;
+  }
+
+  const int idx_begin = segment_sizes_offsets[id];
+  const int idx_end = (id == num_of_segments-1)?num_of_split_segments:segment_sizes_offsets[id+1];
+  acc_type<scalar_t, true> weight = 0;
+  for (int idx=idx_begin; idx < idx_end; ++idx) {
+    weight += grad_weight_per_segment[idx*stride + startFeature];
+  }
+  const int weightRow = input[segment_offsets[id]] * stride;
+  gradWeight[weightRow + startFeature] = weight;
+}
+
+} // anon namespace
+
+
+Tensor embedding_bag_backward_cuda_kernel(
+        const Tensor &grad,
+        const Tensor &orig_indices,
+        const Tensor &sorted_indices,
+        const Tensor &offset2bag,
+        const Tensor &bag_size,
+        const Tensor &count,
+        int64_t num_weights,
+        bool scale_grad_by_freq,
+        bool mode_mean,
+        const Tensor &per_sample_weights) {
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
+  auto policy = thrust::cuda::par(allocator).on(stream);
+  const ptrdiff_t numel = sorted_indices.numel();
+
+  auto grad_weight = at::zeros({num_weights, grad.size(-1)}, grad.options());
+  const int64_t stride = grad_weight.stride(0);
+
+  thrust::device_vector<int64_t> segment_offsets(numel);
+  int64_t num_of_segments;
+  {
+    auto sorted_indices_dev = thrust::device_ptr<int64_t>(sorted_indices.data<int64_t>());
+    auto dummy = at::empty_like(sorted_indices);
+    auto dummy_dev = thrust::device_ptr<int64_t>(dummy.data<int64_t>());
+    auto ends = thrust::unique_by_key_copy(
+            policy,
+            sorted_indices_dev,
+            sorted_indices_dev + numel,
+            thrust::make_counting_iterator(0),
+            dummy_dev,
+            thrust::raw_pointer_cast(segment_offsets.data()));
+    num_of_segments = thrust::get<0>(ends) - dummy_dev;
+  }
+
+  thrust::device_vector<int64_t> segment_sizes(num_of_segments);
+  {
+    segment_sizes_kernel<<<THCCeilDiv(num_of_segments, (ptrdiff_t)32), 32, 0, stream>>> (
+            thrust::raw_pointer_cast(segment_sizes.data()),
+            thrust::raw_pointer_cast(segment_offsets.data()),
+            num_of_segments,
+            NROWS_PER_THREAD,
+            numel);
+  }
+  thrust::device_vector<int64_t> segment_sizes_offsets(num_of_segments);
+  thrust::exclusive_scan(
+          policy,
+          segment_sizes.begin(),
+          segment_sizes.end(),
+          segment_sizes_offsets.begin());
+
+  const int num_of_split_segments = segment_sizes[num_of_segments-1] + segment_sizes_offsets[num_of_segments-1];
+  thrust::device_vector<int64_t> split_segment_offsets(num_of_split_segments);
+  {
+    split_segment_offsets_kernel<<<THCCeilDiv(num_of_segments, (ptrdiff_t)32), 32, 0, stream>>> (
+            thrust::raw_pointer_cast(split_segment_offsets.data()),
+            thrust::raw_pointer_cast(segment_sizes.data()),
+            thrust::raw_pointer_cast(segment_sizes_offsets.data()),
+            thrust::raw_pointer_cast(segment_offsets.data()),
+            num_of_segments,
+            NROWS_PER_THREAD);
+  }
+
+  auto grad_weight_per_segment = at::empty({num_of_split_segments, stride}, grad.options());
+  const int stride_warped = THCCeilDiv(stride, (ptrdiff_t)WARP_SIZE)*WARP_SIZE;
+  const int block = std::min(stride_warped, MAX_BLOCK_SIZE);
+  const int grid = THCCeilDiv((ptrdiff_t)num_of_split_segments*stride_warped, (ptrdiff_t)block);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+          grad.scalar_type(), "embedding_bag_backward_cuda_compute_grad_weight", [&] {
+            compute_grad_weight_bags<scalar_t><<<grid, block, 0, stream>>>(
+                  orig_indices.data<int64_t>(),
+                  grad.data<scalar_t>(),
+                  offset2bag.data<int64_t>(),
+                  count.defined() ? count.data<int64_t>() : nullptr, numel, stride,
+                  mode_mean, bag_size.data<int64_t>(),
+                  per_sample_weights.defined() ? per_sample_weights.data<scalar_t>() : NULL,
+                  per_sample_weights.defined() ? per_sample_weights.stride(0) : 0,
+                  thrust::raw_pointer_cast(split_segment_offsets.data()),
+                  num_of_split_segments, grad_weight_per_segment.data<scalar_t>(), stride_warped);
+          });
+  THCudaCheck(cudaGetLastError());
+
+  const int grid2 = THCCeilDiv(num_of_segments*stride_warped, (ptrdiff_t)block);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+          grad.scalar_type(), "embedding_bag_backward_cuda_sum_and_scatter", [&] {
+            sum_and_scatter<scalar_t><<<grid2, block, 0, stream>>>(
+                  sorted_indices.data<int64_t>(),
+                  grad_weight.data<scalar_t>(),
+                  stride,
+                  thrust::raw_pointer_cast(segment_offsets.data()),
+                  num_of_segments, grad_weight_per_segment.data<scalar_t>(),
+                  thrust::raw_pointer_cast(segment_sizes_offsets.data()),
+                  num_of_split_segments, stride_warped);
+          });
+  THCudaCheck(cudaGetLastError());
+  return grad_weight;
+}
+
+Tensor embedding_backward_cuda_kernel(
+        const Tensor &grad,
+        const Tensor &orig_indices,
+        const Tensor &sorted_indices,
+        const Tensor &count,
+        int64_t num_weights,
+        int64_t padding_idx) {
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  auto allocator = THCThrustAllocator(globalContext().lazyInitCUDA());
+  auto policy = thrust::cuda::par(allocator).on(stream);
+  const ptrdiff_t numel = sorted_indices.numel();
+
+  auto grad_weight = at::zeros({num_weights, grad.size(-1)}, grad.options());
+  const int64_t stride = grad_weight.stride(0);
+
+  thrust::device_vector<int64_t> segment_offsets(numel);
+  int64_t num_of_segments;
+  {
+    auto sorted_indices_dev = thrust::device_ptr<int64_t>(sorted_indices.data<int64_t>());
+    auto dummy = at::empty_like(sorted_indices);
+    auto dummy_dev = thrust::device_ptr<int64_t>(dummy.data<int64_t>());
+    auto ends = thrust::unique_by_key_copy(
+            policy,
+            sorted_indices_dev,
+            sorted_indices_dev + numel,
+            thrust::make_counting_iterator(0),
+            dummy_dev,
+            thrust::raw_pointer_cast(segment_offsets.data()));
+    num_of_segments = thrust::get<0>(ends) - dummy_dev;
+  }
+
+  thrust::device_vector<int64_t> segment_sizes(num_of_segments);
+  {
+    segment_sizes_kernel<<<THCCeilDiv(num_of_segments, (ptrdiff_t)32), 32, 0, stream>>> (
+            thrust::raw_pointer_cast(segment_sizes.data()),
+            thrust::raw_pointer_cast(segment_offsets.data()),
+            num_of_segments,
+            NROWS_PER_THREAD,
+            numel);
+  }
+  thrust::device_vector<int64_t> segment_sizes_offsets(num_of_segments);
+  thrust::exclusive_scan(
+          policy,
+          segment_sizes.begin(),
+          segment_sizes.end(),
+          segment_sizes_offsets.begin());
+
+  const int num_of_split_segments = segment_sizes[num_of_segments-1] + segment_sizes_offsets[num_of_segments-1];
+  thrust::device_vector<int64_t> split_segment_offsets(num_of_split_segments);
+  {
+    split_segment_offsets_kernel<<<THCCeilDiv(num_of_segments, (ptrdiff_t)32), 32, 0, stream>>> (
+            thrust::raw_pointer_cast(split_segment_offsets.data()),
+            thrust::raw_pointer_cast(segment_sizes.data()),
+            thrust::raw_pointer_cast(segment_sizes_offsets.data()),
+            thrust::raw_pointer_cast(segment_offsets.data()),
+            num_of_segments,
+            NROWS_PER_THREAD);
+  }
+
+  auto grad_weight_per_segment = at::empty({num_of_split_segments, stride}, grad.options());
+  const int stride_warped = THCCeilDiv(stride, (ptrdiff_t)WARP_SIZE)*WARP_SIZE;
+  const int block = std::min(stride_warped, MAX_BLOCK_SIZE);
+  const int grid = THCCeilDiv((ptrdiff_t)num_of_split_segments*stride_warped, (ptrdiff_t)block);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+          grad.scalar_type(), "embedding_bag_backward_cuda_compute_grad_weight", [&] {
+            compute_grad_weight<scalar_t><<<grid, block, 0, stream>>>(
+                  orig_indices.data<int64_t>(),
+                  grad.data<scalar_t>(),
+                  count.defined() ? count.data<int64_t>() : nullptr,
+                  numel, stride,
+                  thrust::raw_pointer_cast(split_segment_offsets.data()),
+                  num_of_split_segments,
+                  grad_weight_per_segment.data<scalar_t>(),
+                  padding_idx,
+                  stride_warped);
+          });
+  THCudaCheck(cudaGetLastError());
+
+  const int grid2 = THCCeilDiv(num_of_segments*stride_warped, (ptrdiff_t)block);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+          grad.scalar_type(), "embedding_bag_backward_cuda_sum_and_scatter", [&] {
+            sum_and_scatter<scalar_t><<<grid2, block, 0, stream>>>(
+                  sorted_indices.data<int64_t>(),
+                  grad_weight.data<scalar_t>(),
+                  stride,
+                  thrust::raw_pointer_cast(segment_offsets.data()),
+                  num_of_segments, grad_weight_per_segment.data<scalar_t>(),
+                  thrust::raw_pointer_cast(segment_sizes_offsets.data()),
+                  num_of_split_segments, stride_warped);
+          });
+  THCudaCheck(cudaGetLastError());
+  return grad_weight;
+}
+
+}}

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -148,10 +148,11 @@ __global__ void compute_grad_weight(
 
   accscalar_t weight = 0;
   for (int idx=idx_begin; idx < idx_end; ++idx) {
-    const accscalar_t scale = count ? (accscalar_t)1.0 / count[idx] : 1.0;
-    const int gradOutputRow = indices[idx] * stride;
-
-    weight += gradOutput[gradOutputRow + startFeature] * scale;
+    const int64_t target_row = indices[idx];
+    if (target_row != padding_idx) {
+      const accscalar_t scale = count ? (accscalar_t)1.0 / count[idx] : 1.0;
+      weight += gradOutput[target_row * stride + startFeature] * scale;
+    }
   }
   grad_weight_per_segment[id * stride + startFeature] = weight;
 }

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cuh
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cuh
@@ -1,0 +1,43 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/NativeFunctions.h>
+
+#include <ATen/AccumulateType.h>
+
+#include <THC/THCDeviceUtils.cuh>
+#include <THC/THCTensorMathReduce.cuh>
+#include <THC/THCTensorSort.cuh>
+#include <THC/THCThrustAllocator.cuh>
+#include <THC/THCAtomics.cuh>
+
+#include <thrust/execution_policy.h>
+#include <thrust/unique.h>
+#include <thrust/device_vector.h>
+
+#pragma once
+
+namespace at {
+namespace native {
+
+Tensor embedding_bag_backward_cuda_kernel(
+        const Tensor &grad,
+        const Tensor &orig_indices,
+        const Tensor &sorted_indices,
+        const Tensor &offset2bag,
+        const Tensor &bag_size,
+        const Tensor &count,
+        int64_t num_weights,
+        bool scale_grad_by_freq,
+        bool mode_mean,
+        const Tensor& per_sample_weights);
+
+Tensor embedding_backward_cuda_kernel(
+    const Tensor &grad,
+    const Tensor &orig_indices,
+    const Tensor &sorted_indices,
+    const Tensor &count,
+    int64_t num_weights,
+    int64_t padding_idx);
+
+}}

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cuh
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cuh
@@ -20,24 +20,17 @@
 namespace at {
 namespace native {
 
-Tensor embedding_bag_backward_cuda_kernel(
-        const Tensor &grad,
-        const Tensor &orig_indices,
-        const Tensor &sorted_indices,
-        const Tensor &offset2bag,
-        const Tensor &bag_size,
-        const Tensor &count,
-        int64_t num_weights,
-        bool scale_grad_by_freq,
-        bool mode_mean,
-        const Tensor& per_sample_weights);
-
 Tensor embedding_backward_cuda_kernel(
     const Tensor &grad,
     const Tensor &orig_indices,
     const Tensor &sorted_indices,
     const Tensor &count,
     int64_t num_weights,
-    int64_t padding_idx);
+    int padding_idx = -1,
+    bool scale_grad_by_freq = false,
+    bool mode_mean = false,
+    const Tensor &offset2bag = Tensor(),
+    const Tensor &bag_size = Tensor(),
+    const Tensor &per_sample_weights = Tensor());
 
 }}

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -15,7 +15,7 @@
 #include <thrust/unique.h>
 #include <thrust/device_vector.h>
 
-#include "EmbeddingBackwardKernel.cuh"
+#include <ATen/native/cuda/EmbeddingBackwardKernel.cuh>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -183,10 +183,9 @@ Tensor embedding_bag_backward_cuda_sum_avg(
         thrust::make_reverse_iterator(count_data + numel),
         thrust::equal_to<int64_t>(), thrust::maximum<int64_t>());
   }
-
-  return embedding_bag_backward_cuda_kernel(grad, orig_indices, sorted_indices,
-          offset2bag, bag_size, count, num_weights, scale_grad_by_freq,
-          mode == MODE_MEAN, per_sample_weights);
+  return embedding_backward_cuda_kernel(grad, orig_indices, sorted_indices,
+      count, num_weights, /* padding_idx= */ -1, scale_grad_by_freq,
+      mode == MODE_MEAN, offset2bag, bag_size, per_sample_weights);
 }
 
 template <typename scalar_t>

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -61,7 +61,7 @@ DOUBLE_TENSORTYPES = [torch.double]
 
 dtype2prec = {torch.float: 1e-5,
               torch.double: 1e-5,
-              torch.half: 1e-2}
+              torch.half: 1e-1}
 
 
 # WARNING: If you add a new top-level test case to this file, you MUST

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -61,7 +61,7 @@ DOUBLE_TENSORTYPES = [torch.double]
 
 dtype2prec = {torch.float: 1e-5,
               torch.double: 1e-5,
-              torch.half: 1e-1}
+              torch.half: 1e-2}
 
 
 # WARNING: If you add a new top-level test case to this file, you MUST


### PR DESCRIPTION
Re-implementation of the `embedding_dense_backward_cuda()` and the `embedding_bag_backward_cuda_sum_avg()` functions. 

#### Performance
Running a [Mortgage Workflow](https://github.com/EvenOldridge/MortgageWorkflowA) with a block size of 100K on a DXG-2 (single GPU), we see a 270% speedup:
```
Original version:    370,168 example/s
Optimized version: 1,034,228 example/s
```
The original version is bounded by the `EmbeddingBag_accGradParametersKernel_sum_avg`, which takes 70% of the CUDA execution time. In the optimized version, the optimized kernel now takes only 17% of the time. 

#### Greater Numerical Stability 
An added benefit is greater numerical stability. Instead of doing a flat sum where a single variable are used to accumulate the weights, this code uses two-steps where each GPU-thread computes a sub-result defined by `NROWS_PER_THREAD` before the final result are accumulated.