### PR TITLE
Fix the problem in parseOctal and throw exception if use \xhh to specify hex value

### DIFF
--- a/torch/csrc/jit/script/parse_string_literal.h
+++ b/torch/csrc/jit/script/parse_string_literal.h
@@ -67,11 +67,14 @@ inline std::string parseStringLiteral(
       case 't':
         c = '\t';
         break;
-      case 'h':
+      case 'x':
         throw ErrorReport(range) << "unsupported hex specifier";
+      case 'u':
+      case 'U':
+        throw ErrorReport(range) << "unsupported unicode specifier";
       default:
-        // \0NN
-        if (auto v = parseOctal(str, pos + 1)) {
+        // octal value in format \nnn, n is [0-7]
+        if (auto v = parseOctal(ret_str, pos)) {
           to_erase = 4;
           c = *v;
         } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23208 expose parse_schema and __eq__ function to python and add round trip tests
* #23207 Expose an API to iterate all the registered operators
* #23206 Align AliasInfo's operator<< with FunctionSchema
* #23205 Support IntList in Dict's shalloEquals
* #23204 Support variadic returns in Schema's operator<<
* #23203 Align the operator<< for Argument with FunctionSchema parser
* #23202 Fix the operator== for Argument
* #23201 Align String str() with the format in FunctionSchema
* #23200 Align Dict str() with the format in FunctionSchema
* #23199 Support parsing variadic return schema
* **#23198 Fix the problem in parseOctal and throw exception if use \xhh to specify hex value**

follow the rules:
1) https://docs.python.org/2.0/ref/strings.html
2) https://en.cppreference.com/w/cpp/language/escape
didn't find anything about the format \h

Differential Revision: [D16431215](https://our.internmc.facebook.com/intern/diff/D16431215/)