### PR TITLE
port fmod from TH to ATen

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1923,43 +1923,6 @@
     - THTensor* self
 ]]
 [[
-  name: _th_fmod
-  return: argument 0
-  variants:
-    - function
-  options:
-    - cname: fmod
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - THTensor* self
-        - real other
-    - cname: cfmod
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - arg: THTensor* self
-          broadcast: other fallback
-        - THTensor* other
-]]
-[[
-  name: _th_fmod_
-  return: argument 0
-  variants: function
-  options:
-    - cname: fmod
-      arguments:
-        - THTensor* self
-        - THTensor* self
-        - real other
-    - cname: cfmod
-      arguments:
-        - THTensor* self
-        - arg: THTensor* self
-          broadcast: other inplace fallback
-        - THTensor* other
-]]
-[[
   name: _th_remainder
   return: argument 0
   variants:

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -269,6 +269,13 @@ public:
     }
     return ret;
   }
+  Vec256<T> fmod(const Vec256<T> &exp) const {
+    Vec256<T> ret;
+    for (int64_t i = 0; i < size(); i++) {
+      ret[i] = std::fmod(values[i], exp[i]);
+    }
+    return ret;
+  }
 #define DEFINE_COMP(binary_pred)                                              \
   Vec256<T> operator binary_pred(const Vec256<T> &other) const {              \
     Vec256<T> vec;                                                            \

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -173,6 +173,9 @@ public:
   Vec256<double> pow(const Vec256<double> &b) const {
     return Vec256<double>(Sleef_powd4_u10(values, b));
   }
+  Vec256<double> fmod(const Vec256<double> &b) const {
+    return Vec256<double>(Sleef_fmodd4(values, b));
+  }
   // Comparison using the _CMP_**_OQ predicate.
   //   `O`: get false if an operand is NaN
   //   `Q`: do not raise if an operand is NaN

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -181,6 +181,9 @@ public:
   Vec256<float> pow(const Vec256<float> &b) const {
     return Vec256<float>(Sleef_powf8_u10(values, b));
   }
+  Vec256<float> fmod(const Vec256<float> &b) const {
+    return Vec256<float>(Sleef_fmodf8(values, b));
+  }
   // Comparison using the _CMP_**_OQ predicate.
   //   `O`: get false if an operand is NaN
   //   `Q`: do not raise if an operand is NaN

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -14,6 +14,7 @@ DEFINE_DISPATCH(sub_stub);
 DEFINE_DISPATCH(mul_stub);
 DEFINE_DISPATCH(div_stub);
 DEFINE_DISPATCH(atan2_stub);
+DEFINE_DISPATCH(fmod_stub);
 
 Tensor& add_out(Tensor& result, const Tensor& self, const Tensor& other, Scalar alpha) {
   if (other.is_sparse()) {
@@ -167,6 +168,21 @@ Tensor& atan2_(Tensor& self, const Tensor& other) {
   return native::atan2_out(self, self, other);
 }
 
+Tensor& fmod_out(Tensor& result, const Tensor& self, const Tensor& other) {
+  auto iter = TensorIterator::binary_op(result, self, other);
+  fmod_stub(iter.device_type(), iter);
+  return result;
+}
+
+Tensor fmod(const Tensor& self, const Tensor& other) {
+  Tensor result = at::empty_like(self);
+  return native::fmod_out(result, self, other);
+}
+
+Tensor& fmod_(Tensor& self, const Tensor& other) {
+  return native::fmod_out(self, self, other);
+}
+
 // These are still needed because we don't have C++ conversions from number
 // types (int, float, etc.) to Tensor (only to Scalar). They're not exposed
 // to Python.
@@ -211,6 +227,19 @@ Tensor& sub_(Tensor& self, Scalar other, Scalar alpha) {
 
 Tensor rsub(const Tensor& self, Scalar other, Scalar alpha) {
   return native::rsub(self, wrapped_scalar_tensor(other), alpha);
+}
+
+Tensor fmod(const Tensor& self, Scalar other) {
+  return native::fmod(self, wrapped_scalar_tensor(other));
+}
+
+Tensor& fmod_(Tensor& self, Scalar other) {
+  return native::fmod_(self, wrapped_scalar_tensor(other));
+}
+
+
+Tensor& fmod_out(Tensor& result, const Tensor& self, Scalar other) {
+  return native::fmod_out(result, self, wrapped_scalar_tensor(other));
 }
 
 }

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -15,5 +15,6 @@ DECLARE_DISPATCH(binary_fn_alpha, sub_stub);
 DECLARE_DISPATCH(binary_fn, mul_stub);
 DECLARE_DISPATCH(binary_fn, div_stub);
 DECLARE_DISPATCH(binary_fn, atan2_stub);
+DECLARE_DISPATCH(binary_fn, fmod_stub);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -81,24 +81,8 @@ void div_kernel(TensorIterator& iter) {
   }
 }
 
-//static void fmod_kernel(TensorIterator& iter, Scalar value_scalar) {
-//  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "fmod_cpu", [&] {
-//      auto value = value_scalar.to<scalar_t>();
-//      auto value_vec = Vec256<scalar_t>(value);
-//      cpu_kernel_vec(
-//              iter,
-//              [=](scalar_t a) -> scalar_t {
-//                  return std::fmod(a, value);
-//              },
-//              [=](Vec256<scalar_t> a) {
-//                  return a.fmod(value_vec);
-//              });
-//  });
-//}
-
-
 void fmod_kernel(TensorIterator& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "fmod_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "fmod_cpu", [&] {
       cpu_kernel_vec(
         iter,
         [=](scalar_t a, scalar_t b) -> scalar_t {

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -81,6 +81,35 @@ void div_kernel(TensorIterator& iter) {
   }
 }
 
+//static void fmod_kernel(TensorIterator& iter, Scalar value_scalar) {
+//  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "fmod_cpu", [&] {
+//      auto value = value_scalar.to<scalar_t>();
+//      auto value_vec = Vec256<scalar_t>(value);
+//      cpu_kernel_vec(
+//              iter,
+//              [=](scalar_t a) -> scalar_t {
+//                  return std::fmod(a, value);
+//              },
+//              [=](Vec256<scalar_t> a) {
+//                  return a.fmod(value_vec);
+//              });
+//  });
+//}
+
+
+void fmod_kernel(TensorIterator& iter) {
+  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "fmod_cpu", [&] {
+      cpu_kernel_vec(
+        iter,
+        [=](scalar_t a, scalar_t b) -> scalar_t {
+            return std::fmod(a, b);
+        },
+        [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
+            return a.fmod(b);
+        });
+  });
+}
+
 } // anonymous namespace
 
 
@@ -89,5 +118,6 @@ REGISTER_DISPATCH(sub_stub, &sub_kernel);
 REGISTER_DISPATCH(mul_stub, &mul_kernel);
 REGISTER_DISPATCH(div_stub, &div_kernel);
 REGISTER_DISPATCH(atan2_stub, &atan2_kernel);
+REGISTER_DISPATCH(fmod_stub, &fmod_kernel);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -70,6 +70,14 @@ void atan2_kernel_cuda(TensorIterator& iter) {
   });
 }
 
