### PR TITLE
Remove numpy assert that fails on Windows (older numpy versions).

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8888,7 +8888,6 @@ class _TestTorchMixin(object):
         a = np.array(x, copy=False)
         b = np.array(y, copy=False)
         expected = np.matmul(a, b)
-        self.assertTrue(expected.flags['C_CONTIGUOUS'])
 
         ans = torch.matmul(x, y)
         self.assertTrue(ans.is_contiguous())


### PR DESCRIPTION
Fixes #24001.