### PR TITLE
Make the signature of fill_out consistent with fill_.

### DIFF
--- a/aten/src/ATen/native/Fill.cpp
+++ b/aten/src/ATen/native/Fill.cpp
@@ -16,7 +16,7 @@ Tensor& fill_out(Tensor& self, const Scalar value) {
   return self;
 }
 
-Tensor& fill_(Tensor& self, Scalar value) {
+Tensor& fill_(Tensor& self, const Scalar value) {
   return fill_out(self, value);
 }
 

--- a/aten/src/ATen/native/Fill.h
+++ b/aten/src/ATen/native/Fill.h
@@ -8,6 +8,6 @@
 
 namespace at { namespace native {
 
-DECLARE_DISPATCH(void(*)(TensorIterator&, Scalar), fill_stub);
+DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar), fill_stub);
 
 }} // namespace at::native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22761 Make the signature of fill_out consistent with fill_.**
* #22760 Move the body of fill_kernel_impl into fill_kernel_cuda
* #22758 Move fill and fill_diagonal to Fill.cpp, Fill.h, and FillKernel.{cpp,cu}

value should be const.

Differential Revision: [D16257779](https://our.internmc.facebook.com/intern/diff/D16257779)