### PR TITLE
Fix tensor construction from array

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -793,15 +793,15 @@ Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options) {
 }
 
 template <typename T>
-Tensor tensor_cuda(ArrayRef<T> values, const TensorOptions& options) {
+Tensor tensor_backend(ArrayRef<T> values, const TensorOptions& options) {
   auto cpu_tensor = tensor_cpu(values, options.device(DeviceType::CPU));
   return cpu_tensor.to(options.device());
 }
 
 #define TENSOR(T, _1)                                               \
   Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
-    if (options.device().is_cuda()) {                               \
-      return tensor_cuda(values, options);                          \
+    if (options.device().type() != c10::DeviceType::CPU) {          \
+      return tensor_backend(values, options);                       \
     } else {                                                        \
       return tensor_cpu(values, options);                           \
     }                                                               \


### PR DESCRIPTION
fixes https://github.com/pytorch/xla/issues/929
The original issue complains about no storage because it is trying to construct a xla tensor from tensor_cpu method. 
https://github.com/pytorch/pytorch/blob/56fb5e03b53f1687fc93e1821e772c09c0ce5ed0/aten/src/ATen/native/TensorFactories.cpp#L731
In general for backend other than CPU,  this `at::tensor` should construct a CPU tensor and move the tensor to the right backend.