+void fmod_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "fmod_cuda", [&]() {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+      return THCNumerics<scalar_t>::fmod(a, b);
+    });
+  });
+}
+
 REGISTER_DISPATCH(add_stub, &add_kernel_cuda);
 REGISTER_DISPATCH(sub_stub, &sub_kernel_cuda);
 REGISTER_DISPATCH(div_stub, &div_kernel_cuda);

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -83,5 +83,6 @@ REGISTER_DISPATCH(sub_stub, &sub_kernel_cuda);
 REGISTER_DISPATCH(div_stub, &div_kernel_cuda);
 REGISTER_DISPATCH(mul_stub, &mul_kernel_cuda);
 REGISTER_DISPATCH(atan2_stub, &atan2_kernel_cuda);
+REGISTER_DISPATCH(fmod_stub, &fmod_kernel_cuda);
 
 }} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3398,15 +3398,9 @@
 
 - func: fmod_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
-  dispatch:
-    CPU: fmod_
-    CUDA: legacy::cuda::_th_fmod_
 
 - func: fmod_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
-  dispatch:
-    CPU: fmod_
-    CUDA: legacy::cuda::_th_fmod_
 
 - func: remainder_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
@@ -4047,26 +4041,14 @@
   named_guard: False
 
 - func: fmod.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
-  dispatch:
-    CPU: fmod_out
-    CUDA: legacy::cuda::_th_fmod_out
 
 - func: fmod.Scalar(Tensor self, Scalar other) -> Tensor
   variants: method, function
-  dispatch:
-    CPU: fmod
-    CUDA: legacy::cuda::_th_fmod
 
 - func: fmod.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
