### PR TITLE
always restore dlopen flag in dyndep

### DIFF
--- a/caffe2/python/extension_loader.py
+++ b/caffe2/python/extension_loader.py
@@ -18,6 +18,12 @@ def DlopenGuard(extra_flags=ctypes.RTLD_GLOBAL):
     if _set_global_flags:
         old_flags = sys.getdlopenflags()
         sys.setdlopenflags(old_flags | extra_flags)
-    yield
-    if _set_global_flags:
-        sys.setdlopenflags(old_flags)
+
+    # in case we dlopen something that doesn't exist, yield will fail and throw;
+    # we need to remember reset the old flags to clean up, otherwise RTLD_GLOBAL
+    # flag will stick around and create symbol conflict problems
+    try:
+        yield
+    finally:
+        if _set_global_flags:
+            sys.setdlopenflags(old_flags)


### PR DESCRIPTION
Summary: When we use `extension_loader.DlopenGuard()` to dyndep or import modules, it sets a `RTLD_GLOBAL` flag, and restores the original flags after the `yield`. However, if the modules is not there, yield will fail, and the flags won't be restored, creating all kinds of symbol conflict problems.

Reviewed By: bddppq

Differential Revision: D16311949

