### PR TITLE
[quantization] State dict serialization of nnq.Linear

### DIFF
--- a/test/test_nn_quantized.py
+++ b/test/test_nn_quantized.py
@@ -46,7 +46,6 @@ class ModuleAPITest(QuantizationTestCase):
         """test API functionality for nn.quantized.linear and nn._intrinsic.quantized.linear_relu"""
         W = torch.rand(out_features, in_features).float()
         W_q = torch.quantize_linear(W, 0.1, 4, torch.qint8)
-        W_pack = torch.ops.quantized.fbgemm_linear_prepack(W_q)
         X = torch.rand(batch_size, in_features).float()
         X_q = torch.quantize_linear(X, 0.2, 10, torch.quint8)
         B = torch.rand(out_features).float() if use_bias else None
@@ -57,7 +56,10 @@ class ModuleAPITest(QuantizationTestCase):
             qlinear = nnq_fused.LinearReLU(in_features, out_features)
         else:
             qlinear = nnq.Linear(in_features, out_features)
-        qlinear._packed_weight = W_pack
+        qlinear.set_weight(W_q)
+        # Simple round-trip test to ensure weight()/set_weight() API
+        self.assertEqual(qlinear.weight(), W_q)
+        W_pack = qlinear._packed_weight
         qlinear.bias = B_q if use_bias else None
         qlinear.scale = float(scale)
         qlinear.zero_point = int(zero_point)

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -150,8 +150,8 @@ class Linear(torch.nn.Module):
         self.zero_point = int(state_dict[prefix + 'zero_point'])
         state_dict.pop(prefix + 'zero_point')
 
-        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
-                                      missing_keys, unexpected_keys, error_msgs)
+        super(Linear, self)._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                                  missing_keys, unexpected_keys, error_msgs)
 
     # Function rather than property to make sure that JIT serialization doesn't
     # register this as an attribute

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -93,6 +93,7 @@ class Linear(torch.nn.Module):
         >>> print(output.size())
         torch.Size([128, 30])
     """
+
     def __init__(self, in_features, out_features, bias_=True):
         super(Linear, self).__init__()
         # We don't muck around with buffers or attributes or anything here
@@ -117,6 +118,45 @@ class Linear(torch.nn.Module):
     def forward(self, x):
         return torch.ops.quantized.fbgemm_linear(
             x, self._packed_weight, self.bias, self.scale, self.zero_point)
+
+    # ===== Serialization methods =====
+    # The special consideration here is that we have to unpack the weights into their
+    # regular QTensor form for serialization. Packed weights should not live
+    # outside the process in which they were created, rather they should be derived
+    # from the QTensor weight.
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        super()._save_to_state_dict(destination, prefix, keep_vars)
+        destination[prefix + 'weight'] = torch.ops.quantized.fbgemm_linear_unpack(
+            self._packed_weight)
+        destination[prefix + 'scale'] = torch.tensor(self.scale)
+        destination[prefix + 'zero_point'] = torch.tensor(self.zero_point)
+        if self.bias is not None:
+            destination[prefix + 'bias'] = self.bias
+
+    # ===== Deserialization methods =====
+    # Counterpart to the serialization methods, we must pack the serialized QTensor
+    # weight into its packed format for use by the FBGEMM ops.
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(state_dict[prefix + 'weight'])
+        if prefix + 'bias' in state_dict:
+            self.bias.copy_(state_dict[prefix + 'bias'])
+            state_dict.pop(prefix + 'bias')
+        state_dict.pop(prefix + 'weight')
+        self.scale = float(state_dict[prefix + 'scale'])
+        state_dict.pop(prefix + 'scale')
+        self.zero_point = int(state_dict[prefix + 'zero_point'])
+        state_dict.pop(prefix + 'zero_point')
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
+
+    # Function rather than property to make sure that JIT serialization doesn't
+    # register this as an attribute
+    def weight(self):
+        return torch.ops.quantized.fbgemm_linear_unpack(self._packed_weight)
+
+    def set_weight(self, w):
+        self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(w)
 
     @staticmethod
     def from_float(mod):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24117 [quantization] JIT serialization for Conv2d
* #24116 [quantization] state_dict serialization for Conv2d + some bugfixes
* #24115 [quantization] Re-work Conv2d
* #24048 [quantization] JIT Serialization of nnq.Linear
* **#24047 [quantization] State dict serialization of nnq.Linear**
* #24046 [quantization] Simplified nnq.Linear class

Add `_{save_to,load_from}_state_dict` methods to `nnq.Linear` that explicitly deal with conversions from the Python attributes to the serialized state dict form

Differential Revision: [D16728346](https://our.internmc.facebook.com/intern/diff/D16728346)