### PR TITLE
Add document of functions nn.init.ones_/zeros_

### DIFF
--- a/docs/source/nn.init.rst
+++ b/docs/source/nn.init.rst
@@ -9,6 +9,8 @@ torch.nn.init
 .. autofunction:: uniform_
 .. autofunction:: normal_
 .. autofunction:: constant_
+.. autofunction:: ones_
+.. autofunction:: zeros_
 .. autofunction:: eye_
 .. autofunction:: dirac_
 .. autofunction:: xavier_uniform_

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -122,7 +122,7 @@ def constant_(tensor, val):
 
 def ones_(tensor):
     # type: (Tensor) -> Tensor
-    r"""Fills the input Tensor with ones`.
+    r"""Fills the input Tensor with the scalar value `1`.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`
@@ -136,7 +136,7 @@ def ones_(tensor):
 
 def zeros_(tensor):
     # type: (Tensor) -> Tensor
-    r"""Fills the input Tensor with zeros`.
+    r"""Fills the input Tensor with the scalar value `0`.
 
     Args:
         tensor: an n-dimensional `torch.Tensor`


### PR DESCRIPTION
Functions `nn.init.ones_` and `nn.init.zeros_` were not documented. As mentioned in #9886 