### PR TITLE
support Elastic regularizer and Piece Warmup policy for learning rate warm up

### DIFF
--- a/caffe2/python/layer_model_helper.py
+++ b/caffe2/python/layer_model_helper.py
@@ -365,6 +365,7 @@ class LayerModelHelper(model_helper.ModelHelper):
 
             self.params.append(param.parameter)
             if isinstance(param, layers.LayerParameter):
+                logger.info("Add parameter regularizer {0}".format(param.parameter))
                 self.param_to_reg[param.parameter] = param.regularizer
             elif isinstance(param, ParameterInfo):
                 # TODO:
@@ -613,12 +614,15 @@ class LayerModelHelper(model_helper.ModelHelper):
         train_init_net,
         blob_to_device=None,
     ):
+        logger.info("apply regularizer on loss")
         for param, regularizer in viewitems(self.param_to_reg):
             if regularizer is None:
                 continue
+            logger.info("add regularizer {0} for param {1} to loss".format(regularizer, param))
             assert isinstance(regularizer, Regularizer)
             added_loss_blob = regularizer(train_net, train_init_net, param, grad=None,
                                           by=RegularizationBy.ON_LOSS)
+            logger.info(added_loss_blob)
             if added_loss_blob is not None:
                 self.add_loss(
                     schema.Scalar(blob=added_loss_blob),
@@ -632,6 +636,7 @@ class LayerModelHelper(model_helper.ModelHelper):
         grad_map,
         blob_to_device=None,
     ):
+        logger.info("apply regulizer after optimizer")
         CPU = muji.OnCPU()
         # if given, blob_to_device is a map from blob to device_option
         blob_to_device = blob_to_device or {}
@@ -639,6 +644,7 @@ class LayerModelHelper(model_helper.ModelHelper):
             if regularizer is None:
                 continue
             assert isinstance(regularizer, Regularizer)
+            logger.info("add regularizer {0} for param {1} to optimizer".format(regularizer, param))
             device = get_param_device(
                 param,
                 grad_map.get(str(param)),

--- a/caffe2/python/regularizer.py
+++ b/caffe2/python/regularizer.py
@@ -99,6 +99,24 @@ class L2Norm(Regularizer):
         return output_blob
 
 
+class ElasticNet(Regularizer):
+    def __init__(self, l1, l2):
+        super(ElasticNet, self).__init__()
+        self.l1 = l1
+        self.l2 = l2
+
+    def _run_on_loss(self, net, param_init_net, param, grad=None):
+        output_blob = net.NextScopedBlob(param + "_elastic_net_regularization")
+        l2_blob = net.NextScopedBlob(param + "_l2_blob")
+        l1_blob = net.NextScopedBlob(param + "_l1_blob")
+        net.LpNorm([param], [l2_blob], p=2)
+        net.LpNorm([param], [l1_blob], p=1)
+        net.Scale([l2_blob], [l2_blob], scale=self.l2)
+        net.Scale([l1_blob], [l1_blob], scale=self.l1)
+        net.Add([l1_blob, l2_blob], [output_blob])
+        return output_blob
+
+
 class MaxNorm(Regularizer):
     def __init__(self, norm=1.0):
         super(MaxNorm, self).__init__()

--- a/caffe2/sgd/learning_rate_functors.h
+++ b/caffe2/sgd/learning_rate_functors.h
@@ -161,6 +161,31 @@ class ConstantWarmupLearningRate : public LearningRateFunctor<T> {
   uint64_t num_iter_;
 };
 
+// ConstantWarmup: return scale when iter < num_iter, and 1 otherwise
+template <typename T>
+class PieceWarmupLearningRate : public LearningRateFunctor<T> {
+ public:
+  PieceWarmupLearningRate(
+      const T m1,
+      const int64_t n1,
+      const T m2,
+      const int64_t n2,
+      const T m3)
+      : m1_(m1), m2_(m2), m3_(m3), n1_(n1), n2_(n2){};
+
+  T operator()(const int64_t iter) const override {
+    if (iter < n1_) {
+      return m1_;
+    } else if (iter < n2_) {
+      return m2_;
+    }
+    return m3_;
+  }
+
+  T m1_, m2_, m3_;
+  uint64_t n1_, n2_;
+};
+
 // hill: the learning rate changes according to following 3 stages
 // 1) linear warmup (increasing) at first num_iter steps from start_multiplier
 // 2) inverse shrink (decreasing) afterwards (gamma, power)

--- a/caffe2/sgd/learning_rate_op.cc
+++ b/caffe2/sgd/learning_rate_op.cc
@@ -47,6 +47,11 @@ Optional:
   `multiplier`: defaults to 0.5
   `multiplier_1`: defaults to 1
   `multiplier_2`: defaults to 1
+  `m1`: defaults to 0.5, the first piece lr of piece warmup
+  `n1`: defaults to 0, iter threshold of the first piece lr
+  `m2`: defaults to 0.5, the second piece lr of piece warmup
+  `n2`: defaults to 0, iter threshold of the second piece lr
+  `m3`: defaults to 0.5, the third piece lr of piece warmup
 
 
 Usage:
@@ -88,6 +93,11 @@ Example usage:
     .Arg(
         "sub_policy_num_iters",
         "(int array, default empty) number of iterations for each sub learning rate policy in composite policy")
+    .Arg("m1", "")
+    .Arg("n1", "")
+    .Arg("m2", "")
+    .Arg("n2", "")
+    .Arg("m3", "")
     .Input(0, "input", "description needed")
     .Output(0, "output", "description needed")
     .DeviceInferenceFunction([](const OperatorDef& def) {

--- a/caffe2/sgd/learning_rate_op.h
+++ b/caffe2/sgd/learning_rate_op.h
@@ -134,6 +134,15 @@ class LearningRateOp final : public Operator<Context> {
           this->template GetSingleArgument<int>(arg_prefix + "num_iter", 0);
       DCHECK_GT(multiplier, 0);
       return new ConstantWarmupLearningRate<T>(multiplier, num_iter);
+    } else if (policy == "pieceWarmup") {
+      T m1 = this->template GetSingleArgument<float>(arg_prefix + "m1", 0.5);
+      int64_t n1 =
+          this->template GetSingleArgument<int64_t>(arg_prefix + "n1", 0);
+      T m2 = this->template GetSingleArgument<float>(arg_prefix + "m2", 0.5);
+      int64_t n2 =
+          this->template GetSingleArgument<int64_t>(arg_prefix + "n1", 0);
+      T m3 = this->template GetSingleArgument<float>(arg_prefix + "m3", 0.5);
+      return new PieceWarmupLearningRate<T>(m1, n1, m2, n2, m3);
     } else if (policy == "composite") {
       std::vector<int> sub_policy_num_iters =
           this->template GetRepeatedArgument<int>("sub_policy_num_iters");


### PR DESCRIPTION
Basically, the updates on the files are summarized as below:

- adding logger messages
`caffe2/python/layer_model_helper.py`
- add ElasticNet regularizer, which combines both L1 and L2 regularization
`caffe2/python/regularizer.py`
- implement piecewarmup, specifically warm up with three constant pieces
`caffe2/sgd/learning_rate_functors.h, caffe2/sgd/learning_rate_op.cc, caffe2/sgd/learning_rate_op.h`

Differential Revision: D15923430

fbshipit-source-id: 5dfaf1a9a102aae20767e34eea70f5f186664d40

