### PR TITLE
[Not for Landing] Update FBGEMM to the latest version with VNNI instruction support and latest ASMJIT version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -105,7 +105,7 @@
 [submodule "third_party/fbgemm"]
     ignore = dirty
     path = third_party/fbgemm
-    url = https://github.com/pytorch/fbgemm
+    url = https://github.com/jianyuh/fbgemm
 [submodule "third_party/foxi"]
     ignore = dirty
     path = third_party/foxi


### PR DESCRIPTION

We would like to update FBGEMM with VNNI instruction support and newer version of ASMJIT support:
https://github.com/pytorch/FBGEMM/pull/114

The CMake version incompatibility issue has been resolved in
https://github.com/asmjit/asmjit/pull/252

This PR is purely for checking if our FBGEMM PR (https://github.com/pytorch/FBGEMM/pull/114) will break PyTorch OSS test. It is not intended for landing.

