### PR TITLE
Add get_accessed_features function to ModelLayer class

### DIFF
--- a/caffe2/python/layers/feature_sparse_to_dense.py
+++ b/caffe2/python/layers/feature_sparse_to_dense.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from caffe2.python import schema
-from caffe2.python.layers.layers import ModelLayer
+from caffe2.python.layers.layers import ModelLayer, AccessedFeatures
 
 
 class FeatureSparseToDense(ModelLayer):
@@ -294,3 +294,16 @@ class FeatureSparseToDense(ModelLayer):
             if feature_specs.feature_type == "FLOAT":
                 metadata[-1][0]["cardinality"] = 1
         return metadata
+
+    def get_accessed_features(self):
+        accessed_features = {}
+
+        # The features that are accessed are just those features that appear in
+        # the input specs
+        for field, feature_specs in self.input_specs:
+            accessed_features[field] = AccessedFeatures(
+                feature_specs.feature_type,
+                set(feature_specs.feature_ids)
+            )
+
+        return accessed_features

--- a/caffe2/python/layers/layers.py
+++ b/caffe2/python/layers/layers.py
@@ -243,6 +243,10 @@ def is_request_only_scalar(scalar):
             return False
     return True
 
+# Contains features accessed in a model layer of a given type
+# type: A string representing the kind of feature, consistent with FeatureSpec
+# ids: A set of feature IDs that are accessed in the model layer
+AccessedFeatures = namedtuple("AccessedFeatures", ["type", "ids"])
 
 class ModelLayer(object):
     def __init__(
@@ -354,6 +358,13 @@ class ModelLayer(object):
 
     def get_memory_usage(self):
         return 0
+
+    def get_accessed_features(self):
+        """
+        Return a map from field to AccessedFeatures, the map should contain all
+        features accessed in the model layer
+        """
+        return {}
 
     def add_init_params(self, init_net):
         """


### PR DESCRIPTION
Summary:
We need a way to figure get a complete list fo features that are used in training a model.  One way to do this is to make it possible to get the list of features used in each Model Layer.  Then once the model is complete we can go through the layers and aggregate the features.

I've introduced a function to expose that information here, get_accessed_features, and implemented it in the FeatureSparseToDense layer to start with.

I've tried to include the minimum amount of information to make this useful, while making it easy to integrate into the variety of model layers.  This is, for example, why AccessedFeatures does not contain feature_names which is not always present in a model layer.  I debated whether or not to include feature_type, but I think that's useful enough, and easy enough to figure out in a model layer, that it's worth including.

Differential Revision: D16361015

