### PR TITLE
[JIT] Fix a bunch of issues with SourceRanges and serialization

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3378,6 +3378,47 @@ def foo(xyz):
         self.assertEqual(records1, records2)
         self.assertEqual(records2, records3)
 
+    def test_serialized_source_ranges_no_dups(self):
+        class FooTest3(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, lim):
+                first = 1
+                second = 1
+                i = 1
+                somenum = 5
+                dontmutateme = 3
+                third = 0
+                while bool(i < lim):
+                    third = first + second
+                    first = second
+                    second = third
+                    j = 0
+                    while j < 10:
+                        somenum = somenum * 2
+                        j = j + 1
+                    i = i + j
+                    i = i + dontmutateme
+
+                st = second + third
+                fs = first + second
+                return third, st, fs
+
+        ft3 = FooTest3()
+
+        def debug_records_from_mod(mod):
+            buffer = io.BytesIO()
+            torch.jit.save(ft3, buffer)
+            buffer.seek(0)
+            archive = zipfile.ZipFile(buffer)
+            debug_file = archive.open('archive/debug/archive.pkl')
+            return pickle.load(debug_file), buffer
+
+        records, _ = debug_records_from_mod(ft3)
+        for i in range(len(records) - 1):
+            offset, source_range = records[i]
+            offset2, source_range2 = records[i + 1]
+            self.assertNotEqual(source_range, source_range2)
+
     def test_tensor_shape(self):
         x = torch.empty(34, 56, 78)
 

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -204,8 +204,7 @@ SourceRange Node::sourceRange() const {
   if (source_range_) {
     return *source_range_;
   }
-  std::stringstream ss;
-  return SourceRange(ss.str());
+  return SourceRange();
 }
 
 static std::ostream& indent(std::ostream& out, size_t level) {

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -1248,7 +1248,7 @@ void Node::removeFromList() {
 }
 
 inline const SourceRange& fakeRange() {
-  static SourceRange range(std::make_shared<Source>(""), 0, 1);
+  static SourceRange range;
   return range;
 }
 

--- a/torch/csrc/jit/passes/python_print.cpp
+++ b/torch/csrc/jit/passes/python_print.cpp
@@ -168,7 +168,7 @@ const static std::unordered_set<std::string> reserved_names = {
 
 struct PythonPrintPass {
   using SourceRangeStack = std::vector<SourceRange>;
-  SourceRangeStack source_range_stack_ = {SourceRange("")};
+  SourceRangeStack source_range_stack_ = {SourceRange()};
 
   struct WithSourceRange {
     explicit WithSourceRange(SourceRangeStack* stack, Node* n) : stack(stack) {

--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -14,6 +14,10 @@ c10::optional<SourceRange> Source::findSourceRangeThatGenerated(
 
 // a range of a shared string 'file_' with
 C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
+  // This is an empty SourceRange, used as a sentinel value.
+  if (!source_) {
+    return;
+  }
   const std::string& str = source_->text();
   if (size() == str.size()) {
     // this is just the entire file, not a subset, so print it out.
@@ -66,11 +70,9 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
   if (!str.empty() && str.back() != '\n')
     out << "\n";
   // Retrieve original SourceRange, if present.
-  if (source_) {
-    if (auto orig_source_range = findSourceRangeThatGenerated()) {
-      out << "Compiled from code ";
-      orig_source_range->highlight(out);
-    }
+  if (auto orig_source_range = findSourceRangeThatGenerated()) {
+    out << "Compiled from code ";
+    orig_source_range->highlight(out);
   }
 }
 

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -108,6 +108,7 @@ struct CAFFE2_API SourceRange {
       : source_(std::make_shared<Source>(std::move(string_range))),
         start_(0),
         end_(source_->text().size()) {}
+  SourceRange() : source_(nullptr), start_(0), end_(0) {}
 
   const std::string text() const {
     return source_->text().substr(start(), end() - start());

--- a/torch/csrc/jit/source_range.h
+++ b/torch/csrc/jit/source_range.h
@@ -104,10 +104,6 @@ struct Source {
 struct CAFFE2_API SourceRange {
   SourceRange(std::shared_ptr<Source> source_, size_t start_, size_t end_)
       : source_(std::move(source_)), start_(start_), end_(end_) {}
-  explicit SourceRange(std::string string_range)
-      : source_(std::make_shared<Source>(std::move(string_range))),
-        start_(0),
-        end_(source_->text().size()) {}
   SourceRange() : source_(nullptr), start_(0), end_(0) {}
 
   const std::string text() const {

--- a/torch/csrc/jit/source_range_serialization.cpp
+++ b/torch/csrc/jit/source_range_serialization.cpp
@@ -130,7 +130,7 @@ c10::optional<SourceRange> ConcreteSourceRangeUnpickler::
     findSourceRangeThatGenerated(const SourceRange& range) {
   unpickle();
 
-  auto query = TaggedRange(range.start(), SourceRange{""});
+  auto query = TaggedRange(range.start(), SourceRange{});
   auto entry = std::upper_bound(
       unpickled_records->begin(),
       unpickled_records->end(),

--- a/torch/csrc/jit/source_range_serialization.cpp
+++ b/torch/csrc/jit/source_range_serialization.cpp
@@ -31,7 +31,12 @@ class SourceRangeDeserializer {
     std::shared_ptr<Source> source_ = deserialize_source(tup_elems[0]);
     int64_t start_ = tup_elems[1].toInt();
     int64_t end_ = tup_elems[2].toInt();
-    return SourceRange(source_, start_, end_);
+
+    if (source_) {
+      return SourceRange(source_, start_, end_);
+    } else {
+      return SourceRange();
+    }
   }
 
  private:
@@ -43,6 +48,9 @@ class SourceRangeDeserializer {
 
     auto tup_elems = tup->elements();
     TORCH_INTERNAL_ASSERT(tup_elems.size() == 3);
+    if (tup_elems[0].toString()->string() == "") {
+      return nullptr;
+    }
     std::string text_ = tup_elems[0].toString()->string();
     c10::optional<std::string> filename_ =
         tup_elems[1].toOptional<std::string>();

--- a/torch/csrc/jit/source_range_serialization.cpp
+++ b/torch/csrc/jit/source_range_serialization.cpp
@@ -71,8 +71,12 @@ c10::IValue SourceRangeSerializer::serialize_source(
   if (serialized_sources.count(s)) {
     return serialized_sources.at(s);
   }
-  std::vector<c10::IValue> elements{
-      s->text(), s->filename(), (int64_t)s->starting_line_no()};
+  std::vector<c10::IValue> elements;
+  if (s == nullptr) {
+    elements = {"", "", 0};
+  } else {
+    elements = {s->text(), s->filename(), (int64_t)s->starting_line_no()};
+  }
   auto serialized = c10::ivalue::Tuple::create(std::move(elements));
   serialized_sources[s] = serialized;
   return serialized;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23341 [JIT] Fix SourceRange comparison**

This fixes a bunch of issues with SourceRanges:

1) "empty" SourceRanges were allocating a new Source for each instance, incuring a lot of cost and breaking comparison
2) Constants move around in compilation and it's not useful to have SourceRanges for them anyway, so we just serialize an empty one
3) `printOutputDefinition` needs to set the source range stackto properly serialize the right thing

Differential Revision: [D16505398](https://our.internmc.facebook.com/intern/diff/D16505398)