### PR TITLE
Perform string uniquing by value in pickle serialization.

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -141,7 +141,7 @@ void Pickler::pushIValueImpl(const IValue& ivalue) {
       push<OpCode>(OpCode::NEWFALSE);
     }
   } else if (ivalue.isString()) {
-    pushStringImpl(ivalue.toStringRef());
+    pushString(ivalue.toStringRef());
   } else if (ivalue.isGenericList()) {
     pushGenericList(ivalue);
   } else if (ivalue.isGenericDict()) {


### PR DESCRIPTION
On my testcase, this reduces the uncompressed size of TorchScript
debug info from 281KB to 76KB.  With zip compression enabled, this
saves about 2.5KB of final size.

