### PR TITLE
Remove hard Caffe2 dependency for TensorBoard

### DIFF
--- a/torch/utils/tensorboard/_convert_np.py
+++ b/torch/utils/tensorboard/_convert_np.py
@@ -9,8 +9,6 @@ import numpy as np
 import torch
 import six
 
-from caffe2.python import workspace
-
 
 def make_np(x):
     """
@@ -40,5 +38,6 @@ def _prepare_pytorch(x):
 
 
 def _prepare_caffe2(x):
+    from caffe2.python import workspace
     x = workspace.FetchBlob(x)
     return x


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/24175 and https://github.com/pytorch/pytorch/issues/15618

We should not be importing caffe2 (and dependencies like future, etc) unless needed within `torch.utils.tensorboard`.