### PR TITLE
Properly mangle `nn.Module.__construct`

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1517,7 +1517,7 @@ if _enabled:
             else:
                 self.__dict__['_c'] = torch._C.ScriptModule(_qualified_name, _compilation_unit, True)
 
-            Module._construct(self)
+            Module.__construct(self)
             Module.__setattr__(self, "training", True)
 
             self._parameters = OrderedParameterDict(self._c)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1517,7 +1517,7 @@ if _enabled:
             else:
                 self.__dict__['_c'] = torch._C.ScriptModule(_qualified_name, _compilation_unit, True)
 
-            Module.__construct(self)
+            Module._Module__construct(self)
             Module.__setattr__(self, "training", True)
 
             self._parameters = OrderedParameterDict(self._c)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -69,12 +69,12 @@ class Module(object):
     _version = 1
 
     def __init__(self):
-        self._construct()
+        self.__construct()
         # initialize self.training separately from the rest of the internal
         # state, as it is managed differently by nn.Module and ScriptModule
         self.training = True
 
-    def _construct(self):
+    def __construct(self):
         """
         Initializes internal Module state, shared by both nn.Module and ScriptModule.
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23779 Properly mangle `nn.Module.__construct`**

Mangling is two underscores, not one :(. We want this method to be
private so that inheritors who define a `__construct` do not interfere
with Module initialization

Differential Revision: [D16645156](https://our.internmc.facebook.com/intern/diff/D16645156)