### PR TITLE
python udf over rpc

### DIFF
--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python3
+
 import sys
+import unittest
 
 import torch
 import torch.distributed as dist
@@ -6,11 +9,33 @@ import torch.distributed as dist
 from common_distributed import MultiProcessTestCase
 from common_utils import load_tests, run_tests
 
+# it is used to test python user defined function over rpc
+def my_function(a, b, c):
+    return a + b + c
+
+# it is used to test python user defined function over rpc
+def no_result():
+    print("do nothing")
+
+# it is used to test python user defined class and methods over rpc
+class my_class:
+    def __init__(self, a):
+        self.a = a
+
+    def my_instance_method(self, b):
+        return self.a + b
+
+    @classmethod
+    def my_class_method(cls, d, e):
+        return d + e
+
+    @staticmethod
+    def my_static_method(f):
+        return f > 10
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
-
 
 if not dist.is_available():
     print('c10d not available, skipping tests')
@@ -22,13 +47,14 @@ def _wrap_with_rpc(func):
         store = dist.FileStore(self.file.name, self.world_size)
         dist.init_process_group(backend='gloo', rank=self.rank,
                                 world_size=self.world_size, store=store)
-        dist.init_rpc('worker%d' % self.rank)
+        dist.init_rpc('worker{}'.format(self.rank))
         func(self)
         dist.join_rpc()
 
     return wrapper
 
-
+@unittest.skipIf(sys.version_info < (3, 0), "Pytorch distributed rpc package "
+                 "does not support python2")
 class RpcTest(MultiProcessTestCase):
 
     @property
@@ -39,7 +65,7 @@ class RpcTest(MultiProcessTestCase):
     def test_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, torch.add,
+        ret = dist.rpc('worker{}'.format(dstRank), torch.add,
                        args=(torch.ones(n, n), torch.ones(n, n)))
         self.assertEqual(ret, torch.ones(n, n) * 2)
 
@@ -47,7 +73,7 @@ class RpcTest(MultiProcessTestCase):
     def test_scalar_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, torch.add,
+        ret = dist.rpc('worker{}'.format(dstRank), torch.add,
                        args=(torch.ones(n, n), n))
         self.assertEqual(ret, (torch.ones(n, n) + n))
 
