### PR TITLE
Fix adapative pooling kernel size bug on Power

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -10,11 +10,11 @@ namespace native {
 namespace {
 
   inline int start_index(int a, int b, int c) {
-    return (int)std::floor((float)(a * c) / b);
+    return (a * c) / b;
   }
 
   inline int end_index(int a, int b, int c) {
-    return (int)std::ceil((double)((a + 1) * c) / b);
+    return (((a + 1) * c) - 1) / b + 1;
   }
 
   template <typename scalar_t>

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -14,7 +14,7 @@ namespace {
   }
 
   inline int end_index(int a, int b, int c) {
-    return (int)std::ceil((float)((a + 1) * c) / b);
+    return (int)std::ceil((double)((a + 1) * c) / b);
   }
 
   template <typename scalar_t>

--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -7,11 +7,11 @@ namespace native {
 namespace {
 
 inline int start_index(int a, int b, int c) {
-  return (int)std::floor((float)(a * c) / b);
+  return (a * c) / b;
 }
 
 inline int end_index(int a, int b, int c) {
-  return (int)std::ceil((double)((a + 1) * c) / b);
+  return (((a + 1) * c) - 1) / b + 1;
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -11,7 +11,7 @@ inline int start_index(int a, int b, int c) {
 }
 
 inline int end_index(int a, int b, int c) {
-  return (int)std::ceil((float)((a + 1) * c) / b);
+  return (int)std::ceil((double)((a + 1) * c) / b);
 }
 
 template <typename scalar_t>

--- a/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
@@ -10,11 +10,11 @@ namespace native {
 namespace {
 
 inline int start_index(int a, int b, int c) {
-  return (int)std::floor((float)(a * c) / b);
+  return (a * c) / b;
 }
 
 inline int end_index(int a, int b, int c) {
-  return (int)std::ceil((double)((a + 1) * c) / b);
+  return (((a + 1) * c) - 1) / b + 1;
 }
 
 // #define START_IND(a,b,c) a * c / b

--- a/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling2d.cpp
@@ -14,7 +14,7 @@ inline int start_index(int a, int b, int c) {
 }
 
 inline int end_index(int a, int b, int c) {
-  return (int)std::ceil((float)((a + 1) * c) / b);
+  return (int)std::ceil((double)((a + 1) * c) / b);
 }
 
 // #define START_IND(a,b,c) a * c / b

--- a/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
@@ -10,11 +10,11 @@ namespace native {
 namespace {
 
 inline int start_index(int a, int b, int c) {
-  return (int)std::floor((float)(a * c) / b);
+  return (a * c) / b;
 }
 
 inline int end_index(int a, int b, int c) {
-  return (int)std::ceil((double)((a + 1) * c) / b);
+  return (((a + 1) * c) - 1) / b + 1;
 }
 
 // #define START_IND(a,b,c) a * c / b

--- a/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveMaxPooling3d.cpp
@@ -14,7 +14,7 @@ inline int start_index(int a, int b, int c) {
 }
 
 inline int end_index(int a, int b, int c) {
-  return (int)std::ceil((float)((a + 1) * c) / b);
+  return (int)std::ceil((double)((a + 1) * c) / b);
 }
 
 // #define START_IND(a,b,c) a * c / b

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3987,7 +3987,6 @@ class TestNN(NNTestCase):
 
                     input = torch.randn((1,) + output_size).fill_(1.0)
                     output = module(input)
-                    print(input, output)
                     self.assertAlmostEqual(input, output)
 
     def test_Conv2d_naive_groups(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3976,6 +3976,20 @@ class TestNN(NNTestCase):
                 output = module(input)
                 self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
 
+    def test_adaptive_pooling_kernel_size(self):
+        for dim_size in (7, 13, 93, 221, 415, 497):
+            for numel in (2, 3):
+                for pool_type in ('Max', 'Avg'):
+                    cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
+                    module_cls = getattr(nn, cls_name)
+                    output_size = (dim_size,) * numel
+                    module = module_cls(output_size)
+
+                    input = torch.randn((1,) + output_size).fill_(1.0)
+                    output = module(input)
+                    print(input, output)
+                    self.assertAlmostEqual(input, output)
+
     def test_Conv2d_naive_groups(self):
         self._test_Conv2d_naive_groups()
 


### PR DESCRIPTION
The functions that PyTorch provides for doing adaptive pooling
on the CPU compute the kernel size based off of the size of the
input and output matrices. Rounding differences on Power cause
the results to be slightly off for these computations. This
results in pooling kernels that go over the edge of the matrix
and pick up junk data. Use doubles rather than floats for more
consistent behavior.

This bug was discovered by seeing failing tests in
test/onnx/test_models.py. The result given by VGG models were
different when run on the CPU with PyTorch vs. ONNX.

