### PR TITLE
Add warning for legacy autograd function apply()

### DIFF
--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -680,6 +680,13 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
     std::vector<c10::IValue>(),
     autograd::Node::peek_at_next_sequence_nr());
 
+  THPObjectPtr _legacy(PyObject_GetAttrString(cls, "_is_legacy"));
+  if (_legacy == Py_True) {
+    TORCH_WARN("Legacy autograd function with non-static forward method is deprecated and will be removed in 1.3. ",
+             "Please use new-style autograd function with static forward method. ",
+             "(Example: https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function)");
+  }
+
   THPObjectPtr backward_cls(PyObject_GetAttrString(cls, "_backward_cls"));
   if (!backward_cls) return nullptr;
   THPObjectPtr ctx_obj(PyObject_CallFunctionObjArgs(backward_cls, nullptr));


### PR DESCRIPTION
Running `apply()` on a legacy autograd function can also cause the non-static `forward()` to be called. In order to deprecate legacy autograd functions in 1.3, we should also print warning when the user tries to use legacy autograd function by calling `apply()` on it.