### PR TITLE
[jit] Fix `ScriptModule.__dir__()`

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12692,6 +12692,13 @@ a")
             def fn():
                 return random.randint()
 
+    def test_dir(self):
+        class M(torch.jit.ScriptModule):
+            def forward(self, t):
+                return t
+
+        self.assertTrue('forward' in dir(M()))
+
     def test_inferred_error_msg(self):
         """
         Test that when we get a type mismatch on a function where we inferred

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1610,7 +1610,7 @@ if _enabled:
                 super(ScriptModule, self).__setattr__(attr, _get_valid_constant(attr, value))
 
         def __dir__(self):
-            return sorted(Module.__dir__(self) + self._method_names())
+            return sorted(Module.__dir__(self) + self._c._method_names())
 
         def define(self, lang):
             # We use frames_up=1 to get to the proper surrounding scope. The stack


### PR DESCRIPTION
`_method_names` is on `_c`, so `dir(script_module)` calls previously
didn't work