### PR TITLE
[benchmarking/qlinear] Fix qlinear benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/qlinear_test.py
+++ b/benchmarks/operator_benchmark/pt/qlinear_test.py
@@ -47,8 +47,8 @@ class QLinearBenchmark(op_bench.TorchBenchmarkBase):
         self.input = qX
         self.qlinear = nnq.Linear(IN, OUT)
         self.qlinear.weight = qW
-        self.qlinear.scale = scale
-        self.qlinear.zero_point = zero_point
+        self.qlinear.scale = torch.tensor([scale], dtype=torch.double)
+        self.qlinear.zero_point = torch.tensor([zero_point], dtype=torch.int)
         self.set_module_name("QLinear")
 
     def forward(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24059 [benchmarking/qlinear] Fix qlinear benchmark**

Similar to https://github.com/pytorch/pytorch/pull/24019, scale and zero_point name should match with what's used in other methods of the class. Setting of scale/zero_point has changed.

Differential Revision: [D16712806](https://our.internmc.facebook.com/intern/diff/D16712806/)