### PR TITLE
assert_no_internal_overlap pass op name by const ref

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -23,11 +23,11 @@ MemOverlap has_internal_overlap(TensorImpl* t) {
   return MemOverlap::TOO_HARD;
 }
 
-void assert_no_internal_overlap(const Tensor& t, std::string op) {
+void assert_no_internal_overlap(const Tensor& t, const std::string& op) {
   assert_no_internal_overlap(t.unsafeGetTensorImpl(), op);
 }
 
-void assert_no_internal_overlap(TensorImpl* t, std::string op) {
+void assert_no_internal_overlap(TensorImpl* t, const std::string& op) {
   if (has_internal_overlap(t) == MemOverlap::YES) {
     AT_ERROR(
         op, ": unsupported operation: more than one element of the written-to "

--- a/aten/src/ATen/MemoryOverlap.h
+++ b/aten/src/ATen/MemoryOverlap.h
@@ -16,7 +16,7 @@ enum class MemOverlap { NO, YES, TOO_HARD };
 CAFFE2_API MemOverlap has_internal_overlap(const Tensor& t);
 CAFFE2_API MemOverlap has_internal_overlap(TensorImpl* t);
 
-CAFFE2_API void assert_no_internal_overlap(const Tensor& t, std::string op);
-CAFFE2_API void assert_no_internal_overlap(TensorImpl* t, std::string op);
+CAFFE2_API void assert_no_internal_overlap(const Tensor& t, const std::string& op);
+CAFFE2_API void assert_no_internal_overlap(TensorImpl* t, const std::string& op);
 
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22729 assert_no_internal_overlap pass op name by const ref**
* #22728 Move the storage in empty_cpu

Differential Revision: [D16205448](https://our.internmc.facebook.com/intern/diff/D16205448)