### PR TITLE
[docs] Typo correction in cuda_deterministic_backward.rst

### DIFF
--- a/docs/source/cuda_deterministic_backward.rst
+++ b/docs/source/cuda_deterministic_backward.rst
@@ -1,5 +1,5 @@
 .. note::
 
     When using the CUDA backend, this operation may induce nondeterministic
-    behaviour in be backward that is not easily switched off.
+    behaviour in its backward pass that is not easily switched off.
     Please see the notes on :doc:`/notes/randomness` for background.


### PR DESCRIPTION
I presume this is what was intended.
cc @t-vi 