### PR TITLE
Numerical stability of embedding kernels

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -14,7 +14,6 @@
 #include <thrust/execution_policy.h>
 #include <thrust/unique.h>
 
-#include <torch/types.h>
 
 namespace at {
 namespace native {
@@ -277,8 +276,8 @@ Tensor embedding_backward_cuda_kernel(
       // should match `acc_type`
       using partial_weight_t = acc_type<scalar_t, true>;
       TensorOptions op;
-      if(grad.dtype() == torch::kFloat16) {
-          op = grad.options().dtype(torch::kFloat32);
+      if(grad.dtype() == at::kHalf) {
+          op = grad.options().dtype(at::kFloat);
       } else {
           op = grad.options();
       }

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -142,9 +142,6 @@ __global__ void compute_grad_weight(
   }
   const int idx_begin = segment_offsets[id];
   const int idx_end = (id == num_of_segments-1)?numel:segment_offsets[id+1];
-  if (idx_begin == padding_idx) {
-    return;
-  }
 
   accscalar_t weight = 0;
   for (int idx=idx_begin; idx < idx_end; ++idx) {

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -15,6 +15,8 @@
 #include <thrust/unique.h>
 #include <thrust/device_vector.h>
 
+#include <torch/types.h>
+
 namespace at {
 namespace native {
 
@@ -82,7 +84,8 @@ __global__ void compute_grad_weight_bags(
     int64_t *offset2bag, int64_t *count, ptrdiff_t numel,
     int64_t stride, int mode_mean, const int64_t *bag_size,
     scalar_t* per_sample_weights, int64_t per_sample_weights_stride,
-    int64_t* segment_offsets, int64_t num_of_segments, scalar_t *grad_weight_per_segment,
+    int64_t* segment_offsets, int64_t num_of_segments,
+    acc_type<scalar_t, true> *grad_weight_per_segment,
     const int64_t stride_warped) {
 
   const int gid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -126,7 +129,7 @@ __global__ void compute_grad_weight(
     int64_t stride,
     int64_t* segment_offsets,
     int64_t num_of_segments,
-    scalar_t *grad_weight_per_segment,
+    acc_type<scalar_t, true> *grad_weight_per_segment,
     int padding_idx,
     const int64_t stride_warped) {
 
@@ -158,7 +161,8 @@ __global__ void compute_grad_weight(
 template <typename scalar_t>
 __global__ void sum_and_scatter(
     int64_t *input, scalar_t *gradWeight, int64_t stride,
-    int64_t* segment_offsets, int64_t num_of_segments, const scalar_t *grad_weight_per_segment,
+    int64_t* segment_offsets, int64_t num_of_segments,
+    const acc_type<scalar_t, true> *grad_weight_per_segment,
     const int64_t *segment_sizes_offsets, int64_t num_of_partial_segments,
     const int64_t stride_warped) {
 
@@ -264,59 +268,62 @@ Tensor embedding_backward_cuda_kernel(
             num_of_segments);
   }
 
-  auto grad_weight_per_segment = at::empty({num_of_partial_segments, stride}, grad.options());
   const int stride_warped = ceil_div(stride, WARP_SIZE)*WARP_SIZE;
   const int block = std::min(stride_warped, MAX_BLOCK_SIZE);
   const int grid = ceil_div(num_of_partial_segments*stride_warped, block);
 
-  // Compute the sum of each partial-segment and handle bags
-  if (offset2bag.defined()) {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.scalar_type(), "embedding_bag_backward_cuda_compute_grad_weight", [&] {
-        compute_grad_weight_bags<scalar_t><<<grid, block, 0, stream>>>(
-          orig_indices.data<int64_t>(),
-          grad.data<scalar_t>(),
-          offset2bag.data<int64_t>(),
-          count.defined() ? count.data<int64_t>() : nullptr, numel, stride,
-          mode_mean, bag_size.data<int64_t>(),
-          per_sample_weights.defined() ? per_sample_weights.data<scalar_t>() : NULL,
-          per_sample_weights.defined() ? per_sample_weights.stride(0) : 0,
-          partial_segment_offset.data<int64_t>(),
-          num_of_partial_segments, grad_weight_per_segment.data<scalar_t>(),
-          stride_warped);
-    });
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      grad.scalar_type(), "embedding_bag_backward_cuda_compute_grad_weight", [&] {
-        compute_grad_weight<scalar_t><<<grid, block, 0, stream>>>(
-          orig_indices.data<int64_t>(),
-          grad.data<scalar_t>(),
-          count.defined() ? count.data<int64_t>() : nullptr,
-          numel, stride,
-          partial_segment_offset.data<int64_t>(),
-          num_of_partial_segments,
-          grad_weight_per_segment.data<scalar_t>(),
-          padding_idx,
-          stride_warped);
-    });
-  }
-  THCudaCheck(cudaGetLastError());
-
-  // Finally, we sum all the partial-sums and scatter them
-  // into `grad_weight`.
-  const int grid2 = ceil_div(num_of_segments*stride_warped, block);
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-    grad.scalar_type(), "embedding_bag_backward_cuda_sum_and_scatter", [&] {
-      sum_and_scatter<scalar_t><<<grid2, block, 0, stream>>>(
-        sorted_indices.data<int64_t>(),
-        grad_weight.data<scalar_t>(),
-        stride,
-        thrust::raw_pointer_cast(segment_offsets.data()),
-        num_of_segments, grad_weight_per_segment.data<scalar_t>(),
-        thrust::raw_pointer_cast(partials_per_segment_offset.data()),
-        num_of_partial_segments, stride_warped);
+    grad.scalar_type(), "embedding_bag_backward_cuda_compute_grad_weight", [&] {
+      // For numerical stability, the dtype of `grad_weight_per_segment`
+      // should match `acc_type`
+      using partial_weight_t = acc_type<scalar_t, true>;
+      TensorOptions op;
+      if(grad.dtype() == torch::kFloat16) {
+          op = grad.options().dtype(torch::kFloat32);
+      } else {
+          op = grad.options();
+      }
+      auto grad_weight_per_segment = at::empty({num_of_partial_segments, stride}, op);
+      // Compute the sum of each partial-segment and handle bags
+      if (offset2bag.defined()) {
+            compute_grad_weight_bags<scalar_t><<<grid, block, 0, stream>>>(
+              orig_indices.data<int64_t>(),
+              grad.data<scalar_t>(),
+              offset2bag.data<int64_t>(),
+              count.defined() ? count.data<int64_t>() : nullptr, numel, stride,
+              mode_mean, bag_size.data<int64_t>(),
+              per_sample_weights.defined() ? per_sample_weights.data<scalar_t>() : NULL,
+              per_sample_weights.defined() ? per_sample_weights.stride(0) : 0,
+              partial_segment_offset.data<int64_t>(),
+              num_of_partial_segments, grad_weight_per_segment.data<partial_weight_t>(),
+              stride_warped);
+      } else {
+            compute_grad_weight<scalar_t><<<grid, block, 0, stream>>>(
+              orig_indices.data<int64_t>(),
+              grad.data<scalar_t>(),
+              count.defined() ? count.data<int64_t>() : nullptr,
+              numel, stride,
+              partial_segment_offset.data<int64_t>(),
+              num_of_partial_segments,
+              grad_weight_per_segment.data<partial_weight_t>(),
+              padding_idx,
+              stride_warped);
+      }
+      THCudaCheck(cudaGetLastError());
+
+      // Finally, we sum all the partial-sums and scatter them
+      // into `grad_weight`.
+      const int grid2 = ceil_div(num_of_segments*stride_warped, block);
+          sum_and_scatter<scalar_t><<<grid2, block, 0, stream>>>(
+            sorted_indices.data<int64_t>(),
+            grad_weight.data<scalar_t>(),
+            stride,
+            thrust::raw_pointer_cast(segment_offsets.data()),
+            num_of_segments, grad_weight_per_segment.data<partial_weight_t>(),
+            thrust::raw_pointer_cast(partials_per_segment_offset.data()),
+            num_of_partial_segments, stride_warped);
+      THCudaCheck(cudaGetLastError());
   });
-  THCudaCheck(cudaGetLastError());
   return grad_weight;
 }
 


### PR DESCRIPTION
Address the issue raised in #22377.

The PR #22016 introduces a temporary tensor of weights `grad_weight_per_segment` of the same dtype as the end result, which can be a problem when using `float16`.
In this PR, it now use a `float32` temporary tensor when the input is `float16`.

@ngimel, can I get you to review? I think I have fixed the issues you have pointed out.
