### PR TITLE
add forward declaration in stateful dataset

### DIFF
--- a/torch/csrc/api/include/torch/data/datasets/stateful.h
+++ b/torch/csrc/api/include/torch/data/datasets/stateful.h
@@ -7,6 +7,13 @@
 #include <vector>
 
 namespace torch {
+namespace serialize {
+class OutputArchive;
+class InputArchive;
+} // namespace serialize
+} // namespace torch
+
+namespace torch {
 namespace data {
 namespace datasets {
 


### PR DESCRIPTION
Addressing potential dependency issue by adding forward declaration for OutputArchive/InputArchive. 

This change follows the same pattern in base.h in 'torch/csrc/api/include/torch/data/samplers/base.h'