### PR TITLE
keep reuqires_grad unchanged after converting bn to syncbn

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -493,6 +493,9 @@ class SyncBatchNorm(_BatchNorm):
             if module.affine:
                 module_output.weight.data = module.weight.data.clone().detach()
                 module_output.bias.data = module.bias.data.clone().detach()
+                # keep reuqires_grad unchanged
+                module_output.weight.requires_grad = module.weight.requires_grad
+                module_output.bias.requires_grad = module.bias.requires_grad
             module_output.running_mean = module.running_mean
             module_output.running_var = module.running_var
             module_output.num_batches_tracked = module.num_batches_tracked


### PR DESCRIPTION
After converting BN layers to SyncBN layers, the function will set all `requires_grad = True` regardless of the original requires_grad states. I think it is a bug and have fixed it in this PR.