-  dispatch:
-    CPU: fmod_out
-    CUDA: legacy::cuda::_th_fmod_out
 
 - func: fmod.Tensor(Tensor self, Tensor other) -> Tensor
   variants: method, function
-  dispatch:
-    CPU: fmod
-    CUDA: legacy::cuda::_th_fmod
 
 - func: remainder.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3399,13 +3399,13 @@
 - func: fmod_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_fmod_
+    CPU: fmod_
     CUDA: legacy::cuda::_th_fmod_
 
 - func: fmod_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   variants: method
   dispatch:
-    CPU: legacy::cpu::_th_fmod_
+    CPU: fmod_
     CUDA: legacy::cuda::_th_fmod_
 
 - func: remainder_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
@@ -4048,24 +4048,24 @@
 
 - func: fmod.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: legacy::cpu::_th_fmod_out
+    CPU: fmod_out
     CUDA: legacy::cuda::_th_fmod_out
 
 - func: fmod.Scalar(Tensor self, Scalar other) -> Tensor
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_fmod
+    CPU: fmod
     CUDA: legacy::cuda::_th_fmod
 
 - func: fmod.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
-    CPU: legacy::cpu::_th_fmod_out
+    CPU: fmod_out
     CUDA: legacy::cuda::_th_fmod_out
 
 - func: fmod.Tensor(Tensor self, Tensor other) -> Tensor
   variants: method, function
   dispatch:
-    CPU: legacy::cpu::_th_fmod
+    CPU: fmod
     CUDA: legacy::cuda::_th_fmod
 
 - func: remainder.Scalar_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -865,35 +865,6 @@ void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value)
 #endif
 }
 
-void THTensor_(fmod)(THTensor *r_, THTensor *t, scalar_t value)
-{
-  THTensor_(resizeAs)(r_, t);
-  int64_t r_Size = THTensor_(nElement)(r_);
-  int r_Contig = THTensor_(isContiguous)(r_);
-  int tContig = THTensor_(isContiguous)(t);
-  if (r_Contig && tContig) {
-    scalar_t *tp = t->data<scalar_t>();
-    scalar_t *rp = r_->data<scalar_t>();
-    at::parallel_for(0, r_Size, TH_OMP_OVERHEAD_THRESHOLD,
-        [&](int64_t start, int64_t end) {
-      for (auto i = start; i < end; i++) {
-#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-        rp[i] = fmod(tp[i], value);
-#else
-        rp[i] = tp[i] % value;
-#endif
-      }
-    });
-  } else {
-
-#if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = fmod(*t_data, value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#else
-    TH_TENSOR_APPLY2_PARALLEL(r_Size, r_Contig, tContig, scalar_t, r_, scalar_t, t, *r__data = (*t_data % value);, UNCERTAIN_TH_OMP_OVERHEAD_THRESHOLD);
-#endif
-  }
-}
-
 // Should wrap if the value (a) has a different sign than the divisor (b), but is not 0.
 static inline bool modulo_wrap(scalar_t a, scalar_t b) {
   return (a != 0) && (a < 0) != (b < 0);

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -115,7 +115,6 @@ TH_API void THTensor_(mul)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(div)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(lshift)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(rshift)(THTensor *r_, THTensor *t, scalar_t value);
-TH_API void THTensor_(fmod)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(remainder)(THTensor *r_, THTensor *t, scalar_t value);
 TH_API void THTensor_(clamp)(THTensor *r_, THTensor *t, scalar_t min_value, scalar_t max_value);
 

--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -245,6 +245,7 @@ struct THCNumerics<at::Half> {
   static inline __host__ __device__ at::Half sub(at::Half a, at::Half b) { return a - b; }
   static inline __host__ __device__ at::Half pow(at::Half a, at::Half b) { return ::pow(a, b); }
   static inline __host__ __device__ at::Half atan2(at::Half a, at::Half b) { return ::atan2(a, b); }
+  static inline __host__ __device__ at::Half fmod(at::Half a, at::Half b) { return ::fmod(a, b); }
 
   static inline __host__ __device__ bool isnan(at::Half a) {
     #ifdef _MSC_VER
@@ -323,6 +324,7 @@ struct THCNumerics<float> {
   static inline __host__ __device__  float sub  (float a, float b) { return a - b; }
   static inline __host__ __device__  float pow  (float a, float b) { return powf(a, b); }
   static inline __host__ __device__  float atan2(float a, float b) { return atan2f(a, b); }
+  static inline __host__ __device__  float fmod (float a, float b) { return fmod(a, b); }
   static inline __host__ __device__  bool isnan(float a) { return ::isnan(a); }
   static inline __host__ __device__  bool isinf(float a) { return ::isinf(a); }
 };
@@ -382,6 +384,7 @@ struct THCNumerics<double> {
   static inline __host__ __device__  double sub  (double a, double b) { return a - b; }
   static inline __host__ __device__  double pow  (double a, double b) { return ::pow(a, b); }
   static inline __host__ __device__  double atan2(double a, double b) { return ::atan2(a, b); }
+  static inline __host__ __device__  double fmod (double a, double b) { return ::fmod(a, b); }
   static inline __host__ __device__  bool isnan(double a) { return ::isnan(a); }
   static inline __host__ __device__  bool isinf(double a) { return ::isinf(a); }
 };

--- a/aten/src/THC/generic/THCTensorMathPairwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPairwise.cu
@@ -224,24 +224,6 @@ void THCTensor_(rshift)(THCState* state, THCTensor *self_, THCTensor *src_, scal
 #endif
 }
 
-void THCTensor_(fmod)(THCState *state, THCTensor *self_, THCTensor *src_, scalar_t value)
-{
-  THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));
-  if (self_ == src_) {
-    if (!THC_pointwiseApply1<scalar_t>(state, self_, TensorFmodOp<scalar_t>(value))) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  } else {
-    THCTensor_(resizeAs)(state, self_, src_);
-
-    if (!THC_pointwiseApply2<scalar_t, scalar_t>(state, self_, src_, TensorFmodOp<scalar_t>(value))) {
-      THArgCheck(false, 2, CUTORCH_DIM_WARNING);
-    }
-  }
-
-  THCudaCheck(cudaGetLastError());
-}
-
 void THCTensor_(remainder)(THCState *state, THCTensor *self_, THCTensor *src_, scalar_t value)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src_));

