### PR TITLE
Fix a bug in creating a prefix string in jit log.

### DIFF
--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -39,7 +39,7 @@ std::string jit_log_prefix(
     const char* fn,
     int l,
     const std::string& in_str) {
-  std::stringstream prefix_ss(in_str);
+  std::stringstream prefix_ss;
   prefix_ss << "[";
   prefix_ss << level << " ";
   prefix_ss << c10::detail::StripBasename(std::string(fn)) << ":";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25051 Fix a bug in creating a prefix string in jit log.**

In #24355 I factored out a function for creating a prefix in jit_log,
but I made a copypasta error there: the prefix stringstream was
initialized from the input string instead of an empty string.

Differential Revision: [D16974156](https://our.internmc.facebook.com/intern/diff/D16974156)