### PR TITLE
Replace descriptions of args in doc with template

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -27,15 +27,20 @@ def merge_dicts(*dicts):
     return {x: d[x] for d in dicts for x in d}
 
 
-reduceops_common_args = parse_kwargs("""
+common_args = parse_kwargs("""
+    input (Tensor): the input tensor.
+    out (Tensor, optional): the output tensor.
+""")
+
+reduceops_common_args = merge_dicts(common_args, parse_kwargs("""
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         If specified, the input tensor is casted to :attr:`dtype` before the operation
         is performed. This is useful for preventing data type overflows. Default: None.
-    keepdim (bool): whether the output tensor has :attr:`dim` retained or not
-""")
+    keepdim (bool): whether the output tensor has :attr:`dim` retained or not.
+"""))
 
 multi_dim_common = merge_dicts(reduceops_common_args, parse_kwargs("""
-    dim (int or tuple of ints): the dimension or dimensions to reduce
+    dim (int or tuple of ints): the dimension or dimensions to reduce.
 """), {'keepdim_details': """
 If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension(s) :attr:`dim` where it is of size 1.
@@ -44,15 +49,14 @@ output tensor having 1 (or ``len(dim)``) fewer dimension(s).
 """})
 
 single_dim_common = merge_dicts(reduceops_common_args, parse_kwargs("""
-    dim (int): the dimension to reduce
+    dim (int): the dimension to reduce.
 """), {'keepdim_details': """If :attr:`keepdim` is ``True``, the output tensor is of the same size
 as :attr:`input` except in the dimension :attr:`dim` where it is of size 1.
 Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the output tensor having 1 fewer dimension than :attr:`input`."""})
 
 
-factory_common_args = parse_kwargs("""
-    out (Tensor, optional): the output tensor
+factory_common_args = merge_dicts(common_args, parse_kwargs("""
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
         Default: if ``None``, uses a global default (see :func:`torch.set_default_tensor_type`).
     layout (:class:`torch.layout`, optional): the desired layout of returned Tensor.
@@ -65,10 +69,10 @@ factory_common_args = parse_kwargs("""
         returned tensor. Default: ``False``.
     pin_memory (bool, optional): If set, returned tensor would be allocated in
         the pinned memory. Works only for CPU tensors. Default: ``False``.
-""")
+"""))
 
 factory_like_common_args = parse_kwargs("""
-    input (Tensor): the size of :attr:`input` will determine size of the output tensor
+    input (Tensor): the size of :attr:`input` will determine size of the output tensor.
     layout (:class:`torch.layout`, optional): the desired layout of returned tensor.
         Default: if ``None``, defaults to the layout of :attr:`input`.
     dtype (:class:`torch.dtype`, optional): the desired data type of returned Tensor.
@@ -104,16 +108,16 @@ Computes the element-wise absolute value of the given :attr:`input` tensor.
 
 .. math::
     \text{out}_{i} = |\text{input}_{i}|
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
     >>> torch.abs(torch.tensor([-1, -2, 3]))
     tensor([ 1,  2,  3])
-""")
+""".format(**common_args))
 
 add_docstr(torch.acos,
            r"""
@@ -123,10 +127,10 @@ Returns a new tensor with the arccosine  of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \cos^{-1}(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -135,7 +139,7 @@ Example::
     tensor([ 0.3348, -0.5889,  0.2005, -0.1584])
     >>> torch.acos(a)
     tensor([ 1.2294,  2.2004,  1.3690,  1.7298])
-""")
+""".format(**common_args))
 
 add_docstr(torch.add,
            r"""
@@ -145,17 +149,17 @@ Adds the scalar :attr:`other` to each element of the input :attr:`input`
 and returns a new resulting tensor.
 
 .. math::
-    \text{out} = \text{input} + \text{other}
+    \text{{out}} = \text{{input}} + \text{{other}}
 
 If :attr:`input` is of type FloatTensor or DoubleTensor, :attr:`other` must be
 a real number, otherwise it should be an integer.
 
 Args:
-    input (Tensor): the input tensor
-    other (Number): the number to be added to each element of :attr:`input`
+    {input}
+    value (Number): the number to be added to each element of :attr:`input`
 
 Keyword arguments:
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -175,7 +179,7 @@ The shapes of :attr:`input` and :attr:`other` must be
 :ref:`broadcastable <broadcasting-semantics>`.
 
 .. math::
-    \text{out} = \text{input} + \text{alpha} \times \text{other}
+    \text{{out}} = \text{{input}} + \text{{alpha}} \times \text{{other}}
 
 If :attr:`other` is of type FloatTensor or DoubleTensor, :attr:`alpha` must be
 a real number, otherwise it should be an integer.
@@ -186,7 +190,7 @@ Args:
     other (Tensor): the second input tensor
 
 Keyword arguments:
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -204,7 +208,7 @@ Example::
             [-18.6971, -18.0736, -17.0994, -17.3216],
             [ -6.7845,  -6.1610,  -5.1868,  -5.4090],
             [ -8.9902,  -8.3667,  -7.3925,  -7.6147]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.addbmm,
            r"""
@@ -226,7 +230,7 @@ and :attr:`out` will be a :math:`(n \times p)` tensor.
 
 .. math::
     out = \beta\ \text{input} + \alpha\ (\sum_{i=0}^{b-1} \text{batch1}_i \mathbin{@} \text{batch2}_i)
-
+""" + r"""
 For inputs of type `FloatTensor` or `DoubleTensor`, arguments :attr:`beta` and :attr:`alpha`
 must be real numbers, otherwise they should be integers.
 
@@ -236,7 +240,7 @@ Args:
     alpha (Number, optional): multiplier for `batch1 @ batch2` (:math:`\alpha`)
     batch1 (Tensor): the first batch of matrices to be multiplied
     batch2 (Tensor): the second batch of matrices to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -247,7 +251,7 @@ Example::
     tensor([[  6.6311,   0.0503,   6.9768, -12.0362,  -2.1653],
             [ -4.8185,  -1.4255,  -6.6760,   8.9453,   2.5743],
             [ -3.8202,   4.3691,   1.0943,  -1.1109,   5.4730]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.addcdiv,
            r"""
@@ -258,7 +262,7 @@ multiply the result by the scalar :attr:`value` and add it to :attr:`input`.
 
 .. math::
     \text{out}_i = \text{input}_i + \text{value} \times \frac{\text{tensor1}_i}{\text{tensor2}_i}
-
+""" + r"""
 The shapes of :attr:`input`, :attr:`tensor1`, and :attr:`tensor2` must be
 :ref:`broadcastable <broadcasting-semantics>`.
 
@@ -267,10 +271,10 @@ a real number, otherwise an integer.
 
 Args:
     input (Tensor): the tensor to be added
