### PR TITLE
Fixed RNNImplBase reset and flat_weights methods to handle bidirectional flag correctly

### DIFF
--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -239,3 +239,10 @@ TEST_F(RNNTest, PrettyPrintRNNs) {
       c10::str(RNN(RNNOptions(128, 64).layers(3).dropout(0.2).tanh())),
       "torch::nn::RNN(input_size=128, hidden_size=64, layers=3, dropout=0.2, activation=tanh)");
 }
+
+// This test assures that flatten_parameters does not crash when bidirectional is set to true
+// https://github.com/pytorch/pytorch/issues/19545
+TEST_F(RNNTest, BidirectionalFlattenParameters) {
+  GRU gru(GRUOptions(100, 256).layers(2).bidirectional(true));
+  gru->flatten_parameters();
+}

--- a/test/cpp/api/rnn.cpp
+++ b/test/cpp/api/rnn.cpp
@@ -240,7 +240,8 @@ TEST_F(RNNTest, PrettyPrintRNNs) {
       "torch::nn::RNN(input_size=128, hidden_size=64, layers=3, dropout=0.2, activation=tanh)");
 }
 
-// This test assures that flatten_parameters does not crash when bidirectional is set to true
+// This test assures that flatten_parameters does not crash,
+// when bidirectional is set to true
 // https://github.com/pytorch/pytorch/issues/19545
 TEST_F(RNNTest, BidirectionalFlattenParameters) {
   GRU gru(GRUOptions(100, 256).layers(2).bidirectional(true));

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -40,28 +40,33 @@ RNNImplBase<Derived>::RNNImplBase(
 
 template <typename Derived>
 void RNNImplBase<Derived>::reset() {
-  w_ih.resize(options.layers_);
-  w_hh.resize(options.layers_);
-  b_ih.resize(options.layers_);
-  b_hh.resize(options.layers_);
+  const auto num_directions = options.bidirectional_ ? 2 : 1;
+
+  w_ih.resize(options.layers_ * num_directions);
+  w_hh.resize(options.layers_ * num_directions);
+  b_ih.resize(options.layers_ * num_directions);
+  b_hh.resize(options.layers_ * num_directions);
 
   const int64_t gate_size = options.hidden_size_ * number_of_gates_;
 
   for (int64_t layer = 0; layer < options.layers_; ++layer) {
-    const int64_t input_size =
-        (layer == 0) ? options.input_size_ : options.hidden_size_;
-    w_ih[layer] = this->register_parameter(
-        "weight_ih_l" + std::to_string(layer),
-        torch::empty({gate_size, input_size}));
-    w_hh[layer] = this->register_parameter(
-        "weight_hh_l" + std::to_string(layer),
-        torch::empty({gate_size, options.hidden_size_}));
+    for (auto direction = 0; direction < num_directions; direction++) {
+      const auto layer_input_size = layer == 0 ? options.input_size_ : options.hidden_size_ * num_directions;
+      const auto suffix = direction == 1 ? "_reverse" : "";
+      const auto layer_idx = (layer * num_directions) + direction;
+      w_ih[layer_idx] = this->register_parameter(
+          "weight_ih_l" + std::to_string(layer) + suffix,
+          torch::empty({gate_size, layer_input_size}));
+      w_hh[layer_idx] = this->register_parameter(
+          "weight_hh_l" + std::to_string(layer) + suffix,
+          torch::empty({gate_size, options.hidden_size_}));
 
-    if (options.with_bias_) {
-      b_ih[layer] = this->register_parameter(
-          "bias_ih_l" + std::to_string(layer), torch::empty({gate_size}));
-      b_hh[layer] = this->register_parameter(
-          "bias_hh_l" + std::to_string(layer), torch::empty({gate_size}));
+      if (options.with_bias_) {
+        b_ih[layer_idx] = this->register_parameter(
+            "bias_ih_l" + std::to_string(layer) + suffix, torch::empty({gate_size}));
+        b_hh[layer_idx] = this->register_parameter(
+            "bias_hh_l" + std::to_string(layer) + suffix, torch::empty({gate_size}));
+      }
     }
   }
 
@@ -158,12 +163,16 @@ std::vector<Tensor> RNNImplBase<Derived>::flat_weights() const {
   // Organize all weights in a flat vector in the order
   // (w_ih, w_hh, b_ih, b_hh), repeated for each layer (next to each other).
   std::vector<Tensor> flat;
+  const auto num_directions = options.bidirectional_ ? 2 : 1;
   for (int64_t layer = 0; layer < options.layers_; layer++) {
-    flat.push_back(w_ih[layer]);
-    flat.push_back(w_hh[layer]);
-    if (options.with_bias_) {
-      flat.push_back(b_ih[layer]);
-      flat.push_back(b_hh[layer]);
+    for (auto direction = 0; direction < num_directions; direction++) {
+      const auto layer_idx = (layer * num_directions) + direction;
+      flat.push_back(w_ih[layer_idx]);
+      flat.push_back(w_hh[layer_idx]);
+      if (options.with_bias_) {
+        flat.push_back(b_ih[layer_idx]);
+        flat.push_back(b_hh[layer_idx]);
+      }
     }
   }
   return flat;

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -51,7 +51,8 @@ void RNNImplBase<Derived>::reset() {
 
   for (int64_t layer = 0; layer < options.layers_; ++layer) {
     for (auto direction = 0; direction < num_directions; direction++) {
-      const auto layer_input_size = layer == 0 ? options.input_size_ : options.hidden_size_ * num_directions;
+      const auto layer_input_size = layer == 0 ? options.input_size_ :
+        options.hidden_size_ * num_directions;
       const auto suffix = direction == 1 ? "_reverse" : "";
       const auto layer_idx = (layer * num_directions) + direction;
       w_ih[layer_idx] = this->register_parameter(
@@ -63,9 +64,11 @@ void RNNImplBase<Derived>::reset() {
 
       if (options.with_bias_) {
         b_ih[layer_idx] = this->register_parameter(
-            "bias_ih_l" + std::to_string(layer) + suffix, torch::empty({gate_size}));
+          "bias_ih_l" + std::to_string(layer) + suffix,
+          torch::empty({gate_size}));
         b_hh[layer_idx] = this->register_parameter(
-            "bias_hh_l" + std::to_string(layer) + suffix, torch::empty({gate_size}));
+          "bias_hh_l" + std::to_string(layer) + suffix,
+          torch::empty({gate_size}));
       }
     }
   }


### PR DESCRIPTION
Fixing #19545:
Changed torch/csrc/api/src/nn/modules/rnn.cpp to be consistent with torch/nn/modules/rnn.py