### PR TITLE
Support Half type for randperm.

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -475,11 +475,12 @@ Tensor& randperm_out(Tensor& result, int64_t n) {
 
 Tensor& randperm_out_cpu(Tensor& result, int64_t n, Generator* generator) {
   TORCH_CHECK(n >= 0, "n must be non-negative, got", n);
+  check_supported_max_int_with_precision(n, result);
   result.resize_({n});
   auto gen = get_generator_or_default<CPUGenerator>(generator, detail::getDefaultCPUGenerator());
   // See Note [Acquire lock when using random generators]
   std::lock_guard<std::mutex> lock(gen->mutex_);
-  AT_DISPATCH_ALL_TYPES(result.scalar_type(), "randperm", [&]() -> void {
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, result.scalar_type(), "randperm", [&]() -> void {
     randperm_cpu<scalar_t>(result, n, gen);
   });
 

--- a/aten/src/ATen/native/TensorFactories.h
+++ b/aten/src/ATen/native/TensorFactories.h
@@ -64,5 +64,25 @@ inline void check_size_nonnegative(IntArrayRef size) {
     TORCH_CHECK(x >= 0, "Trying to create tensor with negative dimension ", x, ": ", size);
   }
 }
+
+inline void check_supported_max_int_with_precision(int64_t n, const Tensor& tensor) {
+  TORCH_CHECK(at::scalar_tensor(n, tensor.options()).defined(),
+              "n is too large for result tensor type: '", tensor.type().toString(), "'");
+
+  // Ensure sufficient precision for floating point representation.
+  switch (tensor.scalar_type()) {
+  case at::ScalarType::Half:
+    TORCH_CHECK(n <= (int64_t(1) << 11) + 1, "n cannot be greater than 2049 for Half type.");
+    break;
+  case at::ScalarType::Float:
+    TORCH_CHECK(n <= (int64_t(1) << 24) + 1, "n cannot be greater than 2^24+1 for Float type.");
+    break;
+  case at::ScalarType::Double:  // Unlikely to happen, but doesn't hurt to check
+    TORCH_CHECK(n <= (int64_t(1) << 53) + 1, "n cannot be greater than 2^53+1 for Double type.");
+    break;
+  default:
+    break;
+  }
+}
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -75,40 +75,39 @@ Tensor empty_strided_cuda(IntArrayRef size, IntArrayRef stride, const TensorOpti
 
 Tensor& randperm_out_cuda(Tensor& result, int64_t n, Generator* generator) {
   TORCH_CHECK(n >= 0, "n must be non-negative, got", n);
-  TORCH_CHECK(at::scalar_tensor(n, result.options()).defined(),
-  "n is too large for result tensor type: '", result.type().toString(), "'");
+  check_supported_max_int_with_precision(n, result);
 
   result.resize_({n});
 
-  if (result.scalar_type() == at::ScalarType::Half) {
-    auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
-    result.copy_(randperm_out_cuda(result_float, n, generator));
-  } else {
-    if (n < 30000) {  // For small inputs, we offload it to CPU instead.
-      auto result_cpu = at::empty({n}, result.options().device(kCPU));
-      randperm_out(result_cpu, n, generator);
-      result.copy_(result_cpu);
-    } else {
-      // Generate random values for the keys array
-      AT_DISPATCH_ALL_TYPES(
-        result.scalar_type(), "randperm_out_cuda", [&] {
-          auto keys = at::empty(result.sizes(), result.options()).random_(generator);
-
-          auto result_data = thrust::device_ptr<scalar_t>(result.data<scalar_t>());
-          auto keys_data = thrust::device_ptr<scalar_t>(keys.data<scalar_t>());
-
-          auto state = globalContext().getTHCState();
-          THCThrustAllocator thrustAlloc(state);
-          auto policy = thrust::cuda::par(thrustAlloc).on(at::cuda::getCurrentCUDAStream());
-
-          thrust::sequence(policy, result_data, result_data + n);
-
-          // Use the sorted order of keys to rearrange the result array
-          thrust::sort_by_key(policy, keys_data, keys_data + n, result_data);
-        }
-      );
-    }
+  if (n < 30000) {  // For small inputs, we offload it to CPU instead.
+    auto result_cpu = at::empty({n}, result.options().device(kCPU));
+    randperm_out(result_cpu, n, generator);
+    return result.copy_(result_cpu);
   }
+
+  if (result.scalar_type() == at::ScalarType::Half) {  // Half in thrust is spotty. Avoid.
+    auto result_float = at::empty({n}, initialTensorOptions().device(Device(DeviceType::CUDA)));
+    return result.copy_(randperm_out_cuda(result_float, n, generator));
+  }
+
+  // Generate random values for the keys array
+  AT_DISPATCH_ALL_TYPES(
+    result.scalar_type(), "randperm_out_cuda", [&] {
+      auto keys = at::empty(result.sizes(), result.options()).random_(generator);
+
+      auto result_data = thrust::device_ptr<scalar_t>(result.data<scalar_t>());
+      auto keys_data = thrust::device_ptr<scalar_t>(keys.data<scalar_t>());
+
+      auto state = globalContext().getTHCState();
+      THCThrustAllocator thrustAlloc(state);
+      auto policy = thrust::cuda::par(thrustAlloc).on(at::cuda::getCurrentCUDAStream());
+
+      thrust::sequence(policy, result_data, result_data + n);
+
+      // Use the sorted order of keys to rearrange the result array
+      thrust::sort_by_key(policy, keys_data, keys_data + n, result_data);
+    }
+  );
 
   return result;
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4631,10 +4631,23 @@ class _TestTorchMixin(object):
 
         # randperm of 0 elements is an empty tensor
         res1 = torch.randperm(0)
-        res2 = torch.LongTensor(5)
+        res2 = torch.LongTensor()
         torch.randperm(0, out=res2)
         self.assertEqual(res1.numel(), 0)
         self.assertEqual(res2.numel(), 0)
+
+        # n is too large for a floating point type
+        res = torch.HalfTensor()
+        torch.randperm(2**11 + 1, out=res)  # No exception expected
+        self.assertRaises(RuntimeError, lambda: torch.randperm(2**11 + 2, out=res))
+
+        res = torch.FloatTensor()
+        torch.randperm(2**24 + 1, out=res)
+        self.assertRaises(RuntimeError, lambda: torch.randperm(2**24 + 2, out=res))
+
+        res = torch.DoubleTensor()
+        torch.randperm(2**25, out=res)  # 2**53+1 is too large to run
+        self.assertRaises(RuntimeError, lambda: torch.randperm(2**53 + 2, out=res))
 
     def test_random(self):
         # This test is flaky with p<=(2/(ub-lb))^200=6e-36


### PR DESCRIPTION
Previously randperm supports Half type only on CUDA. This commit adds Half support for the CPU version. Precision check for floating point type is also added to ensure that integers can be properly represented.