### PR TITLE
add JIT path to the benchmark

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import benchmark_core
+import torch
+import cpp_extension # noqa
 
 
 """PyTorch performance microbenchmarks.
@@ -21,9 +23,34 @@ class TorchBenchmarkBase(object):
 
     def __init__(self):
         self.user_given_name = None
+        self._jit_forward = None
 
     def forward(self):
         pass 
+
+    def _wrap_forward(self, foo):
+        """ The function passed to JIT trace must have at least one argument, 
+            this function is to wrap the forward method to meet that requirement. 
+            _consume op is used to avoid the dead-code-elimination optimization
+            in JIT. 
+        """
+        return torch.ops.operator_benchmark._consume(self.forward())
+
+    def _generate_jit_forward_graph(self):
+        """ generate a graph for the forward function via tracing 
+        """
+
+        func = torch.jit.trace(self._wrap_forward, torch.rand(1))
+        place_holder = torch.rand(1) # noqa
+
+        @torch.jit.script
+        def _jit_forward_graph(iters, place_holder):
+            # type: (int, Tensor)
+            result = torch.jit.annotate(torch.Tensor, None)
+            for _ in range(iters):
+                result = func(place_holder)
+            return result
+        return _jit_forward_graph
 
     def module_name(self):
         """ this is used to label the operator being benchmarked
@@ -61,17 +88,18 @@ class PyTorchOperatorTestCase(object):
     def __init__(self, op_bench, test_config):
         self.test_config = test_config
         self.op_bench = op_bench
+        self.place_holder_tensor = torch.ones(1)
         self.framework = "PyTorch"
 
     def run_jit_forward(self, num_runs):
-        """ This is a temp solution and will be removed later 
-            Run the forward op with JIT 
+        """ Run the forward path of an op with JIT mode
         """
-        self.op_bench.jit_forward(num_runs)
+        if self.op_bench._jit_forward is None:
+            self.op_bench._jit_forward = self.op_bench._generate_jit_forward_graph()
+        self.op_bench._jit_forward(num_runs, self.place_holder_tensor)
 
     def run_forward(self, num_runs):
-        """ TODO (mingzhe): when JIT is ready, switch this to JIT 
-            Run the forward path of an op in many iterations
+        """ Run the forward path of an op with eager mode
         """
         for _ in range(num_runs):
             self.output = self.op_bench.forward()

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -92,6 +92,12 @@ def main():
     )
 
     parser.add_argument(
+        "--use_jit",
+        help="Run operators with PyTorch JIT mode",
+        action='store_true'
+    )
+
+    parser.add_argument(
         "--forward_only",
         help="Only run the forward path of operators",
         action='store_true'

--- a/benchmarks/operator_benchmark/benchmark_test_generator.py
+++ b/benchmarks/operator_benchmark/benchmark_test_generator.py
@@ -33,11 +33,8 @@ def generate_test(configs, bench_op, OperatorTestCase, run_backward):
         op = bench_op()
         op.init(**test_attrs)
         test_name = op.test_name(**test_attrs)
-        use_jit = False
-        if hasattr(op, "jit_forward") and callable(op.jit_forward):
-            use_jit = True
         input_config = str(test_attrs)[1:-1].replace('\'', '')
-        test_config = TestConfig(test_name, input_config, tags, use_jit, run_backward)
+        test_config = TestConfig(test_name, input_config, tags, run_backward)
         if op is not None:
             OperatorTestCase(
                 op,


### PR DESCRIPTION
Summary:
This diff enables PT operators to run with JIT mode. Users can control eager and JIT mode using the `use_jit` flag.

In this diff, we are putting operators in a loop and passed it to JIT. After that, one extra step which wraps the operator with the `_consume` op is introduced to avoid dead code elimination optimization in JIT.  With that, the reported time includes the real operator execution time plus the `_consume` (directly return input, nothing else if happening inside) op.

Differential Revision: D16033082

