### PR TITLE
Remove dead Decref struct.

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1079,13 +1079,6 @@ bool THPFunction_initModule(PyObject *module)
   return true;
 }
 
-struct Decref {
-  void operator()(PyFunction* p) const {
-    AutoGIL gil;
-    Py_DECREF(p->obj);
-  }
-};
-
 // Similar to shared_from_this. There's a problem that the Python object
 // and its cdata depend on each other being alive, so we can't keep
 // shared_ptrs as members, but we'd like to be able to manage the lifetime of


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22998 Avoid weak_ptr::lock() when shared_ptr is provably live; more error checking.
* #22997 Remove dead Function::get_shared_ptr.
* **#22996 Remove dead Decref struct.**
* #22983 Invert ownership between PyFunction and THPFunction.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>