### PR TITLE
Fixed deprecated use of yaml.load

### DIFF
--- a/aten/src/ATen/cwrap_parser.py
+++ b/aten/src/ATen/cwrap_parser.py
@@ -1,4 +1,9 @@
 import yaml
+try:
+    # use faster C loader if available
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 
 # follows similar logic to cwrap, ignores !inc, and just looks for [[]]
 
@@ -15,7 +20,7 @@ def parse(filename):
                 in_declaration = True
             elif line == ']]':
                 in_declaration = False
-                declaration = yaml.load('\n'.join(declaration_lines))
+                declaration = yaml.load('\n'.join(declaration_lines), Loader=Loader)
                 declarations.append(declaration)
             elif in_declaration:
                 declaration_lines.append(line)

--- a/tools/cwrap/cwrap.py
+++ b/tools/cwrap/cwrap.py
@@ -1,5 +1,10 @@
 import os
 import yaml
+try:
+    # use faster C loader if available
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 from string import Template
 from copy import deepcopy
 from .plugins import ArgcountChecker, OptionalArguments, ArgumentReferences, \
@@ -88,7 +93,7 @@ class cwrap(object):
                 in_declaration = True
             elif line == ']]':
                 in_declaration = False
-                declaration = yaml.load('\n'.join(declaration_lines))
+                declaration = yaml.load('\n'.join(declaration_lines), Loader=Loader)
                 cwrap_common.set_declaration_defaults(declaration)
 
                 # Pass declaration in a list - maybe some plugins want to add


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22988 Fix some misc warnings
* #22987 Fixed all BINARY_COMP implicit signed/unsigned comparisons
* #22986 Fix DCHECK_LT unsigned to signed comparisons
* **#22985 Fixed deprecated use of yaml.load**

Differential Revision: [D16425112](https://our.internmc.facebook.com/intern/diff/D16425112)