### PR TITLE
Properly formats errors rising up from C++ extension compilation

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -791,6 +791,8 @@ class TestCase(expecttest.TestCase):
     if sys.version_info < (3, 2):
         # assertRegexpMatches renamed to assertRegex in 3.2
         assertRegex = unittest.TestCase.assertRegexpMatches
+        # assertNotRegexpMatches renamed to assertNotRegex in 3.2
+        assertNotRegex = unittest.TestCase.assertNotRegexpMatches
         # assertRaisesRegexp renamed to assertRaisesRegex in 3.2
         assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -791,10 +791,13 @@ class TestCase(expecttest.TestCase):
     if sys.version_info < (3, 2):
         # assertRegexpMatches renamed to assertRegex in 3.2
         assertRegex = unittest.TestCase.assertRegexpMatches
-        # assertNotRegexpMatches renamed to assertNotRegex in 3.2
-        assertNotRegex = unittest.TestCase.assertNotRegexpMatches
         # assertRaisesRegexp renamed to assertRaisesRegex in 3.2
         assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
+    if sys.version_info < (3, 5):
+        # assertNotRegexpMatches renamed to assertNotRegex in 3.5
+        assertNotRegex = unittest.TestCase.assertNotRegexpMatches
+
 
 
 def download_file(url, binary=True):

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -622,6 +622,22 @@ class TestCppExtension(common.TestCase):
         finally:
             torch.set_default_dtype(initial_default)
 
+    def test_compilation_error_formatting(self):
+        # Test that the missing-semicolon error is being formatted 
+        # correctly. The pattern will match lines like this:
+        #
+        # int main() { return 0 }
+        #                      ^
+        #                      ;
+        # 
+        # Save yourself some effort and use regex101.com or the like
+        # if you need to update this.
+        pattern = r'int main\(\) { return 0 }\n\s+\^\s+;\n'
+        with self.assertRaisesRegex(RuntimeError, pattern):
+            torch.utils.cpp_extension.load_inline(
+                name="test_compilation_error_formatting",
+                cpp_sources="int main() { return 0 }") 
+
 
 class TestMSNPUTensor(common.TestCase):
     @classmethod

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -627,11 +627,12 @@ class TestCppExtension(common.TestCase):
         # This'll fail if the message has been munged into a single line.
         # It's hard to write anything more specific as every compiler has it's own
         # error formatting.
-        pattern = r'.*[\n\r].*'
-        with self.assertRaisesRegex(RuntimeError, pattern):
+        with self.assertRaises(RuntimeError) as e:
             torch.utils.cpp_extension.load_inline(
                 name="test_compilation_error_formatting",
                 cpp_sources="int main() { return 0 }") 
+        pattern = r'.*(\\n|\\r).*'
+        self.assertNotRegex(str(e), pattern)
 
 
 class TestMSNPUTensor(common.TestCase):

--- a/test/test_cpp_extensions.py
+++ b/test/test_cpp_extensions.py
@@ -623,16 +623,11 @@ class TestCppExtension(common.TestCase):
             torch.set_default_dtype(initial_default)
 
     def test_compilation_error_formatting(self):
-        # Test that the missing-semicolon error is being formatted 
-        # correctly. The pattern will match lines like this:
-        #
-        # int main() { return 0 }
-        #                      ^
-        #                      ;
-        # 
-        # Save yourself some effort and use regex101.com or the like
-        # if you need to update this.
-        pattern = r'int main\(\) { return 0 }\n\s+\^\s+;\n'
+        # Test that the missing-semicolon error message has linebreaks in it. 
+        # This'll fail if the message has been munged into a single line.
+        # It's hard to write anything more specific as every compiler has it's own
+        # error formatting.
+        pattern = r'.*[\n\r].*'
         with self.assertRaisesRegex(RuntimeError, pattern):
             torch.utils.cpp_extension.load_inline(
                 name="test_compilation_error_formatting",

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -955,7 +955,7 @@ def _build_extension_module(name, build_directory, verbose):
         # error.output contains the stdout and stderr of the build attempt.
         message = "Error building extension '{}'".format(name)
         if hasattr(error, 'output') and error.output:
-            message += ": {}".format(str(error.output))
+            message += ": {}".format(error.output.decode())
         raise RuntimeError(message)
 
 


### PR DESCRIPTION
Here's a C++ extension with a missing semicolon:
```python
torch.utils.cpp_extension.load_inline('test', 'int main() { return 0 }')
``` 
which currently generates this error
```
RuntimeError: Error building extension 'test_v6': b'[1/2] c++ -MMD -MF main.o.d -
DTORCH_EXTENSION_NAME=test_v6 -DTORCH_API_INCLUDE_EXTENSION_H -isystem 
/opt/conda/lib/python3.7/site-packages/torch/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/torch/csrc/api/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/TH -isystem /opt/conda/lib/python3.7/site-packages/torch/include/THC 
-isystem /opt/conda/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC -std=c++11 -c 
/tmp/torch_extensions/test/main.cpp -o main.o\nFAILED: main.o \nc++ -MMD -MF main.o.d -
DTORCH_EXTENSION_NAME=test_v6 -DTORCH_API_INCLUDE_EXTENSION_H -isystem 
/opt/conda/lib/python3.7/site-packages/torch/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/torch/csrc/api/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/TH -isystem /opt/conda/lib/python3.7/site-packages/torch/include/THC
 -isystem /opt/conda/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC -std=c++11 -c 
/tmp/torch_extensions/test/main.cpp -o main.o\n/tmp/torch_extensions/test/main.cpp: In 
function \xe2\x80\x98int main()\xe2\x80\x99:\n/tmp/torch_extensions/test/main.cpp:2:23: 
error: expected \xe2\x80\x98;\xe2\x80\x99 before \xe2\x80\x98}\xe2\x80\x99 token\n int 
main() { return 0 }\n                       ^\nninja: build stopped: subcommand failed.\n'
```

After this PR, the error is
```
RuntimeError: Error building extension 'test': [1/2] c++ -MMD -MF main.o.d -
DTORCH_EXTENSION_NAME=test -DTORCH_API_INCLUDE_EXTENSION_H -isystem 
/opt/conda/lib/python3.7/site-packages/torch/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/torch/csrc/api/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/TH -isystem /opt/conda/lib/python3.7/site-packages/torch/include/THC
 -isystem /opt/conda/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC -std=c++11 -c 
/tmp/torch_extensions/test/main.cpp -o main.o
FAILED: main.o 
c++ -MMD -MF main.o.d -DTORCH_EXTENSION_NAME=test -
DTORCH_API_INCLUDE_EXTENSION_H -isystem /opt/conda/lib/python3.7/site-
packages/torch/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/torch/csrc/api/include -isystem /opt/conda/lib/python3.7/site-
packages/torch/include/TH -isystem /opt/conda/lib/python3.7/site-packages/torch/include/THC
 -isystem /opt/conda/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC -std=c++11 -c 
/tmp/torch_extensions/test/main.cpp -o main.o
/tmp/torch_extensions/test/main.cpp: In function ‘int main()’:
/tmp/torch_extensions/test/main.cpp:2:23: error: expected ‘;’ before ‘}’ token
 int main() { return 0 }
                       ^
ninja: build stopped: subcommand failed.
``` 
which is a lot easier to read.