### PR TITLE
[jit] Fix missing `super` call error

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14233,6 +14233,17 @@ class TestRecursiveScript(JitTestCase):
 
         return sm
 
+    def test_init_error(self):
+        class M(nn.Module):
+            def __init__(self):
+                self.x = 2
+
+            def forward(self):
+                pass
+
+        with self.assertRaisesRegex(RuntimeError, "has not been initialized"):
+            torch.jit.script(M())
+
     def test_module_name(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -12,10 +12,6 @@ def copy_to_script_module(original, stubs):
     Copies the parameters, buffers, constants, attributes, and submodules
     of an nn.Module into itself.
     """
-    if not hasattr(original, '_parameters'):
-        raise RuntimeError("'{}' has not been initialized, did you forget to call 'super()'?"
-                           .format(type(original).__name__))
-
     qualified_name = torch.jit._qualified_name(type(original))
     script_module = torch.jit.ScriptModule(_qualified_name=qualified_name)
 
@@ -111,6 +107,10 @@ def recursive_script(mod, exclude_methods=()):
     if isinstance(mod, (torch.nn.ModuleList, torch.nn.Sequential)):
         # Create constant versions for the iterable modules
         return create_constant_iterable_module(mod)
+
+    if not hasattr(mod, '_parameters'):
+        raise RuntimeError("'{}' has not been initialized, did you forget to call 'super()'?"
+                           .format(type(mod).__name__))
 
     methods = ()
     if hasattr(mod, 'forward'):


### PR DESCRIPTION

This was happening too late in the copying code

Differential Revision: [D16902742](https://our.internmc.facebook.com/intern/diff/16902742/)