### PR TITLE
Support custom autograd functions in C++

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TORCH_API_TEST_DIR "${TORCH_ROOT}/test/cpp/api")
 set(TORCH_API_TEST_SOURCES
   ${TORCH_ROOT}/test/cpp/common/main.cpp
+  ${TORCH_API_TEST_DIR}/autograd.cpp
   ${TORCH_API_TEST_DIR}/any.cpp
   ${TORCH_API_TEST_DIR}/dataloader.cpp
   ${TORCH_API_TEST_DIR}/expanding-array.cpp

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+
+#include <torch/autograd.h>
+
+#include <torch/utils.h>
+#include <test/cpp/api/support.h>
+
+using namespace torch;
+
+#define ASSERT_VARIABLE_EQ(a,b) ASSERT_TRUE(torch::allclose((a),(b)))
+
+std::string graph_desc(std::shared_ptr<autograd::Node> node) {
+  if (!node) {
+    return "None";
+  }
+  auto result = node->name() + "(";
+  auto next_edges = node->next_edges();
+  for(auto& edge : next_edges) {
+    result += graph_desc(edge.function);
+  }
+  return result+")";
+}
+
+TEST(CustomAutogradTest, CustomFunction) {
+  struct MyFunction : public torch::autograd::Function<MyFunction> {
+    static variable_list forward(AutogradContext *ctx, Variable var1, int mul, Variable var2) {
+      ctx->saved_data["mul"] = mul;
+      ctx->save_for_backward({var1, var2});
+      return {var1 + mul*var2 + var1*var2};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      int mul = ctx->saved_data["mul"].toInt();
+      auto saved = ctx->get_saved_variables();
+      auto var1 = saved[0];
+      auto var2 = saved[1];
+      variable_list output = {grad_output[0] + grad_output[0]*var2, Variable(), grad_output[0] * mul + grad_output[0] * var1};
+      return output;
+    }
+  };
+
+  Variable x = torch::randn({5,5}, torch::requires_grad());
+  Variable y = torch::randn({5,5}, torch::requires_grad());
+  auto res = MyFunction::apply(x,2,y)[0];
+  auto go = torch::ones({}, torch::requires_grad());
+  res.sum().backward(go, false, true);
+
+  ASSERT_VARIABLE_EQ(x.grad(), y + torch::ones({5,5}));
+  ASSERT_VARIABLE_EQ(y.grad(), x + torch::ones({5,5})*2);
+}
+
+TEST(CustomAutogradTest, FunctionReturnsInput) {
+  struct MyFunction : public torch::autograd::Function<MyFunction> {
+    static variable_list forward(AutogradContext *ctx, Variable var1) {
+      return {var1};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      return {grad_output[0]*2};
+    }
+  };
+
+  Variable x(torch::ones(1, torch::requires_grad()));
+  MyFunction::apply(x)[0].backward(torch::ones(1) , true, true);
+  ASSERT_VARIABLE_EQ(x.grad(), torch::full(1,2));
+}
+
+TEST(CustomAutogradTest, NoGradCustomFunction) {
+  // Custom Function should respect grad mode
+ struct MyOp : public torch::autograd::Function<MyOp> {
+   static variable_list forward(AutogradContext *ctx, Variable x) {
+     return {x+1};
+   }
+
+   static variable_list backward(AutogradContext *ctx, variable_list dy) {
+     return dy;
+   }
+ };
+
+ auto x = torch::ones({5,5}, torch::requires_grad());
+ {
+    at::NoGradGuard no_grad;
+    auto y = MyOp::apply(x)[0];
+    ASSERT_FALSE(y.requires_grad());
+ }
+}
+
+TEST(CustomAutogradTest, MarkNonDifferentiable) {
+  struct MyFunction : public torch::autograd::Function<MyFunction> {
+    static variable_list forward(AutogradContext *ctx, Variable v) {
+      Variable output = v > 0;
+      ctx->mark_non_differentiable({output});
+      return {output};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      return { (grad_output[0]*0.0) };
+    }
+  };
+
+  auto x = torch::randn({5,5}, torch::requires_grad());
+  auto mask = MyFunction::apply(x)[0];
+  ASSERT_FALSE(mask.requires_grad());
+  auto y = x.masked_fill(mask, 0);
+  y.sum().backward();
+}
+
+TEST(CustomAutogradTest, ReturnLeafInplace) {
+  struct Inplace : public torch::autograd::Function<Inplace> {
+    static variable_list forward(AutogradContext *ctx, Variable a, Variable b) {
+      ctx->mark_dirty({a});
+      return {a.add_(b), b+2};
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      return {grad_output[0], grad_output[0] + grad_output[1]};
+    }
+  };
+
+  Variable x = torch::randn({5,5});
+  Variable y = torch::randn({5,5}, torch::requires_grad());
+
+  auto out = Inplace::apply(x,y);
+  auto &q = out[0];
+  ASSERT_TRUE(torch::equal(q, x));
+  ASSERT_TRUE(q.requires_grad());
+  q.sum().backward();
+  ASSERT_VARIABLE_EQ(y.grad(), torch::ones({5,5}));
+}

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -5,11 +5,11 @@
 #include <torch/utils.h>
 #include <test/cpp/api/support.h>
 
-using namespace torch;
+using namespace torch::autograd;
 
 #define ASSERT_VARIABLE_EQ(a,b) ASSERT_TRUE(torch::allclose((a),(b)))
 
-std::string graph_desc(std::shared_ptr<autograd::Node> node) {
+std::string graph_desc(std::shared_ptr<Node> node) {
   if (!node) {
     return "None";
   }
@@ -22,7 +22,7 @@ std::string graph_desc(std::shared_ptr<autograd::Node> node) {
 }
 
 TEST(CustomAutogradTest, CustomFunction) {
-  struct MyFunction : public torch::autograd::Function<MyFunction> {
+  struct MyFunction : public Function<MyFunction> {
     static variable_list forward(AutogradContext *ctx, Variable var1, int mul, Variable var2) {
       ctx->saved_data["mul"] = mul;
       ctx->save_for_backward({var1, var2});
@@ -50,7 +50,7 @@ TEST(CustomAutogradTest, CustomFunction) {
 }
 
 TEST(CustomAutogradTest, FunctionReturnsInput) {
-  struct MyFunction : public torch::autograd::Function<MyFunction> {
+  struct MyFunction : public Function<MyFunction> {
     static variable_list forward(AutogradContext *ctx, Variable var1) {
       return {var1};
     }
@@ -67,7 +67,7 @@ TEST(CustomAutogradTest, FunctionReturnsInput) {
 
 TEST(CustomAutogradTest, NoGradCustomFunction) {
   // Custom Function should respect grad mode
- struct MyOp : public torch::autograd::Function<MyOp> {
+ struct MyOp : public Function<MyOp> {
    static variable_list forward(AutogradContext *ctx, Variable x) {
      return {x+1};
    }
@@ -86,7 +86,7 @@ TEST(CustomAutogradTest, NoGradCustomFunction) {
 }
 
 TEST(CustomAutogradTest, MarkNonDifferentiable) {
-  struct MyFunction : public torch::autograd::Function<MyFunction> {
+  struct MyFunction : public Function<MyFunction> {
     static variable_list forward(AutogradContext *ctx, Variable v) {
       Variable output = v > 0;
       ctx->mark_non_differentiable({output});
@@ -106,7 +106,7 @@ TEST(CustomAutogradTest, MarkNonDifferentiable) {
 }
 
 TEST(CustomAutogradTest, ReturnLeafInplace) {
-  struct Inplace : public torch::autograd::Function<Inplace> {
+  struct Inplace : public Function<Inplace> {
     static variable_list forward(AutogradContext *ctx, Variable a, Variable b) {
       ctx->mark_dirty({a});
       return {a.add_(b), b+2};

--- a/torch/csrc/api/include/torch/all.h
+++ b/torch/csrc/api/include/torch/all.h
@@ -8,3 +8,4 @@
 #include <torch/serialize.h>
 #include <torch/types.h>
 #include <torch/utils.h>
+#include <torch/autograd.h>

--- a/torch/csrc/api/include/torch/autograd.h
+++ b/torch/csrc/api/include/torch/autograd.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <torch/csrc/autograd/custom_function.h>
+
+namespace torch {
+  using Variable = autograd::Variable;
+  using AutogradContext = autograd::AutogradContext;
+  using variable_list = autograd::variable_list;
+} //namespace torch

--- a/torch/csrc/api/include/torch/autograd.h
+++ b/torch/csrc/api/include/torch/autograd.h
@@ -1,9 +1,3 @@
 #pragma once
 
 #include <torch/csrc/autograd/custom_function.h>
-
-namespace torch {
-  using Variable = autograd::Variable;
-  using AutogradContext = autograd::AutogradContext;
-  using variable_list = autograd::variable_list;
-} //namespace torch

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -3,6 +3,21 @@
 
 namespace torch { namespace autograd {
 
+VariableInfo::VariableInfo(const Variable& var)
+  : backend(tensorTypeIdToBackend(var.type_id()))
+  , device(var.device())
+  , scalar_type(var.scalar_type())
+  , size(var.sizes().vec())
+  , requires_grad(var.requires_grad()) {
+}
+
+Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
+  // NB: This will NOT work if we ever get mixed device gradients
+  device_guard.reset_device(device);
+  return at::zeros(size,
+    at::TensorOptions(scalar_type).device(backendToDeviceType(backend)).layout(layout_from_backend(backend)).is_variable(true));
+}
+
 variable_list _wrap_outputs(const variable_list &input_vars,
   const std::unordered_set<at::TensorImpl*> &non_differentiable,
   const std::unordered_set<at::TensorImpl*> &dirty_inputs,
@@ -85,7 +100,56 @@ variable_list _wrap_outputs(const variable_list &input_vars,
   return outputs;
 }
 
+void AutogradContext::save_for_backward(variable_list to_save) {
+  to_save_ = std::move(to_save);
+}
 
+// The logic for handling saved variables here is the same as python_function.cpp
+// See _save_variables() and unpack_saved_variables()
+void AutogradContext::save_variables() {
+  saved_variables_.clear();
+  auto ptr = grad_fn_.lock();
 
+  for (const auto& var : to_save_) {
+    bool is_output = var.grad_fn().get() == ptr.get();
+    saved_variables_.emplace_back(var, is_output);
+  }
+  to_save_.clear();
+}
 
+variable_list AutogradContext::get_saved_variables() const {
+  TORCH_CHECK(!has_freed_buffers, ERR_BACKWARD_TWICE);
+  variable_list saved;
+  saved.reserve(saved_variables_.size());
+  auto ptr = grad_fn_.lock();
+  TORCH_INTERNAL_ASSERT(ptr);
+  for (auto& var : saved_variables_) {
+    saved.push_back(var.unpack(ptr));
+  }
+  return saved;
+}
+
+void AutogradContext::mark_dirty(const variable_list &inputs) {
+  dirty_inputs_.clear();
+  dirty_inputs_.reserve(inputs.size());
+  for(auto& var : inputs) {
+    dirty_inputs_.insert(var.unsafeGetTensorImpl());
+  }
+}
+
+void AutogradContext::mark_non_differentiable(const variable_list &outputs) {
+  non_differentiable_.clear();
+  non_differentiable_.reserve(outputs.size());
+  for(auto& var : outputs) {
+    non_differentiable_.insert(var.unsafeGetTensorImpl());
+  }
+}
+
+const std::unordered_set<at::TensorImpl*>& AutogradContext::get_dirty() const {
+  return dirty_inputs_;
+}
+
+const std::unordered_set<at::TensorImpl*>& AutogradContext::get_non_differentiable() const {
+  return non_differentiable_;
+}
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -118,7 +118,7 @@ void AutogradContext::save_variables() {
 }
 
 variable_list AutogradContext::get_saved_variables() const {
-  TORCH_CHECK(!has_freed_buffers, ERR_BACKWARD_TWICE);
+  TORCH_CHECK(!has_freed_buffers_, ERR_BACKWARD_TWICE);
   variable_list saved;
   saved.reserve(saved_variables_.size());
   auto ptr = grad_fn_.lock();

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -2,6 +2,9 @@
 
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
+#include <ATen/core/ivalue.h>
+#include <c10/util/flat_hash_map.h>
+#include <vector>
 
 namespace torch { namespace autograd {
 
@@ -11,4 +14,266 @@ TORCH_API variable_list _wrap_outputs(
   const std::unordered_set<at::TensorImpl*> &dirty_inputs,
   const at::ArrayRef<Variable> raw_outputs,
   const std::shared_ptr<Node> &cdata);
+
+// To use custom autograd operations implement a CFunction subclass with
+// static backward and forward functions
+//
+// forward() can take as many arguments as you want and should return a
+// variable list. Use of any direct Variable arguments will be registered in
+// the graph but no vectors/sets or any other data structures will be traversed.
+// It should take an AutogradContext* as the first argument. Variables can be
+// saved in the ctx using save_for_backward() and other data can be saved in the
+// map ctx.save in the form of <std::string, at::IValue> pairs.
+//
+// backward() should take an AutogradContext* and a variable list containing as
+// many Variables as there were outputs from forward as arguments. It should
+//  return as many Variables as there were inputs with each of them containing
+// the gradient w.r.t. its corresponding input. Variables saved in forward can
+// be accessed with ctx->get_saved_variables() and other saved data can be
+// accessed from ctx->save.
+//
+// For example:
+// class MyFunction : public Function<MyFunction> {
+//   public:
+//   static variable_list forward(AutogradContext *ctx, int n, Variable var) {
+//      // Save data for backward in context
+//      ctx->save["n"] = n;
+//      var.mul_(2);
+//      // Mark var as modified by inplace operation
+//      ctx->mark_dirty({var});
+//      return std::vector<Variable>({var});
+//   }
+//
+//   static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+//      // Use data saved in forward
+//      auto n = ctx->save["n"].toInt();
+//      return std::vector<Variable>({grad_output[0]*n});
+//   }
+// };
+//
+// To use MyFunction
+// Variable x;
+// auto y = MyFunction::apply(6, x);
+// Example backward call:
+// y[0].sum().backward();
+template <class T>
+struct TORCH_API Function {
+  template<typename... Args>
+  static variable_list apply(Args&&... args);
+};
+
+// Context to save information during forward that can be accessed in backward
+struct TORCH_API AutogradContext {
+  // Can be used to save non-variable data for backward()
+  ska::flat_hash_map<std::string, at::IValue> saved_data;
+
+  // Saves the list of variables for a future call to backward(). This
+  // should be called at most once from inside of forward().
+  void save_for_backward(variable_list to_save);
+  // Marks variables in the list as modified in an in-place operation. This
+  // should be called at most once from inside of forward() and all arguments
+  // should be inputs.
+  void mark_dirty(const variable_list &inputs);
+  // Marks outputs in the list as not requiring gradients. This should be called
+  // at most once from inside of forward() and all arguments should be outputs.
+  void mark_non_differentiable(const variable_list &outputs);
+
+  // Get the list of variables that were saved in forward using
+  // save_for_backward(). Before returning them to the user, a check is made to
+  // ensure that they were not modified by any in-place operations.
+  variable_list get_saved_variables() const;
+  const std::unordered_set<at::TensorImpl*>& get_dirty() const;
+  const std::unordered_set<at::TensorImpl*>& get_non_differentiable() const;
+
+private:
+  std::unordered_set<at::TensorImpl*> non_differentiable_;
+  std::unordered_set<at::TensorImpl*> dirty_inputs_;
+  std::vector<torch::autograd::SavedVariable> saved_variables_;
+  variable_list to_save_;
+
+  std::weak_ptr<Node> grad_fn_;
+  bool has_freed_buffers;
+
+  void save_variables();
+
+  template <class T> friend struct CppNode;
+};
+
+struct TORCH_API VariableInfo {
+  explicit VariableInfo(const Variable& var);
+
+  Variable zeros(at::OptionalDeviceGuard& device_guard) const;
+
+  at::Backend backend = at::Backend::Undefined;
+  at::Device device = at::kCPU;
+  at::ScalarType scalar_type = at::kFloat;
+  std::vector<int64_t> size;
+  bool requires_grad;
+};
+
+// Node representing the operation implemented by the user defined Function
+// Calls to 'apply' are forward to the implementation of backward by the user.
+template <class T>
+struct CppNode : public Node {
+
+  variable_list apply(variable_list&& inputs) override;
+  AutogradContext ctx_;
+  std::vector<bool> is_variable_input_;
+  std::vector<VariableInfo> input_info_;
+  std::vector<VariableInfo> output_info_;
+
+  void release_variables() override;
+
+  void set_ctx_grad_fn(const std::shared_ptr<Node> &node);
+  void save_variables_to_ctx();
+};
+
+template <typename T>
+using enable_if_var_t = typename std::enable_if<std::is_constructible<Variable, T>::value>::type;
+
+template <typename T>
+using enable_if_not_var_t = typename std::enable_if<!std::is_constructible<Variable, T>::value>::type;
+
+template <typename T, typename... Args>
+enable_if_not_var_t<T> extract_vars(std::vector<bool> &is_var, variable_list& list, T&& cur, Args&& ... args) {
+  is_var.push_back(false);
+  extract_vars(is_var, list, std::forward<Args>(args)...);
+}
+
+template <typename T, typename... Args>
+enable_if_var_t<T> extract_vars(std::vector<bool> &is_var, variable_list& list, T&& cur, Args&& ... args) {
+  is_var.push_back(true);
+  list.emplace_back(cur);
+  extract_vars(is_var, list, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void extract_vars(std::vector<bool> &is_var, variable_list& list, Args&& ... args) {
+}
+
+template<class T>
+template<typename... Args>
+variable_list Function<T>::apply(Args&&... args) {
+  std::shared_ptr<CppNode<T>> node(new CppNode<T>(), deleteNode);
+  variable_list input_vars;
+
+  const size_t num_inputs = sizeof...(Args);
+  input_vars.reserve(num_inputs);
+  node->is_variable_input_.reserve(num_inputs);
+  // TODO Add tracing here
+  extract_vars(node->is_variable_input_, input_vars, args...);
+
+  bool is_executable =  GradMode::is_enabled() && any_variable_requires_grad(input_vars);
+  auto next_edges = collect_next_edges(input_vars);
+  node->set_ctx_grad_fn(node);
+  node->set_next_edges(std::move(next_edges));
+  node->clear_input_metadata();
+
+  node->input_info_.reserve(input_vars.size());
+  for (auto& var : input_vars) {
+      node->input_info_.emplace_back(var);
+  }
+
+  variable_list outputs;
+  {
+    AutoGradMode grad_mode(false);
+    outputs = T::forward(&node->ctx_, std::forward<Args>(args)...);
+  }
+
+  auto wrapped_outputs = _wrap_outputs(input_vars, node->ctx_.get_non_differentiable(), node->ctx_.get_dirty(), outputs, is_executable ? node : nullptr);
+
+  node->output_info_.reserve(wrapped_outputs.size());
+  for (auto& output : wrapped_outputs) {
+    if (is_executable) {
+      node->output_info_.emplace_back(output);
+    }
+  }
+
+  return wrapped_outputs;
+}
+
+// The logic here is the same as PyNode::apply, so changes to it should be done
+// in both the places
+template<class T>
+variable_list CppNode<T>::apply(variable_list&& inputs) {
+  at::OptionalDeviceGuard _device_guard;
+
+  int num_inputs = inputs.size();
+  variable_list backward_inputs;
+  backward_inputs.reserve(num_inputs);
+  for (int i = 0 ; i < num_inputs; ++i) {
+    if (inputs[i].defined()) {
+      backward_inputs.emplace_back(inputs[i]);
+    } else {
+      backward_inputs.emplace_back(output_info_[i].zeros(_device_guard));
+    }
+  }
+
+  auto outputs = T::backward(&ctx_, backward_inputs);
+
+  int num_forward_inputs = is_variable_input_.size();
+  int num_outputs = outputs.size();
+  // Returning too many results is ok, but only as long as they're all undefined.
+  // Truncate the result vector in that case.
+  if (num_outputs > num_forward_inputs) {
+    bool all_undef = true;
+    for (int i = num_forward_inputs; i < num_outputs; ++i) {
+      all_undef &= (!outputs[i].defined());
+    }
+    if (all_undef) {
+      outputs.resize(num_forward_inputs);
+      num_outputs = num_forward_inputs;
+    }
+  }
+
+  if (num_outputs != num_forward_inputs) {
+    std::string msg("function ");
+    msg += name() + " returned an incorrect number of gradients (expected ";
+    msg += std::to_string(num_forward_inputs) + ", got " ;
+    msg += std::to_string(num_outputs) + ")";
+    throw std::runtime_error(msg);
+  }
+
+  variable_list results;
+  results.reserve(num_outputs);
+  for (int i = 0; i < num_outputs; ++i) {
+    if (!is_variable_input_[i]) {
+      if (outputs[i].defined()) {
+        std::string msg("function ");
+        msg += name() + " returned a gradient different that is defined at position ";
+        msg += std::to_string(i + 1) + ", but the corresponding forward input was not a Variable";
+        throw std::runtime_error(msg);
+      }
+      continue;
+    }
+    if (!outputs[i].defined()) {
+      auto& info = input_info_[results.size()];
+      if (info.requires_grad) {
+        results.emplace_back(info.zeros(_device_guard));
+      } else {
+        results.emplace_back();
+      }
+    } else {
+      results.emplace_back(outputs[i]);
+    }
+  }
+  return results;
+}
+
+template<class T>
+void CppNode<T>::release_variables() {
+  ctx_.saved_variables_.clear();
+  ctx_.has_freed_buffers = true;
+}
+
+template<class T>
+void CppNode<T>::save_variables_to_ctx() {
+  ctx_.save_variables();
+}
+
+template<class T>
+void CppNode<T>::set_ctx_grad_fn(const std::shared_ptr<Node> &node) {
+  ctx_.grad_fn_ = node;
+}
+
 }} // namespace torch::autograd

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -95,6 +95,8 @@ private:
   std::vector<torch::autograd::SavedVariable> saved_variables_;
   variable_list to_save_;
 
+  // The CppNode in the autograd graph that owns this AutogradContext. We need a
+  // weak_ptr to avoid a refcycle.
   std::weak_ptr<Node> grad_fn_;
   bool has_freed_buffers;
 
@@ -191,6 +193,10 @@ variable_list Function<T>::apply(Args&&... args) {
     if (is_executable) {
       node->output_info_.emplace_back(output);
     }
+  }
+
+  if (is_executable) {
+    node->save_variables_to_ctx();
   }
 
   return wrapped_outputs;

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -64,6 +64,10 @@ struct TORCH_API Function {
 
 // Context to save information during forward that can be accessed in backward
 struct TORCH_API AutogradContext {
+  AutogradContext() = default;
+  AutogradContext(const AutogradContext &other) = delete;
+  AutogradContext& operator=(const AutogradContext& other) = delete;
+
   // Can be used to save non-variable data for backward()
   ska::flat_hash_map<std::string, at::IValue> saved_data;
 

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -8,7 +8,6 @@
 #include <ATen/ATen.h>
 
 #include <torch/csrc/THP.h>
-#include <torch/csrc/autograd/custom_function.h>
 #include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>
@@ -44,21 +43,6 @@ PyObject *THPFunctionClass = nullptr;
   if (!(condition)) { THPUtils_setError(__VA_ARGS__); throw python_error(); }
 
 namespace torch { namespace autograd {
-
-VariableInfo::VariableInfo(const Variable& var)
-  : backend(tensorTypeIdToBackend(var.type_id()))
-  , device(var.device())
-  , scalar_type(var.scalar_type())
-  , size(var.sizes().vec())
-  , requires_grad(var.requires_grad()) {
-}
-
-Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
-  // NB: This will NOT work if we ever get mixed device gradients
-  device_guard.reset_device(device);
-  return at::zeros(size,
-    at::TensorOptions(scalar_type).device(backendToDeviceType(backend)).layout(layout_from_backend(backend)).is_variable(true));
-}
 
 auto PyNode::legacy_apply(const variable_list& inputs) -> variable_list {
   AutoGIL gil;

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -3,6 +3,7 @@
 #include <torch/csrc/python_headers.h>
 
 #include <torch/csrc/Exceptions.h>
+#include <torch/csrc/autograd/custom_function.h>
 #include <torch/csrc/autograd/function.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/autograd/saved_variable.h>
@@ -17,18 +18,6 @@
 
 namespace torch { namespace jit { struct Graph; }}
 namespace torch { namespace autograd {
-
-struct VariableInfo {
-  explicit VariableInfo(const Variable& var);
-
-  Variable zeros(at::OptionalDeviceGuard& device_guard) const;
-
-  at::Backend backend = at::Backend::Undefined;
-  at::Device device = at::kCPU;
-  at::ScalarType scalar_type = at::kFloat;
-  std::vector<int64_t> size;
-  bool requires_grad;
-};
 
 // A Function which is implemented by a Python object (i.e., a THPFunction).
 // Calls to 'apply' are forwarded to the Python method implementation.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23572 Support custom autograd functions in C++**

Summary:
### **(The stack from #23020  was moved into this PR)**

Adding API for custom autograd operations, with user defined forward and backward, [like in python](https://pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd).

The custom operation should be a subclass of Function, with static forward and backward functions. `forward()` can accept any arguments similar to the Python API and `backward()` should accept a variable list as an argument. 

Both `forward()` and `backward() `accept a AutogradContext* which can be used to share data between them. 
Variables can be saved in the context using `save_for_backward()` and other data can be saved in the map `save` in the form of `<std::string, at::IValue>` pairs. Variables saved in forward can be accessed with `get_saved_variables()`.

Example usage:
```
class MyFunction : public Function<MyFunction> {
  public:
  static variable_list forward(AutogradContext *ctx, int n, Variable var) {
     // Save data for backward in context
     ctx->saved_data["n"] = n;
     return {var};
  }

  static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
     // Use data saved in forward
     auto n = ctx->saved_data["n"].toInt();
     return {grad_output[0]*n};
  }
};

```
Then, it can be used with:
```
Variable x;
MyFunction::apply(6, x);
```

Also AutogradContext has methods to mark outputs as non differentiable and mark inputs as dirty similar to the [Python API](https://github.com/pytorch/pytorch/blob/ff23a02ac4fdf1fe76d5b24666333f1ea0a918b7/torch/autograd/function.py#L26). 

Test Plan:
Added tests for the custom autograd function API based on test_autograd.py. Currently only the tests for the basic functionality have been added. More tests will be added later.

Differential Revision: [D16583428](https://our.internmc.facebook.com/intern/diff/D16583428)