### PR TITLE
Fused the Adam Optimizer using Numba/CUDA

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -92,6 +92,8 @@ class Adam(Optimizer):
             for param in group['params']:
                 if param.grad is None:
                     continue
+
+                # Perform optimization step
                 grad = param.grad.data
                 p = param.data
                 if grad.is_sparse:
@@ -123,6 +125,7 @@ class Adam(Optimizer):
                 weight_decay = group['weight_decay']
                 eps = group['eps']
                 beta1, beta2 = group['betas']
+
                 state['step'] += 1
                 bias_correction1 = 1 - beta1 ** state['step']
                 bias_correction2 = math.sqrt(1 - beta2 ** state['step'])

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -12,18 +12,18 @@ if not strtobool(os.environ.get('NO_NUMBA', 'n')) and _check_module_exists("numb
     NUMBA_CUDA_EXIST = numba.cuda.is_available()
 
     @numba.cuda.jit()
-    def numba_cuda_kernel(param, grad, exp_avg, exp_avg_sq, beta1, 
-                          beta2, step_size, bias_correction2, eps, 
+    def numba_cuda_kernel(param, grad, exp_avg, exp_avg_sq, beta1,
+                          beta2, step_size, bias_correction2, eps,
                           weight_decay):
         i = numba.cuda.grid(1)
         if i >= param.size:
             return
 
         if weight_decay != 0:
-            grad[i] += weight_decay * param[i]            
+            grad[i] += weight_decay * param[i]
 
         exp_avg[i] = exp_avg[i] * beta1 + (1 - beta1) * grad[i]
-        exp_avg_sq[i] = exp_avg_sq[i] * beta2 + (1 - beta2) * grad[i]*grad[i]
+        exp_avg_sq[i] = exp_avg_sq[i] * beta2 + (1 - beta2) * grad[i] * grad[i]
 
         denom = math.sqrt(exp_avg_sq[i]) / bias_correction2 + eps
         param[i] = param[i] + (-step_size) * (exp_avg[i] / denom)
@@ -80,7 +80,7 @@ class Adam(Optimizer):
                 and returns the loss.
         """
 
-        # In order to reduce Numba overhead, we save the device arrays 
+        # In order to reduce Numba overhead, we save the device arrays
         # between calls to `step()` in `_nbstate`.
         self._nbstate = getattr(self, '_nbstate', {})
 
@@ -97,7 +97,7 @@ class Adam(Optimizer):
                 grad = param.grad.data
                 p = param.data
                 if grad.is_sparse:
-                    raise RuntimeError('Adam does not support sparse gradients,' 
+                    raise RuntimeError('Adam does not support sparse gradients,'
                                        'please consider SparseAdam instead')
                 amsgrad = group['amsgrad']
 
@@ -118,7 +118,8 @@ class Adam(Optimizer):
                             'param': numba.cuda.as_cuda_array(p.data.flatten()),
                             'grad': numba.cuda.as_cuda_array(grad.flatten()),
                             'exp_avg': numba.cuda.as_cuda_array(state['exp_avg'].data.flatten()),
-                            'exp_avg_sq': numba.cuda.as_cuda_array(state['exp_avg_sq'].data.flatten()),
+                            'exp_avg_sq': numba.cuda.as_cuda_array(state['exp_avg_sq'].
+                                                                   data.flatten()),
                             'blockspergrid': math.ceil(p.data.numel() / NUMBA_CUDA_THREAD_PER_BLOCK)
                         }
 
@@ -133,12 +134,18 @@ class Adam(Optimizer):
 
                 if param in self._nbstate:
                     s = self._nbstate[param]
-                    numba_cuda_kernel[s['blockspergrid'], NUMBA_CUDA_THREAD_PER_BLOCK]  \
-                        (s['param'], s['grad'], s['exp_avg'], s['exp_avg_sq'], beta1, 
-                        beta2, step_size, bias_correction2, eps, weight_decay)           
-                else:         
+                    numba_cuda_kernel[s['blockspergrid'],
+                                      NUMBA_CUDA_THREAD_PER_BLOCK](s['param'],
+                                                                   s['grad'],
+                                                                   s['exp_avg'],
+                                                                   s['exp_avg_sq'],
+                                                                   beta1, beta2,
+                                                                   step_size,
+                                                                   bias_correction2,
+                                                                   eps, weight_decay)
+                else:
                     if weight_decay != 0:
-                        grad.add_(weight_decay, p.data)                               
+                        grad.add_(weight_decay, p.data)
                     exp_avg = state['exp_avg'].data
                     exp_avg_sq = state['exp_avg_sq'].data
                     # Decay the first and second moment running average coefficient

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -58,35 +58,37 @@ class Adam(Optimizer):
             loss = closure()
 
         for group in self.param_groups:
-            for p in group['params']:
-                if p.grad is None:
+            for param in group['params']:
+                if param.grad is None:
                     continue
-                grad = p.grad.data
+                grad = param.grad.data
+                p = param.data
                 if grad.is_sparse:
                     raise RuntimeError('Adam does not support sparse gradients, please consider SparseAdam instead')
                 amsgrad = group['amsgrad']
 
-                state = self.state[p]
+                state = self.state[param]
 
                 # State initialization
                 if len(state) == 0:
                     state['step'] = 0
                     # Exponential moving average of gradient values
-                    state['exp_avg'] = torch.zeros_like(p.data)
+                    state['exp_avg'] = torch.zeros_like(p)
                     # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = torch.zeros_like(p.data)
+                    state['exp_avg_sq'] = torch.zeros_like(p)
                     if amsgrad:
                         # Maintains max of all exp. moving avg. of sq. grad. values
-                        state['max_exp_avg_sq'] = torch.zeros_like(p.data)
+                        state['max_exp_avg_sq'] = torch.zeros_like(p)
 
-                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
-                if amsgrad:
-                    max_exp_avg_sq = state['max_exp_avg_sq']
+                eps = group['eps']
                 beta1, beta2 = group['betas']
+                exp_avg = state['exp_avg'].data
+                exp_avg_sq = state['exp_avg_sq'].data
 
                 state['step'] += 1
                 bias_correction1 = 1 - beta1 ** state['step']
                 bias_correction2 = 1 - beta2 ** state['step']
+                step_size = group['lr'] / bias_correction1
 
                 if group['weight_decay'] != 0:
                     grad.add_(group['weight_decay'], p.data)
@@ -95,14 +97,13 @@ class Adam(Optimizer):
                 exp_avg.mul_(beta1).add_(1 - beta1, grad)
                 exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
                 if amsgrad:
+                    max_exp_avg_sq = state['max_exp_avg_sq']
                     # Maintains the maximum of all 2nd moment running avg. till now
                     torch.max(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)
                     # Use the max. for normalizing running avg. of gradient
-                    denom = (max_exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(group['eps'])
+                    denom = (max_exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
                 else:
-                    denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(group['eps'])
-
-                step_size = group['lr'] / bias_correction1
+                    denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
 
                 p.data.addcdiv_(-step_size, exp_avg, denom)
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -2,8 +2,8 @@ import math
 import os
 from distutils.util import strtobool
 import torch
-from .optimizer import Optimizer
-from ..hub import _check_module_exists
+from torch.optim.optimizer import Optimizer
+from torch.hub import _check_module_exists
 
 NUMBA_CUDA_EXIST = False
 NUMBA_CUDA_THREAD_PER_BLOCK = 512

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -2,8 +2,8 @@ import math
 import os
 from distutils.util import strtobool
 import torch
-from .optimizer import Optimizer
-from ..hub import _check_module_exists
+from torch.optim.optimizer import Optimizer
+from torch.hub import _check_module_exists
 
 NUMBA_CUDA_EXIST = False
 NUMBA_CUDA_THREAD_PER_BLOCK = 512


### PR DESCRIPTION
This PR uses Numba/CUDA to optimize the performance of the Adam Optimizer. 

My initial approach was to use TorchScript to accelerate the computation intensive part of the Adam Optimizer. However, my benchmark shows that Numba is superior in this case (see #23655).

### Results
Wall-clock time of a single step:
```
Original:    0.0322 s
TorchScript: 0.0280 s
Numba:       0.0108 s (~3x speedup)
```
Throughput in a [MortgageWorkflow](https://github.com/EvenOldridge/MortgageWorkflowA):
```
Original: 145251 example/s
Numba:    281723 example/s (~2x speedup)
```

### Hackability
In order to make it _hackable_, the CUDA kernel is implemented using Numba as opposed to implementing it in C++. 
As @soumith has stated, the optimizers must be [hackability](https://github.com/pytorch/pytorch/pull/23522#issuecomment-516172948). I hope that this is hackable enough?