### PR TITLE
Don't warn when using conda compilers with utils.cpp_extension

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -110,7 +110,8 @@ def _is_binary_build():
 
 
 def _accepted_compilers_for_platform():
-    return ['clang++', 'clang'] if sys.platform.startswith('darwin') else ['g++', 'gcc']
+    # gnu-c++ and gnu-cc are the conda gcc compilers
+    return ['clang++', 'clang'] if sys.platform.startswith('darwin') else ['g++', 'gcc', 'gnu-c++', 'gnu-cc']
 
 
 def get_default_build_root():


### PR DESCRIPTION
The conda compiler are gcc/c++ 7.3.0, but have custom version strings
for clarity:

    x86_64-conda_cos6-linux-gnu-cc
    x86_64-conda_cos6-linux-gnu-c++

Using these compilers to build a C++ or CUDA extension now gives this warning (unnecessarily):

```
                               !! WARNING !!

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Your compiler (/home/rgommers/anaconda3/envs/pytorch-nightly/bin/x86_64-conda_cos6-linux-gnu-c++) is not compatible with the compiler Pytorch was
built with for this platform, which is g++ on linux.
...
```

