### PR TITLE
Make flake8 complain about trailing whitespace

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@ max-line-length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
-    E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
+    E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,E302,E303,
     # these ignores are from flake8-bugbear; please fix!
     B007,B008,
     # these ignores are from flake8-comprehensions; please fix!

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -154,14 +154,14 @@ class PyTorchOperatorTestCase(object):
             for _ in range(num_runs):
                 start_time = time.time()
                 self.output = self.op_bench.forward()
-                if cuda_sync: 
+                if cuda_sync:
                     torch.cuda.synchronize(torch.cuda.current_device())
                 end_time = time.time()
                 self.time_series.append((end_time - start_time) * 1e3)
         else:
             for _ in range(num_runs):
                 self.output = self.op_bench.forward()
-            if cuda_sync: 
+            if cuda_sync:
                 torch.cuda.synchronize(torch.cuda.current_device())
 
     def _output_mean(self):

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -318,14 +318,14 @@ def get_operator_range(chars_range):
     if chars_range == 'None' or chars_range is None:
         return None
 
-    if all(item not in chars_range for item in [',', '-']): 
-        raise ValueError("The correct format for operator_range is " 
+    if all(item not in chars_range for item in [',', '-']):
+        raise ValueError("The correct format for operator_range is "
                          "<start>-<end>, or <point>, <start>-<end>")
 
     ops_start_chars_set = set()
     ranges = chars_range.split(',')
-    for item in ranges: 
-        if len(item) == 1: 
+    for item in ranges:
+        if len(item) == 1:
             ops_start_chars_set.add(item.lower())
             continue
         start, end = item.split("-")

--- a/benchmarks/operator_benchmark/c2/add_test.py
+++ b/benchmarks/operator_benchmark/c2/add_test.py
@@ -6,16 +6,16 @@ from __future__ import unicode_literals
 import operator_benchmark as op_bench
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
-from caffe2.python import core 
+from caffe2.python import core
 
 
 """Microbenchmarks for element-wise Add operator. Supports both Caffe2/PyTorch."""
 
-# Configs for C2 add operator 
+# Configs for C2 add operator
 add_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 10, 3),
-    K=[2 ** x for x in range(0, 3)], 
+    K=[2 ** x for x in range(0, 3)],
     dtype=["int", "float"],
     tags=["long"]
 )
@@ -27,20 +27,20 @@ add_short_configs = op_bench.config_list(
         [16, 16, 64, "float"],
         [64, 64, 128, "int"],
     ],
-    attr_names=["M", "N", "K", "dtype"], 
-    tags=["short"], 
+    attr_names=["M", "N", "K", "dtype"],
+    tags=["short"],
 )
 
 class AddBenchmark(op_bench_c2.Caffe2BenchmarkBase):
-    def init(self, M, N, K, dtype): 
-        self.input_one = self.tensor([M, N, K], dtype) 
-        self.input_two = self.tensor([M, N, K], dtype) 
+    def init(self, M, N, K, dtype):
+        self.input_one = self.tensor([M, N, K], dtype)
+        self.input_two = self.tensor([M, N, K], dtype)
         self.output = self.tensor([M, N, K], dtype)
         self.set_module_name("add")
 
     def forward(self):
         op = core.CreateOperator(
-            "Add", [self.input_one, self.input_two], self.output, **self.args 
+            "Add", [self.input_one, self.input_two], self.output, **self.args
         )
         return op
 

--- a/benchmarks/operator_benchmark/c2/matmul_test.py
+++ b/benchmarks/operator_benchmark/c2/matmul_test.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import operator_benchmark as op_bench
 import benchmark_caffe2 as op_bench_c2
 from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
-from caffe2.python import core 
+from caffe2.python import core
 
 """Microbenchmarks for MatMul operator"""
 
@@ -15,7 +15,7 @@ from caffe2.python import core
 mm_long_configs = op_bench.cross_product_configs(
     M=[8, 64, 128],
     N=range(2, 10, 3),
-    K=[2 ** x for x in range(0, 3)], 
+    K=[2 ** x for x in range(0, 3)],
     trans_a=[True, False],
     trans_b=[True, False],
     tags=["long"]
@@ -28,13 +28,13 @@ mm_short_configs = op_bench.config_list(
         [1024, 1024, 256, True, False],
         [8192, 8192, 1024, True, False],
     ],
-    attr_names=["M", "N", "K", "trans_a", "trans_b"], 
-    tags=["short"], 
+    attr_names=["M", "N", "K", "trans_a", "trans_b"],
+    tags=["short"],
 )
 
 
 class MatMulBenchmark(op_bench_c2.Caffe2BenchmarkBase):
