### PR TITLE
Set caffe2_tvm_min_ops to 8

### DIFF
--- a/caffe2/opt/tvm_transformer.cc
+++ b/caffe2/opt/tvm_transformer.cc
@@ -8,7 +8,7 @@ C10_DEFINE_bool(
 
 C10_DEFINE_int32(
     caffe2_tvm_min_ops,
-    1,
+    8,
     "Minimal number of supported ops for the subgraph to be lowered to TVM");
 
 namespace caffe2 {


### PR DESCRIPTION
Summary: Set `caffe2_tvm_min_ops` to 8 for production and tests.

Differential Revision: D16659420

