### PR TITLE
[jit] fix test_jit.py so it can be run in parallel

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3495,26 +3495,26 @@ def foo(xyz):
 
         ft3 = FooTest3()
 
-        def debug_records_from_mod(mod):
+        def debug_records_from_mod(self, mod):
             buffer = io.BytesIO()
             torch.jit.save(ft3, buffer)
             buffer.seek(0)
             archive = zipfile.ZipFile(buffer)
-            for name in archive.namelist():
-                if "debug_pkl" in name:
-                    pkl_name = name
-            debug_file = archive.open(pkl_name)
+            files = filter(lambda x: x.startswith('archive/code/'), archive.namelist())
+            debug_files = list(filter(lambda f: f.endswith('.debug_pkl'), files))
+            self.assertEqual(len(debug_files), 1)
+            debug_file = archive.open(debug_files[0])
             return pickle.load(debug_file), buffer
 
-        records1, buffer = debug_records_from_mod(ft3)
+        records1, buffer = debug_records_from_mod(self, ft3)
 
         buffer.seek(0)
         loaded = torch.jit.load(buffer)
-        records2, buffer = debug_records_from_mod(loaded)
+        records2, buffer = debug_records_from_mod(self, loaded)
 
         buffer.seek(0)
         loaded2 = torch.jit.load(buffer)
-        records3, _ = debug_records_from_mod(loaded2)
+        records3, _ = debug_records_from_mod(self, loaded2)
 
         self.assertEqual(records1, records2)
         self.assertEqual(records2, records3)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1398,7 +1398,6 @@ graph(%Ra, %Rb):
         with warnings.catch_warnings(record=True) as warns:
             traced_fn = torch.jit.trace(fn, torch.tensor([1]))
         warns = [str(w.message) for w in warns]
-        self.assertEqual(len(warns), 7)
         self.assertIn('a Python integer', warns[0])
         self.assertIn('a Python boolean', warns[1])
         self.assertIn('a Python index', warns[2])
@@ -3415,7 +3414,7 @@ def foo(x):
         bytesio = io.BytesIO(buffer)
         scripted = torch.jit.load(bytesio)
 
-        fc = FileCheck().check('code/__torch__.py:6:12')
+        fc = FileCheck().check(':6:12')
         fc.run(scripted.graph)
         fc.run(str(scripted.graph))
 
@@ -3501,7 +3500,10 @@ def foo(xyz):
             torch.jit.save(ft3, buffer)
             buffer.seek(0)
             archive = zipfile.ZipFile(buffer)
-            debug_file = archive.open('archive/code/__torch__.py.debug_pkl')
+            for name in archive.namelist():
+                if "debug_pkl" in name:
+                    pkl_name = name
+            debug_file = archive.open(pkl_name)
             return pickle.load(debug_file), buffer
 
         records1, buffer = debug_records_from_mod(ft3)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24311 [jit] fix test_jit.py so it can be run in parallel**

Now you can run tests with `pytest -n auto test/test_jit.py` to get
tests to run in parallel. On my devfair in opt mode, this takes < 30
seconds, which is a huge improvement.

The actual changes are places where we hard-coded certain things that
got changed due to how pytest-xdist distributes tests:
1. Warnings are filtered after they are tripped once, so
`test_trace_warn` shouldn't rely on warning counts.

2. various file/save things hardcoded paths inappropraitely

Differential Revision: [D16801256](https://our.internmc.facebook.com/intern/diff/D16801256)