### PR TITLE
increase predefined_minimum_secs to reduce variation

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -63,7 +63,7 @@ class BenchmarkRunner(object):
         self.iters = 100
         self.has_explicit_iteration_count = False
         self.multiplier = 2
-        self.predefined_minimum_secs = 4
+        self.predefined_minimum_secs = 6
         self.max_iters = 1e6
         self.use_jit = args.use_jit
         self.num_runs = args.num_runs


### PR DESCRIPTION
Summary:
In the latest run on AI-PEP, there are 6 tests out of 342 which has more than 7% variation. Around 20 tests which has variations between 4% to 7%. The rest are within 4%. This diff tries to further reduce the variation to 4% for all tests.

Each test has to run predefined_minimum_secs seconds before exiting. Increasing that value makes all tests run longer. Based on the experimental results, we will see what's the right value to use.

Differential Revision: D16622361

