### PR TITLE
Move the storage in empty_cpu

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -106,7 +106,7 @@ Tensor empty_cpu(IntArrayRef size, const TensorOptions& options, c10::optional<c
     allocator,
     /*resizeable=*/true);
 
-  auto tensor = detail::make_tensor<TensorImpl>(storage_impl, at::CPUTensorId());
+  auto tensor = detail::make_tensor<TensorImpl>(std::move(storage_impl), at::CPUTensorId());
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22729 assert_no_internal_overlap pass op name by const ref
* **#22728 Move the storage in empty_cpu**

Differential Revision: [D16205449](https://our.internmc.facebook.com/intern/diff/D16205449)