### PR TITLE
[jit] Make classtypes hold a weak_ptr to their CU

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -270,23 +270,14 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
 // User-defined object.
 struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
  public:
-  // temporary way to break cyclic dependencies in modules by forcing the deletion
-  // of functions when the module object is destructed
-  typedef void (*OnDelete)(ivalue::Object*);
-  Object(
-      StrongTypePtr type,
-      size_t numSlots,
-      OnDelete on_delete)
-      : type_(std::move(type)), on_delete_(on_delete) {
+  Object(StrongTypePtr type, size_t numSlots) : type_(std::move(type)) {
     slots_.resize(numSlots);
   }
 
   static c10::intrusive_ptr<Object> create(
       StrongTypePtr type,
-      size_t numSlots,
-      OnDelete on_delete = nullptr) {
-    return c10::make_intrusive<Object>(
-        std::move(type), numSlots, on_delete);
+      size_t numSlots) {
+    return c10::make_intrusive<Object>(std::move(type), numSlots);
   }
 
   /**
@@ -336,15 +327,11 @@ struct C10_EXPORT ivalue::Object final : c10::intrusive_ptr_target {
   std::shared_ptr<torch::jit::script::CompilationUnit> compilation_unit() {
     return type_.cu_;
   }
-  // temporarily defined in class_type.cpp to
-  // ensure Modules do not leak memory
-  ~Object();
 
  private:
   void resizeObject(size_t slot);
   StrongTypePtr type_;
   std::vector<IValue> slots_;
-  OnDelete on_delete_;
 };
 
 std::vector<std::pair<IValue, IValue>> iterationOrder(const c10::Dict<IValue, IValue>& dict);

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1360,7 +1360,8 @@ struct CAFFE2_API ClassType : public NamedType {
   // Create a class type with name `name` and its methods stored in `cu`.
   static ClassTypePtr create(
       c10::optional<QualifiedName> qualifiedName,
-      std::shared_ptr<CompilationUnit> cu, bool is_module = false);
+      std::weak_ptr<CompilationUnit> cu,
+      bool is_module = false);
 
   DEFINE_IS_SUBCLASS(ClassType);
   bool operator==(const Type& rhs) const override {
@@ -1477,7 +1478,10 @@ struct CAFFE2_API ClassType : public NamedType {
   static const TypeKind Kind = TypeKind::ClassType;
 
  private:
-  ClassType(c10::optional<QualifiedName> name, std::shared_ptr<CompilationUnit> cu, bool is_module);
+  ClassType(
+      c10::optional<QualifiedName> name,
+      std::weak_ptr<CompilationUnit> cu,
+      bool is_module);
 
   // Mapping of attribute names -> their type.
   // NOTE: this does not contain methods, which are stored in the module
@@ -1488,7 +1492,7 @@ struct CAFFE2_API ClassType : public NamedType {
   std::vector<std::string> attributeNames_;
   std::vector<TypePtr> attributeTypes_;
   // Holds method attributes
-  std::shared_ptr<CompilationUnit> compilation_unit_;
+  std::weak_ptr<CompilationUnit> compilation_unit_;
 
 
   // if present, this class inherits from torch.nn.Module

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -5,14 +5,6 @@
 #include <c10/macros/Macros.h>
 namespace c10 {
 
-namespace ivalue {
-Object::~Object() {
-  if (on_delete_) {
-    on_delete_(this);
-  }
-}
-} // namespace ivalue
-
 std::ostream& operator<<(std::ostream & out, const Type & t) {
   if(auto value = t.cast<CompleteTensorType>()) {
     out << toString(value->scalarType()) << "(";

--- a/test/cpp/jit/test_class_import.h
+++ b/test/cpp/jit/test_class_import.h
@@ -37,8 +37,8 @@ class FooTest:
 )JIT";
 
 void testClassImport() {
-  CompilationUnit cu1;
-  CompilationUnit cu2;
+  auto cu1 = std::make_shared<CompilationUnit>();
+  auto cu2 = std::make_shared<CompilationUnit>();
   std::vector<at::Tensor> constantTable;
   // Import different versions of FooTest into two namespaces.
   import_libs(
@@ -57,19 +57,19 @@ void testClassImport() {
   // We should get the correct version of `FooTest` for whichever namespace we
   // are referencing
   c10::QualifiedName base("__torch__");
-  auto classType1 = cu1.get_class(c10::QualifiedName(base, "FooTest"));
+  auto classType1 = cu1->get_class(c10::QualifiedName(base, "FooTest"));
   ASSERT_TRUE(classType1->hasAttribute("x"));
   ASSERT_FALSE(classType1->hasAttribute("dx"));
 
-  auto classType2 = cu2.get_class(c10::QualifiedName(base, "FooTest"));
+  auto classType2 = cu2->get_class(c10::QualifiedName(base, "FooTest"));
   ASSERT_TRUE(classType2->hasAttribute("dx"));
   ASSERT_FALSE(classType2->hasAttribute("x"));
 
   // We should only see FooNestedTest in the first namespace
-  auto c = cu1.get_class(c10::QualifiedName(base, "FooNestedTest"));
+  auto c = cu1->get_class(c10::QualifiedName(base, "FooNestedTest"));
   ASSERT_TRUE(c);
 
-  c = cu2.get_class(c10::QualifiedName(base, "FooNestedTest"));
+  c = cu2->get_class(c10::QualifiedName(base, "FooNestedTest"));
   ASSERT_FALSE(c);
 }
 
@@ -78,13 +78,13 @@ void testScriptObject() {
   Module m2("m2");
   std::vector<at::Tensor> constantTable;
   import_libs(
-      *m1.class_compilation_unit(),
+      m1.class_compilation_unit(),
       "__torch__",
       std::make_shared<Source>(classSrcs1),
       constantTable,
       nullptr);
   import_libs(
-      *m2.class_compilation_unit(),
+      m2.class_compilation_unit(),
       "__torch__",
       std::make_shared<Source>(classSrcs2),
       constantTable,

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -908,15 +908,14 @@ void ScriptModuleSerializer::convertModule(
     module_name << prefix << "_";
   module_name << name;
 
-  if (module.class_compilation_unit()->get_functions().size() > 0) {
+  if (module.type()->methods().size() > 0) {
     std::ostringstream methods;
     SourceRangeRecords source_ranges;
     methods << "op_version_set = " << CURRENT_OP_VERSION_SET << "\n";
     PythonPrint(
         methods,
         source_ranges,
-        *module.class_compilation_unit(),
-        /*is_method=*/true,
+        module,
         tensor_table_,
         class_table_,
         /*enforce_importable=*/true);

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -269,7 +269,7 @@ void ScriptModuleDeserializer::importCallback(const std::string& qualifier) {
   auto src = std::make_shared<Source>(
       std::string(static_cast<const char*>(data.get()), size), path, 0);
   script::import_libs(
-      *main_module_.class_compilation_unit(),
+      main_module_.class_compilation_unit(),
       qualifier,
       src,
       tensor_table_,
@@ -358,7 +358,6 @@ void ScriptModuleDeserializer::convertModule(
     std::function<void(const std::string&)> import_callback =
         [this](const std::string& qualifier) { importCallback(qualifier); };
     script::import_methods(
-        *main_module_.class_compilation_unit(),
         module,
         src,
         tensor_table_,

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -107,10 +107,10 @@ struct ConstantTableValue : public SugaredValue {
 // constants.
 struct SourceResolver : public Resolver {
   explicit SourceResolver(
-      const CompilationUnit& lib_cu,
+      std::shared_ptr<CompilationUnit> cu,
       size_t version,
       const std::vector<at::Tensor>& constant_table)
-      : lib_cu_(lib_cu) {
+      : cu_(cu) {
     env_ = {
         {"torch", std::make_shared<BuiltinModule>("aten", version)},
         {"ops", std::make_shared<OpsValue>(version)},
@@ -140,34 +140,34 @@ struct SourceResolver : public Resolver {
 
     if (name == "__torch__") {
       return std::make_shared<ClassNamespaceValue>(
-          c10::QualifiedName(name), lib_cu_);
+          c10::QualifiedName(name), *cu_);
     }
     return nullptr;
   }
 
   TypePtr resolveType(const std::string& name, const SourceRange& loc) const override {
-    return lib_cu_.get_type(c10::QualifiedName(name));
+    return cu_->get_type(c10::QualifiedName(name));
   }
 
  private:
   // Compilation unit to look classes up in
-  const CompilationUnit& lib_cu_;
+  std::shared_ptr<CompilationUnit> cu_;
   std::unordered_map<std::string, std::shared_ptr<SugaredValue>> env_;
 };
 
 struct SourceImporter {
   SourceImporter(
-      const CompilationUnit& lib_cu,
+      const std::shared_ptr<CompilationUnit> cu,
       const std::shared_ptr<Source>& src,
       const std::vector<at::Tensor>& constant_table,
       const std::function<void(const std::string&)>& import_callback)
       : p_(src),
-        lib_cu_(lib_cu),
+        cu_(cu),
         import_callback_(import_callback),
         constant_table_(constant_table) {
     version_ = parseVersionNumber();
     resolver_ =
-        std::make_shared<SourceResolver>(lib_cu_, version_, constant_table_);
+        std::make_shared<SourceResolver>(cu_, version_, constant_table_);
   }
 
   void checkVersionNumber() {
@@ -180,7 +180,7 @@ struct SourceImporter {
     }
   }
 
-  void importLibs(CompilationUnit& owner, const std::string& class_qualifier) {
+  void importLibs(std::shared_ptr<CompilationUnit> owner, const std::string& class_qualifier) {
     checkVersionNumber();
     auto& L = p_.lexer();
 
@@ -190,7 +190,6 @@ struct SourceImporter {
       auto parsed_treeref = p_.parseClassLike();
       if (parsed_treeref->kind() == TK_CLASS_DEF) {
         auto class_def = ClassDef(parsed_treeref);
-        auto cu = std::make_shared<CompilationUnit>();
         const auto qualified_classname = QualifiedName(
             QualifiedName(class_qualifier), class_def.name().name());
 
@@ -202,10 +201,10 @@ struct SourceImporter {
         }
 
         auto class_type =
-            ClassType::create(c10::QualifiedName(qualified_classname), cu);
-        owner.register_class(class_type);
+            ClassType::create(c10::QualifiedName(qualified_classname), owner);
+        owner->register_class(class_type);
         const auto self = SimpleSelf(class_type);
-        cu->define(qualified_classname, definitions, resolvers, &self);
+        owner->define(qualified_classname, definitions, resolvers, &self);
       } else if (parsed_treeref->kind() == TK_NAMED_TUPLE_DEF) {
         auto named_tuple_def = NamedTupleDef(parsed_treeref);
 
@@ -233,7 +232,7 @@ struct SourceImporter {
             field_types,
             qualified_name,
             TupleType::namedTupleSchemaFromNamesAndTypes(qualified_name, field_names, field_types));
-        owner.register_class(tt);
+        owner->register_class(tt);
       } else {
         TORCH_INTERNAL_ASSERT(
             false,
@@ -245,7 +244,6 @@ struct SourceImporter {
 
   void importFunctions(
       const c10::optional<c10::QualifiedName>& prefix,
-      CompilationUnit& cu,
       const Self* self) {
     checkVersionNumber();
     parseImportsAndDoCallback();
@@ -257,7 +255,7 @@ struct SourceImporter {
       definitions.emplace_back(def);
       resolvers.emplace_back(resolver_);
     }
-    cu.define(prefix, definitions, resolvers, self);
+    cu_->define(prefix, definitions, resolvers, self);
   }
 
   size_t parseVersionNumber() {
@@ -303,7 +301,7 @@ struct SourceImporter {
  private:
   Parser p_;
   size_t version_;
-  const CompilationUnit& lib_cu_;
+  std::shared_ptr<CompilationUnit> cu_;
   const std::function<void(const std::string&)>& import_callback_;
   const std::vector<at::Tensor>& constant_table_;
   std::shared_ptr<SourceResolver> resolver_;
@@ -311,18 +309,16 @@ struct SourceImporter {
 
 void import_functions(
     const c10::optional<c10::QualifiedName>& prefix,
-    const CompilationUnit& lib_cu,
-    CompilationUnit& cu,
+    std::shared_ptr<CompilationUnit> cu,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
     const Self* self,
     const std::function<void(const std::string&)>& import_callback) {
-  SourceImporter importer(lib_cu, src, constant_table, import_callback);
-  importer.importFunctions(prefix, cu, self);
+  SourceImporter importer(cu, src, constant_table, import_callback);
+  importer.importFunctions(prefix, self);
 }
 
 void import_methods(
-    const CompilationUnit& lib_cu,
     const Module& mod,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
@@ -330,8 +326,7 @@ void import_methods(
   auto self = SimpleSelf(mod.type());
   import_functions(
       mod.name(),
-      lib_cu,
-      *mod.module_object()->type()->compilation_unit(),
+      mod.class_compilation_unit(),
       src,
       constant_table,
       &self,
@@ -339,13 +334,13 @@ void import_methods(
 }
 
 void import_libs(
-    CompilationUnit& lib_cu,
+    std::shared_ptr<CompilationUnit> cu,
     const std::string& class_qualifier,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
     const std::function<void(const std::string&)>& import_callback) {
-  SourceImporter importer(lib_cu, src, constant_table, import_callback);
-  importer.importLibs(lib_cu, class_qualifier);
+  SourceImporter importer(cu, src, constant_table, import_callback);
+  importer.importLibs(cu, class_qualifier);
 }
 
 } // namespace script

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -15,8 +15,6 @@ namespace script {
 
 // Add the methods defined in `src` to the module `mod`.
 TORCH_API void import_methods(
-    // CompilationUnit in which to look up any classes used
-    const CompilationUnit& lib_cu,
     const script::Module& mod,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
@@ -26,7 +24,7 @@ TORCH_API void import_methods(
 // Define the list of classes in `src`.
 TORCH_API void import_libs(
     // The compilation unit that will own the imported libs
-    CompilationUnit& lib_cu,
+    std::shared_ptr<CompilationUnit> cu,
     // Qualifier for any classes that `src` defines. Looks like a module path,
     // like "foo.bar.baz"
     const std::string& class_qualifier,
@@ -42,10 +40,8 @@ TORCH_API void import_libs(
 TORCH_API void import_functions(
     // Prefix to use when importing these functions in to the CU
     const c10::optional<c10::QualifiedName>& prefix,
-    // CompilationUnit in which to look up any classes used
-    const CompilationUnit& lib_cu,
     // CompilationoUnit to define the functions in.
-    CompilationUnit& cu,
+    std::shared_ptr<CompilationUnit> cu,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
     const Self* self = nullptr,

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -1222,9 +1222,9 @@ struct PythonPrintPass {
     }
   }
 
-  void printCompilationUnit(const script::CompilationUnit& cu) {
-    for (auto& func : cu.get_functions()) {
-      printFunction(*func);
+  void printModuleMethods(const script::Module& module) {
+    for (const auto method : module.type()->methods()) {
+      printFunction(*method);
     }
   }
 
@@ -1282,13 +1282,13 @@ void PythonPrint(
 void PythonPrint(
     std::ostream& out,
     SourceRangeRecords& source_ranges_out,
-    const script::CompilationUnit& cu,
-    bool is_method,
+    const script::Module& module,
     std::vector<at::Tensor>& tensor_table,
     std::vector<c10::NamedTypePtr>& class_table,
     bool enforce_importable) {
-  PythonPrintPass pp(tensor_table, class_table, enforce_importable, is_method);
-  pp.printCompilationUnit(cu);
+  PythonPrintPass pp(
+      tensor_table, class_table, enforce_importable, /*isMethod=*/true);
+  pp.printModuleMethods(module);
   pp.print(out, source_ranges_out);
 }
 

--- a/torch/csrc/jit/passes/python_print.h
+++ b/torch/csrc/jit/passes/python_print.h
@@ -24,8 +24,7 @@ TORCH_API void PythonPrint(
 TORCH_API void PythonPrint(
     std::ostream& out,
     SourceRangeRecords& source_ranges_out,
-    const script::CompilationUnit& cu,
-    bool is_method,
+    const script::Module& module,
     std::vector<at::Tensor>& tensor_table,
     std::vector<c10::NamedTypePtr>& class_table,
     bool enforce_importable);

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -421,9 +421,9 @@ inline IValue toIValue(
       auto classType = type->expect<ClassType>();
       // 1. create a bare ivalue
       const size_t numAttrs = classType->numAttributes();
+      auto cu = classType->compilation_unit();
       auto userObj = c10::ivalue::Object::create(
-          c10::StrongTypePtr(classType->compilation_unit(), classType),
-          numAttrs);
+          c10::StrongTypePtr(cu, classType), numAttrs);
 
       // 2. copy all the contained types
       for (size_t slot = 0; slot < numAttrs; slot++) {

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1083,9 +1083,10 @@ RegisterOperators reg(
          [](const Node* node) {
            const auto type = node->output()->type()->expect<ClassType>();
            const size_t numAttrs = type->numAttributes();
-           return [type, numAttrs](Stack& stack) {
+           auto cu = type->compilation_unit();
+           return [cu, type, numAttrs](Stack& stack) {
              auto userObj = c10::ivalue::Object::create(
-                 c10::StrongTypePtr(type->compilation_unit(), type), numAttrs);
+                 c10::StrongTypePtr(cu, type), numAttrs);
              push(stack, std::move(userObj));
              return 0;
            };

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -9,19 +9,25 @@ namespace c10 {
 
 Function* ClassType::getMethod(const std::string& name) const {
   const auto qualname = QualifiedName(*qualified_name_obj(), name);
-  return compilation_unit_->find_function(qualname);
+  auto cu = compilation_unit_.lock();
+  TORCH_INTERNAL_ASSERT(cu);
+  return cu->find_function(qualname);
 }
 
 std::shared_ptr<CompilationUnit> ClassType::compilation_unit() {
-  return compilation_unit_;
+  auto cu = compilation_unit_.lock();
+  TORCH_INTERNAL_ASSERT(cu);
+  return cu;
 }
 std::shared_ptr<const CompilationUnit> ClassType::compilation_unit() const {
-  return compilation_unit_;
+  auto cu = compilation_unit_.lock();
+  TORCH_INTERNAL_ASSERT(cu);
+  return cu;
 }
 
 ClassTypePtr ClassType::create(
     c10::optional<QualifiedName> qualifiedName,
-    std::shared_ptr<CompilationUnit> cu,
+    std::weak_ptr<CompilationUnit> cu,
     bool is_module) {
   return ClassTypePtr(new ClassType(std::move(qualifiedName), std::move(cu), is_module));
 }
@@ -69,7 +75,7 @@ const std::vector<Function*>& ClassType::methods() const {
 
 ClassType::ClassType(
     c10::optional<QualifiedName> name,
-    std::shared_ptr<CompilationUnit> cu,
+    std::weak_ptr<CompilationUnit> cu,
     bool is_module)
     : NamedType(TypeKind::ClassType, name), compilation_unit_(std::move(cu)) {
   if (is_module) {

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -332,7 +332,8 @@ void addFunctionToModule(Module& module, const StrongFunctionPtr& func) {
   auto v = graph->insertInput(0, "self");
   v->setType(module.module_object()->type());
   const auto name = QualifiedName(module.name(), "forward");
-  module.module_object()->compilation_unit()->create_function(name, graph);
+  auto method = module.class_compilation_unit()->create_function(name, graph);
+  module.type()->addMethod(method);
 }
 
 void initJitScriptBindings(PyObject* module) {
@@ -548,8 +549,7 @@ void initJitScriptBindings(PyObject* module) {
             PythonPrint(
                 ss,
                 source_ranges,
-                *self.class_compilation_unit(),
-                true,
+                self,
                 tensors,
                 classes,
                 false);
@@ -795,12 +795,11 @@ void initJitScriptBindings(PyObject* module) {
 
   m.def(
       "_jit_import_functions",
-      [](CompilationUnit& cu,
+      [](std::shared_ptr<CompilationUnit> cu,
          const std::string& src,
          const std::vector<at::Tensor>& constant_table) {
         import_functions(
             c10::nullopt,
-            *get_python_cu(),
             cu,
             std::make_shared<Source>(src),
             constant_table,
@@ -832,8 +831,7 @@ void initJitScriptBindings(PyObject* module) {
       PythonPrint(
           ss,
           source_ranges,
-          *self->class_compilation_unit(),
-          true,
+          *self,
           constants,
           classes,
           true);

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -430,15 +430,12 @@ struct TORCH_API Module {
       const c10::optional<at::ScalarType>& dtype,
       bool non_blocking);
 
-  static void clearMethods(c10::ivalue::Object* self) {
-    self->compilation_unit()->drop_all_functions();
-  }
   static ModulePtr create_module_object(std::string class_name) {
     auto cu = std::make_shared<CompilationUnit>();
     auto cls = ClassType::create(
         QualifiedName(std::move(class_name)), cu, /*is_module=*/true);
     return c10::ivalue::Object::create(
-        c10::StrongTypePtr(std::move(cu), std::move(cls)), 0, clearMethods);
+        c10::StrongTypePtr(std::move(cu), std::move(cls)), 0);
   }
   // mutable be we lazily initialize in module_object.
   mutable ModulePtr module_value_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22727 [jit] Make `load()` create only one CU
* **#22902 [jit] Make classtypes hold a weak_ptr to their CU**
* #22901 [jit] Make traced fns also go into the global python CU

This breaks the ownership cycle between modules and their functions.

Differential Revision: [D16278159](https://our.internmc.facebook.com/intern/diff/D16278159)