### PR TITLE
[reland][qat] Quantization aware training in eager mode

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -1,13 +1,53 @@
 r"""Importing this file includes common utility methods and base clases for
 checking quantization api and properties of resulting modules.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import torch.nn.quantized as nnq
 from common_utils import TestCase
 from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, default_qconfig
 
+def test_only_eval_fn(model, calib_data):
+    r"""
+    Default evaluation function takes a torch.utils.data.Dataset or a list of
+    input Tensors and run the model on the dataset
+    """
+    total, correct = 0, 0
+    for data, target in calib_data:
+        output = model(data)
+        _, predicted = torch.max(output, 1)
+        total += target.size(0)
+        correct += (predicted == target).sum().item()
+    return correct / total
+
+_default_loss_fn = torch.nn.CrossEntropyLoss()
+def test_only_train_fn(model, train_data, loss_fn=_default_loss_fn):
+    r"""
+    Default train function takes a torch.utils.data.Dataset and train the model
+    on the dataset
+    """
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+    train_loss, correct, total = 0, 0, 0
+    for i in range(10):
+        model.train()
+        for data, target in train_data:
+            optimizer.zero_grad()
+            output = model(data)
+            loss = loss_fn(output, target)
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
+            _, predicted = torch.max(output, 1)
+            total += target.size(0)
+            correct += (predicted == target).sum().item()
+    return train_loss, correct, total
+
+
 # QuantizationTestCase used as a base class for testing quantization on modules
 class QuantizationTestCase(TestCase):
+    def setUp(self):
+        self.calib_data = [(torch.rand(20, 5, dtype=torch.float), torch.randint(0, 1, (20,), dtype=torch.long)) for _ in range(20)]
+        self.train_data = [(torch.rand(20, 5, dtype=torch.float), torch.randint(0, 1, (20,), dtype=torch.long)) for _ in range(20)]
 
     def checkNoPrepModules(self, module):
         r"""Checks the module does not contain child
@@ -134,4 +174,21 @@ class ManualQuantModel(torch.nn.Module):
     def forward(self, x):
         x = self.quant(x)
         x = self.fc(x)
+        return self.dequant(x)
+
+class ManualQATModel(torch.nn.Module):
+    r"""A Module with manually inserted `QuantStub` and `DeQuantStub`
+    """
+    def __init__(self):
+        super(ManualQATModel, self).__init__()
+        self.qconfig = default_qconfig
+        self.quant = QuantStub()
+        self.dequant = DeQuantStub()
+        self.fc1 = torch.nn.Linear(5, 5).to(dtype=torch.float)
+        self.fc2 = torch.nn.Linear(5, 10).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.quant(x)
+        x = self.fc1(x)
+        x = self.fc2(x)
         return self.dequant(x)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -1,23 +1,21 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch
 import torch.nn.quantized as nnq
-from torch.quantization import default_eval_fn, QConfig, default_qconfig, \
-    default_observer, quantize, prepare, convert
-
+from torch.quantization import QConfig, \
+    default_qconfig, default_qat_qconfig, default_observer, default_weight_observer, \
+    quantize, prepare, convert, prepare_qat, quantize_qat
 from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
-    TwoLayerLinearModel, NestedModel, WrappedModel, ManualQuantModel
+    TwoLayerLinearModel, NestedModel, WrappedModel, ManualQuantModel, \
+    ManualQATModel, test_only_eval_fn, test_only_train_fn
 
-
-calib_data = [torch.rand(20, 5, dtype=torch.float) for _ in range(20)]
-
-class ModelQuantizeAPITest(QuantizationTestCase):
+class PostTrainingQuantTest(QuantizationTestCase):
 
     def test_single_layer(self):
         r"""Quantize SingleLayerLinearModel which has one Linear module, make sure it is swapped
         to nnq.Linear which is the quantized version of the module
         """
-        model = SingleLayerLinearModel()
+        model = SingleLayerLinearModel().eval()
         qconfig_dict = {
             '': default_qconfig
         }
