### PR TITLE
Add TensorIterator::unary_opize for more flexible construction of unary ops.

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -549,18 +549,21 @@ TensorIterator TensorIterator::binary_op(Tensor& out, const Tensor& a,
   return iter;
 }
 
-TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a,
-    bool check_internal_overlap) {
-  auto iter = TensorIterator();
+TensorIterator TensorIterator::unary_op(Tensor& out, const Tensor& a, bool check_internal_overlap) {
+  TensorIterator iter;
+  return iter.unary_opize(out, a, check_internal_overlap);
+}
+
+TensorIterator& TensorIterator::unary_opize(Tensor& out, const Tensor& a, bool check_internal_overlap) {
   if (check_internal_overlap) {
-    iter.check_and_add_output(out);
+    this->check_and_add_output(out);
   } else {
-    iter.add_output(out);
+    this->add_output(out);
   }
-  iter.add_input(a);
-  iter.num_outputs_ = 1;
-  iter.build();
-  return iter;
+  this->add_input(a);
+  this->num_outputs_ = 1;
+  this->build();
+  return *this;
 }
 
 TensorIterator TensorIterator::nullary_op(Tensor& out) {

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -145,8 +145,8 @@ struct CAFFE2_API TensorIterator {
 
   static TensorIterator binary_op(Tensor& out, const Tensor& a, const Tensor& b,
     bool check_internal_overlap = false);
-  static TensorIterator unary_op(Tensor& out, const Tensor& a,
-    bool check_internal_overlap = false);
+  static TensorIterator unary_op(Tensor& out, const Tensor& a, bool check_internal_overlap = false);
+  TensorIterator& unary_opize(Tensor& out, const Tensor& a, bool check_internal_overlap = false);
   static TensorIterator nullary_op(Tensor& out);
   static TensorIterator reduce_op(Tensor& out, const Tensor& a);
   static TensorIterator reduce_op(Tensor& out1, Tensor& out2, const Tensor& a);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#23904 Add TensorIterator::unary_opize for more flexible construction of unary ops.**
* #23860 Recommend logical_not() instead of bitwise_not() when applying sub and neg on bool tensors.
* #23847 Add logical_xor operator
* #23839 Add logical_not operator.

Now options of a TensorIterator object can be adjusted before
TensorIterator::unary_op() is called.

Differential Revision: [D16678298](https://our.internmc.facebook.com/intern/diff/D16678298)