### PR TITLE
Create C2 operator to replace values in embedding table

### DIFF
--- a/caffe2/operators/copy_rows_to_tensor_op.cc
+++ b/caffe2/operators/copy_rows_to_tensor_op.cc
@@ -1,0 +1,34 @@
+#include "copy_rows_to_tensor_op.h"
+
+namespace caffe2 {
+namespace {
+REGISTER_CPU_OPERATOR(CopyRowsToTensor, CopyRowsToTensorOp<CPUContext>);
+
+OPERATOR_SCHEMA(CopyRowsToTensor)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .EnforceInplace({{0, 0}})
+    .SetDoc(R"DOC(
+      This operator takes in a 2d tensor, a list of indices, and a 1d tensor
+      with the same width of the 2d tensor. It will replace the rows in 2d
+      tensor specified in indices with the 2d tensor. The operator does an
+      in-place change to the input tensor.
+      Example:
+        INPUT_TENSOR = [[1, 2], [3, 4], [5, 6]]
+        INDICES = [1]
+        ROW = [9, 0]
+        OUTPUT_TENSOR = [[1, 2], [9, 0], [5, 6]]
+      )DOC")
+    .Input(0, "input_tensor", "Input tensor needs to be modified.")
+    .Input(1, "indices", "Indices of rows need to be copied")
+    .Input(2, "row", "1-d tensor that is going to replace the rows")
+    .Output(0, "output_tensor", "updated tensor")
+    .TensorInferenceFunction([](const OperatorDef& /*def*/,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out(1);
+      out[0] = in[0];
+      return out;
+    });
+
+} // namespace
+} // namespace caffe2

--- a/caffe2/operators/copy_rows_to_tensor_op.h
+++ b/caffe2/operators/copy_rows_to_tensor_op.h
@@ -1,0 +1,56 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
+
+namespace caffe2 {
+template <class Context>
+class CopyRowsToTensorOp : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  CopyRowsToTensorOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws) {}
+
+  bool RunOnDevice() override {
+    return DispatchHelper<
+        TensorTypes<at::Half, float, double, int32_t, int64_t>>::
+        call(this, Input(INPUT_TENSOR));
+  }
+
+  template <typename T>
+  bool DoRunWithType() {
+    auto& input_tensor = Input(INPUT_TENSOR);
+    auto& indices = Input(INDICES);
+    auto& row = Input(ROW);
+    auto tensor_width = input_tensor.size(1);
+    CAFFE_ENFORCE_EQ(input_tensor.dim(), 2, "INPUT_TENSOR should be 2-d");
+    CAFFE_ENFORCE_EQ(indices.dim(), 1, "INDICES should be 1-d");
+    CAFFE_ENFORCE_EQ(row.dim(), 1, "ROW should be 1-d");
+    CAFFE_ENFORCE_EQ(
+        tensor_width,
+        row.size(0),
+        "width of input tensor should match lengths of row");
+    const auto* indices_data = indices.template data<int64_t>();
+    const auto* row_data = row.template data<T>();
+    auto* output = Output(0);
+    auto* output_data = output->template mutable_data<T>();
+    CAFFE_ENFORCE(
+        IsInputOutputAlias(0, 0), "Input 0 and Output 0 should be alias.");
+    for (size_t i = 0; i < indices.sizes()[0]; ++i) {
+      std::memcpy(
+          output_data + indices_data[i] * tensor_width,
+          row_data,
+          tensor_width * sizeof(T));
+    }
+    return true;
+  }
+
+ protected:
+  INPUT_TAGS(INPUT_TENSOR, INDICES, ROW);
+};
+} // namespace caffe2

--- a/caffe2/python/layers/layers.py
+++ b/caffe2/python/layers/layers.py
@@ -1,35 +1,77 @@
 ## @package layers
 # Module caffe2.python.layers.layers
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+from collections import namedtuple
 
+import numpy as np
+from caffe2.proto import caffe2_pb2
 from caffe2.python import core, schema, scope, utils, workspace
 from caffe2.python.layers.tags import TagContext
-from caffe2.proto import caffe2_pb2
 
-from collections import namedtuple
-import numpy as np
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Some types to simplify descriptions of things traveling between ops
 IdList = schema.List(np.int64)
 IdScoreList = schema.Map(np.int64, np.float32)
