### PR TITLE
Add ReduceOp.XOR to torch.distributed

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -139,6 +139,11 @@ def simple_reduce_tests(rank, world_size):
             torch.Tensor([rank + 1.0]),
             torch.Tensor([world_size]),
         ),
+        (
+            c10d.ReduceOp.XOR,
+            torch.LongTensor([(rank + 1) % 2]),
+            torch.LongTensor([((world_size + 1) / 2) % 2]),
+        ),
     ]
 
 
@@ -164,6 +169,11 @@ def simple_multi_input_reduce_tests(rank, world_size):
             [torch.Tensor([2 * rank + 1.0]), torch.Tensor([2 * rank + 2.0])],
             torch.Tensor([2 * world_size]),
         ),
+        (
+            c10d.ReduceOp.XOR,
+            [torch.LongTensor([(rank + 1) % 2]), torch.LongTensor([rank % 2])],
+            torch.LongTensor([(world_size / 2) % 2]),
+        )
     ]
 
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -77,7 +77,7 @@ PyObject* c10d_init(PyObject* _unused) {
 
   py::enum_<::c10d::ReduceOp>(module, "ReduceOp", R"(
 An enum-like class of available reduce operations: ``SUM``, ``PRODUCT``,
-``MIN``, and ``MAX``.
+``MIN``, ``MAX``, and ``XOR``.
 
 The values of this class can be accessed as attributes, e.g., ``ReduceOp.SUM``.
 They are used in specifying strategies for reduction collectives, e.g.,
@@ -85,7 +85,8 @@ They are used in specifying strategies for reduction collectives, e.g.,
       .value("SUM", ::c10d::ReduceOp::SUM)
       .value("PRODUCT", ::c10d::ReduceOp::PRODUCT)
       .value("MIN", ::c10d::ReduceOp::MIN)
-      .value("MAX", ::c10d::ReduceOp::MAX);
+      .value("MAX", ::c10d::ReduceOp::MAX)
+      .value("XOR", ::c10d::ReduceOp::XOR);
 
   py::class_<::c10d::BroadcastOptions>(module, "BroadcastOptions")
       .def(py::init<>())

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -85,7 +85,7 @@ dist_backend = Backend
 class reduce_op(object):
     r"""
     Deprecated enum-like class for reduction operations: ``SUM``, ``PRODUCT``,
-    ``MIN``, and ``MAX``.
+    ``MIN``, ``MAX``, and ``XOR``.
 
     :class:`~torch.distributed.ReduceOp` is recommended to use instead.
     """

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -10,6 +10,7 @@ enum class ReduceOp : std::uint8_t {
   PRODUCT,
   MIN,
   MAX,
+  XOR,
   UNUSED,
 };
 


### PR DESCRIPTION
Summary:
Add ReduceOp.XOR to torch.distributed for use with torch.LongTensor allreduce functions and modify unit-tests accordingly

Differential Revision: D15223418

