### PR TITLE
Expose the quantized inputs and output of dynamic quantized int8 FC operator for debugging

### DIFF
--- a/caffe2/operators/quantized/int8_fc_op.cc
+++ b/caffe2/operators/quantized/int8_fc_op.cc
@@ -11,7 +11,7 @@ REGISTER_CPU_OPERATOR(Int8FC, int8::Int8FCOp);
 using namespace std::placeholders;
 OPERATOR_SCHEMA(Int8FC)
     .NumInputs(3)
-    .NumOutputs(1)
+    .NumOutputs(1, 4)
     .TensorInferenceFunction(std::bind(FCShapeInference, _1, _2, false))
     .CostInferenceFunction(std::bind(CostInferenceForFC, _1, _2, false))
     .SetDoc(R"DOC(


### PR DESCRIPTION
Summary:
Currently if we use dynamic quantization we don't have the access to the internally quantized inputs and output for debugging.

To make the debugging easier, this diff expose the quantized X, W and Y for debugging if debug outputs are attached to the operator and caffe2_dnnlowp_force_slow_path flag is set.

The quantized inputs and output are exposed as the extra outputs.

The example Int8FC op with debug outputs appended looks like:
```
op {
  input: "X"
  input: "W"
  input: "b"
  output: "Y"
  output: "X_q"
  output: "W_q"
  output: "Y_q"
  name: ""
  type: "Int8FC"
  arg {
    name: "axis"
    i: 1
  }
  ...
}
```

Next need to expose the quantization parameters.

Differential Revision: D16566753

