### PR TITLE
[jit] big cpp test reorg

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -466,7 +466,6 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/ScriptCall.cpp
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/ScriptRet.cpp
       ${TORCH_SRC_DIR}/csrc/jit/export.cpp
-      ${TORCH_ROOT}/test/cpp/jit/test.cpp
     )
     if (NOT WIN32)
       list(APPEND TORCH_SRCS

--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(JIT_TEST_ROOT ${TORCH_ROOT}/test/cpp/jit)
 
+file(GLOB JIT_TEST_SRCS ${JIT_TEST_ROOT}/test_*.cpp)
+set(JIT_TEST_SRCS ${JIT_TEST_SRCS} PARENT_SCOPE)
+
 add_executable(test_jit
   ${TORCH_ROOT}/test/cpp/common/main.cpp
-  ${JIT_TEST_ROOT}/test.cpp)
+  ${JIT_TEST_ROOT}/gtest.cpp
+  ${JIT_TEST_SRCS})
 
 target_link_libraries(test_jit PRIVATE torch gtest)
 target_include_directories(test_jit PRIVATE ${ATen_CPU_INCLUDE})
-target_compile_definitions(test_jit PRIVATE USE_GTEST)
 
 if (USE_CUDA)
   target_link_libraries(test_jit PRIVATE

--- a/test/cpp/jit/README.md
+++ b/test/cpp/jit/README.md
@@ -1,7 +1,6 @@
-# JIT CPP Tests
+# JIT C++ Tests
 
 ## How to add a new test
-
 First, create a new test file. Test files should have be placed in this
 directory, with a name that starts with `test_`, like `test_foo.cpp`.
 
@@ -36,3 +35,35 @@ Then, register your test in `tests.h`:
   _(CaseOne)  // note that the `test` prefix is omitted.
   _(CaseTwo)
 ```
+
+We glob all the test files together in `CMakeLists.txt` so that you don't
+have to edit it every time you add a test. Unfortunately, this means that in
+order to get the build to pick up your new test file, you need to re-run
+cmake:
+```
+python setup.py build --cmake
+```
+
+## Why do we have two different test runners?
+We have two different ways of running our cpp tests:
+1. With `gtest`, from a standalone binary.
+2. With Python, from `TestJit.test_cpp` and `TestJit.test_cpp_cuda` (in
+   `test/test_jit.py`)
+
+We want both because we need to test things from a pure-C++ environment and
+with all our various Python patch-points enabled.
+
+## How do I run the tests?
+The following commands assume you are in PyTorch root.
+
+1. With `gtest`:
+   ```bash
+   # (re)build the test binary
+   ninja build/bin/test_jit
+   # run
+   build/bin/test_jit --gtest_filter='glob_style_filter*'
+   ```
+2. With Python:
+   ```
+   python test/test_jit.py TestJit.test_cpp TestJit.test_cpp_cuda
+   ```

--- a/test/cpp/jit/README.md
+++ b/test/cpp/jit/README.md
@@ -1,0 +1,38 @@
+# JIT CPP Tests
+
+## How to add a new test
+
+First, create a new test file. Test files should have be placed in this
+directory, with a name that starts with `test_`, like `test_foo.cpp`.
+
+Here is an example test file you can copy-paste.
+```cpp
+#include <test/cpp/jit/test_base.h>
+
+// Tests go in torch::jit
+namespace torch {
+namespace jit {
+
+// 1. Test cases are void() functions.
+// 2. They start with the prefix `test`
+void testCaseOne() {
+    // ...
+}
+
+void testCaseTwo() {
+    // ...
+}
+}
+}
+```
+
+Then, register your test in `tests.h`:
+```cpp
+// Add to TH_FORALL_TESTS_CUDA instead for CUDA-requiring tests
+#define TH_FORALL_TESTS(_)             \
+  _(ADFormulas)                        \
+  _(Attributes)                        \
+  ...
+  _(CaseOne)  // note that the `test` prefix is omitted.
+  _(CaseTwo)
+```

--- a/test/cpp/jit/gtest.cpp
+++ b/test/cpp/jit/gtest.cpp
@@ -1,0 +1,23 @@
+#include <test/cpp/jit/tests.h>
+
+#include <gtest/gtest.h>
+
+namespace torch {
+namespace jit {
+
+#define JIT_GTEST(name) \
+  TEST(JitTest, name) { \
+    test##name();       \
+  }
+TH_FORALL_TESTS(JIT_GTEST)
+#undef JIT_TEST
+
+#define JIT_GTEST_CUDA(name)   \
+  TEST(JitTest, name##_CUDA) { \
+    test##name();              \
+  }
+TH_FORALL_TESTS_CUDA(JIT_GTEST_CUDA)
+#undef JIT_TEST_CUDA
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/jit/irparser.h>
 #include "test/cpp/jit/test_base.h"

--- a/test/cpp/jit/test_argument_spec.cpp
+++ b/test/cpp/jit/test_argument_spec.cpp
@@ -1,12 +1,9 @@
-#pragma once
-
 #include <torch/jit.h>
 #include "test/cpp/jit/test_utils.h"
 #include "torch/csrc/jit/argument_spec.h"
 
 namespace torch {
 namespace jit {
-namespace test {
 
 int device(const autograd::Variable& v) {
   return v.type().is_cuda() ? v.get_device() : -1;
@@ -194,6 +191,5 @@ void testArgumentSpec() {
   ASSERT_EQ(spec.count(c), 1);
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_autodiff.cpp
+++ b/test/cpp/jit/test_autodiff.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 #include "torch/csrc/jit/argument_spec.h"
@@ -22,7 +20,6 @@
 
 namespace torch {
 namespace jit {
-namespace test {
 
 using namespace torch::autograd;
 
@@ -246,6 +243,5 @@ void testDifferentiateWithRequiresGrad() {
       ->run(*grad_spec.df);
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_class_import.cpp
+++ b/test/cpp/jit/test_class_import.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <test/cpp/jit/test_base.h>
 #include <test/cpp/jit/test_utils.h>
 
@@ -10,7 +8,8 @@
 
 namespace torch {
 namespace jit {
-namespace script {
+
+using namespace torch::jit::script;
 
 static const auto classSrcs1 = R"JIT(
 op_version_set = 1
@@ -97,12 +96,12 @@ void testScriptObject() {
   auto x = torch::ones({2, 3});
   auto obj = m2.create_class(c10::QualifiedName(base, "FooTest"), x).toObject();
   auto dx = obj->getAttr("dx");
-  ASSERT_TRUE(test::almostEqual(x, dx.toTensor()));
+  ASSERT_TRUE(almostEqual(x, dx.toTensor()));
 
   auto new_x = torch::rand({2, 3});
   obj->setAttr("dx", new_x);
   auto new_dx = obj->getAttr("dx");
-  ASSERT_TRUE(test::almostEqual(new_x, new_dx.toTensor()));
+  ASSERT_TRUE(almostEqual(new_x, new_dx.toTensor()));
 }
 
 static const auto methodSrc = R"JIT(
@@ -130,6 +129,5 @@ void testClassDerive() {
   ASSERT_TRUE(newCls2->getMethod(method->name()));
 }
 
-} // namespace script
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_class_parser.cpp
+++ b/test/cpp/jit/test_class_parser.cpp
@@ -1,11 +1,10 @@
-#pragma once
-
 #include <test/cpp/jit/test_base.h>
 #include <torch/csrc/jit/script/parser.h>
+#include <torch/csrc/jit/script/resolver.h>
 
 namespace torch {
 namespace jit {
-namespace script {
+using namespace torch::jit::script;
 const auto testSource = R"JIT(
   class FooTest:
     def __init__(self, x):
@@ -34,6 +33,5 @@ void testClassParser() {
   ASSERT_FALSE(Assign(classDef.body()[2]).rhs().present());
   ASSERT_TRUE(Assign(classDef.body()[2]).type().present());
 }
-} // namespace script
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_code_template.cpp
+++ b/test/cpp/jit/test_code_template.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
@@ -7,7 +5,6 @@
 
 namespace torch {
 namespace jit {
-namespace test {
 
 static const auto ct = CodeTemplate(R"(
   int foo($args) {
@@ -62,6 +59,6 @@ void testCodeTemplate() {
     ASSERT_EQ(s, ct_expect);
   }
 }
-} // namespace test
+
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_constant_pooling.cpp
+++ b/test/cpp/jit/test_constant_pooling.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/irparser.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>

--- a/test/cpp/jit/test_constant_propagation.cpp
+++ b/test/cpp/jit/test_constant_propagation.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/irparser.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>

--- a/test/cpp/jit/test_create_autodiff_subgraphs.cpp
+++ b/test/cpp/jit/test_create_autodiff_subgraphs.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
@@ -7,7 +5,6 @@
 
 namespace torch {
 namespace jit {
-namespace test {
 
 void testCreateAutodiffSubgraphs() {
   auto graph = build_lstm();
@@ -23,6 +20,5 @@ void testCreateAutodiffSubgraphs() {
       ->run(*graph);
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_custom_operators.cpp
+++ b/test/cpp/jit/test_custom_operators.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
@@ -11,7 +9,6 @@
 
 namespace torch {
 namespace jit {
-namespace test {
 
 void testCustomOperators() {
   {
@@ -192,6 +189,5 @@ void testIValueKWargs() {
   ASSERT_EQ(result.toInt(), 19);
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_dce.cpp
+++ b/test/cpp/jit/test_dce.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <test/cpp/jit/test_base.h>
 #include <test/cpp/jit/test_utils.h>
 

--- a/test/cpp/jit/test_dynamic_dag.cpp
+++ b/test/cpp/jit/test_dynamic_dag.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
@@ -7,7 +5,6 @@
 
 namespace torch {
 namespace jit {
-namespace test {
 
 std::unique_ptr<detail::DynamicDAG<std::string>> newDynamicDAG() {
   return std::unique_ptr<detail::DynamicDAG<std::string>>(
@@ -198,6 +195,5 @@ void testDynamicDAG() {
   testContractEdgeBasic();
   testContractEdgeCycleDetection();
 }
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_fuser.cpp
+++ b/test/cpp/jit/test_fuser.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 
 #include <torch/csrc/jit/passes/canonicalize.h>
@@ -61,7 +59,6 @@
 
 namespace torch {
 namespace jit {
-namespace {
 
 using Var = SymbolicVariable;
 
@@ -172,7 +169,7 @@ void testFusion() {
   testConcat(2);
 }
 
-void testRegisterFusionCachesKernel(std::ostream& out = std::cout) {
+void testRegisterFusionCachesKernel() {
   // Build up a fake graph with a FusionGroup
   auto createGraphWithNames = [](std::string cname, std::string dname) {
     auto graph = std::make_shared<Graph>();
@@ -218,6 +215,5 @@ void testRegisterFusionCachesKernel(std::ostream& out = std::cout) {
   // and therefore share a KernelSpec to share kernels for specializations
   ASSERT_EQ(second_key, expected_key);
 }
-} // namespace
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_graph_executor.cpp
+++ b/test/cpp/jit/test_graph_executor.cpp
@@ -1,12 +1,9 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 #include "torch/csrc/jit/graph_executor.h"
 
 namespace torch {
 namespace jit {
-namespace test {
 
 void testGraphExecutor() {
   constexpr int batch_size = 4;
@@ -33,6 +30,5 @@ void testGraphExecutor() {
   ASSERT_TRUE(almostEqual(stack[1].toTensor(), v(r1)));
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_interpreter.cpp
+++ b/test/cpp/jit/test_interpreter.cpp
@@ -1,11 +1,8 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
 namespace torch {
 namespace jit {
-namespace test {
 
 void testInterp() {
   constexpr int batch_size = 4;
@@ -30,6 +27,5 @@ void testInterp() {
   ASSERT_TRUE(exactlyEqual(outputs[0], hx));
   ASSERT_TRUE(exactlyEqual(outputs[1], cx));
 }
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_ir.cpp
+++ b/test/cpp/jit/test_ir.cpp
@@ -1,11 +1,8 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
 namespace torch {
 namespace jit {
-namespace test {
 
 void testAttributes() {
   Graph g;
@@ -35,7 +32,7 @@ void testAttributes() {
   ASSERT_EQ(attr2.f(one), 5);
 }
 
-void testBlocks(std::ostream& out = std::cout) {
+void testBlocks() {
   auto g = std::make_shared<Graph>();
   // auto g = *graph;
   auto a = Var::asNewInput(*g, "a");
@@ -84,6 +81,5 @@ void testBlocks(std::ostream& out = std::cout) {
       ->run(*g2);
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_irparser.cpp
+++ b/test/cpp/jit/test_irparser.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <torch/csrc/jit/ir.h>
 #include <torch/csrc/jit/irparser.h>
 #include <torch/csrc/jit/testing/file_check.h>

--- a/test/cpp/jit/test_ivalue.cpp
+++ b/test/cpp/jit/test_ivalue.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <ATen/ATen.h>
 #include "ATen/core/ivalue.h"
 #include "test/cpp/jit/test_base.h"
@@ -7,9 +5,6 @@
 
 namespace torch {
 namespace jit {
-namespace {
-
-using Var = SymbolicVariable;
 
 using namespace torch::autograd;
 
@@ -44,7 +39,7 @@ void testIValue() {
   ASSERT_TRUE(dlist.isNone());
   dlist = IValue(c10::List<double>({3.4}));
   ASSERT_TRUE(dlist.toDoubleListRef().equals({3.4}));
-  IValue the_list(ivalue::Tuple::create({IValue(3.4), IValue(4), IValue(foo)}));
+  IValue the_list(at::ivalue::Tuple::create({IValue(3.4), IValue(4), IValue(foo)}));
   ASSERT_EQ(foo.use_count(), 3);
   ASSERT_TRUE(the_list.isTuple());
   auto first = the_list.toTuple()->elements()[1];
@@ -59,6 +54,5 @@ void testIValue() {
   ASSERT_EQ(tv.use_count(), 2);
 }
 
-} // namespace
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <ATen/ATen.h>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>
@@ -70,8 +68,11 @@
 
 namespace torch {
 namespace jit {
-c10::OperatorOptions aliasAnalysisFromSchema();
-namespace test {
+c10::OperatorOptions aliasAnalysisFromSchema() {
+  c10::OperatorOptions result;
+  result.setAliasAnalysis(c10::AliasAnalysisKind::FROM_SCHEMA);
+  return result;
+}
 
 using Var = SymbolicVariable;
 
@@ -1166,6 +1167,5 @@ void testInsertConstant() {
       "Expected OptionalType");
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_netdef_converter.cpp
+++ b/test/cpp/jit/test_netdef_converter.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <torch/csrc/jit/netdef_converter.h>
 #include "test/cpp/jit/test_base.h"
 

--- a/test/cpp/jit/test_peephole_optimize.cpp
+++ b/test/cpp/jit/test_peephole_optimize.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <test/cpp/jit/test_base.h>
 #include <test/cpp/jit/test_utils.h>
 
@@ -10,9 +8,7 @@ namespace torch {
 namespace jit {
 
 using namespace script;
-using namespace testing;
 
-namespace test {
 
 void testPeepholeOptimize() {
   // test is / is not none optimization
@@ -99,6 +95,5 @@ graph(%1 : Float(*, *, *)?):
     testing::FileCheck().check_count("unwrap", 2)->run(*graph);
   }
 }
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_qualified_name.cpp
+++ b/test/cpp/jit/test_qualified_name.cpp
@@ -1,4 +1,3 @@
-#pragma once
 
 #include <ATen/core/qualified_name.h>
 #include <c10/util/Exception.h>
@@ -8,7 +7,6 @@ using c10::QualifiedName;
 
 namespace torch {
 namespace jit {
-namespace test {
 void testQualifiedName() {
   {
     // Test prefix construction
@@ -66,6 +64,5 @@ void testQualifiedName() {
     ASSERT_FALSE(foo2.isPrefixOf(foo3));
   }
 }
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <test/cpp/jit/test_base.h>
 #include <test/cpp/jit/test_utils.h>
 
@@ -12,7 +10,7 @@
 
 namespace torch {
 namespace jit {
-namespace script {
+using namespace script;
 
 void testSaveExtraFilesHook() {
   // no secrets
@@ -74,6 +72,5 @@ void testImportTooNew() {
   ASSERT_ANY_THROW(LEGACY_import_methods(m, src, constant_table, nullptr));
 }
 
-} // namespace script
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_subgraph_matcher.cpp
+++ b/test/cpp/jit/test_subgraph_matcher.cpp
@@ -1,11 +1,9 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
+#include "test/cpp/jit/test_utils.h"
 #include "torch/csrc/jit/subgraph_matcher.h"
 
 namespace torch {
 namespace jit {
-namespace {
 
 void testTrivial1() {
   Graph graph, pattern;
@@ -361,7 +359,7 @@ graph(%x, %y):
   AT_ASSERT(findPatternMatches(pattern1, graph).size() == 0);
 }
 
-void testAttributes() {
+void testMatchesAttributes() {
   Graph graph;
   script::parseIR(
       R"IR(
@@ -479,10 +477,9 @@ void testSubgraphMatching() {
   testOverlappingMatches();
   testMatchInBasicBlocks1();
   testMatchInBasicBlocks2();
-  testAttributes();
+  testMatchesAttributes();
   testBadPattern();
 }
 
-} // namespace
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_subgraph_utils.cpp
+++ b/test/cpp/jit/test_subgraph_utils.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "test/cpp/jit/test_base.h"
 #include "test/cpp/jit/test_utils.h"
 
@@ -8,7 +6,6 @@
 
 namespace torch {
 namespace jit {
-namespace test {
 
 void testSubgraphUtils() {
   auto graph = build_lstm();
@@ -40,6 +37,5 @@ void testSubgraphUtils() {
   ASSERT_EQ(originalNodes.size(), newNodes.size());
 }
 
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/test_utils.cpp
+++ b/test/cpp/jit/test_utils.cpp
@@ -1,0 +1,149 @@
+#include <test/cpp/jit/test_utils.h>
+
+namespace torch {
+namespace jit {
+
+Stack createStack(std::vector<at::Tensor>&& list) {
+  return Stack(
+      std::make_move_iterator(list.begin()),
+      std::make_move_iterator(list.end()));
+}
+
+void assertAllClose(const tensor_list& a, const tensor_list& b) {
+  ASSERT_EQ(a.size(), b.size());
+  for (size_t i = 0; i < a.size(); ++i) {
+    ASSERT_TRUE(a[i].is_same_size(b[i]));
+    ASSERT_TRUE(a[i].allclose(b[i]));
+  }
+}
+
+std::vector<at::Tensor> run(
+    InterpreterState& interp,
+    const std::vector<at::Tensor>& inputs) {
+  std::vector<IValue> stack(inputs.begin(), inputs.end());
+  interp.run(stack);
+  return fmap(stack, [](const IValue& i) { return i.toTensor(); });
+}
+
+std::pair<tensor_list, tensor_list> runGradient(
+    Gradient& grad_spec,
+    tensor_list& tensors_in,
+    tensor_list& tensor_grads_in) {
+  static const auto as_tensorlist = [](const Stack& stack) {
+    return fmap(stack, [](const IValue& i) { return i.toTensor(); });
+  };
+  Code f_code{grad_spec.f}, df_code{grad_spec.df};
+  InterpreterState f_interpreter{f_code}, df_interpreter{df_code};
+
+  auto f_stack = fmap<IValue>(tensors_in);
+  f_interpreter.run(f_stack);
+
+  Stack df_stack;
+  df_stack.insert(
+      df_stack.end(), tensor_grads_in.begin(), tensor_grads_in.end());
+  for (auto offset : grad_spec.df_input_captured_inputs)
+    df_stack.push_back(tensors_in[offset]);
+  for (auto offset : grad_spec.df_input_captured_outputs)
+    df_stack.push_back(f_stack[offset]);
+  df_interpreter.run(df_stack);
+
+  // Outputs of f needs to be sliced
+  f_stack.erase(f_stack.begin() + grad_spec.f_real_outputs, f_stack.end());
+  return std::make_pair(as_tensorlist(f_stack), as_tensorlist(df_stack));
+}
+
+std::tuple<Var, Var> build_lstm_body(
+    Graph& g,
+    Var input,
+    Var hx,
+    Var cx,
+    Var w_ih,
+    Var w_hh) {
+  auto gates = input.mm(w_ih);
+  gates = gates + hx.mm(w_hh);
+  auto outputs = gates.chunk(4, 1);
+  auto ingate = outputs[0];
+  auto forgetgate = outputs[1];
+  auto cellgate = outputs[2];
+  auto outgate = outputs[3];
+  ingate = ingate.sigmoid();
+  outgate = outgate.sigmoid();
+  cellgate = cellgate.tanh();
+  forgetgate = forgetgate.sigmoid();
+
+  auto cy = forgetgate * cx;
+  cy = cy + ingate * cellgate;
+  auto hy = outgate * cy.tanh();
+
+  return std::make_tuple(hy, cy);
+}
+
+std::shared_ptr<Graph> build_lstm() {
+  auto r = std::make_shared<Graph>();
+  auto& g = *r;
+  Value* input = g.addInput();
+  Value* hx = g.addInput();
+  Value* cx = g.addInput();
+  Value* w_ih = g.addInput();
+  Value* w_hh = g.addInput();
+
+  Var hy;
+  Var cy;
+  std::tie(hy, cy) = build_lstm_body(g, input, hx, cx, w_ih, w_hh);
+
+  hy.addAsOutput();
+  cy.addAsOutput();
+  g.lint();
+
+  return r;
+}
+
+at::Tensor t_use(at::Tensor x) {
+  return x;
+}
+at::Tensor t_def(at::Tensor x) {
+  return x.t();
+}
+
+bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
+  double maxValue = 0.0;
+  for (auto& tensor : inputs) {
+    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
+  }
+  return diff.abs().max().item<float>() < 2e-6 * maxValue;
+}
+bool almostEqual(const at::Tensor& a, const at::Tensor& b) {
+  return checkRtol(a - b, {a, b});
+}
+
+bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
+  return (a - b).abs().max().item<float>() == 0.f;
+}
+
+std::pair<at::Tensor, at::Tensor> lstm(
+    at::Tensor input,
+    at::Tensor hx,
+    at::Tensor cx,
+    at::Tensor w_ih,
+    at::Tensor w_hh) {
+  auto gates = input.mm(t_use(w_ih)) + hx.mm(t_use(w_hh));
+
+  auto chunked_gates = gates.chunk(4, 1);
+  auto ingate = chunked_gates[0];
+  auto forgetgate = chunked_gates[1];
+  auto cellgate = chunked_gates[2];
+  auto outgate = chunked_gates[3];
+
+  ingate = ingate.sigmoid();
+  outgate = outgate.sigmoid();
+  cellgate = cellgate.tanh();
+  forgetgate = forgetgate.sigmoid();
+
+  auto cy = (forgetgate * cx) + (ingate * cellgate);
+  auto hy = outgate * cy.tanh();
+
+  return {hy, cy};
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/jit/test_utils.h
+++ b/test/cpp/jit/test_utils.h
@@ -4,11 +4,11 @@
 #include "test/cpp/jit/test_base.h"
 #include "torch/csrc/jit/autodiff.h"
 #include "torch/csrc/jit/interpreter.h"
+#include "torch/csrc/jit/irparser.h"
 #include "torch/csrc/jit/symbolic_variable.h"
 
 namespace torch {
 namespace jit {
-namespace test {
 
 using Var = SymbolicVariable;
 using tensor_list = std::vector<at::Tensor>;
@@ -17,54 +17,18 @@ using namespace torch::autograd;
 // work around the fact that variable_tensor_list doesn't duplicate all
 // of std::vector's constructors.
 // most constructors are never used in the implementation, just in our tests.
-Stack createStack(std::vector<at::Tensor>&& list) {
-  return Stack(
-      std::make_move_iterator(list.begin()),
-      std::make_move_iterator(list.end()));
-}
+Stack createStack(std::vector<at::Tensor>&& list);
 
-void assertAllClose(const tensor_list& a, const tensor_list& b) {
-  ASSERT_EQ(a.size(), b.size());
-  for (size_t i = 0; i < a.size(); ++i) {
-    ASSERT_TRUE(a[i].is_same_size(b[i]));
-    ASSERT_TRUE(a[i].allclose(b[i]));
-  }
-}
+void assertAllClose(const tensor_list& a, const tensor_list& b);
 
 std::vector<at::Tensor> run(
     InterpreterState& interp,
-    const std::vector<at::Tensor>& inputs) {
-  std::vector<IValue> stack(inputs.begin(), inputs.end());
-  interp.run(stack);
-  return fmap(stack, [](const IValue& i) { return i.toTensor(); });
-}
+    const std::vector<at::Tensor>& inputs);
 
 std::pair<tensor_list, tensor_list> runGradient(
     Gradient& grad_spec,
     tensor_list& tensors_in,
-    tensor_list& tensor_grads_in) {
-  static const auto as_tensorlist = [](const Stack& stack) {
-    return fmap(stack, [](const IValue& i) { return i.toTensor(); });
-  };
-  Code f_code{grad_spec.f}, df_code{grad_spec.df};
-  InterpreterState f_interpreter{f_code}, df_interpreter{df_code};
-
-  auto f_stack = fmap<IValue>(tensors_in);
-  f_interpreter.run(f_stack);
-
-  Stack df_stack;
-  df_stack.insert(
-      df_stack.end(), tensor_grads_in.begin(), tensor_grads_in.end());
-  for (auto offset : grad_spec.df_input_captured_inputs)
-    df_stack.push_back(tensors_in[offset]);
-  for (auto offset : grad_spec.df_input_captured_outputs)
-    df_stack.push_back(f_stack[offset]);
-  df_interpreter.run(df_stack);
-
-  // Outputs of f needs to be sliced
-  f_stack.erase(f_stack.begin() + grad_spec.f_real_outputs, f_stack.end());
-  return std::make_pair(as_tensorlist(f_stack), as_tensorlist(df_stack));
-}
+    tensor_list& tensor_grads_in);
 
 std::tuple<Var, Var> build_lstm_body(
     Graph& g,
@@ -72,96 +36,27 @@ std::tuple<Var, Var> build_lstm_body(
     Var hx,
     Var cx,
     Var w_ih,
-    Var w_hh) {
-  auto gates = input.mm(w_ih);
-  gates = gates + hx.mm(w_hh);
-  auto outputs = gates.chunk(4, 1);
-  auto ingate = outputs[0];
-  auto forgetgate = outputs[1];
-  auto cellgate = outputs[2];
-  auto outgate = outputs[3];
-  ingate = ingate.sigmoid();
-  outgate = outgate.sigmoid();
-  cellgate = cellgate.tanh();
-  forgetgate = forgetgate.sigmoid();
+    Var w_hh);
 
-  auto cy = forgetgate * cx;
-  cy = cy + ingate * cellgate;
-  auto hy = outgate * cy.tanh();
+std::shared_ptr<Graph> build_lstm();
 
-  return std::make_tuple(hy, cy);
-}
-
-std::shared_ptr<Graph> build_lstm() {
-  auto r = std::make_shared<Graph>();
-  auto& g = *r;
-  Value* input = g.addInput();
-  Value* hx = g.addInput();
-  Value* cx = g.addInput();
-  Value* w_ih = g.addInput();
-  Value* w_hh = g.addInput();
-
-  Var hy;
-  Var cy;
-  std::tie(hy, cy) = build_lstm_body(g, input, hx, cx, w_ih, w_hh);
-
-  hy.addAsOutput();
-  cy.addAsOutput();
-  g.lint();
-
-  return r;
-}
-
-at::Tensor t_use(at::Tensor x) {
-  return x;
-}
-at::Tensor t_def(at::Tensor x) {
-  return x.t();
-}
+at::Tensor t_use(at::Tensor x);
+at::Tensor t_def(at::Tensor x);
 
 // given the difference of output vs expected tensor, check whether the
 // difference is within a relative tolerance range. This is a standard way of
 // matching tensor values upto certain precision
-bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
-  double maxValue = 0.0;
-  for (auto& tensor : inputs) {
-    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
-  }
-  return diff.abs().max().item<float>() < 2e-6 * maxValue;
-}
-bool almostEqual(const at::Tensor& a, const at::Tensor& b) {
-  return checkRtol(a - b, {a, b});
-}
+bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs);
+bool almostEqual(const at::Tensor& a, const at::Tensor& b);
 
-bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
-  return (a - b).abs().max().item<float>() == 0.f;
-}
+bool exactlyEqual(const at::Tensor& a, const at::Tensor& b);
 
 std::pair<at::Tensor, at::Tensor> lstm(
     at::Tensor input,
     at::Tensor hx,
     at::Tensor cx,
     at::Tensor w_ih,
-    at::Tensor w_hh) {
-  auto gates = input.mm(t_use(w_ih)) + hx.mm(t_use(w_hh));
+    at::Tensor w_hh);
 
-  auto chunked_gates = gates.chunk(4, 1);
-  auto ingate = chunked_gates[0];
-  auto forgetgate = chunked_gates[1];
-  auto cellgate = chunked_gates[2];
-  auto outgate = chunked_gates[3];
-
-  ingate = ingate.sigmoid();
-  outgate = outgate.sigmoid();
-  cellgate = cellgate.tanh();
-  forgetgate = forgetgate.sigmoid();
-
-  auto cy = (forgetgate * cx) + (ingate * cellgate);
-  auto hy = outgate * cy.tanh();
-
-  return {hy, cy};
-}
-
-} // namespace test
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/tests.h
+++ b/test/cpp/jit/tests.h
@@ -1,43 +1,10 @@
-#if defined(USE_GTEST)
-#include <gtest/gtest.h>
-#endif
+#pragma once
 
-#include <c10/macros/Export.h>
-
-// To add a new test file:
-// 1. Add a test_foo.h file in this directory
-// 2. include test_base.h
-// 3. Write your tests as pure functions starting with "test", like "testFoo"
-// 4. Include test_foo.h here and add it to the appropriate macro listing
-#include <test/cpp/jit/test_alias_analysis.h>
-#include <test/cpp/jit/test_argument_spec.h>
-#include <test/cpp/jit/test_autodiff.h>
-#include <test/cpp/jit/test_class_import.h>
-#include <test/cpp/jit/test_class_parser.h>
-#include <test/cpp/jit/test_code_template.h>
-#include <test/cpp/jit/test_constant_pooling.h>
-#include <test/cpp/jit/test_constant_propagation.h>
-#include <test/cpp/jit/test_create_autodiff_subgraphs.h>
-#include <test/cpp/jit/test_custom_operators.h>
-#include <test/cpp/jit/test_dce.h>
-#include <test/cpp/jit/test_dynamic_dag.h>
-#include <test/cpp/jit/test_fuser.h>
-#include <test/cpp/jit/test_graph_executor.h>
-#include <test/cpp/jit/test_interpreter.h>
-#include <test/cpp/jit/test_ir.h>
-#include <test/cpp/jit/test_irparser.h>
-#include <test/cpp/jit/test_ivalue.h>
-#include <test/cpp/jit/test_misc.h>
-#include <test/cpp/jit/test_netdef_converter.h>
-#include <test/cpp/jit/test_peephole_optimize.h>
-#include <test/cpp/jit/test_qualified_name.h>
-#include <test/cpp/jit/test_save_load.h>
-#include <test/cpp/jit/test_subgraph_matcher.h>
-#include <test/cpp/jit/test_subgraph_utils.h>
+/**
+ * See README.md for instructions on how to add a new test.
+ */
 #include <torch/csrc/WindowsTorchApiMacro.h>
-
-using namespace torch::jit::script;
-using namespace torch::jit::test;
+#include <c10/macros/Export.h>
 
 namespace torch {
 namespace jit {
@@ -106,34 +73,16 @@ namespace jit {
   _(ModuleConversion)           \
   _(Interp)
 
-#if defined(USE_GTEST)
+#define DECLARE_JIT_TEST(name) void test##name();
+TH_FORALL_TESTS(DECLARE_JIT_TEST)
+TH_FORALL_TESTS_CUDA(DECLARE_JIT_TEST)
+#undef DECLARE_JIT_TEST
 
-#define JIT_GTEST(name) \
-  TEST(JitTest, name) { \
-    test##name();       \
-  }
-TH_FORALL_TESTS(JIT_GTEST)
-#undef JIT_TEST
+// This test is special since it requires prior setup in python.
+// So it is not part of the general test list (which is shared between the gtest
+// and python test runners), but is instead invoked manually by the
+// torch_python_test.cpp
+void testEvalModeForLoadedModule();
 
-#define JIT_GTEST_CUDA(name)   \
-  TEST(JitTest, name##_CUDA) { \
-    test##name();              \
-  }
-TH_FORALL_TESTS_CUDA(JIT_GTEST_CUDA)
-#undef JIT_TEST_CUDA
-#endif
-
-#define JIT_TEST(name) test##name();
-TORCH_API void runJITCPPTests(bool runCuda) {
-  TH_FORALL_TESTS(JIT_TEST)
-  if (runCuda) {
-    TH_FORALL_TESTS_CUDA(JIT_TEST)
-  }
-
-  // This test is special since it requires prior setup in python.
-  // So it's included here but not in the pure cpp gtest suite
-  testEvalModeForLoadedModule();
-}
-#undef JIT_TEST
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/torch_python_test.cpp
+++ b/test/cpp/jit/torch_python_test.cpp
@@ -1,8 +1,14 @@
 #include <test/cpp/jit/tests.h>
+#include <c10/util/Exception.h>
 
 namespace torch {
 namespace jit {
 
+#if defined(_WIN32)
+void runJITCPPTests(bool runCuda) {
+  TORCH_INTERNAL_ASSERT("JIT tests not yet supported on Windows");
+}
+#else
 #define JIT_TEST(name) test##name();
 TORCH_API void runJITCPPTests(bool runCuda) {
   TH_FORALL_TESTS(JIT_TEST)
@@ -17,5 +23,6 @@ TORCH_API void runJITCPPTests(bool runCuda) {
   testEvalModeForLoadedModule();
 }
 #undef JIT_TEST
+#endif
 } // namespace jit
 } // namespace torch

--- a/test/cpp/jit/torch_python_test.cpp
+++ b/test/cpp/jit/torch_python_test.cpp
@@ -1,0 +1,21 @@
+#include <test/cpp/jit/tests.h>
+
+namespace torch {
+namespace jit {
+
+#define JIT_TEST(name) test##name();
+TORCH_API void runJITCPPTests(bool runCuda) {
+  TH_FORALL_TESTS(JIT_TEST)
+  if (runCuda) {
+    TH_FORALL_TESTS_CUDA(JIT_TEST)
+  }
+
+  // This test is special since it requires prior setup in python.
+  // So it is not part of the general test list (which is shared between the gtest
+  // and python test runners), but is instead invoked manually by the
+  // torch_python_test.cpp
+  testEvalModeForLoadedModule();
+}
+#undef JIT_TEST
+} // namespace jit
+} // namespace torch

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -439,6 +439,7 @@ def add_torch_libs():
         deps=[
             ":torch-cpp-cpu",
             ":thnn",
+            "//caffe2/test/cpp/jit:test",
             "//caffe2/torch/fb/init:init",
             "//caffe2/torch/lib/c10d:c10d_cpu",
             "//caffe2/torch/lib/libshm:libshm",
@@ -459,6 +460,7 @@ def add_torch_libs():
         deps=[
             ":torch-cpp-cuda",
             ":thnn",
+            "//caffe2/test/cpp/jit:test",
             "//caffe2/torch/fb/init:init",
             "//caffe2/torch/lib/c10d:c10d",
             "//caffe2/torch/lib/libshm:libshm",

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -105,6 +105,8 @@ set(TORCH_PYTHON_SRCS
     ${TORCH_SRC_DIR}/csrc/utils/tensor_numpy.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tensor_types.cpp
     ${TORCH_SRC_DIR}/csrc/utils/tuple_parser.cpp
+    ${TORCH_ROOT}/test/cpp/jit/torch_python_test.cpp
+    ${JIT_TEST_SRCS}
     )
 
 set(TORCH_PYTHON_INCLUDE_DIRECTORIES

--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -88,13 +88,7 @@ bool loadPythonClasses() {
 }
 } // anonymous namespace
 
-#if defined(_WIN32)
-void runJITCPPTests(bool runCuda) {
-  AT_ERROR("JIT tests not yet supported on Windows");
-}
-#else
-CAFFE2_API void runJITCPPTests(bool runCuda);
-#endif
+TORCH_API void runJITCPPTests(bool runCuda);
 
 void initJITBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();

--- a/torch/csrc/jit/testing/file_check.h
+++ b/torch/csrc/jit/testing/file_check.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <string>
+#include <memory>
 
 namespace torch {
 namespace jit {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24801 [jit] big cpp test reorg**

This is to fix the ODR-violations in fbcode static builds, which have been broken for several months. 

This PR is unfortunately quite large, but the changes are only mechanical:
1. Tests defined in header files -> tests defined in cpp files
2. Remove the `torch::jit::testing` namespace -> `torch::jit`.
3. Single `test.h` file that aggregates all tests.
4. Separate out files for gtest and python versions of the tests instead of using a build flag
5. Add a readme for how to add a new test, and explaining a bit about why the cpp tests are the way they are.

Differential Revision: [D16878605](https://our.internmc.facebook.com/intern/diff/D16878605)