### PR TITLE
Refactor named inference rule for reductions

### DIFF
--- a/aten/src/ATen/NamedTensor.h
+++ b/aten/src/ATen/NamedTensor.h
@@ -23,6 +23,8 @@ struct CAFFE2_API NamedTensorMeta : public c10::NamedTensorMetaInterface {
 
   explicit NamedTensorMeta(DimnameList names)
     : names_(names.vec()) {}
+  explicit NamedTensorMeta(std::vector<Dimname>&& names)
+    : names_(std::move(names)) {}
 
   std::unique_ptr<c10::NamedTensorMetaInterface> clone() const override {
     return torch::make_unique<NamedTensorMeta>(names_);
@@ -36,6 +38,11 @@ struct CAFFE2_API NamedTensorMeta : public c10::NamedTensorMetaInterface {
     std::copy(new_names.begin(), new_names.end(), names_.begin());
   }
 
+  void set_names_(std::vector<Dimname>&& new_names) {
+    TORCH_INTERNAL_ASSERT(new_names.size() == names_.size());
+    names_ = std::move(new_names);
+  }
+
  private:
   std::vector<Dimname> names_;
 };
@@ -45,6 +52,7 @@ namespace impl {
 // Some helper functions on TensorImpl. Useful for working with names in TH.
 // XXX: Ideally these would exist as methods on TensorImpl
 CAFFE2_API void internal_set_names_inplace(TensorImpl* impl, optional<DimnameList> names);
+CAFFE2_API void internal_set_names_inplace(TensorImpl* impl, std::vector<Dimname>&& names, bool validate_names);
 CAFFE2_API optional<DimnameList> internal_get_names(TensorImpl* impl);
 CAFFE2_API bool internal_is_named(TensorImpl* impl);
 

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -14,6 +14,7 @@ inline bool has_names(TensorList tensors) {
 
 // Sets the names of `tensor` to be `names`.
 CAFFE2_API void internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names);
+CAFFE2_API void internal_set_names_inplace(Tensor& tensor, std::vector<Dimname>&& names, bool validate_names);
 
 // Converts dim to an positional index. Errors if `dim` cannot be used to
 // refer to any dimension of tensor.
@@ -32,9 +33,10 @@ unify_from_right(optional<DimnameList> names, optional<DimnameList> other);
 
 namespace namedinference {
 
-optional<std::vector<Dimname>> erase_name(optional<DimnameList> self_names, int64_t dim);
 void propagate_names(Tensor& result, const Tensor& src);
 void propagate_names(TensorImpl* result, /*const */TensorImpl* src);
+
+void propagate_names_except(Tensor& result, const Tensor& src, IntArrayRef excluded_idxs);
 
 } // namespace namedinference
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -459,9 +459,6 @@ Tensor select(const Tensor& self, int64_t dim, int64_t index) {
     AT_INDEX_ERROR("select(): index ", index, " out of range for tensor of size ",
                    self.sizes(), " at dimension ", dim);
   }
-#ifdef BUILD_NAMEDTENSOR
-  const auto outnames = namedinference::erase_name(self.names(), dim);
-#endif
   if (index < 0) {
     index += size;
   }
@@ -472,9 +469,7 @@ Tensor select(const Tensor& self, int64_t dim, int64_t index) {
   strides.erase(strides.begin() + dim);
   auto result = self.as_strided(sizes, strides, storage_offset);
 #ifdef BUILD_NAMEDTENSOR
-  if (outnames) {
-    internal_set_names_inplace(result, *outnames);
-  }
+  namedinference::propagate_names_except(result, self, {dim});
 #endif
   return result;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23172 Implement tensor.set_names_, tensor.names setter
* #23106 Named inference rule for torch.prod
* #23081 Implement named inference rule for torch.sum
* **#23075 Refactor named inference rule for reductions**
* #22989 Implement tensor.size(Dimname), tensor.stride(Dimname)

Performed the following changes:
- Made it possible to std::move a vector<Dimname> directly into
NamedTensorMeta for efficiency. This is useful because reductions end up
creating a new vector<Dimname>; the previous ctor would copy this
vector<Dimname>.
- Cleaned up the API

Test Plan
- `python test/test_namedtensor.py -v` [namedtensor ci]

Differential Revision: [](https://our.internmc.facebook.com/intern/diff/)

Differential Revision: [D16419173](https://our.internmc.facebook.com/intern/diff/D16419173)