### PR TITLE
Fix build failure on OSX

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -54,8 +54,8 @@
 #ifdef USE_DISTRIBUTED
 #ifdef USE_C10D
 #include <torch/csrc/distributed/c10d/c10d.h>
-#endif
 #include <torch/csrc/distributed/rpc/rpc.h>
+#endif
 #endif
 
 #define WITH_NUMPY_IMPORT_ARRAY
@@ -626,8 +626,8 @@ PyObject* initModule() {
 #ifdef USE_DISTRIBUTED
 #ifdef USE_C10D
   THPUtils_addPyMethodDefs(methods, torch::distributed::c10d::python_functions());
+  THPUtils_addPyMethodDefs(methods, torch::distributed::rpc::python_functions());
 #endif
-THPUtils_addPyMethodDefs(methods, torch::distributed::rpc::python_functions());
 #endif
 
 #if PY_MAJOR_VERSION == 2


### PR DESCRIPTION
#23228 caused build failure on OSX, because `rpc.h` is included as long as `USE_DISTRIBUTED=1`, but `rpc/init.cpp` (and others) is only included when [`NOT APPLE`](https://github.com/pytorch/pytorch/blob/919024f9ba32be66ca664dcdd3a720870ebf12c3/torch/CMakeLists.txt#L228). So, it cannot find `python_functions` defined in `init.cpp` on MacOS. This PR attempt to fix it by wrapping `rpc.h` with [`USE_C10D`](https://github.com/pytorch/pytorch/blob/919024f9ba32be66ca664dcdd3a720870ebf12c3/torch/CMakeLists.txt#L235), which is only set when NOT APPLE. 

I tried this fix locally and it works.