### PR TITLE
Remove versions constraints from `external_deps`

### DIFF
--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -363,8 +363,8 @@ def add_torch_libs():
             "//caffe2/torch/lib/libshm:libshm",
         ],
         external_deps=[
-            ("cudnn", "7.1.2", "cudnn-lazy"),
-            ("nccl", "2.1.15", "nccl-lazy"),
+            ("cudnn", None, "cudnn-lazy"),
+            ("nccl", None, "nccl-lazy"),
             ("cuda", None, "nvToolsExt-lazy"),
             ("cuda", None, "nvrtc-lazy"),
             ("cuda", None, "nvrtc-builtins-lazy"),


### PR DESCRIPTION
Summary: As per attached tasks, these are noops and are being deprecated/removed.

Differential Revision: D15901131

