### PR TITLE
Use set -x to help investigate doc push errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1056,7 +1056,7 @@ jobs:
         name: Doc Build and Push
         no_output_timeout: "1h"
         command: |
-          set -e
+          set -ex
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
@@ -1106,7 +1106,7 @@ jobs:
         name: Doc Build and Push
         no_output_timeout: "1h"
         command: |
-          set -e
+          set -ex
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -59,7 +59,7 @@
         name: Doc Build and Push
         no_output_timeout: "1h"
         command: |
-          set -e
+          set -ex
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null
@@ -109,7 +109,7 @@
         name: Doc Build and Push
         no_output_timeout: "1h"
         command: |
-          set -e
+          set -ex
           export COMMIT_DOCKER_IMAGE=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           echo "DOCKER_IMAGE: "${COMMIT_DOCKER_IMAGE}
           docker pull ${COMMIT_DOCKER_IMAGE} >/dev/null


### PR DESCRIPTION
I couldn't find any verbosity options in the [`docker pull` command docs](https://docs.docker.com/engine/reference/commandline/pull/), but
`docker pull` [got a `--quiet` option](https://github.com/docker/cli/pull/882) in a recent version (not sure if we're using that version), and `--quiet` for `docker push` [is forthcoming](https://github.com/docker/cli/pull/1221).