-    value (Number, optional): multiplier for :math:`\text{tensor1} / \text{tensor2}`
+    value (Number, optional): multiplier for :math:`\text{{tensor1}} / \text{{tensor2}}`
     tensor1 (Tensor): the numerator tensor
     tensor2 (Tensor): the denominator tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -281,7 +285,7 @@ Example::
     tensor([[-0.2312, -3.6496,  0.1312],
             [-1.0428,  3.4292, -0.1030],
             [-0.5369, -0.9829,  0.0430]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.addcmul,
            r"""
@@ -293,8 +297,8 @@ and add it to :attr:`input`.
 
 .. math::
     \text{out}_i = \text{input}_i + \text{value} \times \text{tensor1}_i \times \text{tensor2}_i
-
-The shapes of :attr:`input`, :attr:`tensor1`, and :attr:`tensor2` must be
+""" + r"""
+The shapes of :attr:`tensor`, :attr:`tensor1`, and :attr:`tensor2` must be
 :ref:`broadcastable <broadcasting-semantics>`.
 
 For inputs of type `FloatTensor` or `DoubleTensor`, :attr:`value` must be
@@ -305,7 +309,7 @@ Args:
     value (Number, optional): multiplier for :math:`tensor1 .* tensor2`
     tensor1 (Tensor): the tensor to be multiplied
     tensor2 (Tensor): the tensor to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -316,7 +320,7 @@ Example::
     tensor([[-0.8635, -0.6391,  1.6174],
             [-0.7617, -0.5879,  1.7388],
             [-0.8353, -0.6249,  1.6511]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.addmm,
            r"""
@@ -335,7 +339,7 @@ and :attr:`out` will be a :math:`(n \times p)` tensor.
 
 .. math::
     \text{out} = \beta\ \text{input} + \alpha\ (\text{mat1}_i \mathbin{@} \text{mat2}_i)
-
+""" + r"""
 For inputs of type `FloatTensor` or `DoubleTensor`, arguments :attr:`beta` and
 :attr:`alpha` must be real numbers, otherwise they should be integers.
 
@@ -345,7 +349,7 @@ Args:
     alpha (Number, optional): multiplier for :math:`mat1 @ mat2` (:math:`\alpha`)
     mat1 (Tensor): the first matrix to be multiplied
     mat2 (Tensor): the second matrix to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -355,7 +359,7 @@ Example::
     >>> torch.addmm(M, mat1, mat2)
     tensor([[-4.8716,  1.4671, -1.3746],
             [ 0.7573, -3.9555, -2.8681]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.addmv,
            r"""
@@ -375,7 +379,7 @@ size `m`, then :attr:`input` must be
 
 .. math::
     \text{out} = \beta\ \text{input} + \alpha\ (\text{mat} \mathbin{@} \text{vec})
-
+""" + r"""
 For inputs of type `FloatTensor` or `DoubleTensor`, arguments :attr:`beta` and
 :attr:`alpha` must be real numbers, otherwise they should be integers
 
@@ -385,7 +389,7 @@ Args:
     alpha (Number, optional): multiplier for :math:`mat @ vec` (:math:`\alpha`)
     mat (Tensor): matrix to be multiplied
     vec (Tensor): vector to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -394,7 +398,7 @@ Example::
     >>> vec = torch.randn(3)
     >>> torch.addmv(M, mat, vec)
     tensor([-0.3768, -5.5565])
-""")
+""".format(**common_args))
 
 add_docstr(torch.addr,
            r"""
@@ -409,7 +413,7 @@ outer product between :attr:`vec1` and :attr:`vec2` and the added matrix
 
 .. math::
     \text{out} = \beta\ \text{input} + \alpha\ (\text{vec1} \otimes \text{vec2})
-
+""" + r"""
 If :attr:`vec1` is a vector of size `n` and :attr:`vec2` is a vector
 of size `m`, then :attr:`input` must be
 :ref:`broadcastable <broadcasting-semantics>` with a matrix of size
@@ -422,10 +426,10 @@ For inputs of type `FloatTensor` or `DoubleTensor`, arguments :attr:`beta` and
 Args:
     beta (Number, optional): multiplier for :attr:`input` (:math:`\beta`)
     input (Tensor): matrix to be added
-    alpha (Number, optional): multiplier for :math:`\text{vec1} \otimes \text{vec2}` (:math:`\alpha`)
+    alpha (Number, optional): multiplier for :math:`\text{{vec1}} \otimes \text{{vec2}}` (:math:`\alpha`)
     vec1 (Tensor): the first vector of the outer product
     vec2 (Tensor): the second vector of the outer product
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -436,7 +440,7 @@ Example::
     tensor([[ 1.,  2.],
             [ 2.,  4.],
             [ 3.,  6.]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.allclose,
            r"""
@@ -446,7 +450,7 @@ This function checks if all :attr:`input` and :attr:`other` satisfy the conditio
 
 .. math::
     \lvert \text{input} - \text{other} \rvert \leq \texttt{atol} + \texttt{rtol} \times \lvert \text{other} \rvert
-
+""" + r"""
 elementwise, for all elements of :attr:`input` and :attr:`other`. The behaviour of this function is analogous to
 `numpy.allclose <https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html>`_
 
@@ -489,7 +493,7 @@ Create a view of an existing `torch.Tensor` :attr:`input` with specified
 
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     size (tuple or ints): the shape of the output tensor
     stride (tuple or ints): the stride of the output tensor
     storage_offset (int, optional): the offset in the underlying storage of the output tensor
@@ -508,7 +512,7 @@ Example::
     >>> t = torch.as_strided(x, (2, 2), (1, 2), 1)
     tensor([[0.6291, 0.1586],
             [1.0795, 2.1939]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.as_tensor,
            r"""
@@ -551,10 +555,10 @@ Returns a new tensor with the arcsine  of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \sin^{-1}(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -563,7 +567,7 @@ Example::
     tensor([-0.5962,  1.4985, -0.4396,  1.4525])
     >>> torch.asin(a)
     tensor([-0.6387,     nan, -0.4552,     nan])
-""")
+""".format(**common_args))
 
 add_docstr(torch.atan,
            r"""
@@ -573,10 +577,10 @@ Returns a new tensor with the arctangent  of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \tan^{-1}(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -585,7 +589,7 @@ Example::
     tensor([ 0.2341,  0.2539, -0.6256, -0.6448])
     >>> torch.atan(a)
     tensor([ 0.2299,  0.2487, -0.5591, -0.5727])
-""")
+""".format(**common_args))
 
 add_docstr(torch.atan2,
            r"""
@@ -600,7 +604,7 @@ The shapes of :attr:`input` and :attr:`other` must be
 Args:
     input (Tensor): the first input tensor
     other (Tensor): the second input tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -609,7 +613,7 @@ Example::
     tensor([ 0.9041,  0.0196, -0.3108, -2.4423])
     >>> torch.atan2(a, torch.randn(4))
     tensor([ 0.9833,  0.0811, -1.9743, -1.4151])
-""")
+""".format(**common_args))
 
 add_docstr(torch.baddbmm,
            r"""
@@ -631,17 +635,17 @@ same as the scaling factors used in :meth:`torch.addbmm`.
 
 .. math::
     \text{out}_i = \beta\ \text{input}_i + \alpha\ (\text{batch1}_i \mathbin{@} \text{batch2}_i)
-
+""" + r"""
 For inputs of type `FloatTensor` or `DoubleTensor`, arguments :attr:`beta` and
 :attr:`alpha` must be real numbers, otherwise they should be integers.
 
 Args:
     beta (Number, optional): multiplier for :attr:`input` (:math:`\beta`)
     input (Tensor): the tensor to be added
-    alpha (Number, optional): multiplier for :math:`\text{batch1} \mathbin{@} \text{batch2}` (:math:`\alpha`)
+    alpha (Number, optional): multiplier for :math:`\text{{batch1}} \mathbin{{@}} \text{{batch2}}` (:math:`\alpha`)
     batch1 (Tensor): the first batch of matrices to be multiplied
     batch2 (Tensor): the second batch of matrices to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -650,7 +654,7 @@ Example::
     >>> batch2 = torch.randn(10, 4, 5)
     >>> torch.baddbmm(M, batch1, batch2).size()
     torch.Size([10, 3, 5])
-""")
+""".format(**common_args))
 
 add_docstr(torch.bernoulli,
            r"""
@@ -669,7 +673,7 @@ in :attr:`input`.
 
 .. math::
     \text{out}_{i} \sim \mathrm{Bernoulli}(p = \text{input}_{i})
-
+""" + r"""
 The returned :attr:`out` tensor only has values 0 or 1 and is of the same
 shape as :attr:`input`.
 
@@ -678,7 +682,7 @@ point ``dtype``.
 
 Args:
     input (Tensor): the input tensor of probability values for the Bernoulli distribution
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -702,7 +706,7 @@ Example::
     tensor([[ 0.,  0.,  0.],
             [ 0.,  0.,  0.],
             [ 0.,  0.,  0.]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.bincount,
            r"""
@@ -753,16 +757,14 @@ Computes the bitwise NOT of the given input tensor. The input tensor must be of
 integral or Boolean types. For bool tensors, it computes the logical NOT.
 
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example:
 
     >>> torch.bitwise_not(torch.tensor([-1, -2, 3], dtype=torch.int8))
     tensor([ 0,  1, -4], dtype=torch.int8)
-    >>> torch.bitwise_not(torch.tensor([True, False], dtype=torch.bool))
-    tensor([False,  True])
-""")
+""".format(**common_args))
 
 add_docstr(torch.bmm,
            r"""
@@ -780,14 +782,14 @@ If :attr:`input` is a :math:`(b \times n \times m)` tensor, :attr:`mat2` is a
 
 .. math::
     \text{out}_i = \text{input}_i \mathbin{@} \text{mat2}_i
-
+""" + r"""
 .. note:: This function does not :ref:`broadcast <broadcasting-semantics>`.
           For broadcasting matrix products, see :func:`torch.matmul`.
 
 Args:
     input (Tensor): the first batch of matrices to be multiplied
     mat2 (Tensor): the second batch of matrices to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -796,7 +798,7 @@ Example::
     >>> res = torch.bmm(input, mat2)
     >>> res.size()
     torch.Size([10, 3, 5])
-""")
+""".format(**common_args))
 
 add_docstr(torch.stack,
            r"""
@@ -810,8 +812,8 @@ Arguments:
     tensors (sequence of Tensors): sequence of tensors to concatenate
     dim (int): dimension to insert. Has to be between 0 and the number
         of dimensions of concatenated tensors (inclusive)
-    out (Tensor, optional): the output tensor
-""")
+    {out}
+""".format(**common_args))
 
 add_docstr(torch.chunk,
            r"""
@@ -846,7 +848,7 @@ Args:
         Non-empty tensors provided must have the same shape, except in the
         cat dimension.
     dim (int, optional): the dimension over which the tensors are concatenated
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -866,7 +868,7 @@ Example::
              -1.0969, -0.4614],
             [-0.1034, -0.5790,  0.1497, -0.1034, -0.5790,  0.1497, -0.1034,
              -0.5790,  0.1497]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.ceil,
            r"""
@@ -877,10 +879,10 @@ the smallest integer greater than or equal to each element.
 
 .. math::
     \text{out}_{i} = \left\lceil \text{input}_{i} \right\rceil = \left\lfloor \text{input}_{i} \right\rfloor + 1
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -889,7 +891,7 @@ Example::
     tensor([-0.6341, -1.4208, -1.0900,  0.5826])
     >>> torch.ceil(a)
     tensor([-0., -1., -1.,  1.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.reciprocal,
            r"""
@@ -899,10 +901,10 @@ Returns a new tensor with the reciprocal of the elements of :attr:`input`
 
 .. math::
     \text{out}_{i} = \frac{1}{\text{input}_{i}}
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -911,7 +913,7 @@ Example::
     tensor([-0.4595, -2.1219, -1.4314,  0.7298])
     >>> torch.reciprocal(a)
     tensor([-2.1763, -0.4713, -0.6986,  1.3702])
-""")
+""".format(**common_args))
 
 add_docstr(torch.cholesky, r"""
 cholesky(input, upper=False, out=None) -> Tensor
@@ -981,13 +983,13 @@ If :attr:`upper` is ``False``, :math:`u` is and lower triangular and `c` is
 returned such that:
 
 .. math::
-    c = (u u^T)^{-1} b
+    c = (u u^T)^{{-1}} b
 
 If :attr:`upper` is ``True`` or not provided, :math:`u` is upper triangular
 and `c` is returned such that:
 
 .. math::
-    c = (u^T u)^{-1} b
+    c = (u^T u)^{{-1}} b
 
 `torch.cholesky_solve(b, u)` can take in 2D inputs `b, u` or inputs that are
 batches of 2D matrices. If the inputs are batches, then returns
@@ -1043,13 +1045,13 @@ If :attr:`upper` is ``False``, :math:`u` is lower triangular
 such that the returned tensor is
 
 .. math::
-    inv = (uu^{T})^{-1}
+    inv = (uu^{{T}})^{{-1}}
 
 If :attr:`upper` is ``True`` or not provided, :math:`u` is upper
 triangular such that the returned tensor is
 
 .. math::
-    inv = (u^T u)^{-1}
+    inv = (u^T u)^{{-1}}
 
 Args:
     input (Tensor): the input 2-D tensor :math:`u`, a upper or lower triangular
@@ -1089,15 +1091,15 @@ a resulting tensor:
         x_i & \text{if } \text{min} \leq x_i \leq \text{max} \\
         \text{max} & \text{if } x_i > \text{max}
     \end{cases}
-
+""" + r"""
 If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, args :attr:`min`
 and :attr:`max` must be real numbers, otherwise they should be integers.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     min (Number): lower-bound of the range to be clamped to
     max (Number): upper-bound of the range to be clamped to
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1115,9 +1117,9 @@ If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, :attr:`value`
 should be a real number, otherwise it should be an integer.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     value (Number): minimal value of each element in the output
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1135,9 +1137,9 @@ If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, :attr:`value`
 should be a real number, otherwise it should be an integer.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     value (Number): maximal value of each element in the output
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1146,7 +1148,7 @@ Example::
     tensor([ 0.7753, -0.4702, -0.4599,  1.1899])
     >>> torch.clamp(a, max=0.5)
     tensor([ 0.5000, -0.4702, -0.4599,  0.5000])
-""")
+""".format(**common_args))
 
 add_docstr(torch.cos,
            r"""
@@ -1156,10 +1158,10 @@ Returns a new tensor with the cosine  of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \cos(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -1168,7 +1170,7 @@ Example::
     tensor([ 1.4309,  1.2706, -0.8562,  0.9796])
     >>> torch.cos(a)
     tensor([ 0.1395,  0.2957,  0.6553,  0.5574])
-""")
+""".format(**common_args))
 
 add_docstr(torch.cosh,
            r"""
@@ -1179,10 +1181,10 @@ Returns a new tensor with the hyperbolic cosine  of the elements of
 
 .. math::
     \text{out}_{i} = \cosh(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -1191,7 +1193,7 @@ Example::
     tensor([ 0.1632,  1.1835, -0.6979, -0.7325])
     >>> torch.cosh(a)
     tensor([ 1.0133,  1.7860,  1.2536,  1.2805])
-""")
+""".format(**common_args))
 
 add_docstr(torch.cross,
            r"""
@@ -1208,10 +1210,10 @@ If :attr:`dim` is not given, it defaults to the first dimension found with the
 size 3.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     other (Tensor): the second input tensor
     dim  (int, optional): the dimension to take the cross-product in.
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1237,7 +1239,7 @@ Example::
             [-2.4490, -1.5687,  1.9792],
             [-0.8304, -1.3037,  0.5650],
             [-1.2329,  1.9883,  1.0551]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.cumprod,
            r"""
@@ -1253,10 +1255,10 @@ a vector of size N, with elements.
     y_i = x_1 \times x_2\times x_3\times \dots \times x_i
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim  (int): the dimension to do the operation over
     {dtype}
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1288,10 +1290,10 @@ a vector of size N, with elements.
     y_i = x_1 + x_2 + x_3 + \dots + x_i
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim  (int): the dimension to do the operation over
     {dtype}
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1320,9 +1322,9 @@ The argument :attr:`diagonal` controls which diagonal to consider:
 - If :attr:`diagonal` < 0, it is below the main diagonal.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     diagonal (int, optional): the diagonal to consider
-    out (Tensor, optional): the output tensor
+    {out}
 
 .. seealso::
 
@@ -1359,7 +1361,7 @@ Get the k-th diagonal of a given matrix::
     tensor([-0.4264,-0.2429,-1.6300])
     >>> torch.diag(a, 1)
     tensor([ 0.0255, 0.1374])
-""")
+""".format(**common_args))
 
 add_docstr(torch.diag_embed,
            r"""
@@ -1388,7 +1390,7 @@ the same arguments yields a matrix identical to input. However,
 need to be explicitly specified.
 
 Args:
-    input (Tensor): the input tensor. Must be at least 1-dimensional.
+    {input} Must be at least 1-dimensional.
     offset (int, optional): which diagonal to consider. Default: 0
         (main diagonal).
     dim1 (int, optional): first dimension with respect to which to
@@ -1420,7 +1422,7 @@ Example::
 
             [[ 0.0000,  0.0000,  0.0000,  0.0000],
              [ 0.0000,  0.0000,  0.0000,  0.0000]]])
