### PR TITLE
Simplify NamedType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -741,11 +741,16 @@ struct NamedType;
 using NamedTypePtr = std::shared_ptr<NamedType>;
 
 struct CAFFE2_API NamedType : public Type {
-  NamedType(TypeKind tk) : Type(tk) {}
+  NamedType(TypeKind tk, c10::optional<QualifiedName> name)
+      : Type(tk), name_(std::move(name)) {}
 
   // Fully qualified name of type
   // Looks like: "foo.bar.Baz".
-  virtual const c10::optional<QualifiedName>& name() const = 0;
+  const c10::optional<QualifiedName>& name() const {
+    return name_;
+  }
+private:
+  c10::optional<QualifiedName> name_;
 };
 
 struct TupleType;
@@ -770,10 +775,6 @@ struct CAFFE2_API TupleType : public NamedType {
   
   at::ArrayRef<TypePtr> elements() const {
     return elements_;
-  }
-
-  const c10::optional<c10::QualifiedName>& name() const override {
-    return name_;
   }
 
   bool operator==(const Type& rhs) const override;
@@ -823,7 +824,6 @@ struct CAFFE2_API TupleType : public NamedType {
 
   std::vector<TypePtr> elements_;
   bool has_free_variables_;
-  c10::optional<c10::QualifiedName> name_;
   std::shared_ptr<FunctionSchema> schema_;
 };
 
@@ -982,15 +982,9 @@ struct CAFFE2_API FunctionType : public NamedType {
   }
   static const TypeKind Kind = TypeKind::FunctionType;
 
-  const c10::optional<c10::QualifiedName>& name() const override {
-    return name_;
-  }
-
  private:
   FunctionType(Function* function);
   Function* function_;
-  // Holder for the name so we can return a const ref
-  c10::optional<c10::QualifiedName> name_;
 };
 
 struct NoneType;
@@ -1313,10 +1307,6 @@ struct CAFFE2_API ClassType : public NamedType {
     return n.qualifiedName();
   }
 
-  const c10::optional<c10::QualifiedName>& name() const override {
-    return name_;
-  }
-
   TypePtr getAttribute(const std::string& name) const {
     AT_ASSERT(attributeNames_.size() == attributeTypes_.size());
     size_t pos = 0;
@@ -1415,7 +1405,7 @@ struct CAFFE2_API ClassType : public NamedType {
   ClassTypePtr refine(at::ArrayRef<TypePtr> refined_slots) const;
 
   TypePtr createWithContained(std::vector<TypePtr> contained_types) const override {
-    auto ptr = ClassType::create(name_, compilation_unit_);
+    auto ptr = ClassType::create(name(), compilation_unit_);
     AT_ASSERT(numAttributes() == contained_types.size());
     for(size_t i = 0; i < attributeNames_.size(); ++i) {
       AT_ASSERT(attributeTypes_[i]->isSubtypeOf(contained_types[i]));
@@ -1462,7 +1452,6 @@ struct CAFFE2_API ClassType : public NamedType {
   // List of methods associated with this class.
   std::vector<Function*> methods_;
 
-  c10::optional<QualifiedName> name_;
 };
 
 } // namespace c10

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -543,9 +543,8 @@ TupleType::TupleType(
     std::vector<TypePtr> elements,
     c10::optional<c10::QualifiedName> name,
     std::shared_ptr<FunctionSchema> schema)
-    : NamedType(TypeKind::TupleType),
+    : NamedType(TypeKind::TupleType, std::move(name)),
       elements_(std::move(elements)),
-      name_(std::move(name)),
       schema_(std::move(schema)) {
   has_free_variables_ =
       std::any_of(elements_.begin(), elements_.end(), [](TypePtr v) {
@@ -594,8 +593,8 @@ bool TupleType::operator==(const Type& rhs) const {
 
 std::string TupleType::str() const {
   std::stringstream ss;
-  if (schema_ && name_) {
-    ss << name_->qualifiedName();
+  if (schema_ && name()) {
+    ss << name()->qualifiedName();
   } else {
     ss << "(";
     for(size_t i = 0; i < elements().size(); ++i) {
@@ -609,8 +608,8 @@ std::string TupleType::str() const {
 }
 std::string TupleType::python_str() const {
   std::stringstream ss;
-  if (schema_ && name_) {
-    ss << name_->qualifiedName();
+  if (schema_ && name()) {
+    ss << name()->qualifiedName();
   } else {
     ss << "Tuple[";
     for(size_t i = 0; i < elements().size(); ++i) {

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -7,9 +7,8 @@ namespace c10 {
 // This file exists because we need to reference module.h, which we can't from
 // c10. Sigh...
 FunctionType::FunctionType(Function* function)
-    : NamedType(TypeKind::FunctionType),
-      function_(function),
-      name_(function->qualname()) {}
+    : NamedType(TypeKind::FunctionType, function->qualname()),
+      function_(function) {}
 
 Function* ClassType::getMethod(const std::string& name) const {
   for (auto method : methods_) {
@@ -39,7 +38,7 @@ ClassTypePtr ClassType::create(
 }
 
 ClassTypePtr ClassType::refine(at::ArrayRef<TypePtr> refined_slots) const {
-  auto ptr = ClassType::create(name_, compilation_unit_);
+  auto ptr = ClassType::create(name(), compilation_unit_);
   AT_ASSERT(numAttributes() == refined_slots.size());
   for(size_t i = 0; i < attributeNames_.size(); ++i) {
     AT_ASSERT(refined_slots[i]->isSubtypeOf(attributeTypes_[i]));
@@ -87,9 +86,8 @@ ClassType::ClassType(
     c10::optional<QualifiedName> name,
     std::weak_ptr<CompilationUnit> cu,
     bool is_module)
-    : NamedType(TypeKind::ClassType),
-      compilation_unit_(std::move(cu)),
-      name_(std::move(name)) {
+    : NamedType(TypeKind::ClassType, std::move(name)),
+      compilation_unit_(std::move(cu)) {
   if (is_module) {
     parameterSlots_ = std::make_shared<std::vector<bool>>();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25058 Simplify NamedType**

The signature of name() returns a reference so the only resonable way to implement the function is to return a reference
to the name in the struct anyway. This devirtualizes it, and just puts the name into the struct.

Differential Revision: [D16974556](https://our.internmc.facebook.com/intern/diff/D16974556)