### PR TITLE
Skip setting `CUDA_NVCC_EXECUTABLE` if `CACHE_WRAPPER_DIR` not set.

### DIFF
--- a/.jenkins/caffe2/build.sh
+++ b/.jenkins/caffe2/build.sh
@@ -156,7 +156,9 @@ if [[ $BUILD_ENVIRONMENT == *cuda* ]]; then
   build_args+=("TORCH_CUDA_ARCH_LIST=Maxwell")
 
   # Explicitly set path to NVCC such that the symlink to ccache or sccache is used
-  build_args+=("CUDA_NVCC_EXECUTABLE=${CACHE_WRAPPER_DIR}/nvcc")
+  if [ -n "${CACHE_WRAPPER_DIR}" ]; then
+    build_args+=("CUDA_NVCC_EXECUTABLE=${CACHE_WRAPPER_DIR}/nvcc")
+  fi
 
   # Ensure FindCUDA.cmake can infer the right path to the CUDA toolkit.
   # Setting PATH to resolve to the right nvcc alone isn't enough.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25006 Skip setting `CUDA_NVCC_EXECUTABLE` if `CACHE_WRAPPER_DIR` not set.**

Builds without sccache or ccache would run into issues since
`CACHE_WRAPPER_DIR` would not be set. As a result `CUDA_NVCC_EXECUTABLE` would
be set to /nvcc and the build would fail.

Differential Revision: [D16954651](https://our.internmc.facebook.com/intern/diff/D16954651/)