### PR TITLE
add notes about overshoot in bicubic mode

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2366,6 +2366,12 @@ def upsample(input, size=None, scale_factor=None, mode='nearest', align_corners=
             ``'bilinear'``, ``'bicubic'`` or ``'trilinear'``.
             Default: ``False``
 
+    .. note::
+        With ``mode='bicubic'``, it's possible to cause overshoot, in other words it can produce
+        negative values or values greater than 255 for images.
+        Explicitly call ``result.clamp(min=0, max=255)`` if you want to reduce the overshoot
+        when displaying the image.
+
     .. warning::
         With ``align_corners = True``, the linearly interpolating modes
         (`linear`, `bilinear`, and `trilinear`) don't proportionally align the
@@ -2412,6 +2418,12 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
             This only has effect when :attr:`mode` is ``'linear'``,
             ``'bilinear'``, ``'bicubic'``, or ``'trilinear'``.
             Default: ``False``
+
+    .. note::
+        With ``mode='bicubic'``, it's possible to cause overshoot, in other words it can produce
+        negative values or values greater than 255 for images.
+        Explicitly call ``result.clamp(min=0, max=255)`` if you want to reduce the overshoot
+        when displaying the image.
 
     .. warning::
         With ``align_corners = True``, the linearly interpolating modes


### PR DESCRIPTION
fix #21044

Bicubic interpolation can cause overshoot.

Opencv keeps results dtype aligned with input dtype: 
- If input is uint8, the result is clamped [0, 255]
- If input is float, the result is unclamped.

In Pytorch case, we only accept float input, so we'll keep the result unclamped, and add some notes so that users can explicitly call `torch.clamp()` when necessary. 