### PR TITLE
torch::optional

### DIFF
--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -1092,4 +1092,8 @@ struct hash<c10::optional<T&>> {
 #undef TR2_OPTIONAL_REQUIRES
 #undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 
+namespace torch {
+  template<class T> using Optional = c10::optional<T>;
+}
+
 #endif // C10_UTIL_OPTIONAL_H_

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -1093,7 +1093,7 @@ struct hash<c10::optional<T&>> {
 #undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 
 namespace torch {
-  template<class T> using Optional = c10::optional<T>;
+  template<class T> using optional = c10::optional<T>;
 }
 
 #endif // C10_UTIL_OPTIONAL_H_


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23326 torch::Optional**

We have torch::List and torch::Dict and c10::optional to be used by custom operators.
This seems inconsistent. Let's expose c10::optional as torch::Optional to make naming more consistent.

Differential Revision: [D16464701](https://our.internmc.facebook.com/intern/diff/D16464701/)