### PR TITLE
Disable test_proper_exit flaky worker_kill

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1209,8 +1209,8 @@ class TestDataLoader(TestCase):
                 exit_methods = [None, 'loader_error', 'loader_kill']
 
             for exit_method in exit_methods:
-                if exit_method == 'worker_kill' and hold_iter_reference:
-                    # FIXME: this combination sometimes hangs.
+                if exit_method == 'worker_kill':
+                    # FIXME: This sometimes hangs. See #16608.
                     continue
 
                 desc = []


### PR DESCRIPTION
I learned from https://github.com/pytorch/pytorch/pull/22058 that `worker_kill` is just flaky, regardless of `hold_iter_reference`. So let's disable it altogether for now.