### PR TITLE
[jit] Enable recursive script mode as the default

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2079,6 +2079,7 @@ graph(%Ra, %Rb):
         self.assertEqual(test_fn(ten, mask), traced_test_fn(ten, mask))
 
     def test_sparse_tensors_error(self):
+        @torch.jit.ignore
         def get_sparse():
             return torch.sparse.FloatTensor(2, 3)
 
@@ -2593,6 +2594,7 @@ graph(%Ra, %Rb):
                 z = x
             return x, z
 
+        @torch.jit.ignore
         def python_fn(x):
             return x + 10
 
@@ -6975,6 +6977,7 @@ a")
                 super(M, self).__init__(False)
                 self.value = 1
 
+            @torch.jit.ignore
             def foo(self):
                 return torch.ones(2, 2) + self.value
 
@@ -7666,6 +7669,7 @@ a")
                 def __init__(self):
                     super(M2, self).__init__(True)
 
+                    @torch.jit.ignore
                     def myfunc():
                         return torch.zeros(1, 2, 3), torch.zeros(1, 2, 3)
 
@@ -7832,6 +7836,7 @@ a")
 
     def test_python_call_non_tensor_wrong(self):
         with self.assertRaisesRegex(RuntimeError, r"but instead got value of type tuple"):
+            @torch.jit.ignore
             def foo():
                 # type: () -> Tensor
                 return ((3, 4),)  # noqa: T484
@@ -8100,6 +8105,7 @@ a")
         self.checkScript(fn_string, ("1", ("3", "4")), optimize=True)
 
     def test_type_annotations_varargs(self):
+        @torch.jit.ignore
         def fn_varargs(x, *args):
             return args[0] if args else x
 
@@ -8133,6 +8139,7 @@ a")
             with open(script_path, 'w') as f:
                 f.write(code)
             fn = get_fn('test_type_annotation_py3', script_path)
+            fn = torch.jit.ignore(fn)
 
             with self.assertRaisesRegex(RuntimeError, r"Expected a value of type 'Tensor' for argument"
                                                       r" '0' but instead found type 'Tuple\[Tensor,"):
@@ -8176,14 +8183,17 @@ a")
 
     def test_type_annotation_module(self):
         class BaseModule(torch.jit.ScriptModule):
+            @torch.jit.ignore
             def foo(self, x):
                 # type: (Tensor) -> Tensor
                 return x + 1
 
+            @torch.jit.ignore
             def bar(self, x, y):
                 # type: (Tensor, Tensor) -> Tuple[Tensor, Tensor]
                 return x + y, y
 
+            @torch.jit.ignore
             def baz(self, x, y):
                 return x
 
@@ -8677,17 +8687,18 @@ a")
             example_outputs=outputs)
 
     def test_onnx_export_script_python_fail(self):
-        class ModuleToInline(torch.jit.ScriptModule):
+        class PythonModule(torch.jit.ScriptModule):
             def __init__(self):
-                super(ModuleToInline, self).__init__()
+                super(PythonModule, self).__init__()
 
+            @torch.jit.ignore
             def forward(self, x):
                 return torch.neg(x)
 
         class ModuleToExport(torch.jit.ScriptModule):
             def __init__(self):
                 super(ModuleToExport, self).__init__()
-                self.mod = ModuleToInline()
+                self.mod = PythonModule()
 
             @torch.jit.script_method
             def forward(self, x):
@@ -10041,6 +10052,7 @@ a")
 
     def test_wrong_return_type(self):
         with self.assertRaisesRegex(RuntimeError, 'but instead got value of type tuple'):
+            @torch.jit.ignore
             def somefunc():
                 # type: () -> Tuple[Tuple[Tensor, Tensor]]
                 return torch.zeros(3, 4), torch.zeros(4, 5)  # noqa: T484
@@ -10362,6 +10374,7 @@ a")
         FileCheck().check_count("aten::mm", 2).check("aten::add").run(str(tm.graph))
 
     def test_call_python_fn_from_script_fn(self):
+        @torch.jit.ignore
         def python_fn(x):
             return torch.neg(x)
 
@@ -10452,6 +10465,7 @@ a")
                 return sm(x) + 1
 
     def test_call_python_fn_from_script_module(self):
+        @torch.jit.ignore
         def python_fn(x):
             return torch.neg(x)
 
@@ -10474,6 +10488,7 @@ a")
                 super(PythonMod, self).__init__()
                 self.param = torch.nn.Parameter(torch.rand(3, 5))
 
+            @torch.jit.ignore
             def forward(self, x):
                 return torch.mm(x, self.param)
 
