### PR TITLE
DEPRECATE_MESSAGE doesn't actually get expanded; inline it at both sites.

### DIFF
--- a/torch/csrc/api/include/torch/torch.h
+++ b/torch/csrc/api/include/torch/torch.h
@@ -5,13 +5,10 @@
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 #include <torch/extension.h>
 
-#define DEPRECATE_MESSAGE \
-    "Including torch/torch.h for C++ extensions is deprecated. Please include torch/extension.h"
-
 #ifdef _MSC_VER
-#  pragma message ( DEPRECATE_MESSAGE )
+#  pragma message ( "Including torch/torch.h for C++ extensions is deprecated. Please include torch/extension.h" )
 #else
-#  warning DEPRECATE_MESSAGE
+#  warning "Including torch/torch.h for C++ extensions is deprecated. Please include torch/extension.h"
 #endif
 
 #endif // defined(TORCH_API_INCLUDE_EXTENSION_H)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23379 DEPRECATE_MESSAGE doesn't actually get expanded; inline it at both sites.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16495278](https://our.internmc.facebook.com/intern/diff/D16495278)