### PR TITLE
Remove escape_path in our build system.

### DIFF
--- a/cmake/Modules_CUDA_fix/upstream/FindCUDA/run_nvcc.cmake
+++ b/cmake/Modules_CUDA_fix/upstream/FindCUDA/run_nvcc.cmake
@@ -85,7 +85,8 @@ list(REMOVE_DUPLICATES CUDA_NVCC_INCLUDE_DIRS)
 set(CUDA_NVCC_INCLUDE_ARGS)
 foreach(dir ${CUDA_NVCC_INCLUDE_DIRS})
   # Extra quotes are added around each flag to help nvcc parse out flags with spaces.
-  list(APPEND CUDA_NVCC_INCLUDE_ARGS "-I${dir}")
+  file(TO_CMAKE_PATH "${dir}" converted_dir)
+  list(APPEND CUDA_NVCC_INCLUDE_ARGS "-I${converted_dir}")
 endforeach()
 
 # Clean up list of compile definitions, add -D flags, and append to nvcc_flags

--- a/tools/build_pytorch_libs.py
+++ b/tools/build_pytorch_libs.py
@@ -3,7 +3,6 @@ import sys
 from glob import glob
 import shutil
 
-from .setup_helpers import escape_path
 from .setup_helpers.env import IS_64BIT, IS_WINDOWS, check_negative_env_flag
 from .setup_helpers.cmake import USE_NINJA
 from .setup_helpers.cuda import USE_CUDA, CUDA_HOME
@@ -36,10 +35,10 @@ def _create_build_env():
     # have cmake read the environment
     my_env = os.environ.copy()
     if USE_CUDNN:
-        my_env['CUDNN_LIBRARY'] = escape_path(CUDNN_LIBRARY)
-        my_env['CUDNN_INCLUDE_DIR'] = escape_path(CUDNN_INCLUDE_DIR)
+        my_env['CUDNN_LIBRARY'] = CUDNN_LIBRARY
+        my_env['CUDNN_INCLUDE_DIR'] = CUDNN_INCLUDE_DIR
     if USE_CUDA:
-        my_env['CUDA_BIN_PATH'] = escape_path(CUDA_HOME)
+        my_env['CUDA_BIN_PATH'] = CUDA_HOME
 
     if IS_WINDOWS and USE_NINJA:
         # When using Ninja under Windows, the gcc toolchain will be chosen as

--- a/tools/setup_helpers/__init__.py
+++ b/tools/setup_helpers/__init__.py
@@ -2,14 +2,6 @@ import os
 import sys
 
 
-def escape_path(path):
-    "Can be replaced by pathlib.as_posix when Python 3 is required."
-
-    if os.path.sep != '/' and path is not None:
-        return path.replace(os.path.sep, '/')
-    return path
-
-
 def which(thefile):
     path = os.environ.get("PATH", os.defpath).split(os.pathsep)
     for d in path:

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -11,7 +11,7 @@ import distutils
 import distutils.sysconfig
 from distutils.version import LooseVersion
 
-from . import escape_path, which
+from . import which
 from .env import (BUILD_DIR, IS_64BIT, IS_DARWIN, IS_WINDOWS, check_negative_env_flag)
 from .cuda import USE_CUDA
 from .dist_check import USE_DISTRIBUTED, USE_GLOO_IBVERBS
@@ -225,6 +225,7 @@ class CMake:
             var: var for var in
             ('BLAS',
              'BUILDING_WITH_TORCH_LIBS',
+             'CUDA_NVCC_EXECUTABLE',
              'EXPERIMENTAL_SINGLE_THREAD_POOL',
              'INSTALL_TEST',
              'MKL_THREADING',
@@ -278,12 +279,11 @@ class CMake:
         build_options.update(cmake__options)
 
         CMake.defines(args,
-                      PYTHON_EXECUTABLE=escape_path(sys.executable),
-                      PYTHON_LIBRARY=escape_path(cmake_python_library),
-                      PYTHON_INCLUDE_DIR=escape_path(distutils.sysconfig.get_python_inc()),
+                      PYTHON_EXECUTABLE=sys.executable,
+                      PYTHON_LIBRARY=cmake_python_library,
+                      PYTHON_INCLUDE_DIR=distutils.sysconfig.get_python_inc(),
                       TORCH_BUILD_VERSION=version,
-                      NUMPY_INCLUDE_DIR=escape_path(NUMPY_INCLUDE_DIR),
-                      CUDA_NVCC_EXECUTABLE=escape_path(os.getenv('CUDA_NVCC_EXECUTABLE')),
+                      NUMPY_INCLUDE_DIR=NUMPY_INCLUDE_DIR,
                       **build_options)
 
         if USE_GLOO_IBVERBS:

--- a/tools/setup_helpers/cuda.py
+++ b/tools/setup_helpers/cuda.py
@@ -4,7 +4,7 @@ import re
 import ctypes.util
 from subprocess import Popen, PIPE
 
-from . import escape_path, which
+from . import which
 from .env import IS_WINDOWS, IS_LINUX, IS_DARWIN, check_env_flag, check_negative_env_flag
 
 LINUX_HOME = '/usr/local/cuda'
@@ -14,7 +14,6 @@ WINDOWS_HOME = glob.glob('C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v*.
 def find_nvcc():
     nvcc = which('nvcc')
     if nvcc is not None:
-        nvcc = escape_path(nvcc)
         return os.path.dirname(nvcc)
     else:
         return None


### PR DESCRIPTION
Which was added in #16412.

Also make some CUDNN_* CMake variables to be build options so as to avoid direct reading using `$ENV` from environment variables from CMake scripts.