### PR TITLE
Add totalGlobalMemory in CUDACachingAllocator

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -53,6 +53,8 @@ C10_CUDA_API void     resetMaxMemoryAllocated(int device);
 C10_CUDA_API uint64_t currentMemoryCached(int device);
 C10_CUDA_API uint64_t maxMemoryCached(int device);
 C10_CUDA_API void     resetMaxMemoryCached(int device);
+C10_CUDA_API uint64_t totalGlobalMemory(int device);
+C10_CUDA_API void initTotalGlobalMemory(int device);
 
 C10_CUDA_API std::mutex* getFreeMutex();
 


### PR DESCRIPTION
This PR adds the function getting total global memory of GPU.
It is useful to control and monitor cache-rate.
