### PR TITLE
[jit] Resolve with closed over variables instead of stack frame

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12865,6 +12865,9 @@ a")
         self.assertEqual(m.int64_max, imported.int64_max)
         self.assertEqual(m.int64_min, imported.int64_min)
 
+    def test_script_scope(self):
+        scripted = torch.jit.script(torch.nn.functional.pad)
+
     @unittest.skipIf(IS_WINDOWS, "NYI: TemporaryFileName on Windows")
     def test_serialization_sharing(self):
         class M(torch.jit.ScriptModule):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1086,8 +1086,6 @@ def _compile_and_register_class(obj, rcb, qualified_name):
 def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if not _enabled:
         return obj
-    if _rcb is None:
-        _rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
 
     if isinstance(obj, torch.nn.Module):
         return _convert_to_script_module(obj)
@@ -1096,10 +1094,23 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if inspect.isclass(obj):
         if not _is_new_style_class(obj):
             raise RuntimeError("TorchScript classes must be new-style classes. Please inherit from 'object'")
+        if _rcb is None:
+            _rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
         ast = get_jit_def(obj)
+        if _rcb is None:
+            closure_rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
+            stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
+            def _rcb(name):
+                # since type comments aren't captured in the function's closures,
+                # we still need to try to the rcb based on stack frames if the
+                # closure rcb fails
+                result = closure_rcb(name)
+                if result:
+                    return result
+                return stack_rcb(name)
         fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
         # Forward docstrings
         fn.__doc__ = obj.__doc__

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1103,6 +1103,7 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
         if _rcb is None:
             closure_rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
             stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
+
             def _rcb(name):
                 # since type comments aren't captured in the function's closures,
                 # we still need to try to the rcb based on stack frames if the


### PR DESCRIPTION
Previously we looked at the stack frame of the function that called
`script` to resolve variables. This doesn't work if someone calls script
with a function defined somewhere else that references captured
variables. We already have a mechanism to look at the closed over
variables for a function, so this changes the `rcb` to use that.


Differential Revision: [D16391346](https://our.internmc.facebook.com/intern/diff/16391346/)