### PR TITLE
weight_names bug fix

### DIFF
--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -24,7 +24,8 @@ def onnxifi_caffe2_net(
         debug=False,
         use_onnx=True,
         adjust_batch=True,
-        black_list=None):
+        black_list=None,
+        weight_names=None):
     """
     Transform the caffe2_net by collapsing ONNXIFI-runnable nodes into Onnxifi c2 ops
     """
@@ -34,6 +35,7 @@ def onnxifi_caffe2_net(
     pred_net_str = C.onnxifi(pred_net.SerializeToString(),
                              shape_hints,
                              black_list if black_list else [],
+                             weight_names if weight_names is not None else [],
                              max_batch_size,
                              max_seq_size,
                              adjust_batch,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -428,7 +428,8 @@ void addObjectMethods(py::module& m) {
         auto p = c10::intrusive_ptr<c10::TensorImpl, at::UndefinedTensorImpl>::
             unsafe_reclaim_from_nonowning(static_cast<c10::TensorImpl*>(ptr));
         TORCH_CHECK(p.defined(), "Can't wrap undefined tensor");
-        TORCH_CHECK(!p->requires_grad(), "Can wrap only non-requires-grad tensor");
+        TORCH_CHECK(
+            !p->requires_grad(), "Can wrap only non-requires-grad tensor");
         auto at_tensor = at::Tensor::wrap_tensor_impl(std::move(p));
         BlobSetTensor(blob, Tensor(std::move(at_tensor)));
       });
@@ -1702,6 +1703,7 @@ void addGlobalMethods(py::module& m) {
       [](const py::bytes& pred_net_str,
          const std::unordered_map<std::string, std::vector<int>>& shapes,
          const std::vector<int>& black_list,
+         const std::vector<std::string>& weight_names,
          int max_batch_size,
          int max_seq_size,
          bool adjust_batch,
@@ -1727,9 +1729,18 @@ void addGlobalMethods(py::module& m) {
         Workspace* curr_ws = GetCurrentWorkspace();
         std::unordered_set<int> blacklist_set(
             black_list.begin(), black_list.end());
-        auto weight_names = curr_ws->Blobs();
+        std::vector<std::string> weight_names_overwrite{};
+        if (weight_names.size() == 0) {
+          weight_names_overwrite = curr_ws->Blobs();
+        } else {
+          weight_names_overwrite = weight_names;
+        }
         ts.transform(
-            curr_ws, &pred_net, weight_names, tensor_shapes, blacklist_set);
+            curr_ws,
+            &pred_net,
+            weight_names_overwrite,
+            tensor_shapes,
+            blacklist_set);
         std::string pred_net_str2;
         pred_net.SerializeToString(&pred_net_str2);
         return py::bytes(pred_net_str2);


### PR DESCRIPTION
Summary:
Problem:
In experiment running feed model 127607201 (/mnt/public/tracelog/feed_repro2/127607201_0.predictor), encountered blob dimensionality mismatch error when running onnxified net. This is due to the model initializing input blobs in current workspace with blob size 0, and onnxifi() falsely identified those input blobs as weight blobs and assigned wrong dimension.

Solution:
Add option to pass correct weight blob names to onnxifi() instead of using all blobs in current workspace.

Differential Revision: D16661396

