### PR TITLE
make custom op work in OSS environment

### DIFF
--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import torch
+import cpp_extension # noqa
+
+import unittest
+
+
+
+class TestConsumeOp(unittest.TestCase):
+    def test_jit_consume_op(self):
+        iters = 6
+
+        def foo(x):
+            for i in range(iters):
+                result = torch.ops.operator_benchmark._consume(torch.sum(x))
+            return result
+
+        r = torch.jit.trace(foo, (torch.rand(2, 2)))
+
+        graph = str(r.graph)
+        occurance = graph.count("aten::sum")
+
+        x = torch.rand(2, 2)
+        value = r(x)
+        self.assertEqual(value, torch.sum(x))
+        self.assertEqual(occurance, iters)

--- a/benchmarks/operator_benchmark/pt_extension/extension.cpp
+++ b/benchmarks/operator_benchmark/pt_extension/extension.cpp
@@ -1,0 +1,20 @@
+#include <torch/extension.h>
+#include <torch/script.h>
+
+using torch::Tensor;
+
+Tensor consume(Tensor a) {
+  return a;
+}
+
+// When JIT tracing is used on function with constant for loop,
+// the for loop is optimized away because of dead code elimination.
+// That caused an issue for our op benchmark which needs to run an op
+// in a loop and report the execution time. This diff resolves that issue by
+// registering this consume op with correct alias information which is DEFAULT.
+auto reg = torch::jit::RegisterOperators()
+  .op("operator_benchmark::_consume", &consume);
+
+PYBIND11_MODULE(cpp_extension, m) {
+  m.def("_consume", &consume, "consume");
+}

--- a/benchmarks/operator_benchmark/pt_extension/setup.py
+++ b/benchmarks/operator_benchmark/pt_extension/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+from torch.utils.cpp_extension import CppExtension, BuildExtension
+
+setup(name='cpp_extension',
+      ext_modules=[CppExtension('cpp_extension', ['extension.cpp'])],
+      cmdclass={'build_ext': BuildExtension})


### PR DESCRIPTION
Summary: The custom op is required to make the op benchmark work with JIT. Running this command `python setup.py install` in the pt_extension directory to install it. It is required.

Differential Revision: D16214430

