### PR TITLE
Removes SymbolicVariable from tests

### DIFF
--- a/test/cpp/jit/test_autodiff.cpp
+++ b/test/cpp/jit/test_autodiff.cpp
@@ -167,15 +167,29 @@ void testADFormulas() {
 }
 
 void testDifferentiate() {
+  // Note: can't use IRParser for this test due to issue #23989
   auto graph = std::make_shared<Graph>();
-  at::ScalarType s = at::ScalarType::Float;
-  auto type = ProfiledTensorType::create(s, at::kCPU, {2, 3, 4}, {12, 4, 1});
+  const auto type = ProfiledTensorType::create(at::ScalarType::Float, at::kCPU, {2, 3, 4}, {12, 4, 1});
 
-  // Build up a fake graph
-  auto a = SymbolicVariable::asNewInput(*graph, type);
-  auto b = SymbolicVariable::asNewInput(*graph, type);
-  auto c = a * b * a + b;
-  graph->registerOutput(c.value());
+  // Builds graph a * b * a + b
+  auto* a = graph->addInput()->setType(type);
+  auto* b = graph->addInput()->setType(type);
+  auto* cOne = graph->insertConstant(1);
+
+  auto* ab = graph->insertNode(graph->create(aten::mul, /*num_outputs =*/ 1));
+  ab->addInput(a);
+  ab->addInput(b);
+
+  auto* aba = graph->insertNode(graph->create(aten::mul, /*num_outputs =*/ 1));
+  aba->addInput(ab->output());
+  aba->addInput(a);
+
+  auto* abaplusb = graph->insertNode(graph->create(aten::add, /*num_outputs =*/ 1));
+  abaplusb->addInput(aba->output());
+  abaplusb->addInput(b);
+  abaplusb->addInput(cOne);
+
+  graph->registerOutput(abaplusb->output());
 
   auto grad_spec = differentiate(graph);
   std::vector<size_t> expected_captured_inputs = {0, 1};
@@ -200,27 +214,31 @@ void testDifferentiate() {
 }
 
 void testDifferentiateWithRequiresGrad() {
-  // Build up a fake graph
-  auto graph = std::make_shared<Graph>();
-  auto a = SymbolicVariable::asNewInput(*graph);
-  auto b = SymbolicVariable::asNewInput(*graph);
-  auto d = b * b + b;
-  auto e = (d + a) * a + b;
-  graph->registerOutput(d.value());
-  graph->registerOutput(e.value());
+  const auto graph_string = R"IR(
+    graph(%0 : Tensor,
+          %1 : Tensor):
+      %2 : int = prim::Constant[value=1]()
+      %3 : Tensor = aten::mul(%1, %1)
+      %4 : Tensor = aten::add(%3, %1, %2)
+      %5 : Tensor = aten::add(%4, %0, %2)
+      %6 : Tensor = aten::mul(%5, %0)
+      %7 : Tensor = aten::add(%6, %1, %2)
+      return (%4, %7))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::script::parseIR(graph_string, g.get());
 
   auto a_var = autograd::make_variable(
       at::empty_strided(2, 2, at::CPU(at::kFloat).options()), true);
   auto b_var = autograd::make_variable(
       at::empty_strided(2, 2, at::CPU(at::kFloat).options()), false);
 
-  ArgumentSpecCreator asc(*graph);
-  asc.specializeTypes(*graph, asc.create(true, {a_var, b_var}));
+  ArgumentSpecCreator asc(*g);
+  asc.specializeTypes(*g, asc.create(true, {a_var, b_var}));
 
-  PropagateInputShapes(graph);
-  PropagateRequiresGrad(graph);
+  PropagateInputShapes(g);
+  PropagateRequiresGrad(g);
 
-  auto grad_spec = differentiate(graph);
+  auto grad_spec = differentiate(g);
   std::vector<size_t> expected_input_vjps = {1, 2}; // for e and %4 = (d + a)
   std::vector<size_t> expected_output_vjps = {0}; // only a requires grad
   ASSERT_EQ(grad_spec.f_real_outputs, 2);

--- a/test/cpp/jit/test_fuser.cpp
+++ b/test/cpp/jit/test_fuser.cpp
@@ -12,6 +12,7 @@
 #include "torch/csrc/jit/dynamic_dag.h"
 #include "torch/csrc/jit/fuser/interface.h"
 #include "torch/csrc/jit/import.h"
+#include "torch/csrc/jit/irparser.h"
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/passes/alias_analysis.h"
 #include "torch/csrc/jit/passes/common_subexpression_elimination.h"
@@ -25,10 +26,11 @@
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/passes/utils/subgraph_utils.h"
 #include "torch/csrc/jit/symbolic_script.h"
-#include "torch/csrc/jit/symbolic_variable.h"
 #include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/utils/hash.h"
 #include "torch/csrc/utils/memory.h"
+
+
 
 #include "torch/csrc/autograd/engine.h"
 #include "torch/csrc/autograd/variable.h"
@@ -60,15 +62,16 @@
 namespace torch {
 namespace jit {
 
-using Var = SymbolicVariable;
-
 void testFusion() {
   auto testSimple = [&] {
+    const auto graph_string = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor):
+        %2 : Tensor = aten::mul(%0, %1)
+        return (%2))IR";
     Graph graph;
-    Var i0 = Var::asNewInput(graph);
-    Var i1 = Var::asNewInput(graph);
-    auto o0 = i0 * i1;
-    o0.addAsOutput();
+    torch::jit::script::parseIR(graph_string, &graph);
+
     auto a = at::rand({3, 4}, at::kCUDA);
     auto b = at::rand({4, 3}, at::kCUDA).transpose(0, 1);
     auto o = at::zeros({3, 4}, at::kCUDA);
@@ -82,25 +85,25 @@ void testFusion() {
   testSimple();
 
   auto testOne = [&](int ti, int tj) {
+    const auto graph_string = R"IR(
+      graph(%0 : Tensor,
+            %1 : Tensor,
+            %2 : Tensor,
+            %3 : Tensor,
+            %4 : Tensor):
+        %5 : Tensor = aten::sigmoid(%4)
+        %6 : Tensor = aten::sigmoid(%3)
+        %7 : Tensor = aten::tanh(%2)
+        %8 : Tensor = aten::sigmoid(%1)
+        %9 : Tensor = aten::mul(%6, %0)
+        %10 : Tensor = aten::mul(%5, %7)
+        %11 : int = prim::Constant[value=1]()
+        %12 : Tensor = aten::add(%9, %10, %11)
+        %13 : Tensor = aten::tanh(%12)
+        %14 : Tensor = aten::mul(%8, %13)
+        return (%14, %12))IR";
     Graph graph;
-
-    Var i0 = Var::asNewInput(graph);
-    Var i1 = Var::asNewInput(graph);
-    Var i2 = Var::asNewInput(graph);
-    Var i3 = Var::asNewInput(graph);
-    Var i4 = Var::asNewInput(graph);
-
-    auto p22 = i4.sigmoid();
-    auto p20 = i3.sigmoid();
-    auto p18 = i2.tanh();
-    auto p16 = i1.sigmoid();
-    auto p14 = p20 * i0;
-    auto p11 = p22 * p18;
-    auto o1 = p14 + p11;
-    auto p5 = o1.tanh();
-    auto o0 = p16 * p5;
-    o0.addAsOutput();
-    o1.addAsOutput();
+    torch::jit::script::parseIR(graph_string, &graph);
 
     graph.lint();
 
@@ -136,57 +139,67 @@ void testFusion() {
   testOne(1, 2);
   testOne(0, 2);
 
-  auto createFusedConcat =
-      [](Graph& graph, at::ArrayRef<Value*> inputs, int64_t dim) -> Value* {
-    return graph
-        .insertNode(graph.create(prim::FusedConcat, inputs)->i_(attr::dim, dim))
-        ->output();
-  };
+  const auto graph_string0 = R"IR(
+    graph(%0 : Tensor,
+          %1 : Tensor):
+      %2 : Tensor = aten::mul(%0, %1)
+      %3 : Tensor = prim::FusedConcat[dim=0](%0, %2)
+      return (%2, %3))IR";
+  const auto graph_string1 = R"IR(
+    graph(%0 : Tensor,
+          %1 : Tensor):
+      %2 : Tensor = aten::mul(%0, %1)
+      %3 : Tensor = prim::FusedConcat[dim=1](%0, %2)
+      return (%2, %3))IR";
+  const auto graph_string2 = R"IR(
+    graph(%0 : Tensor,
+          %1 : Tensor):
+      %2 : Tensor = aten::mul(%0, %1)
+      %3 : Tensor = prim::FusedConcat[dim=2](%0, %2)
+      return (%2, %3))IR";
 
-  auto testConcat = [&](int dim) {
-    Graph graph;
-    Var i0 = Var::asNewInput(graph);
-    Var i1 = Var::asNewInput(graph);
-    auto o0 = i0 * i1;
-    o0.addAsOutput();
-    Var(createFusedConcat(graph, {i0, o0}, dim)).addAsOutput();
+  auto a = at::rand({3, 4, 5}, at::kCUDA);
+  auto b = at::rand({4, 3, 5}, at::kCUDA).transpose(0, 1);
+  const auto o_r = a * b;
 
-    auto a = at::rand({3, 4, 5}, at::kCUDA);
-    auto b = at::rand({4, 3, 5}, at::kCUDA).transpose(0, 1);
+  std::vector<std::string> graph_strings{graph_string0,
+                                         graph_string1,
+                                         graph_string2};
+  for (auto i = decltype(graph_strings.size()){0}; i < graph_strings.size(); ++i) {
+    Graph g;
+    torch::jit::script::parseIR(graph_strings[i], &g);
 
-    auto o_r = a * b;
-    auto o2_r = at::cat({a, o_r}, dim);
-    auto outputs = debugLaunchGraph(graph, {a, b});
+    auto outputs = debugLaunchGraph(g, {a, b});
     ASSERT_EQ(outputs.size(), 2);
 
     float max_diff = (o_r - outputs[0]).abs().max().item<double>();
     ASSERT_EQ(max_diff, 0);
+
+    const auto o2_r = at::cat({a, o_r}, i);
     float max_diff2 = (o2_r - outputs[1]).abs().max().item<double>();
     ASSERT_EQ(max_diff2, 0);
   };
-  testConcat(0);
-  testConcat(1);
-  testConcat(2);
 }
 
 void testRegisterFusionCachesKernel() {
-  // Build up a fake graph with a FusionGroup
-  auto createGraphWithNames = [](std::string cname, std::string dname) {
-    auto graph = std::make_shared<Graph>();
-    at::ScalarType s = at::ScalarType::Float;
-    auto type = ProfiledTensorType::create(s, at::kCPU, {2, 3, 4}, {12, 4, 1});
-    auto a = SymbolicVariable::asNewInput(*graph, type);
-    auto b = SymbolicVariable::asNewInput(*graph, type);
-    auto c = a * b;
-    auto d = c * a;
-    c.value()->setDebugName(cname);
-    d.value()->setDebugName(dname);
-    graph->registerOutput(d.value());
-    torch::jit::overrideCanFuseOnCPU(true);
-    FuseGraph(graph);
-    torch::jit::overrideCanFuseOnCPU(false);
-    return graph;
-  };
+  // Constructs two functionally equivalent graphs
+  const auto graph0_string = R"IR(
+    graph(%0 : Float(2, 3, 4),
+          %1 : Float(2, 3, 4)):
+      %c0 : Float(2, 3, 4) = aten::mul(%0, %1)
+      %d0 : Float(2, 3, 4) = aten::mul(%c0, %0)
+      return (%d0))IR";
+  auto g0 = std::make_shared<Graph>();
+  torch::jit::script::parseIR(graph0_string, g0.get());
+
+  const auto graph1_string = R"IR(
+    graph(%0 : Float(2, 3, 4),
+          %1 : Float(2, 3, 4)):
+      %c1 : Float(2, 3, 4) = aten::mul(%0, %1)
+      %d1 : Float(2, 3, 4) = aten::mul(%c1, %0)
+      return (%d1))IR";
+  auto g1 = std::make_shared<Graph>();
+  torch::jit::script::parseIR(graph1_string, g1.get());
 
   auto getFusionGroup = [](const std::shared_ptr<Graph>& graph) {
     const auto& nodes = graph->nodes();
@@ -200,16 +213,17 @@ void testRegisterFusionCachesKernel() {
     return *maybe_fusion_group;
   };
 
-  // Create two alpha-equivalent fusion groups
-  auto graph1 = createGraphWithNames("c1", "d1");
-  auto fg1 = getFusionGroup(graph1);
+  // Creates two alpha-equivalent fusion groups
+  torch::jit::overrideCanFuseOnCPU(true);
+  FuseGraph(g0);
+  FuseGraph(g1);
+  torch::jit::overrideCanFuseOnCPU(false);
+  auto fg0 = getFusionGroup(g0);
+  auto fg1 = getFusionGroup(g1);
 
-  auto graph2 = createGraphWithNames("c2", "d2");
-  auto fg2 = getFusionGroup(graph2);
-
-  // Register both with the fusion compiler.
-  auto expected_key = registerFusion(fg1);
-  auto second_key = registerFusion(fg2);
+  // Registers both with the fusion compiler.
+  auto expected_key = registerFusion(fg0);
+  auto second_key = registerFusion(fg1);
 
   // Because the graphs are alpha-equivalent, they should return the same key
   // and therefore share a KernelSpec to share kernels for specializations

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -19,6 +19,7 @@
 #include "torch/csrc/jit/fuser/interface.h"
 #include "torch/csrc/jit/import.h"
 #include "torch/csrc/jit/interpreter.h"
+#include "torch/csrc/jit/irparser.h"
 #include "torch/csrc/jit/pass_manager.h"
 #include "torch/csrc/jit/passes/alias_analysis.h"
 #include "torch/csrc/jit/passes/bailout_graph.h"
@@ -36,7 +37,6 @@
 #include "torch/csrc/jit/passes/shape_analysis.h"
 #include "torch/csrc/jit/passes/utils/subgraph_utils.h"
 #include "torch/csrc/jit/symbolic_script.h"
-#include "torch/csrc/jit/symbolic_variable.h"
 #include "torch/csrc/jit/tracer.h"
 #include "torch/csrc/utils/hash.h"
 #include "torch/csrc/utils/memory.h"
@@ -73,8 +73,6 @@ c10::OperatorOptions aliasAnalysisFromSchema() {
   result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
   return result;
 }
-
-using Var = SymbolicVariable;
 
 using namespace torch::autograd;
 
@@ -359,23 +357,23 @@ void testATenNativeBatchNorm() {
 }
 
 void testCustomFusion() {
-  auto graph = std::make_shared<Graph>();
-  at::ScalarType s = at::ScalarType::Float;
-  auto type = ProfiledTensorType::create(s, at::kCPU, {2, 3, 4}, {12, 4, 1});
-  auto a = SymbolicVariable::asNewInput(*graph, type);
-  auto b = SymbolicVariable::asNewInput(*graph, type);
-  auto c = a * b;
-  auto d = c * a;
-  graph->registerOutput(d.value());
+  auto graph_string = R"IR(
+    graph(%0 : Float(2, 3, 4),
+          %1 : Float(2, 3, 4)):
+      %2 : Tensor = aten::mul(%0, %1)
+      %3 : Tensor = aten::mul(%2, %0)
+      return (%3))IR";
+  auto g = std::make_shared<Graph>();
+  torch::jit::script::parseIR(graph_string, g.get());
 
   torch::jit::overrideCanFuseOnCPU(true);
   CustomFuseGraph(
-      graph,
+      g,
       [](Node* n) { return n->kind() != prim::Param; },
       Symbol::fromQualString("prim::FusionGroup"));
   torch::jit::overrideCanFuseOnCPU(false);
 
-  const auto& nodes = graph->nodes();
+  const auto& nodes = g->nodes();
   auto fusion_group =
       std::find_if(nodes.begin(), nodes.end(), [](const Node* node) {
         return node->kind() == Symbol::fromQualString("prim::FusionGroup");
@@ -393,32 +391,24 @@ void testCustomFusion() {
 }
 
 void testCustomFusionNestedBlocks() {
+  auto graph_string = R"IR(
+  graph(%0 : Float(2, 3, 4),
+        %1 : Float(2, 3, 4),
+        %2 : Float(2, 3, 4)):
+    %3 : int = prim::Constant[value=1]()
+    %4 : Tensor = prim::If(%2)
+      block0():
+        %5 : Tensor = aten::mul(%0, %2)
+        %6 : Tensor = aten::mul(%5, %1)
+        -> (%6)
+      block1():
+        %7 : Tensor = aten::add(%0, %2, %3)
+        %8 : Tensor = aten::add(%7, %1, %3)
+        -> (%8)
+    %9 : Tensor = aten::add(%4, %2, %3)
+    return (%4))IR";
   auto g = std::make_shared<Graph>();
-  at::ScalarType s = at::ScalarType::Float;
-  auto type = ProfiledTensorType::create(s, at::kCPU, {2, 3, 4}, {12, 4, 1});
-
-  // test CustomFusion in nested blocks;
-  auto a = SymbolicVariable::asNewInput(*g, type);
-  auto b = SymbolicVariable::asNewInput(*g, type);
-  auto c = SymbolicVariable::asNewInput(*g, type);
-
-  auto r =
-      g->appendNode(g->create(prim::If, {c.value()}));
-  auto then_block = r->addBlock();
-  auto else_block = r->addBlock();
-  {
-    WithInsertPoint guard(then_block);
-    auto d = c * a;
-    auto t = d * b;
-    then_block->registerOutput(t.value());
-  }
-  {
-    WithInsertPoint guard(else_block);
-    auto d = c + a;
-    auto t = d + b;
-    else_block->registerOutput(t.value());
-  }
-  g->registerOutput((Var(r->output()) + c).value());
+  torch::jit::script::parseIR(graph_string, g.get());
 
   CustomFuseGraph(
       g,

--- a/test/cpp/jit/test_utils.h
+++ b/test/cpp/jit/test_utils.h
@@ -5,12 +5,10 @@
 #include "torch/csrc/jit/autodiff.h"
 #include "torch/csrc/jit/interpreter.h"
 #include "torch/csrc/jit/irparser.h"
-#include "torch/csrc/jit/symbolic_variable.h"
 
 namespace torch {
 namespace jit {
 
-using Var = SymbolicVariable;
 using tensor_list = std::vector<at::Tensor>;
 using namespace torch::autograd;
 
@@ -29,14 +27,6 @@ std::pair<tensor_list, tensor_list> runGradient(
     Gradient& grad_spec,
     tensor_list& tensors_in,
     tensor_list& tensor_grads_in);
-
-std::tuple<Var, Var> build_lstm_body(
-    Graph& g,
-    Var input,
-    Var hx,
-    Var cx,
-    Var w_ih,
-    Var w_hh);
 
 std::shared_ptr<Graph> build_lstm();
 


### PR DESCRIPTION
This PR removes SymbolicVariable from all tests as well as the specialize_autogradzero and canonicalize_ops passes. These passes used SymbolicVariable in a relatively simple way compared to its few remaining uses. 

Removing SymbolicVariable means graphs must be constructed by other methods. IRParser was preferred for tests, but tests requiring pointers to graph internals or differentiation use direct construction instead. See #23989, which was discovered during this process, for why IRParser cannot be used when differentiation is required. Direct construction was also used in the updated passes.



