### PR TITLE
[WIP] Create new ChainLR.

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -13,7 +13,7 @@ from torch import sparse
 from torch.optim.lr_scheduler import LambdaLR, StepLR, MultiStepLR, \
     ExponentialLR, CosineAnnealingLR, ReduceLROnPlateau, _LRScheduler, \
     CyclicLR, CosineAnnealingWarmRestarts
-from torch.optim.chain_lr_scheduler import LambdaChainLR, StepChainLR, MultiStepChainLR, \
+from torch.optim.chain_lr_scheduler import StepChainLR, MultiStepChainLR, \
     ExponentialChainLR, CosineAnnealingChainLR
 from common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests, \
     skipIfRocm

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -17,6 +17,7 @@ from .rmsprop import RMSprop  # noqa: F401
 from .optimizer import Optimizer  # noqa: F401
 from .lbfgs import LBFGS  # noqa: F401
 from . import lr_scheduler  # noqa: F401
+from . import chain_lr_scheduler  # noqa: F401
 
 del adadelta
 del adagrad

--- a/torch/optim/__init__.pyi
+++ b/torch/optim/__init__.pyi
@@ -1,3 +1,0 @@
-from .sgd import SGD as SGD
-from .adam import Adam as Adam
-from . import lr_scheduler as lr_scheduler

--- a/torch/optim/chain_lr_scheduler.py
+++ b/torch/optim/chain_lr_scheduler.py
@@ -1,0 +1,172 @@
+import types
+import math
+import warnings
+from torch._six import inf
+from collections import Counter
+from functools import partial, wraps
+from bisect import bisect_right
+
+from .optimizer import Optimizer
+from .lr_scheduler import LambdaLR, StepLR, MultiStepLR, ExponentialLR, CosineAnnealingLR
+
+
+class LambdaChainLR(LambdaLR):
+    """Sets the learning rate of each parameter group to the initial lr
+    times a given function. When last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        lr_lambda (function or list): A function which computes a multiplicative
+            factor given an integer parameter epoch, or a list of such
+            functions, one for each group in optimizer.param_groups.
+        last_epoch (int): The index of last epoch. Default: -1.
+
+    Example:
+        >>> # Assuming optimizer has two groups.
+        >>> lambda1 = lambda epoch: epoch // 30
+        >>> lambda2 = lambda epoch: 0.95 ** epoch
+        >>> scheduler = LambdaLR(optimizer, lr_lambda=[lambda1, lambda2])
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+    """
+
+
+    def _compute_lr(self):
+        if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
+            return [group['lr'] for group in self.optimizer.param_groups]
+        return [group['lr'] * self.gamma
+                for group in self.optimizer.param_groups]
+
+
+class StepChainLR(StepLR):
+    """Decays the learning rate of each parameter group by gamma every
+    step_size epochs. Notice that such decay can happen simultaneously with
+    other changes to the learning rate from outside this scheduler. When
+    last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        step_size (int): Period of learning rate decay.
+        gamma (float): Multiplicative factor of learning rate decay.
+            Default: 0.1.
+        last_epoch (int): The index of last epoch. Default: -1.
+
+    Example:
+        >>> # Assuming optimizer uses lr = 0.05 for all groups
+        >>> # lr = 0.05     if epoch < 30
+        >>> # lr = 0.005    if 30 <= epoch < 60
+        >>> # lr = 0.0005   if 60 <= epoch < 90
+        >>> # ...
+        >>> scheduler = StepLR(optimizer, step_size=30, gamma=0.1)
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+    """
+
+    def _compute_lr(self):
+       if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
+           return [group['lr'] for group in self.optimizer.param_groups]
+       return [group['lr'] * self.gamma
+               for group in self.optimizer.param_groups]
+
+
+class MultiStepChainLR(MultiStepLR):
+    """Decays the learning rate of each parameter group by gamma once the
+    number of epoch reaches one of the milestones. Notice that such decay can
+    happen simultaneously with other changes to the learning rate from outside
+    this scheduler. When last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        milestones (list): List of epoch indices. Must be increasing.
+        gamma (float): Multiplicative factor of learning rate decay.
+            Default: 0.1.
+        last_epoch (int): The index of last epoch. Default: -1.
+
+    Example:
+        >>> # Assuming optimizer uses lr = 0.05 for all groups
+        >>> # lr = 0.05     if epoch < 30
+        >>> # lr = 0.005    if 30 <= epoch < 80
+        >>> # lr = 0.0005   if epoch >= 80
+        >>> scheduler = MultiStepLR(optimizer, milestones=[30,80], gamma=0.1)
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+    """
+
+    def _compute_lr(self):
+        if self.last_epoch not in self._milestones_counter:
+            return [group['lr'] for group in self.optimizer.param_groups]
+        return [group['lr'] * self.gamma ** self._milestones_counter[self.last_epoch]
+                for group in self.optimizer.param_groups]
+
+
+class ExponentialChainLR(ExponentialLR):
+    """Decays the learning rate of each parameter group by gamma every epoch.
+    When last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        gamma (float): Multiplicative factor of learning rate decay.
+        last_epoch (int): The index of last epoch. Default: -1.
+    """
+
+    def _compute_lr(self):
+        if self.last_epoch == 0:
+            return self.base_lrs
+        return [group['lr'] * self.gamma
+                for group in self.optimizer.param_groups]
+
+
+class CosineAnnealingChainLR(CosineAnnealingLR):
+    r"""Set the learning rate of each parameter group using a cosine annealing
+    schedule, where :math:`\eta_{max}` is set to the initial lr and
+    :math:`T_{cur}` is the number of epochs since the last restart in SGDR:
+
+    .. math::
+        \eta_{t+1} = \eta_{min} + (\eta_t - \eta_{min})\frac{1 +
+        \cos(\frac{T_{cur}+1}{T_{max}}\pi)}{1 + \cos(\frac{T_{cur}}{T_{max}}\pi)},
+        T_{cur} \neq (2k+1)T_{max};\\
+        \eta_{t+1} = \eta_{t} + (\eta_{max} - \eta_{min})\frac{1 -
+        \cos(\frac{1}{T_{max}}\pi)}{2},
+        T_{cur} = (2k+1)T_{max}.\\
+
+    When last_epoch=-1, sets initial lr as lr. Notice that because the schedule
+    is defined recursively, the learning rate can be simultaneously modified
+    outside this scheduler by other operators. If the learning rate is set
+    solely by this scheduler, the learning rate at each step becomes:
+
+    .. math::
+        \eta_t = \eta_{min} + \frac{1}{2}(\eta_{max} - \eta_{min})(1 +
+        \cos(\frac{T_{cur}}{T_{max}}\pi))
+
+    It has been proposed in
+    `SGDR: Stochastic Gradient Descent with Warm Restarts`_. Note that this only
+    implements the cosine annealing part of SGDR, and not the restarts.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        T_max (int): Maximum number of iterations.
+        eta_min (float): Minimum learning rate. Default: 0.
+        last_epoch (int): The index of last epoch. Default: -1.
+
+    .. _SGDR\: Stochastic Gradient Descent with Warm Restarts:
+        https://arxiv.org/abs/1608.03983
+    """
+
+    def _compute_lr(self):
+        if self.last_epoch == 0:
+            return self.base_lrs
+        elif (self.last_epoch - 1 - self.T_max) % (2 * self.T_max) == 0:
+            return [group['lr'] + (base_lr - self.eta_min) *
+                    (1 - math.cos(math.pi / self.T_max)) / 2
+                    for base_lr, group in
+                    zip(self.base_lrs, self.optimizer.param_groups)]
+        return [(1 + math.cos(math.pi * self.last_epoch / self.T_max)) /
+                (1 + math.cos(math.pi * (self.last_epoch - 1) / self.T_max)) *
+                (group['lr'] - self.eta_min) + self.eta_min
+                for group in self.optimizer.param_groups]

