### PR TITLE
[quant][ez] Change condition in swap module

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -273,7 +273,7 @@ def swap_module(mod, mapping):
         The corresponding quantized module of `mod`
     """
     new_mod = mod
-    if hasattr(mod, 'observer'):
+    if hasattr(mod, 'qconfig') and mod.qconfig is not None:
         if type(mod) in mapping:
             new_mod = mapping[type(mod)].from_float(mod)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23561 [quant][ez] Change condition in swap module**

Summary:
Right now we use `observer` to indicate whether user want quantization or not,
this constrains us to always insert observer even if that is not needed. This
pr changes to check for qconfig instead.

Test Plan:
python test/test_quantization.py

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D16570928](https://our.internmc.facebook.com/intern/diff/D16570928)