### PR TITLE
[jit] use save/load for emitFunctionHook

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1686,7 +1686,9 @@ graph(%Ra, %Rb):
 
         ge = self.checkTrace(fn, [torch.randn(2, 2)] * 2)
         inputs = set(ge.graph.inputs())
-        self.assertTrue(len(inputs) == 2)
+        # three instead of 2 because the export/import in checkTrace adds a
+        # `self` module argument
+        self.assertTrue(len(inputs) == 3)
 
     def test_repeated_output(self):
         def fn(a, b):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -599,6 +599,7 @@ void initJitScriptBindings(PyObject* module) {
             std::ostringstream buf;
             Module module("__main__");
             addFunctionToModule(module, self);
+            module.save(buf, _extra_files);
             return py::bytes(buf.str());
           },
           py::arg("_extra_files") = ExtraFilesMap())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22504 [WIP] classtypes hold weak_ptr
* #22221 [jit] _script_compile and _script_class_compile add to the python CU
* #22207 [jit] refactor self to be a class again
* #22206 [jit] Give functions qualified names
* **#22503 [jit] use save/load for emitFunctionHook**
* #22205 [jit] remove unused argument in import.cpp
* #22204 [jit] improvements to QualifiedName
* #22203 [jit] refactoring of module/object
* #22202 [jit] Make CompilationUnit own Functions
* #22502 [jit] make test context managers exception safe

1. Fix the `Function::save_to_buffer` so it actually works :O
2. Use the same save/load path for both emitFunctionHook and
emitModuleHook, eliminating the need to mess with CUs directly