-    def init(self, M, N, K, trans_a, trans_b): 
+    def init(self, M, N, K, trans_a, trans_b):
         self.input_one = self.tensor([N, M]) if trans_a else self.tensor([M, N])
         self.input_two = self.tensor([K, N]) if trans_b else self.tensor([N, K])
         self.args = {'trans_a': trans_a, 'trans_b': trans_b}
@@ -43,7 +43,7 @@ class MatMulBenchmark(op_bench_c2.Caffe2BenchmarkBase):
 
     def forward(self):
         op = core.CreateOperator(
-            "MatMul", [self.input_one, self.input_two], self.output, **self.args 
+            "MatMul", [self.input_one, self.input_two], self.output, **self.args
         )
         return op
 

--- a/benchmarks/operator_benchmark/common/tests/add_ops_list_test.py
+++ b/benchmarks/operator_benchmark/common/tests/add_ops_list_test.py
@@ -23,7 +23,7 @@ unary_ops_list = op_bench.op_list(
 
 
 class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, op_func): 
+    def init(self, M, N, op_func):
         self.input_one = torch.rand(M, N)
         self.op_func = op_func
 

--- a/benchmarks/operator_benchmark/common/tests/c2_cpu_gpu_forward_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/c2_cpu_gpu_forward_backward_test.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import operator_benchmark as op_bench
-from caffe2.python import core 
+from caffe2.python import core
 
 
 add_configs = op_bench.cross_product_configs(
@@ -12,24 +12,24 @@ add_configs = op_bench.cross_product_configs(
 )
 
 class AddBenchmark(op_bench.Caffe2BenchmarkBase):
-    def init(self, M, N, K, device): 
+    def init(self, M, N, K, device):
         self.set_module_name("add")
-        self.input_one = self.tensor([M, N, K], device=device) 
-        self.input_two = self.tensor([M, N, K], device=device) 
-        self.input_one_grad = self.tensor([M, N, K], device=device) 
-        self.input_two_grad = self.tensor([M, N, K], device=device) 
+        self.input_one = self.tensor([M, N, K], device=device)
+        self.input_two = self.tensor([M, N, K], device=device)
+        self.input_one_grad = self.tensor([M, N, K], device=device)
+        self.input_two_grad = self.tensor([M, N, K], device=device)
         self.output = self.tensor([M, N, K], device=device)
 
     def forward(self):
         op = core.CreateOperator(
-            "Add", [self.input_one, self.input_two], self.output, **self.args 
+            "Add", [self.input_one, self.input_two], self.output, **self.args
         )
         return op
 
     def backward(self):
         grad_op = core.CreateOperator(
-            "AddGradient", [self.output, self.input_one, self.input_two], 
-            [self.input_one_grad, self.input_two_grad], **self.args 
+            "AddGradient", [self.output, self.input_one, self.input_two],
+            [self.input_one_grad, self.input_two_grad], **self.args
         )
         return grad_op
 

--- a/benchmarks/operator_benchmark/common/tests/jit_forward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/jit_forward_test.py
@@ -6,8 +6,8 @@ intraop_bench_configs = op_bench.config_list(
     attrs=[
         [8, 16],
     ],
-    attr_names=["M", "N"], 
-    tags=["short"], 
+    attr_names=["M", "N"],
+    tags=["short"],
 )
 
 @torch.jit.script
@@ -25,9 +25,9 @@ class TorchSumBenchmark(op_bench.TorchBenchmarkBase):
         self.input_one = torch.rand(M, N)
         self.set_module_name("sum")
 
-    # This is a very temporary method and will be removed soon, so 
+    # This is a very temporary method and will be removed soon, so
     # don't use this method in your benchmark
-    # TODO(mingzhe): use one forward method for both JIT and Eager 
+    # TODO(mingzhe): use one forward method for both JIT and Eager
     def jit_forward(self, iters):
         return torch_sumall(self.input_one, iters)
 

--- a/benchmarks/operator_benchmark/common/tests/pt_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/pt_backward_test.py
@@ -11,9 +11,9 @@ add_configs = op_bench.cross_product_configs(
 )
 
 # This benchmark uses the auto_set to automatically set requires_grad
-# for both inputs. The test name can also be used for filtering. 
+# for both inputs. The test name can also be used for filtering.
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K): 
+    def init(self, M, N, K):
         self.input_one = torch.rand(M, N, K, requires_grad=self.auto_set())
         self.input_two = torch.rand(M, N, K, requires_grad=self.auto_set())
         self.set_module_name("add")

