### PR TITLE
Fix validation of dynamic axes names

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -31,6 +31,17 @@ class TestUtilityFuns(TestCase):
         except ValueError:
             self.assertFalse(torch.onnx.is_in_onnx_export())
 
+    def test_validate_dynamic_axes_invalid_input_output_name(self):
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            utils._validate_dynamic_axes({'input1': {}, 'output': {},
+                                         'invalid_name1': {}, 'invalid_name2': {}},
+                                          None, ['input1', 'input2'], ['output'])
+            messages = [str(warning.message) for warning in w]
+        assert "Provided key invalid_name1 for dynamic axes is not a valid input/output name" in messages
+        assert "Provided key invalid_name2 for dynamic axes is not a valid input/output name" in messages
+        assert len(messages) == 2
+
     def test_constant_fold_transpose(self):
         class TransposeModule(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -37,7 +37,7 @@ class TestUtilityFuns(TestCase):
             warnings.simplefilter("always")
             utils._validate_dynamic_axes({'input1': {}, 'output': {},
                                          'invalid_name1': {}, 'invalid_name2': {}},
-                                          None, ['input1', 'input2'], ['output'])
+                                         None, ['input1', 'input2'], ['output'])
             messages = [str(warning.message) for warning in w]
         assert "Provided key invalid_name1 for dynamic axes is not a valid input/output name" in messages
         assert "Provided key invalid_name2 for dynamic axes is not a valid input/output name" in messages

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -34,6 +34,7 @@ class TestUtilityFuns(TestCase):
     def test_validate_dynamic_axes_invalid_input_output_name(self):
         import warnings
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             utils._validate_dynamic_axes({'input1': {}, 'output': {},
                                          'invalid_name1': {}, 'invalid_name2': {}},
                                           None, ['input1', 'input2'], ['output'])

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -703,11 +703,7 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
         if (output_names is None) or len(output_names) == 0:
             output_names = [y.debugName() for y in model.graph.outputs()]
 
-    valid_names = set()
-    if input_names is not None:
-        valid_names.add(x for x in input_names)
-    if output_names is not None:
-        valid_names.add(x for x in output_names)
+    valid_names = set((input_names or []) + (output_names or []))
 
     # If dynamic axes are provided as a list rather than dictionary, they should
     # first get converted to a dictionary in expected format. If desired axes names


### PR DESCRIPTION
Existing code adds two enumerators to the set instead of forming their union.

