### PR TITLE
Refactor named tensor helper code

### DIFF
--- a/aten/src/ATen/NamedTensor.cpp
+++ b/aten/src/ATen/NamedTensor.cpp
@@ -12,5 +12,81 @@ bool NamedTensorMeta::has_names() const {
       });
 }
 
+namespace impl {
+
+// Two Dimnames cannot be in the same Tensor if one of them can refer to the other.
+// In practice, this constraint means that a Tensor cannot have duplicate names
+// unless they are tagged and the tags are different.
+static DimnameList::const_iterator find_incompatible_name(
+    DimnameList::const_iterator begin,
+    DimnameList::const_iterator end,
+    const Dimname& target) {
+  return std::find_if(begin, end,
+      [&target](const Dimname& candidate) {
+        return target.can_refer_to(candidate) || candidate.can_refer_to(target);
+      });
+}
+
+static void check_unique_names(DimnameList names) {
+  // Strategy: Compare each element with the ones that come after it.
+  // Although this is O(N^2), in practice N is small (no more than 25).
+  for (auto it = names.begin(); it != names.end(); ++it) {
+    auto dup = find_incompatible_name(it + 1, names.end(), *it);
+    while (dup != names.end()) {
+      // Simple error message if you're not using tags
+      TORCH_CHECK(it->type() == NameType::TAGGED || dup->type() == NameType::TAGGED,
+          "Cannot construct a tensor with duplicate names. Got names: ",
+          names, ".");
+
+      // Complicated error message if you're using tags
+      TORCH_CHECK(false,
+          "Cannot construct a tensor with duplicate names unless they are tagged ",
+          "and have different tags. Got names: ", names, ", offending names: (",
+          *it, " and ", *dup, ").");
+      dup = find_incompatible_name(dup + 1, names.end(), *it);
+    }
+  }
+}
+
+static NamedTensorMeta* get_named_tensor_meta(TensorImpl* impl) {
+  return static_cast<NamedTensorMeta*>(impl->named_tensor_meta());
+}
+
+void internal_set_names_inplace(TensorImpl* impl, optional<DimnameList> names) {
+  if (!names) {
+    impl->set_named_tensor_meta(nullptr);
+    return;
+  }
+  auto ndim = impl->dim();
+  TORCH_CHECK(ndim == names->size(),
+      "Number of names (", names->size(), ") and "
+      "number of dimensions in tensor (", ndim, ") ",
+      "do not match.");
+  check_unique_names(*names);
+
+  auto* meta = get_named_tensor_meta(impl);
+  if (meta == nullptr) {
+    impl->set_named_tensor_meta(torch::make_unique<NamedTensorMeta>(*names));
+  } else {
+    meta->set_names_(*names);
+  }
+}
+
+optional<DimnameList> internal_get_names(TensorImpl* impl) {
+  const auto* meta = get_named_tensor_meta(impl);
+  if (meta == nullptr) {
+    return nullopt;
+  } else {
+    return meta->names();
+  }
+}
+
+bool internal_is_named(TensorImpl* impl) {
+  const auto* named_tensor_meta = get_named_tensor_meta(impl);
+  return named_tensor_meta != nullptr && named_tensor_meta->has_names();
+}
+
+} // namespace impl
+
 } // namespace at
 #endif

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -5,60 +5,8 @@
 
 namespace at {
 
-// Two Dimnames cannot be in the same Tensor if one of them can refer to the other.
-// In practice, this constraint means that a Tensor cannot have duplicate names
-// unless they are tagged and the tags are different.
-static DimnameList::const_iterator find_incompatible_name(
-    DimnameList::const_iterator begin,
-    DimnameList::const_iterator end,
-    const Dimname& target) {
-  return std::find_if(begin, end,
-      [&target](const Dimname& candidate) {
-        return target.can_refer_to(candidate) || candidate.can_refer_to(target);
-      });
-}
-
-static void check_unique_names(DimnameList names) {
-  // Strategy: Compare each element with the ones that come after it.
-  // Although this is O(N^2), in practice N is small (no more than 25).
-  for (auto it = names.begin(); it != names.end(); ++it) {
-    auto dup = find_incompatible_name(it + 1, names.end(), *it);
-    while (dup != names.end()) {
-      // Simple error message if you're not using tags
-      TORCH_CHECK(it->type() == NameType::TAGGED || dup->type() == NameType::TAGGED,
-          "Cannot construct a tensor with duplicate names. Got names: ",
-          names, ".");
-
-      // Complicated error message if you're using tags
-      TORCH_CHECK(false,
-          "Cannot construct a tensor with duplicate names unless they are tagged ",
-          "and have different tags. Got names: ", names, ", offending names: (",
-          *it, " and ", *dup, ").");
-      dup = find_incompatible_name(dup + 1, names.end(), *it);
-    }
-  }
-}
-
 void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
-  if (!names) {
-    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(nullptr);
-    return;
-  }
-
-  auto ndim = tensor.dim();
-  TORCH_CHECK(ndim == names->size(),
-      "Number of names (", names->size(), ") and "
-      "number of dimensions in tensor (", ndim, ") ",
-      "do not match.");
-  check_unique_names(*names);
-
-  auto* meta = tensor.get_named_tensor_meta();
-  if (meta == nullptr) {
-    tensor.unsafeGetTensorImpl()->set_named_tensor_meta(
-        torch::make_unique<NamedTensorMeta>(*names));
-  } else {
-    meta->set_names_(*names);
-  }
+  impl::internal_set_names_inplace(tensor.unsafeGetTensorImpl(), names);
 }
 
 // Returns "Tensor['N', 'C', 'H', 'W']" for a tensor with names ('N', 'C', 'H', 'W').

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -175,12 +175,7 @@ class CAFFE2_API Tensor {
   }
 #ifdef NAMEDTENSOR_ENABLED
   optional<DimnameList> names() const {
-    const auto* meta = get_named_tensor_meta();
-    if (meta == nullptr) {
-      return nullopt;
-    } else {
-      return meta->names();
-    }
+    return impl::internal_get_names(unsafeGetTensorImpl());
   }
 #endif
   int64_t ndimension() const {

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1779,8 +1779,7 @@ inline const NamedTensorMeta* Tensor::get_named_tensor_meta() const {
 }
 
 inline bool Tensor::is_named() const {
-  auto* named_tensor_meta = get_named_tensor_meta();
-  return named_tensor_meta != nullptr && named_tensor_meta->has_names();
+  return impl::internal_is_named(unsafeGetTensorImpl());
 }
 #endif
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -175,12 +175,7 @@ class CAFFE2_API Tensor {
   }
 #ifdef NAMEDTENSOR_ENABLED
   optional<DimnameList> names() const {
-    const auto* meta = get_named_tensor_meta();
-    if (meta == nullptr) {
-      return nullopt;
-    } else {
-      return meta->names();
-    }
+    return impl::internal_get_names(unsafeGetTensorImpl());
   }
 #endif
   int64_t ndimension() const {

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -110,8 +110,7 @@ inline const NamedTensorMeta* Tensor::get_named_tensor_meta() const {
 }
 
 inline bool Tensor::is_named() const {
-  auto* named_tensor_meta = get_named_tensor_meta();
-  return named_tensor_meta != nullptr && named_tensor_meta->has_names();
+  return impl::internal_is_named(unsafeGetTensorImpl());
 }
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22268 Named inference rule for more pointwise ops.
* #22267 Enable named inference for some unary pointwise ops
* #22223 Implement unify_from_right
* #22151 Named inference rule for `abs`.
* **#22150 Refactor named tensor helper code**
* #22077 Refactor function_wrapper.create_generic
* #21795 Implement tensor.select(Dimname,int)

A lot of these helper functions *should* be methods on TensorImpl, but
they're not due to working around some issues. All of these helper
functions should exist in NamedTensor.cpp. They'll be useful for
implementing named inference rules in TH (since tensors in TH are
TensorImpl*).

Test Plan
- [namedtensor ci]

gh-metadata: pytorch pytorch 22150 gh/zou3519/60/head

Differential Revision: [D15970325](https://our.internmc.facebook.com/intern/diff/D15970325)