### PR TITLE
[jit][fuser] avoid kernel launches for zero-sized tensor inputs

### DIFF
--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -46,6 +46,18 @@ class TestFuser(JitTestCase):
     def test_abs_cuda(self):
         self._test_fused_abs(device="cuda")
 
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @skipIfRocm
+    def test_zero_element_tensors(self):
+        def decode(sin_t, cos_t):
+            theta = torch.atan2(sin_t.float(), cos_t.float())
+            return theta
+
+        sin = torch.zeros(0, device="cuda")
+        cos = torch.zeros(0, device="cuda")
+        inputs = [sin, cos]
+        ge = self.checkScript(decode, inputs)
+
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
     def test_arg_configurations_smoke_cuda(self):
         # A smoke test to make sure we won't use the same kernel for contiguous

--- a/torch/csrc/jit/fuser/executor.cpp
+++ b/torch/csrc/jit/fuser/executor.cpp
@@ -313,8 +313,11 @@ void launchFusion(
       }
     }
   }
-
-  fusion.launch_raw(numel, arguments);
+  // Skip launching the kernel for zero-element tensor inputs
+  // launches are skipped, empty zero-sized output is returned
+  if (numel != 0) {
+    fusion.launch_raw(numel, arguments);
+  }
 }
 
 bool runFusion(const int64_t key, Stack& stack, std::string* code_out) {

--- a/torch/csrc/jit/fuser/executor.cpp
+++ b/torch/csrc/jit/fuser/executor.cpp
@@ -315,7 +315,7 @@ void launchFusion(
   }
   // Skip launching the kernel for zero-element tensor inputs
   // launches are skipped, empty zero-sized output is returned
-  if (numel != 0) {
+  if (numel > 0) {
     fusion.launch_raw(numel, arguments);
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22790 [jit][fuser] avoid kernel launches for zero-sized tensor inputs**

Fixes https://github.com/pytorch/pytorch/issues/22747

Differential Revision: [D16226168](https://our.internmc.facebook.com/intern/diff/D16226168)