### PR TITLE
Enable C2 operators running with {cpu, gpu} * {forward, backward}

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -135,6 +135,37 @@ def config_list(**configs):
     return generated_configs
 
 
+def op_list(**configs):
+    """Generate a list of ops organized in a specific format.
+       It takes two parameters which are "attr_names" and "attr". 
+       attrs stores the name and function of operators. 
+       Args: 
+           configs: key-value pairs including the name and function of 
+           operators. attrs and attr_names must be present in configs. 
+       Return: 
+           a sequence of dictionaries which stores the name and function 
+           of ops in a specifal format
+       Example:
+       attrs = [
+           ["abs", torch.abs],
+           ["abs_", torch.abs_],
+       ]
+       attr_names = ["op_name", "op"].
+
+       With those two examples, 
+       we will generate (({"op_name": "abs"}, {"op" : torch.abs}),
+                         ({"op_name": "abs_"}, {"op" : torch.abs_}))
+    """
+    generated_configs = []
+    if "attrs" not in configs:
+        raise ValueError("Missing attrs in configs")
+    for inputs in configs["attrs"]:
+        tmp_result = {configs["attr_names"][i] : input_value
+                      for i, input_value in enumerate(inputs)}
+        generated_configs.append(tmp_result)
+    return generated_configs
+
+
 def is_caffe2_enabled(framework_arg):
     return 'Caffe2' in framework_arg
 

--- a/benchmarks/operator_benchmark/c2/add_test.py
+++ b/benchmarks/operator_benchmark/c2/add_test.py
@@ -14,25 +14,26 @@ add_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 10, 3),
     K=[2 ** x for x in range(0, 3)], 
+    dtype=["int", "float"],
     tags=["long"]
 )
 
 
 add_short_configs = op_bench.config_list(
     attrs=[
-        [8, 16, 32],
-        [16, 16, 64],
-        [64, 64, 128],
+        [8, 16, 32, "int"],
+        [16, 16, 64, "float"],
+        [64, 64, 128, "int"],
     ],
-    attr_names=["M", "N", "K"], 
+    attr_names=["M", "N", "K", "dtype"], 
     tags=["short"], 
 )
 
 class AddBenchmark(op_bench.Caffe2BenchmarkBase):
-    def init(self, M, N, K): 
-        self.input_one = self.tensor(M, N, K) 
-        self.input_two = self.tensor(M, N, K) 
-        self.output = self.tensor(M, N, K)
+    def init(self, M, N, K, dtype): 
+        self.input_one = self.tensor([M, N, K], dtype) 
+        self.input_two = self.tensor([M, N, K], dtype) 
+        self.output = self.tensor([M, N, K], dtype)
         self.set_module_name("add")
 
     def forward(self):

