### PR TITLE
Remove preprocessing of CFLAGS, CPPFLAGS, and LDFLAGS in Python scripts.

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -187,9 +187,6 @@ class CMake:
                 toolset_expr = ','.join(["{}={}".format(k, v) for k, v in toolset_dict.items()])
                 args.append('-T' + toolset_expr)
 
-        cflags = os.getenv('CFLAGS', "") + " " + os.getenv('CPPFLAGS', "")
-        ldflags = os.getenv('LDFLAGS', "")
-
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(
             os.path.abspath(__file__))))
         install_dir = os.path.join(base_dir, "torch")
@@ -259,10 +256,6 @@ class CMake:
         # Options starting with CMAKE_
         cmake__options = {
             'CMAKE_INSTALL_PREFIX': install_dir,
-            'CMAKE_C_FLAGS': cflags,
-            'CMAKE_CXX_FLAGS': cflags,
-            'CMAKE_EXE_LINKER_FLAGS': ldflags,
-            'CMAKE_SHARED_LINKER_FLAGS': ldflags,
         }
 
         # We set some CMAKE_* options in our Python build code instead of relying on the user's direct settings. Emit an


### PR DESCRIPTION
After #23455, there is no need of this preprocessing in Python scripts.
They will be automatically processed in CMake (plus CPPFLAGS here
probably meant to be CXXFLAGS).

Reference:

- https://cmake.org/cmake/help/v3.15/envvar/CFLAGS.html
- https://cmake.org/cmake/help/v3.15/envvar/CXXFLAGS.html
- https://cmake.org/cmake/help/v3.15/envvar/LDFLAGS.html