### PR TITLE
Fixes bugs in torch.multinomial without replacement

### DIFF
--- a/aten/src/ATen/test/cuda_distributions_test.cu
+++ b/aten/src/ATen/test/cuda_distributions_test.cu
@@ -138,8 +138,11 @@ TEST(DistributionsTest, TestPhiloxIncrementSmallMultinomialTensor) {
   at::manual_seed(123);
 
   // get some multinomial samples
+  // this will trigger torch.multinomial without replacement
+  // which increments philox offset by 4*num_samples times.
+  // num_samples in the following call is 4.
   at::empty({10}, at::TensorOptions(at::kCUDA)).multinomial(4);
 
-  // expected uniforms will start from counter offset of 4
-  assert_with_expected_uniforms(4);
+  // expected uniforms will start from counter offset of 4*4
+  assert_with_expected_uniforms(16);
 }

--- a/aten/src/THC/THCTensorRandom.cuh
+++ b/aten/src/THC/THCTensorRandom.cuh
@@ -283,8 +283,10 @@ sampleMultinomialWithReplacement(std::pair<uint64_t, uint64_t> seeds,
   // At the moment, each warp computes one sample value in the binary
   // search due to divergence. It seems possible to compute multiple
   // values and limit divergence though later on.
+  
+  // global index formula for 1D grid of 2D blocks
+  int idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
 
-  int idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.x;
   curandStatePhilox4_32_10_t state;
   curand_init(seeds.first, idx, seeds.second, &state);
 
@@ -330,7 +332,9 @@ sampleMultinomialWithoutReplacement(std::pair<uint64_t, uint64_t> seeds,
   // search due to divergence. It seems possible to compute multiple
   // values and limit divergence though later on.
 
-  int idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.x;
+  // global index formula for 1D grid of 2D blocks
+  int idx = blockIdx.x * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
+
   curandStatePhilox4_32_10_t state;
   curand_init(seeds.first, idx, seeds.second, &state);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22183 Fixes philox_engine_input in torch.multinomial without replacement**

### Summary
Fixes: https://github.com/pytorch/pytorch/issues/22086. For torch.multinomial without replacement, I incremented philox_engine_inputs outside the for loop, whereas it should have been inside. Hence, since the for loop launches multiple kernels, the philox_engine_inputs weren't being updated and the same randoms were being used, which is seen in Issue#22086. In addition, the global thread index inside sampleMultinomialWith* kernels were not correct. They are now correctly following the global index formula for a kernel launch of 1D grid with 2D block.

CC: @LeviViana

Differential Revision: [D15985324](https://our.internmc.facebook.com/intern/diff/D15985324)