### PR TITLE
Fast path for binary ops that bypass tensor iterator.

### DIFF
--- a/aten/src/ATen/native/FastPathBinaryOps.h
+++ b/aten/src/ATen/native/FastPathBinaryOps.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at { namespace native {
+
+bool all_cpu_fast_path_conds_satisfied(const Tensor& t1, const Tensor& t2);
+bool all_cpu_fast_path_conds_satisfied(const Tensor& t);
+
+using fast_path_binary_fn_alpha = void(*)(Tensor& result, const Tensor& self,
+    const Tensor& other, Scalar alpha);
+using fast_path_binary_fn = void(*)(Tensor& result, const Tensor& self,
+    const Tensor& other);
+
+DECLARE_DISPATCH(fast_path_binary_fn_alpha, fast_path_add_stub);
+DECLARE_DISPATCH(fast_path_binary_fn_alpha, fast_path_sub_stub);
+DECLARE_DISPATCH(fast_path_binary_fn, fast_path_mul_stub);
+DECLARE_DISPATCH(fast_path_binary_fn, fast_path_div_stub);
+
+}} // namespace at::native

--- a/aten/src/ATen/native/FastPathConditions.h
+++ b/aten/src/ATen/native/FastPathConditions.h
@@ -1,0 +1,34 @@
+#include <ATen/ATen.h>
+
+namespace at {
+namespace native {
+
+namespace {
+inline bool all_dims_are_same(const Tensor& t1, const Tensor& t2) {
+  if (t1.ndimension() != t2.ndimension()) {
+    return false;
+  }
+
+  IntArrayRef t1_size = t1.sizes();
+  IntArrayRef t2_size = t2.sizes();
+  for (int64_t i = 0; i < t1.ndimension(); ++i) {
+    if (t1_size[i] != t2_size[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
+
+namespace binary_op_fast_path_conditions {
+
+bool enable_contiguous_eq_size_cpu_fastpath(const Tensor& t1, const Tensor& t2) {
+  return all_dims_are_same(t1, t2) && t2.is_contiguous() &&
+         t1.device().is_cpu() && t2.device().is_cpu() &&
+         t1.is_contiguous() &&
+         (t1.scalar_type() == t2.scalar_type());
+}
+
+} // binary_op_fast_path_conditions
+} // native
+} // at

--- a/aten/src/ATen/native/cpu/FastPathBinaryOpsKernelCPU.cpp
+++ b/aten/src/ATen/native/cpu/FastPathBinaryOpsKernelCPU.cpp
@@ -1,0 +1,70 @@
+#include <cmath>
+#include <iostream>
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/cpu/vec256/vec256.h>
+#include <ATen/cpu/vec256/functional.h>
+#include <ATen/native/FastPathBinaryOps.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+#include <ATen/native/cpu/Loops.h>
+
+namespace at { namespace native {
+
+namespace {
+
+#define FAST_PATH_BINARY_LOOP(scalar_type, ...)               \
+  scalar_type* result_ptr = result.data<scalar_type>();       \
+  const scalar_type* self_ptr = self.data<scalar_type>();     \
+  const scalar_type* other_ptr = other.data<scalar_type>();   \
+  for (int i = begin; i < end; ++i) {                         \
+    __VA_ARGS__                                               \
+  }
+
+void fast_path_add_kernel(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha_scalar) {
+  int64_t num_elements = self.numel();
+  at::parallel_for(0, num_elements, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "fast_path_add_cpu", [&]() {
+      auto alpha = alpha_scalar.to<scalar_t>();
+      FAST_PATH_BINARY_LOOP(scalar_t, result_ptr[i] = self_ptr[i] + other_ptr[i] * alpha;)
+    });
+  });
+}
+
+void fast_path_sub_kernel(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha_scalar) {
+  fast_path_add_kernel(result, self, other, -alpha_scalar);
+}
+
+void fast_path_mul_kernel(Tensor& result, const Tensor& self, const Tensor& other) {
+  int64_t num_elements = self.numel();
+  if (self.scalar_type() == ScalarType::Bool) {
+    at::parallel_for(0, num_elements, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    FAST_PATH_BINARY_LOOP(bool, result_ptr[i] = self_ptr[i] && other_ptr[i];)
+    });
+  } else {
+    at::parallel_for(0, num_elements, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    AT_DISPATCH_ALL_TYPES(self.scalar_type(), "fast_path_mul_cpu", [&]() {
+      FAST_PATH_BINARY_LOOP(scalar_t, result_ptr[i] = self_ptr[i] * other_ptr[i];)
+    });
+    });
+  }
+}
+
+void fast_path_div_kernel(Tensor& result, const Tensor& self, const Tensor& other) {
+  int64_t num_elements = self.numel();
+  at::parallel_for(0, num_elements, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    AT_DISPATCH_INTEGRAL_TYPES(self.scalar_type(), "fast_path_div_cpu", [&]() {
+      FAST_PATH_BINARY_LOOP(scalar_t, result_ptr[i] = self_ptr[i] / other_ptr[i];)
+    });
+  });
+}
+
+} // anonymous namespace
+
+
+REGISTER_DISPATCH(fast_path_add_stub, &fast_path_add_kernel);
+REGISTER_DISPATCH(fast_path_sub_stub, &fast_path_sub_kernel);
+REGISTER_DISPATCH(fast_path_mul_stub, &fast_path_mul_kernel);
+REGISTER_DISPATCH(fast_path_div_stub, &fast_path_div_kernel);
+
+}} // namespace at::native