-""")
+""".format(**common_args))
 
 
 add_docstr(torch.diagflat,
@@ -1439,7 +1441,7 @@ The argument :attr:`offset` controls which diagonal to consider:
 - If :attr:`offset` < 0, it is below the main diagonal.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     offset (int, optional): the diagonal to consider. Default: 0 (main
         diagonal).
 
@@ -1467,7 +1469,7 @@ Examples::
             [ 0.0000, -0.3018,  0.0000,  0.0000],
             [ 0.0000,  0.0000, -0.1516,  0.0000],
             [ 0.0000,  0.0000,  0.0000,  1.9342]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.diagonal,
            r"""
@@ -1489,7 +1491,7 @@ of the input. However, :meth:`torch.diag_embed` has different default
 dimensions, so those need to be explicitly specified.
 
 Args:
-    input (Tensor): the input tensor. Must be at least 2-dimensional.
+    {input} Must be at least 2-dimensional.
     offset (int, optional): which diagonal to consider. Default: 0
         (main diagonal).
     dim1 (int, optional): first dimension with respect to which to
@@ -1523,7 +1525,7 @@ Examples::
 
             [[-1.7325, -0.3081,  0.6166,  0.2335],
              [ 1.0500,  0.7336, -0.3836, -1.1015]]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.digamma,
            r"""
@@ -1555,7 +1557,7 @@ The shapes of :attr:`input` and :attr:`other` must be
 :ref:`broadcastable <broadcasting-semantics>`.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     other (Tensor): the Right-hand-side input tensor
     p (float, optional): the norm to be computed
 
@@ -1575,7 +1577,7 @@ Example::
     tensor(inf)
     >>> torch.dist(x, y, 1)
     tensor(2.6537)
-""")
+""".format(**common_args))
 
 add_docstr(torch.div,
            r"""
@@ -1591,9 +1593,9 @@ If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, :attr:`other`
 should be a real number, otherwise it should be an integer
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     other (Number): the number to be divided to each element of :attr:`input`
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1612,11 +1614,11 @@ of the tensor :attr:`other`. The resulting tensor is returned. The shapes of
 
 .. math::
     \text{out}_i = \frac{\text{input}_i}{\text{other}_i}
-
+""" + r"""
 Args:
     input (Tensor): the numerator tensor
     other (Tensor): the denominator tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1634,7 +1636,7 @@ Example::
             [ 0.2260, -3.4507, -1.2086,  6.8988],
             [ 0.1322,  4.9764, -0.9564,  5.3480],
             [-0.2278, -0.1068, -1.4678,  6.3936]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.dot,
            r"""
@@ -1696,7 +1698,7 @@ The second argument can be a number or a tensor whose shape is
 Args:
     input (Tensor): the tensor to compare
     other (Tensor or float): the tensor or value to compare
-    out (Tensor, optional): the output tensor. Must be a `BoolTensor`
+    {out} Must be a `ByteTensor`
 
 Returns:
     Tensor: A ``torch.BoolTensor`` containing a True at each location where comparison is true
@@ -1704,8 +1706,9 @@ Returns:
 Example::
 
     >>> torch.eq(torch.tensor([[1, 2], [3, 4]]), torch.tensor([[1, 1], [4, 4]]))
-    tensor([[True, False], [False, True]])
-""")
+    tensor([[ 1,  0],
+            [ 0,  1]], dtype=torch.uint8)
+""".format(**common_args))
 
 add_docstr(torch.equal,
            r"""
@@ -1727,16 +1730,16 @@ Computes the error function of each element. The error function is defined as fo
 
 .. math::
     \mathrm{erf}(x) = \frac{2}{\sqrt{\pi}} \int_{0}^{x} e^{-t^2} dt
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
     >>> torch.erf(torch.tensor([0, -1., 10.]))
     tensor([ 0.0000, -0.8427,  1.0000])
-""")
+""".format(**common_args))
 
 add_docstr(torch.erfc,
            r"""
