### PR TITLE
Rename torch::autograd::Function to torch::autograd::Node

### DIFF
--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -15,7 +15,7 @@ torch/csrc/autograd/generated/
 #
 # It delegates to the following scripts:
 #
-#  gen_autograd_functions.py: generates subclasses of torch::autograd::Functions
+#  gen_autograd_functions.py: generates subclasses of torch::autograd::Node
 #  gen_variable_type.py: generates VariableType.h which contains all tensor methods
 #  gen_python_functions.py: generates Python bindings to THPVariable
 #

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -1,7 +1,7 @@
 # Generates C++ autograd functions for the derivatives of ATen operations
 #
 # This writes two files:
-#  Functions.h/cpp: subclasses of autograd::Function
+#  Functions.h/cpp: subclasses of autograd::Node
 #  python_functions.h/cpp: Python bindings for the above classes
 #
 import os
@@ -94,7 +94,7 @@ def gen_autograd_functions_python(out, autograd_functions, template_path):
 def gen_autograd_functions(out, autograd_functions, template_path, file_basename):
     """Functions.h and Functions.cpp body
 
-    These contain the auto-generated subclasses of torch::autograd::Function
+    These contain the auto-generated subclasses of torch::autograd::Node
     for each every differentiable torch function.
     """
 
@@ -208,7 +208,7 @@ def process_function(func):
 
     env['body'] = body
     if func['name'] in UNTRACEABLE_FUNCTIONS:
