### PR TITLE
Add missing algorithm header to Array utility

### DIFF
--- a/c10/util/Array.h
+++ b/c10/util/Array.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <c10/util/C++17.h>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Summary:
This header uses `std::swap_ranges` function which is defined in `<algorithm>` header (https://en.cppreference.com/w/cpp/algorithm/swap_ranges). Therefore this file isn't guaranteed to compile on all platforms.

This diff fixes the problem by adding the missing header.

Differential Revision: D15971425

