### PR TITLE
Update on "[CI] Enable trusty with GCC 7 on diffs"

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -20,10 +20,13 @@ CONFIG_TREE_DATA = [
                     ("namedtensor", [XImportant(True)]),
                 ]),
             ]),
-            ("7", [XImportant("3.6")]),
+            ("7", [X("3.6")]),
         ]),
     ]),
     ("xenial", [
+        ("gcc", [
+            ("7", [XImportant("3.6")]),
+        ]),
         ("clang", [
             ("5", [
                 XImportant("3.6"),  # This is actually the ASAN build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,6 +814,21 @@ jobs:
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
+  pytorch_linux_xenial_py3_gcc7_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-gcc7-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-gcc7:327"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_gcc7_test:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-gcc7-test
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-gcc7:327"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    <<: *pytorch_linux_test_defaults
+
   pytorch_linux_xenial_py3_clang5_asan_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-asan-build
@@ -2712,10 +2727,27 @@ workflows:
       - pytorch_linux_trusty_py3_6_gcc7_build:
           requires:
             - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
       - pytorch_linux_trusty_py3_6_gcc7_test:
           requires:
             - setup
             - pytorch_linux_trusty_py3_6_gcc7_build
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+      - pytorch_linux_xenial_py3_gcc7_build:
+          requires:
+            - setup
+      - pytorch_linux_xenial_py3_gcc7_test:
+          requires:
+            - setup
+            - pytorch_linux_xenial_py3_gcc7_build
       - pytorch_linux_xenial_py3_clang5_asan_build:
           requires:
             - setup

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -17,7 +17,7 @@ default_set = [
     # PyTorch ASAN
     'pytorch-linux-xenial-py3-clang5-asan',
     # PyTorch DEBUG
-    'pytorch-linux-trusty-py3.6-gcc7',
+    'pytorch_linux_xenial_py3_gcc7',
 
     # Caffe2 CPU
     'caffe2-py2-mkl-ubuntu16.04',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D16862005](https://our.internmc.facebook.com/intern/diff/D16862005)

This will give us diff signal for CPU-only builds with FBGEMM enabled, ensuring quantization gets timely signal