### PR TITLE
[fix] conv module missing return

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -339,8 +339,8 @@ class Conv2d(_ConvNd):
             False, _pair(0), groups, bias, padding_mode)
 
     def forward(self, input):
-        conv2d_forward(input, self.padding_mode, self.padding, self.weight,
-                       self.bias, self.stride, self.dilation, self.groups)
+        return conv2d_forward(input, self.padding_mode, self.padding, self.weight,
+                              self.bias, self.stride, self.dilation, self.groups)
 
 class Conv3d(_ConvNd):
     r"""Applies a 3D convolution over an input signal composed of several input


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23058 [fix] conv module missing return**

att

Differential Revision: [D16373996](https://our.internmc.facebook.com/intern/diff/D16373996/)