### PR TITLE
deepCopy also copies type information of lists

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -435,6 +435,10 @@ public:
   // TODO Test use_count
   size_t use_count() const;
 
+  // private API for now because the return type will change to TypePtr
+  // instead of optional<TypePtr> once types are mandatory.
+  optional<TypePtr> _elementType() const;
+
 private:
   explicit List(c10::intrusive_ptr<detail::ListImpl<StorageT>>&& elements);
   friend struct IValue;

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -289,4 +289,9 @@ size_t List<T>::use_count() const {
   return impl_.use_count();
 }
 
+template<class T>
+optional<TypePtr> List<T>::_elementType() const {
+  return impl_->elementType;
+}
+
 }

--- a/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
+++ b/torch/csrc/jit/passes/utils/check_alias_annotation.cpp
@@ -26,21 +26,14 @@ IValue deepCopy(const IValue& self) {
   // Lists of ivalues should recursively deep copy their contents
   if (self.isGenericList()) {
     auto source = std::move(self).toGenericList();
-    auto deepCopyGenericList = [&] (c10::impl::GenericList& dest) {
-      dest.reserve(source.size());
-      for (const IValue& value : source) {
-        dest.push_back(deepCopy(value));
-      }
-    };
-    if (source._elementType().has_value()) {
-      auto newList = c10::impl::GenericList(*source._elementType());
-      deepCopyGenericList(newList);
-      return newList;
-    } else {
-      auto newList = c10::impl::GenericList(c10::impl::deprecatedUntypedList());
-      deepCopyGenericList(newList);
-      return newList;
+    auto newList = source._elementType().has_value()
+        ? c10::impl::GenericList(*source._elementType())
+        : c10::impl::GenericList(c10::impl::deprecatedUntypedList());
+    newList.reserve(source.size());
+    for (const IValue& value : source) {
+      newList.push_back(deepCopy(value));
     }
+    return newList;
   }
 
   // Regular lists can copy assign


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23271 deepCopy also copies type information of lists**

Differential Revision: [D16449220](https://our.internmc.facebook.com/intern/diff/D16449220/)