### PR TITLE
[quant] Remove qconfig_dict from API

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -10,7 +10,8 @@ checking quantization api and properties of resulting modules.
 import torch
 import torch.nn.quantized as nnq
 from common_utils import TestCase
-from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, default_qconfig
+from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, \
+    default_qconfig, QConfig, default_observer, default_weight_observer
 
 def test_only_eval_fn(model, calib_data):
     r"""
@@ -89,7 +90,7 @@ class QuantizationTestCase(TestCase):
         self.assertEqual(type(mod.quant), nnq.Quantize)
         self.assertEqual(type(mod.dequant), nnq.DeQuantize)
 
-    def checkQuantizedLinear(self, mod):
+    def checkWrappedQuantizedLinear(self, mod):
         r"""Checks that mod has been swapped for an nnq.Linear
             module, the bias is qint32, and that the module
             has Quantize and DeQuantize submodules
@@ -97,6 +98,10 @@ class QuantizationTestCase(TestCase):
         self.assertEqual(type(mod.module), nnq.Linear)
         self.assertEqual(mod.module.bias.dtype, torch.qint32)
         self.checkQuantDequant(mod)
+
+    def checkQuantizedLinear(self, mod):
+        self.assertEqual(type(mod), nnq.Linear)
+        self.assertEqual(mod.bias.dtype, torch.qint32)
 
     def checkLinear(self, mod):
         self.assertEqual(type(mod), torch.nn.Linear)
@@ -106,7 +111,8 @@ class QuantizationTestCase(TestCase):
 class SingleLayerLinearModel(torch.nn.Module):
     def __init__(self):
         super(SingleLayerLinearModel, self).__init__()
-        self.fc1 = torch.nn.Linear(5, 5).to(dtype=torch.float)
+        self.qconfig = default_qconfig
+        self.fc1 = QuantWrapper(torch.nn.Linear(5, 5).to(dtype=torch.float))
 
     def forward(self, x):
         x = self.fc1(x)
@@ -117,6 +123,18 @@ class TwoLayerLinearModel(torch.nn.Module):
         super(TwoLayerLinearModel, self).__init__()
         self.fc1 = torch.nn.Linear(5, 8).to(dtype=torch.float)
         self.fc2 = torch.nn.Linear(8, 5).to(dtype=torch.float)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return x
+
+class AnnotatedTwoLayerLinearModel(torch.nn.Module):
+    def __init__(self):
+        super(AnnotatedTwoLayerLinearModel, self).__init__()
+        self.fc1 = torch.nn.Linear(5, 8).to(dtype=torch.float)
+        self.fc2 = QuantWrapper(torch.nn.Linear(8, 5).to(dtype=torch.float))
+        self.fc2.qconfig = default_qconfig
 
     def forward(self, x):
         x = self.fc1(x)
@@ -146,6 +164,99 @@ class NestedModel(torch.nn.Module):
         x = self.fc3(x)
         return x
 
