### PR TITLE
Add torch._C._BUILD_NAMEDTENSOR()

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -8,7 +8,7 @@ import sys
 
 
 skipIfNamedTensorDisabled = \
-    unittest.skipIf(not torch._compiled_with_BUILD_NAMEDTENSOR(),
+    unittest.skipIf(not torch._C._BUILD_NAMEDTENSOR,
                     'PyTorch not compiled with namedtensor support')
 
 def pass_name_to_python_arg_parser(name):

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -7,11 +7,8 @@ import torch
 import sys
 
 
-def namedtensor_enabled():
-    return '-DBUILD_NAMEDTENSOR' in torch.__config__.show()
-
 skipIfNamedTensorDisabled = \
-    unittest.skipIf(not namedtensor_enabled(),
+    unittest.skipIf(not torch.compiled_with_BUILD_NAMEDTENSOR(),
                     'PyTorch not compiled with namedtensor support')
 
 def pass_name_to_python_arg_parser(name):

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -8,7 +8,7 @@ import sys
 
 
 skipIfNamedTensorDisabled = \
-    unittest.skipIf(not torch.compiled_with_BUILD_NAMEDTENSOR(),
+    unittest.skipIf(not torch._compiled_with_BUILD_NAMEDTENSOR(),
                     'PyTorch not compiled with namedtensor support')
 
 def pass_name_to_python_arg_parser(name):

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -334,11 +334,6 @@ def compiled_with_cxx11_abi():
     return _C._GLIBCXX_USE_CXX11_ABI
 
 
-def _compiled_with_BUILD_NAMEDTENSOR():
-    r"""Returns whether PyTorch was built with BUILD_NAMEDTENSOR=1"""
-    return _C._BUILD_NAMEDTENSOR
-
-
 # Import the ops "namespace"
 from torch._ops import ops  # noqa: F401
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -334,7 +334,7 @@ def compiled_with_cxx11_abi():
     return _C._GLIBCXX_USE_CXX11_ABI
 
 
-def compiled_with_BUILD_NAMEDTENSOR():
+def _compiled_with_BUILD_NAMEDTENSOR():
     r"""Returns whether PyTorch was built with BUILD_NAMEDTENSOR=1"""
     return _C._BUILD_NAMEDTENSOR
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -334,6 +334,11 @@ def compiled_with_cxx11_abi():
     return _C._GLIBCXX_USE_CXX11_ABI
 
 
+def compiled_with_BUILD_NAMEDTENSOR():
+    r"""Returns whether PyTorch was built with BUILD_NAMEDTENSOR=1"""
+    return _C._BUILD_NAMEDTENSOR
+
+
 # Import the ops "namespace"
 from torch._ops import ops  # noqa: F401
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -745,7 +745,7 @@ PyObject* initModule() {
 #endif
 
 #ifdef BUILD_NAMEDTENSOR
-  ASSERT_TRUE(set_module_attr("_BUILD_NAMEDTENSOR", _GLIBCXX_USE_CXX11_ABI ? Py_True : Py_False));
+  ASSERT_TRUE(set_module_attr("_BUILD_NAMEDTENSOR", Py_True));
 #else
   ASSERT_TRUE(set_module_attr("_BUILD_NAMEDTENSOR", Py_False));
 #endif

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -744,6 +744,12 @@ PyObject* initModule() {
   ASSERT_TRUE(set_module_attr("_GLIBCXX_USE_CXX11_ABI", Py_False));
 #endif
 
+#ifdef BUILD_NAMEDTENSOR
+  ASSERT_TRUE(set_module_attr("_BUILD_NAMEDTENSOR", _GLIBCXX_USE_CXX11_ABI ? Py_True : Py_False));
+#else
+  ASSERT_TRUE(set_module_attr("_BUILD_NAMEDTENSOR", Py_False));
+#endif
+
   auto defaultGenerator = at::detail::getDefaultCPUGenerator();
   THPDefaultCPUGenerator = (THPGenerator*)THPGenerator_initDefaultGenerator(defaultGenerator);
   // This reference is meant to be given away, so no need to incref here.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23625 Implement tensor.align_to(names), torch.align_tensors(*tensors)
* #23624 Add name propagation for at::alias, add tensor.set_names
* #23316 Add names to repr for named tensors
* **#23623 Add torch._C._BUILD_NAMEDTENSOR()**

This is a quick, not-user-facing check for if pytorch was built with BUILD_NAMEDTENSOR=1.

Test Plan:
- run tests [namedtensor ci]

gh-metadata: pytorch pytorch 23623 gh/zou3519/85/head

Differential Revision: [D16621829](https://our.internmc.facebook.com/intern/diff/D16621829)