### PR TITLE
Hotpatch CXXFLAGS to be the same as CFLAGS if CXXFLAGS is not set.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@
 #   CFLAGS
 #     flags to apply to both C and C++ files to be compiled (a quirk of setup.py
 #     which we have faithfully adhered to in our build system is that CFLAGS
-#     also applies to C++ files, in contrast to the default behavior of autogoo
-#     and cmake build systems.)
+#     also applies to C++ files (unless CXXFLAGS is set), in contrast to the
+#     default behavior of autogoo and cmake build systems.)
 #
 #   CC
 #     the C/C++ compiler to use (NB: the CXX flag has no effect for distutils

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -187,9 +187,6 @@ class CMake:
                 toolset_expr = ','.join(["{}={}".format(k, v) for k, v in toolset_dict.items()])
                 args.append('-T' + toolset_expr)
 
-        cflags = os.getenv('CFLAGS', "") + " " + os.getenv('CPPFLAGS', "")
-        ldflags = os.getenv('LDFLAGS', "")
-
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(
             os.path.abspath(__file__))))
         install_dir = os.path.join(base_dir, "torch")
@@ -259,10 +256,6 @@ class CMake:
         # Options starting with CMAKE_
         cmake__options = {
             'CMAKE_INSTALL_PREFIX': install_dir,
-            'CMAKE_C_FLAGS': cflags,
-            'CMAKE_CXX_FLAGS': cflags,
-            'CMAKE_EXE_LINKER_FLAGS': ldflags,
-            'CMAKE_SHARED_LINKER_FLAGS': ldflags,
         }
 
         # We set some CMAKE_* options in our Python build code instead of relying on the user's direct settings. Emit an

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -67,6 +67,10 @@ def hotpatch_build_env_vars():
 
 hotpatch_build_env_vars()
 
+# We promised that CXXFLAGS should also be affected by CFLAGS
+if 'CFLAGS' in os.environ and 'CXXFLAGS' not in os.environ:
+    os.environ['CXXFLAGS'] = os.environ['CFLAGS']
+
 
 class BuildType(object):
     """Checks build type. The build type will be given in :attr:`cmake_build_type_env`. If :attr:`cmake_build_type_env`


### PR DESCRIPTION
This fixes build regression caused by #23528 because we used to let CXXFLAGS equal CFLAGS.

cc @suo