### PR TITLE
Update on "[CI] Enable trusty with GCC 7 on diffs"

### DIFF
--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -17,7 +17,7 @@ default_set = [
     # PyTorch ASAN
     'pytorch-linux-xenial-py3-clang5-asan',
     # PyTorch DEBUG
-    'pytorch-linux-trusty-py3.6-gcc5.4',
+    'pytorch-linux-trusty-py3.6-gcc7',
 
     # Caffe2 CPU
     'caffe2-py2-mkl-ubuntu16.04',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D16862005](https://our.internmc.facebook.com/intern/diff/D16862005)

This will give us diff signal for CPU-only builds with FBGEMM enabled, ensuring quantization gets timely signal