### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -867,6 +867,7 @@ if __name__ == '__main__':
         download_url='https://github.com/pytorch/pytorch/tags',
         author='PyTorch Team',
         author_email='packages@pytorch.org',
+        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
         # PyPI package information.
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
`python_requires` helps the installer choose the correct version of this package for the user's running Python.

This is especially necessary when dropping Python 2 (#23795) but is useful now too.