### PR TITLE
Implementation quantize operation for mkldnn tensor.

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -6,12 +6,13 @@
 
 #include <ideep.hpp>
 
-namespace at { namespace native {
+namespace at {
+namespace native {
 
 /**
  * `IntrusivePtrTargetWrapper` wraps a custom storage handle  of a tensor
-*  (as template param) and inherits `c10::intrusive_ptr_target` so that it
-*  can be used with `c10::intrusive_ptr`.
+ *  (as template param) and inherits `c10::intrusive_ptr_target` so that it
+ *  can be used with `c10::intrusive_ptr`.
  *
  * It currently only supports wrapping the custom handle by:
  * - Constructing with an existing custom handle by copy/move constructor.
@@ -22,13 +23,13 @@ namespace at { namespace native {
  */
 template <typename T>
 struct CAFFE2_API IntrusivePtrTargetWrapper : c10::intrusive_ptr_target {
-private:
+ private:
   T target_;
 
-public:
+ public:
   IntrusivePtrTargetWrapper() = delete;
-  IntrusivePtrTargetWrapper(const T& target): target_(target) {}
-  IntrusivePtrTargetWrapper(T&& target): target_(std::move(target)) {}
+  IntrusivePtrTargetWrapper(const T& target) : target_(target) {}
+  IntrusivePtrTargetWrapper(T&& target) : target_(std::move(target)) {}
 
   T& get_target() {
     return target_;
@@ -46,15 +47,19 @@ Tensor new_with_itensor_mkldnn(ideep::tensor&& it, const TensorOptions& options)
   auto dims = it.get_dims();
   IDeepTensorWrapperPtr handle = c10::make_intrusive<IDeepTensorWrapper>(std::move(it));
   return detail::make_tensor<MKLDNNTensorImpl>(
-    MkldnnCPUTensorId(), options.dtype(), options.device(), handle,
-    std::vector<int64_t>(dims.begin(), dims.end()));
+      MkldnnCPUTensorId(), options.dtype(), options.device(), handle,
+      std::vector<int64_t>(dims.begin(), dims.end()));
 }
 
 ideep::tensor& itensor_from_mkldnn(const MKLDNNTensor& mkldnn_tensor) {
-  AT_ASSERTM(mkldnn_tensor.is_mkldnn(),
-             "mkldnn_to_dense expects MKL-DNN tensor input");
-  AT_ASSERTM(!mkldnn_tensor.is_variable(), "_internal_get_MKLDNNImpl: should not be a variable");
-  MKLDNNTensorImpl *mklimpl = static_cast<MKLDNNTensorImpl *>(mkldnn_tensor.unsafeGetTensorImpl());
+  AT_ASSERTM(
+      mkldnn_tensor.is_mkldnn(),
+      "mkldnn_to_dense expects MKL-DNN tensor input");
+  AT_ASSERTM(
+      !mkldnn_tensor.is_variable(),
+      "_internal_get_MKLDNNImpl: should not be a variable");
+  MKLDNNTensorImpl* mklimpl =
+      static_cast<MKLDNNTensorImpl*>(mkldnn_tensor.unsafeGetTensorImpl());
   return mklimpl->unsafe_opaque_handle()->get_target();
 }
 
@@ -62,8 +67,9 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
   AT_ASSERTM(
       tensor.type_id() == CPUTensorId(),
       "itensor_view_from_dense expects dense CPU tensor input");
-  AT_ASSERTM(tensor.scalar_type() == ScalarType::Float,
-             "itensor_view_from_dense expects float tensor input");
+  AT_ASSERTM(
+      tensor.scalar_type() == ScalarType::Float,
+      "itensor_view_from_dense expects float tensor input");
   AT_ASSERTM(
       !tensor.is_variable(),
       "itensor_view_from_dense: should not be a variable");
@@ -71,6 +77,8 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
            ideep::tensor::data_type::f32},
           tensor.template data<float>()};
 }
-}}
+
+} // namespace native
+} // namespace at
 
 #endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -21,6 +21,24 @@ struct AllocForMKLDNN {
   }
 };
 