--- a/benchmarks/operator_benchmark/common/tests/pt_configs_list_test.py
+++ b/benchmarks/operator_benchmark/common/tests/pt_configs_list_test.py
@@ -9,7 +9,7 @@ import torch
 """Microbenchmarks for element-wise Add operator. Supports both Caffe2/PyTorch."""
 
 add_short_configs = op_bench.config_list(
-    attr_names=['M', 'N', 'K'], 
+    attr_names=['M', 'N', 'K'],
     attrs=[
         [8, 16, 32],
         [16, 16, 64],
@@ -19,12 +19,12 @@ add_short_configs = op_bench.config_list(
         'device': ['cpu', 'cuda'],
         'dtype': [torch.float, torch.float64],
     },
-    tags=['short'], 
+    tags=['short'],
 )
 
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, device, dtype): 
+    def init(self, M, N, K, device, dtype):
         self.input_one = torch.rand(M, N, K, device=device, dtype=dtype, requires_grad=True)
         self.input_two = torch.rand(M, N, K, device=device, dtype=dtype)
         self.set_module_name('add')

--- a/benchmarks/operator_benchmark/common/tests/pt_cpu_gpu_forward_backward_test.py
+++ b/benchmarks/operator_benchmark/common/tests/pt_cpu_gpu_forward_backward_test.py
@@ -13,7 +13,7 @@ add_configs = op_bench.cross_product_configs(
 
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K, device): 
+    def init(self, M, N, K, device):
         self.input_one = torch.rand(M, N, K, device=device, requires_grad=True)
         self.input_two = torch.rand(M, N, K, device=device, requires_grad=True)
         self.set_module_name("add")

