### PR TITLE
[RFC] Move XLA build to clang7

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -16,7 +16,6 @@ CONFIG_TREE_DATA = [
             ("5.4", [
                 XImportant("3.6"),
                 ("3.6", [
-                    ("xla", [XImportant(True)]),
                     ("namedtensor", [XImportant(True)]),
                 ]),
             ]),
@@ -27,6 +26,11 @@ CONFIG_TREE_DATA = [
                 XImportant("3.6"),  # This is actually the ASAN build
                 ("3.6", [
                     ("namedtensor", [XImportant(True)]),  # ASAN
+                ]),
+            ]),
+            ("7", [
+                ("3.6", [
+                    ("xla", [XImportant(True)]),
                 ]),
             ]),
         ]),

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -193,6 +193,7 @@ def instantiate_configs():
 
         distro_name = fc.find_prop("distro_name")
         compiler_name = fc.find_prop("compiler_name")
+        is_xla = fc.find_prop("is_xla") or False
 
         python_version = None
         if compiler_name == "cuda" or compiler_name == "android":
@@ -217,7 +218,7 @@ def instantiate_configs():
             parms_list.append(gcc_version)
 
             # TODO: This is a nasty special case
-            if compiler_name == "clang":
+            if compiler_name == "clang" and not is_xla:
                 parms_list.append("asan")
                 python_version = fc.find_prop("pyver")
                 parms_list[0] = fc.find_prop("abbreviated_pyver")
@@ -226,7 +227,6 @@ def instantiate_configs():
             # TODO The gcc version is orthogonal to CUDA version?
             parms_list.append("gcc7")
 
-        is_xla = fc.find_prop("is_xla") or False
         is_namedtensor = fc.find_prop("is_namedtensor") or False
         is_important = fc.find_prop("is_important") or False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -775,19 +775,6 @@ jobs:
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
-  pytorch_xla_linux_xenial_py3_6_gcc5_4_build:
-    environment:
-      BUILD_ENVIRONMENT: pytorch-xla-linux-xenial-py3.6-gcc5.4-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:332"
-    <<: *pytorch_linux_build_defaults
-
-  pytorch_xla_linux_xenial_py3_6_gcc5_4_test:
-    environment:
-      BUILD_ENVIRONMENT: pytorch-xla-linux-xenial-py3.6-gcc5.4-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:332"
-    resource_class: large
-    <<: *pytorch_linux_test_defaults
-
   pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-py3.6-gcc5.4-build
@@ -841,6 +828,19 @@ jobs:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-py3-clang5-asan-test
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:332"
       PYTHON_VERSION: "3.6"
+    resource_class: large
+    <<: *pytorch_linux_test_defaults
+
+  pytorch_xla_linux_xenial_py3_6_clang7_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-xla-linux-xenial-py3.6-clang7-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:332"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_xla_linux_xenial_py3_6_clang7_test:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-xla-linux-xenial-py3.6-clang7-test
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:332"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
@@ -2685,13 +2685,6 @@ workflows:
           requires:
             - setup
             - pytorch_linux_xenial_py3_6_gcc5_4_build
-      - pytorch_xla_linux_xenial_py3_6_gcc5_4_build:
-          requires:
-            - setup
-      - pytorch_xla_linux_xenial_py3_6_gcc5_4_test:
-          requires:
-            - setup
-            - pytorch_xla_linux_xenial_py3_6_gcc5_4_build
       - pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build:
           requires:
             - setup
@@ -2730,6 +2723,13 @@ workflows:
           requires:
             - setup
             - pytorch_namedtensor_linux_xenial_py3_clang5_asan_build
+      - pytorch_xla_linux_xenial_py3_6_clang7_build:
+          requires:
+            - setup
+      - pytorch_xla_linux_xenial_py3_6_clang7_test:
+          requires:
+            - setup
+            - pytorch_xla_linux_xenial_py3_6_clang7_build
       - pytorch_linux_xenial_cuda9_cudnn7_py2_build:
           requires:
             - setup

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -45,7 +45,7 @@ default_set = [
     'pytorch-linux-xenial-py3-clang5-android-ndk-r19c',
 
     # XLA
-    'pytorch-xla-linux-xenial-py3.6-gcc5.4',
+    'pytorch-xla-linux-xenial-py3.6-clang7',
 
     # Other checks
     'pytorch-short-perf-test-gpu',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24814 [RFC] Move XLA build to clang7**
* #24506 [CI] Move CPU-only jobs to xenial

This will ensure that the build of PyTorch is consistent with the build of TF/XLA wrt ABI. Currently XLA/TF is hard-coded to use clang7 to build