### PR TITLE
Per Channel quantization APIs

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -619,6 +619,8 @@ class CAFFE2_API Tensor {
   Tensor dequantize() const;
   double q_scale() const;
   int64_t q_zero_point() const;
+  Tensor q_scales() const;
+  Tensor q_zero_points() const;
   Tensor int_repr() const;
   QScheme qscheme() const;
   Tensor to(const TensorOptions & options, bool non_blocking=false, bool copy=false) const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1069,6 +1069,14 @@ inline int64_t Tensor::q_zero_point() const {
     static auto table = globalATenDispatch().getOpTable("aten::q_zero_point(Tensor self) -> int");
     return table->getOp<int64_t (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
 }
+inline Tensor Tensor::q_scales() const {
+    static auto table = globalATenDispatch().getOpTable("aten::q_scales(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
+}
+inline Tensor Tensor::q_zero_points() const {
+    static auto table = globalATenDispatch().getOpTable("aten::q_zero_points(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);
+}
 inline Tensor Tensor::int_repr() const {
     static auto table = globalATenDispatch().getOpTable("aten::int_repr(Tensor self) -> Tensor");
     return table->getOp<Tensor (const Tensor &)>(tensorTypeIdToBackend(type_id()), is_variable())(*this);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -753,6 +753,10 @@
   dispatch:
     QuantizedCPU: empty_affine_quantized_cpu
 
+- func: _empty_perchannel_affine_quantized_like(Tensor self, Tensor zero_points, int[] size, int[] axis, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=contiguous_format) -> Tensor
+  dispatch:
+    QuantizedCPU: empty_perchannel_affine_quantized_cpu
+
 - func: resize_(Tensor(a!) self, int[] size) -> Tensor(a!)
   variants: method
   device_guard: False
@@ -2868,6 +2872,10 @@
 - func: _per_tensor_affine_qtensor(Tensor self, float scale, int zero_point) -> Tensor
   dispatch:
     CPU: per_tensor_affine_qtensor_cpu
+
+- func: _per_channel_affine_qtensor(Tensor self, Tensor scale, Tensor zero_point, int[] axis) -> Tensor
+  dispatch:
+    CPU: per_channel_affine_qtensor_cpu
 
 - func: qscheme(Tensor self) -> QScheme
   variants: method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2850,6 +2850,16 @@
   dispatch:
     QuantizedCPU: q_zero_point_quant
 
+- func: q_scales(Tensor self) -> Tensor
+  variants: function, method
+  dispatch:
+    QuantizedCPU: q_scales_quant
+
+- func: q_zero_points(Tensor self) -> Tensor
+  variants: function, method
+  dispatch:
+    QuantizedCPU: q_zero_points_quant
+
 - func: int_repr(Tensor self) -> Tensor
   variants: function, method
   dispatch:

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -78,6 +78,22 @@ int64_t q_zero_point_quant(const Tensor& self) {
   return static_cast<PerTensorAffineQuantizer*>(quantizer.get())->zero_point();
 }
 
+Tensor q_scales_quant(const Tensor& self) {
+  auto quantizer = get_qtensorimpl(self)->quantizer();
+  TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
+  return at::tensor(
+      static_cast<PerChannelAffineQuantizer*>(quantizer.get())->scales(),
+      self.options().dtype(at::kDouble));
+}
+
+Tensor q_zero_points_quant(const Tensor& self) {
+  auto quantizer = get_qtensorimpl(self)->quantizer();
+  TORCH_CHECK(quantizer->qscheme() == kPerChannelAffine);
+  return at::tensor(
+      static_cast<PerChannelAffineQuantizer*>(quantizer.get())->zero_points(),
+      self.options().dtype(at::kLong));
+}
+
 Quantizer* quantizer(const Tensor& self) {
   return get_qtensorimpl(self)->quantizer().get();
 }

--- a/aten/src/ATen/test/quantized_test.cpp
+++ b/aten/src/ATen/test/quantized_test.cpp
@@ -96,3 +96,32 @@ TEST(TestQTensor, EmptyQuantized) {
     ASSERT_EQ(r_data[i], (val - zero_point) * scale);
   }
 }
+
+TEST(TestQTensor, EmptyPerchannelQuantized) {
+  int numel = 10;
+  auto scales = rand({numel}).toType(kDouble);
+  auto zero_points = randint(10, {10}).toType(kLong);
+  int val = 100;
+  int ch_axis = 0;
+  Tensor q = at::_empty_perchannel_affine_quantized_like(
+      scales,
+      zero_points,
+      {numel},
+      {ch_axis},
+      at::device(at::kCPU).dtype(kQUInt8));
+  // Assigning to QTensor
+  auto* q_data = q.data<quint8>();
+  for (int i = 0; i < numel; ++i) {
+    q_data[i].val_ = val;
+  }
+
+  // dequantize
+  auto r = q.dequantize();
+  auto* r_data = r.data<float>();
+  for (int i = 0; i < numel; ++i) {
+    ASSERT_EQ(
+        r_data[i],
+        (val - zero_points[i].item().to<int>()) *
+            scales[i].item().to<float>());
+  }
+}

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -368,6 +368,8 @@ view of a storage and defines numeric operations on it.
    .. automethod:: qscheme
    .. automethod:: q_scale
    .. automethod:: q_zero_point
+   .. automethod:: q_scales
+   .. automethod:: q_zero_points
    .. automethod:: random_
    .. automethod:: reciprocal
    .. automethod:: reciprocal_

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -45,13 +45,15 @@ class TestQuantizedTensor(TestCase):
         qr[:] = x
         self.assertEqual(qr.item(), 15)
         # we can also print a qtensor
-        self.assertEqual(str(qr),
+        self.assertEqual(' '.join(str(qr).split()),
                          "tensor([15.], size=(1,), dtype=torch.quint8, " +
+                         "quantization_scheme=torch.per_tensor_affine, " +
                          "scale=1.0, zero_point=2)")
         empty_r = torch.ones((0, 1), dtype=torch.float)
         empty_qr = torch.quantize_linear(empty_r, scale, zero_point, torch.quint8)
-        self.assertEqual(str(empty_qr),
+        self.assertEqual(' '.join(str(empty_qr).split()),
                          "tensor([], size=(0, 1), dtype=torch.quint8, " +
+                         "quantization_scheme=torch.per_tensor_affine, " +
                          "scale=1.0, zero_point=2)")
 
     def test_qtensor_quant_dequant(self):

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -64,6 +64,22 @@ class TestQuantizedTensor(TestCase):
         rqr = qr.dequantize()
         self.assertTrue(np.allclose(r.numpy(), rqr.numpy(), atol=2 / scale))
 
+    def test_perchannel_qtensor_creation(self):
+        numel = 10
+        ch_axis = 0
+        scales = torch.rand(numel, dtype=torch.double)
+        zero_points = torch.randint(0 , 10, size=(numel,), dtype=torch.long)
+        q = torch._empty_perchannel_affine_quantized_like(scales, zero_points, [numel], [ch_axis], dtype=torch.quint8)
+        self.assertEqual(scales, q.q_scales())
+        self.assertEqual(zero_points, q.q_zero_points())
+
+        # create Tensor from uint8_t Tensor, scales and zero_points
+        int_tensor = torch.randint(0, 100, size=(numel,), dtype=torch.uint8)
+        q = torch._per_channel_affine_qtensor(int_tensor, scales, zero_points, [ch_axis])
+        self.assertEqual(int_tensor, q.int_repr())
+        self.assertEqual(scales, q.q_scales())
+        self.assertEqual(zero_points, q.q_zero_points())
+
     def test_qtensor_creation(self):
         scale = 0.5
         zero_point = 10

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1870,6 +1870,22 @@ Given a Tensor quantized by linear(affine) quantization,
 returns the zero_point of the underlying quantizer().
 """)
 
+add_docstr_all('q_scales',
+               r"""
+q_scales() -> Tensor
+
+Given a Tensor quantized by linear (affine) per-channel quantization,
+returns a Tensor of scales of the underlying quantizer().
+""")
+
+add_docstr_all('q_zero_points',
+               r"""
+q_zero_points() -> Tensor
+
+Given a Tensor quantized by linear (affine) per-channel quantization,
+returns a tensor of zero_points of the underlying quantizer().
+""")
+
 add_docstr_all('random_',
                r"""
 random_(from=0, to=None, *, generator=None) -> Tensor

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -273,11 +273,13 @@ def _str(self):
         suffixes.append('size=' + str(tuple(self.shape)))
         if not has_default_dtype:
             suffixes.append('dtype=' + str(self.dtype))
-        # TODO: change to a call to self.q_scheme() when we add q_scheme method
-        # and uncomment this
-        # suffixes.append('quantization_scheme=' + 'per_tensor_affine')
-        suffixes.append('scale=' + str(self.q_scale()))
-        suffixes.append('zero_point=' + str(self.q_zero_point()))
+        suffixes.append('quantization_scheme=' + str(self.qscheme()))
+        if self.qscheme() == torch.per_tensor_affine or self.qscheme() == torch.per_tensor_symmetric:
+            suffixes.append('scale=' + str(self.q_scale()))
+            suffixes.append('zero_point=' + str(self.q_zero_point()))
+        elif self.qscheme() == torch.per_channel_affine or self.qscheme() == torch.per_channel_symmetric:
+            suffixes.append('scale=' + str(self.q_scales()))
+            suffixes.append('zero_point=' + str(self.q_zero_points()))
         tensor_str = _tensor_str(self.dequantize(), indent)
     else:
         if self.numel() == 0 and not self.is_sparse:


### PR DESCRIPTION
Summary:
Adding per channel qtensor creation APIs

Added two tests:

EmptyPerchannelQuantized in aten/src/ATen/test/quantized_test.cpp

test_perchannel_qtensor_creation in test/test_quantized_tensor.py

Differential Revision: D16696959

