### PR TITLE
[ONNX] Update ONNX constant folding to support opset 10.

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -13,8 +13,7 @@ import copy
 
 
 class TestUtilityFuns(TestCase):
-    from torch.onnx.symbolic_helper import _export_onnx_opset_version
-    opset_version = _export_onnx_opset_version
+    opset_version = 9
 
     def test_is_in_onnx_export(self):
         test_self = self

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -13,6 +13,8 @@ import copy
 
 
 class TestUtilityFuns(TestCase):
+    from torch.onnx.symbolic_helper import _export_onnx_opset_version
+    opset_version = _export_onnx_opset_version
 
     def test_is_in_onnx_export(self):
         test_self = self
@@ -26,7 +28,7 @@ class TestUtilityFuns(TestCase):
         x = torch.randn(3, 4)
         f = io.BytesIO()
         try:
-            torch.onnx.export(MyModule(), x, f)
+            torch.onnx.export(MyModule(), x, f, opset_version=self.opset_version)
         except ValueError:
             self.assertFalse(torch.onnx.is_in_onnx_export())
 
@@ -37,7 +39,7 @@ class TestUtilityFuns(TestCase):
                 b = torch.transpose(a, 1, 0)
                 return b + x
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         x = torch.ones(3, 2)
         graph, _, __ = utils._model_to_graph(TransposeModule(), (x, ),
                                              do_constant_folding=True,
@@ -55,7 +57,7 @@ class TestUtilityFuns(TestCase):
                 b = torch.narrow(a, 0, 0, 1)
                 return b + x
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         x = torch.ones(1, 3)
         graph, _, __ = utils._model_to_graph(NarrowModule(), (x, ),
                                              do_constant_folding=True,
@@ -73,7 +75,7 @@ class TestUtilityFuns(TestCase):
                 b = a[1:10]         # index exceeds dimension
                 return b + x
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         x = torch.ones(1, 3)
         graph, _, __ = utils._model_to_graph(SliceIndexExceedsDimModule(), (x, ),
                                              do_constant_folding=True,
@@ -92,7 +94,7 @@ class TestUtilityFuns(TestCase):
                 b = a[0:-1]        # index relative to the end
                 return b + x
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         x = torch.ones(1, 3)
         graph, _, __ = utils._model_to_graph(SliceNegativeIndexModule(), (x, ),
                                              do_constant_folding=True,
@@ -110,7 +112,7 @@ class TestUtilityFuns(TestCase):
                 b = torch.unsqueeze(a, 0)
                 return b + x
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         x = torch.ones(1, 2, 3)
         graph, _, __ = utils._model_to_graph(UnsqueezeModule(), (x, ),
                                              do_constant_folding=True,
@@ -129,7 +131,7 @@ class TestUtilityFuns(TestCase):
                 c = torch.cat((a, b), 0)
                 return b + c
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         x = torch.ones(2, 3)
         graph, _, __ = utils._model_to_graph(ConcatModule(), (x, ),
                                              do_constant_folding=True,
@@ -149,7 +151,7 @@ class TestUtilityFuns(TestCase):
             def forward(self, input, initial_state):
                 return self.mygru(input, initial_state)
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         input = torch.randn(5, 3, 7)
         h0 = torch.randn(1, 3, 3)
         graph, _, __ = utils._model_to_graph(GruNet(), (input, h0),
@@ -169,7 +171,7 @@ class TestUtilityFuns(TestCase):
             def forward(self, A):
                 return torch.matmul(A, torch.transpose(self.B, -1, -2))
 
-        _set_opset_version(9)
+        _set_opset_version(self.opset_version)
         A = torch.randn(2, 3)
         graph, _, __ = utils._model_to_graph(MatMulNet(), (A),
                                              do_constant_folding=True)
@@ -185,9 +187,10 @@ class TestUtilityFuns(TestCase):
 
         def is_model_stripped(f, strip_doc_string=None):
             if strip_doc_string is None:
-                torch.onnx.export(MyModule(), x, f)
+                torch.onnx.export(MyModule(), x, f, opset_version=self.opset_version)
             else:
-                torch.onnx.export(MyModule(), x, f, strip_doc_string=strip_doc_string)
+                torch.onnx.export(MyModule(), x, f, strip_doc_string=strip_doc_string,
+                                  opset_version=self.opset_version)
             model = onnx.load(io.BytesIO(f.getvalue()))
             model_strip = copy.copy(model)
             onnx.helper.strip_doc_string(model_strip)
@@ -197,6 +200,11 @@ class TestUtilityFuns(TestCase):
         self.assertTrue(is_model_stripped(io.BytesIO()))
         # test strip_doc_string=False
         self.assertFalse(is_model_stripped(io.BytesIO(), False))
+
+# opset 10 tests
+TestUtilityFuns_opset10 = type(str("TestUtilityFuns_opset10"),
+                               (TestCase,),
+                               dict(TestUtilityFuns.__dict__, opset_version=10))
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -115,8 +115,9 @@ void initJITBindings(PyObject* module) {
       .def(
           "_jit_pass_onnx_constant_fold",
           [](std::shared_ptr<Graph>& graph,
-             std::map<std::string, at::Tensor>& paramsDict) {
-            ConstantFoldONNX(graph->block(), paramsDict); // overload resolution
+             std::map<std::string, at::Tensor>& paramsDict,
+             int opset_version) {
+            ConstantFoldONNX(graph->block(), paramsDict, opset_version); // overload resolution
             return paramsDict;
           },
           pybind11::return_value_policy::move)

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -64,62 +64,85 @@ void eraseUnusedBlockInputs(Block* b) {
   }
 }
 
+void handleNegativeStartEndIndex(int64_t& start, int64_t& end, int64_t& axis,
+                                 c10::IntArrayRef tensorSizes) {
+  if (start < 0) {
+    start = tensorSizes[axis] + start;
+  }
+  if (end < 0) {
+    end = tensorSizes[axis] + end;
+  }
+  // index higher than dimension is treated as the end.
+  if (end > tensorSizes[axis]) {
+    end = tensorSizes[axis];
+  }      
+}
+
 c10::optional<at::Tensor> runTorchSlice_opset9(const Node* node, 
                      std::vector<at::Tensor>& inputTensorValues) {
   assert(inputTensorValues.size() == 1);
-    if (!(node->hasAttributeS("starts") && node->hasAttributeS("ends"))) {
+  if (inputTensorValues.size() != 1) {
+    std::cerr << "Warning: Constant folding - Invalid number of inputs found for opset 9 onnx::Slice op. "
+              << "Constant folding not applied." << std::endl;
+    return c10::nullopt;
+  }
+  if (!(node->hasAttributeS("starts") && node->hasAttributeS("ends"))) {
+    return c10::nullopt;
+  }
+  auto startsAttr = node->is(attr::starts);
+  auto endsAttr = node->is(attr::ends);
+  if (startsAttr.size() != endsAttr.size()) {
+    return c10::nullopt;
+  }
+  std::vector<int64_t> axesAttr;
+  if (node->hasAttributeS("axes")) {
+    axesAttr = node->is(attr::axes);
+  } else {
+    axesAttr.resize(startsAttr.size());
+    std::iota(axesAttr.begin(), axesAttr.end(), 0);
+  }
+  auto updated_val = inputTensorValues[0];
+  for (size_t i = 0; i < axesAttr.size(); ++i) {
+    // ONNX slice accepts negative starts and ends values.
+    int64_t axis = axesAttr[i], start = startsAttr[i], end = endsAttr[i];
+    handleNegativeStartEndIndex(start, end, axis, updated_val.sizes());
+    int64_t length = end - start;
+    if (length < 0 || start > updated_val.sizes()[axis] - length)
       return c10::nullopt;
-    }
-    auto startsAttr = node->is(attr::starts);
-    auto endsAttr = node->is(attr::ends);
-    if (startsAttr.size() != endsAttr.size()) {
-      return c10::nullopt;
-    }
-    std::vector<int64_t> axesAttr;
-    if (node->hasAttributeS("axes")) {
-      axesAttr = node->is(attr::axes);
-    } else {
-      axesAttr.resize(startsAttr.size());
-      std::iota(axesAttr.begin(), axesAttr.end(), 0);
-    }
-    auto updated_val = inputTensorValues[0];
-    for (size_t i = 0; i < axesAttr.size(); ++i) {
-      // ONNX slice accepts negative starts and ends values.
-      int64_t axis = axesAttr[i], start = startsAttr[i], end = endsAttr[i];
-      if (start < 0) {
-        start = updated_val.sizes()[axis] + start;
-      }
-      if (end < 0) {
-        end = updated_val.sizes()[axis] + end;
-      }
-      // index higher than dimension is treated as the end.
-      if (end > updated_val.sizes()[axis]) {
-        end = updated_val.sizes()[axis];
-      }      
-      int64_t length = end - start;
-      if (length < 0 || start > updated_val.sizes()[axis] - length)
-        return c10::nullopt;
-      updated_val = at::narrow(updated_val, axis, start, length);
-    }
-    return c10::optional<at::Tensor>(updated_val);
+    updated_val = at::narrow(updated_val, axis, start, length);
+  }
+  return c10::optional<at::Tensor>(updated_val);
 }
 
 c10::optional<at::Tensor> runTorchSlice_opset10(const Node* node, 
                      std::vector<at::Tensor>& inputTensorValues) {
-  assert(inputTensorValues.size() > 2 &&  inputTensorValues.size() < 6);
+  if (inputTensorValues.size() < 3 || inputTensorValues.size() > 5) {
+    std::cerr << "Warning: Constant folding - Invalid number of inputs found for opset 10 onnx::Slice op. "
+              << "Constant folding not applied." << std::endl;
+    return c10::nullopt;
+  }
   // Checking validity of 'starts' and 'ends' input
-  assert(inputTensorValues[1].sizes().size() == 1 &&
-         inputTensorValues[2].sizes().size() == 1);             
+  if (inputTensorValues[1].sizes().size() != 1 || inputTensorValues[2].sizes().size() != 1) {
+    std::cerr << "Warning: Constant folding - Invalid 'starts' or 'ends' inputs found for opset 10 onnx::Slice op. "
+              << "Constant folding not applied." << std::endl;
+    return c10::nullopt;
+  }            
   if (inputTensorValues[1].sizes()[0] != inputTensorValues[2].sizes()[0] ) {
     // Number of elements of 'starts' and 'ends' 1-D input tensors should be the same
     return c10::nullopt;
   }
   // Checking 'axes' input, if available.
   std::vector<int64_t> axes;
-  if (inputTensorValues.size() > 3) {
-    assert(inputTensorValues[3].sizes().size() == 1); 
+  if (inputTensorValues.size() > 3) { 
+    if (inputTensorValues[3].sizes().size() != 1) {
+      std::cerr << "Warning: Constant folding - Invalid 'axes' input found for opset 10 onnx::Slice op. "
+                << "Constant folding not applied." << std::endl;
+      return c10::nullopt;
+    }
     if (inputTensorValues[3].sizes()[0] != inputTensorValues[1].sizes()[0] ) {
       // Number of elements of 'axes' and 'ends' 1-D input tensors should be the same
+      std::cerr << "Warning: Constant folding - Invalid 'axes' or 'ends' inputs found for opset 10 onnx::Slice op. "
+                << "Constant folding not applied." << std::endl;
       return c10::nullopt;
     }
     auto axes_a = inputTensorValues[3].accessor<int64_t, 1>();
@@ -133,15 +156,23 @@ c10::optional<at::Tensor> runTorchSlice_opset10(const Node* node,
   }
   // Checking 'steps' input, if available.
   if (inputTensorValues.size() > 4) {
-    assert(inputTensorValues[4].sizes().size() == 1); 
+    if (inputTensorValues[4].sizes().size() != 1) {
+      std::cerr << "Warning: Constant folding - Invalid 'steps' input found for opset 10 onnx::Slice op. "
+                << "Constant folding not applied." << std::endl;
+      return c10::nullopt;
+    }
     if (inputTensorValues[4].sizes()[0] != inputTensorValues[1].sizes()[0] ) {
       // Number of elements of 'steps' and 'ends' 1-D input tensors should be the same
+      std::cerr << "Warning: Constant folding - Invalid 'steps' or 'ends' inputs found for opset 10 onnx::Slice op. "
+                << "Constant folding not applied." << std::endl;
       return c10::nullopt;
     }
     auto steps_a = inputTensorValues[4].accessor<int64_t, 1>();
     for (size_t i = 0; i < inputTensorValues[4].sizes()[0]; ++i) {
       // Only steps == 1 are supported for constant-folding.
       if (steps_a[i] != 1) {
+        std::cerr << "Warning: Constant folding - Only steps=1 can be constant folded for opset 10 onnx::Slice op. "
+                << "Constant folding not applied." << std::endl;
         return c10::nullopt;
       }
     }
@@ -151,18 +182,8 @@ c10::optional<at::Tensor> runTorchSlice_opset10(const Node* node,
   auto updated_val = inputTensorValues[0];
   for (size_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
     // ONNX slice accepts negative starts and ends values.
-    int64_t start = starts_a[i], end = ends_a[i];
-    int64_t axis = axes[i];
-    if (start < 0) {
-      start = updated_val.sizes()[axis] + start;
-    }
-    if (end < 0) {
-      end = updated_val.sizes()[axis] + end;
-    }
-    // index higher than dimension is treated as the end.
-    if (end > updated_val.sizes()[axis]) {
-      end = updated_val.sizes()[axis];
-    }      
+    int64_t start = starts_a[i], end = ends_a[i], axis = axes[i];
+    handleNegativeStartEndIndex(start, end, axis, updated_val.sizes());
     int64_t length = end - start;
     if (length < 0 || start > updated_val.sizes()[axis] - length)
       return c10::nullopt;
@@ -184,8 +205,9 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       return runTorchSlice_opset10(node, inputTensorValues);
     }
     else {
-      throw std::runtime_error(
-          "constant_fold: Unsupported opset version for onnx::Slice node.");
+      std::cerr << "Warning: Constant folding - unsupported opset version. "
+              << "Constant folding not applied." << std::endl;
+      return c10::nullopt;
     }
   } else if (node->kind() == onnx::Concat) {
     if (!node->hasAttributeS("axis")) {
@@ -301,6 +323,12 @@ std::vector<Node*> getOnnxConstParentsToRemove(Node* node) {
 // This method updates the block in-place to fold all the one-time
 // constant-based computations/ops into an initializer node.
 void ConstantFoldONNX(Block* b, ParamMap& paramsDict, int opset_version) {
+  if (opset_version != 9 && opset_version != 10) {
+    // Number of elements of 'axes' and 'ends' 1-D input tensors should be the same
+    std::cerr << "Warning: Constant folding supported for only opsets 9 and 10. "
+              << "Constant folding not applied." << std::endl;
+    return;
+  }
   AT_ASSERT(b->param_node());
   auto valsToParamsMap = buildValueToParamsMap(b, paramsDict);
   // Only the root block is constant-folded. Folding nested blocks is

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -64,12 +64,9 @@ void eraseUnusedBlockInputs(Block* b) {
   }
 }
 
-c10::optional<at::Tensor> runTorchBackendForOnnx(
-    const Node* node,
-    std::vector<at::Tensor>& inputTensorValues) {
-  at::Tensor updated_val;
-  if (node->kind() == onnx::Slice) {
-    assert(inputTensorValues.size() == 1);
+c10::optional<at::Tensor> runTorchSlice_opset9(const Node* node, 
+                     std::vector<at::Tensor>& inputTensorValues) {
+  assert(inputTensorValues.size() == 1);
     if (!(node->hasAttributeS("starts") && node->hasAttributeS("ends"))) {
       return c10::nullopt;
     }
@@ -85,7 +82,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       axesAttr.resize(startsAttr.size());
       std::iota(axesAttr.begin(), axesAttr.end(), 0);
     }
-    updated_val = inputTensorValues[0];
+    auto updated_val = inputTensorValues[0];
     for (size_t i = 0; i < axesAttr.size(); ++i) {
       // ONNX slice accepts negative starts and ends values.
       int64_t axis = axesAttr[i], start = startsAttr[i], end = endsAttr[i];
@@ -105,6 +102,91 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       updated_val = at::narrow(updated_val, axis, start, length);
     }
     return c10::optional<at::Tensor>(updated_val);
+}
+
+c10::optional<at::Tensor> runTorchSlice_opset10(const Node* node, 
+                     std::vector<at::Tensor>& inputTensorValues) {
+  assert(inputTensorValues.size() > 2 &&  inputTensorValues.size() < 6);
+  // Checking validity of 'starts' and 'ends' input
+  assert(inputTensorValues[1].sizes().size() == 1 &&
+         inputTensorValues[2].sizes().size() == 1);             
+  if (inputTensorValues[1].sizes()[0] != inputTensorValues[2].sizes()[0] ) {
+    // Number of elements of 'starts' and 'ends' 1-D input tensors should be the same
+    return c10::nullopt;
+  }
+  // Checking 'axes' input, if available.
+  std::vector<int64_t> axes;
+  if (inputTensorValues.size() > 3) {
+    assert(inputTensorValues[3].sizes().size() == 1); 
+    if (inputTensorValues[3].sizes()[0] != inputTensorValues[1].sizes()[0] ) {
+      // Number of elements of 'axes' and 'ends' 1-D input tensors should be the same
+      return c10::nullopt;
+    }
+    auto axes_a = inputTensorValues[3].accessor<int64_t, 1>();
+    axes.reserve(inputTensorValues[3].sizes()[0]); 
+    for (size_t i = 0; i < inputTensorValues[3].sizes()[0]; ++i) {
+      axes[i] = axes_a[i];
+    }
+  }
+  else {
+    axes = std::vector<int64_t>(inputTensorValues[1].sizes()[0], 0);
+  }
+  // Checking 'steps' input, if available.
+  if (inputTensorValues.size() > 4) {
+    assert(inputTensorValues[4].sizes().size() == 1); 
+    if (inputTensorValues[4].sizes()[0] != inputTensorValues[1].sizes()[0] ) {
+      // Number of elements of 'steps' and 'ends' 1-D input tensors should be the same
+      return c10::nullopt;
+    }
+    auto steps_a = inputTensorValues[4].accessor<int64_t, 1>();
+    for (size_t i = 0; i < inputTensorValues[4].sizes()[0]; ++i) {
+      // Only steps == 1 are supported for constant-folding.
+      if (steps_a[i] != 1) {
+        return c10::nullopt;
+      }
+    }
+  }
+  auto starts_a = inputTensorValues[1].accessor<int64_t, 1>();
+  auto ends_a = inputTensorValues[2].accessor<int64_t, 1>();
+  auto updated_val = inputTensorValues[0];
+  for (size_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
+    // ONNX slice accepts negative starts and ends values.
+    int64_t start = starts_a[i], end = ends_a[i];
+    int64_t axis = axes[i];
+    if (start < 0) {
+      start = updated_val.sizes()[axis] + start;
+    }
+    if (end < 0) {
+      end = updated_val.sizes()[axis] + end;
+    }
+    // index higher than dimension is treated as the end.
+    if (end > updated_val.sizes()[axis]) {
+      end = updated_val.sizes()[axis];
+    }      
+    int64_t length = end - start;
+    if (length < 0 || start > updated_val.sizes()[axis] - length)
+      return c10::nullopt;
+    updated_val = at::narrow(updated_val, axis, start, length);
+  }
+  return c10::optional<at::Tensor>(updated_val);
+}
+
+c10::optional<at::Tensor> runTorchBackendForOnnx(
+    const Node* node,
+    std::vector<at::Tensor>& inputTensorValues,
+    int opset_version) {
+  at::Tensor updated_val;
+  if (node->kind() == onnx::Slice) {
+    if (opset_version == 9) {
+      return runTorchSlice_opset9(node, inputTensorValues);
+    }
+    else if (opset_version == 10) {
+      return runTorchSlice_opset10(node, inputTensorValues);
+    }
+    else {
+      throw std::runtime_error(
+          "constant_fold: Unsupported opset version for onnx::Slice node.");
+    }
   } else if (node->kind() == onnx::Concat) {
     if (!node->hasAttributeS("axis")) {
       return c10::nullopt;
@@ -218,7 +300,7 @@ std::vector<Node*> getOnnxConstParentsToRemove(Node* node) {
 
 // This method updates the block in-place to fold all the one-time
 // constant-based computations/ops into an initializer node.
-void ConstantFoldONNX(Block* b, ParamMap& paramsDict) {
+void ConstantFoldONNX(Block* b, ParamMap& paramsDict, int opset_version) {
   AT_ASSERT(b->param_node());
   auto valsToParamsMap = buildValueToParamsMap(b, paramsDict);
   // Only the root block is constant-folded. Folding nested blocks is
@@ -234,13 +316,14 @@ void ConstantFoldONNX(Block* b, ParamMap& paramsDict) {
       // onnx::Constant, then skip this node.
       continue;
     }
+
     auto inputTensorValues = getValues(node, valsToParamsMap);
     if (inputTensorValues.empty()) {
       // This is a terminal node with no inputs, such as onnx::Constant. Skip
       // it.
       continue;
     }
-    auto updatedValWrapped = runTorchBackendForOnnx(node, inputTensorValues);
+    auto updatedValWrapped = runTorchBackendForOnnx(node, inputTensorValues, opset_version);
     if (updatedValWrapped == c10::nullopt) {
       // Constant folding is not supported for this op. Skip it.
       continue;

--- a/torch/csrc/jit/passes/onnx/constant_fold.h
+++ b/torch/csrc/jit/passes/onnx/constant_fold.h
@@ -5,7 +5,7 @@
 namespace torch {
 namespace jit {
 
-void ConstantFoldONNX(Block* b, std::map<std::string, at::Tensor>& paramDict);
+void ConstantFoldONNX(Block* b, std::map<std::string, at::Tensor>& paramDict, int opset_version);
 
 }
 } // namespace torch

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -349,8 +349,9 @@ def _model_to_graph(model, args, verbose=False, training=False,
     param_names = input_and_param_names[len(input_and_param_names) - len(params):]
     params_dict = dict(zip(param_names, params))
 
-    if do_constant_folding and _export_onnx_opset_version == 9:
-        params_dict = torch._C._jit_pass_onnx_constant_fold(graph, params_dict)
+    if do_constant_folding and _export_onnx_opset_version in [9, 10]:
+        params_dict = torch._C._jit_pass_onnx_constant_fold(graph, params_dict,
+                                                            _export_onnx_opset_version)
         torch._C._jit_pass_dce_allow_deleting_nodes_with_side_effects(graph)
 
     if verbose:


### PR DESCRIPTION
Currently ONNX constant folding (`do_constant_folding=True` arg in `torch.onnx.export` API) supports only opset 9 of ONNX. For opset 10, it is a no-op. This change enables ONNX constant folding for opset 10. Specifically there are three main changes:
1) Turn on constant folding ONNX pass for opset 10.
2) Update support for opset 10 version of `onnx::Slice` op for backend computation during constant folding.
3) Enable constant folding tests in `test/onnx/test_utility_funs.py` for multiple opsets (9 and 10).