### PR TITLE
Remove TensorIterator::Builder

### DIFF
--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -119,12 +119,12 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
     self.set_quantizer_(at::make_per_tensor_affine_quantizer(src.q_scale(), src.q_zero_point(), src.scalar_type()));
   }
 
-  auto builder = TensorIterator::Builder();
-  builder.add_output(self);
-  builder.add_input(src);
-  builder.dont_resize_outputs();
-  builder.dont_compute_common_dtype();
-  auto iter = builder.build();
+  auto iter = TensorIterator();
+  iter.add_output(self);
+  iter.add_input(src);
+  iter.dont_resize_outputs();
+  iter.dont_compute_common_dtype();
+  iter.build();
 
   if (iter.numel() == 0) {
     return self;

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -206,26 +206,28 @@ static TensorIterator make_index_put_iterator(const AdvancedIndex& info, const T
     AT_ERROR("shape mismatch: value tensor of shape ", value.sizes(),
              " cannot be broadcast to indexing result of shape ", info.src.sizes());
   }
-  auto builder = TensorIterator::Builder();
-  builder.dont_compute_common_dtype();
-  builder.dont_resize_outputs();
-  builder.add_output(info.src);
-  builder.add_input(value, info.src.device(), info.src.scalar_type());
+  auto iter = TensorIterator();
+  iter.dont_compute_common_dtype();
+  iter.dont_resize_outputs();
+  iter.add_output(info.src);
+  iter.add_input(value, info.src.device(), info.src.scalar_type());
   for (auto& index : info.indices) {
-    builder.add_input(index);
+    iter.add_input(index);
   }
-  return builder.build();
+  iter.build();
+  return iter;
 }
 
 static TensorIterator make_index_iterator(const AdvancedIndex& info) {
-  auto builder = TensorIterator::Builder();
-  builder.dont_compute_common_dtype();
-  builder.add_output(Tensor(), info.src.device(), info.src.scalar_type());
-  builder.add_input(info.src);
+  auto iter = TensorIterator();
+  iter.dont_compute_common_dtype();
+  iter.add_output(Tensor(), info.src.device(), info.src.scalar_type());
+  iter.add_input(info.src);
   for (auto& index : info.indices) {
-    builder.add_input(index);
+    iter.add_input(index);
   }
-  return builder.build();
+  iter.build();
+  return iter;
 }
 
 Tensor index(const Tensor & self, TensorList indices) {

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -501,43 +501,48 @@ void TensorIterator::select_all_keeping_dim(int start_dim, IntArrayRef indices) 
 }
 
 TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a, const Tensor& b) {
-  auto builder = TensorIterator::Builder();
-  builder.add_output(out);
-  builder.add_input(a);
-  builder.add_input(b);
-  builder.iter_.allow_cpu_scalars_ = true;
-  return builder.build();
+  auto iter = TensorIterator();
+  iter.add_output(out);
+  iter.add_input(a);
+  iter.add_input(b);
+  iter.allow_cpu_scalars_ = true;
+  iter.build();
+  return iter;
 }
 
 TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a) {
-  auto builder = TensorIterator::Builder();
-  builder.add_output(out);
-  builder.add_input(a);
-  return builder.build();
+  auto iter = TensorIterator();
+  iter.add_output(out);
+  iter.add_input(a);
+  iter.num_outputs_ = 1;
+  iter.build();
+  return iter;
 }
 
 TensorIterator TensorIterator::nullary_op(Tensor& out) {
-  auto builder = TensorIterator::Builder();
-  builder.add_output(out);
+  auto iter = TensorIterator();
+  iter.add_output(out);
   // FIXME: workaround for bug: https://github.com/pytorch/pytorch/issues/20342
-  builder.iter_.resize_outputs_ = false;
-  return builder.build();
+  iter.resize_outputs_ = false;
+  iter.build();
+  return iter;
 }
 
 TensorIterator TensorIterator::reduce_op(Tensor& out, const Tensor& a) {
-  AT_ASSERT(out.defined());
-  auto builder = TensorIterator::Builder();
-  builder.add_output(out);
-  builder.add_input(a);
-  builder.iter_.promote_gpu_output_dtypes_ = true;
-  builder.iter_.resize_outputs_ = false;
-  builder.iter_.is_reduction_ = true;
-  return builder.build();
+  TORCH_INTERNAL_ASSERT(out.defined());
+  auto iter = TensorIterator();
+  iter.add_output(out);
+  iter.add_input(a);
+  iter.promote_gpu_output_dtypes_ = true;
+  iter.resize_outputs_ = false;
+  iter.is_reduction_ = true;
+  iter.build();
+  return iter;
 }
 
 TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tensor& a) {
-  AT_ASSERT(out1.defined());
-  AT_ASSERT(out2.defined());
+  TORCH_INTERNAL_ASSERT(out1.defined());
+  TORCH_INTERNAL_ASSERT(out2.defined());
   TORCH_CHECK((!a.is_cuda() && !out1.is_cuda() && !out2.is_cuda()) || (a.device() == out1.device() && out1.device() == out2.device()),
       "reduce_op(): expected input and both outputs to be on same device, but input is on ", a.device(),
       ", output1 is on ", out1.device(), " and output2 is on", out2.device());
@@ -547,14 +552,15 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
       " and output2 has ", out2.sizes());
   TORCH_CHECK(out1.strides() == out2.strides(), "reduce_op(): expected both outputs to have same strides, but output1 has ", out1.strides(),
            " and output2 has ", out2.strides());
