### PR TITLE
Fix set_grad for extension backends

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -271,7 +271,9 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad)
       "can't assign Variable as its own grad");
 
   auto& grad = ((THPVariable*)py_grad)->cdata;
-  bool gradIsSparse = var.dtype() == grad.dtype() && toSparse(tensorTypeIdToBackend(var.type_id())) == tensorTypeIdToBackend(grad.type_id());
+  bool gradIsSparse = (var.dtype() == grad.dtype() &&
+                       var.device().type() == grad.device().type() &&
+                       layout_from_backend(tensorTypeIdToBackend(grad.type_id())) == kSparse);
   THPUtils_assertRet(-1, grad.type() == var.type() || gradIsSparse,
       "assigned grad has data of a different type");
   if (var.is_cuda()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23516 Fix set_grad for extension backends**

The `toSparse()` call throws for all backends that don't have a sparse. Changed it so that it works for backends that don't have a corresponding sparse backend.

@soumyarooproy

Differential Revision: [D16546732](https://our.internmc.facebook.com/intern/diff/D16546732)