### PR TITLE
Debug MSELoss: wrong document

### DIFF
--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -388,7 +388,7 @@ class MSELoss(_Loss):
     :math:`x` and :math:`y` are tensors of arbitrary shapes with a total
     of :math:`n` elements each.
 
-    The sum operation still operates over all the elements, and divides by :math:`n`.
+    The mean operation still operates over all the elements, and divides by :math:`n`.
 
     The division by :math:`n` can be avoided if one sets ``reduction = 'sum'``.
 


### PR DESCRIPTION
Original: The **sum** operation still operates over all the elements, and divides by :math:`n`.
sum --> mean

