### PR TITLE
[Pytorch-iOS] Fix the iOS build

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -457,7 +457,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_ROOT}/test/cpp/jit/test.cpp
     )
 
-  if (NOT WIN32)
+  if (NOT WIN32 AND NOT INTERN_BUILD_MOBILE)
     list(APPEND TORCH_SRCS
       ${TORCH_SRC_DIR}/csrc/jit/fuser/cpu/fused_kernel.cpp
     )


### PR DESCRIPTION
### Summary

The legacy iOS build script (`build_ios.sh`) is still working, but the output is in caffe2, not Pytorch. To build Pytorch on iOS, we can set the value of `BUILD_CAFFE2_MOBILE` to `NO`, and turn on another cmake flag - `INTERN_BUILD_MOBILE` @ljk53  has created for Android. 

There is a minor issue in `used_kernel.cpp` that will cause a compiling error when running `build_ios.sh`, as it uses a `system`API that has been deprecated since iOS 11. The fix below ignores this file since it's not needed for mobile compilation.

### Test Plan

The `build_ios.sh` completed successfully, and all the generated static libraries can be compiled and linked successfully on iOS devices.

### Build script

```shell
./scripts/build_ios.sh \
-DBUILD_CAFFE2_MOBILE=OFF \
-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())') \
-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')
```
### Compiling error

```
/Users/taox/Projects/pytorch/torch/csrc/jit/fuser/cpu/fused_kernel.cpp:28:11: error: call to unavailable function 'system': not available on iOS
  return (system(cmd.c_str()) == 0);
          ^~~~~~
/Applications/Xcode_10.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/usr/include/stdlib.h:190:6: note: candidate function has been explicitly made unavailable
int      system(const char *) __DARWIN_ALIAS_C(system);
```                                           