### PR TITLE
Improve c10 dispatcher lookup perf

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -7,6 +7,62 @@
 
 namespace c10 {
 namespace impl {
+  class OperatorEntry;
+}
+
+/**
+ * This class represents an operator kernel, i.e. an operator *after* it was
+ * dispatched to a certain device. You can use it to call the kernel.
+ *
+ * You can keep this OpKernel instance around to avoid future dispatch
+ * when you know it'd dispatch to the same kernel anyhow.
+ *
+ * Also, keeping around the OpKernel instance will keep around a local cache
+ * that is used by some kernels to get better performance when they're called
+ * multiple times (mostly Caffe2 kernels do that).
+ *
+ * OpKernel is only threadsafe if the kernel is threadsafe. There are no mutexes
+ * protecting the kernel cache, so if the kernel uses the cache and doesn't have
+ * mutexes for it, it will likely not be threadsafe.
+ */
+class CAFFE2_API OpKernel final {
+public:
+  OpKernel(OpKernel&&) noexcept = default;
+  OpKernel& operator=(OpKernel&&) noexcept = default;
+  OpKernel(const OpKernel&) = delete;
+  OpKernel& operator=(const OpKernel&) = delete;
+
+  /**
+   * Call the operator kernel with the given arguments.
+   */
+  void call(Stack* stack) const {
+    // TODO Make boxed kernels mandatory and remove this check
+    TORCH_CHECK(nullptr != kernel_, "Tried to call OpKernel::call() for a kernel that doesn't have an boxed version.");
+
+    return (*kernel_)(stack, cache_.get());
+  }
+
+  template<class Result, class... Args>
+  Result callUnboxed(Args... args) const {
+    // TODO Should we box and call the boxed kernel instead of failing?
+    TORCH_CHECK(nullptr != unboxed_kernel_, "Tried to call OpKernel::callUnboxed() for a kernel that doesn't have an unboxed version.");
+
+    using OpSignature = Result (c10::KernelCache*, Args...);
+    OpSignature* kernel = reinterpret_cast<OpSignature*>(unboxed_kernel_);
+    return (*kernel)(cache_.get(), std::forward<Args>(args)...);
+  }
+
+private:
+  explicit OpKernel(KernelFunction* kernel, const KernelCacheCreatorFunction& cache_creator, void* unboxed_kernel)
+  : kernel_(kernel), cache_(cache_creator()), unboxed_kernel_(unboxed_kernel) {}
+  friend class impl::OperatorEntry;
+
+  KernelFunction* kernel_; // can be nullptr, not all kernels have this
+  std::unique_ptr<c10::KernelCache> cache_;
+  void* unboxed_kernel_; // can be nullptr, not all kernels have this
+};
+
+namespace impl {
 
 // This is a private class used inside the Dispatcher to represent an operator
 // and its dispatch table. This is not part of the public API.
@@ -23,15 +79,17 @@ public:
     return schema_;
   }
 
-  DispatchTableEntry lookupKernel(const Stack* stack) const {
+  OpKernel lookupKernel(const Stack* stack) const {
     return dispatchTable_.read([&] (const DispatchTable& dispatchTable) {
-      return dispatchTable.lookup(stack);
+      const DispatchTableEntry& kernel = dispatchTable.lookup(stack);
+      return OpKernel(kernel.kernel_func, kernel.cache_creator_func, kernel.unboxed_kernel_func);
     });
   }
 
-  DispatchTableEntry lookupKernel(TensorTypeId dispatchKey) const {
+  OpKernel lookupKernel(TensorTypeId dispatchKey) const {
     return dispatchTable_.read([&] (const DispatchTable& dispatchTable) {
-      return dispatchTable.lookup(dispatchKey);
+      const DispatchTableEntry& kernel = dispatchTable.lookup(dispatchKey);
+      return OpKernel(kernel.kernel_func, kernel.cache_creator_func, kernel.unboxed_kernel_func);
     });
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24882 Improve c10 dispatcher lookup perf**

Previously, looking up a kernel accidentally copied the DispatchTableEntry, which has as its member a std::function cache creator function.
Being an std::function, it was expensive to copy and cost us more than 50ns on each op call.
This diff fixes this by not copying DispatchTableEntry anymore.

Differential Revision: [D16910530](https://our.internmc.facebook.com/intern/diff/D16910530/)