### PR TITLE
make OMP_NUM_THREADS default in launch.py

### DIFF
--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
 r"""
 `torch.distributed.launch` is a module that spawns up multiple distributed
 training processes on each of the training nodes.
@@ -190,7 +193,6 @@ def parse_args():
     parser.add_argument('training_script_args', nargs=REMAINDER)
     return parser.parse_args()
 
-
 def main():
     args = parse_args()
 
@@ -204,6 +206,15 @@ def main():
     current_env["WORLD_SIZE"] = str(dist_world_size)
 
     processes = []
+
+    if 'OMP_NUM_THREADS' not in os.environ and args.nproc_per_node > 1:
+        current_env["OMP_NUM_THREADS"] = str(1)
+        print("*****************************************\n"
+              "Setting OMP_NUM_THREADS environment variable for each process "
+              "to be {} in default, to avoid your system being overloaded, "
+              "please further tune the variable for optimal performance in "
+              "your application as needed. \n"
+              "*****************************************".format(current_env["OMP_NUM_THREADS"]))
 
     for local_rank in range(0, args.nproc_per_node):
         # each process's rank


### PR DESCRIPTION
Summary:
per https://github.com/pytorch/pytorch/issues/22260, default number of open mp threads are spawned to be the same of number of cores available, for multi processing data parallel cases, too many threads may be spawned and could overload the CPU, resulting in performance regression.

so set OMP_NUM_THREADS = number of CPU processors/number of processes in default to neither overload or waste CPU threads

Differential Revision: D16092225

