### PR TITLE
Tests for C++ Autograd API

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TORCH_API_TEST_DIR "${TORCH_ROOT}/test/cpp/api")
 set(TORCH_API_TEST_SOURCES
   ${TORCH_ROOT}/test/cpp/common/main.cpp
+  ${TORCH_API_TEST_DIR}/autograd.cpp
   ${TORCH_API_TEST_DIR}/any.cpp
   ${TORCH_API_TEST_DIR}/dataloader.cpp
   ${TORCH_API_TEST_DIR}/expanding-array.cpp

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+
+#include <torch/autograd.h>
+
+#include <torch/utils.h>
+#include <test/cpp/api/support.h>
+
+using namespace torch;
+
+#define ASSERT_VARIABLE_EQ(a,b) ASSERT_TRUE(torch::allclose((a),(b)))
+
+std::string graph_desc(std::shared_ptr<autograd::Node> node) {
+  if (!node) {
+    return "None";
+  }
+  auto result = node->name() + "(";
+  auto next_edges = node->next_edges();
+  for(auto& edge : next_edges) {
+    result += graph_desc(edge.function);
+  }
+  return result+")";
+}
+
+TEST(AutogradTest, CustomFunction) {
+  struct MyFunction : public torch::autograd::Function<MyFunction> {
+    static variable_list forward(AutogradContext *ctx, Variable var1, int mul, Variable var2) {
+      ctx->saved_data["mul"] = mul;
+      ctx->save_for_backward({var1, var2});
+      return {var1 + mul*var2 + var1*var2};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      int mul = ctx->saved_data["mul"].toInt();
+      auto saved = ctx->get_saved_variables();
+      auto var1 = saved[0];
+      auto var2 = saved[1];
+      variable_list output = {grad_output[0] + grad_output[0]*var2, Variable(), grad_output[0] * mul + grad_output[0] * var1};
+      return output;
+    }
+  };
+
+  Variable x = torch::randn({5,5}, torch::requires_grad());
+  Variable y = torch::randn({5,5}, torch::requires_grad());
+  auto res = MyFunction::apply(x,2,y)[0];
+  auto go = torch::ones({}, torch::requires_grad());
+  res.sum().backward(go, false, true);
+
+  ASSERT_VARIABLE_EQ(x.grad(), y + torch::ones({5,5}));
+  ASSERT_VARIABLE_EQ(y.grad(), x + torch::ones({5,5})*2);
+}
+
+TEST(AutogradTest, FunctionReturnsInput) {
+  struct MyFunction : public torch::autograd::Function<MyFunction> {
+    static variable_list forward(AutogradContext *ctx, Variable var1) {
+      return {var1};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      return {grad_output[0]*2};
+    }
+  };
+
+  Variable x(torch::ones(1, torch::requires_grad()));
+  MyFunction::apply(x)[0].backward(torch::ones(1) , true, true);
+  ASSERT_VARIABLE_EQ(x.grad(), torch::full(1,2));
+}
+
+TEST(AutogradTest, NoGradCustomFunction) {
+  // Custom Function should respect grad mode
+ struct MyOp : public torch::autograd::Function<MyOp> {
+   static variable_list forward(AutogradContext *ctx, Variable x) {
+     return {x+1};
+   }
+
+   static variable_list backward(AutogradContext *ctx, variable_list dy) {
+     return dy;
+   }
+ };
+
+ auto x = torch::ones({5,5}, torch::requires_grad());
+ {
+    at::NoGradGuard no_grad;
+    auto y = MyOp::apply(x)[0];
+    ASSERT_FALSE(y.requires_grad());
+ }
+}
+
+TEST(AutogradTest, MarkNonDifferentiable) {
+  struct MyFunction : public torch::autograd::Function<MyFunction> {
+    static variable_list forward(AutogradContext *ctx, Variable v) {
+      Variable output = v > 0;
+      ctx->mark_non_differentiable({output});
+      return {output};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      return { (grad_output[0]*0.0) };
+    }
+  };
+
+  auto x = torch::randn({5,5}, torch::requires_grad());
+  auto mask = MyFunction::apply(x)[0];
+  ASSERT_FALSE(mask.requires_grad());
+  auto y = x.masked_fill(mask, 0);
+  y.sum().backward();
+}
+
+TEST(AutogradTest, ReturnLeafInplace) {
+  struct Inplace : public torch::autograd::Function<Inplace> {
+    static variable_list forward(AutogradContext *ctx, Variable a, Variable b) {
+      ctx->mark_dirty({a});
+      return {a.add_(b), b+2};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      return {grad_output[0], grad_output[0] + grad_output[1]};
+    }
+  };
+
+  Variable x = torch::randn({5,5});
+  Variable y = torch::randn({5,5}, torch::requires_grad());
+
+  auto out = Inplace::apply(x,y);
+  auto &q = out[0];
+  ASSERT_TRUE(torch::equal(q, x));
+  ASSERT_TRUE(q.requires_grad());
+  q.sum().backward();
+  ASSERT_VARIABLE_EQ(y.grad(), torch::ones({5,5}));
+}

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -21,7 +21,7 @@ std::string graph_desc(std::shared_ptr<autograd::Node> node) {
   return result+")";
 }
 
-TEST(AutogradTest, CustomFunction) {
+TEST(CustomAutogradTest, CustomFunction) {
   struct MyFunction : public torch::autograd::Function<MyFunction> {
     static variable_list forward(AutogradContext *ctx, Variable var1, int mul, Variable var2) {
       ctx->saved_data["mul"] = mul;
@@ -49,7 +49,7 @@ TEST(AutogradTest, CustomFunction) {
   ASSERT_VARIABLE_EQ(y.grad(), x + torch::ones({5,5})*2);
 }
 
-TEST(AutogradTest, FunctionReturnsInput) {
+TEST(CustomAutogradTest, FunctionReturnsInput) {
   struct MyFunction : public torch::autograd::Function<MyFunction> {
     static variable_list forward(AutogradContext *ctx, Variable var1) {
       return {var1};
@@ -65,7 +65,7 @@ TEST(AutogradTest, FunctionReturnsInput) {
   ASSERT_VARIABLE_EQ(x.grad(), torch::full(1,2));
 }
 
-TEST(AutogradTest, NoGradCustomFunction) {
+TEST(CustomAutogradTest, NoGradCustomFunction) {
   // Custom Function should respect grad mode
  struct MyOp : public torch::autograd::Function<MyOp> {
    static variable_list forward(AutogradContext *ctx, Variable x) {
@@ -85,7 +85,7 @@ TEST(AutogradTest, NoGradCustomFunction) {
  }
 }
 
-TEST(AutogradTest, MarkNonDifferentiable) {
+TEST(CustomAutogradTest, MarkNonDifferentiable) {
   struct MyFunction : public torch::autograd::Function<MyFunction> {
     static variable_list forward(AutogradContext *ctx, Variable v) {
       Variable output = v > 0;
@@ -105,7 +105,7 @@ TEST(AutogradTest, MarkNonDifferentiable) {
   y.sum().backward();
 }
 
-TEST(AutogradTest, ReturnLeafInplace) {
+TEST(CustomAutogradTest, ReturnLeafInplace) {
   struct Inplace : public torch::autograd::Function<Inplace> {
     static variable_list forward(AutogradContext *ctx, Variable a, Variable b) {
       ctx->mark_dirty({a});

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -244,7 +244,7 @@ if (USE_NCCL)
 endif()
 
 # In the most recent CMake versions, a new 'TRANSFORM' subcommand of 'list' allows much of the boilerplate of defining the lists
-# of type stub files to be omitted. 
+# of type stub files to be omitted.
 # For comptability with older CMake versions, we omit it for now, but leave it as a comment in case comptability with the older
 # CMake versions is eventually dropped.
 # set(Modules

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -244,7 +244,7 @@ if (USE_NCCL)
 endif()
 
 # In the most recent CMake versions, a new 'TRANSFORM' subcommand of 'list' allows much of the boilerplate of defining the lists
-# of type stub files to be omitted.
+# of type stub files to be omitted. 
 # For comptability with older CMake versions, we omit it for now, but leave it as a comment in case comptability with the older
 # CMake versions is eventually dropped.
 # set(Modules

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -8,3 +8,4 @@
 #include <torch/serialize.h>
 #include <torch/types.h>
 #include <torch/utils.h>
+#include <torch/autograd.h>

--- a/torch/csrc/api/include/torch/autograd.h
+++ b/torch/csrc/api/include/torch/autograd.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <torch/csrc/autograd/custom_function.h>
+
+namespace torch {
+  using Variable = autograd::Variable;
+  using AutogradContext = autograd::AutogradContext;
+  using variable_list = autograd::variable_list;
+} //namespace torch


### PR DESCRIPTION
### All the PRs in this stack have been moved to #23572, abandoning this PR

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23533 Tests for C++ Autograd API**
* #23184 API for AutogradContext
* #23020 Support custom autograd functions in C++

Summary: Tests for the custom autograd function API based on test_autograd.py. Currently only the tests for the basic functionality have been added. More tests will be added later.