--- a/benchmarks/operator_benchmark/c2/matmul_test.py
+++ b/benchmarks/operator_benchmark/c2/matmul_test.py
@@ -33,10 +33,10 @@ mm_short_configs = op_bench.config_list(
 
 class MatMulBenchmark(op_bench.Caffe2BenchmarkBase):
     def init(self, M, N, K, trans_a, trans_b): 
-        self.input_one = self.tensor(N, M) if trans_a else self.tensor(M, N)
-        self.input_two = self.tensor(K, N) if trans_b else self.tensor(N, K)
+        self.input_one = self.tensor([N, M]) if trans_a else self.tensor([M, N])
+        self.input_two = self.tensor([K, N]) if trans_b else self.tensor([N, K])
         self.args = {'trans_a': trans_a, 'trans_b': trans_b}
-        self.output = self.tensor(M, K)
+        self.output = self.tensor([M, K])
         self.set_module_name("matmul")
 
     def forward(self):

--- a/benchmarks/operator_benchmark/common/tests/c2_cpu_gpu_forward_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/c2_cpu_gpu_forward_backward_test.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import operator_benchmark as op_bench
+from caffe2.python import core 
+
+
+add_configs = op_bench.cross_product_configs(
+    M=[8],
+    N=[8],
+    K=[8],
+    tags=["short"],
+    device=["cuda", "cpu"]
+)
+
+class AddBenchmark(op_bench.Caffe2BenchmarkBase):
+    def init(self, M, N, K, device): 
+        self.set_module_name("add")
+        self.input_one = self.tensor([M, N, K], device=device) 
+        self.input_two = self.tensor([M, N, K], device=device) 
+        self.input_one_grad = self.tensor([M, N, K], device=device) 
+        self.input_two_grad = self.tensor([M, N, K], device=device) 
+        self.output = self.tensor([M, N, K], device=device)
+
+    def forward(self):
+        op = core.CreateOperator(
+            "Add", [self.input_one, self.input_two], self.output, **self.args 
+        )
+        return op
+
+    def backward(self):
+        grad_op = core.CreateOperator(
+            "AddGradient", [self.output, self.input_one, self.input_two], 
+            [self.input_one_grad, self.input_two_grad], **self.args 
+        )
+        return grad_op
+
+
+op_bench.generate_c2_test(add_configs, AddBenchmark)
+op_bench.generate_c2_gradient_test(add_configs, AddBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/ops/tests/add_ops_list_test.py
+++ b/benchmarks/operator_benchmark/ops/tests/add_ops_list_test.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import operator_benchmark as op_bench
+import torch
+
+
+# Configs for pointwise unary ops
+unary_ops_configs = op_bench.config_list(
+    attrs=[
+        [128, 128],
+    ],
+    attr_names=["M", "N"],
+    tags=["short"]
+)
+
+
+unary_ops_list = op_bench.op_list(
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["abs", torch.abs],
+        ["acos", torch.acos],
+    ],
+)
+
+
+class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, op_func): 
+        self.input_one = torch.rand(M, N)
+        self.op_func = op_func
+
+    def forward(self):
+        return self.op_func(self.input_one)
+
+
+op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -29,7 +29,7 @@ pool_1d_configs = op_bench.config_list(
 
 
 pool_1d_ops_list = op_bench.op_list(
-    attr_names=["op_name", "op"],
+    attr_names=["op_name", "op_func"],
     attrs=[
         ["MaxPool1d", nn.MaxPool1d],
         ["AvgPool1d", nn.AvgPool1d],
@@ -38,19 +38,17 @@ pool_1d_ops_list = op_bench.op_list(
 
 
 class Pool1dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, kernel, stride, N, C, L):
+    def init(self, kernel, stride, N, C, L, op_func):
         self.input = torch.rand(N, C, L) 
         self.kernel = kernel
         self.stride = stride
-
-    def set_op(self, op):
-        self.op = op(self.kernel, stride=self.stride)
+        self.op_func = op_func(self.kernel, stride=self.stride)
 
     def forward(self):
-        return self.op(self.input)
+        return self.op_func(self.input)
 
 
-op_bench.generate_pt_tests_from_list(pool_1d_ops_list, pool_1d_configs, Pool1dBenchmark)
+op_bench.generate_pt_tests_from_op_list(pool_1d_ops_list, pool_1d_configs, Pool1dBenchmark)
 
 
 """
@@ -73,7 +71,7 @@ pool_2d_configs = op_bench.config_list(
 
 
 pool_2d_ops_list = op_bench.op_list(
-    attr_names=["op_name", "op"],
+    attr_names=["op_name", "op_func"],
     attrs=[
         ["MaxPool2d", nn.MaxPool2d],
         ["AvgPool2d", nn.AvgPool2d],
@@ -82,19 +80,17 @@ pool_2d_ops_list = op_bench.op_list(
 
 
 class Pool2dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, kernel, stride, N, C, H, W):
+    def init(self, kernel, stride, N, C, H, W, op_func):
         self.input = torch.rand(N, C, H, W) 
         self.kernel = kernel
         self.stride = stride
-
-    def set_op(self, op):
-        self.op = op(self.kernel, stride=self.stride)
+        self.op_func = op_func(self.kernel, stride=self.stride)
 
     def forward(self):
-        return self.op(self.input)
+        return self.op_func(self.input)
 
 
-op_bench.generate_pt_tests_from_list(pool_2d_ops_list, pool_2d_configs, Pool2dBenchmark)
+op_bench.generate_pt_tests_from_op_list(pool_2d_ops_list, pool_2d_configs, Pool2dBenchmark)
 
 
 """
@@ -117,7 +113,7 @@ pool_3d_configs = op_bench.config_list(
 
 
 pool_3d_ops_list = op_bench.op_list(
-    attr_names=["op_name", "op"],
+    attr_names=["op_name", "op_func"],
     attrs=[
         ["MaxPool3d", nn.MaxPool3d],
         ["AvgPool3d", nn.AvgPool3d],
@@ -126,19 +122,17 @@ pool_3d_ops_list = op_bench.op_list(
 
 
 class Pool3dBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, kernel, stride, N, C, D, H, W):
+    def init(self, kernel, stride, N, C, D, H, W, op_func):
         self.input = torch.rand(N, C, D, H, W) 
         self.kernel = kernel
         self.stride = stride
-
-    def set_op(self, op):
-        self.op = op(self.kernel, stride=self.stride)
+        self.op_func = op_func(self.kernel, stride=self.stride)
 
     def forward(self):
-        return self.op(self.input)
+        return self.op_func(self.input)
 
 
-op_bench.generate_pt_tests_from_list(pool_3d_ops_list, pool_3d_configs, Pool3dBenchmark)
+op_bench.generate_pt_tests_from_op_list(pool_3d_ops_list, pool_3d_configs, Pool3dBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/softmax_test.py
+++ b/benchmarks/operator_benchmark/pt/softmax_test.py
@@ -49,7 +49,7 @@ class SoftmaxBenchmark(op_bench.TorchBenchmarkBase):
         return self.op_func(self.input_one)
 
 
-op_bench.generate_pt_tests_from_list(softmax_ops_list, softmax_configs, SoftmaxBenchmark)
+op_bench.generate_pt_tests_from_op_list(softmax_ops_list, softmax_configs, SoftmaxBenchmark)
 
 
 if __name__ == "__main__":

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -24,16 +24,16 @@ unary_ops_configs = op_bench.config_list(
 
 
 class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, op_function): 
+    def init(self, M, N, op_func): 
         self.input_one = torch.rand(M, N)
-        self.op_function = op_function
+        self.op_func = op_func
 
     def forward(self):
-        return self.op_function(self.input_one)
+        return self.op_func(self.input_one)
 
 
 unary_ops_list = op_bench.op_list(
-    attr_names=["op_name", "op_function"],
+    attr_names=["op_name", "op_func"],
     attrs=[
         ["abs", torch.abs],
         ["abs_", torch.abs_],
@@ -119,7 +119,7 @@ unary_ops_list = op_bench.op_list(
 )
 
 
-op_bench.generate_pt_tests_from_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
+op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: This diff enables c2 operators to run the combination of {cpu, gpu} * {forward, backward}.

Differential Revision: D15781789

