### PR TITLE
[quant] fix qat tests

### DIFF
--- a/torch/nn/qat/modules/linear.py
+++ b/torch/nn/qat/modules/linear.py
@@ -28,8 +28,8 @@ class Linear(NNLinear):
                  weight_fake_quant=default_qat_qconfig.weight):
         assert bias, 'nobias is not supported in Quantized Linear module yet'
         super(Linear, self).__init__(in_features, out_features, bias)
-        self.observer = activation_fake_quant
-        self.weight_fake_quant = weight_fake_quant
+        self.observer = activation_fake_quant()
+        self.weight_fake_quant = weight_fake_quant()
 
     def forward(self, input):
         return self.observer(F.linear(input, self.weight_fake_quant(self.weight), self.bias))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23124 [quant] fix qat tests**

missed instantiating observers in linear

Differential Revision: [D16401066](https://our.internmc.facebook.com/intern/diff/D16401066/)