### PR TITLE
Fix named tensor build by enabling tensor.is_pinned and removing support  for clone()

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1557,6 +1557,7 @@
 
 - func: is_pinned(Tensor self) -> bool
   variants: method
+  named_guard: False
 
 - func: pin_memory(Tensor self) -> Tensor
   variants: method
@@ -2400,7 +2401,6 @@
     SparseCUDA: clone_sparse
     MkldnnCPU: mkldnn_clone
     QuantizedCPU: quantized_clone
-  named_guard: False
 
 - func: resize_as_(Tensor(a!) self, Tensor the_template) -> Tensor(a!)
   variants: function, method

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -300,7 +300,6 @@ class TestNamedTensor(TestCase):
             fn_method_and_inplace('clamp', -1, 1),
             fn_method_and_inplace('clamp_min', -2),
             fn_method_and_inplace('clamp_max', 2),
-            method('clone'),
             method('cauchy_'),
             fn_method_and_inplace('cos'),
             fn_method_and_inplace('cosh'),


### PR DESCRIPTION
`is_pinned` was moved to native_functions.yaml, disabling it for named
tensors. This PR re-enables its usage for named tensors.

I wrote a named inference rule for torch.clone(), but something happened
to it. Disable it for now so we can get the namedtensor ci to be green.

Test Plan:
- Run tests [namedtensor ci]