### PR TITLE
Add BPR loss to TTSN

### DIFF
--- a/caffe2/python/layers/bpr_loss.py
+++ b/caffe2/python/layers/bpr_loss.py
@@ -1,0 +1,49 @@
+## @package bpr_loss
+# Module caffe2.python.layers.bpr_loss
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from caffe2.python import schema
+from caffe2.python.layers.layers import (
+    ModelLayer,
+)
+from caffe2.python.layers.tags import (
+    Tags
+)
+import numpy as np
+
+
+# ref: https://arxiv.org/pdf/1205.2618.pdf
+class BPRLoss(ModelLayer):
+
+    def __init__(self, model, input_record, name='bpr_loss', **kwargs):
+        super(BPRLoss, self).__init__(model, name, input_record, **kwargs)
+        assert schema.is_schema_subset(
+            schema.Struct(
+                ('pos_prediction', schema.Scalar()),
+                ('neg_prediction', schema.List(np.float32)),
+            ),
+            input_record
+        )
+        self.tags.update([Tags.EXCLUDE_FROM_PREDICTION])
+        self.output_schema = schema.Scalar(
+            np.float32,
+            self.get_next_blob_reference('output'))
+
+    def add_ops(self, net):
+        # formula:
+        # loss = - SUM(Ln(Sigmoid(Simlarity(u, pos) - Simlarity(u, neg))))
+        neg_score = self.input_record.neg_prediction['values']()
+
+        pos_score = net.LengthsTile(
+            [
+                self.input_record.pos_prediction(),
+                self.input_record.neg_prediction['lengths']()
+            ],
+            net.NextScopedBlob('pos_score_repeated')
+        )
+        # https://www.tensorflow.org/api_docs/python/tf/math/log_sigmoid
+        softplus = net.Softplus([net.Sub([neg_score, pos_score])])
+        net.ReduceFrontSum(softplus, self.output_schema.field_blobs())

--- a/caffe2/python/layers_test.py
+++ b/caffe2/python/layers_test.py
@@ -842,6 +842,24 @@ class TestLayers(LayersTestCase):
         self.run_train_net_forward_only()
         self.assertEqual(schema.Scalar((np.float32, tuple())), loss)
 
+    def testBPRLoss(self):
+        input_record = self.new_record(schema.Struct(
+            ('pos_prediction', schema.Scalar((np.float32, (1,)))),
+            ('neg_prediction', schema.List(np.float32)),
+        ))
+        pos_items = np.array([0.8, 0.9], dtype=np.float32)
+        neg_lengths = np.array([1, 2], dtype=np.int32)
+        neg_items = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        schema.FeedRecord(
+            input_record,
+            [pos_items, neg_lengths, neg_items]
+        )
+        loss = self.model.BPRLoss(input_record)
+        self.run_train_net_forward_only()
+        self.assertEqual(schema.Scalar((np.float32, tuple())), loss)
+        result = workspace.FetchBlob('bpr_loss/output')
+        np.testing.assert_array_almost_equal(np.array(1.24386, dtype=np.float32), result)
+
     def testBatchMSELoss(self):
         input_record = self.new_record(schema.Struct(
             ('label', schema.Scalar((np.float64, (1,)))),


### PR DESCRIPTION
Summary:
many literatures mentioned BPR is useful for improving recommendation quality. Add a BPR loss so that we can train TTSN with it. Would like to see if it can improve retrieval models.

reference: https://arxiv.org/pdf/1205.2618.pdf

Differential Revision: D16812513

