### PR TITLE
Update the way boolean tensor are being printed

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10481,6 +10481,15 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         self.assertEqual(x.__repr__(), str(x))
         self.assertExpectedInline(str(x), '''tensor(2.0000e-05)''')
 
+        # test print boolean tensor
+        x = torch.tensor([True])
+        self.assertEqual(x.__repr__(), str(x))
+        self.assertExpectedInline(str(x), '''tensor([True])''')
+
+        x = torch.tensor(True)
+        self.assertEqual(x.__repr__(), str(x))
+        self.assertExpectedInline(str(x), '''tensor(True)''')
+
         # [Numpy] test print float in sci_mode when min < 0.0001.
         x = torch.tensor([0.00002])
         self.assertEqual(x.__repr__(), str(x))

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -248,7 +248,7 @@ def _str(self):
         if self.device.type == 'cpu' or torch.cuda.current_device() != self.device.index:
             suffixes.append('device=\'' + str(self.device) + '\'')
 
-    has_default_dtype = self.dtype == torch.get_default_dtype() or self.dtype == torch.int64 or self.dtype == torch.bool
+    has_default_dtype = self.dtype in (torch.get_default_dtype(), torch.int64, torch.bool)
     if self.is_sparse:
         suffixes.append('size=' + str(tuple(self.shape)))
         suffixes.append('nnz=' + str(self._nnz()))

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -248,8 +248,7 @@ def _str(self):
         if self.device.type == 'cpu' or torch.cuda.current_device() != self.device.index:
             suffixes.append('device=\'' + str(self.device) + '\'')
 
-    has_default_dtype = self.dtype == torch.get_default_dtype() or self.dtype == torch.int64
-
+    has_default_dtype = self.dtype == torch.get_default_dtype() or self.dtype == torch.int64 or self.dtype == torch.bool
     if self.is_sparse:
         suffixes.append('size=' + str(tuple(self.shape)))
         suffixes.append('nnz=' + str(self._nnz()))
@@ -290,6 +289,7 @@ def _str(self):
         else:
             if not has_default_dtype:
                 suffixes.append('dtype=' + str(self.dtype))
+
             if self.layout != torch.strided:
                 tensor_str = _tensor_str(self.to_dense(), indent)
             else:


### PR DESCRIPTION
In case when the boolean tensor gets printed out, no need to specify the dtype. 

Example:
```
>> x = torch.tensor([[True, True, True], [True, True, True]])
>> print(x)
tensor([[True, True, True],
        [True, True, True]])

>> x = torch.tensor([True])
>> print(x)
tensor([True])

>> x = torch.tensor(True)
>> print(x)
tensor(True)
```