### PR TITLE
Add warning for legacy autograd function

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -167,7 +167,6 @@ class TestAutograd(TestCase):
         MyFunction()(y).sum().backward()
         self.assertEqual(v.grad.data, torch.zeros(shape))
 
-    @unittest.skipIf(not PY3, "catch_warnings doesn't work in this case in Python 2.7")
     def test_legacy_function_deprecation_warning(self):
         with warnings.catch_warnings(record=True) as w:
             # Ensure warnings are being shown
@@ -180,6 +179,8 @@ class TestAutograd(TestCase):
 
                 def backward(self, grad_output):
                     return grad_output
+
+            MyFunction()(torch.randn(3, 4))
 
             # Check warning occurs
             self.assertIn(

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -168,16 +168,13 @@ class TestAutograd(TestCase):
         self.assertEqual(v.grad.data, torch.zeros(shape))
 
     def test_legacy_function_deprecation_warning(self):
-        class MyFunction(Function):
-            def forward(self, x):
-                return x
-
-            def backward(self, grad_output):
-                return grad_output
-
-        x = torch.randn(3, 5).requires_grad_()
         with warnings.catch_warnings(record=True) as warns:
-            MyFunction()(x)
+            class MyFunction(Function):
+                def forward(self, x):
+                    return x
+
+                def backward(self, grad_output):
+                    return grad_output
         self.assertIn(
             'Legacy autograd function with non-static forward method is deprecated',
             warns[0])

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -169,15 +169,21 @@ class TestAutograd(TestCase):
 
     def test_legacy_function_deprecation_warning(self):
         with warnings.catch_warnings(record=True) as w:
+            # Ensure warnings are being shown
+            warnings.simplefilter("always")
+
+            # Trigger Warning
             class MyFunction(Function):
                 def forward(self, x):
                     return x
 
                 def backward(self, grad_output):
                     return grad_output
-        self.assertIn(
-            'Legacy autograd function with non-static forward method is deprecated',
-            str(w[0].message))
+
+            # Check warning occurs
+            self.assertIn(
+                'Legacy autograd function with non-static forward method is deprecated',
+                str(w[0]))
 
     def test_invalid_gradients(self):
         class MyFunction(Function):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -167,6 +167,7 @@ class TestAutograd(TestCase):
         MyFunction()(y).sum().backward()
         self.assertEqual(v.grad.data, torch.zeros(shape))
 
+    @unittest.skipIf(not PY3, "catch_warnings doesn't work in this case in Python 2.7")
     def test_legacy_function_deprecation_warning(self):
         with warnings.catch_warnings(record=True) as w:
             # Ensure warnings are being shown

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -167,6 +167,21 @@ class TestAutograd(TestCase):
         MyFunction()(y).sum().backward()
         self.assertEqual(v.grad.data, torch.zeros(shape))
 
+    def test_legacy_function_deprecation_warning(self):
+        class MyFunction(Function):
+            def forward(self, x):
+                return x
+
+            def backward(self, grad_output):
+                return grad_output
+
+        x = torch.randn(3, 5)
+        with warnings.catch_warnings(record=True) as warns:
+            MyFunction()(x)
+        self.assertIn(
+            'Legacy autograd function with non-static forward method is deprecated',
+            warns[0])
+
     def test_invalid_gradients(self):
         class MyFunction(Function):
             @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -175,9 +175,9 @@ class TestAutograd(TestCase):
             def backward(self, grad_output):
                 return grad_output
 
-        x = torch.randn(3, 5)
+        x = torch.randn(3, 5).requires_grad_()
         with warnings.catch_warnings(record=True) as warns:
-            MyFunction()(x).sum().backward()
+            MyFunction()(x)
         self.assertIn(
             'Legacy autograd function with non-static forward method is deprecated',
             warns[0])

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -168,7 +168,7 @@ class TestAutograd(TestCase):
         self.assertEqual(v.grad.data, torch.zeros(shape))
 
     def test_legacy_function_deprecation_warning(self):
-        with warnings.catch_warnings(record=True) as warns:
+        with warnings.catch_warnings(record=True) as w:
             class MyFunction(Function):
                 def forward(self, x):
                     return x
@@ -177,7 +177,7 @@ class TestAutograd(TestCase):
                     return grad_output
         self.assertIn(
             'Legacy autograd function with non-static forward method is deprecated',
-            warns[0])
+            str(w[0].message))
 
     def test_invalid_gradients(self):
         class MyFunction(Function):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -177,7 +177,7 @@ class TestAutograd(TestCase):
 
         x = torch.randn(3, 5)
         with warnings.catch_warnings(record=True) as warns:
-            MyFunction()(x)
+            MyFunction()(x).sum().backward()
         self.assertIn(
             'Legacy autograd function with non-static forward method is deprecated',
             warns[0])

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -98,6 +98,10 @@ class FunctionMeta(type):
 
         # old-style functions
         if not has_static_forward:
+            warnings.warn('Legacy autograd function with non-static forward method is deprecated. '
+                          'Please use new-style autograd function with static forward method. '
+                          '(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)',
+                          DeprecationWarning)
             return super(FunctionMeta, cls).__init__(name, bases, attrs)
 
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -100,8 +100,7 @@ class FunctionMeta(type):
         if not has_static_forward:
             warnings.warn('Legacy autograd function with non-static forward method is deprecated. '
                           'Please use new-style autograd function with static forward method. '
-                          '(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)',
-                          DeprecationWarning)
+                          '(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)')
             return super(FunctionMeta, cls).__init__(name, bases, attrs)
 
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -98,9 +98,6 @@ class FunctionMeta(type):
 
         # old-style functions
         if not has_static_forward:
-            warnings.warn('Legacy autograd function with non-static forward method is deprecated. '
-                          'Please use new-style autograd function with static forward method. '
-                          '(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)')
             return super(FunctionMeta, cls).__init__(name, bases, attrs)
 
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -631,6 +631,10 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
     std::vector<c10::IValue>(),
     autograd::Function::peek_at_next_sequence_nr());
 
+  TORCH_WARN("Legacy autograd function with non-static forward method is deprecated. ",
+             "Please use new-style autograd function with static forward method. ",
+             "(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)");
+
   auto info_pair = unpack_input<true>(_inputs);
   auto& unpacked_input = info_pair.first;
   auto& input_info = info_pair.second;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -631,7 +631,7 @@ PyObject *THPFunction_do_forward(THPFunction *self, PyObject *_inputs)
     std::vector<c10::IValue>(),
     autograd::Function::peek_at_next_sequence_nr());
 
-  TORCH_WARN("Legacy autograd function with non-static forward method is deprecated. ",
+  TORCH_WARN("Legacy autograd function with non-static forward method is deprecated and will be removed in 1.3. ",
              "Please use new-style autograd function with static forward method. ",
              "(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)");
 


### PR DESCRIPTION
When working on https://github.com/pytorch/pytorch/pull/22762, we discovered that we haven't actually deprecated legacy autograd function. This PR puts up the deprecation warning for 1.2, with the goal to remove legacy function support completely in the near future.