### PR TITLE
dictPop: dereference dict.find() iterator before calling dict.erase()

### DIFF
--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2021,18 +2021,19 @@ int dictPop(Stack& stack) {
   }
   auto key = pop(stack);
   auto dict = pop(stack).toGenericDict();
-  auto value = dict.find(key);
-  if (value == dict.end()) {
+  auto iter = dict.find(key);
+  if (iter == dict.end()) {
     if (has_default) {
       push(stack, default_value);
     } else {
       AT_ERROR("KeyError: ", key);
     }
   } else {
+    // note: before erase
+    push(stack, iter->value());
     auto erase_count = dict.erase(key);
     TORCH_CHECK(
         erase_count == 1, "Expected to erase 1 item, found ", erase_count);
-    push(stack, value->value());
   }
   return 0;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25056 dictPop: dereference dict.find() iterator before calling dict.erase()**

For some combinations of key and entry ordering (and only on an OSX
build) dict.pop() would return a value other than the popped one,
failing test_pop in test_jit.py. Caused by erase() mutating the
iterator returned from find(), fixed by dereferencing it first.

Differential Revision: [D16975020](https://our.internmc.facebook.com/intern/diff/D16975020)