### PR TITLE
wip

### DIFF
--- a/aten/src/ATen/Dimname.h
+++ b/aten/src/ATen/Dimname.h
@@ -52,5 +52,13 @@ CAFFE2_API bool match(Dimname dimname, Dimname other);
 
 CAFFE2_API std::ostream& operator<<(std::ostream& out, const Dimname& dimname);
 
+inline bool operator==(const Dimname& lhs, const Dimname& rhs) {
+  return lhs.full_name() == rhs.full_name();
+}
+
+inline bool operator!=(const Dimname& lhs, const Dimname& rhs) {
+  return !(lhs == rhs);
+}
+
 } // namespace at
 #endif

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -35,6 +35,14 @@ CAFFE2_API std::vector<int64_t> dimnames_to_positions(const Tensor& tensor, Dimn
 CAFFE2_API optional<std::vector<Dimname>>
 unify_from_right(optional<DimnameList> names, optional<DimnameList> other);
 
+// [Alignment rules]
+// Aligns the names in first and second according to the following rules:
+// 1) Check that the shorter of (tensor.names, other.names) is a subsequence
+//    (not necessarily contiguous) of the other.
+// 2) Aligning the shorter name to the longer name must NOT change the absolute
+//    position from the right of any unnamed dimension.
+CAFFE2_API DimnameList infer_alignment(DimnameList first, DimnameList second);
+
 namespace namedinference {
 
 // Propagates all names from src to result.

--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -10,5 +10,44 @@ Tensor& set_names_(Tensor& self, optional<DimnameList> names) {
   return at::internal_set_names_inplace(self, names);
 }
 
+Tensor align_to(const Tensor& tensor, DimnameList names) {
+  auto tensor_sizes = tensor.sizes();
+  TORCH_CHECK(
+      tensor.has_names() || tensor_sizes.size() == 0,
+      "align_to: input tensor must have named dimensions.");
+  TORCH_CHECK(
+      names.size() >= tensor.dim(),
+      "Cannot align tensor with dims ", tensor.names().value(),
+      " to a shorter list of dims ", names, ".");
+
+  std::vector<int64_t> expanded_sizes(names.size(), 1);
+  auto tensor_names = *tensor.names();
+  ptrdiff_t dim = (ptrdiff_t)tensor.dim() - 1;
+  ptrdiff_t idx = (ptrdiff_t)names.size() - 1;
+  for (; idx >= 0 && dim >= 0; --idx) {
+    TORCH_INTERNAL_ASSERT(!tensor_names[dim].is_tagged() && !names[idx].is_tagged(), "Tagged names NYI");
+    if (tensor_names[dim] != names[idx]) {
+      continue;
+    }
+    if (tensor_names[dim].is_wildcard()) {
+      TORCH_CHECK(
+          tensor_sizes.size() - dim == names.size() - idx,
+          "Aligning tensor `a` with dims ", tensor_names, " to `names` ", names,
+          "would change the absolute position from the right of an unnamed dimension. ",
+          "Please name unnamed dimensions to avoid ambiguity.")
+    }
+    expanded_sizes[idx] = tensor_sizes[dim];
+    --dim;
+  }
+  TORCH_CHECK(
+      dim == -1,
+      "Could not align tensor `a` with dims ", tensor_names,
+      " to `names` ", names, " because `a.names` is not a subsequence of `names`.");
+
+  auto result = tensor.view(expanded_sizes);
+  at::internal_set_names_inplace(result, names);
+  return result;
+}
+
 }}  // namespace at::native
 #endif

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -39,6 +39,9 @@
   variants: method
   named_guard: False
 
+- func: align_to(Tensor self, DimnameList names) -> Tensor
+  named_guard: False
+
 - func: _cudnn_ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
   dispatch:
     CUDA: _cudnn_ctc_loss
@@ -2996,6 +2999,7 @@
     CPU: legacy::cpu::_th_set_
     CUDA: legacy::cuda::_th_set_
     QuantizedCPU: set_storage_cpu
+  named_guard: False
 
 - func: set_(Tensor(a!) self, Tensor source) -> Tensor(a!)
   variants: method
@@ -3057,6 +3061,7 @@
     CUDA: view
     MkldnnCPU: mkldnn_view
     QuantizedCPU: view
+  named_guard: False
 
 - func: put_(Tensor(a!) self, Tensor index, Tensor source, bool accumulate=False) -> Tensor(a!)
   variants: method

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -10,6 +10,7 @@ using at::Dimname;
 using at::DimnameList;
 using at::NamedTensorMeta;
 using at::Symbol;
