### PR TITLE
Fix CUDNN location related build issue on Antergos Linux (based on Arch)

### DIFF
--- a/tools/setup_helpers/cudnn.py
+++ b/tools/setup_helpers/cudnn.py
@@ -18,6 +18,7 @@ if USE_CUDA and not check_negative_env_flag('USE_CUDNN'):
         '/usr/lib/x86_64-linux-gnu/',
         '/usr/lib/powerpc64le-linux-gnu/',
         '/usr/lib/aarch64-linux-gnu/',
+        '/usr/lib/',
     ] + gather_paths([
         'LIBRARY_PATH',
     ]) + gather_paths([


### PR DESCRIPTION
The issue is that `python setup.py install` will fail right at the end
of the build, with:

```
  File "setup.py", line 380, in run
    report('-- Detected cuDNN at ' + CUDNN_LIBRARY + ', ' + CUDNN_INCLUDE_DIR)
TypeError: must be str, not NoneType
```

This is due to `USE_CUDNN` being True, but CUDNN library and include dir
not being auto-detected.  On this distro, the CUDA install goes into
`/opt/cuda/` while CUDNN goes into `/usr/lib`.

```
$ locate libcudnn.so
...
/usr/lib/libcudnn.so
/usr/lib/libcudnn.so.7
/usr/lib/libcudnn.so.7.6.1

$ locate libcublas.so  # targets/... symlinked from /opt/cuda/lib64
...
/opt/cuda/targets/x86_64-linux/lib/libcublas.so
```

One could work around this by setting `CUDNN_LIB_DIR`, but that's
annoying and you only find out after running into this.

The path is added after `CUDA_HOME`, so should not be a problem on
systems which have multiple CUDA installs and select one via `CUDA_HOME`

