### PR TITLE
Replace uint8 with int8 in Linear and LSTM quantization path

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -987,15 +987,15 @@ std::tuple<Tensor, Tensor, Tensor> quantized_lstm(
                     num_layers, dropout_p, train, bidirectional, batch_first);
     return std::make_tuple(output, hy, cy);
   }
-  auto result_dtype = dtype.has_value() ? dtype.value() : at::kByte;
+  auto result_dtype = dtype.has_value() ? dtype.value() : at::kChar;
   check_device(_input, _params, hx);
   auto input = batch_first ? _input.transpose(0, 1) : _input;
   TORCH_CHECK(has_biases, "quantized LSTM requires biases");
-  TORCH_CHECK(result_dtype == at::kByte || result_dtype == at::kHalf,
+  TORCH_CHECK(result_dtype == at::kChar || result_dtype == at::kHalf,
               "dtype is not supported");
 
   std::tuple<Tensor, Tensor, Tensor> results;
-  if (result_dtype == at::kByte) {
+  if (result_dtype == at::kChar) {
     auto params = gather_quantized_params(_params);
     results = _lstm_impl<FullLayer, FullBidirectionalLayer>(
         input, params, hx[0], hx[1], num_layers,

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6508,7 +6508,7 @@ a")
                 requires_grad=False)
 
             ref = copy.deepcopy(cell)
-            cell_int8 = torch.jit.quantized.quantize_rnn_modules(cell, dtype=torch.uint8)
+            cell_int8 = torch.jit.quantized.quantize_rnn_modules(cell, dtype=torch.int8)
             cell_fp16 = torch.jit.quantized.quantize_rnn_modules(cell, dtype=torch.float16)
 
             niter = 10

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -251,7 +251,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                      'batch_first', 'dropout', 'bidirectional', '_packed_weights',
                      '_quantized_weights', 'dtype']
 
-    def __init__(self, other, dtype=torch.uint8): 
+    def __init__(self, other, dtype=torch.int8): 
         super(QuantizedRNNBase, self).__init__()
         self.mode = other.mode
         self.input_size = other.input_size
@@ -272,7 +272,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
         if self.mode != 'LSTM' and self.mode != 'GRU':
             raise RuntimeError('Only LSTM or GRU is supported for QuantizedRNN')
 
-        if dtype != torch.uint8 and dtype != torch.float16:
+        if dtype != torch.int8 and dtype != torch.float16:
             raise RuntimeError('Unsupported dtype: {}'.format(dtype))
 
         self._all_weights = []
@@ -293,7 +293,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
                     orig_weights.append(weight_name)
                     self.register_buffer(weight_name, weight)
 
-                    if dtype == torch.uint8: 
+                    if dtype == torch.int8: 
                         # for each layer, for each direction we need to quantize and pack
                         # weights and pack parameters in this order:
                         #
@@ -422,7 +422,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
     # @torch._jit_internal.torch.jit.script_method
     @torch.jit.script_method
     def _unpack(self):
-        if self.dtype == torch.uint8:
+        if self.dtype == torch.int8:
             packed_weights = self._get_packed_weights()
             quantized_weights = self._get_quantized_weights()
             assert len(packed_weights) == len(quantized_weights)
@@ -607,7 +607,7 @@ def quantize_rnn_cell_modules(module):
     return module
 
 
-def quantize_linear_modules(module, dtype=torch.uint8):
+def quantize_linear_modules(module, dtype=torch.int8):
     reassign = {}
     for name, mod in module.named_modules():
         if mod is module:
@@ -619,7 +619,7 @@ def quantize_linear_modules(module, dtype=torch.uint8):
     for name, mod in reassign.items():
         setattr(module, name, mod)
     if isinstance(module, torch.nn.Linear):
-        if dtype == torch.uint8:
+        if dtype == torch.int8:
             return QuantizedLinear(module)
         elif dtype == torch.float16:
             return QuantizedLinearFP16(module)
@@ -629,7 +629,7 @@ def quantize_linear_modules(module, dtype=torch.uint8):
     return module
 
 
-def quantize_rnn_modules(module, dtype=torch.uint8):
+def quantize_rnn_modules(module, dtype=torch.int8):
     reassign = {}
     for name, mod in module.named_modules():
         if mod is module:
@@ -641,7 +641,7 @@ def quantize_rnn_modules(module, dtype=torch.uint8):
     for name, mod in reassign.items():
         setattr(module, name, mod)
     if isinstance(module, torch.nn.LSTM):
-        if dtype != torch.uint8 and dtype != torch.float16:
+        if dtype != torch.int8 and dtype != torch.float16:
             raise RuntimeError("Unsupported dtype: {}".format(dtype))
         return QuantizedLSTM(module, dtype)
     if isinstance(module, torch.nn.GRU):


### PR DESCRIPTION
Summary: This diff replaces uint8 with int8 to match with the underlying kernel implementation.  When we do int8 quantization,  we are computing with uint8 (input activation) * int8 (weight) -> uint8 (output activation). The weight is quantized into int8.

Differential Revision: D16469435