+IdListWithEvicted = schema.ListWithEvicted(np.int64)
+IdScoreListWithEvicted = schema.MapWithEvicted(np.int64, np.float32)
+
+
+def almost_equal_schemas(
+    record,
+    original_schema,
+    check_field_names=True,
+    check_field_types=True,
+    check_field_metas=False,
+):
+    if original_schema == IdList:
+        return schema.equal_schemas(
+            record,
+            IdList,
+            check_field_names=check_field_names,
+            check_field_types=check_field_types,
+            check_field_metas=check_field_metas,
+        ) or schema.equal_schemas(
+            record,
+            IdListWithEvicted,
+            check_field_names=check_field_names,
+            check_field_types=check_field_types,
+            check_field_metas=check_field_metas,
+        )
+    elif original_schema == IdScoreList:
+        return schema.equal_schemas(
+            record,
+            IdScoreList,
+            check_field_names=check_field_names,
+            check_field_types=check_field_types,
+            check_field_metas=check_field_metas,
+        ) or schema.equal_schemas(
+            record,
+            IdScoreListWithEvicted,
+            check_field_names=check_field_names,
+            check_field_types=check_field_types,
+            check_field_metas=check_field_metas,
+        )
+    else:
+        return schema.equal_schemas(record, original_schema)
 
 
 def get_key(record):
-    if schema.equal_schemas(record, IdList):
-        key = 'values'
-    elif schema.equal_schemas(record, IdScoreList, check_field_types=False):
-        key = 'values:keys'
+    if almost_equal_schemas(record, IdList):
+        key = "values"
+    elif almost_equal_schemas(
+        record, IdScoreList, check_field_types=False
+    ):
+        key = "values:keys"
     else:
-        raise NotImplementedError('Not implemented for {}'.format(record))
-    assert record[key].metadata is not None, (
-        "Blob {} doesn't have metadata".format(str(record[key]())))
+        raise NotImplementedError("Not implemented for {}".format(record))
+    assert record[key].metadata is not None, "Blob {} doesn't have metadata".format(
+        str(record[key]())
+    )
     return record[key]
 
 
@@ -39,22 +81,18 @@ def get_categorical_limit(record):
 
 
 def get_avg_length(record):
-    return record['lengths'].metadata.expected_value
+    return record["lengths"].metadata.expected_value
 
 
 def set_request_only(field):
     for f in field.all_scalars():
         categorical_limit, expected_value = None, None
         if not f.metadata:
-            feature_specs = schema.FeatureSpec(
-                feature_is_request_only=True,
-            )
+            feature_specs = schema.FeatureSpec(feature_is_request_only=True)
         elif not f.metadata.feature_specs:
             categorical_limit = f.metadata.categorical_limit
             expected_value = f.metadata.expected_value
-            feature_specs = schema.FeatureSpec(
-                feature_is_request_only=True,
-            )
+            feature_specs = schema.FeatureSpec(feature_is_request_only=True)
         else:
             categorical_limit = f.metadata.categorical_limit
             expected_value = f.metadata.expected_value
@@ -68,8 +106,9 @@ def set_request_only(field):
 
         # make sure not to set categorical_limit for a non-integer field
         if not np.issubdtype(f.field_type(), np.integer):
