### PR TITLE
Update argument list for non-fbgemm path for qconv_prepack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -85,6 +85,9 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
 #else // USE_FBGEMM
   Tensor operator()(
       Tensor, /* weight */
+      torch::List<int64_t>, /* stride */
+      torch::List<int64_t>, /* padding */
+      torch::List<int64_t>, /* dilation */
       int64_t /* groups */
   ) {
     TORCH_CHECK(


### PR DESCRIPTION
Summary: non-fbgemm path should have the same arguments as fbgemm path.

Reviewed By: jianyuh

Differential Revision: D16547637

