### PR TITLE
Tentatively remove special treatment of Half type in randperm_out_cuda

### DIFF
--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -80,34 +80,29 @@ Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
 
   result.resize_({n});
 
-  if (result.scalar_type() == at::ScalarType::Half) {
-    auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
-    result.copy_(randperm_out_cuda(result_float, n, generator));
+  if (n < 30000) {  // For small inputs, we offload it to CPU instead.
+    auto result_cpu = at::empty({n}, result.options().device(kCPU));
+    randperm_out(result_cpu, n, generator);
+    result.copy_(result_cpu);
   } else {
-    if (n < 30000) {  // For small inputs, we offload it to CPU instead.
-      auto result_cpu = at::empty({n}, result.options().device(kCPU));
-      randperm_out(result_cpu, n, generator);
-      result.copy_(result_cpu);
-    } else {
-      // Generate random values for the keys array
-      AT_DISPATCH_ALL_TYPES(
-        result.scalar_type(), "randperm_out_cuda", [&] {
-          auto keys = at::empty(result.sizes(), result.options()).random_(generator);
+    // Generate random values for the keys array
+    AT_DISPATCH_ALL_TYPES(
+      result.scalar_type(), "randperm_out_cuda", [&] {
+        auto keys = at::empty(result.sizes(), result.options()).random_(generator);
 
-          auto result_data = thrust::device_ptr<scalar_t>(result.data<scalar_t>());
-          auto keys_data = thrust::device_ptr<scalar_t>(keys.data<scalar_t>());
+        auto result_data = thrust::device_ptr<scalar_t>(result.data<scalar_t>());
+        auto keys_data = thrust::device_ptr<scalar_t>(keys.data<scalar_t>());
 
-          auto state = globalContext().getTHCState();
-          THCThrustAllocator thrustAlloc(state);
-          auto policy = thrust::cuda::par(thrustAlloc).on(at::cuda::getCurrentCUDAStream());
+        auto state = globalContext().getTHCState();
+        THCThrustAllocator thrustAlloc(state);
+        auto policy = thrust::cuda::par(thrustAlloc).on(at::cuda::getCurrentCUDAStream());
 
-          thrust::sequence(policy, result_data, result_data + n);
+        thrust::sequence(policy, result_data, result_data + n);
 
-          // Use the sorted order of keys to rearrange the result array
-          thrust::sort_by_key(policy, keys_data, keys_data + n, result_data);
-        }
-      );
-    }
+        // Use the sorted order of keys to rearrange the result array
+        thrust::sort_by_key(policy, keys_data, keys_data + n, result_data);
+      }
+    );
   }
 
   return result;


### PR DESCRIPTION
The special treatment was first added in edfcbfbe1f66a7025162951246d883fc25c82017 (#7606), but it does not seem to be necessary.

---

Could @yf225 give a little explanation, perhaps?

---

The diff shown on GitHub is pretty messy because of the indentation changes, but all I have done is the following (plus indentation changes):


```diff
 --- a/aten/src/ATen/native/cuda/TensorFactories.cu
 +++ b/aten/src/ATen/native/cuda/TensorFactories.cu
 @@ -80,10 +80,6 @@ Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
  
    result.resize_({n});
  
 -  if (result.scalar_type() == at::ScalarType::Half) {
 -    auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
 -    result.copy_(randperm_out_cuda(result_float, n, generator));
 -  } else {
    if (n < 30000) {  // For small inputs, we offload it to CPU instead.
      auto result_cpu = at::empty({n}, result.options().device(kCPU));
      randperm_out(result_cpu, n, generator);
 @@ -108,7 +104,6 @@ Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
        }
      );
    }
 -  }
  
    return result;
  }
```