### PR TITLE
Rename cpu-only to cpuonly, as dash features are not supported.

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -26,7 +26,7 @@ pkg="/final_pkgs/\$(ls /final_pkgs)"
 if [[ "$PACKAGE_TYPE" == conda ]]; then
   conda install -y "\$pkg" --offline
   if [[ "$DESIRED_CUDA" == 'cpu' ]]; then
-    conda install -y cpu-only -c pytorch
+    conda install -y cpuonly -c pytorch
   fi
   retry conda install -yq future numpy protobuf six
   if [[ "$DESIRED_CUDA" != 'cpu' ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23879 Rename cpu-only to cpuonly, as dash features are not supported.**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16670379](https://our.internmc.facebook.com/intern/diff/D16670379)