### PR TITLE
[docker] Add support for pytorch-built-in docker image

### DIFF
--- a/docker/caffe2/jenkins/build.sh
+++ b/docker/caffe2/jenkins/build.sh
@@ -81,6 +81,10 @@ if [[ "$image" == *-glibc* ]]; then
   GLIBC_VERSION="$(echo "${image}" | perl -n -e'/glibc(\d+(\.\d+)?)/ && print $1')"
 fi
 
+if [[ "$image" == *-build_pytorch* ]]; then
+  BUILD_PYTORCH=yes
+fi
+
 # Copy over common scripts to directory containing the Dockerfile to build
 cp -a common/* "$(dirname ${DOCKERFILE})"
 
@@ -112,5 +116,6 @@ docker build \
        --build-arg "CLANG_VERSION=${CLANG_VERSION}" \
        --build-arg "CMAKE_VERSION=${CMAKE_VERSION:-}" \
        --build-arg "ROCM_VERSION=${ROCM_VERSION}" \
+	   --build-arg "BUILD_PYTORCH=${BUILD_PYTORCH}" \
        "$@" \
        "$(dirname ${DOCKERFILE})"

--- a/docker/caffe2/jenkins/build.sh
+++ b/docker/caffe2/jenkins/build.sh
@@ -116,6 +116,6 @@ docker build \
        --build-arg "CLANG_VERSION=${CLANG_VERSION}" \
        --build-arg "CMAKE_VERSION=${CMAKE_VERSION:-}" \
        --build-arg "ROCM_VERSION=${ROCM_VERSION}" \
-	   --build-arg "BUILD_PYTORCH=${BUILD_PYTORCH}" \
+       --build-arg "BUILD_PYTORCH=${BUILD_PYTORCH}" \
        "$@" \
        "$(dirname ${DOCKERFILE})"

--- a/docker/caffe2/jenkins/common/install_pytorch.sh
+++ b/docker/caffe2/jenkins/common/install_pytorch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+pip install numpy
+git clone https://github.com/pytorch/pytorch.git --recursive
+cd pytorch
+git checkout 7fcfed19e7c4805405f3bec311fc056803ca7afb
+pip install -r requirements.txt
+/usr/bin/python3.6 setup.py install
+cd ..
+

--- a/docker/caffe2/jenkins/ubuntu/Dockerfile
+++ b/docker/caffe2/jenkins/ubuntu/Dockerfile
@@ -54,6 +54,12 @@ ADD ./install_cmake.sh install_cmake.sh
 RUN if [ -n "${CMAKE_VERSION}" ]; then bash ./install_cmake.sh; fi
 RUN rm install_cmake.sh
 
+# (optional) Install a steady version of PyTorch
+ARG BUILD_PYTORCH
+ADD ./install_pytorch.sh install_pytorch.sh
+RUN if [ -n "${BUILD_PYTORCH}" ]; then bash ./install_pytorch.sh; fi
+RUN rm install_pytorch.sh
+
 # (optional) Add Jenkins user
 ARG JENKINS
 ARG JENKINS_UID


### PR DESCRIPTION
I will add a new docker image with a pytorch built in; before that I would like to have this feature in our docker image control system.