### PR TITLE
Do not force USE_SYSTEM_EIGEN_INSTALL to be OFF in Python build scripts

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -251,7 +251,6 @@ class CMake:
             'USE_CUDA': USE_CUDA,
             'USE_DISTRIBUTED': USE_DISTRIBUTED,
             'USE_NUMPY': USE_NUMPY,
-            'USE_SYSTEM_EIGEN_INSTALL': 'OFF'
         })
 
         # Options starting with CMAKE_


### PR DESCRIPTION
Not sure whether 34c0043aaee971a0539c8c3c49c4839f67ae001d still makes sense.

`USE_SYSTEM_EIGEN_INSTALL` is OFF by default (as set in CMakeLists.txt). If a user wants to change this build option, I don't see any reason to force them to do it in `CMakeCache.txt`.