### PR TITLE
Add clone() implementation for QTensor

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2364,6 +2364,7 @@
     SparseCPU: clone_sparse
     SparseCUDA: clone_sparse
     MkldnnCPU: mkldnn_clone
+    QuantizedCPU: quantized_clone
 
 - func: resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
   variants: function, method

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -116,19 +116,13 @@ Tensor& set_quantizer_(Tensor& self, ConstQuantizerPtr quantizer) {
 }
 
 Tensor quantized_clone(const Tensor& self) {
-  TORCH_CHECK(
-      isQIntType(self.scalar_type()),
-      "Input tensor must have a quantized ScalarType");
-  auto quantizer = get_qtensorimpl(self)->quantizer();
 
-  TORCH_CHECK(quantizer->qscheme() == kPerTensorAffine);
-  auto scale = static_cast<PerTensorAffineQuantizer*>(quantizer.get())->scale();
-  auto zero_point =
-      static_cast<PerTensorAffineQuantizer*>(quantizer.get())->zero_point();
+  auto scale = self.q_scale();
+  auto zero_point = self.q_zero_point();
 
   Tensor dst = at::_empty_affine_quantized(
       self.sizes(),
-      self.options().dtype(toQIntType(self.scalar_type())),
+      self.options().dtype(self.scalar_type()),
       scale,
       zero_point);
 

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -117,14 +117,11 @@ Tensor& set_quantizer_(Tensor& self, ConstQuantizerPtr quantizer) {
 
 Tensor quantized_clone(const Tensor& self) {
 
-  auto scale = self.q_scale();
-  auto zero_point = self.q_zero_point();
-
   Tensor dst = at::_empty_affine_quantized(
       self.sizes(),
       self.options().dtype(self.scalar_type()),
-      scale,
-      zero_point);
+      self.q_scale(),
+      self.q_zero_point());
 
   at::native::copy_(dst, self, false);
 

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -116,7 +116,6 @@ Tensor& set_quantizer_(Tensor& self, ConstQuantizerPtr quantizer) {
 }
 
 Tensor quantized_clone(const Tensor& self) {
-
   Tensor dst = at::_empty_affine_quantized(
       self.sizes(),
       self.options(),
@@ -126,7 +125,6 @@ Tensor quantized_clone(const Tensor& self) {
   at::native::copy_(dst, self, false);
 
   return dst;
-
 }
 
 } // namespace native

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -119,7 +119,7 @@ Tensor quantized_clone(const Tensor& self) {
 
   Tensor dst = at::_empty_affine_quantized(
       self.sizes(),
-      self.options().dtype(self.scalar_type()),
+      self.options(),
       self.q_scale(),
       self.q_zero_point());
 

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -195,7 +195,6 @@ class TestQuantizedTensor(TestCase):
 
     def test_qtensor_clone(self):
 
-        val = 100
         numel = 10
 
         scale = 0.5

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -195,34 +195,25 @@ class TestQuantizedTensor(TestCase):
 
     def test_qtensor_clone(self):
 
-        scale = 0.5
-        zero_point = 10
         val = 100
         numel = 10
 
-        # Case1 : Copy from same scale and zero_point
-        q = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
-        q2 = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
+        scale_1 = 3.2
+        zero_point_1 = 5
+        scale_2 = 0.5
+        zero_point_2 = 10
 
-        q = q2.clone()
-
-        self.assertEqual(q.int_repr(), q2.int_repr())
-        self.assertEqual(q.q_scale(), q2.q_scale())
-        self.assertEqual(q.q_zero_point(), q2.q_zero_point())
-
-        # Case 2 : Copying from different scale and zero_point.
-        scale = 3.2
-        zero_point = 5
-        q = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
+        q = torch._empty_affine_quantized([numel], scale=scale_1, zero_point=zero_point_1, dtype=torch.quint8)
+        q2 = torch._empty_affine_quantized([numel], scale=scale_2, zero_point=zero_point_2, dtype=torch.quint8)
 
         # Check whether original scale and zero_points are set correctly.
-        self.assertEqual(q.q_scale(), scale)
-        self.assertEqual(q.q_zero_point(), zero_point)
+        self.assertEqual(q.q_scale(), scale_1)
+        self.assertEqual(q.q_zero_point(), zero_point_1)
 
         q = q2.clone()
 
         # Check to make sure the scale and zero_point has been copied.
-        self.assertEqual(q.int_repr(), q2.int_repr())
+        self.assertEqual(q, q2)
         self.assertEqual(q.q_scale(), q2.q_scale())
         self.assertEqual(q.q_zero_point(), q2.q_zero_point())
 

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -198,24 +198,15 @@ class TestQuantizedTensor(TestCase):
         val = 100
         numel = 10
 
-        scale_1 = 3.2
-        zero_point_1 = 5
-        scale_2 = 0.5
-        zero_point_2 = 10
+        scale = 0.5
+        zero_point = 10
 
-        q = torch._empty_affine_quantized([numel], scale=scale_1, zero_point=zero_point_1, dtype=torch.quint8)
-        q2 = torch._empty_affine_quantized([numel], scale=scale_2, zero_point=zero_point_2, dtype=torch.quint8)
-
-        # Check whether original scale and zero_points are set correctly.
-        self.assertEqual(q.q_scale(), scale_1)
-        self.assertEqual(q.q_zero_point(), zero_point_1)
+        q2 = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
 
         q = q2.clone()
 
         # Check to make sure the scale and zero_point has been copied.
         self.assertEqual(q, q2)
-        self.assertEqual(q.q_scale(), q2.q_scale())
-        self.assertEqual(q.q_zero_point(), q2.q_zero_point())
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -194,16 +194,11 @@ class TestQuantizedTensor(TestCase):
         self.assertEqual(q.q_zero_point(), q2.q_zero_point())
 
     def test_qtensor_clone(self):
-
         numel = 10
-
         scale = 0.5
         zero_point = 10
-
         q2 = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
-
         q = q2.clone()
-
         # Check to make sure the scale and zero_point has been copied.
         self.assertEqual(q, q2)
 

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -193,6 +193,38 @@ class TestQuantizedTensor(TestCase):
         self.assertEqual(q.q_scale(), q2.q_scale())
         self.assertEqual(q.q_zero_point(), q2.q_zero_point())
 
+    def test_qtensor_clone(self):
+
+        scale = 0.5
+        zero_point = 10
+        val = 100
+        numel = 10
+
+        # Case1 : Copy from same scale and zero_point
+        q = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
+        q2 = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
+
+        q = q2.clone()
+
+        self.assertEqual(q.int_repr(), q2.int_repr())
+        self.assertEqual(q.q_scale(), q2.q_scale())
+        self.assertEqual(q.q_zero_point(), q2.q_zero_point())
+
+        # Case 2 : Copying from different scale and zero_point.
+        scale = 3.2
+        zero_point = 5
+        q = torch._empty_affine_quantized([numel], scale=scale, zero_point=zero_point, dtype=torch.quint8)
+
+        # Check whether original scale and zero_points are set correctly.
+        self.assertEqual(q.q_scale(), scale)
+        self.assertEqual(q.q_zero_point(), zero_point)
+
+        q = q2.clone()
+
+        # Check to make sure the scale and zero_point has been copied.
+        self.assertEqual(q.int_repr(), q2.int_repr())
+        self.assertEqual(q.q_scale(), q2.q_scale())
+        self.assertEqual(q.q_zero_point(), q2.q_zero_point())
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22510 Add clone() implementation for QTensor**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16059576/)

Added a new function to implement clone operation on quantized tensors. Also added a test case which can be tested as shown in test plan.

This change is required to be able to call torch.jit.trace on quantized models.
Clone implementation calls copy_ on QTensor internally.

Differential Revision: [D16059576](https://our.internmc.facebook.com/intern/diff/D16059576/)