### PR TITLE
throw remote exception on client side

### DIFF
--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -5,7 +5,6 @@ import unittest
 
 import torch
 import torch.distributed as dist
-
 from common_distributed import MultiProcessTestCase
 from common_utils import load_tests, run_tests
 
@@ -19,17 +18,26 @@ def my_function(a, b, c):
 def no_result():
     print("do nothing")
 
+
 def nested_rpc(dst):
     return dist.rpc(dst, torch.add, args=(torch.ones(2, 2), 1))
 
+
 def light_rpc():
     return 0
+
 
 def heavy_rpc(tensor):
     for i in range(1, 100):
         tensor *= i
         tensor /= i + 1
     return 0
+
+
+# it is used to test python user defined function over rpc
+def raise_func():
+    raise ValueError("Expected error")
+
 
 # it is used to test python user defined class and methods over rpc
 class my_class:
@@ -54,26 +62,28 @@ load_tests = load_tests
 
 
 if not dist.is_available():
-    print('c10d not available, skipping tests')
+    print("c10d not available, skipping tests")
     sys.exit(0)
 
 
 def _wrap_with_rpc(func):
     def wrapper(self):
         store = dist.FileStore(self.file.name, self.world_size)
-        dist.init_process_group(backend='gloo', rank=self.rank,
-                                world_size=self.world_size, store=store)
-        dist.init_rpc('worker{}'.format(self.rank))
+        dist.init_process_group(
+            backend="gloo", rank=self.rank, world_size=self.world_size, store=store
+        )
+        dist.init_rpc("worker{}".format(self.rank))
         func(self)
         dist.join_rpc()
 
     return wrapper
 
 
-@unittest.skipIf(sys.version_info < (3, 0), "Pytorch distributed rpc package "
-                 "does not support python2")
+@unittest.skipIf(
+    sys.version_info < (3, 0),
+    "Pytorch distributed rpc package " "does not support python2",
+)
 class RpcTest(MultiProcessTestCase):
-
     @property
     def world_size(self):
         return 4
@@ -82,26 +92,32 @@ class RpcTest(MultiProcessTestCase):
     def test_add(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), torch.add,
-                       args=(torch.ones(n, n), torch.ones(n, n)))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank),
+            torch.add,
+            args=(torch.ones(n, n), torch.ones(n, n)),
+        )
         self.assertEqual(ret, torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
     def test_scalar_add(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), torch.add,
-                       args=(torch.ones(n, n), n))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank), torch.add, args=(torch.ones(n, n), n)
+        )
         self.assertEqual(ret, (torch.ones(n, n) + n))
 
     @_wrap_with_rpc
     def test_async_add(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        fut = dist.rpc('worker{}'.format(dst_rank),
-                       torch.add,
-                       args=(torch.ones(n, n), torch.ones(n, n)),
-                       async_call=True)
+        fut = dist.rpc(
+            "worker{}".format(dst_rank),
+            torch.add,
+            args=(torch.ones(n, n), torch.ones(n, n)),
+            async_call=True,
+        )
         self.assertEqual(fut.wait(), torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
@@ -110,7 +126,7 @@ class RpcTest(MultiProcessTestCase):
         dst_rank = n % self.world_size
         x = torch.ones(self.world_size, self.world_size)
         x[self.rank][self.rank] = 0
-        ret = dist.rpc('worker{}'.format(dst_rank), torch.nonzero, args=(x,))
+        ret = dist.rpc("worker{}".format(dst_rank), torch.nonzero, args=(x,))
         self.assertEqual(ret, x.nonzero())
 
     @_wrap_with_rpc
@@ -118,8 +134,11 @@ class RpcTest(MultiProcessTestCase):
         dst_rank = (self.rank + 1) % self.world_size
         for i in range(20):
             n = i + self.rank + 1
-            ret = dist.rpc('worker{}'.format(dst_rank), torch.add,
-                           args=(torch.ones(n, n), torch.ones(n, n)))
+            ret = dist.rpc(
+                "worker{}".format(dst_rank),
+                torch.add,
+                args=(torch.ones(n, n), torch.ones(n, n)),
+            )
             self.assertEqual(ret, torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
@@ -128,11 +147,15 @@ class RpcTest(MultiProcessTestCase):
         for i in range(20):
             dist.sync_rpc()
             n = i + self.rank + 1
-            ret1 = dist.rpc('worker{}'.format(dst_rank), torch.add,
-                            args=(torch.ones(n, n), torch.ones(n, n)))
+            ret1 = dist.rpc(
+                "worker{}".format(dst_rank),
+                torch.add,
+                args=(torch.ones(n, n), torch.ones(n, n)),
+            )
             dist.sync_rpc()
-            ret2 = dist.rpc('worker{}'.format(dst_rank), torch.add,
-                            args=(torch.ones(n, n), 2))
+            ret2 = dist.rpc(
+                "worker{}".format(dst_rank), torch.add, args=(torch.ones(n, n), 2)
+            )
             dist.sync_rpc()
             self.assertEqual(ret1, torch.ones(n, n) * 2)
             self.assertEqual(ret2, torch.ones(n, n) * 3)
@@ -141,14 +164,20 @@ class RpcTest(MultiProcessTestCase):
     def test_join_rpc(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), torch.add,
-                       args=(torch.ones(n, n), torch.ones(n, n)))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank),
+            torch.add,
+            args=(torch.ones(n, n), torch.ones(n, n)),
+        )
         self.assertEqual(ret, torch.ones(n, n) * 2)
         dist.join_rpc()
 
         with self.assertRaisesRegex(RuntimeError, "^RPC has not been initialized"):
