### PR TITLE
Bug fix: Fix OpenCV 4 compatibility

### DIFF
--- a/caffe2/video/video_input_op.h
+++ b/caffe2/video/video_input_op.h
@@ -573,7 +573,12 @@ bool VideoInputOp<Context>::GetImageAndLabelsFromDBValue(
             &encoded_size,
             CV_8UC1,
             const_cast<char*>(encoded_image_str.data())),
-        CV_LOAD_IMAGE_COLOR);
+#if CV_MAJOR_VERSION <= 3
+        CV_LOAD_IMAGE_COLOR
+#else
+        cv::IMREAD_COLOR
+#endif
+        );
     if (src.rows == 0 or src.cols == 0) {
       throw std::runtime_error("Both rows and cols are 0 for image");
     }
@@ -606,13 +611,22 @@ bool VideoInputOp<Context>::GetImageAndLabelsFromDBValue(
     img = scaled_img;
   } else {
     cv::cvtColor(
-        scaled_img, img, (channels_rgb_ == 1) ? CV_BGR2GRAY : CV_GRAY2BGR);
+#if CV_MAJOR_VERSION <= 3
+        scaled_img, img, (channels_rgb_ == 1) ? CV_BGR2GRAY : CV_GRAY2BGR
+#else
+        scaled_img, img, (channels_rgb_ == 1) ? cv::COLOR_BGR2GRAY : cv::COLOR_GRAY2BGR
+#endif
+        );
   }
 
   cv::Mat rgb_img;
 
   if (channels_rgb_ == 1) {
+#if CV_MAJOR_VERSION <= 3
     cv::cvtColor(img, rgb_img, CV_BGR2RGB);
+#else
+    cv::cvtColor(img, rgb_img, cv::COLOR_BGR2RGB);
+#endif
   } else {
     rgb_img = img;
   }


### PR DESCRIPTION
This fix adds macro guards to switch b/w OpenCV 3 & and constants. For example, `CV_LOAD_IMAGE_COLOR` vs `cv::IMREAD_COLOR`.