### PR TITLE
[jit] kill TK_NAMED_TUPLE_DEF

### DIFF
--- a/test/cpp/jit/test_class_parser.h
+++ b/test/cpp/jit/test_class_parser.h
@@ -22,7 +22,7 @@ void testClassParser() {
   std::vector<Def> definitions;
   std::vector<Resolver> resolvers;
 
-  const auto classDef = ClassDef(p.parseClassLike());
+  const auto classDef = ClassDef(p.parseClass());
   p.lexer().expect(TK_EOF);
 
   ASSERT_EQ(classDef.name().name(), "FooTest");

--- a/torch/csrc/jit/script/lexer.h
+++ b/torch/csrc/jit/script/lexer.h
@@ -103,8 +103,7 @@ namespace script {
   _(TK_CONTINUE, "continue", "continue")         \
   _(TK_PASS, "pass", "pass")                     \
   _(TK_CLASS_DEF, "class", "class")              \
-  _(TK_IMPORT, "import", "import")               \
-  _(TK_NAMED_TUPLE_DEF, "named tuple", "")
+  _(TK_IMPORT, "import", "import")
 
 static const char* valid_single_char_tokens = "+-*/%@()[]:,={}><.?!&^|";
 

--- a/torch/csrc/jit/script/parser.cpp
+++ b/torch/csrc/jit/script/parser.cpp
@@ -634,39 +634,15 @@ struct ParserImpl {
         paramlist.range(), List<Param>(paramlist), return_annotation);
   }
 
-  TreeRef parseNamedTuple(const Ident& name) {
-    const auto& range = name.range();
-    L.expect(')');
-    L.expect(':');
-    L.expect(TK_INDENT);
-    std::vector<Ident> fields;
-    std::vector<Maybe<Expr>> type_exprs;
-    while (L.cur().kind != TK_DEDENT) {
-      fields.push_back(parseIdent());
-      type_exprs.push_back(maybeParseTypeAnnotation());
-      L.expect(TK_NEWLINE);
-    }
-    L.expect(TK_DEDENT);
-    return NamedTupleDef::create(
-        range,
-        name,
-        List<Ident>::create(range, fields),
-        List<Maybe<Expr>>::create(range, type_exprs));
-  }
-
-  TreeRef parseClassLike() {
+TreeRef parseClass() {
     L.expect(TK_CLASS_DEF);
     const auto name = parseIdent();
     Maybe<Expr> superclass = Maybe<Expr>::create(name.range());
     if (L.nextIf('(')) {
       // Only support inheriting from NamedTuple right now.
       auto id = parseExp();
-      if (id.kind() == TK_VAR && Var(id).name().name() == "NamedTuple") {
-        return parseNamedTuple(name);
-      } else {
-        superclass = Maybe<Expr>::create(id.range(), id);
-        L.expect(')');
-      }
+      superclass = Maybe<Expr>::create(id.range(), id);
+      L.expect(')');
     }
     L.expect(':');
     const auto statements =
@@ -724,8 +700,8 @@ Parser::~Parser() = default;
 TreeRef Parser::parseFunction(bool is_method) {
   return pImpl->parseFunction(is_method);
 }
-TreeRef Parser::parseClassLike() {
-  return pImpl->parseClassLike();
+TreeRef Parser::parseClass() {
+  return pImpl->parseClass();
 }
 Lexer& Parser::lexer() {
   return pImpl->lexer();

--- a/torch/csrc/jit/script/parser.h
+++ b/torch/csrc/jit/script/parser.h
@@ -20,7 +20,7 @@ TORCH_API Decl mergeTypesFromTypeComment(
 struct TORCH_API Parser {
   explicit Parser(const std::shared_ptr<Source>& src);
   TreeRef parseFunction(bool is_method);
-  TreeRef parseClassLike();
+  TreeRef parseClass();
   Decl parseTypeComment();
   Expr parseExp();
   Lexer& lexer();

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -28,8 +28,6 @@ namespace script {
 // ClassDef = ClassDef(Ident name,                                      TK_CLASS_DEF
 //                     Maybe<Expr> superclass,
 //                     List<Stmt> body)
-// NamedTupleDef = NamedTupleDef(Ident name, List<Ident> fields,
-//                               List<Maybe<Expr>> types)
 //
 // Stmt  = If(Expr cond, List<Stmt> true_body, List<Stmt> false_body)   TK_IF
 //       | For(List<Expr> targets, List<Expr> iters, List<Stmt> body)   TK_FOR
@@ -443,29 +441,6 @@ struct ClassDef : public TreeView {
       const List<Stmt>& body) {
     return ClassDef(
         Compound::create(TK_CLASS_DEF, range, {name, superclass, body}));
-  }
-};
-
-struct NamedTupleDef : public TreeView {
-  explicit NamedTupleDef(const TreeRef& tree) : TreeView(tree) {
-    tree->match(TK_NAMED_TUPLE_DEF);
-  }
-  Ident name() const {
-    return Ident(subtree(0));
-  }
-  List<Ident> fields() const {
-    return List<Ident>(subtree(1));
-  }
-  List<Maybe<Expr>> type_exprs() const {
-    return List<Maybe<Expr>>(subtree(2));
-  }
-  static NamedTupleDef create(
-      const SourceRange& range,
-      const Ident& name,
-      const List<Ident>& fields,
-      const List<Maybe<Expr>>& type_exprs) {
-    return NamedTupleDef(Compound::create(
-        TK_NAMED_TUPLE_DEF, range, {name, fields, type_exprs}));
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23799 [wip] serializing function calls
* **#24350 [jit] kill TK_NAMED_TUPLE_DEF**
* #24349 [jit] copy methods when creating a derived class type

`TK_NAMED_TUPLE_DEF` shouldn't exist, because NamedTuples are not
distinct syntactic things. The fact that NamedTuples and Classes are
treated differently is a property of our implementation, not the
language grammar.

This PR kills it and re-uses `CLASS_DEF` instead.

Differential Revision: [D16825273](https://our.internmc.facebook.com/intern/diff/D16825273)