### PR TITLE
[ONNX] Specify onnxruntime version to install for CI tests

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -130,7 +130,7 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   # JIT C++ extensions require ninja, so put it into PATH.
   export PATH="/var/lib/jenkins/.local/bin:$PATH"
   if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
-    pip install -q --user onnxruntime
+    pip install -q --user onnxruntime==0.4.0
   fi
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi


### PR DESCRIPTION
No real change on the CI since currently the default latest is 0.4.0. @houseroad @bddppq 