### PR TITLE
Specify build dir as a global variable in BUILD_DIR in the build system.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,7 @@ elif sha != 'Unknown':
     version += '+' + sha[:7]
 report("Building wheel {}-{}".format(package_name, version))
 
-cmake = CMake('build')
+cmake = CMake()
 
 # all the work we need to do _before_ setup runs
 def build_deps():

--- a/tools/build_libtorch.py
+++ b/tools/build_libtorch.py
@@ -20,4 +20,4 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     build_caffe2(version=None, cmake_python_library=None, build_python=False,
-                 rerun_cmake=True, cmake_only=False, cmake=CMake('build'))
+                 rerun_cmake=True, cmake_only=False, cmake=CMake())

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -12,7 +12,7 @@ import distutils.sysconfig
 from distutils.version import LooseVersion
 
 from . import escape_path, which
-from .env import (IS_64BIT, IS_DARWIN, IS_WINDOWS, check_env_flag, check_negative_env_flag, build_type)
+from .env import (BUILD_DIR, IS_64BIT, IS_DARWIN, IS_WINDOWS, check_env_flag, check_negative_env_flag, build_type)
 from .cuda import USE_CUDA
 from .dist_check import USE_DISTRIBUTED, USE_GLOO_IBVERBS
 from .numpy_ import USE_NUMPY, NUMPY_INCLUDE_DIR
@@ -35,7 +35,7 @@ USE_NINJA = (not check_negative_env_flag('USE_NINJA') and
 class CMake:
     "Manages cmake."
 
-    def __init__(self, build_dir):
+    def __init__(self, build_dir=BUILD_DIR):
         self._cmake_command = CMake._get_cmake_command()
         self.build_dir = build_dir
 

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -14,6 +14,8 @@ CONDA_DIR = os.path.join(os.path.dirname(sys.executable), '..')
 
 IS_64BIT = (struct.calcsize("P") == 8)
 
+BUILD_DIR = 'build'
+
 
 def check_env_flag(name, default=''):
     return os.getenv(name, default).upper() in ['ON', '1', 'YES', 'TRUE', 'Y']


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23331 Update doc about subsequent builds: options can be changed in build/CMakeCache.txt
* #23323 For second-time build, let build_type be inferred from CMakeCache.txt.
* **#23318 Specify build dir as a global variable in BUILD_DIR in the build system.**

This avoids specifying the actual build dir in multiple spots.

Differential Revision: [D16493987](https://our.internmc.facebook.com/intern/diff/D16493987)