### PR TITLE
[quant] skip nn.Identity in add_observer

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -54,9 +54,8 @@ def _observer_forward_hook(self, input, output):
     """
     return self.observer(output)
 
-DEFAULT_SKIP_LIST = [nn.Identity]
+DEFAULT_SKIP_LIST = [nn.Identity, nn.MaxPool2d]
 
-# TODO(jerryzh): remove_observer?
 def add_observer(module, skip_list=DEFAULT_SKIP_LIST):
     r"""Add observer for the leaf child of the module.
 

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -54,8 +54,10 @@ def _observer_forward_hook(self, input, output):
     """
     return self.observer(output)
 
+DEFAULT_SKIP_LIST = [nn.Identity]
+
 # TODO(jerryzh): remove_observer?
-def add_observer(module):
+def add_observer(module, skip_list=DEFAULT_SKIP_LIST):
     r"""Add observer for the leaf child of the module.
 
     This function insert observer module to all leaf child module that
@@ -74,7 +76,8 @@ def add_observer(module):
 
     # Insert observers only for leaf nodes, note that this observer is for
     # the output of the module, for input QuantStub will observe them
-    if hasattr(module, 'qconfig') and module.qconfig is not None and len(module._modules) == 0:
+    if hasattr(module, 'qconfig') and module.qconfig is not None and \
+        len(module._modules) == 0 and type(module) not in DEFAULT_SKIP_LIST:
         # observer and hook will be gone after we swap the module
         module.add_module('observer', module.qconfig.activation())
         module.register_forward_hook(_observer_forward_hook)

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -77,7 +77,7 @@ def add_observer(module, skip_list=DEFAULT_SKIP_LIST):
     # Insert observers only for leaf nodes, note that this observer is for
     # the output of the module, for input QuantStub will observe them
     if hasattr(module, 'qconfig') and module.qconfig is not None and \
-        len(module._modules) == 0 and type(module) not in DEFAULT_SKIP_LIST:
+        len(module._modules) == 0 and type(module) not in skip_list:
         # observer and hook will be gone after we swap the module
         module.add_module('observer', module.qconfig.activation())
         module.register_forward_hook(_observer_forward_hook)

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -76,7 +76,7 @@ def add_observer(module, skip_list=DEFAULT_SKIP_LIST):
     # Insert observers only for leaf nodes, note that this observer is for
     # the output of the module, for input QuantStub will observe them
     if hasattr(module, 'qconfig') and module.qconfig is not None and \
-        len(module._modules) == 0 and type(module) not in skip_list:
+       len(module._modules) == 0 and type(module) not in skip_list:
         # observer and hook will be gone after we swap the module
         module.add_module('observer', module.qconfig.activation())
         module.register_forward_hook(_observer_forward_hook)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23500 [quant] skip nn.Identity in add_observer**

Summary:
We don't need observer for nn.Identity

Test Plan:
e2e test in quantizing resnext 101

Reviewers:
pt1quant
Subscribers:

Tasks:

Tags:

Differential Revision: [D16550190](https://our.internmc.facebook.com/intern/diff/D16550190)