### PR TITLE
Deprecate vector/unordered_map again

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -198,6 +198,9 @@ struct CAFFE2_API IValue final {
   // IntList
   IValue(c10::List<int64_t> v);
   IValue(c10::ArrayRef<int64_t> v);
+  /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
+  /// \endcond
   IValue(std::vector<int64_t> v);
   bool isIntList() const { return Tag::IntList == tag; }
   c10::List<int64_t> toIntList() &&;
@@ -215,6 +218,9 @@ struct CAFFE2_API IValue final {
 
   // DoubleList
   IValue(c10::List<double> v);
+  /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
+  /// \endcond
   IValue(std::vector<double> v);
   bool isDoubleList() const { return Tag::DoubleList == tag; }
   c10::List<double> toDoubleList() &&;
@@ -223,6 +229,9 @@ struct CAFFE2_API IValue final {
 
   // BoolList
   IValue(c10::List<bool> v);
+  /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
+  /// \endcond
   IValue(std::vector<bool> v);
   bool isBoolList() const { return Tag::BoolList == tag; }
   c10::List<bool> toBoolList() &&;
@@ -230,6 +239,9 @@ struct CAFFE2_API IValue final {
 
   //TensorList
   IValue(c10::List<at::Tensor> v);
+  /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
+  /// \endcond
   IValue(std::vector<at::Tensor> v);
   bool isTensorList() const { return Tag::TensorList == tag; }
   c10::List<at::Tensor> toTensorList() &&;
@@ -246,6 +258,9 @@ struct CAFFE2_API IValue final {
   template<class T>
   IValue(c10::List<T> v);
   template<class T>
+  /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
+  C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
+  /// \endcond
   IValue(std::vector<T> v);
 
   // GenericDict
@@ -258,6 +273,9 @@ struct CAFFE2_API IValue final {
   IValue(c10::Dict<Key, Value> v);
 
   template<class Key, class Value>
+  /// \cond DOXYGEN_CANNOT_HANDLE_CONSTRUCTORS_WITH_MACROS_SO_EXCLUDE_THIS_LINE_FROM_DOXYGEN
+  C10_DEPRECATED_MESSAGE("IValues based on std::unordered_map<K, V> are slow and deprecated. Please use c10::Dict<K, V> instead.")
+  /// \endcond
   IValue(std::unordered_map<Key, Value> v);
 
   template<class T>

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -413,6 +413,7 @@ struct _fake_type {};
 // The _fake_type<T> parameter allows us to overload
 // based on the return type.
 template <class Elem>
+C10_DEPRECATED_MESSAGE("IValues based on std::vector<T> are potentially slow and deprecated. Please use c10::List<T> instead.")
 std::vector<Elem> generic_to(
     IValue ivalue,
     _fake_type<std::vector<Elem>>) {
@@ -443,6 +444,7 @@ c10::Dict<Key, Value> generic_to(
 }
 
 template <typename K, typename V>
+C10_DEPRECATED_MESSAGE("IValues based on std::unordered_map are slow and deprecated. Please use c10::Dict<K, V> instead.")
 std::unordered_map<K, V> generic_to(
     IValue ivalue,
     _fake_type<std::unordered_map<K, V>>) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1184,7 +1184,7 @@ class ShapePropagator {
             "aten::min_values(Tensor self, int[] dim, bool keepdim) -> Tensor",
         },
         [](Node* node) -> type_vec_t {
-          if (auto dim = node->get<std::vector<int64_t>>(attr::dim)) {
+          if (auto dim = node->get<torch::List<int64_t>>(attr::dim)) {
             return multidim_reduce_with_postprocess(
                 node,
                 /*num_reduced_dim=*/dim->size(),
@@ -1206,7 +1206,7 @@ class ShapePropagator {
             "aten::sum(Tensor self, int[] dim, bool keepdim) -> Tensor",
         },
         [](Node* node) -> type_vec_t {
-          if (auto dim = node->get<std::vector<int64_t>>(attr::dim)) {
+          if (auto dim = node->get<torch::List<int64_t>>(attr::dim)) {
             // TODO: can dim contain duplicates?
             return multidim_reduce_with_postprocess(
                 node, /*num_reduced_dim=*/dim->size(), /*upcast_integer=*/true);


### PR DESCRIPTION
The deprecation was temporarily removed in https://github.com/pytorch/pytorch/pull/21999 because it threw warnings on our codebase.

https://github.com/pytorch/pytorch/pull/22162 fixed these internal call sites so we can now re-enable the deprecation.

I checked locally that this PR doesn't add any new warnings.