--- a/benchmarks/operator_benchmark/common/tests/random_sample_test.py
+++ b/benchmarks/operator_benchmark/common/tests/random_sample_test.py
@@ -8,19 +8,19 @@ configs = op_bench.random_sample_configs(
     N=[7, 8, 9, 10, 11, 12],
     K=[13, 14, 15, 16, 17, 18],
     # probs saves the weights of each value
-    probs=op_bench.attr_probs( 
+    probs=op_bench.attr_probs(
         M=[0.5, 0.2, 0.1, 0.05, 0.03, 0.1],
         N=[0.1, 0.3, 0.4, 0.02, 0.03, 0.04],
         K=[0.03, 0.6, 0.04, 0.02, 0.03, 0.01],
     ),
-    # this is the number of returned inputs 
-    total_samples=10, 
+    # this is the number of returned inputs
+    total_samples=10,
     tags=["short"],
 )
 
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
-    def init(self, M, N, K): 
+    def init(self, M, N, K):
         self.input_one = torch.rand(M, N, K)
         self.input_two = torch.rand(M, N, K)
         self.set_module_name("add")

--- a/benchmarks/operator_benchmark/pt/fill_test.py
+++ b/benchmarks/operator_benchmark/pt/fill_test.py
@@ -34,7 +34,7 @@ class Fill_Benchmark(op_bench.TorchBenchmarkBase):
         return self.input_one.fill_(10)
 
 
-op_bench.generate_pt_test(fill_short_configs + fill_long_configs, 
+op_bench.generate_pt_test(fill_short_configs + fill_long_configs,
                           Fill_Benchmark)
 
 

--- a/caffe2/python/operator_test/group_conv_test.py
+++ b/caffe2/python/operator_test/group_conv_test.py
@@ -43,7 +43,7 @@ class TestGroupConvolution(hu.HypothesisTestCase):
         else:
             # TODO: Group conv in NHWC not implemented for GPU yet.
             assume(group == 1 or order == "NCHW" or gc.device_type == caffe2_pb2.CPU)
-           
+
             if group != 1 and order == "NHWC":
                 dc = [d for d in dc if d.device_type == caffe2_pb2.CPU]
 

--- a/scripts/diagnose_protobuf.py
+++ b/scripts/diagnose_protobuf.py
@@ -26,7 +26,7 @@ try:
     import google.protobuf
     python_version = google.protobuf.__version__
     python_protobuf_installed = True
-except ImportError: 
+except ImportError:
     print("DEBUG: cannot find python protobuf install.")
     python_protobuf_installed = False
 

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ if IS_WINDOWS:
     cmake_python_library = "{}/libs/python{}.lib".format(
         distutils.sysconfig.get_config_var("prefix"),
         distutils.sysconfig.get_config_var("VERSION"))
-    # Fix virtualenv builds 
+    # Fix virtualenv builds
     # TODO: Fix for python < 3.3
     if not os.path.exists(cmake_python_library):
         cmake_python_library = "{}/libs/python{}.lib".format(

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2061,7 +2061,7 @@ TestONNXRuntime_opset11 = type(str("TestONNXRuntime_opset11"),
                                dict(TestONNXRuntime.__dict__, opset_version=11))
 
 
-# opset 9 tests, with keep_initializers_as_inputs=False for 
+# opset 9 tests, with keep_initializers_as_inputs=False for
 # IR version 4 style export.
 TestONNXRuntime_opset9_IRv4 = type(str("TestONNXRuntime_opset9_IRv4"),
                                    (unittest.TestCase,),
@@ -2069,7 +2069,7 @@ TestONNXRuntime_opset9_IRv4 = type(str("TestONNXRuntime_opset9_IRv4"),
                                    keep_initializers_as_inputs=False))
 
 
-# opset 10 tests, with keep_initializers_as_inputs=False for 
+# opset 10 tests, with keep_initializers_as_inputs=False for
 # IR version 4 style export.
 TestONNXRuntime_opset10_IRv4 = type(str("TestONNXRuntime_opset10_IRv4"),
                                     (unittest.TestCase,),
@@ -2077,7 +2077,7 @@ TestONNXRuntime_opset10_IRv4 = type(str("TestONNXRuntime_opset10_IRv4"),
                                     keep_initializers_as_inputs=False))
 
 
-# opset 11 tests, with keep_initializers_as_inputs=False for 
+# opset 11 tests, with keep_initializers_as_inputs=False for
 # IR version 4 style export.
 TestONNXRuntime_opset11_IRv4 = type(str("TestONNXRuntime_opset11_IRv4"),
                                     (unittest.TestCase,),

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -186,7 +186,7 @@ class TestTypePromotion(TestCase):
             tensor[torch.abs(tensor) < 0.05] = 5
         return tensor
 
-    # verifies that torch.<op>(first, second) is the same as 
+    # verifies that torch.<op>(first, second) is the same as
     # torch.<op>(first.to(common_dtype), second.to(common_dtype)) in cases where that should hold.
     @float_double_default_dtype
     def test_many_promotions(self, device):

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -22,7 +22,7 @@ def find_cudnn_windows_lib():
     # Override the default search process
     # Fixes https://github.com/pytorch/pytorch/issues/20202
     # The libary selection will be done in these directories one by one
-    # 1. [Package Root]\Lib 
+    # 1. [Package Root]\Lib
     #    That's where our libraries are in, which should be loaded first.
     # 2. Default directories
     #    That is stored in the environment variable `PATH`.

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -294,7 +294,7 @@ def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
 
     Args:
         tensor: an n-dimensional `torch.Tensor`
-        a: the negative slope of the rectifier used after this layer (only 
+        a: the negative slope of the rectifier used after this layer (only
         used with ``'leaky_relu'``)
         mode: either ``'fan_in'`` (default) or ``'fan_out'``. Choosing ``'fan_in'``
             preserves the magnitude of the variance of the weights in the
@@ -329,7 +329,7 @@ def kaiming_normal_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
 
     Args:
         tensor: an n-dimensional `torch.Tensor`
-        a: the negative slope of the rectifier used after this layer (only 
+        a: the negative slope of the rectifier used after this layer (only
         used with ``'leaky_relu'``)
         mode: either ``'fan_in'`` (default) or ``'fan_out'``. Choosing ``'fan_in'``
             preserves the magnitude of the variance of the weights in the

--- a/torch/nn/utils/prune.py
+++ b/torch/nn/utils/prune.py
@@ -44,8 +44,8 @@ class BasePruningMethod(ABC):
 
         Args:
             t (torch.Tensor): tensor representing the parameter to prune
-            default_mask (torch.Tensor): Base mask from previous pruning 
-                iterations, that need to be respected after the new mask is 
+            default_mask (torch.Tensor): Base mask from previous pruning
+                iterations, that need to be respected after the new mask is
                 applied. Same dims as ``t``.
 
         Returns:
@@ -89,7 +89,7 @@ class BasePruningMethod(ABC):
                 will act.
             args: arguments passed on to a subclass of
                 :class:`BasePruningMethod`
-            kwargs: keyword arguments passed on to a subclass of a 
+            kwargs: keyword arguments passed on to a subclass of a
                 :class:`BasePruningMethod`
         """
 
@@ -159,7 +159,7 @@ class BasePruningMethod(ABC):
         # pruning
         orig = getattr(module, name)
 
-        # If this is the first time pruning is applied, take care of moving 
+        # If this is the first time pruning is applied, take care of moving
         # the original tensor to a new parameter called name + '_orig' and
         # and deleting the original parameter
         if not isinstance(method, PruningContainer):
@@ -174,7 +174,7 @@ class BasePruningMethod(ABC):
         else:
             default_mask = getattr(module, name + "_mask").detach().clone(memory_format=torch.contiguous_format)
 
-        # Use try/except because if anything goes wrong with the mask 
+        # Use try/except because if anything goes wrong with the mask
         # computation etc., you'd want to roll back.
         try:
             # get the final mask, computed according to the specific method
@@ -201,7 +201,7 @@ class BasePruningMethod(ABC):
         according to the pruning rule specified in :meth:`compute_mask`.
 
         Args:
-            t (torch.Tensor): tensor to prune (of same dimensions as 
+            t (torch.Tensor): tensor to prune (of same dimensions as
                 ``default_mask``).
             default_mask (torch.Tensor, optional): mask from previous pruning
                 iteration, if any. To be considered when determining what
@@ -221,7 +221,7 @@ class BasePruningMethod(ABC):
         named ``name+'_orig'`` is removed from the parameter list. Similarly,
         the buffer named ``name+'_mask'`` is removed from the buffers.
 
-        Note: 
+        Note:
             Pruning itself is NOT undone or reversed!
         """
         # before removing pruning from a tensor, it has to have been applied
@@ -249,8 +249,8 @@ class PruningContainer(BasePruningMethod):
     Keeps track of the order in which pruning methods are applied and handles
     combining successive pruning calls.
 
-    Accepts as argument an instance of a BasePruningMethod or an iterable of 
-    them. 
+    Accepts as argument an instance of a BasePruningMethod or an iterable of
+    them.
     """
 
     def __init__(self, *args):
@@ -298,13 +298,13 @@ class PruningContainer(BasePruningMethod):
         return self._pruning_methods[idx]
 
     def compute_mask(self, t, default_mask):
-        r"""Applies the latest ``method`` by computing the new partial masks 
+        r"""Applies the latest ``method`` by computing the new partial masks
         and returning its combination with the ``default_mask``.
         The new partial mask should be computed on the entries or channels
-        that were not zeroed out by the ``default_mask``. 
-        Which portions of the tensor ``t`` the new mask will be calculated from 
+        that were not zeroed out by the ``default_mask``.
+        Which portions of the tensor ``t`` the new mask will be calculated from
         depends on the ``PRUNING_TYPE`` (handled by the type handler):
-            * for 'unstructured', the mask will be computed from the raveled 
+            * for 'unstructured', the mask will be computed from the raveled
             list of nonmasked entries;
 
             * for 'structured', the mask will be computed from the nonmasked
@@ -334,7 +334,7 @@ class PruningContainer(BasePruningMethod):
 
             Returns:
                 new_mask (torch.Tensor): new mask that combines the effects
-                    of the old mask and the new mask from the current 
+                    of the old mask and the new mask from the current
                     pruning method (of same dimensions as mask and t).
             """
             new_mask = mask  # start off from existing mask
@@ -428,7 +428,7 @@ class RandomUnstructured(BasePruningMethod):
             will act.
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
     """
 
@@ -471,7 +471,7 @@ class RandomUnstructured(BasePruningMethod):
                 will act.
             amount (int or float): quantity of parameters to prune.
                 If ``float``, should be between 0.0 and 1.0 and represent the
-                fraction of parameters to prune. If ``int``, it represents the 
+                fraction of parameters to prune. If ``int``, it represents the
                 absolute number of parameters to prune.
         """
         return super(RandomUnstructured, cls).apply(
@@ -480,13 +480,13 @@ class RandomUnstructured(BasePruningMethod):
 
 
 class L1Unstructured(BasePruningMethod):
-    r"""Prune (currently unpruned) units in a tensor by zeroing out the ones 
+    r"""Prune (currently unpruned) units in a tensor by zeroing out the ones
     with the lowest L1-norm.
 
     Args:
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
     """
 
@@ -533,7 +533,7 @@ class L1Unstructured(BasePruningMethod):
                 will act.
             amount (int or float): quantity of parameters to prune.
                 If ``float``, should be between 0.0 and 1.0 and represent the
-                fraction of parameters to prune. If ``int``, it represents the 
+                fraction of parameters to prune. If ``int``, it represents the
                 absolute number of parameters to prune.
         """
         return super(L1Unstructured, cls).apply(module, name, amount=amount)
@@ -545,7 +545,7 @@ class RandomStructured(BasePruningMethod):
     Args:
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
         dim (int, optional): index of the dim along which we define
             channels to prune. Default: -1.
@@ -562,14 +562,14 @@ class RandomStructured(BasePruningMethod):
     def compute_mask(self, t, default_mask):
         r"""Computes and returns a mask for the input tensor ``t``.
         Starting from a base ``default_mask`` (which should be a mask of ones
-        if the tensor has not been pruned yet), generate a random mask to 
+        if the tensor has not been pruned yet), generate a random mask to
         apply on top of the ``default_mask`` by randomly zeroing out channels
         along the specified dim of the tensor.
 
         Args:
             t (torch.Tensor): tensor representing the parameter to prune
-            default_mask (torch.Tensor): Base mask from previous pruning 
-                iterations, that need to be respected after the new mask is 
+            default_mask (torch.Tensor): Base mask from previous pruning
+                iterations, that need to be respected after the new mask is
                 applied. Same dims as ``t``.
 
         Returns:
@@ -616,7 +616,7 @@ class RandomStructured(BasePruningMethod):
         if nparams_toprune == 0:  # k=0 not supported by torch.kthvalue
             mask = default_mask
         else:
-            # apply the new structured mask on top of prior (potentially 
+            # apply the new structured mask on top of prior (potentially
             # unstructured) mask
             mask = make_mask(t, self.dim, tensor_size, nparams_toprune)
             mask *= default_mask.to(dtype=mask.dtype)
@@ -634,7 +634,7 @@ class RandomStructured(BasePruningMethod):
                 will act.
             amount (int or float): quantity of parameters to prune.
                 If ``float``, should be between 0.0 and 1.0 and represent the
-                fraction of parameters to prune. If ``int``, it represents the 
+                fraction of parameters to prune. If ``int``, it represents the
                 absolute number of parameters to prune.
             dim (int, optional): index of the dim along which we define
                 channels to prune. Default: -1.
@@ -651,7 +651,7 @@ class LnStructured(BasePruningMethod):
     Args:
         amount (int or float): quantity of channels to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
         n (int, float, inf, -inf, 'fro', 'nuc'): See documentation of valid
             entries for argument ``p`` in :func:`torch.norm`.
@@ -677,8 +677,8 @@ class LnStructured(BasePruningMethod):
 
         Args:
             t (torch.Tensor): tensor representing the parameter to prune
-            default_mask (torch.Tensor): Base mask from previous pruning 
-                iterations, that need to be respected after the new mask is 
+            default_mask (torch.Tensor): Base mask from previous pruning
+                iterations, that need to be respected after the new mask is
                 applied.  Same dims as ``t``.
 
         Returns:
@@ -753,7 +753,7 @@ class LnStructured(BasePruningMethod):
                 will act.
             amount (int or float): quantity of parameters to prune.
                 If ``float``, should be between 0.0 and 1.0 and represent the
-                fraction of parameters to prune. If ``int``, it represents the 
+                fraction of parameters to prune. If ``int``, it represents the
                 absolute number of parameters to prune.
             n (int, float, inf, -inf, 'fro', 'nuc'): See documentation of valid
                 entries for argument ``p`` in :func:`torch.norm`.
@@ -829,10 +829,10 @@ def random_unstructured(module, name, amount):
     by removing the specified ``amount`` of (currently unpruned) units
     selected at random.
     Modifies module in place (and also return the modified module) by:
-    1) adding a named buffer called ``name+'_mask'`` corresponding to the 
+    1) adding a named buffer called ``name+'_mask'`` corresponding to the
     binary mask applied to the parameter `name` by the pruning method.
     2) replacing the parameter ``name`` by its pruned version, while the
-    original (unpruned) parameter is stored in a new parameter named 
+    original (unpruned) parameter is stored in a new parameter named
     ``name+'_orig'``.
 
     Args:
@@ -841,7 +841,7 @@ def random_unstructured(module, name, amount):
                 will act.
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
 
     Returns:
@@ -861,12 +861,12 @@ def l1_unstructured(module, name, amount):
     r"""Prunes tensor corresponding to parameter called ``name`` in ``module``
     by removing the specified `amount` of (currently unpruned) units with the
     lowest L1-norm.
-    Modifies module in place (and also return the modified module) 
+    Modifies module in place (and also return the modified module)
     by:
-    1) adding a named buffer called ``name+'_mask'`` corresponding to the 
+    1) adding a named buffer called ``name+'_mask'`` corresponding to the
     binary mask applied to the parameter ``name`` by the pruning method.
-    2) replacing the parameter ``name`` by its pruned version, while the 
-    original (unpruned) parameter is stored in a new parameter named 
+    2) replacing the parameter ``name`` by its pruned version, while the
+    original (unpruned) parameter is stored in a new parameter named
     ``name+'_orig'``.
 
     Args:
@@ -875,7 +875,7 @@ def l1_unstructured(module, name, amount):
                 will act.
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
 
     Returns:
@@ -894,12 +894,12 @@ def random_structured(module, name, amount, dim):
     r"""Prunes tensor corresponding to parameter called ``name`` in ``module``
     by removing the specified ``amount`` of (currently unpruned) channels
     along the specified ``dim`` selected at random.
-    Modifies module in place (and also return the modified module) 
+    Modifies module in place (and also return the modified module)
     by:
-    1) adding a named buffer called ``name+'_mask'`` corresponding to the 
+    1) adding a named buffer called ``name+'_mask'`` corresponding to the
     binary mask applied to the parameter ``name`` by the pruning method.
-    2) replacing the parameter ``name`` by its pruned version, while the 
-    original (unpruned) parameter is stored in a new parameter named 
+    2) replacing the parameter ``name`` by its pruned version, while the
+    original (unpruned) parameter is stored in a new parameter named
     ``name+'_orig'``.
 
     Args:
@@ -908,7 +908,7 @@ def random_structured(module, name, amount, dim):
                 will act.
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
         dim (int): index of the dim along which we define channels to prune.
 
@@ -931,12 +931,12 @@ def ln_structured(module, name, amount, n, dim):
     r"""Prunes tensor corresponding to parameter called ``name`` in ``module``
     by removing the specified ``amount`` of (currently unpruned) channels
     along the specified ``dim`` with the lowest L``n``-norm.
-    Modifies module in place (and also return the modified module) 
+    Modifies module in place (and also return the modified module)
     by:
-    1) adding a named buffer called ``name+'_mask'`` corresponding to the 
+    1) adding a named buffer called ``name+'_mask'`` corresponding to the
     binary mask applied to the parameter ``name`` by the pruning method.
     2) replacing the parameter ``name`` by its pruned version, while the
