### PR TITLE
Revert "make FunctionType a NamedType (#23697)"

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1217,7 +1217,7 @@ struct CAFFE2_API StringType : public Type {
 struct FunctionType;
 using FunctionTypePtr = std::shared_ptr<FunctionType>;
 using ::torch::jit::Function;
-struct CAFFE2_API FunctionType : public NamedType {
+struct CAFFE2_API FunctionType : public Type {
   static FunctionTypePtr create(Function* function) {
     return FunctionTypePtr(
         new FunctionType(function)); // NOLINT(modernize-make-shared)
@@ -1241,15 +1241,11 @@ struct CAFFE2_API FunctionType : public NamedType {
   }
   static const TypeKind Kind = TypeKind::FunctionType;
 
-  const c10::optional<c10::QualifiedName>& name() const override {
-    return name_;
-  }
-
  private:
-  FunctionType(Function* function);
+  FunctionType(Function* function)
+      : Type(TypeKind::FunctionType), function_(function) {}
+
   Function* function_;
-  // Holder for the name so we can return a const ref
-  c10::optional<c10::QualifiedName> name_;
 };
 
 struct NoneType;

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -6,10 +6,6 @@ namespace c10 {
 
 // This file exists because we need to reference module.h, which we can't from
 // c10. Sigh...
-FunctionType::FunctionType(Function* function)
-    : NamedType(TypeKind::FunctionType),
-      function_(function),
-      name_(function->qualname()) {}
 
 Function* ClassType::getMethod(const std::string& name) const {
   for (auto method : methods_) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24269 Revert "make FunctionType a NamedType (#23697)"**
* #24254 Revert "Move TensorOptions to ATen/core (#22020)"

This reverts commit 3f90b85ebc91d7fca6d030c1b908cef65a1fbceb.