### PR TITLE
Change handling of DataParallel in ONNX exporter

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -746,10 +746,6 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 return input - 1
         self.run_model_test(MyModel(), train=False, batch_size=BATCH_SIZE)
 
-    def test_dataparallel(self):
-        model = nn.DataParallel(nn.ReflectionPad2d((1, 2, 3, 4)))
-        self.run_model_test(model, train=False, batch_size=BATCH_SIZE)
-
     def test_embedding(self):
         model = nn.Embedding(10, 3, padding_idx=-1)
         input = torch.LongTensor(list(range(10))[::-1])

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -200,10 +200,23 @@ class TestUtilityFuns(TestCase):
         # test strip_doc_string=False
         self.assertFalse(is_model_stripped(io.BytesIO(), False))
 
+    # NB: remove this test once DataParallel can be correctly handled
+    def test_error_on_data_parallel(self):
+        model = torch.nn.DataParallel(torch.nn.ReflectionPad2d((1, 2, 3, 4)))
+        x = torch.randn(1, 2, 3, 4)
+        f = io.BytesIO()
+        with self.assertRaisesRegex(ValueError,
+                                    'torch.nn.DataParallel is not supported by ONNX '
+                                    'exporter, please use \'attribute\' module to '
+                                    'unwrap model from torch.nn.DataParallel. Try '):
+            torch.onnx.export(model, x, f, opset_version=self.opset_version)
+
+
 # opset 10 tests
 TestUtilityFuns_opset10 = type(str("TestUtilityFuns_opset10"),
                                (TestCase,),
                                dict(TestUtilityFuns.__dict__, opset_version=10))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -307,11 +307,14 @@ def _export(model, args, f, export_params=True, verbose=False, training=False,
             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None, propagate=False,
             opset_version=None, _retain_param_name=False, do_constant_folding=False,
             strip_doc_string=True, dynamic_axes=None):
+    if isinstance(model, torch.nn.DataParallel):
+        raise ValueError('torch.nn.DataParallel is not supported by ONNX '
+                         'exporter, please use \'attribute\' module to '
+                         'unwrap model from torch.nn.DataParallel. Try '
+                         'torch.onnx.export(model.module, ...)')
     global __IN_ONNX_EXPORT
     assert __IN_ONNX_EXPORT is False
     __IN_ONNX_EXPORT = True
-    if isinstance(model, torch.nn.DataParallel):
-        model = model.module
     try:
         from torch.onnx.symbolic_helper import _default_onnx_opset_version, _set_opset_version
         from torch.onnx.symbolic_helper import _set_operator_export_type


### PR DESCRIPTION
Don't automatically unwrap top layer DataParalllel for users. Instead, we provide useful error information and tell users what action to take.