+class AnnotatedNestedModel(torch.nn.Module):
+    def __init__(self):
+        super(AnnotatedNestedModel, self).__init__()
+        self.sub1 = LinearReluModel()
+        self.sub2 = TwoLayerLinearModel()
+        self.fc3 = QuantWrapper(torch.nn.Linear(5, 5).to(dtype=torch.float))
+        self.fc3.qconfig = default_qconfig
+        self.sub2.fc1 = QuantWrapper(self.sub2.fc1)
+        self.sub2.fc1.qconfig = default_qconfig
+
+    def forward(self, x):
+        x = self.sub1(x)
+        x = self.sub2(x)
+        x = self.fc3(x)
+        return x
+
+class AnnotatedSubNestedModel(torch.nn.Module):
+    def __init__(self):
+        super(AnnotatedSubNestedModel, self).__init__()
+        self.sub1 = LinearReluModel()
+        self.sub2 = QuantWrapper(TwoLayerLinearModel())
+        self.fc3 = QuantWrapper(torch.nn.Linear(5, 5).to(dtype=torch.float))
+        self.fc3.qconfig = default_qconfig
+        self.sub2.qconfig = default_qconfig
+
+    def forward(self, x):
+        x = self.sub1(x)
+        x = self.sub2(x)
+        x = self.fc3(x)
+        return x
+
+class AnnotatedCustomConfigNestedModel(torch.nn.Module):
+    def __init__(self):
+        super(AnnotatedCustomConfigNestedModel, self).__init__()
+        self.sub1 = LinearReluModel()
+        self.sub2 = TwoLayerLinearModel()
+        self.fc3 = QuantWrapper(torch.nn.Linear(5, 5).to(dtype=torch.float))
+        self.fc3.qconfig = default_qconfig
+        self.sub2.qconfig = default_qconfig
+
+        custum_options = {
+            'dtype': torch.quint8,
+            'qscheme': torch.per_tensor_affine
+        }
+        custom_qconfig = QConfig(weight=default_weight_observer(),
+                                 activation=default_observer(**custum_options))
+        self.sub2.fc1.qconfig = custom_qconfig
+
+        self.sub2.fc1 = QuantWrapper(self.sub2.fc1)
+        self.sub2.fc2 = QuantWrapper(self.sub2.fc2)
+
+    def forward(self, x):
+        x = self.sub1(x)
+        x = self.sub2(x)
+        x = self.fc3(x)
+        return x
+
+class QuantSubModel(torch.nn.Module):
+    def __init__(self):
+        super(QuantSubModel, self).__init__()
+        self.sub1 = LinearReluModel()
+        self.sub2 = QuantWrapper(TwoLayerLinearModel())
+        self.sub2.qconfig = default_qconfig
+        self.fc3 = torch.nn.Linear(5, 5).to(dtype=torch.float)
+        self.fc3.qconfig = default_qconfig
+
+    def forward(self, x):
+        x = self.sub1(x)
+        x = self.sub2(x)
+        x = self.fc3(x)
+        return x
+
+class CustomeQConfigModel(torch.nn.Module):
+    def __init__(self):
+        super(CustomQConfigModel, self).__init__()
+        self.sub1 = LinearReluModel()
+        self.sub2 = QuantWrapper(TwoLayerLinearModel())
+        custum_options = {
+            'dtype': torch.quint8,
+            'qscheme': torch.per_tensor_affine
+        }
+        custom_qconfig = QConfig(weight=default_weight_observer(),
+                                 activation=default_observer(**custum_options))
+        self.sub2.qconfig = custom_qconfig
+        self.fc3 = torch.nn.Linear(5, 5).to(dtype=torch.float)
+        self.fc3.qconfig = default_qconfig
+
+    def forward(self, x):
+        x = self.sub1(x)
+        x = self.sub2(x)
+        x = self.fc3(x)
+        return x
+
 class InnerModule(torch.nn.Module):
     def __init__(self):
         super(InnerModule, self).__init__()
@@ -156,9 +267,9 @@ class InnerModule(torch.nn.Module):
     def forward(self, x):
         return self.relu(self.fc2(self.relu(self.fc1(x))))
 
-class WrappedModel(torch.nn.Module):
+class SkipQuantModel(torch.nn.Module):
     def __init__(self):
-        super(WrappedModel, self).__init__()
+        super(SkipQuantModel, self).__init__()
         self.qconfig = default_qconfig
         self.sub = QuantWrapper(InnerModule())
         self.fc = torch.nn.Linear(5, 5).to(dtype=torch.float)
@@ -168,11 +279,11 @@ class WrappedModel(torch.nn.Module):
     def forward(self, x):
         return self.fc(self.sub(x))
 
-class ManualQuantModel(torch.nn.Module):
+class QuantStubModel(torch.nn.Module):
     r"""A Module with manually inserted `QuantStub` and `DeQuantStub`
     """
     def __init__(self):
-        super(ManualQuantModel, self).__init__()
+        super(QuantStubModel, self).__init__()
         self.qconfig = default_qconfig
         self.quant = QuantStub()
         self.dequant = DeQuantStub()

--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -11,7 +11,8 @@ import torch
 import torch.nn.quantized as nnq
 from common_utils import TestCase
 from torch.quantization import QuantWrapper, QuantStub, DeQuantStub, \
-    default_qconfig, QConfig, default_observer, default_weight_observer
+    default_qconfig, QConfig, default_observer, default_weight_observer, \
+    default_qat_qconfig
 
 def test_only_eval_fn(model, calib_data):
     r"""
@@ -299,7 +300,7 @@ class ManualLinearQATModel(torch.nn.Module):
     """
     def __init__(self):
         super(ManualLinearQATModel, self).__init__()
-        self.qconfig = default_qconfig
+        self.qconfig = default_qat_qconfig
         self.quant = QuantStub()
         self.dequant = DeQuantStub()
         self.fc1 = torch.nn.Linear(5, 5).to(dtype=torch.float)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -2,25 +2,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 import torch.nn.quantized as nnq
-from torch.quantization import QConfig, \
-    default_qconfig, default_qat_qconfig, default_observer, default_weight_observer, \
+from torch.quantization import default_qconfig, default_qat_qconfig, \
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules
 
 from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
