### PR TITLE
[torch.distributed][RPC] Add test case for nested RPC

### DIFF
--- a/test/common_distributed.py
+++ b/test/common_distributed.py
@@ -83,7 +83,6 @@ TIMEOUT_OVERRIDE = {}
 def get_timeout(test_id):
     return TIMEOUT_OVERRIDE.get(test_id.split('.')[-1], TIMEOUT_DEFAULT)
 
-
 class MultiProcessTestCase(TestCase):
     MAIN_PROCESS_RANK = -1
 
@@ -96,7 +95,7 @@ class MultiProcessTestCase(TestCase):
         @wraps(fn)
         def wrapper(self):
             if self.rank == self.MAIN_PROCESS_RANK:
-                self._join_processes(fn)
+                self._join_processes()
             else:
                 fn(self)
         return wrapper
@@ -137,7 +136,7 @@ class MultiProcessTestCase(TestCase):
         getattr(self, self.id().split(".")[2])()
         sys.exit(0)
 
-    def _join_processes(self, fn):
+    def _join_processes(self):
         timeout = get_timeout(self.id())
         start_time = time.time()
         for p in self.processes:

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 
 import torch
@@ -6,11 +8,30 @@ import torch.distributed as dist
 from common_distributed import MultiProcessTestCase
 from common_utils import load_tests, run_tests
 
+def my_function(a, b, c):
+    return a + b + c
+
+def no_result():
+    print("do nothing")
+
+class my_class:
+    def __init__(self, a):
+        self.a = a
+
+    def my_instance_method(self, b):
+        return self.a + b
+
+    @classmethod
+    def my_class_method(cls, d, e):
+        return d + e
+
+    @staticmethod
+    def my_static_method(f):
+        return f > 10
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
-
 
 if not dist.is_available():
     print('c10d not available, skipping tests')
@@ -27,7 +48,6 @@ def _wrap_with_rpc(func):
         dist.join_rpc()
 
     return wrapper
-
 
 class RpcTest(MultiProcessTestCase):
 
@@ -109,6 +129,72 @@ class RpcTest(MultiProcessTestCase):
 
         # it's safe to call join_rpc() multiple times
         dist.join_rpc()
