### PR TITLE
Implement dropout for sparse int64 features where a lengths array is provided to denote the number of elements corresponding to each example in the batch.

### DIFF
--- a/caffe2/operators/sparse_dropout_with_replacement_op.cc
+++ b/caffe2/operators/sparse_dropout_with_replacement_op.cc
@@ -1,0 +1,131 @@
+#include "caffe2/operators/sparse_dropout_with_replacement_op.h"
+
+#include <algorithm>
+#include <iterator>
+
+namespace caffe2 {
+
+template <>
+bool SparseDropoutWithReplacementOp<CPUContext>::RunOnDevice() {
+  auto& X = Input(0);
+  CAFFE_ENFORCE_EQ(X.ndim(), 1, "Input tensor should be 1-D");
+  const int64_t* Xdata = X.data<int64_t>();
+  auto& Lengths = Input(1);
+  CAFFE_ENFORCE_EQ(Lengths.ndim(), 1, "Lengths tensor should be 1-D");
+  auto* OutputLengths = Output(1, Lengths.size(), at::dtype<int32_t>());
+  int32_t const* input_lengths_data = Lengths.template data<int32_t>();
+  int32_t* output_lengths_data =
+      OutputLengths->template mutable_data<int32_t>();
+  // Check that input lengths add up to the length of input data
+  int total_input_length = 0;
+  for (int i = 0; i < Lengths.numel(); ++i) {
+    total_input_length += input_lengths_data[i];
+  }
+  CAFFE_ENFORCE_EQ(
+      total_input_length,
+      X.numel(),
+      "Inconsistent input data. Number of elements should match total length.");
+
+  std::bernoulli_distribution dist(1. - ratio_);
+  auto& gen = context_.RandGenerator();
+  int32_t total_output_length = 0;
+  vector<bool> selected(Lengths.numel(), true);
+  for (int i = 0; i < Lengths.numel(); ++i) {
+    if (dist(gen)) {
+      output_lengths_data[i] = input_lengths_data[i];
+    } else {
+      // Replace with a single dropout value.  Even if input length is 0.
+      output_lengths_data[i] = 1;
+      selected[i] = false;
+    }
+    total_output_length += output_lengths_data[i];
+  }
+
+  auto* Y = Output(0, {total_output_length}, at::dtype<int64_t>());
+  int64_t* Ydata = Y->template mutable_data<int64_t>();
+
+  int input_index = 0;
+  int output_index = 0;
+  for (int i = 0; i < Lengths.numel(); ++i) {
+    if (selected[i]) {
+      // Copy logical elements from input to output
+      for (int j = input_index; j < input_index + input_lengths_data[i]; ++j) {
+        Ydata[output_index++] = Xdata[j];
+      }
+    } else {
+      Ydata[output_index++] = replacement_value_;
+    }
+    input_index += input_lengths_data[i];
+  }
+  return true;
+}
+
+REGISTER_CPU_OPERATOR(
+    SparseDropoutWithReplacement,
+    SparseDropoutWithReplacementOp<CPUContext>);
+
+OPERATOR_SCHEMA(SparseDropoutWithReplacement)
+    .NumInputs(2)
+    .SameNumberOfOutput()
+    .SetDoc(R"DOC(
+
+`SparseDropoutWithReplacement` takes a 1-d input tensor and a lengths tensor.
+Values in the Lengths tensor represent how many input elements consitute each
+example in a given batch.  The set of input values for an example will be
+replaced with the single dropout value with probability given by the `ratio`
+argument.
+
+<details>
+
+<summary> <b>Example</b> </summary>
+
+**Code**
+
+```
+workspace.ResetWorkspace()
+
+op = core.CreateOperator(
+    "SparseDropoutWithReplacement",
+    ["X", "Lengths"],
+    ["Y", "OutputLengths"],
+    ratio=0.5,
+    replacement_value=-1
+)
+
+workspace.FeedBlob("X", np.array([1, 2, 3, 4, 5]).astype(np.int64))
+workspace.FeedBlob("Lengths", np.array([2, 3]).astype(np.int32))
+print("X:", workspace.FetchBlob("X"))
+print("Lengths:", workspace.FetchBlob("Lengths"))
+workspace.RunOperatorOnce(op)
+print("Y:", workspace.FetchBlob("Y"))
+print("OutputLengths:", workspace.FetchBlob("OutputLengths"))
+```
+
+**Result**
+
+```
+X: [1, 2, 3, 4, 5]
+Lengths: [2, 3]
+Y: [1, 2, -1]
+OutputLengths: [2, 1]
+```
+
+</details>
+
+)DOC")
+    .Arg(
+        "ratio",
+        "*(type: float; default: 0.0)* Probability of an element to be replaced.")
+    .Arg(
+        "replacement_value",
+        "*(type: int64_t; default: 0)* Value elements are replaced with.")
+    .Input(0, "X", "*(type: Tensor`<int64_t>`)* Input data tensor.")
+    .Input(
+        1,
+        "Lengths",
+        "*(type: Tensor`<int32_t>`)* Lengths tensor for input.")
+    .Output(0, "Y", "*(type: Tensor`<int64_t>`)* Output tensor.")
+    .Output(1, "OutputLengths", "*(type: Tensor`<int32_t>`)* Output tensor.");
+
+NO_GRADIENT(SparseDropoutWithReplacement);
+} // namespace caffe2

