### PR TITLE
Cleanup interface of inlineCallTo.

### DIFF
--- a/torch/csrc/jit/autodiff.cpp
+++ b/torch/csrc/jit/autodiff.cpp
@@ -165,8 +165,8 @@ static c10::optional<std::vector<Value*>> build_script_grad(
   {
     WithInsertPoint guard(node->next());
     auto fw_graph = compiled_graphs->forward;
-    new_outputs = inlineCallTo(
-        *graph, *fw_graph, node->inputs(), /*unpack_outputs=*/true);
+    new_outputs = insertGraph(*graph, *fw_graph, node->inputs());
+    new_outputs = unpackOutputs(new_outputs);
     auto outputs = node->outputs();
     AT_ASSERT(new_outputs.size() == outputs.size() + 1);
     for (size_t i = 0; i < outputs.size(); ++i) {
@@ -184,8 +184,8 @@ static c10::optional<std::vector<Value*>> build_script_grad(
   auto it = grad_vec.begin();
   grad_vec.insert(it, new_outputs.back());
   ArrayRef<Value*> grad(grad_vec);
-  auto grad_inputs =
-      inlineCallTo(*graph, *bw_graph, grad, /*unpack_outputs=*/true);
+  auto grad_inputs = insertGraph(*graph, *bw_graph, grad);
+  grad_inputs = unpackOutputs(grad_inputs);
   return grad_inputs;
 };
 

--- a/torch/csrc/jit/graph_executor_impl.h
+++ b/torch/csrc/jit/graph_executor_impl.h
@@ -99,8 +99,7 @@ struct GraphExecutorImplBase {
       }
     }
     PropagateInputShapes(local_graph);
-    auto output_values =
-        inlineCallTo(*state->graph, *local_graph, input_values);
+    auto output_values = insertGraph(*state->graph, *local_graph, input_values);
 
     auto outputs = last(stack, num_outputs);
     for (size_t i = 0; i < outputs.size(); ++i) {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -1315,13 +1315,27 @@ struct TORCH_API PythonOp : public Node {
 TORCH_API void LintGraph(std::shared_ptr<Graph>& graph);
 
 TORCH_API at::ArrayRef<Value*> createTupleUnpack(Value* v);
-// unpack_outputs - if true, and the callee returns a single tuple value, then
-// insert a tuple unpack node
-//                  and return the resulting values
-TORCH_API std::vector<Value*> inlineCallTo(
+
+/** Insert graph \p CALLEE into graph \p G using \p INPUTS as input values.
+ *
+ * The insertion happens at the current insertion point.
+ */
+TORCH_API std::vector<Value*> insertGraph(
     Graph& g,
     Graph& callee,
-    ArrayRef<Value*> inputs,
-    bool unpack_outputs = false);
+    ArrayRef<Value*> inputs);
+
+/** Insert graph \p CALLEE after node \p TO_REPLACE, remove the node and
+ * replace all its uses with corresponding outputs of the inserted graph. The
+ * function asserts that the number of outputs of the original node and the
+ * graph are the same.
+ */
+TORCH_API std::vector<Value*> inlineCallTo(Node* to_replace, Graph& callee);
+
+/** If there is only one value in \p OUTPUTS and its kind is Tuple, insert a
+ * tuple unpack node and return the resulting values.
+ */
+TORCH_API std::vector<Value*> unpackOutputs(const std::vector<Value*>& outputs);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -107,11 +107,10 @@ bool DecomposeOps(Block* block, script::CompilationUnit& decompose_funcs) {
 
       decomposed = true;
       WithInsertPoint guard(*it);
-
       std::shared_ptr<Graph> d_graph =
           decompose_funcs.get_function("addmm").graph();
       Value* new_output =
-          inlineCallTo(*it->owningGraph(), *d_graph, it->inputs()).at(0);
+          insertGraph(*it->owningGraph(), *d_graph, it->inputs()).at(0);
       // Set the output of the decomposed graph to have the same output type as
       // the original op otherwise the canonicalized graph will have TensorType
       // as the output of this node which is incorrect
@@ -140,7 +139,7 @@ bool DecomposeOps(Block* block, script::CompilationUnit& decompose_funcs) {
       // inline the compiled decomposed batchnorm
       std::shared_ptr<Graph> d_graph =
           decompose_funcs.get_function("batch_norm").graph();
-      Value* new_output = inlineCallTo(*graph, *d_graph, inputs).at(0);
+      Value* new_output = insertGraph(*graph, *d_graph, inputs).at(0);
 
       // post processing the graph
       Value* weight = it->namedInput(attr::weight);
@@ -175,7 +174,7 @@ bool DecomposeOps(Block* block, script::CompilationUnit& decompose_funcs) {
       // inline the compiled decomposed layernorm
       std::shared_ptr<Graph> d_graph =
           decompose_funcs.get_function("layer_norm").graph();
-      Value* new_output = inlineCallTo(*graph, *d_graph, inputs).at(0);
+      Value* new_output = insertGraph(*graph, *d_graph, inputs).at(0);
 
       // post processing the graph
       Value* weight = it->namedInput(attr::weight);

--- a/torch/csrc/jit/passes/inline_fork_wait.cpp
+++ b/torch/csrc/jit/passes/inline_fork_wait.cpp
@@ -12,7 +12,7 @@ void InlineForkWait(
       auto graph = b->owningGraph();
       auto subgraph = n->g(attr::Subgraph);
 
-      auto output = inlineCallTo(*graph, *subgraph, n->inputs());
+      auto output = insertGraph(*graph, *subgraph, n->inputs());
 
       future_remap[n->output()] = output.at(0);
     } else if (n->kind() == aten::wait) {

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -9,31 +9,18 @@ namespace prim {
 using namespace ::c10::prim;
 }
 
-static void replace(
-    Node* to_replace,
-    const Function* fn,
-    at::ArrayRef<Value*> inputs) {
-  WithInsertPoint guard(to_replace);
-  auto new_output =
-      inlineCallTo(*to_replace->owningGraph(), *fn->graph(), inputs).at(0);
-  if (to_replace->output()->hasDebugName()) {
-    new_output->setDebugName(to_replace->output()->debugName());
-  }
-  to_replace->output()->replaceAllUsesWith(new_output);
-}
-
 void inlineCalls(Block* block) {
   for (auto it = block->nodes().begin(), end = block->nodes().end();
        it != end;) {
     Node* cur = *it++;
     switch (cur->kind()) {
       case prim::CallFunction: {
-        AT_ASSERT(cur->inputs().at(0)->node()->kind() == prim::Constant);
-        auto function_constant = cur->inputs().at(0)->node();
+        AT_ASSERT(cur->input(0)->node()->kind() == prim::Constant);
+        auto function_constant = cur->input(0)->node();
         auto fun_type =
             function_constant->output()->type()->expect<FunctionType>();
-        replace(cur, fun_type->function(), cur->inputs().slice(1));
-        cur->destroy();
+        cur->removeInput(0);
+        inlineCallTo(cur, *fun_type->function()->graph());
         if (!function_constant->hasUses()) {
           function_constant->destroy();
         }
@@ -41,9 +28,8 @@ void inlineCalls(Block* block) {
       case prim::CallMethod: {
         const std::string& name = cur->s(attr::name);
         auto function =
-            cur->inputs().at(0)->type()->expect<ClassType>()->getMethod(name);
-        replace(cur, function, cur->inputs());
-        cur->destroy();
+            cur->input(0)->type()->expect<ClassType>()->getMethod(name);
+        inlineCallTo(cur, *function->graph());
       } break;
       default: {
         for (auto b : cur->blocks()) {

--- a/torch/csrc/jit/passes/subgraph_rewrite.cpp
+++ b/torch/csrc/jit/passes/subgraph_rewrite.cpp
@@ -81,7 +81,7 @@ void SubgraphRewriter::rewriteSinglePatternOnGraph(
     // new ones.
     WithInsertPoint insert_point(match.anchor);
     std::vector<Value*> new_outputs =
-        inlineCallTo(*graph, replacement_graph, inputs);
+        insertGraph(*graph, replacement_graph, inputs);
 
     // Record all planned rewritings
     AT_ASSERT(outputs.size() == new_outputs.size());

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -38,7 +38,7 @@ void unmergeSubgraph(Node* subgraphNode) {
   // Inline the graph, replace uses of node outputs and destroy the node
   auto outerGraph = subgraphNode->owningGraph();
   WithInsertPoint guard(subgraphNode);
-  const auto subgraphOutputs = inlineCallTo(
+  const auto subgraphOutputs = insertGraph(
       *outerGraph, *getSubgraph(subgraphNode), subgraphNode->inputs());
   AT_ASSERT(subgraphOutputs.size() >= subgraphNode->outputs().size());
   for (size_t i = 0; i < subgraphNode->outputs().size(); ++i) {

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -530,7 +530,7 @@ Value* emitBuiltinCall(
               allow_conversions)) {
         // we inline builtin calls because they are normally very small
         // wrappers and are not useful for keeping around to debug
-        return inlineCallTo(graph, *method->graph(), result->inputs).at(0);
+        return insertGraph(graph, *method->graph(), result->inputs).at(0);
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23539 Cleanup interface of inlineCallTo.**

The concrete changes are:
- Split `unpackOutputs` to a separate function, thus removing an extra
parameter of inlineCallTo (which was rarely used).
- Split `insertGraph` from `inlineCallTo`. The first one just inserts
the graph to wherever the current insert point, the second replaces a
specific node: the node is used as the insertion point, its outputs
are replaced with the new ones, and the node itself is then removed.

Differential Revision: [D16555365](https://our.internmc.facebook.com/intern/diff/D16555365)