### PR TITLE
[jit] Add `@script` decorator for Modules

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12741,7 +12741,7 @@ class TestRecursiveScript(JitTestCase):
             def forward(self, x):
                 return x + self.x
 
-        self.assertExportImportModule(M())
+        self.assertExportImportModule(M(2), (torch.randn(2, 2),))
 
     @unittest.skipIf(True, "Class annotations are a thing in > 3.5, need to fix for < 3.7")
     def test_constants_with_final(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12731,6 +12731,18 @@ class TestRecursiveScript(JitTestCase):
 
         return sm
 
+    def test_module_decorator(self):
+        @torch.jit.script
+        class M(torch.nn.Module):
+            def __init__(self, x):
+                super(M, self).__init__()
+                self.x = 2
+
+            def forward(self, x):
+                return x + self.x
+
+        self.assertExportImportModule(M())
+
     @unittest.skipIf(True, "Class annotations are a thing in > 3.5, need to fix for < 3.7")
     def test_constants_with_final(self):
         class M(torch.nn.Module):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1140,11 +1140,10 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
         _rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
 
     if torch._C._jit_recursive_script():
-        if inspect.isclass(obj):
-            if inspect.isclass(obj) and issubclass(obj, torch.nn.Module):
-                if not _is_new_style_class(obj):
-                    raise RuntimeError("TorchScript modules must be new-style classes. Please inherit from 'nn.Module'")
-                return script_wrapper(obj)
+        if inspect.isclass(obj) and issubclass(obj, torch.nn.Module):
+            if not _is_new_style_class(obj):
+                raise RuntimeError("TorchScript modules must be new-style classes. Please inherit from 'nn.Module'")
+            return script_wrapper(obj)
         if isinstance(obj, torch.nn.Module):
             return _convert_to_script_module(obj)
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1108,7 +1108,7 @@ def _enable_recursive_script():
     torch._C._jit_recursive_script(False)
 
 
-def script_wrapper(module_class):
+def script_module_decorator(module_class):
     """
     Wraps the `__new__` of a class so that construction always returns a
     ScriptModule
@@ -1143,7 +1143,7 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
         if inspect.isclass(obj) and issubclass(obj, torch.nn.Module):
             if not _is_new_style_class(obj):
                 raise RuntimeError("TorchScript modules must be new-style classes. Please inherit from 'nn.Module'")
-            return script_wrapper(obj)
+            return script_module_decorator(obj)
         if isinstance(obj, torch.nn.Module):
             return _convert_to_script_module(obj)
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1114,13 +1114,22 @@ def script_wrapper(module_class):
     ScriptModule
     """
     original_new = getattr(module_class, '__new__', lambda self: None)
-    @functools.wraps(original_new)
-    def new_new(cls, *args, **kwargs):
-        x = original_new(cls)
-        x.__init__(*args, **kwargs)
-        return torch.jit.script(x)
 
-    module_class.__new__ = new_new
+    # We wrap `__new__` so that we can intercept instantiations of `module_class`
+    # and wrap them with `torch.jit.script` calls
+    @functools.wraps(original_new)
+    def torchscript__new__wrapper(cls, *args, **kwargs):
+        # Run original new
+        nn_module = original_new(cls)
+
+        # Since we don't return the module itself from this wrapper, its `__init__`
+        # is never automatically called, so we have to do it explicitly here
+        nn_module.__init__(*args, **kwargs)
+
+        # Compile the module
+        return torch.jit.script(nn_module)
+
+    module_class.__new__ = torchscript__new__wrapper
     return module_class
 
 
@@ -1133,6 +1142,8 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if torch._C._jit_recursive_script():
         if inspect.isclass(obj):
             if inspect.isclass(obj) and issubclass(obj, torch.nn.Module):
+                if not _is_new_style_class(obj):
+                    raise RuntimeError("TorchScript modules must be new-style classes. Please inherit from 'nn.Module'")
                 return script_wrapper(obj)
         if isinstance(obj, torch.nn.Module):
             return _convert_to_script_module(obj)


### PR DESCRIPTION
This lets you put `@torch.jit.script` on an `nn.Module`, which then will
wrap any instantiations of the module with a `script` call. This lets
users make classes that will always be used as `ScriptModule`s without
having to call `script()` every time