### PR TITLE
[C++ API] Fix SGD memory leak when there is weight_decay

### DIFF
--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -26,6 +26,7 @@ void SGD::step() {
     auto update = p.grad();
 
     if (options.weight_decay_ > 0) {
+      NoGradGuard guard;
       update += options.weight_decay_ * p;
     }
 


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/20146. I am working on another PR that adds CPU and CUDA memory leak checking to all C++ API tests.