### PR TITLE
CI: install clang-tidy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,12 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: "3.6"
+  - script: |
+      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+      sudo apt-get update
+      sudo apt-get install -y clang-tidy-8
+      sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8 1000
   - script: git branch master origin/master
   - script: pip install pyyaml
   - script: tools/run-clang-tidy-in-ci.sh


### PR DESCRIPTION
Install clang-tidy (from LLVM 8) for the `clang_tidy` job.