### PR TITLE
Don't end on inplace operators in einsum

### DIFF
--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -119,9 +119,11 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntArra
 
   // finally squeeze summed dimensions if desired
   if (! keepdim) {
+    auto sizes = result.sizes().vec();
     for (int i = dim-1; i>=0; i--)
       if (sum_dims[i])
-        result.squeeze_(i);
+        sizes.erase(sizes.begin() + i);
+    result = result.view(sizes);
   }
   return result;
 }
@@ -354,8 +356,11 @@ Tensor einsum(std::string eqn, TensorList tensors) {
     result = at::native::sumproduct_pair(result, preprocessed_operands[i], sum_dims, true);
   }
   // finally, we squeeze out all non-result dimensions
+  auto sizes = result.sizes().vec();
   for (int64_t dim = num_total_idxes-1; dim >= num_output_dims; dim--)
-    result.squeeze_(dim);
+    sizes.erase(sizes.begin() + dim);
+
+  result = result.view(sizes);
   return result;
 }
 

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -120,9 +120,11 @@ static Tensor sumproduct_pair(const Tensor& left_, const Tensor& right_, IntArra
   // finally squeeze summed dimensions if desired
   if (! keepdim) {
     auto sizes = result.sizes().vec();
-    for (int i = dim-1; i>=0; i--)
-      if (sum_dims[i])
+    for (int i = dim-1; i>=0; i--) {
+      if (sum_dims[i]) {
         sizes.erase(sizes.begin() + i);
+      }
+    }
     result = result.view(sizes);
   }
   return result;
@@ -357,8 +359,9 @@ Tensor einsum(std::string eqn, TensorList tensors) {
   }
   // finally, we squeeze out all non-result dimensions
   auto sizes = result.sizes().vec();
-  for (int64_t dim = num_total_idxes-1; dim >= num_output_dims; dim--)
+  for (int64_t dim = num_total_idxes-1; dim >= num_output_dims; dim--) {
     sizes.erase(sizes.begin() + dim);
+  }
 
   result = result.view(sizes);
   return result;


### PR DESCRIPTION
Returning the result of an inplace `squeeze_` in `einsum` (which itself is traced) interacts badly with `autograd.Function`.

I must admit that I'm not 100% certain whether it should be necessary to change this, but I consider this a good change overall.

Fixes: #22072 
