### PR TITLE
Fix port assignment conflict

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -469,10 +469,9 @@ class RendezvousTCPTest(TestCase):
             gen = c10d.rendezvous('tcp://127.0.0.1:23456?rank=0')
             next(gen)
 
-    @retry_on_address_already_in_use_error
     def test_nominal(self):
         addr = 'localhost'
-        port = common.find_free_port()
+        port = 0
         url = 'tcp://%s:%d?world_size=%d' % (addr, port, 1)
         gen0 = c10d.rendezvous(url + "&rank=0")
         store0, rank0, size0 = next(gen0)

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -81,7 +81,7 @@ def _tcp_rendezvous_handler(url):
         return _rendezvous_error("tcp:// rendezvous: " + msg)
 
     result = urlparse(url)
-    if not result.port:
+    if result.port is None:
         raise _error("port number missing")
     query = dict(pair.split("=") for pair in filter(None, result.query.split("&")))
     if "rank" not in query:


### PR DESCRIPTION
Summary:
# Problem

Currently, "RuntimeError: Address already in use" would sporadically occur in RPC tests launched by TestPilot (weird given that ports are randomly chosen from a fairly large range). We should fix this because it makes unit tests unnecessarily flaky.

# Solution

There was a bug in `caffe2/torch/distributed/rendezvous.py`, stoping use from using port:0.

- Fix `torch/distributed/rendezvous.py`
- Use port=0 as Linux syscall standard provides with.

Differential Revision: D16231860

