### PR TITLE
Enhance tensor indexSelect and add_out_dense_sparse_cpu performance

### DIFF
--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -221,8 +221,12 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
 
   index = THLongTensor_newContiguous(index);
   index_data = THLongTensor_data(index);
+  bool src_is_contiguous = src->is_contiguous();
+  if (!src_is_contiguous) {
+    src = THTensor_(newContiguous)(src);
+  }
 
-  if (dim == 0 && THTensor_(isContiguous)(src) && THTensor_(isContiguous)(tensor))
+  if (dim == 0 && THTensor_(isContiguous)(tensor))
   {
     tensor_data = tensor->data<scalar_t>();
     src_data = src->data<scalar_t>();
@@ -282,6 +286,9 @@ void THTensor_(indexSelect)(THTensor *tensor, THTensor *src, int dim, THLongTens
     }
   }
 
+  if (!src_is_contiguous) {
+    c10::raw::intrusive_ptr::decref(src);
+  }
   THLongTensor_free(index);
 }
 


### PR DESCRIPTION
This is to enhance Tensor indexSelect and add_out_dense_sparse_cpu performance
1) THTensorEvenMoreMath.cpp
    To make the src become continuous can make Tensor indexSelect go into the parallelized path almost thus reduced the time mostly on this function
2) SparseTensorMath.cpp
    Enhanced handling on add_out_dense_sparse_cpu for the hybrid sparse tensor. 