### PR TITLE
Fix load op to return the shape info as before when loading multiple blobs

### DIFF
--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -15,14 +15,28 @@ template <int VALUE_TYPE = TensorProto_DataType_FLOAT>
 std::vector<TensorShape> LoadTensorInference(
     const OperatorDef& def,
     const vector<TensorShape>& /* unused */) {
-  vector<TensorShape> out(1);
   ArgumentHelper helper(def);
-  out[0].set_data_type(static_cast<TensorProto_DataType>(
-      helper.GetSingleArgument<int>("dtype", VALUE_TYPE)));
-
   auto shape = helper.GetRepeatedArgument<int64_t>("shape");
-  for (auto d : shape) {
-    out[0].add_dims(d);
+  vector<TensorShape> out;
+  // Currently load op supports only shape.
+  // TODO: We have to extend it to support shapes vector.
+  // Since it support just one shape, we return
+  // the right shape information only when there is just one blob loaded.
+  // Otherwise, we return unknown TensorShapes.
+  if (def.output_size() == 1 && shape.size() > 0) {
+    TensorShape ts;
+    ts.set_data_type(static_cast<TensorProto_DataType>(
+        helper.GetSingleArgument<int>("dtype", VALUE_TYPE)));
+    for (auto d : shape) {
+      ts.add_dims(d);
+    }
+    out.push_back(ts);
+  } else {
+    for (int i = 0; i < def.output_size(); i++) {
+      TensorShape ts;
+      ts.set_unknown_shape(true);
+      out.push_back(ts);
+    }
   }
   return out;
 }


### PR DESCRIPTION
Summary:
Changing the load op to take in shapes vector needs changes in lots of places (almost all usages of load op).
Instead this is a small and safe change where the behavior is unchanged if we are loading multiple blobs and when loading a single blob without shape information.

If you are loading just one blob and the shape information is provided, then this returns the right shape info back.

For all other cases, behavior is unchanged as before we introduced the issue.

This fixes the issue reported by Andrey in D16229465

Differential Revision: D16428140

