### PR TITLE
Rename copy_tensor_data to copy_tensor_metadata

### DIFF
--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -122,7 +122,7 @@ private:
   OpaqueHandle opaque_handle_;
 
   /**
-   * Copy the storage pointer and the tensor metadata fields (e.g. sizes / strides / storage_offset)
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
    * from one TensorImpl to another TensorImpl.
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -88,7 +88,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<OpaqueTensorImpl<OpaqueHandle>>(
       type_id(), dtype(), device(), opaque_handle_, sizes_);
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),
       /*version_counter=*/version_counter,
@@ -106,7 +106,7 @@ struct CAFFE2_API OpaqueTensorImpl : public TensorImpl {
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
     AT_ASSERT(typeid(*(impl.get())) == typeid(OpaqueTensorImpl<OpaqueHandle>));
     auto opaque_impl = static_cast<const OpaqueTensorImpl<OpaqueHandle>*>(impl.get());
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/opaque_impl,
       /*dest_impl=*/this,
       /*version_counter=*/version_counter(),
@@ -127,12 +127,12 @@ private:
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
    */
-  static void copy_tensor_data(
+  static void copy_tensor_metadata(
       const OpaqueTensorImpl<OpaqueHandle>* src_opaque_impl,
       OpaqueTensorImpl<OpaqueHandle>* dest_opaque_impl,
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) {
-    TensorImpl::copy_tensor_data(src_opaque_impl, dest_opaque_impl, version_counter, allow_tensor_metadata_change);
+    TensorImpl::copy_tensor_metadata(src_opaque_impl, dest_opaque_impl, version_counter, allow_tensor_metadata_change);
 
     // OpaqueTensorImpl-specific fields.
     dest_opaque_impl->opaque_handle_ = src_opaque_impl->opaque_handle_;

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -222,7 +222,7 @@ private:
     explicit SparseTensorImpl(at::TensorTypeId, const caffe2::TypeMeta&, at::Tensor indices, at::Tensor values);
 
   /**
-   * Copy the storage pointer and the tensor metadata fields (e.g. sizes / strides / storage_offset)
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
    * from one TensorImpl to another TensorImpl.
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -193,7 +193,7 @@ public:
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(type_id(), dtype());
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),
       /*version_counter=*/version_counter,
@@ -211,7 +211,7 @@ public:
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
     AT_ASSERT(typeid(*(impl.get())) == typeid(SparseTensorImpl));
     auto sparse_impl = static_cast<const SparseTensorImpl*>(impl.get());
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/sparse_impl,
       /*dest_impl=*/this,
       /*version_counter=*/version_counter(),
@@ -227,12 +227,12 @@ private:
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
    */
-  static void copy_tensor_data(
+  static void copy_tensor_metadata(
       const SparseTensorImpl* src_sparse_impl,
       SparseTensorImpl* dest_sparse_impl,
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) {
-    TensorImpl::copy_tensor_data(src_sparse_impl, dest_sparse_impl, version_counter, allow_tensor_metadata_change);
+    TensorImpl::copy_tensor_metadata(src_sparse_impl, dest_sparse_impl, version_counter, allow_tensor_metadata_change);
 
     // Sparse-specific fields
     dest_sparse_impl->sparse_dim_ = src_sparse_impl->sparse_dim();

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -40,7 +40,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<QTensorImpl>(
         Storage(storage()), type_id(), quantizer_);
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),
       /*version_counter=*/version_counter,
@@ -59,7 +59,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
     AT_ASSERT(typeid(*(impl.get())) == typeid(QTensorImpl));
     auto q_impl = static_cast<const QTensorImpl*>(impl.get());
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/q_impl,
       /*dest_impl=*/this,
       /*version_counter=*/version_counter(),
@@ -77,12 +77,12 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
    */
-  static void copy_tensor_data(
+  static void copy_tensor_metadata(
       const QTensorImpl* src_q_impl,
       QTensorImpl* dest_q_impl,
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) {
-    TensorImpl::copy_tensor_data(src_q_impl, dest_q_impl, version_counter, allow_tensor_metadata_change);
+    TensorImpl::copy_tensor_metadata(src_q_impl, dest_q_impl, version_counter, allow_tensor_metadata_change);
 
     // OpaqueTensorImpl-specific fields.
     dest_q_impl->quantizer_ = src_q_impl->quantizer_;

--- a/aten/src/ATen/quantized/QTensorImpl.h
+++ b/aten/src/ATen/quantized/QTensorImpl.h
@@ -72,7 +72,7 @@ struct CAFFE2_API QTensorImpl : public c10::TensorImpl {
   QuantizerPtr quantizer_;
 
   /**
-   * Copy the storage pointer and the tensor metadata fields (e.g. sizes / strides / storage_offset)
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
    * from one TensorImpl to another TensorImpl.
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -878,16 +878,17 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   // NOTE [ TensorImpl Shallow-Copying ]
   //
-  // TensorImpl shallow-copying is used when we want to have two Variables share the same storage pointer
-  // and tensor metadata, but each with a different autograd history. Example call sites:
+  // TensorImpl shallow-copying is used when we want to have two Variables share the same tensor metadata
+  // (e.g. sizes / strides / storage pointer / storage_offset), but each with a different autograd history.
+  // Example call sites:
   //
   // 1. `var_detached = var.detach()` uses `shallow_copy_and_detach()` to create `var_detached` that shares
-  // the same storage pointer and tensor metadata with `var`, but with a completely new autograd history.
-  // 2. `var.set_data(tensor)` uses `shallow_copy_from()` to copy storage pointer and tensor metadata from
+  // the same tensor metadata with `var`, but with a completely new autograd history.
+  // 2. `var.set_data(tensor)` uses `shallow_copy_from()` to copy tensor metadata from
   // `tensor` into `var`, while keeping `var`'s original AutogradMeta.
   //
   // Functions that shallow-copy a TensorImpl (such as `shallow_copy_and_detach()` / `shallow_copy_from()` /
-  // `copy_tensor_metadata()`) copy the storage pointer and the tensor metadata fields (e.g. sizes / strides /
+  // `copy_tensor_metadata()`) copy the tensor metadata fields (e.g. sizes / strides / storage pointer /
   // storage_offset) by value. However, the following fields are not copied:
   //
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
@@ -1457,7 +1458,7 @@ protected:
   }
 
   /**
-   * Copy the storage pointer and the tensor metadata fields (e.g. sizes / strides / storage_offset)
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
    * from one TensorImpl to another TensorImpl.
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -887,15 +887,15 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // `tensor` into `var`, while keeping `var`'s original AutogradMeta.
   //
   // Functions that shallow-copy a TensorImpl (such as `shallow_copy_and_detach()` / `shallow_copy_from()` /
-  // `copy_tensor_data()`) copy the storage pointer and the tensor metadata fields (e.g. sizes / strides /
+  // `copy_tensor_metadata()`) copy the storage pointer and the tensor metadata fields (e.g. sizes / strides /
   // storage_offset) by value. However, the following fields are not copied:
   //
   // 1. the AutogradMeta pointer, because it is unique for each Variable.
   // 2. the version counter, because the destination TensorImpl's version counter is either set to the
-  // passed-in `version_counter` (in `shallow_copy_and_detach()` and `copy_tensor_data()`), or it is kept
+  // passed-in `version_counter` (in `shallow_copy_and_detach()` and `copy_tensor_metadata()`), or it is kept
   // intact (in `shallow_copy_from()`). See NOTE [ Version Counter Sharing ] for details.
   //
-  // In `shallow_copy_and_detach()` and `copy_tensor_data()`, the passed-in `allow_tensor_metadata_change`
+  // In `shallow_copy_and_detach()` and `copy_tensor_metadata()`, the passed-in `allow_tensor_metadata_change`
   // determines whether the TensorImpl shallow-copy allows changes to its metadata (e.g. sizes / strides /
   // storage / storage_offset). See NOTE [ Metadata Change for a Detached Tensor ] for details.
   //
@@ -913,7 +913,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const {
     auto impl = c10::make_intrusive<TensorImpl>(Storage(storage()), type_id());
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/this,
       /*dest_impl=*/impl.get(),
       /*version_counter=*/version_counter,
@@ -930,7 +930,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * see NOTE [ TensorImpl Shallow-Copying ].
    */
   virtual void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) {
-    copy_tensor_data(
+    copy_tensor_metadata(
       /*src_impl=*/impl.get(),
       /*dest_impl=*/this,
       /*version_counter=*/version_counter(),
@@ -1462,7 +1462,7 @@ protected:
    *
    * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
    */
-  static void copy_tensor_data(
+  static void copy_tensor_metadata(
       const TensorImpl* src_impl,
       TensorImpl* dest_impl,
       const c10::VariableVersion& version_counter,
@@ -1553,7 +1553,7 @@ protected:
   // tensor to also be updated.
   //
   // NOTE: For a full list of tensor metadata fields, please see
-  // `shallow_copy_and_detach()` in TensorImpl and its subclasses to find
+  // `copy_tensor_metadata()` in TensorImpl and its subclasses to find
   // which fields are copied by value.
   bool allow_tensor_metadata_change_ = true;
 


### PR DESCRIPTION
The original name `copy_tensor_data` could be confusing because users are not sure whether it deep-copies data in the tensor's storage or just copies the tensor's metadata. The renaming makes it more clear.

cc. @ailzhang This might break XLA build, but I think the renaming makes it more clear why we use `copy_tensor_data` in XLATensorImpl's shallow-copy functions.