### PR TITLE
Add GradMode::is_enabled() check to requires_grad()

### DIFF
--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -5,6 +5,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/autograd/edge.h>
 #include <torch/csrc/autograd/function_hook.h>
+#include <torch/csrc/autograd/grad_mode.h>
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
@@ -376,7 +377,7 @@ struct TORCH_API Variable::AutogradMeta : public c10::AutogradMetaInterface {
   }
 
   bool requires_grad() const override {
-    return requires_grad_ || grad_fn_;
+    return (requires_grad_ || grad_fn_) && GradMode::is_enabled();
   }
 
   /// Accesses the gradient `Variable` of this `Variable`.
@@ -477,7 +478,7 @@ struct TORCH_API Variable::DifferentiableViewMeta : public Variable::AutogradMet
   uint32_t attr_version;
 
   bool requires_grad() const override {
-    return requires_grad_ || grad_fn_ || (is_view_ && base_.requires_grad());
+    return (requires_grad_ || grad_fn_ || (is_view_ && base_.requires_grad())) && GradMode::is_enabled();
   }
 
   DifferentiableViewMeta(at::TensorImpl* self_impl, Variable base, Edge gradient_edge);


### PR DESCRIPTION
As part of https://github.com/pytorch/pytorch/pull/22473, we want to be able to check `tensor.requires_grad()` from Caffe2, which needs to take `autograd::GradMode` into consideration. This PR adds the `GradMode::is_enabled()`check into `requires_grad()`, so that the effect of `GradMode::is_enabled()` is always accounted for when `tensor.requires_grad()` is called. 

After this change, we will be able to simplify a few call sites of `GradMode::is_enabled()` (e.g. `compute_requires_grad` / `check_inplace`), since they currently check both `requires_grad()` and `GradMode::is_enabled()` at the same time. I will make such changes in a follow-up PR.