### PR TITLE
Fix memory leak in Adam, Adagrad, RMSProp

### DIFF
--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -24,6 +24,7 @@ void Adagrad::step() {
     }
 
     if (options.weight_decay_ > 0) {
+      NoGradGuard guard;
       p.grad() = p.grad() + options.weight_decay_ * p;
     }
 

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -23,6 +23,7 @@ void Adam::step() {
     }
 
     if (options.weight_decay_ > 0) {
+      NoGradGuard guard;
       p.grad() = p.grad() + options.weight_decay_ * p;
     }
 

--- a/torch/csrc/api/src/optim/rmsprop.cpp
+++ b/torch/csrc/api/src/optim/rmsprop.cpp
@@ -24,6 +24,7 @@ void RMSprop::step() {
     }
 
     if (options.weight_decay_ > 0) {
+      NoGradGuard guard;
       p.grad() = p.grad() + options.weight_decay_ * p;
     }
 


### PR DESCRIPTION
As reported in LaurentMazare/tch-rs#76, the memory grows when weight_decay is present when using Adam. It applies the same fix in #23007 to Adam, Adagrad and RMSProp.