### PR TITLE
Move Quantization Models to common_quantization

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -4,6 +4,7 @@ checking quantization api and properties of resulting modules.
 import torch
 import torch.nn.quantized as nnq
 from common_utils import TestCase
+from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, default_qconfig
 
 # QuantizationTestCase used as a base class for testing quantization on modules
 class QuantizationTestCase(TestCase):
@@ -52,3 +53,85 @@ class QuantizationTestCase(TestCase):
 
     def checkLinear(self, mod):
         self.assertEqual(type(mod), torch.nn.Linear)
+
+
+# Below are a series of neural net models to use in testing quantization
+class SingleLayerLinearModel(torch.nn.Module):
+    def __init__(self):
+        super(SingleLayerLinearModel, self).__init__()
+        self.fc1 = torch.nn.Linear(5, 5).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        return x
+
+class TwoLayerLinearModel(torch.nn.Module):
+    def __init__(self):
+        super(TwoLayerLinearModel, self).__init__()
+        self.fc1 = torch.nn.Linear(5, 8).to(dtype=torch.float)
+        self.fc2 = torch.nn.Linear(8, 5).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return x
+
+class LinearReluModel(torch.nn.Module):
+    def __init__(self):
+        super(LinearReluModel, self).__init__()
+        self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        x = self.relu(self.fc(x))
+        return x
+
+class NestedModel(torch.nn.Module):
+    def __init__(self):
+        super(NestedModel, self).__init__()
+        self.sub1 = LinearReluModel()
+        self.sub2 = TwoLayerLinearModel()
+        self.fc3 = torch.nn.Linear(5, 5).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.sub1(x)
+        x = self.sub2(x)
+        x = self.fc3(x)
+        return x
+
+class InnerModule(torch.nn.Module):
+    def __init__(self):
+        super(InnerModule, self).__init__()
+        self.fc1 = torch.nn.Linear(5, 8).to(dtype=torch.float)
+        self.relu = torch.nn.ReLU()
+        self.fc2 = torch.nn.Linear(8, 5).to(dtype=torch.float)
+
+    def forward(self, x):
+        return self.relu(self.fc2(self.relu(self.fc1(x))))
+
+class WrappedModel(torch.nn.Module):
+    def __init__(self):
+        super(WrappedModel, self).__init__()
+        self.qconfig = default_qconfig
+        self.sub = QuantWrapper(InnerModule())
+        self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
+        # don't quantize this fc
+        self.fc.qconfig = None
+
+    def forward(self, x):
+        return self.fc(self.sub(x))
+
+class ManualQuantModel(torch.nn.Module):
+    r"""A Module with manually inserted `QuantStub` and `DeQuantStub`
+    """
+    def __init__(self):
+        super(ManualQuantModel, self).__init__()
+        self.qconfig = default_qconfig
+        self.quant = QuantStub()
+        self.dequant = DeQuantStub()
+        self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.quant(x)
+        x = self.fc(x)
+        return self.dequant(x)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -1,92 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import torch.nn.quantized as nnq
-from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, \
-    default_eval_fn, QConfig, default_qconfig, default_observer, quantize, \
-    prepare, convert
+from torch.quantization import default_eval_fn, QConfig, default_qconfig, \
+    default_observer, quantize, prepare, convert
 
 from common_utils import run_tests
-from common_quantization import QuantizationTestCase
+from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
+    TwoLayerLinearModel, NestedModel, WrappedModel, ManualQuantModel
 
-class SingleLayerLinearModel(torch.nn.Module):
-    def __init__(self):
-        super(SingleLayerLinearModel, self).__init__()
-        self.fc1 = torch.nn.Linear(5, 5).to(dtype=torch.float)
-
-    def forward(self, x):
-        x = self.fc1(x)
-        return x
-
-class TwoLayerLinearModel(torch.nn.Module):
-    def __init__(self):
-        super(TwoLayerLinearModel, self).__init__()
-        self.fc1 = torch.nn.Linear(5, 8).to(dtype=torch.float)
-        self.fc2 = torch.nn.Linear(8, 5).to(dtype=torch.float)
-
-    def forward(self, x):
-        x = self.fc1(x)
-        x = self.fc2(x)
-        return x
-
-class LinearReluModel(torch.nn.Module):
-    def __init__(self):
-        super(LinearReluModel, self).__init__()
-        self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
-        self.relu = torch.nn.ReLU()
-
-    def forward(self, x):
-        x = self.relu(self.fc(x))
-        return x
-
-class NestedModel(torch.nn.Module):
-    def __init__(self):
-        super(NestedModel, self).__init__()
-        self.sub1 = LinearReluModel()
-        self.sub2 = TwoLayerLinearModel()
-        self.fc3 = torch.nn.Linear(5, 5).to(dtype=torch.float)
-
-    def forward(self, x):
-        x = self.sub1(x)
-        x = self.sub2(x)
-        x = self.fc3(x)
-        return x
-
-class InnerModule(torch.nn.Module):
-    def __init__(self):
-        super(InnerModule, self).__init__()
-        self.fc1 = torch.nn.Linear(5, 8).to(dtype=torch.float)
-        self.relu = torch.nn.ReLU()
-        self.fc2 = torch.nn.Linear(8, 5).to(dtype=torch.float)
-
-    def forward(self, x):
-        return self.relu(self.fc2(self.relu(self.fc1(x))))
-
-class WrappedModel(torch.nn.Module):
-    def __init__(self):
-        super(WrappedModel, self).__init__()
-        self.qconfig = default_qconfig
-        self.sub = QuantWrapper(InnerModule())
-        self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
-        # don't quantize this fc
-        self.fc.qconfig = None
-
-    def forward(self, x):
-        return self.fc(self.sub(x))
-
-class ManualQuantModel(torch.nn.Module):
-    r"""A Module with manually inserted `QuantStub` and `DeQuantStub`
-    """
-    def __init__(self):
-        super(ManualQuantModel, self).__init__()
-        self.qconfig = default_qconfig
-        self.quant = QuantStub()
-        self.dequant = DeQuantStub()
-        self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
-
-    def forward(self, x):
-        x = self.quant(x)
-        x = self.fc(x)
-        return self.dequant(x)
 
 calib_data = [torch.rand(20, 5, dtype=torch.float) for _ in range(20)]
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22706 Move Quantization Models to common_quantization**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16189865/)

Moved the models used for quantization test from the test_quantization.py file to common_quantization.py

Differential Revision: [D16189865](https://our.internmc.facebook.com/intern/diff/D16189865/)