### PR TITLE
Set HAVE_MKL to true if MKL_FOUND

### DIFF
--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -97,6 +97,7 @@ IF(MKL_FOUND)
   SET(MKL_cmake_included TRUE)
   # Does not override if there's already value set, e.g. TBB
   SET(MKLDNN_THREADING "OMP:COMP" CACHE STRING "")
+  set(HAVE_MKL TRUE)
 ENDIF(MKL_FOUND)
 
 MESSAGE(STATUS "MKLDNN_THREADING = ${MKLDNN_THREADING}")


### PR DESCRIPTION
On setting `MKLDNN_THREADING=OMP:INTEL`, the CMake configure stage fails with:
```
CMake Error at third_party/ideep/mkl-dnn/cmake/OpenMP.cmake:67 (message):
  Intel OpenMP runtime could not be found.  Please either use OpenMP runtime
  that comes with the compiler (via -DMKLDNN_THREADING={OMP,OMP:COMP}), or
  install Intel MKL / Intel MKL-ML (e.g.  scripts/prepare_mkl.sh)
```