### PR TITLE
Speed up binary half operators on CUDA with computing capacity >= 5.3

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -54,19 +54,35 @@ inline __device__ Half __ldg(const Half* ptr) {
 /// Arithmetic
 
 inline C10_HOST_DEVICE Half operator+(const Half& a, const Half& b) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hadd(static_cast<half>(a), static_cast<half>(b));
+#else
   return static_cast<float>(a) + static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE Half operator-(const Half& a, const Half& b) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hsub(static_cast<half>(a), static_cast<half>(b));
+#else
   return static_cast<float>(a) - static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE Half operator*(const Half& a, const Half& b) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hmul(static_cast<half>(a), static_cast<half>(b));
+#else
   return static_cast<float>(a) * static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE Half operator/(const Half& a, const Half& b) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hdiv(static_cast<half>(a), static_cast<half>(b));
+#else
   return static_cast<float>(a) / static_cast<float>(b);
+#endif
 }
 
 inline C10_HOST_DEVICE Half operator-(const Half& a) {
@@ -74,6 +90,14 @@ inline C10_HOST_DEVICE Half operator-(const Half& a) {
   return __hneg(a);
 #else
   return -static_cast<float>(a);
+#endif
+}
+
+inline C10_HOST_DEVICE Half half_fma (const Half& a, const Half& b, const Half& c) {
+#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+  return __hfma(a, b, c);
+#else
+  return static_cast<float>(a) * static_cast<float>(b) + static_cast<float>(c);
 #endif
 }
 


### PR DESCRIPTION
By employing __hadd, __hsub, __hmul, __hdiv, and __hfma.

Benchmark on half:

```python
import timeit

for n, t in [(1000, 40_000),
             (100_000, 40_000)]:
    for op in ('+', '-', '*', '/'):
        print(f'a {op} b (a.numel() == b.numel() == {n}) for {t} times')
        print(f'{t} times', end='\t\t')
        print(timeit.timeit(f'a {op} a; torch.cuda.synchronize()',
                            setup=f'import torch; a = torch.rand({n},
device="cuda", dtype=torch.half); b = torch.rand({n}, device="cuda",
dtype=torch.half)',
                            number=t))

```

Result (P100, built with computing capacity 6.0):

Before:

    a + b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.420216642320156
    a - b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.463516090065241
    a * b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.279749475419521
    a / b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.305952042341232
    a + b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.409606941044331
    a - b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.448739491403103
    a * b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.270783081650734
    a / b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.3004531264305115

After:

    a + b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.390979401767254
    a - b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.408378504216671
    a * b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.255346201360226
    a / b (a.numel() == b.numel() == 1000) for 40000 times
    40000 times             4.266323361545801
    a + b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.385917637497187
    a - b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.395326219499111
    a * b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.254821352660656
    a / b (a.numel() == b.numel() == 100000) for 40000 times
    40000 times             4.257668096572161

Difference is not significant but certainly doesn't hurt. The
improvements over speed and memory may become obvious in a larger scale.

The "add" operator is also changed to use a specifically defined fma
function for half. This is because nvcc does not seem to be able to
optimize `a*b+c` as a single fma operation if the operands are halves
(while it can when the operands are float). Below is my test:

```cuda
#include <cuda_fp16.h>

__global__ void test_fma_float(float a, float b, float c, float& d) {
  d = a + b * c;
}

__global__ void test_fma_half(half a, half b, half c, half& d) {
  d = a + b * c;
}

__global__ void test_fma_half_single(half a, half b, half c, half& d) {
  d = __hfma(b, c, a);
}
```

File generated from `nvcc -O3 -ptx -src-in-ptx -arch=sm_60 test.cu`:

```
//
// Generated by NVIDIA NVVM Compiler
//
// Compiler Build ID: CL-24817639
// Cuda compilation tools, release 10.0, V10.0.130
// Based on LLVM 3.4svn
//

.version 6.3
.target sm_60
.address_size 64

	// .globl	_Z14test_fma_floatfffRf

.visible .entry _Z14test_fma_floatfffRf(
	.param .f32 _Z14test_fma_floatfffRf_param_0,
	.param .f32 _Z14test_fma_floatfffRf_param_1,
	.param .f32 _Z14test_fma_floatfffRf_param_2,
	.param .u64 _Z14test_fma_floatfffRf_param_3
)
{
	.reg .f32 	%f<5>;
	.reg .b64 	%rd<3>;


	ld.param.f32 	%f1, [_Z14test_fma_floatfffRf_param_0];
	ld.param.f32 	%f2, [_Z14test_fma_floatfffRf_param_1];
	ld.param.f32 	%f3, [_Z14test_fma_floatfffRf_param_2];
	ld.param.u64 	%rd1, [_Z14test_fma_floatfffRf_param_3];
	cvta.to.global.u64 	%rd2, %rd1;
	fma.rn.f32 	%f4, %f2, %f3, %f1;
	st.global.f32 	[%rd2], %f4;
	ret;
}

	// .globl	_Z13test_fma_half6__halfS_S_RS_
.visible .entry _Z13test_fma_half6__halfS_S_RS_(
	.param .align 2 .b8 _Z13test_fma_half6__halfS_S_RS__param_0[2],
	.param .align 2 .b8 _Z13test_fma_half6__halfS_S_RS__param_1[2],
	.param .align 2 .b8 _Z13test_fma_half6__halfS_S_RS__param_2[2],
	.param .u64 _Z13test_fma_half6__halfS_S_RS__param_3
)
{
	.reg .b16 	%rs<7>;
	.reg .b64 	%rd<3>;


	ld.param.u16 	%rs5, [_Z13test_fma_half6__halfS_S_RS__param_0];
	ld.param.u16 	%rs2, [_Z13test_fma_half6__halfS_S_RS__param_1];
	ld.param.u16 	%rs3, [_Z13test_fma_half6__halfS_S_RS__param_2];
	ld.param.u64 	%rd1, [_Z13test_fma_half6__halfS_S_RS__param_3];
	cvta.to.global.u64 	%rd2, %rd1;
	// inline asm
	{mul.f16 %rs1,%rs2,%rs3;
}
	// inline asm
	// inline asm
	{add.f16 %rs4,%rs5,%rs1;
}
	// inline asm
	st.global.u16 	[%rd2], %rs4;
	ret;
}

	// .globl	_Z20test_fma_half_single6__halfS_S_RS_
.visible .entry _Z20test_fma_half_single6__halfS_S_RS_(
	.param .align 2 .b8 _Z20test_fma_half_single6__halfS_S_RS__param_0[2],
	.param .align 2 .b8 _Z20test_fma_half_single6__halfS_S_RS__param_1[2],
	.param .align 2 .b8 _Z20test_fma_half_single6__halfS_S_RS__param_2[2],
	.param .u64 _Z20test_fma_half_single6__halfS_S_RS__param_3
)
{
	.reg .b16 	%rs<5>;
	.reg .b64 	%rd<3>;


	ld.param.u16 	%rs4, [_Z20test_fma_half_single6__halfS_S_RS__param_0];
	ld.param.u16 	%rs2, [_Z20test_fma_half_single6__halfS_S_RS__param_1];
	ld.param.u16 	%rs3, [_Z20test_fma_half_single6__halfS_S_RS__param_2];
	ld.param.u64 	%rd1, [_Z20test_fma_half_single6__halfS_S_RS__param_3];
	cvta.to.global.u64 	%rd2, %rd1;
	// inline asm
	{fma.rn.f16 %rs1,%rs2,%rs3,%rs4;
}
	// inline asm
	st.global.u16 	[%rd2], %rs1;
	ret;
}
```

Note the `fma.rn.f32`, `fma.rn.f16`, `mul.f16` and `add.f16` lines.