-            assert categorical_limit is None, \
-                "categorical_limit shouldn't be set for no-integer field"
+            assert (
+                categorical_limit is None
+            ), "categorical_limit shouldn't be set for no-integer field"
 
         f.set_metadata(
             schema.Metadata(
@@ -84,14 +123,15 @@ class InstantiationContext(object):
     """
     List of contexts where layer could be instantitated
     """
+
     # The layers support this context will accumulate predictions, labels,
     # weights. The accumulated data can later be used to compute
     # calibration or for other
     # purpose.
-    ACCUMULATE_PRED = 'accumulate_pred'
-    EVAL = 'eval'
-    PREDICTION = 'prediction'
-    TRAINING = 'training'
+    ACCUMULATE_PRED = "accumulate_pred"
+    EVAL = "eval"
+    PREDICTION = "prediction"
+    TRAINING = "training"
 
 
 _LAYER_REGISTRY = {}
@@ -114,15 +154,21 @@ def create_layer(layer_name, *args, **kwargs):
     return _LAYER_REGISTRY[layer_name](*args, **kwargs)
 
 
-LayerPsParam = namedtuple('LayerPsParam', ['sparse_key', 'average_length'])
+LayerPsParam = namedtuple("LayerPsParam", ["sparse_key", "average_length"])
 
 
 class LayerParameter(object):
-
-    def __init__(self, parameter=None, optimizer=None, initializer=None,
-                 ps_param=None, regularizer=None):
-        assert isinstance(parameter, core.BlobReference), \
-            "expect {0} to be a blob reference".format(str(parameter))
+    def __init__(
+        self,
+        parameter=None,
+        optimizer=None,
+        initializer=None,
+        ps_param=None,
+        regularizer=None,
+    ):
+        assert isinstance(
+            parameter, core.BlobReference
+        ), "expect {0} to be a blob reference".format(str(parameter))
         # need to put the following line (shape) before initialier
         # shape will be updated once initializer is (re)set
         self._shape = None
@@ -138,8 +184,9 @@ class LayerParameter(object):
 
     @initializer.setter
     def initializer(self, op):
-        assert op is None or core.IsOperator(getattr(op, 'type', None)), \
-            "initializer expects an operator, got type: {}".format(type(op))
+        assert op is None or core.IsOperator(
+            getattr(op, "type", None)
+        ), "initializer expects an operator, got type: {}".format(type(op))
         self._initializer = op
         if op is not None:
             self.shape = self._infer_shape_from_initializer()
@@ -150,14 +197,15 @@ class LayerParameter(object):
 
     @shape.setter
     def shape(self, shape):
-        assert self.shape is None or self.shape == shape, \
-            "inconsistent shape for layer parameter:"\
+        assert self.shape is None or self.shape == shape, (
+            "inconsistent shape for layer parameter:"
             " {}, expect: {}, but got {}".format(self, self.shape, shape)
+        )
         self._shape = shape
 
     def _infer_shape_from_initializer(self):
         for arg in self.initializer.arg:
-            if arg.name == 'shape':
+            if arg.name == "shape":
                 return list(arg.ints)
         with workspace.WorkspaceGuard("model_init_by_loading_params"):
             try:
@@ -173,7 +221,8 @@ class LayerParameter(object):
             except RuntimeError as exp:
                 logger.warning(
                     "Cannot infer the shape of blob {} from operator {}: {}".format(
-                        self.parameter, self.initializer.type, exp)
+                        self.parameter, self.initializer.type, exp
+                    )
                 )
                 workspace.ResetWorkspace()
                 return None
@@ -186,16 +235,25 @@ def is_request_only_scalar(scalar):
     if len(scalar.field_metadata()) == 0:
         return False
     for metadata in scalar.field_metadata():
-        if not (metadata and metadata.feature_specs and getattr(
-                metadata.feature_specs, 'feature_is_request_only', False)):
+        if not (
+            metadata
+            and metadata.feature_specs
+            and getattr(metadata.feature_specs, "feature_is_request_only", False)
+        ):
             return False
     return True
 
 
 class ModelLayer(object):
-
-    def __init__(self, model, prefix, input_record,
-                 predict_input_record_fields=None, tags=None, **kwargs):
+    def __init__(
+        self,
+        model,
+        prefix,
+        input_record,
+        predict_input_record_fields=None,
+        tags=None,
+        **kwargs
+    ):
         """
         Base class for model layers. Layer is an abstraction that allows to
         provide model description in terms of meta-operators, where each of the
@@ -224,8 +282,7 @@ class ModelLayer(object):
         if predict_input_record_fields:
             if not isinstance(predict_input_record_fields, list):
                 predict_input_record_fields = [predict_input_record_fields]
-            self._predict_input_record = self._input_record[
-                predict_input_record_fields]
+            self._predict_input_record = self._input_record[predict_input_record_fields]
         else:
             self._predict_input_record = None
 
@@ -254,10 +311,9 @@ class ModelLayer(object):
 
     def _check_output_schema(self):
         assert self._output_schema is not None, "Schema is not initialized"
-        assert (self._predict_output_schema is None or
-                schema.is_schema_subset(self._predict_output_schema,
-                                        self._output_schema)), (
-            "predict_output_schema is not a subset of the output_schema")
+        assert self._predict_output_schema is None or schema.is_schema_subset(
+            self._predict_output_schema, self._output_schema
+        ), "predict_output_schema is not a subset of the output_schema"
 
     @property
     def predict_input_record(self):
@@ -300,9 +356,9 @@ class ModelLayer(object):
         return 0
 
     def add_init_params(self, init_net):
-        '''
+        """
         Adds layer initialization operators to passed net.
-        '''
+        """
         for param in self.params:
             # TODO(amalevich): Either return back to lambdas, that add
             # all params (looks a bit safer and breaking less
@@ -317,28 +373,32 @@ class ModelLayer(object):
             if not init_op:
                 continue
 
-            if not init_op.HasField('device_option') and\
-                    current_device_scope:
+            if not init_op.HasField("device_option") and current_device_scope:
                 init_op = caffe2_pb2.OperatorDef()
                 init_op.CopyFrom(param.initializer)
                 init_op.device_option.CopyFrom(current_device_scope)
 
             # do not add duplicated init ops
-            if any(utils.OpAlmostEqual(op, init_op, 'debug_info')
-                   for op in init_net._net.op):
+            if any(
+                utils.OpAlmostEqual(op, init_op, "debug_info")
+                for op in init_net._net.op
+            ):
                 continue
 
             init_net._net.op.extend([init_op])
 
-    def create_param(self, param_name, shape, initializer, optimizer,
-                     ps_param=None, regularizer=None):
+    def create_param(
+        self, param_name, shape, initializer, optimizer, ps_param=None, regularizer=None
+    ):
         with scope.NameScope(self.name, reset=True):
-            param = self.model.create_param(param_name=param_name,
-                                            shape=shape,
-                                            initializer=initializer,
-                                            optimizer=optimizer,
-                                            ps_param=ps_param,
-                                            regularizer=regularizer)
+            param = self.model.create_param(
+                param_name=param_name,
+                shape=shape,
+                initializer=initializer,
+                optimizer=optimizer,
+                ps_param=ps_param,
+                regularizer=regularizer,
+            )
 
             # make sure we don't share parameters in the same layer
             assert all(param.parameter != p.parameter for p in self.params)
@@ -350,20 +410,20 @@ class ModelLayer(object):
         with scope.NameScope(self.name, reset=True):
             return self.model.net.NextScopedBlob(name)
 
-    def add_operators(self, net, init_net=None,
-                      context=InstantiationContext.TRAINING):
-        '''
+    def add_operators(self, net, init_net=None, context=InstantiationContext.TRAINING):
+        """
         Adds layer trainig or initialization operators to the passed in net.
         init_net can be None and can be called independently from add_init_params
-        '''
+        """
         # Namescope below should warranty that all intermediate blobs will be
         # assiciated with the layer that produces them
         with scope.NameScope(self.name):
-            if context not in {InstantiationContext.PREDICTION,
-                               InstantiationContext.EVAL,
-                               InstantiationContext.ACCUMULATE_PRED}:
-                assert init_net, (
-                    "Only prediction and eval context don't need init_net")
+            if context not in {
+                InstantiationContext.PREDICTION,
+                InstantiationContext.EVAL,
+                InstantiationContext.ACCUMULATE_PRED,
+            }:
+                assert init_net, "Only prediction and eval context don't need init_net"
             if init_net:
                 self.add_init_params(init_net)
             if context == InstantiationContext.TRAINING:
@@ -375,9 +435,10 @@ class ModelLayer(object):
             else:
                 self.add_ops(net)
 
-            if context in {InstantiationContext.TRAINING,
-                           InstantiationContext.EVAL} \
-               and self._export_params_for_metrics:
+            if (
+                context in {InstantiationContext.TRAINING, InstantiationContext.EVAL}
+                and self._export_params_for_metrics
+            ):
                 self.add_param_copy_operators(net)
 
     def add_ops(self, net):
@@ -419,5 +480,6 @@ class ModelLayer(object):
         # Export copies of parameters
         for param in self.params:
             param_copy_ref = self.get_next_blob_reference(
-                str(param).split("/")[-1] + "_copy")
+                str(param).split("/")[-1] + "_copy"
+            )
             self.model.add_metric_field(str(param.parameter), param_copy_ref)

