### PR TITLE
[pytorch][mobile] disable custom class logic for mobile build to avoid rtti

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -578,6 +578,9 @@ struct StrongTypePtr {
 };
 
 TORCH_API std::unordered_map<std::string, c10::StrongTypePtr>& getCustomClassTypeMap();
+
+#ifndef C10_MOBILE
+
 template<typename T>
 c10::StrongTypePtr getCustomClassType() {
   auto tmap = c10::getCustomClassTypeMap();
@@ -593,6 +596,20 @@ inline bool isCustomClassRegistered() {
   auto tmap = c10::getCustomClassTypeMap();
   return tmap.find(typeid(T).name()) != tmap.end();
 }
+
+#else  // C10_MOBILE
+
+template<typename T>
+c10::StrongTypePtr getCustomClassType() {
+  throw c10::Error("Custom class is not supported on mobile.", "");
+}
+
+template<typename T>
+inline bool isCustomClassRegistered() {
+  return false;
+}
+
+#endif  // C10_MOBILE
 
 TORCH_API std::unordered_map<std::string, std::function<PyObject*(void*)>>&
 getClassConverter();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25001 [pytorch][mobile] get rid of dynamic_cast in Quantizer
* **#24994 [pytorch][mobile] disable custom class logic for mobile build to avoid rtti**
* #24993 [pytorch][buck] small change for lite-interpreter build
* #24992 [pytorch][buck] add new source file

Use C10_MOBILE to gate CustomClass lookup logic for mobile build, which uses
typeid() and requires "-frtti" which is off by default for internal mobile build.

Not sure whether we ever need CustomClass for internal use cases. Feel the change
is not too intrusive - but I'm willing to hear others' thoughts.

Differential Revision: [D16951430](https://our.internmc.facebook.com/intern/diff/D16951430/)