### PR TITLE
support Gather different indices for different examples in one batch

### DIFF
--- a/caffe2/operators/batch_gather_ops.cc
+++ b/caffe2/operators/batch_gather_ops.cc
@@ -17,7 +17,7 @@ OPERATOR_SCHEMA(BatchGather)
 
       vector<int> output_dims =
           caffe2::gather_helper::calc_output_shape_vector<int>(
-              data_dims, indices_dims, 1);
+              data_dims, indices_dims, 1, false);
       out[0] = CreateTensorShape(output_dims, TensorProto::FLOAT);
       return out;
     })

--- a/caffe2/operators/batch_gather_ops.cu
+++ b/caffe2/operators/batch_gather_ops.cu
@@ -18,7 +18,7 @@ template <typename TInd>
 bool BatchGatherOp<CUDAContext>::DoRunWithType() {
   // BatchGather is a special-case of Gather with Axis = 1, wrap = false.
   return gather_helper::gather_impl_cuda<TInd>(
-      this, DATA, INDICES, 0, 1, false);
+      this, DATA, INDICES, 0, 1, false, match_outer_);
 }
 
 template <typename T_INDEX, typename TData>
@@ -68,10 +68,12 @@ bool BatchGatherGradientOp<CUDAContext>::DoRunWithType() {
 template <>
 template <typename TInd, typename TData>
 bool BatchGatherGradientOp<CUDAContext>::DoRunWithType2() {
+  CAFFE_ENFORCE(
+      !match_outer_, "match_outer=true is currently only supported for CPU");
+
   auto& data = Input(DATA);
   auto& indices = Input(INDICES);
   auto& grad = Input(GRAD);
-  
 
   // ONNX allows negative axis to index from the back, valid range: [-r, r].
   int axis = axis_;

--- a/caffe2/operators/batch_gather_ops.h
+++ b/caffe2/operators/batch_gather_ops.h
@@ -13,7 +13,13 @@ template <class Context>
 class BatchGatherOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
-  USE_SIMPLE_CTOR_DTOR(BatchGatherOp)
+
+  template <class... Args>
+  explicit BatchGatherOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        OP_SINGLE_ARG(bool, "match_outer", match_outer_, false) {}
+
+  // virtual ~BatchGatherOp() noexcept {}
 
   bool RunOnDevice() override {
     return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
@@ -24,9 +30,12 @@ class BatchGatherOp final : public Operator<Context> {
   bool DoRunWithType() {
     // BatchGather is a special-case of Gather with Axis = 1.
     return gather_helper::gather_impl<TInd, Context>(
-        this, DATA, INDICES, 0, 1, false);
+        this, DATA, INDICES, 0, 1, false, match_outer_);
   }
   INPUT_TAGS(DATA, INDICES);
+
+ protected:
+  bool match_outer_;
 };
 
 template <class Context>
@@ -34,12 +43,13 @@ class BatchGatherGradientOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
 
-  // Constructor to recieve axis in case it was passed for GatherOp gradient,
+  // Constructor to receive axis in case it was passed for GatherOp gradient,
   // use default of 1 for batch gather otherwise.
   template <class... Args>
   explicit BatchGatherGradientOp(Args&&... args)
       : Operator<Context>(std::forward<Args>(args)...),
-        OP_SINGLE_ARG(int, "axis", axis_, 1) {}
+        OP_SINGLE_ARG(int, "axis", axis_, 1),
+        OP_SINGLE_ARG(bool, "match_outer", match_outer_, false) {}
   virtual ~BatchGatherGradientOp() noexcept {}
 
   bool RunOnDevice() override {
@@ -62,6 +72,7 @@ class BatchGatherGradientOp final : public Operator<Context> {
 
     // ONNX allows negative axis to index from the back, valid range: [-r, r].
     int axis = axis_;
+    bool match_outer = match_outer_;
     if (axis < 0) {
       axis = data.dim() + axis;
     }
@@ -90,15 +101,24 @@ class BatchGatherGradientOp final : public Operator<Context> {
     auto batch_size = data.size_from_dim(axis);
     auto block_size = data.size_from_dim(axis + 1);
     auto N = indices.numel();
-    auto gathered_grad_batch_size = N * block_size;
 
+    auto idx_inner_dims_product = indices.size_from_dim(axis);
+    if (match_outer) {
+      CAFFE_ENFORCE_GE(axis, 1, "Axis should be at least 1");
+      for (auto i = 0; i < axis; i++) {
+        CAFFE_ENFORCE_EQ(
+            data.size(i),
+            indices.size(i),
+            "INDICES must have the same outer dims as DATA (before dim AXIS)");
+      }
+      N = idx_inner_dims_product;
+    }
+
+    auto gathered_grad_batch_size = N * block_size;
     // Check indexing bounds.
     auto src_indexing_axis_dim = data.dim(axis);
     gather_helper::check_indexarray_range<TInd>(
-      idxs,
-      N,
-      src_indexing_axis_dim,
-      false);
+        idxs, N, src_indexing_axis_dim, false);
 
     for (auto batch = 0; batch < outer_dims_product; ++batch) {
       auto grad_batch_base = grad_data + batch * gathered_grad_batch_size;
@@ -106,6 +126,9 @@ class BatchGatherGradientOp final : public Operator<Context> {
 
       for (auto i = 0; i < N; ++i) {
         auto idx = idxs[i];
+        if (match_outer) {
+          idx = idxs[batch * idx_inner_dims_product + i];
+        }
         if (idx < 0) {
           idx = idx + src_indexing_axis_dim;
         }
@@ -135,8 +158,10 @@ class BatchGatherGradientOp final : public Operator<Context> {
   }
 
   INPUT_TAGS(DATA, INDICES, GRAD);
-protected:
+
+ protected:
   int axis_;
+  bool match_outer_;
 };
 
 } // namespace caffe2

--- a/caffe2/operators/gather_op.cc
+++ b/caffe2/operators/gather_op.cc
@@ -79,12 +79,14 @@ OUTPUT:
                                 const vector<TensorShape>& in) {
       ArgumentHelper helper(def);
       const int axis = helper.GetSingleArgument<int>("axis", 0);
+      const bool match_outer =
+          helper.GetSingleArgument<bool>("match_outer", false);
       const auto& data_dims = GetDimsVector(in[0]);
       const auto& indices_dims = GetDimsVector(in[1]);
 
       vector<int> output_dims =
           caffe2::gather_helper::calc_output_shape_vector<int>(
-              data_dims, indices_dims, axis);
+              data_dims, indices_dims, axis, match_outer);
       vector<TensorShape> out(1);
       out[0] = CreateTensorShape(output_dims, in[0].data_type());
       return out;

--- a/caffe2/operators/gather_op.cu
+++ b/caffe2/operators/gather_op.cu
@@ -15,7 +15,7 @@ template <typename Index>
 bool GatherOp<CUDAContext>::DoRunWithType() {
   // Use shared implementation with BatchGather
   return gather_helper::gather_impl_cuda<Index>(
-      this, DATA, INDICES, 0, axis_, wrap_indices_);
+      this, DATA, INDICES, 0, axis_, wrap_indices_, match_outer_);
 }
 
 REGISTER_CUDA_OPERATOR(Gather, GatherOp<CUDAContext>);

--- a/caffe2/operators/gather_op.cuh
+++ b/caffe2/operators/gather_op.cuh
@@ -44,11 +44,14 @@ static bool gather_impl_cuda(
     int indicesIdx,
     int outputIdx,
     int axis,
-    bool wrap_indices) {
+    bool wrap_indices,
+    bool match_outer) {
   const Tensor& data = op->Input(dataIdx);
   const Tensor& indices = op->Input(indicesIdx);
   const TypeMeta dataType = data.dtype();
   size_t item_bytesize = dataType.itemsize();
+
+  CAFFE_ENFORCE(!match_outer, "match_outer=true is currently NOT supported for CUDA");
 
   // ONNX allows negative axis to index from the back, valid range: [-r, r].
   if (axis < 0) {
@@ -62,7 +65,7 @@ static bool gather_impl_cuda(
   // New shape:
   //  [data dims before axis] + [indices dims] + [data dims after axis]
   vector<int64_t> shape =
-      calc_output_shape_vector<int64_t>(data.sizes(), indices.sizes(), axis);
+      calc_output_shape_vector<int64_t>(data.sizes(), indices.sizes(), axis, match_outer);
   Tensor* output = op->Output(outputIdx, shape, at::dtype(dataType));
   float* out = static_cast<float*>(output->raw_mutable_data(dataType));
 

--- a/caffe2/operators/gather_op.h
+++ b/caffe2/operators/gather_op.h
@@ -15,7 +15,8 @@ template <typename IndexType, typename DataDimsVec, typename IndexDimsVec>
 static vector<IndexType> calc_output_shape_vector(
     const DataDimsVec& data_dims,
     const IndexDimsVec& indices_dims,
-    int axis) {
+    int axis,
+    bool match_outer) {
   vector<IndexType> shape;
   // If the dimension we are indexing is empty, just use data_dims as shape.
   // This replicates behavior in (https://github.com/pytorch/pytorch/pull/13781)
@@ -24,7 +25,12 @@ static vector<IndexType> calc_output_shape_vector(
     shape.insert(shape.end(), data_dims.begin(), data_dims.end());
   } else {
     shape.insert(shape.end(), data_dims.begin(), data_dims.begin() + axis);
-    shape.insert(shape.end(), indices_dims.begin(), indices_dims.end());
+    if (match_outer) {
+      shape.insert(
+          shape.end(), indices_dims.begin() + axis, indices_dims.end());
+    } else {
+      shape.insert(shape.end(), indices_dims.begin(), indices_dims.end());
+    }
     shape.insert(shape.end(), data_dims.begin() + axis + 1, data_dims.end());
   }
   return shape;
@@ -60,7 +66,8 @@ static bool gather_impl(
     int indicesIdx,
     int outputIdx,
     int axis,
-    bool wrap_indices) {
+    bool wrap_indices,
+    bool match_outer) {
   // If we endup using it on GPU doing O(N) memcpy is probably not best :)
   // TODO: implement prefetching if it starts mattering (TF does it)
 
@@ -79,8 +86,8 @@ static bool gather_impl(
 
   // New shape:
   //  [data dims before axis] + [indices dims] + [data dims after axis]
-  vector<int64_t> shape =
-      calc_output_shape_vector<int64_t>(data.sizes(), indices.sizes(), axis);
+  vector<int64_t> shape = calc_output_shape_vector<int64_t>(
+      data.sizes(), indices.sizes(), axis, match_outer);
   Tensor* output = op->Output(outputIdx, shape, at::dtype(dataType));
   auto out = static_cast<char*>(output->raw_mutable_data(dataType));
 
@@ -103,7 +110,19 @@ static bool gather_impl(
   auto src_batch_bytesize = data.size_from_dim(axis) * item_bytesize;
   // Treat indices as a single block even if they have multiple dimensions.
   // The "gathered batch" is a cumulative result combining indexed blocks.
+  auto idx_inner_dims_product = indices.size_from_dim(axis);
   auto N = indices.numel();
+  if (match_outer) {
+    CAFFE_ENFORCE_GE(axis, 1, "Axis should be at least 1");
+    for (auto i = 0; i < axis; i++) {
+      CAFFE_ENFORCE_EQ(
+          data.size(i),
+          indices.size(i),
+          "INDICES must have the same outer dims as DATA (before dim AXIS)");
+    }
+    N = idx_inner_dims_product;
+  }
+
   auto gathered_batch_bytesize = N * block_size * item_bytesize;
 
   check_indexarray_range<Index>(idxs, N, src_indexing_axis_dim, wrap_indices);
@@ -117,6 +136,9 @@ static bool gather_impl(
 
       for (auto i = 0; i < N; ++i) {
         auto idx = idxs[i];
+        if (match_outer) {
+          idx = idxs[batch * idx_inner_dims_product + i];
+        }
         if (wrap_indices && idx < 0) {
           idx = idx + src_indexing_axis_dim;
         }
@@ -129,6 +151,9 @@ static bool gather_impl(
     for (auto batch = 0; batch < outer_dims_product; ++batch) {
       for (auto i = 0; i < N; ++i) {
         auto idx = idxs[i];
+        if (match_outer) {
+          idx = idxs[batch * idx_inner_dims_product + i];
+        }
         if (wrap_indices && idx < 0) {
           idx = idx + src_indexing_axis_dim;
         }
@@ -152,7 +177,8 @@ class GatherOp : public Operator<Context> {
   template <class... Args>
   explicit GatherOp(Args&&... args)
       : Operator<Context>(std::forward<Args>(args)...),
-        OP_SINGLE_ARG(int, "axis", axis_, 0) {
+        OP_SINGLE_ARG(int, "axis", axis_, 0),
+        OP_SINGLE_ARG(bool, "match_outer", match_outer_, false) {
     // TBD: We may want to fix the old index wrap behaviour once we have
     // operator versioning, to only apply it when needed as otherwise its likely
     // an error.
@@ -177,7 +203,7 @@ class GatherOp : public Operator<Context> {
   template <typename Index>
   bool DoRunWithType() {
     return gather_helper::gather_impl<Index, Context>(
-        this, DATA, INDICES, 0, axis_, wrap_indices_);
+        this, DATA, INDICES, 0, axis_, wrap_indices_, match_outer_);
   }
 
   INPUT_TAGS(DATA, INDICES);
@@ -185,6 +211,7 @@ class GatherOp : public Operator<Context> {
  protected:
   int axis_;
   bool wrap_indices_;
+  bool match_outer_;
 };
 
 } // namespace caffe2

--- a/caffe2/python/operator_test/gather_ops_test.py
+++ b/caffe2/python/operator_test/gather_ops_test.py
@@ -35,6 +35,28 @@ def ref_gather(axis):
         return [output]
     return inner
 
+# Gather(..., match_outer==True)
+def ref_gather_match_outer(axis=1):
+    def inner(data, ind):
+        if ind.size == 0 or data.shape[axis] == 0:
+            shape = list(data.shape)
+            shape[0] = 0
+            return [np.zeros(tuple(shape)).astype(np.float32)]
+        input_shape = list(data.shape)
+        output_shape = input_shape[:axis] + list(ind.shape[axis:]) + input_shape[axis + 1:]
+        output = np.zeros(tuple(output_shape)).astype(np.float32)
+        if axis == 1:
+            for i in range(data.shape[0]):
+                output[i] = data[i, ind[i], ]
+        elif axis == 2:
+            for i in range(data.shape[0]):
+                for j in range(data.shape[1]):
+                    output[i, j] = data[i, j, ind[i, j], ]
+        else:
+            raise NotImplementedError
+        return [output]
+    return inner
+
 class TestGatherOps(serial.SerializedTestCase):
     @given(rows_num=st.integers(0, 10000),
            index_num=st.integers(0, 5000),
@@ -58,9 +80,9 @@ class TestGatherOps(serial.SerializedTestCase):
     # Test axis == 2, this keeps outer dimension but will replace data
     # within axis by lookup of index array (repeated for each outer entry)
     @given(batch_num=st.integers(1, 4000),
-        rows_num=st.integers(1, 6),
-        index_num=st.integers(1, 20),
-        **hu.gcs)
+           rows_num=st.integers(1, 6),
+           index_num=st.integers(1, 20),
+           **hu.gcs)
     def test_gather_ops_axis2(self, batch_num, rows_num, index_num, gc, dc):
         data = np.random.random((batch_num, rows_num, 5)).astype(np.float32)
         ind = np.random.randint(5, size=(index_num, )).astype('int32')
@@ -72,6 +94,75 @@ class TestGatherOps(serial.SerializedTestCase):
 
         self.assertReferenceChecks(gc, op, [data, ind], ref_gather(axis=2))
         self.assertDeviceChecks(dc, op, [data, ind], [0])
+        return
+
+    # Test match_outer == true, the indices has the same outer dimensions as data
+    @given(batch_num=st.integers(1, 40),
+           rows_num=st.integers(1, 6),
+           index_num=st.integers(1, 20),
+           **hu.gcs)
+    def test_gather_ops_match_outer(self, batch_num, rows_num, index_num, gc, dc):
+        data = np.random.random((batch_num, rows_num, 5)).astype(np.float32)
+        ind = np.random.randint(rows_num, size=(batch_num, index_num)).astype('int32')
+        op = core.CreateOperator(
+            'Gather',
+            ['data', 'ind'],
+            ['output'],
+            axis=1,
+            match_outer=True)
+
+        self.assertReferenceChecks(gc, op, [data, ind], ref_gather_match_outer())
+        self.assertDeviceChecks(dc, op, [data, ind], [0])
+        self.assertGradientChecks(gc, op, [data, ind], 0, [0])
+        return
+
+    # Test BatchGather with match_outer == true, the indices has the same outer dimensions as data
+    # Note BatchGather is equivalent to Gather(..., axis=1)
+    @given(batch_num=st.integers(1, 40),
+           rows_num=st.integers(1, 6),
+           index_num=st.integers(1, 20),
+           **hu.gcs)
+    def test_batch_gather_op_match_outer(self, batch_num, rows_num, index_num, gc, dc):
+        data = np.random.random((batch_num, rows_num, 5)).astype(np.float32)
+        ind = np.random.randint(rows_num, size=(batch_num, index_num)).astype('int32')
+        op = core.CreateOperator(
+            'BatchGather',
+            ['data', 'ind'],
+            ['output'],
+            match_outer=True)
+
+        self.assertReferenceChecks(gc, op, [data, ind], ref_gather_match_outer())
+        self.assertDeviceChecks(dc, op, [data, ind], [0])
+        self.assertGradientChecks(gc, op, [data, ind], 0, [0])
+        return
+
+    # when the data is larger,
+    # this test sometimes passes, sometimes fails,
+    # test log here: https://fb.quip.com/SeiyAVWQXvsN (second run failed)
+    # after some digging, this turns out to be numerical error,
+    # the failed run has max|grad - estimated_grad| = 0.009
+    # so here we changed the gradient checking threshold to 0.02 for this test to pass
+    @given(batch_num=st.integers(1, 30),
+           rows_num=st.integers(1, 6),
+           index_num=st.integers(1, 10),
+           index_num2=st.integers(1, 10),
+           axis2_num=st.integers(1, 10),
+           **hu.gcs)
+    def test_gather_op_match_outer_axis2_data4D_ind4D(
+        self, batch_num, rows_num, axis2_num, index_num, index_num2, gc, dc
+    ):
+        data = np.random.random((batch_num, rows_num, axis2_num, 5)).astype(np.float32)
+        ind = np.random.randint(axis2_num, size=(batch_num, rows_num, index_num, index_num2)).astype('int32')
+        op = core.CreateOperator(
+            'Gather',
+            ['data', 'ind'],
+            ['output'],
+            axis=2,
+            match_outer=True)
+
+        self.assertReferenceChecks(gc, op, [data, ind], ref_gather_match_outer(axis=2))
+        self.assertDeviceChecks(dc, op, [data, ind], [0])
+        self.assertGradientChecks(gc, op, [data, ind], 0, [0], threshold=0.02)
         return
 
 


### PR DESCRIPTION
Summary:
for example:

Inputs:
  data:
   [[[2 4 2 0],
     [0 1 2 0],
     [1 1 0 0]],
    [[3 4 1 3],
     [0 3 2 2],
     [4 1 0 4]]]

  idx:
    [[0 2],
     [0 1]]

outputs:
  [[[2 4 2 0],
    [1 1 0 0]],
   [[3 4 1 3],
    [0 3 2 2]]]

data and idx must have the same first dimension

Must call Gather with arg axis=1, match_outer=True

Differential Revision: D16452539

