### PR TITLE
[jit] move cpp tests to python extension

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -466,7 +466,6 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/ScriptCall.cpp
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/ScriptRet.cpp
       ${TORCH_SRC_DIR}/csrc/jit/export.cpp
-      ${TORCH_ROOT}/test/cpp/jit/test.cpp
     )
     if (NOT WIN32)
       list(APPEND TORCH_SRCS

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -147,7 +147,6 @@ libtorch_sources = [
     "torch/csrc/jit/fuser/cpu/fused_kernel.cpp",
     "torch/csrc/jit/fuser/interface.cpp",
     "torch/csrc/jit/function.cpp",
-    "test/cpp/jit/test.cpp",
 ]
 
 libtorch_cuda_sources = [
@@ -279,6 +278,10 @@ def add_torch_libs():
         "torch/csrc/utils/tensor_numpy.cpp",
         "torch/csrc/utils/tensor_types.cpp",
         "torch/csrc/utils/tuple_parser.cpp",
+        # test.cpp included here to enable running cpp tests from python
+        # runner. Ideally we'd create a separate python extension for it, but
+        # it's too much hassle
+        "test/cpp/jit/test.cpp",
     ]
 
     libtorch_python_cuda_sources = [

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -105,6 +105,10 @@ set(TORCH_PYTHON_SRCS
     ${TORCH_SRC_DIR}/csrc/utils/tensor_numpy.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tensor_types.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tuple_parser.cpp
+    # test.cpp included here to enable running cpp tests from python runner.
+    # Ideally we'd create a separate python extension for it, but it's too much
+    # hassle
+    ${TORCH_ROOT}/test/cpp/jit/test.cpp
     )
 
 set(TORCH_PYTHON_INCLUDE_DIRECTORIES


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24458 [jit] move cpp tests to python extension**

Trying to avoid ODR violations in fbcode opt builds. dogsciencing.

Confirmed that this fixes the internal build failures. I also had to remove duplicate inclusion `torch/csrc/api/src/jit.cpp` (it was in both the python extension and libtorch).
This is a remake of https://github.com/pytorch/pytorch/pull/19658

Differential Revision: [D16854303](https://our.internmc.facebook.com/intern/diff/D16854303)