### PR TITLE
Support load_state_dict func for nn.MultiheadAttention

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -728,12 +728,6 @@ class MultiheadAttention(Module):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        if prefix + '_qkv_same_embed_dim' not in state_dict.keys():
-            # In the early version of torch.nn.MultiheadAttention, q_proj_weight, k_proj_weight,
-            # and v_proj_weight are saved as in_proj_weight.
-            # If so, there is no attribute _qkv_same_embed_dim.
-            # To resolve the BC breaking, we just need to add the attribute _qkv_same_embed_dim.
-            state_dict[prefix + '_qkv_same_embed_dim'] = False
         super(MultiheadAttention, self)._load_from_state_dict(
             state_dict, prefix, local_metadata, strict,
             missing_keys, unexpected_keys, error_msgs)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -726,6 +726,18 @@ class MultiheadAttention(Module):
         if self.bias_v is not None:
             xavier_normal_(self.bias_v)
 
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        if prefix + '_qkv_same_embed_dim' is not in state_dict.keys():
+            # In the early version of torch.nn.MultiheadAttention, q_proj_weight, k_proj_weight,
+            # and v_proj_weight are saved as in_proj_weight.
+            # If so, there is no attribute _qkv_same_embed_dim.
+            # To resolve the BC breaking, we just need to add the attribute _qkv_same_embed_dim.
+            state_dict[prefix + '_qkv_same_embed_dim'] = False
+        super(MultiheadAttention, self)._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict,
+            missing_keys, unexpected_keys, error_msgs)
+
     def forward(self, query, key, value, key_padding_mask=None,
                 need_weights=True, attn_mask=None):
         r"""
@@ -756,7 +768,7 @@ class MultiheadAttention(Module):
         - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
           L is the target sequence length, S is the source sequence length.
         """
-        if hasattr(self, '_qkv_same_embed_dim') and self._qkv_same_embed_dim is False:
+        if not self._qkv_same_embed_dim:
             return F.multi_head_attention_forward(
                 query, key, value, self.embed_dim, self.num_heads,
                 self.in_proj_weight, self.in_proj_bias,
@@ -768,11 +780,6 @@ class MultiheadAttention(Module):
                 q_proj_weight=self.q_proj_weight, k_proj_weight=self.k_proj_weight,
                 v_proj_weight=self.v_proj_weight)
         else:
-            if not hasattr(self, '_qkv_same_embed_dim'):
-                warnings.warn('A new version of MultiheadAttention module has been implemented. \
-                    Please re-train your model with the new module',
-                              UserWarning)
-
             return F.multi_head_attention_forward(
                 query, key, value, self.embed_dim, self.num_heads,
                 self.in_proj_weight, self.in_proj_bias,

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -728,7 +728,7 @@ class MultiheadAttention(Module):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
-        if prefix + '_qkv_same_embed_dim' is not in state_dict.keys():
+        if prefix + '_qkv_same_embed_dim' not in state_dict.keys():
             # In the early version of torch.nn.MultiheadAttention, q_proj_weight, k_proj_weight,
             # and v_proj_weight are saved as in_proj_weight.
             # If so, there is no attribute _qkv_same_embed_dim.


### PR DESCRIPTION
Add _load_from_state_dict func in nn.MultiheadAttention func. JIT currently doesn't support `hasattr` func. We choose to apply load_state_dict func for the backward compatibility. Current users should not be affected by the change. Relevant PR #24204 

The changes have been tested to load a MultiheadAttention model trained by PyTorch 1.1. If users have an old MultiheadAttention model, please consider the following script to run inference.

```
import torch
import torch.nn as nn

model = torch.load("model_old.pt")  # Load an old model
state_dict = model.state_dict()
new_model = nn.MultiheadAttention(64, 4)  # A model with the new version of MultiheadAttention 
new_model.load_state_dict(state_dict)
```