### PR TITLE
[JIT] Add support to register a custom GraphExecutor Implementation

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -363,6 +363,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/attributes.cpp
     ${TORCH_SRC_DIR}/csrc/jit/argument_spec.cpp
     ${TORCH_SRC_DIR}/csrc/jit/export.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/custom_graph_executor_impl.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pass_manager.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pickler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/graph_executor.cpp

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -362,8 +362,8 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/autodiff.cpp
     ${TORCH_SRC_DIR}/csrc/jit/attributes.cpp
     ${TORCH_SRC_DIR}/csrc/jit/argument_spec.cpp
-    ${TORCH_SRC_DIR}/csrc/jit/export.cpp
     ${TORCH_SRC_DIR}/csrc/jit/custom_graph_executor_impl.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/export.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pass_manager.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pickler.cpp
     ${TORCH_SRC_DIR}/csrc/jit/graph_executor.cpp

--- a/test/jit_utils.py
+++ b/test/jit_utils.py
@@ -446,11 +446,11 @@ class JitTestCase(TestCase):
 
 @contextmanager
 def enable_profiling_mode():
-    torch._C._jit_set_profiling_mode(True)
+    torch._C._jit_set_graph_executor("executor::profiling")
     try:
         yield
     finally:
-        torch._C._jit_set_profiling_mode(False)
+    torch._C._jit_reset_graph_executor()
 
 _inline_everything = True
 @contextmanager

--- a/test/jit_utils.py
+++ b/test/jit_utils.py
@@ -450,7 +450,7 @@ def enable_profiling_mode():
     try:
         yield
     finally:
-    torch._C._jit_reset_graph_executor()
+        torch._C._jit_reset_graph_executor()
 
 _inline_everything = True
 @contextmanager

