### PR TITLE
Prevent xla-build from clobbering pytorch_linux_trusty_py3_6_gcc5_4_test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,15 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
-          # Note [namedtensor build image]
-          # The namedtensor build uses the same docker image as
+          # Note [Special build images]
+          # The namedtensor and xla builds use the same docker image as
           # pytorch-linux-trusty-py3.6-gcc5.4-build. In the push step, we have to
-          # distinguish between these two so the test can pick up the correct image.
+          # distinguish between them so the test can pick up the correct image.
           output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           if [[ ${BUILD_ENVIRONMENT} == *"namedtensor"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
+          elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-xla
           else
             export COMMIT_DOCKER_IMAGE=$output_image
           fi
@@ -132,11 +134,13 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
       no_output_timeout: "90m"
       command: |
         set -e
-        # See Note [namedtensor build image]
+        # See Note [Special build images]
         output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}
         if [[ ${BUILD_ENVIRONMENT} == *"namedtensor"* ]]; then
           export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
           NAMED_FLAG="export BUILD_NAMEDTENSOR=1"
+        elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
+          export COMMIT_DOCKER_IMAGE=$output_image-xla
         else
           export COMMIT_DOCKER_IMAGE=$output_image
         fi

--- a/.circleci/verbatim-sources/linux-build-defaults.yml
+++ b/.circleci/verbatim-sources/linux-build-defaults.yml
@@ -42,13 +42,15 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
 
         # Push intermediate Docker image for next phase to use
         if [ -z "${BUILD_ONLY}" ]; then
-          # Note [namedtensor build image]
-          # The namedtensor build uses the same docker image as
+          # Note [Special build images]
+          # The namedtensor and xla builds use the same docker image as
           # pytorch-linux-trusty-py3.6-gcc5.4-build. In the push step, we have to
-          # distinguish between these two so the test can pick up the correct image.
+          # distinguish between them so the test can pick up the correct image.
           output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}
           if [[ ${BUILD_ENVIRONMENT} == *"namedtensor"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
+          elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-xla
           else
             export COMMIT_DOCKER_IMAGE=$output_image
           fi
@@ -74,11 +76,13 @@ pytorch_linux_test_defaults: &pytorch_linux_test_defaults
       no_output_timeout: "90m"
       command: |
         set -e
-        # See Note [namedtensor build image]
+        # See Note [Special build images]
         output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}
         if [[ ${BUILD_ENVIRONMENT} == *"namedtensor"* ]]; then
           export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
           NAMED_FLAG="export BUILD_NAMEDTENSOR=1"
+        elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
+          export COMMIT_DOCKER_IMAGE=$output_image-xla
         else
           export COMMIT_DOCKER_IMAGE=$output_image
         fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23304 Prevent xla-build from clobbering pytorch_linux_trusty_py3_6_gcc5_4_test**

This fixes a race condition where the
pytorch_xla_linux_trusty_py3_6_gcc5_4_build and
pytorch_linux_trusty_py3_6_gcc5_4_build both push to the same docker
image by making them push to different docker images.

This was leading to problems where
pytorch_linux_trusty_py3_6_gcc5_4_test would incorrectly use a docker
image with the xla build, leading to incorrect signal and hard-to-debug
problems because the xla build is a bit different from a regular pytorch
build.

Test Plan
- It's hard to trigger this race condition on demand, so just run all
the CIs for now. [namedtensor ci]

Differential Revision: [D16459166](https://our.internmc.facebook.com/intern/diff/D16459166)