--- a/benchmarks/framework_overhead_benchmark/C2Module.py
+++ b/benchmarks/framework_overhead_benchmark/C2Module.py
@@ -18,12 +18,15 @@ class C2SimpleNet(object):
     needed for the op.
     Provides forward method to run the net niter times.
     """
-    def __init__(self, op_name, num_inputs=1, debug=False):
+    def __init__(self, module_config, debug=False):
+        op_name = module_config.c2_op
+        num_inputs = module_config.num_params
+        tensor_size = module_config.size
         self.input_names = []
         self.net = core.Net("framework_benchmark_net")
         self.input_names = ["in_{}".format(i) for i in range(num_inputs)]
         for i in range(num_inputs):
-            add_blob(workspace, self.input_names[i], [1])
+            add_blob(workspace, self.input_names[i], tensor_size)
         self.net.AddExternalInputs(self.input_names)
         op_constructor = getattr(self.net, op_name)
         op_constructor(self.input_names)

--- a/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
+++ b/benchmarks/framework_overhead_benchmark/SimpleAddModule.py
@@ -5,7 +5,7 @@ from utils import NUM_LOOP_ITERS
 def add_tensors_loop(x, y):
     z = torch.add(x, y)
     for i in range(NUM_LOOP_ITERS):
-        z = torch.add(z, x)
+        z = torch.add(z, y)
     return z
 
 class SimpleAddModule(torch.nn.Module):

--- a/benchmarks/framework_overhead_benchmark/framework_overhead_benchmark.py
+++ b/benchmarks/framework_overhead_benchmark/framework_overhead_benchmark.py
@@ -59,7 +59,7 @@ def benchmark_simple_fn(args, config, module_config, module_type, result):
         f_name += "_" + str(module_config.size)
         graph_mode_str = "Graph mode" + ":" + str(module_config.graph_mode)
         result_key = ','.join((f_name, graph_mode_str))
-        module = WrapperModule(module_type, module_config, args.debug, args.save)
+        module = WrapperModule(module_type, module_config, args.debug, args.broadcast, args.save)
         latency_per_iter_ms = benchmark_module(config, module, args.use_throughput_benchmark)
         result[result_key] = latency_per_iter_ms
 
@@ -70,6 +70,7 @@ def main():
     parser.add_argument("--use_throughput_benchmark", default=False, dest="use_throughput_benchmark", action="store_true")
     parser.add_argument("--debug", default=False, dest="debug", action="store_true")
     parser.add_argument("--save", default=False, dest="save", action="store_true")
+    parser.add_argument("--broadcast", default=False, dest="broadcast", action="store_true")
     parser.add_argument("--eager_mode", default=False, dest="eager_mode", action="store_true")
     parser.add_argument("--num_warmup_iters", type=int, default=100)
     parser.add_argument("--num_iters", type=int, default=1000)
@@ -82,7 +83,7 @@ def main():
         "Benchmarking of C2 net via throughput benchmarking is not yet supported"
 
     #scalar_sizes = [8, 16, 32, 64, 128, 256, 512]
-    scalar_sizes = [1]
+    scalar_sizes = [1, 16, 64]
     tensor_sizes = gen_shapes(scalar_sizes, 1)
     num_warmup_iters = args.num_warmup_iters
     num_iters = args.num_iters

--- a/benchmarks/framework_overhead_benchmark/pt_wrapper_module.py
+++ b/benchmarks/framework_overhead_benchmark/pt_wrapper_module.py
@@ -22,11 +22,12 @@ class WrapperModule(object):
     """
     def __init__(self, wrapped_type, module_config, debug, save=False):
         pt_fn = module_config.pt_fn
+        tensor_size = module_config.size
         self.module = wrapped_type(pt_fn)
         self.tensor_inputs = []
         self.module_name = wrapped_type.__name__
         for _ in range(module_config.num_params):
