### PR TITLE
Update ThroughputBenchmark to reflect new script::Module API (no
shared_ptr in the bindind)

### DIFF
--- a/torch/csrc/utils/init.cpp
+++ b/torch/csrc/utils/init.cpp
@@ -23,7 +23,7 @@ void initThroughputBenchmarkBindings(PyObject* module) {
       .def_readonly("num_iters", &BenchmarkExecutionStats::num_iters);
 
   py::class_<ThroughputBenchmark>(m, "ThroughputBenchmark", py::dynamic_attr())
-      .def(py::init<std::shared_ptr<jit::script::Module>>())
+      .def(py::init<jit::script::Module>())
       .def(py::init<py::object>())
       .def(
           "add_input",

--- a/torch/csrc/utils/throughput_benchmark.cpp
+++ b/torch/csrc/utils/throughput_benchmark.cpp
@@ -32,8 +32,8 @@ py::object ThroughputBenchmark::runOnce(py::args&& args, py::kwargs&& kwargs)  {
 }
 
 ThroughputBenchmark::ThroughputBenchmark(
-    std::shared_ptr<jit::script::Module> script_module)
-    : script_module_(std::move(script_module)) {}
+    jit::script::Module script_module)
+    : script_module_(script_module) {}
 
 ThroughputBenchmark::ThroughputBenchmark(
     py::object module)
@@ -62,7 +62,7 @@ template <>
 void ScriptModuleBenchmark::runOnce(ScriptModuleInput&& input) const {
   CHECK(initialized_);
   // TODO: provide guarantees that compiler won't optimize this out
-  model_->get_method("forward").function()(std::move(input));
+  model_.get_method("forward").function()(std::move(input));
 }
 
 template <>
@@ -70,12 +70,12 @@ ScriptModuleOutput ScriptModuleBenchmark::runOnce(
     py::args&& args,
     py::kwargs&& kwargs) const {
   CHECK(initialized_);
-  auto& function = model_->get_method("forward").function();
+  auto& function = model_.get_method("forward").function();
   ScriptModuleInput stack = jit::createStackForSchema(
       function.getSchema(),
       std::move(args),
       std::move(kwargs),
-      model_->module_object());
+      model_.module_object());
   return function(std::move(stack));
 }
 
@@ -97,10 +97,10 @@ ModuleOutput ModuleBenchmark::runOnce(py::args&& args, py::kwargs&& kwargs)
 template <>
 void ScriptModuleBenchmark::addInput(py::args&& args, py::kwargs&& kwargs) {
   jit::Stack stack = jit::createStackForSchema(
-      model_->get_method("forward").function().getSchema(),
+      model_.get_method("forward").function().getSchema(),
       std::move(args),
       std::move(kwargs),
-      model_->module_object());
+      model_.module_object());
   inputs_.emplace_back(std::move(stack));
 }
 

--- a/torch/csrc/utils/throughput_benchmark.h
+++ b/torch/csrc/utils/throughput_benchmark.h
@@ -106,7 +106,7 @@ Input cloneInput(const Input& input);
 typedef BenchmarkHelper<
     ScriptModuleInput,
     at::IValue,
-    std::shared_ptr<jit::script::Module>>
+    jit::script::Module>
     ScriptModuleBenchmark;
 typedef BenchmarkHelper<ModuleInput, py::object, py::object> ModuleBenchmark;
 
@@ -150,7 +150,7 @@ void ModuleBenchmark::addInput(py::args&& args, py::kwargs&& kwargs);
  */
 class C10_HIDDEN ThroughputBenchmark {
  public:
-  explicit ThroughputBenchmark(std::shared_ptr<jit::script::Module> module);
+  explicit ThroughputBenchmark(jit::script::Module module);
   explicit ThroughputBenchmark(py::object module);
 
   // Add one more input example. This input example should be in the exact


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22293 ThroughputBenchmark: improve formatting for ExecutionStats&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16023999/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22292 PyTorch ThroughputBenchmark: fix inaccuracy in number of iterations reporting&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16023963/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22291 Update ThroughputBenchmark to reflect new script::Module API (no
shared_ptr in the bindind)**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16023640/)

There was a race between landing the benchmark diff and
https://github.com/pytorch/pytorch/pull/21934 from zdevito. This PR
should fix the issue.

Differential Revision: [D16023640](https://our.internmc.facebook.com/intern/diff/D16023640/)