@@ -27,26 +25,26 @@ class ModelQuantizeAPITest(QuantizationTestCase):
         self.checkHasPrepModules(model.fc1)
         self.checkObservers(model)
 
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
             self.checkNoPrepModules(model)
             self.checkHasPrepModules(model.fc1)
             self.checkQuantizedLinear(model.fc1)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(SingleLayerLinearModel(), default_eval_fn, calib_data, qconfig_dict)
+        model = quantize(SingleLayerLinearModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
         checkQuantized(model)
 
     def test_two_layers(self):
         r"""TwoLayerLinearModel has two Linear modules but we only quantize the second one
         `fc2`, and `fc1`is not quantized
         """
-        model = TwoLayerLinearModel()
+        model = TwoLayerLinearModel().eval()
         qconfig_dict = {
             'fc2': default_qconfig
         }
@@ -57,7 +55,7 @@ class ModelQuantizeAPITest(QuantizationTestCase):
         self.checkNoPrepModules(model.fc1)
         self.checkHasPrepModules(model.fc2)
 
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
@@ -66,19 +64,19 @@ class ModelQuantizeAPITest(QuantizationTestCase):
             self.checkHasPrepModules(model.fc2)
             self.assertEqual(type(model.fc1), torch.nn.Linear)
             self.checkQuantizedLinear(model.fc2)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(TwoLayerLinearModel(), default_eval_fn, calib_data, qconfig_dict)
+        model = quantize(TwoLayerLinearModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
         checkQuantized(model)
 
     def test_nested1(self):
         r"""Test quantization for nested model, top level 'fc3' and
         'fc1' of submodule 'sub2', 'sub2.fc2' is not quantized
         """
-        model = NestedModel()
+        model = NestedModel().eval()
         qconfig_dict = {
             'fc3': default_qconfig,
             'sub2.fc1': default_qconfig
@@ -98,7 +96,7 @@ class ModelQuantizeAPITest(QuantizationTestCase):
 
         model = prepare(model, qconfig_dict)
         checkPrepModules(model, True)
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
@@ -107,12 +105,12 @@ class ModelQuantizeAPITest(QuantizationTestCase):
             self.checkQuantizedLinear(model.fc3)
             self.checkQuantizedLinear(model.sub2.fc1)
             self.checkLinear(model.sub2.fc2)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(NestedModel(), default_eval_fn, calib_data, qconfig_dict)
+        model = quantize(NestedModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
         checkQuantized(model)
 
 
@@ -123,7 +121,7 @@ class ModelQuantizeAPITest(QuantizationTestCase):
         QuantStub/DeQuantStub, see `test_quant_dequant_wrapper` and
         `test_manual`
         """
-        model = NestedModel()
+        model = NestedModel().eval()
         qconfig_dict = {
             'fc3': default_qconfig,
             'sub2': default_qconfig
@@ -144,7 +142,7 @@ class ModelQuantizeAPITest(QuantizationTestCase):
 
         checkPrepModules(model, True)
 
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
@@ -154,24 +152,24 @@ class ModelQuantizeAPITest(QuantizationTestCase):
             self.checkQuantizedLinear(model.sub2.fc1)
             self.checkQuantizedLinear(model.sub2.fc2)
             self.checkQuantizedLinear(model.fc3)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(NestedModel(), default_eval_fn, calib_data, qconfig_dict)
+        model = quantize(NestedModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
         checkQuantized(model)
 
     def test_nested3(self):
         r"""More complicated nested test case with child qconfig overrides
         parent qconfig
         """
-        model = NestedModel()
+        model = NestedModel().eval()
         custum_options = {
             'dtype': torch.quint8,
             'qscheme': torch.per_tensor_affine
         }
-        custom_qconfig = QConfig(weight=default_observer(),
+        custom_qconfig = QConfig(weight=default_weight_observer(),
                                  activation=default_observer(**custum_options))
         qconfig_dict = {
             'fc3': default_qconfig,
@@ -194,7 +192,7 @@ class ModelQuantizeAPITest(QuantizationTestCase):
 
         checkPrepModules(model, True)
 
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
@@ -202,26 +200,26 @@ class ModelQuantizeAPITest(QuantizationTestCase):
             self.checkQuantizedLinear(model.sub2.fc1)
             self.checkQuantizedLinear(model.sub2.fc2)
             self.checkQuantizedLinear(model.fc3)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(NestedModel(), default_eval_fn, calib_data, qconfig_dict)
+        model = quantize(NestedModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
         checkQuantized(model)
 
     def test_quant_wrapper(self):
         r"""User need to modify the original code with QuantWrapper,
         and call the quantization utility functions.
         """
-        model = WrappedModel()
+        model = WrappedModel().eval()
 
         # since we didn't provide qconfig_dict, the model is modified inplace
         # but we can do `model = prepare(model)` as well
         prepare(model)
         self.checkObservers(model)
 
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
@@ -230,12 +228,12 @@ class ModelQuantizeAPITest(QuantizationTestCase):
             self.assertEqual(type(model.sub.module.fc1), nnq.Linear)
             self.assertEqual(type(model.sub.module.fc2), nnq.Linear)
             self.assertEqual(type(model.sub.module.relu), nnq.ReLU)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(WrappedModel(), default_eval_fn, calib_data, {})
+        model = quantize(WrappedModel().eval(), test_only_eval_fn, self.calib_data, {})
         checkQuantized(model)
 
 
@@ -243,25 +241,59 @@ class ModelQuantizeAPITest(QuantizationTestCase):
         r"""User inserts QuantStub and DeQuantStub in model code
         and call the quantization utility functions.
         """
-        model = ManualQuantModel()
+        model = ManualQuantModel().eval()
         # propagate the qconfig of parents to children, model is changed
         # inplace
         prepare(model)
         self.checkObservers(model)
 
-        default_eval_fn(model, calib_data)
+        test_only_eval_fn(model, self.calib_data)
         convert(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.fc), nnq.Linear)
-            default_eval_fn(model, calib_data)
+            test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(ManualQuantModel(), default_eval_fn, calib_data)
+        model = quantize(ManualQuantModel().eval(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
+class QuantizationAwareTrainingTest(QuantizationTestCase):
+    def test_manual(self):
+        model = ManualQATModel()
+        model.qconfig = default_qat_qconfig
+
+        model = prepare_qat(model)
+        self.checkObservers(model)
+
+        test_only_train_fn(model, self.train_data)
+        convert(model)
+
+        def checkQuantized(model):
+            self.assertEqual(type(model.fc1), nnq.Linear)
+            self.assertEqual(type(model.fc2), nnq.Linear)
+            test_only_eval_fn(model, self.calib_data)
+
+        model = ManualQATModel()
+        model.qconfig = default_qat_qconfig
+        model = quantize_qat(model, test_only_train_fn, self.train_data)
+        checkQuantized(model)
+
+    def test_eval_only_fake_quant(self):
+        r"""Using FakeQuant in evaluation only mode,
+        this is useful for estimating accuracy loss when we quantize the
+        network
+        """
+        model = ManualQATModel()
+        model.qconfig = default_qat_qconfig
+
+        model = prepare_qat(model)
+        self.checkObservers(model)
+
+        model.eval()
+        test_only_eval_fn(model, self.calib_data)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -19,21 +19,13 @@ class Linear(NNLinear):
         observer: fake quant module for output activation, it's called observer
             to align with post training flow
         weight: fake quant module for weight
-
-    Examples::
-
-        >>> m = nn.qat.Linear(20, 30)
-        >>> input = torch.randn(128, 20)
-        >>> output = m(input)
-        >>> print(output.size())
-        torch.Size([128, 30])
     """
     __constants__ = ['bias', 'in_features', 'out_features']
     __FLOAT_MODULE__ = NNLinear
 
     def __init__(self, in_features, out_features, bias=True,
-                 activation_fake_quant=default_qat_qconfig.activation(),
-                 weight_fake_quant=default_qat_qconfig.weight()):
+                 activation_fake_quant=default_qat_qconfig.activation,
+                 weight_fake_quant=default_qat_qconfig.weight):
         assert bias, 'nobias is not supported in Quantized Linear module yet'
         super(Linear, self).__init__(in_features, out_features, bias)
         self.observer = activation_fake_quant
@@ -56,8 +48,8 @@ class Linear(NNLinear):
             assert mod.qconfig, 'Input float module must has valid qconfig'
             qconfig = mod.qconfig
         qat_linear = cls(mod.in_features, mod.out_features,
-                         activation_fake_quant=qconfig.activation(),
-                         weight_fake_quant=qconfig.weight())
+                         activation_fake_quant=qconfig.activation,
+                         weight_fake_quant=qconfig.weight)
         qat_linear.weight = mod.weight
         qat_linear.bias = mod.bias
         return qat_linear

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 from ...modules.module import Module
 from ...modules.linear import Linear as NNLinear
+# from ...qat.modules.linear import Linear as QATLinear
 
 class Quantize(Module):
     r"""Quantizes an incoming tensor
@@ -154,13 +155,17 @@ class Linear(NNLinear):
             Args: `mod` a float module, either produced by torch.quantization utilities
             or directly from user
         """
-        assert type(mod) == NNLinear, 'nnq.Linear.from_float only works for nn.Linear'
-        assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
-        assert hasattr(mod, 'observer'), 'Input float module must have observer attached'
+        if hasattr(mod, 'weight_fake_quant'):
+            # assert type(mod) == QATLinear, 'training mode nnq.Linear.from_float only works for nn.qat.Linear'
+            weight_observer = mod.weight_fake_quant
+        else:
+            assert type(mod) == NNLinear, 'nnq.Linear.from_float only works for nn.Linear'
+            assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
+            assert hasattr(mod, 'observer'), 'Input float module must have observer attached'
+            weight_observer = mod.qconfig.weight()
+            weight_observer(mod.weight)
         activation_observer = mod.observer
         act_qparams = activation_observer.calculate_qparams()
-        weight_observer = mod.qconfig.weight()
-        weight_observer(mod.weight)
         wt_qparams = weight_observer.calculate_qparams()
         bias_scale = (wt_qparams[0] * act_qparams[0]).float()
         qweight = torch.quantize_linear(mod.weight.float(), wt_qparams[0], wt_qparams[1].long().item(), torch.qint8)

--- a/torch/quantization/QConfig.py
+++ b/torch/quantization/QConfig.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import namedtuple
 from .observer import *
+from .fake_quantize import *
 
 QConfig = namedtuple('QConfig',
                      ['weight', 'activation'])
 
 default_qconfig = QConfig(default_weight_observer(),
                           default_observer())
+
+default_qat_qconfig = QConfig(default_weight_fake_quant(),
+                              default_fake_quant())

--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -9,7 +9,7 @@ def default_eval_fn(model, calib_data):
     Default evaluation function takes a torch.utils.data.Dataset or a list of
     input Tensors and run the model on the dataset
     """
-    for data in calib_data:
+    for data, target in calib_data:
         model(data)
 
 _all__ = [
@@ -25,5 +25,7 @@ _all__ = [
     'Observer', 'WeightObserver', 'observer', 'default_observer',
     'default_weight_observer',
     # QConfig
-    'QConfig', 'default_qconfig'
+    'QConfig', 'default_qconfig',
+    # QAT utilities
+    'default_qat_qconfig', 'prepare_qat', 'quantize_qat'
 ]

--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 from torch.nn import Module
 from .observer import default_observer
+from functools import partial
 
 class FakeQuantize(Module):
     ''' Simulate the quantize and dequantize operations in training time.
@@ -47,3 +48,16 @@ class FakeQuantize(Module):
                 X, self.scale.double(), self.zero_point.long(), self.quant_min,
                 self.quant_max)
         return X
+
+def fake_quant(fake_quant_cls, **kwargs):
+    return partial(fake_quant_cls, **kwargs)
+
+def default_fake_quant(**kwargs):
+    return fake_quant(FakeQuantize, **kwargs)
+
+def default_weight_fake_quant(**kwargs):
+    kwargs.setdefault('dtype', torch.qint8)
+    kwargs.setdefault('qscheme', torch.per_tensor_symmetric)
+    kwargs.setdefault('quant_min', -128)
+    kwargs.setdefault('quant_max', 127)
+    return fake_quant(FakeQuantize, **kwargs)

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import torch.nn as nn
 import torch.nn.quantized as nnq
+import torch.nn.qat as qat
 import torch
 
 def propagate_qconfig_helper(module, qconfig_dict, qconfig_parent=None, prefix=''):
@@ -51,7 +52,8 @@ def propagate_qconfig(module, qconfig_dict=None):
 def _observer_forward_hook(self, input, output):
     r"""Forward hook that calls observer on the output
     """
-    self.observer(output)
+    return self.observer(output)
+
 
 # TODO(jerryzh): remove_observer?
 def add_observer(module):
@@ -92,9 +94,10 @@ class QuantWrapper(nn.Module):
     def __init__(self, module):
         super(QuantWrapper, self).__init__()
         qconfig = module.qconfig if hasattr(module, 'qconfig') else None
-        self.quant = QuantStub(qconfig)
-        self.dequant = DeQuantStub()
-        self.module = module
+        self.add_module('quant', QuantStub(qconfig))
+        self.add_module('dequant', DeQuantStub(qconfig))
+        self.add_module('module', module)
+        self.train(module.training)
 
     def forward(self, X):
         X = self.quant(X)
@@ -123,25 +126,30 @@ def add_quant_dequant(module):
         module._modules[name] = add_quant_dequant(child)
     return module
 
-def prepare(module, qconfig_dict=None):
-    r"""Prepares the module for calibration or training given a qconfig_dict.
-    Note that the module will be modified inplace but in case the input module
-    is a leaf module, a wrapped module will be returned.
+def prepare(model, qconfig_dict=None):
+    r"""Prepares the model for calibration or training given a qconfig_dict.
+    Note that the model will be modified inplace but in case the input model
+    is a leaf model, a wrapped model will be returned.
 
     Args:
-        mod: input module
+        mod: input model
         qconfig_dict: dictionary that maps from name of submodule to quantization
                       configuration
     Return:
-        A module with qconfig propogated, observer and quant dequant or fake
-        quant modules attached, a module that is ready for calibration or
+        A model with qconfig propogated, observer and quant dequant or fake
+        quant modules attached, a model that is ready for calibration or
         training
     """
-    propagate_qconfig(module, qconfig_dict)
+    propagate_qconfig(model, qconfig_dict)
     if qconfig_dict:
-        module = add_quant_dequant(module)
-    add_observer(module)
-    return module
+        model = add_quant_dequant(model)
+    add_observer(model)
+    return model
+
+def prepare_qat(model, qconfig_dict=None):
+    model = prepare(model, qconfig_dict)
+    model = convert(model, DEFAULT_QAT_MODULE_MAPPING)
+    return model
 
 class QuantStub(nn.Module):
     r"""Quantize stub module, before calibration, this is same as an observer,
@@ -163,19 +171,21 @@ class DeQuantStub(nn.Module):
     r"""Dequantize stub module, before calibration, this is same as identity,
     this will be swapped as `nnq.DeQuantize` in `convert`.
     """
-    def __init__(self):
+    def __init__(self, qconfig=None):
         super(DeQuantStub, self).__init__()
+        if qconfig:
+            self.qconfig = qconfig
 
     def forward(self, x):
         return x
 
-def quantize(module, eval_fn, eval_args, qconfig_dict=None):
-    r"""Converts a float module to quantized module.
+def quantize(model, run_fn, run_args, qconfig_dict=None):
+    r"""Converts a float model to quantized model.
 
-    First it will prepare the module for calibration or training, then it calls
-    `eval_fn` which will run the calibration step or training step,
-    after that we will call `convert` which will convert the module to a
-    quantized module.
+    First it will prepare the model for calibration or training, then it calls
+    `run_fn` which will run the calibration step or training step,
+    after that we will call `convert` which will convert the model to a
+    quantized model.
 
     When `qconfig_dict` is None or empty dictionary, we will assume user will
     insert quant/dequant stubs and add qconfig in approporiate places.
@@ -183,29 +193,47 @@ def quantize(module, eval_fn, eval_args, qconfig_dict=None):
     stubs using QuantWrapper for all the leaf modules.
 
     Args:
-        module: input module
-        eval_fn: a function for evaluating the prepared module, can be a
-            function that simply runs the prepared module or a training loop
-        eval_args: positional arguments for `eval_fn`
+        model: input model
+        run_fn: a function for evaluating the prepared model, can be a
+            function that simply runs the prepared model or a training loop
+        run_args: positional arguments for `run_fn`
         qconfig_dict: dictionary that maps from name of submodule to quantization
             configuration, qconfig applies to all submodules of a given
-            module unless qconfig for the submodules are specified(when the
+            model unless qconfig for the submodules are specified(when the
             submodule already has qconfig attribute)
 
 
     Return:
-        A quantized module
+        A quantized model
     """
-    module = prepare(module, qconfig_dict)
-    eval_fn(module, eval_args)
-    convert(module)
-    return module
+    model.eval()
+    model = prepare(model, qconfig_dict)
+    run_fn(model, run_args)
+    convert(model)
+    return model
+
+def quantize_qat(model, run_fn, run_args, qconfig_dict=None):
+    r"""Do quantization aware training and output a quantized model
+    """
+    model.train()
+    model = prepare_qat(model, qconfig_dict)
+    run_fn(model, run_args)
+    convert(model)
+    return model
 
 # Map for swapping float module to quantized ones
 DEFAULT_MODULE_MAPPING = {
     torch.nn.Linear: nnq.Linear,
     torch.nn.ReLU: nnq.ReLU,
     QuantStub: nnq.Quantize,
+    DeQuantStub: nnq.DeQuantize,
+    # QAT modules:
+    qat.Linear: nnq.Linear,
+}
+
+# Map for swapping float module to qat modules
+DEFAULT_QAT_MODULE_MAPPING = {
+    torch.nn.Linear: qat.Linear,
 }
 
 def convert(module, mapping=DEFAULT_MODULE_MAPPING):
@@ -246,8 +274,5 @@ def swap_module(mod, mapping):
     if hasattr(mod, 'observer'):
         if type(mod) in mapping:
             new_mod = mapping[type(mod)].from_float(mod)
-
-    if type(mod) == DeQuantStub:
-        new_mod = nnq.DeQuantize.from_float(mod)
 
     return new_mod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23085 [quant] Add fused modules in nn._intrinsic
* #23084 [qat] Conv module
* **#23082 [reland][qat] Quantization aware training in eager mode**

Add support for quantization aware training in eager mode

Modifications to Post training flow:
## Prepare
* Fusion: e.g. (Conv, Bn) → ConvBn (float)
* Swapping: To insert fake_quant to weight, we need to swap the float modules that has weight with different qat modules, e.g. Conv → torch.nn.qat.Conv , ConvBn → torch.nn._intrinsic.qat.ConvBn
```
    * previously we were thinking about modify the weight in forward_pre hook and change it back in forward_hook:
        * def forward_pre_hook(self, input):
                self.float_weight = self.weight
                self.weight = self.fake_quantize(self.float_weight)

            def forward_hook(self, input):
                self.weight = self.float_weight
```

* Assignments to self.weight are needed because we can’t change forward function and in forward function they are using self.weight.
* But we will need to keep two copies of weight in this case, so it’s probably better to just swap the module
* So we want to just swap Conv to torch.nn.qat.Conv and Linear to torch.nn.qat.Linear
* qat modules will have fake_quant for output and weights inserted in forward function

## Convert
* flow should be identical to ptq, but the swapping dictionary is slightly different since modules are changed in prepare step.

Differential Revision: [D16379374](https://our.internmc.facebook.com/intern/diff/D16379374/)