@@ -10488,9 +10503,9 @@ a")
                 return self.pm(torch.mm(x, self.param))
 
         sm = ScriptMod()
-        # Note: the call into PythonMod appears as ^<python_value>(). Parameters
+        # Note: the call into PythonMod appears as ^forward(). Parameters
         # are NOT inlined
-        FileCheck().check("aten::mm").check("python_value").run(str(sm.graph))
+        FileCheck().check("aten::mm").check("forward").run(str(sm.graph))
 
     def test_call_tracing_fn_from_script_module(self):
         @_trace(torch.rand(3, 3))
@@ -11425,6 +11440,7 @@ a")
         self.checkScript(fn, (input,))
 
     def test_python_op_exception(self):
+        @torch.jit.ignore
         def python_op(x):
             raise Exception("bad!")
 
@@ -13107,13 +13123,6 @@ a")
 
 
 class TestRecursiveScript(JitTestCase):
-    """
-    Tests in this class are all run under `with torch.jit._enable_recursive_script()`
-    """
-    def run(self, result=None):
-        with torch.jit._enable_recursive_script():
-            super(TestRecursiveScript, self).run(result)
-
     def checkModule(self, nn_module, args):
         """
         Check that a nn.Module's results in Script mode match eager and that it
@@ -14272,6 +14281,7 @@ def check_against_reference(self, func, reference_func, args, kwargs=None,
 # to resolve variable names. This function cannot be made local to
 # TestAutodiffSubgraphSlicing because those tests call torch.jit.script on functions
 # in a different scope than they are defined in.
+@torch.jit.ignore
 def pyfn(a, b):
     return a * b
 
@@ -16578,6 +16588,7 @@ class TestDict(JitTestCase):
                 return x.get(y)  # noqa: T484
 
     def test_dict_to_python(self):
+        @torch.jit.ignore
         def python_lookup(my_dict, keys):
             # type: (Dict[str, int], List[str]) -> List[int]
             return [my_dict[k] for k in keys]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15559,6 +15559,7 @@ class TestDataParallel(JitTestCase):
             self.m = nn.Sequential(nn.Linear(2, 2), nn.BatchNorm1d(2),
                                    nn.ReLU(), nn.Linear(2, 2))
 
+        @torch.jit.ignore
         def forward(self, input):
             return self.m(input)
 
@@ -15567,6 +15568,7 @@ class TestDataParallel(JitTestCase):
             super(TestDataParallel.Mpy1, self).__init__()
             self.m = block
 
+        @torch.jit.ignore
         def forward(self, input):
             return self.m.forward(input)
 
@@ -15576,6 +15578,7 @@ class TestDataParallel(JitTestCase):
             self.m1 = block1
             self.m2 = block2
 
+        @torch.jit.ignore
         def forward(self, input):
             x = self.m1.forward(input)
             return self.m2(x)

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -724,7 +724,7 @@ inline py::object invokeScriptFunctionFromPython(
     AutoNoGIL no_gil_guard;
     callee.run(stack);
   }
-  AT_CHECK(
+  TORCH_CHECK(
       stack.size() > 0,
       "Expected values in the stack after execution but found none");
   return toPyObject(std::move(stack.back()));

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -687,12 +687,6 @@ void initJitScriptBindings(PyObject* module) {
         return ss.str();
       });
   m.def(
-      "_jit_recursive_script",
-      []() { return getRecursiveScriptMode(); });
-  m.def(
-      "_jit_recursive_script",
-      [](bool recurse) { getRecursiveScriptMode() = recurse; });
-  m.def(
       "_jit_script_compile",
       [](const std::string& qualname,
          const Def& def,

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -277,7 +277,7 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
         self_, py::cast<std::vector<std::string>>(overloads));
   }
   if (!py::hasattr(py_module_, field.c_str())) {
-    throw ErrorReport(loc) << "module has no attribute '" << field;
+    throw ErrorReport(loc) << "module has no attribute '" << field << "'";
   }
   py::object attr = py::getattr(py_module_, field.c_str());
 

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -26,11 +26,6 @@ c10::optional<StrongFunctionPtr> as_function(const py::object& obj) {
   return c10::nullopt;
 }
 
-thread_local bool recurse_on_python_ops = false;
-bool& getRecursiveScriptMode() {
-  return recurse_on_python_ops;
-}
-
 FunctionSchema PythonValue::getSchema(
     const size_t n_args,
     const size_t n_binders) {
@@ -244,11 +239,6 @@ std::shared_ptr<SugaredValue> OverloadedMethodValue::call(
                          << err.str();
 }
 
-bool should_recurse(py::object obj) {
-  return py::cast<bool>(py::module::import("torch.jit")
-                            .attr("_is_recursive_script_enabled")(obj));
-}
-
 std::shared_ptr<SugaredValue> ModuleValue::attr(
     const SourceRange& loc,
     Function& m,
@@ -310,35 +300,33 @@ std::shared_ptr<SugaredValue> ModuleValue::attr(
     return std::make_shared<ConstantParameterList>(list);
   }
 
-  // If recursive script mode is on, create a ScriptModule and register it as
+  // Recursively create a ScriptModule and register it as
   // as submodule or register a python method as a script::Method
-  if (should_recurse(attr)) {
-    if (py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
-      // If the module is a submodule of the py_module, convert it to a
-      // ScriptModule and add it as a submodule to the script::Module. This
-      // enables lazy strong-ification of modules.
-      auto result =
-          py::module::import("torch.jit")
-              .attr("_make_strong_submodule")(field, attr, py_module_);
-      if (!result.is_none()) {
-        auto submodule = as_module(result);
-        TORCH_CHECK(
-            submodule,
-            "Result of torch.jit._make_strong_submodule "
-            "was not a ScriptModule");
-        // The module was a submodule of the nn.Module, so register it here
-        // and return the submodule.
-        module_.register_module(field, *submodule);
-        auto v = module_.find_module(field);
-        return std::make_shared<ModuleValue>(
-            m.graph()->insertGetAttr(self_, field), *v, result);
-      }
-    } else if (py::isinstance<py::function>(attr)) {
-      auto stub = py::module::import("torch.jit")
-                      .attr("_create_method_from_fn")(py_module_, attr);
-      if (!stub.is_none()) {
-        return SimpleValue(self_).attr(loc, m, field);
-      }
+  if (py::isinstance(attr, py::module::import("torch.nn").attr("Module"))) {
+    // If the module is a submodule of the py_module, convert it to a
+    // ScriptModule and add it as a submodule to the script::Module. This
+    // enables lazy strong-ification of modules.
+    auto result =
+        py::module::import("torch.jit")
+            .attr("_make_strong_submodule")(field, attr, py_module_);
+    if (!result.is_none()) {
+      auto submodule = as_module(result);
+      TORCH_CHECK(
+          submodule,
+          "Result of torch.jit._make_strong_submodule "
+          "was not a ScriptModule");
+      // The module was a submodule of the nn.Module, so register it here
+      // and return the submodule.
+      module_.register_module(field, *submodule);
+      auto v = module_.find_module(field);
+      return std::make_shared<ModuleValue>(
+          m.graph()->insertGetAttr(self_, field), *v, result);
+    }
+  } else if (py::isinstance<py::function>(attr)) {
+    auto stub = py::module::import("torch.jit")
+                    .attr("_create_method_from_fn")(py_module_, attr);
+    if (!stub.is_none()) {
+      return SimpleValue(self_).attr(loc, m, field);
     }
   }
 
@@ -522,7 +510,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     }
   }
 
-  if (should_recurse(obj) && py::isinstance<py::function>(obj)) {
+  py::bool_ isFunction = py::module::import("inspect").attr("isfunction")(obj);
+if (py::cast<bool>(isFunction)) {
     auto compiled_fn =
         py::module::import("torch.jit").attr("_try_compile_fn")(obj, loc);
     if (auto callee = as_function(compiled_fn)) {

--- a/torch/csrc/jit/script/python_sugared_value.h
+++ b/torch/csrc/jit/script/python_sugared_value.h
@@ -191,7 +191,7 @@ struct VISIBILITY_HIDDEN BooleanDispatchValue : public SugaredValue {
   py::dict dispatched_fn_;
 };
 
-TORCH_API bool& getRecursiveScriptMode();
+TORCH_API bool getRecursiveScriptMode();
 
 } // namespace script
 } // namespace jit

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1072,22 +1072,6 @@ def _qualified_name(obj):
     return module_name + "." + name
 
 
-def _is_recursive_script_enabled(value):
-    # TODO: [enable recursive script]
-    # when recursive script is made the default, remove this method
-    enabled = torch._C._jit_recursive_script()
-    module = inspect.getmodule(value)
-    if module is not None and 'torch.nn' in module.__name__:
-        enabled = True
-    return enabled
-
-@contextlib.contextmanager
-def _enable_recursive_script():
-    torch._C._jit_recursive_script(True)
-    yield
-    torch._C._jit_recursive_script(False)
-
-
 def script(obj, optimize=True, _frames_up=0, _rcb=None):
     if not _enabled:
         return obj
@@ -1095,8 +1079,7 @@ def script(obj, optimize=True, _frames_up=0, _rcb=None):
         _rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
 
     if isinstance(obj, torch.nn.Module):
-        if _is_recursive_script_enabled(obj):
-            return _convert_to_script_module(obj)
+        return _convert_to_script_module(obj)
 
     qualified_name = _qualified_name(obj)
     if inspect.isclass(obj):
@@ -1643,15 +1626,6 @@ if _enabled:
                 elif item is self:
                     continue
                 elif isinstance(item, (Parameter, Module, Attribute)):
-                    if isinstance(item, (ModuleList, Sequential)):
-                        # These are in __constants__, so ignore them here
-
-                        if not _is_recursive_script_enabled(item):
-                            # For recursive script, these are constantified after
-                            # they are used, so they don't need to be in constants.
-                            # The `continue` here should be deleted along with
-                            # [weak script refactor]
-                            continue
                     ScriptModule.__setattr__(self, name, item)
 
             # Copy buffers
@@ -1698,6 +1672,7 @@ if _enabled:
             self.__dict__["_overloads"] = dict(getattr(original, "__overloads__", {}))
 
             self.__dict__["_initialized"] = True
+            self.__dict__["_original_type"] = type(original)
             _create_methods_from_stubs(self, stubs)
 
         def __getattr__(self, attr):
@@ -1711,7 +1686,13 @@ if _enabled:
                 if original_module and self.__dict__["_initialized"]:
                     # get attr from original if it is still alive
                     return getattr(original_module, attr)
-
+                elif self.__dict__["_initialized"]:
+                    # original module is dead, try looking up the value on the
+                    # original type
+                    fn = getattr(self.__dict__["_original_type"], attr, None)
+                    if fn is not None and inspect.isfunction(fn):
+                        # bind the function to this instance and return it
+                        return fn.__get__(self, self.__dict__["_original_type"])
                 # If it's not on this module and it wasn't on the original
                 # module (or the original is dead), throw the exception
                 raise e
@@ -1740,8 +1721,7 @@ def _convert_to_script_module(mod):
     """
     Makes a ScriptModule from an nn.Module. If `_methods` is provided,
     these methods are treated as @script_methods. If not, it defaults to
