### PR TITLE
Allow empty Variables to be saved for backwards

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -111,8 +111,13 @@ void AutogradContext::save_variables() {
   auto ptr = grad_fn_.lock();
 
   for (const auto& var : to_save_) {
-    bool is_output = var.grad_fn().get() == ptr.get();
-    saved_variables_.emplace_back(var, is_output);
+    // Allow empty variables to be saved
+    if (var.defined()) {
+      bool is_output = var.grad_fn().get() == ptr.get();
+      saved_variables_.emplace_back(var, is_output);
+    } else {
+      saved_variables_.emplace_back();
+    }
   }
   to_save_.clear();
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23618 Allow empty Variables to be saved for backwards**

Summary: For example: `save_for_backward({Variable(), x, Variable()})` should be allowed, so that this is consistent with the python API behaviour.

Test Plan: Added a test similar to the python test `test_save_none_for_backward` from test_autograd.py.

Differential Revision: [D16589402](https://our.internmc.facebook.com/intern/diff/D16589402)