### PR TITLE
Configure pytorch-probot

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,0 +1,1 @@
+tracking_issue: 24422


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24423 Configure pytorch-probot**

This enables auto-CC'ing based on labels, see
https://github.com/pytorch/pytorch/issues/24422

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D16833974](https://our.internmc.facebook.com/intern/diff/D16833974)