### PR TITLE
Make aten_to_numpy_dtype in tensor_numpy.h public.

### DIFF
--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -69,8 +69,6 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
   return result;
 }
 
-static int aten_to_numpy_dtype(const ScalarType scalar_type);
-
 PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   if (tensor.is_cuda()) {
     throw TypeError(
@@ -177,7 +175,7 @@ at::Tensor tensor_from_numpy(PyObject* obj) {
   );
 }
 
-static int aten_to_numpy_dtype(const ScalarType scalar_type) {
+int aten_to_numpy_dtype(const ScalarType scalar_type) {
   switch (scalar_type) {
     case kDouble: return NPY_DOUBLE;
     case kFloat: return NPY_FLOAT;

--- a/torch/csrc/utils/tensor_numpy.h
+++ b/torch/csrc/utils/tensor_numpy.h
@@ -8,6 +8,7 @@ namespace torch { namespace utils {
 PyObject* tensor_to_numpy(const at::Tensor& tensor);
 at::Tensor tensor_from_numpy(PyObject* obj);
 
+int aten_to_numpy_dtype(const at::ScalarType scalar_type);
 at::ScalarType numpy_dtype_to_aten(int dtype);
 
 bool is_numpy_scalar(PyObject* obj);


### PR DESCRIPTION
The corresponding numpy_dtype_to_aten is public already so this
should be fine. Tests still pass.

