### PR TITLE
Ignore bugprone-lambda-function-name in clang-tidy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: '
   ,bugprone-*
   ,-bugprone-forward-declaration-namespace
   ,-bugprone-macro-parentheses
+  ,-bugprone-lambda-function-name
   ,cppcoreguidelines-*
   ,-cppcoreguidelines-interfaces-global-init
   ,-cppcoreguidelines-owning-memory


### PR DESCRIPTION
Fixes: https://github.com/pytorch/pytorch/issues/23947.

In https://github.com/pytorch/pytorch/pull/23970, I ignored these in dispatch macros, but I think it's more maintainable to just block this globally.  And it's a pretty minor issue if it happens anyway.

