### PR TITLE
Update on "[CI] Enable trusty with GCC 7 on diffs"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2681,10 +2681,20 @@ workflows:
       - pytorch_linux_trusty_py3_6_gcc5_4_build:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
       - pytorch_linux_trusty_py3_6_gcc5_4_test:
           requires:
             - setup
             - pytorch_linux_trusty_py3_6_gcc5_4_build
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
       - pytorch_xla_linux_trusty_py3_6_gcc5_4_build:
           requires:
             - setup
@@ -2702,20 +2712,10 @@ workflows:
       - pytorch_linux_trusty_py3_6_gcc7_build:
           requires:
             - setup
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
       - pytorch_linux_trusty_py3_6_gcc7_test:
           requires:
             - setup
             - pytorch_linux_trusty_py3_6_gcc7_build
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
       - pytorch_linux_xenial_py3_clang5_asan_build:
           requires:
             - setup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D16862005](https://our.internmc.facebook.com/intern/diff/D16862005)

This will give us diff signal for CPU-only builds with FBGEMM enabled, ensuring quantization gets timely signal