### PR TITLE
Update on "[CI] Enable CPU-only xenial with GCC 7 on diffs"

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -14,7 +14,7 @@ CONFIG_TREE_DATA = [
         ("gcc", [
             ("4.8", [X("3.6")]),
             ("5.4", [
-                X("3.6"),
+                XImportant("3.6"),
                 ("3.6", [
                     ("xla", [XImportant(True)]),
                     ("namedtensor", [XImportant(True)]),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D16862005](https://our.internmc.facebook.com/intern/diff/D16862005)

This will give us diff signal for CPU-only builds with FBGEMM enabled, ensuring quantization gets timely signal