### PR TITLE
Observer returns original tensor for post training quantization

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -35,6 +35,7 @@ class Observer(nn.Module):
         else:
             self.min_val = torch.min(torch.min(x), self.min_val)
             self.max_val = torch.max(torch.max(x), self.max_val)
+        return x
 
     def calculate_qparams(self):
         if self.dtype == torch.qint8:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24196 Observer returns original tensor for post training quantization**

Observer returns output with no changes for post training quant. This unifies observer semantics for QAT and PTQ.

Differential Revision: [D16768277](https://our.internmc.facebook.com/intern/diff/D16768277/)