### PR TITLE
ptype propagation on torch functions

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1791,6 +1791,11 @@ class TestNN(NNTestCase):
             self.assertIsInstance(l.weight.data, torch.cuda.FloatTensor)
             self.assertIsInstance(l.bias.data, torch.cuda.FloatTensor)
 
+    def test_ptype_non_propagation(self):
+        p = Parameter(torch.rand((3,), dtype=torch.double, requires_grad=False))
+        self.assertIs((p + 1).__class__, torch.Tensor)
+        self.assertIsNot((p + 1).__class__, Parameter)
+
     def test_non_leaf_parameters(self):
         l1 = nn.Linear(10, 10)
         l2 = nn.Linear(10, 10)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -16,6 +16,7 @@ import gzip
 import types
 import textwrap
 import re
+from collections import OrderedDict
 from torch._utils_internal import get_file_path_2
 from torch.utils.dlpack import from_dlpack, to_dlpack
 from torch._utils import _rebuild_tensor
@@ -96,6 +97,47 @@ class BytesIOContext(io.BytesIO):
 
     def __exit__(self, *args):
         pass
+
+
+def _rebuild_subclass(type_, data, requires_grad, backward_hooks):
+    param = type_(data, requires_grad)
+    # NB: This line exists only for backwards compatibility; the
+    # general expectation is that backward_hooks is an empty
+    # OrderedDict.  See Note [Don't serialize hooks]
+    param._backward_hooks = backward_hooks
+
+    return param
+
+
+class TensorSubclass(torch.Tensor):
+
+    def __new__(cls, data=None, requires_grad=False):
+        if data is None:
+            data = torch.Tensor()
+        self = torch.Tensor._make_subclass(cls, data, requires_grad)
+        return self
+
+    def __deepcopy__(self, memo):
+        if id(self) in memo:
+            return memo[id(self)]
+        else:
+            result = type(self)(self.data.clone(), self.requires_grad)
+            memo[id(self)] = result
+            return result
+
+    def __reduce_ex__(self, proto):
+        # See Note [Don't serialize hooks]
+        return _rebuild_subclass, (self.__class__, self.data, self.requires_grad, OrderedDict())
+
+
+class A(TensorSubclass):
+    pass
+
+class B(TensorSubclass):
+    pass
+
+class C(A, B):
+    pass
 
 
 # This is intentionally prefixed by an underscore. Otherwise pytest will try to
@@ -2856,6 +2898,66 @@ class _TestTorchMixin(object):
         do_test_dtypes(self, all_dtypes, torch.strided, torch.device('cpu'))
         if torch.cuda.is_available():
             do_test_dtypes(self, all_dtypes, torch.strided, torch.device('cuda:0'))
