### PR TITLE
[fix] In the case of non-DimensionedTensorTypes, default to checking if either CPU or GPU fusion is enabled

### DIFF
--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -172,6 +172,9 @@ struct GraphFuser {
   bool isFusableDevice(Value *v) {
     auto tensor_type = v->type()->cast<DimensionedTensorType>();
     if (!tensor_type) {
+      if (v->type()->cast<TensorType>()) {
+        return canFuseOnCPU() || canFuseOnGPU();
+      }
       return true;
     }
     if (tensor_type->device().is_cpu()) {
@@ -191,6 +194,9 @@ struct GraphFuser {
       if (output->uses().size() > 0) {
         fusableDevice &= isFusableDevice(output);
       }
+    }
+    for (const auto& input : node->inputs()) {
+      fusableDevice &= isFusableDevice(input);
     }
     return fusableDevice && isFusableMap(node);
   }

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -195,9 +195,6 @@ struct GraphFuser {
         fusableDevice &= isFusableDevice(output);
       }
     }
-    for (const auto& input : node->inputs()) {
-      fusableDevice &= isFusableDevice(input);
-    }
     return fusableDevice && isFusableMap(node);
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22658 [fix] In the case of non-DimensionedTensorTypes, default to checking if either CPU or GPU fusion is enabled**

Differential Revision: [D16209907](https://our.internmc.facebook.com/intern/diff/D16209907)