### PR TITLE
[WIP] Assign each RpcAgent a unique ID, and use ID to send RPC messages.

### DIFF
--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -44,6 +44,15 @@ class RpcTest(MultiProcessTestCase):
         self.assertEqual(ret, torch.ones(n, n) * 2)
 
     @_wrap_with_rpc
+    def test_add_with_id(self):
+        n = self.rank + 1
+        dstRank = n % self.world_size
+        workder_id = dist.get_id('worker{}'.format(dstRank))
+        ret = dist.rpc(workder_id, torch.add,
+                       args=(torch.ones(n, n), torch.ones(n, n)))
+        self.assertEqual(ret, torch.ones(n, n) * 2)
+
+    @_wrap_with_rpc
     def test_scalar_add(self):
         n = self.rank + 1
         dstRank = n % self.world_size

--- a/torch/csrc/distributed/rpc/ProcessGroupAgent.h
+++ b/torch/csrc/distributed/rpc/ProcessGroupAgent.h
@@ -34,7 +34,9 @@ class ProcessGroupAgent : public RpcAgent {
   // SendWork object, and put the SendWork into a queue. Another thread will
   // consume SendWork from the queue and send it out.
   std::shared_ptr<FutureMessage> send(
-      const std::string& to, Message&& message) override;
+      uint64_t to, Message&& message) override;
+
+  uint64_t getId(const std::string& workerName) override;
 
   void join() override;
 
