### PR TITLE
Add missing functions and methods for channelwise quantization

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -619,6 +619,8 @@ class CAFFE2_API Tensor {
   Tensor dequantize() const;
   double q_scale() const;
   int64_t q_zero_point() const;
+  Tensor q_scales() const;
+  Tensor q_zero_points() const;
   Tensor int_repr() const;
   QScheme qscheme() const;
   Tensor to(const TensorOptions & options, bool non_blocking=false, bool copy=false) const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1069,6 +1069,14 @@ inline int64_t Tensor::q_zero_point() const {
     static auto table = globalATenDispatch().getOpTable("aten::q_zero_point(Tensor self) -> int");
     return table->getOp<int64_t (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
 }
+inline Tensor Tensor::q_scales() const {
+    static auto table = globalATenDispatch().getOpTable("aten::q_scales(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
+}
+inline Tensor Tensor::q_zero_points() const {
+    static auto table = globalATenDispatch().getOpTable("aten::q_zero_points(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
+}
 inline Tensor Tensor::int_repr() const {
     static auto table = globalATenDispatch().getOpTable("aten::int_repr(Tensor self) -> Tensor");
     return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2850,6 +2850,16 @@
   dispatch:
     QuantizedCPU: q_zero_point_quant
 
+- func: q_scales(Tensor self) -> Tensor
+  variants: function, method
+  dispatch:
+    QuantizedCPU: q_scales_quant
+
+- func: q_zero_points(Tensor self) -> Tensor
+  variants: function, method
+  dispatch:
+    QuantizedCPU: q_zero_points_quant
+
 - func: int_repr(Tensor self) -> Tensor
   variants: function, method
   dispatch:

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -78,6 +78,22 @@ int64_t q_zero_point_quant(const Tensor& self) {
   return static_cast<PerTensorAffineQuantizer*>(quantizer.get())->zero_point();
 }
 
+Tensor q_scales_quant(const Tensor& self) {
+  auto quantizer = get_qtensorimpl(self)->quantizer();
+  TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
+  return at::tensor(
+      static_cast<PerChannelAffineQuantizer*>(quantizer.get())->scales(),
+      self.options().dtype(at::kDouble));
+}
+
+Tensor q_zero_points_quant(const Tensor& self) {
+  auto quantizer = get_qtensorimpl(self)->quantizer();
+  TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
+  return at::tensor(
+      static_cast<PerChannelAffineQuantizer*>(quantizer.get())->zero_points(),
+      self.options().dtype(at::kLong));
+}
+
 Quantizer* quantizer(const Tensor& self) {
   return get_qtensorimpl(self)->quantizer().get();
 }

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -368,6 +368,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: qscheme
    .. automethod:: q_scale
    .. automethod:: q_zero_point
+   .. automethod:: q_scales
+   .. automethod:: q_zero_points
    .. automethod:: random_
    .. automethod:: reciprocal
    .. automethod:: reciprocal_

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -45,13 +45,15 @@ class TestQuantizedTensor(TestCase):
         qr[:] = x
         self.assertEqual(qr.item(), 15)
         # we can also print a qtensor
-        self.assertEqual(str(qr),
+        self.assertEqual(' '.join(str(qr).split()),
                          "tensor([15.], size=(1,), dtype=torch.quint8, " +
+                         "quantization_scheme=torch.per_tensor_affine, " +
                          "scale=1.0, zero_point=2)")
         empty_r = torch.ones((0, 1), dtype=torch.float)
         empty_qr = torch.quantize_linear(empty_r, scale, zero_point, torch.quint8)
-        self.assertEqual(str(empty_qr),
+        self.assertEqual(' '.join(str(empty_qr).split()),
                          "tensor([], size=(0, 1), dtype=torch.quint8, " +
+                         "quantization_scheme=torch.per_tensor_affine, " +
                          "scale=1.0, zero_point=2)")
 
     def test_qtensor_quant_dequant(self):

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1870,6 +1870,22 @@ Given a Tensor quantized by linear(affine) quantization,
 returns the zero_point of the underlying quantizer().
 """)
 
+add_docstr_all('q_scales',
+               r"""
+q_scales() -> Tensor
+
+Given a Tensor quantized by linear (affine) per-channel quantization,
+returns a Tensor of scales of the underlying quantizer().
+""")
+
+add_docstr_all('q_zero_points',
+               r"""
+q_zero_points() -> Tensor
+
+Given a Tensor quantized by linear (affine) per-channel quantization,
+returns a tensor of zero_points of the underlying quantizer().
+""")
+
 add_docstr_all('random_',
                r"""
 random_(from=0, to=None, *, generator=None) -> Tensor

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -273,11 +273,13 @@ def _str(self):
         suffixes.append('size=' + str(tuple(self.shape)))
         if not has_default_dtype:
             suffixes.append('dtype=' + str(self.dtype))
-        # TODO: change to a call to self.q_scheme() when we add q_scheme method
-        # and uncomment this
-        # suffixes.append('quantization_scheme=' + 'per_tensor_affine')
-        suffixes.append('scale=' + str(self.q_scale()))
-        suffixes.append('zero_point=' + str(self.q_zero_point()))
+        suffixes.append('quantization_scheme=' + str(self.qscheme()))
+        if self.qscheme() == torch.per_tensor_affine or self.qscheme() == torch.per_tensor_symmetric:
+            suffixes.append('scale=' + str(self.q_scale()))
+            suffixes.append('zero_point=' + str(self.q_zero_point()))
+        elif self.qscheme() == torch.per_channel_affine or self.qscheme() == torch.per_channel_symmetric:
+            suffixes.append('scale=' + str(self.q_scales()))
+            suffixes.append('zero_point=' + str(self.q_zero_points()))
         tensor_str = _tensor_str(self.dequantize(), indent)
     else:
         if self.numel() == 0 and not self.is_sparse:


### PR DESCRIPTION
Summary:
1) Functions and methods to get scales and zero_points for channelwise quantization were missing. Adding these.
2) Correctly print quantized tensors for channelwise quantization.

Differential Revision: D16659715