--- a/torch/csrc/jit/custom_graph_executor_impl.cpp
+++ b/torch/csrc/jit/custom_graph_executor_impl.cpp
@@ -46,8 +46,9 @@ RegisterGraphExecutorImpl::RegisterGraphExecutorImpl(
   auto& executors = getGraphExecutorImpls();
   TORCH_CHECK(
       executors.emplace(name, creator).second,
-      "Cannot register GraphExecutorImpl for ",
-      name.toDisplayString());
+      "GraphExecutorImpl for ",
+      name.toDisplayString(),
+      " has already been registered");
 }
 
 GraphExecutorImplCreator getGraphExecutorImpl() {

--- a/torch/csrc/jit/custom_graph_executor_impl.cpp
+++ b/torch/csrc/jit/custom_graph_executor_impl.cpp
@@ -1,0 +1,39 @@
+#include <torch/csrc/jit/custom_graph_executor_impl.h>
+
+namespace torch {
+namespace jit {
+
+thread_local Symbol executor_key = kDefaultExecutor;
+Symbol& getGraphExecutorName() {
+  return executor_key;
+}
+
+/* Meyers Singleton */
+std::unordered_map<Symbol, GraphExecutorImplCreator>& getGraphExecutorImpls() {
+  static std::unordered_map<Symbol, GraphExecutorImplCreator> executors;
+  return executors;
+};
+
+RegisterGraphExecutorImpl::RegisterGraphExecutorImpl(
+    Symbol name,
+    GraphExecutorImplCreator creator) {
+  auto& executors = getGraphExecutorImpls();
+  TORCH_CHECK(
+      executors.emplace(name, creator).second,
+      "Cannot register GraphExecutorImpl for ",
+      name.toDisplayString());
+}
+
+GraphExecutorImplCreator getGraphExecutorImpl() {
+  auto& executors = getGraphExecutorImpls();
+  auto it = executors.find(executor_key);
+
+  TORCH_CHECK(
+      it != executors.end(),
+      "No GraphExecutorImpl registered for ",
+      executor_key.toDisplayString());
+  return it->second;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/custom_graph_executor_impl.cpp
+++ b/torch/csrc/jit/custom_graph_executor_impl.cpp
@@ -5,8 +5,6 @@ namespace jit {
 
 extern const Symbol kDefaultExecutor =
     Symbol::fromQualString("executor::default");
-extern const Symbol kProfilingExecutor =
-    Symbol::fromQualString("executor::profiling");
 
 namespace {
 

--- a/torch/csrc/jit/custom_graph_executor_impl.cpp
+++ b/torch/csrc/jit/custom_graph_executor_impl.cpp
@@ -3,16 +3,39 @@
 namespace torch {
 namespace jit {
 
-thread_local Symbol executor_key = kDefaultExecutor;
-Symbol& getGraphExecutorName() {
-  return executor_key;
-}
+namespace {
+
+struct GraphExecutorImplState {
+  Symbol name = kDefaultExecutor;
+  bool impl_cached = false;
+  GraphExecutorImplCreator impl_fn;
+};
+thread_local GraphExecutorImplState executor_state;
 
 /* Meyers Singleton */
 std::unordered_map<Symbol, GraphExecutorImplCreator>& getGraphExecutorImpls() {
   static std::unordered_map<Symbol, GraphExecutorImplCreator> executors;
   return executors;
-};
+}
+
+} // namespace
+
+Symbol getGraphExecutorName() {
+  return executor_state.name;
+}
+
+void setGraphExecutorName(Symbol name) {
+  auto& executors = getGraphExecutorImpls();
+  auto it = executors.find(name);
+  TORCH_CHECK(
+      it != executors.end(),
+      "No GraphExecutorImpl registered for ",
+      name.toDisplayString());
+
+  executor_state.name = name;
+  executor_state.impl_cached = true;
+  executor_state.impl_fn = it->second;
+}
 
 RegisterGraphExecutorImpl::RegisterGraphExecutorImpl(
     Symbol name,
@@ -25,14 +48,9 @@ RegisterGraphExecutorImpl::RegisterGraphExecutorImpl(
 }
 
 GraphExecutorImplCreator getGraphExecutorImpl() {
-  auto& executors = getGraphExecutorImpls();
-  auto it = executors.find(executor_key);
-
-  TORCH_CHECK(
-      it != executors.end(),
-      "No GraphExecutorImpl registered for ",
-      executor_key.toDisplayString());
-  return it->second;
+  if (!executor_state.impl_cached)
+    setGraphExecutorName(executor_state.name);
+  return executor_state.impl_fn;
 }
 
 } // namespace jit

--- a/torch/csrc/jit/custom_graph_executor_impl.cpp
+++ b/torch/csrc/jit/custom_graph_executor_impl.cpp
@@ -3,6 +3,11 @@
 namespace torch {
 namespace jit {
 
+extern const Symbol kDefaultExecutor =
+    Symbol::fromQualString("executor::default");
+extern const Symbol kProfilingExecutor =
+    Symbol::fromQualString("executor::profiling");
+
 namespace {
 
 struct GraphExecutorImplState {

--- a/torch/csrc/jit/custom_graph_executor_impl.h
+++ b/torch/csrc/jit/custom_graph_executor_impl.h
@@ -10,10 +10,8 @@ namespace jit {
 using GraphExecutorImplCreator =
     std::function<GraphExecutorImplBase*(std::shared_ptr<Graph>, bool)>;
 
-static const Symbol kDefaultExecutor =
-    Symbol::fromQualString("executor::default");
-static const Symbol kProfilingExecutor =
-    Symbol::fromQualString("executor::profiling");
+extern const Symbol kDefaultExecutor;
+extern const Symbol kProfilingExecutor;
 
 struct TORCH_API RegisterGraphExecutorImpl {
   RegisterGraphExecutorImpl(Symbol name, GraphExecutorImplCreator creator);

--- a/torch/csrc/jit/custom_graph_executor_impl.h
+++ b/torch/csrc/jit/custom_graph_executor_impl.h
@@ -10,8 +10,7 @@ namespace jit {
 using GraphExecutorImplCreator =
     std::function<GraphExecutorImplBase*(std::shared_ptr<Graph>, bool)>;
 
-extern const Symbol kDefaultExecutor;
-extern const Symbol kProfilingExecutor;
+TORCH_API extern const Symbol kDefaultExecutor;
 
 struct TORCH_API RegisterGraphExecutorImpl {
   RegisterGraphExecutorImpl(Symbol name, GraphExecutorImplCreator creator);

--- a/torch/csrc/jit/custom_graph_executor_impl.h
+++ b/torch/csrc/jit/custom_graph_executor_impl.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <torch/csrc/jit/graph_executor_impl.h>
+
+#include <ATen/core/interned_strings.h>
+
+namespace torch {
+namespace jit {
+
+using GraphExecutorImplCreator =
+    std::function<GraphExecutorImplBase*(std::shared_ptr<Graph>, bool)>;
+
+static const Symbol kDefaultExecutor =
+    Symbol::fromQualString("executor::default");
+static const Symbol kProfilingExecutor =
+    Symbol::fromQualString("executor::profiling");
+
+struct TORCH_API RegisterGraphExecutorImpl {
+  RegisterGraphExecutorImpl(Symbol name, GraphExecutorImplCreator creator);
+};
+
+TORCH_API GraphExecutorImplCreator getGraphExecutorImpl();
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -598,7 +598,7 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
 RegisterGraphExecutorImpl reg_graph_executor_impl(
     kDefaultExecutor,
     [](const std::shared_ptr<Graph>& graph, bool optimize) {
-      return new GraphExecutorImpl(graph, optimize);
+      return new GraphExecutorImpl(std::move(graph), optimize);
     });
 
 GraphExecutor::GraphExecutor(std::shared_ptr<Graph> graph, bool optimize)

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -597,7 +597,7 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
 
 RegisterGraphExecutorImpl reg_graph_executor_impl(
     kDefaultExecutor,
-    [](std::shared_ptr<Graph> graph, bool optimize) {
+    [](const std::shared_ptr<Graph>& graph, bool optimize) {
       return new GraphExecutorImpl(graph, optimize);
     });
 

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -603,7 +603,7 @@ RegisterGraphExecutorImpl reg_graph_executor_impl(
 
 GraphExecutor::GraphExecutor(std::shared_ptr<Graph> graph, bool optimize)
     : pImpl(dynamic_cast<GraphExecutorImplBase*>(
-          getGraphExecutorImpl()(graph, optimize))) {}
+          getGraphExecutorImpl()(std::move(graph), optimize))) {}
 
 void GraphExecutor::run(Stack& inputs) {
   return pImpl->run(inputs);

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -58,7 +58,8 @@ TORCH_API void runRequiredPasses(const std::shared_ptr<Graph>& g);
 TORCH_API void debugSetAutodiffSubgraphInlining(bool state);
 TORCH_API std::shared_ptr<Graph> lastExecutedOptimizedGraph();
 
-TORCH_API Symbol& getGraphExecutorName();
+TORCH_API Symbol getGraphExecutorName();
+TORCH_API void setGraphExecutorName(Symbol name);
 
 namespace detail {
 

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -58,7 +58,7 @@ TORCH_API void runRequiredPasses(const std::shared_ptr<Graph>& g);
 TORCH_API void debugSetAutodiffSubgraphInlining(bool state);
 TORCH_API std::shared_ptr<Graph> lastExecutedOptimizedGraph();
 
-TORCH_API bool& getProfilingMode();
+TORCH_API Symbol& getGraphExecutorName();
 
 namespace detail {
 

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -3,6 +3,7 @@
 
 #include <torch/csrc/jit/argument_spec.h>
 #include <torch/csrc/jit/autodiff.h>
+#include <torch/csrc/jit/custom_graph_executor_impl.h>
 #include <torch/csrc/jit/export.h>
 #include <torch/csrc/jit/fuser/interface.h>
 #include <torch/csrc/jit/fuser/kernel_cache.h>
@@ -347,9 +348,7 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_reset_graph_executor",
-          []() {
-            setGraphExecutorName(Symbol::fromQualString("executor::default"));
-          })
+          []() { setGraphExecutorName(kDefaultExecutor); })
       .def(
           "_jit_set_inline_everything_mode",
           [](bool enabled) { script::getInlineEverythingMode() = enabled; })

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -342,19 +342,13 @@ void initJITBindings(PyObject* module) {
             checkAliasAnnotation(g, std::move(stack), unqualified_op_name);
           })
       .def(
-          "_jit_set_profiling_mode",
-          [](bool profiling_flag) {
-            getGraphExecutorName() =
-                (profiling_flag) ? kProfilingExecutor : kDefaultExecutor;
-          })
-      .def(
           "_jit_set_graph_executor",
           [](const std::string& name) {
-            getGraphExecutorName() = Symbol::fromQualString(name);
+            setGraphExecutorName(Symbol::fromQualString(name));
           })
       .def(
           "_jit_reset_graph_executor",
-          []() { getGraphExecutorName() = kDefaultExecutor; })
+          []() { setGraphExecutorName(kDefaultExecutor); })
       .def(
           "_jit_set_inline_everything_mode",
           [](bool enabled) { script::getInlineEverythingMode() = enabled; })

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -3,7 +3,6 @@
 
 #include <torch/csrc/jit/argument_spec.h>
 #include <torch/csrc/jit/autodiff.h>
-#include <torch/csrc/jit/custom_graph_executor_impl.h>
 #include <torch/csrc/jit/export.h>
 #include <torch/csrc/jit/fuser/interface.h>
 #include <torch/csrc/jit/fuser/kernel_cache.h>
@@ -348,7 +347,9 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_reset_graph_executor",
-          []() { setGraphExecutorName(kDefaultExecutor); })
+          []() {
+            setGraphExecutorName(Symbol::fromQualString("executor::default"));
+          })
       .def(
           "_jit_set_inline_everything_mode",
           [](bool enabled) { script::getInlineEverythingMode() = enabled; })

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -3,6 +3,7 @@
 
 #include <torch/csrc/jit/argument_spec.h>
 #include <torch/csrc/jit/autodiff.h>
+#include <torch/csrc/jit/custom_graph_executor_impl.h>
 #include <torch/csrc/jit/export.h>
 #include <torch/csrc/jit/fuser/interface.h>
 #include <torch/csrc/jit/fuser/kernel_cache.h>
@@ -342,7 +343,18 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_set_profiling_mode",
-          [](bool profiling_flag) { getProfilingMode() = profiling_flag; })
+          [](bool profiling_flag) {
+            getGraphExecutorName() =
+                (profiling_flag) ? kProfilingExecutor : kDefaultExecutor;
+          })
+      .def(
+          "_jit_set_graph_executor",
+          [](const std::string& name) {
+            getGraphExecutorName() = Symbol::fromQualString(name);
+          })
+      .def(
+          "_jit_reset_graph_executor",
+          []() { getGraphExecutorName() = kDefaultExecutor; })
       .def(
           "_jit_set_inline_everything_mode",
           [](bool enabled) { script::getInlineEverythingMode() = enabled; })

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -82,7 +82,7 @@ GraphExecutorState ProfilingGraphExecutorImpl::getDebugState() {
 
 RegisterGraphExecutorImpl reg_profiling_graph_executor_impl(
     kProfilingExecutor,
-    [](std::shared_ptr<Graph> graph, bool optimize) {
+    [](const std::shared_ptr<Graph>& graph, bool optimize) {
       return new ProfilingGraphExecutorImpl(graph, optimize);
     });
 

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -81,7 +81,7 @@ GraphExecutorState ProfilingGraphExecutorImpl::getDebugState() {
 }
 
 RegisterGraphExecutorImpl reg_profiling_graph_executor_impl(
-    kProfilingExecutor,
+    Symbol::fromQualString("executor::profiling"),
     [](const std::shared_ptr<Graph>& graph, bool optimize) {
       return new ProfilingGraphExecutorImpl(graph, optimize);
     });

--- a/torch/csrc/jit/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/profiling_graph_executor_impl.cpp
@@ -80,13 +80,11 @@ GraphExecutorState ProfilingGraphExecutorImpl::getDebugState() {
   AT_ERROR("not supported");
 }
 
-namespace {
-RegisterGraphExecutorImpl r(
+RegisterGraphExecutorImpl reg_profiling_graph_executor_impl(
     kProfilingExecutor,
     [](std::shared_ptr<Graph> graph, bool optimize) {
       return new ProfilingGraphExecutorImpl(graph, optimize);
     });
-} // namespace
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This change adds support for registering and running custom GraphExecutor Implementations. Currently, extensions can register custom operations and passes, but this only provides a limited interface. This generalizes the way the ProfilingGraphExecutorImpl is used with minimal overheads 