### PR TITLE
remove caffe2/core dependency from ATen/core/jit_type.h

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -6,7 +6,6 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/qualified_name.h>
 #include <c10/util/TypeList.h>
-#include <caffe2/core/common.h>
 
 #include <c10/util/Optional.h>
 

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -9,7 +9,7 @@ namespace jit {
 struct GuardElimination {
   GuardElimination(std::shared_ptr<Graph> graph)
       : graph_(std::move(graph)),
-        aliasDb_(caffe2::make_unique<AliasDb>(graph_)) {}
+        aliasDb_(c10::guts::make_unique<AliasDb>(graph_)) {}
 
   void run() {
     moveGuardsToDefs(graph_->block());


### PR DESCRIPTION
Summary: This include doesn't seem to be needed. Remove it to simplify mobile build dependency.

Differential Revision: D16088224

