### PR TITLE
[JIT] Make typing understand exceptions

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11452,20 +11452,39 @@ a")
         with self.assertRaisesRegex(RuntimeError, "expected value of type Tensor"):
             foo_except_used()
 
+        @torch.jit.script
+        def foo_no_decl_always_throws():
+            raise "Hi"
+
+        # function that has no declared type but always throws set to None
+        output_type = next(foo_no_decl_always_throws.graph.outputs()).type()
+        self.assertTrue(str(output_type) == "None")
+
+        @torch.jit.script
+        def foo_decl_always_throws():
+            # type: () -> Tensor
+            raise Exception("Hi")
+
+        output_type = next(foo_decl_always_throws.graph.outputs()).type()
+        self.assertTrue(str(output_type) == "Tensor")
+
         # We don't validate the expr following raise
         @torch.jit.script
         def foo():
             raise 3 + 4
 
-        # no control flow analysis yet
-        with self.assertRaisesRegex(RuntimeError, "a is not defined in the false"):
-            @torch.jit.script
-            def foo():
+        # a escapes scope
+        @torch.jit.script
+        def foo():
+            if True:
+                a = 1
+            else:
                 if True:
-                    a = 1
+                    raise Exception("Hi")
                 else:
                     raise Exception("Hi")
-                return a
+            return a
+        self.assertEqual(foo(), 1)
 
     def test_assertions(self):
         cu = torch.jit.CompilationUnit('''
@@ -12445,6 +12464,111 @@ a")
                 return x
         self.assertEqual(test(None), 1)
         self.assertEqual(test(2), 2)
+
+    def test_excpetions_with_control_flow(self):
+        def test_num_ifs(func, num_ifs):
+            g = torch.jit.script(func).graph
+            FileCheck().check_count("prim::If", num_ifs, exactly=True).run(g)
+
+        def no_guard_ifs_added(x):
+            # type: (int) -> int
+            if x == 1:
+                return 1
+            else:
+                if x == 2:
+                    raise RuntimeError("hi")
+                else:
+                    raise RuntimeError("hi")
+
+        self.checkScript(no_guard_ifs_added, (1,))
+        self.checkScriptRaisesRegex(no_guard_ifs_added, (2,), Exception, "")
+        test_num_ifs(no_guard_ifs_added, 2)
+
+        def no_ifs_added(x):
+            # type: (int) -> int
+            if x < 0:
+                raise RunTimeError("hi")
+            return x
+
+        self.checkScript(no_ifs_added, (1,))
+        self.checkScriptRaisesRegex(no_ifs_added, (-2,), Exception, "")
+        test_num_ifs(no_ifs_added, 1)
+
+        def test_if_might(x):
+            # type: (int)
+            if x > 0:
+                if x == 1:
+                    return 1
+                else:
+                    a = 2
+            else:
+                raise RunTimeError("hi")
+            return a + 2
+
+        self.checkScript(test_if_might, (1,))
+        self.checkScript(test_if_might, (3,))
+        self.checkScriptRaisesRegex(no_ifs_added, (-2,), Exception, "")
+        test_num_ifs(test_if_might, 3)  # one if added to guard a + 2
+
+        def test_loop_no_escape(x):
+            # type: (int)
+            if x >= 0:
+                for i in range(x):
+                    raise RunTimeError("hi")
+            else:
+                return 5
+            return x + 3
+
+        self.checkScript(test_loop_no_escape, (0,))
+        self.checkScript(test_loop_no_escape, (-1,))
+        self.checkScriptRaisesRegex(test_loop_no_escape, (1,), Exception, "")
+
+        # one if added to guard x + 3, the throw in loop does not escape
+        test_num_ifs(test_loop_no_escape, 2)
+
+        def test_loop_exception_with_continue(x):
+            # type: (int)
+            i = 0
+            for i in range(5):
+                if i == x:
+                    raise RunTimeError("hi")
+                else:
+                    continue
+                print(i)
+            return i + 5
+
+        self.checkScript(test_loop_exception_with_continue, (-1,))
+        self.checkScriptRaisesRegex(test_loop_exception_with_continue, (1,), Exception, "")
+        test_num_ifs(test_loop_exception_with_continue, 1)  # no ifs added to guard print
+
+
+    def test_exception_exits_closure(self):
+        code = dedent('''
+            def no_return_func(self):
+                # type: (Tensor) -> Tensor
+                output = torch.tanh(self)
+                def backward(grad_output):
+                    raise "Hi"
+        ''')
+        with self.assertRaisesRegex(RuntimeError, "does not return along all"):
+            cu = torch.jit.CompilationUnit(code)
+
+        code = dedent('''
+            def test_exit_pair_reset(x):
+                # type: (int) -> int
+                if x > 0:
+                    a = 0
+                    def backward(grad_output):
+                        raise "Hi"
+                else:
+                    return x
+                return a + 1
+        ''')
+        func = torch.jit.CompilationUnit(code).test_exit_pair_reset
+        self.assertEqual(func(1,), 1)
+        self.assertEqual(func(-1,), -1)
+        FileCheck().check_count("prim::If", 2, exactly=True).check("aten::add")\
+            .run(func.graph)  # if added to guard a + 1
 
     def test_non_final_return(self):
         def simple(x):

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1490,13 +1490,6 @@ struct to_ir {
   // raise a
   //
   // We ignore the expression following raise
-  //
-  // NYI: add exception logic to control-flow nodes
-  // if True:
-  //   a = 1
-  // else
-  //   raise Exception("Hi")
-  // print(a)
   void emitRaise(const SourceRange& loc) {
     const std::string exception = "Exception";
     auto string_input = insertConstant(*graph, exception, nullptr, loc);

--- a/torch/csrc/jit/script/exit_transforms.cpp
+++ b/torch/csrc/jit/script/exit_transforms.cpp
@@ -8,6 +8,12 @@
 namespace torch {
 namespace jit {
 
+// WILL states that a node/block must hit the exit, MIGHT that it may happen,
+// WONT that it will not happen. THROWS states that a node/block always throws,
+// and allows us to create better graphs by not conditionalizing execution
+// when it is not necessary. It is an optimization; replacing it with WONT
+// would preserve graph semantics.
+
 enum class ExitStatus { WILL, MIGHT, WONT, THROWS };
 
 enum class Transform { Returns, LoopContinuations };
@@ -163,7 +169,8 @@ struct ExitTransformer {
     Block* body = loop.bodyBlock();
     auto exit_pair = transformExits(body);
     // if we're not exiting to outside the loop we don't need to do any work.
-    // since we may not enter the loop return WONT for the THROWS case
+    // since we may not enter the loop return WONT for the THROWS case.
+
     if (getExitStatus(exit_pair) == ExitStatus::WONT ||
         getExitStatus(exit_pair) == ExitStatus::THROWS) {
       return constructWontExitPair();

--- a/torch/csrc/jit/script/exit_transforms.cpp
+++ b/torch/csrc/jit/script/exit_transforms.cpp
@@ -8,32 +8,16 @@
 namespace torch {
 namespace jit {
 
-namespace {
-
-void registerBlockOutputs(Block* b, at::ArrayRef<Value*> outs) {
-  for (Value* out : outs) {
-    b->registerOutput(out);
-  }
-}
-
-Symbol owningNodeKind(Block* block) {
-  if (block->owningNode()) {
-    return block->owningNode()->kind();
-  }
-  return Symbol();
-}
-
-} // namespace
-
-enum class ExitStatus { WILL, MIGHT, WONT };
+enum class ExitStatus { WILL, MIGHT, WONT, THROWS };
 
 enum class Transform { Returns, LoopContinuations };
 
 // hasExited() indicates whether or not an exit has been hit.
 // The ExitTransform pass maintains a false boolean false_val_ && a true boolean
-// true_val_.
-// if hasExited() == true_val_ then we have exited, if == false_val_ we have
-// not. Otherwise, we might have exited.
+// true_val_, and an uninitialized boolean throws_val_.
+// if hasExited() == true_val_ then we have exited, if hasExited() == false_val_
+// we have not, hasExited() == throws_val_ we have hit a block that throws.
+// Otherwise, we might have exited.
 // exitValues() are the values that we are propagating to a destination block.
 // this is used for block outputs of loops and outputs of functions & closures
 struct ExitPair : public std::pair<Value*, std::vector<Value*>> {
@@ -70,48 +54,61 @@ struct ExitPair : public std::pair<Value*, std::vector<Value*>> {
  * For blocks and control flow nodes that have an exit statement that may
  * have been hit, we conditionalize all execution on a boolean value that
  * indicates whether we have hit the exit, hasExited().
+ *
+ * The pass keeps tracks of blocks that always throw, so that we can construct
+ * simpler graphs. For example, if in one block of an if statement we return
+ * and in the other we throw, we can treat the node as always returning instead
+ * of conditionalizing execution in the remainder of the block.
  */
 struct ExitTransformer {
   ExitTransformer(std::shared_ptr<Graph> graph) : graph_(std::move(graph)) {
     WithInsertPoint guard(graph_->block()->nodes().front());
     true_val_ = graph_->insertConstant(true);
     false_val_ = graph_->insertConstant(false);
+    // this value will never be used, since we will always throw before it is
+    // accessed
+    throws_val_ = getUnitValue(BoolType::get());
   };
 
   void transformReturnStmts() {
     current_exit_kind_ = prim::ReturnStmt;
-    convertReturnOutputsToReturnStmts(graph_->block());
     transformExits(graph_->block());
   }
 
   void transformLoopContinuations() {
     current_exit_kind_ = prim::LoopContinuation;
-    convertLoopOutputsToContinuations(graph_->block());
     transformExits(graph_->block());
   }
 
  private:
-  // The Logic for the exit transform simplifies if the block outputs
-  // are converted to Exits before running. Now the exit status for all
-  // targeted blocks must be will exit.
-  static void convertBlockOutputsToNode(Block* block, Symbol kind) {
-    auto ret_node = block->return_node();
-    auto node = block->owningGraph()->create(kind, 0)->insertBefore(ret_node);
-    for (auto inp : ret_node->inputs()) {
-      node->addInput(inp);
-    }
-    removeOutputs(block);
+  ExitPair constructThrowsExitPair() {
+    return ExitPair(throws_val_, std::vector<Value*>({}));
+  }
+  ExitPair constructWontExitPair() {
+    return ExitPair(false_val_, std::vector<Value*>({}));
+  }
+  ExitPair constructWillExitPair(at::ArrayRef<Value*> exit_val_ref) {
+    return ExitPair(true_val_, exit_val_ref);
   }
 
-  static void convertLoopOutputsToContinuations(Block* block) {
-    for (Node* n : block->nodes()) {
-      for (Block* b : n->blocks()) {
-        convertLoopOutputsToContinuations(b);
-      }
+  ExitStatus getExitStatus(ExitPair& exit_pair) {
+    Value* exit_v = exit_pair.hasExited();
+    if (exit_v == true_val_) {
+      return ExitStatus::WILL;
+    } else if (exit_v == false_val_) {
+      return ExitStatus::WONT;
+    } else if (exit_v == throws_val_) {
+      return ExitStatus::THROWS;
+    } else {
+      return ExitStatus::MIGHT;
     }
-    if (owningNodeKind(block) == prim::Loop) {
-      convertBlockOutputsToNode(block, prim::LoopContinuation);
+  }
+
+  static Symbol owningNodeKind(Block* block) {
+    if (block->owningNode()) {
+      return block->owningNode()->kind();
     }
+    return Symbol();
   }
 
   static bool isGraphOrClosureBlock(Block* block) {
@@ -119,20 +116,15 @@ struct ExitTransformer {
         owningNodeKind(block) == prim::Function;
   }
 
-  static void convertReturnOutputsToReturnStmts(Block* block) {
-    for (Node* n : block->nodes()) {
-      for (Block* b : n->blocks()) {
-        convertReturnOutputsToReturnStmts(b);
-      }
-    }
-    if (isGraphOrClosureBlock(block)) {
-      convertBlockOutputsToNode(block, prim::ReturnStmt);
-    }
-  }
-
   static void removeOutputs(Block* b) {
     while (b->outputs().size() > 0) {
       b->eraseOutput(0);
+    }
+  }
+
+  static void registerBlockOutputs(Block* b, at::ArrayRef<Value*> outs) {
+    for (Value* out : outs) {
+      b->registerOutput(out);
     }
   }
 
@@ -166,8 +158,10 @@ struct ExitTransformer {
     Block* body = loop.bodyBlock();
     auto exit_pair = transformExits(body);
     // if we're not exiting to outside the loop we don't need to do any work.
-    if (getExitStatus(exit_pair) == ExitStatus::WONT) {
-      return exit_pair;
+    // since we may not enter the loop return WONT for the THROWS case
+    if (getExitStatus(exit_pair) == ExitStatus::WONT ||
+        getExitStatus(exit_pair) == ExitStatus::THROWS) {
+      return constructWontExitPair();
     }
 
     // if we are, we need to update the loop continue condition so that
@@ -229,6 +223,25 @@ struct ExitTransformer {
     return ExitPair(new_has_exited, exit_vals);
   }
 
+  ExitStatus calcIfExitStatus(ExitStatus then_status, ExitStatus else_status) {
+    // if one branch throws, we can take the status of the other
+    if (then_status == ExitStatus::THROWS) {
+      return else_status;
+    } else if (else_status == ExitStatus::THROWS) {
+      return then_status;
+    }
+
+    if (then_status == ExitStatus::WONT && else_status == ExitStatus::WONT) {
+      return ExitStatus::WONT;
+    }
+
+    if (then_status == ExitStatus::WILL && else_status == ExitStatus::WILL) {
+      return ExitStatus::WILL;
+    }
+
+    return ExitStatus::MIGHT;
+  }
+
   // Recursively transforms the if node
   ExitPair transformIf(Node* node) {
     auto then_block = node->blocks().at(0);
@@ -239,25 +252,31 @@ struct ExitTransformer {
     auto then_status = getExitStatus(then_pair);
     auto else_status = getExitStatus(else_pair);
 
-    if (then_status == ExitStatus::WONT && else_status == ExitStatus::WONT) {
-      return ExitPair(false_val_, std::vector<Value*>({}));
+    auto if_status = calcIfExitStatus(then_status, else_status);
+
+    if (if_status == ExitStatus::THROWS) {
+      return constructThrowsExitPair();
+    }
+    if (if_status == ExitStatus::WONT) {
+      return constructWontExitPair();
     }
 
     // for the block that is not exitting, its' exit values will not get
     // used so we create uninitialized values of the same type as the other
-    // block
-    if (then_status == ExitStatus::WONT) {
+    // block.
+    if (then_status == ExitStatus::WONT || then_status == ExitStatus::THROWS) {
       std::vector<Value*> exit_vals =
           matchValuesWithUnitialized(else_pair.exitValues());
-      then_pair = ExitPair(false_val_, exit_vals);
-    } else if (else_status == ExitStatus::WONT) {
+      then_pair = ExitPair(then_pair.hasExited(), exit_vals);
+    } else if (
+        else_status == ExitStatus::WONT || else_status == ExitStatus::THROWS) {
       std::vector<Value*> exit_vals =
           matchValuesWithUnitialized(then_pair.exitValues());
-      else_pair = ExitPair(false_val_, exit_vals);
+      else_pair = ExitPair(else_pair.hasExited(), exit_vals);
     }
 
     Value* has_exited;
-    if (then_status == ExitStatus::WILL && else_status == ExitStatus::WILL) {
+    if (if_status == ExitStatus::WILL) {
       // Need to maintain the invariant that if hasExited() == true_val_
       // then we have exited.
       has_exited = true_val_;
@@ -270,17 +289,6 @@ struct ExitTransformer {
     auto exit_vals =
         node->outputs().slice(node->outputs().size() - num_exit_vals);
     return ExitPair(has_exited, exit_vals);
-  }
-
-  ExitStatus getExitStatus(ExitPair& exit_pair) {
-    Value* exit_v = exit_pair.hasExited();
-    if (exit_v == true_val_) {
-      return ExitStatus::WILL;
-    } else if (exit_v == false_val_) {
-      return ExitStatus::WONT;
-    } else {
-      return ExitStatus::MIGHT;
-    }
   }
 
   // Guards the remaining nodes in the block with an if node that takes
@@ -376,15 +384,18 @@ struct ExitTransformer {
   ExitPair transformExits(Block* block) {
     Block* prev_target_block = target_block_;
     updateTargetBlock(block);
-    ExitPair exit_pair = ExitPair(false_val_, std::vector<Value*>({}));
+    ExitPair exit_pair = constructWontExitPair();
     for (auto it = block->nodes().begin(); it != block->nodes().end();) {
       Node* node = *it;
       it++;
       switch (node->kind()) {
+        case prim::RaiseException: {
+          exit_pair = constructThrowsExitPair();
+        } break;
         case prim::ReturnStmt:
         case prim::LoopContinuation: {
           if (node->kind() == current_exit_kind_) {
-            exit_pair = ExitPair(true_val_, node->inputs());
+            exit_pair = constructWillExitPair(node->inputs());
             node->destroy();
           }
         } break;
@@ -403,7 +414,7 @@ struct ExitTransformer {
       // all subsequent nodes in the block. if we've hit a node that will exit
       // we can remove all subsequent nodes.
       ExitStatus status = getExitStatus(exit_pair);
-      if (status == ExitStatus::WILL) {
+      if (status == ExitStatus::WILL || status == ExitStatus::THROWS) {
         deleteAfterExitNodes(block, it);
         break;
       }
@@ -419,12 +430,25 @@ struct ExitTransformer {
     // exit values. since the exit does not extend outside this block,
     // update returned exit to false. then, reset the target_block to whatever
     // it was previously
-    // this will occur with a Loop block when transforming LoopContinuations
-    // and a Graph/Closure block when transforming ReturnStmts.
     if (target_block_ == block) {
-      TORCH_INTERNAL_ASSERT(getExitStatus(exit_pair) == ExitStatus::WILL);
-      registerBlockOutputs(block, exit_pair.exitValues());
-      exit_pair = ExitPair(false_val_, std::vector<Value*>({}));
+      if (getExitStatus(exit_pair) == ExitStatus::MIGHT) {
+        auto new_if =
+            graph_->create(prim::If, 0)->insertBefore(block->return_node());
+        new_if->addBlock();
+        new_if->addBlock();
+        new_if->addInput(exit_pair.hasExited());
+        addIfOutputs(new_if, exit_pair.exitValues(), block->outputs());
+        exit_pair = constructWillExitPair(new_if->outputs());
+      }
+
+      if (getExitStatus(exit_pair) == ExitStatus::WILL) {
+        removeOutputs(block);
+        registerBlockOutputs(block, exit_pair.exitValues());
+      }
+
+      // reset the exiting status so that e.g. an exception from a closure block
+      // wont propagate to the enclosing function
+      exit_pair = constructWontExitPair();
     }
     target_block_ = prev_target_block;
     return exit_pair;
@@ -449,6 +473,7 @@ struct ExitTransformer {
   Symbol current_exit_kind_;
   Value* true_val_;
   Value* false_val_;
+  Value* throws_val_;
 
   // when we see current_exit_kind_, this is the block that the values are
   // exiting to. For example when we are transforming LoopContinuations
@@ -475,9 +500,6 @@ struct ExitTransformer {
 // and does not exit in the other, we use a boolean value to indicate if the
 // exit has been hit or not. Then, we conditionalize further execution.
 //
-// The logic for the pass simplifies removing Loop Block Outputs and replacing
-// them with LoopContinuations. We run that pass first, then we remove
-// LoopContinuations
 // Python example:
 // while i < 5:
 //   if i == 3:


### PR DESCRIPTION
When we're emitting an if node, if one branch exits allow variables in the other branch to escape scope. This is using the same machinery that already exists for early returns so there are minimal changes to the compiler. Most of the changes are in the exit_transform pass so we don't create terrible graphs when exceptions exist. In a follow up PR i will add a writeup of the transform pass to docs since this should be the last change made to it for a while.

This will allow assertions to refine Optional types, as well as allow JIT to understand things like: 
```
def foo(x):
    if x == 1:
        raise Exception()
    else:
        a = 1
    return a
```

If you look in nn/functional.py, like 3/4 of the TODOs are this issue. One note is that if a function always throws, I accepted whatever the annotation for the return type is if it exists and otherwise set it to None. This is consistent with what mypy does. 




   