### PR TITLE
Respect pre-defined DOCKER_IMAGE value in binary_populate_env.sh

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -29,6 +29,7 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
 fi
 
 # Pick docker image
+export DOCKER_IMAGE=${DOCKER_IMAGE:-}
 if [[ -z "$DOCKER_IMAGE" ]]; then
   if [[ "$PACKAGE_TYPE" == conda ]]; then
     export DOCKER_IMAGE="soumith/conda-cuda"

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -29,12 +29,14 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
 fi
 
 # Pick docker image
-if [[ "$PACKAGE_TYPE" == conda ]]; then
-  export DOCKER_IMAGE="soumith/conda-cuda"
-elif [[ "$DESIRED_CUDA" == cpu ]]; then
-  export DOCKER_IMAGE="soumith/manylinux-cuda100"
-else
-  export DOCKER_IMAGE="soumith/manylinux-cuda${DESIRED_CUDA:2}"
+if [[ -z "$DOCKER_IMAGE" ]]; then
+  if [[ "$PACKAGE_TYPE" == conda ]]; then
+    export DOCKER_IMAGE="soumith/conda-cuda"
+  elif [[ "$DESIRED_CUDA" == cpu ]]; then
+    export DOCKER_IMAGE="soumith/manylinux-cuda100"
+  else
+    export DOCKER_IMAGE="soumith/manylinux-cuda${DESIRED_CUDA:2}"
+  fi
 fi
 
 # Upload to parallel folder for gcc abis


### PR DESCRIPTION
`binary_populate_env.sh` is used by `binary_linux_test`, and for libtorch with new ABI we need to run the tests on a docker image different from `soumith/manylinux-cudaXX`. In such cases, we should respect the actual DOCKER_IMAGE value defined in the CircleCI job description.