### PR TITLE
Install dvipng and latex in doc build.

### DIFF
--- a/.circleci/scripts/python_doc_push_script.sh
+++ b/.circleci/scripts/python_doc_push_script.sh
@@ -2,7 +2,7 @@
 
 # Install dependencies
 sudo apt-get -y update
-sudo apt-get -y install expect-dev
+sudo apt-get --no-install-recommends -y install expect-dev dvipng texlive-latex-extra
 
 # This is where the local pytorch install in the docker image is located
 pt_checkout="/var/lib/jenkins/workspace"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23302 Install dvipng and latex in doc build.**

Fixes #23294

Signed-off-by: Edward Z. Yang <ezyang@mit.edu>