+
+    def test_ptype_propagation(self):
+        a = A(torch.rand((3,), dtype=torch.double, requires_grad=False))
+        b = B(torch.rand((3,), dtype=torch.double, requires_grad=False))
+        c = C(torch.rand((3,), dtype=torch.double, requires_grad=False))
+
+        out_a = A(torch.rand((3,), dtype=torch.double, requires_grad=False))
+        out_b = B(torch.rand((3,), dtype=torch.double, requires_grad=False))
+        out_c = C(torch.rand((3,), dtype=torch.double, requires_grad=False))
+
+        # test subclass serialization
+        filename = "saved_state.p"
+        with open(filename, "wb") as file_id:
+            pickle.dump(c, file_id)
+        with open(filename, "rb") as file_id:
+            c = pickle.load(file_id)
+        os.remove(filename)
+        self.assertIsInstance(c, C)
+
+        # test deep copy
+        c_copy = copy.deepcopy(c)
+        self.assertEqual(c_copy, c)
+        self.assertNotEqual(id(c_copy), id(c))
+
+        # test boolean return
+        self.assertIsInstance(np.equal(a, c), torch.Tensor)
+        self.assertIs(np.equal(a, c).dtype, torch.uint8)
+        self.assertIsInstance(torch.equal(a, c), bool)
+
+        # test indexing
+        d = C(torch.rand((3, 3, 3,), dtype=torch.double, requires_grad=False))
+        self.assertIsInstance(c[None], C)
+        self.assertIsInstance(c[...], C)
+        self.assertIsInstance(c[0], C)
+        self.assertIsInstance(c[slice(0, 1, 1)], C)
+        self.assertIsInstance(d[None, ..., 0, slice(0, 1, 1)], C)  # multi-index
+
+        # test ptype propagation with numpy ufuncs
+        if False:  # TEST_NUMPY
+            np_func = np.add
+            self.assertIsInstance(np_func(a, 1), A)
+            self.assertIsInstance(np_func(1, a), A)
+            self.assertIsInstance(np_func(a, b), A)
+            self.assertIsInstance(np_func(b, a), B)
+            self.assertIsInstance(np_func(c, a), C)
+            self.assertIsInstance(np_func(a, c), C)
+            self.assertIsInstance(np_func(a, 1, out=out_a), A)
+            self.assertIsInstance(np_func(1, a, out=out_a), A)
+            self.assertIsInstance(np_func(a, b, out=out_a), A)
+            self.assertIsInstance(np_func(b, a, out=out_b), B)
+            self.assertIsInstance(np_func(c, a, out=out_c), C)
+            self.assertIsInstance(np_func(a, c, out=out_c), C)
+
+        # test ptype propatation with tensor functions
+        th_func = torch.add
+        self.assertIsInstance(th_func(a, 1), A)
+        self.assertIsInstance(th_func(a, b), A)
+        self.assertIsInstance(th_func(b, a), B)
+        self.assertIsInstance(th_func(c, a), C)
+        self.assertIsInstance(th_func(a, c), C)
 
     def test_copy_dtypes(self):
         all_dtypes = torch.testing.get_all_dtypes()

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -55,6 +55,7 @@ static PyObject * ${pycname}(PyObject* self_, PyObject* args, PyObject* kwargs)
   ${unpack_self}
   ParsedArgs<${max_args}> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
+  ${declare_dynamic_return_type}
   ${declare_namedtuple_return_types}
   ${dispatch}
   Py_RETURN_NONE;
@@ -66,9 +67,10 @@ PY_VARIABLE_METHOD_NOARGS = CodeTemplate("""\
 static PyObject * ${pycname}(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
+  ${declare_dynamic_return_type}
   ${declare_namedtuple_return_types}
   ${unpack_self}
-  return wrap(${namedtuple_return_type}${dispatch_name}(${actuals}));
+  return wrap(${dynamic_return_type}${dispatch_name}(${actuals}));
   END_HANDLE_TH_ERRORS
 }
 """)
