### PR TITLE
Support sparse gradients in DistributedDataParallel

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -48,7 +48,12 @@ PyObject* c10d_init(PyObject* _unused) {
       .def(py::init<
            std::vector<std::vector<torch::autograd::Variable>>,
            std::vector<std::vector<size_t>>,
-           std::shared_ptr<::c10d::ProcessGroup>>())
+           std::shared_ptr<::c10d::ProcessGroup>,
+           std::vector<std::vector<bool>>>(),
+           py::arg("replicas"),
+           py::arg("bucket_indices"),
+           py::arg("process_group"),
+           py::arg("expect_sparse_gradients") = std::vector<std::vector<bool>>())
       .def(
           "initialize_buckets",
           &::c10d::Reducer::initialize_buckets,
@@ -543,6 +548,7 @@ They are used in specifying strategies for reduction collectives, e.g.,
       &::c10d::compute_bucket_assignment_by_size,
       py::arg("tensors"),
       py::arg("bucket_size"),
+      py::arg("expect_sparse_gradient") = std::vector<bool>(),
       py::call_guard<py::gil_scoped_release>());
 
   module.def(

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -41,9 +41,11 @@ inline int64_t current_time_in_nanos() {
 Reducer::Reducer(
     std::vector<std::vector<torch::autograd::Variable>> replicas,
     std::vector<std::vector<size_t>> bucket_indices,
-    std::shared_ptr<c10d::ProcessGroup> process_group)
+    std::shared_ptr<c10d::ProcessGroup> process_group,
+    std::vector<std::vector<bool>> expect_sparse_gradients)
     : replicas_(std::move(replicas)),
       process_group_(std::move(process_group)),
+      expect_sparse_gradients_(std::move(expect_sparse_gradients)),
       expect_autograd_hooks_(false),
       require_finalize_(false),
       has_marked_unused_parameters_(false),
@@ -51,6 +53,13 @@ Reducer::Reducer(
       backward_stats_base_(0) {
   AT_ASSERTM(replicas_.size() >= 1, "Expected at least one model replica.");
   AT_ASSERTM(replicas_[0].size() >= 1, "Expected at least one parameter.");
+
+  // If `expect_sparse_gradients` is not specified, initialize it such that
+  // we do not expect sparse gradients for any parameter.
+  if (expect_sparse_gradients_.empty()) {
+    expect_sparse_gradients_ = std::vector<std::vector<bool>>(replicas_.size(), std::vector<bool>(replicas_[0].size(), false));
+  }
+  AT_ASSERT(expect_sparse_gradients_.size() == replicas_.size());
 
   // Verify that all specified variables require gradients,
   // and that they have the same size across replicas.
@@ -62,6 +71,11 @@ Reducer::Reducer(
       AT_ASSERTM(
           replicas_[replica_index].size() == replicas_[0].size(),
           "Model replicas must have an equal number of parameters.");
+      AT_ASSERTM(
+          expect_sparse_gradients_[replica_index].size() ==
+              expect_sparse_gradients_[0].size(),
+          "Expected number of entries in expect_sparse_gradients ",
+          "to be equal across replicas.");
       for (size_t variable_index = 0; variable_index < variable_count;
            variable_index++) {
         AT_ASSERTM(
@@ -75,6 +89,11 @@ Reducer::Reducer(
             replicas_[replica_index][variable_index].dtype() ==
                 replicas_[0][variable_index].dtype(),
             "Variables across model replicas must have identical dtype.");
+        AT_ASSERTM(
+            expect_sparse_gradients_[replica_index][variable_index] ==
+                expect_sparse_gradients_[0][variable_index],
+            "Expected the same variables across replicas to either both ",
+            "or neither expect a sparse gradient.");
       }
     }
   }
@@ -157,6 +176,64 @@ Reducer::~Reducer() noexcept(false) {
   }
 }
 
+void Reducer::mark_variable_ready_dense(
+    size_t replica_index,
+    size_t variable_index) {
+  const auto& bucket_index = variable_locators_[variable_index];
+  auto& bucket = buckets_[bucket_index.bucket_index];
+  auto& replica = bucket.replicas[replica_index];
+  auto& variable = replica.variables[bucket_index.intra_bucket_index];
+  const auto offset = replica.offsets[bucket_index.intra_bucket_index];
+  const auto length = replica.lengths[bucket_index.intra_bucket_index];
+
+  // Copy contents of gradient tensor to bucket tensor.
+  // If the gradient is not set, we assume it wasn't computed
+  // as part of the current backwards pass, and zero the part
+  // of the bucket it would otherwise hold.
+  auto bucket_view = replica.contents.narrow(0, offset, length);
+  auto& grad = variable.grad();
+  if (grad.defined()) {
+    // Ensure that the gradient type matches the bucket type.
+    AT_ASSERTM(
+        grad.type() == bucket_view.type(),
+        "Expected ",
+        bucket_view.type(),
+        ", got ",
+        grad.type());
+    // Assert that the grad tensor and the bucket don't share storage.
+    // If they did, we could avoid the copy altogether.
+    // The reason for not doing this is that existing code calls
+    // `detach_` from `zero_grad`, which is incompatible with views.
+    AT_ASSERT(!grad.is_alias_of(bucket_view));
+    AT_ASSERT(grad.device() == bucket_view.device());
+    AT_ASSERT(grad.numel() == bucket_view.numel());
+    bucket_view.copy_(grad.view({-1}), /* non_blocking */ true);
+  } else {
+    bucket_view.zero_();
+  }
+}
+
+void Reducer::mark_variable_ready_sparse(
+    size_t replica_index,
+    size_t variable_index) {
+  const auto& bucket_index = variable_locators_[variable_index];
+  auto& bucket = buckets_[bucket_index.bucket_index];
+  auto& replica = bucket.replicas[replica_index];
+  auto& variable = replica.variables[bucket_index.intra_bucket_index];
+  auto& grad = variable.grad();
+  AT_ASSERTM(grad.defined(), "Expected sparse gradient to be defined.");
+  AT_ASSERTM(
+      grad.options().layout() == c10::kSparse,
+      "Expected variable to have sparse gradient.");
+
+  // Sparse tensors cannot be grouped together with other sparse tensors
+  // in a single reduction operation like we can for dense tensors.
+  // Therefore, the `offsets` and `lengths` vectors in the bucket replica
+  // struct are empty, and there is no pre-existing accumulation tensor.
+  // Directly assign the sparse tensor to the `contents` field.
+  replica.contents = grad;
+}
+
 // Called when the gradient for the specified variable is ready.
 // It can be called from two places:
 // - By an autograd thread after executing a gradient accumulator function.
@@ -214,28 +291,10 @@ void Reducer::mark_variable_ready(
         "`torch.nn.parallel.DistributedDataParallel`.");
   }
 
-  auto& variable = replica.variables[bucket_index.intra_bucket_index];
-  const auto offset = replica.offsets[bucket_index.intra_bucket_index];
-  const auto length = replica.lengths[bucket_index.intra_bucket_index];
-
-  // Copy contents of gradient tensor to bucket tensor.
-  // If the gradient is not set, we assume it wasn't computed
-  // as part of the current backwards pass, and zero the part
-  // of the bucket it would otherwise hold.
-  auto bucket_view = replica.contents.narrow(0, offset, length);
-  auto& grad = variable.grad();
-  if (grad.defined()) {
-    // Assert that the grad tensor and the bucket don't share storage.
-    // If they did, we could avoid the copy altogether.
-    // The reason for not doing this is that existing code calls
-    // `detach_` from `zero_grad`, which is incompatible with views.
-    AT_ASSERT(!grad.is_alias_of(bucket_view));
-    AT_ASSERT(grad.type() == variable.type());
-    AT_ASSERT(grad.device() == variable.device());
-    AT_ASSERT(grad.numel() == length);
-    bucket_view.copy_(grad.view({-1}), /* non_blocking */ true);
+  if (bucket.expect_sparse_gradient) {
+    mark_variable_ready_sparse(replica_index, variable_index);
   } else {
-    bucket_view.zero_();
+    mark_variable_ready_dense(replica_index, variable_index);
   }
 
   // TODO(@pietern): Make this work for both CPU/CUDA tensors.
@@ -329,46 +388,69 @@ void Reducer::initialize_buckets(
     AT_ASSERTM(
         bucket_indices[bucket_index].size() > 0, "Empty bucket specified.");
 
+    // Variables that expect sparse gradients must have their own bucket.
+    if (bucket_indices[bucket_index].size() == 1) {
+      const auto variable_index = bucket_indices[bucket_index].front();
+      bucket.expect_sparse_gradient =
+          expect_sparse_gradients_[0][variable_index];
+    } else {
+      for (const auto variable_index : bucket_indices[bucket_index]) {
+        AT_ASSERTM(
+            !expect_sparse_gradients_[0][variable_index],
+            "Buckets with more than one variable cannot include variables ",
+            "that expect a sparse gradient.");
+      }
+    }
+
     // Iterate over model replicas.
     for (size_t replica_index = 0; replica_index < replica_count;
          replica_index++) {
-      at::TensorOptions options;
       BucketReplica replica;
-      size_t offset = 0;
 
-      // Iterate over bucket variables.
-      for (const auto variable_index : bucket_indices[bucket_index]) {
-        AT_ASSERTM(
-            variable_index < replicas_[replica_index].size(),
-            "Out of range variable index specified.");
+      if (bucket.expect_sparse_gradient) {
+        const auto variable_index = bucket_indices[bucket_index].front();
         const auto& variable = replicas_[replica_index][variable_index];
-        if (!options.has_device()) {
-          options = options.device(variable.device());
-        } else {
-          AT_ASSERTM(
-              variable.device() == options.device(),
-              "All parameters in a bucket must be placed on the same device.");
-        }
-        if (!options.has_dtype()) {
-          options = options.dtype(variable.dtype());
-        } else {
-          AT_ASSERTM(
-              variable.dtype() == options.dtype(),
-              "All parameters in a bucket must have the same dtype.");
-        }
-        const auto length = variable.numel();
-        replica.variables.push_back(variable);
-        replica.offsets.push_back(offset);
-        replica.lengths.push_back(length);
-        offset += length;
-      }
+        AT_ASSERT(bucket_indices[bucket_index].size() == 1);
+        replica.variables = {variable};
+      } else {
+        at::TensorOptions options;
+        size_t offset = 0;
 
-      // Allocate bucket contents tensor.
-      // This must be a Variable because as of Apr 2019 there is still
-      // a distinction between the Tensor and Variable types, and it
-      // is not recommended (or sometimes even possible) to mix and match.
-      replica.contents = torch::autograd::make_variable_consuming(
-          at::empty({static_cast<long>(offset)}, options));
+        // Iterate over bucket variables.
+        for (const auto variable_index : bucket_indices[bucket_index]) {
+          AT_ASSERTM(
+              variable_index < replicas_[replica_index].size(),
+              "Out of range variable index specified.");
+          const auto& variable = replicas_[replica_index][variable_index];
+          if (!options.has_device()) {
+            options = options.device(variable.device());
+          } else {
+            AT_ASSERTM(
+                variable.device() == options.device(),
+                "All parameters in a bucket must be ",
+                "placed on the same device.");
+          }
+          if (!options.has_dtype()) {
+            options = options.dtype(variable.dtype());
+          } else {
+            AT_ASSERTM(
+                variable.dtype() == options.dtype(),
+                "All parameters in a bucket must have the same dtype.");
+          }
+          const auto length = variable.numel();
+          replica.variables.push_back(variable);
+          replica.offsets.push_back(offset);
+          replica.lengths.push_back(length);
+          offset += length;
+        }
+
+        // Allocate bucket contents tensor.
+        // This must be a Variable because as of Apr 2019 there is still
+        // a distinction between the Tensor and Variable types, and it
+        // is not recommended (or sometimes even possible) to mix and match.
+        replica.contents = torch::autograd::make_variable_consuming(
+            at::empty({static_cast<long>(offset)}, options));
+      }
 
       // Add bucket replica to enclosing bucket.
       bucket.replicas.push_back(std::move(replica));
@@ -486,6 +568,41 @@ void Reducer::prepare_for_backward(
   }
 }
 
+// A bucket with one or more dense tensors needs to be unflattened.
+void Reducer::finalize_bucket_dense(Bucket& bucket) {
+  for (auto& replica : bucket.replicas) {
+    for (size_t intra_bucket_index = 0;
+         intra_bucket_index < replica.variables.size();
+         intra_bucket_index++) {
+      auto& variable = replica.variables[intra_bucket_index];
+      const auto offset = replica.offsets[intra_bucket_index];
+      const auto length = replica.lengths[intra_bucket_index];
+      auto bucket_view =
+          replica.contents.narrow(0, offset, length).view(variable.sizes());
+      auto& grad = variable.grad();
+      if (!grad.defined()) {
+        grad = at::empty(bucket_view.sizes(), bucket_view.options());
+      }
+      grad.copy_(bucket_view);
+    }
+  }
+}
+
+// A bucket with a single sparse tensor doesn't need to be unflattened,
+// but merely assigned to the corresponding variable its grad.
+void Reducer::finalize_bucket_sparse(Bucket& bucket) {
+  const auto result = bucket.work->result();
+  AT_ASSERT(bucket.replicas.size() == result.size());
+  for (size_t i = 0; i < bucket.replicas.size(); i++) {
+    auto& replica = bucket.replicas[i];
+    AT_ASSERT(replica.variables.size() == 1);
+    auto& variable = replica.variables.front();
+    // The c10d API doesn't work with torch::autograd::Variable. We have to
+    // manually box it when assigning to the grad. See #19145.
+    variable.grad() = torch::autograd::make_variable(result[i]);
+  }
+}
+
 void Reducer::finalize_backward() {
   // No longer expect autograd hooks to fire after this function returns.
   AT_ASSERT(expect_autograd_hooks_);
@@ -502,21 +619,10 @@ void Reducer::finalize_backward() {
   for (auto& bucket : buckets_) {
     AT_ASSERT(bucket.work);
     bucket.work->wait();
-    for (auto& replica : bucket.replicas) {
-      for (size_t intra_bucket_index = 0;
-           intra_bucket_index < replica.variables.size();
-           intra_bucket_index++) {
-        auto& variable = replica.variables[intra_bucket_index];
-        const auto offset = replica.offsets[intra_bucket_index];
-        const auto length = replica.lengths[intra_bucket_index];
-        auto bucket_view =
-            replica.contents.narrow(0, offset, length).view(variable.sizes());
-        auto& grad = variable.grad();
-        if (!grad.defined()) {
-          grad = at::empty(bucket_view.sizes(), bucket_view.options());
-        }
-        grad.copy_(bucket_view);
-      }
+    if (bucket.expect_sparse_gradient) {
+      finalize_bucket_sparse(bucket);
+    } else {
+      finalize_bucket_dense(bucket);
     }
   }
 }
@@ -550,7 +656,13 @@ inline bool operator==(const BucketKey& lhs, const BucketKey& rhs) {
 // of device placement and will not allow buckets to span devices.
 std::vector<std::vector<size_t>> compute_bucket_assignment_by_size(
     const std::vector<at::Tensor>& tensors,
-    std::vector<size_t> bucket_size_limits) {
+    const std::vector<size_t>& bucket_size_limits,
+    const std::vector<bool>& expect_sparse_gradient) {
+  // Either expect_sparse_gradient is not specified or it has as many elements
+  // as the vector with tensors.
+  AT_ASSERT(expect_sparse_gradient.empty() || (tensors.size() == expect_sparse_gradient.size()));
+  AT_ASSERT(tensors.size() > 0);
+
   std::vector<std::vector<size_t>> result;
   result.reserve(tensors.size());
 
@@ -558,7 +670,7 @@ std::vector<std::vector<size_t>> compute_bucket_assignment_by_size(
   // This is done so that we can use the consecutive bucket limits per type.
   std::unordered_map<
       BucketKey,
-      std::vector<size_t>::iterator,
+      std::vector<size_t>::const_iterator,
       torch::hash<BucketKey>>
       bucket_size_limit_iterators;
 
@@ -575,6 +687,14 @@ std::vector<std::vector<size_t>> compute_bucket_assignment_by_size(
   for (size_t i = 0; i < tensors.size(); i++) {
     const auto& tensor = tensors[i];
     AT_ASSERTM(!tensor.is_sparse(), "No support for sparse tensors.");
+
+    // If we expect a sparse gradient to be produced for this tensor, it cannot
+    // be grouped together with other gradients and gets its own bucket.
+    if (!expect_sparse_gradient.empty() && expect_sparse_gradient[i]) {
+      result.push_back({i});
+      continue;
+    }
+
     auto key = BucketKey(tensor.scalar_type(), tensor.device());
     auto& bucket = buckets[key];
     bucket.indices.push_back(i);

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -22,7 +22,8 @@ class Reducer {
   explicit Reducer(
       std::vector<std::vector<torch::autograd::Variable>> replicas,
       std::vector<std::vector<size_t>> bucket_indices,
-      std::shared_ptr<c10d::ProcessGroup> process_group);
+      std::shared_ptr<c10d::ProcessGroup> process_group,
+      std::vector<std::vector<bool>> expect_sparse_gradients);
 
   ~Reducer() noexcept(false);
 
@@ -47,9 +48,13 @@ class Reducer {
   }
 
  protected:
+  // Forward declaration.
+  struct Bucket;
+
   std::mutex mutex_;
   std::vector<std::vector<torch::autograd::Variable>> replicas_;
   std::shared_ptr<c10d::ProcessGroup> process_group_;
+  std::vector<std::vector<bool>> expect_sparse_gradients_;
 
   std::vector<std::vector<std::shared_ptr<torch::autograd::Function>>>
       grad_accumulators_;
@@ -62,12 +67,20 @@ class Reducer {
   bool has_marked_unused_parameters_;
   size_t next_bucket_;
 
+  void mark_variable_ready_dense(size_t replica_index, size_t variable_index);
+
+  void mark_variable_ready_sparse(size_t replica_index, size_t variable_index);
+
   void mark_variable_ready(
       size_t replica_index,
       size_t variable_index,
       bool called_from_autograd = false);
 
   void mark_bucket_ready(size_t bucket_index);
+
+  void finalize_bucket_dense(Bucket& replica);
+
+  void finalize_bucket_sparse(Bucket& replica);
 
   void finalize_backward();
 
@@ -119,6 +132,10 @@ class Reducer {
 
     // Keep work handle around when this set of buckets is being reduced.
     std::shared_ptr<c10d::ProcessGroup::Work> work;
+
+    // If this bucket should expect a single sparse gradient.
+    // Implies: replicas[i].variables.size() == 1.
+    bool expect_sparse_gradient = false;
   };
 
   std::vector<Bucket> buckets_;
@@ -146,6 +163,7 @@ class Reducer {
 
 std::vector<std::vector<size_t>> compute_bucket_assignment_by_size(
     const std::vector<at::Tensor>& tensors,
-    std::vector<size_t> bucket_size);
+    const std::vector<size_t>& bucket_size,
+    const std::vector<bool>& expect_sparse_gradient = {});
 
 } // namespace c10d

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -325,9 +325,34 @@ class DistributedDataParallel(Module):
         self.modules_params = [list(m.parameters()) for m in self._module_copies]
         self.modules_buffers = [list(m.buffers()) for m in self._module_copies]
 
-        param_list = [
-            list(filter(lambda p: p.requires_grad, module.parameters()))
-            for module in self._module_copies]
+        # Build tuple of (module, parameter) for all parameters that require grads.
+        modules_and_parameters = [
+            [
+                (module, parameter)
+                for module in replica.modules()
+                for parameter in filter(
+                    lambda parameter: parameter.requires_grad,
+                    module.parameters(recurse=False))
+            ] for replica in self._module_copies]
+
+        # Build list of parameters.
+        parameters = [
+            list(parameter for _, parameter in replica)
+            for replica in modules_and_parameters]
+
+        # Checks if a module will produce a sparse gradient.
+        def produces_sparse_gradient(module):
+            if isinstance(module, torch.nn.Embedding):
+                return module.sparse
+            if isinstance(module, torch.nn.EmbeddingBag):
+                return module.sparse
+            return False
+
+        # Build list of booleans indicating whether or not to expect sparse
+        # gradients for the corresponding parameters.
+        expect_sparse_gradient = [
+            list(produces_sparse_gradient(module) for module, _ in replica)
+            for replica in modules_and_parameters]
 
         # The bucket size limit is specified in the constructor.
         # Additionally, we allow for a single small bucket for parameters
@@ -335,16 +360,18 @@ class DistributedDataParallel(Module):
         # a much larger bucket, adding unnecessary latency after gradient
         # computation finishes. Experiments showed 1MB is a reasonable value.
         bucket_indices = dist._compute_bucket_assignment_by_size(
-            param_list[0],
-            [1024 * 1024, self.bucket_bytes_cap])
+            parameters[0],
+            [1024 * 1024, self.bucket_bytes_cap],
+            expect_sparse_gradient[0])
 
         # Note: reverse list of buckets because we want to approximate the
         # order in which their gradients are produced, and assume they
         # are used in the forward pass in the order they are defined.
         self.reducer = dist.Reducer(
-            param_list,
+            parameters,
             list(reversed(bucket_indices)),
-            self.process_group)
+            self.process_group,
+            expect_sparse_gradient)
 
         # passing a handle to torch.nn.SyncBatchNorm layer
         self._passing_sync_batchnorm_handle(self._module_copies)


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22037 Support sparse gradients in DistributedDataParallel**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15926383/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22036 Add sparse tensor allreduce&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15926384/)

This adds support for sparse gradients to the reducer as well as to
the DistributedDataParallel wrapper. Note that an out of band signal
is needed whether or not a dense parameter (e.g. an embedding) is
expected to receive a sparse gradient or not. This information is
passed to the bucket assignment computation routine and the reducer as
a vector of booleans. Every parameter for which we expect a sparse
gradient is assigned its own bucket, as we cannot easily group
multiple unrelated sparse tensors.

Differential Revision: [D15926383](https://our.internmc.facebook.com/intern/diff/D15926383/)