@@ -55,7 +81,7 @@ class RpcTest(MultiProcessTestCase):
     def test_async_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        fut = dist.rpc('worker%d' % dstRank,
+        fut = dist.rpc('worker{}'.format(dstRank),
                        torch.add,
                        args=(torch.ones(n, n), torch.ones(n, n)),
                        async_call=True)
@@ -67,7 +93,7 @@ class RpcTest(MultiProcessTestCase):
         dstRank = n % self.world_size
         x = torch.ones(self.world_size, self.world_size)
         x[self.rank][self.rank] = 0
-        ret = dist.rpc('worker%d' % dstRank, torch.nonzero, args=(x,))
+        ret = dist.rpc('worker{}'.format(dstRank), torch.nonzero, args=(x,))
         self.assertEqual(ret, x.nonzero())
 
     @_wrap_with_rpc
@@ -75,7 +101,7 @@ class RpcTest(MultiProcessTestCase):
         dstRank = (self.rank + 1) % self.world_size
         for i in range(20):
             n = i + self.rank + 1
-            ret = dist.rpc('worker%d' % dstRank, torch.add,
+            ret = dist.rpc('worker{}'.format(dstRank), torch.add,
                            args=(torch.ones(n, n), torch.ones(n, n)))
             self.assertEqual(ret, torch.ones(n, n) * 2)
 
@@ -85,10 +111,10 @@ class RpcTest(MultiProcessTestCase):
         for i in range(20):
             dist.sync_rpc()
             n = i + self.rank + 1
-            ret1 = dist.rpc('worker%d' % dstRank, torch.add,
+            ret1 = dist.rpc('worker{}'.format(dstRank), torch.add,
                             args=(torch.ones(n, n), torch.ones(n, n)))
             dist.sync_rpc()
-            ret2 = dist.rpc('worker%d' % dstRank, torch.add,
+            ret2 = dist.rpc('worker{}'.format(dstRank), torch.add,
                             args=(torch.ones(n, n), 2))
             dist.sync_rpc()
             self.assertEqual(ret1, torch.ones(n, n) * 2)
@@ -98,17 +124,86 @@ class RpcTest(MultiProcessTestCase):
     def test_join_rpc(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, torch.add,
+        ret = dist.rpc('worker{}'.format(dstRank), torch.add,
                        args=(torch.ones(n, n), torch.ones(n, n)))
         self.assertEqual(ret, torch.ones(n, n) * 2)
         dist.join_rpc()
 
         with self.assertRaisesRegex(RuntimeError, "^RPC has not been initialized"):
-            dist.rpc('worker%d' % dstRank, torch.add,
+            dist.rpc('worker{}'.format(dstRank), torch.add,
                      args=(torch.ones(n, n), torch.ones(n, n)))
 
         # it's safe to call join_rpc() multiple times
         dist.join_rpc()
+
+    @_wrap_with_rpc
+    def test_py_built_in(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), min, args=(n, n + 1, n + 2))
+        self.assertEqual(ret, min(n, n + 1, n + 2))
+
+    @_wrap_with_rpc
+    def test_py_user_defined(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), my_function, kwargs={"a" : n, "b" : n + 1, "c" : n + 2})
+        self.assertEqual(ret, my_function(n, n + 1, n + 2))
+
+    @_wrap_with_rpc
+    def test_py_class_constructor(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), my_class, args=(n,))
+        self.assertEqual(ret.a, n)
+
+    @_wrap_with_rpc
+    def test_py_class_instance_method(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), my_class(2).my_instance_method, args=(n,))
+        self.assertEqual(ret, my_class(2).my_instance_method(n))
+
+    @_wrap_with_rpc
+    def test_py_class_method(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), my_class.my_class_method, args=(n, n + 1))
+        self.assertEqual(ret, my_class.my_class_method(n, n + 1))
+
+    @_wrap_with_rpc
+    def test_py_class_static_method(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), my_class.my_static_method, args=(n + 10,))
+        self.assertEqual(ret, my_class.my_static_method(n + 10))
+
+    @_wrap_with_rpc
+    def test_py_multi_async_call(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        fut1 = dist.rpc('worker{}'.format(dstRank), my_class.my_static_method, args=(n + 10,), async_call=True)
+        fut2 = dist.rpc('worker{}'.format(dstRank), min, args=(n, n + 1, n + 2), async_call=True)
+        self.assertEqual(fut1.wait(), my_class.my_static_method(n + 10))
+        self.assertEqual(fut2.wait(), min(n, n + 1, n + 2))
+
+    @_wrap_with_rpc
+    def test_py_no_return_result(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), no_result)
+        self.assertEqual(ret, no_result())
+
+    @_wrap_with_rpc
+    def test_py_function_exception(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker{}'.format(dstRank), no_result, args=(10,))
+        try:
+            no_result(10)
+        except Exception as e:
+            expected = "run_python_udf_internal caught exception: " + str(e)
+        self.assertEqual(ret, expected)
 
 if __name__ == '__main__':
     run_tests()

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -239,6 +239,7 @@ def add_torch_libs():
         "torch/csrc/distributed/rpc/ProcessGroupAgent.cpp",
         "torch/csrc/distributed/rpc/functions.cpp",
         "torch/csrc/distributed/rpc/python_functions.cpp",
+        "torch/csrc/distributed/rpc/PythonRpcHandler.cpp",
         "torch/csrc/jit/init.cpp",
         "torch/csrc/jit/passes/inline_fork_wait.cpp",
         "torch/csrc/jit/passes/onnx.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -230,6 +230,7 @@ if (USE_DISTRIBUTED)
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/ProcessGroupAgent.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/functions.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/python_functions.cpp
+        ${TORCH_SRC_DIR}/csrc/distributed/rpc/PythonRpcHandler.cpp
         )
       list(APPEND TORCH_PYTHON_LINK_LIBRARIES c10d)
       list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_C10D)

