### PR TITLE
Polish torch::Dict

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -70,9 +70,6 @@ bool operator==(const DictIterator<Key, Value, Iterator>& lhs, const DictIterato
  */
 template<class Key, class Value, class Iterator>
 class DictEntryRef final {
-private:
-  static constexpr bool is_const_ref() { return std::is_const<typename Iterator::value_type>::value; }
-
 public:
   explicit DictEntryRef(Iterator iterator)
   : iterator_(std::move(iterator)) {}
@@ -87,12 +84,19 @@ public:
 
   template<class Value_>
   void setValue(Value_&& value) const {
-    static_assert(!is_const_ref(), "setValue() cannot be called on const_iterator.");
     static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of setValue()");
     iterator_->second = Value(std::forward<Value_>(value));
   }
 
 private:
+  // allow copying and moving, but only our friends (i.e. the Dict class) can do
+  // it. Copying/moving this reference wrapper would be too ambiguous to allow it
+  // in the public API.
+  DictEntryRef(const DictEntryRef&) = default;
+  DictEntryRef& operator=(const DictEntryRef&) = default;
+  DictEntryRef(DictEntryRef&&) noexcept = default;
+  DictEntryRef& operator=(DictEntryRef&& rhs) & noexcept = default;
+
   Iterator iterator_;
   friend class DictIterator<Key, Value, Iterator>;
   friend class Dict<Key, Value>;
@@ -107,10 +111,16 @@ public:
   explicit DictIterator() = default;
   ~DictIterator() = default;
 
-  DictIterator(const DictIterator&) = default;
-  DictIterator(DictIterator&&) noexcept = default;
-  DictIterator& operator=(const DictIterator&) = default;
-  DictIterator& operator=(DictIterator&&) = default;
+  DictIterator(const DictIterator& rhs): entryRef_(rhs.entryRef_) {}
+  DictIterator(DictIterator&& rhs) noexcept: entryRef_(std::move(rhs.entryRef_)) {}
+  DictIterator& operator=(const DictIterator& rhs) {
+    entryRef_ = rhs.entryRef_;
+    return *this;
+  }
+  DictIterator& operator=(DictIterator&& rhs) noexcept {
+    entryRef_ = std::move(rhs.entryRef_);
+    return *this;
+  }
 
   DictIterator& operator++() {
       ++entryRef_.iterator_;
@@ -131,35 +141,42 @@ public:
     return &entryRef_;
   }
 
-  // the template automatically disables the operator when we are already a
-  // const_iterator, because that would cause a lot of compiler warnings otherwise.
-  template<class const_iterator_ = typename detail::DictImpl::dict_map_type::const_iterator, class = guts::enable_if_t<!std::is_same<const_iterator_, Iterator>::value>>
-  /* implicit */ operator DictIterator<Key, Value, const_iterator_>() const
-  {
-      return DictIterator<Key, Value, const_iterator_> { const_iterator_ { entryRef_.iterator_ } };
+  friend typename std::iterator<std::random_access_iterator_tag, DictEntryRef<Key, Value, Iterator>>::difference_type operator-(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.entryRef_.iterator_ - rhs.entryRef_.iterator_;
   }
 
 private:
   explicit DictIterator(Iterator iterator): entryRef_(std::move(iterator)) {}
 
+  friend bool operator==(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.entryRef_.iterator_ == rhs.entryRef_.iterator_;
+  }
+
+  friend bool operator!=(const DictIterator& lhs, const DictIterator& rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend bool operator<(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.entryRef_.iterator_ < rhs.entryRef_.iterator_;
+  }
+
+  friend bool operator<=(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.entryRef_.iterator_ <= rhs.entryRef_.iterator_;
+  }
+
+  friend bool operator>(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.entryRef_.iterator_ > rhs.entryRef_.iterator_;
+  }
+
+  friend bool operator>=(const DictIterator& lhs, const DictIterator& rhs) {
+    return lhs.entryRef_.iterator_ >= rhs.entryRef_.iterator_;
+  }
+
   DictEntryRef<Key, Value, Iterator> entryRef_;
 
   friend class DictIterator<Key, Value, typename detail::DictImpl::dict_map_type::iterator>;
   friend class Dict<Key, Value>;
-  friend bool operator==<Key, Value, Iterator>(const DictIterator& lhs, const DictIterator& rhs);
-
-  // TODO We also need comparison operators <, >, <=, >=, see ListIterator.
 };
-
-template<class Key, class Value, class Iterator>
-inline bool operator==(const DictIterator<Key, Value, Iterator>& lhs, const DictIterator<Key, Value, Iterator>& rhs) {
-  return lhs.entryRef_.iterator_ == rhs.entryRef_.iterator_;
-}
-
-template<class Key, class Value, class Iterator>
-inline bool operator!=(const DictIterator<Key, Value, Iterator>& lhs, const DictIterator<Key, Value, Iterator>& rhs) {
-  return !(lhs == rhs);
-}
 
 template<class Key, class Value> Dict<Key, Value> toTypedDict(Dict<IValue, IValue> dict);
 template<class Key, class Value> Dict<IValue, IValue> toGenericDict(Dict<Key, Value> dict);
@@ -207,7 +224,6 @@ public:
   using mapped_type = Value;
   using size_type = typename detail::DictImpl::dict_map_type::size_type;
   using iterator = impl::DictIterator<Key, Value, typename detail::DictImpl::dict_map_type::iterator>;
-  using const_iterator = impl::DictIterator<Key, Value, typename detail::DictImpl::dict_map_type::const_iterator>;
 
   /**
    * Creates an empty dict.
@@ -247,37 +263,13 @@ public:
    * Returns an iterator to the first element of the container.
    * If the container is empty, the returned iterator will be equal to end().
    */
-  iterator begin();
-
-  /**
-   * Returns an iterator to the first element of the container.
-   * If the container is empty, the returned iterator will be equal to end().
-   */
-  const_iterator begin() const;
-
-  /**
-   * Returns an iterator to the first element of the container.
-   * If the container is empty, the returned iterator will be equal to end().
-   */
-  const_iterator cbegin() const;
+  iterator begin() const;
 
   /**
    * Returns an iterator to the element following the last element of the container.
    * This element acts as a placeholder; attempting to access it results in undefined behavior.
    */
-  iterator end();
-
-  /**
-   * Returns an iterator to the element following the last element of the container.
-   * This element acts as a placeholder; attempting to access it results in undefined behavior.
-   */
-  const_iterator end() const;
-
-  /**
-   * Returns an iterator to the element following the last element of the container.
-   * This element acts as a placeholder; attempting to access it results in undefined behavior.
-   */
-  const_iterator cend() const;
+  iterator end() const;
 
   /**
    * Checks if the container has no elements.
@@ -293,7 +285,7 @@ public:
    * Erases all elements from the container. After this call, size() returns zero.
    * Invalidates any references, pointers, or iterators referring to contained elements. May also invalidate past-the-end iterators.
    */
-  void clear();
+  void clear() const;
 
   /**
    * Inserts element(s) into the container, if the container doesn't already contain an element with an equivalent key.
@@ -302,7 +294,7 @@ public:
    * @return A pair consisting of an iterator to the inserted element (or to the element that prevented the insertion) and a bool denoting whether the insertion took place.
    */
   template<class Key_, class Value_>
-  std::pair<iterator, bool> insert(Key_&& key, Value_&& value);
+  std::pair<iterator, bool> insert(Key_&& key, Value_&& value) const;
 
   /**
    * If an element with the given key already exists, it is overwritten with the given value.
@@ -312,14 +304,14 @@ public:
    * @return The bool component is true if the insertion took place and false if the assignment took place. The iterator component is pointing at the element that was inserted or updated.
    */
   template<class Key_, class Value_>
-  std::pair<iterator, bool> insert_or_assign(Key_&& key, Value_&& value);
+  std::pair<iterator, bool> insert_or_assign(Key_&& key, Value_&& value) const;
 
   /**
    * Removes the element pointed to by iter.
    * May invalidate any references, pointers, or iterators referring to contained elements.
    * The iterator iter must be valid and dereferenceable. Thus the end() iterator (which is valid, but is not dereferenceable) cannot be used as a value for iter.
    */
-  void erase(const_iterator iter);
+  void erase(iterator iter) const;
 
   /**
    * Removes the element with the given key, if it exists.
@@ -327,7 +319,7 @@ public:
    *
    * @return The number of elements removed. This is either '1' if an element with the key existed, or '0' if it didn't.
    */
-  C10_NODISCARD size_t erase(const Key& key);
+  C10_NODISCARD size_t erase(const Key& key) const;
 
   /**
    * Returns the mapped value of the element with key equivalent to key.
@@ -341,15 +333,7 @@ public:
    * @return Iterator to an element with key equivalent to key.
    *         If no such element is found, past-the-end (see end()) iterator is returned.
    */
-  iterator find(const Key& key);
-
-  /**
-   * Finds an element with key equivalent to key.
-   *
-   * @return Iterator to an element with key equivalent to key.
-   *         If no such element is found, past-the-end (see end()) iterator is returned.
-   */
-  const_iterator find(const Key& key) const;
+  iterator find(const Key& key) const;
 
   /**
    * Checks if there is an element with key equivalent to key in the container.
@@ -362,7 +346,7 @@ public:
    * Increase the capacity so that at least count elements can be stored without
    * having to reallocate or rehash.
    */
-  void reserve(size_type count);
+  void reserve(size_type count) const;
 };
 
 namespace impl {

--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -61,8 +61,6 @@ struct DictImpl final : public c10::intrusive_ptr_target {
 
 namespace impl {
 template<class Key, class Value, class Iterator> class DictIterator;
-template<class Key, class Value, class Iterator>
-bool operator==(const DictIterator<Key, Value, Iterator>& lhs, const DictIterator<Key, Value, Iterator>& rhs);
 
 /**
  * A reference to an entry in the Dict.
@@ -100,7 +98,6 @@ private:
   Iterator iterator_;
   friend class DictIterator<Key, Value, Iterator>;
   friend class Dict<Key, Value>;
-  friend bool operator==<Key, Value, Iterator>(const DictIterator<Key, Value, Iterator>& lhs, const DictIterator<Key, Value, Iterator>& rhs);
 };
 
 // this wraps map_type::iterator to make sure user code can't rely
@@ -148,28 +145,32 @@ public:
 private:
   explicit DictIterator(Iterator iterator): entryRef_(std::move(iterator)) {}
 
+  const Iterator& get_iterator_() const {
+    return entryRef_.iterator_;
+  }
+
   friend bool operator==(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.entryRef_.iterator_ == rhs.entryRef_.iterator_;
+    return lhs.get_iterator_() == rhs.get_iterator_();
   }
 
   friend bool operator!=(const DictIterator& lhs, const DictIterator& rhs) {
-    return !(lhs == rhs);
+    return lhs.get_iterator_() != rhs.get_iterator_();
   }
 
   friend bool operator<(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.entryRef_.iterator_ < rhs.entryRef_.iterator_;
+    return lhs.get_iterator_() < rhs.get_iterator_();
   }
 
   friend bool operator<=(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.entryRef_.iterator_ <= rhs.entryRef_.iterator_;
+    return lhs.get_iterator_() <= rhs.get_iterator_();
   }
 
   friend bool operator>(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.entryRef_.iterator_ > rhs.entryRef_.iterator_;
+    return lhs.get_iterator_() > rhs.get_iterator_();
   }
 
   friend bool operator>=(const DictIterator& lhs, const DictIterator& rhs) {
-    return lhs.entryRef_.iterator_ >= rhs.entryRef_.iterator_;
+    return lhs.get_iterator_() >= rhs.get_iterator_();
   }
 
   DictEntryRef<Key, Value, Iterator> entryRef_;

--- a/aten/src/ATen/core/Dict_inl.h
+++ b/aten/src/ATen/core/Dict_inl.h
@@ -111,33 +111,13 @@ Dict<Key, Value> Dict<Key, Value>::copy() const {
 }
 
 template<class Key, class Value>
-typename Dict<Key, Value>::iterator Dict<Key, Value>::begin() {
+typename Dict<Key, Value>::iterator Dict<Key, Value>::begin() const {
   return iterator{impl_->dict.begin()};
 }
 
 template<class Key, class Value>
-typename Dict<Key, Value>::const_iterator Dict<Key, Value>::begin() const {
-  return const_iterator{impl_->dict.begin()};
-}
-
-template<class Key, class Value>
-typename Dict<Key, Value>::const_iterator Dict<Key, Value>::cbegin() const {
-  return const_iterator{impl_->dict.cbegin()};
-}
-
-template<class Key, class Value>
-typename Dict<Key, Value>::iterator Dict<Key, Value>::end() {
+typename Dict<Key, Value>::iterator Dict<Key, Value>::end() const {
   return iterator{impl_->dict.end()};
-}
-
-template<class Key, class Value>
-typename Dict<Key, Value>::const_iterator Dict<Key, Value>::end() const {
-  return const_iterator{impl_->dict.end()};
-}
-
-template<class Key, class Value>
-typename Dict<Key, Value>::const_iterator Dict<Key, Value>::cend() const {
-  return const_iterator{impl_->dict.cend()};
 }
 
 template<class Key, class Value>
@@ -151,13 +131,13 @@ typename Dict<Key, Value>::size_type Dict<Key, Value>::size() const {
 }
 
 template<class Key, class Value>
-void Dict<Key, Value>::clear() {
+void Dict<Key, Value>::clear() const {
   impl_->dict.clear();
 }
 
 template<class Key, class Value>
 template<class Key_, class Value_>
-std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert(Key_&& key, Value_&& value) {
+std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert(Key_&& key, Value_&& value) const {
   static_assert(std::is_constructible<Key, Key_>::value, "Wrong type for the key argument of Dict::insert");
   static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of Dict::insert");
   auto inserted = impl_->dict.insert(std::pair<IValue, IValue>{
@@ -168,7 +148,7 @@ std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert(Ke
 
 template<class Key, class Value>
 template<class Key_, class Value_>
-std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert_or_assign(Key_&& key, Value_&& value) {
+std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert_or_assign(Key_&& key, Value_&& value) const {
   static_assert(std::is_constructible<Key, Key_>::value, "Wrong type for the key argument of Dict::insert_or_assign");
   static_assert(std::is_constructible<Value, Value_>::value, "Wrong type for the value argument of Dict::insert_or_assign");
   auto inserted = impl_->dict.insert_or_assign(
@@ -178,12 +158,12 @@ std::pair<typename Dict<Key, Value>::iterator, bool> Dict<Key, Value>::insert_or
 }
 
 template<class Key, class Value>
-void Dict<Key, Value>::erase(const_iterator iter) {
+void Dict<Key, Value>::erase(iterator iter) const {
   impl_->dict.erase(iter.entryRef_.iterator_);
 }
 
 template<class Key, class Value>
-C10_NODISCARD size_t Dict<Key, Value>::erase(const Key& key) {
+C10_NODISCARD size_t Dict<Key, Value>::erase(const Key& key) const {
   return impl_->dict.erase(key);
 }
 
@@ -193,13 +173,8 @@ Value Dict<Key, Value>::at(const Key& key) const {
 }
 
 template<class Key, class Value>
-typename Dict<Key, Value>::iterator Dict<Key, Value>::find(const Key& key) {
+typename Dict<Key, Value>::iterator Dict<Key, Value>::find(const Key& key) const {
   return iterator{impl_->dict.find(key)};
-}
-
-template<class Key, class Value>
-typename Dict<Key, Value>::const_iterator Dict<Key, Value>::find(const Key& key) const {
-  return const_iterator{impl_->dict.find(key)};
 }
 
 template<class Key, class Value>
@@ -208,7 +183,7 @@ bool Dict<Key, Value>::contains(const Key& key) const {
 }
 
 template<class Key, class Value>
-void Dict<Key, Value>::reserve(size_type count) {
+void Dict<Key, Value>::reserve(size_type count) const {
   impl_->dict.reserve(count);
 }
 

--- a/aten/src/ATen/core/Dict_test.cpp
+++ b/aten/src/ATen/core/Dict_test.cpp
@@ -91,11 +91,7 @@ TEST(DictTest, whenInsertOrAssigningExistingKey_thenDoesModifyDict) {
 
 TEST(DictTest, givenEmptyDict_whenIterating_thenBeginIsEnd) {
   Dict<int64_t, string> dict;
-  const Dict<int64_t, string> cdict;
   EXPECT_EQ(dict.begin(), dict.end());
-  EXPECT_EQ(dict.cbegin(), dict.cend());
-  EXPECT_EQ(cdict.begin(), cdict.end());
-  EXPECT_EQ(cdict.cbegin(), cdict.cend());
 }
 
 TEST(DictTest, givenMutableDict_whenIterating_thenFindsElements) {
@@ -151,7 +147,7 @@ TEST(DictTest, givenConstDict_whenIterating_thenFindsElements) {
   const Dict<int64_t, string>& dict = dict_;
   bool found_first = false;
   bool found_second = false;
-  for (Dict<int64_t, string>::const_iterator iter = dict.begin(); iter != dict.end(); ++iter) {
+  for (Dict<int64_t, string>::iterator iter = dict.begin(); iter != dict.end(); ++iter) {
     if (iter->key() == 3) {
       EXPECT_EQ("3", iter->value());
       EXPECT_FALSE(found_first);
@@ -197,13 +193,6 @@ TEST(DictTest, givenIterator_thenCanModifyValue) {
   dict.insert(3, "old_value");
   dict.begin()->setValue("new_value");
   EXPECT_EQ("new_value", dict.begin()->value());
-}
-
-TEST(DictTest, givenOneElementDict_whenErasingByConstIterator_thenDictIsEmpty) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-  dict.erase(dict.cbegin());
-  EXPECT_TRUE(dict.empty());
 }
 
 TEST(DictTest, givenOneElementDict_whenErasingByIterator_thenDictIsEmpty) {
@@ -265,7 +254,7 @@ TEST(DictTest, givenConstDict_whenCallingFindOnExistingKey_thenFindsCorrectEleme
   dict_.insert(3, "3");
   dict_.insert(4, "4");
   const Dict<int64_t, string>& dict = dict_;
-  Dict<int64_t, string>::const_iterator found = dict.find(3);
+  Dict<int64_t, string>::iterator found = dict.find(3);
   EXPECT_EQ(3, found->key());
   EXPECT_EQ("3", found->value());
 }
@@ -275,7 +264,7 @@ TEST(DictTest, givenConstDict_whenCallingFindOnNonExistingKey_thenReturnsEnd) {
   dict_.insert(3, "3");
   dict_.insert(4, "4");
   const Dict<int64_t, string>& dict = dict_;
-  Dict<int64_t, string>::const_iterator found = dict.find(5);
+  Dict<int64_t, string>::iterator found = dict.find(5);
   EXPECT_EQ(dict.end(), found);
 }
 
@@ -379,16 +368,7 @@ TEST(DictTest, whenMoveAssigningDict_thenOldIsEmpty) {
   EXPECT_TRUE(dict1.empty());
 }
 
-TEST(DictTest, givenMutableIterator_whenAssigningToConstIterator_thenWorks) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-  Dict<int64_t, string>::iterator iter = dict.begin();
-  Dict<int64_t, string>::const_iterator const_iter = iter;
-  EXPECT_EQ(3, const_iter->key());
-  EXPECT_EQ("3", const_iter->value());
-}
-
-TEST(DictTest, givenMutableIterator_whenPostfixIncrementing_thenMovesToNextAndReturnsOldPosition) {
+TEST(DictTest, givenIterator_whenPostfixIncrementing_thenMovesToNextAndReturnsOldPosition) {
   Dict<int64_t, string> dict;
   dict.insert(3, "3");
   dict.insert(4, "4");
@@ -399,18 +379,7 @@ TEST(DictTest, givenMutableIterator_whenPostfixIncrementing_thenMovesToNextAndRe
   EXPECT_EQ(dict.begin()->key(), iter2->key());
 }
 
-TEST(DictTest, givenConstIterator_whenPostfixIncrementing_thenMovesToNextAndReturnsOldPosition) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-  dict.insert(4, "4");
-
-  Dict<int64_t, string>::const_iterator iter1 = dict.cbegin();
-  Dict<int64_t, string>::const_iterator iter2 = iter1++;
-  EXPECT_NE(dict.begin()->key(), iter1->key());
-  EXPECT_EQ(dict.begin()->key(), iter2->key());
-}
-
-TEST(DictTest, givenMutableIterator_whenPrefixIncrementing_thenMovesToNextAndReturnsNewPosition) {
+TEST(DictTest, givenIterator_whenPrefixIncrementing_thenMovesToNextAndReturnsNewPosition) {
   Dict<int64_t, string> dict;
   dict.insert(3, "3");
   dict.insert(4, "4");
@@ -421,18 +390,7 @@ TEST(DictTest, givenMutableIterator_whenPrefixIncrementing_thenMovesToNextAndRet
   EXPECT_NE(dict.begin()->key(), iter2->key());
 }
 
-TEST(DictTest, givenConstIterator_whenPrefixIncrementing_thenMovesToNextAndReturnsNewPosition) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-  dict.insert(4, "4");
-
-  Dict<int64_t, string>::const_iterator iter1 = dict.cbegin();
-  Dict<int64_t, string>::const_iterator iter2 = ++iter1;
-  EXPECT_NE(dict.begin()->key(), iter1->key());
-  EXPECT_NE(dict.begin()->key(), iter2->key());
-}
-
-TEST(DictTest, givenEqualMutableIterators_thenAreEqual) {
+TEST(DictTest, givenEqualIterators_thenAreEqual) {
   Dict<int64_t, string> dict;
   dict.insert(3, "3");
   dict.insert(4, "4");
@@ -443,7 +401,7 @@ TEST(DictTest, givenEqualMutableIterators_thenAreEqual) {
   EXPECT_FALSE(iter1 != iter2);
 }
 
-TEST(DictTest, givenDifferentMutableIterators_thenAreNotEqual) {
+TEST(DictTest, givenDifferentIterators_thenAreNotEqual) {
   Dict<int64_t, string> dict;
   dict.insert(3, "3");
   dict.insert(4, "4");
@@ -456,31 +414,7 @@ TEST(DictTest, givenDifferentMutableIterators_thenAreNotEqual) {
   EXPECT_TRUE(iter1 != iter2);
 }
 
-TEST(DictTest, givenEqualConstIterators_thenAreEqual) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-  dict.insert(4, "4");
-
-  Dict<int64_t, string>::const_iterator iter1 = dict.cbegin();
-  Dict<int64_t, string>::const_iterator iter2 = dict.cbegin();
-  EXPECT_TRUE(iter1 == iter2);
-  EXPECT_FALSE(iter1 != iter2);
-}
-
-TEST(DictTest, givenDifferentConstIterators_thenAreNotEqual) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-  dict.insert(4, "4");
-
-  Dict<int64_t, string>::const_iterator iter1 = dict.cbegin();
-  Dict<int64_t, string>::const_iterator iter2 = dict.cbegin();
-  iter2++;
-
-  EXPECT_FALSE(iter1 == iter2);
-  EXPECT_TRUE(iter1 != iter2);
-}
-
-TEST(DictTest, givenMutableIterator_whenDereferencing_thenPoint64_tsToCorrectElement) {
+TEST(DictTest, givenIterator_whenDereferencing_thenPointsToCorrectElement) {
   Dict<int64_t, string> dict;
   dict.insert(3, "3");
 
@@ -491,18 +425,7 @@ TEST(DictTest, givenMutableIterator_whenDereferencing_thenPoint64_tsToCorrectEle
   EXPECT_EQ("3", iter->value());
 }
 
-TEST(DictTest, givenConstIterator_whenDereferencing_thenPoint64_tsToCorrectElement) {
-  Dict<int64_t, string> dict;
-  dict.insert(3, "3");
-
-  Dict<int64_t, string>::const_iterator iter = dict.cbegin();
-  EXPECT_EQ(3, (*iter).key());
-  EXPECT_EQ("3", (*iter).value());
-  EXPECT_EQ(3, iter->key());
-  EXPECT_EQ("3", iter->value());
-}
-
-TEST(DictTest, givenMutableIterator_whenWritingToValue_thenWorks) {
+TEST(DictTest, givenIterator_whenWritingToValue_thenChangesValue) {
   Dict<int64_t, string> dict;
   dict.insert(3, "3");
 
@@ -513,6 +436,19 @@ TEST(DictTest, givenMutableIterator_whenWritingToValue_thenWorks) {
 
   iter->setValue("new_value_2");
   EXPECT_EQ("new_value_2", dict.begin()->value());
+}
+
+TEST(ListTest_IValueBasedList, givenIterator_whenWritingToValueFromIterator_thenChangesValue) {
+  Dict<int64_t, string> dict;
+  dict.insert(3, "3");
+  dict.insert(4, "4");
+  dict.insert(5, "5");
+
+  (*dict.find(3)).setValue(dict.find(4)->value());
+  EXPECT_EQ("4", dict.find(3)->value());
+
+  dict.find(3)->setValue(dict.find(5)->value());
+  EXPECT_EQ("5", dict.find(3)->value());
 }
 
 TEST(DictTest, isReferenceType) {

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -451,7 +451,7 @@ std::unordered_map<K, V> generic_to(
     _fake_type<std::unordered_map<K, V>>) {
   std::unordered_map<K, V> specialized_dict;
 
-  for (auto item : std::move(ivalue).toGenericDict()) {
+  for (const auto& item : std::move(ivalue).toGenericDict()) {
     specialized_dict[item.key().to<K>()] = item.value().to<V>();
   }
 

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -235,7 +235,7 @@ bool isSubvalueOf(const IValue& ivalue, TypePtr type) {
     auto dict_type = type->expect<DictType>();
     const auto dict = ivalue.toGenericDict();
     return std::all_of(
-        dict.begin(), dict.end(), [=](const c10::impl::GenericDict::const_iterator::value_type& item) {
+        dict.begin(), dict.end(), [=](const c10::impl::GenericDict::iterator::value_type& item) {
           return isSubvalueOf(item.key(), dict_type->getKeyType()) &&
               isSubvalueOf(item.value(), dict_type->getValueType());
         });

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1843,7 +1843,7 @@ int dictUpdate(Stack& stack) {
   auto to_add = pop(stack).toGenericDict();
   auto dict = pop(stack).toGenericDict();
 
-  for (auto item : to_add) {
+  for (const auto& item : to_add) {
     dict.insert(item.key(), item.value());
   }
   return 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23344 Polish torch::Dict**

torch::List recently received some polishing that now also is done for Dict. This should be done before the PyTorch 1.2 release because of backwards compatibility.

- Dict is just a reference type, so "const Dict" should have the same capabilities as "Dict", constness is not guaranteed in any way.
- DictIterator gets comparison operators <, <=, >, >=

Differential Revision: [D16468800](https://our.internmc.facebook.com/intern/diff/D16468800/)