### PR TITLE
[quantization] Fix incorrect type annotation on Linear __setstate__

### DIFF
--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -168,7 +168,7 @@ class Linear(torch.nn.Module):
 
     @torch.jit.export
     def __setstate__(self, state):
-        # type: (Tuple[int, int, torch.Tensor, torch.Tensor, float, int]) -> None
+        # type: (Tuple[int, int, Optional[torch.Tensor], torch.Tensor, float, int]) -> None
         self.in_features = state[0]
         self.out_features = state[1]
         self.bias = state[2]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23987 [WIP][quantization] JIT trace testing
* #24211 [quantization] equal() for QuantizedCPU
* #24201 [quantization] test_nn_quantized -> test_quantized_nn_mods
* **#24209 [quantization] Fix incorrect type annotation on Linear __setstate__**
* #24206 [quantization] fix py2 imports in _intrinsic/modules

Differential Revision: [D16777886](https://our.internmc.facebook.com/intern/diff/D16777886)