### PR TITLE
Use a ptr to store autograd profiler rng

### DIFF
--- a/torch/csrc/autograd/record_function.cpp
+++ b/torch/csrc/autograd/record_function.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/autograd/record_function.h>
 #include <torch/csrc/autograd/function.h>
+#include <torch/csrc/utils/memory.h>
 
 #include <cstdlib>
 #include <random>
@@ -82,9 +83,10 @@ class CallbackManager {
   double sampling_prob = 1.0;
 
   static double sample_zero_one() {
-    static thread_local auto gen = std::mt19937(std::random_device()());
+    static thread_local auto gen =
+        torch::make_unique<std::mt19937>(std::random_device()());
     std::uniform_real_distribution<double> dist(0.0, 1.0);
-    return dist(gen);
+    return dist(*gen);
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24889 Use a ptr to store autograd profiler rng**

Trying to fix #2575. [Here](https://gist.github.com/suo/7b0bc4b49d3c9e095b9f7eef8fa7c6e8) is all TLS in libtorch.so (thanks @ezyang for figuring how to find this)

I noticed that `CallbackManager::sample_zero_one()::gen` has size 5000,
which seems a lot bigger than the other ones. So make it heap-allocated
instead.

Caveat: I have no idea if this will actually fix anything, or whether
making this variable heap-allocated is a bad idea.

Differential Revision: [D16912540](https://our.internmc.facebook.com/intern/diff/D16912540)