### PR TITLE
[jit] PythonOp should use conservative alias analysis

### DIFF
--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -339,7 +339,6 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::TupleIndex:
     case prim::TupleSlice:
     case prim::ListUnpack:
-    case prim::PythonOp:
     case prim::GetAttr:
       return analyzeExtractor(node);
     case prim::ConstantChunk:
@@ -358,6 +357,7 @@ void AliasDb::analyzeImpl(Node* node) {
       return;
     case prim::CallFunction:
     case prim::CallMethod:
+    case prim::PythonOp:
       // TODO: this can be improved with summarizes of what the function does
       // for now we assume the worst
       return analyzeConservative(node);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25040 [jit] PythonOp should use conservative alias analysis**

PythonOps can mutate the inputs, so it should not use the Extractor
analysis but instead the Conservative one (which may write to any input.

Differential Revision: [D16967473](https://our.internmc.facebook.com/intern/diff/D16967473)