### PR TITLE
Prevent VS from emitting errors when using swap in Optional.h

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -516,7 +516,7 @@ class optional : private OptionalBase<T> {
   // 20.5.4.4, Swap
   void swap(optional<T>& rhs) noexcept(
       std::is_nothrow_move_constructible<T>::value&& noexcept(
-          swap(std::declval<T&>(), std::declval<T&>()))) {
+          std::swap(std::declval<T&>(), std::declval<T&>()))) {
     if (initialized() == true && rhs.initialized() == false) {
       rhs.initialize(std::move(**this));
       clear();


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/21706