--- a/caffe2/python/operator_test/copy_rows_to_tensor_op_test.py
+++ b/caffe2/python/operator_test/copy_rows_to_tensor_op_test.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import caffe2.python.hypothesis_test_util as hu
+import numpy as np
+from caffe2.python import core
+from hypothesis import given, strategies as st
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_input_tensors():
+    height = np.random.randint(1, 10)
+    width = np.random.randint(1, 10)
+    dtype = np.float32
+    print("height", height)
+    print("width", width)
+    input_tensor = hu.arrays(
+        dims=[height, width],
+        dtype=dtype,
+        elements=st.integers(min_value=0, max_value=100),
+    )
+
+    return input_tensor
+
+
+class TestCopyRowsToTensor(hu.HypothesisTestCase):
+    @given(input_tensor=get_input_tensors(), **hu.gcs_cpu_only)
+    def test_copy_rows_to_tensor(self, input_tensor, gc, dc):
+        dtype = np.random.choice([np.float16, np.float32, np.int32, np.int64], 1)[0]
+        input_tensor = np.array(input_tensor).astype(dtype)
+        height = np.shape(input_tensor)[0]
+        width = np.shape(input_tensor)[1]
+        row = np.random.rand(width).astype(dtype)
+        indices_lengths = np.random.randint(height)
+        all_indices = np.arange(height)
+        np.random.shuffle(all_indices)
+        indices = all_indices[:indices_lengths]
+
+        def ref(input_tensor, indices, row):
+            for idx in indices:
+                input_tensor[idx] = row
+            return [input_tensor]
+
+        self.assertReferenceChecks(
+            device_option=gc,
+            op=core.CreateOperator(
+                "CopyRowsToTensor", ["input_tensor", "indices", "row"], ["input_tensor"]
+            ),
+            inputs=[input_tensor, indices, row],
+            reference=ref,
+        )
+
+    @given(input_tensor=get_input_tensors(), **hu.gcs_cpu_only)
+    def test_copy_rows_to_tensor_invalid_input(self, input_tensor, gc, dc):
+        input_tensor = np.array(input_tensor).astype(np.float32)
+        height = np.shape(input_tensor)[0]
+        width = np.shape(input_tensor)[1]
+        row = np.random.rand(width + 1).astype(np.float32)
+        indices_lengths = np.random.randint(height)
+        all_indices = np.arange(height)
+        np.random.shuffle(all_indices)
+        indices = all_indices[:indices_lengths]
+
+        self.assertRunOpRaises(
+            device_option=gc,
+            op=core.CreateOperator(
+                "CopyRowsToTensor", ["input_tensor", "indices", "row"], ["input_tensor"]
+            ),
+            inputs=[input_tensor, indices, row],
+            exception=RuntimeError,
+            regexp="width of input tensor should match lengths of row",
+        )

