### PR TITLE
Vectorize LowerCholeskyTransform

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -544,19 +544,11 @@ class LowerCholeskyTransform(Transform):
     def __eq__(self, other):
         return isinstance(other, LowerCholeskyTransform)
 
-    def _call_on_event(self, x):
-        return x.tril(-1) + x.diag().exp().diag()
-
-    def _inverse_on_event(self, y):
-        return y.tril(-1) + y.diag().log().diag()
-
     def _call(self, x):
-        flat_x = x.reshape((-1,) + x.shape[-2:])
-        return torch.stack([self._call_on_event(flat_x[i]) for i in range(flat_x.size(0))]).view(x.shape)
+        return x.tril(-1) + x.diagonal(dim1=-2, dim2=-1).exp().diag_embed()
 
     def _inverse(self, y):
-        flat_y = y.reshape((-1,) + y.shape[-2:])
-        return torch.stack([self._inverse_on_event(flat_y[i]) for i in range(flat_y.size(0))]).view(y.shape)
+        return y.tril(-1) + y.diagonal(dim1=-2, dim2=-1).log().diag_embed()
 
 
 class CatTransform(Transform):


### PR DESCRIPTION
Removes older `torch.stack`-based logic in favor of `torch.diagonal()` and `torch.diag_embed()`.

I see 100x speedup in my application, where my batched matrix has shape `(800, 32 ,32)`.
```py
import torch
from torch.distributions import constraints, transform_to
x = torch.randn(800, 32, 32, requires_grad=True)

# Before this PR:
%%timeit
transform_to(constraints.lower_cholesky)(x).sum().backward()
# 579 ms ± 34.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# After this PR:
%%timeit
transform_to(constraints.lower_cholesky)(x).sum().backward()
# 4.5 ms ± 241 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```