--- a/torch/csrc/distributed/rpc/ProcessGroupAgent.cpp
+++ b/torch/csrc/distributed/rpc/ProcessGroupAgent.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/ProcessGroupAgent.h>
+#include <Python.h>
 
 namespace torch {
 namespace distributed {
@@ -77,6 +78,7 @@ ProcessGroupAgent::ProcessGroupAgent(
   for (auto& entry : nameMap_) {
     names_[entry.second] = entry.first;
   }
+  PythonRpcHandler::init();
   sendThread_ = std::thread(&ProcessGroupAgent::sendLoop, this);
   listenerThread_ = std::thread(&ProcessGroupAgent::listenLoop, this);
 }

--- a/torch/csrc/distributed/rpc/ProcessGroupAgent.h
+++ b/torch/csrc/distributed/rpc/ProcessGroupAgent.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/distributed/rpc/FutureMessage.h>
 #include <torch/csrc/distributed/rpc/RpcAgent.h>
 #include <torch/csrc/distributed/rpc/functions.h>
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
 
 #include <deque>
 #include <thread>

--- a/torch/csrc/distributed/rpc/PythonRpcHandler.cpp
+++ b/torch/csrc/distributed/rpc/PythonRpcHandler.cpp
@@ -1,0 +1,46 @@
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+namespace {
+  py::object module_;
+  py::object runUDFFunction_;
+  py::object loadResultFunction_;
+} // anonymous namespace
+
+namespace PythonRpcHandler {
+  void init() {
+    AutoGIL ag;
+    if (module_ == nullptr) {
+      module_ = py::module::import("torch.distributed.internal_rpc_utils");
+    }
+    if (runUDFFunction_ == nullptr) {
+      runUDFFunction_ = module_.attr("run_python_udf_internal");
+    }
+    if (loadResultFunction_ == nullptr) {
+      loadResultFunction_ = module_.attr("load_python_udf_result_internal");
+    }
+  }
+
+  std::vector<char> generatePythonUDFResult(
+    const Message& request) {
+    AutoGIL ag;
+    auto pargs = py::bytes(request.payload().data(), request.payload().size());
+    py::bytes pres = runUDFFunction_(pargs);
+    const auto& presStr = static_cast<std::string>(pres);
+    std::vector<char> payload(presStr.begin(), presStr.end());
+    return payload;
+  }
+
+  py::object loadPythonUDFResult(const Message& message) {
+    AutoGIL ag;
+    auto pargs = py::bytes(message.payload().data(), message.payload().size());
+    return loadResultFunction_(pargs);
+  }
+} // PythonRpcHandler
+
+
+} // rpc
+} // distributed
+} // torch

--- a/torch/csrc/distributed/rpc/PythonRpcHandler.h
+++ b/torch/csrc/distributed/rpc/PythonRpcHandler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <torch/csrc/distributed/rpc/Message.h>
+#include <torch/csrc/utils/pybind.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+namespace PythonRpcHandler {
+// initialize python module object and function objects in which python user
+// defined function (UDF) will run there
+void init();
+// execute python UDF, result is pickled to binary string
+std::vector<char> generatePythonUDFResult(const Message& request);
+// returned python UDF result is pickled binary string, so run python
+// function to unpickle the python UDF result and return pyObject to user
+py::object loadPythonUDFResult(const Message& message);
+}
+
+}
+}
+}

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -21,6 +21,17 @@ void processRequestBlocking(
       agent.send(from, std::move(response));
       break;
     }
+    case MessageType::PYTHON_CALL: {
+      std::vector<torch::Tensor> tensorTable;
+      agent.send(
+          from,
+          Message(
+              PythonRpcHandler::generatePythonUDFResult(request),
+              std::move(tensorTable),
+              MessageType::PYTHON_RET,
+              request.id()));
+      break;
+    }
     default: {
       AT_ERROR("Request type ", request.type(), " not supported.");
     }

