### PR TITLE
Another dce fix

### DIFF
--- a/torch/csrc/jit/fuser/fallback.cpp
+++ b/torch/csrc/jit/fuser/fallback.cpp
@@ -13,6 +13,14 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
+namespace {
+c10::OperatorOptions aliasAnalysisIsSpecialCase() {
+  c10::OperatorOptions options;
+  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
+  return options;
+}
+}
+
 // Registers fused operators so that fused graphs can properly generate fallback
 // code.
 RegisterOperators reg_fused_operators(
@@ -29,7 +37,7 @@ RegisterOperators reg_fused_operators(
         pack(stack, std::move(result));
         return 0;
       };
-    })});
+    }, aliasAnalysisIsSpecialCase())});
 
 void runFallback(int64_t key, Stack& stack) {
   auto maybe_spec = retrieve(key);

--- a/torch/csrc/jit/fuser/fallback.cpp
+++ b/torch/csrc/jit/fuser/fallback.cpp
@@ -13,14 +13,6 @@ namespace torch {
 namespace jit {
 namespace fuser {
 
-namespace {
-c10::OperatorOptions aliasAnalysisIsSpecialCase() {
-  c10::OperatorOptions options;
-  options.setAliasAnalysis(AliasAnalysisKind::INTERNAL_SPECIAL_CASE);
-  return options;
-}
-}
-
 // Registers fused operators so that fused graphs can properly generate fallback
 // code.
 RegisterOperators reg_fused_operators(
@@ -37,7 +29,7 @@ RegisterOperators reg_fused_operators(
         pack(stack, std::move(result));
         return 0;
       };
-    }, aliasAnalysisIsSpecialCase())});
+    })});
 
 void runFallback(int64_t key, Stack& stack) {
   auto maybe_spec = retrieve(key);

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -351,7 +351,7 @@ def _model_to_graph(model, args, verbose=False, training=False,
 
     if do_constant_folding and _export_onnx_opset_version == 9:
         params_dict = torch._C._jit_pass_onnx_constant_fold(graph, params_dict)
-        torch._C._jit_pass_dce(graph)
+        torch._C._jit_pass_dce_allow_deleting_nodes_with_side_effects(graph)
 
     if verbose:
         print(graph)


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22239 Open up AliasAnalysisKind for any ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15996322/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22175 AliasAnalysisKind::CONSERVATIVE/FROM_SCHEMA&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15929595/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22520 Don't use DeadCodeElimination from LowerAllTuples&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16115449/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22499 Another dce fix**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16111969/)

Another place where onnx export is running dead code elimination after making the jit graph invalid. Fixing it.

Differential Revision: [D16111969](https://our.internmc.facebook.com/intern/diff/D16111969/)