-    `('forward',)`. Methods accessed in forward are scripted on demand if
-    `_enable_recursive_script()` is used.
+    `('forward',)`. Methods accessed in forward are scripted on demand.
     """
     if isinstance(mod, ScriptModule):
         return mod
@@ -1753,8 +1733,6 @@ def _convert_to_script_module(mod):
     methods = ()
     if hasattr(mod, 'forward'):
         if mod.forward.__func__ == torch.nn.Module.forward:
-            # TODO: [enable recursive script]
-            # forward was not overrided
             raise RuntimeError("No forward method was defined on {}".format(mod))
         if not _jit_internal.is_ignored_fn(mod.forward):
             methods = ('forward',)
@@ -1869,12 +1847,12 @@ class _ConstModuleList(ScriptModule):
 
         if isinstance(modules, OrderedDict):
             for key, module in modules.items():
-                if isinstance(module, torch.nn.Module) and _is_recursive_script_enabled(module):
+                if isinstance(module, torch.nn.Module):
                     module = _convert_to_script_module(module)
                 self.add_module(key, module)
         else:
             for i, module in enumerate(modules):
-                if isinstance(module, torch.nn.Module) and _is_recursive_script_enabled(module):
+                if isinstance(module, torch.nn.Module):
                     module = _convert_to_script_module(module)
                 self.add_module(str(i), module)
 

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1690,7 +1690,7 @@ if _enabled:
                     # original module is dead, try looking up the value on the
                     # original type
                     fn = getattr(self.__dict__["_original_type"], attr, None)
-                    if fn is not None and inspect.isfunction(fn):
+                    if fn is not None and inspect.isroutine(fn):
                         # bind the function to this instance and return it
                         return fn.__get__(self, self.__dict__["_original_type"])
                 # If it's not on this module and it wasn't on the original


### PR DESCRIPTION
This fixes up the test suite (mostly just adding `@ignore` decorations
to tests that need to call Python function) so that it all passes with
recursive script enabled.

The main user-facing result of this change is that Python functions are
compiled without any decorators, so non-TorchScriptable code must be
decorated with `@torch.jit.ignore` (or
`@torch.jit.ignore(drop_on_export=True` to maintain the functionality of
the current `@ignore`)

Details can be found in #20939

Differential Revision: [D16277608](https://our.internmc.facebook.com/intern/diff/16277608/)