### PR TITLE
Remove dead Function::get_shared_ptr.

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -201,13 +201,6 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
     return sequence_nr_;
   }
 
-  /// Returns a shared pointer to `this`. `PyFunction`s are not managed by
-  /// `shared_ptr`s by default, but are bound to the lifetime of their Python
-  /// object instead.
-  virtual std::shared_ptr<Function> get_shared_ptr() {
-    return shared_from_this();
-  }
-
   /// Returns the name of the dynamic type of the function, for debugging.
   virtual std::string name() const;
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -229,10 +229,6 @@ auto PyFunction::name() const -> std::string {
   return name;
 }
 
-auto PyFunction::get_shared_ptr() -> std::shared_ptr<Function> {
-  return THPFunction_asFunction((THPFunction*)obj);
-}
-
 }} // namespace torch::autograd
 
 // Traverse and clear are required for supporting Python's GC cycle handling.

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -40,7 +40,6 @@ struct PyFunction : public Function {
 
   void release_variables() override;
   std::string name() const override;
-  std::shared_ptr<Function> get_shared_ptr() override;
   bool is_traceable() override;
 
   // THPFunction this Function is wrapping.  Owning!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #22998 Avoid weak_ptr::lock() when shared_ptr is provably live; more error checking.
* **#22997 Remove dead Function::get_shared_ptr.**
* #22996 Remove dead Decref struct.
* #22983 Invert ownership between PyFunction and THPFunction.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>