### PR TITLE
Fix QNNPACK and NNPACK settings

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -21,8 +21,6 @@ from .nccl import (USE_SYSTEM_NCCL, NCCL_INCLUDE_DIR, NCCL_ROOT_DIR,
                    NCCL_SYSTEM_LIB, USE_NCCL)
 from .numpy_ import USE_NUMPY, NUMPY_INCLUDE_DIR
 from .rocm import USE_ROCM
-from .nnpack import USE_NNPACK
-from .qnnpack import USE_QNNPACK
 
 
 def _which(thefile):
@@ -280,8 +278,6 @@ class CMake:
             'USE_DISTRIBUTED': USE_DISTRIBUTED,
             'USE_FBGEMM': not (check_env_flag('NO_FBGEMM') or
                                check_negative_env_flag('USE_FBGEMM')),
-            'USE_NNPACK': USE_NNPACK,
-            'USE_QNNPACK': USE_QNNPACK,
             'USE_NCCL': USE_NCCL,
             'USE_SYSTEM_NCCL': USE_SYSTEM_NCCL,
             'USE_NUMPY': USE_NUMPY,

--- a/tools/setup_helpers/nnpack.py
+++ b/tools/setup_helpers/nnpack.py
@@ -1,6 +1,3 @@
-from .env import check_env_flag
+from .env import check_negative_env_flag
 
-if check_env_flag('NO_NNPACK'):
-    USE_NNPACK = False
-else:
-    USE_NNPACK = True
+USE_NNPACK = not check_negative_env_flag('USE_NNPACK')

--- a/tools/setup_helpers/nnpack.py
+++ b/tools/setup_helpers/nnpack.py
@@ -1,3 +1,0 @@
-from .env import check_negative_env_flag
-
-USE_NNPACK = not check_negative_env_flag('USE_NNPACK')

--- a/tools/setup_helpers/qnnpack.py
+++ b/tools/setup_helpers/qnnpack.py
@@ -1,3 +1,0 @@
-from .env import check_negative_env_flag
-
-USE_QNNPACK = not check_negative_env_flag('USE_QNNPACK')

--- a/tools/setup_helpers/qnnpack.py
+++ b/tools/setup_helpers/qnnpack.py
@@ -1,6 +1,3 @@
-from .env import check_env_flag
+from .env import check_negative_env_flag
 
-if check_env_flag('NO_QNNPACK'):
-    USE_QNNPACK = False
-else:
-    USE_QNNPACK = True
+USE_QNNPACK = not check_negative_env_flag('USE_QNNPACK')


### PR DESCRIPTION
`setup.py` recommends setting `USE_QNNPACK=0` and `USE_NNPACK=0` to disable building QNNPACK and NNPACK respectively. However this wasn't reflected correctly because we were looking for `NO_QNNPACK` and `NO_NNPACK`. This PR fixes it.