### PR TITLE
pickler read guard

### DIFF
--- a/torch/csrc/jit/import.cpp
+++ b/torch/csrc/jit/import.cpp
@@ -163,18 +163,18 @@ script::Module ScriptModuleDeserializer::deserialize(
     size_t bytes_read = 0;
     auto data = reinterpret_cast<const char*>(pickle_ptr.get());
     auto reader = [&](char* buffer, size_t len) {
+      if (bytes_read + len > pickle_size) {
+        return false;
+      }
       // Copy len bytes into buffer
       const char* start = data + bytes_read;
       std::memcpy(buffer, start, len);
       bytes_read += len;
+      return true;
     };
-    auto bounds_checker = [&]() { return bytes_read < pickle_size; };
 
     Unpickler unpickler(
-        reader,
-        bounds_checker,
-        &tensor_table_,
-        [&](const c10::QualifiedName& qn) {
+        reader, &tensor_table_, [&](const c10::QualifiedName& qn) {
           importCallback(qn.prefix());
           return c10::StrongTypePtr(
               compilation_unit_, compilation_unit_->get_class(qn));

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -811,7 +811,9 @@ OpCode Unpickler::readInstruction() {
 std::string Unpickler::readBytes(size_t length) {
   std::string data(length, 0);
   // This is fine since C++11 has contiguous strings
-  reader_(&data[0], length);
+  if (!reader_(&data[0], length)) {
+    AT_ERROR("Unexpected end of pickler archive.");
+  }
   return data;
 }
 

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -560,14 +560,12 @@ void Unpickler::run() {
       "Only Pickle protocol 2 is supported, found protocol = ",
       protocol);
 
-  while (bounds_checker_()) {
+  while (true) {
     OpCode opcode = readInstruction();
     if (opcode == OpCode::STOP) {
       return;
     }
   }
-
-  AT_ERROR("Overran buffer while unpickling data, didn't find STOP opcode");
 }
 void Unpickler::setInput(size_t memo_id) {
   AT_ASSERT(!stack_.empty());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24433 pickler read guard**

bounds checker was only used once per instruction. If a read in the
middle of an instruction went of the end of the stream, it would just
read invalid memory. This replaces bounds checker with just one
guarded read function.

Differential Revision: [D16836178](https://our.internmc.facebook.com/intern/diff/D16836178)