### PR TITLE
Suppress implicit-fallthrough warning on g++ >= 7 in caffe2/utils/math_cpu.cc

### DIFF
--- a/caffe2/utils/math_cpu.cc
+++ b/caffe2/utils/math_cpu.cc
@@ -110,6 +110,7 @@ C10_EXPORT void Gemm<float, CPUContext>(
           return;
         default:
           LOG(FATAL) << "Unexpected CBLAS_TRANSPOSE for trans_B";
+          return;  // The line above calls `abort()`. Should never reach here.
       }
     }
     case CblasTrans: {
@@ -126,6 +127,7 @@ C10_EXPORT void Gemm<float, CPUContext>(
           return;
         default:
           LOG(FATAL) << "Unexpected CBLAS_TRANSPOSE for trans_B";
+          return;  // The line above calls `abort()`. Should never reach here.
       }
     }
     default:
@@ -175,6 +177,7 @@ C10_EXPORT void GemmEx<float, CPUContext>(
           return;
         default:
           LOG(FATAL) << "Unexpected CBLAS_TRANSPOSE for trans_B";
+          return;  // The line above calls `abort()`. Should never reach here.
       }
     }
     case CblasTrans: {
@@ -198,6 +201,7 @@ C10_EXPORT void GemmEx<float, CPUContext>(
           return;
         default:
           LOG(FATAL) << "Unexpected CBLAS_TRANSPOSE for trans_B";
+          return;  // The line above calls `abort()`. Should never reach here.
       }
     }
     default:


### PR DESCRIPTION
These implicit fallthroughs lead to the following warning on g++ 7, because g++ could not recognize the implicit `abort` call in `LOG(FATAL)`. We suppress by adding explicit `return`s.

    /home/hong/wsrc/pytorch/caffe2/utils/math_cpu.cc: In function void
    caffe2::math::GemmEx(CBLAS_TRANSPOSE, CBLAS_TRANSPOSE, int
    , int, int, T, const T*, int, const T*, int, T, T*, int, Context*) [with
    T = float; Context = caffe2::CPUContext; Engine = caf
    fe2::DefaultEngine]:
    /home/hong/wsrc/pytorch/c10/util/logging_is_not_google_glog.h:98:10:
    warning: this statement may fall through [-Wimplicit-fall
    through=]
       ::c10::MessageLogger((char*)__FILE__, __LINE__, n).stream()
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/hong/wsrc/pytorch/caffe2/utils/math_cpu.cc:179:11: note: in
    expansion of macro LOG
               LOG(FATAL) << "Unexpected CBLAS_TRANSPOSE for trans_B";
               ^
    /home/hong/wsrc/pytorch/caffe2/utils/math_cpu.cc:182:5: note: here
         case CblasTrans: {
         ^~~~
    In file included from /home/hong/wsrc/pytorch/c10/util/Logging.h:28:0,
                     from /home/hong/wsrc/pytorch/caffe2/core/logging.h:2,
                     from /home/hong/wsrc/pytorch/caffe2/core/types.h:9,
                     from /home/hong/wsrc/pytorch/caffe2/utils/math.h:17,
                     from
    /home/hong/wsrc/pytorch/caffe2/utils/math_cpu.cc:14:
    /home/hong/wsrc/pytorch/c10/util/logging_is_not_google_glog.h:98:10:
    warning: this statement may fall through [-Wimplicit-fall
    through=]
       ::c10::MessageLogger((char*)__FILE__, __LINE__, n).stream()
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/hong/wsrc/pytorch/caffe2/utils/math_cpu.cc:202:11: note: in
    expansion of macro LOG
               LOG(FATAL) << "Unexpected CBLAS_TRANSPOSE for trans_B";
               ^
    /home/hong/wsrc/pytorch/caffe2/utils/math_cpu.cc:205:5: note: here
         default:
         ^~~~~~~