### PR TITLE
Switch from KaTeX to imgmath for documentation rendering.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,20 +52,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.katex',
+    'sphinx.ext.imgmath',
 ]
-
-# katex options
-#
-#
-
-katex_options = r'''
-delimiters : [
-   {left: "$$", right: "$$", display: true},
-   {left: "\\(", right: "\\)", display: false},
-   {left: "\\[", right: "\\]", display: true}
-]
-'''
 
 napoleon_use_ivar = True
 
@@ -121,12 +109,6 @@ todo_include_todos = True
 autodoc_inherit_docstrings = False
 
 
-# -- katex javascript in header
-#
-#    def setup(app):
-#    app.add_javascript("https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js")
-
-
 # -- Options for HTML output ----------------------------------------------
 #
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -167,7 +149,6 @@ def setup(app):
     # and can be moved outside of this function (and the setup(app) function
     # can be deleted).
     html_css_files = [
-        'https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css'
     ]
 
     # In Sphinx 1.8 it was renamed to `add_css_file`, 1.7 and prior it is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23025 Switch from KaTeX to imgmath for documentation rendering.**

Emprically, KaTeX is bad user experience for users who don't have
powerful CPUs.  With x4 CPU slowdown emulation in Chrome, I notice
that imgmath takes a third of the time to render than KaTeX.

This requires https://github.com/pytorch/pytorch_sphinx_theme/pull/48 to
be landed first, as otherwise the style sheet renders img incorrectly.

Might be one step on the way to solving #20984.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16441000](https://our.internmc.facebook.com/intern/diff/D16441000)