### PR TITLE
[v1.2] [RETRY] Fixed Bool in IsIntegralType bug (plus review comments)

### DIFF
--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -385,8 +385,8 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntArrayRef inpu
 
 // Convenience function accepting Tensors
 Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, const Tensor& input_lengths, const Tensor& target_lengths, int64_t BLANK, int64_t reduction, bool zero_infinity) {
-  TORCH_CHECK(isIntegralType(input_lengths.scalar_type()), "input_lenghts must be integral");
-  TORCH_CHECK(isIntegralType(target_lengths.scalar_type()), "target_lenghts must be integral");
+  TORCH_CHECK(isIntegralType(input_lengths.scalar_type(), /*includeBool*/ false), "input_lenghts must be integral");
+  TORCH_CHECK(isIntegralType(target_lengths.scalar_type(), /*includeBool*/ false), "target_lenghts must be integral");
 
   Tensor ilc = input_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();
   Tensor tlc = target_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -386,7 +386,7 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntArrayRef inpu
 // Convenience function accepting Tensors
 Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, const Tensor& input_lengths, const Tensor& target_lengths, int64_t BLANK, int64_t reduction, bool zero_infinity) {
   TORCH_CHECK(isIntegralType(input_lengths.scalar_type(), /*includeBool*/ false), "input_lenghts must be integral");
-  TORCH_CHECK(isIntegralType(target_lengths.scalar_type(), /*includeBool*/ false), "target_lenghts must be integral");
+  TORCH_CHECK(isIntegralType(target_lengths.scalar_type(), /*includeBool*/ false), "target_lengths must be integral");
 
   Tensor ilc = input_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();
   Tensor tlc = target_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -385,8 +385,8 @@ Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, IntArrayRef inpu
 
 // Convenience function accepting Tensors
 Tensor ctc_loss(const Tensor& log_probs, const Tensor& targets, const Tensor& input_lengths, const Tensor& target_lengths, int64_t BLANK, int64_t reduction, bool zero_infinity) {
-  TORCH_CHECK(isIntegralType(input_lengths.scalar_type(), /*includeBool*/ false), "input_lenghts must be integral");
-  TORCH_CHECK(isIntegralType(target_lengths.scalar_type(), /*includeBool*/ false), "target_lengths must be integral");
+  TORCH_CHECK(isIntegralType(input_lengths.scalar_type(), /*includeBool=*/false), "input_lenghts must be integral");
+  TORCH_CHECK(isIntegralType(target_lengths.scalar_type(), /*includeBool=*/false), "target_lengths must be integral");
 
   Tensor ilc = input_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();
   Tensor tlc = target_lengths.toType(kLong).toBackend(Backend::CPU).contiguous();

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -34,7 +34,7 @@ DEFINE_DISPATCH(max_values_stub);
 
 static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dtype) {
   ScalarType scalarType = self.scalar_type();
-  ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType) ? ScalarType::Long : scalarType);
+  ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType, /*includeBool*/ false) ? ScalarType::Long : scalarType);
   return self.toType(upcast_scalarType);
 }
 
@@ -194,7 +194,7 @@ static ScalarType get_dtype(Tensor& result, const Tensor& self, optional<ScalarT
     return result.scalar_type();
   }
   ScalarType src_type = self.scalar_type();
-  if (promote_integers && at::isIntegralType(src_type)) {
+  if (promote_integers && at::isIntegralType(src_type, /*includeBool*/ true)) {
     return kLong;
   }
   return src_type;

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -34,7 +34,7 @@ DEFINE_DISPATCH(max_values_stub);
 
 static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dtype) {
   ScalarType scalarType = self.scalar_type();
-  ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType, /*includeBool*/ true) ? ScalarType::Long : scalarType);
+  ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType, /*includeBool=*/true) ? ScalarType::Long : scalarType);
   return self.toType(upcast_scalarType);
 }
 
@@ -194,7 +194,7 @@ static ScalarType get_dtype(Tensor& result, const Tensor& self, optional<ScalarT
     return result.scalar_type();
   }
   ScalarType src_type = self.scalar_type();
