### PR TITLE
[quantization] Simplified nnq.Linear class

### DIFF
--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -1,8 +1,6 @@
 import torch
-try:
-    from typing import Tuple, Optional, List  # noqa: F401
-except ImportError:
-    from torch._jit_internal import Tuple, Optional, List
+
+from torch._jit_internal import Tuple, Optional, List
 
 from torch import Tensor  # noqa
 from torch.nn import _VF

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -1,5 +1,8 @@
 import torch
-from typing import Tuple, Optional, List  # noqa: F401
+try:
+    from typing import Tuple, Optional, List  # noqa: F401
+except ImportError:
+    from torch._jit_internal import Tuple, Optional, List
 
 from torch import Tensor  # noqa
 from torch.nn import _VF

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import torch
-from ...modules.module import Module
-from ...modules.linear import Linear as NNLinear
+from torch.nn.modules.module import Module
+from torch.nn.modules.linear import Linear as NNLinear
 
 from typing import Optional
 

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -4,6 +4,8 @@ import torch
 from ...modules.module import Module
 from ...modules.linear import Linear as NNLinear
 
+from typing import Optional
+
 class Quantize(Module):
     r"""Quantizes an incoming tensor
     Args:
@@ -65,7 +67,7 @@ class DeQuantize(Module):
     def from_float(mod):
         return DeQuantize()
 
-class Linear(NNLinear):
+class Linear(torch.nn.Module):
     r"""
     A quantized linear module with quantized tensor as inputs and outputs.
     We adopt the same interface as `torch.nn.Linear`, please see
@@ -91,63 +93,31 @@ class Linear(NNLinear):
         >>> print(output.size())
         torch.Size([128, 30])
     """
-    __constants__ = ['bias', 'in_features', 'out_features']
-
-    def __init__(self, in_features, out_features, bias=True):
-        super(Linear, self).__init__(in_features, out_features, bias)
-        if bias:
-            del self.bias
-            qbias = torch._empty_affine_quantized(
-                [out_features], scale=1, zero_point=0, dtype=torch.qint32)
-            self.register_buffer('bias', qbias)
+    def __init__(self, in_features, out_features, bias_=True):
+        super(Linear, self).__init__()
+        # We don't muck around with buffers or attributes or anything here
+        # to keep the module simple. *everything* is simply a Python attribute.
+        self.in_features = in_features
+        self.out_features = out_features
+        if bias_:
+            self.bias = torch.jit.annotate(
+                Optional[torch.Tensor],
+                torch._empty_affine_quantized(
+                    [out_features], scale=1, zero_point=0, dtype=torch.qint32))
         else:
-            self.register_buffer('bias', None)
-        del self.weight
+            self.bias = torch.jit.annotate(Optional[torch.Tensor], None)
+
         qweight = torch._empty_affine_quantized(
-            [out_features, in_features], scale=1, zero_point=0,
-            dtype=torch.qint8)
-        self.register_buffer('_packed_weight',
-                             torch.ops.quantized.fbgemm_linear_prepack(qweight))
-        self.register_buffer('scale',
-                             torch.tensor([1.0], dtype=torch.double))
-        self.register_buffer('zero_point',
-                             torch.tensor([0], dtype=torch.long))
+            [out_features, in_features], scale=1, zero_point=0, dtype=torch.qint8)
 
-    @property
-    def weight(self):
-        return torch.ops.quantized.fbgemm_linear_unpack(self._packed_weight)
-
-    @weight.setter
-    def weight(self, w):
-        self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(w)
+        self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(qweight)
+        self.scale = 1.0
+        self.zero_point = 0
 
     def forward(self, x):
-        # Note that we can handle self.bias == None case.
-        Y_q = torch.ops.quantized.fbgemm_linear(
-            x, self._packed_weight,
-            self.bias,
-            float(self.scale),
-            int(self.zero_point))
-        return Y_q
+        return torch.ops.quantized.fbgemm_linear(
+            x, self._packed_weight, self.bias, self.scale, self.zero_point)
 
-    def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super()._save_to_state_dict(destination, prefix, keep_vars)
-        destination[prefix + 'weight'] = torch.ops.quantized.fbgemm_linear_unpack(destination[prefix + '_packed_weight'])
-        destination.pop(prefix + '_packed_weight')
-
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(state_dict[prefix + 'weight'])
-        if prefix + 'bias' in state_dict:
-            self.bias.copy_(state_dict[prefix + 'bias'])
-            state_dict.pop(prefix + 'bias')
-        state_dict.pop(prefix + 'weight')
-        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                      missing_keys, unexpected_keys, error_msgs)
-        return
-
-    # TODO: support initializing from quantization parameters when Quantizer is
-    # exposed in python
     @staticmethod
     def from_float(mod):
         r"""Create a quantized module from a float module or qparams_dict
@@ -170,10 +140,13 @@ class Linear(NNLinear):
         wt_scale, wt_zp = weight_observer.calculate_qparams()
         bias_scale = (wt_scale * act_scale).float()
         qweight = torch.quantize_linear(mod.weight.float(), wt_scale, wt_zp.long().item(), torch.qint8)
-        qbias = torch.quantize_linear(mod.bias.float(), bias_scale, 0, torch.qint32)
+        if mod.bias is not None:
+            qbias = torch.quantize_linear(mod.bias.float(), bias_scale, 0, torch.qint32)
+        else:
+            qbias = None
         qlinear = Linear(mod.in_features, mod.out_features)
         qlinear._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(qweight)
         qlinear.bias = qbias
-        qlinear.scale = torch.tensor([act_scale], dtype=torch.double)
-        qlinear.zero_point = torch.tensor([act_zp], dtype=torch.long)
+        qlinear.scale = float(act_scale)
+        qlinear.zero_point = int(act_zp)
         return qlinear

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -4,10 +4,7 @@ import torch
 from torch.nn.modules.module import Module
 from torch.nn.modules.linear import Linear as NNLinear
 
-try:
-    from typing import Optional
-except ImportError:
-    from torch._jit_internal import Optional
+from torch._jit_internal import Optional
 
 class Quantize(Module):
     r"""Quantizes an incoming tensor

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -4,7 +4,10 @@ import torch
 from torch.nn.modules.module import Module
 from torch.nn.modules.linear import Linear as NNLinear
 
-from typing import Optional
+try:
+    from typing import Optional
+except ImportError:
+    from torch._jit_internal import Optional
 
 class Quantize(Module):
     r"""Quantizes an incoming tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24117 [quantization] JIT serialization for Conv2d
* #24116 [quantization] state_dict serialization for Conv2d + some bugfixes
* #24115 [quantization] Re-work Conv2d
* #24048 [quantization] JIT Serialization of nnq.Linear
* #24047 [quantization] State dict serialization of nnq.Linear
* **#24046 [quantization] Simplified nnq.Linear class**

`nnq.Linear` was a confusing mess of buffers/attributes and Tensor/not tensor members. This PR reworks it to consistently have only Python attributes, with the conversions handled explicitly by state_dict or __{get,set}state__ methods (added in PRs further up the stack

Differential Revision: [D16728345](https://our.internmc.facebook.com/intern/diff/D16728345)