### PR TITLE
BlackBoxPredictor  OSS part 5: glow transforms

### DIFF
--- a/caffe2/opt/custom/glow_net_transform.cc
+++ b/caffe2/opt/custom/glow_net_transform.cc
@@ -1,0 +1,226 @@
+#include "glow_net_transform.h"
+
+#include <caffe2/opt/onnxifi_transformer.h>
+#include <caffe2/utils/string_utils.h>
+
+#include <unordered_set>
+
+C10_DEFINE_bool(
+    onnxifi_debug_mode,
+    false,
+    "Enable onnxifi debug mode.");
+
+C10_DEFINE_bool(
+    onnxifi_adjust_batch,
+    true,
+    "Attach AdjustBatch ops at input/outputs of the Onnxifi ops");
+
+C10_DEFINE_int32(
+    onnxifi_min_ops,
+    1,
+    "Minimum number of ops for a subgraph to be lowered to backend");
+
+C10_DEFINE_string(
+    onnxifi_shape_hints,
+    "",
+    "Shape hints in the form of Name:d0,d1:d2;");
+
+C10_DEFINE_string(
+    onnxifi_blacklist,
+    "",
+    "A list of net positions whose corresponding op will be ignored "
+    "to onnxifi. Example 0-50,61,62-70");
+
+C10_DEFINE_string(
+    onnxifi_blacklist_ops,
+    "",
+    "A list of operator types that will be ignored "
+    "to onnxifi. Example Tanh,Mul");
+
+C10_DEFINE_string(
+    onnxifi_input_output_observe_list,
+    "",
+    "A list of net positins whose corresponding op's inputs and outputs will be"
+    " observed. ");
+
+namespace caffe2 {
+namespace glow {
+
+// The list in in the form of "0-3,5,6-7" which means, we will black list ops
+// with net positions in [0,1,2,3,5,6,7]
+std::unordered_set<int> ParseNetPositionList(const std::string& str) {
+  std::unordered_set<int> net_position_list;
+  if (str.empty()) {
+    return net_position_list;
+  }
+  auto tokens = caffe2::split(',', str);
+  for (const auto& token : tokens) {
+    auto range = caffe2::split('-', token);
+    if (range.size() == 1) {
+      net_position_list.emplace(std::stoi(range[0]));
+    } else if (range.size() == 2) {
+      int from = std::stoi(range[0]);
+      int to = std::stoi(range[1]);
+      for (int i = from; i <= to; ++i) {
+        net_position_list.emplace(i);
+      }
+    } else if (range.size() > 2) {
+      LOG(WARNING) << "Ignoring illegal range: " << token;
+    }
+  }
+  return net_position_list;
+}
+
+namespace {
+
+std::unordered_set<std::string> parseBlackListOps(const std::string& str) {
+  std::unordered_set<std::string> ops;
+  if (str.empty()) {
+    return ops;
+  }
+  auto tokens = caffe2::split(',', str);
+  for (const auto& token : tokens) {
+    ops.emplace(token);
+  }
+  return ops;
+}
+} // namespace
+
+// Carrying out the ONNXIFI transform
+void onnxifi(
+    NetDef* net,
+    Workspace* ws,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::string>& output_names,
+    const std::vector<std::string>& weight_names,
+    const std::unordered_set<int>& blacklist,
+    const std::unordered_map<std::string, TensorShape>& shape_hints,
+    bool use_onnx,
+    size_t max_batch_size,
+    size_t max_seq_size) {
+  // Clean up the external input/output of the net
+  net->mutable_external_input()->Clear();
+  net->mutable_external_output()->Clear();
+  for (const auto& i : input_names) {
+    net->add_external_input(i);
+  }
+  for (const auto& w : weight_names) {
+    net->add_external_input(w);
+  }
+  for (const auto& o : output_names) {
+    net->add_external_output(o);
+  }
+
+  // ONNXIFI transform
+  OnnxifiTransformerOptions opts;
+  opts.use_onnx = use_onnx;
+  opts.bound_shape_spec.max_batch_size = max_batch_size;
+  opts.bound_shape_spec.max_seq_size = max_seq_size;
+  opts.debug = FLAGS_onnxifi_debug_mode;
+  opts.adjust_batch = FLAGS_onnxifi_adjust_batch;
+  opts.min_ops = FLAGS_onnxifi_min_ops;
+
+  auto more_shape_hints = shape_hints;
+  if (!FLAGS_onnxifi_shape_hints.empty()) {
+    auto hints = caffe2::split(';', FLAGS_onnxifi_shape_hints);
+    for (const auto& hint : hints) {
+      auto kv = caffe2::split(':', hint);
+      if (kv.size() == 2) {
+        auto dims = caffe2::split(',', kv.back());
+        TensorShape input;
+        input.set_data_type(TensorProto_DataType_FLOAT);
+        bool valid = true;
+        for (const auto& d : dims) {
+          try {
+            input.add_dims(std::stoi(d));
+          } catch (const std::exception &e) {
+            valid = false;
+            CAFFE_THROW("Cannot parse shape hint: ", hint);
+          }
+        }
+        if (valid) {
+          more_shape_hints.emplace(kv.front(), input);
+        }
+      } else {
+        CAFFE_THROW("Cannot parse shape hint: ", hint);
+      }
+    }
+  }
+
+  // Parse the blacklist
+  auto more_blacklist = ParseNetPositionList(FLAGS_onnxifi_blacklist);
+  for (const auto& b : blacklist) {
+    more_blacklist.emplace(b);
+  }
+
+  // ONNX mode will change the op order so it doesn't apply here
+  if (!opts.use_onnx) {
+    auto blacklisted_ops = parseBlackListOps(FLAGS_onnxifi_blacklist_ops);
+    int i = 0;
+    for (const auto& op : net->op()) {
+      if (blacklisted_ops.count(op.type())) {
+        more_blacklist.emplace(i);
+      }
+      ++i;
+    }
+  }
+
+  // Attach observation nodes
+  //
+  // When we want to observe intermediate tensors value out of the onnxifi op,
+  // we use the following trick:
+  //
+  // 1. for specified op, we find its input and outputs.
+  // 2. for each input and output, we create a new copy op and attach it as an
+  // input to the copy.
+  // 3. we blacklist these new copy operators from onnxification. This forces
+  // these intermediate tensors to also become outputs of the onnxifi op.
+  // 4. we put the right arguments on the copy ops so TensorObserver can print
+  // out the values.
+  auto ops_to_observe =
+      ParseNetPositionList(FLAGS_onnxifi_input_output_observe_list);
+  std::unordered_set<std::string> tensors_to_observe;
+  for (const auto& op : ops_to_observe) {
+    if (op >= net->op().size()) {
+      CAFFE_THROW(
+          "Cannot observe operator at position ", op, " (out of range)");
+    }
+    const auto& op_to_observe = net->op(op);
+    tensors_to_observe.insert(
+        op_to_observe.input().begin(), op_to_observe.input().end());
+
+    if ((op_to_observe.type() == "Concat" ||
+         op_to_observe.type() == "Reshape") &&
+        op_to_observe.output().size() == 2) {
+      tensors_to_observe.insert(op_to_observe.output(0));
+    } else {
+      tensors_to_observe.insert(
+          op_to_observe.output().begin(), op_to_observe.output().end());
+    }
+  }
+  for (const auto& tensor : tensors_to_observe) {
+    OperatorDef copy_op;
+    copy_op.set_type("Copy");
+    copy_op.add_input(tensor);
+    copy_op.add_output(tensor + "_copy_output_ignore");
+    auto pos = net->op().size();
+    AddArgument(kNetPos, pos, &copy_op);
+    AddArgument("observe_input_tensors", 1, &copy_op);
+    net->add_op()->CopyFrom(copy_op);
+    more_blacklist.emplace(pos);
+  }
+
+  OnnxifiTransformer ts(opts);
+  ts.transform(ws, net, weight_names, more_shape_hints, more_blacklist);
+  if (FLAGS_onnxifi_debug_mode) {
+    WriteProtoToTextFile(*net, "debug_transformed_net.pb_txt");
+  }
+
+  // Cleanup the input from the workspace
+  for (const auto& i : input_names) {
+    ws->RemoveBlob(i);
+  }
+}
+
+} // namespace glow
+} // namespace caffe2