@@ -59,7 +61,6 @@ class ProcessGroupAgent : public RpcAgent {
   std::atomic<int64_t> nextId_;
   // names_[rank] stores the name of the corresponding worker, use this vector
   // to get worker name from rank and pass it to the RequestCallback.
-  std::vector<std::string> names_;
   std::deque<SendWork> sendQueue_;
   std::mutex sendQueueMutex_;
   std::condition_variable workProduceCV_;

--- a/torch/csrc/distributed/rpc/RpcAgent.cpp
+++ b/torch/csrc/distributed/rpc/RpcAgent.cpp
@@ -4,8 +4,8 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-RpcAgent::RpcAgent(std::string workerName, RequestCallback cb)
-    : workerName_(std::move(workerName)), cb_(std::move(cb)) {}
+RpcAgent::RpcAgent(std::string workerName, uint64_t id, RequestCallback cb)
+    : workerName_(std::move(workerName)), id_(id), cb_(std::move(cb)) {}
 
 RpcAgent::~RpcAgent() = default;
 

--- a/torch/csrc/distributed/rpc/RpcAgent.h
+++ b/torch/csrc/distributed/rpc/RpcAgent.h
@@ -8,57 +8,61 @@ namespace distributed {
 namespace rpc {
 
 
-// RpcAgent is the base class for sending and receiving RPC messages. It
+// ``RpcAgent`` is the base class for sending and receiving RPC messages. It
 // provides a unified ``send`` API for both request and response messages, and
 // will invoke the given ``RequestCallback`` to process received requests. It
 // should immediately become ready to serve request and accept response after
 // construction.
 class RpcAgent;
 
-// RpcAgent implementation should invoke ``RequestCallback`` to process received
-// requests. There is no restriction on the implementation's threading model.
-// This function takes the name of the request sender, the an rvalue reference
-// of the Message object, and a reference to the RpcAgent itself. Having a
-// reference to the RpcAgent allows the ``RequestCallback`` implementation to
-// be both stateless and non-blocking. It may enqueue the message and the
-// RpcAgent reference, and use a different set of threads to process them later.
-using RequestCallback = std::function<void(std::string, Message&&, RpcAgent&)>;
+// ``RpcAgent`` implementation should invoke ``RequestCallback`` to process
+// received requests. There is no restriction on the implementation's threading
+// model. This function takes the id of the request sender, the an rvalue
+// reference of the Message object, and a reference to the ``RpcAgent`` itself.
+// Having a reference to the ``RpcAgent`` allows the ``RequestCallback``
+// implementation to be both stateless and non-blocking. For example, t may
+// enqueue the message and the ``RpcAgent`` reference, and use a different set
+// of threads to process them later.
+using RequestCallback = std::function<void(uint64_t, Message&&, RpcAgent&)>;
 
 class RpcAgent {
  public:
-  // The ``workerName`` is the globally unique name for this RpcAgent. It is up
-  // to the RpcAgent implementation to determine how to resolve names.
+  // ``workerName`` is the globally unique name for this ``RpcAgent``. It is up
+  // to the ``RpcAgent`` implementation to determine how to resolve names.
+  // ``id`` is the globally unique ID for this ``RpcAgent``. This should be
+  // determined by the ``RpcAgent`` implementation.
   // The ``RequestCallback`` will be invoked to handle received requests. This
-  // RpcAgent base class makes no assumption on the thread-safeness of the
-  // ``RequestCallback``. RpcAgent implementations need to make sure that its
-  // threading model conform to ``RequestCallback``'s requirement.
-  RpcAgent(std::string workerName, RequestCallback cb);
+  // ``RpcAgent`` base class makes no assumption on the thread-safeness of the
+  // ``RequestCallback``. ``RpcAgent`` implementations need to make sure that
+  // its threading model conform to ``RequestCallback``'s requirement.
+  RpcAgent(std::string workerName, uint64_t id, RequestCallback cb);
 
   virtual ~RpcAgent();
 
-  // Send a message to the ``RpcAgent`` of name ``to`` and returns a
+  // Send a message to the ``RpcAgent`` of id ``to`` and returns a
   // ``FutureMessage`` ptr. The implementation must be asynchronous, i.e., it
   // cannot block until it receives the response.
   //
   // If ``message.isRequest()`` is true, the ``FutureMessage`` will be completed
   // when the response arrives. For other message types, the Future should be
   // ignored by the caller.
-  //
-  // TODO: avoid passing strings all the time, e.g., by using symbols as a
-  // faster alternative.
   virtual std::shared_ptr<FutureMessage> send(
-      const std::string& to, Message&& message) = 0;
+      uint64_t to, Message&& message) = 0;
+
+  // Return the id of the given ``workerName``.
+  virtual uint64_t getId(const std::string& workerName) = 0;
 
   // Call sync and join all internal threads. This method should be called
   // before every RPC process exits.
   virtual void join() = 0;
 
-  // Synchronize the this process with other RpcAgent processes. Block until all
-  // RpcAgents reach this method and send all pending messages.
+  // Synchronize the this process with other ``RpcAgent`` processes. Block until
+  // all ``RpcAgent``s reach this method and send all pending messages.
   virtual void sync() = 0;
 
  protected:
   const std::string workerName_;
+  const uint64_t id_;
   const RequestCallback cb_;
 };
 

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -4,8 +4,7 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-void processRequestBlocking(
-    const std::string& from, Message&& request, RpcAgent& agent) {
+void processRequestBlocking(uint64_t from, Message&& request, RpcAgent& agent) {
   switch (request.type()) {
     case MessageType::SCRIPT_CALL: {
       ScriptCall op = ScriptCall::fromMessage(request);

--- a/torch/csrc/distributed/rpc/functions.h
+++ b/torch/csrc/distributed/rpc/functions.h
@@ -10,8 +10,7 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-void processRequestBlocking(
-    const std::string& from, Message&& message, RpcAgent& agent);
+void processRequestBlocking(uint64_t from, Message&& message, RpcAgent& agent);
 
 } // rpc
 } // distributed

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -49,6 +49,9 @@ PyObject* rpc_init(PyObject* /* unused */) {
           .def(py::init<std::string,
                         std::unordered_map<std::string, int>,
                         std::shared_ptr<::c10d::ProcessGroup>>())
+          .def("get_id",
+               &ProcessGroupAgent::getId,
+               py::call_guard<py::gil_scoped_release>())
           .def("join",
                &ProcessGroupAgent::join,
                py::call_guard<py::gil_scoped_release>())
@@ -58,11 +61,11 @@ PyObject* rpc_init(PyObject* /* unused */) {
 
   module.def("invoke_rpc", [](
       RpcAgent& agent,
-      const std::string& dstName,
+      uint64_t dst,
       const std::string& opName,
       const py::args& args,
       const py::kwargs& kwargs) {
-    return py_rpc(agent, dstName, opName, args, kwargs);
+    return py_rpc(agent, dst, opName, args, kwargs);
   });
 
   Py_RETURN_TRUE;

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -20,7 +20,7 @@ py::object to_py_obj(const Message& message) {
 
 std::shared_ptr<FutureMessage> py_rpc(
     RpcAgent& agent,
-    const std::string& dstName,
+    uint64_t dst,
     const std::string& opName,
     const py::args& args,
     const py::kwargs& kwargs) {
@@ -34,8 +34,7 @@ std::shared_ptr<FutureMessage> py_rpc(
         Stack stack = torch::jit::createStackForSchema(
             op->schema(), args, kwargs, c10::nullopt);
 
-        return agent.send(
-            dstName, ScriptCall(op, std::move(stack)).toMessage());
+        return agent.send(dst, ScriptCall(op, std::move(stack)).toMessage());
       } catch (std::runtime_error) {}
     }
   }

--- a/torch/csrc/distributed/rpc/python_functions.h
+++ b/torch/csrc/distributed/rpc/python_functions.h
@@ -18,7 +18,7 @@ py::object to_py_obj(const Message& message);
 
 std::shared_ptr<FutureMessage> py_rpc(
     RpcAgent& agent,
-    const std::string& dstName,
+    uint64_t dst,
     const std::string& opName,
     const py::args& args,
     const py::kwargs& kwargs);

--- a/torch/distributed/rpc.py
+++ b/torch/distributed/rpc.py
@@ -9,6 +9,12 @@ import torch
 _agent = None
 
 
+def _check_initialized():
+    if _agent is None:
+        raise RuntimeError("RPC has not been initialized. "
+                           "Call init_rpc(name) first.")
+
+
 def _collect_worker_names(name, group):
     from . import all_gather
     from . import get_world_size
@@ -57,10 +63,7 @@ def sync_rpc():
     level, if multiple threads are spawned, only one of them should call this
     method at a time.
     """
-    if _agent is None:
-        raise RuntimeError("RPC has not been initialized. "
-                           "Call init_rpc(name) first.")
-
+    _check_initialized()
     _agent.sync()
 
 
@@ -96,6 +99,11 @@ def init_rpc(name, backend='pg'):
         raise RuntimeError("Unrecognized RPC backend ", backend)
 
 
+def get_id(workerName):
+    _check_initialized()
+    return _agent.get_id(workerName)
+
+
 def rpc(to, func, args=None, kwargs=None, async_call=False):
     r"""
     Make an RPC call to run function ``func`` on worker ``to``. By default, it
@@ -104,7 +112,7 @@ def rpc(to, func, args=None, kwargs=None, async_call=False):
     thread-safe.
 
     Arguments:
-        to (str): name of the destination worker.
+        to (int or str): id or name of the destination worker.
         func (callable): a builtin function (e.g., ``torch.add``).
         args (tuple): the argument tuple for the ``func`` invocation.
         kwargs (dict): is a dictionary of keyword arguments for the ``func``
@@ -156,9 +164,7 @@ def rpc(to, func, args=None, kwargs=None, async_call=False):
         >>> dist.init_rpc("worker1")
         >>> dist.join_rpc()
     """
-    if _agent is None:
-        raise RuntimeError("RPC has not been initialized. "
-                           "Call init_rpc(name) first.")
+    _check_initialized()
 
     qualified_name = torch.jit._find_builtin(func)
     if qualified_name is None:
@@ -166,6 +172,8 @@ def rpc(to, func, args=None, kwargs=None, async_call=False):
 
     args = args if args else ()
     kwargs = kwargs if kwargs else {}
+    if isinstance(to, str):
+        to = _agent.get_id(to)
     fut = invoke_rpc(_agent, to, qualified_name, *args, **kwargs)
 
     if async_call:


### PR DESCRIPTION
As pointed out by @apaszke in a comment for #23228, using string names in `send` is inefficient. 

Moreover, when we add `RRef` later, `RpcAgent` will frequently check `RRef` ownership. It will be slow as well if we have to go though string comparison every time. 

Don't merge before #23569