### PR TITLE
[wip] load to a single CU

### DIFF
--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -81,6 +81,7 @@ class ScriptModuleDeserializer final {
 
   std::unordered_set<std::string> imported_libs_;
 
+  std::shared_ptr<script::CompilationUnit> compilation_unit_;
   script::Module main_module_;
 };
 
@@ -437,13 +438,14 @@ script::Module load(
     std::unique_ptr<ReadAdapterInterface> rai,
     c10::optional<c10::Device> device,
     script::ExtraFilesMap& extra_files) {
-  script::Module module("__main__");
+  auto cu = std::make_shared<script::CompilationUnit>();
+  script::Module module("__main__", cu);
 
   auto module_lookup = [&](const std::vector<std::string>& qualified_name) {
     script::Module curr = module;
     for (const auto& name : qualified_name) {
       if (!curr.find_module(name)) {
-        curr.register_module(name, script::Module("__main__"));
+        curr.register_module(name, script::Module("__main__", cu));
       }
       curr = curr.get_module(name);
     }

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -347,7 +347,7 @@ void initJitScriptBindings(PyObject* module) {
   // Methods here are prefixed with _ since they should not be
   // public.
   py::class_<Module>(m, "ScriptModule")
-      .def(py::init<std::string>())
+      .def(py::init<std::string, std::shared_ptr<CompilationUnit>>())
       .def(
           "save",
           [](Module& m,

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -108,8 +108,8 @@ struct TORCH_API Method {
 };
 
 struct TORCH_API Module {
-  Module(std::string class_name)
-      : module_value_(create_module_object(std::move(class_name))) {}
+  explicit Module(std::string class_name);
+  Module(std::string class_name, std::shared_ptr<CompilationUnit> cu);
   // module_value_ null and will be lazily initialized if is needed
   Module() {}
   Module(ModulePtr module_value) : module_value_(std::move(module_value)) {}
@@ -320,14 +320,8 @@ struct TORCH_API Module {
     return c10::nullopt;
   }
 
-  ModulePtr module_object() const {
-    if (!module_value_) {
-      // User has created a Model without assigning it to something already
-      // loaded. This is done in tests, and when using the .define method.
-      module_value_ = create_module_object("__main__");
-    }
-    return module_value_;
-  }
+  ModulePtr module_object() const;
+
   ClassTypePtr type() const {
     return module_object()->type();
   }
@@ -430,13 +424,6 @@ struct TORCH_API Module {
       const c10::optional<at::ScalarType>& dtype,
       bool non_blocking);
 
-  static ModulePtr create_module_object(std::string class_name) {
-    auto cu = std::make_shared<CompilationUnit>();
-    auto cls = ClassType::create(
-        QualifiedName(std::move(class_name)), cu, /*is_module=*/true);
-    return c10::ivalue::Object::create(
-        c10::StrongTypePtr(std::move(cu), std::move(cls)), 0);
-  }
   // mutable be we lazily initialize in module_object.
   mutable ModulePtr module_value_;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22713 [wip] load to a single CU**
* #22504 [jit] Make classtypes hold a weak_ptr to their CU
* #22692 [jit] Make traced fns also go into the global python CU
* #22221 [jit] _script_compile and _script_class_compile add to the python CU
* #22667 [jit] make CompilationUnit::define return defined functions
* #22712 [jit] refactor self to be a class again
* #22711 [jit] Give functions qualified names

gh-metadata: pytorch pytorch 22713 gh/suo/85/head