### PR TITLE
Perform weight re-init for embedding table in sparse_lookup.py

### DIFF
--- a/caffe2/python/operator_test/copy_rows_to_tensor_op_test.py
+++ b/caffe2/python/operator_test/copy_rows_to_tensor_op_test.py
@@ -15,8 +15,6 @@ def get_input_tensors():
     height = np.random.randint(1, 10)
     width = np.random.randint(1, 10)
     dtype = np.float32
-    print("height", height)
-    print("width", width)
     input_tensor = hu.arrays(
         dims=[height, width],
         dtype=dtype,
@@ -43,12 +41,12 @@ class TestCopyRowsToTensor(hu.HypothesisTestCase):
             for idx in indices:
                 input_tensor[idx] = row
             return [input_tensor]
-
+        op = core.CreateOperator(
+            "CopyRowsToTensor", ["input_tensor", "indices", "row"], ["input_tensor"]
+        )
         self.assertReferenceChecks(
             device_option=gc,
-            op=core.CreateOperator(
-                "CopyRowsToTensor", ["input_tensor", "indices", "row"], ["input_tensor"]
-            ),
+            op=op,
             inputs=[input_tensor, indices, row],
             reference=ref,
         )


### PR DESCRIPTION
Summary: This is the last step of LRU hash eviction weight re-init. This diff checks if there's evicted values in sparse_lookup, if so call op created in D15709866 to re-init the values for indicies in evicted_values. Also created gradient op for the operator. The gradient op just passes the output gradient as input gradient.

Differential Revision: D16044736

