### PR TITLE
Fix in ivalue::Future

### DIFF
--- a/aten/src/ATen/ParallelNative.h
+++ b/aten/src/ATen/ParallelNative.h
@@ -60,9 +60,6 @@ inline void parallel_for(
       internal::_unset_thread_num();
     };
 
-    // using shared_ptr to share ownership of the future with the lambda,
-    // to ensure we don't destroy future while lambda is still
-    // running in markCompleted
     std::vector<c10::ivalue::Future> futures(num_tasks);
     for (size_t task_id = 1; task_id < num_tasks; ++task_id) {
       int64_t local_start = begin + task_id * chunk_size;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22114 Fix in ivalue::Future**
* #22062 Fix sequential MKL case

Summary:
We need to make sure that waiters are woken up after
markCompleted is fully finished

Test Plan:
ran intra_inter_benchmark with PARALLEL_BACKEND=NATIVE build

Differential Revision: [D15958901](https://our.internmc.facebook.com/intern/diff/D15958901)