### PR TITLE
Fix qconv benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -34,17 +34,15 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
         scale = 1.0 / 255
         zero_point = 0
         X = torch.randn(N, IC, H, W, dtype=torch.float32)
-        X = X.permute([0, 2, 3, 1]).contiguous()
         qX = torch.quantize_linear(X, scale=scale, zero_point=zero_point, dtype=torch.quint8)
         W = torch.randn(OC, IC // G, kernel, kernel, dtype=torch.float32)
-        W = W.permute([0, 2, 3, 1]).contiguous()
         qW = torch.quantize_linear(W, scale=scale, zero_point=0, dtype=torch.qint8)
 
         self.input = qX
         self.qconv2d = nnq.Conv2d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
         self.qconv2d.weight = qW
-        self.qconv2d.scale = scale
-        self.qconv2d.zero_point = zero_point
+        self.qconv2d.scale = torch.tensor([scale], dtype=torch.double)
+        self.qconv2d.zero_point = torch.tensor([zero_point], dtype=torch.int)
         self.set_module_name("QConv2d")
 
     def forward(self):

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -102,28 +102,6 @@ class Conv2d(_ConvNd):
                                                                       self.dilation,
                                                                       self.groups)
 
-    @property
-    def scale(self):
-        return self._scale.item()
-
-    @scale.setter
-    def scale(self, s):
-        if isinstance(s, torch.Tensor):
-            self._scale = s
-        else:
-            self._scale = torch.tensor([s], dtype=torch.double)
-
-    @property
-    def zero_point(self):
-        return self._zero_point.item()
-
-    @zero_point.setter
-    def zero_point(self, zp):
-        if isinstance(zp, torch.Tensor):
-            self._zero_point = zp
-        else:
-            self._zero_point = torch.Tensor([zp]).to(torch.int)
-
     def forward(self, input):
         # Temporarily using len(shape) instead of ndim due to JIT issue
         # https://github.com/pytorch/pytorch/issues/23890


### PR DESCRIPTION
Summary:
Permutes are done inside the module. We don't need them outside.

Setting of scale/zero_point has changed.

Differential Revision: D16712437

