### PR TITLE
Add support to print QTensor in cpp

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -246,7 +246,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     }
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;
-      stream << "[ " << tensor_.toString() << "{} ]";
+      stream << "[ " << tensor_.toString() << "{}";
     } else if(tensor.ndimension() == 1) {
       if (tensor.numel() > 0) {
         double scale;
@@ -260,12 +260,12 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
           stream << std::setw(sz) << tensor_p[i]/scale << std::endl;
         }
       }
-      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "} ]";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "}";
     } else if(tensor.ndimension() == 2) {
       if (tensor.numel() > 0) {
         __printMatrix(stream, tensor, linesize, 0);
       }
-      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "} ]";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "}";
     } else {
       if (tensor.numel() > 0) {
         __printTensor(stream, tensor, linesize);
@@ -274,7 +274,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       for(int64_t i = 1; i < tensor.ndimension(); i++) {
         stream << "," << tensor.size(i);
       }
-      stream << "} ]";
+      stream << "}";
     }
     if (tensor_.is_quantized()) {
       stream << ", qscheme: " << toString(tensor_.qscheme());

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -277,9 +277,9 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       stream << "} ]";
     }
     if (tensor_.is_quantized()) {
+      stream << ", qscheme: " << toString(tensor_.qscheme());
       stream << ", scale: " << tensor_.q_scale();
       stream << ", zero_point: " << tensor_.q_zero_point();
-      stream << ", qscheme: " << toString(tensor_.qscheme());
     }
     stream << " ]";
   }

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -246,7 +246,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     }
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;
-      stream << "[ " << tensor_.toString() << "{}";
+      stream << "[ " << tensor_.toString() << "{} ]";
     } else if(tensor.ndimension() == 1) {
       if (tensor.numel() > 0) {
         double scale;
@@ -260,12 +260,12 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
           stream << std::setw(sz) << tensor_p[i]/scale << std::endl;
         }
       }
-      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "}";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "} ]";
     } else if(tensor.ndimension() == 2) {
       if (tensor.numel() > 0) {
         __printMatrix(stream, tensor, linesize, 0);
       }
-      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "}";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "} ]";
     } else {
       if (tensor.numel() > 0) {
         __printTensor(stream, tensor, linesize);
@@ -274,11 +274,12 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       for(int64_t i = 1; i < tensor.ndimension(); i++) {
         stream << "," << tensor.size(i);
       }
-      stream << "}";
+      stream << "} ]";
     }
     if (tensor_.is_quantized()) {
       stream << ", scale: " << tensor_.q_scale();
       stream << ", zero_point: " << tensor_.q_zero_point();
+      stream << ", qscheme: " << toString(tensor_.qscheme());
     }
     stream << " ]";
   }

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -238,10 +238,15 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
     stream << "size:\n" << tensor_.sizes() << "\n";
     stream << "]";
   } else {
-    Tensor tensor = tensor_.to(kCPU, kDouble).contiguous();
+    Tensor tensor;
+    if (tensor_.is_quantized()) {
+      Tensor tensor = tensor_.dequantize().to(kCPU, kDouble).contiguous();
+    } else {
+      tensor = tensor_.to(kCPU, kDouble).contiguous();
+    }
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;
-      stream << "[ " << tensor_.toString() << "{} ]";
+      stream << "[ " << tensor_.toString() << "{}";
     } else if(tensor.ndimension() == 1) {
       if (tensor.numel() > 0) {
         double scale;
@@ -255,12 +260,12 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
           stream << std::setw(sz) << tensor_p[i]/scale << std::endl;
         }
       }
-      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "} ]";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "}";
     } else if(tensor.ndimension() == 2) {
       if (tensor.numel() > 0) {
         __printMatrix(stream, tensor, linesize, 0);
       }
-      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "} ]";
+      stream << "[ " << tensor_.toString() << "{" << tensor.size(0) << "," <<  tensor.size(1) << "}";
     } else {
       if (tensor.numel() > 0) {
         __printTensor(stream, tensor, linesize);
@@ -269,8 +274,13 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       for(int64_t i = 1; i < tensor.ndimension(); i++) {
         stream << "," << tensor.size(i);
       }
-      stream << "} ]";
+      stream << "}";
     }
+    if (tensor_.is_quantized()) {
+      stream << ", scale: " << tensor_.q_scale();
+      stream << ", zero_point: " << tensor_.q_zero_point();
+    }
+    stream << " ]";
   }
   return stream;
 }


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#22950 Add support to print QTensor in cpp**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D16286397/)

Print quantized tensor by first dequantizing it and then printing. Also print the scale, zero_point. size and type of tensor.

Differential Revision: [D16286397](https://our.internmc.facebook.com/intern/diff/D16286397/)