### PR TITLE
[BC-breaking] Remove legacy autograd function

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -153,20 +153,6 @@ class TestAutograd(TestCase):
             MyFunction.apply(v.clone()).backward()
             self.assertEqual(v.grad, torch.full(shape, 2))
 
-    def test_legacy_function_none_grad(self):
-        class MyFunction(Function):
-            def forward(self, x):
-                return torch.zeros(2, 2, 2)
-
-            def backward(self, grad_output):
-                return None
-
-        shape = (2, 3)
-        v = torch.ones(shape, requires_grad=True)
-        y = v[0, 0].expand(3, 5).t().sum()
-        MyFunction()(y).sum().backward()
-        self.assertEqual(v.grad.data, torch.zeros(shape))
-
     def test_invalid_gradients(self):
         class MyFunction(Function):
             @staticmethod
@@ -504,31 +490,28 @@ class TestAutograd(TestCase):
         # WARNING: this is a test for autograd internals.
         # You should never have to use such things in your code.
         class NoneGradientFunction(Function):
-
-            def forward(self, x, y):
-                assert self.needs_input_grad[0]
-                assert not self.needs_input_grad[1]
+            @staticmethod
+            def forward(ctx, x, y):
+                assert ctx.needs_input_grad[0]
+                assert not ctx.needs_input_grad[1]
                 return x, y
 
-            def backward(self, grad_x, grad_y):
+            @staticmethod
+            def backward(ctx, grad_x, grad_y):
                 return grad_x, None
 
-        fn = NoneGradientFunction()
         was_called = [False]
 
-        def hook(grad_input, grad_output):
-            self.assertIsInstance(grad_input, tuple)
-            self.assertIsInstance(grad_output, tuple)
-            self.assertIsNotNone(grad_input[0])
-            self.assertIsNotNone(grad_input[1])
-            self.assertIsNotNone(grad_output[0])
-            self.assertIsNotNone(grad_output[1])
+        def hook(grad):
+            self.assertIsNotNone(grad)
             was_called[0] = True
-        fn.register_hook(hook)
 
         x = torch.randn(5, 5, requires_grad=True)
         y = torch.randn(5, 5)
-        sum(fn(x, y)).sum().backward()
+        rx, ry = NoneGradientFunction.apply(x, y)
+        rx.register_hook(hook)
+        ry.register_hook(hook)
+        sum(rx, ry).sum().backward()
         self.assertTrue(was_called[0])
 
     def test_retain_grad(self):
@@ -601,14 +584,15 @@ class TestAutograd(TestCase):
 
     def test_sparse_backward(self):
         class FixedGradientFunction(Function):
-            def __init__(self, grad):
-                self.grad = grad
-
-            def forward(self, x):
+            @staticmethod
+            def forward(ctx, x, grad_x):
+                ctx.save_for_backward(grad_x)
                 return x
 
