### PR TITLE
Add support to print QTensor in cpp

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -238,7 +238,17 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     stream << "size:\n" << tensor_.sizes() << "\n";
     stream << "]";
   } else {
-    Tensor tensor = tensor_.to(kCPU, kDouble).contiguous();
+    Tensor tensor;
+    if (tensor_.is_quantized()) {
+      tensor = tensor_.dequantize().to(kCPU, kDouble).contiguous();
+      stream << "[ " << tensor_.toString() << "{}\n";
+      stream << "size: " << tensor_.sizes() << "\n";
+      stream << "scale: " << tensor_.q_scale() << "\n";
+      stream << "zero_point: " << tensor_.q_zero_point() << " ]\n";
+    }
+    else {
+      tensor = tensor_.to(kCPU, kDouble).contiguous();
+    }
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;
       stream << "[ " << tensor_.toString() << "{} ]";

--- a/torch/nn/quantized/__init__.py
+++ b/torch/nn/quantized/__init__.py
@@ -1,4 +1,2 @@
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from .modules import *  # noqa: F401
+from . import functional  # noqa: F401
+from .modules import *


### PR DESCRIPTION
Summary: Print quantized tensor by first dequantizing it and then printing. Also print the scale, zero_point. size and type of tensor.

Differential Revision: D16286397