+inline ideep::tensor::data_type get_mkldnn_dtype(ScalarType type, int64_t zero_point = 0) {
+  switch (type) {
+    case kFloat:
+      return ideep::tensor::data_type::f32;
+    case kQInt32:
+      return ideep::tensor::data_type::s32;
+    case kQUInt8:
+      if (zero_point == 0)
+        return ideep::tensor::data_type::u8;
+      else
+        return ideep::tensor::data_type::s8;
+    case kQInt8:
+      return ideep::tensor::data_type::s8;
+    default:
+      AT_ERROR("get_mkldnn_dtype: unsupported data type");
+  }
+}
+
 // Construct aten MKL-DNN tensor given an ideep tensor
 Tensor new_with_itensor_mkldnn(ideep::tensor&& it, const TensorOptions& options);
 
@@ -30,6 +48,21 @@ ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 // Construct an `ideep::tensor` "view" from dense tensor, note the
 // ideep::tensor will share the underlying buffer
 ideep::tensor itensor_view_from_dense(const Tensor& tensor);
+
+// Convert zero_point scales to min_max scales
+// NOTE:
+//  The scales in operator is saved in pytorch format,
+//  while pytorch scales are the reciprocals of MKL-DNN scales.
+//  This function is provided to convert scales from pytorch to MKL-DNN
+inline ideep::scale_t ConvertScales(
+    const std::vector<float>& scales_z) {
+  ideep::scale_t scales (scales_z);
+  for (auto it = scales.begin(); it != scales.end(); it++) {
+    *it = 1.0f / *it;
+  }
+  return scales;
+}
+
 }}
 
 #endif // AT_MKLDNN_ENABLED

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -3,36 +3,158 @@
 #include <ATen/Config.h>
 #include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <ATen/native/utils/ParamUtils.h>
