### PR TITLE
include conv_op_impl.h from conv_dnnlowp_op.cc

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -10,6 +10,7 @@
 #endif
 
 #include "caffe2/core/tensor_int8.h"
+#include "caffe2/operators/conv_op_impl.h"
 #include "caffe2/utils/cpuid.h"
 
 #include <fbgemm/src/RefImplementations.h>


### PR DESCRIPTION
Summary: To make sure template instantiation.

Reviewed By: jianyuh

Differential Revision: D16094183

