### PR TITLE
[fix] Convert bias to float in quantized conv module

### DIFF
--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -222,7 +222,7 @@ class Conv2d(torch.nn.Module):
                     mod.bias is not None, mod.padding_mode)
         qconv.set_weight(qweight)
         if mod.bias is not None:
-            qconv.bias = torch.quantize_linear(mod.bias, bias_scale, 0, torch.qint32)
+            qconv.bias = torch.quantize_linear(mod.bias.float(), bias_scale, 0, torch.qint32)
         else:
             qconv.bias = None
         qconv.scale = float(act_scale)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24426 [quant][graphmode] insert_quant_dequant jit pass
* #24425 [quant][graphmode] PreapreQuant step
* **#24424 [fix] Convert bias to float in quantized conv module**

Summary:
att

Test Plan:
python test/test_quantization.py

Reviewers:
quantization
Subscribers:

Tasks:

Tags:

Differential Revision: [D16839540](https://our.internmc.facebook.com/intern/diff/D16839540)