### PR TITLE
Skip test_slogdet_sign if LAPACK library is not installed

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -229,6 +229,7 @@ class TestAutograd(TestCase):
             torch.sparse_coo_tensor(torch.tensor([[1, 1]]).long(), torch.tensor([1., 1.])),
             True)
 
+    @skipIfNoLapack
     def test_slogdet_sign(self):
         a = torch.randn(3, 3, requires_grad=True)
         s, logdet = a.slogdet()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22551 Skip test_slogdet_sign if LAPACK library is not installed**

Summary:
If the LAPACK library is not installed, this test currently fails with the error:
RuntimeError: lu: LAPACK library not found in compilation

Test Plan: ran test locally

Differential Revision: [D16132182](https://our.internmc.facebook.com/intern/diff/D16132182)