### PR TITLE
Fix the RNN contiguous warning if the whole model parameters are flattened.

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1191,7 +1191,10 @@ Tensor try_get_weight_buf(
   // Try to get parameter storage
   auto & any_param = parameters.at(0);
   auto param_storage = any_param.storage();
-  auto weight_buf = at::empty({0}, any_param.options()).set_(param_storage);
+  auto param_offset = any_param.storage_offset();
+  std::initializer_list<int64_t> buffer_size = {
+    static_cast<int64_t>(param_storage.size()) - param_offset, 1};
+  auto weight_buf = at::empty({0}, any_param.options()).set_(param_storage, param_offset, buffer_size, {});
   if (weight_buf.size(0) < num_params) {
     return {};
   } else if (weight_buf.size(0) > num_params) {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1193,7 +1193,7 @@ Tensor try_get_weight_buf(
   auto param_storage = any_param.storage();
   auto param_offset = any_param.storage_offset();
   std::initializer_list<int64_t> buffer_size = {
-    static_cast<int64_t>(param_storage.size()) - param_offset, 1};
+    static_cast<int64_t>(param_storage.size()) - param_offset};
   auto weight_buf = at::empty({0}, any_param.options()).set_(param_storage, param_offset, buffer_size, {});
   if (weight_buf.size(0) < num_params) {
     return {};


### PR DESCRIPTION
Users may want to flatten the parameters of whole model to achieve high performance. For example, some of the MLPerf models submitted are using flattened parameters to reduce the number of CUDA kernels launched, especially there are tons of small parameters.

However, if the RNN parameters are copied to a new place, it will throw a lot of RNN contiguous warnings, although the RNN parameters are *flattened* at new place too.

This PR try to fix the problem by detecting the weight_buf with an offset, which will return the flattened weight_buf correctly and get rid of the RNN contiguous warnings.

As a simple example, please run following codes:

```python
#!/usr/bin/env python

import torch

torch.manual_seed(1234)
model = torch.nn.Sequential(
    torch.nn.Embedding(32320, 1024),
    torch.nn.LSTM(1024, 1024),
).cuda().half()

nelem = 0
for p in model.parameters():
    nelem += p.numel()

params = torch.empty(nelem, dtype=torch.half, device='cuda')
with torch.no_grad():
    ptr = 0
    for p in model.parameters():
        params[ptr:ptr+p.numel()].copy_(p.data.view(-1))
        p.set_(source=params.storage(), storage_offset=ptr, size=p.size())
        ptr += p.numel()

x = torch.randint(0, 32320, (128, 38), device='cuda')
y = model(x)

torch.cuda.synchronize()
print(y[0].sum())
``` 