### PR TITLE
[jit] Add `@ignore` for script classes

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13586,6 +13586,23 @@ class TestRecursiveScript(JitTestCase):
 
         self.checkModule(M(), (torch.randn(2, 2),))
 
+    def test_ignore_class(self):
+        @torch.jit.ignore
+        class MyScriptClass(object):
+            def unscriptable(self):
+                return "a" + 200
+
+
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super(TestModule, self).__init__()
+
+            def forward(self, x):
+                return MyScriptClass()
+
+        with self.assertRaisesRegex(RuntimeError, "cannot instantiate class object"):
+            t = torch.jit.script(TestModule())
+
     def test_method_call(self):
         class M(nn.Module):
             def test(self, x):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -94,6 +94,8 @@ def createResolutionCallbackFromClosure(fn):
 def can_compile_class(cls):
     # If any of the functions on a type don't have a code object, this type can't
     # be compiled and is probably a builtin / bound from C
+    if is_ignored_fn(cls):
+        return False
     fns = [getattr(cls, name) for name in cls.__dict__ if inspect.isroutine(getattr(cls, name))]
     has_code = [hasattr(fn, '__code__') for fn in fns]
     return all(has_code)


### PR DESCRIPTION
This lets you mark a class so that it won't be recursively compiled.

This also runs up against a weird thing on the UX side, that to ignore a
module you have to `@ignore` its `forward()` method but to ignore a
class you use `@ignore` on the class declaration. The `@ignore` on the
class declaration matches the use of `@script` for script classes but is
confusing to those that don't know the difference between script classes
/ modules.

Differential Revision: [D16770068](https://our.internmc.facebook.com/intern/diff/16770068/)