### PR TITLE
Use at::AutoNonVariableTypeMode before calling ATen tensor factory functions

### DIFF
--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -11,7 +11,10 @@ from .gen_variable_type import format_trace
 FUNCTION_TEMPLATE = CodeTemplate("""\
 inline at::Tensor ${name}(${formals}) {
   ${pre_record_trace}
-  at::Tensor tensor = at::${name}(${actuals});
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    return at::${name}(${actuals});
+  })();
   at::Tensor result =
     autograd::make_variable_consuming(std::move(tensor), /*requires_grad=*/${requires_grad});
   ${post_record_trace}

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -22,8 +22,10 @@ namespace torch {
 #define TENSOR(T, S, _1)                                                   \
   inline at::Tensor tensor(                                                \
       at::ArrayRef<T> values, const at::TensorOptions& options) {          \
-    at::Tensor result =                                                    \
-        at::tensor(values, at::TensorOptions(options).is_variable(false)); \
+    at::Tensor result = ([&]() {                                           \
+      at::AutoNonVariableTypeMode non_var_type_mode(true);                 \
+      return at::tensor(values, at::TensorOptions(options).is_variable(false)); \
+    })();                                                                  \
     return autograd::make_variable(result, options.requires_grad());       \
   }                                                                        \
   inline at::Tensor tensor(                                                \
@@ -62,8 +64,10 @@ inline at::Tensor from_blob(
     at::IntArrayRef strides,
     const Deleter& deleter,
     const at::TensorOptions& options = at::TensorOptions()) {
-  at::Tensor tensor =
-      at::from_blob(data, sizes, strides, deleter, options.is_variable(false));
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    return at::from_blob(data, sizes, strides, deleter, options.is_variable(false));
+  })();
   return autograd::make_variable(tensor, options.requires_grad());
 }
 
@@ -96,8 +100,10 @@ inline at::Tensor from_blob(
     at::IntArrayRef sizes,
     const Deleter& deleter,
     const at::TensorOptions& options = at::TensorOptions()) {
-  at::Tensor tensor =
-      at::from_blob(data, sizes, deleter, options.is_variable(false));
+  at::Tensor tensor = ([&]() {
+    at::AutoNonVariableTypeMode non_var_type_mode(true);
+    return at::from_blob(data, sizes, deleter, options.is_variable(false));
+  })();
   return autograd::make_variable(tensor, options.requires_grad());
 }
 


### PR DESCRIPTION
As part of the Variable/Tensor merge, one invariant for tensor libraries such as ATen / Caffe2 / XLA is that they should only deal with Tensors, not Variables. However, currently in `variable_factories.h` we are potentially passing Variables into those tensor libraries without the `at::AutoNonVariableTypeMode` guard, which will cause those libraries to treat those Variables as Variables (i.e. their `is_variable()` is true), not Tensors.

Consider the following example for `full_like`:
```cpp
inline at::Tensor full_like(const at::Tensor & self, at::Scalar fill_value) {
  ...
  // Both ATen and XLA rely on `at::full_like` to dispatch to library specific implementations.
  //
  // When `self` is a Variable, since we are not using `at::AutoNonVariableTypeMode`,
  // `at::full_like` will also use `self` as a Variable (and it will see that `self.is_variable()` is true),
  // which breaks the invariant that ATen / XLA should never deal with Variables.
  at::Tensor tensor = at::full_like(self, fill_value, self.options().is_variable(false));
  at::Tensor result =
    autograd::make_variable_consuming(std::move(tensor), /*requires_grad=*/false);
  ...
  return result;
}
```

Instead, the invariant-preserving implementation would be:
```cpp
inline at::Tensor full_like(const at::Tensor & self, at::Scalar fill_value) {
  ...
  at::Tensor tensor = ([&]() {
    at::AutoNonVariableTypeMode non_var_type_mode(true);
    // Both ATen and XLA rely on `at::full_like` to dispatch to library specific implementations.
    //
    // When `self` is a Variable, since we have `at::AutoNonVariableTypeMode` in the scope,
    // `at::full_like` will use `self` as a Tensor (and it will see that `self.is_variable()` is false),
    // which preserves the invariant that ATen / XLA should only deal with Tensors.
    return at::full_like(self, fill_value, self.options().is_variable(false));
  })();
  at::Tensor result =
    autograd::make_variable_consuming(std::move(tensor), /*requires_grad=*/false);
  ...
  return result;
}
```
This PR makes the suggested change for all variable factory functions.

cc. @ailzhang This should allow us to remove all `tensor_data()` calls in the XLA codebase.