-    original (unpruned) parameter is stored in a new parameter named 
+    original (unpruned) parameter is stored in a new parameter named
     ``name+'_orig'``.
 
     Args:
@@ -945,7 +945,7 @@ def ln_structured(module, name, amount, n, dim):
                 will act.
         amount (int or float): quantity of parameters to prune.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
         n (int, float, inf, -inf, 'fro', 'nuc'): See documentation of valid
             entries for argument ``p`` in :func:`torch.norm`.
@@ -968,10 +968,10 @@ def global_unstructured(parameters, pruning_method, **kwargs):
     Globally prunes tensors corresponding to all parameters in ``parameters``
     by applying the specified ``pruning_method``.
     Modifies modules in place by:
-    1) adding a named buffer called ``name+'_mask'`` corresponding to the 
+    1) adding a named buffer called ``name+'_mask'`` corresponding to the
     binary mask applied to the parameter ``name`` by the pruning method.
     2) replacing the parameter ``name`` by its pruned version, while the
-    original (unpruned) parameter is stored in a new parameter named 
+    original (unpruned) parameter is stored in a new parameter named
     ``name+'_orig'``.
 
     Args:
@@ -979,22 +979,22 @@ def global_unstructured(parameters, pruning_method, **kwargs):
             the model to prune in a global fashion, i.e. by aggregating all
             weights prior to deciding which ones to prune. module must be of
             type :class:`nn.Module`, and name must be a string.
