### PR TITLE
Add type stubs to import 'nn' modules

### DIFF
--- a/torch/__init__.pyi.in
+++ b/torch/__init__.pyi.in
@@ -24,6 +24,7 @@ from .autograd import no_grad as no_grad, enable_grad as enable_grad, \
     set_grad_enabled as set_grad_enabled
 from . import cuda as cuda
 from . import optim as optim
+from . import nn as nn
 
 class dtype: ...
 
@@ -126,3 +127,4 @@ def compiled_with_cxx11_abi() -> bool: ...
 # (similar to `unique`, `lu`, etc.); as such, it is not
 # possible to type correctly
 def nonzero(input: Tensor, *, out: Optional[Tensor]=None, as_tuple: Optional[bool]=None): ...
+

--- a/torch/nn/__init__.pyi
+++ b/torch/nn/__init__.pyi
@@ -1,0 +1,5 @@
+from .modules import * 
+from .parameter import Parameter as Parameter
+from .parallel import DataParallel as DataParallel
+from . import init as init
+from . import utils as utils

--- a/torch/nn/modules/__init__.pyi.in
+++ b/torch/nn/modules/__init__.pyi.in
@@ -1,3 +1,4 @@
+from .module import Module as Module
 from .activation import CELU as CELU, ELU as ELU, GLU as GLU, Hardshrink as Hardshrink, Hardtanh as Hardtanh, \
     LeakyReLU as LeakyReLU, LogSigmoid as LogSigmoid, LogSoftmax as LogSoftmax, PReLU as PReLU, RReLU as RReLU, \
     ReLU as ReLU, ReLU6 as ReLU6, SELU as SELU, Sigmoid as Sigmoid, Softmax as Softmax, Softmax2d as Softmax2d, \

--- a/torch/nn/modules/conv.pyi.in
+++ b/torch/nn/modules/conv.pyi.in
@@ -53,8 +53,10 @@ class Conv3d(_ConvNd):
 class _ConvTransposeMixin:
     def forward(self, input: Tensor, output_size: Optional[List[int]] = ...): ...
 
-
-class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
+# We need a '# type: ignore' at the end of the declaration of each class that inherits from 
+# `_ConvTransposeMixin` since the `forward` method declared in `_ConvTransposeMixin` is 
+# incompatible with the `forward` method declared in `Module`.
+class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):  # type: ignore
     def __init__(self, in_channels: int, out_channels: int, kernel_size: _size_1_t, stride: _size_1_t = ...,
                  padding: _size_1_t = ..., output_padding: _size_1_t = ..., groups: int = ..., bias: bool = ...,
                  dilation: int = ..., padding_mode: str = ...) -> None: ...
@@ -62,7 +64,7 @@ class ConvTranspose1d(_ConvTransposeMixin, _ConvNd):
     def forward(self, input: Tensor, output_size: Optional[List[int]] = ...) -> Tensor: ...
 
 
-class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
+class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):  # type: ignore
     def __init__(self, in_channels: int, out_channels: int, kernel_size: _size_2_t, stride: _size_2_t = ...,
                  padding: _size_2_t = ..., output_padding: _size_2_t = ..., groups: int = ..., bias: bool = ...,
                  dilation: int = ..., padding_mode: str = ...) -> None: ...
@@ -70,7 +72,7 @@ class ConvTranspose2d(_ConvTransposeMixin, _ConvNd):
     def forward(self, input: Tensor, output_size: Optional[List[int]] = ...) -> Tensor: ...
 
 
-class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):
+class ConvTranspose3d(_ConvTransposeMixin, _ConvNd):  # type: ignore
     def __init__(self, in_channels: int, out_channels: int, kernel_size: _size_3_t, stride: _size_3_t = ...,
                  padding: _size_3_t = ..., output_padding: _size_3_t = ..., groups: int = ..., bias: bool = ...,
                  dilation: int = ..., padding_mode: str = ...) -> None: ...

--- a/torch/nn/parallel/scatter_gather.pyi
+++ b/torch/nn/parallel/scatter_gather.pyi
@@ -9,8 +9,12 @@ T = TypeVar('T', Dict, List, Tuple)
 @overload
 def scatter(inputs: Tensor, target_gpus: _devices_t, dim: int = ...) -> Tuple[Tensor, ...]: ...
 
+# flake8 will raise a spurious error here since `torch/__init__.pyi` has not been generated yet
+# so mypy will interpret `Tensor` as `Any` since it is an import from what it belives to be an
+# untyped module. Thus to mypy, the first definition of `scatter` looks strictly more general
+# than this overload.
 @overload
-def scatter(inputs: T, target_gpus: _devices_t, dim: int = ...) -> List[T]: ...
+def scatter(inputs: T, target_gpus: _devices_t, dim: int = ...) -> List[T]: ...  # type: ignore 
 
 
 # TODO More precise types here.

--- a/torch/nn/utils/spectral_norm.pyi
+++ b/torch/nn/utils/spectral_norm.pyi
@@ -1,6 +1,6 @@
 from typing import Any, Optional, TypeVar
 from ... import Tensor
-from .. import Module
+from ..modules import Module
 
 
 class SpectralNorm:

--- a/torch/nn/utils/weight_norm.pyi
+++ b/torch/nn/utils/weight_norm.pyi
@@ -1,5 +1,5 @@
 from typing import Any, TypeVar
-from .. import Module
+from ..modules import Module
 
 
 class WeightNorm:


### PR DESCRIPTION
Forgot to mirror the `nn/ __init__.py` semantics in the new `nn` type stub.