### PR TITLE
Comment on why Windows build_pytorch.bat builds twice

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -69,6 +69,9 @@ set CXX=sccache cl
 
 set CMAKE_GENERATOR=Ninja
 
+:: The following code will try to build PyTorch twice if USE_CUDA is neither 0
+:: nor 1. It is intended so that both builds can be folded into 1 CI run.
+
 if not "%USE_CUDA%"=="1" (
   if "%REBUILD%"=="" (
     set NO_CUDA=1


### PR DESCRIPTION
I've noticed that Windows CI seems to build twice, e.g., https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-win-ws2016-cuda9-cudnn7-py3-build/60304/console

This adds a comment explaining why.
