### PR TITLE
at::view (#23239)

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -195,22 +195,6 @@
     - THTensor* self
 ]]
 [[
-  name: _th_view
-  cname: newView
-  cpu_half: True
-  cpu_bool: True
-  cuda_bool: True
-  cpu_bfloat16: True
-  variants:
-    - function
-  device_guard: False
-  return: THTensor*
-  arguments:
-    - THTensor* self
-    - arg: IntArrayRefSize size
-      long_args: True
-]]
-[[
   name: _th_resize_as_
   cname: resizeAs
   cpu_half: True

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -909,9 +909,34 @@ Tensor view(const Tensor& self, IntArrayRef size) {
     "not compatible with input tensor's size and stride (at least one dimension"
     " spans across two contiguous subspaces). Use .reshape(...) instead.");
   auto stride_value = *stride;
-  auto self_ = self.clone();
-  self_.set_(self.storage(), self.storage_offset(), inferred_size,
-             stride_value);
+  Tensor self_;
+  if (self.is_quantized()) {
+    TORCH_CHECK(self.qscheme() == kPerTensorAffine,
+                "Only PerTensorAffine quantization is supported right now");
+    auto impl = c10::make_intrusive<QTensorImpl>(Storage(self.storage()), self.type_id(),
+                    get_qtensorimpl(self)->quantizer());
+    impl->set_storage_offset(self.storage_offset());
+    impl->set_sizes_and_strides(inferred_size, stride_value);
+    self_ = Tensor(impl);
+  } else if (self.is_cuda()) {
+    // NOTE: This path of constructing the Tensor directly with the viewed
+    // Storage is necessary to allow `view` not to have a device_guard.
+    // Taking the common TH path of allocating a storage on the current device
+    // [via THCTensor_(new)] and then swapping out the storage later can change
+    // the device out from under the tensor.  Having the device be consistent
+    // through a Tensor's lifetime is an invariant we wish to keep to support
+    // caching, simplicity, etc.
+    auto storage = self.storage();
+    self_ = Tensor(c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
+              std::move(storage),
+              at::CUDATensorId()
+            ));
+  } else {
+    auto impl = c10::make_intrusive<TensorImpl>(Storage(self.storage()), self.type_id());
+    impl->set_storage_offset(self.storage_offset());
+    impl->set_sizes_and_strides(inferred_size, stride_value);
+    self_ = Tensor(impl);
+  }
   return self_;
 }
 

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -193,22 +193,6 @@ THTensor *THTensor_(newTranspose)(THTensor *tensor, int dimension1_, int dimensi
   return self;
 }
 
-THTensor *THTensor_(newView)(THTensor *tensor, at::IntArrayRef size)
-{
-  ptrdiff_t numel = THTensor_(nElement)(tensor);
-  THTensor *self = THTensor_(new)();
-  auto inferred_size = at::infer_size(size, numel);
-  auto stride = THTensor_compute_stride(tensor->sizes(),
-                                        tensor->strides(),
-                                        inferred_size);
-  THArgCheck(stride.has_value(), 2, "view size is "
-    "not compatible with input tensor's size and stride (at least one dimension spans "
-    "across two contiguous subspaces). Use .reshape(...) instead.");
-  auto stride_value = *stride;
-  THTensor_setStorage(self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, stride_value);
-  return self;
-}
-
 /* Resize */
 void THTensor_(resize)(THTensor *self, at::IntArrayRef size, at::IntArrayRef stride)
 {

--- a/aten/src/TH/generic/THTensor.hpp
+++ b/aten/src/TH/generic/THTensor.hpp
@@ -10,7 +10,6 @@
 
 TH_CPP_API void THTensor_(setStorage)(THTensor *self, THStorage *storage_, ptrdiff_t storageOffset_,
                                       at::IntArrayRef size_, at::IntArrayRef stride_);
-TH_CPP_API THTensor *THTensor_(newView)(THTensor *tensor, at::IntArrayRef size);
 /* strides.data() might be NULL */
 TH_CPP_API THTensor *THTensor_(newWithStorage)(THStorage *storage, ptrdiff_t storageOffset,
                                                at::IntArrayRef sizes, at::IntArrayRef strides);

--- a/aten/src/THC/generic/THCTensor.cpp
+++ b/aten/src/THC/generic/THCTensor.cpp
@@ -3,6 +3,7 @@
 #else
 
 #include <ATen/InferSize.h>
+#include <ATen/NativeFunctions.h>
 
 /**** access methods ****/
 THCStorage *THCTensor_(storage)(THCState *state, const THCTensor *self)
@@ -197,34 +198,6 @@ THCTensor *THCTensor_(newTranspose)(THCState *state, THCTensor *tensor, int dime
   return self;
 }
 
-THCTensor *THCTensor_(newView)(THCState *state, THCTensor *tensor, at::IntArrayRef size)
-{
-  ptrdiff_t numel = THCTensor_(nElement)(state, tensor);
-  auto inferred_size = at::infer_size(size, numel);
-  auto stride = THTensor_compute_stride(tensor->sizes(),
-                                        tensor->strides(),
-                                        inferred_size);
-  THArgCheck(stride.has_value(), 2, "view size is "
-    "not compatible with input tensor's size and stride (at least one dimension spans "
-    "across two contiguous subspaces). Use .reshape(...) instead.");
-  auto stride_value = *stride;
-
-  // NOTE: This path of constructing the Tensor directly with the viewed Storage is necessary
-  // to allow `view` not to have a device_guard.  Taking the common TH path of allocating a storage
-  // on the current device [via THCTensor_(new)] and then swapping out the storage later can change
-  // the device out from under the tensor.  Having the device be consistent through a Tensor's lifetime
-  // is an invariant we wish to keep to support caching, simplicity, etc.
-  auto storage = tensor->storage();
-  THCTensor *self = c10::make_intrusive<at::TensorImpl, at::UndefinedTensorImpl>(
-    std::move(storage),
-    at::CUDATensorId()
-  ).release();
-
-  THCTensor_setStorage(state, self, THTensor_getStoragePtr(tensor), tensor->storage_offset(), inferred_size, stride_value);
-
-  return self;
-}
-
 // Collapses the first two dimensions of a tensor.
 // Assumes the input tensor is contiguous.
 THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
@@ -237,7 +210,7 @@ THCTensor *THCTensor_(newFoldBatchDim)(THCState *state, THCTensor *input) {
   for (int i = 2; i < in_dims; i++) {
     new_size[i - 1] = THCTensor_(size)(state, input, i);
   }
-  THCTensor *output = THCTensor_(newView)(state, input, new_size);
+  THCTensor *output = at::native::view(THTensor_wrap(input), new_size).unsafeGetTensorImpl();
   return output;
 }
 


### PR DESCRIPTION
Summary:
accidently calls clone, but what we want is creating an empty tensor and set storage.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/23239
ghstack-source-id: 87043230

Differential Revision: D16442756

