### PR TITLE
Add mpi:// initialization method for torch.distributed

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -187,7 +187,9 @@ def test_distributed(executable, test_module, test_directory, options):
         if backend == 'mpi' and not mpi_available:
             continue
         for init_method in ['file://', 'env://', 'mpi://']:
-            if backend == 'mpi' and init_method.startswith('mpi:'):
+            # The MPI backend only needs to be tested with a single
+            # initialization method (because it doesn't use initialization).
+            if backend == 'mpi' and init_method != 'env://':
                 continue
             tmp_dir = tempfile.mkdtemp()
             if options.verbose:

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -140,7 +140,7 @@ def skip_if_no_gpu(func):
 
 def skip_if_small_worldsize(func):
     # Short circuit if we're not spawning processes for every test
-    if BACKEND == 'mpi' or INIT_METHOD == 'mpi://':
+    if BACKEND == 'mpi' or INIT_METHOD.startswith('mpi://'):
         if int(os.environ["WORLD_SIZE"]) <= 2:
             return unittest.skip("worldsize is too small to run group tests")
         return lambda func: func
@@ -196,7 +196,7 @@ def require_num_gpus(n):
     """
 
     # Short circuit if we're not spawning processes for every test
-    if BACKEND == 'mpi' or INIT_METHOD == 'mpi://':
+    if BACKEND == 'mpi' or INIT_METHOD.startswith('mpi://'):
         if not torch.cuda.is_available():
             return unittest.skip("CUDA is not available")
         if torch.cuda.device_count() < n:
@@ -1573,7 +1573,7 @@ class _DistTestBase(object):
         self.assertEqual(process_group_sync, process_group)
 
 
-if (BACKEND == "gloo" or BACKEND == "nccl") and INIT_METHOD != "mpi://":
+if (BACKEND == "gloo" or BACKEND == "nccl") and not INIT_METHOD.startswith("mpi://"):
     WORLD_SIZE = os.environ["WORLD_SIZE"]
 
     class TestDistBackend(TestCase, _DistTestBase):
@@ -1697,7 +1697,7 @@ if (BACKEND == "gloo" or BACKEND == "nccl") and INIT_METHOD != "mpi://":
             self.assertEqual(first_process.exitcode, 0)
 
 
-elif BACKEND == "mpi" or INIT_METHOD == "mpi://":
+elif BACKEND == "mpi" or INIT_METHOD.startswith("mpi://"):
     WORLD_SIZE = os.environ["WORLD_SIZE"]
 
     # Force MPI initialization method to use a fixed port

--- a/torch/distributed/_object.py
+++ b/torch/distributed/_object.py
@@ -1,0 +1,53 @@
+import io
+import torch
+
+
+def _object_to_tensor(obj):
+    """
+    Serialize Python object to torch.ByteTensor.
+    """
+    buf = io.BytesIO()
+    torch.save(obj, buf)
+    return torch.ByteTensor(list(buf.getvalue()))
+
+
+def _tensor_to_object(tensor):
+    """
+    Deserialize Python object from torch.ByteTensor.
+    """
+    buf = io.BytesIO(bytearray(tensor.tolist()))
+    buf.seek(0)
+    return torch.load(buf)
+
+
+def _broadcast_object(process_group, obj=None, root=0):
+    """
+    Broadcast Python object from root to all processes in the process group.
+
+    Arguments:
+        process_group (ProcessGroup): The process group to use.
+        obj (object, optional): The object to broadcast.
+                                Must be set only on the root process.
+        root (int, optional): The rank of the root process.
+
+    Returns:
+        The broadcast object. On the root process it returns a copy of
+        the `obj` argument (after serialization and deserialization).
+
+    """
+    tensor = None
+    length = torch.empty([1], dtype=torch.uint8)
+    if process_group.rank() == root:
+        tensor = _object_to_tensor(obj)
+        length[0] = tensor.size(0)
+
+    # Broadcast length of the serialized data.
+    process_group.broadcast(length, root=root).wait()
+
+    # Broadcast serialized data itself.
+    if process_group.rank() != root:
+        tensor = torch.empty([length[0]], dtype=torch.uint8)
+    process_group.broadcast(tensor, root=root).wait()
+
+    # Load object from serialized data.
+    return _tensor_to_object(tensor)

--- a/torch/distributed/process_group.py
+++ b/torch/distributed/process_group.py
@@ -1,0 +1,58 @@
+_GLOO_AVAILABLE = True
+_NCCL_AVAILABLE = True
+_MPI_AVAILABLE = True
+
+try:
+    from . import ProcessGroupGloo  # noqa: F401
+except ImportError:
+    _GLOO_AVAILABLE = False
+
+try:
+    from . import ProcessGroupNCCL  # noqa: F401
+except ImportError:
+    _NCCL_AVAILABLE = False
+
+try:
+    from . import ProcessGroupMPI  # noqa: F401
+except ImportError:
+    _MPI_AVAILABLE = False
+
+
+def is_gloo_available():
+    """
+    Returns if the Gloo backend is available.
+
+    """
+    return _GLOO_AVAILABLE
+
+
+def is_nccl_available():
+    """
+    Returns if the NCCL backend is available.
+
+    """
+    return _NCCL_AVAILABLE
+
+
+def is_mpi_available():
+    """
+    Returns if the MPI backend is available.
+
+    """
+    return _MPI_AVAILABLE
+
+
+__all__ = [
+    'is_gloo_available',
+    'is_nccl_available',
+    'is_mpi_available',
+]
+
+if is_gloo_available():
+    __all__.append('ProcessGroupGloo')
+
+if is_nccl_available():
+    __all__.append('ProcessGroupNCCL')
+
+if is_mpi_available():
+    __all__.append('ProcessGroupMPI')


### PR DESCRIPTION
This initialization method can be used if a set of PyTorch processes
is launched through mpirun and MPI is available out of the box.
Currently, those runs must use the file://, env://, or tcp://
initialization methods, which can be cumbersome (e.g. reliance on a
shared filesystem, or having to know the IP address of rank 0).

If MPI support is available, and a set of processes is launched
through mpirun, the `init_method` keyword argument to
`torch.distributed.init_process_group` defaults to `mpi://`.

For those jobs, you can now simply call:

```
torch.distributed.init_process_group(backend='nccl')
```

The test suite was adapted to support testing of the Gloo and NCCL
backends when using the MPI initialization method.

Closes #8290.

