### PR TITLE
Fixing size implementation for struct slot_list_impl

### DIFF
--- a/torch/csrc/jit/script/module.h
+++ b/torch/csrc/jit/script/module.h
@@ -524,7 +524,7 @@ struct TORCH_API slot_list_impl {
   size_t size() const {
     if (!size_) {
       size_ = size_t(0);
-      for (Slot s : *(this)) {
+      for (T s : *(this)) {
         ++*size_;
       }
     }


### PR DESCRIPTION
Making size() function work for variable use slot_list_impl<T> when T is not Slot