-    TwoLayerLinearModel, NestedModel, WrappedModel, ManualQuantModel, \
+    TwoLayerLinearModel, SkipQuantModel, QuantStubModel, \
     ModForFusion, ManualLinearQATModel, ManualConvLinearQATModel, test_only_eval_fn, test_only_train_fn
+
+from common_quantization import AnnotatedTwoLayerLinearModel, AnnotatedNestedModel, \
+    AnnotatedSubNestedModel, AnnotatedCustomConfigNestedModel
 
 class PostTrainingQuantTest(QuantizationTestCase):
     def test_single_layer(self):
         r"""Quantize SingleLayerLinearModel which has one Linear module, make sure it is swapped
         to nnq.Linear which is the quantized version of the module
         """
-        model = SingleLayerLinearModel().eval()
-        qconfig_dict = {
-            '': default_qconfig
-        }
-        model = prepare(model, qconfig_dict)
+        model = SingleLayerLinearModel()
+        model = prepare(model)
         # Check if observers and quant/dequant nodes are inserted
         self.checkNoPrepModules(model)
         self.checkHasPrepModules(model.fc1)
@@ -32,24 +31,21 @@ class PostTrainingQuantTest(QuantizationTestCase):
         def checkQuantized(model):
             self.checkNoPrepModules(model)
             self.checkHasPrepModules(model.fc1)