-  if (promote_integers && at::isIntegralType(src_type, /*includeBool*/ true)) {
+  if (promote_integers && at::isIntegralType(src_type, /*includeBool=*/true)) {
     return kLong;
   }
   return src_type;

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -34,7 +34,7 @@ DEFINE_DISPATCH(max_values_stub);
 
 static inline Tensor integer_upcast(const Tensor& self, optional<ScalarType> dtype) {
   ScalarType scalarType = self.scalar_type();
-  ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType, /*includeBool*/ false) ? ScalarType::Long : scalarType);
+  ScalarType upcast_scalarType = dtype.value_or(at::isIntegralType(scalarType, /*includeBool*/ true) ? ScalarType::Long : scalarType);
   return self.toType(upcast_scalarType);
 }
 

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -49,7 +49,7 @@ void mul_kernel(TensorIterator& iter) {
 }
 
 void div_kernel(TensorIterator& iter) {
-  if (isIntegralType(iter.dtype())) {
+  if (isIntegralType(iter.dtype(), /*includeBool*/ false)) {
     // There's no SIMD integer division, so don't try to vectorize it.
     // TODO: if the divisor is a scalar, rewrite as multiplication by a constant.
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "div_cpu", [&]() {

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -26,7 +26,7 @@ static void sub_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
 }
 
 void div_kernel_cuda(TensorIterator& iter) {
-  if (!isIntegralType(iter.dtype()) && iter.is_cpu_scalar(2)) {
+  if (!isIntegralType(iter.dtype(), /*includeBool*/ false) && iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -196,9 +196,15 @@ static inline size_t elementSize(ScalarType t) {
 }
 
 static inline bool isIntegralType(ScalarType t) {
+  // C10_DEPRECATED_MESSAGE("isIntegralType is deprecated. Please use the overload with includeBool parameter instead.")
   return (
       t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||
-      t == ScalarType::Long || t == ScalarType::Short || t == ScalarType::Bool);
+      t == ScalarType::Long || t == ScalarType::Short);
+}
+
+static inline bool isIntegralType(ScalarType t, bool includeBool) {
+  bool isIntegral = isIntegralType(t);
+  return includeBool ? isIntegral || (t == ScalarType::Bool) : isIntegral;
 }
 
 static inline bool isFloatingType(ScalarType t) {

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -203,7 +203,10 @@ static inline bool isIntegralType(ScalarType t) {
 }
 
 static inline bool isIntegralType(ScalarType t, bool includeBool) {
-  bool isIntegral = isIntegralType(t);
+  bool isIntegral = (
+      t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||
+      t == ScalarType::Long || t == ScalarType::Short);
+
   return includeBool ? isIntegral || (t == ScalarType::Bool) : isIntegral;
 }
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -195,8 +195,8 @@ static inline size_t elementSize(ScalarType t) {
 #undef CASE_ELEMENTSIZE_CASE
 }
 
+C10_DEPRECATED_MESSAGE("isIntegralType is deprecated. Please use the overload with 'includeBool' parameter instead.")
 static inline bool isIntegralType(ScalarType t) {
-  // C10_DEPRECATED_MESSAGE("isIntegralType is deprecated. Please use the overload with includeBool parameter instead.")
   return (
       t == ScalarType::Byte || t == ScalarType::Char || t == ScalarType::Int ||
       t == ScalarType::Long || t == ScalarType::Short);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2611,10 +2611,16 @@ class _TestTorchMixin(object):
             aRes = torch.cumsum(a, 0)
             bRes = torch.cumsum(b, 0)
             self.assertEqual(aRes, bRes)
+            self.assertEqual(aRes, torch.tensor([[1, 0, 1],
+                                                 [1, 0, 1],
+                                                 [2, 1, 2]]))
 
             aRes = torch.cumsum(a, 1)
             bRes = torch.cumsum(b, 1)
             self.assertEqual(aRes, bRes)
+            self.assertEqual(aRes, torch.tensor([[1, 1, 2],
+                                                 [0, 0, 0],
+                                                 [1, 2, 3]]))
 
     def test_cumprod(self):
         for d in torch.testing.get_all_device_types():
@@ -2631,10 +2637,16 @@ class _TestTorchMixin(object):
             aRes = torch.cumprod(a, 0)
             bRes = torch.cumprod(b, 0)
             self.assertEqual(aRes, bRes)
+            self.assertEqual(aRes, torch.tensor([[1, 0, 1],
+                                                 [0, 0, 0],
+                                                 [0, 0, 0]]))
 
             aRes = torch.cumprod(a, 1)
             bRes = torch.cumprod(b, 1)
             self.assertEqual(aRes, bRes)
+            self.assertEqual(aRes, torch.tensor([[1, 0, 0],
+                                                 [0, 0, 0],
+                                                 [1, 1, 1]]))
 
     def _test_reduce_integer_upcast(self, fn, has_out=True):
         shape = (3, 4, 5)

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -294,7 +294,7 @@ static PyObject * THPVariable_index_scalar(PyObject* self, PyObject* args) {
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   // TODO: change the condition to `self_.dim() != 0` once we expose scalars
   // in PyTorch.
-  if (!isIntegralType(self_.scalar_type()) || self_.numel() != 1) {
+  if (!isIntegralType(self_.scalar_type(), /*includeBool*/ false) || self_.numel() != 1) {
     throw TypeError("only integer tensors of a single element can be converted to an index");
   }
   return wrap(dispatch_to_CLong(self_));
@@ -310,7 +310,7 @@ static Tensor dispatch_invert(const Tensor & self) {
 static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  if (!isIntegralType(self_.scalar_type()) && self_.scalar_type() != at::kBool) {
+  if (!isIntegralType(self_.scalar_type(), /*includeBool*/ true)) {
     throw TypeError("~ (operator.invert) is only implemented on integer and Boolean-type tensors");
   }
   return THPVariable_Wrap(dispatch_invert(self_));

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -294,7 +294,7 @@ static PyObject * THPVariable_index_scalar(PyObject* self, PyObject* args) {
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
   // TODO: change the condition to `self_.dim() != 0` once we expose scalars
   // in PyTorch.
-  if (!isIntegralType(self_.scalar_type(), /*includeBool*/ false) || self_.numel() != 1) {
+  if (!isIntegralType(self_.scalar_type(), /*includeBool=*/true) || self_.numel() != 1) {
     throw TypeError("only integer tensors of a single element can be converted to an index");
   }
   return wrap(dispatch_to_CLong(self_));
@@ -310,7 +310,7 @@ static Tensor dispatch_invert(const Tensor & self) {
 static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
-  if (!isIntegralType(self_.scalar_type(), /*includeBool*/ true)) {
+  if (!isIntegralType(self_.scalar_type(), /*includeBool=*/true)) {
     throw TypeError("~ (operator.invert) is only implemented on integer and Boolean-type tensors");
   }
   return THPVariable_Wrap(dispatch_invert(self_));

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -84,7 +84,12 @@ PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   TORCH_CHECK(r.idx == 0, "Not a type");
 
   at::ScalarType scalar_type = r.scalartype(0);
-  if (!at::isIntegralType(scalar_type, /*includeBool*/ true) && !at::isQIntType(scalar_type)) {
+  if (scalar_type == at::ScalarType::Bool) {
+    return PyErr_Format(
+        PyExc_TypeError,
+	"torch.bool is not supported by torch.iinfo");
+  }
+  if (!at::isIntegralType(scalar_type, /*includeBool=*/false) && !at::isQIntType(scalar_type)) {
     return PyErr_Format(
         PyExc_TypeError,
         "torch.iinfo() requires an integer input type. Use torch.finfo to handle '%s'",
@@ -141,7 +146,7 @@ static PyObject* THPFInfo_min(THPFInfo* self, void*) {
 }
 
 static PyObject* THPIInfo_max(THPFInfo* self, void*) {
-  if (at::isIntegralType(self->type, /*includeBool*/ false)) {
+  if (at::isIntegralType(self->type, /*includeBool=*/false)) {
     return AT_DISPATCH_INTEGRAL_TYPES(self->type, "max", [] {
       return THPUtils_packInt64(std::numeric_limits<scalar_t>::max());
     });
@@ -153,7 +158,7 @@ static PyObject* THPIInfo_max(THPFInfo* self, void*) {
 }
 
 static PyObject* THPIInfo_min(THPFInfo* self, void*) {
-  if (at::isIntegralType(self->type, /*includeBool*/ false)) {
+  if (at::isIntegralType(self->type, /*includeBool=*/false)) {
     return AT_DISPATCH_INTEGRAL_TYPES(self->type, "min", [] {
       return THPUtils_packInt64(std::numeric_limits<scalar_t>::lowest());
     });

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -84,7 +84,7 @@ PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   TORCH_CHECK(r.idx == 0, "Not a type");
 
   at::ScalarType scalar_type = r.scalartype(0);
-  if (!at::isIntegralType(scalar_type, /*includeBool*/ false) && !at::isQIntType(scalar_type)) {
+  if (!at::isIntegralType(scalar_type, /*includeBool*/ true) && !at::isQIntType(scalar_type)) {
     return PyErr_Format(
         PyExc_TypeError,
         "torch.iinfo() requires an integer input type. Use torch.finfo to handle '%s'",

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -87,7 +87,7 @@ PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   if (scalar_type == at::ScalarType::Bool) {
     return PyErr_Format(
         PyExc_TypeError,
-	"torch.bool is not supported by torch.iinfo");
+        "torch.bool is not supported by torch.iinfo");
   }
   if (!at::isIntegralType(scalar_type, /*includeBool=*/false) && !at::isQIntType(scalar_type)) {
     return PyErr_Format(

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -84,7 +84,7 @@ PyObject* THPIInfo_pynew(PyTypeObject* type, PyObject* args, PyObject* kwargs) {
   TORCH_CHECK(r.idx == 0, "Not a type");
 
   at::ScalarType scalar_type = r.scalartype(0);
-  if (!at::isIntegralType(scalar_type) && !at::isQIntType(scalar_type)) {
+  if (!at::isIntegralType(scalar_type, /*includeBool*/ false) && !at::isQIntType(scalar_type)) {
     return PyErr_Format(
         PyExc_TypeError,
         "torch.iinfo() requires an integer input type. Use torch.finfo to handle '%s'",
@@ -141,7 +141,7 @@ static PyObject* THPFInfo_min(THPFInfo* self, void*) {
 }
 
 static PyObject* THPIInfo_max(THPFInfo* self, void*) {
-  if (at::isIntegralType(self->type)) {
+  if (at::isIntegralType(self->type, /*includeBool*/ false)) {
     return AT_DISPATCH_INTEGRAL_TYPES(self->type, "max", [] {
       return THPUtils_packInt64(std::numeric_limits<scalar_t>::max());
     });
@@ -153,7 +153,7 @@ static PyObject* THPIInfo_max(THPFInfo* self, void*) {
 }
 
 static PyObject* THPIInfo_min(THPFInfo* self, void*) {
-  if (at::isIntegralType(self->type)) {
+  if (at::isIntegralType(self->type, /*includeBool*/ false)) {
     return AT_DISPATCH_INTEGRAL_TYPES(self->type, "min", [] {
       return THPUtils_packInt64(std::numeric_limits<scalar_t>::lowest());
     });

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -175,7 +175,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
       auto scalar_type = var.scalar_type();
-      if (var.dim() == 0 && at::isIntegralType(scalar_type, /*includeBool*/ true)) {
+      if (var.dim() == 0 && at::isIntegralType(scalar_type, /*includeBool=*/true)) {
         if (scalar_type != at::kByte && scalar_type != at::kBool) {
           result = applySelect(result, dim, THPUtils_unpackLong(obj), i);
         } else {

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -175,7 +175,7 @@ static Variable applySlicing(const Variable& self, PyObject* index, variable_lis
     } else if (THPVariable_Check(obj)) {
       auto& var = THPVariable_Unpack(obj);
       auto scalar_type = var.scalar_type();
-      if (var.dim() == 0 && at::isIntegralType(scalar_type)) {
+      if (var.dim() == 0 && at::isIntegralType(scalar_type, /*includeBool*/ true)) {
         if (scalar_type != at::kByte && scalar_type != at::kBool) {
           result = applySelect(result, dim, THPUtils_unpackLong(obj), i);
         } else {

--- a/torch/csrc/jit/fuser/codegen.cpp
+++ b/torch/csrc/jit/fuser/codegen.cpp
@@ -105,7 +105,7 @@ static std::string typeCastedValueName(
     const at::ScalarType outtype,
     const std::string& vn) {
   if (t->kind() == TypeKind::IntType || t->kind() == TypeKind::BoolType) {
-    if (!isIntegralType(outtype)) {
+    if (!isIntegralType(outtype, /*includeBool*/ false)) {
       return std::string("((") + calcScalarTypeName(outtype) + ") " + vn + ")";
     }
     return vn;

--- a/torch/csrc/jit/fuser/codegen.cpp
+++ b/torch/csrc/jit/fuser/codegen.cpp
@@ -105,7 +105,7 @@ static std::string typeCastedValueName(
     const at::ScalarType outtype,
     const std::string& vn) {
   if (t->kind() == TypeKind::IntType || t->kind() == TypeKind::BoolType) {
-    if (!isIntegralType(outtype, /*includeBool*/ false)) {
+    if (!isIntegralType(outtype, /*includeBool=*/false)) {
       return std::string("((") + calcScalarTypeName(outtype) + ") " + vn + ")";
     }
     return vn;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -39,7 +39,7 @@ bool isValidArgumentForRunning(Value* v) {
   if (toIValue(v))
     return true;
   if (CompleteTensorTypePtr tt = v->type()->cast<CompleteTensorType>()) {
-    return !at::isIntegralType(tt->scalarType());
+    return !at::isIntegralType(tt->scalarType(), /*includeBool*/ false);
   }
   return v->type()->isSubtypeOf(FloatType::get());
 }

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -39,7 +39,7 @@ bool isValidArgumentForRunning(Value* v) {
   if (toIValue(v))
     return true;
   if (CompleteTensorTypePtr tt = v->type()->cast<CompleteTensorType>()) {
-    return !at::isIntegralType(tt->scalarType(), /*includeBool*/ false);
+    return !at::isIntegralType(tt->scalarType(), /*includeBool=*/false);
   }
   return v->type()->isSubtypeOf(FloatType::get());
 }

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -86,7 +86,7 @@ void checkImplicitTensorToNum(at::Tensor t, bool toInt) {
     throw std::runtime_error(
         "Cannot input a tensor of dimension other than 0 as a scalar argument");
   }
-  if (toInt && !isIntegralType(t.scalar_type())) {
+  if (toInt && !isIntegralType(t.scalar_type(), /*includeBool*/ false)) {
     std::stringstream ss;
     ss << "Cannot input a tensor of type " << t.scalar_type()
        << " as an integral argument";

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -86,7 +86,7 @@ void checkImplicitTensorToNum(at::Tensor t, bool toInt) {
     throw std::runtime_error(
         "Cannot input a tensor of dimension other than 0 as a scalar argument");
   }
-  if (toInt && !isIntegralType(t.scalar_type(), /*includeBool*/ false)) {
+  if (toInt && !isIntegralType(t.scalar_type(), /*includeBool=*/false)) {
     std::stringstream ss;
     ss << "Cannot input a tensor of type " << t.scalar_type()
        << " as an integral argument";

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -156,7 +156,7 @@ bool FunctionParameter::check(PyObject* obj) {
       }
       if (THPVariable_Check(obj)) {
         auto& var = ((THPVariable*)obj)->cdata;
-        return at::isIntegralType(var.scalar_type(), /*includeBool*/ false) && !var.requires_grad() && var.dim() == 0;
+        return at::isIntegralType(var.scalar_type(), /*includeBool=*/false) && !var.requires_grad() && var.dim() == 0;
       }
       return false;
     }

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -156,7 +156,7 @@ bool FunctionParameter::check(PyObject* obj) {
       }
       if (THPVariable_Check(obj)) {
         auto& var = ((THPVariable*)obj)->cdata;
-        return at::isIntegralType(var.scalar_type()) && !var.requires_grad() && var.dim() == 0;
+        return at::isIntegralType(var.scalar_type(), /*includeBool*/ false) && !var.requires_grad() && var.dim() == 0;
       }
       return false;
     }


### PR DESCRIPTION
Original PR:
This [PR](https://github.com/pytorch/pytorch/pull/23346) caused [this](https://github.com/pytorch/pytorch/issues/23882) bug.

Fix:
- Deprecate old isIntegralType and add overload which takes a boolean flag which tells if torch.bool should be included in integral types or not.

Testing:
- Added extra test cases
- Tested via running unit tests locally.