### PR TITLE
Fix dataloader._shutdown_workers if not all workers are started

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -896,7 +896,10 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
 
                 # Exit workers now.
                 self.workers_done_event.set()
-                for worker_id in range(self.num_workers):
+                for worker_id in range(len(self.workers)):
+                    # Get number of workers from `len(self.workers)` instead of
+                    # `self.num_workers` in case we error before starting all
+                    # workers.
                     if self.workers_status[worker_id]:
                         self._shutdown_worker(worker_id)
                 for w in self.workers:


### PR DESCRIPTION
Otherwise you may see errors like
```
Exception ignored in: <function _MultiProcessingDataLoaderIter.__del__ at 0x000001F99F5CB9D8>
Traceback (most recent call last):
  File "C:\Users\Divyansh J\Anaconda3\envs\pytorch\lib\site-packages\torch\utils\data\dataloader.py", line 883, in __del__
    self._shutdown_workers()
  File "C:\Users\Divyansh J\Anaconda3\envs\pytorch\lib\site-packages\torch\utils\data\dataloader.py", line 860, in _shutdown_workers
    if self.workers_status[worker_id]:
IndexError: list index out of range
```

e.g. https://discuss.pytorch.org/t/how-to-construct-dataset-with-iterator-for-multi-process-dataloader/49612/5