@@ -1747,16 +1750,16 @@ The complementary error function is defined as follows:
 
 .. math::
     \mathrm{erfc}(x) = 1 - \frac{2}{\sqrt{\pi}} \int_{0}^{x} e^{-t^2} dt
-
+""" + r"""
 Args:
-    tensor (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
     >>> torch.erfc(torch.tensor([0, -1., 10.]))
     tensor([ 1.0000, 1.8427,  0.0000])
-""")
+""".format(**common_args))
 
 add_docstr(torch.erfinv,
            r"""
@@ -1767,16 +1770,16 @@ The inverse error function is defined in the range :math:`(-1, 1)` as:
 
 .. math::
     \mathrm{erfinv}(\mathrm{erf}(x)) = x
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
     >>> torch.erfinv(torch.tensor([0, 0.5, -1.]))
     tensor([ 0.0000,  0.4769,    -inf])
-""")
+""".format(**common_args))
 
 add_docstr(torch.exp,
            r"""
@@ -1787,16 +1790,16 @@ of the input tensor :attr:`input`.
 
 .. math::
     y_{i} = e^{x_{i}}
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
     >>> torch.exp(torch.tensor([0, math.log(2.)]))
     tensor([ 1.,  2.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.expm1,
            r"""
@@ -1807,16 +1810,16 @@ of :attr:`input`.
 
 .. math::
     y_{i} = e^{x_{i}} - 1
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
     >>> torch.expm1(torch.tensor([0, math.log(2.)]))
     tensor([ 0.,  1.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.eye,
            r"""
@@ -1853,10 +1856,10 @@ the largest integer less than or equal to each element.
 
 .. math::
     \text{out}_{i} = \left\lfloor \text{input}_{i} \right\rfloor
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -1865,7 +1868,7 @@ Example::
     tensor([-0.8166,  1.5308, -0.2530, -0.2091])
     >>> torch.floor(a)
     tensor([-1.,  1., -1., -1.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.fmod,
            r"""
@@ -1882,7 +1885,7 @@ When :attr:`other` is a tensor, the shapes of :attr:`input` and
 Args:
     input (Tensor): the dividend
     other (Tensor or float): the divisor, which may be either a number or a tensor of the same shape as the dividend
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -1892,7 +1895,7 @@ Example::
     tensor([ 1.0000,  0.5000,  0.0000,  1.0000,  0.5000])
 
 
-""")
+""".format(**common_args))
 
 add_docstr(torch.frac,
            r"""
@@ -1941,7 +1944,7 @@ flatten(input, start_dim=0, end_dim=-1) -> Tensor
 Flattens a contiguous range of dims in a tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     start_dim (int): the first dim to flatten
     end_dim (int): the last dim to flatten
 
@@ -1956,7 +1959,7 @@ Example::
     >>> torch.flatten(t, start_dim=1)
     tensor([[1, 2, 3, 4],
             [5, 6, 7, 8]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.gather,
            r"""
@@ -1975,7 +1978,7 @@ If :attr:`input` is an n-dimensional tensor with size
 and ``dim = i``, then :attr:`index` must be an :math:`n`-dimensional tensor with
 size :math:`(x_0, x_1, ..., x_{i-1}, y, x_{i+1}, ..., x_{n-1})` where :math:`y \geq 1`
 and :attr:`out` will have the same size as :attr:`index`.
-
+""" + r"""
 Args:
     input (Tensor): the source tensor
     dim (int): the axis along which to index
@@ -2187,11 +2190,11 @@ The elements are sorted into equal width bins between :attr:`min` and
 maximum values of the data are used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     bins (int): number of histogram bins
     min (int): lower end of the range (inclusive)
     max (int): upper end of the range (inclusive)
-    out (Tensor, optional): the output tensor
+    {out}
 
 Returns:
     Tensor: Histogram represented as a tensor
@@ -2200,7 +2203,7 @@ Example::
 
     >>> torch.histc(torch.tensor([1., 2, 1]), bins=4, min=0, max=3)
     tensor([ 0.,  2.,  1.,  0.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.index_select,
            r"""
@@ -2219,10 +2222,10 @@ of :attr:`index`; other dimensions have the same size as in the original tensor.
           storage if necessary.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim (int): the dimension in which we index
     index (LongTensor): the 1-D tensor containing the indices to index
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -2239,7 +2242,7 @@ Example::
     tensor([[ 0.1427, -0.5414],
             [-0.4664, -0.1228],
             [-1.1734,  0.7230]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.inverse,
            r"""
@@ -2257,7 +2260,7 @@ individual inverses.
 Args:
     input (Tensor): the input tensor of size :math:`(*, n, n)` where `*` is zero or more
                     batch dimensions
-    out (Tensor, optional): the optional output tensor
+    {out}
 
 Example::
 
@@ -2277,7 +2280,7 @@ Example::
     >>> z = torch.matmul(x, y)
     >>> torch.max(torch.abs(z - torch.eye(4).expand_as(x))) # Max non-zero
     tensor(1.9073e-06)
-""")
+""".format(**common_args))
 
 add_docstr(torch.isnan,
            r"""
@@ -2323,10 +2326,10 @@ they are of size 1. Otherwise, :attr:`dim` is squeezed
 :attr:`indices` tensors having 1 fewer dimension than the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     k (int): k for the k-th smallest element
     dim (int, optional): the dimension to find the kth value along
-    keepdim (bool): whether the output tensors have :attr:`dim` retained or not
+    {keepdim}
     out (tuple, optional): the output tuple of (Tensor, LongTensor)
                            can be optionally given to be used as output buffers
 
@@ -2344,7 +2347,7 @@ Example::
             [ 4.,  5.,  6.]])
     >>> torch.kthvalue(x, 2, 0, True)
     torch.return_types.kthvalue(values=tensor([[4., 5., 6.]]), indices=tensor([[1, 1, 1]]))
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.le,
            r"""
@@ -2378,7 +2381,7 @@ on a scalar or tensor :attr:`weight` and returns the resulting :attr:`out` tenso
 
 .. math::
     \text{out}_i = \text{start}_i + \text{weight}_i \times (\text{end}_i - \text{start}_i)
-
+""" + r"""
 The shapes of :attr:`start` and :attr:`end` must be
 :ref:`broadcastable <broadcasting-semantics>`. If :attr:`weight` is a tensor, then
 the shapes of :attr:`weight`, :attr:`start`, and :attr:`end` must be :ref:`broadcastable <broadcasting-semantics>`.
@@ -2387,7 +2390,7 @@ Args:
     input (Tensor): the tensor with the starting points
     end (Tensor): the tensor with the ending points
     weight (float or tensor): the weight for the interpolation formula
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -2401,7 +2404,7 @@ Example::
     tensor([ 5.5000,  6.0000,  6.5000,  7.0000])
     >>> torch.lerp(start, end, torch.full_like(start, 0.5))
     tensor([ 5.5000,  6.0000,  6.5000,  7.0000])
-""")
+""".format(**common_args))
 
 add_docstr(torch.linspace,
            r"""
@@ -2445,10 +2448,10 @@ of :attr:`input`.
 
 .. math::
     y_{i} = \log_{e} (x_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -2457,7 +2460,7 @@ Example::
     tensor([-0.7168, -0.5471, -0.8933, -1.4428, -0.1190])
     >>> torch.log(a)
     tensor([ nan,  nan,  nan,  nan,  nan])
-""")
+""".format(**common_args))
 
 add_docstr(torch.log10,
            r"""
@@ -2468,10 +2471,10 @@ of :attr:`input`.
 
 .. math::
     y_{i} = \log_{10} (x_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -2483,7 +2486,7 @@ Example::
     >>> torch.log10(a)
     tensor([-0.2820, -0.0290, -0.1392, -0.8857, -0.6476])
 
-""")
+""".format(**common_args))
 
 add_docstr(torch.log1p,
            r"""
@@ -2493,13 +2496,13 @@ Returns a new tensor with the natural logarithm of (1 + :attr:`input`).
 
 .. math::
     y_i = \log_{e} (x_i + 1)
-
+""" + r"""
 .. note:: This function is more accurate than :func:`torch.log` for small
           values of :attr:`input`
 
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -2508,7 +2511,7 @@ Example::
     tensor([-1.0090, -0.9923,  1.0249, -0.5372,  0.2492])
     >>> torch.log1p(a)
     tensor([    nan, -4.8653,  0.7055, -0.7705,  0.2225])
-""")
+""".format(**common_args))
 
 add_docstr(torch.log2,
            r"""
@@ -2519,10 +2522,10 @@ of :attr:`input`.
 
 .. math::
     y_{i} = \log_{2} (x_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -2534,7 +2537,7 @@ Example::
     >>> torch.log2(a)
     tensor([-0.2483, -0.3213, -0.0042, -0.9196, -4.3504])
 
-""")
+""".format(**common_args))
 
 add_docstr(torch.logspace,
            r"""
@@ -2586,10 +2589,10 @@ For summation index :math:`j` given by `dim` and other indices :math:`i`, the re
 {keepdim_details}
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
-    out (Tensor, optional): the output tensor
+    {out}
 
 
 Example::
@@ -2702,7 +2705,7 @@ Arguments:
     input (Tensor): the RHS tensor of size :math:`(b, m, k)`
     LU_data (Tensor): the pivoted LU factorization of A from :meth:`torch.lu` of size :math:`(b, m, m)`
     LU_pivots (IntTensor): the pivots of the LU factorization from :meth:`torch.lu` of size :math:`(b, m)`
-    out (Tensor, optional): the optional output tensor
+    {out}
 
 Example::
 
@@ -2713,7 +2716,7 @@ Example::
     >>> torch.norm(torch.bmm(A, x) - b)
     tensor(1.00000e-07 *
            2.8312)
-""")
+""".format(**common_args))
 
 add_docstr(torch.masked_select,
            r"""
@@ -2729,9 +2732,9 @@ to match, but they must be :ref:`broadcastable <broadcasting-semantics>`.
           as the original tensor
 
 Args:
-    input (Tensor): the input data
-    mask  (BoolTensor): the tensor containing the boolean mask to index with
-    out (Tensor, optional): the output tensor
+    {input}
+    mask  (ByteTensor): the tensor containing the binary mask to index with
+    {out}
 
 Example::
 
@@ -2747,7 +2750,7 @@ Example::
             [False, False, False, True]])
     >>> torch.masked_select(x, mask)
     tensor([ 1.2252,  0.5002,  0.6248,  2.0139])
-""")
+""".format(**common_args))
 
 add_docstr(torch.matrix_rank,
            r"""
@@ -2794,7 +2797,7 @@ raised to the power :attr:`n`.  For a batch of matrices, the batched inverse
 is returned.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     n (int): the power to raise the matrix to
 
 Example::
@@ -2812,7 +2815,7 @@ Example::
 
             [[  0.2468,  -6.7168],
              [  2.0774,  -0.8187]]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.max,
            r"""
@@ -2821,7 +2824,7 @@ add_docstr(torch.max,
 Returns the maximum value of all elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -2844,9 +2847,9 @@ Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting
 in the output tensors having 1 fewer dimension than :attr:`input`.
 
 Args:
-    input (Tensor): the input tensor
-    dim (int): the dimension to reduce
-    keepdim (bool, optional): whether the output tensors have :attr:`dim` retained or not. Default: ``False``.
+    {input}
+    {dim}
+    {keepdim} Default: ``False``.
     out (tuple, optional): the result tuple of two output tensors (max, max_indices)
 
 Example::
@@ -2870,14 +2873,14 @@ but they must be :ref:`broadcastable <broadcasting-semantics>`.
 
 .. math::
     \text{out}_i = \max(\text{tensor}_i, \text{other}_i)
-
+""" + r"""
 .. note:: When the shapes do not match, the shape of the returned output tensor
           follows the :ref:`broadcasting rules <broadcasting-semantics>`.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     other (Tensor): the second input tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -2889,7 +2892,7 @@ Example::
     tensor([ 0.8722, -1.7421, -0.4141, -0.5055])
     >>> torch.max(a, b)
     tensor([ 0.8722, -0.7416,  0.2653, -0.1584])
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.argmax,
            r"""
@@ -2901,7 +2904,7 @@ This is the second value returned by :meth:`torch.max`. See its
 documentation for the exact semantics of this method.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -2922,11 +2925,9 @@ This is the second value returned by :meth:`torch.max`. See its
 documentation for the exact semantics of this method.
 
 Args:
-    input (Tensor): the input tensor
-    dim (int): the dimension to reduce. If ``None``, the argmax of the
-        flattened input is returned.
-    keepdim (bool): whether the output tensors have :attr:`dim`
-        retained or not. Ignored if ``dim=None``.
+    {input}
+    {dim} If ``None``, the argmax of the flattened input is returned.
+    {keepdim} Ignored if ``dim=None``.
 
 Example::
 
@@ -2938,7 +2939,7 @@ Example::
             [-1.6092,  0.5419, -0.2993,  0.3195]])
     >>> torch.argmax(a, dim=1)
     tensor([ 0,  2,  0,  1])
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.mean,
            r"""
@@ -2947,7 +2948,7 @@ add_docstr(torch.mean,
 Returns the mean value of all elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -2966,10 +2967,10 @@ reduce over all of them.
 {keepdim_details}
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
-    out (Tensor): the output tensor
+    {out}
 
 Example::
 
@@ -2995,7 +2996,7 @@ add_docstr(torch.median,
 Returns the median value of all elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -3019,9 +3020,9 @@ Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the outputs tensor having 1 fewer dimension than :attr:`input`.
 
 Args:
-    input (Tensor): the input tensor
-    dim (int): the dimension to reduce
-    keepdim (bool): whether the output tensors have :attr:`dim` retained or not
+    {input}
+    {dim}
+    {keepdim}
     values (Tensor, optional): the output tensor
     indices (Tensor, optional): the output index tensor
 
@@ -3035,7 +3036,7 @@ Example::
             [ 1.0778, -1.9510,  0.7048,  0.4742, -0.7125]])
     >>> torch.median(a, 1)
     torch.return_types.median(values=tensor([-0.3982,  0.2270,  0.2488,  0.4742]), indices=tensor([1, 4, 4, 3]))
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.min,
            r"""
