### PR TITLE
Build binaries with local version string specifying CUDA version

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -52,7 +52,7 @@ fi
 
 # We put this here so that OVERRIDE_PACKAGE_VERSION below can read from it
 export DATE="$(date -u +%Y%m%d)"
-export PYTORCH_BUILD_VERSION="1.2.0.dev$DATE"
+export PYTORCH_BUILD_VERSION="1.2.0.dev$DATE+$DESIRED_CUDA"
 export PYTORCH_BUILD_NUMBER=1
 
 cat >>"$envfile" <<EOL


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23325 Build binaries with local version string specifying CUDA version**

Fixes #19990

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16473826](https://our.internmc.facebook.com/intern/diff/D16473826)