### PR TITLE
Disable the copy constructor and = operator of DispatchStub

### DIFF
--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -59,6 +59,10 @@ template <typename rT, typename T, typename... Args>
 struct CAFFE2_API DispatchStub<rT (*)(Args...), T> {
   using FnPtr = rT (*) (Args...);
 
+  DispatchStub() = default;
+  DispatchStub(const DispatchStub&) = delete;
+  DispatchStub& operator=(const DispatchStub&) = delete;
+
   template <typename... ArgTypes>
   rT operator()(DeviceType device_type, ArgTypes&&... args) {
     if (device_type == DeviceType::CPU) {
@@ -131,7 +135,11 @@ struct RegisterHIPDispatch {
 // not work with MSVC. So do a `using`-declaration if you need to pass in such
 // `fn`, e.g., grid_sampler_2d_backward_cpu_kernel in GridSampleKernel.h.
 #define DECLARE_DISPATCH(fn, name)         \
-  struct name : DispatchStub<fn, name> {}; \
+  struct name : DispatchStub<fn, name> {   \
+    name() = default;                      \
+    name(const name&) = delete;            \
+    name& operator=(const name&) = delete; \
+  };                                       \
   extern CAFFE2_API struct name name
 
 #define DEFINE_DISPATCH(name) struct name name


### PR DESCRIPTION
They are not supposed to be copied.

