### PR TITLE
Support LSTM with FP16 weight

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -138,6 +138,31 @@ struct QuantizedCellParams {
   }
 };
 
+struct QuantizedCellParamsFP16 {
+  QuantizedCellParamsFP16(const Tensor &_packed_ih, const Tensor &_packed_hh,
+                          const Tensor &_b_ih, const Tensor &_b_hh)
+      : packed_ih(_packed_ih), packed_hh(_packed_hh),
+        b_ih(_b_ih), b_hh(_b_hh) {}
+
+  const Tensor &packed_ih;
+  const Tensor &packed_hh;
+  const Tensor &b_ih;
+  const Tensor &b_hh;
+
+  Tensor matmul_ih(Tensor /* unused */) const {
+    TORCH_CHECK(false, "matmul is not supported with quantized cell params");
+  }
+  Tensor matmul_hh(Tensor /* unused */) const {
+    TORCH_CHECK(false, "matmul is not supported with quantized cell params");
+  }
+  Tensor linear_ih(Tensor input) const {
+    return at::fbgemm_linear_fp16_weight(input, packed_ih, b_ih);
+  }
+  Tensor linear_hh(Tensor h) const {
+    return at::fbgemm_linear_fp16_weight(h, packed_hh, b_hh);
+  }
+};
+
 // Gathers every two elements of a vector in a vector of pairs
 template<typename T>
 static std::vector<pair_of<T>> pair_vec(const std::vector<T>& vals) {
@@ -193,6 +218,17 @@ static std::vector<QuantizedCellParams> gather_quantized_params(TensorList param
   return result;
 }
 
+static std::vector<QuantizedCellParamsFP16> gather_quantized_params_fp16(
+    TensorList params) {
+  static at::Tensor undefined;
+  std::vector<QuantizedCellParamsFP16> result;
+  TORCH_CHECK(params.size() % 4 == 0,
+              "incorrect number of quantized RNN parameters FP16");
+  for (size_t i = 0; i < params.size(); i += 4) {
+    result.emplace_back(params[i], params[i + 1], params[i + 2], params[i + 3]);
+  }
+  return result;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // HIDDEN STATE FUNCTIONS
@@ -936,30 +972,46 @@ Tensor rnn_relu_cell(
 // Quantized implementations
 //
 // These implementations use FBGEMM to do the i2h and h2h linear layers with
-// an int8 quantized weight. This is advantageous in small-batch-size scenarios
-// where runtime is dominated by memory fetches of the weight matrix.
+// an int8 or float16 quantized weight. This is advantageous in small-batch-size
+// scenarios where runtime is dominated by memory fetches of the weight matrix.
 
 std::tuple<Tensor, Tensor, Tensor> quantized_lstm(
       const Tensor& _input, TensorList hx,
       TensorList _params, bool has_biases,
-      int64_t num_layers, double dropout_p, bool train, bool bidirectional, bool batch_first) {
+      int64_t num_layers, double dropout_p, bool train, bool bidirectional,
+      bool batch_first, c10::optional<ScalarType> dtype) {
   TORCH_CHECK(hx.size() == 2, "lstm expects two hidden states");
   if (at::cudnn_is_acceptable(_input)) {
     Tensor output, hy, cy;
     lstm_cudnn_stub(_input.type().device_type(), output, hy, cy, _input, hx, _params, has_biases,
-            num_layers, dropout_p, train, bidirectional, batch_first);
+                    num_layers, dropout_p, train, bidirectional, batch_first);
     return std::make_tuple(output, hy, cy);
   }
+  auto result_dtype = dtype.has_value() ? dtype.value() : at::kByte;
   check_device(_input, _params, hx);
   auto input = batch_first ? _input.transpose(0, 1) : _input;
   TORCH_CHECK(has_biases, "quantized LSTM requires biases");
-  auto params = gather_quantized_params(_params);
-  auto results = _lstm_impl<FullLayer, FullBidirectionalLayer>(
-      input, params, hx[0], hx[1], num_layers, dropout_p, train, bidirectional);
+  TORCH_CHECK(result_dtype == at::kByte || result_dtype == at::kHalf,
+              "dtype is not supported");
+
+  std::tuple<Tensor, Tensor, Tensor> results;
+  if (result_dtype == at::kByte) {
+    auto params = gather_quantized_params(_params);
+    results = _lstm_impl<FullLayer, FullBidirectionalLayer>(
+        input, params, hx[0], hx[1], num_layers,
+        dropout_p, train, bidirectional);
+  } else {
+    auto params = gather_quantized_params_fp16(_params);
+    results = _lstm_impl<FullLayer, FullBidirectionalLayer>(
+        input, params, hx[0], hx[1], num_layers,
+        dropout_p, train, bidirectional);
+  }
+
   if (batch_first) {
     std::get<0>(results) = std::get<0>(results).transpose(0, 1);
   }
   return results;
+
 }
 
 #define DEFINE_QUANTIZED_RNN_CELL(name, hx_type, cell_type, return_type, prepare_hx_fn) \

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2904,7 +2904,7 @@
 - func: rnn_relu_cell(Tensor input, Tensor hx, Tensor w_ih, Tensor w_hh, Tensor? b_ih=None, Tensor? b_hh=None) -> Tensor
 
 # Quantized RNN layers
-- func: quantized_lstm(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor)
+- func: quantized_lstm(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first, *, ScalarType? dtype=None) -> (Tensor, Tensor, Tensor)
 
 # Quantized GRU layers
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6506,7 +6506,8 @@ a")
                 requires_grad=False)
 
             ref = copy.deepcopy(cell)
-            cell = torch.jit.quantized.quantize_rnn_modules(cell)
+            cell_int8 = torch.jit.quantized.quantize_rnn_modules(cell, dtype=torch.uint8)
+            cell_fp16 = torch.jit.quantized.quantize_rnn_modules(cell, dtype=torch.float16)
 
             niter = 10
             x = torch.tensor([[100, -155],
@@ -6523,26 +6524,39 @@ a")
             elif isinstance(ref, torch.nn.GRU):
                 hiddens = hx
 
-            # Compare quantized to unquantized
-            output, final_hiddens = cell(x, hiddens)
             ref_out, ref_hid = ref(x, hiddens)
 
-            torch.testing.assert_allclose(output, ref_out)
-            for out, ref in zip(final_hiddens, ref_hid):
+            # Compare int8 quantized to unquantized
+            output_int8, final_hiddens_int8 = cell_int8(x, hiddens)
+
+            torch.testing.assert_allclose(output_int8, ref_out)
+            for out, ref in zip(final_hiddens_int8, ref_hid):
                 torch.testing.assert_allclose(out, ref)
 
-            if isinstance(cell, torch.jit.quantized.QuantizedLSTM):
-                class ScriptWrapper(torch.jit.ScriptModule):
-                    def __init__(self, cell):
-                        super(ScriptWrapper, self).__init__()
-                        self.cell = cell
+            # Compare fp16 quantized to unquantized
+            output_fp16, final_hiddens_fp16 = cell_fp16(x, hiddens)
 
-                    @torch.jit.script_method
-                    def forward(self, x, hiddens):
-                        # type: (torch.Tensor, Tuple[torch.Tensor, torch.Tensor])
-                        #        -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
-                        return self.cell(x, hiddens)
-            elif isinstance(cell, torch.jit.quantized.QuantizedGRU):
+            torch.testing.assert_allclose(output_fp16, ref_out)
+            for out, ref in zip(final_hiddens_fp16, ref_hid):
+                torch.testing.assert_allclose(out, ref)
+
+            def compare_quantized_unquantized(ScriptWrapper, cell): 
+                wrapper = ScriptWrapper(cell)
+
+                # Compare quantize scripted module to unquantized
+                script_out, script_hid = wrapper(x, hiddens)
+                torch.testing.assert_allclose(script_out, ref_out)
+                for out, ref in zip(script_hid, ref_hid):
+                    torch.testing.assert_allclose(out, ref)
+
+                # Compare export/import to unquantized
+                export_import_wrapper = self.getExportImportCopyWithPacking(wrapper)
+                ei_out, ei_hid = export_import_wrapper(x, hiddens)
+                torch.testing.assert_allclose(ei_out, ref_out)
+                for out, ref in zip(ei_hid, ref_hid):
+                    torch.testing.assert_allclose(out, ref)
+
+            if isinstance(cell, torch.jit.quantized.QuantizedGRU):
                 class ScriptWrapper(torch.jit.ScriptModule):
                     def __init__(self, cell):
                         super(ScriptWrapper, self).__init__()
@@ -6553,20 +6567,20 @@ a")
                         # type: (torch.Tensor, torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]
                         return self.cell(x, hiddens)
 
-            wrapper = ScriptWrapper(cell)
+                compare_quantized_unquantized(ScriptWrapper, cell)
+            elif isinstance(cell, torch.jit.quantized.QuantizedLSTM):
+                for cell in [cell_int8, cell_fp16]:
+                    class ScriptWrapper(torch.jit.ScriptModule):
+                        def __init__(self, cell):
+                            super(ScriptWrapper, self).__init__()
+                            self.cell = cell
 
-            # Compare quantize scripted module to unquantized
-            script_out, script_hid = wrapper(x, hiddens)
-            torch.testing.assert_allclose(script_out, ref_out)
-            for out, ref in zip(script_hid, ref_hid):
-                torch.testing.assert_allclose(out, ref)
-
-            # Compare export/import to unquantized
-            export_import_wrapper = self.getExportImportCopyWithPacking(wrapper)
-            ei_out, ei_hid = export_import_wrapper(x, hiddens)
-            torch.testing.assert_allclose(ei_out, ref_out)
-            for out, ref in zip(ei_hid, ref_hid):
-                torch.testing.assert_allclose(out, ref)
+                        @torch.jit.script_method
+                        def forward(self, x, hiddens):
+                            # type: (torch.Tensor, Tuple[torch.Tensor, torch.Tensor])
+                            #        -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+                            return self.cell(x, hiddens)
+                    compare_quantized_unquantized(ScriptWrapper, cell)
 
     def test_script_module(self):
         class M1(torch.jit.ScriptModule):

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -249,9 +249,9 @@ def apply_permutation(tensor, permutation, dim=1):
 class QuantizedRNNBase(torch.jit.ScriptModule):
     __constants__ = ['mode', 'input_size', 'hidden_size', 'num_layers', 'bias',
                      'batch_first', 'dropout', 'bidirectional', '_packed_weights',
-                     '_quantized_weights']
+                     '_quantized_weights', 'dtype']
 
-    def __init__(self, other):
+    def __init__(self, other, dtype=torch.uint8): 
         super(QuantizedRNNBase, self).__init__()
         self.mode = other.mode
         self.input_size = other.input_size
@@ -264,6 +264,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
         self.dropout = other.dropout
         self.bidirectional = other.bidirectional
         num_directions = 2 if self.bidirectional else 1
+        self.dtype = dtype
 
         assert self.bias
 
@@ -271,40 +272,62 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
         if self.mode != 'LSTM' and self.mode != 'GRU':
             raise RuntimeError('Only LSTM or GRU is supported for QuantizedRNN')
 
+        if dtype != torch.uint8 and dtype != torch.float16:
+            raise RuntimeError('Unsupported dtype: {}'.format(dtype))
+
         self._all_weights = []
         packed_weights = []
         quantized_weights = []
+        orig_weights = []
         for layer in range(self.num_layers):
             for direction in range(num_directions):
                 layer_input_size = self.input_size if layer == 0 else self.hidden_size * num_directions
-                # for each layer, for each direction we need to quantize and pack
-                # weights and pack parameters in this order:
-                #
-                #   w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,
-                #   col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh
 
-                def process_weights(ihhh, layer, suffix):
+                def process_weights(ihhh, layer, suffix, dtype):
                     weight_name = 'weight_{}_l{}{}'.format(ihhh, layer, suffix)
                     bias_name = 'bias_{}_l{}{}'.format(ihhh, layer, suffix)
 
                     weight = getattr(other, weight_name)
                     bias = getattr(other, bias_name)
 
-                    qweight, col_offsets, scale, zero_point = \
-                        torch.fbgemm_linear_quantize_weight(weight.clone().float())
-                    packed_weight = torch.fbgemm_pack_quantized_matrix(
-                        qweight, weight.size(1), weight.size(0))
+                    orig_weights.append(weight_name)
+                    self.register_buffer(weight_name, weight)
 
-                    params = [qweight, bias, packed_weight, col_offsets, scale, zero_point]
-                    pos_names = ['w', 'b', 'packed', 'col_offsets', 'scale', 'zero_point']
-                    ret_name = ['{}_{}_l{}{}'.format(name, ihhh, layer, suffix) for name in pos_names]
-                    quantized_weights.append(ret_name[0])
-                    packed_weights.append(ret_name[2])
-                    return params, ret_name
+                    if dtype == torch.uint8: 
+                        # for each layer, for each direction we need to quantize and pack
+                        # weights and pack parameters in this order:
+                        #
+                        #   w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,
+                        #   col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh
+                        qweight, col_offsets, scale, zero_point = \
+                            torch.fbgemm_linear_quantize_weight(weight.clone().float())
+                        packed_weight = torch.fbgemm_pack_quantized_matrix(
+                            qweight, weight.size(1), weight.size(0))
+
+                        params = [qweight, bias, packed_weight, col_offsets, scale, zero_point]
+                        pos_names = ['w', 'b', 'packed', 'col_offsets', 'scale', 'zero_point']
+                        ret_name = ['{}_{}_l{}{}'.format(name, ihhh, layer, suffix) for name in pos_names]
+                        quantized_weights.append(ret_name[0])
+                        packed_weights.append(ret_name[2])
+                        return params, ret_name
+                    else: 
+                        # for each layer, for each direction we need to quantize and pack
+                        # weights and pack parameters in this order:
+                        #
+                        #   packed_ih, packed_hh, b_ih, b_hh
+                        packed_weight = torch.fbgemm_pack_gemm_matrix_fp16(
+                            weight.clone().float())
+
+                        params = [packed_weight, bias]
+                        pos_names = ['packed', 'b']
+                        ret_name = ['{}_{}_l{}{}'.format(name, ihhh, layer, suffix) for name in pos_names]
+                        packed_weights.append(ret_name[0])
+                        quantized_weights.append(ret_name[0])
+                        return params, ret_name
 
                 suffix = '_reverse' if direction == 1 else ''
-                ih_params, ih_param_names = process_weights('ih', layer, suffix)
-                hh_params, hh_param_names = process_weights('hh', layer, suffix)
+                ih_params, ih_param_names = process_weights('ih', layer, suffix, dtype)
+                hh_params, hh_param_names = process_weights('hh', layer, suffix, dtype)
 
                 for (ih, ih_name), (hh, hh_name) in zip(zip(ih_params, ih_param_names), zip(hh_params, hh_param_names)):
                     self.register_buffer(ih_name, torch.tensor(ih) if not isinstance(ih, torch.Tensor) else ih)
@@ -313,6 +336,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
 
         self._packed_weights = packed_weights
         self._quantized_weights = quantized_weights
+        self._orig_weights = orig_weights
 
     @torch.jit.script_method
     def check_input(self, input, batch_sizes):
@@ -385,20 +409,37 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
     def _get_quantized_weights(self):
         return [getattr(self, name) for name in self._quantized_weights]
 
+    def _get_orig_weights_names(self):
+        return self._orig_weights
+
+    @_parameter_list(_get_orig_weights_names)
+    def _get_orig_weights(self):
+        return [getattr(self, name) for name in self._get_orig_weights]
+
     # TODO: for some reason torch.jit.script_method causes a destruction of the
     # module to occur, which in turn frees the packed_ih object via its DataPtr
     # deleter. This is bizarre and should probably get fixed.
     # @torch._jit_internal.torch.jit.script_method
     @torch.jit.script_method
     def _unpack(self):
-        packed_weights = self._get_packed_weights()
-        quantized_weights = self._get_quantized_weights()
-        assert len(packed_weights) == len(quantized_weights)
-        for i in range(len(packed_weights)):
-            packed = packed_weights[i]
-            quantized = quantized_weights[i]
-            packed.set_(torch.fbgemm_pack_quantized_matrix(
-                quantized, quantized.size(1), quantized.size(0)))
+        if self.dtype == torch.uint8:
+            packed_weights = self._get_packed_weights()
+            quantized_weights = self._get_quantized_weights()
+            assert len(packed_weights) == len(quantized_weights)
+            for i in range(len(packed_weights)):
+                packed = packed_weights[i]
+                quantized = quantized_weights[i]
+                packed.set_(torch.fbgemm_pack_quantized_matrix(
+                    quantized, quantized.size(1), quantized.size(0)))
+        else: 
+            packed_weights = self._get_packed_weights()
+            orig_weights = self._get_orig_weights()
+            assert len(packed_weights) == len(orig_weights)
+            for i in range(len(packed_weights)):
+                packed = packed_weights[i]
+                orig_weight = orig_weights[i]
+                packed.set_(torch.fbgemm_pack_gemm_matrix_fp16(
+                    orig_weight))
 
     @torch.jit.script_method
     def _pack(self):
@@ -409,6 +450,9 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
 
 class QuantizedLSTM(QuantizedRNNBase):
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
+
+    def __init__(self, other, dtype): 
+        super(QuantizedLSTM, self).__init__(other, dtype)
 
     @torch.jit.script_method
     def forward_impl(self, input, hx, batch_sizes, max_batch_size, sorted_indices):
@@ -428,7 +472,7 @@ class QuantizedLSTM(QuantizedRNNBase):
         assert batch_sizes is None
         result = _VF.quantized_lstm(input, hx, self._get_all_weights(), self.bias, self.num_layers,
                                     float(self.dropout), self.training, self.bidirectional,
-                                    self.batch_first)
+                                    self.batch_first, dtype=self.dtype)
         output = result[0]
         hidden = result[1:]
 
@@ -585,19 +629,21 @@ def quantize_linear_modules(module, dtype=torch.uint8):
     return module
 
 
-def quantize_rnn_modules(module):
+def quantize_rnn_modules(module, dtype=torch.uint8):
     reassign = {}
     for name, mod in module.named_modules():
         if mod is module:
             continue
-        new_mod = quantize_rnn_modules(mod)
+        new_mod = quantize_rnn_modules(mod, dtype)
         if new_mod is not mod:
             reassign[name] = new_mod
 
     for name, mod in reassign.items():
         setattr(module, name, mod)
     if isinstance(module, torch.nn.LSTM):
-        return QuantizedLSTM(module)
+        if dtype != torch.uint8 and dtype != torch.float16:
+            raise RuntimeError("Unsupported dtype: {}".format(dtype))
+        return QuantizedLSTM(module, dtype)
     if isinstance(module, torch.nn.GRU):
         return QuantizedGRU(module)
     return module


### PR DESCRIPTION
Summary:
This diff implements LSTM with FP16 weights based on FBGEMM.

At a high level, here are the steps:
1. Quantize and pack weight in every layer of LSTM
2. Pass weights from step 1 to the ATen `quantized_lstm` function which does matrix multiplication with FP16 weight. The following code shows the dtype of each variable used in MM:
Y  =   X * W + B
(fp32, fp32, fp16, fp32)

Differential Revision: D16389595

