### PR TITLE
Reduce excessive CI printing in TestHub

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -534,7 +534,8 @@ class TestHub(TestCase):
         hub_model = hub.load(
             'pytorch/vision',
             'resnet18',
-            pretrained=True)
+            pretrained=True,
+            progress=False)
         self.assertEqual(sum_of_model_parameters(hub_model),
                          SUM_OF_PRETRAINED_RESNET18_PARAMS)
 
@@ -544,7 +545,8 @@ class TestHub(TestCase):
         hub_model = hub.load(
             'pytorch/vision',
             'resnet18',
-            pretrained=True)
+            pretrained=True,
+            progress=False)
         self.assertEqual(sum_of_model_parameters(hub_model),
                          SUM_OF_PRETRAINED_RESNET18_PARAMS)
         assert os.path.exists(temp_dir + '/pytorch_vision_master')


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/21132 reverted https://github.com/pytorch/pytorch/pull/19606.

Now these tests again print like 40% lines of CI outputs (e.g., https://circleci.com/gh/pytorch/pytorch/2041825?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

This PR now uses the functionality introduced in https://github.com/pytorch/vision/issues/862. 