### PR TITLE
Enabled masked fill and scatter for bool tensors

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -68,6 +68,8 @@
 ]]
 [[
   name: _th_masked_fill_
+  cpu_bool: True
+  cuda_bool: True
   cname: maskedFill
   variants: function
   return: self
@@ -86,6 +88,8 @@
 ]]
 [[
   name: _th_masked_fill_bool_
+  cpu_bool: True
+  cuda_bool: True
   cname: maskedFillBool
   variants: function
   return: self
@@ -104,6 +108,8 @@
 ]]
 [[
   name: _th_masked_scatter_
+  cpu_bool: True
+  cuda_bool: True
   cname: maskedCopy
   variants: function
   return: self
@@ -115,6 +121,8 @@
 ]]
 [[
   name: _th_masked_scatter_bool_
+  cpu_bool: True
+  cuda_bool: True
   cname: maskedCopyBool
   variants: function
   return: self

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -562,8 +562,6 @@ void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scal
                        })
 }
 
-#if !defined(TH_REAL_IS_BOOL)
-
 void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
 {
   int64_t tensor_size = THTensor_(nElement)(tensor);
@@ -672,6 +670,8 @@ void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* s
                    });
   c10::raw::intrusive_ptr::decref(srct);
 }
+
+#if !defined(TH_REAL_IS_BOOL)
 
 void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src)
 {

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -76,12 +76,12 @@ TH_API void THTensor_(scatter)(THTensor *tensor, int dim, THLongTensor *index, T
 TH_API void THTensor_(scatterAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 TH_API void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scalar_t val);
 
-#if !defined(TH_REAL_IS_BOOL) /* non bool only part */
-
 TH_API void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopy)(THTensor *tensor, THByteTensor *mask, THTensor* src);
 TH_API void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value);
 TH_API void THTensor_(maskedCopyBool)(THTensor *tensor, THBoolTensor *mask, THTensor* src);
+
+#if !defined(TH_REAL_IS_BOOL) /* non bool only part */
 
 TH_API void THTensor_(indexAdd)(THTensor *tensor, int dim, THLongTensor *index, THTensor *src);
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7984,8 +7984,8 @@ class _TestTorchMixin(object):
             x = torch.tensor([[True, True, True], [True, True, True]], device=device)
             res = torch.zeros(3, 3, dtype=torch.bool, device=device)
             res = res.scatter_(0, torch.tensor([[0, 1, 2], [0, 1, 2]], device=device), x)
-            self.assertEqual(res, torch.tensor([[True, False, False], 
-                                                [False, True, False], 
+            self.assertEqual(res, torch.tensor([[True, False, False],
+                                                [False, True, False],
                                                 [False, False, True]], device=device))
 
     def test_scatter_add_bool(self):
@@ -7993,8 +7993,8 @@ class _TestTorchMixin(object):
             x = torch.tensor([[True, True, True, True, True], [True, True, True, True, True]], device=device)
             res = torch.zeros(3, 5, dtype=torch.bool, device=device)
             res = res.scatter_add_(0, torch.tensor([[0, 1, 2, 0, 0], [2, 0, 0, 1, 2]], device=device), x)
-            self.assertEqual(res, torch.tensor([[True, True, True, True, True], 
-                                                [False, True, False, True, False], 
+            self.assertEqual(res, torch.tensor([[True, True, True, True, True],
+                                                [False, True, False, True, False],
                                                 [True, False, True, False, True]], device=device))
 
     def test_masked_scatter(self):
@@ -8020,6 +8020,19 @@ class _TestTorchMixin(object):
             src = torch.randn(num_copy - 1)
             with self.assertRaises(RuntimeError):
                 dest.masked_scatter_(mask, src)
+
+    def test_masked_scatter_bool_tensor(self):
+        for device in torch.testing.get_all_device_types():
+            src = torch.tensor([True, True, True], device=device)
+            dst = torch.tensor([False, False, False], device=device)
+            mask = torch.tensor([False, True, False], device=device)
+
+            dst.masked_scatter_(mask, src)
+            self.assertEqual(dst, torch.tensor([False, True, False], device=device))
+
+            mask = torch.tensor([True, False, True], device=device)
+            dst = dst.masked_scatter(mask, src)
+            self.assertEqual(dst, torch.tensor([True, True, True], device=device))
 
     def test_masked_select(self):
         for dtype in [torch.uint8, torch.bool]:
@@ -8052,6 +8065,17 @@ class _TestTorchMixin(object):
             dst.masked_fill_((dst > 0).to(dtype), val)
             dst2.masked_fill_((dst2 > 0).to(dtype), val)
             self.assertEqual(dst, dst2, 0)
+
+    def test_masked_fill_bool_tensor(self):
+        for device in torch.testing.get_all_device_types():
+            dst = torch.tensor([True, False, True], device=device)
+            mask = torch.tensor([False, True, False], device=device)
+
+            dst.masked_fill_(mask, True)
+            self.assertEqual(dst, torch.tensor([True, True, True], device=device))
+
+            dst = dst.masked_fill(mask, False)
+            self.assertEqual(dst, torch.tensor([True, False, True], device=device))
 
     def test_abs(self):
         def _test_abs(tensors_dict):


### PR DESCRIPTION
Enabled masked_fill, masked_fill_, masked_scatter_, masked_scatter on bool tensors. 
Tested via unit tests