@@ -3044,7 +3045,7 @@ add_docstr(torch.min,
 Returns the minimum value of all elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -3067,9 +3068,9 @@ Otherwise, :attr:`dim` is squeezed (see :func:`torch.squeeze`), resulting in
 the output tensors having 1 fewer dimension than :attr:`input`.
 
 Args:
-    input (Tensor): the input tensor
-    dim (int): the dimension to reduce
-    keepdim (bool): whether the output tensors have :attr:`dim` retained or not
+    {input}
+    {dim}
+    {keepdim}
     out (tuple, optional): the tuple of two output tensors (min, min_indices)
 
 Example::
@@ -3094,14 +3095,14 @@ but they must be :ref:`broadcastable <broadcasting-semantics>`.
 
 .. math::
     \text{out}_i = \min(\text{tensor}_i, \text{other}_i)
-
+""" + r"""
 .. note:: When the shapes do not match, the shape of the returned output tensor
           follows the :ref:`broadcasting rules <broadcasting-semantics>`.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     other (Tensor): the second input tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3113,7 +3114,7 @@ Example::
     tensor([-0.1369,  0.1555,  0.4019, -0.1929])
     >>> torch.min(a, b)
     tensor([-0.1369, -1.1740, -0.6460, -0.1929])
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.argmin,
            r"""
@@ -3125,7 +3126,7 @@ This is the second value returned by :meth:`torch.min`. See its
 documentation for the exact semantics of this method.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -3146,11 +3147,9 @@ This is the second value returned by :meth:`torch.min`. See its
 documentation for the exact semantics of this method.
 
 Args:
-    input (Tensor): the input tensor
-    dim (int): the dimension to reduce. If ``None``, the argmin of the
-        flattened input is returned.
-    keepdim (bool): whether the output tensors have :attr:`dim`
-        retained or not. Ignored if ``dim=None``.
+    {input}
+    {dim} If ``None``, the argmin of the flattened input is returned.
+    {keepdim} Ignored if ``dim=None``.
 
 Example::
 
@@ -3162,7 +3161,7 @@ Example::
             [ 1.7809, -1.2960,  0.9384,  0.1438]])
     >>> torch.argmin(a, dim=1)
     tensor([ 2,  1,  3,  1])
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.mm,
            r"""
@@ -3179,7 +3178,7 @@ If :attr:`input` is a :math:`(n \times m)` tensor, :attr:`mat2` is a
 Args:
     input (Tensor): the first matrix to be multiplied
     mat2 (Tensor): the second matrix to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3188,7 +3187,7 @@ Example::
     >>> torch.mm(mat1, mat2)
     tensor([[ 0.4851,  0.5037, -0.3633],
             [-0.0760, -3.6705,  2.4784]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.matmul,
            r"""
@@ -3222,7 +3221,7 @@ The behavior depends on the dimensionality of the tensors as follows:
 Arguments:
     input (Tensor): the first tensor to be multiplied
     other (Tensor): the second tensor to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3252,7 +3251,7 @@ Example::
     >>> torch.matmul(tensor1, tensor2).size()
     torch.Size([10, 3, 5])
 
-""")
+""".format(**common_args))
 
 add_docstr(torch.mode,
            r"""
@@ -3273,9 +3272,9 @@ in the output tensors having 1 fewer dimension than :attr:`input`.
 .. note:: This function is not defined for ``torch.cuda.Tensor`` yet.
 
 Args:
-    input (Tensor): the input tensor
-    dim (int): the dimension to reduce
-    keepdim (bool): whether the output tensors have :attr:`dim` retained or not
+    {input}
+    {dim}
+    {keepdim}
     values (Tensor, optional): the output tensor
     indices (Tensor, optional): the output index tensor
 
@@ -3287,7 +3286,7 @@ Example::
     >>> b = a + (torch.randn(50, 1) * 5).long()
     >>> torch.mode(b, 0)
     torch.return_types.mode(values=tensor([6, 5, 1, 0, 2]), indices=tensor([2, 2, 2, 2, 2]))
-""")
+""".format(**single_dim_common))
 
 add_docstr(torch.mul,
            r"""
@@ -3298,14 +3297,14 @@ Multiplies each element of the input :attr:`input` with the scalar
 
 .. math::
     \text{out}_i = \text{other} \times \text{input}_i
-
+""" + r"""
 If :attr:`input` is of type `FloatTensor` or `DoubleTensor`, :attr:`other`
 should be a real number, otherwise it should be an integer
 
 Args:
-    input (Tensor): the input tensor
-    other (Number): the number to be multiplied to each element of :attr:`input`
-    out (Tensor, optional): the output tensor
+    {input}
+    value (Number): the number to be multiplied to each element of :attr:`input`
+    {out}
 
 Example::
 
@@ -3325,11 +3324,11 @@ The shapes of :attr:`input` and :attr:`other` must be
 
 .. math::
     \text{out}_i = \text{input}_i \times \text{other}_i
-
+""" + r"""
 Args:
     input (Tensor): the first multiplicand tensor
     other (Tensor): the second multiplicand tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3347,7 +3346,7 @@ Example::
             [-0.1614, -0.0382,  0.1645, -0.7021],
             [ 0.0360,  0.0085, -0.0367,  0.1567],
             [ 0.4312,  0.1019, -0.4394,  1.8753]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.multinomial,
            r"""
@@ -3368,7 +3367,7 @@ Indices are ordered from left to right according to when each was sampled
 If :attr:`input` is a vector, :attr:`out` is a vector of size :attr:`num_samples`.
 
 If :attr:`input` is a matrix with `m` rows, :attr:`out` is an matrix of shape
-:math:`(m \times \text{num\_samples})`.
+:math:`(m \times \text{{num\_samples}})`.
 
 If replacement is ``True``, samples are drawn with replacement.
 
@@ -3384,7 +3383,7 @@ Args:
     input (Tensor): the input tensor containing probabilities
     num_samples (int): number of samples to draw
     replacement (bool, optional): whether to draw with replacement or not
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3396,7 +3395,7 @@ Example::
     not enough non-negative category to sample) at ../aten/src/TH/generic/THTensorRandom.cpp:320
     >>> torch.multinomial(weights, 4, replacement=True)
     tensor([ 2,  1,  1,  1])
-""")
+""".format(**common_args))
 
 add_docstr(torch.mv,
            r"""
@@ -3413,7 +3412,7 @@ size :math:`m`, :attr:`out` will be 1-D of size :math:`n`.
 Args:
     input (Tensor): matrix to be multiplied
     vec (Tensor): vector to be multiplied
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3421,7 +3420,7 @@ Example::
     >>> vec = torch.randn(3)
     >>> torch.mv(mat, vec)
     tensor([ 1.0404, -0.6361])
-""")
+""".format(**common_args))
 
 add_docstr(torch.mvlgamma,
            r"""