-            def backward(self, grad_x):
-                return self.grad
+            @staticmethod
+            def backward(ctx, grad_x):
+                saved_grad_x, = ctx.saved_tensors
+                return saved_grad_x, None
 
         size = torch.Size([6, 3, 2])
         i1 = torch.LongTensor([
@@ -624,21 +608,19 @@ class TestAutograd(TestCase):
         v2 = torch.DoubleTensor([[1, 2], [4, 3], [4, 5], [7, 8]])
         sparse_grad2 = torch.sparse.DoubleTensor(i2, v2, size)
         dense_grad = torch.rand(size).double()
-        sparse_fn1 = FixedGradientFunction(sparse_grad1)
-        sparse_fn2 = FixedGradientFunction(sparse_grad2)
-        dense_fn = FixedGradientFunction(dense_grad)
+        fn = FixedGradientFunction
 
         # sparse first
         x = torch.randn(size, requires_grad=True)
-        (sparse_fn1(x) + dense_fn(x) + sparse_fn2(x)).sum().backward()
+        (fn.apply(x, sparse_grad1) + fn.apply(x, dense_grad) + fn.apply(x, sparse_grad2)).sum().backward()
         self.assertEqual(x.grad, dense_grad + sparse_grad1 + sparse_grad2)
         # dense first
         x = torch.randn(size, requires_grad=True)
-        (dense_fn(x) + sparse_fn1(x) + sparse_fn2(x)).sum().backward()
+        (fn.apply(x, dense_grad) + fn.apply(x, sparse_grad1) + fn.apply(x, sparse_grad2)).sum().backward()
         self.assertEqual(x.grad, dense_grad + sparse_grad1 + sparse_grad2)
         # sparse only
         x = torch.randn(size, requires_grad=True)
-        (sparse_fn1(x) + sparse_fn2(x)).sum().backward()
+        (fn.apply(x, sparse_grad1) + fn.apply(x, sparse_grad2)).sum().backward()
         self.assertEqual(x.grad, sparse_grad1 + sparse_grad2)
 
     def test_sparse_mm_backward(self):
@@ -1913,18 +1895,19 @@ class TestAutograd(TestCase):
 
     def test_return_leaf(self):
         class Identity(Function):
-
-            def forward(self, a, b):
+            @staticmethod
+            def forward(ctx, a, b):
                 return a, a + b
 
-            def backward(self, grad_a, grad_b):
+            @staticmethod
+            def backward(ctx, grad_a, grad_b):
                 return grad_a + grad_b, grad_b
 
         hook_called = [False]
         x = torch.randn(5, 5, requires_grad=True)
         y = torch.randn(5, 5, requires_grad=True)
 
-        q, p = Identity()(x, y)
+        q, p = Identity.apply(x, y)
 
         # Make sure hooks only receive grad from usage of q, not x.
         def hook(grad):
@@ -1939,21 +1922,22 @@ class TestAutograd(TestCase):
 
     def test_return_leaf_inplace(self):
         class Inplace(InplaceFunction):
-
-            def forward(self, a, b):
-                self.mark_dirty(a)
+            @staticmethod
+            def forward(ctx, a, b):
+                ctx.mark_dirty(a)
                 return a.add_(b), b + 2
 
-            def backward(self, grad_a, grad_b):
+            @staticmethod
+            def backward(ctx, grad_a, grad_b):
                 return grad_a, grad_a + grad_b
 
         x = torch.randn(5, 5)
         y = torch.randn(5, 5, requires_grad=True)
 
         fn = Inplace(True)
-        q, p = fn(x, y)
+        q, p = fn.apply(x, y)
         self.assertIs(q, x)
-        self.assertIs(q.grad_fn, fn)
+        self.assertIs(q.grad_fn.__class__, fn._backward_cls)
         self.assertTrue(q.requires_grad)
         q.sum().backward()
         self.assertEqual(y.grad.data, torch.ones(5, 5))
@@ -2052,33 +2036,35 @@ class TestAutograd(TestCase):
         test_case = self
 
         class MyFn(Function):
-
-            def forward(self, input):
-                self.save_for_backward(None, input, None)
+            @staticmethod
+            def forward(ctx, input):
+                ctx.save_for_backward(None, input, None)
                 return input * input
 
-            def backward(self, grad_output):
-                n1, input, n2 = self.saved_tensors
+            @staticmethod
+            def backward(ctx, grad_output):
+                n1, input, n2 = ctx.saved_tensors
                 test_case.assertIsNone(n1)
                 test_case.assertIsNone(n2)
                 return 2 * input * grad_output
 
         x = torch.randn(5, 5, requires_grad=True)
-        y = MyFn()(x)
+        y = MyFn.apply(x)
         y.sum().backward()
         self.assertEqual(x.grad, 2 * x)
 
     def test_too_many_grads(self):
         class MyFn(Function):
-
-            def forward(self, input):
+            @staticmethod
+            def forward(ctx, input):
                 return input
 
-            def backward(self, grad_output):
+            @staticmethod
+            def backward(ctx, grad_output):
                 return grad_output, None, None
 
         x = torch.randn(5, 5, requires_grad=True)
-        y = MyFn()(x)
+        y = MyFn.apply(x)
         y.sum().backward()
         self.assertEqual(x.grad, torch.ones_like(x))
 
@@ -2098,29 +2084,32 @@ class TestAutograd(TestCase):
 
     def test_dep_nograd(self):
         class F1(Function):
-
-            def forward(self, input):
+            @staticmethod
+            def forward(ctx, input):
                 out = torch.randn(input.size())
-                self.mark_non_differentiable(out)
+                ctx.mark_non_differentiable(out)
                 return input, out
 
-            def backward(self, grad_output, ignored):
+            @staticmethod
+            def backward(ctx, grad_output, ignored):
                 return grad_output
 
         class F2(Function):
-
-            def forward(self, input, ignored):
+            @staticmethod
+            def forward(ctx, input, ignored):
                 return input
 
-            def backward(self, grad_output):
+            @staticmethod
+            def backward(ctx, grad_output):
                 return grad_output, None
 
         x = torch.randn(5, requires_grad=True)
-        a, b = F1()(x)
+        a, b = F1.apply(x)
         b = b + 1  # separate F1 from F2 by another op
         self.assertTrue(a.requires_grad)
         self.assertFalse(b.requires_grad)
-        c = F2()(a, b)
+        c = F2.apply(a, b)
+        print(c.grad_fn)
         c.backward(torch.ones(c.size()))
         self.assertEqual(x.grad.data, torch.ones(x.size()))
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -71,7 +71,6 @@ class _HookMixin(object):
 
 
 class BackwardCFunction(_C._FunctionBase, _ContextMethodMixin, _HookMixin):
-    _is_legacy = False
 
     def apply(self, *args):
         return self._forward_cls.backward(self, *args)
@@ -81,7 +80,6 @@ class FunctionMeta(type):
     """Function metaclass.
 
     This metaclass sets up the following properties:
-        _is_legacy: True if forward is not defined as a static method.
         _backward_cls: The Function class corresponding to the differentiated
             version of this function (which is generated on the fly by this
             metaclass).
@@ -94,11 +92,9 @@ class FunctionMeta(type):
                 has_static_forward = isinstance(forward, staticmethod) or isinstance(forward, classmethod)
                 break
 
-        cls._is_legacy = not has_static_forward
-
-        # old-style functions
+        # old-style functions are not supported anymore
         if not has_static_forward:
-            return super(FunctionMeta, cls).__init__(name, bases, attrs)
+            raise RuntimeError('Legacy function with non-static forward method is not supported anymore.')
 
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})
         cls._backward_cls = backward_fn

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -36,7 +36,6 @@ struct PyFunction : public Function {
   PyFunction(PyObject* obj) : obj(obj) {}
 
   variable_list apply(variable_list&& inputs) override;
-  variable_list legacy_apply(const variable_list& inputs);
 
   void release_variables() override;
   std::string name() const override;

--- a/torch/nn/_functions/thnn/normalization.py
+++ b/torch/nn/_functions/thnn/normalization.py
@@ -7,39 +7,38 @@ from . import _all_functions
 
 class CrossMapLRN2d(Function):
 
-    def __init__(self, size, alpha=1e-4, beta=0.75, k=1):
-        super(CrossMapLRN2d, self).__init__()
-        self.size = size
-        self.alpha = alpha
-        self.beta = beta
-        self.k = k
-        self._backend = None
-        self.scale = None
+    @staticmethod
+    def forward(ctx, input, size, alpha=1e-4, beta=0.75, k=1):
+        ctx.size = size
+        ctx.alpha = alpha
+        ctx.beta = beta
+        ctx.k = k
+        ctx._backend = None
+        ctx.scale = None
 
-    def forward(self, input):
         assert input.dim() == 4
 
-        self.scale = self.scale or input.new()
+        ctx.scale = ctx.scale or input.new()
         output = input.new()
 
         backend = type2backend[input.type()]
         if backend is not None:
             try:
                 backend.SpatialCrossMapLRN_updateOutput
-                self._backend = backend
+                ctx._backend = backend
             except NotImplementedError:
                 pass
 
-        if self._backend is not None:
-            self._backend.SpatialCrossMapLRN_updateOutput(
-                self._backend.library_state,
+        if ctx._backend is not None:
+            ctx._backend.SpatialCrossMapLRN_updateOutput(
+                ctx._backend.library_state,
                 input,
                 output,
-                self.scale,
-                self.size,
-                self.alpha,
-                self.beta,
-                self.k
+                ctx.scale,
+                ctx.size,
+                ctx.alpha,
+                ctx.beta,
+                ctx.k
             )
         else:
             batch_size = input.size(0)
@@ -48,16 +47,16 @@ class CrossMapLRN2d(Function):
             input_width = input.size(3)
 
             output.resize_as_(input)
-            self.scale.resize_as_(input)
+            ctx.scale.resize_as_(input)
 
             # use output storage as temporary buffer
             input_square = output
             torch.pow(input, 2, out=input_square)
 
-            pre_pad = int((self.size - 1) / 2 + 1)
+            pre_pad = int((ctx.size - 1) / 2 + 1)
             pre_pad_crop = channels if pre_pad > channels else pre_pad
 
-            scale_first = self.scale.select(1, 0)
+            scale_first = ctx.scale.select(1, 0)
             scale_first.zero_()
             # compute first feature map normalization
             for c in range(pre_pad_crop):
@@ -66,8 +65,8 @@ class CrossMapLRN2d(Function):
             # reuse computations for next feature maps normalization
             # by adding the next feature map and removing the previous
             for c in range(1, channels):
-                scale_previous = self.scale.select(1, c - 1)
-                scale_current = self.scale.select(1, c)
+                scale_previous = ctx.scale.select(1, c - 1)
+                scale_current = ctx.scale.select(1, c)
                 scale_current.copy_(scale_previous)
                 if c < channels - pre_pad + 1:
                     square_next = input_square.select(1, c + pre_pad - 1)
@@ -77,30 +76,31 @@ class CrossMapLRN2d(Function):
                     square_previous = input_square.select(1, c - pre_pad)
                     scale_current.add_(-1, square_previous)
 
-            self.scale.mul_(self.alpha / self.size).add_(self.k)
+            ctx.scale.mul_(ctx.alpha / ctx.size).add_(ctx.k)
 
-            torch.pow(self.scale, -self.beta, out=output)
+            torch.pow(ctx.scale, -ctx.beta, out=output)
             output.mul_(input)
 
-        self.save_for_backward(input, output)
+        ctx.save_for_backward(input, output)
         return output
 
-    def backward(self, grad_output):
-        input, output = self.saved_tensors
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, output = ctx.saved_tensors
         grad_input = grad_output.new()
 
-        if self._backend is not None:
-            self._backend.SpatialCrossMapLRN_updateGradInput(
-                self._backend.library_state,
+        if ctx._backend is not None:
+            ctx._backend.SpatialCrossMapLRN_updateGradInput(
+                ctx._backend.library_state,
                 input,
                 grad_output,
                 grad_input,
-                self.scale,
+                ctx.scale,
                 output,
-                self.size,
-                self.alpha,
-                self.beta,
-                self.k
+                ctx.size,
+                ctx.alpha,
+                ctx.beta,
+                ctx.k
             )
         else:
             batch_size = input.size(0)
@@ -108,31 +108,31 @@ class CrossMapLRN2d(Function):
             input_height = input.size(2)
             input_width = input.size(3)
 
-            paddded_ratio = input.new(channels + self.size - 1, input_height,
+            paddded_ratio = input.new(channels + ctx.size - 1, input_height,
                                       input_width)
             accum_ratio = input.new(input_height, input_width)
 
-            cache_ratio_value = 2 * self.alpha * self.beta / self.size
-            inversePrePad = int(self.size - (self.size - 1) / 2)
+            cache_ratio_value = 2 * ctx.alpha * ctx.beta / ctx.size
+            inversePrePad = int(ctx.size - (ctx.size - 1) / 2)
 
             grad_input.resize_as_(input)
-            torch.pow(self.scale, -self.beta, out=grad_input).mul_(grad_output)
+            torch.pow(ctx.scale, -ctx.beta, out=grad_input).mul_(grad_output)
 
             paddded_ratio.zero_()
             padded_ratio_center = paddded_ratio.narrow(0, inversePrePad,
                                                        channels)
             for n in range(batch_size):
                 torch.mul(grad_output[n], output[n], out=padded_ratio_center)
-                padded_ratio_center.div_(self.scale[n])
+                padded_ratio_center.div_(ctx.scale[n])
                 torch.sum(
-                    paddded_ratio.narrow(0, 0, self.size - 1), 0, keepdim=False, out=accum_ratio)
+                    paddded_ratio.narrow(0, 0, ctx.size - 1), 0, keepdim=False, out=accum_ratio)
                 for c in range(channels):
-                    accum_ratio.add_(paddded_ratio[c + self.size - 1])
+                    accum_ratio.add_(paddded_ratio[c + ctx.size - 1])
                     grad_input[n][c].addcmul_(-cache_ratio_value, input[n][c],
                                               accum_ratio)
                     accum_ratio.add_(-1, paddded_ratio[c])
 
-        return grad_input
+        return grad_input, None, None, None, None
 
 
 _all_functions.append(CrossMapLRN2d)

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -61,8 +61,8 @@ class CrossMapLRN2d(Module):
         self.k = k
 
     def forward(self, input):
-        return self._backend.CrossMapLRN2d(self.size, self.alpha, self.beta,
-                                           self.k)(input)
+        return self._backend.CrossMapLRN2d.apply(input, self.size, self.alpha, self.beta,
+                                           self.k)
 
     def extra_repr(self):
         return '{size}, alpha={alpha}, beta={beta}, k={k}'.format(**self.__dict__)


### PR DESCRIPTION
Legacy autograd function has been deprecated for 3 major releases, and therefore it should okay to remove it completely. This fixes issues such as https://github.com/pytorch/pytorch/issues/16947.

Note that this PR is BC-breaking because legacy autograd function (with non-static forward method) will not be supported after this PR.