### PR TITLE
Improve the error message for ONNX export and make the export work for cyclegan

### DIFF
--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -101,7 +101,8 @@ static void VisitNode(Node* n, Node* insert_point) {
     if (TupleTypePtr tt = input->type()->cast<TupleType>()) {
       TORCH_CHECK(
           white_list.count(n->kind()) > 0,
-          "tuple appears in op that does not forward tuples");
+          "tuple appears in op that does not forward tuples, ",
+          "unsupported kind: ", n->kind().toQualString());
       TORCH_CHECK(
           input->node()->kind() == prim::TupleConstruct,
           "tuple use not matched to tuple construct");
@@ -130,7 +131,8 @@ static void VisitNode(Node* n, Node* insert_point) {
     if (TupleTypePtr tt = output->type()->cast<TupleType>()) {
       TORCH_CHECK(
           white_list.count(n->kind()) > 0,
-          "tuple appears in op that does not forward tuples");
+          "tuple appears in op that does not forward tuples, ",
+          "unsupported kind: ", n->kind().toQualString());
       for (size_t j = 0; j < tt->elements().size(); j++) {
         n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);
       }


### PR DESCRIPTION
Summary:
Two problems:
1) we need to unwrap dataparallel
2) input is cpu tensor but model is still gpu

This diff also improve the error message and get rid of ifbpy dependence

Differential Revision: D16462330

