### PR TITLE
[ROCm] Clean cmake infrastructure up

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -887,20 +887,20 @@ if(USE_ROCM)
     endforeach()
 
     set(Caffe2_HIP_INCLUDE
-      ${hip_INCLUDE_DIRS} ${hcc_INCLUDE_DIRS} ${hsa_INCLUDE_DIRS} ${rocrand_INCLUDE_DIRS} ${hiprand_INCLUDE_DIRS} ${rocblas_INCLUDE_DIRS} ${miopen_INCLUDE_DIRS} ${thrust_INCLUDE_DIRS} $<INSTALL_INTERFACE:include> ${Caffe2_HIP_INCLUDE})
+      ${hip_INCLUDE_DIRS} ${hcc_INCLUDE_DIRS} ${hsa_INCLUDE_DIRS} ${hiprand_INCLUDE_DIRS} ${rocblas_INCLUDE_DIRS} ${miopen_INCLUDE_DIRS} ${thrust_INCLUDE_DIRS} $<INSTALL_INTERFACE:include> ${Caffe2_HIP_INCLUDE})
 
     # This is needed for library added by hip_add_library (same for hip_add_executable)
     hip_include_directories(${Caffe2_HIP_INCLUDE})
 
     set(Caffe2_HIP_DEPENDENCY_LIBS
-      ${rocrand_LIBRARIES} ${hiprand_LIBRARIES} ${hipsparse_LIBRARIES} ${PYTORCH_HIP_HCC_LIBRARIES} ${PYTORCH_MIOPEN_LIBRARIES})
+      ${PYTORCH_HIP_HCC_LIBRARIES} ${PYTORCH_MIOPEN_LIBRARIES})
 
     # Note [rocblas & rocfft cmake bug]
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # TODO: There is a bug in rocblas's & rocfft's cmake files that exports the wrong targets name in ${rocblas_LIBRARIES}
     # If you get this wrong, you'll get a complaint like 'ld: cannot find -lrocblas-targets'
     list(APPEND Caffe2_HIP_DEPENDENCY_LIBS
-      roc::rocblas roc::rocfft)
+      roc::rocblas roc::rocfft hip::hiprand roc::hipsparse)
   else()
     caffe2_update_option(USE_ROCM OFF)
   endif()

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -38,13 +38,6 @@ ELSE()
   SET(ROCBLAS_PATH $ENV{ROCBLAS_PATH})
 ENDIF()
 
-# ROCSPARSE_PATH
-IF(NOT DEFINED ENV{ROCSPARSE_PATH})
-  SET(ROCSPARSE_PATH ${ROCM_PATH}/rocsparse)
-ELSE()
-  SET(ROCSPARSE_PATH $ENV{ROCSPARSE_PATH})
-ENDIF()
-
 # ROCFFT_PATH
 IF(NOT DEFINED ENV{ROCFFT_PATH})
   SET(ROCFFT_PATH ${ROCM_PATH}/rocfft)
@@ -71,20 +64,6 @@ IF(NOT DEFINED ENV{HIPRAND_PATH})
   SET(HIPRAND_PATH ${ROCM_PATH}/hiprand)
 ELSE()
   SET(HIPRAND_PATH $ENV{HIPRAND_PATH})
-ENDIF()
-
-# ROCRAND_PATH
-IF(NOT DEFINED ENV{ROCRAND_PATH})
-  SET(ROCRAND_PATH ${ROCM_PATH}/rocrand)
-ELSE()
-  SET(ROCRAND_PATH $ENV{ROCRAND_PATH})
-ENDIF()
-
-# MIOPENGEMM
-IF(NOT DEFINED ENV{MIOPENGEMM_PATH})
-  SET(MIOPENGEMM_PATH ${ROCM_PATH}/miopengemm)
-ELSE()
-  SET(MIOPENGEMM_PATH $ENV{MIOPENGEMM_PATH})
 ENDIF()
 
 # MIOPEN_PATH
