### PR TITLE
[jit] Give functions qualified names

### DIFF
--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,7 +11,11 @@ namespace jit {
 
 std::shared_ptr<script::CompilationUnit> compile(const std::string& source) {
   auto module = std::make_shared<script::CompilationUnit>();
-  module->define(source, script::nativeResolver(), nullptr);
+  module->define(
+      c10::nullopt,
+      source,
+      script::nativeResolver(),
+      nullptr);
   return module;
 }
 

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -745,11 +745,11 @@ bool ScriptModuleSerializer::moduleHasValidGetSetState(
   // Check __setstate__ if the method exists
   //   __setstate__ is expected to be (self, T) -> None
   // TODO: use getMethod("__getstate__") once methods are not lowered
-  auto setstate = module.class_compilation_unit()->find_function("__setstate__");
-  if (setstate == nullptr) {
+  auto setstate = module.find_method("__setstate__");
+  if (!setstate) {
     return false;
   }
-  auto set_schema = setstate->getSchema();
+  auto set_schema = setstate->function().getSchema();
 
   TORCH_CHECK(
       set_schema.arguments().size() == 2,

--- a/torch/csrc/jit/function.h
+++ b/torch/csrc/jit/function.h
@@ -14,7 +14,7 @@ using Kwargs = std::unordered_map<std::string, IValue>;
 // underlying Function that also provides a `self` object.
 struct TORCH_API Function {
   Function(
-      std::string name,
+      c10::QualifiedName name,
       bool optimize,
       std::shared_ptr<Graph> graph,
       std::function<void(Function&)> function_creator)
@@ -43,8 +43,12 @@ struct TORCH_API Function {
     return graph_;
   }
 
-  const std::string& name() const {
+  const c10::QualifiedName& qualname() const {
     return name_;
+  }
+
+  const std::string& name() const {
+    return name_.name();
   }
 
   // if this isn't yet defined, run its method_creator function
@@ -114,7 +118,7 @@ struct TORCH_API Function {
     return {function.name(), "", std::move(args), std::move(returns)};
   }
 
-  std::string name_;
+  c10::QualifiedName name_;
   std::shared_ptr<Graph> graph_; // for debugging and for inlining
   bool optimize_;
 

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -279,11 +279,10 @@ void ScriptModuleDeserializer::importCallback(const std::string& qualifier) {
 void ScriptModuleDeserializer::moduleSetState(
     const script::Module& module,
     IValue state) {
-  auto setstate =
-      module.class_compilation_unit()->find_function("__setstate__");
+  auto setstate = module.find_method("__setstate__");
 
   TORCH_CHECK(
-      setstate != nullptr,
+      setstate,
       "Cannot call '__setstate__' method because"
       " it does not exist");
 

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -187,19 +187,20 @@ struct SourceImporter {
     while (L.cur().kind != TK_EOF) {
       parseImportsAndDoCallback();
 
-      std::vector<Def> definitions;
-      std::vector<ResolverPtr> resolvers;
       auto parsed_treeref = p_.parseClassLike();
       if (parsed_treeref->kind() == TK_CLASS_DEF) {
         auto class_def = ClassDef(parsed_treeref);
+        auto cu = std::make_shared<CompilationUnit>();
+        const auto qualified_classname = QualifiedName(
+            QualifiedName(class_qualifier), class_def.name().name());
+
+        std::vector<Def> definitions;
+        std::vector<ResolverPtr> resolvers;
         for (const auto& method_def : class_def.defs()) {
           definitions.emplace_back(method_def);
           resolvers.emplace_back(resolver_);
         }
 
-        auto cu = std::make_shared<CompilationUnit>();
-        const auto qualified_classname =
-            class_qualifier + "." + class_def.name().name();
         auto class_type =
             ClassType::create(c10::QualifiedName(qualified_classname), cu);
         owner.register_class(class_type);
@@ -207,7 +208,7 @@ struct SourceImporter {
           v->setType(class_type);
           return std::make_shared<SimpleValue>(v);
         };
-        cu->define(definitions, resolvers, self);
+        cu->define(qualified_classname, definitions, resolvers, self);
       } else if (parsed_treeref->kind() == TK_NAMED_TUPLE_DEF) {
         auto named_tuple_def = NamedTupleDef(parsed_treeref);
 
@@ -245,7 +246,10 @@ struct SourceImporter {
     }
   }
 
-  void importFunctions(CompilationUnit& cu, const Self& self) {
+  void importFunctions(
+      const c10::optional<c10::QualifiedName>& prefix,
+      CompilationUnit& cu,
+      const Self& self) {
     checkVersionNumber();
     parseImportsAndDoCallback();
 
@@ -256,7 +260,7 @@ struct SourceImporter {
       definitions.emplace_back(def);
       resolvers.emplace_back(resolver_);
     }
-    cu.define(definitions, resolvers, self);
+    cu.define(prefix, definitions, resolvers, self);
   }
 
   size_t parseVersionNumber() {
@@ -309,6 +313,7 @@ struct SourceImporter {
 };
 
 void import_functions(
+    const c10::optional<c10::QualifiedName>& prefix,
     const CompilationUnit& lib_cu,
     CompilationUnit& cu,
     const std::shared_ptr<Source>& src,
@@ -316,7 +321,7 @@ void import_functions(
     const Self& self,
     const std::function<void(const std::string&)>& import_callback) {
   SourceImporter importer(lib_cu, src, constant_table, import_callback);
-  importer.importFunctions(cu, self);
+  importer.importFunctions(prefix, cu, self);
 }
 
 void import_methods(
@@ -330,6 +335,7 @@ void import_methods(
     return std::make_shared<SimpleValue>(v);
   };
   import_functions(
+      mod.name(),
       lib_cu,
       *mod.module_object()->type()->compilation_unit(),
       src,

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -40,6 +40,8 @@ TORCH_API void import_libs(
 // If present, it determines the SugaredValue for the first argument
 // and that argument is no longer expected to have type annotations.
 TORCH_API void import_functions(
+    // Prefix to use when importing these functions in to the CU
+    const c10::optional<c10::QualifiedName>& prefix,
     // CompilationUnit in which to look up any classes used
     const CompilationUnit& lib_cu,
     // CompilationoUnit to define the functions in.

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -99,11 +99,13 @@ bool DecomposeOps(Block* block, script::CompilationUnit& decompose_funcs) {
       decomposed = true;
       WithInsertPoint guard(*it);
 
-      std::shared_ptr<Graph> d_graph = decompose_funcs.get_function("addmm").graph();
-      Value* new_output = inlineCallTo(*it->owningGraph(), *d_graph, it->inputs()).at(0);
-      // Set the output of the decomposed graph to have the same output type as the
-      // original op otherwise the canonicalized graph will have
-      // TensorType as the output of this node which is incorrect
+      std::shared_ptr<Graph> d_graph =
+          decompose_funcs.get_function("addmm").graph();
+      Value* new_output =
+          inlineCallTo(*it->owningGraph(), *d_graph, it->inputs()).at(0);
+      // Set the output of the decomposed graph to have the same output type as
+      // the original op otherwise the canonicalized graph will have TensorType
+      // as the output of this node which is incorrect
       new_output->setType(it->output()->type());
       it->output()->replaceAllUsesWith(new_output);
       it.destroyCurrent();
@@ -127,7 +129,8 @@ bool DecomposeOps(Block* block, script::CompilationUnit& decompose_funcs) {
       };
 
       // inline the compiled decomposed batchnorm
-      std::shared_ptr<Graph> d_graph = decompose_funcs.get_function("batch_norm").graph();
+      std::shared_ptr<Graph> d_graph =
+          decompose_funcs.get_function("batch_norm").graph();
       Value* new_output = inlineCallTo(*graph, *d_graph, inputs).at(0);
 
       // post processing the graph
@@ -161,7 +164,8 @@ bool DecomposeOps(Block* block, script::CompilationUnit& decompose_funcs) {
       };
 
       // inline the compiled decomposed layernorm
-      std::shared_ptr<Graph> d_graph = decompose_funcs.get_function("layer_norm").graph();
+      std::shared_ptr<Graph> d_graph =
+          decompose_funcs.get_function("layer_norm").graph();
       Value* new_output = inlineCallTo(*graph, *d_graph, inputs).at(0);
 
       // post processing the graph

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -66,7 +66,8 @@ struct BuiltinFunctionRegistry {
   void loadSource(const std::string& source) {
     std::shared_ptr<CompilationUnit> cu = std::make_shared<CompilationUnit>();
     modules.emplace_back(cu);
-    cu->define(source, script::nativeResolver(), /*self=*/nullptr);
+    cu->define(
+        c10::nullopt, source, script::nativeResolver(), /*self=*/nullptr);
     for (auto& method : cu->get_functions()) {
       builtins_by_name_[Symbol::fromQualString("aten::" + method->name())]
           .push_back(method);

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -8,7 +8,8 @@ namespace c10 {
 // c10. Sigh...
 
 Function* ClassType::getMethod(const std::string& name) const {
-  return compilation_unit_->find_function(name);
+  const auto qualname = QualifiedName(*qualified_name_obj(), name);
+  return compilation_unit_->find_function(qualname);
 }
 
 std::shared_ptr<CompilationUnit> ClassType::compilation_unit() {
@@ -63,7 +64,17 @@ size_t ClassType::addAttribute(
 }
 
 std::vector<Function*> ClassType::methods() const {
-  return compilation_unit()->get_functions();
+  // TODO: this needs to be made more efficient!
+  // This grabs all the functions in the CU and filters them by qualified name.
+  auto cuFunctions = compilation_unit()->get_functions();
+  const auto& classname = *qualified_name_obj();
+  cuFunctions.erase(
+      std::remove_if(
+          cuFunctions.begin(),
+          cuFunctions.end(),
+          [&](Function* fn) { return !classname.isPrefixOf(fn->qualname()); }),
+      cuFunctions.end());
+  return cuFunctions;
 }
 
 ClassType::ClassType(

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -198,6 +198,7 @@ static void clearMethods(c10::ivalue::Object* self) {
 
 void Module::define(const std::string& src, const ResolverPtr& resolver) {
   class_compilation_unit()->define(
+      name(),
       src,
       resolver ? resolver : script::nativeResolver(),
       simpleSelf(module_object()->type()));
@@ -225,13 +226,13 @@ void Module::copy_into(
   }
 
   for (auto& fn : class_compilation_unit()->get_functions()) {
-    curr.clone_method(*this, fn->name(), type_remap);
+    curr.clone_method(*this, fn->qualname(), type_remap);
   }
 }
 
 void Module::clone_method(
     const Module& orig,
-    const std::string& name,
+    const QualifiedName& qualname,
     const std::unordered_map<TypePtr, TypePtr>& type_remap) {
   // type remapping - when we copy method implementations from one module
   // singleton to another, we need to update the types of the self arguments
@@ -249,11 +250,11 @@ void Module::clone_method(
       return in;
     return it->second;
   };
-  const Function& fn = orig.class_compilation_unit()->get_function(name);
+  const Function& fn = orig.class_compilation_unit()->get_function(qualname);
   auto graph = fn.graph()->copy();
   graph->remapTypes(type_remap_fn);
   auto schema = fn.getSchema().cloneWithRemappedTypes(type_remap_fn);
-  auto copied = class_compilation_unit()->create_function(fn.name(), graph);
+  auto copied = class_compilation_unit()->create_function(qualname, graph);
   copied->setSchema(std::move(schema));
 }
 
@@ -269,7 +270,8 @@ void Module::clone_method(const Module& orig, const std::string& name) {
       to_scan.emplace_back(s.to_module(), entry.second.get_module(s.name()));
     }
   }
-  return clone_method(orig, name, type_remap);
+  const auto qualname = getNameForMethod(name);
+  return clone_method(orig, qualname, type_remap);
 }
 
 void Module::train(bool on) {

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -115,6 +115,10 @@ struct TORCH_API Module {
   Module(ModulePtr module_value) : module_value_(std::move(module_value)) {}
   ~Module() {}
 
+  const c10::QualifiedName& name() const {
+    return *module_object()->type()->qualified_name_obj();
+  }
+
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
   void set_optimized(bool o) {
@@ -222,8 +226,9 @@ struct TORCH_API Module {
     }
     return c10::nullopt;
   }
-  c10::optional<Method> find_method(const std::string& name) const {
-    if (const auto fn = class_compilation_unit()->find_function(name)) {
+  c10::optional<Method> find_method(const std::string& basename) const {
+    if (const auto fn = class_compilation_unit()->find_function(
+            getNameForMethod(basename))) {
       return Method(module_object(), fn);
     }
     return c10::nullopt;
@@ -306,7 +311,7 @@ struct TORCH_API Module {
   void clone_method(const Module& orig, const std::string& name);
 
   at::optional<EntityType> kind_of(const std::string& name) const {
-    if (class_compilation_unit()->find_function(name)) {
+    if (class_compilation_unit()->find_function(getNameForMethod(name))) {
       return EntityType::METHOD;
     }
     if (auto offset = type()->findAttributeSlot(name)) {
@@ -353,8 +358,12 @@ struct TORCH_API Module {
  private:
   void clone_method(
       const Module& orig,
-      const std::string& name,
+      const QualifiedName& name,
       const std::unordered_map<TypePtr, TypePtr>& type_remap);
+
+  c10::QualifiedName getNameForMethod(std::string basename) const {
+    return QualifiedName(name(), basename);
+  }
   static const char* toString(EntityType t) {
     switch (t) {
       case EntityType::MODULE:

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -183,6 +183,7 @@ void SimpleValue::setAttr(
     // We are initializing if:
     const auto isInitializing =
         // 1. The method we're currently inserting into is an init method
+        // TODO this can be a qualified name check
         m.name() == "__init__" &&
         // 2. The `self` arg matches this value's type (i.e. we are in the init
         // method for this class, not some other class)
@@ -252,8 +253,9 @@ std::shared_ptr<SugaredValue> SimpleValue::call(
         m.graph()
             ->insertNode(m.graph()->createTuple(context->node()->inputs()))
             ->output();
+    // TODO this needs to go in `m`s compilation unit
     auto cu = std::make_shared<CompilationUnit>();
-    auto fn = cu->create_function("anon", graph);
+    auto fn = cu->create_function(QualifiedName("anon"), graph);
     auto ret = StrongFunctionPtr(std::move(cu), fn);
 
     std::vector<NamedValue> ctx_inputs = {close_context};

--- a/torch/csrc/jit/symbolic_script.cpp
+++ b/torch/csrc/jit/symbolic_script.cpp
@@ -1398,7 +1398,7 @@ void loadModule(const script::CompilationUnit& module) {
 void loadFunctions() {
   for (const std::string& str : functions) {
     script::CompilationUnit cu;
-    cu.define(str, script::nativeResolver(), nullptr);
+    cu.define(c10::nullopt, str, script::nativeResolver(), nullptr);
     loadModule(cu);
   }
 }

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1094,17 +1094,17 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
         if _is_recursive_script_enabled(obj):
             return _convert_to_script_module(obj)
 
+    qualified_name = _qualified_name(obj)
     if inspect.isclass(obj):
         if not _is_new_style_class(obj):
             raise RuntimeError("TorchScript classes must be new-style classes. Please inherit from 'object'")
-        qualified_name = _qualified_name(obj)
         ast = get_jit_class_def(obj, obj.__name__)
         _jit_script_class_compile(qualified_name, ast, _rcb)
         _add_script_class(obj, qualified_name)
         return obj
     else:
         ast = get_jit_def(obj)
-        fn = torch._C._jit_script_compile(ast, _rcb, get_default_args(obj))
+        fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
         # Forward docstrings
         fn.__doc__ = obj.__doc__
         return fn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22727 [wip] load to a single CU
* #22726 [jit] Make classtypes hold a weak_ptr to their CU
* #22725 [jit] Make traced fns also go into the global python CU
* #22724 [jit] _script_compile and _script_class_compile add to the python CU
* #22723 [jit] make CompilationUnit::define return defined functions
* #22722 [jit] refactor self to be a class again
* **#22721 [jit] Give functions qualified names**

This makes it so that all code objects owned by a CompilationUnit will
have a qualified name.

This also means that Module performs one new duty: it does
qualified name resolution by concating the Module qualified name with
the method name to find the method in the owning CU.

Differential Revision: [D16197606](https://our.internmc.facebook.com/intern/diff/D16197606)