### PR TITLE
Omit local version identifier for default configuration.

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -52,7 +52,7 @@ fi
 
 # We put this here so that OVERRIDE_PACKAGE_VERSION below can read from it
 export DATE="$(date -u +%Y%m%d)"
-if [[ "$(uname)" == 'Darwin' ]]; then
+if [[ "$(uname)" == 'Darwin' ]] || [[ "$DESIRED_CUDA" == "cu100" ]]; then
   export PYTORCH_BUILD_VERSION="1.2.0.dev$DATE"
 else
   export PYTORCH_BUILD_VERSION="1.2.0.dev$DATE+$DESIRED_CUDA"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23654 Omit local version identifier for default configuration.**
* #23611 Fix CPU-only binary testing by properly installing cpu-only first.

Default configuration at time of writing is CUDA 10 (but
with 10.1 coming soon)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16601097](https://our.internmc.facebook.com/intern/diff/D16601097)