### PR TITLE
Change kernel_size to self.kernel_size to resolve error in quantized conv module

### DIFF
--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -80,8 +80,8 @@ class Conv2d(torch.nn.Module):
         # Initialize as NCHW. set_weight will internally transpose to
         # NHWC
         qweight = torch._empty_affine_quantized(
-            [out_channels, in_channels // self.groups, kernel_size[0],
-             kernel_size[1]],
+            [out_channels, in_channels // self.groups, self.kernel_size[0],
+                self.kernel_size[1]],
             scale=1, zero_point=0, dtype=torch.qint8)
         self.set_weight(qweight)
         self.bias = torch._empty_affine_quantized([out_channels],


### PR DESCRIPTION
Summary:
We are attempting to subscript a variable `kernel_size` that may not be
an iterable in the `conv.py` module currently. This leads to errors unless the
user passes in an iterable for kernel_size. D16830855 changed
`self.kernel_size` to be a pair type, but did not actually use the variable.
We want to use `self.kernel_size` which is a pair even if the user passed in an int for `kernel_size` so that we stop having the subscripting error.

Differential Revision: D16859809

