### PR TITLE
Negate halves on GPU using __hneg() when possible, instead of using float conversion.

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -70,7 +70,11 @@ inline C10_HOST_DEVICE Half operator/(const Half& a, const Half& b) {
 }
 
 inline C10_HOST_DEVICE Half operator-(const Half& a) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hneg(a);
+#else
   return -static_cast<float>(a);
+#endif
 }
 
 inline C10_HOST_DEVICE Half& operator+=(Half& a, const Half& b) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23626 Negate halves on GPU using __hneg() when possible, instead of using float conversion.**
* #23621 Recommend `~` and `bitwise_not()` when user tries to apply neg (`-`) on a bool tensor.
* #23617 Migrate neg's CUDA implementation to ATen.

Differential Revision: [D16656730](https://our.internmc.facebook.com/intern/diff/D16656730)