-            self.tensor_inputs.append(torch.randn(1))
+            self.tensor_inputs.append(torch.randn(tensor_size))
         if module_config.graph_mode:
             self.module = torch.jit.trace(self.module, self.tensor_inputs)
             if save:

--- a/benchmarks/framework_overhead_benchmark/pt_wrapper_module.py
+++ b/benchmarks/framework_overhead_benchmark/pt_wrapper_module.py
@@ -20,13 +20,18 @@ class WrapperModule(object):
         save:
             - In graph mode, whether graph is to be saved.
     """
-    def __init__(self, wrapped_type, module_config, debug, save=False):
+    def __init__(self, wrapped_type, module_config, debug, broadcast=False, save=False):
         pt_fn = module_config.pt_fn
         tensor_size = module_config.size
         self.module = wrapped_type(pt_fn)
         self.tensor_inputs = []
         self.module_name = wrapped_type.__name__
         for _ in range(module_config.num_params):
+            self.tensor_inputs.append(torch.randn(tensor_size))
+        if broadcast:
+            self.tensor_inputs.pop()
+            tensor_size.pop()
+            tensor_size.append(1)
             self.tensor_inputs.append(torch.randn(tensor_size))
         if module_config.graph_mode:
             self.module = torch.jit.trace(self.module, self.tensor_inputs)

--- a/benchmarks/framework_overhead_benchmark/utils.py
+++ b/benchmarks/framework_overhead_benchmark/utils.py
@@ -5,7 +5,7 @@ from torch.utils import ThroughputBenchmark
 
 NUM_LOOP_ITERS = 1000
 BenchmarkConfig = namedtuple('BenchmarkConfig', 'num_warmup_iters num_iters')
-ModuleConfig = namedtuple('ModuleConfig', 'pt_fn c2_op num_params graph_mode')
+ModuleConfig = namedtuple('ModuleConfig', 'pt_fn c2_op num_params size graph_mode')
 
 def ms_to_us(time_ms):
     return (time_ms * 1e3)
@@ -33,3 +33,11 @@ def benchmark_module(config, module, use_throughput_benchmark=False):
     end = time.time()
     time_elapsed_s = (end - start)
     return (secs_to_ms(time_elapsed_s) / config.num_iters / NUM_LOOP_ITERS)
+
+def gen_shapes(sizes, num_dims=1):
+    assert num_dims > 0
+    return_sizes = []
+    for s in sizes:
+        tensor_size = [s for _ in range(num_dims)]
+        return_sizes.append(tensor_size)
+    return return_sizes


### PR DESCRIPTION
Summary:
Changes add fast path to bypass tensor iterator when tensors:
- are on cpu.
- are contig.
- have the same number of dimensions.
- each dimension has the same size.
- are of the same type.

Results on top of master using framework overhead benchmar:
Experimented with 3 sizes: 1, 16, 64. All 1 dim tensors.
In case of broadcast, the second tensor of the add was of 1 element.

On master:
add_tensors_loop:Num Operands=2_[1],Graph mode:True, latency per iter (us):1.7277789115905762
add_tensors_loop:Num Operands=2_[16],Graph mode:True, latency per iter (us):1.8338178396224976
add_tensors_loop:Num Operands=2_[64],Graph mode:True, latency per iter (us):1.8206777572631836
On master with broadcast:
add_tensors_loop:Num Operands=2_[1],Graph mode:True, latency per iter (us):1.711668610572815
add_tensors_loop:Num Operands=2_[16],Graph mode:True, latency per iter (us):1.8416098356246948
add_tensors_loop:Num Operands=2_[64],Graph mode:True, latency per iter (us):1.895913004875183

===========

With fast path:
add_tensors_loop:Num Operands=2_[1],Graph mode:True, latency per iter (us):1.2124907970428467
add_tensors_loop:Num Operands=2_[16],Graph mode:True, latency per iter (us):1.2013496160507202
add_tensors_loop:Num Operands=2_[64],Graph mode:True, latency per iter (us):1.2547712326049805
Fast path with broadcast:
add_tensors_loop:Num Operands=2_[1],Graph mode:True, latency per iter (us):1.2107170820236206
add_tensors_loop:Num Operands=2_[16],Graph mode:True, latency per iter (us):2.0033864974975586
add_tensors_loop:Num Operands=2_[64],Graph mode:True, latency per iter (us):1.9163089990615845

Non broadcast case fast path saves about 500 to 600ns. Adding fast path has some overhead when we don't end up taking the fast path as in the case of broadcast. This is about 50-150ns.

Differential Revision: D16359346

