### PR TITLE
[pt1][quant] Dynamic Quantized Linear operator and module

### DIFF
--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -231,7 +231,6 @@ class TestQuantizedLinear(unittest.TestCase):
         # Assert close: FP32 computation vs. INT8 computation with dynamic quantization
         torch.testing.assert_allclose(Y_dq, Y_ref, rtol=0.1, atol=1e-3)
 
-
     """Tests the correctness of the quantized linear and linear_relu op."""
     @given(
         batch_size=st.integers(1, 4),

--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -1,12 +1,13 @@
 
 from .activation import ReLU  # noqa: F401
 from .conv import Conv2d
-from .linear import Linear, Quantize, DeQuantize  # noqa: F401
+from .linear import Linear, DynamicLinear, Quantize, DeQuantize  # noqa: F401
 
 __all__ = [
     'Conv2d',
     'DeQuantize',
     'Linear',
+    'DynamicLinear',
     'Quantize',
     'ReLU'
 ]

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
-from torch.nn.parameter import Parameter
 from ...modules.module import Module
 from ...modules.linear import Linear as NNLinear
 
@@ -189,8 +188,8 @@ class DynamicLinear(NNLinear):
                 module which are of shape :math:`(\text{out\_features}, \text{in\_features})`.
         bias:   the non-learnable bias of the module of shape :math:`(\text{out\_features})`.
                 If :attr:`bias` is ``True``, the values are initialized to zero.
-        out_scale: `scale` parameter of output Quantized Tensor, type: double
-        out_zero_point: `zero_point` parameter for output Quantized Tensor, type: long
+        scale: `scale` parameter of weight Quantized Tensor, type: double
+        zero_point: `zero_point` parameter for weight Quantized Tensor, type: long
 
     Examples::
 


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22891 [pt1][quant] Dynamic Quantized Linear operator and module**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16258664/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22956 [pt1][quant] Remove K and N function arguments for fbgemm_pack_quantized_matrix&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16297724/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22955 [pt1][quant] Change fbgemm_linear_{int8,fp16}_weight to fbgemm_linear_{int8,fp16}_weight_fp32_activation&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16297512/)

- Add a unit test for the Dynamic Quantized Linear operator (```torch.fbgemm_linear_quantize_weight```, ```torch.fbgemm_pack_quantized_matrix```, and ```torch.fbgemm_linear_int8_weight```) in ```test_quantized.py```.
- Add the Dynamic Quantized Linear module in ```torch/nn/quantized/modules/linear.py```. This is in a rudimentary stage. Will add more functions later.
- Add a unit test for the Dynamic Quantized Linear module  in ```test_nn_quantized.py```.

Differential Revision: [D16258664](https://our.internmc.facebook.com/intern/diff/D16258664/)