### PR TITLE
Remove torch::autograd::Node::get_shared_ptr()

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -201,13 +201,6 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
     return sequence_nr_;
   }
 
-  /// Returns a shared pointer to `this`. `PyNode`s are not managed by
-  /// `shared_ptr`s by default, but are bound to the lifetime of their Python
-  /// object instead.
-  virtual std::shared_ptr<Node> get_shared_ptr() {
-    return shared_from_this();
-  }
-
   /// Returns the name of the dynamic type of the function, for debugging.
   virtual std::string name() const;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23307 Remove torch::autograd::Node::get_shared_ptr()**

Summary: This change was done in #22983 but got overwritten in https://github.com/pytorch/pytorch/pull/23269/ after merging.

Differential Revision: [D16460972](https://our.internmc.facebook.com/intern/diff/D16460972)