### PR TITLE
Refactor and expose metadata of tum_history layer for online prediction

### DIFF
--- a/caffe2/python/layers/sparse_feature_hash.py
+++ b/caffe2/python/layers/sparse_feature_hash.py
@@ -42,8 +42,8 @@ class SparseFeatureHash(ModelLayer):
             self.modulo = modulo or self.extract_hash_size(input_record.items.metadata)
             metadata = schema.Metadata(
                 categorical_limit=self.modulo,
-                feature_specs=input_record.items.metadata.feature_specs,
-                expected_value=input_record.items.metadata.expected_value
+                feature_specs=input_record.items.metadata.feature_specs if input_record.items.metadata else None,
+                expected_value=input_record.items.metadata.expected_value if input_record.items.metadata else None
             )
             with core.NameScope(name):
                 self.output_schema = schema.NewRecord(model.net, IdList)


### PR DESCRIPTION
Summary:
1. combine content dense and context dense into dense in output schema
2. move sparse feature hashing out of tum_history layer
3. expose metadata for tum_history layer, which will be used as input_schema for online eval.
4. add tag to exclude tum_history layer from online predict net, data fetching & feature extraction logic will be re-written in TUM evaluator c++ application.

Differential Revision: D16570968