-            dist.rpc('worker{}'.format(dst_rank), torch.add,
-                     args=(torch.ones(n, n), torch.ones(n, n)))
+            dist.rpc(
+                "worker{}".format(dst_rank),
+                torch.add,
+                args=(torch.ones(n, n), torch.ones(n, n)),
+            )
 
         # it's safe to call join_rpc() multiple times
         dist.join_rpc()
@@ -157,61 +186,67 @@ class RpcTest(MultiProcessTestCase):
     def test_py_built_in(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), min, args=(n, n + 1, n + 2))
+        ret = dist.rpc("worker{}".format(dst_rank), min, args=(n, n + 1, n + 2))
         self.assertEqual(ret, min(n, n + 1, n + 2))
 
     @_wrap_with_rpc
     def test_py_user_defined(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank),
-                       my_function,
-                       kwargs={"a" : n, "b" : n + 1, "c" : n + 2})
+        ret = dist.rpc(
+            "worker{}".format(dst_rank),
+            my_function,
+            kwargs={"a": n, "b": n + 1, "c": n + 2},
+        )
         self.assertEqual(ret, my_function(n, n + 1, n + 2))
 
     @_wrap_with_rpc
     def test_py_class_constructor(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), my_class, args=(n,))
+        ret = dist.rpc("worker{}".format(dst_rank), my_class, args=(n,))
         self.assertEqual(ret.a, n)
 
     @_wrap_with_rpc
     def test_py_class_instance_method(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank),
-                       my_class(2).my_instance_method, args=(n,))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank), my_class(2).my_instance_method, args=(n,)
+        )
         self.assertEqual(ret, my_class(2).my_instance_method(n))
 
     @_wrap_with_rpc
     def test_py_class_method(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank),
-                       my_class.my_class_method, args=(n, n + 1))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank), my_class.my_class_method, args=(n, n + 1)
+        )
         self.assertEqual(ret, my_class.my_class_method(n, n + 1))
 
     @_wrap_with_rpc
     def test_py_class_static_method(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank),
