### PR TITLE
[jit] prefix module qualified names with __module__

### DIFF
--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -35,7 +35,7 @@ struct QualifiedName {
     cacheAccessors();
   }
 
-  /* implicit */ QualifiedName(const std::vector<std::string>& atoms) {
+  explicit QualifiedName(std::vector<std::string> atoms) {
     for (const auto& atom : atoms) {
       TORCH_CHECK(!atom.empty(), "Atom cannot be empty");
       TORCH_CHECK(

--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -305,7 +305,8 @@ script::Module ScriptModuleDeserializer::convertModule(
   for (const auto& atom : atoms) {
     moduleStack_.emplace_back(atom);
   }
-  auto module = script::Module(moduleStack_, compilation_unit_);
+  auto module =
+      script::Module(c10::QualifiedName(moduleStack_), compilation_unit_);
   for (int i = 0; i < module_def.submodules_size(); ++i) {
     const torch::ModuleDef& sub_def = module_def.submodules(i);
     auto submodule = convertModule(sub_def);

--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -16,6 +16,15 @@ static ModulePtr create_module_object(
     c10::QualifiedName class_name,
     std::shared_ptr<CompilationUnit> cu,
     bool shouldMangle = false) {
+  // XXX: This is a temporary hack so that module names cannot clash with
+  // builtins like `torch`. Delete this with the new serialization format.
+  std::vector<std::string> new_class_name{"__module__"};
+  new_class_name.insert(
+      new_class_name.end(),
+      class_name.atoms().begin(),
+      class_name.atoms().end());
+  class_name = c10::QualifiedName(std::move(new_class_name));
+
   if (shouldMangle && cu->get_class(class_name) != nullptr) {
     class_name = cu->mangle(class_name);
   }


### PR DESCRIPTION
This is temporary, won't be needed with the new serialization format.
But for now, since the main module gets its name from the archive name,
we need this for safety, other wise something like
`torch.jit.save("torch.pt") will break things.


