### PR TITLE
Let users pass CMake-specific options starting with CMAKE_ to CMake.

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -237,15 +237,15 @@ class CMake:
         })
 
         for var, val in my_env.items():
-            # We currently pass over all environment variables that start with "BUILD_" or "USE_". This is because we
-            # currently have no reliable way to get the list of all build options we have specified in CMakeLists.txt.
-            # (`cmake -L` won't print dependent options when the dependency condition is not met.) We will possibly
-            # change this in the future by parsing CMakeLists.txt ourselves (then additional_options would also not be
-            # needed to be specified here).
+            # We currently pass over all environment variables that start with "BUILD_", "USE_", and "CMAKE_". This is
+            # because we currently have no reliable way to get the list of all build options we have specified in
+            # CMakeLists.txt. (`cmake -L` won't print dependent options when the dependency condition is not met.) We
+            # will possibly change this in the future by parsing CMakeLists.txt ourselves (then additional_options would
+            # also not be needed to be specified here).
             true_var = additional_options.get(var)
             if true_var is not None:
                 build_options[true_var] = val
-            elif var.startswith(('USE_', 'BUILD_')):
+            elif var.startswith(('BUILD_', 'USE_', 'CMAKE_')):
                 build_options[var] = val
 
         # Some options must be post-processed. Ideally, this list will be shrunk to only one or two options in the
@@ -254,8 +254,8 @@ class CMake:
         # "BUILD_" or "USE_" and must be overwritten here.
         build_options.update({
             # Note: Do not add new build options to this dict if it is directly read from environment variable -- you
-            # only need to add one in `CMakeLists.txt`. All build options that start with "BUILD_" or "USE_" are
-            # automatically passed to CMake; For other options you can add to additional_options above.
+            # only need to add one in `CMakeLists.txt`. All build options that start with "BUILD_", "USE_", or "CMAKE_"
+            # are automatically passed to CMake; For other options you can add to additional_options above.
             'BUILD_PYTHON': build_python,
             'BUILD_TEST': build_test,
             'USE_CUDA': USE_CUDA,

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -266,6 +266,24 @@ class CMake:
             'USE_SYSTEM_EIGEN_INSTALL': 'OFF'
         })
 
+        # Options starting with CMAKE_
+        cmake__options = {
+            'CMAKE_INSTALL_PREFIX': install_dir,
+            'CMAKE_C_FLAGS': cflags,
+            'CMAKE_CXX_FLAGS': cflags,
+            'CMAKE_EXE_LINKER_FLAGS': ldflags,
+            'CMAKE_SHARED_LINKER_FLAGS': ldflags,
+        }
+
+        # We set some CMAKE_* options in our Python build code instead of relying on the user's direct settings. Emit an
+        # error if the user also attempts to set these CMAKE options directly.
+        specified_cmake__options = set(build_options).intersection(cmake__options)
+        if len(specified_cmake__options) > 0:
+            print(', '.join(specified_cmake__options) +
+                  ' should not be specified in the environment variable. They are directly set by PyTorch build script.')
+            sys.exit(1)
+        build_options.update(cmake__options)
+
         CMake.defines(args,
                       PYTHON_EXECUTABLE=escape_path(sys.executable),
                       PYTHON_LIBRARY=escape_path(cmake_python_library),
@@ -273,11 +291,6 @@ class CMake:
                       TORCH_BUILD_VERSION=version,
                       INSTALL_TEST=build_test,
                       NUMPY_INCLUDE_DIR=escape_path(NUMPY_INCLUDE_DIR),
-                      CMAKE_INSTALL_PREFIX=install_dir,
-                      CMAKE_C_FLAGS=cflags,
-                      CMAKE_CXX_FLAGS=cflags,
-                      CMAKE_EXE_LINKER_FLAGS=ldflags,
-                      CMAKE_SHARED_LINKER_FLAGS=ldflags,
                       CUDA_NVCC_EXECUTABLE=escape_path(os.getenv('CUDA_NVCC_EXECUTABLE')),
                       **build_options)
 


### PR DESCRIPTION
This should make it more convenient to follow #8433's suggestion.