### PR TITLE
[quantization] Assert weight_observer has the correct dtype

### DIFF
--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -63,6 +63,7 @@ class Linear(nnq.Linear):
         assert type(mod) == NNLinear, 'nn.quantized.dynamic.Linear.from_float only works for nn.Linear'
         assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
         weight_observer = mod.qconfig.weight()
+        assert weight_observer.dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
         weight_observer(mod.weight)
         wt_scale, wt_zp = weight_observer.calculate_qparams()
         qweight = torch.quantize_linear(mod.weight.float(), wt_scale, wt_zp.long().item(), torch.qint8)

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -213,6 +213,7 @@ class Conv2d(torch.nn.Module):
             weight_observer(mod.weight)
         act_scale, act_zp = activation_observer.calculate_qparams()
         wt_scale, wt_zp = weight_observer.calculate_qparams()
+        assert weight_observer.dtype == torch.qint8, 'Weight observer must have a dtype of qint8'
         bias_scale = (wt_scale * act_scale).float()
         qweight = torch.quantize_linear(
             mod.weight.float().contiguous(),

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -212,8 +212,8 @@ class Conv2d(torch.nn.Module):
             weight_observer = mod.qconfig.weight()
             weight_observer(mod.weight)
         act_scale, act_zp = activation_observer.calculate_qparams()
-        wt_scale, wt_zp = weight_observer.calculate_qparams()
         assert weight_observer.dtype == torch.qint8, 'Weight observer must have a dtype of qint8'
+        wt_scale, wt_zp = weight_observer.calculate_qparams()
         bias_scale = (wt_scale * act_scale).float()
         qweight = torch.quantize_linear(
             mod.weight.float().contiguous(),

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -212,8 +212,8 @@ class Linear(torch.nn.Module):
             weight_observer = mod.qconfig.weight()
             weight_observer(mod.weight)
         act_scale, act_zp = activation_observer.calculate_qparams()
-        wt_scale, wt_zp = weight_observer.calculate_qparams()
         assert weight_observer.dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
+        wt_scale, wt_zp = weight_observer.calculate_qparams()
         bias_scale = (wt_scale * act_scale).float()
         qweight = torch.quantize_linear(mod.weight.float(), wt_scale, wt_zp.long().item(), torch.qint8)
         if mod.bias is not None:

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -213,6 +213,7 @@ class Linear(torch.nn.Module):
             weight_observer(mod.weight)
         act_scale, act_zp = activation_observer.calculate_qparams()
         wt_scale, wt_zp = weight_observer.calculate_qparams()
+        assert weight_observer.dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
         bias_scale = (wt_scale * act_scale).float()
         qweight = torch.quantize_linear(mod.weight.float(), wt_scale, wt_zp.long().item(), torch.qint8)
         if mod.bias is not None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24443 [quantization] extra_repr for quantized modules
* **#24436 [quantization] Assert weight_observer has the correct dtype**
* #24431 [quantization] Fix QConfig_dynamic typename

Differential Revision: [D16847141](https://our.internmc.facebook.com/intern/diff/D16847141)