-        env['superclass'] = 'Function'
+        env['superclass'] = 'Node'
     else:
         env['superclass'] = 'TraceableFunction'
     return nested_dict(env, func)

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -216,7 +216,7 @@ if (${cond}) {
 """)
 
 RECORD_FUNCTION = CodeTemplate("""\
-RECORD_FUNCTION("${name}", std::vector<c10::IValue>({${input_names}}), Function::peek_at_next_sequence_nr());
+RECORD_FUNCTION("${name}", std::vector<c10::IValue>({${input_names}}), Node::peek_at_next_sequence_nr());
 """)
 
 SELECT = CodeTemplate("""\
@@ -609,7 +609,7 @@ def emit_body(declaration):
         if is_out_fn:
             setup = ['throw_error_out_requires_grad("{}");'.format(base_name)]
             body = []
-            body.append(DECLARE_GRAD_FN.substitute(op='Function'))
+            body.append(DECLARE_GRAD_FN.substitute(op='Node'))
             body.append(SETUP_DERIVATIVE.substitute(
                 setup=setup,
                 args_with_derivatives=[arg['name'] for arg in differentiable_inputs]))

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -61,7 +61,7 @@ namespace {
 
 // Autograd function for the replicate step in data parallel. This is only used
 // in data parallel, and should not be exposed as a user API.
-struct ReduceAdd : public autograd::Function {
+struct ReduceAdd : public autograd::Node {
   explicit ReduceAdd(const at::Device& destination_device)
       : destination_device_(destination_device) {};
   ~ReduceAdd() override {}

--- a/torch/csrc/autograd/README.md
+++ b/torch/csrc/autograd/README.md
@@ -20,14 +20,14 @@ The most complicated application of this principle is Function, which also
 supports users implementing custom behavior in Python.  We have the following
 classes:
 
-* `Function` in `function.h`, the C++ type.
+* `Node` in `function.h`, the C++ type.
 * `THPFunction` in `python_function.h`, the Python object type.  In
   `python_function.cpp`, you can see the boilerplate that tells the Python
   interpreter about this object.
-* `PyFunction` in `python_function.h`, a subclass of `Function` which forwards
+* `PyFunction` in `python_function.h`, a subclass of `Node` which forwards
   `apply` to a Python `THPFunction`. (NOT a Python object, despite its name!)
 
 Outside of `PyFunction`, the C++ objects largely avoid referencing Python
 objects (there are a few exceptions, like `pyobj` in `Variable`, and
 `PyFunction`, whose whole point is to let C++ call into Python). And `pyobj`
-in `Function` to ensure uniqueness of the associated python wrapper (if it exists).
+in `Node` to ensure uniqueness of the associated python wrapper (if it exists).

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -56,14 +56,14 @@ inline void throw_error_out_requires_grad(const char* name) {
 
 // TODO: Blegh, bare references
 
-inline void rebase_history(Variable& var, std::shared_ptr<Function> grad_fn) {
+inline void rebase_history(Variable& var, std::shared_ptr<Node> grad_fn) {
   if (grad_fn && var.defined()) {
     grad_fn->add_input_metadata(var);
     var.rebase_history({std::move(grad_fn), 0});
   }
 }
 
-inline void rebase_history(std::vector<Variable>&& vars, std::shared_ptr<Function> grad_fn) {
+inline void rebase_history(std::vector<Variable>&& vars, std::shared_ptr<Node> grad_fn) {
   if (grad_fn) {
     for (auto& var : vars) {
       if (var.defined()) {
@@ -71,7 +71,7 @@ inline void rebase_history(std::vector<Variable>&& vars, std::shared_ptr<Functio
         auto output_nr = grad_fn->add_input_metadata(var);
         var.rebase_history({std::move(grad_fn), output_nr});
       } else {
-        grad_fn->add_input_metadata(Function::undefined_input());
+        grad_fn->add_input_metadata(Node::undefined_input());
       }
     }
   }

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -7,7 +7,7 @@ variable_list _wrap_outputs(const variable_list &input_vars,
   const std::unordered_set<at::TensorImpl*> &non_differentiable,
   const std::unordered_set<at::TensorImpl*> &dirty_inputs,
   const at::ArrayRef<Variable> raw_outputs,
-  const std::shared_ptr<Function> &cdata) {
+  const std::shared_ptr<Node> &cdata) {
 
   std::unordered_set<at::TensorImpl*> inputs;
   inputs.reserve(input_vars.size());

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -10,5 +10,5 @@ TORCH_API variable_list _wrap_outputs(
   const std::unordered_set<at::TensorImpl*> &non_differentiable,
   const std::unordered_set<at::TensorImpl*> &dirty_inputs,
   const at::ArrayRef<Variable> raw_outputs,
-  const std::shared_ptr<Function> &cdata);
+  const std::shared_ptr<Node> &cdata);
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/edge.h
+++ b/torch/csrc/autograd/edge.h
@@ -8,13 +8,13 @@
 
 namespace torch { namespace autograd {
 
-struct Function;
+struct Node;
 
 /// Represents a particular input of a function.
 struct Edge {
   Edge() noexcept : function(nullptr), input_nr(0) {}
 
-  Edge(std::shared_ptr<Function> function_, uint32_t input_nr_) noexcept
+  Edge(std::shared_ptr<Node> function_, uint32_t input_nr_) noexcept
       : function(std::move(function_)), input_nr(input_nr_) {}
 
   /// Convenience method to test if an edge is valid.
@@ -32,7 +32,7 @@ struct Edge {
   }
 
   /// The function this `Edge` points to.
-  std::shared_ptr<Function> function;
+  std::shared_ptr<Node> function;
 
   /// The identifier of a particular input to the function.
   uint32_t input_nr;

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -34,10 +34,10 @@ struct TORCH_API Engine {
   Engine();
   virtual ~Engine();
 
-  using ready_queue_type = std::deque<std::pair<std::shared_ptr<Function>, InputBuffer>>;
-  using dependencies_type = std::unordered_map<Function*, int>;
+  using ready_queue_type = std::deque<std::pair<std::shared_ptr<Node>, InputBuffer>>;
+  using dependencies_type = std::unordered_map<Node*, int>;
 
-  // Given a list of (Function, input number) pairs computes the value of the graph
+  // Given a list of (Node, input number) pairs computes the value of the graph
   // by following next_edge references.
   virtual variable_list execute(
       const edge_list& roots,
@@ -54,7 +54,7 @@ struct TORCH_API Engine {
   bool is_checkpoint_valid();
 
 protected:
-  void compute_dependencies(Function* root, GraphTask& task);
+  void compute_dependencies(Node* root, GraphTask& task);
   void evaluate_function(FunctionTask& task);
   ReadyQueue& ready_queue(at::Device device);
   ReadyQueue& ready_queue_by_index(int device_index);

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -19,19 +19,19 @@ namespace torch { namespace autograd {
 /// numbers.
 thread_local uint64_t Function_next_sequence_nr_ = 0;
 
-uint64_t Function::peek_at_next_sequence_nr() {
+uint64_t Node::peek_at_next_sequence_nr() {
   return Function_next_sequence_nr_;
 }
 
-uint64_t& Function::get_next_sequence_nr() {
+uint64_t& Node::get_next_sequence_nr() {
   return Function_next_sequence_nr_;
 }
 
-auto Function::name() const -> std::string {
+auto Node::name() const -> std::string {
   return c10::demangle(typeid(*this).name());
 }
 
-AnomalyMetadata* Function::metadata() noexcept {
+AnomalyMetadata* Node::metadata() noexcept {
   if (!anomaly_metadata_) {
     anomaly_metadata_ = Engine::get_default_engine().make_anomaly_metadata();
   }
@@ -39,8 +39,8 @@ AnomalyMetadata* Function::metadata() noexcept {
 }
 
 static void gatherFunctions(
-    Function* func,
-    std::vector<std::shared_ptr<Function>>& stack) {
+    Node* func,
+    std::vector<std::shared_ptr<Node>>& stack) {
   func->release_variables();
 
   for (auto& edge : func->next_edges()) {
@@ -55,29 +55,29 @@ static void gatherFunctions(
 /*
   * Fix for #5534: prevent stack overflow on deletion of deep computation graph
   *
-  * Sometimes one can end up with a very big computation graph of Functions
-  * and Edges. Each std::shared_ptr<Function> contains a list of Edge, and
-  * each Edge contains a std::shared_ptr<Function>. Deleting a
-  * std::shared_ptr<Function> can trigger the recursive deletion of other
-  * std::shared_ptr<Function>'s: this can stack overflow if the graph
+  * Sometimes one can end up with a very big computation graph of Nodes
+  * and Edges. Each std::shared_ptr<Node> contains a list of Edge, and
+  * each Edge contains a std::shared_ptr<Node>. Deleting a
+  * std::shared_ptr<Node> can trigger the recursive deletion of other
+  * std::shared_ptr<Node>'s: this can stack overflow if the graph
   * is deep enough. Here is an example of such a graph:
   *
-  * shared_ptr<Function> -> Edge -> shared_ptr<Function> -> Edge -> ... -> shared_ptr<Function>
+  * shared_ptr<Node> -> Edge -> shared_ptr<Node> -> Edge -> ... -> shared_ptr<Node>
   *
   * The solution here is to detect when we are decrementing away the last
-  * reference to a Function, and when doing so to buffer up the Function's
+  * reference to a Node, and when doing so to buffer up the Node's
   * that will be recursively decremented.  We can then decrement (and free)
-  * the original Function without causing a recursive cascade, before
+  * the original Node without causing a recursive cascade, before
   * draining the buffer applying the same behavior.  This is, in effect,
   * converting recursion to a loop, using a heap buffer in place of the
   * recursive call stack.
   */
-void deleteFunction(Function* function) {
+void deleteFunction(Node* function) {
   // To avoid stack overflow on large computational graphs,
   // we need to track reference decrementing and freeing
   // on the heap.
   function->release_variables();
-  std::vector<std::shared_ptr<Function>> stack;
+  std::vector<std::shared_ptr<Node>> stack;
   gatherFunctions(function, stack);
   delete function;
 

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -34,33 +34,33 @@ using saved_variable_list = std::vector<SavedVariable>;
 using IndexRange = std::pair<size_t, size_t>;
 
 // Custom deleter to prevent stack overflows.
-TORCH_API void deleteFunction(Function* function);
+TORCH_API void deleteFunction(Node* function);
 
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-///                               Function
+///                               Node
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/// A `Function` is an abstract class that represents an operation taking zero
+/// A `Node` is an abstract class that represents an operation taking zero
 /// or more input `Variable`s and producing zero or more output `Variable`s. All
 /// functions in PyTorch's autograd machinery derive from this class and
 /// override its `apply` method. Instances of such subclasses will then be
 /// invokeable via the call operator.
 ///
-///                    Functions in the Autograd Graph
+///                    Nodes in the Autograd Graph
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/// When viewing the autograd system as a graph, `Function`s are the vertices or
+/// When viewing the autograd system as a graph, `Node`s are the vertices or
 /// nodes, connected to each other via (directed) `Edge`s, which themselves are
-/// represented via (`Function`, input_nr) pairs. `Variable`s are the outputs to
-/// and inputs of `Function`s, and travel between these edges during execution
+/// represented via (`Node`, input_nr) pairs. `Variable`s are the outputs to
+/// and inputs of `Node`s, and travel between these edges during execution
 /// of the graph. When two or more `Edge`s (from different sources) point at the
-/// same input to a `Function`, the values produced along all of these edges are
-/// implicitly summed prior to being forwarded to the target `Function`.
+/// same input to a `Node`, the values produced along all of these edges are
+/// implicitly summed prior to being forwarded to the target `Node`.
 ///
 ///                              Hierarchy
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// Subclasses usually represent differentiable functions as well as their
 /// gradient operators. Note, however, that due to the very general definition
-/// of a `Function` taking *zero* or more inputs and producing *zero* or more
-/// outputs, uses of `Function`s are flexible and extend beyond purely
+/// of a `Node` taking *zero* or more inputs and producing *zero* or more
+/// outputs, uses of `Node`s are flexible and extend beyond purely
 /// mathematical operations. For example, the `AccumulateGrad` function is a
 /// *sink*: it takes one input, but produces no outputs, instead accumulating
 /// the input as a side effect. At the other extreme, the `GraphRoot` function
@@ -68,28 +68,28 @@ TORCH_API void deleteFunction(Function* function);
 ///
 ///                              Interface
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/// The most important method on `Function` is the call operator, which takes in
+/// The most important method on `Node` is the call operator, which takes in
 /// a list of variables and produces a list of variables. The precise size of
 /// these lists can be determined with `num_inputs()` and `num_outputs()`.
-/// `Function`s are stitched together via their `next_edge` interface, which let
-/// you manipulate the set of outgoing edges of a `Function`. You can add an
+/// `Node`s are stitched together via their `next_edge` interface, which let
+/// you manipulate the set of outgoing edges of a `Node`. You can add an
 /// edge with `add_next_edge()`, retrieve an edge with `next_edge(index)` and
 /// iterate over them via the `next_edges()` method. Other methods exist for
-/// integration with the JIT and other parts of PyTorch. Every `Function` has a
-/// *sequence number* that increases monotonically in the order of `Function`
+/// integration with the JIT and other parts of PyTorch. Every `Node` has a
+/// *sequence number* that increases monotonically in the order of `Node`
 /// construction. It can be retrieved via the `sequence_nr()` method. Note that
-/// this sequence number is *thread local*. This means that when `Function`s
+/// this sequence number is *thread local*. This means that when `Node`s
 /// `A`, `B` and `C` are created consecutively in the same thread, their
 /// sequence numbers will be ordered `A` < `B` < `C`. If, however, `A` and `B`
 /// are created in one thread and `C` is created in a new thread, there are *no
 /// guarantees* w.r.t. the ordering of `C` relative to `A` or `B`.
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-struct TORCH_API Function : std::enable_shared_from_this<Function> {
+struct TORCH_API Node : std::enable_shared_from_this<Node> {
  public:
-  /// Construct a new `Function` with the given `next_edges`. `sequence_nr` is
+  /// Construct a new `Node` with the given `next_edges`. `sequence_nr` is
   /// a (currently THE) hint to prioritization in the backward() pass, with
   /// higher sequence numbers prioritized before lower sequence numbers.
-  explicit Function(
+  explicit Node(
       uint64_t sequence_nr,
       edge_list&& next_edges = edge_list())
       : sequence_nr_(sequence_nr),
@@ -99,15 +99,15 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
     }
   }
 
-  explicit Function(edge_list&& next_edges = edge_list())
-      : Function(get_next_sequence_nr()++, std::move(next_edges)) {}
+  explicit Node(edge_list&& next_edges = edge_list())
+      : Node(get_next_sequence_nr()++, std::move(next_edges)) {}
 
-  /// Functions are neither copyable nor moveable.
-  Function(const Function& other) = delete;
-  Function(Function&& other) = delete;
-  Function& operator=(const Function& other) = delete;
-  Function& operator=(Function&& other) = delete;
-  virtual ~Function() = default;
+  /// Nodes are neither copyable nor moveable.
+  Node(const Node& other) = delete;
+  Node(Node&& other) = delete;
+  Node& operator=(const Node& other) = delete;
+  Node& operator=(Node&& other) = delete;
+  virtual ~Node() = default;
 
   /// Evaluates the function on the given inputs and returns the result of the
   /// function call.
@@ -196,9 +196,16 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
   // Miscellaneous Methods
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  /// The sequence number of this `Function`.
+  /// The sequence number of this `Node`.
   uint64_t sequence_nr() const noexcept {
     return sequence_nr_;
+  }
+
+  /// Returns a shared pointer to `this`. `PyFunction`s are not managed by
+  /// `shared_ptr`s by default, but are bound to the lifetime of their Python
+  /// object instead.
+  virtual std::shared_ptr<Node> get_shared_ptr() {
+    return shared_from_this();
   }
 
   /// Returns the name of the dynamic type of the function, for debugging.
@@ -222,18 +229,18 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
     });
   }
 
-  /// Returns the `PyObject` stored for this `Function` (for Python
+  /// Returns the `PyObject` stored for this `Node` (for Python
   /// interaction).
   PyObject* pyobj() const noexcept {
     return pyobj_;
   }
 
-  /// Sets the `PyObject` stored for this `Function` (for Python interaction).
+  /// Sets the `PyObject` stored for this `Node` (for Python interaction).
   void set_pyobj(PyObject* pyobj) noexcept {
     pyobj_ = pyobj;
   }
 
-  /// Returns the anomaly metadata stored for this `Function`.
+  /// Returns the anomaly metadata stored for this `Node`.
   /// If none exist, creates a new empty one.
   AnomalyMetadata* metadata() noexcept;
 
@@ -298,7 +305,7 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
     return false;
   }
 
-  /// A `Function` is said to pass state transparently to backward, if the
+  /// A `Node` is said to pass state transparently to backward, if the
   /// state consists only of (Saved)Variables and only non-variable objects
   /// that parameterize the operation in some way that defines the graph
   /// structure AND the backward function is traceable. In particular,
@@ -316,13 +323,13 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
  protected:
   static uint64_t& get_next_sequence_nr();
 
-  /// Performs the `Function`'s actual operation.
+  /// Performs the `Node`'s actual operation.
   virtual variable_list apply(variable_list&& inputs) = 0;
 
   /// Calls `apply()`, but instruments it with tracing machinery.
   variable_list traced_apply(variable_list inputs);
 
-  // Since `Function`s are neither copyable nor moveable, we can have const
+  // Since `Node`s are neither copyable nor moveable, we can have const
   // fields.
   const uint64_t sequence_nr_;
 
@@ -334,16 +341,16 @@ struct TORCH_API Function : std::enable_shared_from_this<Function> {
   at::SmallVector<InputMetadata, 2> input_metadata_;
 };
 
-/// See Function::is_traceable() for definition.
-struct TraceableFunction : public Function {
-  using Function::Function;
+/// See Node::is_traceable() for definition.
+struct TraceableFunction : public Node {
+  using Node::Node;
   bool is_traceable() final {
     return true;
   }
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-//                       Associated Free Functions
+//                       Associated Free Nodes
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 namespace detail {
@@ -367,14 +374,14 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
 /// This sets the `grad_fn` property of the `variable`. This function assumes
 /// that the `Variable` is a new input to the gradient function and its
 /// `input_nr` thus equal to `function->num_inputs()`. Additionally, it
-/// increments the `Function`'s number of inputs by one. Approximately
+/// increments the `Node`'s number of inputs by one. Approximately
 /// equivalent to `variable.set_gradient_edge(function,
 /// function->add_input_metadata(variable.dispatch_type(), variable.sizes()))`.
-/// If you don't want the `Function`'s `num_inputs` to be incremented, use
+/// If you don't want the `Node`'s `num_inputs` to be incremented, use
 /// `set_gradient_edge` directly.
 inline void create_gradient_edge(
     Variable& variable,
-    std::shared_ptr<Function> function) {
+    std::shared_ptr<Node> function) {
   // Copy before move.
   const auto input_nr = function->add_input_metadata(variable);
   variable.set_gradient_edge({std::move(function), input_nr});

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -17,7 +17,7 @@ namespace torch { namespace autograd {
 // AccumulateGrad sets sequence_nr to the max value so it's always called
 // ASAP during backwards.
 AccumulateGrad::AccumulateGrad(Variable variable_)
-    : Function(/*sequence_nr=*/UINT64_MAX)
+    : Node(/*sequence_nr=*/UINT64_MAX)
     , variable(std::move(variable_)) {
   add_input_metadata(variable);
 }

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -6,7 +6,7 @@
 
 namespace torch { namespace autograd {
 
-struct TORCH_API AccumulateGrad : public Function {
+struct TORCH_API AccumulateGrad : public Node {
   explicit AccumulateGrad(Variable variable_);
 
   variable_list apply(variable_list&& grads) override;

--- a/torch/csrc/autograd/functions/basic_ops.h
+++ b/torch/csrc/autograd/functions/basic_ops.h
@@ -10,9 +10,9 @@
 
 namespace torch { namespace autograd {
 
-struct TORCH_API Error : public Function {
+struct TORCH_API Error : public Node {
   Error(std::string msg, edge_list&& next_edges)
-    : Function(std::move(next_edges))
+    : Node(std::move(next_edges))
     , msg(std::move(msg)) {}
 
   Error(std::string msg)
@@ -36,11 +36,11 @@ struct TORCH_API NotImplemented : public Error {
 };
 
 // Identity in forward, Error in backward. Used to implement @once_differentiable
-struct TORCH_API DelayedError : public Function {
+struct TORCH_API DelayedError : public Node {
   DelayedError(std::string msg, int num_inputs)
     : msg(std::move(msg)) {
       for (int i = 0; i < num_inputs; i++)
-        add_input_metadata(Function::undefined_input());
+        add_input_metadata(Node::undefined_input());
     }
 
   variable_list apply(variable_list&& inputs) override;
@@ -48,9 +48,9 @@ struct TORCH_API DelayedError : public Function {
   std::string msg;
 };
 
-struct TORCH_API GraphRoot : public Function {
+struct TORCH_API GraphRoot : public Node {
   GraphRoot(edge_list functions, variable_list inputs)
-      : Function(std::move(functions)),
+      : Node(std::move(functions)),
         outputs(std::move(inputs)) {}
 
   variable_list apply(variable_list&& inputs) override {

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -34,7 +34,7 @@ variable_list Scatter::apply(variable_list&& inputs) {
   AT_ASSERT(inputs.size() == 1);
   auto& input = inputs.front();
 
-  std::shared_ptr<Function> grad_fn;
+  std::shared_ptr<Node> grad_fn;
   if (compute_requires_grad(input)) {
     grad_fn =
         std::make_shared<Gather>(/*destination_device=*/input.device(), dim_);
@@ -101,7 +101,7 @@ variable_list Gather::apply(variable_list&& inputs) {
     }
   }
 
-  std::shared_ptr<Function> grad_fn;
+  std::shared_ptr<Node> grad_fn;
   if (compute_requires_grad(inputs)) {
     std::vector<at::Device> source_devices;
     std::vector<int64_t> input_sizes;

--- a/torch/csrc/autograd/functions/comm.h
+++ b/torch/csrc/autograd/functions/comm.h
@@ -15,7 +15,7 @@ namespace torch {
 namespace autograd {
 
 //TODO: change it to TORCH_API when we merge the libs
-struct AT_CUDA_API Scatter : public Function {
+struct AT_CUDA_API Scatter : public Node {
   explicit Scatter(
       std::vector<at::Device> devices,
       const c10::optional<std::vector<int64_t>>& chunk_sizes = c10::nullopt,
@@ -34,7 +34,7 @@ struct AT_CUDA_API Scatter : public Function {
   bool unsqueeze_scalars_;
 };
 
-struct AT_CUDA_API Gather : public Function {
+struct AT_CUDA_API Gather : public Node {
   explicit Gather(const at::Device& destination_device, int64_t dim = 0);
   ~Gather() override;
 

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -26,7 +26,7 @@ struct DelayedErrorCtor {
 };
 
 struct NoCtor {
-  Function* operator()(PyObject* args) {
+  Node* operator()(PyObject* args) {
     throw std::runtime_error("Cannot construct");
   }
 };

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -42,8 +42,8 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
 CopySlices::CopySlices(
     const Variable& base_var,
     at::TensorGeometry view_,
-    std::shared_ptr<Function> fn_)
-    : Function(),
+    std::shared_ptr<Node> fn_)
+    : Node(),
       base(base_var),
       view(std::move(view_)),
       fn(std::move(fn_)) {

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -13,7 +13,7 @@
 
 namespace torch { namespace autograd {
 
-struct TORCH_API CopyBackwards : public Function {
+struct TORCH_API CopyBackwards : public Node {
   variable_list apply(variable_list&& grads) override;
 
   at::DeprecatedTypeProperties *src_type = nullptr; // initialized for safety.
@@ -27,18 +27,18 @@ struct TORCH_API CopyBackwards : public Function {
 // grad_fn is updated to become a `CopySlice` wrapping the backward of the
 // in-place operation.
 // See NOTE [ Autograd View Variables ].
-struct TORCH_API CopySlices : public Function {
+struct TORCH_API CopySlices : public Node {
   CopySlices(
       const Variable& base_var,
       at::TensorGeometry view_,
-      std::shared_ptr<Function> fn_);
+      std::shared_ptr<Node> fn_);
 
   variable_list apply(variable_list&& inputs) override;
   void release_variables() override;
 
   at::TensorGeometry base;
   at::TensorGeometry view;
-  std::shared_ptr<Function> fn;
+  std::shared_ptr<Node> fn;
 };
 
 }}

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -29,7 +29,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
         autograd::create_gradient_edge(variable, grad_fn);
         result.push_back(std::move(variable));
       } else {
-        grad_fn->add_input_metadata(Function::undefined_input());
+        grad_fn->add_input_metadata(Node::undefined_input());
         result.emplace_back();
       }
     }

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -13,7 +13,7 @@
 
 namespace torch { namespace autograd {
 
-using function_constructor = std::function<std::shared_ptr<Function>(edge_list&&)>;
+using function_constructor = std::function<std::shared_ptr<Node>(edge_list&&)>;
 
 /**
  * Wraps the tensor outputs in variables and creates the grad_fn and sets the
@@ -50,20 +50,20 @@ inline bool compute_requires_grad(Args&&... args) {
 
 inline void set_history(
     at::Tensor& variable,
-    const std::shared_ptr<Function>& grad_fn) {
+    const std::shared_ptr<Node>& grad_fn) {
   AT_ASSERT(grad_fn);
   if (variable.defined()) {
     auto output_nr =
         grad_fn->add_input_metadata(variable);
     as_variable_ref(variable).set_gradient_edge({grad_fn, output_nr});
   } else {
-    grad_fn->add_input_metadata(Function::undefined_input());
+    grad_fn->add_input_metadata(Node::undefined_input());
   }
 }
 
 inline void set_history(
     std::vector<Variable>&& variables,
-    const std::shared_ptr<Function>& grad_fn) {
+    const std::shared_ptr<Node>& grad_fn) {
   for (auto& variable : variables) {
     set_history(variable, grad_fn);
   }
@@ -71,7 +71,7 @@ inline void set_history(
 
 inline void set_history(
     std::vector<Variable>& variables,
-    const std::shared_ptr<Function>& grad_fn) {
+    const std::shared_ptr<Node>& grad_fn) {
   for (auto& variable : variables) {
     set_history(variable, grad_fn);
   }

--- a/torch/csrc/autograd/profiler.h
+++ b/torch/csrc/autograd/profiler.h
@@ -21,7 +21,7 @@ typedef struct CUevent_st* CUDAEventStub;
 
 namespace torch { namespace autograd {
 
-struct Function;
+struct Node;
 
 namespace profiler {
 

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -198,7 +198,7 @@ struct DefaultFunctionType {
   PyTypeObject type;
 };
 
-PyObject* functionToPyObject(const std::shared_ptr<Function>& cdata)
+PyObject* functionToPyObject(const std::shared_ptr<Node>& cdata)
 {
   static DefaultFunctionType default_type;
 
@@ -227,7 +227,7 @@ PyObject* functionToPyObject(const std::shared_ptr<Function>& cdata)
     THPObjectPtr obj(type->tp_alloc(type, 0));
     if (!obj) return nullptr;
     THPCppFunction* f = (THPCppFunction*)obj.get();
-    new (&f->cdata) std::shared_ptr<Function>(cdata);
+    new (&f->cdata) std::shared_ptr<Node>(cdata);
 
     // No INCREF here as we only have a weak reference
     cdata->set_pyobj(obj.release());
@@ -242,7 +242,7 @@ void registerCppFunction(const std::type_info& type, PyTypeObject* pytype)
   cpp_function_types[std::type_index(type)] = THPObjectPtr((PyObject*)pytype);
 }
 
-PyObject* registerFunctionHook(Function& fn, PyObject* hook)
+PyObject* registerFunctionHook(Node& fn, PyObject* hook)
 {
   PyObject* dict = Py_None;
   for (const auto& hook : fn.post_hooks()) {

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -12,7 +12,7 @@ namespace torch { namespace autograd {
 
 struct THPCppFunction {
   PyObject_HEAD
-  std::shared_ptr<Function> cdata;
+  std::shared_ptr<Node> cdata;
 };
 
 template<typename Ctor>
@@ -22,7 +22,7 @@ PyObject* CppFunction_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
   if (!obj) return nullptr;
   THPCppFunction* f = (THPCppFunction*)obj.get();
   HANDLE_TH_ERRORS
-  new (&f->cdata) std::shared_ptr<Function>(Ctor()(args));
+  new (&f->cdata) std::shared_ptr<Node>(Ctor()(args));
   END_HANDLE_TH_ERRORS
   if (!f->cdata) {
     return nullptr;
@@ -50,7 +50,7 @@ PyObject* THPCppFunction_name(PyObject* self);
 PyTypeObject* _initFunctionPyTypeObject(PyTypeObject& type, const char* name,
   PyGetSetDef* function_properties, PyMethodDef* function_methods);
 
-PyObject* registerFunctionHook(Function& fn, PyObject* hook);
+PyObject* registerFunctionHook(Node& fn, PyObject* hook);
 
 template<typename Ctor>
 PyTypeObject* createForwardFunctionPyTypeObject(PyTypeObject& type, const char* name,
@@ -61,6 +61,6 @@ PyTypeObject* createForwardFunctionPyTypeObject(PyTypeObject& type, const char* 
 }
 
 void registerCppFunction(const std::type_info& type, PyTypeObject* pytype);
-PyObject* functionToPyObject(const std::shared_ptr<Function>& cdata);
+PyObject* functionToPyObject(const std::shared_ptr<Node>& cdata);
 
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -32,7 +32,7 @@ struct VariableInfo {
 
 // A Function which is implemented by a Python object (i.e., a THPFunction).
 // Calls to 'apply' are forwarded to the Python method implementation.
-struct PyFunction : public Function {
+struct PyFunction : public Node {
   PyFunction(THPObjectPtr obj) : obj(obj.release()) {}
 
   variable_list apply(variable_list&& inputs) override;
@@ -102,7 +102,7 @@ struct THPFunction {
     // it is guaranteed that cdata.lock()->obj == this
     //
     // In most ordinary use, this field should always be non-NULL; e.g.,
-    // when we allocate a THPFunction because we are running Function.apply,
+    // when we allocate a THPFunction because we are running Node.apply,
     // after constructing a THPFunction, we immediately allocate a PyFunction
     // for it.  We can't enforce this directly in the constructor of
     // THPFunction though, because there's no way to keep it live long enough

--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -162,7 +162,7 @@ void RecordFunction::before(std::string name, int64_t sequence_nr) {
   processCallbacks();
 }
 
-void RecordFunction::before(Function* fn, int64_t sequence_nr) {
+void RecordFunction::before(Node* fn, int64_t sequence_nr) {
   if (!hasCallbacks()) {
     return;
   }

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -6,7 +6,7 @@
 
 namespace torch { namespace autograd {
 
-struct Function;
+struct Node;
 
 namespace profiler {
 
@@ -34,7 +34,7 @@ struct TORCH_API RecordFunction {
   // start callbacks
   void before(const char* name, int64_t sequence_nr = -1);
   void before(std::string name, int64_t sequence_nr = -1);
-  void before(Function* fn, int64_t sequence_nr = -1);
+  void before(Node* fn, int64_t sequence_nr = -1);
 
   template<typename F>
   void before(
@@ -57,7 +57,7 @@ struct TORCH_API RecordFunction {
   // Destructor calls end callbacks
   virtual ~RecordFunction();
 
-  inline Function* func() const {
+  inline Node* func() const {
     return fn_;
   }
 
@@ -84,7 +84,7 @@ struct TORCH_API RecordFunction {
  private:
   void processCallbacks();
 
-  Function* fn_ = nullptr;
+  Node* fn_ = nullptr;
   StringView name_;
   int64_t sequence_nr_ = -1;
   std::vector<c10::IValue> inputs_;

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -33,7 +33,7 @@ SavedVariable::SavedVariable(const Variable& variable, bool is_output) {
   }
 }
 
-Variable SavedVariable::unpack(std::shared_ptr<Function> saved_for) const {
+Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
   if (!data_.defined()) {
     if (!was_default_constructed_) {
       throw std::runtime_error(ERR_BACKWARD_TWICE);

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -10,7 +10,7 @@
 namespace torch { namespace autograd {
 
 struct Variable;
-struct Function;
+struct Node;
 
 TORCH_API extern const char* ERR_BACKWARD_TWICE;
 
@@ -26,7 +26,7 @@ class TORCH_API SavedVariable {
   /// Reconstructs the saved variable. Pass `saved_for` as the gradient
   /// function if constructing the `SavedVariable` with it would have caused a
   /// circular reference.
-  Variable unpack(std::shared_ptr<Function> saved_for = nullptr) const;
+  Variable unpack(std::shared_ptr<Node> saved_for = nullptr) const;
 
   void reset_data() {
     return data_.reset();
@@ -43,8 +43,8 @@ class TORCH_API SavedVariable {
   // is false, then this is a leaf node. Note that the grad_fn is not saved if
   // it would create a circular reference. In that case, the grad_fn must be
   // passed in to the unpack function when reconstructing the Variable.
-  std::shared_ptr<Function> grad_fn_;
-  std::weak_ptr<Function> grad_accumulator_;
+  std::shared_ptr<Node> grad_fn_;
+  std::weak_ptr<Node> grad_accumulator_;
   c10::VariableVersion version_counter_;
 
   uint32_t saved_version_ = 0;

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -34,7 +34,7 @@ Variable::AutogradMeta::AutogradMeta(at::TensorImpl* self_impl, bool requires_gr
       "requires_grad should be false if grad_fn is set");
 }
 
-std::shared_ptr<Function> Variable::grad_accumulator() const {
+std::shared_ptr<Node> Variable::grad_accumulator() const {
   auto autograd_meta = get_autograd_meta();
   if (autograd_meta->grad_fn_) {
     throw std::logic_error(
@@ -132,7 +132,7 @@ Variable::DifferentiableViewMeta::~DifferentiableViewMeta() {
   base_.reset();
 }
 
-const std::shared_ptr<Function>& Variable::grad_fn() const {
+const std::shared_ptr<Node>& Variable::grad_fn() const {
   if (is_view()) {
     auto diff_view_meta = static_cast<Variable::DifferentiableViewMeta*>(get_autograd_meta());
     std::lock_guard<std::mutex> lock(diff_view_meta->mutex_);

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -18,14 +18,14 @@
 
 namespace torch { namespace autograd {
 
-struct Function;
+struct Node;
 
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ///                                Variable
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// A `Variable` augments a `Tensor` with the ability to interact in our
 /// autograd machinery. Conceptually, `Variable`s travel along `Edge`s between
-/// `Function`s in the autograd graph. A `Variable` can either be a leaf, like a
+/// `Node`s in the autograd graph. A `Variable` can either be a leaf, like a
 /// weight in a neural network, or an interior variable, when it is the result
 /// of an operation between variables. Every `Variable` also stores another
 /// `Variable` called its `grad` (gradient). If the variable is a leaf, its
@@ -164,7 +164,7 @@ struct TORCH_API Variable : public at::Tensor {
   /// and expecting the original variable `var` to also be updated.
   at::Tensor variable_data() const noexcept;
 
-  // Gradient Function and Edges
+  // Gradient Node and Edges
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   /// Gets the gradient function of the `Variable`. If this is a leaf variable,
@@ -174,28 +174,28 @@ struct TORCH_API Variable : public at::Tensor {
   /// Gets the up-to-date grad_fn. If the shared data or base was modified, we
   /// re-create the grad_fn to express the up-to-date view relationship between
   /// this and the base Variable.
-  const std::shared_ptr<Function>& grad_fn() const;
+  const std::shared_ptr<Node>& grad_fn() const;
 
   /// Gets the raw gradient function pointer, whatever it currently is.
-  Function* grad_fn_unsafe() const;
+  Node* grad_fn_unsafe() const;
 
   /// Set the gradient accumulator of the `Variable`. This is only applicable to
   /// leaf variables. Interior variables should call `set_gradient_edge()`.
-  void set_grad_accumulator(std::weak_ptr<Function> grad_accumulator);
+  void set_grad_accumulator(std::weak_ptr<Node> grad_accumulator);
 
   /// Attempts to get a pointer to the gradient accumulator of the `Variable`,
   /// if it still exists. If the gradient accumulator function has been
   /// destroyed, returns a `nullptr`.
-  std::shared_ptr<Function> try_get_grad_accumulator() const;
+  std::shared_ptr<Node> try_get_grad_accumulator() const;
 
   /// Gets the gradient accumulator of the `Variable` if it has one, or else
   /// create one on the fly and return it.
-  std::shared_ptr<Function> grad_accumulator() const;
+  std::shared_ptr<Node> grad_accumulator() const;
 
   /// Returns the "canonical" gradient edge of this `Variable`, i.e. either the
   /// gradient function if this is an interior `Variable`, or the gradient
   /// accumulator otherwise. If the `Variable` is interior, the returned `Edge`
-  /// will store the input index of the `Function` to which this variable is
+  /// will store the input index of the `Node` to which this variable is
   /// connected in its `input_nr` field. For leaves, the `input_nr` is always
   /// zero. Note that `set_gradient_edge` and `gradient_edge` are not
   /// symmetric. You must use `set_gradient_edge` to set the `grad_fn` and
@@ -251,9 +251,9 @@ struct TORCH_API Variable : public at::Tensor {
   /// `Variable`.
   void set_gradient_edge(Edge edge) noexcept;
 
-  /// Returns the input index of the gradient `Function` to which this
-  /// `Variable` is connected.  Note: input indexes of the gradient `Function`
-  /// correspond to output indexes of the corresponding forward `Function`.
+  /// Returns the input index of the gradient `Node` to which this
+  /// `Variable` is connected.  Note: input indexes of the gradient `Node`
+  /// correspond to output indexes of the corresponding forward `Node`.
   uint32_t output_nr() const noexcept;
 
   /// True if this `Variable` is a leaf and thus does not have a `grad_fn`.
@@ -334,8 +334,8 @@ struct TORCH_API Variable::AutogradMeta : public c10::AutogradMetaInterface {
   std::string name;
 
   Variable grad_;
-  std::shared_ptr<Function> grad_fn_;
-  std::weak_ptr<Function> grad_accumulator_;
+  std::shared_ptr<Node> grad_fn_;
+  std::weak_ptr<Node> grad_accumulator_;
 
   std::vector<std::shared_ptr<FunctionPreHook>> hooks_;
 
@@ -597,19 +597,19 @@ inline at::Tensor Variable::variable_data() const noexcept {
   return at::Tensor(self_impl_copy);
 }
 
-// Gradient Function and Edges
+// Gradient Node and Edges
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-inline Function* Variable::grad_fn_unsafe() const {
+inline Node* Variable::grad_fn_unsafe() const {
   return get_autograd_meta()->grad_fn_.get();
 }
 
 inline void Variable::set_grad_accumulator(
-    std::weak_ptr<Function> grad_accumulator) {
+    std::weak_ptr<Node> grad_accumulator) {
   get_autograd_meta()->grad_accumulator_ = std::move(grad_accumulator);
 }
 
-inline std::shared_ptr<Function> Variable::try_get_grad_accumulator() const {
+inline std::shared_ptr<Node> Variable::try_get_grad_accumulator() const {
   return get_autograd_meta()->grad_accumulator_.lock();
 }
 

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -491,8 +491,8 @@ void Reducer::initialize_buckets(
 void Reducer::prepare_for_backward(
     const std::vector<torch::autograd::Variable>& outputs) {
   std::lock_guard<std::mutex> lock(mutex_);
-  std::unordered_set<torch::autograd::Function*> seen;
-  std::vector<torch::autograd::Function*> queue;
+  std::unordered_set<torch::autograd::Node*> seen;
+  std::vector<torch::autograd::Node*> queue;
 
   // Check that any prior reduction has finished.
   // The variable `require_finalize_` is true until all gradients

--- a/torch/csrc/distributed/c10d/reducer.h
+++ b/torch/csrc/distributed/c10d/reducer.h
@@ -62,10 +62,10 @@ class Reducer {
   std::shared_ptr<c10d::ProcessGroup> process_group_;
   std::vector<std::vector<bool>> expect_sparse_gradients_;
 
-  std::vector<std::vector<std::shared_ptr<torch::autograd::Function>>>
+  std::vector<std::vector<std::shared_ptr<torch::autograd::Node>>>
       grad_accumulators_;
-  std::unordered_map<torch::autograd::Function*, VariableIndex> func_;
-  std::vector<std::pair<uintptr_t, std::shared_ptr<torch::autograd::Function>>>
+  std::unordered_map<torch::autograd::Node*, VariableIndex> func_;
+  std::vector<std::pair<uintptr_t, std::shared_ptr<torch::autograd::Node>>>
       hooks_;
 
   bool expect_autograd_hooks_;

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -111,7 +111,7 @@ struct CaptureList {
 
   void unpack(
       Stack& stack,
-      const std::shared_ptr<autograd::Function>& saved_for) {
+      const std::shared_ptr<autograd::Node>& saved_for) {
     auto var_capture_it = var_captures_.begin();
     auto ivalue_capture_it = ivalue_captures_.begin();
     auto size_it = sizes_.begin();
@@ -189,7 +189,7 @@ struct UnpackInstructions {
   std::vector<size_t> sizes_;
 };
 
-struct DifferentiableGraphBackward : public autograd::Function {
+struct DifferentiableGraphBackward : public autograd::Node {
   DifferentiableGraphBackward(
       GraphExecutor executor,
       size_t input_size,
@@ -213,7 +213,7 @@ struct DifferentiableGraphBackward : public autograd::Function {
     // Here stack.size()[=1] with a TensorList IValue of
     // backward graph output.
     // num_outputs()[=2], however, is the number of outputs of
-    // grad_fn (an autograd::Function). grad_fn's outputs are
+    // grad_fn (an autograd::Node). grad_fn's outputs are
     // grads with regard to Tensor/Variables `x`, but not
     // graph input TensorList [x, x]. These two grads will
     // be accumulated to x.grad later using autograd::InputBuffer.
@@ -262,7 +262,7 @@ struct DifferentiableGraphBackward : public autograd::Function {
       autograd::create_gradient_edge(output, shared_from_this());
       output.set_requires_grad(true);
     } else {
-      add_input_metadata(autograd::Function::undefined_input{});
+      add_input_metadata(autograd::Node::undefined_input{});
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23269 Rename torch::autograd::Function to torch::autograd::Node**

Summary:
We will be adding an API for custom autograd functions in C++ (https://github.com/pytorch/pytorch/pull/23020) and we would like to expose it as `torch::autograd::Function` (which is different from the current `torch::autograd::Function`) to match the Python API. So, I plan to rename the current `torch::autograd::Function` to `torch::autograd::Node` and `torch::autograd::PyFunction` to `torch::autograd::PyNode`.  `FunctionTask`, and `deleteFunction` renamed to `NodeTask`, `deleteNode` for consistency.

Differential Revision: [D16454878](https://our.internmc.facebook.com/intern/diff/D16454878)