### PR TITLE
[ONNX] Momentum setting in SyncBatchNorm forward (inference) pass.

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -58,7 +58,7 @@ class _BatchNorm(Module):
     def forward(self, input):
         self._check_input_dim(input)
 
-        # exponential_average_factor is self.momentum set to
+        # exponential_average_factor is set to self.momentum 
         # (when it is available) only so that if gets updated
         # in ONNX graph when this node is exported to ONNX.
         if self.momentum is None:
@@ -428,7 +428,13 @@ class SyncBatchNorm(_BatchNorm):
 
         self._check_input_dim(input)
 
-        exponential_average_factor = 0.0
+        # exponential_average_factor is set to self.momentum 
+        # (when it is available) only so that if gets updated
+        # in ONNX graph when this node is exported to ONNX.
+        if self.momentum is None:
+            exponential_average_factor = 0.0
+        else:
+            exponential_average_factor = self.momentum
 
         if self.training and self.track_running_stats:
             self.num_batches_tracked += 1


### PR DESCRIPTION
This is a fix for a potential ONNX export issue with SyncBatchNorm where irrespective of the value of momentum, the value for momentum in ONNX BN node is always 0. The details are captured in https://github.com/pytorch/pytorch/issues/18525.

The fix in this PR for `SyncBatchNorm` is very similar to the fix that went in https://github.com/pytorch/pytorch/pull/18764 for `BatchNorm` (I think this site was just missed). 

Please note that there are no ONNX test points added for this, because SyncBatchNorm works exclusively with tensors on GPU and the ONNX test passes are CPU only. If there's a way to add a test point, please let me know. 