### PR TITLE
Limit overall number of threads used by TBB

### DIFF
--- a/aten/src/ATen/ParallelNativeTBB.cpp
+++ b/aten/src/ATen/ParallelNativeTBB.cpp
@@ -6,6 +6,8 @@
 #include <mutex>
 
 #include "tbb/tbb.h"
+#define TBB_PREVIEW_GLOBAL_CONTROL 1
+#include "tbb/global_control.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -18,9 +20,25 @@
 namespace at {
 
 namespace {
-  static thread_local tbb::task_scheduler_init tbb_init_(intraop_default_num_threads());
-  std::atomic<int> num_intraop_threads_{-1};
-  static thread_local tbb::task_group tg_;
+static thread_local tbb::task_scheduler_init tbb_init_(intraop_default_num_threads());
+std::atomic<int> num_intraop_threads_{-1};
+static thread_local tbb::task_group tg_;
+
+std::mutex global_thread_mutex_;
+std::shared_ptr<tbb::global_control> global_thread_limit_ = nullptr;
+
+void _internal_set_num_threads(int nthreads) {
+  TORCH_INTERNAL_ASSERT(nthreads > 0);
+  {
+    std::unique_lock<std::mutex> lk(global_thread_mutex_);
+    global_thread_limit_ = std::make_shared<tbb::global_control>(
+        tbb::global_control::max_allowed_parallelism, nthreads);
+  }
+  if (tbb_init_.is_active()) {
+    tbb_init_.terminate();
+  }
+  tbb_init_.initialize(nthreads);
+}
 }
 
 void init_num_threads() {
@@ -36,21 +54,14 @@ void init_num_threads() {
   if (nthreads < 0) {
     nthreads = intraop_default_num_threads();
   }
-  TORCH_INTERNAL_ASSERT(nthreads > 0);
-  if (tbb_init_.is_active()) {
-    tbb_init_.terminate();
-  }
-  tbb_init_.initialize(nthreads);
+  _internal_set_num_threads(nthreads);
 }
 
 void set_num_threads(int nthreads) {
   TORCH_CHECK(nthreads > 0);
   int no_value = -1;
   if (num_intraop_threads_.compare_exchange_strong(no_value, nthreads)) {
-    if (tbb_init_.is_active()) {
-      tbb_init_.terminate();
-    }
-    tbb_init_.initialize(nthreads);
+    _internal_set_num_threads(nthreads);
     return;
   }
   TORCH_CHECK(false,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22062 Fix sequential MKL case
* #22051 Update intra_inter_benchmark
* #22047 Experimental option to use single thread pool
* **#22045 Limit overall number of threads used by TBB**

Summary:
Using global control to set a limit on number of threads used by TBB

Test Plan:
PARALLEL_BACKEND=NATIVE_TBB USE_OPENMP=0 USE_TBB=1 MKL_SEQ=1
MKLDNN_THREADING=SEQ USE_CUDA=0 BLAS=MKL USE_MKLDNN=1 BUILD_BINARY=1
python setup.py develop --cmake

./build/bin/parallel_info
./build/bin/thread_init_test
./build/bin/test_parallel

Differential Revision: [D15930319](https://our.internmc.facebook.com/intern/diff/D15930319)