### PR TITLE
[jit] Clear compilation callstack on each compilation

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13664,6 +13664,30 @@ class TestRecursiveScript(JitTestCase):
 
         self.checkModule(M(), (torch.randn(2, 2),))
 
+    def test_repeated_error_stack(self):
+        def d(x):
+            return "a" - 2
+
+        def c(x):
+            return d(x)
+
+        def b(x):
+            return c(x)
+
+        def a(x):
+            return b(x)
+
+        try:
+            torch.jit.script(a)
+        except Exception as e:
+            FileCheck().check_count("is being compiled", 2).run(str(e))
+
+        try:
+            torch.jit.script(a)
+        except Exception as e:
+            # Make sure that no entries are left over from the previous failure
+            FileCheck().check_count("is being compiled", 2).run(str(e))
+
     def test_method_call(self):
         class M(nn.Module):
             def test(self, x):

--- a/torch/csrc/jit/script/error_report.cpp
+++ b/torch/csrc/jit/script/error_report.cpp
@@ -33,6 +33,11 @@ void ErrorReport::CallStack::pop_function() {
   calls.pop_back();
 }
 
+void ErrorReport::CallStack::clear() {
+  calls.clear();
+  pending_range = nullptr;
+}
+
 const char* ErrorReport::what() const noexcept {
   std::stringstream msg;
   msg << "\n" << ss.str();

--- a/torch/csrc/jit/script/error_report.h
+++ b/torch/csrc/jit/script/error_report.h
@@ -26,6 +26,7 @@ struct CAFFE2_API ErrorReport : public std::exception {
     static void update_pending_range(const SourceRange& range);
     static void push_function(const std::string& name);
     static void pop_function();
+    static void clear();
   };
 
  private:

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -564,6 +564,9 @@ void initJitScriptBindings(PyObject* module) {
       .def(py::init<SourceRange>())
       .def("what", &ErrorReport::what);
 
+  // See https://github.com/pytorch/pytorch/pull/23458
+  m.def("_clear_compilation_stack_DELETEME", ErrorReport::CallStack::clear);
+
   py::class_<CompilationUnit, std::shared_ptr<CompilationUnit>>(
       m, "CompilationUnit")
       .def(py::init<>())

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1006,7 +1006,8 @@ def _try_compile_fn(fn, loc):
     # extract the necessary info from the closed over variables on the function
     # object
     rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
-    return torch.jit.script(fn, _rcb=rcb)
+    qualified_name = _qualified_name(fn)
+    return _compile_function(fn, qualified_name=qualified_name, _rcb=rcb)
 
 
 @contextlib.contextmanager
@@ -1057,6 +1058,26 @@ def _compile_and_register_class(obj, rcb, qualified_name):
     ast = get_jit_class_def(obj, obj.__name__)
     _jit_script_class_compile(qualified_name, ast, rcb)
     _add_script_class(obj, qualified_name)
+
+
+def _compile_function(fn, qualified_name, _rcb=None, _frames_up=1):
+    ast = get_jit_def(fn)
+    if _rcb is None:
+        closure_rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
+        stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 2)
+
+        def _rcb(name):
+            # since type comments aren't captured in the function's closures,
+            # we still need to try to the rcb based on stack frames if the
+            # closure rcb fails
+            result = closure_rcb(name)
+            if result:
+                return result
+            return stack_rcb(name)
+    script_fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(fn))
+    # Forward docstrings
+    script_fn.__doc__ = fn.__doc__
+    return script_fn
 
 
 def script(obj, optimize=None, _frames_up=0, _rcb=None):
@@ -1136,6 +1157,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
     if optimize is not None:
         warnings.warn("`optimize` is deprecated and has no effect. Use `with torch.jit.optimized_execution() instead")
 
+    torch._C._clear_compilation_stack_DELETEME()
     if isinstance(obj, torch.nn.Module):
         return _convert_to_script_module(obj)
 
@@ -1156,23 +1178,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
-        ast = get_jit_def(obj)
-        if _rcb is None:
-            closure_rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
-            stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
-
-            def _rcb(name):
-                # since type comments aren't captured in the function's closures,
-                # we still need to try to the rcb based on stack frames if the
-                # closure rcb fails
-                result = closure_rcb(name)
-                if result:
-                    return result
-                return stack_rcb(name)
-        fn = torch._C._jit_script_compile(qualified_name, ast, _rcb, get_default_args(obj))
-        # Forward docstrings
-        fn.__doc__ = obj.__doc__
-        return fn
+        return _compile_function(fn=obj, qualified_name=qualified_name, _rcb=_rcb)
 
 
 ScriptMethodStub = namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1007,7 +1007,7 @@ def _try_compile_fn(fn, loc):
     # object
     rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
     qualified_name = _qualified_name(fn)
-    return _compile_function(fn, qualified_name=qualified_name, _rcb=rcb)
+    return _compile_function(fn, qualified_name=qualified_name, _frames_up=1, _rcb=rcb)
 
 
 @contextlib.contextmanager
@@ -1060,11 +1060,11 @@ def _compile_and_register_class(obj, rcb, qualified_name):
     _add_script_class(obj, qualified_name)
 
 
-def _compile_function(fn, qualified_name, _rcb=None, _frames_up=1):
+def _compile_function(fn, qualified_name, _frames_up, _rcb=None):
     ast = get_jit_def(fn)
     if _rcb is None:
         closure_rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
-        stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 2)
+        stack_rcb = _jit_internal.createResolutionCallback(_frames_up + 1)
 
         def _rcb(name):
             # since type comments aren't captured in the function's closures,
@@ -1178,7 +1178,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         _compile_and_register_class(obj, _rcb, qualified_name)
         return obj
     else:
-        return _compile_function(fn=obj, qualified_name=qualified_name, _rcb=_rcb)
+        return _compile_function(fn=obj, qualified_name=qualified_name, _frames_up=_frames_up + 1, _rcb=_rcb)
 
 
 ScriptMethodStub = namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))


### PR DESCRIPTION
This is a redo of #23458 since that was getting weird Windows failures
since it changed `CallStack` to be a `RAII`-type resource. This PR is a
temporary fix for the 1.2 release, but #23458 should be landed in favor
of this eventually.