### PR TITLE
Adding  module unregisteration to C++ API

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -120,7 +120,7 @@ TEST_F(ModuleTest, UnregisterModuleThrowsForUnknownModuleName) {
   TestModel model;
   ASSERT_THROWS_WITH(
       model.unregister_module("linear"),
-      "No Module with name `linear' is registered");
+      "No Module with name `linear` is registered");
   model.register_module("linear", torch::nn::Linear(3, 4));
   model.unregister_module("linear");
   ASSERT_TRUE(model.children().empty());

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -115,7 +115,7 @@ TEST_F(ModuleTest, ReplaceModule) {
   ASSERT_EQ(model->l1.get(), model->named_modules()["l1"]->as<Linear>());
 }
 
-TEST_F(ModuleTest, UnregisterModuleThrowsForUnknownModuleName) {
+TEST_F(ModuleTest, UnregisterModule) {
   struct TestModel : public torch::nn::Module {};
   TestModel model;
   ASSERT_THROWS_WITH(

--- a/test/cpp/api/ordered_dict.cpp
+++ b/test/cpp/api/ordered_dict.cpp
@@ -140,11 +140,14 @@ TEST(OrderedDictTest, CanIterateItems) {
 TEST(OrderedDictTest, EraseWorks) {
   OrderedDict<int> dict = {{"a", 1}, {"b", 2}, {"c", 3}};
   dict.erase("b");
-  ASSERT_EQ(dict[0], 1);
-  ASSERT_EQ(dict[1], 3);
+  ASSERT_FALSE(dict.contains("b"));
+  ASSERT_EQ(dict["a"], 1);
+  ASSERT_EQ(dict["c"], 3);
   dict.erase("a");
-  ASSERT_EQ(dict[0], 3);
+  ASSERT_FALSE(dict.contains("a"));
+  ASSERT_EQ(dict["c"], 3);
   dict.erase("c");
+  ASSERT_FALSE(dict.contains("c"));
   ASSERT_TRUE(dict.is_empty());
 }
 

--- a/test/cpp/api/ordered_dict.cpp
+++ b/test/cpp/api/ordered_dict.cpp
@@ -137,6 +137,17 @@ TEST(OrderedDictTest, CanIterateItems) {
   ASSERT_EQ(iterator, dict.end());
 }
 
+TEST(OrderedDictTest, EraseWorks) {
+  OrderedDict<int> dict = {{"a", 1}, {"b", 2}, {"c", 3}};
+  dict.erase("b");
+  ASSERT_EQ(dict[0], 1);
+  ASSERT_EQ(dict[1], 3);
+  dict.erase("a");
+  ASSERT_EQ(dict[0], 3);
+  dict.erase("c");
+  ASSERT_TRUE(dict.is_empty());
+}
+
 TEST(OrderedDictTest, ClearMakesTheDictEmpty) {
   OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
   ASSERT_FALSE(dict.is_empty());

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -383,8 +383,8 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
 
   /// Serializes the `Module` into the given `OutputArchive`.
   ///
-  /// If the `Module` contains unserializable submodules (e.g.
-  /// `nn::Functional`), those submodules are skipped when serializing.
+  /// If the `Module` contains unserializable submodules (e.g. `nn::Functional`),
+  /// those submodules are skipped when serializing.
   virtual void save(serialize::OutputArchive& archive) const;
 
   /// Deserializes the `Module` from the given `InputArchive`.

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -383,15 +383,15 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
 
   /// Serializes the `Module` into the given `OutputArchive`.
   ///
-  /// If the `Module` contains unserializable submodules (e.g. `nn::Functional`),
-  /// those submodules are skipped when serializing.
+  /// If the `Module` contains unserializable submodules (e.g.
+  /// `nn::Functional`), those submodules are skipped when serializing.
   virtual void save(serialize::OutputArchive& archive) const;
 
   /// Deserializes the `Module` from the given `InputArchive`.
   ///
-  /// If the `Module` contains unserializable submodules (e.g. `nn::Functional`),
-  /// we don't check the existence of those submodules in the `InputArchive` when
-  /// deserializing.
+  /// If the `Module` contains unserializable submodules (e.g.
+  /// `nn::Functional`), we don't check the existence of those submodules in the
+  /// `InputArchive` when deserializing.
   virtual void load(serialize::InputArchive& archive);
 
   /// Streams a pretty representation of the `Module` into the given `stream`.
@@ -477,9 +477,11 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
 
   /// Replaces a registered submodule with this `Module`.
   ///
-  /// This takes care of the registration, if you used submodule members, you should
+  /// This takes care of the registration, if you used submodule members, you
+  /// should
   //  assign the submodule as well, i.e. use as
-  ///     module->submodule_ = module->replace_module("linear", torch::nn::Linear(3, 4));
+  ///     module->submodule_ = module->replace_module("linear",
+  ///     torch::nn::Linear(3, 4));
   /// It only works when a module of the name is already registered.
   ///
   /// This is useful for replacing a module after initialization, e.g.
@@ -492,7 +494,8 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   /// Replaces a registered submodule with this `Module`.
   /// This method deals with `ModuleHolder`s.
   ///
-  /// This takes care of the registration, if you used submodule members, you should
+  /// This takes care of the registration, if you used submodule members, you
+  /// should
   //  assign the submodule as well, i.e. use as
   ///     module->submodule_ = module->replace_module("linear", linear_holder);
   /// It only works when a module of the name is already registered.
@@ -503,6 +506,10 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
   std::shared_ptr<ModuleType> replace_module(
       const std::string& name,
       ModuleHolder<ModuleType> module_holder);
+
+  /// Unregisters a submodule from this `Module`. If there is no such module
+  /// with `name` an exception is thrown.
+  void unregister_module(const std::string& name);
 
  private:
   // Friend classes.

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -225,7 +225,7 @@ class OrderedDict<Key, Value>::Item {
   }
 
   /// Returns a `(key, value)` pair.
-  std::pair<const Key, Value> pair() const noexcept {
+  const std::pair<const Key, Value> &pair() const noexcept {
     return pair_;
   }
 

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -225,14 +225,14 @@ class OrderedDict<Key, Value>::Item {
   }
 
   /// Returns a `(key, value)` pair.
-  const std::pair<const Key, Value>& pair() const noexcept {
+  std::pair<const Key, Value> pair() const noexcept {
     return pair_;
   }
 
  private:
   /// This is stored as an std::pair because it will make Python binding a lot,
-  /// lot easier.
-  ::std::pair<const Key, Value> pair_;
+  /// lot easier. Key shouldn't be const here so that erase function can work.
+  ::std::pair<Key, Value> pair_;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ OrderedDict ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -414,9 +414,14 @@ template <typename Key, typename Value>
 void OrderedDict<Key, Value>::erase(const Key& key) {
   auto it = index_.find(key);
   TORCH_CHECK(it != index_.end(), "Key '", key, "' doesn't exist");
+
   auto index = it->second;
   index_.erase(it);
   items_.erase(items_.begin() + index);
+
+  for (auto& pair : index_)
+    if (pair.second > index)
+      --pair.second;
 }
 
 template <typename Key, typename Value>

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -146,6 +146,10 @@ class OrderedDict {
   /// `other` is already present in this `OrderedDict`, an exception is thrown.
   void update(const OrderedDict& other);
 
+  /// Removes the item that has `key` from this `OrderedDict` if exists and if
+  /// it doesn't an exception is thrown.
+  void erase(const Key& key);
+
   /// Removes all items from this `OrderedDict`.
   void clear();
 
@@ -404,6 +408,15 @@ const Value* OrderedDict<Key, Value>::find(const Key& key) const noexcept {
 template <typename Key, typename Value>
 bool OrderedDict<Key, Value>::contains(const Key& key) const noexcept {
   return find(key) != nullptr;
+}
+
+template <typename Key, typename Value>
+void OrderedDict<Key, Value>::erase(const Key& key) {
+  auto it = index_.find(key);
+  TORCH_CHECK(it != index_.end(), "Key '", key, "' doesn't exist");
+  auto index = it->second;
+  index_.erase(it);
+  items_.erase(items_.begin() + index);
 }
 
 template <typename Key, typename Value>

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -76,6 +76,7 @@ const std::string& Module::name() const noexcept {
 }
 
 std::shared_ptr<Module> Module::clone(const optional<Device>& device) const {
+  (void)device;
   AT_ERROR(
       "clone() has not been implemented for ",
       name(),
@@ -330,6 +331,15 @@ Tensor& Module::register_buffer(std::string name, Tensor tensor) {
   return buffers_.insert(std::move(name), std::move(tensor));
 }
 
+void Module::unregister_module(const std::string& name) {
+  TORCH_CHECK(
+      children_.contains(name),
+      "No Module with name `",
+      name,
+      "` is registered");
+  children_.erase(name);
+}
+
 void Module::pretty_print(std::ostream& stream) const {
   stream << name();
 }
@@ -350,7 +360,10 @@ void Module::pretty_print_recursive(
   }
 }
 
-void Module::clone_(Module& other, const optional<Device>& device) {}
+void Module::clone_(Module& other, const optional<Device>& device) {
+  (void)other;
+  (void)device;
+}
 
 void Module::apply_to_submodules(
     const NamedModulePointerApplyFunction& function,
@@ -367,6 +380,7 @@ std::shared_ptr<Module> Module::shared_from_this_checked() const {
   try {
     ptr = shared_from_this();
   } catch (const std::bad_weak_ptr& e) {
+    (void)e;
     AT_ERROR(
         "It looks like you attempted to retrieve your top-level module "
         "as a shared_ptr, but it is not stored in a shared_ptr. "


### PR DESCRIPTION
This is a PR for ```unregister_module``` function for ```module``` class. We need  to be able to erase submodules from ```Module```. I thought of this feature when I was writing ```ModuleList``` class and wanted to have a method to delete items from ```ModuleList``` because the ```Python``` API supports it.