### PR TITLE
[jit] Bind `Function` to `torch.jit.Function`

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -324,6 +324,10 @@ import torch.__future__
 
 _C._init_names(list(torch._storage_classes))
 
+# Import C bindings that depend on the `torch.jit` module
+_C._init_jit_dependent_bindings()
+torch.jit.post_dependent_bindings_init()
+
 # attach docstrings to torch and tensor functions
 from . import _torch_docs, _tensor_docs, _storage_docs
 del _torch_docs, _tensor_docs, _storage_docs

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -414,7 +414,7 @@ for i in range(2, 7):
 # Retrieves a fully-qualified name (module hierarchy + classname) for a given obj.
 def _qualified_name(obj):
     # short-circuit in cases where the object already has a known qualified name
-    if isinstance(obj, torch._C.Function):
+    if isinstance(obj, torch.jit.Function):
         return obj.qualified_name
 
     name = obj.__name__

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -359,7 +359,10 @@ void initJITBindings(PyObject* module) {
           "_jit_fuser_get_fused_kernel_code",
           [](Graph& g, std::vector<at::Tensor> inps) {
             return debugGetFusedKernelCode(g, inps);
-          });
+          })
+      .def("_init_jit_dependent_bindings", [](){
+        script::initScriptDependentBindings();
+      });
 
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<CompleteArgumentSpec>(m, "CompleteArgumentSpec")

--- a/torch/csrc/jit/script/init.h
+++ b/torch/csrc/jit/script/init.h
@@ -6,6 +6,7 @@ namespace torch {
 namespace jit {
 namespace script {
 void initJitScriptBindings(PyObject* module);
+void initScriptDependentBindings();
 
 } // namespace script
 } // namespace jit

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1991,8 +1991,9 @@ def _graph_for(self, *args, **kwargs):
     return last_executed_optimized_graph()
 
 torch._C.ScriptMethod.graph_for = _graph_for
-torch._C.Function.graph_for = _graph_for
-Function = torch._C.Function
+
+def post_dependent_bindings_init():
+    torch.jit.Function.graph_for = _graph_for
 
 if not torch._C._jit_init():
     raise RuntimeError("JIT initialization failed")


### PR DESCRIPTION
The result of this change is that `torch._C.Function` is renamed to
`torch.jit.Function`

Since `torch.jit` depends on our C bindings, this also adds a second
binding intialization that happens after `torch.jit` is defined. Since
`torch.jit` also defines properties on `Function`, there is another
binding initialization in `torch/__init__.py` that happens after the 2nd
round of C bindings.