-
-namespace at { namespace native {
+#include <ATen/Parallel.h>
 
 #if AT_MKLDNN_ENABLED()
 
+namespace {
+template <typename T>
+void mkldnn_tensor_to_buffer(const at::Tensor& mkldnn_tensor, T* output_point) {
+  ideep::tensor& input = at::native::itensor_from_mkldnn(mkldnn_tensor);
+  // NHWC is a public format in MKL-DNN so we have to explicitly convert it to
+  // NCHW tensor to align with PyTorch format.
+  if (input.is_nhwc_format()) {
+    ideep::tensor output;
+    output.init({input.get_dims(), input.get_data_type()}, output_point);
+    if (input.has_scale())
+      output.set_scale(input.get_scale());
+    output.feed_from(input);
+  } else {
+    input.to_public_format(output_point);
+  }
+
+  // MKLDNN support symatric quantized tensor only,so we need to convert asymatric
+  // quantized tensor to symatric quantized tensor here.
+  if (input.get_data_type() == ideep::tensor::data_type::s8 &&
+      mkldnn_tensor.scalar_type() == at::kQUInt8) {
+    auto data_src = reinterpret_cast<int8_t*>(output_point);
+    auto data_dst = reinterpret_cast<uint8_t*>(output_point);
+    auto n = mkldnn_tensor.numel();
+    at::parallel_for(0, n, 2048, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; i++)
+        data_dst[i] = static_cast<int>(data_src[i]) + 128;
+    });
+  }
+}
+
+template <typename T>
+void dense_tensor_to_mkldnn(
+    const at::Tensor& cpu_tensor,
+    at::Tensor& mkldnn_tensor) {
+  ideep::tensor& tensor_out = at::native::itensor_from_mkldnn(mkldnn_tensor);
+  auto scalar_type = cpu_tensor.scalar_type();
+  // MKLDNN support symatric quantized tensor only,so we need to convert asymatric
+  // quantized tensor to symatric quantized tensor here.
+  if (scalar_type == at::kQUInt8 &&
+      tensor_out.get_data_type() == ideep::tensor::data_type::s8) {
+    uint8_t* data_src =
+        reinterpret_cast<uint8_t*>(cpu_tensor.template data<c10::quint8>());
+    auto data_dst = reinterpret_cast<int8_t*>(
+        at::native::itensor_from_mkldnn(mkldnn_tensor).get_data_handle());
+    auto n = cpu_tensor.numel();
+    at::parallel_for(0, n, 2048, [&](int64_t begin, int64_t end) {
+      for (int64_t i = begin; i < end; i++)
+        data_dst[i] = static_cast<int>(data_src[i]) - 128;
+    });
+  } else {
+    ideep::tensor tensor_in;
+    tensor_in.init(
+        {tensor_out.get_dims(), at::native::get_mkldnn_dtype(scalar_type)},
+        cpu_tensor.template data<T>());
+    if (c10::isQIntType(scalar_type)) {
+      auto scale = cpu_tensor.q_scale();
+      tensor_in.set_scale(at::native::ConvertScales({scale}));
+    }
+    tensor_out.feed_from(tensor_in);
+  }
+}
+} // namespace
+
+namespace at {
+namespace native {
+
 Tensor mkldnn_to_dense(const Tensor& mkldnn_tensor) {
-  ideep::tensor& stensor = itensor_from_mkldnn(mkldnn_tensor);
-  auto dims = stensor.get_dims();
+  ideep::tensor& tensor_src = itensor_from_mkldnn(mkldnn_tensor);
   // NOTE: int32_t dims from ideep::tensor but sizes needs int64_t
-  Tensor cpu_tensor = at::empty(
-    std::vector<int64_t>(dims.begin(), dims.end()),
-    mkldnn_tensor.options().layout(c10::kStrided));
-  stensor.to_public(cpu_tensor.template data<float>());
+  auto dims = tensor_src.get_dims();
+
+  Tensor cpu_tensor;
+
+  if (tensor_src.is_empty())
+    return cpu_tensor;
+
+  auto scalar_type = mkldnn_tensor.scalar_type();
+  if (isQIntType(scalar_type)) {
+    ideep::scale_t scale_mkldnn {1};
+    if (tensor_src.has_scale()) {
+      scale_mkldnn = tensor_src.get_scale();
+      AT_ASSERTM(scale_mkldnn.size() == 1, "Only support per tensor quantized tensor.");
+    }
+    auto scale = ConvertScales(scale_mkldnn);
+    cpu_tensor = empty_affine_quantized_cpu(
+        std::vector<int64_t>(dims.begin(), dims.end()),
+        mkldnn_tensor.options().layout(c10::kStrided),
+        scale[0],
+        (tensor_src.get_data_type() == ideep::tensor::data_type::s8 && scalar_type == kQUInt8) ? 128
+                                                                           : 0);
+    AT_DISPATCH_QINT_TYPES(scalar_type, "mkldnn_to_dense", [&]() {
+      mkldnn_tensor_to_buffer<scalar_t>(mkldnn_tensor, cpu_tensor.template data<scalar_t>());
+    });
+  } else {
+    AT_ASSERTM(scalar_type == kFloat, "Only support float data type!");
+    cpu_tensor = at::empty(
+        std::vector<int64_t>(dims.begin(), dims.end()),
+        mkldnn_tensor.options().layout(c10::kStrided));
+    mkldnn_tensor_to_buffer<float>(mkldnn_tensor, cpu_tensor.template data<float>());
+  }
   return cpu_tensor;
 }
 
 Tensor dense_to_mkldnn(const Tensor& cpu_tensor) {
-  AT_ASSERTM(cpu_tensor.type_id() == CPUTensorId(),
-             "dense_to_mkldnn expects dense CPU tensor input");
-  AT_ASSERTM(cpu_tensor.scalar_type() == ScalarType::Float,
-             "dense_to_mkldnn expects float tensor input");
-  AT_ASSERTM(cpu_tensor.dim() <= 5,
-             "Can't convert cpu tensor with the number of dimensions > 5");
+  auto scalar_type = cpu_tensor.scalar_type();
+  int64_t zero_point;
+
+  AT_ASSERTM(
+      cpu_tensor.type_id() == CPUTensorId() ||
+          cpu_tensor.type_id() == QuantizedCPUTensorId(),
+      "dense_to_mkldnn expects dense CPU or quantizedCPU tensor input");
+  if (cpu_tensor.type_id() == QuantizedCPUTensorId()) {
+    zero_point = cpu_tensor.q_zero_point();
+    AT_ASSERTM(
+        (zero_point == 0 ||zero_point == 128),
+        "mkldnn only support 0 or 128 zero point in quantized tensor");
+  } else
+    AT_ASSERTM(
+        scalar_type == kFloat,
+        "dense_to_mkldnn expects float tensor input");
+  AT_ASSERTM(
+      cpu_tensor.dim() <= 5,
+      "Can't convert cpu tensor to mkldnn tensor with the number of dimensions > 5");
   // TODO: consider to convert non-contiguous tensor to `ideep::tensor` directly.
   auto cpu_tensor_cont = cpu_tensor.contiguous();
-  Tensor mkldnn_tensor = empty_mkldnn(cpu_tensor_cont.sizes(), cpu_tensor_cont.options());
-  ideep::tensor& dtensor = itensor_from_mkldnn(mkldnn_tensor);
-  dtensor.feed_from(dtensor.get_dims(),
-                    ideep::tensor::data_type::f32,
-                    (cpu_tensor_cont.template data<float>()));
+  Tensor mkldnn_tensor;
+  if (cpu_tensor.type_id() == QuantizedCPUTensorId()) {
+    mkldnn_tensor = empty_affine_quantized_mkldnn(
+        cpu_tensor_cont.sizes(), cpu_tensor_cont.options(), cpu_tensor.q_scale(), zero_point);
+  } else
+    mkldnn_tensor =
+        empty_mkldnn(cpu_tensor_cont.sizes(), cpu_tensor_cont.options());
+
+  switch (scalar_type) {
+    case kFloat:
+      dense_tensor_to_mkldnn<float>(cpu_tensor_cont, mkldnn_tensor);
+      break;
+    case kQUInt8:
+    case kQInt8:
+    case kQInt32:
+      AT_DISPATCH_QINT_TYPES(scalar_type, "dense_to_mkldnn", [&]() {
+        dense_tensor_to_mkldnn<scalar_t>(cpu_tensor_cont, mkldnn_tensor);
+      });
+      break;
+    default:
+      AT_ERROR("dense_to_mkldnn: unsupport data type!");
+  }
+
   return mkldnn_tensor;
 }
 
@@ -72,7 +194,12 @@ Tensor mkldnn_reorder_conv2d_weight(
   return new_with_itensor_mkldnn(std::move(result), self.options());
 }
 
+} // namespace native
+} // namespace at
 #else
