### PR TITLE
Experimental option to use single thread pool

### DIFF
--- a/aten/src/ATen/ParallelThreadPoolNative.cpp
+++ b/aten/src/ATen/ParallelThreadPoolNative.cpp
@@ -67,7 +67,11 @@ int get_num_interop_threads() {
 }
 
 void launch(std::function<void()> func) {
+#if AT_EXPERIMENTAL_SINGLE_THREAD_POOL
+  intraop_launch(func);
+#else
   get_pool().run(func);
+#endif
 }
 
 } // namespace at

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -876,6 +876,11 @@ elseif ("${PARALLEL_BACKEND}" STREQUAL "NATIVE_TBB")
 else()
   message(FATAL_ERROR "Unknown parallel backend: ${PARALLEL_BACKEND}")
 endif()
+set(EXPERIMENTAL_SINGLE_THREAD_POOL "0" CACHE STRING
+  "Experimental option to use a single thread pool for inter- and intra-op parallelism")
+if ("${EXPERIMENTAL_SINGLE_THREAD_POOL}")
+  target_compile_definitions(torch PUBLIC "-DAT_EXPERIMENTAL_SINGLE_THREAD_POOL=1")
+endif()
 
 if (MSVC AND NOT BUILD_SHARED_LIBS)
   # Note [Supporting both static and dynamic libraries on Windows]

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -310,6 +310,9 @@ class CMake:
         parallel_backend = os.getenv('PARALLEL_BACKEND')
         if parallel_backend:
             CMake.defines(args, PARALLEL_BACKEND=parallel_backend)
+        single_thread_pool = os.getenv('EXPERIMENTAL_SINGLE_THREAD_POOL')
+        if single_thread_pool:
+            CMake.defines(args, EXPERIMENTAL_SINGLE_THREAD_POOL=single_thread_pool)
 
         if USE_GLOO_IBVERBS:
             CMake.defines(args, USE_IBVERBS="1", USE_GLOO_IBVERBS="1")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22047 Experimental option to use single thread pool**
* #22045 Limit overall number of threads used by TBB

Summary:
We typically use two separate thread pools for inter-
and intra-op parallelism. However, in some cases, we can use a single
thread pool, e.g. in case of TBB. This PR adds an experimental option
that uses intraop_launch instead of launch.

Test Plan:
EXPERIMENTAL_SINGLE_THREAD_POOL=1 PARALLEL_BACKEND=NATIVE_TBB
USE_OPENMP=0 USE_TBB=1 MKL_SEQ=1 MKLDNN_THREADING=SEQ USE_CUDA=0
BLAS=MKL USE_MKLDNN=1 BUILD_BINARY=1 python setup.py develop --cmake
./build/bin/parallel_info
./build/bin/thread_init_test
./build/bin/test_parallel
./build/bin/intra_inter_benchmark



Differential Revision: [D15931188](https://our.internmc.facebook.com/intern/diff/D15931188)