### PR TITLE
Add `requires_grad_(bool)` API to Tensor

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -786,6 +786,7 @@ class CAFFE2_API Tensor {
   bool equal(const Tensor & other) const;
   Tensor pow(const Tensor & exponent) const;
   Tensor alias() const;
+  Tensor & requires_grad_(bool requires_grad=true);
 
   // We changed .dtype() to return a TypeMeta in #12766. Ideally, we want the
   // at::kDouble and its friends to be TypeMeta's, but that hasn't happened yet.

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1738,6 +1738,10 @@ inline Tensor Tensor::alias() const {
     static auto table = globalATenDispatch().getOpTable("aten::alias(Tensor(a) self) -> Tensor(a)");
     return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
 }
+inline Tensor & Tensor::requires_grad_(bool requires_grad) {
+    static auto table = globalATenDispatch().getOpTable("aten::requires_grad_(Tensor(a!) self, bool requires_grad=True) -> Tensor(a!)");
+    return table->getOp<Tensor & (Tensor &, bool)>(tensorTypeIdToBackend(type_id()), is_variable())(*this, requires_grad);
+}
 
 inline bool Tensor::is_variable() const noexcept {
   return impl_->is_variable();

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1,6 +1,5 @@
 # See README.md in this directory for more guidance
 
-
 # Temporary type cast operators. These are needed to trace type-casts now since
 # Type's are not supported in the IR. Instead, we call down to these
 # specialized operators for each datatype.
@@ -5451,3 +5450,8 @@
   dispatch:
     CPU: im2col_backward_cpu
     CUDA: im2col_backward_cuda
+
+## Autograd functions
+
+- func: requires_grad_(Tensor(a!) self, bool requires_grad=True) -> Tensor(a!)
+  variants: method

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -304,3 +304,14 @@ TEST(TensorTest, Item_CUDA) {
     ASSERT_EQ(scalar.to<int>(), 123);
   }
 }
+
+TEST(TensorTest, SetRequiresGradInplace) {
+  auto tensor = torch::empty({3, 4}, at::TensorOptions().requires_grad(false));
+  ASSERT_FALSE(tensor.requires_grad());
+
+  tensor.requires_grad_(true);
+  ASSERT_TRUE(tensor.requires_grad());
+
+  tensor.requires_grad_(false);
+  ASSERT_FALSE(tensor.requires_grad());
+}

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -576,7 +576,8 @@ def create_python_bindings(python_functions, has_self, is_module=False):
                 has_type_input_arg = True
             elif arg['simple_type'] == 'TensorOptions':
                 has_options_arg = True
-            if arg['name'] == 'requires_grad':
+            # We only allow `tensor.requires_grad_()` method to have `requires_grad` as pre-defined argument
+            if not name == 'requires_grad_' and arg['name'] == 'requires_grad':
                 raise ValueError("argument named requires_grad not supported")
 
         has_tensor_return = False

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -455,29 +455,6 @@ static PyObject * THPVariable_record_stream(PyObject* self, PyObject* arg)
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPVariable_requires_grad_(PyObject* self, PyObject* args, PyObject* kwargs)
-{
-  HANDLE_TH_ERRORS
-  static PythonArgParser parser({
-    "requires_grad_(bool requires_grad=True)",
-  });
-  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  ParsedArgs<1> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  auto requires_grad = r.toBool(0);
-  // should we throw if requires_grad is true?  var.requires_grad = True throws here
-  // but it's nice to let this be a no-op.
-  if (!self_.is_leaf() && !requires_grad) {
-    throw std::runtime_error(autograd::utils::requires_grad_leaf_error(requires_grad));
-  }
-  if (requires_grad && !self_.is_floating_point()) {
-    throw std::runtime_error("only Tensors of floating point dtype can require gradients");
-  }
-  self_.set_requires_grad(requires_grad);
-  return THPVariable_Wrap(self_);
-  END_HANDLE_TH_ERRORS
-}
-
 inline bool dispatch_is_contiguous(Tensor & self, MemoryFormat memory_format) {
   return self.is_contiguous(memory_format);
 }
@@ -767,7 +744,6 @@ PyMethodDef variable_methods[] = {
   {"nonzero", (PyCFunction)THPVariable_nonzero, METH_VARARGS | METH_KEYWORDS, NULL},
   {"numpy", (PyCFunction)THPVariable_numpy, METH_NOARGS, NULL},
   {"record_stream", (PyCFunction)THPVariable_record_stream, METH_O, NULL},
-  {"requires_grad_", (PyCFunction)THPVariable_requires_grad_, METH_VARARGS | METH_KEYWORDS, NULL},
   {"short", (PyCFunction)THPVariable_short, METH_NOARGS, NULL},
   {"size", (PyCFunction)THPVariable_size, METH_VARARGS | METH_KEYWORDS, NULL},
   {"storage", (PyCFunction)THPVariable_storage, METH_NOARGS, NULL},

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -19,6 +19,23 @@
 #include <vector>
 #include <typeinfo>
 
+namespace at {
+namespace native {
+
+Tensor & requires_grad_(Tensor & self, bool requires_grad) {
+  // should we throw if requires_grad is true?  var.requires_grad = True throws here
+  // but it's nice to let this be a no-op.
+  if (!self.is_leaf() && !requires_grad) {
+    throw std::runtime_error(torch::autograd::utils::requires_grad_leaf_error(requires_grad));
+  }
+  if (requires_grad && !self.is_floating_point()) {
+    throw std::runtime_error("only Tensors of floating point dtype can require gradients");
+  }
+  self.set_requires_grad(requires_grad);
+}
+
+}} // namespace at::native
+
 namespace torch {
 namespace autograd {
 Variable::AutogradMeta::AutogradMeta(at::TensorImpl* self_impl, bool requires_grad, Edge gradient_edge) {


### PR DESCRIPTION
This PR adds `requires_grad_(bool)` API to Tensor, to match the Python API and allow constructing and setting `requires_grad` for a tensor in one line:
```cpp
auto tensor = at::rand(sizes, t.options()).requires_grad_(requires_grad);
```