### PR TITLE
Speeds up fast-path for 1D tensors

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -16,8 +16,13 @@ void TensorIterator::reorder_dimensions() {
   // at the front. NOTE: that this inverts the order of C-contiguous tensors.
   // strides[0] is the fastest moving dimension instead of strides[ndim - 1].
 
-  // initialize perm with n-1, n-2, ..., 1, 0
   perm_.resize(ndim());
+  if (ndim() == 1) {
+    perm_[0] = 0;
+    return;
+  }
+
+  // initialize perm with n-1, n-2, ..., 1, 0
   std::iota(perm_.rbegin(), perm_.rend(), 0);
 
   // returns 1 if the dim0 should come after dim1, -1 if dim0 should come
@@ -209,7 +214,7 @@ void TensorIterator::allocate_outputs() {
 }
 
 void TensorIterator::coalesce_dimensions() {
-  if (ndim() == 0) {
+  if (ndim() <= 1) {
     return;
   }
 


### PR DESCRIPTION
Using PMCTest (https://www.agner.org/optimize/) to measure
TensorIterator construction, this results in ~600 fewer instructions
retired (~300 fewer cycles) for constructing TensorIterator on a 1D
tensor. (Should be roughly ~100 ns, but it's hard to measure that
precisely end-to-end).

```
Before:
     Clock   Core cyc   Instruct       Uops   L1D Miss
      5082       2768       5690       7644          3

After:
     Clock   Core cyc   Instruct       Uops   L1D Miss
      4518       2437       5109       6992          0
```

Note that Instruct is reliable, Core cyc is a little noisy, and Clock
is a little more noisy.

