### PR TITLE
Add CUDA state (pre/post-)checks

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -518,7 +518,7 @@ class TestCase(expecttest.TestCase):
             if not getattr(self, self._testMethodName).__dict__.get('slow_test', False):
                 raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")
 
-        if torch.cuda.is_available():
+        if torch.cuda._initialized and torch.cuda.is_available():
             try:
                 torch.cuda.synchronize()
             except RuntimeError:
@@ -532,7 +532,7 @@ class TestCase(expecttest.TestCase):
         set_rng_seed(SEED)
 
     def tearDown(self):
-        if torch.cuda.is_available():
+        if torch.cuda._initialized and torch.cuda.is_available():
             try:
                 torch.cuda.synchronize()
             except RuntimeError:

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -517,7 +517,20 @@ class TestCase(expecttest.TestCase):
             if not getattr(self, self._testMethodName).__dict__.get('slow_test', False):
                 raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")
 
+        if (torch.cuda.is_available()):
+            try:
+                torch.cuda.synchronize()
+            except RuntimeError:
+                self.fail("Unusable CUDA state. Please check previous tests for errors.")
+
         set_rng_seed(SEED)
+
+    def tearDown(self):
+        if (torch.cuda.is_available()):
+            try:
+                torch.cuda.synchronize()
+            except RuntimeError:
+                self.fail("Unrecoverable CUDA failure. Follow-up tests will randomly fail.")
 
     def assertTensorsSlowEqual(self, x, y, prec=None, message=''):
         max_err = 0

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -526,7 +526,8 @@ class TestCase(expecttest.TestCase):
                     raise unittest.SkipTest("Unusable CUDA state. Please check previous tests for errors.")
                 else:
                     TestCase._cuda_failure_reported = True
-                    self.fail("Unusable CUDA state. Please check previous tests for errors.")
+                    self.fail("Unusable CUDA state. Please check previous tests for errors."
+                              " Run tests with CUDA_LAUNCH_BLOCKING=1 to debug issue.")
 
         set_rng_seed(SEED)
 
@@ -536,7 +537,8 @@ class TestCase(expecttest.TestCase):
                 torch.cuda.synchronize()
             except RuntimeError:
                 TestCase._cuda_failure_reported = True
-                self.fail("Unrecoverable CUDA failure. Follow-up tests will randomly fail.")
+                self.fail("Unrecoverable CUDA failure. Follow-up tests will randomly fail."
+                          " Run tests with CUDA_LAUNCH_BLOCKING=1 to debug issue.")
 
     def assertTensorsSlowEqual(self, x, y, prec=None, message=''):
         max_err = 0


### PR DESCRIPTION
Some tests might corrupt CUDA device and leave it broken. This situation makes it hard to find where the error is. Introducing pre and post checks for every test isolates errors.