### PR TITLE
Remove API-level guard on NeuralNetworks.h

### DIFF
--- a/caffe2/mobile/contrib/nnapi/NeuralNetworks.h
+++ b/caffe2/mobile/contrib/nnapi/NeuralNetworks.h
@@ -42,8 +42,6 @@
  *   - DO NOT CHANGE THE LAYOUT OR SIZE OF STRUCTURES
  */
 
-#if __ANDROID_API__ >= __ANDROID_API_O_MR1__
-
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/cdefs.h>
@@ -1921,8 +1919,6 @@ int ANeuralNetworksEvent_wait(ANeuralNetworksEvent* event);
 void ANeuralNetworksEvent_free(ANeuralNetworksEvent* event);
 
 __END_DECLS
-
-#endif  //  __ANDROID_API__ >= 27
 
 #endif  // ANDROID_ML_NN_RUNTIME_NEURAL_NETWORKS_H
 


### PR DESCRIPTION
Summary: Android NDK r20 removes the guard `(__ANDROID_API__ <= __ANDROID_API_O_MR1__)`, so we do it here also. There is insufficient reason to keep these decls undefined for earlier API levels. NDK r15 and earlier don't even define `__ANDROID_API_O_MR1__`, so the preprocessor defaults it to 0 and the guard evaluates as TRUE.

Reviewed By: smeenai, hlu1

Differential Revision: D16084105