--- a/caffe2/python/schema.py
+++ b/caffe2/python/schema.py
@@ -276,6 +276,88 @@ class List(Field):
         raise KeyError('Field not found in list: %s.' % item)
 
 
+class ListWithEvicted(List):
+    """
+    This class is similar with List, but containing extra field evicted_values for
+    LRU Hashing.
+    """
+    def __init__(self, values, lengths_blob=None, evicted_values=None):
+        if isinstance(evicted_values, Field):
+            assert isinstance(evicted_values, Scalar)
+            self._evicted_values = _normalize_field(evicted_values)
+        else:
+            self._evicted_values = Scalar(np.int64, evicted_values)
+        List.__init__(self, values, lengths_blob=lengths_blob)
+
+    def field_names(self):
+        value_fields = self._items.field_names()
+        return (
+            ['lengths'] + [_join_field_name('values', v) for v in value_fields] + ["_evicted_values"]
+        )
+
+    def field_types(self):
+        return self.lengths.field_types() + self._items.field_types() + self._evicted_values.field_types()
+
+    def field_metadata(self):
+        return self.lengths.field_metadata() + self._items.field_metadata() + self._evicted_values.field_metadata()
+
+    def field_blobs(self):
+        return self.lengths.field_blobs() + self._items.field_blobs() + self._evicted_values.field_blobs()
+
+    def all_scalars(self):
+        return self.lengths.all_scalars() + self._items.all_scalars() + self._evicted_values.all_scalars()
+
+    def has_blobs(self):
+        return self.lengths.has_blobs() and self._items.has_blobs() + self._evicted_values.has_blobs()
+
+    def clone(self, keep_blobs=True):
+        return type(self)(
+            _normalize_field(self._items, keep_blobs=keep_blobs),
+            _normalize_field(self.lengths, keep_blobs=keep_blobs),
+            _normalize_field(self._evicted_values, keep_blobs=keep_blobs)
+        )
+
+    def _pprint_impl(self, indent, str_buffer):
+        str_buffer.write('  ' * indent + "ListWithEvicted(\n")
+        str_buffer.write('  ' * (indent + 1) + "lengths=\n")
+        self.lengths._pprint_impl(indent=indent + 2, str_buffer=str_buffer)
+        str_buffer.write('  ' * (indent + 1) + "_items=\n")
+        self._items._pprint_impl(indent=indent + 2, str_buffer=str_buffer)
+        str_buffer.write('  ' * (indent + 1) + "_evicted_Values=\n")
+        self._items._pprint_impl(indent=indent + 2, str_buffer=str_buffer)
+        str_buffer.write('  ' * indent + ")\n")
+
+
+    def __getattr__(self, item):
+        """If the value of this list is a struct,
+        allow to introspect directly into its fields."""
+        if item.startswith('__'):
+            raise AttributeError(item)
+        if item == "_evicted_values":
+            return self._evicted_values
+        if isinstance(self._items, Struct):
+            return getattr(self._items, item)
+        elif item == 'value' or item == 'items':
+            return self._items
+        else:
+            raise AttributeError('Field not found in list: %s.' % item)
+
+    def __getitem__(self, item):
+        names = item.split(FIELD_SEPARATOR, 1)
+
+        if len(names) == 1:
+            if item == 'lengths':
+                return self.lengths
+            elif item == 'values':
+                return self._items
+            elif item == '_evicted_values':
+                return self._evicted_values
+        else:
+            if names[0] == 'values':
+                return self._items[names[1]]
+        raise KeyError('Field not found in list: %s.' % item)
+
+
 class Struct(Field):
     """Represents a named list of fields sharing the same domain.
     """
