### PR TITLE
Attempt to fix windows build.

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -301,7 +301,7 @@ struct CAFFE2_API VaryingShape {
   VaryingShape(c10::ArrayRef<int64_t> vec)
       : VaryingShape(ListOfOptionalInts(vec.begin(), vec.end())){}
 
-  VaryingShape(c10::optional<size_t> size = c10::nullopt) {
+  VaryingShape(c10::optional<size_t> size = c10::nullopt) : dims_(c10::nullopt) {
     if (size) {
       dims_ = ListOfOptionalInts(*size);
     }


### PR DESCRIPTION
It looks like https://github.com/pytorch/pytorch/pull/24455 broke the windows build, probably an instance of:
https://github.com/pytorch/pytorch/issues/12117.

I don't have a windows machine handy and I'm not sure:
1) what the rules are with dependent constructors
2) if the type is used transitively

but this is a minimal attempt at fixing.

