### PR TITLE
[jit] Better error message for using Python builtin_function_or_method

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -10782,7 +10782,7 @@ a")
 
     def test_unsupported_builtin_error(self):
         with self.assertRaisesRegex(RuntimeError,
-                                    "calling a python builtin_function_or_method which is currently not supported"):
+                                    "Python builtin <built-in function hypot> is currently"):
             @torch.jit.script
             def test_unsupported(a):
                 return math.hypot(a, 2.0)

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -123,7 +123,7 @@ struct AttributeError : public std::exception {
     std::stringstream ss;
     if (!defined) {
       ss << "required keyword attribute '" << name.toUnqualString()
-         << "' is undefined.";
+         << "' is undefined";
     } else {
       ss << "required keyword attribute '" << name.toUnqualString()
          << "' has the wrong type";

--- a/torch/csrc/jit/import_source.cpp
+++ b/torch/csrc/jit/import_source.cpp
@@ -93,7 +93,7 @@ struct ConstantTableValue : public SugaredValue {
     if (offset < 0 || size_t(offset) >= constants_.size()) {
       throw ErrorReport(loc) << "constant index " << offset
                              << " is out of bounds (constant table has "
-                             << constants_.size() << " entries).";
+                             << constants_.size() << " entries)";
     }
     Value* value = m.graph()->insertConstant(constants_[offset], nullptr, loc);
     return std::make_shared<SimpleValue>(value);
@@ -176,7 +176,7 @@ struct SourceImporter {
       throw ErrorReport(p_.lexer().cur().range)
           << "Attempting to load a script generated from a newer version of PyTorch. Maximum supported TorchScript version is "
           << CURRENT_OP_VERSION_SET
-          << " but the script being loaded is version " << version_ << ".";
+          << " but the script being loaded is version " << version_;
     }
   }
 

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -650,7 +650,7 @@ struct PythonPrintPass {
       throw script::ErrorReport(stmt.node()->sourceRange())
           << "loop cannot be printed as python "
           << "because it has gone through an optimization "
-          << "that combined while and for loops. File a bug.";
+          << "that combined while and for loops. File a bug";
     }
 
     bool emit_as_for_loop = loop_type == LoopView::For;
@@ -786,7 +786,7 @@ struct PythonPrintPass {
         if (enforce_importable_ && node->inputs().size() != 1) {
           throw script::ErrorReport(node->sourceRange())
               << "Exportable methods must have a single return value. "
-              << "Normal use of ScriptMethods should enforce this.";
+              << "Normal use of ScriptMethods should enforce this";
         }
         if (node->inputs().size() > 0) {
           indent();

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -170,7 +170,7 @@ class ShapePropagator {
     // prevented it
     std::stringstream ss;
     ss << "unable to create representative value for: " << type_->str()
-       << ". File a bug report.";
+       << ". File a bug report";
     throw std::runtime_error(ss.str());
   }
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1362,7 +1362,7 @@ struct to_ir {
     auto body = stmt.body();
     if (stmt.itrs().size() != 1) {
       throw ErrorReport(stmt)
-          << "List of iterables is not supported currently.";
+          << "List of iterables is not supported currently";
     }
     // Emit loop information for builtinFunction values like range(), zip(),
     // enumerate() or SimpleValue like List, Tensor, Dict, etc.
@@ -1464,19 +1464,19 @@ struct to_ir {
         num_starred++;
       } else {
         throw ErrorReport(assignee) << "lhs of assignment must be a variable, "
-                                    << "subscript, or starred expression.";
+                                    << "subscript, or starred expression";
       }
     }
 
     if (num_starred > 1) {
       throw ErrorReport(r)
-          << "Only one starred expression is allowed on the lhs.";
+          << "Only one starred expression is allowed on the lhs";
     }
 
     if (num_starred > 0 && num_normal_assign == 0) {
       throw ErrorReport(r) << "A Starred expression may only appear on the "
                            << "lhs within the presence of another non-starred"
-                           << " expression.";
+                           << " expression";
     }
 
     return num_starred;
@@ -1523,7 +1523,7 @@ struct to_ir {
       default:
         throw ErrorReport(stmt.lhs())
             << "unexpected expression on "
-            << "left-hand side of augmented assignment.";
+            << "left-hand side of augmented assignment";
     }
   }
 
@@ -1665,7 +1665,7 @@ struct to_ir {
         throw ErrorReport(subscriptExprs)
             << "Sliced expression not yet supported for"
             << " subscripted list augmented assignment. "
-            << "File a bug if you want this.";
+            << "File a bug if you want this";
       }
       const auto idxValue = emitExpr(subscriptExprs[0]);
 
@@ -1735,7 +1735,7 @@ struct to_ir {
         throw ErrorReport(subscript)
             << "Sliced expression not yet supported for"
             << " subscripted list assignment. "
-            << "File a bug if you want this.";
+            << "File a bug if you want this";
       }
 
       std::vector<NamedValue> args;
@@ -1798,7 +1798,7 @@ struct to_ir {
           auto var = Starred(assignee).expr();
           if (var.kind() != TK_VAR) {
             throw ErrorReport(var)
-                << "Cannot pack a tuple into a non-variable.";
+                << "Cannot pack a tuple into a non-variable";
           }
           size_t n_matched = outputs.size() - n_binders;
           ArrayRef<std::shared_ptr<SugaredValue>> outputs_ref = outputs;
@@ -1850,7 +1850,7 @@ struct to_ir {
         break;
       default:
         throw ErrorReport(stmt.lhs())
-            << "unexpected expression on left-hand side of assignment.";
+            << "unexpected expression on left-hand side of assignment";
     }
   }
 
@@ -2443,7 +2443,7 @@ struct to_ir {
       }
       case TK_STARRED: {
         throw ErrorReport(tree)
-            << "Unexpected starred expansion. File a bug report.";
+            << "Unexpected starred expansion. File a bug report";
       }
       case TK_CONST: {
         return emitConst(Const(tree));
@@ -2751,7 +2751,7 @@ struct to_ir {
     if (!sliceable->type()->isSubtypeOf(TensorType::get())) {
       throw ErrorReport(loc)
           << "Unsupported operation: attempted to use multidimensional "
-          << "indexing on a non-tensor type.";
+          << "indexing on a non-tensor type";
     }
 
     std::vector<Value*> tensor_indices;

--- a/torch/csrc/jit/script/final_returns.cpp
+++ b/torch/csrc/jit/script/final_returns.cpp
@@ -13,7 +13,7 @@ struct ReturnInfo {
 
 void checkNoReturn(const TreeRef& ref) {
   if (ref->kind() == TK_RETURN) {
-    throw ErrorReport(ref) << "return is not allowed from a loop.";
+    throw ErrorReport(ref) << "return is not allowed from a loop";
   }
   // do not search into first-class functions
   if (ref->kind() == TK_DEF) {
@@ -56,7 +56,7 @@ ReturnInfo makeReturnsFinal(
           if (!rest_final.returns_) {
             throw ErrorReport(if_stmt)
                 << "This if statement performs an early return, but the block of code that follows it does not return."
-                << " Early returns are only allowed when the block following them also returns.";
+                << " Early returns are only allowed when the block following them also returns";
           }
           changed.emplace_back(
               if_stmt.withNewBranches(true_final.stmts_, rest_final.stmts_));
@@ -77,7 +77,7 @@ ReturnInfo makeReturnsFinal(
         }
         throw ErrorReport(if_stmt)
             << "This if statement contains some paths that return and some paths that do not. "
-            << "If statements must either entirely return or never return.";
+            << "If statements must either entirely return or never return";
       } break;
       case TK_WHILE:
       case TK_FOR:

--- a/torch/csrc/jit/script/function_schema_parser.cpp
+++ b/torch/csrc/jit/script/function_schema_parser.cpp
@@ -194,7 +194,7 @@ struct SchemaParser {
         return c10::impl::toList(fmap(vs, [](IValue v) { return v.toBool(); }));
       default:
         throw ErrorReport(range)
-            << "lists are only supported for float or int types.";
+            << "lists are only supported for float or int types";
     }
   }
   IValue parseConstantList(TypeKind kind) {

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -487,10 +487,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
 
   if (py::isinstance<py::function>(obj)) {
     if (typeString(obj) == "builtin_function_or_method") {
-      throw ErrorReport(loc)
-          << "You are calling a python builtin_function_or_method "
-          << "which is currently not supported in Torchscript."
-          << "Please open a feature request to add it.";
+      throw ErrorReport(loc) << "Python builtin " << py::str(obj)
+                             << " is currently not supported in Torchscript.";
     }
   }
 

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -488,7 +488,7 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   if (py::isinstance<py::function>(obj)) {
     if (typeString(obj) == "builtin_function_or_method") {
       throw ErrorReport(loc) << "Python builtin " << py::str(obj)
-                             << " is currently not supported in Torchscript.";
+                             << " is currently not supported in Torchscript";
     }
   }
 

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -207,7 +207,7 @@ void SimpleValue::setAttr(
       if (insertPoint->owningBlock() != topLevelBlock) {
         throw ErrorReport(loc)
             << "First assignment cannot be in a control-flow block. "
-            << "Initialize the field at the top level first.";
+            << "Initialize the field at the top level first";
       }
     } else {
       throw ErrorReport(loc)
@@ -407,7 +407,7 @@ std::shared_ptr<SugaredValue> ClassValue::call(
   auto self = g.insertNode(g.createObject(type_))->output();
   if (!type_->getMethod("__init__")) {
     throw ErrorReport(loc)
-        << "Class " << type_->basename() << " does not have an __init__ function defined.";
+        << "Class " << type_->basename() << " does not have an __init__ function defined";
   }
 
   // Call the init function


### PR DESCRIPTION
* better error in `toSugaredValue`
* removes a bunch of periods on error messages, `ErrorReport` already adds a `:` at the end of the message
Differential Revision: [D16291079](https://our.internmc.facebook.com/intern/diff/16291079/)