### PR TITLE
Added checks for the output sizes in FractionalMaxPool2d and FractionalMaxPool3d

### DIFF
--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -15,20 +15,17 @@ static std::vector<int> fractional_max_pool2d_generate_intervals(
   int inputSize,
   int outputSize,
   int poolSize) {
-    std::vector<int> sequence(outputSize);
+  scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
+    static_cast<scalar_t>(outputSize - 1);
+  std::vector<int> sequence(outputSize);
 
-      if (outputSize > 1) {
-      scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
-        static_cast<scalar_t>(outputSize - 1);
+  for (int i = 0; i < outputSize - 1; ++i) {
+    sequence[i] =
+      static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
+  }
+  sequence[outputSize - 1] = inputSize - poolSize;
 
-      for (int i = 0; i < outputSize - 1; ++i) {
-        sequence[i] =
-          static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
-      }
-    }
-
-    sequence[outputSize - 1] = inputSize - poolSize;
-    return sequence;
+  return sequence;
 }
 
 template <typename scalar_t>
@@ -169,6 +166,10 @@ void fractional_max_pool2d_out_cpu_template(
   TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
     "fractional_max_pool2d(): pool width ", poolSizeW,
     " too large relative to input width ", inputW);
+  TORCH_CHECK(outputW > 1,
+    "fractional_max_pool2d(): output width has to be longer than 1");
+  TORCH_CHECK(outputW > 1,
+    "fractional_max_pool2d(): output width has to be longer than 1");
 
   if (ndims == 3) {
     /* resize output */

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -15,17 +15,20 @@ static std::vector<int> fractional_max_pool2d_generate_intervals(
   int inputSize,
   int outputSize,
   int poolSize) {
-  scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
-    static_cast<scalar_t>(outputSize - 1);
-  std::vector<int> sequence(outputSize);
+    std::vector<int> sequence(outputSize);
 
-  for (int i = 0; i < outputSize - 1; ++i) {
-    sequence[i] =
-      static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
-  }
-  sequence[outputSize - 1] = inputSize - poolSize;
+      if (outputSize > 1) {
+      scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
+        static_cast<scalar_t>(outputSize - 1);
 
-  return sequence;
+      for (int i = 0; i < outputSize - 1; ++i) {
+        sequence[i] =
+          static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
+      }
+    }
+
+    sequence[outputSize - 1] = inputSize - poolSize;
+    return sequence;
 }
 
 template <typename scalar_t>
@@ -166,10 +169,6 @@ void fractional_max_pool2d_out_cpu_template(
   TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
     "fractional_max_pool2d(): pool width ", poolSizeW,
     " too large relative to input width ", inputW);
-  TORCH_CHECK(outputW > 1,
-    "fractional_max_pool2d(): output width has to be longer than 1");
-  TORCH_CHECK(outputW > 1,
-    "fractional_max_pool2d(): output width has to be longer than 1");
 
   if (ndims == 3) {
     /* resize output */

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -166,6 +166,10 @@ void fractional_max_pool2d_out_cpu_template(
   TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
     "fractional_max_pool2d(): pool width ", poolSizeW,
     " too large relative to input width ", inputW);
+  TORCH_CHECK(outputW > 1,
+    "fractional_max_pool2d(): output width has to be longer than 1");
+  TORCH_CHECK(outputW > 1,
+    "fractional_max_pool2d(): output width has to be longer than 1");
 
   if (ndims == 3) {
     /* resize output */

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -15,22 +15,18 @@ static std::vector<int> generate_intervals(
   int64_t inputSize,
   int64_t outputSize,
   int64_t poolSize) {
-    std::vector<int> sequence(outputSize);
+  scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
+    static_cast<scalar_t>(outputSize - 1);
+  std::vector<int> sequence(outputSize);
 
-    if (outputSize > 1) {
-      scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
-        static_cast<scalar_t>(outputSize - 1);
+  for (int i = 0; i < outputSize - 1; ++i) {
+    sequence[i] =
+      static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
+  }
+  sequence[outputSize - 1] = inputSize - poolSize;
 
-      for (int i = 0; i < outputSize - 1; ++i) {
-        sequence[i] =
-          static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
-      }
-    }
-
-    sequence[outputSize - 1] = inputSize - poolSize;
-    return sequence;
+  return sequence;
 }
-
 
 template<typename scalar_t>
 static void fractional_max_pool3d_out_single_batch_frame(
@@ -192,6 +188,10 @@ void fractional_max_pool3d_out_cpu_template(
   TORCH_CHECK(outputH + poolSizeH - 1 < inputH,
            "fractional_max_pool3d_out(): pool height ", poolSizeH,
            " too large relative to input height ", inputH);
+  TORCH_CHECK(outputW > 1,
+           "fractional_max_pool3d_out(): output width has to be longer than 1");
+  TORCH_CHECK(outputW > 1,
+           "fractional_max_pool3d_out(): output width has to be longer than 1");
 
   /* get contiguous input */
   auto input = input_.contiguous();

--- a/aten/src/ATen/native/FractionalMaxPool3d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool3d.cpp
@@ -15,18 +15,22 @@ static std::vector<int> generate_intervals(
   int64_t inputSize,
   int64_t outputSize,
   int64_t poolSize) {
-  scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
-    static_cast<scalar_t>(outputSize - 1);
-  std::vector<int> sequence(outputSize);
+    std::vector<int> sequence(outputSize);
 
-  for (int i = 0; i < outputSize - 1; ++i) {
-    sequence[i] =
-      static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
-  }
-  sequence[outputSize - 1] = inputSize - poolSize;
+    if (outputSize > 1) {
+      scalar_t alpha = static_cast<scalar_t>(inputSize - poolSize) /
+        static_cast<scalar_t>(outputSize - 1);
 
-  return sequence;
+      for (int i = 0; i < outputSize - 1; ++i) {
+        sequence[i] =
+          static_cast<int>((i + sample) * alpha) - static_cast<int>(sample * alpha);
+      }
+    }
+
+    sequence[outputSize - 1] = inputSize - poolSize;
+    return sequence;
 }
+
 
 template<typename scalar_t>
 static void fractional_max_pool3d_out_single_batch_frame(

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -165,6 +165,10 @@ void fractional_max_pool2d_out_cuda_template(
   TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
            "pool_size width ", poolSizeW,
            " too large relative to input width ", inputW);
+  TORCH_CHECK(outputW > 1,
+              "fractional_max_pool2d(): output width has to be longer than 1");
+  TORCH_CHECK(outputW > 1,
+              "fractional_max_pool2d(): output width has to be longer than 1");
 
   if (ndims == 3) {
     /* resize output */

--- a/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool3d.cu
@@ -198,6 +198,10 @@ void fractional_max_pool3d_out_cuda_template(
       "fractional_max_pool3d_out_cuda_template(): ",
       "pool width (", poolSizeW, ") too large relative to input width (",
       inputW, ")");
+      TORCH_CHECK(outputW > 1,
+               "fractional_max_pool3d_out(): output width has to be longer than 1");
+      TORCH_CHECK(outputW > 1,
+               "fractional_max_pool3d_out(): output width has to be longer than 1");
 
     if (ndims == 4) {
       /* resize output */

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3155,6 +3155,9 @@ class TestNN(NNTestCase):
         gradcheck(func, [x])
         gradgradcheck(func, [x])
 
+        x = torch.randn(2, 2, 2)
+        self.assertRaises(RuntimeError, lambda: F.fractional_max_pool2d(x, (1, 1), output_size=(3, 3)))
+
     def test_Dropout(self):
         input = torch.Tensor(1000)
         self._test_dropout(nn.Dropout, False, input)


### PR DESCRIPTION
Fixing #18705
The problem was with output width parameter which didnt have a proper check and this can lead to a situation when we have division by 0. 

Fix:
- Added output width check

Test: 
- Added test case