### PR TITLE
Fix get_all_math_dtypes for device='cuda' retuning None

### DIFF
--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -96,10 +96,10 @@ def get_all_math_dtypes(device):
               torch.float32, torch.float64]
 
     # torch.float16 is a math dtype on cuda but not cpu.
-    if device == 'cpu':
-        return dtypes
-    else:
-        return dtypes.append(torch.float16)
+    if device.startswith('cuda'):
+        dtypes.append(torch.float16)
+
+    return dtypes
 
 
 def get_all_device_types():


### PR DESCRIPTION
This PR fixes the invalid None return when calling get_all_math_dtype(device='cuda').

Issue came from the __append__ method which doesn't have any return value used in `return dtypes.append(...)`