### PR TITLE
Add resnext 32x4d shapes to benchmark

### DIFF
--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import operator_benchmark as op_bench
 import torch
@@ -22,10 +18,41 @@ qconv_2d_configs = op_bench.config_list(
         [1, 256, 256, 56, 56, 1, 1, 1, 0],
         [1, 512, 512, 56, 56, 32, 3, 2, 1],
     ],
-    attr_names=[
-        "N", "IC", "OC", "H", "W", "G", "kernel", "stride", "pad"
-    ],
+    attr_names=["N", "IC", "OC", "H", "W", "G", "kernel", "stride", "pad"],
     tags=["short"],
+)
+
+# Configs for convolution shapes from Resnext-101 32x4d
+resnext_32_4d_shape_configs = op_bench.config_list(
+    attrs=[
+        [1, 1024, 1024, 14, 14, 1, 1, 1, 0],  # op#312
+        [1, 1024, 1024, 14, 14, 32, 3, 2, 1],  # op#315
+        [1, 1024, 2048, 14, 14, 1, 1, 2, 0],  # op#320
+        [1, 1024, 512, 14, 14, 1, 1, 1, 0],  # op#92
+        [1, 1024, 1024, 7, 7, 32, 3, 1, 1],  # op#327
+        [1, 1024, 2048, 7, 7, 1, 1, 1, 0],  # op#318
+        [1, 128, 128, 56, 56, 32, 3, 1, 1],  # op#9
+        [1, 128, 256, 56, 56, 1, 1, 1, 0],  # op#12
+        [1, 2048, 1024, 7, 7, 1, 1, 1, 0],  # op#324
+        [1, 256, 256, 28, 28, 32, 3, 1, 1],  # op#53
+        [1, 256, 512, 28, 28, 1, 1, 1, 0],  # op#44
+        [1, 256, 128, 56, 56, 1, 1, 1, 0],  # op#28
+        [1, 256, 128, 56, 56, 1, 1, 1, 1],  # op#18
+        [1, 256, 256, 56, 56, 1, 1, 1, 0],  # op#38
+        [1, 256, 256, 56, 56, 32, 3, 2, 1],  # op#41
+        [1, 256, 512, 56, 56, 1, 1, 2, 0],  # op#46
+        [1, 3, 64, 224, 224, 1, 7, 2, 3],  # op#2
+        [1, 512, 1024, 14, 14, 1, 1, 1, 0],  # op#86
+        [1, 512, 512, 14, 14, 32, 3, 1, 1],  # op#95
+        [1, 512, 1024, 28, 28, 1, 1, 2, 0],  # op#88
+        [1, 512, 256, 28, 28, 1, 1, 1, 0],  # op#50
+        [1, 512, 512, 28, 28, 1, 1, 1, 0],  # op#80
+        [1, 512, 512, 28, 28, 32, 3, 2, 1],  # op#83
+        [1, 64, 128, 56, 56, 1, 1, 1, 0],  # op#6
+        [1, 64, 256, 56, 56, 1, 1, 1, 0],  # op#14
+    ],
+    attr_names=["N", "IC", "OC", "H", "W", "G", "kernel", "stride", "pad"],
+    tags=["resnext101_32x4d"],
 )
 
 
@@ -34,7 +61,9 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
         scale = 1.0 / 255
         zero_point = 0
         X = torch.randn(N, IC, H, W, dtype=torch.float32)
-        qX = torch.quantize_linear(X, scale=scale, zero_point=zero_point, dtype=torch.quint8)
+        qX = torch.quantize_linear(
+            X, scale=scale, zero_point=zero_point, dtype=torch.quint8
+        )
         W = torch.randn(OC, IC // G, kernel, kernel, dtype=torch.float32)
         qW = torch.quantize_linear(W, scale=scale, zero_point=0, dtype=torch.qint8)
 
@@ -50,6 +79,7 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
 
 
 op_bench.generate_pt_test(qconv_2d_configs, QConv2dBenchmark)
+op_bench.generate_pt_test(resnext_32_4d_shape_configs, QConv2dBenchmark)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Adds resnext-1011 32x4d shapes to the qconv benchmarks. (Also ran the code formatter)

Differential Revision: D16845746

