### PR TITLE
allow passing a list of operators to benchmark

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -87,13 +87,13 @@ class BenchmarkRunner(object):
                 print("# {}".format(test_case.test_config.test_name))
         elif self.args.list_ops:
             print("# List of Operators to run:")
-            if self.args.operator is None:
+            if self.args.operators is None:
                 ops = set(test_case.op_bench.module_name()
                           for _, test_case in BENCHMARK_TESTER.items())
                 for op in ops: 
                     print("# {}".format(op))
             else:
-                print("# {}".format(self.args.operator))
+                print("# {}".format(self.args.operators))
 
     def _print_perf_result(self, reported_run_time_us, test_case):
         if self.args.ai_pep_format:
@@ -200,12 +200,14 @@ class BenchmarkRunner(object):
         op_test_config = test_case.test_config
 
         if self.args.framework:
-            frameworks = benchmark_utils.get_requested_frameworks(self.args.framework)
+            frameworks = benchmark_utils.process_arg_list(self.args.framework)
+
+        operators = benchmark_utils.process_arg_list(self.args.operators) if self.args.operators else None
 
         # Filter framework, operator, test_name, tag, forward_only
         if (self._check_keep(op_test_config.test_name, self.args.test_name) and
             self._check_keep(op_test_config.tag, self.args.tag_filter) and
-            self._check_keep(test_case.op_bench.module_name(), self.args.operator) and
+            self._check_keep_list(test_case.op_bench.module_name(), operators) and
             self._check_keep_list(test_case.framework, frameworks) and
                 (not self.args.forward_only or op_test_config.run_backward != self.args.forward_only)):
             return True

--- a/benchmarks/operator_benchmark/benchmark_runner.py
+++ b/benchmarks/operator_benchmark/benchmark_runner.py
@@ -30,9 +30,8 @@ def main():
 
     # This option is used to filter test cases to run.
     parser.add_argument(
-        '--operator',
-        help='Run the test cases that contain the provided operator'
-        ' as a substring of their names',
+        '--operators',
+        help='Filter tests based on comma-delimited list of operators to test',
         default=None)
 
     parser.add_argument(

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -174,8 +174,8 @@ def is_pytorch_enabled(framework_arg):
     return 'PyTorch' in framework_arg
 
 
-def get_requested_frameworks(framework_arg):
-    return [fr.strip() for fr in framework_arg.split(',') if len(fr.strip()) > 0]
+def process_arg_list(arg_list):
+    return [fr.strip() for fr in arg_list.split(',') if len(fr.strip()) > 0]
 
 
 class SkipInputShape(Exception):


### PR DESCRIPTION
Summary: Replace the argument name from `operator` to `operators` which can take a list of operators to test.

Differential Revision: D16520779

