### PR TITLE
Remove gradient value as input from SparseNormalize op

### DIFF
--- a/caffe2/operators/sparse_normalize_op.cc
+++ b/caffe2/operators/sparse_normalize_op.cc
@@ -6,9 +6,6 @@ namespace caffe2 {
 
 template <>
 bool SparseNormalizeOp<float, CPUContext>::RunOnDevice() {
-  CAFFE_ENFORCE_EQ(
-      Input(PARAM).size_from_dim(1),
-      Input(GRAD).size_from_dim(Input(INDICES).dim()));
 
   return DispatchHelper<TensorTypes<int32_t, int64_t>>::call(
      this, Input(INDICES));
@@ -29,7 +26,7 @@ bool SparseNormalizeOp<float, CPUContext>::DoRunWithType() {
   }
 
   // embedding length, e.g. 32, 64, 128
-  auto block_size = Input(GRAD).numel() / n;
+  auto block_size = Input(PARAM).size_from_dim(1);
   for (int i = 0; i < n; ++i) {
     auto idx = indices[i];
     auto offsetIdx = idx * block_size;
@@ -52,11 +49,10 @@ bool SparseNormalizeOp<float, CPUContext>::DoRunWithType() {
 
 REGISTER_CPU_OPERATOR(SparseNormalize, SparseNormalizeOp<float, CPUContext>);
 OPERATOR_SCHEMA(SparseNormalize)
-    .NumInputs(3)
+    .NumInputs(2)
     .NumOutputs(1)
     .Input(0, "param", "Parameters to be normalized")
     .Input(1, "indices", "Sparse indices")
-    .Input(2, "grad", "Gradient computed")
     .Output(0, "output_param", "Normalized parameters")
     .EnforceOneToOneInplace()
     .Arg(

--- a/caffe2/operators/sparse_normalize_op.h
+++ b/caffe2/operators/sparse_normalize_op.h
@@ -26,7 +26,7 @@ class CAFFE2_API SparseNormalizeOp final : public Operator<Context> {
  protected:
   bool use_max_norm_;
   float norm_;
-  INPUT_TAGS(PARAM, INDICES, GRAD);
+  INPUT_TAGS(PARAM, INDICES);
   OUTPUT_TAGS(OUTPUT_PARAM);
 };
 

--- a/caffe2/python/operator_test/sparse_normalize_test.py
+++ b/caffe2/python/operator_test/sparse_normalize_test.py
@@ -24,22 +24,22 @@ class TestSparseNormalize(hu.HypothesisTestCase):
     # Suppress filter_too_much health check.
     # Likely caused by `assume` call falling through too often.
     @settings(suppress_health_check=[HealthCheck.filter_too_much])
-    @given(inputs=hu.tensors(n=2, min_dim=2, max_dim=2),
+    @given(inputs=hu.tensors(n=1, min_dim=2, max_dim=2),
            use_max_norm=st.booleans(),
            norm=st.floats(min_value=1.0, max_value=4.0),
            data_strategy=st.data(),
            **hu.gcs_cpu_only)
     def test_sparse_normalize(self, inputs, use_max_norm, norm,
                               data_strategy, gc, dc):
-        param, grad = inputs
+        param = inputs
         param += 0.02 * np.sign(param)
         param[param == 0.0] += 0.02
 
         # Create an indexing array containing values that are lists of indices,
-        # which index into grad
+        # which index into param
         indices = data_strategy.draw(
             hu.tensor(dtype=np.int64, min_dim=1, max_dim=1,
-                      elements=st.sampled_from(np.arange(grad.shape[0]))),
+                      elements=st.sampled_from(np.arange(param.shape[0]))),
         )
         hypothesis.note('indices.shape: %s' % str(indices.shape))
 
@@ -47,18 +47,15 @@ class TestSparseNormalize(hu.HypothesisTestCase):
         hypothesis.assume(np.array_equal(np.unique(indices.flatten()),
                                          np.sort(indices.flatten())))
 
-        # Sparsify grad
-        grad = grad[indices]
-
         op = core.CreateOperator(
             "SparseNormalize",
-            ["param", "indices", "grad"],
+            ["param", "indices"],
             ["param"],
             use_max_norm=use_max_norm,
             norm=norm,
         )
 
-        def ref_sparse_normalize(param, indices, grad):
+        def ref_sparse_normalize(param, indices):
             param_out = np.copy(param)
             for _, index in enumerate(indices):
                 param_out[index] = self.ref_normalize(
@@ -68,8 +65,8 @@ class TestSparseNormalize(hu.HypothesisTestCase):
                 )
             return (param_out,)
 
-        # self.assertDeviceChecks(dc, op, [param, indices, grad], [0])
+        # self.assertDeviceChecks(dc, op, [param, indices], [0])
         self.assertReferenceChecks(
-            gc, op, [param, indices, grad],
+            gc, op, [param, indices],
             ref_sparse_normalize
         )

--- a/caffe2/python/regularizer.py
+++ b/caffe2/python/regularizer.py
@@ -175,7 +175,7 @@ class MaxNorm(Regularizer):
         assert self.norm > 0, "norm should be bigger than 0."
         if isinstance(grad, core.GradientSlice):
             net.SparseNormalize(
-                [param, grad.indices, grad.values],
+                [param, grad.indices],
                 [param],
                 use_max_norm=True,
                 norm=self.norm,
@@ -193,7 +193,7 @@ class ConstantNorm(Regularizer):
         assert self.norm > 0, "norm should be bigger than 0."
         if isinstance(grad, core.GradientSlice):
             net.SparseNormalize(
-                [param, grad.indices, grad.values],
+                [param, grad.indices],
                 [param],
                 use_max_norm=False,
                 norm=self.norm,


### PR DESCRIPTION
Summary: SparseNormalize does not need to know the gradient value to the lookup table, only the indices of the embeddings that need to be updated. By removing this input, we allow SparseNormalize to be used alongside SparseAdagradFusion

Differential Revision: D16809919

