### PR TITLE
[jit] fix importing for module defs that are named "foo.bar"

### DIFF
--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -92,6 +92,10 @@ struct QualifiedName {
     return name_;
   }
 
+  const std::vector<std::string>& atoms() const {
+    return atoms_;
+  }
+
   bool operator==(const QualifiedName& other) const {
     return this->qualifiedName_ == other.qualifiedName_;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23367 [jit] fix importing for module defs that are named "foo.bar"**

As title. This is a non-issue with the new serialization format, but the
transitionary state is broken if you name the archive for a model
"foo.bar".

Differential Revision: [D16478637](https://our.internmc.facebook.com/intern/diff/D16478637)