### PR TITLE
[WIP] Disabled minus for bool

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -31,6 +31,7 @@ void add_kernel(TensorIterator& iter, Scalar alpha_scalar) {
 }
 
 void sub_kernel(TensorIterator& iter, Scalar alpha_scalar) {
+  TORCH_CHECK(iter.dtype() != kBool, "torch boolean subtraction, the `-` operator, is not supported, use the `^` operator instead.");
   add_kernel(iter, -alpha_scalar);
 }
 

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -22,6 +22,7 @@ void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
 }
 
 static void sub_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
+  TORCH_CHECK(iter.dtype() != kBool, "torch boolean subtraction, the `-` operator, is not supported, use the `^` operator instead.");
   return add_kernel_cuda(iter, -alpha_scalar);
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1628,6 +1628,13 @@ class _TestTorchMixin(object):
         res2 = x1.sum(axis=(0, 2), keepdims=True)
         self.assertEqual(res1, res2)
 
+    def test_sum_for_bool(self):
+        for device in torch.testing.get_all_device_types():
+            a = torch.tensor([True, False], device=device)
+            self.assertRaises(RuntimeError, lambda: a - a)
+            self.assertRaises(RuntimeError, lambda: a - 1)
+            self.assertRaises(RuntimeError, lambda: 1 - a)
+
     def test_add(self):
         for device in torch.testing.get_all_device_types():
             # [res] torch.add([res,] tensor1, tensor2)


### PR DESCRIPTION
We want to disable minus ops for bool tensors to force users to use botwise_not() or '^' operators. 
Tested via unit tests.