### PR TITLE
Import logsumexp from scipy.special rather than scipy.misc (for scipy…

### DIFF
--- a/caffe2/python/operator_test/crf_test.py
+++ b/caffe2/python/operator_test/crf_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from caffe2.python import workspace, crf, brew
 from caffe2.python.model_helper import ModelHelper
 import numpy as np
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
 from hypothesis import given


### PR DESCRIPTION
… 1.3 and later)

scipy deprecated `logsumexp` in version 1.1.0. At this point `logsumexp` was available from both scipy.misc and scipy.special. With version 1.3.0, scipy removed `logsumexp` from scipy.misc but it continues to be available in scipy.special.
