### PR TITLE
a convenience helper for logging nodes

### DIFF
--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -17,6 +17,40 @@ JitLoggingLevels jit_log_level() {
   return log_level;
 }
 
+template <typename T>
+void logArguments(std::ostream& ss, T t) {
+  ss << t;
+}
+
+template <>
+void logArguments<Value*>(std::ostream& ss, Value* v) {
+  ss << v->debugName();
+}
+
+template <typename T, typename... Rest>
+void logArguments(std::ostream& ss, T t, Rest... rest) {
+  logArguments(ss, t);
+  ss << ", ";
+  logArguments(ss, rest...);
+}
+
+template <typename... Args>
+std::string logNode(Node* node, Args... args) {
+  std::stringstream ss;
+  ss << "(";
+  for (size_t i = 0; i < node->outputs().size(); i++) {
+    if (i != 0) {
+      ss << ", ";
+    }
+    node->outputs()[i]->debugName();
+  }
+  ss << ") = ";
+  ss << node->kind().toQualString() << "(";
+  logArguments(ss, args...);
+  ss << ")";
+  return ss.str();
+}
+
 std::string debugValueOrDefault(const Node* n) {
   return n->outputs().size() > 0 ? n->outputs().at(0)->debugName() : "n/a";
 }

--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -21,6 +21,9 @@ enum class JitLoggingLevels {
   GRAPH_DEBUG,
 };
 
+template <typename... Args>
+std::string logNode(Node* node, Args... args);
+
 std::string debugValueOrDefault(const Node* n);
 
 JitLoggingLevels jit_log_level();


### PR DESCRIPTION
It's really helpful when crafting a trace message to be able to intermix real values and string values. For example, `Replacing %25 = aten::add(%24, 0) with %24`. If we just print the node it will show another random value for `0` . Or for eliding some arguments that aren't relevant for a particular transformation. For example, "Replacing %b in  TupleConstruct(%b, ...)".
`GRAPH_UPDATE("Replacing ", logNode(node, non_null_input, "0"), " with ", non_null_input)`