### PR TITLE
Fix forwarding of arguments into kernel function

### DIFF
--- a/aten/src/ATen/core/op_registration/kernel_function.h
+++ b/aten/src/ATen/core/op_registration/kernel_function.h
@@ -11,7 +11,7 @@ namespace detail {
   template<class FuncType, FuncType* kernel_func, class ReturnType, class... Parameters>
   class WrapKernelFunction_<FuncType, kernel_func, ReturnType, guts::typelist::typelist<Parameters...>> final : public c10::OperatorKernel {
   public:
-    auto operator()(Parameters&&... args) -> decltype((*kernel_func)(std::forward<Parameters>(args)...)) {
+    auto operator()(Parameters... args) -> decltype((*kernel_func)(std::forward<Parameters>(args)...)) {
       return (*kernel_func)(std::forward<Parameters>(args)...);
     }
   };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23412 Fix forwarding of arguments into kernel function**

They should be forwarded by their actual type, not their rvalue reference.
This looked like perfect forwarding but actually wasn't.

Differential Revision: [D16507872](https://our.internmc.facebook.com/intern/diff/D16507872/)