-                       my_class.my_static_method, args=(n + 10,))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank), my_class.my_static_method, args=(n + 10,)
+        )
         self.assertEqual(ret, my_class.my_static_method(n + 10))
 
     @_wrap_with_rpc
     def test_py_multi_async_call(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        fut1 = dist.rpc('worker{}'.format(dst_rank),
-                        my_class.my_static_method,
-                        args=(n + 10,),
-                        async_call=True)
-        fut2 = dist.rpc('worker{}'.format(dst_rank),
-                        min,
-                        args=(n, n + 1, n + 2),
-                        async_call=True)
+        fut1 = dist.rpc(
+            "worker{}".format(dst_rank),
+            my_class.my_static_method,
+            args=(n + 10,),
+            async_call=True,
+        )
+        fut2 = dist.rpc(
+            "worker{}".format(dst_rank), min, args=(n, n + 1, n + 2), async_call=True
+        )
         self.assertEqual(fut1.wait(), my_class.my_static_method(n + 10))
         self.assertEqual(fut2.wait(), min(n, n + 1, n + 2))
 
@@ -219,26 +254,33 @@ class RpcTest(MultiProcessTestCase):
     def test_py_no_return_result(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), no_result)
+        ret = dist.rpc("worker{}".format(dst_rank), no_result)
         self.assertEqual(ret, no_result())
 
     @_wrap_with_rpc
     def test_py_function_exception(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), no_result, args=(10,))
-        try:
-            no_result(10)
-        except Exception as e:
-            expected = "run_python_udf_internal caught exception: " + str(e)
-        self.assertEqual(ret, expected)
+        with self.assertRaisesRegex(Exception, "TypeError"):
+            ret = dist.rpc("worker{}".format(dst_rank), no_result, args=(10,))
+
+    @_wrap_with_rpc
+    def test_py_raise_in_user_func(self):
+        n = self.rank + 1
+        dst_rank = n % self.world_size
+        fut = dist.rpc("worker{}".format(dst_rank), raise_func, async_call=True)
+        with self.assertRaisesRegex(Exception, "ValueError"):
+            fut.wait()
 
     @_wrap_with_rpc
     def test_nested_rpc(self):
         n = self.rank + 1
         dst_rank = n % self.world_size
-        ret = dist.rpc('worker{}'.format(dst_rank), nested_rpc,
-                       args=('worker{}'.format(self.rank),))
+        ret = dist.rpc(
+            "worker{}".format(dst_rank),
+            nested_rpc,
+            args=("worker{}".format(self.rank),),
+        )
         self.assertEqual(ret, torch.ones(2, 2) + 1)
 
     def _stress_test_rpc(self, f, repeat=1000, args=()):
@@ -249,15 +291,17 @@ class RpcTest(MultiProcessTestCase):
         futs = []
         tik = time.time()
         for _ in range(repeat):
-            fut = dist.rpc('worker{}'.format(dst_rank), f, args=args, async_call=True)
+            fut = dist.rpc("worker{}".format(dst_rank), f, args=args, async_call=True)
             futs.append(fut)
 
         for fut in futs:
             self.assertEqual(fut.wait(), 0)
         tok = time.time()
-        print("Rank {} finished testing {} {} times in {} seconds.".format(
-            self.rank, f.__name__, repeat, tok - tik
-        ))
+        print(
+            "Rank {} finished testing {} {} times in {} seconds.".format(
+                self.rank, f.__name__, repeat, tok - tik
+            )
+        )
 
     @_wrap_with_rpc
     def test_stress_light_rpc(self):
@@ -267,5 +311,6 @@ class RpcTest(MultiProcessTestCase):
     def test_stress_heavy_rpc(self):
         self._stress_test_rpc(heavy_rpc, repeat=20, args=(torch.ones(100, 100),))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -4,32 +4,61 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