--- a/caffe2/operators/sparse_dropout_with_replacement_op.h
+++ b/caffe2/operators/sparse_dropout_with_replacement_op.h
@@ -1,0 +1,35 @@
+#ifndef CAFFE2_OPERATORS_SPARSE_DROPOUT_WITH_REPLACEMENT_OP_H_
+#define CAFFE2_OPERATORS_SPARSE_DROPOUT_WITH_REPLACEMENT_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context>
+class SparseDropoutWithReplacementOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  template <class... Args>
+  explicit SparseDropoutWithReplacementOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        ratio_(this->template GetSingleArgument<float>("ratio", 0.0)),
+        replacement_value_(
+            this->template GetSingleArgument<int64_t>("replacement_value", 0)) {
+    // It is allowed to drop all or drop none.
+    CAFFE_ENFORCE_GE(ratio_, 0.0, "Ratio should be a valid probability");
+    CAFFE_ENFORCE_LE(ratio_, 1.0, "Ratio should be a valid probability");
+  }
+
+  bool RunOnDevice() override;
+
+ protected:
+  float ratio_;
+  int64_t replacement_value_;
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_SPARSE_DROPOUT_WITH_REPLACEMENT_OP_H_

--- a/caffe2/python/operator_test/sparse_dropout_with_replacement_op_test.py
+++ b/caffe2/python/operator_test/sparse_dropout_with_replacement_op_test.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import core
+from hypothesis import given
+import caffe2.python.hypothesis_test_util as hu
+import numpy as np
+
+
+class SparseDropoutWithReplacementTest(hu.HypothesisTestCase):
+    @given(**hu.gcs_cpu_only)
+    def test_no_dropout(self, gc, dc):
+        X = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).astype(np.int64)
+        Lengths = np.array([2, 2, 2, 2, 2]).astype(np.int32)
+        replacement_value = -1
+        self.ws.create_blob("X").feed(X)
+        self.ws.create_blob("Lengths").feed(Lengths)
+        sparse_dropout_op = core.CreateOperator(
+            "SparseDropoutWithReplacement", ["X", "Lengths"], ["Y", "LY"],
+            ratio=0.0, replacement_value=replacement_value)
+        self.ws.run(sparse_dropout_op)
+        Y = self.ws.blobs["Y"].fetch()
+        OutputLengths = self.ws.blobs["LY"].fetch()
+        self.assertListEqual(X.tolist(), Y.tolist(),
+                             "Values should stay unchanged")
+        self.assertListEqual(Lengths.tolist(), OutputLengths.tolist(),
+                             "Lengths should stay unchanged.")
+
+    @given(**hu.gcs_cpu_only)
+    def test_all_dropout(self, gc, dc):
+        X = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).astype(np.int64)
+        Lengths = np.array([2, 2, 2, 2, 2]).astype(np.int32)
+        replacement_value = -1
+        self.ws.create_blob("X").feed(X)
+        self.ws.create_blob("Lengths").feed(Lengths)
+        sparse_dropout_op = core.CreateOperator(
+            "SparseDropoutWithReplacement", ["X", "Lengths"], ["Y", "LY"],
+            ratio=1.0, replacement_value=replacement_value)
+        self.ws.run(sparse_dropout_op)
+        y = self.ws.blobs["Y"].fetch()
+        lengths = self.ws.blobs["LY"].fetch()
+        for elem in y:
+            self.assertEqual(elem, replacement_value, "Expected all \
+                negative elements when dropout ratio is 1.")
+        for length in lengths:
+            self.assertEqual(length, 1)
+        self.assertEqual(sum(lengths), len(y))
+
+    @given(**hu.gcs_cpu_only)
+    def test_all_dropout_empty_input(self, gc, dc):
+        X = np.array([]).astype(np.int64)
+        Lengths = np.array([0]).astype(np.int32)
+        replacement_value = -1
+        self.ws.create_blob("X").feed(X)
+        self.ws.create_blob("Lengths").feed(Lengths)
+        sparse_dropout_op = core.CreateOperator(
+            "SparseDropoutWithReplacement", ["X", "Lengths"], ["Y", "LY"],
+            ratio=1.0, replacement_value=replacement_value)
+        self.ws.run(sparse_dropout_op)
+        y = self.ws.blobs["Y"].fetch()
+        lengths = self.ws.blobs["LY"].fetch()
+        self.assertEqual(len(y), 1, "Expected single dropout value")
+        self.assertEqual(len(lengths), 1, "Expected single element \
+            in lengths array")
+        self.assertEqual(lengths[0], 1, "Expected 1 as sole length")
+        self.assertEqual(sum(lengths), len(y))


### PR DESCRIPTION
Summary: Implement sparse dropout with replacement value.

Differential Revision: D16267012

