### PR TITLE
add custom StatValue support into StatRegistry

### DIFF
--- a/caffe2/core/stats_test.cc
+++ b/caffe2/core/stats_test.cc
@@ -2,8 +2,8 @@
 #include <iostream>
 #include <thread>
 
-#include "caffe2/core/stats.h"
 #include <gtest/gtest.h>
+#include "caffe2/core/stats.h"
 
 namespace caffe2 {
 namespace {
@@ -142,6 +142,45 @@ TEST(StatsTest, StatsTestStatic) {
       toMap(data),
       ExportedStatMap(
           {{"i1/cpuUsage", 80}, {"i1/memUsage", 50}, {"i2/memUsage", 90}}));
+}
+
+static std::atomic<int64_t> svCount{0};
+static std::atomic<int64_t> svValue{0};
+
+struct CustomStatValue : public StatValue {
+  int64_t increment(int64_t inc) override {
+    svCount += 1;
+    return svValue += inc;
+  }
+
+  int64_t reset(int64_t) override {
+    return 0;
+  }
+
+  int64_t get() const override {
+    return 0;
+  }
+};
+
+TEST(StatsTest, StatValueCreator) {
+  auto& registry = StatRegistry::get();
+  std::string name = "";
+  registry.setStatValueCreator([&](const std::string& n) {
+    name = n;
+    return caffe2::make_unique<CustomStatValue>();
+  });
+
+  struct TestStats {
+    CAFFE_STAT_CTOR(TestStats);
+    CAFFE_EXPORTED_STAT(bar);
+  };
+  TestStats foo("foo");
+  CAFFE_EVENT(foo, bar, 5);
+  CAFFE_EVENT(foo, bar, 10);
+
+  ASSERT_EQ(name, "foo/bar");
+  ASSERT_EQ(svCount.load(), 2);
+  ASSERT_EQ(svValue.load(), 15);
 }
 } // namespace
 } // namespace caffe2


### PR DESCRIPTION
Summary: In distributed training we're using a thread to periodically poll stats and log them after doing some custom aggregations on them. This will allow us to add custom stat handling logic that will log directly to ODS and let ODS do all the aggregations. We lose most of the functionality of ODS if we do ourselves first.

Differential Revision: D15975737