+void sendException(
+    const std::string& from,
+    const Message& request,
+    RpcAgent& agent,
+    const std::exception& e) {
+  const char* err = e.what();
+  std::vector<char> payload(err, err + strlen(err));
+  agent.send(
+      from,
+      Message(
+          std::move(payload),
+          std::vector<torch::Tensor>(),
+          MessageType::EXCEPTION,
+          request.id()));
+}
+
 void processRequestBlocking(
-    const std::string& from, Message&& request, RpcAgent& agent) {
+    const std::string& from,
+    Message&& request,
+    RpcAgent& agent) {
   switch (request.type()) {
     case MessageType::SCRIPT_CALL: {
-      ScriptCall op = ScriptCall::fromMessage(request);
+      try {
+        ScriptCall op = ScriptCall::fromMessage(request);
 
-      auto stack = op.stack();
-      op.op()->getOperation()(stack);
-      AT_ASSERT(stack.size() == 1, "Return value of a builtin operator or a "
-          "TorchScript function should be a single IValue, got a vector of "
-          "size ", stack.size());
+        auto stack = op.stack();
+        op.op()->getOperation()(stack);
+        AT_ASSERT(
+            stack.size() == 1,
+            "Return value of a builtin operator or a "
+            "TorchScript function should be a single IValue, got a vector of "
+            "size ",
+            stack.size());
 
-      auto response = ScriptRet(std::move(stack.front())).toMessage();
-      response.setId(request.id());
-      agent.send(from, std::move(response));
+        auto response = ScriptRet(std::move(stack.front())).toMessage();
+        response.setId(request.id());
+        agent.send(from, std::move(response));
+      } catch (std::exception& e) {
+        sendException(from, request, agent, e);
+      }
       break;
     }
     case MessageType::PYTHON_CALL: {
-      std::vector<torch::Tensor> tensorTable;
-      agent.send(
-          from,
-          Message(
-              PythonRpcHandler::generatePythonUDFResult(request),
-              std::move(tensorTable),
-              MessageType::PYTHON_RET,
-              request.id()));
+      try {
+        auto payload = PythonRpcHandler::generatePythonUDFResult(request);
+        agent.send(
+            from,
+            Message(
+                std::move(payload),
+                std::vector<torch::Tensor>(),
+                MessageType::PYTHON_RET,
+                request.id()));
+      } catch (std::exception& e) {
+        sendException(from, request, agent, e);
+      }
       break;
     }
     default: {
@@ -38,6 +67,6 @@ void processRequestBlocking(
   }
 }
 
-}
-}
-}
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/functions.h
+++ b/torch/csrc/distributed/rpc/functions.h
@@ -7,14 +7,21 @@
 #include <torch/csrc/distributed/rpc/script_call.h>
 #include <torch/csrc/distributed/rpc/script_ret.h>
 
-
 namespace torch {
 namespace distributed {
 namespace rpc {
 
 void processRequestBlocking(
-    const std::string& from, Message&& message, RpcAgent& agent);
+    const std::string& from,
+    Message&& message,
+    RpcAgent& agent);
 
-} // rpc
-} // distributed
-} // torch
+void sendException(
+    const std::string& from,
+    const Message& request,
+    RpcAgent& agent,
+    const std::exception& e);
+
+} // namespace rpc
+} // namespace distributed
+} // namespace torch

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -13,6 +13,7 @@ enum MessageType {
   PYTHON_CALL,
   PYTHON_RET,
   SHUTDOWN,
+  EXCEPTION,
   UNKNOWN
 };
 

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <torch/csrc/distributed/rpc/future_message.h>
 #include <torch/csrc/distributed/rpc/message.h>
 #include <torch/csrc/distributed/rpc/python_rpc_handler.h>
@@ -9,7 +8,6 @@
 #include <torch/csrc/distributed/rpc/script_ret.h>
 #include <torch/csrc/jit/pybind_utils.h>
 #include <torch/csrc/utils/pybind.h>
-
 
 namespace torch {
 namespace distributed {
@@ -24,11 +22,11 @@ std::shared_ptr<FutureMessage> py_rpc_builtin(
     const py::args& args,
     const py::kwargs& kwargs);
 
-std::shared_ptr<FutureMessage>  py_rpc_python_udf(
+std::shared_ptr<FutureMessage> py_rpc_python_udf(
     RpcAgent& agent,
     const std::string& dstName,
     const std::string& pickledPythonUDF);
 
-}
-}
-}
+} // namespace rpc
+} // namespace distributed
+} // namespace torch


### PR DESCRIPTION
Summary: catch exception thrown on server, send the exception message back to client and rethrow it.

1. wrapped exception + traceback thrown in python, passed them back as python result string and then threw them on client.
2. C++ exception are passed as exception message type and then threw them on client

Differential Revision: D16748748

