### PR TITLE
[jit] Use original module's class name for ScriptModules

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13124,6 +13124,18 @@ class TestRecursiveScript(JitTestCase):
 
         return sm
 
+    def test_module_name(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.x = 2
+
+            def forward(self, t):
+                return t + self.x
+
+        m = torch.jit.script(MyModule())
+        FileCheck().check("ClassType<MyModule>").run(m.graph)
+
     @unittest.skipIf(True, "Class annotations are a thing in > 3.5, need to fix for < 3.7")
     def test_constants_with_final(self):
         class M(torch.nn.Module):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1483,8 +1483,10 @@ if _enabled:
                       input = F.relu(self.conv2(input))
                       return input
         """
-        def __init__(self, optimize=True):
-            self.__dict__['_c'] = torch._C.ScriptModule(type(self).__name__)
+        def __init__(self, optimize=True, _name=None):
+            if _name is None:
+                _name = type(self).__name__
+            self.__dict__['_c'] = torch._C.ScriptModule(_name)
             Module.__init__(self)
             self._c._set_optimized(optimize)
             self._parameters = OrderedParameterDict(self._c)
@@ -1618,7 +1620,7 @@ if _enabled:
             # Guards behavior of __setattr__ and __getattr__ so ScriptModule
             # __init__ can run correctly
             self.__dict__['_initialized'] = False
-            super(WeakScriptModuleProxy, self).__init__()
+            super(WeakScriptModuleProxy, self).__init__(_name=type(original).__name__)
             # Store a weak reference to the original module
             self.__dict__["_original"] = weakref.ref(original)
 


### PR DESCRIPTION
Since recursive script creates a ScriptModule from an `nn.Module`,
there's no ties to the original module to pull a type name from, so we
have to explicitly pass it in.

Differential Revision: [D16268547](https://our.internmc.facebook.com/intern/diff/16268547/)