-        pruning_method (function): a valid pruning function from this module, 
-            or a custom one implemented by the user that satisfies the 
+        pruning_method (function): a valid pruning function from this module,
+            or a custom one implemented by the user that satisfies the
             implementation guidelines and has ``PRUNING_TYPE='unstructured'``.
         kwargs: other keyword arguments such as:
-            amount (int or float): quantity of parameters to prune across the 
+            amount (int or float): quantity of parameters to prune across the
             specified parameters.
             If ``float``, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If ``int``, it represents the 
+            fraction of parameters to prune. If ``int``, it represents the
             absolute number of parameters to prune.
 
     Raises:
         TypeError: if ``PRUNING_TYPE != 'unstructured'``
 
     Note:
-        Since global structured pruning doesn't make much sense unless the 
-        norm is normalized by the size of the parameter, we now limit the 
+        Since global structured pruning doesn't make much sense unless the
+        norm is normalized by the size of the parameter, we now limit the
         scope of global pruning to unstructured methods.
 
     Examples:
@@ -1071,12 +1071,12 @@ def global_unstructured(parameters, pruning_method, **kwargs):
 def custom_from_mask(module, name, mask):
     r"""Prunes tensor corresponding to parameter called ``name`` in ``module``
     by applying the pre-computed mask in ``mask``.
-    Modifies module in place (and also return the modified module) 
+    Modifies module in place (and also return the modified module)
     by:
-    1) adding a named buffer called ``name+'_mask'`` corresponding to the 
+    1) adding a named buffer called ``name+'_mask'`` corresponding to the
     binary mask applied to the parameter ``name`` by the pruning method.
     2) replacing the parameter ``name`` by its pruned version, while the
-    original (unpruned) parameter is stored in a new parameter named 
+    original (unpruned) parameter is stored in a new parameter named
     ``name+'_orig'``.
 
     Args:
@@ -1086,7 +1086,7 @@ def custom_from_mask(module, name, mask):
         mask (Tensor): binary mask to be applied to the parameter.
 
     Returns:
-        module (nn.Module): modified (i.e. pruned) version of the input module 
+        module (nn.Module): modified (i.e. pruned) version of the input module
 
     Examples:
         >>> m = prune.custom_from_mask(
@@ -1107,7 +1107,7 @@ def remove(module, name):
     named ``name+'_orig'`` is removed from the parameter list. Similarly,
     the buffer named ``name+'_mask'`` is removed from the buffers.
 
-    Note: 
+    Note:
         Pruning itself is NOT undone or reversed!
 
     Args:
@@ -1163,12 +1163,12 @@ def _validate_pruning_amount_init(amount):
     Args:
         amount (int or float): quantity of parameters to prune.
             If float, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If int, it represents the 
+            fraction of parameters to prune. If int, it represents the
             absolute number of parameters to prune.
 
     Raises:
         ValueError: if amount is a float not in [0, 1], or if it's a negative
-            integer. 
+            integer.
         TypeError: if amount is neither a float nor an integer.
 
     Note:
@@ -1199,7 +1199,7 @@ def _validate_pruning_amount(amount, tensor_size):
     Args:
         amount (int or float): quantity of parameters to prune.
             If float, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If int, it represents the 
+            fraction of parameters to prune. If int, it represents the
             absolute number of parameters to prune.
         tensor_size (int): absolute number of parameters in the tensor
             to prune.
@@ -1235,7 +1235,7 @@ def _validate_structured_pruning(t):
 
 
 def _compute_nparams_toprune(amount, tensor_size):
-    r"""Since amount can be expressed either in absolute value or as a 
+    r"""Since amount can be expressed either in absolute value or as a
     percentage of the number of units/channels in a tensor, this utility
     function converts the percentage to absolute value to standardize
     the handling of pruning.
@@ -1243,7 +1243,7 @@ def _compute_nparams_toprune(amount, tensor_size):
     Args:
         amount (int or float): quantity of parameters to prune.
             If float, should be between 0.0 and 1.0 and represent the
-            fraction of parameters to prune. If int, it represents the 
+            fraction of parameters to prune. If int, it represents the
             absolute number of parameters to prune.
         tensor_size (int): absolute number of parameters in the tensor
             to prune.
@@ -1271,10 +1271,10 @@ def _validate_pruning_dim(t, dim):
 
 
 def _compute_norm(t, n, dim):
-    r"""Compute the L_n-norm across all entries in tensor `t` along all dimension 
+    r"""Compute the L_n-norm across all entries in tensor `t` along all dimension
     except for the one identified by dim.
     Example: if `t` is of shape, say, 3x2x4 and dim=2 (the last dim),
-    then norm will have Size [4], and each entry will represent the 
+    then norm will have Size [4], and each entry will represent the
     `L_n`-norm computed using the 3x2=6 entries for each of the 4 channels.
 
     Args:

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -141,7 +141,7 @@ def _slice(g, input, axes, starts, ends, steps=None, dynamic_slice=False):
         assert steps is None or len(starts) == len(steps)
         if len(starts) == 1 and starts[0] == 0 and ends[0] == 9223372036854775807 \
            and (steps is None or (len(steps) == 1 and steps[0] == 1)):
-            return input    
+            return input
         axes = g.op("Constant", value_t=torch.tensor(axes))
         starts = g.op("Constant", value_t=torch.tensor(starts))
         ends = g.op("Constant", value_t=torch.tensor(ends))

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -18,7 +18,7 @@ class QConfig(namedtuple('QConfig', ['activation', 'weight'])):
     Observer classes have usually reasonable default arguments, but they can be overwritten with `with_args`
     method (that behaves like functools.partial):
 
-      my_qconfig = QConfig(activation=MinMaxObserver.with_args(dtype=torch.qint8), 
+      my_qconfig = QConfig(activation=MinMaxObserver.with_args(dtype=torch.qint8),
       weight=default_observer.with_args(dtype=torch.qint8))
     """
     def __new__(cls, activation, weight):


### PR DESCRIPTION
Plenty of editors trim trailing whitespace on save, causing unintended
file modifications, and consequently time spent dealing with it.

To fix up the tree, I ran:

```
git ls-files | grep -E '\.py$' | xargs -t -n1 sed -i 's/[ \t]*$//'
```

