### PR TITLE
Norm preserving initialization for WeightNorm

### DIFF
--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -75,15 +75,15 @@ def weight_norm(module, name='weight', dim=0, init='default', gamma=2.):
 
     Weight normalization is a reparameterization that decouples the magnitude
     of a weight tensor from its direction. This replaces the parameter specified
-    by `name` (e.g. "weight") with two parameters: one specifying the magnitude
-    (e.g. "weight_g") and one specifying the direction (e.g. "weight_v").
+    by :attr:`name` (e.g. ``'weight'``) with two parameters: one specifying the magnitude
+    (e.g. ``'weight_g'``) and one specifying the direction (e.g. ``'weight_v'``).
     Weight normalization is implemented via a hook that recomputes the weight
     tensor from the magnitude and direction before every :meth:`~Module.forward`
     call.
 
-    By default, with `dim=0`, the norm is computed independently per output
+    By default, with ``dim=0``, the norm is computed independently per output
     channel/plane. To compute a norm over the entire weight tensor, use
-    `dim=None`.
+    ``dim=None``.
 
     See https://arxiv.org/abs/1602.07868
 
@@ -106,6 +106,7 @@ def weight_norm(module, name='weight', dim=0, init='default', gamma=2.):
     Example::
 
         >>> m = weight_norm(nn.Linear(20, 40), name='weight')
+        >>> m
         Linear (20 -> 40)
         >>> m.weight_g.size()
         torch.Size([40, 1])
@@ -121,7 +122,7 @@ def remove_weight_norm(module, name='weight'):
     r"""Removes the weight normalization reparameterization from a module.
 
     Args:
-        module (nn.Module): containing module
+        module (Module): containing module
         name (str, optional): name of weight parameter
 
     Example:

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -3,7 +3,7 @@ Weight Normalization from https://arxiv.org/abs/1602.07868
 """
 import math
 from torch.nn.parameter import Parameter
-from torch import _weight_norm, norm_except_dim, ones_like
+from torch import _weight_norm, norm_except_dim, full_like
 from torch.nn.init import _calculate_fan_in_and_fan_out
 
 
@@ -44,7 +44,7 @@ class WeightNorm(object):
             g_init = norm_except_dim(weight, 2, dim)
         elif init == 'norm_preserving':
             fan_in, fan_out = _calculate_fan_in_and_fan_out(weight)
-            g_init = ones_like(norm_except_dim(weight, 2, dim)) * math.sqrt(gamma * fan_in / fan_out)
+            g_init = full_like(norm_except_dim(weight, 2, dim), math.sqrt(gamma * fan_in / fan_out))
 
         # add g and v as new parameters and express w as g/||v|| * v
         module.register_parameter(name + '_g', Parameter(g_init.data))

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -88,7 +88,7 @@ def weight_norm(module, name='weight', dim=0, init='default', gamma=2.):
     See https://arxiv.org/abs/1602.07868
 
     Args:
-        module (nn.Module): containing module
+        module (Module): containing module
         name (str, optional): name of weight parameter
         dim (int, optional): dimension over which to compute the norm
         init (str, optional): initialization scheme; one in ['default', 'norm_preserving']
@@ -107,7 +107,7 @@ def weight_norm(module, name='weight', dim=0, init='default', gamma=2.):
 
         >>> m = weight_norm(nn.Linear(20, 40), name='weight')
         >>> m
-        Linear (20 -> 40)
+        Linear(in_features=20, out_features=40, bias=True)
         >>> m.weight_g.size()
         torch.Size([40, 1])
         >>> m.weight_v.size()

--- a/torch/nn/utils/weight_norm.py
+++ b/torch/nn/utils/weight_norm.py
@@ -1,8 +1,10 @@
 r"""
 Weight Normalization from https://arxiv.org/abs/1602.07868
 """
+import math
 from torch.nn.parameter import Parameter
-from torch import _weight_norm, norm_except_dim
+from torch import _weight_norm, norm_except_dim, ones_like
+from torch.nn.init import _calculate_fan_in_and_fan_out
 
 
 class WeightNorm(object):
@@ -18,7 +20,10 @@ class WeightNorm(object):
         return _weight_norm(v, g, self.dim)
 
     @staticmethod
