### PR TITLE
[ROCm] For int64_t atomicAdd, use the available compiler builtin on ROCm.

### DIFF
--- a/aten/src/THC/THCAtomics.cuh
+++ b/aten/src/THC/THCAtomics.cuh
@@ -92,7 +92,11 @@ static inline  __device__ void atomicAdd(int16_t *address, int16_t val) {
 }
 
 static inline __device__ void atomicAdd(int64_t *address, int64_t val) {
+#ifdef __HIP_PLATFORM_HCC__
+  __atomic_fetch_add(address, val, __ATOMIC_RELAXED);
+#else
   AtomicAddIntegerImpl<int64_t, sizeof(int64_t)>()(address, val);
+#endif
 }
 
 static inline __device__ void atomicAdd(bool *address, bool val) {


### PR DESCRIPTION
Do not use the explicit CAS loop. This will perform better if there is
any contention. Since this feature is ROCm-only, the HIP layer provides no
helper function.