+using at::Tensor;
 using torch::make_unique;
 
 TEST(NamedTensorTest, defaultMetadata) {
@@ -174,6 +175,97 @@ TEST(NamedTensorTest, unifyFromRight) {
   check_unify_error({ W, H }, { C, H });
   check_unify_error({ None, H }, { H, None });
   check_unify_error({ H, None, C }, { H });
+}
+
+TEST(NamedTensorTest, infer_alignment) {
+  auto N = dimnameFromString("N");
+  auto C = dimnameFromString("C");
+  auto H = dimnameFromString("H");
+  auto W = dimnameFromString("W");
+  auto None = dimnameFromString("*");
+
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({C}, {C}), {C}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({}, {C}), {C}));
+
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({N, C, H}, {C}), {N, C, H}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({N, C, H}, {N}), {N, C, H}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({N, C, H}, {H}), {N, C, H}));
+
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({N, H}, {N, C, H, W}), {N, C, H, W}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({C, H}, {N, C, H, W}), {N, C, H, W}));
+
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({None}, {None}), {None}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({N, None}, {N, C, H, None}), {N, C, H, None}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({C, None}, {N, C, H, None}), {N, C, H, None}));
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({N, None, C, None}, {N, H, None, C, None}), {N, H, None, C, None}));
+
+  ASSERT_TRUE(dimnames_equal(at::infer_alignment({None, N}, {C, None, N}), {C, None, N}));
+
+  ASSERT_THROW(at::infer_alignment({C}, {H}), c10::Error);
+  ASSERT_THROW(at::infer_alignment({N, C}, {C, N}), c10::Error);
+  ASSERT_THROW(at::infer_alignment({N, None}, {C}), c10::Error);
+  ASSERT_THROW(at::infer_alignment({None, C, N, None}, {None, N, None}), c10::Error);
+  ASSERT_THROW(at::infer_alignment({None, N}, {None, H, N}), c10::Error);
+}
+
+void check_align_to(const Tensor& tensor, DimnameList names) {
+  auto orig_names = tensor.names().value();
+  auto output = at::align_to(tensor, names);
+  ASSERT_TRUE(dimnames_equal(output.names().value(), names));
+
+  for (auto it = names.begin(); it != names.end(); ++it) {
+    if (it->is_wildcard()) {
+      size_t output_dim = std::distance(names.begin(), it);
+      size_t input_dim = tensor.dim() - std::distance(it, names.end());
+      if (tensor.dim() != 0) {
+        ASSERT_EQ(output.size(output_dim), tensor.size(input_dim));
+        ASSERT_EQ(output.stride(output_dim), tensor.stride(input_dim));
+      } else {
+        ASSERT_EQ(output.size(output_dim), 1);
+      }
+      continue;
+    }
+
+    const auto& name = *it;
+    if (std::find_if(orig_names.begin(), orig_names.end(),
+        [&](const Dimname& other) { return name.full_name() == other.full_name(); })
+        != orig_names.end()) {
+      ASSERT_EQ(output.size(name), tensor.size(name));
+      ASSERT_EQ(output.stride(name), tensor.stride(name));
+    } else {
+      ASSERT_EQ(output.size(name), 1);
+    }
+  }
+}
+
+Tensor make_empty(at::IntArrayRef sizes, at::DimnameList names) {
+  return at::empty(sizes, names);
+}
+
+TEST(NamedTensorTest, align_to) {
+  auto N = dimnameFromString("N");
+  auto C = dimnameFromString("C");
+  auto H = dimnameFromString("H");
+  auto W = dimnameFromString("W");
+  auto None = dimnameFromString("*");
+
+  //check_align_to(make_empty({2}, {C}), {C});
+  check_align_to(make_empty({2}, {C}), {N, C});
+  //check_align_to(make_empty({2}, {C}), {C, N});
+
+  //check_align_to(make_empty({2, 3}, {C, H}), {C, N, H, W});
+  //check_align_to(make_empty({2, 3}, {C, None}), {C, N, H, None});
+  //check_align_to(make_empty({2, 3, 5}, {C, None, None}), {C, N, H, None, None});
+  //check_align_to(make_empty({2, 3, 5}, {C, None, None}), {C, N, H, None, None});
+
+  //check_align_to(make_empty({}, {}), {C, N});
+  //check_align_to(make_empty({}, {}), {C, None});
+
+  //ASSERT_THROW(at::align_to(make_empty({2, 3}, {C, H}), {C, None}), c10::Error);
+  //ASSERT_THROW(at::align_to(make_empty({2, 3}, {C, None}), {C, H}), c10::Error);
+  //ASSERT_THROW(at::align_to(make_empty({2, 3}, {C, H}), {N, W}), c10::Error);
+  //ASSERT_THROW(at::align_to(make_empty({2, 3}, {C, H}), {H, C}), c10::Error);
+  //ASSERT_THROW(at::align_to(make_empty({2, 3}, {None, H}), {None}), c10::Error);
 }
 
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23435 wip**
* #23436 Make torch.view drop all names on named tensors
* #23316 Add names to repr for named tensors
* #23315 Rename tensor.is_named to has_named, expose has_named to python.
* #23237 Enable named tensors for arithmetic, clone, and tensor conversion ops
* #23229 Named inference rule for copy_
* #23193 Implement named inference rule for mul