-    def apply(module, name, dim):
+    def apply(module, name, dim, init, gamma):
+        assert init in ['default', 'norm_preserving'], \
+            "Invalid init for WeightNorm ({}). It must be one of ['default', 'norm_preserving']".format(init)
+
         for k, hook in module._forward_pre_hooks.items():
             if isinstance(hook, WeightNorm) and hook.name == name:
                 raise RuntimeError("Cannot register two weight_norm hooks on "
@@ -34,8 +39,15 @@ class WeightNorm(object):
         # remove w from parameter list
         del module._parameters[name]
 
+        # initial value for g
+        if init == 'default':
+            g_init = norm_except_dim(weight, 2, dim)
+        elif init == 'norm_preserving':
+            fan_in, fan_out = _calculate_fan_in_and_fan_out(weight)
+            g_init = ones_like(norm_except_dim(weight, 2, dim)) * math.sqrt(gamma * fan_in / fan_out)
+
         # add g and v as new parameters and express w as g/||v|| * v
-        module.register_parameter(name + '_g', Parameter(norm_except_dim(weight, 2, dim).data))
+        module.register_parameter(name + '_g', Parameter(g_init.data))
         module.register_parameter(name + '_v', Parameter(weight.data))
         setattr(module, name, fn.compute_weight(module))
 
@@ -55,7 +67,7 @@ class WeightNorm(object):
         setattr(module, self.name, self.compute_weight(module))
 
 
-def weight_norm(module, name='weight', dim=0):
+def weight_norm(module, name='weight', dim=0, init='default', gamma=2.):
     r"""Applies weight normalization to a parameter in the given module.
 
     .. math::
@@ -63,22 +75,30 @@ def weight_norm(module, name='weight', dim=0):
 
     Weight normalization is a reparameterization that decouples the magnitude
     of a weight tensor from its direction. This replaces the parameter specified
-    by :attr:`name` (e.g. ``'weight'``) with two parameters: one specifying the magnitude
-    (e.g. ``'weight_g'``) and one specifying the direction (e.g. ``'weight_v'``).
+    by `name` (e.g. "weight") with two parameters: one specifying the magnitude
+    (e.g. "weight_g") and one specifying the direction (e.g. "weight_v").
     Weight normalization is implemented via a hook that recomputes the weight
     tensor from the magnitude and direction before every :meth:`~Module.forward`
     call.
 
-    By default, with ``dim=0``, the norm is computed independently per output
+    By default, with `dim=0`, the norm is computed independently per output
     channel/plane. To compute a norm over the entire weight tensor, use
-    ``dim=None``.
+    `dim=None`.
 
     See https://arxiv.org/abs/1602.07868
 
     Args:
-        module (Module): containing module
+        module (nn.Module): containing module
         name (str, optional): name of weight parameter
         dim (int, optional): dimension over which to compute the norm
+        init (str, optional): initialization scheme; one in ['default', 'norm_preserving']
+        gamma (float, optional): gamma parameter for the init scheme in Arpit et al. 2019
+                $\mathbf{g} = \sqrt{\gamma \cdot \text{fan-in} / \text{fan-out}} \cdot \mathbf{1}$
+            Gamma needs to be set as follows:
+                Layer without non-linearity:    gamma=1
+                Layer followed by ReLU:         gamma=2
+                Last layer in a resblock:       gamma=1/B_k, where B_k is the number of resblocks in the k-th stage
+            See https://arxiv.org/abs/1906.02341
 
     Returns:
         The original module with the weight norm hook
@@ -86,15 +106,14 @@ def weight_norm(module, name='weight', dim=0):
     Example::
 
         >>> m = weight_norm(nn.Linear(20, 40), name='weight')
-        >>> m
-        Linear(in_features=20, out_features=40, bias=True)
+        Linear (20 -> 40)
         >>> m.weight_g.size()
         torch.Size([40, 1])
         >>> m.weight_v.size()
         torch.Size([40, 20])
 
     """
-    WeightNorm.apply(module, name, dim)
+    WeightNorm.apply(module, name, dim, init, gamma)
     return module
 
 
@@ -102,7 +121,7 @@ def remove_weight_norm(module, name='weight'):
     r"""Removes the weight normalization reparameterization from a module.
 
     Args:
-        module (Module): containing module
+        module (nn.Module): containing module
         name (str, optional): name of weight parameter
 
     Example:


### PR DESCRIPTION
This PR implements the initialization for WeightNorm described in [Arpit et al. (2019)](https://arxiv.org/abs/1906.02341)

The paper shows improvements for this initialization scheme over the data-dependent initialization (which is not currently implemented in PyTorch) and the current default PyTorch initialization.