### PR TITLE
[jit] make the optimization flag more consistent

### DIFF
--- a/torch/csrc/api/src/jit.cpp
+++ b/torch/csrc/api/src/jit.cpp
@@ -11,11 +11,7 @@ namespace jit {
 
 std::shared_ptr<script::CompilationUnit> compile(const std::string& source) {
   auto module = std::make_shared<script::CompilationUnit>();
-  module->define(
-      c10::nullopt,
-      source,
-      script::nativeResolver(),
-      nullptr);
+  module->define(c10::nullopt, source, script::nativeResolver(), nullptr, true);
   return module;
 }
 

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -266,7 +266,11 @@ void ScriptModuleDeserializer::importCallback(const std::string& qualifier) {
   auto src = std::make_shared<Source>(
       std::string(static_cast<const char*>(data.get()), size), path, 0);
   script::import_libs(
-      compilation_unit_, qualifier, src, tensor_table_, import_callback);
+      compilation_unit_,
+      qualifier,
+      src,
+      tensor_table_,
+      import_callback);
 }
 
 void ScriptModuleDeserializer::moduleSetState(

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -44,6 +44,7 @@ TORCH_API void import_functions(
     std::shared_ptr<CompilationUnit> cu,
     const std::shared_ptr<Source>& src,
     const std::vector<at::Tensor>& constant_table,
+    bool optimize,
     const Self* self = nullptr,
     const std::function<void(const std::string&)>& import_callback = nullptr);
 

--- a/torch/csrc/jit/script/builtin_functions.cpp
+++ b/torch/csrc/jit/script/builtin_functions.cpp
@@ -67,7 +67,11 @@ struct BuiltinFunctionRegistry {
     std::shared_ptr<CompilationUnit> cu = std::make_shared<CompilationUnit>();
     modules.emplace_back(cu);
     cu->define(
-        c10::nullopt, source, script::nativeResolver(), /*self=*/nullptr);
+        c10::nullopt,
+        source,
+        script::nativeResolver(),
+        /*self=*/nullptr,
+        /*optimize=*/true);
     for (auto& method : cu->get_functions()) {
       builtins_by_name_[Symbol::fromQualString("aten::" + method->name())]
           .push_back(method);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -591,8 +591,7 @@ struct to_ir {
 
     CompilationUnit cu;
     // set optimize to false since we don't need to run it in optimize mode
-    cu.set_optimized(false);
-    cu.define(c10::nullopt, {def}, {resolver}, nullptr);
+    cu.define(c10::nullopt, {def}, {resolver}, nullptr, /*optimize=*/false);
     Stack stack;
     cu.get_function(def.name().name()).run(stack);
     return stack.at(0).toTuple()->elements();
@@ -2939,7 +2938,7 @@ struct FunctionResolver : public Resolver {
 CompilationUnit::CompilationUnit(const std::string& source)
     : CompilationUnit() {
   // calles the define with native resolver to generate the graph for functions
-  define(c10::nullopt, source, nativeResolver(), nullptr);
+  define(c10::nullopt, source, nativeResolver(), nullptr, true);
 }
 
 // Mangle a qualified name so that it is globally unique.
@@ -2966,6 +2965,7 @@ std::unique_ptr<Function> CompilationUnit::define(
     const ResolverPtr& resolver,
     const Self* self,
     const std::unordered_map<std::string, Function*>& function_table,
+    bool optimize,
     bool shouldMangle) const {
   TORCH_INTERNAL_ASSERT(resolver);
   auto _resolver = resolver;
@@ -3000,7 +3000,7 @@ std::unique_ptr<Function> CompilationUnit::define(
     }
   }
   auto fn = torch::make_unique<Function>(
-      std::move(name), is_optimized(), std::make_shared<Graph>(), creator);
+      std::move(name), optimize, std::make_shared<Graph>(), creator);
   if (self) {
     // Register this as a method on `self`'s type
     self->getClassType()->addMethod(fn.get());
@@ -3013,6 +3013,7 @@ std::vector<Function*> CompilationUnit::define(
     const std::vector<Def>& definitions,
     const std::vector<ResolverPtr>& resolvers,
     const Self* self,
+    bool optimize,
     bool shouldMangle) {
   TORCH_INTERNAL_ASSERT(definitions.size() == resolvers.size());
   // We need to compile `__init__` first, since it can determine what attributes
@@ -3036,6 +3037,7 @@ std::vector<Function*> CompilationUnit::define(
         resolvers[*init_idx],
         self,
         function_table,
+        optimize,
         shouldMangle);
     const auto& name = fn->name();
     function_table[name] = fn.get();
@@ -3055,6 +3057,7 @@ std::vector<Function*> CompilationUnit::define(
         resolvers[i],
         self,
         function_table,
+        optimize,
         shouldMangle);
     const auto& name = fn->name();
     function_table[name] = fn.get();
@@ -3072,7 +3075,8 @@ std::vector<Function*> CompilationUnit::define(
     const c10::optional<QualifiedName>& prefix,
     const std::string& source,
     const ResolverPtr& resolver,
-    const Self* self) {
+    const Self* self,
+    bool optimize) {
   Parser p(std::make_shared<Source>(source, "<string>", 1));
   std::vector<Def> definitions;
   std::vector<ResolverPtr> resolvers;
@@ -3081,7 +3085,7 @@ std::vector<Function*> CompilationUnit::define(
     definitions.push_back(def);
     resolvers.push_back(resolver);
   }
-  return define(prefix, definitions, resolvers, self);
+  return define(prefix, definitions, resolvers, self, optimize);
 }
 
 void runCleanupPasses(std::shared_ptr<Graph>& to_clean, bool convert_ssa) {

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -225,7 +225,11 @@ static void clearMethods(c10::ivalue::Object* self) {
 void Module::define(const std::string& src, const ResolverPtr& resolver) {
   const auto self = SimpleSelf(type());
   class_compilation_unit()->define(
-      name(), src, resolver ? resolver : script::nativeResolver(), &self);
+      name(),
+      src,
+      resolver ? resolver : script::nativeResolver(),
+      &self,
+      is_optimized());
 }
 
 void Module::copy_into(
@@ -280,8 +284,8 @@ void Module::clone_method(
   graph->remapTypes(type_remap_fn);
   auto schema = fn.getSchema().cloneWithRemappedTypes(type_remap_fn);
   const auto this_method_name = getNameForMethod(orig_method_name.name());
-  auto copied =
-      class_compilation_unit()->create_function(this_method_name, graph);
+  auto copied = class_compilation_unit()->create_function(
+      this_method_name, graph, orig.is_optimized());
   copied->setSchema(std::move(schema));
 }
 

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -112,7 +112,8 @@ struct TORCH_API Module {
   Module(c10::QualifiedName, std::shared_ptr<CompilationUnit> cu);
   // module_value_ null and will be lazily initialized if is needed
   Module() {}
-  Module(ModulePtr module_value) : module_value_(std::move(module_value)) {}
+  explicit Module(ModulePtr module_value)
+      : module_value_(std::move(module_value)) {}
   ~Module() {}
 
   const c10::QualifiedName& name() const {
@@ -122,11 +123,11 @@ struct TORCH_API Module {
   // note this doesn't change the flags of existing methods just ones
   // added afterward.
   void set_optimized(bool o) {
-    class_compilation_unit()->set_optimized(o);
+    class_compilation_unit()->set_optimized(name(), o);
   }
 
   bool is_optimized() const {
-    return class_compilation_unit()->is_optimized();
+    return class_compilation_unit()->is_optimized(name());
   }
 
   IValue forward(std::vector<IValue> inputs) {

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -255,7 +255,8 @@ std::shared_ptr<SugaredValue> SimpleValue::call(
             ->output();
     // TODO this needs to go in `m`s compilation unit
     auto cu = std::make_shared<CompilationUnit>();
-    auto fn = cu->create_function(QualifiedName("anon"), graph);
+    auto fn =
+        cu->create_function(QualifiedName("anon"), graph, /*optimized=*/true);
     auto ret = StrongFunctionPtr(std::move(cu), fn);
 
     std::vector<NamedValue> ctx_inputs = {close_context};

--- a/torch/csrc/jit/symbolic_script.cpp
+++ b/torch/csrc/jit/symbolic_script.cpp
@@ -1399,7 +1399,7 @@ void loadModule(const script::CompilationUnit& module) {
 void loadFunctions() {
   for (const std::string& str : functions) {
     script::CompilationUnit cu;
-    cu.define(c10::nullopt, str, script::nativeResolver(), nullptr);
+    cu.define(c10::nullopt, str, script::nativeResolver(), nullptr, true);
     loadModule(cu);
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23098 [wip][jit] serialize modules as classes
* #23154 [jit] Put all modules in the global Python CU
* **#23153 [jit] make the optimization flag more consistent**
* #23109 [jit] add simple inheritance support to AST
* #23097 [jit] do base module initialization lazily on import
* #23033 [jit] make RHS  of assignment optional
* #23031 [jit] Parse all stmts in class defs

1. Optimizations were previosuly set per-compilation unit. Now that
there can be multiple modules in a single CU, I changed it to be a table
of qualified name => flag. In the long run this should just be a regular
attribute of the class type, but I just want to unblock things for now.
2. Pass the optimization flag through @script more consistenly