### PR TITLE
Resolve unused variables in tests

### DIFF
--- a/test/onnx/export_onnx_tests_filter.py
+++ b/test/onnx/export_onnx_tests_filter.py
@@ -33,8 +33,8 @@ def collect_generated_testcases(root_dir=test_onnx_common.pytorch_converted_dir,
                 model_file = os.path.join(dir_name, "model.onnx")
                 data_dir_pattern = os.path.join(dir_name, "test_data_set_*")
                 for data_dir in glob.glob(data_dir_pattern):
-                    for device in ['CPU', 'CUDA']:
-                        run_generated_test(model_file, data_dir)
+                    for device in torch.testing.get_all_device_types():
+                        run_generated_test(model_file, data_dir, device)
                 if expect:
                     expect_file = os.path.join(_expect_dir,
                                                "PyTorch-generated-{}.expect".format(d))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2959,7 +2959,7 @@ class TestNN(NNTestCase):
         n = 3
         x = torch.tensor([], device=device, dtype=torch.long)
         for sparse in [True, False]:
-            Embed = torch.nn.EmbeddingBag(m, n, sparse=True)
+            Embed = torch.nn.EmbeddingBag(m, n, sparse=sparse)
 
             output = Embed(input=x, offsets=torch.tensor([0], device=device, dtype=torch.long))
             self.assertEqual(output, torch.zeros_like(output))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3509,26 +3509,28 @@ class _TestTorchMixin(object):
         torch.set_default_tensor_type(saved_type)
 
     def test_bool_tensor_comparison_ops(self):
-        a = torch.tensor([True, False, True, False, True, False], dtype=torch.bool)
-        b = torch.tensor([True, False, True, True, True, True], dtype=torch.bool)
         for device in torch.testing.get_all_device_types():
-            self.assertEqual(a == b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.uint8))
-            self.assertEqual(a != b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.uint8))
-            self.assertEqual(a < b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.uint8))
-            self.assertEqual(a > b, torch.tensor([0, 0, 0, 0, 0, 0], dtype=torch.uint8))
-            self.assertEqual(a >= b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.uint8))
-            self.assertEqual(a <= b, torch.tensor([1, 1, 1, 1, 1, 1], dtype=torch.uint8))
-            self.assertEqual(a > False, torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.uint8))
-            self.assertEqual(a == torch.tensor(True, dtype=torch.bool), torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.uint8))
-            self.assertEqual(a == torch.tensor(0, dtype=torch.bool), torch.tensor([0, 1, 0, 1, 0, 1], dtype=torch.uint8))
+            a = torch.tensor([True, False, True, False, True, False], dtype=torch.bool, device=device)
+            b = torch.tensor([True, False, True, True, True, True], dtype=torch.bool, device=device)
+            self.assertEqual(a == b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.bool, device=device))
+            self.assertEqual(a != b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.bool, device=device))
+            self.assertEqual(a < b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.bool, device=device))
+            self.assertEqual(a > b, torch.tensor([0, 0, 0, 0, 0, 0], dtype=torch.bool, device=device))
+            self.assertEqual(a >= b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.bool, device=device))
+            self.assertEqual(a <= b, torch.tensor([1, 1, 1, 1, 1, 1], dtype=torch.bool, device=device))
+            self.assertEqual(a > False, torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.bool, device=device))
+            self.assertEqual(a == torch.tensor(True, dtype=torch.bool, device=device),
+                             torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.bool, device=device))
+            self.assertEqual(a == torch.tensor(0, dtype=torch.bool, device=device),
+                             torch.tensor([0, 1, 0, 1, 0, 1], dtype=torch.bool, device=device))
             self.assertFalse(a.equal(b))
 
     def test_bool_tensor_value_change(self):
         for device in torch.testing.get_all_device_types():
-            x = torch.tensor([True, False], dtype=torch.bool)
+            x = torch.tensor([True, False], dtype=torch.bool, device=device)
             x[0] = False
             x[1] = True
-            self.assertEqual(x, torch.tensor([False, True], dtype=torch.bool))
+            self.assertEqual(x, torch.tensor([False, True], dtype=torch.bool, device=device))
 
     def test_unfold_all_devices_and_dtypes(self):
         for device in torch.testing.get_all_device_types():


### PR DESCRIPTION
Variables such as `device` and `sparse` in for loops should be used in tests.