### PR TITLE
Added type annotations to unpooling layers

### DIFF
--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -279,6 +279,7 @@ class MaxUnpool1d(_MaxUnpoolNd):
         self.padding = _single(padding)
 
     def forward(self, input, indices, output_size=None):
+        #type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
         return F.max_unpool1d(input, indices, self.kernel_size, self.stride,
                               self.padding, output_size)
 
@@ -352,6 +353,7 @@ class MaxUnpool2d(_MaxUnpoolNd):
         self.padding = _pair(padding)
 
     def forward(self, input, indices, output_size=None):
+        #type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
         return F.max_unpool2d(input, indices, self.kernel_size, self.stride,
                               self.padding, output_size)
 
@@ -414,6 +416,7 @@ class MaxUnpool3d(_MaxUnpoolNd):
         self.padding = _triple(padding)
 
     def forward(self, input, indices, output_size=None):
+        #type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
         return F.max_unpool3d(input, indices, self.kernel_size, self.stride,
                               self.padding, output_size)
 

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -279,7 +279,7 @@ class MaxUnpool1d(_MaxUnpoolNd):
         self.padding = _single(padding)
 
     def forward(self, input, indices, output_size=None):
-        #type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
+        # type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
         return F.max_unpool1d(input, indices, self.kernel_size, self.stride,
                               self.padding, output_size)
 
@@ -353,7 +353,7 @@ class MaxUnpool2d(_MaxUnpoolNd):
         self.padding = _pair(padding)
 
     def forward(self, input, indices, output_size=None):
-        #type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
+        # type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
         return F.max_unpool2d(input, indices, self.kernel_size, self.stride,
                               self.padding, output_size)
 
@@ -416,7 +416,7 @@ class MaxUnpool3d(_MaxUnpoolNd):
         self.padding = _triple(padding)
 
     def forward(self, input, indices, output_size=None):
-        #type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
+        # type: (Tensor, Tensor, Optional[List[int]]) -> Tensor
         return F.max_unpool3d(input, indices, self.kernel_size, self.stride,
                               self.padding, output_size)
 


### PR DESCRIPTION
Currently, `output_size` gets inferred as a `Tensor` type, which isn't correct.