### PR TITLE
Update docs for softmax in onnx supported operators

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -418,7 +418,7 @@ The following operators are supported:
 * sin
 * size
 * slice
-* softmax (only dim=-1 supported)
+* softmax
 * softplus
 * split
 * sqrt


### PR DESCRIPTION
Update the softmax in onnx supported operators from `softmax (only dim=-1 supported)` to `softmax`, as all cases of dim options are supported in:
[#18482](https://github.com/pytorch/pytorch/pull/18482): ONNX Export All Cases of Softmax