### PR TITLE
C2/glow: assign net_pos to a net before applying onnxifi_blacklist_ops

### DIFF
--- a/caffe2/opt/backend_transformer_base.cc
+++ b/caffe2/opt/backend_transformer_base.cc
@@ -4,10 +4,9 @@
 
 namespace caffe2 {
 
-namespace {
 // Populate 'net_pos' argument for any ops that don't already have it. 'net_pos'
 // we populate here starts after the max 'net_pos' value we encountered.
-void annotateOpIndex(NetDef* net) {
+void BackendTransformerBase::annotateOpIndex(NetDef* net) {
   // find the max net_pos that we have so far.
   int i = -1;
   for (const auto& op : net->op()) {
@@ -23,7 +22,6 @@ void annotateOpIndex(NetDef* net) {
     }
   }
 }
-} // namespace
 
 std::string BackendTransformerBase::getModelId(const NetDef& net) {
   static std::atomic<size_t> seq_id{0};

--- a/caffe2/opt/backend_transformer_base.h
+++ b/caffe2/opt/backend_transformer_base.h
@@ -52,6 +52,8 @@ class BackendTransformerBase {
       const std::unordered_map<std::string, TensorShape>& shape_hints,
       const std::unordered_set<int>& blacklisted_ops) = 0;
 
+  static void annotateOpIndex(NetDef* net);
+
  protected:
   // Get model ID from the NetDef
   std::string getModelId(const NetDef& net);


### PR DESCRIPTION
Summary: Previously for onnxifi_blacklist_ops option, we figure out the net_pos based on the order of ops in the net. But this logic is wrong if the net already has net_pos assigned and we may end up blacklisting unintended ops. Fix this issue to always assign net_pos before computing any blacklist.

Differential Revision: D16789166

