### PR TITLE
Update on "[CI] Enable CPU-only xenial with GCC 7 on diffs"

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -4,7 +4,7 @@ from cimodel.lib.conf_tree import ConfigNode, X, XImportant
 
 
 CONFIG_TREE_DATA = [
-    ("trusty", [
+    ("xenial", [
         (None, [
             XImportant("2.7.9"),
             X("2.7"),
@@ -21,11 +21,6 @@ CONFIG_TREE_DATA = [
                 ]),
             ]),
             ("7", [X("3.6")]),
-        ]),
-    ]),
-    ("xenial", [
-        ("gcc", [
-            ("7", [XImportant("3.6")]),
         ]),
         ("clang", [
             ("5", [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D16862005](https://our.internmc.facebook.com/intern/diff/D16862005)

This will give us diff signal for CPU-only builds with FBGEMM enabled, ensuring quantization gets timely signal