### PR TITLE
Fix two overindent lint errors in test/common_nn.py.

### DIFF
--- a/test/common_nn.py
+++ b/test/common_nn.py
@@ -174,7 +174,7 @@ module_tests = [
         constructor_args=(2, -100),
         input_size=(10, 20),
         reference_fn=(lambda i, *_: ((i * 2) > -100).type_as(i) * i +
-                                   ((i * 2) <= -100).type_as(i) * 1. / 2. * torch.log(1 + torch.exp(2 * i))),
+                                    ((i * 2) <= -100).type_as(i) * 1. / 2. * torch.log(1 + torch.exp(2 * i))),
         desc='beta_threshold',
     ),
     dict(
@@ -2221,7 +2221,7 @@ new_module_tests = [
         constructor_args=(2, -100),
         input_size=(),
         reference_fn=(lambda i, *_: ((i * 2) > -100).type_as(i) * i +
-                                   ((i * 2) <= -100).type_as(i) * 1. / 2. * torch.log(1 + torch.exp(2 * i))),
+                                    ((i * 2) <= -100).type_as(i) * 1. / 2. * torch.log(1 + torch.exp(2 * i))),
         desc='beta_threshold_scalar',
     ),
     dict(


### PR DESCRIPTION
This keeps causing lint tests to fail.