@@ -3511,10 +3510,10 @@ Returns a new tensor with the negative of the elements of :attr:`input`.
 
 .. math::
     \text{out} = -1 \times \text{input}
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -3523,7 +3522,7 @@ Example::
     tensor([ 0.0090, -0.2262, -0.0682, -0.2866,  0.3940])
     >>> torch.neg(a)
     tensor([-0.0090,  0.2262,  0.0682,  0.2866, -0.3940])
-""")
+""".format(**common_args))
 
 add_docstr(torch.nonzero,
            r"""
@@ -3554,7 +3553,7 @@ As a special case, when :attr:`input` has zero dimensions and a nonzero scalar
 value, it is treated as a one-dimensional tensor with one element.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     out (LongTensor, optional): the output tensor containing indices
 
 Returns:
@@ -3587,7 +3586,7 @@ Example::
     (tensor([0, 1, 2, 3]), tensor([0, 1, 2, 3]))
     >>> torch.nonzero(torch.tensor(5), as_tuple=True)
     (tensor([0]),)
-""")
+""".format(**common_args))
 
 add_docstr(torch.normal,
            r"""
@@ -3611,7 +3610,7 @@ total number of elements in each tensor need to be the same.
 Args:
     mean (Tensor): the tensor of per-element means
     std (Tensor): the tensor of per-element standard deviations
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3627,7 +3626,7 @@ elements.
 Args:
     mean (float, optional): the mean for all distributions
     std (Tensor): the tensor of per-element standard deviations
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3658,13 +3657,13 @@ Args:
     mean (float): the mean for all distributions
     std (float): the standard deviation for all distributions
     size (int...): a sequence of integers defining the shape of the output tensor.
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
     >>> torch.normal(2, 3, size=(1, 4))
     tensor([[-1.3987, -1.9544,  3.6048,  0.7909]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.numel,
            r"""
@@ -3673,7 +3672,7 @@ numel(input) -> int
 Returns the total number of elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -3684,7 +3683,7 @@ Example::
     >>> torch.numel(a)
     16
 
-""")
+""".format(**common_args))
 
 add_docstr(torch.ones,
            r"""
@@ -3799,14 +3798,14 @@ When :attr:`exponent` is a tensor, the operation applied is:
 
 .. math::
     \text{out}_i = x_i ^ {\text{exponent}_i}
-
+""" + r"""
 When :attr:`exponent` is a tensor, the shapes of :attr:`input`
 and :attr:`exponent` must be :ref:`broadcastable <broadcasting-semantics>`.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     exponent (float or tensor): the exponent value
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3833,12 +3832,12 @@ The returned tensor :attr:`out` is of the same shape as :attr:`exponent`
 The operation applied is:
 
 .. math::
-    \text{out}_i = \text{self} ^ {\text{exponent}_i}
+    \text{{out}}_i = \text{{self}} ^ {{\text{{exponent}}_i}}
 
 Args:
     self (float): the scalar base value for the power operation
     exponent (Tensor): the exponent tensor
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -3846,7 +3845,7 @@ Example::
     >>> base = 2
     >>> torch.pow(base, exp)
     tensor([  2.,   4.,   8.,  16.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.prod,
            r"""
@@ -3855,7 +3854,7 @@ add_docstr(torch.prod,
 Returns the product of all elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dtype}
 
 Example::
@@ -3874,7 +3873,7 @@ dimension :attr:`dim`.
 {keepdim_details}
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
     {dtype}
@@ -4270,7 +4269,7 @@ Args:
     input (Tensor): the dividend
     other (Tensor or float): the divisor that may be either a number or a
                                Tensor of the same shape as the dividend
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -4283,7 +4282,7 @@ Example::
 
         :func:`torch.fmod`, which computes the element-wise remainder of
         division equivalently to the C library function ``fmod()``.
-""")
+""".format(**common_args))
 
 add_docstr(torch.renorm,
            r"""
@@ -4296,11 +4295,11 @@ than the value :attr:`maxnorm`
 .. note:: If the norm of a row is lower than `maxnorm`, the row is unchanged
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     p (float): the power for the norm computation
     dim (int): the dimension to slice over to get the sub-tensors
     maxnorm (float): the maximum norm to keep each sub-tensor under
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -4317,7 +4316,7 @@ Example::
     tensor([[ 1.0000,  1.0000,  1.0000],
             [ 1.6667,  1.6667,  1.6667],
             [ 1.6667,  1.6667,  1.6667]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.reshape,
            r"""
@@ -4358,8 +4357,8 @@ Returns a new tensor with each of the elements of :attr:`input` rounded
 to the closest integer.
 
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4368,7 +4367,7 @@ Example::
     tensor([ 0.9920,  0.6077,  0.9734, -1.0362])
     >>> torch.round(a)
     tensor([ 1.,  1.,  1., -1.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.rsqrt,
            r"""
@@ -4379,10 +4378,10 @@ the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \frac{1}{\sqrt{\text{input}_{i}}}
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4391,7 +4390,7 @@ Example::
     tensor([-0.0370,  0.2970,  1.5420, -0.9105])
     >>> torch.rsqrt(a)
     tensor([    nan,  1.8351,  0.8053,     nan])
-""")
+""".format(**common_args))
 
 add_docstr(torch.set_flush_denormal,
            r"""
@@ -4447,10 +4446,10 @@ Returns a new tensor with the sigmoid of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \frac{1}{1 + e^{-\text{input}_{i}}}
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4459,7 +4458,7 @@ Example::
     tensor([ 0.9213,  1.0887, -0.8858, -1.7683])
     >>> torch.sigmoid(a)
     tensor([ 0.7153,  0.7481,  0.2920,  0.1458])
-""")
+""".format(**common_args))
 
 add_docstr(torch.sign,
            r"""
@@ -4469,10 +4468,10 @@ Returns a new tensor with the signs of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \operatorname{sgn}(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4481,7 +4480,7 @@ Example::
     tensor([ 0.7000, -1.2000,  0.0000,  2.3000])
     >>> torch.sign(a)
     tensor([ 1., -1.,  0.,  1.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.sin,
            r"""
@@ -4491,10 +4490,10 @@ Returns a new tensor with the sine of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \sin(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4503,7 +4502,7 @@ Example::
     tensor([-0.5461,  0.1347, -2.7266, -0.2746])
     >>> torch.sin(a)
     tensor([-0.5194,  0.1343, -0.4032, -0.2711])
-""")
+""".format(**common_args))
 
 add_docstr(torch.sinh,
            r"""
@@ -4514,10 +4513,10 @@ Returns a new tensor with the hyperbolic sine of the elements of
 
 .. math::
     \text{out}_{i} = \sinh(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4526,7 +4525,7 @@ Example::
     tensor([ 0.5380, -0.8632, -0.1265,  0.9399])
     >>> torch.sinh(a)
     tensor([ 0.5644, -0.9744, -0.1268,  1.0845])
-""")
+""".format(**common_args))
 
 add_docstr(torch.sort,
            r"""
@@ -4545,7 +4544,7 @@ sorted values and `indices` are the indices of the elements in the original
 `input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim (int, optional): the dimension to sort along
     descending (bool, optional): controls the sorting order (ascending or descending)
     out (tuple, optional): the output tuple of (`Tensor`, `LongTensor`) that can
@@ -4573,7 +4572,7 @@ Example::
     tensor([[ 2,  0,  0,  1],
             [ 0,  1,  1,  2],
             [ 1,  2,  2,  0]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.argsort,
            r"""
@@ -4586,7 +4585,7 @@ This is the second value returned by :meth:`torch.sort`.  See its documentation
 for the exact semantics of this method.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim (int, optional): the dimension to sort along
     descending (bool, optional): controls the sorting order (ascending or descending)
 
@@ -4605,7 +4604,7 @@ Example::
             [3, 2, 1, 0],
             [2, 1, 0, 3],
             [3, 2, 1, 0]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.sparse_coo_tensor,
            r"""
@@ -4693,10 +4692,10 @@ Returns a new tensor with the square-root of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \sqrt{\text{input}_{i}}
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -4705,7 +4704,7 @@ Example::
     tensor([-2.0755,  1.0226,  0.0831,  0.4806])
     >>> torch.sqrt(a)
     tensor([    nan,  1.0112,  0.2883,  0.6933])
-""")
+""".format(**common_args))
 
 add_docstr(torch.squeeze,
            r"""
@@ -4726,10 +4725,10 @@ will squeeze the tensor to the shape :math:`(A \times B)`.
           so changing the contents of one will change the contents of the other.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim (int, optional): if given, the input will be squeezed only in
            this dimension
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -4745,7 +4744,7 @@ Example::
     >>> y = torch.squeeze(x, 1)
     >>> y.size()
     torch.Size([2, 2, 1, 2])
-""")
+""".format(**common_args))
 
 add_docstr(torch.std,
            r"""
@@ -4757,7 +4756,7 @@ If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated
 via the biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     unbiased (bool): whether to use the unbiased estimation or not
 
 Example::
@@ -4780,11 +4779,11 @@ If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated
 via the biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
     unbiased (bool): whether to use the unbiased estimation or not
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -4808,7 +4807,7 @@ If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated
 via the biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     unbiased (bool): whether to use the unbiased estimation or not
 
 Example::
@@ -4831,7 +4830,7 @@ If :attr:`unbiased` is ``False``, then the standard-deviation will be calculated
 via the biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
     unbiased (bool): whether to use the unbiased estimation or not
@@ -4855,7 +4854,7 @@ add_docstr(torch.sum,
 Returns the sum of all elements in the :attr:`input` tensor.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dtype}
 
 Example::
@@ -4875,7 +4874,7 @@ reduce over all of them.
 {keepdim_details}
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
     {dtype}
@@ -5050,7 +5049,7 @@ and 1.
 2-D tensor can be seen as a short-hand function for ``transpose(input, 0, 1)``.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
 
 Example::
 
@@ -5072,7 +5071,7 @@ Example::
     tensor([[ 0.4875,  0.3938],
             [ 0.9158, -0.6929],
             [-0.5872,  0.6932]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.flip,
            r"""
@@ -5081,7 +5080,7 @@ flip(input, dims) -> Tensor
 Reverse the order of a n-D tensor along given axis in dims.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dims (a list or tuple): axis to flip on
 
 Example::
@@ -5099,7 +5098,7 @@ Example::
 
             [[ 2,  3],
              [ 0,  1]]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.roll,
            r"""
@@ -5111,7 +5110,7 @@ specified, the tensor will be flattened before rolling and then restored
 to the original shape.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     shifts (int or tuple of ints): The number of places by which the elements
         of the tensor are shifted. If shifts is a tuple, dims must be a tuple of
         the same size, and each dimension will be rolled by the corresponding
@@ -5141,7 +5140,7 @@ Example::
             [8, 7],
             [2, 1],
             [4, 3]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.rot90,
            r"""
@@ -5151,7 +5150,7 @@ Rotate a n-D tensor by 90 degrees in the plane specified by dims axis.
 Rotation direction is from the first towards the second axis if k > 0, and from the second towards the first for k < 0.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     k (int): number of times to rotate
     dims (a list or tuple): axis to rotate
 
@@ -5178,7 +5177,7 @@ Example::
 
             [[5, 7],
              [4, 6]]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.take,
            r"""
@@ -5189,8 +5188,8 @@ The input tensor is treated as if it were viewed as a 1-D tensor. The result
 takes the same shape as the indices.
 
 Args:
-    input (Tensor): the input tensor
-    index (LongTensor): the indices into tensor
+    {input}
+    indices (LongTensor): the indices into tensor
 
 Example::
 
@@ -5198,7 +5197,7 @@ Example::
                             [6, 7, 8]])
     >>> torch.take(src, torch.tensor([0, 2, 5]))
     tensor([ 4,  5,  8])
-""")
+""".format(**common_args))
 
 add_docstr(torch.tan,
            r"""
@@ -5208,10 +5207,10 @@ Returns a new tensor with the tangent of the elements of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \tan(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -5220,7 +5219,7 @@ Example::
     tensor([-1.2027, -1.7687,  0.4412, -1.3856])
     >>> torch.tan(a)
     tensor([-2.5930,  4.9859,  0.4722, -5.3366])
-""")
+""".format(**common_args))
 
 add_docstr(torch.tanh,
            r"""
@@ -5231,10 +5230,10 @@ of :attr:`input`.
 
 .. math::
     \text{out}_{i} = \tanh(\text{input}_{i})
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -5243,7 +5242,7 @@ Example::
     tensor([ 0.8986, -0.7279,  1.1745,  0.2611])
     >>> torch.tanh(a)
     tensor([ 0.7156, -0.6218,  0.8257,  0.2553])
-""")
+""".format(**common_args))
 
 add_docstr(torch.topk,
            r"""
@@ -5263,7 +5262,7 @@ The boolean option :attr:`sorted` if ``True``, will make sure that the returned
 `k` elements are themselves sorted
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     k (int): the k in "top-k"
     dim (int, optional): the dimension to sort along
     largest (bool, optional): controls whether to return largest or
@@ -5280,7 +5279,7 @@ Example::
     tensor([ 1.,  2.,  3.,  4.,  5.])
     >>> torch.topk(x, 3)
     torch.return_types.topk(values=tensor([5., 4., 3.]), indices=tensor([4, 3, 2]))
-""")
+""".format(**common_args))
 
 add_docstr(torch.trace,
            r"""
@@ -5311,7 +5310,7 @@ The resulting :attr:`out` tensor shares it's underlying storage with the
 of the other.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim0 (int): the first dimension to be transposed
     dim1 (int): the second dimension to be transposed
 
@@ -5325,7 +5324,7 @@ Example::
     tensor([[ 1.0028, -0.1669],
             [-0.9893,  0.7299],
             [ 0.5809,  0.4942]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.triangular_solve,
            r"""
@@ -5399,11 +5398,11 @@ diagonal, and similarly a negative value excludes just as many diagonals below
 the main diagonal. The main diagonal are the set of indices
 :math:`\lbrace (i, i) \rbrace` for :math:`i \in [0, \min\{d_{1}, d_{2}\} - 1]` where
 :math:`d_{1}, d_{2}` are the dimensions of the matrix.
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
+    {input}
     diagonal (int, optional): the diagonal to consider
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -5433,7 +5432,7 @@ Example::
             [ 0.4785,  0.0000,  0.0000,  0.0000,  0.0000,  0.0000],
             [ 1.1502,  3.2716,  0.0000,  0.0000,  0.0000,  0.0000],
             [-0.0614, -0.7344, -1.3164,  0.0000,  0.0000,  0.0000]])
-""")
+""".format(**common_args))
 
 # docstr is split in two parts to avoid format mis-captureing :math: braces '{}'
 # as common args.
@@ -5504,11 +5503,11 @@ diagonal, and similarly a negative value includes just as many diagonals below
 the main diagonal. The main diagonal are the set of indices
 :math:`\lbrace (i, i) \rbrace` for :math:`i \in [0, \min\{d_{1}, d_{2}\} - 1]` where
 :math:`d_{1}, d_{2}` are the dimensions of the matrix.
-
+""" + r"""
 Args:
-    input (Tensor): the input tensor
+    {input}
     diagonal (int, optional): the diagonal to consider
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -5546,7 +5545,7 @@ Example::
             [-0.2447,  0.9556, -1.2919,  1.3378, -0.1768, -1.0857],
             [ 0.0000,  0.3146,  0.6576, -1.0432,  0.9348, -0.4410],
             [ 0.0000,  0.0000, -1.3337, -1.6556,  0.4798,  0.2830]])
