### PR TITLE
Fix bug: add batch_first arg on `pack_sequence()`

### DIFF
--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -378,7 +378,7 @@ def pad_sequence(sequences, batch_first=False, padding_value=0):
     return out_tensor
 
 
-def pack_sequence(sequences, enforce_sorted=True):
+def pack_sequence(sequences, batch_first=False, enforce_sorted=True):
     r"""Packs a list of variable length Tensors
 
     ``sequences`` should be a list of Tensors of size ``L x *``, where `L` is
@@ -409,7 +409,8 @@ def pack_sequence(sequences, enforce_sorted=True):
         a :class:`PackedSequence` object
     """
     lengths = [v.size(0) for v in sequences]
-    return pack_padded_sequence(pad_sequence(sequences), lengths, enforce_sorted=enforce_sorted)
+    return pack_padded_sequence(
+        pad_sequence(sequences, batch_first=batch_first), lengths, enforce_sorted=enforce_sorted)
 
 
 def get_packed_sequence(data, batch_sizes, sorted_indices, unsorted_indices):


### PR DESCRIPTION
There is a bug when use `pack_sequence` with 2-dimensional tensors

```
a = torch.FloatTensor(11,5)
b = torch.FloatTensor(10,5)
c = torch.FloatTensor(9,5)
d = [a,b,c]

In [8]: d
Out[8]:
[tensor([[1.0955e-35, 4.5604e-41, 1.0955e-35, 4.5604e-41, 1.5293e-38],
         [0.0000e+00, 5.9218e-39, 4.5604e-41, 1.2191e-43, 0.0000e+00],
         [1.5293e-38, 0.0000e+00, 5.9218e-39, 4.5604e-41, 1.2331e-43],
         [0.0000e+00, 1.5293e-38, 0.0000e+00, 5.9218e-39, 4.5604e-41],
         [1.2472e-43, 0.0000e+00, 1.5293e-38, 0.0000e+00, 5.9218e-39],
         [4.5604e-41, 1.2612e-43, 0.0000e+00, 1.5293e-38, 0.0000e+00],
         [5.9218e-39, 4.5604e-41, 1.2752e-43, 0.0000e+00, 1.5293e-38],
         [0.0000e+00, 5.9218e-39, 4.5604e-41, 1.2892e-43, 0.0000e+00],
         [1.5293e-38, 0.0000e+00, 5.9218e-39, 4.5604e-41, 0.0000e+00],
         [0.0000e+00, 9.1084e-44, 0.0000e+00, 7.1169e-37, 0.0000e+00],
         [1.0955e-35, 4.5604e-41, 0.0000e+00, 0.0000e+00, 0.0000e+00]]),
 tensor([[1.0955e-35, 4.5604e-41, 1.0955e-35, 4.5604e-41, 6.7421e+22],
         [1.3556e-19, 1.8037e+28, 2.1040e-19, 1.8515e+28, 1.7744e+28],
         [5.3831e-14, 1.8037e+28, 6.7120e+22, 2.8231e+23, 7.1377e+31],
         [5.3740e+19, 1.8888e+31, 1.9011e-19, 1.2711e+31, 4.2321e+21],
         [4.5581e+30, 1.1725e-19, 5.0746e+31, 7.5338e+28, 2.8884e+12],
         [7.5338e+28, 1.5769e-19, 1.9432e-19, 1.8888e+31, 2.9597e+21],
         [2.8181e+20, 1.8061e+28, 2.8376e+20, 1.8180e+31, 2.0283e-19],
         [1.0997e-32, 2.8624e+20, 6.9785e+22, 6.6554e-33, 1.3563e-19],
         [1.6114e-19, 1.6020e-19, 4.4721e+21, 1.8506e+28, 6.2753e-07],
         [3.9774e-14, 1.3563e-19, 1.8578e-01, 3.9173e-02, 4.7429e+30]]),
 tensor([[ 6.7301e-37,  0.0000e+00,  6.4034e+20,  1.7444e+22,  1.7851e+31],
         [ 1.1567e-40,  4.0860e-40,  9.4040e-38,  2.0195e-25,  7.5252e+31],
         [ 1.1289e+27,  5.5114e-11,  1.1289e+27,  2.4024e+20,  4.5841e-14],
         [ 3.7143e-39,  5.3735e-14,  2.5353e+30,  5.8855e-44,  2.8500e-41],
         [ 8.2407e+00,  1.2836e-36, -1.5936e+16,  1.1862e+27,  5.2741e+02],
         [-1.3459e-14, -9.0072e+15,  2.8183e+20,  4.3988e+27,  7.1941e+28],
         [ 1.3082e-38, -7.8194e-25,  2.5353e+30,  2.1580e-43,  5.7198e-41],
         [ 1.4918e-38, -3.4390e-12,  2.5353e+30,  2.4663e-43,  6.4373e-41],
         [ 1.6755e-38, -3.6926e-03,  2.5353e+30,  0.0000e+00,  4.4645e-42]])]

In [10]: pack_sequence(d)
Out[10]:
PackedSequence(data=tensor([[ 1.0955e-35,  4.5604e-41,  1.0955e-35,  4.5604e-41,  1.5293e-38],
        [ 1.0955e-35,  4.5604e-41,  1.0955e-35,  4.5604e-41,  6.7421e+22],
        [ 6.7301e-37,  0.0000e+00,  6.4034e+20,  1.7444e+22,  1.7851e+31],
        [ 0.0000e+00,  5.9218e-39,  4.5604e-41,  1.2191e-43,  0.0000e+00],
        [ 1.3556e-19,  1.8037e+28,  2.1040e-19,  1.8515e+28,  1.7744e+28],
        [ 1.1567e-40,  4.0860e-40,  9.4040e-38,  2.0195e-25,  7.5252e+31],
        [ 1.5293e-38,  0.0000e+00,  5.9218e-39,  4.5604e-41,  1.2331e-43],
        [ 5.3831e-14,  1.8037e+28,  6.7120e+22,  2.8231e+23,  7.1377e+31],
        [ 1.1289e+27,  5.5114e-11,  1.1289e+27,  2.4024e+20,  4.5841e-14],
        [ 0.0000e+00,  1.5293e-38,  0.0000e+00,  5.9218e-39,  4.5604e-41],
        [ 5.3740e+19,  1.8888e+31,  1.9011e-19,  1.2711e+31,  4.2321e+21],
        [ 3.7143e-39,  5.3735e-14,  2.5353e+30,  5.8855e-44,  2.8500e-41],
        [ 1.2472e-43,  0.0000e+00,  1.5293e-38,  0.0000e+00,  5.9218e-39],
        [ 4.5581e+30,  1.1725e-19,  5.0746e+31,  7.5338e+28,  2.8884e+12],
        [ 8.2407e+00,  1.2836e-36, -1.5936e+16,  1.1862e+27,  5.2741e+02],
        [ 4.5604e-41,  1.2612e-43,  0.0000e+00,  1.5293e-38,  0.0000e+00],
        [ 7.5338e+28,  1.5769e-19,  1.9432e-19,  1.8888e+31,  2.9597e+21],
        [-1.3459e-14, -9.0072e+15,  2.8183e+20,  4.3988e+27,  7.1941e+28],
        [ 5.9218e-39,  4.5604e-41,  1.2752e-43,  0.0000e+00,  1.5293e-38],
        [ 2.8181e+20,  1.8061e+28,  2.8376e+20,  1.8180e+31,  2.0283e-19],
        [ 1.3082e-38, -7.8194e-25,  2.5353e+30,  2.1580e-43,  5.7198e-41],
        [ 0.0000e+00,  5.9218e-39,  4.5604e-41,  1.2892e-43,  0.0000e+00],
        [ 1.0997e-32,  2.8624e+20,  6.9785e+22,  6.6554e-33,  1.3563e-19],
        [ 1.4918e-38, -3.4390e-12,  2.5353e+30,  2.4663e-43,  6.4373e-41],
        [ 1.5293e-38,  0.0000e+00,  5.9218e-39,  4.5604e-41,  0.0000e+00],
        [ 1.6114e-19,  1.6020e-19,  4.4721e+21,  1.8506e+28,  6.2753e-07],
        [ 1.6755e-38, -3.6926e-03,  2.5353e+30,  0.0000e+00,  4.4645e-42],
        [ 0.0000e+00,  9.1084e-44,  0.0000e+00,  7.1169e-37,  0.0000e+00],
        [ 3.9774e-14,  1.3563e-19,  1.8578e-01,  3.9173e-02,  4.7429e+30],
        [ 1.0955e-35,  4.5604e-41,  0.0000e+00,  0.0000e+00,  0.0000e+00]]), batch_sizes=tensor([3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1]))
```

The result of `pack_sequence`'s is `tensor([3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1])` which is not I meant. It is supposed to be `tensor([11, 10, 9])`.

This is because I can not pass `batch_first` arg on `pack_sequence()`.

So I've fixed it so that it can use `batch_first` arg in calling `pad_sequence()` inside.