### PR TITLE
[docs] Added documentation for nn.functional.bilinear 

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -244,7 +244,7 @@ class _TestTorchMixin(torchtest):
                        'rename',  # BUILD_NAMEDTENSOR only
                        )
         test_namespace(torch.nn)
-        test_namespace(torch.nn.functional, 'assert_int_or_pair', 'bilinear', 'feature_alpha_dropout')
+        test_namespace(torch.nn.functional, 'assert_int_or_pair', 'feature_alpha_dropout')
         # TODO: add torch.* tests when we have proper namespacing on ATen functions
         # test_namespace(torch)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1384,11 +1384,15 @@ def bilinear(input1, input2, weight, bias=None):
 
     Shape:
 
-        - input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}=\text{in1\features}` and :math:`*` means any number of additional dimensions. All but the last dimension of the inputs should be the same.
+        - input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}=\text{in1\features}`
+          and :math:`*` means any number of additional dimensions.
+          All but the last dimension of the inputs should be the same.
         - input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}=\text{in2\features}`
-        - weight: :math:`(\text{out\_features}, \text{in1\_features}, \text{in2\_features})`
+        - weight: :math:`(\text{out\_features}, \text{in1\_features},
+          \text{in2\_features})`
         - bias: :math:`(\text{out\_features})`
-        - output: :math:`(N, *, H_{out})` where :math:`H_{out}=\text{out\_features}` and all but the last dimension are the same shape as the input.
+        - output: :math:`(N, *, H_{out})` where :math:`H_{out}=\text{out\_features}`
+          and all but the last dimension are the same shape as the input.
     """
     return torch.bilinear(input1, input2, weight, bias)
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1380,14 +1380,15 @@ def linear(input, weight, bias=None):
 def bilinear(input1, input2, weight, bias=None):
     # type: (Tensor, Tensor, Tensor, Optional[Tensor]) -> Tensor
     r"""
-    Applies a bilinear transformation to the incoming data: :math:`y = x_1 A x_2 + b`
+    Applies a bilinear transformation to the incoming data:
+    :math:`y = x_1 A x_2 + b`
 
     Shape:
 
-        - input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}=\text{in1\features}`
+        - input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}=\text{in1\_features}`
           and :math:`*` means any number of additional dimensions.
           All but the last dimension of the inputs should be the same.
-        - input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}=\text{in2\features}`
+        - input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}=\text{in2\_features}`
         - weight: :math:`(\text{out\_features}, \text{in1\_features},
           \text{in2\_features})`
         - bias: :math:`(\text{out\_features})`

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1379,6 +1379,17 @@ def linear(input, weight, bias=None):
 
 def bilinear(input1, input2, weight, bias=None):
     # type: (Tensor, Tensor, Tensor, Optional[Tensor]) -> Tensor
+    r"""
+    Applies a bilinear transformation to the incoming data: :math:`y = x_1 A x_2 + b`
+
+    Shape:
+
+        - input1: :math:`(N, *, H_{in1})` where :math:`H_{in1}=\text{in1\features}` and :math:`*` means any number of additional dimensions. All but the last dimension of the inputs should be the same.
+        - input2: :math:`(N, *, H_{in2})` where :math:`H_{in2}=\text{in2\features}`
+        - weight: :math:`(\text{out\_features}, \text{in1\_features}, \text{in2\_features})`
+        - bias: :math:`(\text{out\_features})`
+        - output: :math:`(N, *, H_{out})` where :math:`H_{out}=\text{out\_features}` and all but the last dimension are the same shape as the input.
+    """
     return torch.bilinear(input1, input2, weight, bias)
 
 


### PR DESCRIPTION
Adds documentation for `nn.functional.bilinear`, as requested in #9886.

The format follows that of `nn.functional.linear`, and borrows from `nn.bilinear` in its description of `Tensor` shapes.

I am happy to add more extensive documentation (e.g. "Args," "Example(s)"). From what I gather, the format of comments is inconsistent across functions in `nn.functional.py` and between modules (e.g. `nn.functional` and `nn`). It's my first PR, so guidance for contributing documentation and other code would be greatly appreciated!