### PR TITLE
[quantization] JIT Serialization of nnq.Linear

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -119,12 +119,12 @@ class QuantizationTestCase(TestCase):
 
     # calib_data follows the same schema as calib_data for
     # test_only_eval_fn, i.e. (input iterable, output iterable)
-    def checkScriptable(self, orig_mod, calib_data):
+    def checkScriptable(self, orig_mod, calib_data, check_save_load=False):
         scripted = torch.jit.script(orig_mod)
-        self._checkScriptable(orig_mod, scripted, calib_data)
+        self._checkScriptable(orig_mod, scripted, calib_data, check_save_load)
 
     # Call this twice: once for a scripted module and once for a traced module
-    def _checkScriptable(self, orig_mod, script_mod, calib_data):
+    def _checkScriptable(self, orig_mod, script_mod, calib_data, check_save_load):
         self._checkModuleCorrectnessAgainstOrig(orig_mod, script_mod, calib_data)
 
         # Test save/load
@@ -132,11 +132,12 @@ class QuantizationTestCase(TestCase):
         torch.jit.save(script_mod, buffer)
 
         buffer.seek(0)
-        torch.jit.load(buffer)
+        loaded_mod = torch.jit.load(buffer)
 
         # Pending __get_state_ and __set_state__ support
         # See tracking task https://github.com/pytorch/pytorch/issues/23984
-        # self._checkModuleCorrectnessAgainstOrig(orig_mod, loaded_mod, calib_data)
+        if check_save_load:
+            self._checkModuleCorrectnessAgainstOrig(orig_mod, loaded_mod, calib_data)
 
     def _checkModuleCorrectnessAgainstOrig(self, orig_mod, test_mod, calib_data):
         for (inp, _) in calib_data:

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -4,7 +4,7 @@ import torch
 from torch.nn.modules.module import Module
 from torch.nn.modules.linear import Linear as NNLinear
 
-from typing import Optional
+from typing import Optional, Tuple
 
 class Quantize(Module):
     r"""Quantizes an incoming tensor
@@ -168,7 +168,7 @@ class Linear(torch.nn.Module):
 
     @torch.jit.export
     def __setstate__(self, state):
-        # type: (Tuple[int, int, Tensor, Tensor, float, int]) -> None
+        # type: (Tuple[int, int, torch.Tensor, torch.Tensor, float, int]) -> None
         self.in_features = state[0]
         self.out_features = state[1]
         self.bias = state[2]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24117 [quantization] JIT serialization for Conv2d
* #24116 [quantization] state_dict serialization for Conv2d + some bugfixes
* #24115 [quantization] Re-work Conv2d
* **#24048 [quantization] JIT Serialization of nnq.Linear**
* #24047 [quantization] State dict serialization of nnq.Linear
* #24046 [quantization] Simplified nnq.Linear class

Add `__{g,s}etstate__ methods on `nnq.Linear` for JIT (and torch.{save,load} serialization).

Unfortunately, this unearthed a bug in serialization documented in https://github.com/pytorch/pytorch/issues/24045. The check that triggered the bug has been disabled pending a fix

Differential Revision: [D16728347](https://our.internmc.facebook.com/intern/diff/D16728347)