### PR TITLE
Fix dead code elimination in onnx export

### DIFF
--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -106,7 +106,9 @@ void validateGraph(
     const std::shared_ptr<Graph>& graph,
     onnx_torch::OperatorExportTypes operator_export_type) {
   validateBlock(graph->block(), operator_export_type);
-  EliminateDeadCode(graph->block());
+  // this is run on an onnx graph which doesn't have side effects.
+  // ignore side effects in dead code elimination.
+  EliminateDeadCode(graph->block(), true, DCESideEffectPolicy::IGNORE_SIDE_EFFECTS);
 }
 
 class EncoderBase {

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -108,7 +108,7 @@ void validateGraph(
   validateBlock(graph->block(), operator_export_type);
   // this is run on an onnx graph which doesn't have side effects.
   // ignore side effects in dead code elimination.
-  EliminateDeadCode(graph->block(), true, DCESideEffectPolicy::IGNORE_SIDE_EFFECTS);
+  EliminateDeadCode(graph->block(), true, DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS);
 }
 
 class EncoderBase {

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -127,6 +127,11 @@ void initJITBindings(PyObject* module) {
             return EliminateDeadCode(g->block()); // overload resolution
           })
       .def(
+          "_jit_pass_dce_allow_deleting_nodes_with_side_effects",
+          [](std::shared_ptr<Graph>& g) {
+            return EliminateDeadCode(g->block(), true, DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS); // overload resolution
+          })
+      .def(
           "_jit_pass_cse",
           [](std::shared_ptr<Graph>& g) {
             return EliminateCommonSubexpression(g); // overload resolution

--- a/torch/csrc/jit/passes/dead_code_elimination.h
+++ b/torch/csrc/jit/passes/dead_code_elimination.h
@@ -18,7 +18,7 @@ enum class DCESideEffectPolicy : uint8_t {
   // with this flag, dead code elimination will not check if a node has side
   // effects and treat nodes with side effects like any other node,
   // i.e. delete them if their outputs aren't used anywhere.
-  IGNORE_SIDE_EFFECTS
+  ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS
 };
 
 TORCH_API void EliminateDeadCode(const std::shared_ptr<Graph>& graph, DCESideEffectPolicy sideEffectPolicy = DCESideEffectPolicy::DONT_DELETE_NODES_WITH_SIDE_EFFECTS);

--- a/torch/csrc/jit/passes/dead_code_elimination.h
+++ b/torch/csrc/jit/passes/dead_code_elimination.h
@@ -11,12 +11,23 @@ namespace jit {
 // eliminate mutable ops.
 //
 // So, prefer to use the graph version if you can.
-TORCH_API void EliminateDeadCode(const std::shared_ptr<Graph>& graph);
-TORCH_API void EliminateDeadCode(Block* block, bool recurse = true);
+enum class DCESideEffectPolicy : uint8_t {
+  // default behavior: dead code elimination will check if a node has side effects
+  // and not delete it if it does.
+  DONT_DELETE_NODES_WITH_SIDE_EFFECTS,
+  // with this flag, dead code elimination will not check if a node has side
+  // effects and treat nodes with side effects like any other node,
+  // i.e. delete them if their outputs aren't used anywhere.
+  IGNORE_SIDE_EFFECTS
+};
+
+TORCH_API void EliminateDeadCode(const std::shared_ptr<Graph>& graph, DCESideEffectPolicy sideEffectPolicy = DCESideEffectPolicy::DONT_DELETE_NODES_WITH_SIDE_EFFECTS);
+TORCH_API void EliminateDeadCode(Block* block, bool recurse = true, DCESideEffectPolicy sideEffectPolicy = DCESideEffectPolicy::DONT_DELETE_NODES_WITH_SIDE_EFFECTS);
 
 // Invoke the user-provided callback on all live values before deleting anything
 TORCH_API void EliminateDeadCode(
     Block* block,
-    std::function<void(const std::unordered_set<const Value*>&)> cb);
+    std::function<void(const std::unordered_set<const Value*>&)> cb,
+    DCESideEffectPolicy sideEffectPolicy = DCESideEffectPolicy::DONT_DELETE_NODES_WITH_SIDE_EFFECTS);
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -136,7 +136,6 @@ void preprocessCaffe2Ops(Block* block) {
       }
     }
   }
-  EliminateDeadCode(block);
 }
 
 void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph) {
@@ -345,7 +344,6 @@ void BlockToONNX(
     env.at(output)->setType(output->type());
   }
 
-  EliminateDeadCode(ctx.block);
 }
 
 } // namespace jit

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -136,6 +136,7 @@ void preprocessCaffe2Ops(Block* block) {
       }
     }
   }
+  EliminateDeadCode(block, true, DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS);
 }
 
 void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph) {
@@ -343,7 +344,7 @@ void BlockToONNX(
     ctx.block->registerOutput(env.at(output));
     env.at(output)->setType(output->type());
   }
-
+  EliminateDeadCode(ctx.block, true, DCESideEffectPolicy::ALLOW_DELETING_NODES_WITH_SIDE_EFFECTS);
 }
 
 } // namespace jit

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -214,6 +214,8 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
     torch._C._jit_pass_peephole(graph, True)
     torch._C._jit_pass_lint(graph)
 
+    torch._C._jit_pass_dce(graph)
+
     if operator_export_type != OperatorExportTypes.RAW:
         # onnx only supports tensors, but 1 / 2 = 0.5 and tensor(1) / tensor(2) = 0
         torch._C._jit_pass_prepare_division_for_onnx(graph)
@@ -223,6 +225,9 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
         torch._C._jit_pass_lint(graph)
 
         torch._C._jit_pass_onnx_remove_print(graph)
+
+        torch._C._jit_pass_dce(graph)
+
         torch._C._jit_pass_onnx_preprocess_caffe2(graph)
 
         # onnx only supports tensors, so we turn all out number types into tensors
@@ -232,7 +237,6 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
         torch._C._jit_pass_lint(graph)
         torch._C._jit_pass_onnx_peephole(graph)
         torch._C._jit_pass_lint(graph)
-    torch._C._jit_pass_dce(graph)
     torch._C._jit_pass_lint(graph)
     torch._C._jit_pass_fixup_onnx_loops(graph)
     torch._C._jit_pass_lint(graph)


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22239 Open up AliasAnalysisKind for any ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15996322/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22175 AliasAnalysisKind::CONSERVATIVE/FROM_SCHEMA&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15929595/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22476 Fix dead code elimination in onnx export**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16100172/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22461 EraseNumberTypes cleans itself up&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D16094656/)

Dead code elimination assumes a valid jit graph because it checks if operators have side effects.
The onnx export path destroys the jit graph right before calling dead code elimination, but it actually doesn't care about side effects.
We can just call dead code elimination and disable side effect lookup and things should work.

Differential Revision: [D16100172](https://our.internmc.facebook.com/intern/diff/D16100172/)