### PR TITLE
Fix erase_number_types test

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9332,7 +9332,6 @@ a")
         FileCheck().check("int = prim::Constant").check("aten::add_").run(str(graph))
         self.run_pass('remove_inplace_ops', graph)
         self.run_pass('erase_number_types', graph)
-        self.run_pass('dce', graph)
         FileCheck().check_not("int = prim::Constant").check_not("aten::add_").run(str(graph))
 
     def test_mm_batching(self):


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22239 Open up AliasAnalysisKind for any ops&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15996322/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #22175 AliasAnalysisKind::CONSERVATIVE/FROM_SCHEMA&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D15929595/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#23181 Fix erase_number_types test**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16427819/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #23180 Fix onnx export&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D16427680/)

We can't run dead code elimination after erasing number types because dce relies on graph invariants that erase_number_types breaks.

Differential Revision: [D16427819](https://our.internmc.facebook.com/intern/diff/D16427819/)