### PR TITLE
Fix expansion of stride argument in max_pool3d

### DIFF
--- a/aten/src/ATen/native/DilatedMaxPool3d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool3d.cpp
@@ -147,30 +147,34 @@ void max_pool3d_with_indices_out_cpu_template(
           bool ceil_mode)
 {
   // #20866, #22032: Guarantee this for the official C++ API?
-  TORCH_CHECK((kernel_size.size() == 1 || kernel_size.size() == 3) &&
-              (stride.empty() || stride.size() == 3) &&
-              (padding.size() == 1 || padding.size() == 3) &&
-              (dilation.size() == 1 || dilation.size() == 3),
-    "max_pool3d_with_indices: internal error: all IntArrayRef sizes must be 3");
-
-  TORCH_CHECK((input_.ndimension() == 4 || input_.ndimension() == 5),
-    "non-empty 4D or 5D (batch mode) tensor expected for input");
-
+  TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
+    "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
   const int kT = safe_downcast<int, int64_t>(kernel_size[0]);
   const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
   const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
 
+  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+    "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[1]);
-  const int dW = stride.empty() ? kW : safe_downcast<int, int64_t>(stride[2]);
+  const int dH = stride.empty() ? kH :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[1]);
+  const int dW = stride.empty() ? kW :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[2]);
 
+  TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
+    "max_pool3d: padding must be either be a single int, or a tuple of three ints");
   const int pT = safe_downcast<int, int64_t>(padding[0]);
   const int pH = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[1]);
   const int pW = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[2]);
 
+  TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
+    "max_pool3d: dilation must be either a single int, or a tuple of three ints");
   const int dilationT = safe_downcast<int, int64_t>(dilation[0]);
   const int dilationH = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[1]);
   const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
+
+  TORCH_CHECK((input_.ndimension() == 4 || input_.ndimension() == 5),
+    "non-empty 4D or 5D (batch mode) tensor expected for input");
 
   const int64_t nslices = input_.size(-4);
   const int64_t itime = input_.size(-3);
@@ -351,30 +355,34 @@ Tensor& max_pool3d_with_indices_backward_out_cpu_template(
           bool ceil_mode)
 {
   // #20866, #22032: Guarantee this for the official C++ API?
-  TORCH_CHECK((kernel_size.size() == 1 || kernel_size.size() == 3) &&
-              (stride.empty() || stride.size() == 3) &&
-              (padding.size() == 1 || padding.size() == 3) &&
-              (dilation.size() == 1 || dilation.size() == 3),
-    "max_pool3d_with_indices: internal error: all IntArrayRef sizes must be 3");
-
-  TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
-    "non-empty 4D or 5D (batch mode) tensor expected for input");
-
+  TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
+    "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
   const int kT = safe_downcast<int, int64_t>(kernel_size[0]);
   const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
   const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
 
+  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+    "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[1]);
-  const int dW = stride.empty() ? kW : safe_downcast<int, int64_t>(stride[2]);
+  const int dH = stride.empty() ? kH :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[1]);
+  const int dW = stride.empty() ? kW :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[2]);
 
+  TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
+    "max_pool3d: padding must be either be a single int, or a tuple of three ints");
   const int pT = safe_downcast<int, int64_t>(padding[0]);
   const int pH = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[1]);
   const int pW = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[2]);
 
+  TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
+    "max_pool3d: dilation must be either a single int, or a tuple of three ints");
   const int dilationT = safe_downcast<int, int64_t>(dilation[0]);
   const int dilationH = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[1]);
   const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
+
+  TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
+    "non-empty 4D or 5D (batch mode) tensor expected for input");
 
   const int64_t nslices = input.size(-4);
   const int64_t itime = input.size(-3);

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -290,30 +290,34 @@ void max_pool3d_with_indices_out_cuda_template(
                   {output_arg, indices_arg, input_arg});
 
   // #20866, #22032: Guarantee this for the official C++ API?
-  TORCH_CHECK((kernel_size.size() == 1 || kernel_size.size() == 3) &&
-              (stride.empty() || stride.size() == 3) &&
-              (padding.size() == 1 || padding.size() == 3) &&
-              (dilation.size() == 1 || dilation.size() == 3),
-    "max_pool3d_with_indices: internal error: all IntArrayRef sizes must be 3");
-
-  TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
-    "non-empty 4D or 5D (batch mode) tensor expected for input");
-
+  TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
+    "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
   const int kT = safe_downcast<int, int64_t>(kernel_size[0]);
   const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
   const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
 
+  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+    "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
   const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[1]);
-  const int dW = stride.empty() ? kW : safe_downcast<int, int64_t>(stride[2]);
+  const int dH = stride.empty() ? kH :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[1]);
+  const int dW = stride.empty() ? kW :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[2]);
 