--- a/caffe2/opt/custom/glow_net_transform.h
+++ b/caffe2/opt/custom/glow_net_transform.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <caffe2/core/net.h>
+#include <caffe2/core/workspace.h>
+#include <caffe2/proto/caffe2_pb.h>
+
+namespace caffe2 {
+namespace glow {
+
+// Onnxifi transformation on the net and workspace.  We also
+// needed the input data/shape to populate the shape. In addition, we take a \p
+// blacklist to control and mask what ops we want to consider in onnxifi
+// process. We can also set whether to use ONNX proto or C2 proto through
+// ONNXIFI interface.
+void onnxifi(
+    NetDef* net,
+    Workspace* ws,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::string>& output_names,
+    const std::vector<std::string>& weight_names,
+    const std::unordered_set<int>& blacklist,
+    const std::unordered_map<std::string, TensorShape>& shape_hints,
+    bool use_onnx,
+    size_t max_batch_size = 0,
+    size_t max_seq_size = 0);
+
+std::unordered_set<int> ParseNetPositionList(const std::string& str);
+
+} // namespace glow
+} // namespace caffe2

--- a/caffe2/utils/string_utils.cc
+++ b/caffe2/utils/string_utils.cc
@@ -6,12 +6,15 @@
 
 namespace caffe2 {
 
-std::vector<std::string> split(char separator, const std::string& string) {
+std::vector<std::string>
+split(char separator, const std::string& string, bool ignore_empty) {
   std::vector<std::string> pieces;
   std::stringstream ss(string);
   std::string item;
   while (getline(ss, item, separator)) {
-    pieces.push_back(std::move(item));
+    if (!ignore_empty || !item.empty()) {
+      pieces.push_back(std::move(item));
+    }
   }
   return pieces;
 }

--- a/caffe2/utils/string_utils.h
+++ b/caffe2/utils/string_utils.h
@@ -10,7 +10,8 @@
 
 namespace caffe2 {
 
-CAFFE2_API std::vector<std::string> split(char separator, const std::string& string);
+CAFFE2_API std::vector<std::string>
+split(char separator, const std::string& string, bool ignore_empty = false);
 
 CAFFE2_API std::string trim(const std::string& str);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Overal context: open-source BlackBoxPredictor as the entry
point for inference in Caffe2 (thread safe abstraction for Caffe2
inference). This should be used in ThroughputBenchmark for the purpose
of framework comparison
This specific diff:
There should be no harm in moving transformation code to
OSS. On the advantages side we will be able to compare production
Caffe2 setup with PyTorch in the most fair way via
ThroughputBenchmark. This approach avoid any complicated
transformation regirstries. Building those proper would be significant
engineering effort as well as production risk. In the past we had SEVs
related to transforms being turned off due to various refactors. Given
that we don't plan to build any other significant investments into
transformation logic except existing ones (like TVM and Glow), and
those also relate to open-source technologies, I came up to the
conclusion of moving to OSS the whole thing.

Differential Revision: [D16367134](https://our.internmc.facebook.com/intern/diff/D16367134/)