### PR TITLE
fix _grad_input_padding when dilation>1 (in conv*d_input() in torch.nn.grad.py)

### DIFF
--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -4,7 +4,7 @@ import torch
 from .modules.utils import _single, _pair, _triple
 
 
-def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size):
+def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size, dilation):
     input_size = list(input_size)
     k = grad_output.dim() - 2
 
@@ -16,7 +16,7 @@ def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size):
 
     def dim_size(d):
         return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] +
-                kernel_size[d])
+                (kernel_size[d] - 1) * dilation[d] + 1)
 
     min_sizes = [dim_size(d) for d in range(k)]
     max_sizes = [min_sizes[d] + stride[d] - 1 for d in range(k)]
@@ -65,7 +65,7 @@ def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         raise ValueError("grad.conv1d_input requires specifying an input_size")
 
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size)
+                                             padding, kernel_size, dilation)
 
     return torch.conv_transpose1d(
         grad_output, weight, None, stride, padding, grad_input_padding, groups,
@@ -154,7 +154,7 @@ def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         raise ValueError("grad.conv2d_input requires specifying an input_size")
 
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size)
+                                             padding, kernel_size, dilation)
 
     return torch.conv_transpose2d(
         grad_output, weight, None, stride, padding, grad_input_padding, groups,
@@ -247,7 +247,7 @@ def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         raise ValueError("grad.conv3d_input requires specifying an input_size")
 
     grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size)
+                                             padding, kernel_size, dilation)
 
     return torch.conv_transpose3d(
         grad_output, weight, None, stride, padding, grad_input_padding, groups,


### PR DESCRIPTION
`conv*d_input` functions (in `torch.nn.grad.py`) weren't working when argument passed to `dilation` is `integer greater than 1` because `_grad_input_padding` function was not taking into account `dilation`.
In order to correct this, these changes are implemented:
- `dilation` is now a parameter of `_grad_input_padding`
- `dim_size` function inside `_grad_input_padding` now takes into account `dilation` (in line 19) when calculating *_sizes
- `conv*d_input` functions pass `dilation` as an additional argument to `_grad_input_padding` function

