### PR TITLE
[jit] copy methods when creating a derived class type

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1685,6 +1685,10 @@ struct CAFFE2_API ClassType : public NamedType {
       AT_ASSERT(attributeTypes_[i]->isSubtypeOf(contained_types[i]));
       ptr->addAttribute(attributeNames_[i], contained_types[i]);
     }
+    // Copy methods over
+    for (const auto& method : methods()) {
+      ptr->addMethod(method);
+    }
     return ptr;
   }
 

--- a/test/cpp/jit/test.cpp
+++ b/test/cpp/jit/test.cpp
@@ -95,7 +95,8 @@ namespace jit {
   _(InsertConstant)                    \
   _(DCE)                               \
   _(CustomFusionNestedBlocks)          \
-  _(ImportTooNew)
+  _(ImportTooNew)                      \
+  _(ClassDerive)
 
 #define TH_FORALL_TESTS_CUDA(_) \
   _(ArgumentSpec)               \

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -45,6 +45,10 @@ ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
     AT_ASSERT(refined_slots[i]->isSubtypeOf(attributeTypes_[i]));
     ptr->addAttribute(attributeNames_[i], refined_slots[i]);
   }
+  // Copy methods over
+  for (const auto& method : methods()) {
+    ptr->addMethod(method);
+  }
   return ptr;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23799 [wip] serializing function calls
* #24350 [jit] kill TK_NAMED_TUPLE_DEF
* **#24349 [jit] copy methods when creating a derived class type**

Methods that derive a new class type from the old one need to copy the
`method_` field as well as the attributes.

Differential Revision: [D16825274](https://our.internmc.facebook.com/intern/diff/D16825274)