--- a/torch/csrc/distributed/rpc/functions.h
+++ b/torch/csrc/distributed/rpc/functions.h
@@ -5,6 +5,8 @@
 #include <torch/csrc/distributed/rpc/RpcAgent.h>
 #include <torch/csrc/distributed/rpc/ScriptCall.h>
 #include <torch/csrc/distributed/rpc/ScriptRet.h>
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
+
 
 namespace torch {
 namespace distributed {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -56,13 +56,20 @@ PyObject* rpc_init(PyObject* /* unused */) {
                &ProcessGroupAgent::sync,
                py::call_guard<py::gil_scoped_release>());
 
-  module.def("invoke_rpc", [](
+  module.def("invoke_rpc_builtin", [](
       RpcAgent& agent,
       const std::string& dstName,
       const std::string& opName,
       const py::args& args,
       const py::kwargs& kwargs) {
-    return py_rpc(agent, dstName, opName, args, kwargs);
+    return py_rpc_builtin(agent, dstName, opName, args, kwargs);
+  });
+
+  module.def("invoke_rpc_python_udf", [](
+      RpcAgent& agent,
+      const std::string& dstName,
+      const std::string& pickledPythonUDF) {
+    return py_rpc_python_udf(agent, dstName, pickledPythonUDF);
   });
 
   Py_RETURN_TRUE;

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -8,6 +8,7 @@
 #include <torch/csrc/distributed/rpc/ScriptRet.h>
 #include <torch/csrc/jit/pybind_utils.h>
 #include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
 
 
 namespace torch {
@@ -16,12 +17,17 @@ namespace rpc {
 
 py::object to_py_obj(const Message& message);
 
-std::shared_ptr<FutureMessage> py_rpc(
+std::shared_ptr<FutureMessage> py_rpc_builtin(
     RpcAgent& agent,
     const std::string& dstName,
     const std::string& opName,
     const py::args& args,
     const py::kwargs& kwargs);
+
+std::shared_ptr<FutureMessage>  py_rpc_python_udf(
+    RpcAgent& agent,
+    const std::string& dstName,
+    const std::string& pickledPythonUDF);
 
 }
 }

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import torch
+import sys
 
 
 def is_available():
@@ -15,4 +18,5 @@ if is_available():
     # See the comment in `distributed_c10d.py` above `_backend` on why we expose
     # this.
     from .distributed_c10d import _backend  # noqa: F401
-    from .rpc import *  # noqa: F401
+    if sys.version_info >= (3, 0):
+        from .rpc import *  # noqa: F401

--- a/torch/distributed/internal_rpc_utils.py
+++ b/torch/distributed/internal_rpc_utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import pickle
+import copyreg
+import io
+import collections
+
+def serialize(obj):
+    f = io.BytesIO()
+    p = pickle.Pickler(f)
+    p.dispatch_table = copyreg.dispatch_table.copy()
+    p.dump(obj)
+    return f.getvalue()
+
+def run_python_udf_internal(pickled_python_udf):
+    try:
+        python_udf = pickle.loads(pickled_python_udf)
+        result = python_udf.func(*python_udf.args, **python_udf.kwargs)
+    except Exception as e:
+        result = "run_python_udf_internal caught exception: " + str(e)
+    return serialize(result)
+
+def load_python_udf_result_internal(pickled_python_result):
+    return pickle.loads(pickled_python_result)
+
+
+PythonUDF = collections.namedtuple("PythonUDF", ["func", "args", "kwargs"])

--- a/torch/distributed/rpc.py
+++ b/torch/distributed/rpc.py
@@ -1,5 +1,8 @@
-from . import invoke_rpc
+#!/usr/bin/env python3
+
+from . import invoke_rpc_builtin, invoke_rpc_python_udf
 from . import ProcessGroupAgent
+from .internal_rpc_utils import serialize, PythonUDF
 
 import array
 import sys
@@ -15,8 +18,7 @@ def _collect_worker_names(name, group):
 
     # collect name length
     ws = get_world_size(group)
-    name_bytes = name if sys.version_info < (3, 0) else bytes(name, 'utf8')
-    name_bytes = list(array.array('B', name_bytes))
+    name_bytes = list(array.array('B', bytes(name, 'utf8')))
     name_len = len(name_bytes)
     len_input = torch.ones(1, dtype=torch.int64) * name_len
     len_outputs = [torch.empty(1, dtype=torch.int64) for _ in range(ws)]
@@ -80,6 +82,9 @@ def init_rpc(name, backend='pg'):
                        process group backend ``"pg"`` is the only available
                        backend implementation. (default: ``"pg"``).
     """
+    if sys.version_info < (3, 0):
+        raise RuntimeError("RPC package does not support Python2.")
+
     global _agent
 
     if _agent:
@@ -105,7 +110,7 @@ def rpc(to, func, args=None, kwargs=None, async_call=False):
 
     Arguments:
         to (str): name of the destination worker.
-        func (callable): a builtin function (e.g., ``torch.add``).
+        func (callable): any callable function. builtin functions (like torch.add) can be sent over RPC more efficiently.
         args (tuple): the argument tuple for the ``func`` invocation.
         kwargs (dict): is a dictionary of keyword arguments for the ``func``
                        invocation.
@@ -146,7 +151,7 @@ def rpc(to, func, args=None, kwargs=None, async_call=False):
         >>> dist.init_process_group(backend='gloo', rank=0, world_size=2)
         >>> dist.init_rpc("worker0")
         >>> fut1 = dist.rpc("worker1", torch.add, args=(torch.ones(2), 3), async_call=True)
-        >>> fut2 = dist.rpc("worker1", torch.add, args=(torch.ones(2), 2), async_call=True)
+        >>> fut2 = dist.rpc("worker1", min, args=(1, 2), async_call=True)
         >>> result = fut1.wait() + fut2.wait()
         >>> dist.join_rpc()
 
@@ -156,17 +161,21 @@ def rpc(to, func, args=None, kwargs=None, async_call=False):
         >>> dist.init_rpc("worker1")
         >>> dist.join_rpc()
     """
+    if not callable(func):
+        raise TypeError("function should be callable.")
+
     if _agent is None:
         raise RuntimeError("RPC has not been initialized. "
                            "Call init_rpc(name) first.")
 
     qualified_name = torch.jit._find_builtin(func)
-    if qualified_name is None:
-        raise RuntimeError("unknown builtin function %s." % func)
 
     args = args if args else ()
     kwargs = kwargs if kwargs else {}
-    fut = invoke_rpc(_agent, to, qualified_name, *args, **kwargs)
+    if qualified_name is not None:
+        fut = invoke_rpc_builtin(_agent, to, qualified_name, *args, **kwargs)
+    else:
+        fut = invoke_rpc_python_udf(_agent, to, serialize(PythonUDF(func, args, kwargs)))
 
     if async_call:
         return fut


### PR DESCRIPTION
Summary:
This diff is to support python user defined function over rpc for #23110, work flow is like this:
1. pickle python udf
2. pass pickle to C++
3. C++ pass over rpc from client to server
4. server call runPythonUDF() python function to unpickle and run python udf and pickle the udf result using python embedder
6. pass back serialized result from server to client
7. client call loadPythonUDFResult() python function to unpickle result
7. return it to python

right now, put rpc_sync_builtin() and rpc_async_builtin() as temporary interfaces for builtin operator remote calls, they accept qualified name string, this interface can execute builtin operators in C++ land.

rpc_sync() and rpc_async() accept python callables only right now, it could be user define python functions or builtin operator python functions, the python functions will be executed in python land.

once we can resolve builtin operator python callables to qualified name string, we can merge rpc_sync_builtin() into rpc_sync() then

Differential Revision: D16390764

