### PR TITLE
Remove unused param in Caffe2 LayerNormGradientOp

### DIFF
--- a/caffe2/operators/layer_norm_op.cc
+++ b/caffe2/operators/layer_norm_op.cc
@@ -157,8 +157,7 @@ void LayerNormGradientOp<CPUContext>::GammaBetaBackward(
     const T* rstd,
     const T* g_scale,
     T* dgamma,
-    T* dbeta,
-    T* /* scratch */) {
+    T* dbeta) {
   math::Set<T, CPUContext>(N, T(0), dgamma, &context_);
   math::Set<T, CPUContext>(N, T(0), dbeta, &context_);
   ConstEigenArrayMap<T> dYxX_arr(dYxX, N, M);

--- a/caffe2/operators/layer_norm_op.cu
+++ b/caffe2/operators/layer_norm_op.cu
@@ -49,7 +49,13 @@ __global__ void LayerNormForwardCUDAKernel(
     const T* X,
     const T* scale,
     const T* bias,
-    T* Y);
+    T* Y) {
+  const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
+  if (index < M * N) {
+    const int i = index / N;
+    Y[index] = X[index] * scale[i] + bias[i];
+  }
+}
 
 template <typename T>
 __global__ void LayerNormForwardCUDAKernel(
@@ -60,44 +66,14 @@ __global__ void LayerNormForwardCUDAKernel(
     const T* bias,
     const T* gamma,
     const T* beta,
-    T* Y);
-
-#define DELEGATE_LAYER_NORM_FORWARD_CUDA_KERNEL(T, FmaFunc)                 \
-  template <>                                                               \
-  __global__ void LayerNormForwardCUDAKernel<T>(                            \
-      const int M,                                                          \
-      const int N,                                                          \
-      const T* X,                                                           \
-      const T* scale,                                                       \
-      const T* bias,                                                        \
-      T* Y) {                                                               \
-    const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;    \
-    if (index < M * N) {                                                    \
-      const int i = index / N;                                              \
-      Y[index] = FmaFunc(X[index], scale[i], bias[i]);                      \
-    }                                                                       \
-  }                                                                         \
-  template <>                                                               \
-  __global__ void LayerNormForwardCUDAKernel<T>(                            \
-      const int M,                                                          \
-      const int N,                                                          \
-      const T* X,                                                           \
-      const T* scale,                                                       \
-      const T* bias,                                                        \
-      const T* gamma,                                                       \
-      const T* beta,                                                        \
-      T* Y) {                                                               \
-    const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;    \
-    if (index < M * N) {                                                    \
-      const int i = index / N;                                              \
-      const int j = index % N;                                              \
-      Y[index] =                                                            \
-          FmaFunc(FmaFunc(X[index], scale[i], bias[i]), gamma[j], beta[j]); \
-    }                                                                       \
+    T* Y) {
+  const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
+  if (index < M * N) {
+    const int i = index / N;
+    const int j = index % N;
+    Y[index] = (X[index] * scale[i] + bias[i]) * gamma[j] + beta[j];
   }
-DELEGATE_LAYER_NORM_FORWARD_CUDA_KERNEL(float, fmaf)
-DELEGATE_LAYER_NORM_FORWARD_CUDA_KERNEL(double, fma)
-#undef DELEGATE_LAYER_NORM_FORWARD_CUDA_KERNEL
+}
 
 template <typename T>
 __global__ void ComputeInternalGradientsCUDAKernel(
@@ -173,38 +149,21 @@ __global__ void ComputeFusedParamsCUDAKernel(
     T* rstd,
     T* X_scale,
     T* bias,
-    T* g_scale);
-
-#define DELEGATE_COMPUTE_FUSED_PARAMS_CUDA_KERNEL(T, FmaFunc)               \
-  template <>                                                               \
-  __global__ void ComputeFusedParamsCUDAKernel<T>(                          \
-      const int M,                                                          \
-      const int N,                                                          \
-      const T* mean,                                                        \
-      const T* sigma,                                                       \
-      const T* ds,                                                          \
-      const T* db,                                                          \
-      T* rstd,                                                              \
-      T* X_scale,                                                           \
-      T* bias,                                                              \
-      T* g_scale) {                                                         \
-    const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;    \
-    if (index < M) {                                                        \
-      const T scale = T(1) / static_cast<T>(N);                             \
-      const T rstd_val = T(1) / sigma[index];                               \
-      const T X_scale_val = FmaFunc(db[index], mean[index], -ds[index]) *   \
-          math::utils::Cube<T>(rstd_val) * scale;                           \
-      rstd[index] = rstd_val;                                               \
-      X_scale[index] = X_scale_val;                                         \
-      bias[index] =                                                         \
-          -FmaFunc(X_scale_val, mean[index], db[index] * rstd_val * scale); \
-      if (g_scale != nullptr) {                                             \
-        g_scale[index] = -rstd_val * mean[index];                           \
-      }                                                                     \
-    }                                                                       \
+    T* g_scale) {
+  const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
+  if (index < M) {
+    const T scale = T(1) / static_cast<T>(N);
+    const T rstd_val = T(1) / sigma[index];
+    const T X_scale_val = (db[index] * mean[index] - ds[index]) *
+        math::utils::Cube<T>(rstd_val) * scale;
+    rstd[index] = rstd_val;
+    X_scale[index] = X_scale_val;
+    bias[index] = -(X_scale_val * mean[index] + db[index] * rstd_val * scale);
+    if (g_scale != nullptr) {
+      g_scale[index] = -rstd_val * mean[index];
+    }
   }
-DELEGATE_COMPUTE_FUSED_PARAMS_CUDA_KERNEL(float, fmaf)
-#undef DELEGATE_COMPUTE_FUSED_PARAMS_CUDA_KERNEL
+}
 
 template <typename T>
 __global__ void LayerNormBackwardCUDAKenrel(
@@ -215,7 +174,13 @@ __global__ void LayerNormBackwardCUDAKenrel(
     const T* dY_scale,
     const T* X_scale,
     const T* bias,
-    T* dX);
+    T* dX) {
+  const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
+  if (index < M * N) {
+    const int i = index / N;
+    dX[index] = dY[index] * dY_scale[i] + X[index] * X_scale[i] + bias[i];
+  }
+}
 
 template <typename T>
 __global__ void LayerNormBackwardCUDAKenrel(
@@ -227,49 +192,15 @@ __global__ void LayerNormBackwardCUDAKenrel(
     const T* dY_scale,
     const T* X_scale,
     const T* bias,
-    T* dX);
-
-#define DELEGATE_LAYER_NORM_BACKWARD_CUDA_KERNEL(T, FmaFunc)               \
-  template <>                                                              \
-  __global__ void LayerNormBackwardCUDAKenrel<T>(                          \
-      const int M,                                                         \
-      const int N,                                                         \
-      const T* dY,                                                         \
-      const T* X,                                                          \
-      const T* dY_scale,                                                   \
-      const T* X_scale,                                                    \
-      const T* bias,                                                       \
-      T* dX) {                                                             \
-    const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;   \
-    if (index < M * N) {                                                   \
-      const int i = index / N;                                             \
-      dX[index] = FmaFunc(                                                 \
-          dY[index], dY_scale[i], FmaFunc(X[index], X_scale[i], bias[i])); \
-    }                                                                      \
-  }                                                                        \
-  template <>                                                              \
-  __global__ void LayerNormBackwardCUDAKenrel<T>(                          \
-      const int M,                                                         \
-      const int N,                                                         \
-      const T* dY,                                                         \
-      const T* X,                                                          \
-      const T* gamma,                                                      \
-      const T* dY_scale,                                                   \
-      const T* X_scale,                                                    \
-      const T* bias,                                                       \
-      T* dX) {                                                             \
-    const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;   \
-    if (index < M * N) {                                                   \
-      const int i = index / N;                                             \
-      const int j = index % N;                                             \
-      dX[index] = FmaFunc(                                                 \
-          dY[index],                                                       \
-          dY_scale[i] * gamma[j],                                          \
-          FmaFunc(X[index], X_scale[i], bias[i]));                         \
-    }                                                                      \
+    T* dX) {
+  const int index = blockIdx.x * CAFFE_CUDA_NUM_THREADS + threadIdx.x;
+  if (index < M * N) {
+    const int i = index / N;
+    const int j = index % N;
+    dX[index] =
+        dY[index] * dY_scale[i] * gamma[j] + X[index] * X_scale[i] + bias[i];
   }
-DELEGATE_LAYER_NORM_BACKWARD_CUDA_KERNEL(float, fmaf)
-#undef DELEGATE_LAYER_NORM_BACKWARD_CUDA_KERNEL
+}
 
 } //  namespace
 
@@ -400,8 +331,7 @@ void LayerNormGradientOp<CUDAContext>::GammaBetaBackward(
     const T* rstd,
     const T* g_scale,
     T* dgamma,
-    T* dbeta,
-    T* scratch) {
+    T* dbeta) {
   if (M == 0) {
     math::Set<T, CUDAContext>(N, T(0), dgamma, &context_);
     math::Set<T, CUDAContext>(N, T(0), dbeta, &context_);

--- a/caffe2/operators/layer_norm_op.h
+++ b/caffe2/operators/layer_norm_op.h
@@ -5,8 +5,8 @@
 #include <vector>
 
 #include "caffe2/core/context.h"
-#include "caffe2/core/operator.h"
 #include "caffe2/core/export_caffe2_op_to_c10.h"
+#include "caffe2/core/operator.h"
 #include "caffe2/core/types.h"
 #include "caffe2/utils/math.h"
 
@@ -196,8 +196,7 @@ class LayerNormGradientOp final : public Operator<Context> {
           rstd_data,
           g_scale_data,
           dgamma_data,
-          dbeta_data,
-          dX_data);
+          dbeta_data);
     }
     LayerNormBackward<T>(
         M,
@@ -259,8 +258,7 @@ class LayerNormGradientOp final : public Operator<Context> {
       const T* rstd,
       const T* g_scale,
       T* dgamma,
-      T* dbeta,
-      T* scratch);
+      T* dbeta);
 
   const int axis_;
   const bool elementwise_affine_;


### PR DESCRIPTION
Summary: Remove unused param in Caffe2 LayerNormGradientOp

Differential Revision: D16017117