-""")
+""".format(**common_args))
 
 # docstr is split in two parts to avoid format mis-capturing :math: braces '{}'
 # as common args.
@@ -5608,8 +5607,8 @@ Returns a new tensor with the truncated integer values of
 the elements of :attr:`input`.
 
 Args:
-    input (Tensor): the input tensor
-    out (Tensor, optional): the output tensor
+    {input}
+    {out}
 
 Example::
 
@@ -5618,7 +5617,7 @@ Example::
     tensor([ 3.4742,  0.5466, -0.8008, -0.9079])
     >>> torch.trunc(a)
     tensor([ 3.,  0., -0., -0.])
-""")
+""".format(**common_args))
 
 add_docstr(torch.unsqueeze,
            r"""
@@ -5634,9 +5633,9 @@ can be used. Negative :attr:`dim` will correspond to :meth:`unsqueeze`
 applied at :attr:`dim` = ``dim + input.dim() + 1``.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     dim (int): the index at which to insert the singleton dimension
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -5648,7 +5647,7 @@ Example::
             [ 2],
             [ 3],
             [ 4]])
-""")
+""".format(**common_args))
 
 add_docstr(torch.var,
            r"""
@@ -5660,7 +5659,7 @@ If :attr:`unbiased` is ``False``, then the variance will be calculated via the
 biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     unbiased (bool): whether to use the unbiased estimation or not
 
 Example::
