### PR TITLE
Fixed Error in Transformer Example

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -27,8 +27,8 @@ class Transformer(Module):
         custom_decoder: custom decoder (default=None).
 
     Examples::
-        >>> transformer_model = nn.Transformer(src_vocab, tgt_vocab)
-        >>> transformer_model = nn.Transformer(src_vocab, tgt_vocab, nhead=16, num_encoder_layers=12)
+        >>> transformer_model = nn.Transformer()
+        >>> transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12)
     """
 
     def __init__(self, d_model=512, nhead=8, num_encoder_layers=6,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -27,7 +27,6 @@ class Transformer(Module):
         custom_decoder: custom decoder (default=None).
 
     Examples::
-        >>> transformer_model = nn.Transformer()
         >>> transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12)
         >>> src = torch.rand((10, 32, 512))
         >>> tgt = torch.rand((20, 32, 512))
@@ -144,7 +143,7 @@ class TransformerEncoder(Module):
     Examples::
         >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
         >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6)
-        >>> src = torch.rand(10,32,512)
+        >>> src = torch.rand(10, 32, 512)
         >>> out = transformer_encoder(src)
     """
 
@@ -188,12 +187,9 @@ class TransformerDecoder(Module):
     Examples::
         >>> decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8)
         >>> transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers=6)
-        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
-        >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6)
-        >>> src = torch.rand(10,32,512)
-        >>> tgt = torch.rand(20,32,512)
-        >>> memory = transformer_encoder(src)
-        >>> out = transformer_decoder(tgt,memory)
+        >>> memory = torch.rand(10, 32, 512)
+        >>> tgt = torch.rand(20, 32, 512)
+        >>> out = transformer_decoder(tgt, memory)
         
     """
 
@@ -248,7 +244,7 @@ class TransformerEncoderLayer(Module):
 
     Examples::
         >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
-        >>> src = torch.rand(10,32,512)
+        >>> src = torch.rand(10, 32, 512)
         >>> out = encoder_layer(src)
     """
 
@@ -302,11 +298,9 @@ class TransformerDecoderLayer(Module):
 
     Examples::
         >>> decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8)
-        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
-        >>> src = torch.rand(10,32,512)
-        >>> tgt = torch.rand(20,32,512)
-        >>> memory = encoder_layer(src)
-        >>> out = decoder_layer(tgt,memory)
+        >>> memory = torch.rand(10, 32, 512)
+        >>> tgt = torch.rand(20, 32, 512)
+        >>> out = decoder_layer(tgt, memory)
     """
 
     def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1):

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -29,6 +29,9 @@ class Transformer(Module):
     Examples::
         >>> transformer_model = nn.Transformer()
         >>> transformer_model = nn.Transformer(nhead=16, num_encoder_layers=12)
+        >>> src = torch.rand((10, 32, 512))
+        >>> tgt = torch.rand((20, 32, 512))
+        >>> out = transformer_model(src, tgt)
     """
 
     def __init__(self, d_model=512, nhead=8, num_encoder_layers=6,
@@ -139,8 +142,10 @@ class TransformerEncoder(Module):
         norm: the layer normalization component (optional).
 
     Examples::
-        >>> encoder_layer = nn.TransformerEncoderLayer(d_model, nhead)
-        >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers)
+        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6)
+        >>> src = torch.rand(10,32,512)
+        >>> out = transformer_encoder(src)
     """
 
     def __init__(self, encoder_layer, num_layers, norm=None):
@@ -181,8 +186,15 @@ class TransformerDecoder(Module):
         norm: the layer normalization component (optional).
 
     Examples::
-        >>> decoder_layer = nn.TransformerDecoderLayer(d_model, nhead)
-        >>> transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers)
+        >>> decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        >>> transformer_decoder = nn.TransformerDecoder(decoder_layer, num_layers=6)
+        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        >>> transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=6)
+        >>> src = torch.rand(10,32,512)
+        >>> tgt = torch.rand(20,32,512)
+        >>> memory = transformer_encoder(src)
+        >>> out = transformer_decoder(tgt,memory)
+        
     """
 
     def __init__(self, decoder_layer, num_layers, norm=None):
@@ -235,7 +247,9 @@ class TransformerEncoderLayer(Module):
         dropout: the dropout value (default=0.1).
 
     Examples::
-        >>> encoder_layer = nn.TransformerEncoderLayer(d_model, nhead)
+        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        >>> src = torch.rand(10,32,512)
+        >>> out = encoder_layer(src)
     """
 
     def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1):
@@ -287,7 +301,12 @@ class TransformerDecoderLayer(Module):
         dropout: the dropout value (default=0.1).
 
     Examples::
-        >>> decoder_layer = nn.TransformerDecoderLayer(d_model, nhead)
+        >>> decoder_layer = nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        >>> src = torch.rand(10,32,512)
+        >>> tgt = torch.rand(20,32,512)
+        >>> memory = encoder_layer(src)
+        >>> out = decoder_layer(tgt,memory)
     """
 
     def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1):


### PR DESCRIPTION
In the examples for creating an instance of the Transformer module, src and tgt parameters (from forward) were added which are not present in the __init__ .

