### PR TITLE
[jit][fuser] Remove hard-coded NVRTC specific constant from fuser header

### DIFF
--- a/torch/csrc/jit/fuser/compiler.cpp
+++ b/torch/csrc/jit/fuser/compiler.cpp
@@ -332,10 +332,6 @@ std::shared_ptr<FusedKernel> compileKernel(
     }
   }
 
-  // Have checked the limit at graph_fuser. Assert nothing else changing that.
-  AT_ASSERT((flat_inputs.size() + flat_outputs.size()) <=
-            fusion_kernel_args_limit);
-
   const bool use_cuda = device.is_cuda();
   const std::string name = "kernel_" + std::to_string(next_kernel_id++);
   std::string code =

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -138,7 +138,12 @@ struct GraphFuser {
   FusionCallback callback_ = [&](Node* n) { return isFusableDefault(n); };
   Symbol kind_ = prim::FusionGroup;
 
-  // Default limit works for nvrtc limitations, change with setInputArgLimit
+  // nvrtc has a limit on the number of arguments allowed in a CUDA kernel.
+  // The specific limit is a function of constant memory size, amount available
+  // to pass arguments, and some implementation dependence. Select a safe
+  // limit here.
+  // This limit is also applied to other devices in the fuser by default.
+  // Change with setInputArgLimit
   size_t subgraph_arg_limit_ = 128;
 
   GraphFuser(Block* block, std::shared_ptr<Graph> graph)

--- a/torch/csrc/jit/passes/graph_fuser.h
+++ b/torch/csrc/jit/passes/graph_fuser.h
@@ -5,24 +5,28 @@
 namespace torch {
 namespace jit {
 
-// nvrtc has a limit on the number of arguments allowed in a CUDA kernel.
-// The specific limit is a function of constant memory size, amount available
-// to pass arguments, and some implementation dependence. Select a safe
-// limit here.
-//   This limit is also applied to other devices in the fuser, because we
-// don't consider a kernel with such a large number of arguments would be
-// profitable.
-constexpr size_t fusion_kernel_args_limit = 128;
-
 // NB: Be sure to run DCE before fusion, because dead instructions
 // can prevent fusion opportunities from being exploited.
 // On Windows will noop, NYI
 TORCH_API void FuseGraph(std::shared_ptr<Graph>& graph);
 
+// \brief Custom fusion pass using a node-level callback to
+// determine the inclusion of nodes in a subgraph.
+//
+// This helper omits aliased inputs and fusion across control flow
+// boundaries.
+//
+// \arg graph The graph to be modified in-place
+// \arg is_fusable A callback run on each fusable node in the graph.
+// \arg kind The label given to the resultant fused subgraph
+// \arg arg_limit The maximum number of args the resultant fused subgraph
+//                should have.  Note: This will likely develop into a general
+//                post condition on the fused subgraph.
 TORCH_API void CustomFuseGraph(
     std::shared_ptr<Graph>& graph,
     std::function<bool(Node*)> is_fusable,
-    Symbol kind);
+    Symbol kind,
+    size_t arg_limit=std::numeric_limits<size_t>::max());
 
 TORCH_API bool trackSingleGradSumToSizeToOutputs(
     Value* gradSumToSizeOutput,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22699 [jit][fuser] Remove hard-coded NVRTC specific constant from fuser header**

Differential Revision: [D16192290](https://our.internmc.facebook.com/intern/diff/D16192290)