### PR TITLE
[quantization] fix py2 imports in _intrinsic/modules

### DIFF
--- a/torch/nn/_intrinsic/quantized/modules/__init__.py
+++ b/torch/nn/_intrinsic/quantized/modules/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+# @lint-ignore-every PYTHON3COMPATIMPORTS
 
 from .linear_relu import LinearReLU
 from .conv_relu import ConvReLU2d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23987 [WIP][quantization] JIT trace testing
* #24211 [quantization] equal() for QuantizedCPU
* #24201 [quantization] test_nn_quantized -> test_quantized_nn_mods
* #24209 [quantization] Fix incorrect type annotation on Linear __setstate__
* **#24206 [quantization] fix py2 imports in _intrinsic/modules**

`unicode_literals` messes up python2 when the literals are put in `__all__`, because the python interpreter expects str and not unicode for elements in an import statement. This fixes that

Differential Revision: [D16774391](https://our.internmc.facebook.com/intern/diff/D16774391)