@@ -104,7 +106,7 @@ PY_VARIABLE_SET_REQUIRES_GRAD = CodeTemplate("""\
 ${call_dispatch}.set_requires_grad(${requires_grad})""")
 
 PY_VARIABLE_WRAP = CodeTemplate("""\
-return wrap(${namedtuple_return_type}${call_dispatch});""")
+return wrap(${dynamic_return_type}${call_dispatch});""")
 
 PY_VARIABLE_DISPATCH = CodeTemplate("""\
 inline ${simple_return_type} ${dispatch_name}(${formal_args}) {
@@ -116,6 +118,10 @@ inline ${simple_return_type} ${dispatch_name}(${formal_args}) {
 
 PY_VARIABLE_METHOD_DEF = CodeTemplate("""\
 {"${name}", (PyCFunction)${pycname}, ${flags}, NULL},""")
+
+PY_RETURN_DYNAMIC_DEF = CodeTemplate("""\
+auto *ptype = THPVariable_result_ptype(self_, args);
+""")
 
 PY_RETURN_NAMEDTUPLE_DEF = CodeTemplate("""\
 static PyStructSequence_Field fields${namedtuple_type_index}[] = {
@@ -653,7 +659,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
     def emit_namedtuple_return_type_def(declaration, next_index):
         returns = declaration['returns']
         if len(returns) <= 1 or all(['field_name' not in x for x in returns]):
-            declaration['namedtuple_return_type'] = ''
+            declaration['dynamic_return_type'] = ''
             return '', next_index
         declaration['namedtuple_type_index'] = next_index
         declaration['namedtuple_fields'] = ''
@@ -673,7 +679,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             else:
                 declaration['namedtuple_fields'] += '{"' + x['field_name'] + '", ""}, '
         declaration['namedtuple_size'] = len(returns)
-        declaration['namedtuple_return_type'] = '&type{}, '.format(next_index)
+        declaration['dynamic_return_type'] = '&type{}, '.format(next_index)
         return PY_RETURN_NAMEDTUPLE_DEF.substitute(declaration), next_index + 1
 
     def process_function(name, declarations):
@@ -688,6 +694,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             'max_args': max(len(o['arguments']) + len(o['python_binding_arguments']) for o in declarations),
             'unpack_self': [],
             'dispatch': [],
+            'declare_dynamic_return_type': '',
             'declare_namedtuple_return_types': '',
         }
 
@@ -696,9 +703,18 @@ def create_python_bindings(python_functions, has_self, is_module=False):
 
         # generate namedtuple type declare
         next_index = 0
+        ptype_declared = False
         for declaration in declarations:
-            typedef, next_index = emit_namedtuple_return_type_def(declaration, next_index)
-            env['declare_namedtuple_return_types'] += typedef
+            returns = declaration['returns']
+            if len(returns) <= 1 and returns[0]['dynamic_type'] == 'Tensor':
+                declaration['dynamic_return_type'] = 'ptype, '
+                if ptype_declared is False:
+                    env['declare_dynamic_return_type'] += PY_RETURN_DYNAMIC_DEF.substitute(declaration)
+                next_index += 1
+                ptype_declared = True
+            else:
+                typedef, next_index = emit_namedtuple_return_type_def(declaration, next_index)
+                env['declare_namedtuple_return_types'] += typedef
 
         # emit dispatch
         grouped = group_declarations(declarations)
@@ -723,7 +739,7 @@ def create_python_bindings(python_functions, has_self, is_module=False):
             tmpl = PY_VARIABLE_METHOD_NOARGS
             env['actuals'] = ['self']
             env['flags'] = 'METH_NOARGS'
-            env['namedtuple_return_type'] = declarations[0]['namedtuple_return_type']
+            env['dynamic_return_type'] = declarations[0]['dynamic_return_type']
         else:
             tmpl = PY_VARIABLE_METHOD_VARARGS
             env['flags'] = 'METH_VARARGS | METH_KEYWORDS'

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -22,6 +22,8 @@ THP_API PyObject *THPVariableClass;
 
 bool THPVariable_initModule(PyObject *module);
 THP_API PyObject * THPVariable_Wrap(torch::autograd::Variable var);
+THP_API PyObject * THPVariable_Wrap_Subclass(torch::autograd::Variable var, PyTypeObject *type);
+PyTypeObject* THPVariable_result_ptype(PyObject *self, PyObject *args);
 
 inline bool THPVariable_Check(PyObject *obj)
 {

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -56,6 +56,10 @@ inline PyObject* wrap(at::Tensor tensor) {
   return THPVariable_Wrap(Variable(std::move(tensor)));
 }
 
+inline PyObject* wrap(PyTypeObject *type, at::Tensor tensor) {
+  return THPVariable_Wrap_Subclass(Variable(std::move(tensor)), type);
+}
+
 inline PyObject* wrap(at::Scalar scalar) {
   return wrap(make_variable(scalar_to_tensor(scalar)));
 }

--- a/torch/csrc/utils/numpy_stub.h
+++ b/torch/csrc/utils/numpy_stub.h
@@ -17,5 +17,6 @@
 #endif
 
 #include <numpy/arrayobject.h>
+#include <numpy/ufuncobject.h>
 
 #endif // USE_NUMPY

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -349,12 +349,14 @@ class Tensor(torch._C._TensorBase):
     def resize(self, *sizes):
         warnings.warn("non-inplace resize is deprecated")
         from torch.autograd._functions import Resize
-        return Resize.apply(self, sizes)
+        new_tensor = Resize.apply(self, sizes)
+        return torch.Tensor._make_subclass(self.__class__, new_tensor.data, new_tensor.requires_grad)
 
     def resize_as(self, tensor):
         warnings.warn("non-inplace resize_as is deprecated")
         from torch.autograd._functions import Resize
-        return Resize.apply(self, tensor.size())
+        new_tensor = Resize.apply(self, tensor.size())
+        return torch.Tensor._make_subclass(self.__class__, new_tensor.data, new_tensor.requires_grad)
 
     def split(self, split_size, dim=0):
         r"""See :func:`torch.split`


### PR DESCRIPTION
Resolves issue #17249

Added support for python subclass (ptype) propagation when calling torch functions on Tensors (Parameters are unaffected).

I have addressed and responded to the comments on the previous PR. [#18610](https://github.com/pytorch/pytorch/pull/18610). Please visit this link to see that issues that were resolved. As suggested the changes have been broken in to two PR:

1. **ptype propagation on torch functions.**
2. ptype propagation on numpy #22247

I have also fixed a bug and added tests for ptype propagation during tensor indexing operations.

A simple python script demonstrating ptype propagation is as follows:

```python
import sys
import pickle
import copy
import unittest
from collections import OrderedDict

import numpy as np
from numpy.testing import *

import torch
import torch.multiprocessing as mp


def _rebuild_subclass(type_, data, requires_grad, backward_hooks):
    param = type_(data, requires_grad)
    # NB: This line exists only for backwards compatibility; the
    # general expectation is that backward_hooks is an empty
    # OrderedDict.  See Note [Don't serialize hooks]
    param._backward_hooks = backward_hooks

    return param


class TensorSubclass(torch.Tensor):

    def __new__(cls, data=None, requires_grad=False):
        if data is None:
            data = torch.Tensor()
        self = torch.Tensor._make_subclass(cls, data, requires_grad)
        return self

    def __deepcopy__(self, memo):
        if id(self) in memo:
            return memo[id(self)]
        else:
            result = type(self)(self.data.clone(), self.requires_grad)
            memo[id(self)] = result
            return result

    def __reduce_ex__(self, proto):
        # See Note [Don't serialize hooks]
        return _rebuild_subclass, (self.__class__, self.data, self.requires_grad, OrderedDict())


class A(TensorSubclass):
    pass


class B(TensorSubclass):
    pass


class C(A, B):
    pass


if __name__ == '__main__':
    a_tensor = torch.tensor([1.0, 2.0, 3.0], dtype=torch.double, requires_grad=True)
    b_tensor = torch.tensor([4.0, 5.0, 6.0], dtype=torch.double, requires_grad=True)
    c_tensor = torch.tensor([7.0, 8.0, 9.0], dtype=torch.double, requires_grad=True)
    d_tensor = torch.ones((4, 3, 2), dtype=torch.double, requires_grad=True)
    a = A(a_tensor, requires_grad=True)
    b = B(b_tensor, requires_grad=True)
    c = C(c_tensor, requires_grad=True)
    d = C(d_tensor, requires_grad=True)
    
    print("Subclass")
    print(type(a))
    print(a.requires_grad)
    print(type(b))
    print(b.requires_grad)
    print(type(c))
    print(c.requires_grad)

    print("Torch ptype propagation")
    print(type(a + b))
    print((a + b).requires_grad)
    print(type(a + c))
    print((a + c).requires_grad)

    print("Indexing [None, elipsis, integer, slice")
    print(type(c[None]))
    print(type(c[...]))
    print(type(c[0]))
    print(type(c[slice(0, 1, 1)]))
    print(type(d[None, ..., 0, slice(0, 1, 1)]))

    print("bool")
    print(a == c)
```
