### PR TITLE
[jit][wip][skip ci] Script class attributes + serialization

### DIFF
--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -138,6 +138,7 @@ class Pickler {
   void pushTensor(const IValue& ivalue);
   void pushTensorReference(const IValue& ivalue);
   void pushTuple(const IValue& ivalue);
+  void pushObject(const IValue& ivalue);
 
   void pushBinGet(uint32_t memo_id);
   void pushClass(PicklerClass cls);
@@ -256,6 +257,7 @@ class Unpickler {
   OpCode readOpCode();
   std::string readString();
   void readList();
+  void readObject(std::string module, std::string basename);
   void run();
 
   std::vector<StackItem> stack_;

--- a/torch/csrc/jit/python_ir.cpp
+++ b/torch/csrc/jit/python_ir.cpp
@@ -667,7 +667,11 @@ void initPythonIRBindings(PyObject* module_) {
       .def_static("get", &BoolType::get);
   py::class_<StringType, Type, std::shared_ptr<StringType>>(m, "StringType")
       .def_static("get", &StringType::get);
-
+  py::class_<ClassType, Type, std::shared_ptr<ClassType>>(m, "ClassType")
+      .def(py::init([](const std::string& name,
+                       std::shared_ptr<script::CompilationUnit> cu) {
+        return ClassType::create(c10::QualifiedName(name), cu);
+      }));
   py::class_<TupleType, Type, std::shared_ptr<TupleType>>(m, "TupleType")
       .def(
           py::init([](std::vector<TypePtr> a) { return TupleType::create(a); }))

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -22,6 +22,7 @@ ClassTypePtr ClassType::create(
     c10::optional<QualifiedName> qualifiedName,
     std::shared_ptr<CompilationUnit> cu,
     bool is_module) {
+  std::cout << "Creating a class type: " << qualifiedName->qualifiedName() << "\n";
   return ClassTypePtr(new ClassType(std::move(qualifiedName), std::move(cu), is_module));
 }
 

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -721,6 +721,8 @@ void initJitScriptBindings(PyObject* module) {
               pythonResolver(rcb, classDef.name().name(), classType));
         }
         cu->define(methodDefs, rcbs, simpleSelf(classType));
+
+        return classType;
       });
 
   m.def("parse_type_comment", [](const std::string& comment) {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1099,8 +1099,9 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
             raise RuntimeError("TorchScript classes must be new-style classes. Please inherit from 'object'")
         qualified_name = _qualified_name(obj)
         ast = get_jit_class_def(obj, obj.__name__)
-        _jit_script_class_compile(qualified_name, ast, _rcb)
-        _add_script_class(obj, qualified_name)
+        class_type = _jit_script_class_compile(qualified_name, ast, _rcb)
+        print("got type", class_type)
+        _add_script_class(obj, qualified_name, class_type)
         return obj
     else:
         ast = get_jit_def(obj)
@@ -1538,6 +1539,8 @@ if _enabled:
                 if isinstance(value, Attribute):
                     the_type = torch.jit.annotations.ann_to_type(value.type)
                     try:
+                        print("the_type", the_type)
+                        print("value", value.value)
                         self._c._register_attribute(attr, the_type, value.value)
                     except RuntimeError:
                         raise RuntimeError("Could not register attribute '{}' of type '{}' for a value of type '{}'"
@@ -2026,13 +2029,15 @@ def _register_builtin(fn, op):
 def _find_builtin(fn):
     return _get_builtin_table().get(id(fn))
 
-# qualified_name => ScriptClass mapping
+# qualified_name => TypedClass[ScriptClass, ClassType] mapping
 _script_classes = {}
 
+TypedClass = collections.namedtuple('TypedClass', ['cls', 'type'])
 
-def _add_script_class(cls, name):
+
+def _add_script_class(cls, name, the_type):
     global _script_classes
-    _script_classes[name] = cls
+    _script_classes[name] = TypedClass(cls, the_type)
 
 
 def _get_script_class(name):
@@ -2040,7 +2045,7 @@ def _get_script_class(name):
     if name not in _script_classes:
         raise RuntimeError("Unknown reference to ScriptClass '{}'. "
                            "Did you forget to import it?".format(name))
-    return _script_classes[name]
+    return _script_classes[name].cls
 
 # torch.jit.Error
 Error = torch._C.JITException

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -223,6 +223,14 @@ def ann_to_type(ann):
         return StringType.get()
     elif ann is bool:
         return BoolType.get()
+    elif inspect.isclass(ann):
+        qualname = torch.jit._qualified_name(ann)
+        print(qualname)
+        if qualname in torch.jit._script_classes:
+            return torch.jit._script_classes[qualname].type
+        else:
+            raise ValueError("Class annotation {} is not a script class "
+                             "(did you decorate the class with '@torch.jit.script'?)".format(ann))
     raise ValueError("Unknown type annotation: '{}'".format(ann))
 
 


### PR DESCRIPTION
Picklable classes:

```python
# @torch.jit.script
# class QTensor(object):
#     def __init__(self):
#         self.zero_point = 10
#         self.b = 4

# q = QTensor()
# pickle.dump(q, open("q.pkl", "wb"))
# pickletools.dis(open("q.pkl", "rb"))

# Without __get/setstate__
#  0: \x80 PROTO      3
#  2: c    GLOBAL     '__main__ QTensor'
# 20: q    BINPUT     0
# 22: )    EMPTY_TUPLE
# 23: \x81 NEWOBJ
# 24: q    BINPUT     1
# 26: }    EMPTY_DICT
# 27: q    BINPUT     2
# 29: (    MARK
# 30: X        BINUNICODE 'zero_point'
# 45: q        BINPUT     3
# 47: K        BININT1    10
# 49: X        BINUNICODE 'b'
# 55: q        BINPUT     4
# 57: K        BININT1    4
# 59: u        SETITEMS   (MARK at 29)
# 60: b    BUILD
# 61: .    STOP

# With __getsetstate__
#  0: \x80 PROTO      3
#  2: c    GLOBAL     '__main__ QTensor'
# 20: q    BINPUT     0
# 22: )    EMPTY_TUPLE
# 23: \x81 NEWOBJ
# 24: q    BINPUT     1
# 26: K    BININT1    1
# 28: K    BININT1    2
# 30: K    BININT1    3
# 32: \x87 TUPLE3
# 33: q    BINPUT     2
# 35: b    BUILD
# 36: .    STOP
```