### PR TITLE
[ROCm] Unwrap sccache post-build for ROCm compilations.

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -274,7 +274,9 @@ pip install --user -b /tmp/pip_install_onnx "file://${ROOT_DIR}/third_party/onnx
 if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
   if [ -e /opt/rocm/hcc/bin/clang-7.0_original ]; then
     # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
-    mv /opt/rocm/hcc/bin/clang-7.0_original /opt/rocm/hcc/bin/clang-9
+    # note that the wrapping always names the compiler "clang-7.0_original"
+    WRAPPED=/opt/rocm/hcc/bin/clang-[0-99]
+    mv /opt/rocm/hcc/bin/clang-7.0_original $WRAPPED
   fi
 fi
 

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -277,7 +277,7 @@ if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
     # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
     # note that the wrapping always names the compiler "clang-7.0_original"
     WRAPPED=/opt/rocm/hcc/bin/clang-[0-99]
-    mv $ORIG_COMP $WRAPPED
+    sudo mv $ORIG_COMP $WRAPPED
   fi
 fi
 

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -176,7 +176,7 @@ if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
   # the build process, leaving undefined symbols in the shared lib
   # which will cause undefined symbol errors when later running
   # tests. Setting MAX_JOBS to smaller number to make CI less flaky.
-  export MAX_JOBS=4
+  export MAX_JOBS=3
 
   ########## HIPIFY Caffe2 operators
   ${PYTHON} "${ROOT_DIR}/tools/amd_build/build_amd.py"
@@ -270,5 +270,12 @@ fi
 
 # Install ONNX into a local directory
 pip install --user -b /tmp/pip_install_onnx "file://${ROOT_DIR}/third_party/onnx#egg=onnx"
+
+if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
+  if [ -e /opt/rocm/hcc/bin/clang-7.0_original ]; then
+    # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
+    mv /opt/rocm/hcc/bin/clang-7.0_original /opt/rocm/hcc/bin/clang-9
+  fi
+fi
 
 report_compile_cache_stats

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -176,7 +176,7 @@ if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
   # the build process, leaving undefined symbols in the shared lib
   # which will cause undefined symbol errors when later running
   # tests. Setting MAX_JOBS to smaller number to make CI less flaky.
-  export MAX_JOBS=3
+  export MAX_JOBS=4
 
   ########## HIPIFY Caffe2 operators
   ${PYTHON} "${ROOT_DIR}/tools/amd_build/build_amd.py"

--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -272,11 +272,12 @@ fi
 pip install --user -b /tmp/pip_install_onnx "file://${ROOT_DIR}/third_party/onnx#egg=onnx"
 
 if [[ $BUILD_ENVIRONMENT == *rocm* ]]; then
-  if [ -e /opt/rocm/hcc/bin/clang-7.0_original ]; then
+  ORIG_COMP=/opt/rocm/hcc/bin/clang-*_original
+  if [ -e $ORIG_COMP ]; then
     # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
     # note that the wrapping always names the compiler "clang-7.0_original"
     WRAPPED=/opt/rocm/hcc/bin/clang-[0-99]
-    mv /opt/rocm/hcc/bin/clang-7.0_original $WRAPPED
+    mv $ORIG_COMP $WRAPPED
   fi
 fi
 

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -111,7 +111,10 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
 
   if [ -e /opt/rocm/hcc/bin/clang-7.0_original ]; then
     # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
-    mv /opt/rocm/hcc/bin/clang-7.0_original /opt/rocm/hcc/bin/clang-9
+    # note that the wrapping always names the compiler "clang-7.0_original"
+    WRAPPED=/opt/rocm/hcc/bin/clang-[0-99]
+    mv /opt/rocm/hcc/bin/clang-7.0_original $WRAPPED
+
   fi
   exit 0
 fi

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -114,7 +114,7 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
     # note that the wrapping always names the compiler "clang-7.0_original"
     WRAPPED=/opt/rocm/hcc/bin/clang-[0-99]
-    mv $ORIG_COMP $WRAPPED
+    sudo mv $ORIG_COMP $WRAPPED
 
   fi
   exit 0

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -109,11 +109,12 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # LMDB is needed to read datasets from https://download.caffe2.ai/databases/resnet_trainer.zip
   USE_ROCM=1 USE_LMDB=1 USE_OPENCV=1 python setup.py install --user
 
-  if [ -e /opt/rocm/hcc/bin/clang-7.0_original ]; then
+  ORIG_COMP=/opt/rocm/hcc/bin/clang-*_original
+  if [ -e $ORIG_COMP ]; then
     # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
     # note that the wrapping always names the compiler "clang-7.0_original"
     WRAPPED=/opt/rocm/hcc/bin/clang-[0-99]
-    mv /opt/rocm/hcc/bin/clang-7.0_original $WRAPPED
+    mv $ORIG_COMP $WRAPPED
 
   fi
   exit 0

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -108,6 +108,11 @@ if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # OPENCV is needed to enable ImageInput operator in caffe2 resnet5_trainer
   # LMDB is needed to read datasets from https://download.caffe2.ai/databases/resnet_trainer.zip
   USE_ROCM=1 USE_LMDB=1 USE_OPENCV=1 python setup.py install --user
+
+  if [ -e /opt/rocm/hcc/bin/clang-7.0_original ]; then
+    # runtime compilation of MIOpen kernels manages to crash sccache - hence undo the wrapping
+    mv /opt/rocm/hcc/bin/clang-7.0_original /opt/rocm/hcc/bin/clang-9
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
The sccache wrapping strategy causes problems for at-runtime kernel
compilation of MIOpen kernels. We therefore - after the builds of
caffe2/pytorch are complete - unwrap sccache again by moving the clang-9
actual binary back into its original place.

