### PR TITLE
Make device_of take tensor by const ref

### DIFF
--- a/aten/src/ATen/DeviceGuard.h
+++ b/aten/src/ATen/DeviceGuard.h
@@ -14,7 +14,7 @@ namespace at {
 //    OptionalDeviceGuard guard(device_of(tensor));
 
 /// Return the Device of a Tensor, if the Tensor is defined.
-inline optional<Device> device_of(Tensor t) {
+inline optional<Device> device_of(const Tensor& t) {
   if (t.defined()) {
     return make_optional(t.device());
   } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22556 Make device_of take tensor by const ref**

Taking the Tensor by value incurs significant overhead in framework overhead benchmarks. We can avoid this since `device_of` only reads the tensor and doesn't need its own instance.

Differential Revision: [D16137540](https://our.internmc.facebook.com/intern/diff/D16137540)