### PR TITLE
EraseNumberTypes cleans itself up

### DIFF
--- a/torch/csrc/jit/passes/erase_number_types.cpp
+++ b/torch/csrc/jit/passes/erase_number_types.cpp
@@ -33,6 +33,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
           Value* r = block->owningGraph()->insertConstant(
               scalar_to_tensor(s), nullptr, c10::nullopt, it->scope());
           it->output()->replaceAllUsesWith(r);
+          it.destroyCurrent();
         }
       } break;
       case prim::Bool:
@@ -41,7 +42,7 @@ static void EraseNumberTypesOnBlock(Block* block) {
       case prim::ImplicitTensorToNum:
       case prim::NumToTensor: {
         it->output()->replaceAllUsesWith(it->inputs()[0]);
-        // Let DCE cleanup
+        it.destroyCurrent();
       } break;
       default: {
         for (auto o : it->outputs()) {
@@ -54,7 +55,6 @@ static void EraseNumberTypesOnBlock(Block* block) {
       } break;
     }
   }
-  EliminateDeadCode(block);
 }
 
 void EraseNumberTypes(const std::shared_ptr<Graph>& graph) {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22239 Open up AliasAnalysisKind for any ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15996322/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22175 AliasAnalysisKind::CONSERVATIVE/FROM_SCHEMA&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15929595/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22476 Fix dead code elimination in onnx export&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16100172/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22461 EraseNumberTypes cleans itself up**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D16094656/)

We shouldn't call dead code elimination after EraseNumberTypes because dead code elimination assumes a valid jit graph which EraseNumberTypes just broke.
Let's have it clean up itself isntead.

Differential Revision: [D16094656](https://our.internmc.facebook.com/intern/diff/D16094656/)