### PR TITLE
[pytorch] Rename threading build options

### DIFF
--- a/aten/src/ATen/ParallelCommon.cpp
+++ b/aten/src/ATen/ParallelCommon.cpp
@@ -71,7 +71,7 @@ std::string get_parallel_info() {
   ss << "\tMKL_NUM_THREADS : "
      << get_env_var("MKL_NUM_THREADS", "[not set]") << std::endl;
 
-  ss << "Parallel backend: ";
+  ss << "ATen parallel backend: ";
   #if AT_PARALLEL_OPENMP
   ss << "OpenMP";
   #elif AT_PARALLEL_NATIVE

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -862,23 +862,23 @@ target_compile_options(torch PRIVATE "-DCAFFE2_BUILD_MAIN_LIB")
 target_compile_definitions(torch PRIVATE "-DCAFFE2_BUILD_MAIN_LIB")
 
 
-# Parallelism settings
-#  OPENMP - OpenMP for intra-op, native thread pool for inter-op parallelism
+# ATen parallelism settings
+#  OMP - OpenMP for intra-op, native thread pool for inter-op parallelism
 #  NATIVE - using native thread pool for intra- and inter-op parallelism
-#  NATIVE_TBB - using TBB for intra- and native thread pool for inter-op parallelism
-set(PARALLEL_BACKEND "OPENMP" CACHE STRING "ATen parallel backend")
-message(STATUS "Using parallel backend: ${PARALLEL_BACKEND}")
-if ("${PARALLEL_BACKEND}" STREQUAL "OPENMP")
+#  TBB - using TBB for intra- and native thread pool for inter-op parallelism
+set(ATEN_THREADING "OMP" CACHE STRING "ATen parallel backend")
+message(STATUS "Using ATen parallel backend: ${ATEN_THREADING}")
+if ("${ATEN_THREADING}" STREQUAL "OMP")
   target_compile_definitions(torch PUBLIC "-DAT_PARALLEL_OPENMP=1")
-elseif ("${PARALLEL_BACKEND}" STREQUAL "NATIVE")
+elseif ("${ATEN_THREADING}" STREQUAL "NATIVE")
   target_compile_definitions(torch PUBLIC "-DAT_PARALLEL_NATIVE=1")
-elseif ("${PARALLEL_BACKEND}" STREQUAL "NATIVE_TBB")
+elseif ("${ATEN_THREADING}" STREQUAL "TBB")
   if (NOT USE_TBB)
-    message(FATAL_ERROR "Using NATIVE_TBB backend but USE_TBB is off")
+    message(FATAL_ERROR "Using TBB backend but USE_TBB is off")
   endif()
   target_compile_definitions(torch PUBLIC "-DAT_PARALLEL_NATIVE_TBB=1")
 else()
-  message(FATAL_ERROR "Unknown parallel backend: ${PARALLEL_BACKEND}")
+  message(FATAL_ERROR "Unknown ATen parallel backend: ${ATEN_THREADING}")
 endif()
 set(EXPERIMENTAL_SINGLE_THREAD_POOL "0" CACHE STRING
   "Experimental option to use a single thread pool for inter- and intra-op parallelism")

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@
 #     disables use of MKLDNN
 #
 #   MKLDNN_THREADING
-#     MKL-DNN threading mode (https://github.com/intel/mkl-dnn/)
+#     MKL-DNN threading mode: TBB or OMP (default)
 #
 #   USE_NNPACK=0
 #     disables NNPACK build
@@ -103,7 +103,7 @@
 #     the BLAS will be chosen based on what is found on your system.
 #
 #   MKL_THREADING
-#     MKL flavor: SEQ, TBB or OMP (default)
+#     MKL threading mode: SEQ, TBB or OMP (default)
 #
 #   USE_FBGEMM
 #     Enables use of FBGEMM
@@ -150,15 +150,15 @@
 #   LD_LIBRARY_PATH
 #     we will search for libraries in these paths
 #
-#   PARALLEL_BACKEND
-#     parallel backend to use for intra- and inter-op parallelism
+#   ATEN_THREADING
+#     ATen parallel backend to use for intra- and inter-op parallelism
 #     possible values:
-#       OPENMP - use OpenMP for intra-op and native backend for inter-op tasks
+#       OMP - use OpenMP for intra-op and native backend for inter-op tasks
 #       NATIVE - use native thread pool for both intra- and inter-op tasks
-#       NATIVE_TBB - using TBB for intra- and native thread pool for inter-op parallelism
+#       TBB - using TBB for intra- and native thread pool for inter-op parallelism
 #
 #   USE_TBB
-#      use TBB for parallelization
+#      enable TBB support
 #
 
 from __future__ import print_function

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -242,7 +242,7 @@ class CMake:
              'MKLDNN_THREADING',
              'ONNX_ML',
              'ONNX_NAMESPACE',
-             'PARALLEL_BACKEND',
+             'ATEN_THREADING',
              'WERROR')
         })
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23417 [pytorch][doc] Threading and CPU Inference note
* **#23407 [pytorch] Rename threading build options**

Summary:
PARALLEL_BACKEND -> ATEN_THREADING
  OPENMP -> OMP
  NATIVE_TBB -> TBB
to match MKL_THREADING and MKLDNN_THREADING

Test Plan:
USE_CUDA=0 ATEN_THREADING=TBB USE_OPENMP=0 USE_TBB=1 MKL_THREADING=TBB
BLAS=MKL USE_MKLDNN=1 MKLDNN_THREADING=TBB BUILD_BINARY=1 python
setup.py develop install --cmake

./build/bin/parallel_info

Differential Revision: [D16522538](https://our.internmc.facebook.com/intern/diff/D16522538)