### PR TITLE
Rename torchtest.test_all_device_types to torchtest.for_all_device_types

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -223,7 +223,7 @@ class torchtest():
 
     class _TestTorchMixin(torchtest):
 
-        @torchtest.test_all_device_types()
+        @torchtest.for_all_device_types()
         def test_zeros_like(self, device):
             expected = torch.zeros((100, 100,), device=device)
 
@@ -234,7 +234,7 @@ class torchtest():
         test_zeros_like_cuda (__main__.TestTorch) ... ok
 
     To work properly, test class should be inherited from `torchtest`.
-    test_all_device_types decorator does not guarantee proper functionality in
+    for_all_device_types decorator does not guarantee proper functionality in
     combination with other decorators.
 
     Please do not extend this decorator to support other cases (such as dtype,
@@ -243,7 +243,7 @@ class torchtest():
     https://github.com/pytorch/pytorch/pull/23824 for the reference).
     """
     @classmethod
-    def test_all_device_types(cls):
+    def for_all_device_types(cls):
         def wrapper(fn):
             test_names = []
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2873,7 +2873,7 @@ class _TestTorchMixin(torchtest):
                             self.assertEqual(std1, std2)
                             self.assertEqual(mean1, mean2)
 
-    @torchtest.test_all_device_types()
+    @torchtest.for_all_device_types()
     def test_var_mean_some_dims(self, device):
         sizes = (4, 6, 7, 5, 3)
         dims = len(sizes)
@@ -2890,7 +2890,7 @@ class _TestTorchMixin(torchtest):
                         self.assertEqual(var1, var2)
                         self.assertEqual(mean1, mean2)
 
-    @torchtest.test_all_device_types()
+    @torchtest.for_all_device_types()
     def test_zeros_like(self, device):
         expected = torch.zeros((100, 100,), device=device)
 
@@ -3526,7 +3526,7 @@ class _TestTorchMixin(torchtest):
             x[1] = True
             self.assertEqual(x, torch.tensor([False, True], dtype=torch.bool))
 
-    @torchtest.test_all_device_types()
+    @torchtest.for_all_device_types()
     def test_unfold_all_devices_and_dtypes(self, device):
         for dt in torch.testing.get_all_dtypes():
             if dt == torch.bfloat16:


### PR DESCRIPTION
Rename decorator to `for_all_device_types` as `test_` prefixed name recognized as test in some environments. 

Fixes internal: T48842162