### PR TITLE
Don't require slow test reporting in `run_tests.py --pytest`

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -303,7 +303,7 @@ def get_executable_command(options):
     else:
         executable = [sys.executable]
     if options.pytest:
-        executable += ['-m', 'pytest', '--durations=10']
+        executable += ['-m', 'pytest']
     return executable
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24449 [jit] move TestRecursiveScript
* **#24448 Don't require slow test reporting in `run_tests.py --pytest`**

The setting `--durations=10` was hard-coded, which is annoying as I
don't necessarily care. A good alternative to get the same behavior is:

```
python run_tests.py --pytest -- --durations=10
```

Differential Revision: [D16876380](https://our.internmc.facebook.com/intern/diff/D16876380)