### PR TITLE
Templatize Tensor.data_ptr()

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -280,12 +280,13 @@ class CAFFE2_API Tensor {
   /// TensorOptions.h.
   TensorOptions options() const;
 
-  void* data_ptr() const {
-    return this->unsafeGetTensorImpl()->data();
-  }
+  template <typename T = void>
+  T * data_ptr() const;
 
   template<typename T>
-  T * data() const;
+  T * data() const {
+    return data_ptr<T>();
+  }
 
   template <typename T>
   T item() const;

--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -280,7 +280,11 @@ class CAFFE2_API Tensor {
   /// TensorOptions.h.
   TensorOptions options() const;
 
-  template <typename T = void>
+  void* data_ptr() const {
+    return this->unsafeGetTensorImpl()->data();
+  }
+
+  template <typename T>
   T * data_ptr() const;
 
   template<typename T>

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1850,11 +1850,6 @@ inline bool is_quantized(Tensor self) {
   return self.is_quantized();
 }
 
-template <>
-inline void* Tensor::data_ptr() const {
-  return this->unsafeGetTensorImpl()->data();
-}
-
 #define DEFINE_CAST(T, name)                     \
   template <>                                    \
   inline T* Tensor::data_ptr() const {           \

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -1850,16 +1850,21 @@ inline bool is_quantized(Tensor self) {
   return self.is_quantized();
 }
 
+template <>
+inline void* Tensor::data_ptr() const {
+  return this->unsafeGetTensorImpl()->data();
+}
+
 #define DEFINE_CAST(T, name)                     \
   template <>                                    \
-  inline T* Tensor::data() const {               \
+  inline T* Tensor::data_ptr() const {           \
     TORCH_CHECK(                                 \
         scalar_type() == ScalarType::name,       \
         "expected scalar type ",                 \
         #name,                                   \
         " but found ",                           \
         c10::toString(scalar_type()));           \
-    return static_cast<T*>(this->data_ptr());    \
+    return static_cast<T*>(this->unsafeGetTensorImpl()->data());    \
   }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -280,12 +280,13 @@ class CAFFE2_API Tensor {
   /// TensorOptions.h.
   TensorOptions options() const;
 
-  void* data_ptr() const {
-    return this->unsafeGetTensorImpl()->data();
-  }
+  template <typename T = void>
+  T * data_ptr() const;
 
   template<typename T>
-  T * data() const;
+  T * data() const {
+    return data_ptr<T>();
+  }
 
   template <typename T>
   T item() const;

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -280,7 +280,11 @@ class CAFFE2_API Tensor {
   /// TensorOptions.h.
   TensorOptions options() const;
 
-  template <typename T = void>
+  void* data_ptr() const {
+    return this->unsafeGetTensorImpl()->data();
+  }
+
+  template <typename T>
   T * data_ptr() const;
 
   template<typename T>

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -143,11 +143,6 @@ inline bool is_quantized(Tensor self) {
   return self.is_quantized();
 }
 
-template <>
-inline void* Tensor::data_ptr() const {
-  return this->unsafeGetTensorImpl()->data();
-}
-
 #define DEFINE_CAST(T, name)                     \
   template <>                                    \
   inline T* Tensor::data_ptr() const {           \

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -143,16 +143,21 @@ inline bool is_quantized(Tensor self) {
   return self.is_quantized();
 }
 
+template <>
+inline void* Tensor::data_ptr() const {
+  return this->unsafeGetTensorImpl()->data();
+}
+
 #define DEFINE_CAST(T, name)                     \
   template <>                                    \
-  inline T* Tensor::data() const {               \
+  inline T* Tensor::data_ptr() const {           \
     TORCH_CHECK(                                 \
         scalar_type() == ScalarType::name,       \
         "expected scalar type ",                 \
         #name,                                   \
         " but found ",                           \
         c10::toString(scalar_type()));           \
-    return static_cast<T*>(this->data_ptr());    \
+    return static_cast<T*>(this->unsafeGetTensorImpl()->data());    \
   }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)

--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -304,3 +304,10 @@ TEST(TensorTest, Item_CUDA) {
     ASSERT_EQ(scalar.to<int>(), 123);
   }
 }
+
+TEST(TensorTest, DataPtr) {
+  auto tensor = at::empty({3, 4}, at::kFloat);
+  auto tensor_not_copy = tensor.to(tensor.options());
+  ASSERT_EQ(tensor_not_copy.data_ptr<float>(), tensor.data_ptr<float>());
+  ASSERT_EQ(tensor_not_copy.data_ptr(), tensor.data_ptr());
+}


### PR DESCRIPTION
This PR templatizes `Tensor.data_ptr()`, to prepare for the deprecation of `Tensor.data<T>()` and introduction of `Tensor.data()` that has the same semantics as `Variable.data()`.