### PR TITLE
[jit] refactor self to be a class again

### DIFF
--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -204,11 +204,8 @@ struct SourceImporter {
         auto class_type =
             ClassType::create(c10::QualifiedName(qualified_classname), cu);
         owner.register_class(class_type);
-        auto self = [&](Value* v) {
-          v->setType(class_type);
-          return std::make_shared<SimpleValue>(v);
-        };
-        cu->define(qualified_classname, definitions, resolvers, self);
+        const auto self = SimpleSelf(class_type);
+        cu->define(qualified_classname, definitions, resolvers, &self);
       } else if (parsed_treeref->kind() == TK_NAMED_TUPLE_DEF) {
         auto named_tuple_def = NamedTupleDef(parsed_treeref);
 
@@ -249,7 +246,7 @@ struct SourceImporter {
   void importFunctions(
       const c10::optional<c10::QualifiedName>& prefix,
       CompilationUnit& cu,
-      const Self& self) {
+      const Self* self) {
     checkVersionNumber();
     parseImportsAndDoCallback();
 
@@ -318,7 +315,7 @@ void import_functions(
     CompilationUnit& cu,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
-    const Self& self,
+    const Self* self,
     const std::function<void(const std::string&)>& import_callback) {
   SourceImporter importer(lib_cu, src, constant_table, import_callback);
   importer.importFunctions(prefix, cu, self);
@@ -330,17 +327,14 @@ void import_methods(
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
     const std::function<void(const std::string&)>& import_callback) {
-  auto self = [&](Value* v) {
-    v->setType(mod.module_object()->type());
-    return std::make_shared<SimpleValue>(v);
-  };
+  auto self = SimpleSelf(mod.type());
   import_functions(
       mod.name(),
       lib_cu,
       *mod.module_object()->type()->compilation_unit(),
       src,
       constant_table,
-      self,
+      &self,
       import_callback);
 }
 

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -48,7 +48,7 @@ TORCH_API void import_functions(
     CompilationUnit& cu,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
-    const Self& self = nullptr,
+    const Self* self = nullptr,
     const std::function<void(const std::string&)>& import_callback = nullptr);
 
 } // namespace script

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -30,7 +30,11 @@ struct SugaredValue;
 struct Resolver;
 
 using ResolverPtr = std::shared_ptr<Resolver>;
-using Self = std::function<std::shared_ptr<SugaredValue>(Value*)>;
+struct Self {
+  virtual ~Self() {}
+  virtual std::shared_ptr<SugaredValue> makeSugared(Value* v) const = 0;
+  virtual ClassTypePtr getClassType() const = 0;
+};
 
 // A CompilationUnit is a list of named Functions
 // with helper methods to iterate the list, or invoke the function.
@@ -80,7 +84,7 @@ struct TORCH_API CompilationUnit {
           resolvers, /* determines how we handle free
                      variables in each definition*/
       // if non-null, the first argument to each def, is bound to this value
-      const Self& self);
+      const Self* self);
 
   // same as above but parse the definitions from source
   void define(
@@ -88,7 +92,7 @@ struct TORCH_API CompilationUnit {
       const c10::optional<c10::QualifiedName>& prefix,
       const std::string& source,
       const ResolverPtr& resolver,
-      const Self& self);
+      const Self* self);
 
   Function* create_function(
       c10::QualifiedName name,
@@ -189,7 +193,7 @@ struct TORCH_API CompilationUnit {
       const c10::optional<c10::QualifiedName>& prefix,
       const Def& def,
       const ResolverPtr& resolver,
-      const Self& self,
+      const Self* self,
       const std::unordered_map<std::string, Function*>& function_table) const;
 
   Function& register_function(std::unique_ptr<Function> fn) {

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -492,7 +492,7 @@ struct to_ir {
   to_ir(
       const Def& def,
       ResolverPtr resolver_,
-      const Self& self,
+      const Self* self,
       Function& method) // method being constructed
       : method(method),
         graph(method.graph()),
@@ -542,7 +542,7 @@ struct to_ir {
     return old_frame;
   }
 
-  FunctionSchema emitDef(const Def& def, const Self& self, Block* block) {
+  FunctionSchema emitDef(const Def& def, const Self* self, Block* block) {
     auto schema = extractSchemaFromDef(def, self);
     // TODO need guards on init returning none
     if (schema.returns().size() == 1) {
@@ -597,7 +597,7 @@ struct to_ir {
     return stack.at(0).toTuple()->elements();
   }
 
-  std::vector<Argument> parseArgsFromDecl(const Decl& decl, const Self& self) {
+  std::vector<Argument> parseArgsFromDecl(const Decl& decl, const Self* self) {
     auto params_begin = decl.params().begin();
     auto params_end = decl.params().end();
     if (self) {
@@ -678,7 +678,7 @@ struct to_ir {
         /*default_value =*/c10::nullopt,
         /*kwarg_only =*/false)};
   }
-  FunctionSchema extractSchemaFromDef(const Def& def, const Self& self) {
+  FunctionSchema extractSchemaFromDef(const Def& def, const Self* self) {
     const auto name = def.name().name();
     std::vector<Argument> args = parseArgsFromDecl(def.decl(), self);
     std::vector<Argument> returns = parseReturnFromDecl(def.decl());
@@ -688,7 +688,7 @@ struct to_ir {
 
   std::vector<Argument> emitFormalArguments(
       const Def& def,
-      const Self& self,
+      const Self* self,
       const FunctionSchema& schema,
       Block* block) {
     std::vector<Argument> arguments; // for schema
@@ -712,7 +712,7 @@ struct to_ir {
       const auto& name = (*it).ident().name();
       Value* new_input = block->addInput()->setDebugName(name);
       environment_stack->setSugaredVar(
-          (*it).ident().range(), name, self(new_input));
+          (*it).ident().range(), name, self->makeSugared(new_input));
       arguments.emplace_back(name, new_input->type());
       ++it;
     }
@@ -2916,7 +2916,7 @@ std::unique_ptr<Function> CompilationUnit::define(
     const c10::optional<QualifiedName>& prefix,
     const Def& def,
     const ResolverPtr& resolver,
-    const Self& self,
+    const Self* self,
     const std::unordered_map<std::string, Function*>& function_table) const {
   TORCH_INTERNAL_ASSERT(resolver);
   auto _resolver = resolver;
@@ -2945,7 +2945,7 @@ void CompilationUnit::define(
     const c10::optional<QualifiedName>& prefix,
     const std::vector<Def>& definitions,
     const std::vector<ResolverPtr>& resolvers,
-    const Self& self) {
+    const Self* self) {
   TORCH_INTERNAL_ASSERT(definitions.size() == resolvers.size());
   // We need to compile `__init__` first, since it can determine what attributes
   // are available to other methods. So reorder the definitions accordingly.
@@ -2997,7 +2997,7 @@ void CompilationUnit::define(
     const c10::optional<QualifiedName>& prefix,
     const std::string& source,
     const ResolverPtr& resolver,
-    const Self& self) {
+    const Self* self) {
   Parser p(std::make_shared<Source>(source, "<string>", 1));
   std::vector<Def> definitions;
   std::vector<ResolverPtr> resolvers;

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -213,12 +213,22 @@ FunctionSchema getSchemaWithNameAndDefaults(
       schema.is_varret());
 }
 
-static Self moduleSelf(const Module& m, const py::object& py_m) {
-  return [m, py_m](Value* v) {
-    v->setType(m.module_object()->type());
-    return std::make_shared<ModuleValue>(v, m, py_m);
-  };
-}
+struct VISIBILITY_HIDDEN ModuleSelf : public Self {
+  ModuleSelf(const Module& m, py::object& py_m)
+      : Self(), module_(m), pyModule_(py_m) {}
+
+  std::shared_ptr<SugaredValue> makeSugared(Value* v) const override {
+    v->setType(module_.type());
+    return std::make_shared<ModuleValue>(v, module_, pyModule_);
+  }
+  ClassTypePtr getClassType() const override {
+    return module_.type();
+  }
+
+ private:
+  const Module& module_;
+  const py::object& pyModule_;
+};
 
 static TypePtr getTensorType(
     const at::Tensor& t,
@@ -361,9 +371,9 @@ void initJitScriptBindings(PyObject* module) {
              py::object py_m,
              const std::string& script,
              ResolutionCallback rcb) {
-            c10::optional<Self> self;
+            const auto self = ModuleSelf(m, py_m);
             m.class_compilation_unit()->define(
-                m.name(), script, pythonResolver(rcb), moduleSelf(m, py_m));
+                m.name(), script, pythonResolver(rcb), &self);
             didFinishEmitModule(m);
           })
       .def(
@@ -380,8 +390,8 @@ void initJitScriptBindings(PyObject* module) {
               resolvers.push_back(pythonResolver(callback));
             }
             const auto prefix = QualifiedName(m.name());
-            m.class_compilation_unit()->define(
-                prefix, defs, resolvers, moduleSelf(m, py_m));
+            const auto self = ModuleSelf(m, py_m);
+            m.class_compilation_unit()->define(prefix, defs, resolvers, &self);
             // Stitch in default arguments for each Def if provided
             auto defaults_it = defaults.begin();
             auto defs_it = defs.begin();
@@ -737,8 +747,8 @@ void initJitScriptBindings(PyObject* module) {
           rcbs.push_back(
               pythonResolver(rcb, classDef.name().name(), classType));
         }
-        cu->define(
-            QualifiedName(classname), methodDefs, rcbs, simpleSelf(classType));
+        const auto self = SimpleSelf(classType);
+        cu->define(classname, methodDefs, rcbs, &self);
       });
 
   m.def("parse_type_comment", [](const std::string& comment) {
@@ -781,15 +791,14 @@ void initJitScriptBindings(PyObject* module) {
       "_jit_import_functions",
       [](CompilationUnit& cu,
          const std::string& src,
-         const std::vector<at::Tensor>& constant_table,
-         const Self& self) {
+         const std::vector<at::Tensor>& constant_table) {
         import_functions(
             c10::nullopt,
             *CompilationUnit::_get_python_cu_const(),
             cu,
             std::make_shared<Source>(src),
             constant_table,
-            self,
+            nullptr,
             nullptr);
       });
 

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -197,11 +197,9 @@ static void clearMethods(c10::ivalue::Object* self) {
 }
 
 void Module::define(const std::string& src, const ResolverPtr& resolver) {
+  const auto self = SimpleSelf(type());
   class_compilation_unit()->define(
-      name(),
-      src,
-      resolver ? resolver : script::nativeResolver(),
-      simpleSelf(module_object()->type()));
+      name(), src, resolver ? resolver : script::nativeResolver(), &self);
 }
 
 void Module::copy_into(

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -534,12 +534,20 @@ static inline std::vector<Value*> toValues(
   return fmap(nvs, [&](const NamedValue& v) { return v.value(g); });
 }
 
-static inline Self simpleSelf(const TypePtr& typ) {
-  return [typ](Value* v) {
-    v->setType(typ);
+struct SimpleSelf : public Self {
+  explicit SimpleSelf(ClassTypePtr classType)
+      : Self(), classType_(std::move(classType)) {}
+  std::shared_ptr<SugaredValue> makeSugared(Value* v) const override {
+    v->setType(classType_);
     return std::make_shared<SimpleValue>(v);
-  };
-}
+  }
+  ClassTypePtr getClassType() const override {
+    return classType_;
+  }
+
+ private:
+  ClassTypePtr classType_;
+};
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -916,7 +916,7 @@ class CompilationUnit(object):
     def _import(self, src, constants, op_version_set=1):
         """ test import logic for single function, use only for testing """
         src = "op_version_set = {}\n{}".format(op_version_set, src)
-        torch._C._jit_import_functions(self._c, src, constants, None)
+        torch._C._jit_import_functions(self._c, src, constants)
         return self
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22727 [wip] load to a single CU
* #22726 [jit] Make classtypes hold a weak_ptr to their CU
* #22725 [jit] Make traced fns also go into the global python CU
* #22724 [jit] _script_compile and _script_class_compile add to the python CU
* #22723 [jit] make CompilationUnit::define return defined functions
* **#22722 [jit] refactor self to be a class again**
* #22721 [jit] Give functions qualified names

I want to get the `type` of self (now that everything is ultimately a
class type).

Differential Revision: [D16197607](https://our.internmc.facebook.com/intern/diff/D16197607)