### PR TITLE
[jit] Preserve module names in recursive script

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14281,6 +14281,9 @@ class TestRecursiveScript(JitTestCase):
         f.check('Submodule')
         f.run(out[0])
 
+
+        self.assertEqual(m.original_name, 'MyModule')
+
     def test_class_compile(self):
         def other_fn(a, b):
             # type: (int, Tensor) -> Tensor

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14254,6 +14254,33 @@ class TestRecursiveScript(JitTestCase):
 
         self.checkModule(M(), (torch.randn(2, 2),))
 
+    def test_module_repr(self):
+        class Submodule(nn.Module):
+            def forward(self, x):
+                return x
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.conv = nn.Conv2d(10, 10, 3)
+                self.lin = nn.Linear(10, 10)
+                self.sub = Submodule()
+
+            def forward(self, x):
+                return self.lin(x) + self.sub(x) + self.conv(x)
+
+        m = torch.jit.script(MyModule())
+
+        with self.capture_stdout() as out:
+            print(m)
+
+        f = FileCheck()
+        f.check('MyModule')
+        f.check('Conv2d')
+        f.check('Linear')
+        f.check('Submodule')
+        f.run(out[0])
+
     def test_class_compile(self):
         def other_fn(a, b):
             # type: (int, Tensor) -> Tensor

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1590,9 +1590,13 @@ if _enabled:
             return self.forward.graph_for(*args, **kwargs)
 
         def extra_repr(self):
+            return 'original_name={}'.format(self.original_name)
+
+        @property
+        def original_name(self):
             if type(self) == self._c.name:
                 return ''
-            return 'original={}'.format(self._c.name)
+            return self._c.name
 
 else:
     class ScriptModule(torch.nn.Module):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1589,6 +1589,9 @@ if _enabled:
         def graph_for(self, *args, **kwargs):
             return self.forward.graph_for(*args, **kwargs)
 
+        def _get_name(self):
+            return self._c.name
+
 else:
     class ScriptModule(torch.nn.Module):
         def __init__(self):

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1589,8 +1589,10 @@ if _enabled:
         def graph_for(self, *args, **kwargs):
             return self.forward.graph_for(*args, **kwargs)
 
-        def _get_name(self):
-            return self._c.name
+        def extra_repr(self):
+            if type(self) == self._c.name:
+                return ''
+            return 'original={}'.format(self._c.name)
 
 else:
     class ScriptModule(torch.nn.Module):


### PR DESCRIPTION


Turns
```
ScriptModule(
  (conv): ScriptModule()
  (lin): ScriptModule()
  (sub): ScriptModule()
)
```

into

```
ScriptModule(
  original=MyModule
  (conv): ScriptModule(original=Conv2d)
  (lin): ScriptModule(original=Linear)
  (sub): ScriptModule(original=Submodule)
)
```

Differential Revision: [D16862032](https://our.internmc.facebook.com/intern/diff/16862032/)