### PR TITLE
split onnx passes

### DIFF
--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -107,6 +107,8 @@ void initJITBindings(PyObject* module) {
       .def(
           "_jit_debug_fuser_num_cached_kernel_specs",
           torch::jit::fuser::debugNumCachedKernelSpecs)
+      .def("_jit_pass_onnx_remove_print", RemovePrintOps)
+      .def("_jit_pass_onnx_preprocess_caffe2", PreprocessCaffe2Ops)
       .def("_jit_pass_onnx", ToONNX)
       .def("_jit_pass_lower_all_tuples", LowerAllTuples)
       .def("_jit_pass_onnx_peephole", PeepholeOptimizeONNX)

--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/passes/erase_number_types.h>
 #include <torch/csrc/jit/constants.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
 
 namespace torch {
 namespace jit {
@@ -53,6 +54,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
       } break;
     }
   }
+  EliminateDeadCode(block);
 }
 
 void EraseNumberTypes(const std::shared_ptr<Graph>& graph) {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -35,7 +35,7 @@ void removePrintOps(Block* block) {
   }
 }
 
-void removePrintOps(std::shared_ptr<Graph>& graph) {
+void RemovePrintOps(std::shared_ptr<Graph>& graph) {
   removePrintOps(graph->block());
 }
 
@@ -94,20 +94,14 @@ void preprocessCaffe2Ops(Block* block) {
         }
         if (type->isSubclass(TypeKind::TensorType)) {
           it->addInput(origin_input);
-        } else if (type->kind() == TypeKind::BoolType || type->kind() == TypeKind::FloatType || type->kind() == TypeKind::IntType) {
+        } else if (type->kind() == TypeKind::BoolType || type->kind() == TypeKind::IntType) {
           const auto* constant_node = origin_input->node();
           AT_ASSERT(constant_node->kind() == prim::Constant);
-          const auto& tensor = constant_node->t(attr::value);
-          AT_ASSERT(tensor.numel() == 1);
-          if (type->kind() == TypeKind::IntType || type->kind() == TypeKind::BoolType) {
-            it->i_(Symbol::attr(arg.name()), tensor.item().to<int64_t>());
-          } else if (type->kind() == TypeKind::FloatType) {
-            it->f_(Symbol::attr(arg.name()), tensor.item().to<float>());
-          } else {
-            // TODO handle the StringType, no c10 op accept String as argument yet
-            throw std::runtime_error("Unhandled scalar arg: " + arg.name() +
-                ", type: " + c10::typeKindToString(type->kind()));
-          }
+          it->i_(Symbol::attr(arg.name()), constant_node->i(attr::value));
+        } else if (type->kind() == TypeKind::FloatType) {
+          const auto* constant_node = origin_input->node();
+          AT_ASSERT(constant_node->kind() == prim::Constant);
+          it->f_(Symbol::attr(arg.name()), constant_node->f(attr::value));
         } else if (type->kind() == TypeKind::StringType) {
           const auto* constant_node = origin_input->node();
           AT_ASSERT(constant_node->kind() == prim::Constant);
@@ -129,9 +123,7 @@ void preprocessCaffe2Ops(Block* block) {
             for (const auto* elem_input : list_node->inputs()) {
               const auto* constant_node = elem_input->node();
               AT_ASSERT(constant_node->kind() == prim::Constant);
-              const auto& tensor = constant_node->t(attr::value);
-              AT_ASSERT(tensor.numel() == 1);
-              values.push_back(tensor.item().to<double>());
+              values.push_back(constant_node->f(attr::value));
             }
             it->fs_(Symbol::attr(arg.name()), values);
           } else {
@@ -147,7 +139,7 @@ void preprocessCaffe2Ops(Block* block) {
   EliminateDeadCode(block);
 }
 
-void preprocessCaffe2Ops(std::shared_ptr<Graph>& graph) {
+void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph) {
   preprocessCaffe2Ops(graph->block());
 }
 
@@ -157,8 +149,6 @@ std::shared_ptr<Graph> ToONNX(
     ::torch::onnx::OperatorExportTypes operator_export_type) {
   auto new_graph = std::make_shared<Graph>(graph->current_scope());
   std::unordered_map<Value*, Value*> env;
-  removePrintOps(graph);
-  preprocessCaffe2Ops(graph);
   BlockToONNX(graph->block(), new_graph->block(), operator_export_type, env);
   return new_graph;
 }

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -14,6 +14,8 @@ TORCH_API void BlockToONNX(
     Block* new_block,
     ::torch::onnx::OperatorExportTypes operator_export_type,
     std::unordered_map<Value*, Value*> env);
+TORCH_API void RemovePrintOps(std::shared_ptr<Graph>& graph);
+TORCH_API void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph);
 
 } // namespace jit
 } // namespace torch

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -220,6 +220,9 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
         torch._C._jit_pass_peephole(graph, True)
         torch._C._jit_pass_lint(graph)
 
+        torch._C._jit_pass_onnx_remove_print(graph)
+        torch._C._jit_pass_onnx_preprocess_caffe2(graph)
+
         # onnx only supports tensors, so we turn all out number types into tensors
         torch._C._jit_pass_erase_number_types(graph)
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22413 split onnx passes**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16079890/)

_jit_pass_erase_number_types invalidates the jit graph but parts of _jit_pass_onnx rely on having a valid jit graph.

This splits _jit_pass_onnx into _jit_pass_onnx_remove_print and _jit_pass_onnx_preprocess_caffe2 (which rely on the valid jit graph), runs these before _jit_pass_erase_number_types,
and then runs the rest of _jit_pass_onnx after _jit_pass_erase_number_types

Differential Revision: [D16079890](https://our.internmc.facebook.com/intern/diff/D16079890/)