### PR TITLE
Transfer Learning: Caffe2 load op changes to return shape inference

### DIFF
--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -11,6 +11,22 @@ void LoadOp<CPUContext>::SetCurrentDevice(BlobProto* proto) {
   }
 }
 
+template <int VALUE_TYPE = TensorProto_DataType_FLOAT>
+std::vector<TensorShape> LoadTensorInference(
+    const OperatorDef& def,
+    const vector<TensorShape>& /* unused */) {
+  vector<TensorShape> out(1);
+  ArgumentHelper helper(def);
+  out[0].set_data_type(static_cast<TensorProto_DataType>(
+      helper.GetSingleArgument<int>("dtype", VALUE_TYPE)));
+
+  auto shape = helper.GetRepeatedArgument<int64_t>("shape");
+  for (auto d : shape) {
+    out[0].add_dims(d);
+  }
+  return out;
+}
+
 REGISTER_CPU_OPERATOR(DBExists, DBExistsOp<CPUContext>);
 REGISTER_CPU_OPERATOR(Load, LoadOp<CPUContext>);
 REGISTER_CPU_OPERATOR(Save, SaveOp<CPUContext>);
@@ -70,6 +86,7 @@ print("exists:", workspace.FetchBlob("exists"))
 OPERATOR_SCHEMA(Load)
     .NumInputs(0, INT_MAX)
     .NumOutputs(0, INT_MAX)
+    .TensorInferenceFunction(LoadTensorInference<>)
     .SetDoc(R"DOC(
 The Load operator loads a set of serialized blobs from a db or multiple dbs. It
 takes $[0, \infty)$ number of inputs and $[0, \infty)$ number of outputs, using

--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -86,7 +86,8 @@ class LoadOp final : public Operator<Context> {
         allow_incomplete_(
             this->template GetSingleArgument<bool>("allow_incomplete", false)),
         blob_names_(
-            this->template GetRepeatedArgument<string>("source_blob_names")) {
+            this->template GetRepeatedArgument<string>("source_blob_names")),
+        shape_(this->template GetRepeatedArgument<int64_t>("shape")) {
     if (InputSize() == 0) {
       CAFFE_ENFORCE_GT(db_type_.size(), 0, "Must specify a db type.");
       if (db_names_.empty()) {
@@ -424,6 +425,7 @@ class LoadOp final : public Operator<Context> {
   std::map<string, int> output_indices_;
   std::map<string, int> key_to_dbid_;
   std::vector<std::string> blob_names_;
+  std::vector<int64_t> shape_;
 };
 
 template <class Context>


### PR DESCRIPTION
Summary:
Sending out caffe2 load op changes separately since we want pick it to open source.

This change is needed because the shape information of the blobs is determined from the load operator and that shape information is needed in our download_group.

Differential Revision: D16229465

