### PR TITLE
Return list of AccessedFeatures from get_accessed_features

### DIFF
--- a/caffe2/python/layers/feature_sparse_to_dense.py
+++ b/caffe2/python/layers/feature_sparse_to_dense.py
@@ -2,6 +2,7 @@
 # Module caffe2.python.layers.sparse_to_dense
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from collections import defaultdict
 import numpy as np
 from caffe2.python import schema
 from caffe2.python.layers.layers import ModelLayer, AccessedFeatures
@@ -296,14 +297,16 @@ class FeatureSparseToDense(ModelLayer):
         return metadata
 
     def get_accessed_features(self):
-        accessed_features = {}
+        accessed_features = defaultdict(list)
 
         # The features that are accessed are just those features that appear in
         # the input specs
         for field, feature_specs in self.input_specs:
-            accessed_features[field] = AccessedFeatures(
-                feature_specs.feature_type,
-                set(feature_specs.feature_ids)
+            accessed_features[field].append(
+                AccessedFeatures(
+                    feature_specs.feature_type,
+                    set(feature_specs.feature_ids)
+                )
             )
 
         return accessed_features

--- a/caffe2/python/layers/layers.py
+++ b/caffe2/python/layers/layers.py
@@ -361,8 +361,8 @@ class ModelLayer(object):
 
     def get_accessed_features(self):
         """
-        Return a map from field to AccessedFeatures, the map should contain all
-        features accessed in the model layer
+        Return a map from field to list of AccessedFeatures, the map should
+        contain all features accessed in the model layer
         """
         return {}
 

--- a/caffe2/python/layers_test.py
+++ b/caffe2/python/layers_test.py
@@ -2229,12 +2229,12 @@ class TestLayers(LayersTestCase):
         self.model.FeatureSparseToDense(input_record, input_specs)
 
         expected_accessed_features = {
-            float_features_column: AccessedFeatures(
-                float_features_type, set(float_features_ids)),
-            id_list_features_column: AccessedFeatures(
-                id_list_features_type, set(id_list_features_ids)),
-            id_score_list_features_column: AccessedFeatures(
-                id_score_list_features_type, set(id_score_list_features_ids)),
+            float_features_column: [
+                AccessedFeatures(float_features_type, set(float_features_ids))],
+            id_list_features_column: [
+                AccessedFeatures(id_list_features_type, set(id_list_features_ids))],
+            id_score_list_features_column: [
+                AccessedFeatures(id_score_list_features_type, set(id_score_list_features_ids))],
         }
 
         self.assertEqual(len(self.model.layers), 1)


### PR DESCRIPTION
Summary:
While testing I realized that model layers can extract different types of features from the same column.  For example, MultifeedFeaturesTransform uses float and ID list features from the "features" column.

get_accessed_features returns a map from column to AccessedFeatures, and AccessedFeatures only has the feature IDs for one feature type.  This is incompatible with have multiple types of features per column, one type ends up overwriting another in the map.

To fix this, I've modified get_accessed_features to return a map from column to a list of AccessedFeatures objects.

Differential Revision: D16693845

