### PR TITLE
Optimize performance for unboxed-only kernels

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -54,7 +54,7 @@ public:
 
 private:
   explicit OpKernel(KernelFunction* kernel, const KernelCacheCreatorFunction& cache_creator, void* unboxed_kernel)
-  : kernel_(kernel), cache_(cache_creator()), unboxed_kernel_(unboxed_kernel) {}
+  : kernel_(kernel), cache_(cache_creator ? cache_creator() : nullptr), unboxed_kernel_(unboxed_kernel) {}
   friend class impl::OperatorEntry;
 
   KernelFunction* kernel_; // can be nullptr, not all kernels have this

--- a/aten/src/ATen/core/op_registration/op_registration.cpp
+++ b/aten/src/ATen/core/op_registration/op_registration.cpp
@@ -14,8 +14,8 @@ class RegisterOperators::OperatorRegistrar final {
 public:
   explicit OperatorRegistrar(FunctionSchema&& schema, OperatorOptions&& operatorOptions, c10::optional<TensorTypeId> dispatch_key, KernelFunction* kernel, KernelCacheCreatorFunction&& cache_creator, void* unboxed_kernel, void* unboxed_autograd_kernel)
   : op_(Dispatcher::singleton().registerSchema(std::move(schema), std::move(operatorOptions))), kernel_registration_handle_(c10::nullopt) {
-    // either both, kernel and cache_creator, or none must be set.
-    TORCH_INTERNAL_ASSERT((kernel != nullptr || unboxed_kernel != nullptr) == static_cast<bool>(cache_creator));
+    // cache creator can only be set if the kernel is also set
+    TORCH_INTERNAL_ASSERT((kernel != nullptr || unboxed_kernel != nullptr) || !static_cast<bool>(cache_creator));
 
     if (kernel != nullptr || unboxed_kernel != nullptr) {
       if (dispatch_key.has_value()) {
@@ -170,7 +170,7 @@ OperatorOptions RegisterOperators::makeOperatorOptions_(const RegisterOperators:
 }
 
 void RegisterOperators::registerSchemaAndKernel_(FunctionSchema schema, Options::KernelRegistrationConfig&& kernel, OperatorOptions&& operatorOptions, void* unboxedAutogradKernel) {
-  TORCH_INTERNAL_ASSERT((kernel.kernel_func != nullptr || kernel.unboxed_kernel_func != nullptr) && static_cast<bool>(kernel.cache_creator_func), "Kernel must be set");
+  TORCH_INTERNAL_ASSERT((kernel.kernel_func != nullptr || kernel.unboxed_kernel_func != nullptr), "Kernel must be set");
 
   registrars_.emplace_back(std::move(schema), std::move(operatorOptions), kernel.dispatch_key, kernel.kernel_func, std::move(kernel.cache_creator_func), kernel.unboxed_kernel_func, unboxedAutogradKernel);
 }

--- a/aten/src/ATen/core/op_registration/op_registration.h
+++ b/aten/src/ATen/core/op_registration/op_registration.h
@@ -317,7 +317,7 @@ public:
       return std::move(*this).kernel(
         std::move(dispatch_key),
         nullptr,
-        detail::KernelFactory<KernelFunctor, guts::decay_t<ConstructorParameters>...>(std::forward<ConstructorParameters>(constructorParameters)...),
+        nullptr,  // setting cache creator to nullptr so calling the kernel doesn't need to call it, which would be expensive
         reinterpret_cast<void*>(&detail::wrap_kernel_functor_unboxed<KernelFunctor>::call),
         detail::FunctionSchemaInferer<KernelFunctor>()()
       );


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25055 Optimize performance for unboxed-only kernels**

An ATen kernel registered with the c10 dispatcher doesn't need a cache,
so let's not call a cache creator function when the kernel is looked up.

Differential Revision: [D16974248](https://our.internmc.facebook.com/intern/diff/D16974248/)