### PR TITLE
Use pickle to serialize object.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -467,6 +467,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/message.cpp
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/script_call.cpp
       ${TORCH_SRC_DIR}/csrc/distributed/rpc/script_ret.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/export_bytecode.cpp
       ${TORCH_SRC_DIR}/csrc/jit/export.cpp
     )
     if (NOT WIN32)
@@ -561,7 +562,6 @@ if(USE_ROCM)
 
   list(APPEND Caffe2_CPU_SRCS ${Caffe2_HIP_SRCS})
 endif()
-
 
 # Compile exposed libraries.
 IF (USE_ROCM)

--- a/test/cpp/mobile/CMakeLists.txt
+++ b/test/cpp/mobile/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_executable(test_bc_export
   test_bc_export.cpp)
 
-target_link_libraries(test_bc_export PRIVATE torch gtest)
+caffe2_interface_library(torch torch_whole)
+target_link_libraries(test_bc_export PRIVATE torch_whole gtest)
 target_include_directories(test_bc_export PRIVATE ${ATen_CPU_INCLUDE})
 #target_compile_definitions(test_bc_export PRIVATE USE_GTEST)
 

--- a/test/cpp/mobile/test_bc_export.cpp
+++ b/test/cpp/mobile/test_bc_export.cpp
@@ -1,4 +1,6 @@
 #include <torch/script.h> // One-stop header.
+#include <torch/csrc/jit/export_bytecode.h>
+#include <torch/csrc/jit/export.h>
 //#include <aten/src/ATen/core/ivalue.h>
 
 #include <iostream>
@@ -12,29 +14,23 @@ int main(int argc, const char* argv[]) {
 
   // Deserialize the ScriptModule from a file using torch::jit::load().
   torch::jit::script::Module module = torch::jit::load(argv[1]);
+  torch::jit::mobile::SaveBytecode(module, argv[2]);
 
-//  torch::jit::mobile::save(module, argv[2]);
-  auto compUnit = module.class_compilation_unit();
-  auto funcList = compUnit->get_functions();
-  for (auto func : funcList) {
-    auto funcName = func->name();
-    torch::jit::Code code(func->graph());
-  }
-  std::vector<torch::jit::IValue> inputs;
+//  std::vector<torch::jit::IValue> inputs;
 
-  //  inputs.push_back(torch::ones({1, 2}));
+//  //  inputs.push_back(torch::ones({1, 2}));
 
-  //  inputs.push_back(torch::ones({1, 10}));
+//  //  inputs.push_back(torch::ones({1, 10}));
 
-    inputs.push_back(torch::ones({1, 3, 224, 224}));
-  //  module->run_method("forward", inputs);
-  //  module->save_method("forward", inputs, "/Users/myuan/data/resnet18_eval.bc");
+//    inputs.push_back(torch::ones({1, 3, 224, 224}));
+//  //  module->run_method("forward", inputs);
+//  //  module->save_method("forward", inputs, "/Users/myuan/data/resnet18_eval.bc");
 
-//  inputs.push_back(torch::ones({1, 1, 28, 28}));
+////  inputs.push_back(torch::ones({1, 1, 28, 28}));
 
-  at::Tensor output = module.forward(inputs).toTensor();
-//  module.save("/Users/myuan/data/resnet18/exported.pt");
-  std::cout << output.slice(/*dim=*/1, /*start=*/0, /*end=*/5) << std::endl;
+//  at::Tensor output = module.forward(inputs).toTensor();
+////  module.save("/Users/myuan/data/resnet18/exported.pt");
+//  std::cout << output.slice(/*dim=*/1, /*start=*/0, /*end=*/5) << std::endl;
 
   //  // pytext
   //  auto options = torch::TensorOptions().dtype(torch::kI64);

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -62,6 +62,7 @@ libtorch_sources = [
     "torch/csrc/jit/constants.cpp",
     "torch/csrc/jit/node_hashing.cpp",
     "torch/csrc/jit/export.cpp",
+    "torch/csrc/jit/export_bytecode.cpp",
     "torch/csrc/jit/pass_manager.cpp",
     "torch/csrc/jit/pickler.cpp",
     "torch/csrc/jit/graph_executor.cpp",

--- a/torch/csrc/jit/export_bytecode.h
+++ b/torch/csrc/jit/export_bytecode.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <torch/csrc/jit/script/module.h>
+
+#include <ostream>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+TORCH_API void SaveBytecode(const script::Module& module, const std::string& filename);
+
+}
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
The picking Object is available. Use it to serialize the module object. Later in PR 25064, everything in the layout is serialized in pickle. 

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25064 [WIP] Use pickle on bytecode.
* #25063 Add slot number for GetAttr.
* #25062 Export instruction, operator, constant and tensor tables.
* **#25061 Use pickle to serialize object.**
* #25060 Basic framework of bytecode export