+
+    @_wrap_with_rpc
+    def test_py_built_in(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, min, args=(n, n + 1, n + 2))
+        self.assertEqual(ret, min(n, n + 1, n + 2))
+
+    @_wrap_with_rpc
+    def test_py_user_defined(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, my_function, args=(n, n + 1, n + 2))
+        self.assertEqual(ret, my_function(n, n + 1, n + 2))
+
+    @_wrap_with_rpc
+    def test_py_class_constructor(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, my_class, args=(n,))
+        self.assertEqual(ret.a, n)
+
+    @_wrap_with_rpc
+    def test_py_class_instance_method(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, my_class(2).my_instance_method, args=(n,))
+        self.assertEqual(ret, my_class(2).my_instance_method(n))
+
+    @_wrap_with_rpc
+    def test_py_class_method(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, my_class.my_class_method, args=(n, n + 1))
+        self.assertEqual(ret, my_class.my_class_method(n, n + 1))
+
+    @_wrap_with_rpc
+    def test_py_class_static_method(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, my_class.my_static_method, args=(n + 10,))
+        self.assertEqual(ret, my_class.my_static_method(n + 10))
+
+    @_wrap_with_rpc
+    def test_py_multi_aync_call(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        fut1 = dist.rpc('worker%d' % dstRank, my_class.my_static_method, args=(n + 10,), async_call=True)
+        fut2 = dist.rpc('worker%d' % dstRank, min, args=(n, n + 1, n + 2), async_call=True)
+        self.assertEqual(fut1.wait(), my_class.my_static_method(n + 10))
+        self.assertEqual(fut2.wait(), min(n, n + 1, n + 2))
+
+    @_wrap_with_rpc
+    def test_py_no_return_result(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, no_result)
+        self.assertEqual(ret, no_result())
+
+    @_wrap_with_rpc
+    def test_py_function_exception(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc('worker%d' % dstRank, no_result, args=(10,))
+        expected = "run_python_udf_internal caught exception: no_result() takes 0 positional arguments but 1 was given"
+        self.assertEqual(ret, expected)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -1,18 +1,101 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime
+import functools
 import sys
 
 import torch
 import torch.distributed as dist
-
-from common_distributed import MultiProcessTestCase
+from common_distributed import MultiProcessTestCase, skip_for_known_issues
 from common_utils import load_tests, run_tests
+
+
+class WorkerContext(object):
+    _INITIALIZED = False
+    _WORKER_ID = -1
+    _WORLD_SIZE = 0
+    _WORKER_NAMES = None
+
+    def __new__(cls, worker_id, world_size):
+        cls._WORKER_ID = worker_id
+        cls._WORLD_SIZE = world_size
+        cls._WORKER_NAMES = ["worker%d" % i for i in range(world_size)]
+        cls._INITIALIZED = True
+        return cls  # Never create instance.
+
+    @classmethod
+    def worker_id(cls):
+        assert cls._INITIALIZED is True
+        return cls._WORKER_ID
+
+    @classmethod
+    def world_size(cls):
+        assert cls._INITIALIZED is True
+        return cls._WORLD_SIZE
+
+    @classmethod
+    def worker_name(cls):
+        assert cls._INITIALIZED is True
+        if cls._WORKER_ID == -1:
+            return ""
+        return cls._WORKER_NAMES[cls._WORKER_ID]
+
+
+def sprint(*args, **kwargs):
+    date_str = datetime.datetime.today().strftime("%m%d %H:%M:%S.%f")
+    print(
+        "{date_str}{worker_indent}{worker_name}:".format(
+            date_str=date_str,
+            worker_indent=" " * (WorkerContext.worker_id() + 1) * 2,
+            worker_name=WorkerContext.worker_name(),
+        ),
+        *args,
+        **kwargs
+    )
+
+
+def watch_call(old_func):
+    """Decorate on functions that we would liked to have traces.
+        e.g. `dist.rpc = watch_call(dist.rpc)``
+    """
+
+    @functools.wraps(old_func)
+    def new_func(*args, **kwargs):
+
+        func_name = old_func.__name__
+        sprint(
+            "-> {func_name} Enter ...\n"
+            "  args={args}\n"
+            "  kwargs={kwargs}".format(func_name=func_name, args=args, kwargs=kwargs)
+        )
+        return_value = old_func(*args, **kwargs)
+        sprint("<- {func_name} Exit ...".format(func_name=func_name))
+        return return_value
+
+    return new_func
+
+
+def watch_rpc(old_func):
+    @functools.wraps(old_func)
+    def new_func(to, func, args=None, kwargs=None, async_call=False):
+        sprint(
+            "RPCall {func_name} to {to},\n"
+            "  args={args}\n"
+            "  kwargs={kwargs}".format(
+                func_name=func.__name__, to=to, args=args, kwargs=kwargs
+            )
+        )
+        return old_func(to, func, args=args, kwargs=kwargs, async_call=async_call)
+
+    return new_func
+
+
+dist.rpc = watch_rpc(dist.rpc)
+
 
 def my_function(a, b, c):
     return a + b + c
 
-def no_result():
-    print("do nothing")
 
 class my_class:
     def __init__(self, a):
@@ -29,56 +112,90 @@ class my_class:
     def my_static_method(f):
         return f > 10
 
+
+def no_result():
+    print("do nothing")
+
+
+global_var = False
+
+
+@watch_call
+def modify_global_var(global_var_in):
+    global global_var
+    global_var = global_var_in
+
+
+@watch_call
+def nested_rpc(src_name, ttl, reduce_ttl_on):
+    if WorkerContext.worker_name() == reduce_ttl_on:
+        ttl -= 1
+    if ttl > 0:
+        dist.rpc(
+            to=src_name,
+            func=nested_rpc,
+            args=(WorkerContext.worker_name(), ttl, reduce_ttl_on),
+        )
+
+
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
 
 if not dist.is_available():
-    print('c10d not available, skipping tests')
+    print("c10d not available, skipping tests")
     sys.exit(0)
 
 
 def _wrap_with_rpc(func):
     def wrapper(self):
         store = dist.FileStore(self.file.name, self.world_size)
-        dist.init_process_group(backend='gloo', rank=self.rank,
-                                world_size=self.world_size, store=store)
-        dist.init_rpc('worker%d' % self.rank)
+        dist.init_process_group(
+            backend="gloo", rank=self.rank, world_size=self.world_size, store=store
+        )
+        WorkerContext(worker_id=self.rank, world_size=self.world_size)
+        dist.init_rpc(
+            name=WorkerContext.worker_name(),
+            num_send_recv_threads=self.num_send_recv_threads,
+        )
         func(self)
         dist.join_rpc()
 
     return wrapper
 
-class RpcTest(MultiProcessTestCase):
 
+class RpcTest(MultiProcessTestCase):
     @property
     def world_size(self):
         return 4
+
+    @property
+    def num_send_recv_threads(self):
+        return 2
 
     @_wrap_with_rpc
     def test_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, torch.add,
-                       args=(torch.ones(n, n), torch.ones(n, n)))
+        ret = dist.rpc(
+            "worker%d" % dstRank, torch.add, args=(torch.ones(n, n), torch.ones(n, n))
+        )
         self.assertEqual(ret, torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
     def test_scalar_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, torch.add,
-                       args=(torch.ones(n, n), n))
+        ret = dist.rpc("worker%d" % dstRank, torch.add, args=(torch.ones(n, n), n))
         self.assertEqual(ret, (torch.ones(n, n) + n))
 
     @_wrap_with_rpc
     def test_async_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        fut = dist.rpc('worker%d' % dstRank,
-                       torch.add,
-                       args=(torch.ones(n, n), torch.ones(n, n)),
-                       async_call=True)
+        fut = dist.rpc(
+            "worker%d" % dstRank, torch.add, args=(torch.ones(n, n), torch.ones(n, n))
+        )
         self.assertEqual(fut.wait(), torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
@@ -87,7 +204,7 @@ class RpcTest(MultiProcessTestCase):
         dstRank = n % self.world_size
         x = torch.ones(self.world_size, self.world_size)
         x[self.rank][self.rank] = 0
-        ret = dist.rpc('worker%d' % dstRank, torch.nonzero, args=(x,))
+        ret = dist.rpc("worker%d" % dstRank, torch.nonzero, args=(x,))
         self.assertEqual(ret, x.nonzero())
 
     @_wrap_with_rpc
@@ -95,8 +212,11 @@ class RpcTest(MultiProcessTestCase):
         dstRank = (self.rank + 1) % self.world_size
         for i in range(20):
             n = i + self.rank + 1
-            ret = dist.rpc('worker%d' % dstRank, torch.add,
-                           args=(torch.ones(n, n), torch.ones(n, n)))
+            ret = dist.rpc(
+                "worker%d" % dstRank,
+                torch.add,
+                args=(torch.ones(n, n), torch.ones(n, n)),
+            )
             self.assertEqual(ret, torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
@@ -105,11 +225,13 @@ class RpcTest(MultiProcessTestCase):
         for i in range(20):
             dist.sync_rpc()
             n = i + self.rank + 1
-            ret1 = dist.rpc('worker%d' % dstRank, torch.add,
-                            args=(torch.ones(n, n), torch.ones(n, n)))
+            ret1 = dist.rpc(
+                "worker%d" % dstRank,
+                torch.add,
+                args=(torch.ones(n, n), torch.ones(n, n)),
+            )
             dist.sync_rpc()
-            ret2 = dist.rpc('worker%d' % dstRank, torch.add,
-                            args=(torch.ones(n, n), 2))
+            ret2 = dist.rpc("worker%d" % dstRank, torch.add, args=(torch.ones(n, n), 2))
             dist.sync_rpc()
             self.assertEqual(ret1, torch.ones(n, n) * 2)
             self.assertEqual(ret2, torch.ones(n, n) * 3)
@@ -118,14 +240,18 @@ class RpcTest(MultiProcessTestCase):
     def test_join_rpc(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, torch.add,
-                       args=(torch.ones(n, n), torch.ones(n, n)))
+        ret = dist.rpc(
+            "worker%d" % dstRank, torch.add, args=(torch.ones(n, n), torch.ones(n, n))
+        )
         self.assertEqual(ret, torch.ones(n, n) * 2)
         dist.join_rpc()
 
         with self.assertRaisesRegex(RuntimeError, "^RPC has not been initialized"):
-            dist.rpc('worker%d' % dstRank, torch.add,
-                     args=(torch.ones(n, n), torch.ones(n, n)))
+            dist.rpc(
+                "worker%d" % dstRank,
+                torch.add,
+                args=(torch.ones(n, n), torch.ones(n, n)),
+            )
 
         # it's safe to call join_rpc() multiple times
         dist.join_rpc()
@@ -134,50 +260,57 @@ class RpcTest(MultiProcessTestCase):
     def test_py_built_in(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, min, args=(n, n + 1, n + 2))
+        ret = dist.rpc("worker%d" % dstRank, min, args=(n, n + 1, n + 2))
         self.assertEqual(ret, min(n, n + 1, n + 2))
 
     @_wrap_with_rpc
     def test_py_user_defined(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, my_function, args=(n, n + 1, n + 2))
+        ret = dist.rpc("worker%d" % dstRank, my_function, args=(n, n + 1, n + 2))
         self.assertEqual(ret, my_function(n, n + 1, n + 2))
 
     @_wrap_with_rpc
     def test_py_class_constructor(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, my_class, args=(n,))
+        ret = dist.rpc("worker%d" % dstRank, my_class, args=(n,))
         self.assertEqual(ret.a, n)
 
     @_wrap_with_rpc
     def test_py_class_instance_method(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, my_class(2).my_instance_method, args=(n,))
+        ret = dist.rpc("worker%d" % dstRank, my_class(2).my_instance_method, args=(n,))
         self.assertEqual(ret, my_class(2).my_instance_method(n))
 
     @_wrap_with_rpc
     def test_py_class_method(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, my_class.my_class_method, args=(n, n + 1))
+        ret = dist.rpc("worker%d" % dstRank, my_class.my_class_method, args=(n, n + 1))
         self.assertEqual(ret, my_class.my_class_method(n, n + 1))
 
     @_wrap_with_rpc
     def test_py_class_static_method(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, my_class.my_static_method, args=(n + 10,))
+        ret = dist.rpc("worker%d" % dstRank, my_class.my_static_method, args=(n + 10,))
         self.assertEqual(ret, my_class.my_static_method(n + 10))
 
     @_wrap_with_rpc
     def test_py_multi_aync_call(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        fut1 = dist.rpc('worker%d' % dstRank, my_class.my_static_method, args=(n + 10,), async_call=True)
-        fut2 = dist.rpc('worker%d' % dstRank, min, args=(n, n + 1, n + 2), async_call=True)
+        fut1 = dist.rpc(
+            "worker%d" % dstRank,
+            my_class.my_static_method,
+            args=(n + 10,),
+            async_call=True,
+        )
+        fut2 = dist.rpc(
+            "worker%d" % dstRank, min, args=(n, n + 1, n + 2), async_call=True
+        )
         self.assertEqual(fut1.wait(), my_class.my_static_method(n + 10))
         self.assertEqual(fut2.wait(), min(n, n + 1, n + 2))
 
@@ -185,16 +318,42 @@ class RpcTest(MultiProcessTestCase):
     def test_py_no_return_result(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, no_result)
+        ret = dist.rpc("worker%d" % dstRank, no_result)
         self.assertEqual(ret, no_result())
 
     @_wrap_with_rpc
     def test_py_function_exception(self):
         n = self.rank + 1
         dstRank = n % self.world_size
-        ret = dist.rpc('worker%d' % dstRank, no_result, args=(10,))
+        ret = dist.rpc("worker%d" % dstRank, no_result, args=(10,))
         expected = "run_python_udf_internal caught exception: no_result() takes 0 positional arguments but 1 was given"
         self.assertEqual(ret, expected)
 
-if __name__ == '__main__':
+    @skip_for_known_issues  # No garentee that peer's request futures are all resovled.
+    @_wrap_with_rpc
+    def test_py_modify_global_var(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        ret = dist.rpc("worker%d" % dstRank, modify_global_var, args=(True,))
+        dist.barrier()  # Need an API, dist.rpc_wait_request_futures()
+        self.assertEqual(global_var, True)
+
+    @_wrap_with_rpc
+    def test_py_nested_rpc(self):
+        assert self.world_size >= 2, "Requires 2 workers to reproduce this issue."
+        if WorkerContext.worker_name() == "worker0":
+            to = "worker1"
+            ret = dist.rpc(to, nested_rpc, args=(WorkerContext.worker_name(), self.num_send_recv_threads, to), async_call=False)
+            assert ret is None, str(ret)
+
+    @skip_for_known_issues  # Deadlock if all threads are taken for processing RPC.
+    @_wrap_with_rpc
+    def test_py_nested_rpc_more_than_recv_threads(self):
+        assert self.world_size >= 2, "Requires 2 workers to reproduce this issue."
+        if WorkerContext.worker_name() == "worker0":
+            to = "worker1"
+            ret = dist.rpc(to, nested_rpc, args=(WorkerContext.worker_name(), self.num_send_recv_threads + 1, to), async_call=False)
+            assert ret is None, str(ret)
+
+if __name__ == "__main__":
     run_tests()

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -238,6 +238,7 @@ def add_torch_libs():
         "torch/csrc/distributed/rpc/ProcessGroupAgent.cpp",
         "torch/csrc/distributed/rpc/functions.cpp",
         "torch/csrc/distributed/rpc/python_functions.cpp",
+        "torch/csrc/distributed/rpc/PythonRpcHandler.cpp",
         "torch/csrc/jit/init.cpp",
         "torch/csrc/jit/passes/inline_fork_wait.cpp",
         "torch/csrc/jit/passes/onnx.cpp",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -230,6 +230,7 @@ if (USE_DISTRIBUTED)
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/ProcessGroupAgent.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/functions.cpp
         ${TORCH_SRC_DIR}/csrc/distributed/rpc/python_functions.cpp
+        ${TORCH_SRC_DIR}/csrc/distributed/rpc/PythonRpcHandler.cpp
         )
       list(APPEND TORCH_PYTHON_LINK_LIBRARIES c10d)
       list(APPEND TORCH_PYTHON_COMPILE_DEFINITIONS USE_C10D)

--- a/torch/csrc/distributed/rpc/ProcessGroupAgent.cpp
+++ b/torch/csrc/distributed/rpc/ProcessGroupAgent.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/distributed/rpc/ProcessGroupAgent.h>
+#include <Python.h>
 
 namespace torch {
 namespace distributed {
@@ -77,6 +78,7 @@ ProcessGroupAgent::ProcessGroupAgent(
   for (auto& entry : nameMap_) {
     names_[entry.second] = entry.first;
   }
+  PythonRpcHandler::init();
   sendThread_ = std::thread(&ProcessGroupAgent::sendLoop, this);
   listenerThread_ = std::thread(&ProcessGroupAgent::listenLoop, this);
 }
@@ -99,6 +101,8 @@ void ProcessGroupAgent::join() {
   workProduceCV_.notify_all();
   sendThread_.join();
   listenerThread_.join();
+
+  PythonRpcHandler::cleanUp();
 }
 
 void ProcessGroupAgent::sync() {

--- a/torch/csrc/distributed/rpc/ProcessGroupAgent.h
+++ b/torch/csrc/distributed/rpc/ProcessGroupAgent.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/distributed/rpc/FutureMessage.h>
 #include <torch/csrc/distributed/rpc/RpcAgent.h>
 #include <torch/csrc/distributed/rpc/functions.h>
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
 
 #include <deque>
 #include <thread>

--- a/torch/csrc/distributed/rpc/ProcessGroupAgent.h
+++ b/torch/csrc/distributed/rpc/ProcessGroupAgent.h
@@ -1,27 +1,23 @@
 #pragma once
 
+#include <c10/core/thread_pool.h>
 #include <c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/rpc/FutureMessage.h>
 #include <torch/csrc/distributed/rpc/RpcAgent.h>
 #include <torch/csrc/distributed/rpc/functions.h>
 #include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
 
-#include <deque>
 #include <thread>
 
 namespace torch {
 namespace distributed {
 namespace rpc {
 
-struct SendWork {
-  SendWork(const int dstRank,
-           Message&& message)
-      : dstRank_(dstRank),
-        message_(message) {}
+struct RpcWork {
+  RpcWork(const int rank, Message&& message) : rank_(rank), message_(message) {}
 
-  const int dstRank_;
+  const int rank_;
   Message message_;
-
 };
 
 class ProcessGroupAgent : public RpcAgent {
@@ -29,7 +25,8 @@ class ProcessGroupAgent : public RpcAgent {
 
   ProcessGroupAgent(std::string workerName,
                     std::unordered_map<std::string, int> nameMap,
-                    std::shared_ptr<c10d::ProcessGroup> pg);
+                    std::shared_ptr<c10d::ProcessGroup> pg,
+                    int numSendRecvThreads = 4);
 
   // This method wraps the destination information and the message into a
   // SendWork object, and put the SendWork into a queue. Another thread will
@@ -43,7 +40,8 @@ class ProcessGroupAgent : public RpcAgent {
 
  private:
   // put SendWork into a queue and notify the sendLoop thread
-  void enqueue(SendWork work);
+  void enqueueSend(RpcWork work);
+  void enqueueRecv(RpcWork work);
   // sending out the message
   void sendLoop();
   // receiving messages
@@ -61,12 +59,11 @@ class ProcessGroupAgent : public RpcAgent {
   // names_[rank] stores the name of the corresponding worker, use this vector
   // to get worker name from rank and pass it to the RequestCallback.
   std::vector<std::string> names_;
-  std::deque<SendWork> sendQueue_;
-  std::mutex sendQueueMutex_;
-  std::condition_variable workProduceCV_;
-  std::condition_variable workConsumeCV_;
-  std::thread sendThread_;
+  // one mutex per ProcessGroup rank, as ProcessGroup::send is not thread-safe
+  // when using the same tag.
+  std::unique_ptr<std::mutex[]> sendMutexes_;
   std::thread listenerThread_;
+  ThreadPool threadPool_;
   std::unordered_map<int64_t, std::shared_ptr<FutureMessage>> futures_;
   std::mutex futureMutex_;
 };

--- a/torch/csrc/distributed/rpc/PythonRpcHandler.cpp
+++ b/torch/csrc/distributed/rpc/PythonRpcHandler.cpp
@@ -1,0 +1,88 @@
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+PyObject* PythonRpcHandler::module_ = nullptr;
+PyObject* PythonRpcHandler::runUDFFunction_ = nullptr;
+PyObject* PythonRpcHandler::loadResultFunction_ = nullptr;
+bool PythonRpcHandler::pyInitializerCalled_ = false;
+
+void PythonRpcHandler::init() {
+  if (!Py_IsInitialized()) {
+    Py_Initialize();
+    pyInitializerCalled_ = true;
+  }
+  module_ = PyImport_ImportModule("torch.distributed.internal_rpc_utils");
+  if (module_ == nullptr) {
+    throw std::runtime_error("import internal_rpc_utils module is NULL");
+  }
+  runUDFFunction_ = PyObject_GetAttrString(module_, "run_python_udf_internal");
+  if (runUDFFunction_ == nullptr) {
+    throw std::runtime_error("import run_python_udf_internal is NULL");
+  }
+  loadResultFunction_ = PyObject_GetAttrString(
+    module_, "load_python_udf_result_internal");
+  if (loadResultFunction_ == nullptr) {
+      throw std::runtime_error(
+        "import load_python_udf_result_internal is NULL");
+  }
+}
+
+void PythonRpcHandler::cleanUp() {
+  Py_DECREF(module_);
+  Py_DECREF(runUDFFunction_);
+  Py_DECREF(loadResultFunction_);
+  if(pyInitializerCalled_) {
+    Py_Finalize();
+  }
+}
+
+std::vector<char> PythonRpcHandler::generatePythonUDFResult(
+  const Message& request) {
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  auto pargs =
+      Py_BuildValue("(y#)", request.payload().data(), request.payload().size());
+  if (pargs == nullptr) {
+    throw std::runtime_error("python function args is NULL");
+  }
+  auto pres = PyEval_CallObject(runUDFFunction_, pargs);
+  Py_DECREF(pargs);
+  if (pres == nullptr) {
+    throw std::runtime_error("received null result");
+  }
+  char* res;
+  int size;
+  PyArg_Parse(pres, "y#", &res, &size);
+  if (res == nullptr) {
+    throw std::runtime_error("serialized string is null");
+  }
+  std::vector<char> payload(res, res + size);
+  Py_DECREF(pres);
+  PyGILState_Release(gstate);
+  return payload;
+}
+
+py::object PythonRpcHandler::loadPythonUDFResult(const Message& message) {
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  auto pargs =
+      Py_BuildValue("(y#)", message.payload().data(), message.payload().size());
+  auto pres = PyEval_CallObject(loadResultFunction_, pargs);
+  if (pargs == nullptr) {
+    throw std::runtime_error("python function args is NULL");
+  }
+  Py_DECREF(pargs);
+  if (pres == nullptr) {
+    throw std::runtime_error("recevied null result");
+  }
+  PyGILState_Release(gstate);
+  auto a = py::cast<py::object>(pres);
+  return a;
+}
+
+}
+}
+}

--- a/torch/csrc/distributed/rpc/PythonRpcHandler.h
+++ b/torch/csrc/distributed/rpc/PythonRpcHandler.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <torch/csrc/distributed/rpc/Message.h>
+#include <torch/csrc/utils/pybind.h>
+#include <Python.h>
+
+namespace torch {
+namespace distributed {
+namespace rpc {
+
+class PythonRpcHandler {
+public:
+  static void init();
+  static void cleanUp();
+
+  static std::vector<char> generatePythonUDFResult(const Message& request);
+  static py::object loadPythonUDFResult(const Message& message);
+
+private:
+  static PyObject* module_;
+  static PyObject* runUDFFunction_;
+  static PyObject* loadResultFunction_;
+  static bool pyInitializerCalled_;
+};
+
+}
+}
+}

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -21,6 +21,17 @@ void processRequestBlocking(
       agent.send(from, std::move(response));
       break;
     }
+    case MessageType::PYTHON_CALL: {
+      std::vector<torch::Tensor> tensorTable;
+      agent.send(
+          from,
+          Message(
+              PythonRpcHandler::generatePythonUDFResult(request),
+              std::move(tensorTable),
+              MessageType::PYTHON_RET,
+              request.id()));
+      break;
+    }
     default: {
       AT_ERROR("Request type ", request.type(), " not supported.");
     }

--- a/torch/csrc/distributed/rpc/functions.h
+++ b/torch/csrc/distributed/rpc/functions.h
@@ -5,6 +5,8 @@
 #include <torch/csrc/distributed/rpc/RpcAgent.h>
 #include <torch/csrc/distributed/rpc/ScriptCall.h>
 #include <torch/csrc/distributed/rpc/ScriptRet.h>
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
+
 
 namespace torch {
 namespace distributed {

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -56,13 +56,20 @@ PyObject* rpc_init(PyObject* /* unused */) {
                &ProcessGroupAgent::sync,
                py::call_guard<py::gil_scoped_release>());
 
-  module.def("invoke_rpc", [](
+  module.def("invoke_rpc_builtin", [](
       RpcAgent& agent,
       const std::string& dstName,
       const std::string& opName,
       const py::args& args,
       const py::kwargs& kwargs) {
-    return py_rpc(agent, dstName, opName, args, kwargs);
+    return py_rpc_builtin(agent, dstName, opName, args, kwargs);
+  });
+
+  module.def("invoke_rpc_python_udf", [](
+      RpcAgent& agent,
+      const std::string& dstName,
+      const std::string& pickledPythonUDF) {
+    return py_rpc_python_udf(agent, dstName, pickledPythonUDF);
   });
 
   Py_RETURN_TRUE;

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -48,7 +48,12 @@ PyObject* rpc_init(PyObject* /* unused */) {
           module, "ProcessGroupAgent", rpcAgent)
           .def(py::init<std::string,
                         std::unordered_map<std::string, int>,
-                        std::shared_ptr<::c10d::ProcessGroup>>())
+                        std::shared_ptr<::c10d::ProcessGroup>,
+                        int>(),
+               py::arg("name"),
+               py::arg("name_map"),
+               py::arg("process_group"),
+               py::arg("num_send_recv_threads") = 4)
           .def("join",
                &ProcessGroupAgent::join,
                py::call_guard<py::gil_scoped_release>())

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -8,6 +8,7 @@
 #include <torch/csrc/distributed/rpc/ScriptRet.h>
 #include <torch/csrc/jit/pybind_utils.h>
 #include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/distributed/rpc/PythonRpcHandler.h>
 
 
 namespace torch {
@@ -16,12 +17,17 @@ namespace rpc {
 
 py::object to_py_obj(const Message& message);
 
-std::shared_ptr<FutureMessage> py_rpc(
+std::shared_ptr<FutureMessage> py_rpc_builtin(
     RpcAgent& agent,
     const std::string& dstName,
     const std::string& opName,
     const py::args& args,
     const py::kwargs& kwargs);
+
+std::shared_ptr<FutureMessage>  py_rpc_python_udf(
+    RpcAgent& agent,
+    const std::string& dstName,
+    const std::string& pickledPythonUDF);
 
 }
 }

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import torch
 
 
@@ -16,3 +18,4 @@ if is_available():
     # this.
     from .distributed_c10d import _backend  # noqa: F401
     from .rpc import *  # noqa: F401
+    from .internal_rpc_utils import *  # noqa: F401

--- a/torch/distributed/internal_rpc_utils.py
+++ b/torch/distributed/internal_rpc_utils.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pickle
+import copyreg
+import io
+import collections
+
+def serialize(obj):
+    f = io.BytesIO()
+    p = pickle.Pickler(f)
+    p.dispatch_table = copyreg.dispatch_table.copy()
+    p.dump(obj)
+    return f.getvalue()
+
+def run_python_udf_internal(pickled_python_udf):
+    try:
+        python_udf = pickle.loads(pickled_python_udf)
+        result = python_udf.func(*python_udf.args, **python_udf.kwargs)
+    except Exception as e:
+        result = "run_python_udf_internal caught exception: " + str(e)
+    return serialize(result)
+
+def load_python_udf_result_internal(pickled_python_result):
+    return pickle.loads(pickled_python_result)
+
+
+PythonUDF = collections.namedtuple("PythonUDF", ["func", "args", "kwargs"])

--- a/torch/distributed/rpc.py
+++ b/torch/distributed/rpc.py
@@ -68,7 +68,7 @@ def sync_rpc():
 
 
 # TODO: add a context managet to wrap init_rpc and join_rpc
-def init_rpc(name, backend='pg'):
+def init_rpc(name, backend='pg', num_send_recv_threads=None):
     r"""
     Initialize the local RPC agent which immediately makes the current process
     ready to send and receive RPCs. The caller needs to make sure the specified
@@ -94,7 +94,7 @@ def init_rpc(name, backend='pg'):
         # TODO: issue #23232
         names = _collect_worker_names(name, group)
         name_dict = {names[r] : r for r in range(len(names))}
-        _agent = ProcessGroupAgent(name, name_dict, group)
+        _agent = ProcessGroupAgent(name, name_dict, group, num_send_recv_threads)
     else:
         raise RuntimeError("Unrecognized RPC backend ", backend)
 


### PR DESCRIPTION
Summary:
# Issue

Implementation in https://github.com/pytorch/pytorch/pull/23228 has a recvLoop thread that blocks on running a requested RPC function.

This can't meet the requirement in https://github.com/pytorch/pytorch/issues/23110, where the proposal implies a worker could send out nested RPC.

"Nested RPC" means, an RPC callee could send out another RPC, before the first RPC returns, and since the worker's recv thread would be busy waiting for the return of the first RPC function, there is no available idle thread to receive the return value of the second RPC function.

A diagram showing the case of this issue, https://github.com/pytorch/pytorch/pull/23228#discussion_r311297657.

A more extensive thinking by @mrshenli in https://github.com/pytorch/pytorch/pull/23569#discussion_r311590333.

# Solution

- Add a test case to capture this requirement.

# Misc

- Add debugging utilities that could be quite useful for tracing RPC behaviors and debugging tricky RPC cases similar to this.

Differential Revision: D16682122

