### PR TITLE
Enable addition for bool on CUDA.

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -15,7 +15,7 @@ using namespace vec256;
 
 void add_kernel(TensorIterator& iter, Scalar alpha_scalar) {
   if (iter.dtype() == ScalarType::Bool) {
-    cpu_kernel(iter, [=](bool a, bool b) -> bool { return a + b; });
+    cpu_kernel(iter, [](bool a, bool b) -> bool { return a || b; });
   } else {
     AT_DISPATCH_ALL_TYPES(iter.dtype(), "add_cpu", [&]() {
       auto alpha = alpha_scalar.to<scalar_t>();

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -13,12 +13,16 @@
 namespace at { namespace native {
 
 void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "add_cuda", [&]() {
-    auto alpha = alpha_scalar.to<scalar_t>();
-    gpu_kernel_with_scalars(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return a + alpha * b;
+  if (iter.dtype() == ScalarType::Bool) {
+    gpu_kernel(iter, []GPU_LAMBDA(bool a, bool b) -> bool { return a || b; });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "add_cuda", [&]() {
+      auto alpha = alpha_scalar.to<scalar_t>();
+      gpu_kernel_with_scalars(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        return a + alpha * b;
+      });
     });
-  });
+  }
 }
 
 static void sub_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1062,6 +1062,12 @@ class TestCuda(TestCase):
         self.assertIsInstance(y.cuda().float().cpu(), torch.FloatStorage)
         self.assertIsInstance(y.cuda().float().cpu().int(), torch.IntStorage)
 
+    def test_add_bool(self):
+        cuda = torch.device('cuda:0')
+        m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=cuda)
+        m2 = torch.tensor([True, True, False, False, False, True], dtype=torch.bool, device=cuda)
+        self.assertEqual(m1 + m2, torch.tensor([True, True, False, True, False, True], dtype=torch.bool, device=cuda))
+
     def test_mul_intertype_scalar(self):
         def test_mul(dtype):
             x = torch.tensor(1.5, dtype=dtype, device='cuda')


### PR DESCRIPTION
Current addition for bool tensor is available on CPU, but not on CUDA.
This commit adds bool support to CUDA.