-            self.checkQuantizedLinear(model.fc1)
+            self.checkWrappedQuantizedLinear(model.fc1)
             test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(SingleLayerLinearModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
+        model = quantize(SingleLayerLinearModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
     def test_two_layers(self):
         r"""TwoLayerLinearModel has two Linear modules but we only quantize the second one
         `fc2`, and `fc1`is not quantized
         """
-        model = TwoLayerLinearModel().eval()
-        qconfig_dict = {
-            'fc2': default_qconfig
-        }
-        model = prepare(model, qconfig_dict)
+        model = AnnotatedTwoLayerLinearModel()
+        model = prepare(model)
 
         self.checkNoPrepModules(model)
         self.checkObservers(model)
@@ -64,24 +60,20 @@ class PostTrainingQuantTest(QuantizationTestCase):
             self.checkNoPrepModules(model.fc1)
             self.checkHasPrepModules(model.fc2)
             self.assertEqual(type(model.fc1), torch.nn.Linear)
-            self.checkQuantizedLinear(model.fc2)
+            self.checkWrappedQuantizedLinear(model.fc2)
             test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(TwoLayerLinearModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
+        model = quantize(AnnotatedTwoLayerLinearModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
     def test_nested1(self):
         r"""Test quantization for nested model, top level 'fc3' and
         'fc1' of submodule 'sub2', 'sub2.fc2' is not quantized
         """
-        model = NestedModel().eval()
-        qconfig_dict = {
-            'fc3': default_qconfig,
-            'sub2.fc1': default_qconfig
-        }
+        model = AnnotatedNestedModel()
 
         def checkPrepModules(model, before_calib=False):
             if before_calib:
@@ -95,7 +87,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
             self.checkNoPrepModules(model.sub2.fc2)
             self.checkHasPrepModules(model.fc3)
 
-        model = prepare(model, qconfig_dict)
+        model = prepare(model)
         checkPrepModules(model, True)
         test_only_eval_fn(model, self.calib_data)
         convert(model)
@@ -103,31 +95,21 @@ class PostTrainingQuantTest(QuantizationTestCase):
         def checkQuantized(model):
             checkPrepModules(model)
             self.checkLinear(model.sub1.fc)
-            self.checkQuantizedLinear(model.fc3)
-            self.checkQuantizedLinear(model.sub2.fc1)
+            self.checkWrappedQuantizedLinear(model.fc3)
+            self.checkWrappedQuantizedLinear(model.sub2.fc1)
             self.checkLinear(model.sub2.fc2)
             test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(NestedModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
+        model = quantize(AnnotatedNestedModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
 
     def test_nested2(self):
-        r"""Another test case for quantized, we will quantize all submodules
-        of submodule sub2, this will include redundant quant/dequant, to
-        remove them we need to manually call QuantWrapper or insert
-        QuantStub/DeQuantStub, see `test_quant_dequant_wrapper` and
-        `test_manual`
-        """
-        model = NestedModel().eval()
-        qconfig_dict = {
-            'fc3': default_qconfig,
-            'sub2': default_qconfig
-        }
-        model = prepare(model, qconfig_dict)
+        model = AnnotatedSubNestedModel()
+        model = prepare(model)
 
         def checkPrepModules(model, before_calib=False):
             if before_calib:
@@ -136,9 +118,9 @@ class PostTrainingQuantTest(QuantizationTestCase):
             self.checkNoPrepModules(model.sub1)
             self.checkNoPrepModules(model.sub1.fc)
             self.checkNoPrepModules(model.sub1.relu)
-            self.checkNoPrepModules(model.sub2)
-            self.checkHasPrepModules(model.sub2.fc1)
-            self.checkHasPrepModules(model.sub2.fc2)
+            self.checkHasPrepModules(model.sub2)
+            self.checkNoPrepModules(model.sub2.module.fc1)
+            self.checkNoPrepModules(model.sub2.module.fc2)
             self.checkHasPrepModules(model.fc3)
 
         checkPrepModules(model, True)
@@ -150,34 +132,23 @@ class PostTrainingQuantTest(QuantizationTestCase):
             checkPrepModules(model)
             self.checkLinear(model.sub1.fc)
             self.assertEqual(type(model.sub1.relu), torch.nn.ReLU)
-            self.checkQuantizedLinear(model.sub2.fc1)
-            self.checkQuantizedLinear(model.sub2.fc2)
-            self.checkQuantizedLinear(model.fc3)
+            self.checkQuantizedLinear(model.sub2.module.fc1)
+            self.checkQuantizedLinear(model.sub2.module.fc2)
+            self.checkWrappedQuantizedLinear(model.fc3)
             test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(NestedModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
+        model = quantize(AnnotatedSubNestedModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
     def test_nested3(self):
         r"""More complicated nested test case with child qconfig overrides
         parent qconfig
         """
-        model = NestedModel().eval()
-        custum_options = {
-            'dtype': torch.quint8,
-            'qscheme': torch.per_tensor_affine
-        }
-        custom_qconfig = QConfig(weight=default_weight_observer(),
-                                 activation=default_observer(**custum_options))
-        qconfig_dict = {
-            'fc3': default_qconfig,
-            'sub2': default_qconfig,
-            'sub2.fc1': custom_qconfig
-        }
-        model = prepare(model, qconfig_dict)
+        model = AnnotatedCustomConfigNestedModel()
+        model = prepare(model)
 
         def checkPrepModules(model, before_calib=False):
             if before_calib:
@@ -198,25 +169,22 @@ class PostTrainingQuantTest(QuantizationTestCase):
 
         def checkQuantized(model):
             checkPrepModules(model)
-            self.checkQuantizedLinear(model.sub2.fc1)
-            self.checkQuantizedLinear(model.sub2.fc2)
-            self.checkQuantizedLinear(model.fc3)
+            self.checkWrappedQuantizedLinear(model.sub2.fc1)
+            self.checkWrappedQuantizedLinear(model.sub2.fc2)
+            self.checkWrappedQuantizedLinear(model.fc3)
             test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(NestedModel().eval(), test_only_eval_fn, self.calib_data, qconfig_dict)
+        model = quantize(AnnotatedCustomConfigNestedModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
-    def test_quant_wrapper(self):
-        r"""User need to modify the original code with QuantWrapper,
-        and call the quantization utility functions.
+    def test_skip_quant(self):
+        r"""The case when we want to skip quantizing some layers
         """
-        model = WrappedModel().eval()
 
-        # since we didn't provide qconfig_dict, the model is modified inplace
-        # but we can do `model = prepare(model)` as well
+        model = SkipQuantModel()
         prepare(model)
         self.checkObservers(model)
 
@@ -226,15 +194,15 @@ class PostTrainingQuantTest(QuantizationTestCase):
         def checkQuantized(model):
             self.checkLinear(model.fc)
             self.checkQuantDequant(model.sub)
-            self.assertEqual(type(model.sub.module.fc1), nnq.Linear)
-            self.assertEqual(type(model.sub.module.fc2), nnq.Linear)
+            self.checkQuantizedLinear(model.sub.module.fc1)
+            self.checkQuantizedLinear(model.sub.module.fc2)
             self.assertEqual(type(model.sub.module.relu), nnq.ReLU)
             test_only_eval_fn(model, self.calib_data)
 
         checkQuantized(model)
 
         # test one line API
-        model = quantize(WrappedModel().eval(), test_only_eval_fn, self.calib_data, {})
+        model = quantize(SkipQuantModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
 
@@ -242,7 +210,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         r"""User inserts QuantStub and DeQuantStub in model code
         and call the quantization utility functions.
         """
-        model = ManualQuantModel().eval()
+        model = QuantStubModel()
         # propagate the qconfig of parents to children, model is changed
         # inplace
         prepare(model)
@@ -258,7 +226,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         checkQuantized(model)
 
         # test one line API
-        model = quantize(ManualQuantModel().eval(), test_only_eval_fn, self.calib_data)
+        model = quantize(QuantStubModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
 class QuantizationAwareTrainingTest(QuantizationTestCase):

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 import torch.nn.quantized as nnq
-from torch.quantization import default_qconfig, default_qat_qconfig, \
+from torch.quantization import default_qat_qconfig, \
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules
 
 from common_utils import run_tests
@@ -232,11 +232,8 @@ class PostTrainingQuantTest(QuantizationTestCase):
 class QuantizationAwareTrainingTest(QuantizationTestCase):
     def test_manual(self):
         model = ManualLinearQATModel()
-        model.qconfig = default_qat_qconfig
-
         model = prepare_qat(model)
         self.checkObservers(model)
-
         test_only_train_fn(model, self.train_data)
         convert(model)
 
@@ -244,10 +241,9 @@ class QuantizationAwareTrainingTest(QuantizationTestCase):
             self.assertEqual(type(model.fc1), nnq.Linear)
             self.assertEqual(type(model.fc2), nnq.Linear)
             test_only_eval_fn(model, self.calib_data)
+        checkQuantized(model)
 
-        model = ManualLinearQATModel()
-        model.qconfig = default_qat_qconfig
-        model = quantize_qat(model, test_only_train_fn, self.train_data)
+        model = quantize_qat(ManualLinearQATModel(), test_only_train_fn, self.train_data)
         checkQuantized(model)
 
     def test_eval_only_fake_quant(self):

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -125,28 +125,24 @@ def add_quant_dequant(module):
         module._modules[name] = add_quant_dequant(child)
     return module
 
-def prepare(model, qconfig_dict=None):
-    r"""Prepares the model for calibration or training given a qconfig_dict.
+def prepare(model):
+    r"""Prepares the model for calibration or training.
     Note that the model will be modified inplace but in case the input model
     is a leaf model, a wrapped model will be returned.
 
     Args:
         mod: input model
-        qconfig_dict: dictionary that maps from name of submodule to quantization
-                      configuration
     Return:
         A model with qconfig propogated, observer and quant dequant or fake
         quant modules attached, a model that is ready for calibration or
         training
     """
-    propagate_qconfig(model, qconfig_dict)
-    if qconfig_dict:
-        model = add_quant_dequant(model)
+    propagate_qconfig(model)
     add_observer(model)
     return model
 
-def prepare_qat(model, qconfig_dict=None):
-    model = prepare(model, qconfig_dict)
+def prepare_qat(model):
+    model = prepare(model)
     model = convert(model, DEFAULT_QAT_MODULE_MAPPING)
     return model
 
@@ -178,7 +174,7 @@ class DeQuantStub(nn.Module):
     def forward(self, x):
         return x
 
-def quantize(model, run_fn, run_args, qconfig_dict=None):
+def quantize(model, run_fn, run_args):
     r"""Converts a float model to quantized model.
 
     First it will prepare the model for calibration or training, then it calls
@@ -186,36 +182,26 @@ def quantize(model, run_fn, run_args, qconfig_dict=None):
     after that we will call `convert` which will convert the model to a
     quantized model.
 
-    When `qconfig_dict` is None or empty dictionary, we will assume user will
-    insert quant/dequant stubs and add qconfig in approporiate places.
-    When `qconfig_dict` is not None or empty dictionary, we will add quant/dequant
-    stubs using QuantWrapper for all the leaf modules.
-
     Args:
         model: input model
         run_fn: a function for evaluating the prepared model, can be a
             function that simply runs the prepared model or a training loop
         run_args: positional arguments for `run_fn`
-        qconfig_dict: dictionary that maps from name of submodule to quantization
-            configuration, qconfig applies to all submodules of a given
-            model unless qconfig for the submodules are specified(when the
-            submodule already has qconfig attribute)
-
 
     Return:
         A quantized model
     """
     model.eval()
-    model = prepare(model, qconfig_dict)
+    model = prepare(model)
     run_fn(model, run_args)
     convert(model)
     return model
 
-def quantize_qat(model, run_fn, run_args, qconfig_dict=None):
+def quantize_qat(model, run_fn, run_args):
     r"""Do quantization aware training and output a quantized model
     """
     model.train()
-    model = prepare_qat(model, qconfig_dict)
+    model = prepare_qat(model)
     run_fn(model, run_args)
     convert(model)
     return model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23446 [quant] Remove qconfig_dict from API**
* #23465 [quant] Remove qconfig_dict from API

Summary:
We decided not to allow user to use qconfig_dict to do quantization
since that API is not robust.

Test Plan:
```
python test/test_quantization.py
```

Reviewers:
pt1quant
Subscribers:

Tasks:

Tags: