### PR TITLE
Recommend `~` and `bitwise_not()` when user tries to apply neg (`-`) on a bool tensor.

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -66,6 +66,9 @@ Tensor& neg_(Tensor& self) {
 }
 
 Tensor& neg_out(Tensor& result, const Tensor& self) {
+  TORCH_CHECK(self.scalar_type() != kBool,
+              "Negation, the `-` operator, on a bool tensor is not supported. "
+              "If you are trying to invert a mask, use the `~` or `bitwise_not()` operator instead.");
   checkBackend("neg", result, self.type().backend());
   auto iter = TensorIterator::unary_op(result, self,
     /*check_internal_overlap=*/true);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1772,6 +1772,13 @@ class _TestTorchMixin(object):
             res_neg_op = -a.clone()
             self.assertEqual(res_neg_op, res_add)
 
+            # bool
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"Negation, the `\-` operator, on a bool tensor is not supported. "
+                r"If you are trying to invert a mask, use the `\~` or `bitwise_not\(\)` operator instead.",
+                lambda: - cast(torch.tensor([False, True])))
+
     def test_neg(self):
         self._test_neg(self, lambda t: t)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23626 Negate halves on GPU using __hneg() when possible, instead of using float conversion.
* **#23621 Recommend `~` and `bitwise_not()` when user tries to apply neg (`-`) on a bool tensor.**
* #23617 Migrate neg's CUDA implementation to ATen.

Differential Revision: [D16656729](https://our.internmc.facebook.com/intern/diff/D16656729)