### PR TITLE
fix overspecializing constants in compilation

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7698,14 +7698,14 @@ a")
     def test_import_constants_not_specialized(self):
         class Mod(torch.nn.Module):
             def __init__(self):
-                super().__init__()
+                super(Mod).__init__()
 
             def forward(self, x):
                 return torch.cat(2 * [x], dim=0)
 
         class ScriptMod(torch.jit.ScriptModule):
             def __init__(self, mod):
-                super().__init__()
+                super(ScriptMod).__init__()
                 x = torch.zeros(1, 3)
                 mod_fn = lambda : mod(x)  # noqa: E731
                 self.mod = torch.jit.trace(mod_fn, tuple())

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7697,15 +7697,12 @@ a")
 
     def test_import_constants_not_specialized(self):
         class Mod(torch.nn.Module):
-            def __init__(self):
-                super(Mod).__init__()
-
             def forward(self, x):
                 return torch.cat(2 * [x], dim=0)
 
         class ScriptMod(torch.jit.ScriptModule):
             def __init__(self, mod):
-                super(ScriptMod).__init__()
+                super(ScriptMod, self).__init__()
                 x = torch.zeros(1, 3)
                 mod_fn = lambda : mod(x)  # noqa: E731
                 self.mod = torch.jit.trace(mod_fn, tuple())

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7695,6 +7695,35 @@ a")
         # testing that tensor type of lists is unified
         self.getExportImportCopy(m)
 
+    def test_import_constants_not_specialized(self):
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return torch.cat(2 * [x], dim=0)
+
+        class ScriptMod(torch.jit.ScriptModule):
+            def __init__(self, mod):
+                super().__init__()
+                x = torch.zeros(1, 3)
+                mod_fn = lambda : mod(x)  # noqa: E731
+                self.mod = torch.jit.trace(mod_fn, tuple())
+
+            @torch.jit.script_method
+            def forward(self):
+                return self.mod()
+
+        cm = ScriptMod(Mod())
+        # specialized tensor in graph
+        FileCheck().check("Double(1, 3)").run(cm.forward.graph)
+        buffer = io.BytesIO()
+        torch.jit.save(cm, buffer)
+        buffer.seek(0)
+        # when tensor is loaded as constant it isnt specialized
+        cm_load = torch.jit.load(buffer)
+        FileCheck().check_not("Double(1, 3)").run(cm_load.forward.graph)
+
     def test_type_annotations_repeated_list(self):
         @torch.jit.script
         def float_fn(x, y):

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -96,6 +96,10 @@ struct ConstantTableValue : public SugaredValue {
                              << constants_.size() << " entries).";
     }
     Value* value = m.graph()->insertConstant(constants_[offset], nullptr, loc);
+
+    // specializing tensor type on compilation messes up typing relations
+    value->setType(unshapedType(value->type()));
+
     return std::make_shared<SimpleValue>(value);
   }
 


### PR DESCRIPTION
When we specialize the tensor type of constants in compilation it causes all sorts of problems. 

Fix for https://github.com/pytorch/pytorch/issues/22809