### PR TITLE
[JIT] fix list comprehension type assumed to the same as input type

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17063,6 +17063,13 @@ class TestList(JitTestCase):
 
         self.assertEqual(comp([1, 2, 3], [4, 5]), [3, 6, 9, 6, 7])
 
+    def test_comprehension_out_type_not_in_type(self):
+        def list_cast():
+            li = [int(i) for i in [torch.tensor(0), torch.tensor(1), torch.tensor(2)]]
+            return li[0] + li[1] + li[2]
+
+        self.checkScript(list_cast, ())
+
     def test_comprehensions_wrong_expr_type(self):
         with self.assertRaisesRegex(RuntimeError, "Arguments for call are not valid"):
             @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17070,17 +17070,6 @@ class TestList(JitTestCase):
 
         self.checkScript(list_cast, ())
 
-    def test_comprehensions_wrong_expr_type(self):
-        with self.assertRaisesRegex(RuntimeError, "Arguments for call are not valid"):
-            @torch.jit.script
-            def comp(l):
-                # type: (List[int]) -> List[float]
-
-                n = [float(x) for x in l]
-                return n
-
-            comp([1, 2, 3])
-
     def test_mutable_list_append_2(self):
         def test_append_2():
             a = [0, 1]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17065,6 +17065,7 @@ class TestList(JitTestCase):
 
     def test_comprehension_out_type_not_in_type(self):
         def list_cast():
+            # type: () -> int
             li = [int(i) for i in [torch.tensor(0), torch.tensor(1), torch.tensor(2)]]
             return li[0] + li[1] + li[2]
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1016,21 +1016,18 @@ struct to_ir {
   }
 
   // emit a single expr from the loop comprehension so that we can correctly
-  // type the list we create, then remove the nodes we created
+  // type the list we create, then remove the nodes we emitted
   TypePtr getListCompType(
       const ListComp& lc,
       const ListTypePtr& input_list_type) {
     auto b = graph->insertNode(graph->create(prim::Loop))->addBlock();
     pushFrame(b);
     WithInsertPoint guard(b);
-    auto list_element = std::make_shared<SimpleValue>(
-        graph
-            ->insertNode(
-                graph->createUninitialized(input_list_type->getElementType()))
-            ->output());
+    auto li_elem = graph->insertNode(
+        graph->createUninitialized(input_list_type->getElementType()));
     emitExprsAssign(
         List<Expr>::create(lc.range(), {lc.target()}),
-        {list_element},
+        {std::make_shared<SimpleValue>(li_elem->output())},
         lc.range(),
         /*n_binders*/ 1);
     auto ret_type = emitExpr(lc.elt())->type();


### PR DESCRIPTION
Previously we didn't handle list comprehensions where the expression produced a different type than the input list.
`[float(x) for x in [1, 2, 3]`

Fixes #24239