--- a/torch/optim/chain_lr_scheduler.py
+++ b/torch/optim/chain_lr_scheduler.py
@@ -1,12 +1,5 @@
-import types
 import math
-import warnings
-from torch._six import inf
-from collections import Counter
-from functools import partial, wraps
-from bisect import bisect_right
 
-from .optimizer import Optimizer
 from .lr_scheduler import LambdaLR, StepLR, MultiStepLR, ExponentialLR, CosineAnnealingLR
 
 
@@ -67,10 +60,10 @@ class StepChainLR(StepLR):
     """
 
     def _compute_lr(self):
-       if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
-           return [group['lr'] for group in self.optimizer.param_groups]
-       return [group['lr'] * self.gamma
-               for group in self.optimizer.param_groups]
+        if (self.last_epoch == 0) or (self.last_epoch % self.step_size != 0):
+            return [group['lr'] for group in self.optimizer.param_groups]
+        return [group['lr'] * self.gamma
+                for group in self.optimizer.param_groups]
 
 
 class MultiStepChainLR(MultiStepLR):


### PR DESCRIPTION
The logic for chaining lr scheduler in #21800 may lead to unexpected behavior to the user, see [comment](https://github.com/pytorch/pytorch/issues/22107#issuecomment-506260305). In order to avoid this situation, we decouple the chainable version of a scheduler from its closed form by introducing a new family ChainLR of schedulers, as mentioned [here](https://github.com/pytorch/pytorch/pull/21800#issuecomment-510220723).

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22798 Create new ChainLR.**
* #21800 Revert "Revert "Redefine scheduler to set learning rate using recursive formula" #14010 (#21463)" and enable closed form with non-sequential epoch parameter

Differential Revision: [D16225958](https://our.internmc.facebook.com/intern/diff/D16225958)