### PR TITLE
Correct the type comment of `pad()`

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2771,7 +2771,7 @@ def affine_grid(theta, size, align_corners=None):
 
 
 def pad(input, pad, mode='constant', value=0):
-    # type: (Tensor, List[int], str, float) -> Tensor
+    # type: (Tensor, Tuple[int], str, float) -> Tensor
     r"""Pads tensor.
 
     Padding size:


### PR DESCRIPTION
Original type comment requires `List[int]` for parameter `pad` but in the doc it is a `tuple`.

In PyCharm the wrong type comment will display annoying warnings.