+  TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
+    "max_pool3d: padding must be either be a single int, or a tuple of three ints");
   const int pT = safe_downcast<int, int64_t>(padding[0]);
   const int pH = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[1]);
   const int pW = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[2]);
 
+  TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
+    "max_pool3d: dilation must be either a single int, or a tuple of three ints");
   const int dilationT = safe_downcast<int, int64_t>(dilation[0]);
   const int dilationH = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[1]);
   const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
+
+  TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
+    "non-empty 4D or 5D (batch mode) tensor expected for input");
 
   const int64_t nbatch = input.ndimension() == 5 ? input.size(-5) : 1;
   const int64_t nslices = input.size(-4);
@@ -394,11 +398,31 @@ void max_pool3d_with_indices_backward_out_cuda_template(
                   {gradInput_arg, gradOutput_arg, input_arg, indices_arg});
 
   // #20866, #22032: Guarantee this for the official C++ API?
-  TORCH_CHECK((kernel_size.size() == 1 || kernel_size.size() == 3) &&
-              (stride.empty() || stride.size() == 3) &&
-              (padding.size() == 1 || padding.size() == 3) &&
-              (dilation.size() == 1 || dilation.size() == 3),
-    "max_pool3d_with_indices: internal error: all IntArrayRef sizes must be 3");
+  TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
+    "max_pool3d: kernel_size must either be a single int, or a tuple of three ints")
+  const int kT = safe_downcast<int, int64_t>(kernel_size[0]);
+  const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
+  const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
+
+  TORCH_CHECK(stride.size() == 0 || stride.size() == 1 || stride.size() == 3,
+    "max_pool3d: stride must either be omitted, a single int, or a tuple of three ints")
+  const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
+  const int dH = stride.empty() ? kH :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[1]);
+  const int dW = stride.empty() ? kW :
+                 stride.size() == 1 ? dT : safe_downcast<int, int64_t>(stride[2]);
+
+  TORCH_CHECK(padding.size() == 1 || padding.size() == 3,
+    "max_pool3d: padding must be either be a single int, or a tuple of three ints");
+  const int pT = safe_downcast<int, int64_t>(padding[0]);
+  const int pH = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[1]);
+  const int pW = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[2]);
+
+  TORCH_CHECK(dilation.size() == 1 || dilation.size() == 3,
+    "max_pool3d: dilation must be either a single int, or a tuple of three ints");
+  const int dilationT = safe_downcast<int, int64_t>(dilation[0]);
+  const int dilationH = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[1]);
+  const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
 
   TORCH_CHECK((input.ndimension() == 4 || input.ndimension() == 5),
     "non-empty 4D or 5D (batch mode) tensor expected for input");
@@ -409,22 +433,6 @@ void max_pool3d_with_indices_backward_out_cuda_template(
   // Resize and initialize result tensor.
   gradInput.resize_as_(input);
   gradInput.zero_();
-
-  const int kT = safe_downcast<int, int64_t>(kernel_size[0]);
-  const int kH = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[1]);
-  const int kW = kernel_size.size() == 1 ? kT : safe_downcast<int, int64_t>(kernel_size[2]);
-
-  const int dT = stride.empty() ? kT : safe_downcast<int, int64_t>(stride[0]);
-  const int dH = stride.empty() ? kH : safe_downcast<int, int64_t>(stride[1]);
-  const int dW = stride.empty() ? kW : safe_downcast<int, int64_t>(stride[2]);
-
-  const int pT = safe_downcast<int, int64_t>(padding[0]);
-  const int pH = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[1]);
-  const int pW = padding.size() == 1 ? pT : safe_downcast<int, int64_t>(padding[2]);
-
-  const int dilationT = safe_downcast<int, int64_t>(dilation[0]);
-  const int dilationH = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[1]);
-  const int dilationW = dilation.size() == 1 ? dilationT : safe_downcast<int, int64_t>(dilation[2]);
 
   const int64_t nbatch = input.ndimension() == 5 ? input.size(-5) : 1;
   const int64_t nslices = input.size(-4);

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -296,6 +296,7 @@ void TestView(DeprecatedTypeProperties& type) {
 
 void TestIntArrayRefExpansion(DeprecatedTypeProperties& type) {
   max_pool2d(randn({3, 3, 3, 3}, type.options()), 2, 1, 1, 1);
+  max_pool3d(randn({3, 3, 3, 3, 3}, type.options()), 2, 1, 1, 1);
 }
 
 void test(DeprecatedTypeProperties& type) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23963 Fix expansion of stride argument in avg_pool3d
* #23961 Fix expansion of stride argument in avg_pool2d
* **#23960 Fix expansion of stride argument in max_pool3d**
* #23954 Fix expansion of stride argument in max_pool2d

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16695161](https://our.internmc.facebook.com/intern/diff/D16695161)