### PR TITLE
[JIT] Fix isSubtypeOf implementations

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -787,7 +787,7 @@ struct CAFFE2_API DictType : public Type {
       return getKeyType()->isSubtypeOf(dict_rhs->getKeyType()) &&
           getValueType()->isSubtypeOf(dict_rhs->getValueType());
     }
-    return false;
+    return Type::isSubtypeOf(rhs);
   }
 
   bool hasFreeVariables() const override {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -242,12 +242,6 @@ struct CAFFE2_API OptionalType: public SingleElementType<TypeKind::OptionalType,
     return OptionalTypePtr(new OptionalType(std::move(element))); // NOLINT(modernize-make-shared)
   }
   DEFINE_IS_SUBCLASS(OptionalType);
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if(auto rhs_ = rhs->cast<OptionalType>()) {
-      return getElementType()->isSubtypeOf(rhs_->getElementType());
-    }
-    return false;
-  }
 
   std::string str() const override {
     std::stringstream ss;
@@ -265,6 +259,12 @@ struct CAFFE2_API OptionalType: public SingleElementType<TypeKind::OptionalType,
     return create(contained_types[0]);
   }
 
+  bool operator==(const Type& rhs) const override {
+    if (auto opt_rhs = rhs.cast<OptionalType>()) {
+      return getElementType()->isSubtypeOf(opt_rhs->getElementType());
+    }
+    return false;
+  }
   // common cast Optional[Tensor] for undefined tensor type
   static OptionalTypePtr ofTensor();
 private:
@@ -782,13 +782,6 @@ struct CAFFE2_API DictType : public Type {
   }
 
   DEFINE_IS_SUBCLASS(DictType);
-  bool isSubtypeOf(const TypePtr rhs) const override {
-    if (auto dict_rhs = rhs->cast<DictType>()) {
-      return getKeyType()->isSubtypeOf(dict_rhs->getKeyType()) &&
-          getValueType()->isSubtypeOf(dict_rhs->getValueType());
-    }
-    return Type::isSubtypeOf(rhs);
-  }
 
   bool hasFreeVariables() const override {
     return has_free_variables;

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -470,10 +470,13 @@ const char * typeKindToString(TypeKind kind) {
 }
 
 bool Type::isSubtypeOf(const TypePtr rhs) const {
+  if (*this == *rhs) {
+    return true;
+  }
   if(auto rhs_ = rhs->cast<OptionalType>()) {
     return this->isSubtypeOf(rhs_->getElementType());
   }
-  return *this == *rhs;
+  return false;
 }
 
 std::string ProfiledTensorType::str() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22104 [JIT] Fix DictType isSubtypeOf**

Differential Revision: [D15956726](https://our.internmc.facebook.com/intern/diff/D15956726)

Previously the following would fail:

```
@jit.script
def forward(
    languages: Optional[Dict[int, str]]  
):
    if languages is None:
        print(languages)
```

```
RuntimeError: 
variable 'languages' previously has type Optional[Dict[int, str]] but is now being assigned to a value of type Dict[int, str]:
@jit.script
def forward(
    languages: Optional[Dict[int, str]]  
):
    if languages is None:
       ~~~~~~~~~~~~~~~~~ <--- HERE
        print(languages)
```

Because `Dict[int, str] issubtypeof Optional[Dict[int,str]]` would return false, as we did not fall back to `isSubtypeOf` defined in `Type. This fixes that