### PR TITLE
Do not explicitly set USE_FBGEMM in tools/setup_helpers/cmake.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ option(CAFFE2_STATIC_LINK_CUDA "Statically link CUDA libraries" OFF)
 cmake_dependent_option(
     USE_CUDNN "Use cuDNN" ON
     "USE_CUDA" OFF)
-option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" OFF)
+option(USE_FBGEMM "Use FBGEMM (quantized 8-bit server operators)" ON)
 option(USE_FFMPEG "Use ffmpeg" OFF)
 option(USE_GFLAGS "Use GFLAGS" OFF)
 option(USE_GLOG "Use GLOG" OFF)

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -260,8 +260,6 @@ class CMake:
             'BUILD_TEST': build_test,
             'USE_CUDA': USE_CUDA,
             'USE_DISTRIBUTED': USE_DISTRIBUTED,
-            'USE_FBGEMM': not (check_env_flag('NO_FBGEMM') or
-                               check_negative_env_flag('USE_FBGEMM')),
             'USE_NUMPY': USE_NUMPY,
             'USE_SYSTEM_EIGEN_INSTALL': 'OFF'
         })


### PR DESCRIPTION
Instead, defer its default value to CMakeLists.txt

NO_FBGEMM has already been handled in tools/setup_helpers/env.py
(although deprecated)

