### PR TITLE
[wip][skip ci][jit] Add C++ API for the pickler

### DIFF
--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -1193,5 +1193,18 @@ void ExportModule(
   serializer.serialize(module, extra_files);
 }
 
+void saveIValue(const IValue& ivalue, const std::string& filename) {
+  // Pickle the tensor
+  Pickler pickler;
+  pickler.pushMetadata();
+  pickler.start();
+  pickler.addIValue(value);
+  pickler.finish();
+
+  // Write file
+  std::fstream output(filename, std::ios::out | std::ios::binary);
+  output.write(pickler.stack().data(), pickler.stack().size());
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/export.h
+++ b/torch/csrc/jit/export.h
@@ -51,6 +51,8 @@ TORCH_API void ExportModule(
     const std::string& filename,
     const script::ExtraFilesMap& metadata = script::ExtraFilesMap());
 
+TORCH_API void saveIValue(const IValue& ivalue, const std::string& filename);
+
 // Surrounding system can install an additional hook to produce extra files
 // with metadata based on environment every time a module is serialized.
 using ExportModuleExtraFilesHook =

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -457,5 +457,15 @@ script::Module load(
   return module;
 }
 
+IValue loadIValue(const std::string& filename) {
+  caffe2::serialize::PyTorchStreamReader reader;
+  at::DataPtr data_ptr;
+  size_t size;
+  std::tie(data_ptr, size) = reader.getRecord(name);
+
+  Unpickler unpickler(data_ptr.get(), size, &tensor_table_);
+  return unpickler.parse_ivalue_list();
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/import.h
+++ b/torch/csrc/jit/import.h
@@ -63,5 +63,7 @@ TORCH_API script::Module load(
     c10::optional<c10::Device> device = c10::nullopt,
     script::ExtraFilesMap& extra_files = default_extra_files);
 
+TORCH_API IValue loadIValue(const std::string& filename);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
This lets people save/load raw IValues in C++

This is currently not that useful since the `Unpickler` doesn't know how
to read `torch.save` style tensors, so this is blocked on that