@@ -818,6 +900,22 @@ def Map(
         lengths_blob=lengths_blob
     )
 
+def MapWithEvicted(
+    keys,
+    values,
+    keys_name='keys',
+    values_name='values',
+    lengths_blob=None,
+    evicted_values=None
+):
+    """A map with extra field evicted_values
+    """
+    return ListWithEvicted(
+        Struct((keys_name, keys), (values_name, values)),
+        lengths_blob=lengths_blob,
+        evicted_values=evicted_values
+    )
+
 
 def NamedTuple(name_prefix, *fields):
     return Struct(* [('%s_%d' % (name_prefix, i), field)
@@ -1061,7 +1159,6 @@ def FeedRecord(blob_record, arrays, ws=None):
         else:
             ws.create_blob(str(b))
             ws.blobs[str(b)].feed(v)
-
     assert isinstance(blob_record, Field)
     field_blobs = blob_record.field_blobs()
     assert all(isinstance(v, BlobReference) for v in field_blobs)
@@ -1159,7 +1256,6 @@ def is_schema_subset(schema, original_schema):
     # TODO add more checks
     return set(schema.field_names()).issubset(
         set(original_schema.field_names()))
-
 
 def equal_schemas(schema,
                   original_schema,

--- a/caffe2/python/schema_test.py
+++ b/caffe2/python/schema_test.py
@@ -33,6 +33,16 @@ class TestDB(unittest.TestCase):
         self.assertEqual(s, clone)
         self.assertIsNot(clone, s)
 
+    def testListWithEvictedSubclassClone(self):
+        class Subclass(schema.ListWithEvicted):
+            pass
+
+        s = Subclass(schema.Scalar())
+        clone = s.clone()
+        self.assertIsInstance(clone, Subclass)
+        self.assertEqual(s, clone)
+        self.assertIsNot(clone, s)
+
     def testStructSubclassClone(self):
         class Subclass(schema.Struct):
             pass
@@ -114,6 +124,20 @@ class TestDB(unittest.TestCase):
         )
         self.assertEquals(s['field2:lengths'], a.lengths)
         self.assertEquals(s['field2:values'], a.items)
+        with self.assertRaises(KeyError):
+            s['fields2:items:non_existent']
+        with self.assertRaises(KeyError):
+            s['fields2:non_existent']
+
+    def testListWithEvictedInStructIndexing(self):
+        a = schema.ListWithEvicted(schema.Scalar(dtype=str))
+        s = schema.Struct(
+            ('field1', schema.Scalar(dtype=np.int32)),
+            ('field2', a)
+        )
+        self.assertEquals(s['field2:lengths'], a.lengths)
+        self.assertEquals(s['field2:values'], a.items)
+        self.assertEquals(s['field2:_evicted_values'], a._evicted_values)
         with self.assertRaises(KeyError):
             s['fields2:items:non_existent']
         with self.assertRaises(KeyError):


### PR DESCRIPTION
Summary:
This new operator is used for embedding table weight re-init. After we get the evicted indices, they will be the rows need reseting in embedding table. Then we can create a 1d tensor with default values, and apply this operator to copy the tensor to all evicted rows in embedding table

Will add gradient op in next diff

Differential Revision: D15709866

