### PR TITLE
clang-tidy `-fix`es

### DIFF
--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -99,7 +99,7 @@ private:
   // weak_ptr to avoid a refcycle. Since grad_fn_ owns this AutogradContext, it
   // will always be alive when we want to use it.
   std::weak_ptr<Node> grad_fn_;
-  bool has_freed_buffers_;
+  bool has_freed_buffers_{};
 
   void save_variables();
 

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -34,7 +34,7 @@ struct PyNode : public Node {
   // THPFunction this Function is wrapping.  Owning!
   PyObject* obj;
 
-  ~PyNode() {
+  ~PyNode() override {
     // Can't use THPObjectPtr as a field in this class; destructor won't take
     // out GIL!  When I forgot to do this by hand
     // TestAutograd.test_inplace_view_python called me out about it.

--- a/torch/csrc/autograd/record_function.h
+++ b/torch/csrc/autograd/record_function.h
@@ -28,7 +28,7 @@ struct TORCH_API StringView {
 
 struct TORCH_API RecordFunction {
   // Default constructor is used with before function called afterwards
-  RecordFunction() {}
+  RecordFunction() = default;
 
   // before function initializes RecordFunction members and calls
   // start callbacks

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -97,7 +97,7 @@ struct TORCH_API Variable : public at::Tensor {
   /// See NOTE [ Autograd View Variables ] for details.
   friend Variable make_variable_view(
       Variable base,
-      at::Tensor data,
+      const at::Tensor& data,
       bool is_differentiable,
       bool allow_tensor_metadata_change,
       Edge gradient_edge);
@@ -108,7 +108,7 @@ struct TORCH_API Variable : public at::Tensor {
   /// gradients. NOTE: `data` must *not* be a `Variable` already. Its dynamic
   /// type *must* be `Tensor`.
   friend Variable make_variable(
-      at::Tensor data,
+      const at::Tensor& data,
       bool requires_grad,
       bool allow_tensor_metadata_change);
 
@@ -117,7 +117,7 @@ struct TORCH_API Variable : public at::Tensor {
   /// in the autograd graph, and what particular input of that function, this
   /// variable is connected to.
   friend Variable make_variable(
-      at::Tensor data,
+      const at::Tensor& data,
       Edge gradient_edge,
       bool allow_tensor_metadata_change);
 
@@ -471,7 +471,7 @@ struct TORCH_API Variable::DifferentiableViewMeta : public Variable::AutogradMet
   }
 
   DifferentiableViewMeta(at::TensorImpl* self_impl, Variable base, Edge gradient_edge);
-  ~DifferentiableViewMeta();
+  ~DifferentiableViewMeta() override;
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -491,7 +491,7 @@ struct TORCH_API Variable::DifferentiableViewMeta : public Variable::AutogradMet
 // See NOTE [ Autograd View Variables ] for details.
 inline Variable make_variable_view(
     Variable base,
-    at::Tensor data,
+    const at::Tensor& data,
     bool is_differentiable = true,
     bool allow_tensor_metadata_change = true,
     Edge gradient_edge = Edge()) {
@@ -518,7 +518,7 @@ inline Variable make_variable_view(
 }
 
 inline Variable make_variable(
-    at::Tensor data,
+    const at::Tensor& data,
     bool requires_grad = false,
     bool allow_tensor_metadata_change = true) {
   TORCH_CHECK(
@@ -543,7 +543,7 @@ inline Variable make_variable(
 }
 
 inline Variable make_variable(
-    at::Tensor data,
+    const at::Tensor& data,
     Edge gradient_edge,
     bool allow_tensor_metadata_change = true) {
   TORCH_CHECK(

--- a/torch/csrc/jit/attributes.h
+++ b/torch/csrc/jit/attributes.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <ATen/ATen.h>
 #include <string>
+#include <utility>
+#include <utility>
 #include <vector>
 
 #include <ATen/core/interned_strings.h>
@@ -88,7 +90,7 @@ struct TORCH_API GraphAttr : public AttributeValue {
   using ConstructorType = std::shared_ptr<Graph>;
   using ValueType = std::shared_ptr<Graph>;
   GraphAttr(Symbol name, ConstructorType value_)
-      : AttributeValue(name), value_(value_) {}
+      : AttributeValue(name), value_(std::move(std::move(value_))) {}
   ValueType& value() {
     return value_;
   }

--- a/torch/csrc/jit/constants.cpp
+++ b/torch/csrc/jit/constants.cpp
@@ -4,6 +4,8 @@
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/operator.h>
 
+#include <utility>
+
 namespace torch {
 namespace jit {
 
@@ -21,7 +23,7 @@ Value* insertConstant(
     const c10::TypePtr& result_type,
     c10::optional<SourceRange> loc,
     c10::optional<ScopePtr> scope) {
-  auto value = tryInsertConstant(g, val, result_type, loc, scope);
+  auto value = tryInsertConstant(g, val, result_type, std::move(loc), std::move(scope));
   if (value) {
     return *value;
   }
@@ -129,7 +131,7 @@ RegisterOperators reg({
         [](const Node* node) -> Operation {
           TypePtr type = node->output()->type();
           if (type->isSubtypeOf(TensorType::get())) {
-            auto t = node->t(attr::value);
+            const auto& t = node->t(attr::value);
             return [t](Stack& stack) {
               push(stack, t);
               return 0;

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -27,6 +27,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace torch {
@@ -1072,7 +1073,7 @@ std::string prettyPrint(const onnx::ModelProto& model) {
 } // namespace
 
 void SetExportModuleExtraFilesHook(ExportModuleExtraFilesHook hook) {
-  GetExtraFilesHook() = hook;
+  GetExtraFilesHook() = std::move(hook);
 }
 
 std::string pretty_print_onnx(

--- a/torch/csrc/jit/fuser/kernel_spec.h
+++ b/torch/csrc/jit/fuser/kernel_spec.h
@@ -122,7 +122,7 @@ struct TORCH_API KernelSpec {
       return c10::nullopt;
     return it->second;
   }
-  void cacheKernel(const ArgSpec& arg_spec, std::shared_ptr<FusedKernel> kernel)
+  void cacheKernel(const ArgSpec& arg_spec, const std::shared_ptr<FusedKernel>& kernel)
       const {
     std::lock_guard<std::mutex> guard{mutex_};
     kernels_.emplace(arg_spec, kernel);

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -238,7 +238,7 @@ struct DifferentiableGraphBackward : public autograd::Node {
     for (IValue& v : stack) {
       if (v.isTensorList()) {
         for (const at::Tensor& tensor : v.toTensorListRef()) {
-          produceOutput(output_index++, std::move(tensor), outputs);
+          produceOutput(output_index++, tensor, outputs);
         }
       } else if (v.isTensor()) {
         produceOutput(output_index++, std::move(v).toTensor(), outputs);
@@ -612,7 +612,7 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
   std::unordered_map<ArgumentSpec, ExecutionPlan> plan_cache;
 };
 
-GraphExecutor::GraphExecutor(std::shared_ptr<Graph> graph)
+GraphExecutor::GraphExecutor(const std::shared_ptr<Graph>& graph)
     : pImpl(
           getProfilingMode() ? dynamic_cast<GraphExecutorImplBase*>(
                                    new ProfilingGraphExecutorImpl(graph))

--- a/torch/csrc/jit/graph_executor.h
+++ b/torch/csrc/jit/graph_executor.h
@@ -37,7 +37,7 @@ struct GraphExecutorState {
 struct GraphExecutorImplBase;
 struct TORCH_API GraphExecutor {
   GraphExecutor() = default;
-  GraphExecutor(std::shared_ptr<Graph> graph);
+  GraphExecutor(const std::shared_ptr<Graph>& graph);
   void run(Stack& inputs);
   ExecutionPlan getPlanFor(Stack& inputs);
   explicit operator bool() const {

--- a/torch/csrc/jit/hooks_for_testing.cpp
+++ b/torch/csrc/jit/hooks_for_testing.cpp
@@ -1,20 +1,22 @@
 #include <torch/csrc/jit/hooks_for_testing.h>
 #include <torch/csrc/jit/script/module.h>
 
+#include <utility>
+
 namespace torch {
 namespace jit {
 
 static ModuleHook emit_module_callback;
-void didFinishEmitModule(script::Module module) {
+void didFinishEmitModule(const script::Module& module) {
   if (emit_module_callback) {
-    emit_module_callback(std::move(module));
+    emit_module_callback(module);
   }
 }
 
 static FunctionHook emit_function_callback;
 void didFinishEmitFunction(StrongFunctionPtr fn) {
   if (emit_function_callback) {
-    emit_function_callback(fn);
+    emit_function_callback(std::move(fn));
   }
 }
 

--- a/torch/csrc/jit/hooks_for_testing.h
+++ b/torch/csrc/jit/hooks_for_testing.h
@@ -13,7 +13,7 @@ struct Module;
 using ModuleHook = std::function<void(script::Module module)>;
 using FunctionHook = std::function<void(StrongFunctionPtr function)>;
 
-TORCH_API void didFinishEmitModule(script::Module module);
+TORCH_API void didFinishEmitModule(const script::Module& module);
 TORCH_API void didFinishEmitFunction(StrongFunctionPtr defined);
 TORCH_API void setEmitHooks(ModuleHook for_module, FunctionHook for_fn);
 

--- a/torch/csrc/jit/import_source.h
+++ b/torch/csrc/jit/import_source.h
@@ -24,7 +24,7 @@ TORCH_API void import_methods(
 // Define the list of classes in `src`.
 TORCH_API void import_libs(
     // The compilation unit that will own the imported libs
-    std::shared_ptr<CompilationUnit> cu,
+    const std::shared_ptr<CompilationUnit>& cu,
     // Qualifier for any classes that `src` defines. Looks like a module path,
     // like "foo.bar.baz"
     const std::string& class_qualifier,

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -349,7 +349,7 @@ void initJITBindings(PyObject* module) {
       .def(
           "_jit_try_infer_type",
           [](py::object obj) -> TypePtr {
-            auto match = tryToInferType(obj);
+            auto match = tryToInferType(std::move(obj));
             if (match.type) {
               return *match.type;
             }
@@ -495,7 +495,7 @@ void initJITBindings(PyObject* module) {
       });
   m.def("_jit_get_schemas_for_operator", [](const std::string& qualified_name) {
     auto symbol = Symbol::fromQualString(qualified_name);
-    auto operations = getAllOperatorsFor(symbol);
+    const auto& operations = getAllOperatorsFor(symbol);
     return fmap(operations, [](const std::shared_ptr<Operator>& op) {
       return op->schema();
     });
@@ -508,7 +508,7 @@ void initJITBindings(PyObject* module) {
     c10::intrusive_ptr<c10::ivalue::Future> fut;
   };
 
-  py::class_<PythonFutureWrapper>(m, "Future");
+  py::class_<PythonFutureWrapper> give_me_a_name(m, "Future");
 
   m.def("fork", [](py::args args) {
     AT_ASSERT(args.size() >= 1);
@@ -576,7 +576,7 @@ void initJITBindings(PyObject* module) {
   });
 
   m.def("_jit_assert_is_instance", [](py::object obj, TypePtr type) {
-    toIValue(obj, type);
+    toIValue(std::move(obj), type);
   });
 
   initPythonIRBindings(module);

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -607,7 +607,7 @@ struct CodeImpl {
       at::ArrayRef<Value*> inputs) {
     emitLoadInputs(inputs);
     insertInstruction(CALL, function_table_.size());
-    function_table_.emplace_back(std::move(func));
+    function_table_.emplace_back(func);
   }
 
   void emitNodeAtBlockLevel(Node* node) {

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -77,7 +77,7 @@ struct Suspend : public std::exception {
 
 struct InterpreterContinuation {
   InterpreterContinuation(
-      InterpreterState state_,
+      const InterpreterState& state_,
       Stack stack_,
       bool grad_mode_enabled_)
       : state(state_),

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -81,7 +81,7 @@ struct const_value_list_with_types {
       : values(values), delim(std::move(delim_)) {}
 };
 
-std::ostream& operator<<(std::ostream& out, const_value_list_with_types l) {
+std::ostream& operator<<(std::ostream& out, const const_value_list_with_types& l) {
   size_t i = 0;
   for (auto n : l.values) {
     if (i++ > 0) {
@@ -1478,7 +1478,7 @@ Value* Graph::insertFunctionCall(
     script::MatchedSchema& matched) {
   Value* fn_constant = insertNode(create(prim::Constant))
                            ->output()
-                           ->setType(FunctionType::create(std::move(callee)));
+                           ->setType(FunctionType::create(callee));
   std::vector<Value*> inputs = {fn_constant};
   inputs.insert(inputs.end(), matched.inputs.begin(), matched.inputs.end());
   Value* result = insertNode(create(prim::CallFunction, inputs))
@@ -1519,12 +1519,12 @@ Node* Graph::createClone(
 }
 
 Value* Graph::insertConstant(
-    IValue val,
+    const IValue& val,
     const TypePtr& result_type,
     c10::optional<SourceRange> loc,
     c10::optional<ScopePtr> scope) {
   return jit::insertConstant(
-      *this, std::move(val), result_type, std::move(loc), std::move(scope));
+      *this, val, result_type, std::move(loc), std::move(scope));
 }
 
 std::string Graph::toString(bool print_source_locations) const {

--- a/torch/csrc/jit/ir.h
+++ b/torch/csrc/jit/ir.h
@@ -21,6 +21,8 @@
 #include <functional>
 #include <iostream>
 #include <unordered_set>
+#include <utility>
+#include <utility>
 #include <vector>
 
 // Forward declare, the real meat is in python_ir.cpp
@@ -882,14 +884,14 @@ struct Block {
     return owning_node_;
   }
 
-  Value* addInput(std::string name = "") {
+  Value* addInput(const std::string& name = "") {
     Value* v = input_->addOutput();
-    v->setDebugName(std::move(name));
+    v->setDebugName(name);
     return v;
   }
-  Value* insertInput(size_t i, std::string name = "") {
+  Value* insertInput(size_t i, const std::string& name = "") {
     Value* v = input_->insertOutput(i);
-    v->setDebugName(std::move(name));
+    v->setDebugName(name);
     return v;
   }
   void eraseInput(size_t i) {
@@ -1118,7 +1120,7 @@ struct Graph {
   // Insert constant IValue into the graph. If the type cannot be fully deduced
   // from the ivalue, as with a None that is set to t?, use result_type
   TORCH_API Value* insertConstant(
-      IValue val,
+      const IValue& val,
       const TypePtr& result_type = nullptr,
       c10::optional<SourceRange> loc = c10::nullopt,
       c10::optional<ScopePtr> scope = c10::nullopt);
@@ -1269,7 +1271,7 @@ inline const Graph* Value::owningGraph() const {
 struct ProfileOp : public Node {
   static constexpr Symbol Kind = ::c10::prim::profile;
   ProfileOp(Graph* graph, std::function<void(std::vector<IValue>&)> callback)
-      : Node(graph, ::c10::prim::profile), callback_(callback) {}
+      : Node(graph, ::c10::prim::profile), callback_(std::move(std::move(callback))) {}
 
   void cloneFrom(Node* other_) override;
   Node* allocNewInstance(Graph* g) override;
@@ -1279,7 +1281,7 @@ struct ProfileOp : public Node {
   }
 
   void setCallback(std::function<void(std::vector<IValue>&)> callback) {
-    callback_ = callback;
+    callback_ = std::move(callback);
   }
 
  private:

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -73,7 +73,7 @@ struct TORCH_API Operator {
       c10::OperatorOptions options = c10::OperatorOptions())
       : schema_(std::make_shared<FunctionSchema>(std::move(schema))),
         op_creator_(std::move(op_creator)),
-        options_(std::move(options)) {}
+        options_(options) {}
 
   Operator(
       const std::string& schema,
@@ -81,7 +81,7 @@ struct TORCH_API Operator {
       c10::OperatorOptions options = c10::OperatorOptions())
       : schema_string_(schema),
         op_creator_(std::move(op_creator)),
-        options_(std::move(options)) {}
+        options_(options) {}
 
   // Helper constructor to register `op` to run
   // run for _every_ IR Node where n.kind() == name, regardless of arguments.
@@ -101,7 +101,7 @@ struct TORCH_API Operator {
                 /*is_vararg*/ true,
                 /*is_varret*/ true),
             std::move(op_creator),
-            std::move(options)) {}
+            options) {}
 
   Operator(
       FunctionSchema schema,
@@ -109,7 +109,7 @@ struct TORCH_API Operator {
       c10::OperatorOptions options = c10::OperatorOptions())
       : schema_(std::make_shared<FunctionSchema>(std::move(schema))),
         op_(std::make_shared<Operation>(std::move(op))),
-        options_(std::move(options)) {}
+        options_(options) {}
 
   Operator(
       const std::string& schema,
@@ -117,7 +117,7 @@ struct TORCH_API Operator {
       c10::OperatorOptions options = c10::OperatorOptions())
       : schema_string_(schema),
         op_(std::make_shared<Operation>(std::move(op))),
-        options_(std::move(options)) {}
+        options_(options) {}
 
   bool matches(const Node* node) const;
 

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -37,7 +37,7 @@ class TORCH_API MemoryDAG {
   // explicitly delete copy constructor because otherwise windows build is
   // confused for an exported class see
   // https://stackoverflow.com/a/51033485/105137
-  MemoryDAG() {}
+  MemoryDAG() = default;
   MemoryDAG(const MemoryDAG&) = delete;
   MemoryDAG& operator=(const MemoryDAG&) = delete;
 

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -558,7 +558,7 @@ void Unpickler::setInput(size_t memo_id) {
 // avoid it by calling push_back for bool
 template <typename T>
 inline void append(std::vector<T>& a, T&& e) {
-  a.emplace_back(std::move(e));
+  a.emplace_back(std::forward<T>(e));
 }
 template <>
 inline void append<bool>(std::vector<bool>& a, bool&& e) {

--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <utility>
+#include <utility>
 #include <vector>
 
 #include <ATen/core/ivalue.h>
@@ -115,7 +117,7 @@ struct WriteableTensorData {
  private:
   friend WriteableTensorData getWriteableTensorData(const at::Tensor& tensor);
   at::Tensor tensor_;
-  uint64_t size_;
+  uint64_t size_{};
 };
 
 class Pickler {
@@ -236,7 +238,7 @@ class Unpickler {
       : bytes_(static_cast<const uint8_t*>(data)),
         end_ptr_(bytes_ + size),
         tensor_table_(tensor_table),
-        class_resolver_(class_resolver) {}
+        class_resolver_(std::move(std::move(class_resolver))) {}
 
   std::vector<IValue> parse_ivalue_list();
 

--- a/torch/csrc/jit/python_tracer.cpp
+++ b/torch/csrc/jit/python_tracer.cpp
@@ -12,6 +12,7 @@
 #include <c10/util/Exception.h>
 
 #include <sstream>
+#include <utility>
 
 using namespace torch::autograd;
 using namespace torch::jit;
@@ -156,7 +157,7 @@ void initPythonTracerBindings(PyObject* module) {
       .def("pop_scope", [](TracingState& s) { s.graph->pop_scope(); })
       .def(
           "set_graph",
-          [](TracingState& s, std::shared_ptr<Graph> g) { s.graph = g; })
+          [](TracingState& s, std::shared_ptr<Graph> g) { s.graph = std::move(g); })
       .def("graph", [](TracingState& s) { return s.graph; });
 
   m.def("_tracer_warn_use_python", []() { tracer::setWarn(pythonWarn); });
@@ -169,7 +170,7 @@ void initPythonTracerBindings(PyObject* module) {
   m.def("_tracer_abandon", []() { tracer::abandon(); });
   m.def("_get_tracing_state", []() { return getTracingState(); });
   m.def("_set_tracing_state", [](std::shared_ptr<TracingState> state) {
-    return setTracingState(state);
+    return setTracingState(std::move(state));
   });
   m.def("_get_value_trace", [](const Variable& var) {
     return getValueTrace(var);

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1383,7 +1383,7 @@ void setItem(const c10::List<T>& list, int64_t idx, T&& value) {
   if (normalized_idx < 0 || normalized_idx >= list_size) {
     throw std::out_of_range("list index out of range");
   }
-  list.set(normalized_idx, std::move(value));
+  list.set(normalized_idx, std::forward<T>(value));
 }
 
 template <typename T>
@@ -2912,7 +2912,7 @@ Operation sort_op(
     std::sort(
         g_list.begin(),
         g_list.end(),
-        [lt_func, reverse, &sort_stack](IValue a, IValue b) -> bool {
+        [lt_func, reverse, &sort_stack](const IValue& a, const IValue& b) -> bool {
           // "strict weak ordering" issue - see other sort
           if (a.isSameIdentity(b)) {
             return false;

--- a/torch/csrc/jit/register_string_ops.cpp
+++ b/torch/csrc/jit/register_string_ops.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/custom_operator.h>
 
+#include <utility>
+
 namespace torch {
 namespace jit {
 namespace {
@@ -41,7 +43,7 @@ std::string stringSlice(std::string string, int64_t start, int64_t end, int64_t 
 
 int64_t stringFindImpl(
     std::string string,
-    std::string substr,
+    const std::string& substr,
     int64_t start,
     int64_t end,
     bool reverse = false) {
@@ -376,7 +378,7 @@ auto reg_str_ops_2 =
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
-                  return stringFindImpl(string, substr, start, end);
+                  return stringFindImpl(std::move(string), std::move(substr), start, end);
                 }))
 
         .op("aten::rfind(str self, str substr, int start=0, int end=-1) -> int",
@@ -386,7 +388,7 @@ auto reg_str_ops_2 =
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
-                  return stringFindImpl(string, substr, start, end, true);
+                  return stringFindImpl(std::move(string), std::move(substr), start, end, true);
                 }))
 
         .op("aten::index(str self, str substr, int start=0, int end=-1) -> int",
@@ -396,7 +398,7 @@ auto reg_str_ops_2 =
                                    std::string substr,
                                    int64_t start,
                                    int64_t end) {
-                  auto result = stringFindImpl(string, substr, start, end);
+                  auto result = stringFindImpl(std::move(string), std::move(substr), start, end);
                   if (result < 0) {
                     throw std::runtime_error("ValueError: substring not found");
                   }
@@ -411,7 +413,7 @@ auto reg_str_ops_2 =
                                    int64_t start,
                                    int64_t end) {
                   auto result =
-                      stringFindImpl(string, substr, start, end, true);
+                      stringFindImpl(std::move(string), std::move(substr), start, end, true);
                   if (result < 0) {
                     throw std::runtime_error("ValueError: substring not found");
                   }
@@ -542,7 +544,7 @@ auto reg_str_ops_2 =
                   return ss.str();
                 }))
 
-        .op("aten::lstrip(str self, str chars=' \\n\\t\\f\\v') -> str",
+        .op(R"(aten::lstrip(str self, str chars=' \n\t\f\v') -> str)",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
                 .catchAllKernel([](std::string string, std::string chars) {
@@ -555,7 +557,7 @@ auto reg_str_ops_2 =
                   return string;
                 }))
 
-        .op("aten::rstrip(str self, str chars=' \\n\\t\\f\\v') -> str",
+        .op(R"(aten::rstrip(str self, str chars=' \n\t\f\v') -> str)",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
                 .catchAllKernel([](std::string string, std::string chars) {
@@ -568,7 +570,7 @@ auto reg_str_ops_2 =
                   return string;
                 }))
 
-        .op("aten::strip(str self, str chars=' \\n\\t\\f\\v') -> str",
+        .op(R"(aten::strip(str self, str chars=' \n\t\f\v') -> str)",
             torch::RegisterOperators::options()
                 .aliasAnalysis(AliasAnalysisKind::FROM_SCHEMA)
                 .catchAllKernel([](std::string string, std::string chars) {

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -31,7 +31,7 @@ struct Resolver;
 
 using ResolverPtr = std::shared_ptr<Resolver>;
 struct Self {
-  virtual ~Self() {}
+  virtual ~Self() = default;
   virtual std::shared_ptr<SugaredValue> makeSugared(Value* v) const = 0;
   virtual ClassTypePtr getClassType() const = 0;
 };
@@ -193,7 +193,7 @@ struct TORCH_API CompilationUnit {
   // have isolation.
   void _clear_python_cu() {
     // Delete all the associated class methods
-    for (auto type : classes_) {
+    for (const auto& type : classes_) {
       if (auto cls = type->cast<ClassType>()) {
         for (auto method : cls->methods()) {
           // Tombstone the method in the compilation unit.

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace torch {
@@ -371,8 +372,8 @@ struct Token {
 };
 
 struct Lexer {
-  explicit Lexer(const std::shared_ptr<Source>& source)
-      : source(source),
+  explicit Lexer(std::shared_ptr<Source>  source)
+      : source(std::move(source)),
         pos(0),
         nesting(0),
         indent_stack(),

--- a/torch/csrc/jit/script/logging.h
+++ b/torch/csrc/jit/script/logging.h
@@ -16,7 +16,7 @@ class LoggerBase {
   TORCH_API virtual void addStatValue(
       const std::string& stat_name,
       int64_t val) = 0;
-  virtual ~LoggerBase() {}
+  virtual ~LoggerBase() = default;
 };
 
 TORCH_API LoggerBase* getLogger();
@@ -28,7 +28,7 @@ TORCH_API LoggerBase* setLogger(LoggerBase* logger);
 class NoopLogger : public LoggerBase {
  public:
   void addStatValue(const std::string& stat_name, int64_t val) override {}
-  ~NoopLogger() {}
+  ~NoopLogger() override = default;
 };
 
 // Trivial locking logger. Pass in an instance of this to setLogger() to use it.
@@ -42,7 +42,7 @@ class TORCH_API LockingLogger : public LoggerBase {
   virtual int64_t getCounterValue(const std::string& name) const;
   enum class AggregationType { SUM, AVG };
   void setAggregationType(const std::string& stat_name, AggregationType type);
-  ~LockingLogger() {}
+  ~LockingLogger() override = default;
 
  private:
   mutable std::mutex m;

--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -25,6 +25,8 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <utility>
+#include <utility>
 #include <vector>
 
 // This file contains classes which assist in desugaring Python style
@@ -114,9 +116,9 @@ struct TORCH_API Module {
       std::shared_ptr<CompilationUnit> cu,
       bool shouldMangle = false);
   // module_value_ null and will be lazily initialized if is needed
-  Module() {}
+  Module() = default;
   Module(ModulePtr module_value) : module_value_(std::move(module_value)) {}
-  ~Module() {}
+  ~Module() = default;
 
   const c10::QualifiedName& name() const {
     return *module_object()->type()->qualified_name_obj();
@@ -144,7 +146,7 @@ struct TORCH_API Module {
   // register_buffer method. With this simplification, we only need to track
   // whether a slot is a parameter to be able to classify it.
   void register_buffer(const std::string& name, autograd::Variable v) {
-    set_or_add_slot(name, TensorType::get(), v, EntityType::ATTRIBUTE);
+    set_or_add_slot(name, TensorType::get(), std::move(v), EntityType::ATTRIBUTE);
   }
 
   void register_parameter(
@@ -154,14 +156,14 @@ struct TORCH_API Module {
     set_or_add_slot(
         name,
         TensorType::get(),
-        v,
+        std::move(v),
         is_buffer ? EntityType::ATTRIBUTE : EntityType::PARAMETER);
   }
   void register_attribute(
       const std::string& name,
-      const TypePtr type,
+      const TypePtr& type,
       IValue ivalue) {
-    set_or_add_slot(name, type, ivalue, EntityType::ATTRIBUTE);
+    set_or_add_slot(name, type, std::move(ivalue), EntityType::ATTRIBUTE);
   }
   void register_module(const std::string& name, const Module& module) {
     set_or_add_slot(
@@ -169,7 +171,7 @@ struct TORCH_API Module {
   }
 
   void set_parameter(const std::string& name, at::Tensor v) {
-    get_slot(name, EntityType::PARAMETER).setValue(v);
+    get_slot(name, EntityType::PARAMETER).setValue(std::move(v));
   }
 
   autograd::Variable get_parameter(const std::string& name) const {
@@ -364,7 +366,7 @@ struct TORCH_API Module {
       const std::unordered_map<TypePtr, TypePtr>& type_remap);
 
   c10::QualifiedName getNameForMethod(std::string basename) const {
-    return QualifiedName(name(), basename);
+    return QualifiedName(name(), std::move(basename));
   }
   static const char* toString(EntityType t) {
     switch (t) {
@@ -445,8 +447,8 @@ struct TORCH_API Module {
 // that returns Module via template specialization of the operator* method.
 template <typename T>
 struct TORCH_API slot_iterator_impl {
-  slot_iterator_impl(Module module, c10::optional<EntityType> type, size_t i)
-      : module_(module), type_(type), i_(i) {
+  slot_iterator_impl(const Module& module, c10::optional<EntityType> type, size_t i)
+      : module_(module), type_(std::move(std::move(type))), i_(i) {
     advance_to_valid();
   }
   T operator*() const;
@@ -523,8 +525,8 @@ struct TORCH_API slot_list_impl {
   }
 
  private:
-  slot_list_impl(Module module, c10::optional<EntityType> type)
-      : module_(std::move(module)), type_(type) {
+  slot_list_impl(const Module& module, c10::optional<EntityType> type)
+      : module_(module), type_(std::move(std::move(type))) {
     if (!type_) {
       size_ = module_.num_slots();
     }

--- a/torch/csrc/jit/script/resolver.h
+++ b/torch/csrc/jit/script/resolver.h
@@ -26,7 +26,7 @@ using ResolverPtr = std::shared_ptr<Resolver>;
  * handle the method.
  */
 struct Resolver {
-  virtual ~Resolver() {}
+  virtual ~Resolver() = default;
 
   // Resolve a given name to a SugaredValue. This takes the method `m` that the
   // caller is currently constructing, since we may need to insert nodes into

--- a/torch/csrc/jit/script/script_type_parser.h
+++ b/torch/csrc/jit/script/script_type_parser.h
@@ -16,7 +16,7 @@ namespace script {
  */
 class TORCH_API ScriptTypeParser {
  public:
-  explicit ScriptTypeParser() {}
+  explicit ScriptTypeParser() = default;
   explicit ScriptTypeParser(ResolverPtr resolver)
       : resolver_(std::move(resolver)) {}
   c10::optional<std::string> parseBaseTypeName(const Expr& expr) const;

--- a/torch/csrc/jit/script/slot.h
+++ b/torch/csrc/jit/script/slot.h
@@ -15,7 +15,7 @@ enum class EntityType { MODULE, PARAMETER, ATTRIBUTE, METHOD };
 // a stable location that can hold an IValue.
 // inside a module.
 struct TORCH_API Slot {
-  Slot() {}
+  Slot() = default;
   Slot(c10::intrusive_ptr<c10::ivalue::Object> container, size_t offset)
   : container_(std::move(container)), offset_(offset) {}
 
@@ -55,7 +55,7 @@ struct TORCH_API Slot {
 
 private:
   c10::intrusive_ptr<c10::ivalue::Object> container_;
-  size_t offset_;
+  size_t offset_{};
   friend struct std::hash<Slot>;
   friend struct Module;
 };

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -2,6 +2,8 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
+#include <utility>
 
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/script/error_report.h>
@@ -247,7 +249,7 @@ struct TORCH_API NamedTupleConstructor : public SugaredValue {
 };
 
 struct FunctionValue : public SugaredValue {
-  FunctionValue(Function* callee) : callee_(std::move(callee)) {}
+  FunctionValue(Function* callee) : callee_(callee) {}
   FunctionValue(const StrongFunctionPtr& p)
       : callee_(p.function_), cu_(p.cu_) {}
 
@@ -291,7 +293,7 @@ struct TORCH_API ClosureValue : public SugaredValue {
 // defines how a method obtained from a module behaves in script
 struct MethodValue : public SugaredValue {
   MethodValue(Value* self, std::string method_name)
-      : self_(std::move(self)), method_name_(std::move(method_name)) {}
+      : self_(self), method_name_(std::move(method_name)) {}
 
   std::string kind() const override {
     return "method";
@@ -479,12 +481,12 @@ struct TORCH_API IterableValue : SugaredValue {
 // max_trip_count and set the value table for loop targets
 struct TORCH_API IterableTree : SugaredValue {
   IterableTree() = default;
-  IterableTree(const std::vector<SugaredValuePtr> children)
-      : children_(std::move(children)) {}
+  IterableTree(const std::vector<SugaredValuePtr>& children)
+      : children_(children) {}
   std::string kind() const override {
     return "iterabletree";
   }
-  void addChild(SugaredValuePtr sv) {
+  void addChild(const SugaredValuePtr& sv) {
     children_.emplace_back(sv);
   }
 
@@ -511,7 +513,7 @@ struct TORCH_API IterableTree : SugaredValue {
 //   Foo.__new__(Foo)
 // Foo is a ClassValue, calling `attr("__new__")` will return a ClassNewMethod.
 struct TORCH_API ClassNewMethod : public SugaredValue {
-  ClassNewMethod(ClassTypePtr type) : type_(type) {}
+  ClassNewMethod(ClassTypePtr type) : type_(std::move(std::move(type))) {}
   std::string kind() const override {
     return "class.__new__";
   }

--- a/torch/csrc/jit/script/tree.h
+++ b/torch/csrc/jit/script/tree.h
@@ -102,7 +102,7 @@ struct Tree : c10::intrusive_ptr_target {
       throw std::runtime_error(ss.str());
     }
   }
-  virtual ~Tree() = default;
+  ~Tree() override = default;
 
  private:
   int kind_;

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -394,8 +394,8 @@ struct Def : public TreeView {
   explicit Def(const TreeRef& tree) : TreeView(tree) {
     tree->match(TK_DEF);
   }
-  Def withName(std::string new_name) const {
-    auto new_ident = Ident::create(name().range(), std::move(new_name));
+  Def withName(const std::string& new_name) const {
+    auto new_ident = Ident::create(name().range(), new_name);
     return create(range(), new_ident, decl(), statements());
   }
   Ident name() const {
@@ -420,8 +420,8 @@ struct ClassDef : public TreeView {
   explicit ClassDef(const TreeRef& tree) : TreeView(tree) {
     tree->match(TK_CLASS_DEF);
   }
-  ClassDef withName(std::string new_name) const {
-    auto new_ident = Ident::create(name().range(), std::move(new_name));
+  ClassDef withName(const std::string& new_name) const {
+    auto new_ident = Ident::create(name().range(), new_name);
     return create(range(), new_ident, superclass(), body());
   }
   Ident name() const {

--- a/torch/csrc/jit/source_range_serialization.h
+++ b/torch/csrc/jit/source_range_serialization.h
@@ -35,7 +35,7 @@ class SourceRangeUnpickler {
   virtual c10::optional<SourceRange> findSourceRangeThatGenerated(
       const SourceRange& range) = 0;
 
-  virtual ~SourceRangeUnpickler() {}
+  virtual ~SourceRangeUnpickler() = default;
 };
 
 } // namespace jit

--- a/torch/csrc/jit/symbolic_variable.h
+++ b/torch/csrc/jit/symbolic_variable.h
@@ -3,6 +3,8 @@
 #include <torch/csrc/jit/constants.h>
 #include <torch/csrc/jit/ir.h>
 
+#include <utility>
+
 namespace torch {
 namespace jit {
 
@@ -261,7 +263,7 @@ struct SymbolicVariable {
     return create(t("sinh"), {*this})[0];
   }
   SymbolicVariable sum(c10::optional<c10::ScalarType> dtype=c10::nullopt) const {
-    return create(t("sum"), {*this, insertNullable(dtype)})[0];
+    return create(t("sum"), {*this, insertNullable(std::move(dtype))})[0];
   }
   SymbolicVariable sum(
     int dim,
@@ -273,7 +275,7 @@ struct SymbolicVariable {
         {*this,
           insertConstant(at::IntArrayRef{dim}),
           insertConstant(keepdim),
-          insertNullable(dtype)})[0];
+          insertNullable(std::move(dtype))})[0];
   }
   SymbolicVariable squeeze(Value* dim) const {
     return create(t("squeeze"), {*this, dim})[0];
@@ -329,7 +331,7 @@ struct SymbolicVariable {
   }
 
   SymbolicVariable toType(TypePtr type) const {
-    v->setType(type);
+    v->setType(std::move(type));
     return *this;
   }
 


### PR DESCRIPTION
Automated fixes by running 
```bash
clang-tidy -p build -config '{"Checks": " -* ,bugprone-* ,-bugprone-forward-declaration-namespace ,-bugprone-macro-parentheses ,cppcoreguidelines-* ,-cppcoreguidelines-interfaces-global-init ,-cppcoreguidelines-owning-memory ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay ,-cppcoreguidelines-pro-bounds-constant-array-index ,-cppcoreguidelines-pro-bounds-pointer-arithmetic ,-cppcoreguidelines-pro-type-cstyle-cast ,-cppcoreguidelines-pro-type-reinterpret-cast ,-cppcoreguidelines-pro-type-static-cast-downcast ,-cppcoreguidelines-pro-type-union-access ,-cppcoreguidelines-pro-type-vararg ,-cppcoreguidelines-special-member-functions ,hicpp-exception-baseclass ,hicpp-avoid-goto ,modernize-* ,-modernize-return-braced-init-list ,-modernize-use-auto ,-modernize-use-default-member-init ,-modernize-use-using ,performance-* ,-performance-noexcept-move-constructor ", "WarningsAsErrors": "*", "HeaderFilterRegex": "torch/csrc/.*", "AnalyzeTemporaryDtors": false, "CheckOptions": null}' torch/csrc/jit/argument_spec.cpp torch/csrc/jit/attributes.cpp torch/csrc/jit/autodiff.cpp torch/csrc/jit/constants.cpp torch/csrc/jit/export.cpp torch/csrc/jit/function.cpp torch/csrc/jit/graph_executor.cpp torch/csrc/jit/hooks_for_testing.cpp torch/csrc/jit/import.cpp torch/csrc/jit/import_export_helpers.cpp torch/csrc/jit/import_source.cpp torch/csrc/jit/init.cpp torch/csrc/jit/interpreter.cpp torch/csrc/jit/ir.cpp torch/csrc/jit/irparser.cpp torch/csrc/jit/jit_log.cpp torch/csrc/jit/netdef_converter.cpp torch/csrc/jit/node_hashing.cpp torch/csrc/jit/operator.cpp torch/csrc/jit/operator_options.cpp torch/csrc/jit/pass_manager.cpp torch/csrc/jit/pickler.cpp torch/csrc/jit/print_handler.cpp torch/csrc/jit/profiling_graph_executor_impl.cpp torch/csrc/jit/profiling_record.cpp torch/csrc/jit/python_arg_flatten.cpp torch/csrc/jit/python_interpreter.cpp torch/csrc/jit/python_ir.cpp torch/csrc/jit/python_tracer.cpp torch/csrc/jit/register_c10_ops.cpp torch/csrc/jit/register_prim_ops.cpp torch/csrc/jit/register_special_ops.cpp torch/csrc/jit/register_string_ops.cpp torch/csrc/jit/scope.cpp torch/csrc/jit/source_range.cpp torch/csrc/jit/source_range_serialization.cpp torch/csrc/jit/subgraph_matcher.cpp torch/csrc/jit/symbolic_script.cpp torch/csrc/jit/tracer.cpp -fix
```