### PR TITLE
Add common_quantized test case utilities

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -1,0 +1,54 @@
+r"""Importing this file includes common utility methods and base clases for
+checking quantization api and properties of resulting modules.
+"""
+import torch
+import torch.nn.quantized as nnq
+from common_utils import TestCase
+
+# QuantizationTestCase used as a base class for testing quantization on modules
+class QuantizationTestCase(TestCase):
+
+    def checkNoPrepModules(self, module):
+        r"""Checks the module does not contain child
+            modules for quantization prepration, e.g.
+            quant, dequant and observer
+        """
+        self.assertFalse(hasattr(module, 'quant'))
+        self.assertFalse(hasattr(module, 'dequant'))
+
+    def checkHasPrepModules(self, module):
+        r"""Checks the module contains child
+            modules for quantization prepration, e.g.
+            quant, dequant and observer
+        """
+        self.assertTrue(hasattr(module, 'module'))
+        self.assertTrue(hasattr(module, 'quant'))
+        self.assertTrue(hasattr(module, 'dequant'))
+
+    def checkObservers(self, module):
+        r"""Checks the module or module's leaf descendants
+            have observers in preperation for quantization
+        """
+        if hasattr(module, 'qconfig') and module.qconfig is not None and len(module._modules) == 0:
+            self.assertTrue(hasattr(module, 'observer'))
+        for child in module.children():
+            self.checkObservers(child)
+
+    def checkQuantDequant(self, mod):
+        r"""Checks that mod has nn.Quantize and
+            nn.DeQuantize submodules inserted
+        """
+        self.assertEqual(type(mod.quant), nnq.Quantize)
+        self.assertEqual(type(mod.dequant), nnq.DeQuantize)
+
+    def checkQuantizedLinear(self, mod):
+        r"""Checks that mod has been swapped for an nnq.Linear
+            module, the bias is qint32, and that the module
+            has Quantize and DeQuantize submodules
+        """
+        self.assertEqual(type(mod.module), nnq.Linear)
+        self.assertEqual(mod.module.bias.dtype, torch.qint32)
+        self.checkQuantDequant(mod)
+
+    def checkLinear(self, mod):
+        self.assertEqual(type(mod), torch.nn.Linear)

--- a/test/common_quantized.py
+++ b/test/common_quantized.py
@@ -1,0 +1,30 @@
+r"""Importing this file includes common utility methods for checking quantized
+tensors and modules.
+"""
+import numpy as np
+
+# Quantization references
+def _quantize(x, scale, zero_point, qmin=None, qmax=None, dtype=np.uint8):
+    """Quantizes a numpy array."""
+    if qmin is None:
+        qmin = np.iinfo(dtype).min
+    if qmax is None:
+        qmax = np.iinfo(dtype).max
+    qx = np.round(x / scale + zero_point).astype(np.int64)
+    qx = np.clip(qx, qmin, qmax)
+    qx = qx.astype(dtype)
+    return qx
+
+
+def _dequantize(qx, scale, zero_point):
+    """Dequantizes a numpy array."""
+    x = (qx.astype(np.float) - zero_point) * scale
+    return x
+
+
+def _requantize(x, multiplier, zero_point, qmin=0, qmax=255, qtype=np.uint8):
+    """Requantizes a numpy array, i.e., intermediate int32 or int16 values are
+    converted back to given type"""
+    qx = (x * multiplier).round() + zero_point
+    qx = np.clip(qx, qmin, qmax).astype(qtype)
+    return qx

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -25,7 +25,6 @@ from functools import wraps
 from itertools import product
 from copy import deepcopy
 from numbers import Number
-import numpy as np
 import tempfile
 
 import __main__
@@ -1086,29 +1085,3 @@ else:
                 check_test_defined_in_running_script(test)
                 test_suite.addTest(test)
         return test_suite
-
-# Quantization references
-def _quantize(x, scale, zero_point, qmin=None, qmax=None, dtype=np.uint8):
-    """Quantizes a numpy array."""
-    if qmin is None:
-        qmin = np.iinfo(dtype).min
-    if qmax is None:
-        qmax = np.iinfo(dtype).max
-    qx = np.round(x / scale + zero_point).astype(np.int64)
-    qx = np.clip(qx, qmin, qmax)
-    qx = qx.astype(dtype)
-    return qx
-
-
-def _dequantize(qx, scale, zero_point):
-    """Dequantizes a numpy array."""
-    x = (qx.astype(np.float) - zero_point) * scale
-    return x
-
-
-def _requantize(x, multiplier, zero_point, qmin=0, qmax=255, qtype=np.uint8):
-    """Requantizes a numpy array, i.e., intermediate int32 or int16 values are
-    converted back to given type"""
-    qx = (x * multiplier).round() + zero_point
-    qx = np.clip(qx, qmin, qmax).astype(qtype)
-    return qx

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -13,7 +13,7 @@ from hypothesis_utils import qtensor, array_shapes
 
 from common_utils import TEST_WITH_UBSAN, TestCase, run_tests, IS_WINDOWS
 from common_utils import skipIfNotRegistered
-from common_utils import _quantize, _dequantize, _requantize
+from common_quantized import _quantize, _dequantize, _requantize
 
 
 # Make sure we won't have overflows from vpmaddubsw instruction used in FBGEMM.


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22694 Add common_quantized test case utilities**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16172012/)

Move quantization and quantized utility functions for testing to common_quantized.py and common_quantization.py.  Addditionally, add a quantized test case base class which contains common methods for checking the results of quantization on modules.  As a consequence of the move, fixed the import at the top of test_quantized.py, and test_quantization to use the new utility

Differential Revision: [D16172012](https://our.internmc.facebook.com/intern/diff/D16172012/)