### PR TITLE
Adding FC and Relu QNNPACK ops to C10 registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,10 @@ if(BUILD_NAMEDTENSOR)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_NAMEDTENSOR")
 endif()
 
+if(USE_QNNPACK)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_QNNPACK")
+endif()
+
 # ---[ Whitelist file if whitelist is specified
 include(cmake/Whitelist.cmake)
 

--- a/aten/src/ATen/native/quantized/cpu/init_qnnpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/init_qnnpack.cpp
@@ -1,0 +1,20 @@
+#ifdef USE_QNNPACK
+
+#include <ATen/ATen.h>
+#include <ATen/Config.h>
+#include "init_qnnpack.h"
+#include <qnnpack.h>
+
+namespace at {
+namespace native {
+void initQNNPACK() {
+  static std::once_flag once;
+  static enum qnnp_status qnnpackStatus = qnnp_status_uninitialized;
+  std::call_once(once, []() { qnnpackStatus = qnnp_initialize(); });
+  TORCH_CHECK(
+      qnnpackStatus == qnnp_status_success, "failed to initialize QNNPACK");
+}
+} // namespace native
+} // namespace at
+
+#endif

--- a/aten/src/ATen/native/quantized/cpu/init_qnnpack.h
+++ b/aten/src/ATen/native/quantized/cpu/init_qnnpack.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef USE_QNNPACK
+#include "qnnpack.h"
+
+namespace at {
+namespace native {
+
+void initQNNPACK();
+
+} // namespace native
+} // namespace at
+#endif

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_fc.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_fc.cpp
@@ -1,0 +1,127 @@
+#include <ATen/ATen.h>
+#include <ATen/Config.h>
+#include <ATen/core/op_registration/op_registration.h>
+#include <ATen/quantized/Quantizer.h>
+
+#include "init_qnnpack.h"
+#include "qnnpack_utils.h"
+
+namespace at {
+namespace native {
+namespace {
+
+class QNNPACKLinear final : public torch::OperatorKernel {
+ public:
+#ifdef USE_QNNPACK
+  Tensor operator()(
+      at::Tensor input,
+      at::Tensor weight,
+      at::Tensor bias,
+      double output_scale,
+      int64_t output_zero_point) {
+    TORCH_CHECK(input.dim() >= 2, "Input tensor rank should be >= 2");
+    TORCH_CHECK(weight.dim() == 2, "Weight tensor rank should be == 2");
+
+    Tensor input_contig = input.contiguous();
+
+    // Y(output) = X(input_contig) x W(weight)
+    int64_t rows_x = 1;
+    int64_t cols_x = input_contig.size(input_contig.dim() - 1);
+    for (size_t i = 0; i < input_contig.dim() - 1; ++i) {
+      rows_x *= input_contig.size(i);
+    }
+
+    int64_t rows_y = weight.size(0);
+
+    TORCH_CHECK(
+        cols_x == weight.size(1),
+        "qnnpack_linear(): input size does not match weight dimension 1 size: got ",
+        cols_x,
+        " but expected ",
+        weight.size(1));
+
+    TORCH_CHECK(
+        !bias.defined() || (bias.ndimension() == 1 && bias.size(0) == rows_y),
+        "qnnpack_linear(): Given weight of size ",
+        weight.sizes(),
+        ", expected bias to be 1-dimensional with ",
+        rows_y,
+        " elements",
+        ", but got bias of size ",
+        bias.sizes(),
+        " instead");
+
+    initQNNPACK();
+
+    // Allocate output Tensor and a buffer for QNNPACK to use
+    Tensor output = at::_empty_affine_quantized(
+        {rows_x, rows_y}, input.options(), output_scale, output_zero_point);
+
+    qnnp_operator_t qnnpack_operator{nullptr};
+
+    // QNNPACK expects both weights and inputs to be uint8
+    const qnnp_status createStatus = qnnp_create_fully_connected_nc_q8(
+        cols_x /* input channels */,
+        rows_y /* output channels */,
+        input_contig.q_zero_point() /* input zero_point */,
+        input_contig.q_scale() /* input scale */,
+        weight.q_zero_point() /* kernel zero_point */,
+        weight.q_scale() /* kernel scale */,
+        (uint8_t*)weight.data<c10::quint8>() /* kernel data */,
+        (int32_t*)bias.data<c10::qint32>() /* bias data */,
+        output.q_zero_point() /* output zero_point */,
+        output.q_scale() /* output scale */,
+        std::numeric_limits<uint8_t>::min() /* output_min */,
+        std::numeric_limits<uint8_t>::max() /* output_max */,
+        0 /* flags */,
+        &qnnpack_operator);
+
+    std::unique_ptr<qnnp_operator, QnnpackOperatorDeleter> qnnpack_uniq_ptr(
+        qnnpack_operator);
+
+    TORCH_INTERNAL_ASSERT(
+        createStatus == qnnp_status_success,
+        "failed to create QNNPACK Linear operator");
+    TORCH_INTERNAL_ASSERT(qnnpack_operator != nullptr);
+
+    const qnnp_status setupStatus = qnnp_setup_fully_connected_nc_q8(
+        qnnpack_operator /* fully_connected */,
+        rows_x /* batch_size */,
+        (uint8_t*)input_contig.data<c10::quint8>() /* input */,
+        cols_x /* input stride */,
+        (uint8_t*)output.data<c10::quint8>() /* output */,
+        rows_y /* output stride */);
+
+    TORCH_INTERNAL_ASSERT(
+        setupStatus == qnnp_status_success,
+        "failed to setup QNNPACK Linear operator");
+    const qnnp_status runStatus =
+        qnnp_run_operator(qnnpack_operator, nullptr /* thread pool */);
+
+    TORCH_INTERNAL_ASSERT(
+        runStatus == qnnp_status_success, "failed to run QNNPACK operator");
+
+    return output;
+  }
+#else
+  Tensor operator()(
+      at::Tensor /* input */,
+      at::Tensor /* weight */,
+      at::Tensor /* bias */,
+      double /* output_scale */,
+      int64_t /* output_zero_point */) {
+    TORCH_CHECK(
+        false,
+        "This PyTorch installation was not built "
+        "with QNNPACK operators");
+  }
+#endif
+};
+
+static auto registry = torch::RegisterOperators().op(
+    "quantized::qnnpack_linear(Tensor X, Tensor W, Tensor b, float Y_scale, int Y_zero_point) -> Tensor",
+    torch::RegisterOperators::options().kernel<QNNPACKLinear>(
+        QuantizedCPUTensorId()));
+} // namespace
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_relu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_relu.cpp
@@ -1,0 +1,94 @@
+#include <ATen/ATen.h>
+#include <ATen/core/op_registration/op_registration.h>
+
+#include "init_qnnpack.h"
+#include "qnnpack_utils.h"
+
+namespace at {
+namespace native {
+namespace {
+
+class QNNPACKRelu final : public torch::OperatorKernel {
+ public:
+#ifdef USE_QNNPACK
+  Tensor operator()(Tensor input) {
+    Tensor qy;
+
+    TORCH_CHECK(
+        input.ndimension() > 0, "qnnpack_relu(): Got empty input tensor");
+
+    Tensor input_contig = input.contiguous();
+
+    const auto zero_point = input_contig.q_zero_point();
+
+    initQNNPACK();
+
+    size_t volume = input_contig.numel();
+
+    size_t num_elems_x = 1;
+    for (int i = 1; i < input_contig.ndimension(); ++i) {
+      num_elems_x *= input_contig.size(i);
+    }
+
+    qnnp_operator_t qnnpack_operator{nullptr};
+
+    const qnnp_status createStatus = qnnp_create_clamp_nc_u8(
+        num_elems_x /* channels */,
+        zero_point /* output min */,
+        std::numeric_limits<uint8_t>::max() /* output max */,
+        0 /* flags */,
+        &qnnpack_operator);
+
+    std::unique_ptr<qnnp_operator, QnnpackOperatorDeleter> qnnpack_uniq_ptr(
+        qnnpack_operator);
+
+    TORCH_INTERNAL_ASSERT(
+        createStatus == qnnp_status_success,
+        "failed to create QNNPACK Relu operator");
+    TORCH_INTERNAL_ASSERT(qnnpack_operator != nullptr);
+
+    qy = at::_empty_affine_quantized(
+        input_contig.sizes(),
+        input.options(),
+        input_contig.q_scale(),
+        input_contig.q_zero_point());
+
+    size_t num_elems_y = volume / qy.size(0);
+
+    const qnnp_status setupStatus = qnnp_setup_clamp_nc_u8(
+        qnnpack_operator, /* clamp */
+        input_contig.size(0) /* batch size */,
+        (uint8_t*)input_contig.data<c10::quint8>() /* input data */,
+        num_elems_x /* input stride */,
+        (uint8_t*)qy.data<c10::quint8>() /* output data */,
+        num_elems_y /* output stride */);
+    TORCH_INTERNAL_ASSERT(
+        setupStatus == qnnp_status_success,
+        "failed to setup QNNPACK Relu operator");
+
+    const qnnp_status runStatus =
+        qnnp_run_operator(qnnpack_operator, nullptr /* thread pool */);
+
+    TORCH_INTERNAL_ASSERT(
+        runStatus == qnnp_status_success,
+        "failed to run QNNPACK Relu operator");
+
+    return qy;
+  }
+#else
+  Tensor operator()(Tensor /* input */) {
+    TORCH_CHECK(
+        false,
+        "This PyTorch installation was not built "
+        "with QNNPACK operators");
+  }
+#endif
+};
+
+static auto registry = torch::RegisterOperators().op(
+    "quantized::qnnpack_relu(Tensor input) -> Tensor",
+    torch::RegisterOperators::options().kernel<QNNPACKRelu>(
+        QuantizedCPUTensorId()));
+} // namespace
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef USE_QNNPACK
+#include <qnnpack.h>
+
+struct QnnpackOperatorDeleter {
+  void operator()(qnnp_operator_t op) {
+    qnnp_delete_operator(op);
+  }
+};
+#endif

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -263,6 +263,8 @@ class CMake:
             'USE_DISTRIBUTED': USE_DISTRIBUTED,
             'USE_FBGEMM': not (check_env_flag('NO_FBGEMM') or
                                check_negative_env_flag('USE_FBGEMM')),
+            'USE_QNNPACK': not (check_env_flag('NO_QNNPACK') or
+                                check_negative_env_flag('USE_QNNPACK')),
             'USE_NCCL': USE_NCCL,
             'USE_SYSTEM_NCCL': USE_SYSTEM_NCCL,
             'USE_NUMPY': USE_NUMPY,


### PR DESCRIPTION
Summary:
This is a preliminary change outlining the approach we plan to follow to integrate QNNPACK operators into the pytorch backend. The operators will not be made visibile to the user in the python world, so ultimately we will have a function that calls qnnpack backend based on the environment being run on.

The goal of the project is to integrate QNNPACK library with PyTorch to achieve good performance for quantized mobile models.

Differential Revision: D15806325

