### PR TITLE
Removing deprecated warning message from torch.h

### DIFF
--- a/torch/csrc/api/include/torch/torch.h
+++ b/torch/csrc/api/include/torch/torch.h
@@ -5,10 +5,4 @@
 #ifdef TORCH_API_INCLUDE_EXTENSION_H
 #include <torch/extension.h>
 
-#ifdef _MSC_VER
-#  pragma message ( "Including torch/torch.h for C++ extensions is deprecated. Please include torch/extension.h" )
-#else
-#  warning "Including torch/torch.h for C++ extensions is deprecated. Please include torch/extension.h"
-#endif
-
 #endif // defined(TORCH_API_INCLUDE_EXTENSION_H)


### PR DESCRIPTION
discussed [here](https://github.com/pytorch/vision/issues/1173)