### PR TITLE
Temporarily fix hub SSL cert issue

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -101,7 +101,7 @@ def _download_archive_zip(url, filename):
     # ...
     # urlopen(url, cafile=certifi.where())
     #
-    # But it requires adding a dependency on the certifi package
+    # But it requires adding a dependency on the `certifi` package
     if sys.version_info[0] == 2:
         context = ssl._create_unverified_context()
     else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25042 Temporarily fix hub SSL cert issue**

[ci pytorch_linux_xenial_cuda9_cudnn7_py2_test]

Differential Revision: [D16974162](https://our.internmc.facebook.com/intern/diff/D16974162)