### PR TITLE
Enable log_softmax and CrossEntropyLoss for bfloat16

### DIFF
--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/Config.h>
 #include <c10/util/Half.h>
+#include <c10/util/BFloat16.h>
 
 // Defines the accumulation type for a scalar type.
 // Example:
@@ -31,6 +32,7 @@ template <> struct AccumulateType<char, true> { using type = int64_t; };
 template <> struct AccumulateType<int16_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int32_t, true> { using type = int64_t; };
 template <> struct AccumulateType<int64_t, true> { using type = int64_t; };
+template <> struct AccumulateType<BFloat16, false> { using type = float; };
 template <> struct AccumulateType<float, false> { using type = double; };
 template <> struct AccumulateType<double, false> { using type = double; };
 template <> struct AccumulateType<int8_t, false> { using type = int64_t; };

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <type_traits>
+#include <c10/util/BFloat16.h>
 
 namespace at {
 
@@ -18,5 +19,7 @@ template <typename T,
 inline bool _isnan(T val) {
   return std::isnan(val);
 }
+
+inline bool _isnan(at::BFloat16 val) { return std::isnan(float(val)); }
 
 } // namespace at

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -10,6 +10,7 @@
 #include <ATen/native/Copy.h>
 #include <ATen/NumericUtils.h>
 #include <c10/util/C++17.h>
