### PR TITLE
Correct Python 3.7 Lint failure

### DIFF
--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1437,7 +1437,8 @@ if _enabled:
 
             .. note::
 
-                * The first three trace/trace_module calls are equivalent and return ``ScriptModule`` with a single ``forward`` method.
+                * The first three trace/trace_module calls are equivalent and return ``ScriptModule``
+                  with a single ``forward`` method.
                 * The last ``trace_module`` call produces a ``ScriptModule`` with two methods.
 
                 Tracing only records operations done when the given function is run on the given
@@ -1479,7 +1480,8 @@ if _enabled:
             if _compilation_unit is None:
                 _compilation_unit = _python_cu
             if optimize is not None:
-                warnings.warn("`optimize` is deprecated and has no effect. Use `with torch.jit.optimized_execution() instead")
+                warnings.warn("`optimize` is deprecated and has no effect. Use "
+                              "`with torch.jit.optimized_execution()` instead")
 
             # If we were give a _cpp_module, use that one as the backing cpp
             # module instead of creating a fresh one.


### PR DESCRIPTION
Just fixing an annoying line-too-long Lint failure.

![image](https://user-images.githubusercontent.com/9757500/62962249-8d1d5a80-bdcc-11e9-8fc9-96f0b8fa94a2.png)
![image](https://user-images.githubusercontent.com/9757500/62962212-6fe88c00-bdcc-11e9-99dc-c2c598cb6f26.png)
