### PR TITLE
Fix rotated rect intersection error

### DIFF
--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -434,9 +434,9 @@ double polygon_area(const Eigen::Vector2f* q, const int& m) {
 double rotated_rect_intersection(
     const RotatedRect& rect1,
     const RotatedRect& rect2) {
-  // There are up to 16 intersections returned from
-  // rotated_rect_intersection_pts
-  Eigen::Vector2f intersectPts[16], orderedPts[16];
+  // There are up to 4 x 4 + 4 + 4 = 24 intersections (including dups) returned
+  // from rotated_rect_intersection_pts
+  Eigen::Vector2f intersectPts[24], orderedPts[24];
   int num = 0; // number of intersections
 
   // Find points of intersection
@@ -448,7 +448,24 @@ double rotated_rect_intersection(
   // https://github.com/opencv/opencv/pull/12222
   // Note: it doesn't matter if #intersections is greater than 8 here
   auto ret = rotated_rect_intersection_pts(rect1, rect2, intersectPts, num);
-  CAFFE_ENFORCE(num <= 16);
+
+  if (num > 24) {
+    // should never happen
+    string msg = "";
+    msg += "num_intersections = " + to_string(num);
+    msg += "; rect1.center = (" + to_string(rect1.center.x()) + ", " +
+        to_string(rect1.center.y()) + "), ";
+    msg += "rect1.size = (" + to_string(rect1.size.x()) + ", " +
+        to_string(rect1.size.y()) + "), ";
+    msg += "rect1.angle = " + to_string(rect1.angle);
+    msg += "; rect2.center = (" + to_string(rect2.center.x()) + ", " +
+        to_string(rect2.center.y()) + "), ";
+    msg += "rect2.size = (" + to_string(rect2.size.x()) + ", " +
+        to_string(rect2.size.y()) + "), ";
+    msg += "rect2.angle = " + to_string(rect2.angle);
+    CAFFE_ENFORCE(num <= 24, msg);
+  }
+
   if (num <= 2)
     return 0.0;
 

--- a/caffe2/operators/generate_proposals_op_util_nms_test.cc
+++ b/caffe2/operators/generate_proposals_op_util_nms_test.cc
@@ -463,6 +463,21 @@ TEST(UtilsNMSTest, RotatedBBoxOverlaps) {
   }
 
   {
+    // Angle 0, very similar boxes that can produce 17 candidate 'intersections'
+    Eigen::ArrayXXf boxes(1, 5);
+    boxes << 299.500000, 417.370422, 600.000000, 364.259186, 0.000000;
+
+    Eigen::ArrayXXf query_boxes(1, 5);
+    query_boxes << 299.500000, 417.370422, 600.000000, 364.259155, 0.000000;
+
+    Eigen::ArrayXXf expected(1, 1);
+    expected << 0.99999991489;
+
+    auto actual = utils::bbox_overlaps_rotated(boxes, query_boxes);
+    EXPECT_TRUE(((expected - actual).abs() < 1e-6).all());
+  }
+
+  {
     // Simple case with angle 0 (upright boxes)
     Eigen::ArrayXXf boxes(2, 5);
     boxes << 10.5, 15.5, 21, 31, 0, 14.0, 17, 4, 10, 0;


### PR DESCRIPTION
Summary: There can be up to 32, instead of 16, intersections (including duplications) returned from rotated_rect_intersection_pts, which caused errors of num <= 16 assertions in https://fburl.com/scuba/mzmf49xc (thanks to Ananth's report) when the boxes are extremely close (e.g., the newly added unit test case)

Differential Revision: D16760676

