### PR TITLE
Make device_of take tensor by const ref

### DIFF
--- a/aten/src/ATen/DeviceGuard.h
+++ b/aten/src/ATen/DeviceGuard.h
@@ -14,7 +14,7 @@ namespace at {
 //    OptionalDeviceGuard guard(device_of(tensor));
 
 /// Return the Device of a Tensor, if the Tensor is defined.
-inline optional<Device> device_of(Tensor t) {
+inline optional<Device> device_of(const Tensor& t) {
   if (t.defined()) {
     return make_optional(t.device());
   } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22525 Make device_of take tensor by const ref**
* #22508 Delete weak_intrusive_ptr and WeakIValue

This saves 4% overhead in a no-op overhead benchmark
