### PR TITLE
[JIT] Add the ability to compile exports on traced modules

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -7480,7 +7480,6 @@ a")
         torch.testing.assert_allclose(imported(x), x + torch.neg(torch.ones(3, 4, dtype=torch.float)))
 
     def test_trace_export_fns(self):
-        @torch._jit_internal._trace_compile_exports
         class Foo(torch.nn.Module):
             def __init__(self):
                 super(Foo, self).__init__()
@@ -7509,6 +7508,44 @@ a")
 
         imported = self.getExportImportCopy(traced)
         check(imported)
+
+    def test_trace_export_fns_recursive(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super(Foo, self).__init__()
+                self.a = 3
+
+            @torch.jit.export
+            def __getstate__(self):
+                return (3,)
+
+            @torch.jit.export
+            def __setstate__(self, state):
+                self.a = state[0]
+
+            def forward(self, x):
+                return x + self.a
+
+        class Wrapper(torch.nn.Module):
+            def __init__(self):
+                super(Wrapper, self).__init__()
+                self.foo = Foo()
+
+            def forward(self, x):
+                return self.foo(x)
+
+        f = Wrapper()
+
+        traced = torch.jit.trace(f, (torch.rand(3, 4),))
+        expected_names = ['__getstate__', '__setstate__']
+
+        def check(mod):
+            self.assertTrue(all(name in mod._c._method_names() for name in expected_names))
+
+        check(traced.foo)
+
+        imported = self.getExportImportCopy(traced)
+        check(imported.foo)
 
     def test_pack_unpack_nested(self):
         class SubSubMod(torch.jit.ScriptModule):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -161,6 +161,12 @@ def boolean_dispatch(arg_name, arg_index, default, if_true, if_false, module_nam
     return fn
 
 
+def _trace_compile_exports(fn):
+    # This is a lambda so the field doesn't appear in the TorchScript
+    # class as an attribute
+    fn._trace_compile_exports = lambda self: True
+    return fn
+
 
 class FunctionModifiers(object):
     """

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -902,7 +902,7 @@ def trace_module(mod,
     # is traceable, therefore we can just compile the whole module rather than tracing
     # through it.
     if torch._jit_internal.module_has_exports(mod):
-        module = torch.jit.script(mod)
+        module = torch.jit.script(mod, optimize=optimize)
     else:
         module = make_module(mod, _module_class, _compilation_unit)
 

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -7,7 +7,7 @@ from torch.nn import Module, ModuleList, Parameter, Sequential
 from torch._six import get_function_from_type
 
 
-def copy_to_script_module(original, stubs):
+def copy_to_script_module(original, stubs, _compilation_unit=None):
     """
     Copies the parameters, buffers, constants, attributes, and submodules
     of an nn.Module into itself.
@@ -17,7 +17,7 @@ def copy_to_script_module(original, stubs):
                            .format(type(original).__name__))
 
     qualified_name = torch.jit._qualified_name(type(original))
-    script_module = torch.jit.ScriptModule(_qualified_name=qualified_name)
+    script_module = torch.jit.ScriptModule(_qualified_name=qualified_name, _compilation_unit=_compilation_unit)
 
     constants_set = set(getattr(original, "__constants__", []))
     script_module.__dict__["_constants_set"] = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23987 [quantization] JIT trace testing
* **#24298 [JIT] Add the ability to compile exports on traced modules**
* #24211 [quantization] equal() for QuantizedCPU

This helps in situations like when you have `__{g,s}etstate__` on an `nn.Module` and you'd like to trace the module, but still preserve the serialization methods to make the module semantically correct

Differential Revision: [D16799800](https://our.internmc.facebook.com/intern/diff/D16799800)