### PR TITLE
Override pythons sum() to give the right result for bool tensors

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1735,8 +1735,8 @@ class _TestTorchMixin(object):
         input = torch.tensor([])
         self.assertEqual(sum(input), 0)
 
-        input = torch.tensor([1, 0, 1, 0, 1], dtype=torch.uint8)
-        self.assertEqual(sum(input), 3)
+        input = torch.full((1, 300), 1, dtype=torch.uint8)
+        self.assertEqual(sum(input), 300)
 
         input = torch.tensor([1.1, 0, 1.1, 0, 1.1])
         self.assertEqual(sum(input), 3.3)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1675,7 +1675,7 @@ class _TestTorchMixin(object):
             self.assertEqual(res1, res2)
 
             # inter-type
-            m1 = torch.randn(10, 10, device=device)
+            m1 = torch.randn(2, 2, device=device)
             self.assertEqual(m1 + 3, m1 + torch.tensor(3))
             self.assertEqual(3 + m1, torch.tensor(3) + m1)
             one = torch.tensor(1, dtype=torch.uint8, device=device)
@@ -1724,6 +1724,22 @@ class _TestTorchMixin(object):
         res_csub = a.clone()
         res_csub.sub_(scalar)
         self.assertEqual(res_add, res_csub)
+
+    def test_sum(self):
+        input = [1, 2, 3]
+        self.assertEqual(sum(input), 6)
+
+        input = torch.tensor([True, False, True, False, True])
+        self.assertEqual(sum(input), 3)
+
+        input = torch.tensor([])
+        self.assertEqual(sum(input), 0)
+
+        input = torch.tensor([1, 0, 1, 0, 1], dtype=torch.uint8)
+        self.assertEqual(sum(input), 3)
+
+        input = torch.tensor([1.1, 0, 1.1, 0, 1.1])
+        self.assertEqual(sum(input), 3.3)
 
     @staticmethod
     def _test_neg(self, cast):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1725,7 +1725,7 @@ class _TestTorchMixin(object):
         res_csub.sub_(scalar)
         self.assertEqual(res_add, res_csub)
 
-    def test_sum(self):
+    def test_python_sum(self):
         input = [1, 2, 3]
         self.assertEqual(sum(input), 6)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1675,7 +1675,7 @@ class _TestTorchMixin(object):
             self.assertEqual(res1, res2)
 
             # inter-type
-            m1 = torch.randn(2, 2, device=device)
+            m1 = torch.randn(10, 10, device=device)
             self.assertEqual(m1 + 3, m1 + torch.tensor(3))
             self.assertEqual(3 + m1, torch.tensor(3) + m1)
             one = torch.tensor(1, dtype=torch.uint8, device=device)

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -364,7 +364,7 @@ class Tensor(torch._C._TensorBase):
 
     def __radd__(self, other):
         if isinstance(self, torch.Tensor):
-            if (self.dtype == torch.bool):
+            if (self.dtype == torch.bool or self.dtype == torch.uint8):
                 return torch.sum(self) + other
         return self.__add__(other)
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -362,6 +362,12 @@ class Tensor(torch._C._TensorBase):
     __ge__ = _C._TensorBase.ge
     __abs__ = _C._TensorBase.abs
 
+    def __radd__(self, other):
+        if isinstance(self, torch.Tensor):
+            if (self.dtype == torch.bool):
+                return torch.sum(self) + other
+        return self.__add__(other)
+
     def __len__(self):
         if self.dim() == 0:
             raise TypeError("len() of a 0-d tensor")


### PR DESCRIPTION
We want pythons sum() to treat boolean tensors the same way as torch.sum()
tested via unit tests