### PR TITLE
Add the support of handle Bias being nullptr for torch.ops.quantized.fbgemm_linear

### DIFF
--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -95,7 +95,7 @@ class Linear(NNLinear):
     __constants__ = ['bias', 'in_features', 'out_features']
 
     def __init__(self, in_features, out_features, bias=True):
-        assert bias, 'nobias is not supported in Quantized Linear module yet'
+        # assert bias, 'nobias is not supported in Quantized Linear module yet'
         super(Linear, self).__init__(in_features, out_features, bias)
         del self.weight
         del self.bias


### PR DESCRIPTION
Summary:
- C10 Operator Registration(fbcode/caffe2/aten/src/ATen/core/op_registration/op_registration.cpp) doesn't support None type yet.

- ATen has None Tensor support, e.g., diffusion/FBS/browse/master/fbcode/caffe2/aten/src/ATen/native/native_functions.yaml;3210db0fe278e46fc5c15cecb181a3789000655d$1073

Differential Revision: D16069522

