### PR TITLE
Avoid weak_ptr::lock() when shared_ptr is provably live; more error checking.

### DIFF
--- a/torch/csrc/autograd/functions/pybind.h
+++ b/torch/csrc/autograd/functions/pybind.h
@@ -11,21 +11,4 @@ namespace py = pybind11;
 
 namespace pybind11 { namespace detail {
 
-// handle Python <-> torch::autograd::Function conversions
-template <> struct type_caster<std::shared_ptr<torch::autograd::Function>> {
-public:
-  PYBIND11_TYPE_CASTER(std::shared_ptr<torch::autograd::Function>, _("std::shared_ptr<torch::autograd::Function>"));
-
-  bool load(handle src, bool) {
-    if (!THPFunction_Check(src.ptr())) return false;
-    value = THPFunction_asFunction((THPFunction*)src.ptr());
-    return true;
-  }
-  static handle cast(std::shared_ptr<torch::autograd::Function> src, return_value_policy /* policy */, handle /* parent */) {
-    auto fn = functionToPyObject(std::move(src));
-    return handle(fn);
-  }
-};
-
-
 }} // namespace pybind11::detail

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -107,9 +107,6 @@ bool THPFunction_initModule(PyObject *module);
 extern PyTypeObject THPFunctionType;
 extern PyObject *THPFunctionClass;
 
-// XXX: this function requires the GIL (it can have side effects).
-std::shared_ptr<torch::autograd::PyFunction> THPFunction_asFunction(THPFunction* self);
-
 inline bool THPFunction_Check(PyObject* obj) {
   return PyObject_IsInstance(obj, (PyObject*)&THPFunctionType);
 }

--- a/torch/csrc/autograd/python_legacy_variable.cpp
+++ b/torch/csrc/autograd/python_legacy_variable.cpp
@@ -68,13 +68,11 @@ static PyObject *THPVariable_pynew(PyTypeObject* type, PyObject *args, PyObject 
   // ```
   var.unsafeGetTensorImpl()->set_allow_tensor_metadata_change(true);
 
-  if (grad_fn) {
-    auto grad_fn_ = THPFunction_asFunction((THPFunction*)grad_fn);
-    Edge edge(grad_fn_, grad_fn_->add_input_metadata(var));
-    var.set_gradient_edge(std::move(edge));
-  } else {
-    var.set_requires_grad(requires_grad);
-  }
+  TORCH_CHECK(!grad_fn,
+    "_grad_fn argument to legacy Variable constructor is no longer supported.  "
+    "Instead, please invoke your _grad_fn to produce a variable with it as the "
+    "_grad_fn.");
+  var.set_requires_grad(requires_grad);
 
   if (name) {
     var.set_name(name);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -54,13 +54,6 @@ static PyObject* THPVariable_NewWithVar(PyTypeObject* type, Variable var)
     auto v = (THPVariable*) obj;
     new (&v->cdata) Variable(std::move(var));
     v->cdata.set_pyobj(obj);
-    if (auto fn = dynamic_cast<PyFunction*>(v->cdata.grad_fn_unsafe())) {
-      // Create a new reference to the THPFunction. This ensures that ref count
-      // of the THPFunction is at least the number of referring THPVariables.
-      const auto output_nr = v->cdata.output_nr();
-      auto grad_fn = THPFunction_asFunction((THPFunction*)fn->obj);
-      v->cdata.set_gradient_edge({std::move(grad_fn), output_nr});
-    }
   }
   return obj;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#22998 Avoid weak_ptr::lock() when shared_ptr is provably live; more error checking.**
* #22997 Remove dead Function::get_shared_ptr.
* #22996 Remove dead Decref struct.
* #22983 Invert ownership between PyFunction and THPFunction.

In the original iteration of the patch, I used lock() everywhere to minimize
the amount of code I have to modify.  In this patch, I now eliminate as many
lock()s as I can, when the caller is known to have a strong reference to the
PyFunction, and pass that directly.

Along the way, I also bulk up our error messages for checking the result
of the weak pointer dereference.  Some of these cases can be triggered
by zany use of legacy autograd function API; might as well let people know
what they've done wrong.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>