### PR TITLE
[quant] Add nnq.Identity

### DIFF
--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -7,6 +7,7 @@ from .conv import Conv2d
 from .linear import Linear
 from .linear import Quantize
 from .linear import DeQuantize
+from .linear import Identity
 
 __all__ = [
     'Conv2d',
@@ -15,4 +16,5 @@ __all__ = [
     'MaxPool2d',
     'Quantize',
     'ReLU',
+    'Identity',
 ]

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -2,7 +2,22 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 from ...modules.module import Module
 from ...modules.linear import Linear as NNLinear
+from ...modules.linear import Identity as NNIdentity
 # from ...qat.modules.linear import Linear as QATLinear
+
+class Identity(NNIdentity):
+    r"""A placeholder identity operator that is argument-insensitive.
+    """
+    __FLOAT_MODULE__ = NNIdentity
+
+    def __init__(self, *args, **kwargs):
+        super(Identity, self).__init__()
+
+    @classmethod
+    def from_float(cls, mod):
+        assert type(mod) == cls.__FLOAT_MODULE__, ' nnq.' + cls.__name__ + '.from_float only works for ' + \
+            super(Identity, cls).__name__
+        return Identity()
 
 class Quantize(Module):
     r"""Quantizes an incoming tensor

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -227,6 +227,7 @@ DEFAULT_MODULE_MAPPING = {
     torch.nn.Conv2d: nnq.Conv2d,
     QuantStub: nnq.Quantize,
     DeQuantStub: nnq.DeQuantize,
+    nn.Identity: nnq.Identity,
     # QAT modules:
     qat.Linear: nnq.Linear,
     qat.Conv2d: nnq.Conv2d,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23469 [quant] Add nnq.Identity**

we need nnq.Identity because after fuse modules, we swap some modules as Identity.

Differential Revision: [D16530202](https://our.internmc.facebook.com/intern/diff/D16530202/)