### PR TITLE
Update sparse_adam.py

### DIFF
--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -33,6 +33,15 @@ class SparseAdam(Optimizer):
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
         defaults = dict(lr=lr, betas=betas, eps=eps)
         super(SparseAdam, self).__init__(params, defaults)
+        
+       for group in self.param_groups:
+            for p in group['params']:
+                state = self.state[p]
+                state['step'] = 0
+                # Exponential moving average of gradient values
+                state['exp_avg'] = torch.zeros_like(p.data)
+                # Exponential moving average of squared gradient values
+                state['exp_avg_sq'] = torch.zeros_like(p.data)
 
     def step(self, closure=None):
         """Performs a single optimization step.
@@ -54,15 +63,7 @@ class SparseAdam(Optimizer):
                     raise RuntimeError('SparseAdam does not support dense gradients, please consider Adam instead')
 
                 state = self.state[p]
-
-                # State initialization
-                if len(state) == 0:
-                    state['step'] = 0
-                    # Exponential moving average of gradient values
-                    state['exp_avg'] = torch.zeros_like(p.data)
-                    # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = torch.zeros_like(p.data)
-
+                
                 state['step'] += 1
 
                 grad = grad.coalesce()  # the update is non-linear so indices must be unique


### PR DESCRIPTION
state['step'] = 0 , state['exp_avg'] , and state['exp_avg_sq'] are initialized during the optimizers  __init__ method, instead of during the first step.

This way the optimizer doesn't have to check if it's been initialized at each step. The code is also slightly more compact and easier to follow. 

The main motivation for this change is that I am doing manipulations of the 'exp_avg' and 'exp_avg_sq' for this optimizer, and in order to initialize the code for this, I have to initialize the first step before the main training loop. 

Not a big deal for me, but to others building off my code, it adds a bit of friction in understanding what my code is doing, since I have to give an explanation of why I have to put the first optimizer step outside the main training loop. 
