### PR TITLE
[quantization] Fix QConfig_dynamic typename

### DIFF
--- a/torch/quantization/QConfig.py
+++ b/torch/quantization/QConfig.py
@@ -9,7 +9,7 @@ QConfig = namedtuple('QConfig',
 default_qconfig = QConfig(default_weight_observer(),
                           default_observer())
 
-QConfig_dynamic = namedtuple('QConfig', ['weight'])
+QConfig_dynamic = namedtuple('QConfig_dynamic', ['weight'])
 
 default_dynamic_qconfig = QConfig_dynamic(default_weight_observer())
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24436 [quantization] Assert weight_observer has the correct dtype
* **#24431 [quantization] Fix QConfig_dynamic typename**

Pickle's fully-qualified name lookup would fail when trying to serialize QConfig_dynamic since the __name__ on the instance would refer to the wrong class name

Differential Revision: [D16835705](https://our.internmc.facebook.com/intern/diff/D16835705)