### PR TITLE
[pt1][quant] Fix Lint

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -4,9 +4,9 @@ import unittest
 import torch
 import torch.nn.quantized as nnq
 from torch.quantization import \
-    QConfig_dynamic, default_observer, default_weight_observer, \
+    QConfig_dynamic, default_weight_observer, \
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules, \
-    quantize_dynamic, default_qconfig, default_dynamic_qconfig
+    quantize_dynamic, default_dynamic_qconfig
 
 from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24381 [pt1][quant] Fix Lint**
* #24299 [pt1][quant] Remove the activation observer for default_qconfig
* #24232 [pt1][quant] Make the default qconfig_dict
* #23330 [pt1][quant] Fix the dimension mismatch issues when running the BERT model

As pointed out in https://github.com/pytorch/pytorch/pull/24299#issuecomment-521471089, the previous PR broke the Lint.

Differential Revision: [D16822443](https://our.internmc.facebook.com/intern/diff/D16822443/)