@@ -5683,11 +5682,11 @@ If :attr:`unbiased` is ``False``, then the variance will be calculated via the
 biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
     unbiased (bool): whether to use the unbiased estimation or not
-    out (Tensor, optional): the output tensor
+    {out}
 
 Example::
 
@@ -5711,7 +5710,7 @@ If :attr:`unbiased` is ``False``, then the variance will be calculated via the
 biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     unbiased (bool): whether to use the unbiased estimation or not
 
 Example::
@@ -5733,7 +5732,7 @@ If :attr:`unbiased` is ``False``, then the variance will be calculated via the
 biased estimator. Otherwise, Bessel's correction will be used.
 
 Args:
-    input (Tensor): the input tensor
+    {input}
     {dim}
     {keepdim}
     unbiased (bool): whether to use the unbiased estimation or not
@@ -6767,7 +6766,7 @@ Repeat elements of a tensor.
     This is different from :func:`torch.repeat` but similar to `numpy.repeat`.
 
 Args:
-    input (Tensor): The input tensor
+    {input}
     repeats (Tensor or int): The number of repetitions for each element.
         repeats is broadcasted to fit the shape of the given axis.
     dim (int, optional): The dimension along which to repeat values.
@@ -6799,7 +6798,7 @@ Example::
 If the `repeats` is `tensor([n1, n2, n3, ...])`, then the output will be
 `tensor([0, 0, ..., 1, 1, ..., 2, 2, ..., ...])` where `0` appears `n1` times,
 `1` appears `n2` times, `2` appears `n3` times, etc.
-""")
+""".format(**common_args))
 
 
 add_docstr(torch._C.Generator,


### PR DESCRIPTION
Many descriptions of arguments could be replaced by items in the template such as `factory_common_args`.