### PR TITLE
[wip][jit] Add function templating

### DIFF
--- a/torch/csrc/jit/script/python_sugared_value.h
+++ b/torch/csrc/jit/script/python_sugared_value.h
@@ -121,6 +121,24 @@ struct VISIBILITY_HIDDEN OverloadedMethodValue : public SugaredValue {
   std::vector<std::string> method_names_;
 };
 
+struct VISIBILITY_HIDDEN TemplatedFunctionValue : public PythonValue {
+  TemplatedFunctionValue(py::object callee) : PythonValue(std::move(callee)) {}
+
+  std::string kind() const override {
+    return "templated function";
+  }
+
+  std::shared_ptr<SugaredValue> call(
+      const SourceRange& loc,
+      Function& f,
+      at::ArrayRef<NamedValue> inputs,
+      at::ArrayRef<NamedValue> attributes,
+      size_t n_binders) override;
+
+ private:
+  py::object callee_;
+};
+
 struct VISIBILITY_HIDDEN OverloadedFunctionValue : public SugaredValue {
   OverloadedFunctionValue(std::vector<StrongFunctionPtr> compiled_overloads)
       : compiled_overloads_(std::move(compiled_overloads)) {}

--- a/torch/csrc/jit/script/tree_views.h
+++ b/torch/csrc/jit/script/tree_views.h
@@ -386,6 +386,10 @@ struct Decl : public TreeView {
       const Maybe<Expr>& return_type) {
     return Decl(Compound::create(TK_DECL, range, {params, return_type}));
   }
+
+  Decl withParams(const List<Param> new_params) {
+    return Decl(Compound::create(TK_DECL, range(), {new_params, return_type()}));
+  }
 };
 
 struct Def : public TreeView {

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -164,7 +164,7 @@ def make_strong_submodule(field, module, parent):
     return new_strong_submodule
 
 
-def try_compile_fn(fn, loc):
+def try_compile_fn(fn, loc, _arg_types=None):
     if _jit_internal.is_ignored_fn(fn):
         # Don't do anything for @ignore'd functions
         return None
@@ -183,7 +183,8 @@ def try_compile_fn(fn, loc):
     # extract the necessary info from the closed over variables on the function
     # object
     rcb = _jit_internal.createResolutionCallbackFromClosure(fn)
-    return torch.jit.script(fn, _rcb=rcb)
+    qualified_name = torch.jit._qualified_name(fn)
+    return torch.jit._compile_function(fn, qualified_name, _frames_up=0, _rcb=rcb, _arg_types=_arg_types)
 
 
 def create_constant_iterable_module(module):

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -37,6 +37,25 @@ _eval_env = {
 }
 
 
+def has_signature(fn):
+    if PY35:
+        sig = try_real_annotations(fn)
+        if sig is not None:
+            return True
+
+    type_line = None
+    try:
+        source = dedent(inspect.getsource(fn))
+        type_line = get_type_line(source)
+    except TypeError:
+        pass
+
+    if type_line is None:
+        return False
+
+    return True
+
+
 def get_signature(fn):
     # Python 3.5 adds support for the nice annotation syntax, so try that first.
     if PY35:


### PR DESCRIPTION


On recursively compiled functions, if there are no types present on the function declaration, use the types of the arguments passed at the call site to compile the function instead of assuming everything is a Tensor. This makes converting models easier since you generally won't need to explicitly annotate types and also allows for more generic code.

Limitations / Follow Ups
* Class methods
* Class types can't be used as arguments
* It isn't clear how the function was compiled for template instantiation errors
* Errors on mismatched signatures (e.g. too many arguments) are bad

Differential Revision: [D16928487](https://our.internmc.facebook.com/intern/diff/16928487/)