### PR TITLE
add more options when dumping tensors

### DIFF
--- a/caffe2/operators/fully_connected_op.h
+++ b/caffe2/operators/fully_connected_op.h
@@ -37,6 +37,7 @@ class FullyConnectedOp final : public Operator<Context> {
       typename T_Y,
       typename MATH>
   bool DoRunWithType() {
+    LOG(INFO) << "Running FC " << this->debug_def().input(1);
 #ifdef DNNLOWP_MEASURE_TIME_BREAKDOWN
     std::chrono::time_point<std::chrono::system_clock> t_very_begin, t_begin,
         t_end;

--- a/caffe2/quantization/server/activation_distribution_observer.cc
+++ b/caffe2/quantization/server/activation_distribution_observer.cc
@@ -292,6 +292,17 @@ HistogramNetObserver::HistogramNetObserver(
       cnt_(0),
       mul_nets_(mul_nets),
       out_file_name_(out_file_name) {
+  is_valid_net = false;
+  for (auto* op : subject->GetOperators()) {
+    if (op->debug_def().type() == "FC") {
+      LOG(INFO) << "Attaching HistogramNetObserver to " << this;
+      is_valid_net = true;
+      break;
+    }
+  }
+  if (!is_valid_net) {
+    return;
+  }
   hist_infos_.resize(subject->GetOperators().size());
 
   int i = 0;
@@ -315,6 +326,9 @@ HistogramNetObserver::HistogramNetObserver(
 void HistogramNetObserver::DumpAndReset_(
     const string& out_file_name,
     bool print_total_min_max) {
+  if (!is_valid_net) {
+    return;
+  }
   stringstream file_name;
   file_name << out_file_name;
   if (mul_nets_) {

--- a/caffe2/quantization/server/activation_distribution_observer.h
+++ b/caffe2/quantization/server/activation_distribution_observer.h
@@ -127,6 +127,7 @@ class HistogramNetObserver final : public NetObserver {
    * files for the nets will be appended with netbase addresses.
    */
   bool mul_nets_;
+  bool is_valid_net;
   const std::string out_file_name_;
   std::vector<std::shared_ptr<HistogramObserver::Info>> hist_infos_;
 };

--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -128,6 +128,7 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
 
   float in_qparams_scale_old_{0};
   std::int32_t in_qparams_zero_point_old_{0};
+  int dump_tensor_counter_{0};
 }; // class ConvDNNLowPOp
 
 } // namespace caffe2

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -20,6 +20,7 @@ C10_DEFINE_bool(
     "(currently only honored by FC)");
 
 C10_DECLARE_bool(caffe2_dnnlowp_dump_tensors);
+C10_DECLARE_bool(caffe2_dnnlowp_force_slow_path);
 
 namespace caffe2 {
 
@@ -435,17 +436,52 @@ bool FullyConnectedDNNLowPOp<T, ReluFused>::RunOnDevice() {
     }
 #endif
 
+// #define DNNLOWP_DETAILED_LOG_IN_SLOW_PATH
+#ifdef DNNLOWP_DETAILED_LOG_IN_SLOW_PATH
+    int overflow_cnt = 0, underflow_cnt = 0;
+#endif
+
     Y_int32_.resize(Y->size());
     for (int i = 0; i < M; ++i) {
       for (int j = 0; j < N; ++j) {
         int32_t sum = 0;
+        int32_t sum_actual = 0;
+        float sum_ref = 0;
         for (int k = 0; k < K; ++k) {
+          int x = Xdata[i * K + k];
           int w = Wdata[j * K + k];
-          sum += Xdata[i * K + k] * w;
+          sum += x * w;
+#ifdef DNNLOWP_DETAILED_LOG_IN_SLOW_PATH
+          if (k < K - 1) {
+            int x2 = Xdata[i * K + k + 1];
+            int w2 = Wdata[j * K + k + 1];
+            int sum2 = x * w + x2 * w2;
+            bool overflowed = false, underflowed = false;
+            if (sum2 > numeric_limits<int16_t>::max()) {
+              overflowed = true;
+              ++overflow_cnt;
+            } else if (sum2 < numeric_limits<int16_t>::min()) {
+              underflowed = true;
+              ++underflow_cnt;
+            }
+            if (overflowed || underflowed) {
+              LOG(INFO) << "i " << i << " j " << j << " k " << k << " " << x
+                        << " * " << w << " + " << x2 << " * " << w2 << " = "
+                        << sum2;
+            }
+          }
+#endif
         }
         Y_int32_[i * N + j] = sum;
       } // for each output element
     } // for each row
+
+#ifdef DNNLOWP_DETAILED_LOG_IN_SLOW_PATH
+    LOG(INFO) << "underflow_cnt " << underflow_cnt << " ("
+              << static_cast<float>(underflow_cnt) / (M * N * K) * 100
+              << ") overflow_cnt " << overflow_cnt << " ("
+              << static_cast<float>(overflow_cnt) / (M * N * K) * 100 << ")";
+#endif
   }
 
   if (FLAGS_caffe2_dnnlowp_dump_tensors) {
@@ -588,7 +624,8 @@ bool FullyConnectedDNNLowPOp<T, ReluFused>::GetQuantizationParameters_() {
   int signed_min = -(1 << (qfactory_->GetWeightPrecision() - 1));
   if (is_weight_constant_) {
     bool fast_path = is_same<T, uint8_t>::value && GetCpuId().avx2() &&
-        this->debug_def().engine() != "DNNLOWP_ACC16";
+        this->debug_def().engine() != "DNNLOWP_ACC16" &&
+        !FLAGS_caffe2_dnnlowp_force_slow_path;
 
     if ((fast_path && !Wq_packed_) || (!fast_path && W_quantized_.empty())) {
       if (this->template InputIsType<Int8FCDNNLowPPackedWeightBlob>(1)) {
@@ -638,6 +675,8 @@ bool FullyConnectedDNNLowPOp<T, ReluFused>::GetQuantizationParameters_() {
           reason = "fbgemm only supports AVX2";
         } else if (this->debug_def().engine() == "DNNLOWP_ACC16") {
           reason = "";
+        } else if (FLAGS_caffe2_dnnlowp_force_slow_path) {
+          reason = "slow path enforced";
         } else {
           assert(false);
         }

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.h
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.h
@@ -60,6 +60,7 @@ class FullyConnectedDNNLowPOp
 
   float in_qparams0_scale_old_ = 0;
   std::int32_t in_qparams0_zero_point_old_ = 0;
+  int dump_tensor_counter_{0};
 }; // class FullyConnectedDNNLowPOp
 
 } // namespace caffe2


### PR DESCRIPTION
Summary:
Control dumping activation tensors for the first N batches
Put the address of C2 operator to avoid overwrite in case multiple copies of the same net is running in parallel
Can control the path where we dump tensors

Differential Revision: D15966948