+#include <c10/util/BFloat16.h>
 
 #if defined(__GNUC__)
 #define __at_align32__ __attribute__((aligned(32)))

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -41,7 +41,7 @@ void host_softmax(Tensor output, const Tensor& input, const int64_t dim) {
           for (int64_t d = 1; d < dim_size; d++)
             max_input = std::max(max_input, input_data[d * dim_stride]);
 
-          scalar_t tmpsum = 0;
+          acc_type<scalar_t, false> tmpsum = 0;
           for (int64_t d = 0; d < dim_size; d++) {
             scalar_t z = std::exp(input_data[d * dim_stride] - max_input);
             if (!LogSoftMax) {
@@ -97,7 +97,7 @@ void host_softmax_backward(
           const scalar_t* gradOutput_data =
               gradOutput_data_base + outer_idx * outer_stride + inner_idx;
 
-          scalar_t sum = 0; // TODO was accreal here
+          acc_type<scalar_t, false> sum = 0;
           for (int64_t d = 0; d < dim_size; d++)
             if (LogSoftMax)
               sum += gradOutput_data[d * dim_stride];
@@ -160,9 +160,9 @@ Tensor log_softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half
   if (input.ndimension() > 0 && dim == input.ndimension() - 1) {
     log_softmax_lastdim_kernel(kCPU, output, input);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "log_softmax", [&] {
-      host_softmax<scalar_t, true>(output, input, dim);
-    });
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::ScalarType::BFloat16, input.scalar_type(), "log_softmax",
+        [&] { host_softmax<scalar_t, true>(output, input, dim); });
   }
   return output;
 }
@@ -224,9 +224,11 @@ Tensor log_softmax_backward_cpu(
   if (grad.ndimension() > 0 && dim == grad.ndimension() - 1) {
     log_softmax_backward_lastdim_kernel(kCPU, grad_input, grad, output);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(grad.scalar_type(), "log_softmax_backward", [&] {
-      host_softmax_backward<scalar_t, true>(grad_input, grad, output, dim);
-    });
+    AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::BFloat16, grad.scalar_type(),
+                                   "log_softmax_backward", [&] {
+                                     host_softmax_backward<scalar_t, true>(
+                                         grad_input, grad, output, dim);
+                                   });
   }
   return grad_input;
 }

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -15,12 +15,12 @@ namespace at { namespace native { namespace {
 using namespace vec256;
 
 static void sum_kernel_impl(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES_AND(ScalarType::Bool, iter.dtype(), "sum_cpu", [&] {
-    binary_kernel_reduce_vec(
-      iter,
-      [=](scalar_t a, scalar_t b) -> scalar_t { return a + b; },
-      [=](Vec256<scalar_t> a, Vec256<scalar_t> b) { return a + b; });
-  });
+  AT_DISPATCH_ALL_TYPES_AND2(
+      ScalarType::BFloat16, ScalarType::Bool, iter.dtype(), "sum_cpu", [&] {
+        binary_kernel_reduce_vec(
+            iter, [=](scalar_t a, scalar_t b) -> scalar_t { return a + b; },
+            [=](Vec256<scalar_t> a, Vec256<scalar_t> b) { return a + b; });
+      });
 }
 
 static void mean_kernel_impl(TensorIterator& iter) {

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -232,10 +232,10 @@ static void softmax_lastdim_kernel_impl(Tensor& result, const Tensor& self) {
 static void log_softmax_lastdim_kernel_impl(
     Tensor& result,
     const Tensor& self) {
-  AT_DISPATCH_FLOATING_TYPES(
-      self.scalar_type(), "log_softmax_lastdim_kernel_impl", [&] {
-        vec_host_softmax_lastdim<scalar_t, true>::apply(result, self);
-      });
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      at::ScalarType::BFloat16, self.scalar_type(),
+      "log_softmax_lastdim_kernel_impl",
+      [&] { vec_host_softmax_lastdim<scalar_t, true>::apply(result, self); });
 }
 
 static void softmax_backward_lastdim_kernel_impl(
@@ -253,8 +253,9 @@ static void log_softmax_backward_lastdim_kernel_impl(
     Tensor& grad_input,
     const Tensor& grad,
     const Tensor& output) {
-  AT_DISPATCH_FLOATING_TYPES(
-      grad.scalar_type(), "log_softmax_backward_lastdim_kernel_impl", [&] {
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      at::ScalarType::BFloat16, grad.scalar_type(),
+      "log_softmax_backward_lastdim_kernel_impl", [&] {
         vec_host_softmax_backward_lastdim<scalar_t, true>::apply(
             grad_input, grad, output);
       });

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -42,10 +42,12 @@
 - name: _thnn_nll_loss(Tensor self, LongTensor target, Tensor? weight={}, int64_t reduction=Reduction::Mean, int64_t ignore_index=-100)
   cname: ClassNLLCriterion
   buffers: [total_weight]
-  cpu_bfloat16: True
   scalar_check:
     output: reduction != Reduction::None || self_->dim() == 0
     total_weight: 'true'
+  CPU:
+    forward_scalar_types: ['Float', 'Double', 'Half', 'BFloat16']
+    backward_scalar_types: ['Float', 'Double', 'Half', 'BFloat16']
 
 - name: _thnn_nll_loss2d(Tensor self, LongTensor target, Tensor? weight={}, int64_t reduction=Reduction::Mean, int64_t ignore_index=-100)
   cname: SpatialClassNLLCriterion

--- a/aten/src/ATen/nn.yaml
+++ b/aten/src/ATen/nn.yaml
@@ -42,6 +42,7 @@
 - name: _thnn_nll_loss(Tensor self, LongTensor target, Tensor? weight={}, int64_t reduction=Reduction::Mean, int64_t ignore_index=-100)
   cname: ClassNLLCriterion
   buffers: [total_weight]
+  cpu_bfloat16: True
   scalar_check:
     output: reduction != Reduction::None || self_->dim() == 0
     total_weight: 'true'

--- a/aten/src/ATen/nn_parse.py
+++ b/aten/src/ATen/nn_parse.py
@@ -225,7 +225,7 @@ def unique_args(argslist):
     return result
 
 
-def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_check, backend_types):
+def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_check, backend_types, cpu_bf16):
     """
     cimpls contains information use to call into THNN:
         cname: THNN function name
@@ -235,6 +235,7 @@ def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_ch
     return {
         'mode': 'NN',
         'name': name,
+        'cpu_bfloat16': cpu_bf16,
         'backend_types': backend_types,
         'arguments': arguments,
         'return': 'argument 0' if inplace else get_return(arguments),
@@ -245,7 +246,7 @@ def function_info(name, arguments, cimpls, buffers, backends, inplace, scalar_ch
         'variants': ['function'],
     }
 
-def base_declaration(func, thnn_function, backends, backend_types, inplace=False):
+def base_declaration(func, thnn_function, backends, backend_types, inplace=False, cpu_bf16=False):
     """Creates the NN function without any buffers in it's signature"""
     name, params = re.match(NAME_PARAM_REGEX, func['name']).groups()
     if inplace:
@@ -257,9 +258,9 @@ def base_declaration(func, thnn_function, backends, backend_types, inplace=False
     buffers = [argument_to_declaration('Tensor ' + buf)
                for buf in func.get('buffers', [])]
 
-    return function_info(name, arguments, None, buffers, backends, inplace, func.get('scalar_check'), backend_types)
+    return function_info(name, arguments, None, buffers, backends, inplace, func.get('scalar_check'), backend_types, cpu_bf16)
 
-def forward_declaration(base, thnn_function, backend_types, inplace=False):
+def forward_declaration(base, thnn_function, backend_types, inplace=False, cpu_bf16=False):
     name = '{}_forward'.format(base['name'])
     if inplace:
         name += '_'
@@ -282,9 +283,9 @@ def forward_declaration(base, thnn_function, backend_types, inplace=False):
         output_arg_names = [arg['name'] for arg in arguments if arg.get('output', False)]
         scalar_check = {k: v for (k, v) in scalar_check.items() if k in output_arg_names}
 
-    return function_info(name, arguments, [cimpl], [], base['backends'], inplace, scalar_check, backend_types)
+    return function_info(name, arguments, [cimpl], [], base['backends'], inplace, scalar_check, backend_types, cpu_bf16)
 
-def backward_declaration(base, thnn_functions, backend_types):
+def backward_declaration(base, thnn_functions, backend_types, cpu_bf16):
     name = '{}_backward'.format(base['name'])
 
     arguments = []
@@ -373,7 +374,7 @@ def backward_declaration(base, thnn_functions, backend_types):
                                   "does not exist.  Please explicitly specify scalar_check."
                                   .format(arg['name'], name, base_name)))
 
-    return function_info(name, arguments, cimpls, [], base['backends'], False, scalar_check, backend_types)
+    return function_info(name, arguments, cimpls, [], base['backends'], False, scalar_check, backend_types, cpu_bf16)
 
 
 def parse_nn_yaml(filename):
@@ -415,7 +416,7 @@ def run(paths):
                 if cname + suffix in header_functions:
                     bwd_functions.append(header_functions[cname + suffix])
 
-            default_scalar_types = ['Float', 'Double', 'Half']  # Half will be stripped for CPU backend
+            default_scalar_types = ['Float', 'Double', 'Half', 'BFloat16']  # Half will be stripped for CPU backend
             forward_backend_types = {}
             backward_backend_types = {}
             for backend in backends:
@@ -423,14 +424,15 @@ def run(paths):
                 forward_backend_types[backend] = backend_props.get('forward_scalar_types', default_scalar_types)
                 backward_backend_types[backend] = backend_props.get('backward_scalar_types', default_scalar_types)
 
-            base = base_declaration(func, fwd_function, backends, None)
-            declarations.append(forward_declaration(base, fwd_function, forward_backend_types))
+            cpu_bf16 = func.get('cpu_bfloat16', False)
+            base = base_declaration(func, fwd_function, backends, None, False, cpu_bf16)
+            declarations.append(forward_declaration(base, fwd_function, forward_backend_types, False, cpu_bf16))
             if bwd_functions:
-                declarations.append(backward_declaration(base, bwd_functions, backward_backend_types))
+                declarations.append(backward_declaration(base, bwd_functions, backward_backend_types, cpu_bf16))
 
 
             if func.get('has_inplace', False):
-                declarations.append(base_declaration(func, fwd_function, backends, forward_backend_types, True))
-                declarations.append(forward_declaration(base, fwd_function, forward_backend_types, True))
+                declarations.append(base_declaration(func, fwd_function, backends, forward_backend_types, True, cpu_bf16))
+                declarations.append(forward_declaration(base, fwd_function, forward_backend_types, True, cpu_bf16))
 
     return declarations

--- a/aten/src/TH/THTensor.hpp
+++ b/aten/src/TH/THTensor.hpp
@@ -92,6 +92,9 @@ inline int64_t THTensor_sizeLegacyNoScalars(const THTensor *self, int dim)
 #include <TH/generic/THTensorFastGetSet.hpp>
 #include <TH/THGenerateAllTypes.h>
 
+#include <TH/generic/THTensorFastGetSet.hpp>
+#include <TH/THGenerateBFloat16Type.h>
+
 inline std::vector<int64_t> THTensor_sizesLegacyNoScalars(const THTensor *self) {
   if (self->dim() == 0) {
     return {1};

--- a/aten/src/THNN/THNN.h
+++ b/aten/src/THNN/THNN.h
@@ -22,4 +22,7 @@ typedef void THNNState;
 #include <THNN/generic/THNN.h>
 #include <THGenerateLongType.h>
 
+#include <THNN/generic/THNN.h>
+#include <THGenerateBFloat16Type.h>
+
 #endif

--- a/aten/src/THNN/generic/ClassNLLCriterion.c
+++ b/aten/src/THNN/generic/ClassNLLCriterion.c
@@ -44,7 +44,9 @@ void THNN_(ClassNLLCriterion_updateOutput)(
           continue;
         }
         if (cur_target >= 0 && cur_target < n_classes) {
-            scalar_t cur_weight = weights ? THTensor_(fastGetLegacy1dNoScalars)(weights, cur_target) : 1.0f;
+          scalar_t cur_weight =
+              weights ? THTensor_(fastGetLegacy1dNoScalars)(weights, cur_target)
+                      : (scalar_t)1.0f;
             THTensor_(fastSet1d)(output, i, -THTensor_(fastGet2d)(input, i, cur_target) * cur_weight);
         } else {
           int tmp = -1;
@@ -78,7 +80,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
     int cur_target = target_data[0];
     if (cur_target != ignore_index) {
       THAssert(cur_target >= 0 && cur_target < n_classes);
-      total_weight_data[0] = weights ? weights_data[cur_target] : 1.0f;
+      total_weight_data[0] =
+          weights ? weights_data[cur_target] : (scalar_t)1.0f;
       output_data[0] = -input_data[cur_target] * total_weight_data[0];
     }
   } else if (THTensor_(nDimensionLegacyAll)(input) == 2) {
@@ -93,7 +96,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
       if (cur_target != ignore_index) {
         THAssert(cur_target >= 0 && cur_target < n_classes);
 
-        scalar_t cur_weight = weights ? weights_data[cur_target] : 1.0f;
+        scalar_t cur_weight =
+            weights ? weights_data[cur_target] : (scalar_t)1.0f;
         total_weight_data[0] += cur_weight;
         output_data[0] -= input_data[i * n_target + cur_target] * cur_weight;
       }
@@ -154,7 +158,9 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         if (cur_target == ignore_index) {
           continue;
         }
-        scalar_t weight = weights ? THTensor_(fastGetLegacy1dNoScalars)(weights, cur_target) : 1.0f;
+        scalar_t weight =
+            weights ? THTensor_(fastGetLegacy1dNoScalars)(weights, cur_target)
+                    : (scalar_t)1.0f;
         THTensor_(fastSet2d)(gradInput, i, cur_target, -weight * THTensor_(fastGetLegacy1dNoScalars)(gradOutput, i));
       }
     });
@@ -182,8 +188,9 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
     if (cur_target != ignore_index) {
       THAssert(cur_target >= 0 && cur_target < n_classes);
 
-      gradInput_data[cur_target] =
-        (reduction != Reduction::Mean && weights) ? -weights_data[cur_target] : -1;
+      gradInput_data[cur_target] = (reduction != Reduction::Mean && weights)
+                                       ? -weights_data[cur_target]
+                                       : (scalar_t)-1;
       gradInput_data[cur_target] *= gradOutput_value;
     }
 
@@ -201,7 +208,8 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         THAssert(cur_target >= 0 && cur_target < n_classes);
 
         gradInput_data[i * n_target + cur_target] =
-          -(weights ? weights_data[cur_target] : 1.0f) * gradOutput_value;
+            -(weights ? weights_data[cur_target] : (scalar_t)1.0f) *
+            gradOutput_value;
 
         if (reduction == Reduction::Mean && *total_weight_data) {
           gradInput_data[i * n_target + cur_target] /= *total_weight_data;

--- a/aten/src/THNN/generic/THNN.h
+++ b/aten/src/THNN/generic/THNN.h
@@ -6,6 +6,7 @@
 #include <ATen/core/Generator.h>
 #include <ATen/core/DistributionsHelper.h>
 
+#if !defined(TH_REAL_IS_BFLOAT16)
 TH_API void THNN_(SpatialConvolutionMM_updateOutput)(
           THNNState *state,
           THTensor *input,
@@ -29,9 +30,11 @@ TH_API void THNN_(VolumetricConvolutionMM_updateOutput)(
           int kT, int kW, int kH,
           int dT, int dW, int dH,
           int pT, int pW, int pH);
+#endif
 
 #if !defined(TH_REAL_IS_LONG)
 
+#if !defined(TH_REAL_IS_BFLOAT16)
 TH_API void THNN_(AbsCriterion_updateOutput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor
@@ -61,6 +64,7 @@ TH_API void THNN_(BCECriterion_updateGradInput)(
           THTensor *gradInput,
           int64_t reduction,
           THTensor *weights);          // [OPTIONAL]
+#endif
 
 TH_API void THNN_(ClassNLLCriterion_updateOutput)(
           THNNState *state,            // library's state
@@ -82,6 +86,7 @@ TH_API void THNN_(ClassNLLCriterion_updateGradInput)(
           THTensor *total_weight,      // [BUFFER]
           int64_t ignore_index);       // target index to ignore (loss = 0, gradInput = 0)
 
+#if !defined(TH_REAL_IS_BFLOAT16)
 TH_API void THNN_(ELU_updateOutput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor
@@ -498,5 +503,6 @@ TH_API void THNN_(SpatialClassNLLCriterion_updateGradInput)(
           THTensor *total_weight,      // [BUFFER]
           int64_t ignore_index);       // target index to ignore (loss = 0, gradInput = 0)
 
+#endif
 #endif
 #endif

--- a/aten/src/THNN/init.cpp
+++ b/aten/src/THNN/init.cpp
@@ -70,6 +70,9 @@
 #include <THNN/generic/ClassNLLCriterion.c>
 #include <TH/THGenerateFloatTypes.h>
 
+#include <THNN/generic/ClassNLLCriterion.c>
+#include <TH/THGenerateBFloat16Type.h>
+
 #include <THNN/generic/ELU.c>
 #include <TH/THGenerateFloatTypes.h>
 

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -129,4 +129,34 @@ namespace {
     float res = c10::detail::f32_from_bits(b.x);
     EXPECT_EQ(res, expected);
   }
+
+  float BinaryToFloat(uint32_t bytes) {
+    float res;
+    std::memcpy(&res, &bytes, sizeof(res));
+    return res;
+  }
+
+  struct BFloat16TestParam {
+    uint32_t input;
+    uint16_t rne;
+  };
+
+  class BFloat16Test : public ::testing::Test,
+                       public ::testing::WithParamInterface<BFloat16TestParam> {
+  };
+
+  TEST_P(BFloat16Test, BFloat16RNETest) {
+    float value = BinaryToFloat(GetParam().input);
+    uint16_t rounded = c10::detail::round_to_nearest_even(value);
+    EXPECT_EQ(GetParam().rne, rounded);
+  }
+
+  INSTANTIATE_TEST_CASE_P(
+      BFloat16Test_Instantiation, BFloat16Test,
+      ::testing::Values(BFloat16TestParam{0x3F848000, 0x3F84},
+                        BFloat16TestParam{0x3F848010, 0x3F85},
+                        BFloat16TestParam{0x3F850000, 0x3F85},
+                        BFloat16TestParam{0x3F858000, 0x3F86},
+                        BFloat16TestParam{0x3FFF8000, 0x4000}));
+
 } // namespace

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -39,6 +39,25 @@ namespace {
     }
   }
 
+  TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
+    float in[100];
+    for (int i = 0; i < 100; ++i) {
+      in[i] = i + 1.25;
+    }
+
+    c10::BFloat16 bfloats[100];
+    float out[100];
+
+    for (int i = 0; i < 100; ++i) {
+      bfloats[i].x = c10::detail::round_to_nearest_even(in[i]);
+      out[i] = c10::detail::f32_from_bits(bfloats[i].x);
+
+      // The relative error should be less than 1/(2^7) since BFloat16
+      // has 7 bits mantissa.
+      EXPECT_LE(fabs(out[i] - in[i]) / in[i], 1.0 / 128);
+    }
+  }
+
   TEST(BFloat16Conversion, NaN) {
     float inNaN = float_from_bytes(0, 0xFF, 0x7FFFFF);
     EXPECT_TRUE(std::isnan(inNaN));

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -7,7 +7,8 @@ namespace c10 {
 
 /// Constructors
 inline C10_HOST_DEVICE BFloat16::BFloat16(float value) {
-  x = detail::bits_from_f32(value);
+  // RNE by default
+  x = detail::round_to_nearest_even(value);
 }
 
 /// Implicit conversions
@@ -203,17 +204,64 @@ namespace std {
 
 template <>
 class numeric_limits<c10::BFloat16> {
-  public:
-    static constexpr bool is_signed = true;
-    static constexpr bool is_integer = false;
-    static constexpr bool has_infinity = true;
-    static constexpr bool has_quiet_NaN = true;
-    static constexpr c10::BFloat16 lowest() {
-      return at::BFloat16(0xFF7F, at::BFloat16::from_bits());
-    }
-    static constexpr c10::BFloat16 max() {
-      return at::BFloat16(0x7F7F, at::BFloat16::from_bits());
-    }
+public:
+  static constexpr bool is_signed = true;
+  static constexpr bool is_specialized = true;
+  static constexpr bool is_integer = false;
+  static constexpr bool is_exact = false;
+  static constexpr bool has_infinity = true;
+  static constexpr bool has_quiet_NaN = true;
+  static constexpr bool has_signaling_NaN = true;
+  static constexpr auto has_denorm = numeric_limits<float>::has_denorm;
+  static constexpr auto has_denorm_loss =
+      numeric_limits<float>::has_denorm_loss;
+  static constexpr auto round_style = numeric_limits<float>::round_style;
+  static constexpr bool is_iec559 = false;
+  static constexpr bool is_bounded = true;
+  static constexpr bool is_modulo = false;
+  static constexpr int digits = 8;
+  static constexpr int digits10 = 2;
+  static constexpr int max_digits10 = 4;
+  static constexpr int radix = 2;
+  static constexpr int min_exponent = -125;
+  static constexpr int min_exponent10 = -37;
+  static constexpr int max_exponent = 128;
+  static constexpr int max_exponent10 = 38;
+  static constexpr auto traps = numeric_limits<float>::traps;
+  static constexpr auto tinyness_before =
+      numeric_limits<float>::tinyness_before;
+
+  static constexpr c10::BFloat16 min() {
+    return c10::BFloat16(0x0080, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 lowest() {
+    return c10::BFloat16(0xFF7F, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 max() {
+    return c10::BFloat16(0x7F7F, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 epsilon() {
+    return c10::BFloat16(0x3C00, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 round_error() {
+    return c10::BFloat16(0x3F00, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 infinity() {
+    return c10::BFloat16(0x7F80, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 quiet_NaN() {
+    return c10::BFloat16(0x7FC0, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 signaling_NaN() {
+    return c10::BFloat16(0x7F80, c10::BFloat16::from_bits());
+  }
+  static constexpr c10::BFloat16 denorm_min() {
+    return c10::BFloat16(0x0001, c10::BFloat16::from_bits());
+  }
 };
+
+/// Used by vec256<c10::BFloat16>::map
+inline c10::BFloat16 exp(c10::BFloat16 a) { return std::exp(float(a)); }
+inline c10::BFloat16 log(c10::BFloat16 a) { return std::log(float(a)); }
 
 } // namespace std

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -43,6 +43,19 @@ namespace detail {
 
     return res >> 16;
   }
+
+  inline C10_HOST_DEVICE uint16_t round_to_nearest_even(float src) {
+    if (std::isnan(src)) {
+      return 0x7FC0;
+    } else {
+      union {
+        uint32_t U32;
+        float F32;
+      };
+      F32 = src;
+      return static_cast<uint16_t>((U32 + ((U32 & 0x00010000) >> 1)) >> 16);
+    }
+  }
 } // namespace detail
 
 struct alignas(2) BFloat16 {

--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -52,8 +52,10 @@ namespace detail {
         uint32_t U32;
         float F32;
       };
+
       F32 = src;
-      return static_cast<uint16_t>((U32 + ((U32 & 0x00010000) >> 1)) >> 16);
+      uint32_t rounding_bias = ((U32 >> 16) & 1) + 0x7FFF;
+      return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
     }
   }
 } // namespace detail

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8835,10 +8835,24 @@ class TestNN(NNTestCase):
         self.assertEqual(F.softmin(x, 1), F.softmax(-x, 1))
         self.assertEqual(F.softmin(x, 0), F.softmax(-x, 0))
 
-    def test_log_softmax(self):
-        x_small = torch.ones(1, 2, dtype=torch.float32)
+    @repeat_test_for_types([torch.float, torch.bfloat16])
+    def test_log_softmax(self, dtype=torch.float):
+        x_small = torch.ones(1, 2, dtype=dtype)
         x_big = x_small + 1e16
         self.assertEqual(F.log_softmax(x_small, -1), F.log_softmax(x_big, -1))
+
+    def test_log_softmax_cpu(self, dtype=torch.bfloat16):
+        inputf = torch.rand(32, 100, device="cpu", dtype=torch.float, requires_grad=True)
+        input = inputf.to(dtype).detach().requires_grad_(True)
+        outf = F.log_softmax(inputf, dim=-1)
+        out = F.log_softmax(input, dim=-1)
+        self.assertEqual(out.dtype, dtype)
+        self.assertEqual(out, outf, prec=0.1)
+
+        out.sum().backward()
+        outf.sum().backward()
+        self.assertEqual(input.grad.dtype, dtype)
+        self.assertEqual(input.grad, inputf.grad.to(dtype), prec=0.1)
 
     def test_adaptive_log_softmax(self):
         # args validation
@@ -8933,6 +8947,21 @@ class TestNN(NNTestCase):
         out = asfm.predict(x)
         self.assertEqual(out, asfm.log_prob(x).argmax(dim=1))
 
+    def test_cross_entropy_loss(self, dtype=torch.bfloat16):
+        loss_cpu = nn.CrossEntropyLoss().cpu()
+        inputf = torch.randn(15, 10, device="cpu", dtype=torch.float, requires_grad=True)
+        input = inputf.to(dtype).detach().requires_grad_(True)
+        target = torch.empty(15, dtype=torch.long).random_(10)
+
+        outf = loss_cpu(inputf, target)
+        out = loss_cpu(input, target)
+        self.assertEqual(out.dtype, dtype)
+        self.assertEqual(out, outf, prec=1e-1)
+
+        outf.backward()
+        out.backward()
+        self.assertEqual(input.grad.dtype, dtype)
+        self.assertEqual(input.grad, inputf.grad, prec=1e-1)
 
 class TestNNInit(TestCase):
     def setUp(self):


### PR DESCRIPTION
Enabled torch.nn.functional.log_softmax and torch.nn.CrossEntropyLoss for bfloat16 data type.
In order to do that, following dependency have to be enabled.
- RNE (round to nearest even)
- AccumulateType
- bfloat16 arithmetic operator overload

Also, we implement std::numeric_limits fully support for bfloat16 data type

background for dependency:
- RNE vs truncate
From torch.nn.CrossEntropyLoss test. input_size=(128, 1000)
RNE result:
float    output:  tensor(7.3981, dtype=torch.float32, grad_fn=<NllLossBackward>)
bfloat16 output:  tensor(7.3125, dtype=torch.bfloat16, grad_fn=<NllLossBackward>)
truncate result:
float    output:  tensor(7.3981, dtype=torch.float32, grad_fn=<NllLossBackward>)
bfloat16 output:  tensor(5.8750, dtype=torch.bfloat16, grad_fn=<NllLossBackward>)

- scalar_t vs AccumulateType (AccumulateType of bfloat16 is float)
AccumulateType is essential to keep accuracy, especially for reduction related operation.
we have verified it with both local case and real topology. It turns out that bfloat16 type accumulator would cause huge relative error when elements number is large, even more than 50%.