+
+namespace at {
+namespace native {
 
 Tensor mkldnn_to_dense(const Tensor& mkldnn_tensor) {
   AT_ERROR("MKL-DNN build is disabled");
@@ -91,6 +218,6 @@ Tensor mkldnn_reorder_conv2d_weight(
   AT_ERROR("mkldnn_reorder_conv2d_weight: MKL-DNN build is disabled");
 }
 
+} // namespace native
+} // namespace at
 #endif // AT_MKLDNN_ENABLED()
-
-}}

--- a/aten/src/ATen/native/mkldnn/QTensor.cpp
+++ b/aten/src/ATen/native/mkldnn/QTensor.cpp
@@ -1,0 +1,139 @@
+#include <ATen/native/TensorFactories.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+
+namespace at {
+namespace native {
+
+#if !AT_MKLDNN_ENABLED()
+
+Tensor empty_affine_quantized_mkldnn(
+    IntArrayRef sizes,
+    const TensorOptions& options,
+    double scale,
+    int64_t zero_point,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  AT_ERROR(
+      "empty_affine_quantized_mkldnn: ATen not compiled with MKLDNN support");
+}
+
+Tensor quantize_linear_mkldnn(
+    const Tensor& self,
+    double scale,
+    int64_t zero_point,
+    ScalarType dtype) {
+  AT_ERROR("quantize_linear_mkldnn: ATen not compiled with MKLDNN support");
+}
+
+Tensor dequantize_quant_mkldnn(const Tensor& self) {
+  AT_ERROR("dequantize_quant_mkldnn: ATen not compiled with MKLDNN support");
+}
+
+double q_scale_quant_mkldnn(const Tensor& self) {
+  AT_ERROR("q_scale_quant_mkldnn: ATen not compiled with MKLDNN support");
+}
+
+int64_t q_zero_point_quant_mkldnn(const Tensor& self) {
+  AT_ERROR("q_zero_point_quant_mkldnn: ATen not compiled with MKLDNN support");
+}
+
+#else // AT_MKLDNN_ENABLED()
+
+Tensor empty_affine_quantized_mkldnn(
+    IntArrayRef sizes,
+    const TensorOptions& options,
+    double scale,
+    int64_t zero_point,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TORCH_CHECK(
+      options.has_dtype(),
+      "Must provide data type for Tensor creation functions.");
+  TORCH_CHECK(
+      (options.dtype() == kQUInt8 && (zero_point == 0 || zero_point == 128)) ||
+          ((options.dtype() == kQInt32 || options.dtype() == kQInt8) &&
+           zero_point == 0),
+      "Only support uint8 with 0, 128 zero point and int32,int8 with 0 zero point.");
+  native::check_size_nonnegative(sizes);
+  ideep::tensor::dims dst_dims(sizes.begin(), sizes.end());
+  auto data_type =
+      get_mkldnn_dtype(at::typeMetaToScalarType(options.dtype()), zero_point);
+
+  ideep::tensor itensor;
+  itensor.resize<AllocForMKLDNN>(dst_dims, data_type);
+  ideep::scale_t Y_scales_ = ConvertScales({scale});
+  itensor.set_scale(Y_scales_);
+  return new_with_itensor_mkldnn(std::move(itensor), options);
+}
+
+Tensor quantize_linear_mkldnn(
+    const Tensor& self,
+    double scale,
+    int64_t zero_point,
+    ScalarType dtype) {
+  TORCH_CHECK(
+      self.scalar_type() == kFloat,
+      "Mkldnn quantize only works on Float Tensor.");
+  TORCH_CHECK(
+      self.device() == kCPU,
+      "Mkldnn quantize only works for CPU backend right now.");
+  TORCH_CHECK(
+      (dtype == kQUInt8 && (zero_point == 128 || zero_point == 0)) ||
+          ((dtype == kQInt8 || dtype == kQInt32) && zero_point == 0),
+      "Only support uint8 with 0, 128 zero point and int32,int8 with 0 zero point.");
+
+  ideep::tensor& src_itensor = itensor_from_mkldnn(self);
+
+  TensorOptions options = self.options().dtype(dtype);
+
+  native::check_size_nonnegative(self.sizes());
+  auto data_type = get_mkldnn_dtype(dtype, zero_point);
+
+  ideep::tensor dst_itensor;
+  dst_itensor.init<AllocForMKLDNN>(
+      {src_itensor.get_dims(), data_type, src_itensor.get_public_format()});
+  ideep::scale_t Y_scales_ = ConvertScales({scale});
+  dst_itensor.set_scale(Y_scales_);
+  dst_itensor.feed_from(src_itensor);
+
+  Tensor qtensor = new_with_itensor_mkldnn(std::move(dst_itensor), options);
+
+  return qtensor;
+}
+
+Tensor dequantize_quant_mkldnn(const Tensor& self) {
+  Tensor tensor = empty_mkldnn(self.sizes(), self.options().dtype(kFloat));
+  ideep::tensor& dst_itensor = itensor_from_mkldnn(tensor);
+  ideep::tensor& src_itensor = itensor_from_mkldnn(self);
+  dst_itensor.feed_from(src_itensor);
+  return tensor;
+}
+
+double q_scale_quant_mkldnn(const Tensor& self) {
+  ideep::tensor& itensor = itensor_from_mkldnn(self);
+  TORCH_CHECK(itensor.has_scale(), "quantized tensor hasn't scale!");
+  auto mkldnn_scales = itensor.get_scale();
+  auto scales = ConvertScales(mkldnn_scales);
+  return scales[0];
+}
+
+int64_t q_zero_point_quant_mkldnn(const Tensor& self) {
+  ideep::tensor& itensor = itensor_from_mkldnn(self);
+  switch (self.scalar_type()) {
+    case kQInt32:
+    case kQInt8:
+      return 0;
+    case kQUInt8:
+      if (itensor.get_data_type() == ideep::tensor::data_type::u8)
+        return 0;
+      else if (itensor.get_data_type() == ideep::tensor::data_type::s8)
+        return 128;
+      else
+        AT_ERROR("q_zero_point_quant_mkldnn: unsupport mkldnn data type!");
+    default:
+      AT_ERROR("q_zero_point_quant_mkldnn: unsupport data type!");
+  }
+}
+
+#endif // AT_MKLDNN_ENABLED()
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -722,6 +722,7 @@
 - func: _empty_affine_quantized(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, float scale=1, int zero_point=0, MemoryFormat? memory_format=contiguous_format) -> Tensor
   dispatch:
     QuantizedCPU: empty_affine_quantized_cpu
+    MkldnnCPU: empty_affine_quantized_mkldnn
 
 - func: resize_(Tensor(a!) self, int[] size) -> Tensor(a!)
   variants: method
@@ -2683,6 +2684,7 @@
   variants: method
   dispatch:
     CPU: dense_to_mkldnn
+    QuantizedCPU: dense_to_mkldnn
 
 - func: mkldnn_reorder_conv2d_weight(Tensor self, int[2] padding=0, int[2] stride=1, int[2] dilation=1, int groups=1) -> Tensor
   variants: function
@@ -2696,6 +2698,7 @@
   variants: function
   dispatch:
     CPU: quantize_linear_cpu
+    MkldnnCPU: quantize_linear_mkldnn
 
 - func: quantize_linear_per_channel(Tensor self, Tensor scales, Tensor zero_points, int[] axis, ScalarType dtype) -> Tensor
   variants: function
@@ -2706,6 +2709,7 @@
   variants: function, method
   dispatch:
     QuantizedCPU: dequantize_quant
+    MkldnnCPU: dequantize_quant_mkldnn
 
 - func: _dequantize_linear(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor
   variants: function
@@ -2716,11 +2720,13 @@
   variants: function, method
   dispatch:
     QuantizedCPU: q_scale_quant
+    MkldnnCPU: q_scale_quant_mkldnn
 
 - func: q_zero_point(Tensor self) -> int
   variants: function, method
   dispatch:
     QuantizedCPU: q_zero_point_quant
+    MkldnnCPU: q_zero_point_quant_mkldnn
 
 - func: int_repr(Tensor self) -> Tensor
   variants: function, method

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -406,6 +406,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
   bool is_quantized() const {
+    // mkldnn quantized tensor is represented by non-quantized tensor with data
+    // type,sunch as QInt8...,so we use isQIntType to identify quantized tensor.
+    if (is_mkldnn())
+      return isQIntType(typeMetaToScalarType(dtype()));
     // NB: This method is not virtual and avoid dispatches for performance reasons.
     auto tid = type_id();
     // NB: At the moment, variables have the same TensorTypeId as their


### PR DESCRIPTION
Implemented:
- quantize_linear/dequantize for mkldnn tensor
- get q_scale/q_zero_point for mkldnn tensor
- support to convert quantized mkldnn tensor to dense tensor
- support to convert quantized dense tensor to mkldnn tensor

