### PR TITLE
Attempt to speed up Half on CUDA using __hneg().

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -70,7 +70,11 @@ inline C10_HOST_DEVICE Half operator/(const Half& a, const Half& b) {
 }
 
 inline C10_HOST_DEVICE Half operator-(const Half& a) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hneg(a);
+#else
   return -static_cast<float>(a);
+#endif
 }
 
 inline C10_HOST_DEVICE Half& operator+=(Half& a, const Half& b) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23829 Attempt to speed up Half on CUDA using __hneg().**
* #23828 Recommend `~` and `bitwise_not()` when user tries to apply neg (`-`) on a bool tensor.

Differential Revision: [D16656484](https://our.internmc.facebook.com/intern/diff/D16656484)