### PR TITLE
ignore clang-tidy bugprone-lambda-function-name in dispatch macros.

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -152,6 +152,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)      \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)        \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -166,6 +167,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)        \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, at::Half, __VA_ARGS__)      \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -180,6 +182,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                     \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE, decltype(::detail::ScalarTypeToCType<SCALARTYPE>::t), __VA_ARGS__) \
       default:                                                                                            \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                               \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                   \
     }                                                                                                     \
   }()
@@ -200,6 +203,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexHalf, std::complex<at::Half>, __VA_ARGS__)  \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -216,6 +220,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -234,6 +239,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Long, int64_t, __VA_ARGS__)       \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -249,6 +255,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)  \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -258,12 +265,13 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     const auto& SCALAR_TYPE C10_UNUSED = TYPE;                          \
     switch (TYPE) {                                                     \
       AT_QINT_PRIVATE_CASE_TYPE(                                        \
-          at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)                    \
+          at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)        \
       AT_QINT_PRIVATE_CASE_TYPE(                                        \
-          at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)                 \
+          at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)     \
       AT_QINT_PRIVATE_CASE_TYPE(                                        \
-          at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)                      \
+          at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)          \
       default:                                                          \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */             \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'"); \
     }                                                                   \
   }()
@@ -286,7 +294,8 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)  \
       default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'"); \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
+        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
 
@@ -302,6 +311,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)                                   \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE, decltype(::detail::ScalarTypeToCType<SCALARTYPE>::t), __VA_ARGS__) \
       default:                                                                                            \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                               \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                   \
     }                                                                                                     \
   }()
@@ -319,6 +329,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(SCALARTYPE1, decltype(::detail::ScalarTypeToCType<SCALARTYPE1>::t), __VA_ARGS__) \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE2, decltype(::detail::ScalarTypeToCType<SCALARTYPE2>::t), __VA_ARGS__) \
       default:                                                                                              \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                                 \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                     \
     }                                                                                                       \
   }()
@@ -337,6 +348,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(SCALARTYPE2, decltype(::detail::ScalarTypeToCType<SCALARTYPE2>::t), __VA_ARGS__) \
       AT_PRIVATE_CASE_TYPE(SCALARTYPE3, decltype(::detail::ScalarTypeToCType<SCALARTYPE3>::t), __VA_ARGS__) \
       default:                                                                                              \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                                 \
         AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");                                     \
     }                                                                                                       \
   }()
@@ -359,6 +371,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(                                                                                 \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)                                 \
       default:                                                                                              \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                                 \
         AT_ERROR(#NAME, " not implemented for '", TYPE, "'");                                               \
     }                                                                                                       \
   }()
@@ -383,6 +396,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Short, int16_t, __VA_ARGS__)      \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, at::Half, __VA_ARGS__)      \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()
@@ -407,6 +421,7 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
       AT_PRIVATE_CASE_TYPE(                                                  \
           at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)  \
       default:                                                               \
+        /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                  \
         AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");       \
     }                                                                        \
   }()

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -17,8 +17,9 @@
 PyObject* THPFInfo_New(const at::ScalarType& type) {
   auto finfo = (PyTypeObject*)&THPFInfoType;
   auto self = THPObjectPtr{finfo->tp_alloc(finfo, 0)};
-  if (!self)
+  if (!self) {
     throw python_error();
+  }
   auto self_ = reinterpret_cast<THPDTypeInfo*>(self.get());
   self_->type = type;
   return self.release();
@@ -27,8 +28,9 @@ PyObject* THPFInfo_New(const at::ScalarType& type) {
 PyObject* THPIInfo_New(const at::ScalarType& type) {
   auto iinfo = (PyTypeObject*)&THPIInfoType;
   auto self = THPObjectPtr{iinfo->tp_alloc(iinfo, 0)};
-  if (!self)
+  if (!self) {
     throw python_error();
+  }
   auto self_ = reinterpret_cast<THPDTypeInfo*>(self.get());
   self_->type = type;
   return self.release();


### PR DESCRIPTION
AT_ERROR uses `__func__` to print a message, but this is just operator()
in dispatch macros because of the lambda.  Since we have correct backtraces
it seems best to just ignore these.

Also, makes some minor formatting changes to TypeInfo so that it will trigger
clang-tidy on a file that was complained about.

Fixes: https://github.com/pytorch/pytorch/issues/23947

