### PR TITLE
Revert "Temporarily skip mypy-0.720 to unbreak master type checks"

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -53,11 +53,7 @@ if [[ "$BUILD_ENVIRONMENT" != *ppc64le* ]]; then
   pip_install --user tb-nightly
   # mypy will fail to install on Python <3.4.  In that case,
   # we just won't run these tests.
-
-  # Temporarily skip mypy-0.720, with that our type hints checks failed with
-  # ```torch/__init__.pyi:1307: error: Name 'pstrf' already defined (possibly by an import)```
-  # https://circleci.com/api/v1.1/project/github/pytorch/pytorch/2185641/output/105/0?file=true
-  pip_install --user mypy!=0.720 || true
+  pip_install --user mypy || true
 fi
 
 # faulthandler become built-in since 3.3


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23095 Revert "Temporarily skip mypy-0.720 to unbreak master type checks"**

This reverts commit b5fa9a340a0d174131ad0a452c395860d571b5b0.

Differential Revision: [D16383149](https://our.internmc.facebook.com/intern/diff/D16383149)