@@ -132,23 +111,17 @@ IF(HIP_FOUND)
   set(CMAKE_HCC_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
   ### Remove setting of Flags when FindHIP.CMake PR #558 is accepted.###
 
-  set(rocrand_DIR ${ROCRAND_PATH}/lib/cmake/rocrand)
   set(hiprand_DIR ${HIPRAND_PATH}/lib/cmake/hiprand)
   set(rocblas_DIR ${ROCBLAS_PATH}/lib/cmake/rocblas)
-  set(miopengemm_DIR ${MIOPENGEMM_PATH}/lib/cmake/miopengemm)
   set(miopen_DIR ${MIOPEN_PATH}/lib/cmake/miopen)
   set(rocfft_DIR ${ROCFFT_PATH}/lib/cmake/rocfft)
   set(hipsparse_DIR ${HIPSPARSE_PATH}/lib/cmake/hipsparse)
-  set(rocsparse_DIR ${ROCSPARSE_PATH}/lib/cmake/rocsparse)
 
-  find_package_and_print_version(rocrand REQUIRED)
   find_package_and_print_version(hiprand REQUIRED)
   find_package_and_print_version(rocblas REQUIRED)
   find_package_and_print_version(miopen REQUIRED)
-  find_package_and_print_version(miopengemm REQUIRED)
   find_package_and_print_version(rocfft REQUIRED)
-  #find_package_and_print_version(hipsparse REQUIRED)
-  find_package_and_print_version(rocsparse REQUIRED)
+  find_package_and_print_version(hipsparse REQUIRED)
 
   # TODO: hip_hcc has an interface include flag "-hc" which is only
   # recognizable by hcc, but not gcc and clang. Right now in our
@@ -158,9 +131,6 @@ IF(HIP_FOUND)
   # TODO: miopen_LIBRARIES should return fullpath to the library file,
   # however currently it's just the lib name
   FIND_LIBRARY(PYTORCH_MIOPEN_LIBRARIES ${miopen_LIBRARIES} HINTS ${MIOPEN_PATH}/lib)
-  FIND_LIBRARY(hiprand_LIBRARIES hiprand HINTS ${HIPRAND_PATH}/lib)
-  FIND_LIBRARY(rocsparse_LIBRARIES rocsparse HINTS ${ROCSPARSE_PATH}/lib)
-  FIND_LIBRARY(hipsparse_LIBRARIES hipsparse HINTS ${HIPSPARSE_PATH}/lib)
 
 
   # Necessary includes for building PyTorch since we include HIP headers that depend on hcc/hsa headers.

--- a/docker/caffe2/jenkins/common/install_rocm.sh
+++ b/docker/caffe2/jenkins/common/install_rocm.sh
@@ -19,31 +19,16 @@ install_ubuntu() {
 
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
                    rocm-dev \
-                   rocm-libs \
                    rocm-utils \
                    rocfft \
                    miopen-hip \
-                   miopengemm \
                    rocblas \
                    rocm-profiler \
                    cxlactivitylogger \
-                   rocsparse \
                    hipsparse \
                    rocrand \
                    hip-thrust \
                    rccl
-
-    # HIP has a bug that drops DEBUG symbols in generated MakeFiles.
-    # https://github.com/ROCm-Developer-Tools/HIP/pull/588
-    if [[ -f /opt/rocm/hip/cmake/FindHIP.cmake ]]; then
-        sudo sed -i 's/set(_hip_build_configuration "${CMAKE_BUILD_TYPE}")/string(TOUPPER _hip_build_configuration "${CMAKE_BUILD_TYPE}")/' /opt/rocm/hip/cmake/FindHIP.cmake
-    fi
-
-    # there is a case-sensitivity issue in the cmake files of some ROCm libraries. Fix this here until the fix is released
-    sed -i 's/find_dependency(hip)/find_dependency(HIP)/g' /opt/rocm/rocsparse/lib/cmake/rocsparse/rocsparse-config.cmake
-    sed -i 's/find_dependency(hip)/find_dependency(HIP)/g' /opt/rocm/rocfft/lib/cmake/rocfft/rocfft-config.cmake
-    sed -i 's/find_dependency(hip)/find_dependency(HIP)/g' /opt/rocm/miopen/lib/cmake/miopen/miopen-config.cmake
-    sed -i 's/find_dependency(hip)/find_dependency(HIP)/g' /opt/rocm/rocblas/lib/cmake/rocblas/rocblas-config.cmake
 }
 
 install_centos() {
@@ -65,15 +50,12 @@ install_centos() {
 
   yum install -y \
                    rocm-dev \
-                   rocm-libs \
                    rocm-utils \
                    rocfft \
                    miopen-hip \
-                   miopengemm \
                    rocblas \
                    rocm-profiler \
                    cxlactivitylogger \
-                   rocsparse \
                    hipsparse \
                    rocrand \
                    rccl \


### PR DESCRIPTION
Only check for cmake dependencies we directly depend on (e.g., hipsparse but not rocsparse)

Use cmake targets for ROCm where possible.

While there, update the docker CI build infrastructure to only pull in packages by name we directly depend on (anticipating the demise of, e.g., miopengemm). I do not anticipate a docker rebuild to be necessary at this stage as the changes are somewhat cosmetic.