### PR TITLE
Add qconv_test to benchmarking tests

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_all_test.py
+++ b/benchmarks/operator_benchmark/benchmark_all_test.py
@@ -7,7 +7,7 @@ import operator_benchmark as op_bench
 from pt import ( # noqa
     add_test, batchnorm_test, cat_test, chunk_test, conv_test, # noqa
     gather_test, linear_test, matmul_test, pool_test, # noqa
-    softmax_test, split_test, unary_test # noqa
+    softmax_test, split_test, unary_test, qconv_test, qlinear_test # noqa
 )
 
 


### PR DESCRIPTION
Summary:
Adds the tests defined in `qconv_tests.py` to `benchmark_all_tests.py` so that they are ran by `benchmark_all_tests`.

The next diff will create another `ai_benchmark_test` specifying the qconv operations similar to D16768680. Since AI-PEP integrates with benchmark_all_tests, this should add these qconv benchmarks to AI-PEP.

Differential Revision: D16908445

