### PR TITLE
[jit] make CompilationUnit::define return defined functions

### DIFF
--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -77,7 +77,8 @@ struct TORCH_API CompilationUnit {
   }
 
   // for historic reasons, these are defined in compiler.cpp
-  void define(
+  // Returns the list of Function's just defined.
+  std::vector<Function*> define(
       const c10::optional<c10::QualifiedName>& prefix,
       const std::vector<Def>& definitions,
       const std::vector<ResolverPtr>&
@@ -87,7 +88,8 @@ struct TORCH_API CompilationUnit {
       const Self* self);
 
   // same as above but parse the definitions from source
-  void define(
+  // Returns the list of Function's just defined.
+  std::vector<Function*> define(
       // prefix namespace to put all the defined functions into
       const c10::optional<c10::QualifiedName>& prefix,
       const std::string& source,

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2941,7 +2941,7 @@ std::unique_ptr<Function> CompilationUnit::define(
       std::move(name), is_optimized(), std::make_shared<Graph>(), creator);
 }
 
-void CompilationUnit::define(
+std::vector<Function*> CompilationUnit::define(
     const c10::optional<QualifiedName>& prefix,
     const std::vector<Def>& definitions,
     const std::vector<ResolverPtr>& resolvers,
@@ -2958,7 +2958,7 @@ void CompilationUnit::define(
     }
   }
 
-  std::vector<Function*> methods;
+  std::vector<Function*> functions;
   std::unordered_map<std::string, Function*> function_table;
   if (init_idx.has_value()) {
     // if we have an init, do it first.
@@ -2970,7 +2970,7 @@ void CompilationUnit::define(
         function_table);
     const auto& name = fn->name();
     function_table[name] = fn.get();
-    methods.push_back(fn.get());
+    functions.push_back(fn.get());
     register_function(std::move(fn));
   }
 
@@ -2984,16 +2984,17 @@ void CompilationUnit::define(
         define(prefix, definitions[i], resolvers[i], self, function_table);
     const auto& name = fn->name();
     function_table[name] = fn.get();
-    methods.push_back(fn.get());
+    functions.push_back(fn.get());
     register_function(std::move(fn));
   }
 
-  for (Function* method : methods) {
-    method->ensure_defined();
+  for (Function* function : functions) {
+    function->ensure_defined();
   }
+  return functions;
 }
 
-void CompilationUnit::define(
+std::vector<Function*> CompilationUnit::define(
     const c10::optional<QualifiedName>& prefix,
     const std::string& source,
     const ResolverPtr& resolver,
@@ -3006,7 +3007,7 @@ void CompilationUnit::define(
     definitions.push_back(def);
     resolvers.push_back(resolver);
   }
-  define(prefix, definitions, resolvers, self);
+  return define(prefix, definitions, resolvers, self);
 }
 
 void runCleanupPasses(std::shared_ptr<Graph>& to_clean, bool convert_ssa) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22727 [wip] load to a single CU
* #22726 [jit] Make classtypes hold a weak_ptr to their CU
* #22725 [jit] Make traced fns also go into the global python CU
* #22724 [jit] _script_compile and _script_class_compile add to the python CU
* **#22723 [jit] make CompilationUnit::define return defined functions**
* #22722 [jit] refactor self to be a class again
* #22721 [jit] Give functions qualified names

Doesn't do anything yet, just a mechanical change

Differential Revision: [D16197604](https://our.internmc.facebook.com/intern/diff/D16197604)