--- a/aten/src/THC/generic/THCTensorMathPairwise.h
+++ b/aten/src/THC/generic/THCTensorMathPairwise.h
@@ -18,7 +18,6 @@ THC_API void THCTensor_(mul)(THCState *state, THCTensor *self, THCTensor *src, s
 THC_API void THCTensor_(div)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(lshift)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(rshift)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
-THC_API void THCTensor_(fmod)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 THC_API void THCTensor_(remainder)(THCState *state, THCTensor *self, THCTensor *src, scalar_t value);
 
 #endif

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1940,6 +1940,32 @@ class _TestTorchMixin(object):
             res2[i, 3] = math.fmod(res2[i, 3], q)
         self.assertEqual(res1, res2)
 
+        def _test_fmod_with_size(size, device, is_tensor=True):
+            if is_tensor:
+                a = torch.rand(size=size, device=device, dtype=torch.double)
+                b = torch.rand(size=size, device=device, dtype=torch.double)
+                actual = a.fmod(b)
+                x = a.view(-1)
+                y = b.view(-1)
+                expected = torch.tensor([math.fmod(x[i].item(), y[i].item()) for i in range(x.numel())],
+                                        device=device, dtype=torch.double)
+                self.assertTrue(torch.allclose(expected, actual.view(-1), rtol=0, atol=0.02))
+            else:
+                a = torch.rand(size=size, device=device, dtype=torch.double)
+                b = random.random()
+                actual = a.fmod(b)
+                x = a.view(-1)
+                expected = torch.tensor([math.fmod(x[i].item(), b) for i in range(x.numel())],
+                                        device=device, dtype=torch.double)
+                self.assertTrue(torch.allclose(expected, actual.view(-1), rtol=0, atol=0.02))
+        for device in torch.testing.get_all_device_types():
+            _test_fmod_with_size((2, 2), device)
+            _test_fmod_with_size((3, 3), device)
+            _test_fmod_with_size((5, 5), device)
+            _test_fmod_with_size((2, 2), device, False)
+            _test_fmod_with_size((3, 3), device, False)
+            _test_fmod_with_size((5, 5), device, False)
+
     def test_remainder(self):
         # Check the Floating point case, both tensor and scalar overloads
         for use_item in [True, False]:


### PR DESCRIPTION
#22803

performance benchmarks：

    import timeit
    import torch
    import itertools
    import statistics

    def test_perf(sizes, device, repeat, times):
        def _tensor(name, sizes, device):
            return '''{0} = torch.rand({1}, device="{2}");'''.format(name, sizes, device)

        setup_code = 'import torch;' + _tensor('x', sizes, device) + _tensor('y', sizes, device)
        test_code = '''torch.fmod(y, x);'''
        if device == "cuda":
            test_code = test_code + 'torch.cuda.synchronize()'
        result = timeit.repeat(setup = setup_code,stmt = test_code,repeat = repeat,number = times)
        mean = statistics.mean(result)
        std = statistics.stdev(result)
        print('''sizes = {0} std = {1} mean = {2}'''.format(sizes, std, mean))

    def test_perf_for_device(device, small, mid, large):
        print(device)
        for s in itertools.product((small, mid, large), (small, mid, large)):
            test_perf(str(s), device, 3, 300)

    test_perf_for_device("cpu", 5, 100, 1000)
    test_perf_for_device("cuda", 5, 100, 10000)


pytorch:master

	cpu
	sizes = (5, 5) std = 0.0004191587896767566 mean = 0.0052408403377436725
	sizes = (5, 100) std = 0.00012129380478190695 mean = 0.006508304664748721
	sizes = (5, 1000) std = 0.00018175678335131663 mean = 0.0363664986701527
	sizes = (100, 5) std = 0.00034399426107962946 mean = 0.006770268999389373
	sizes = (100, 100) std = 0.0006779367543473553 mean = 0.07270567266580959
	sizes = (100, 1000) std = 0.01670362224705441 mean = 0.1300258070017056
	sizes = (1000, 5) std = 0.010281040640935534 mean = 0.045936293997025736
	sizes = (1000, 100) std = 0.012529932966256128 mean = 0.12733882099564653
	sizes = (1000, 1000) std = 0.002150238308503937 mean = 1.1608000710014796
	cuda
	sizes = (5, 5) std = 0.00016137550559233116 mean = 0.014315356330674453
	sizes = (5, 100) std = 0.0014720358192929545 mean = 0.015730336332732502
	sizes = (5, 10000) std = 0.0017510024071247026 mean = 0.015462367334597124
	sizes = (100, 5) std = 0.001569950832690219 mean = 0.015847195667447522
	sizes = (100, 100) std = 0.000935629392520788 mean = 0.015551854667137377
	sizes = (100, 10000) std = 0.002454919985869727 mean = 0.04476405966367262
	sizes = (10000, 5) std = 0.0013192075275361463 mean = 0.015794202001416124
	sizes = (10000, 100) std = 0.001418935833245521 mean = 0.04419450566638261
	sizes = (10000, 10000) std = 0.0070977799177425 mean = 3.267501967328523

shihongzhi:feature/port_fmod

	cpu
	sizes = (5, 5) std = 0.0003939277361171243 mean = 0.008732202996422226
	sizes = (5, 100) std = 7.568185896146914e-05 mean = 0.010897216998273507
	sizes = (5, 1000) std = 3.916722355255723e-05 mean = 0.03223436966557832
	sizes = (100, 5) std = 0.00016529833171236708 mean = 0.011018406672519632
	sizes = (100, 100) std = 0.000155446405937598 mean = 0.055315166668151505
	sizes = (100, 1000) std = 0.005295612670839835 mean = 0.09823771333321929
	sizes = (1000, 5) std = 5.087993715488194e-05 mean = 0.03315563267096877
	sizes = (1000, 100) std = 0.004952377745126246 mean = 0.09605619766807649
	sizes = (1000, 1000) std = 0.10362095898303665 mean = 0.9652185496718934
	cuda
	sizes = (5, 5) std = 5.004076916927963e-05 mean = 0.016851375335439418
	sizes = (5, 100) std = 0.0008912925390246038 mean = 0.01788881132476187
	sizes = (5, 10000) std = 0.0009701942336158022 mean = 0.018210363331794117
	sizes = (100, 5) std = 0.0007897575234315655 mean = 0.017682057005004026
	sizes = (100, 100) std = 0.0012395220098068511 mean = 0.016444508665396523
	sizes = (100, 10000) std = 0.000957364387413519 mean = 0.016943917328414198
	sizes = (10000, 5) std = 0.0011325899538680206 mean = 0.017102815332085203
	sizes = (10000, 100) std = 0.0013052748368152663 mean = 0.017058989333842572
	sizes = (10000, 10000) std = 0.024267574119715446 mean = 0.30735275766831666