-  auto builder = TensorIterator::Builder();
-  builder.add_output(out1);
-  builder.add_output(out2);
-  builder.add_input(a);
-  builder.iter_.promote_gpu_output_dtypes_ = true;
-  builder.iter_.resize_outputs_ = false;
-  builder.iter_.is_reduction_ = true;
-  return builder.build();
+  auto iter = TensorIterator();
+  iter.add_output(out1);
+  iter.add_output(out2);
+  iter.add_input(a);
+  iter.promote_gpu_output_dtypes_ = true;
+  iter.resize_outputs_ = false;
+  iter.is_reduction_ = true;
+  iter.build();
+  return iter;
 }
 
 void TensorIterator::mark_outputs() {
@@ -681,32 +687,30 @@ int TensorIterator::get_dim_to_split() const {
   return dim_to_split;
 }
 
-SplitUntil32Bit TensorIterator::with_32bit_indexing() const {
-  return SplitUntil32Bit(*this);
-}
-
-TensorIterator TensorIterator::Builder::build() {
+void TensorIterator::build() {
   // set is_output and is_read_write flags on appropriate tensors
-  iter_.mark_outputs();
+  mark_outputs();
   // compute the broadcasted shape
-  iter_.compute_shape();
+  compute_shape();
   // compute each tensor's stride after broadcasting
-  iter_.compute_strides();
+  compute_strides();
   // re-order dimensions to improve coalescing
-  iter_.reorder_dimensions();
+  reorder_dimensions();
   // compute the result dtype and device
-  iter_.compute_types();
+  compute_types();
   // allocate the output tensor if it's not provided
-  iter_.allocate_outputs();
+  allocate_outputs();
   // coalesce adjacent dimensions when possible
-  iter_.coalesce_dimensions();
+  coalesce_dimensions();
 
-  for (auto& op : iter_.operands_) {
-    AT_ASSERT(op.tensor.defined());
+  for (auto& op : operands_) {
+    TORCH_INTERNAL_ASSERT(op.tensor.defined());
     op.data = op.tensor.data_ptr();
   }
+}
 
-  return std::move(iter_);
+SplitUntil32Bit TensorIterator::with_32bit_indexing() const {
+  return SplitUntil32Bit(*this);
 }
 
 /// SplitUntil32Bit. Recursively splits an iterator into sub-iterators that

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -18,10 +18,10 @@
 //
 // Example:
 //
-//   auto iter = TensorIterator::Builder()
-//      .add_output(output)
-//      .add_input(input)
-//      .build()
+//   auto iter = TensorIterator();
+//   iter.add_output(output);
+//   iter.add_input(input);
+//   iter.build()
 //
 // [MyKernel.cpp / MyKernel.cu]
 //   cpu_kernel(iter, [](float a, float b) {
@@ -117,9 +117,6 @@ struct CAFFE2_API OperandInfo {
 struct SplitUntil32Bit;
 
 struct CAFFE2_API TensorIterator {
-  struct Builder;
-  friend struct Builder;
-
   using DimMask = std::bitset<64>;
   using PtrVector = SmallVector<char*, 4>;
 
@@ -255,6 +252,35 @@ struct CAFFE2_API TensorIterator {
   /// CUDA reductions.
   bool is_final_output() const { return final_output_; }
 
+  /// Construction
+  void add_output(const Tensor& output) {
+    operands_.emplace_back(output);
+    num_outputs_++;
+  }
+
+  void add_output(const Tensor& input, Device device, ScalarType dtype) {
+    operands_.emplace_back(input, device, dtype);
+    num_outputs_++;
+  }
+
+  void add_input(const Tensor& input) {
+    operands_.emplace_back(input);
+  }
+
+  void add_input(const Tensor& input, Device device, ScalarType dtype) {
+    operands_.emplace_back(input, device, dtype);
+  }
+
+  void dont_compute_common_dtype() {
+    compute_common_dtype_ = false;
+  }
+
+  void dont_resize_outputs() {
+    resize_outputs_ = false;
+  }
+
+  void build();
+
 protected:
   void mark_outputs();
   void compute_shape();
@@ -279,41 +305,6 @@ protected:
   bool allow_cpu_scalars_ = false;
   bool promote_gpu_output_dtypes_ = false;
   bool final_output_ = true;
-};
-
-struct TensorIterator::Builder {
-  friend struct TensorIterator;
-
-  void add_output(const Tensor& output) {
-    iter_.operands_.emplace_back(output);
-    iter_.num_outputs_++;
-  }
-
-  void add_output(const Tensor& input, Device device, ScalarType dtype) {
-    iter_.operands_.emplace_back(input, device, dtype);
-    iter_.num_outputs_++;
-  }
-
-  void add_input(const Tensor& input) {
-    iter_.operands_.emplace_back(input);
-  }
-
-  void add_input(const Tensor& input, Device device, ScalarType dtype) {
-    iter_.operands_.emplace_back(input, device, dtype);
-  }
-
-  void dont_compute_common_dtype() {
-    iter_.compute_common_dtype_ = false;
-  }
-
-  void dont_resize_outputs() {
-    iter_.resize_outputs_ = false;
-  }
-
-  TensorIterator build();
-
-protected:
-  TensorIterator iter_;
 };
 
 /// A container-like struct that acts as if it contains splits of a

--- a/aten/src/ATen/native/cpu/LerpKernel.cpp
+++ b/aten/src/ATen/native/cpu/LerpKernel.cpp
@@ -14,11 +14,11 @@ static void lerp_kernel_scalar(
     const Tensor& self,
     const Tensor& end,
     Scalar weight) {
-  auto builder = at::TensorIterator::Builder();
-  builder.add_output(ret);
-  builder.add_input(self);
-  builder.add_input(end);
-  auto iter = builder.build();
+  auto iter = TensorIterator();
+  iter.add_output(ret);
+  iter.add_input(self);
+  iter.add_input(end);
+  iter.build();
   AT_DISPATCH_FLOATING_TYPES(ret.scalar_type(), "lerp_kernel_scalar", [&] {
     scalar_t weight_val = weight.to<scalar_t>();
     at::native::cpu_kernel(
@@ -36,12 +36,12 @@ static void lerp_kernel_tensor(
     const Tensor& self,
     const Tensor& end,
     const Tensor& weights) {
-  auto builder = at::TensorIterator::Builder();
-  builder.add_output(ret);
-  builder.add_input(self);
-  builder.add_input(end);
-  builder.add_input(weights);
-  auto iter = builder.build();
+  auto iter = TensorIterator();
+  iter.add_output(ret);
+  iter.add_input(self);
+  iter.add_input(end);
+  iter.add_input(weights);
+  iter.build();
   AT_DISPATCH_FLOATING_TYPES(ret.scalar_type(), "lerp_kernel_tensor", [&] {
     at::native::cpu_kernel(
         iter,


### PR DESCRIPTION
The builder pattern doesn't seem to work well with return-value-optimization.
This saves ~100 ns in the construction of TensorIterator::binary_op.

```
import torch
x = torch.rand(1)
y = torch.rand(1)
z = torch.rand(1)
%timeit torch.add(x, y, out=z)  # ~1.76 us vs ~1.88 us on my machine
```

cc @resistor @zheng-xq 