### PR TITLE
[jit] restore default constructor of OutputArchive

### DIFF
--- a/torch/csrc/api/include/torch/serialize/output-archive.h
+++ b/torch/csrc/api/include/torch/serialize/output-archive.h
@@ -26,6 +26,7 @@ namespace serialize {
 class TORCH_API OutputArchive final {
  public:
   explicit OutputArchive(std::shared_ptr<jit::script::CompilationUnit> cu);
+  explicit OutputArchive() : cu_(std::make_shared<jit::script::CompilationUnit>()) {}
 
   // Move is allowed.
   OutputArchive(OutputArchive&&) = default;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#24955 [jit] restore default constructor of OutputArchive**

Some third-party code relies on this default constructor. It's not
invalid to construct an OuputArchive with an indepednent CU, so
restoring it.

Differential Revision: [D16935254](https://our.internmc.facebook.com/intern/diff/D16935254)