### PR TITLE
[ONNX] Remove unnecessary squeeze/unsqueeze when exporting batchnorm1d

### DIFF
--- a/caffe2/operators/spatial_batch_norm_op.h
+++ b/caffe2/operators/spatial_batch_norm_op.h
@@ -52,7 +52,6 @@ class SpatialBNOp : public Operator<Context> {
     const auto& bias = Input(BIAS);
 
     const int ndim = X.dim();
-    CAFFE_ENFORCE_GE(ndim, 3);
     const int N = X.dim32(0);
     const int C =
         (order_ == StorageOrder::NCHW ? X.dim32(1) : X.dim32(ndim - 1));
@@ -76,6 +75,8 @@ class SpatialBNOp : public Operator<Context> {
     T* alpha_data = alpha_.template mutable_data<T>();
     T* beta_data = beta_.template mutable_data<T>();
     if (is_test_) {
+      // relax the requirement to ndim >= 2 for ONNX
+      CAFFE_ENFORCE_GE(ndim, 2);
       if (N == 0) {
         return true;
       }
@@ -92,6 +93,7 @@ class SpatialBNOp : public Operator<Context> {
           alpha_data,
           beta_data);
     } else {
+      CAFFE_ENFORCE_GE(ndim, 3);
       auto* saved_mean = Output(SAVED_MEAN, {C}, at::dtype<T>());
       auto* saved_rstd = Output(SAVED_INV_STD, {C}, at::dtype<T>());
       T* saved_mean_data = saved_mean->template mutable_data<T>();

--- a/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
@@ -4,21 +4,11 @@ producer_version: "1.1"
 graph {
   node {
     input: "input"
-    output: "6"
-    op_type: "Unsqueeze"
-    attribute {
-      name: "axes"
-      ints: 2
-      type: INTS
-    }
-  }
-  node {
-    input: "6"
     input: "weight"
     input: "bias"
     input: "running_mean"
     input: "running_var"
-    output: "7"
+    output: "6"
     op_type: "BatchNormalization"
     attribute {
       name: "epsilon"
@@ -29,16 +19,6 @@ graph {
       name: "momentum"
       f: 0.9
       type: FLOAT
-    }
-  }
-  node {
-    input: "7"
-    output: "8"
-    op_type: "Squeeze"
-    attribute {
-      name: "axes"
-      ints: 2
-      type: INTS
     }
   }
   name: "torch-jit-export"
@@ -150,7 +130,7 @@ graph {
     }
   }
   output {
-    name: "8"
+    name: "6"
     type {
       tensor_type {
         elem_type: 1

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -877,9 +877,6 @@ def _convolution(g, input, weight, bias, stride, padding, dilation,
 @parse_args('v', 'v', 'v', 'v', 'v', 'i', 'f', 'f', 'i')
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
     input_sizes = input.type().sizes()
-    if len(input_sizes) == 2:
-        # batchnorm1d accepts 2d and 3d array, but ONNX only accepts 3d
-        input = g.op("Unsqueeze", input, axes_i=[2])
 
     if weight is None or weight.node().mustBeNone():
         assert len(input_sizes) > 1
@@ -896,8 +893,6 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
                momentum_f=1 - momentum,
                outputs=1 if not training else 5)
     if not training:
-        if len(input_sizes) == 2:
-            out = g.op("Squeeze", out, axes_i=[2])
         return out
     else:
         res, new_running_mean, new_running_var, saved_mean, saved_var = out
@@ -905,8 +900,6 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
         new_running_var.setType(running_var.type())
         saved_mean.setDebugName("batch_norm_dead_output-" + saved_mean.debugName())
         saved_var.setDebugName("batch_norm_dead_output-" + saved_var.debugName())
-        if len(input_sizes) == 2:
-            res = g.op("Squeeze", res, axes_i=[2])
         return res
 
 


### PR DESCRIPTION
ONNX BatchNorm op has supported N-d array (instead of only 4d array) since opset 6 (https://github.com/onnx/onnx/blob/master/docs/Changelog.md#BatchNormalization-6)

cc @BowenBao @neginraoof