### PR TITLE
Pin numba to 0.44.0 to fix Windows CI.

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -19,7 +19,8 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     :: We have to pin Python version to 3.6.7, until mkl supports Python 3.7
-    call conda install -y -q python=3.6.7 numpy mkl cffi pyyaml boto3 protobuf numba
+    :: Numba is pinned to 0.44.0 to avoid https://github.com/numba/numba/issues/4352
+    call conda install -y -q python=3.6.7 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0
 )
 pip install -q ninja future hypothesis "librosa>=0.6.2" psutil pillow
 :: No need to install faulthandler since we only test Python >= 3.6 on Windows


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23176 Pin numba to 0.44.0 to fix Windows CI.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16426873](https://our.internmc.facebook.com/intern/diff/D16426873)