### PR TITLE
Export instruction, operator, constant and tensor tables.

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -375,6 +375,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     ${TORCH_SRC_DIR}/csrc/jit/import.cpp
     ${TORCH_SRC_DIR}/csrc/jit/pickle.cpp
     ${TORCH_SRC_DIR}/csrc/jit/import_export_helpers.cpp
+    ${TORCH_SRC_DIR}/csrc/jit/instruction.cpp
     ${TORCH_SRC_DIR}/csrc/jit/interpreter.cpp
     ${TORCH_SRC_DIR}/csrc/jit/constants.cpp
     ${TORCH_SRC_DIR}/csrc/jit/node_hashing.cpp

--- a/test/cpp/mobile/CMakeLists.txt
+++ b/test/cpp/mobile/CMakeLists.txt
@@ -1,8 +1,17 @@
 add_executable(test_bc_export
   test_bc_export.cpp)
 
-caffe2_interface_library(torch torch_whole)
-target_link_libraries(test_bc_export PRIVATE torch_whole gtest)
+#caffe2_interface_library(torch torch_whole)
+#target_link_libraries(test_bc_export PRIVATE torch_whole gtest)
+if(APPLE)
+  target_link_libraries(test_bc_export PRIVATE -Wl,-force_load torch)
+elseif(MSVC)
+  target_link_libraries(test_bc_export PRIVATE -WHOLEARCHIVE:torch)
+else()
+  target_link_libraries(test_bc_export PRIVATE -Wl,--whole-archive,torch -Wl,--no-whole-archive)
+endif()
+
+target_link_libraries(test_bc_export PRIVATE gtest)
 target_include_directories(test_bc_export PRIVATE ${ATen_CPU_INCLUDE})
 #target_compile_definitions(test_bc_export PRIVATE USE_GTEST)
 

--- a/torch/csrc/jit/export.cpp
+++ b/torch/csrc/jit/export.cpp
@@ -32,6 +32,45 @@
 namespace torch {
 namespace jit {
 
+// write the content of the tensor to the file/stream, and save the
+// offset in the storageMap_
+void convertAndWriteTensor(
+    size_t tensor_id,
+    const at::Tensor& tensor,
+    torch::TensorDef* tensor_proto,
+    std::unordered_map<const void*, std::string>& storageMap,
+    caffe2::serialize::PyTorchStreamWriter& writer) {
+  for (auto d : tensor.sizes()) {
+    tensor_proto->add_dims(d);
+  }
+  for (auto s : tensor.strides()) {
+    tensor_proto->add_strides(s);
+  }
+  tensor_proto->set_data_type(caffe2::TypeMetaToDataType(
+      at::scalarTypeToTypeMeta(tensor.scalar_type())));
+  tensor_proto->set_offset(tensor.storage_offset());
+  tensor_proto->set_requires_grad(tensor.requires_grad());
+  tensor_proto->set_is_quantized(tensor.is_quantized());
+  if (tensor.is_quantized()) {
+    tensor_proto->set_scale(tensor.q_scale());
+    tensor_proto->set_zero_point(tensor.q_zero_point());
+  }
+  auto* key = tensor.storage().unsafeGetStorageImpl();
+  auto storage_it = storageMap.find(key);
+  if (storage_it == storageMap.end()) {
+    WriteableTensorData data = getWriteableTensorData(tensor);
+    std::string name = "tensors/" + std::to_string(tensor_id);
+    writer.writeRecord(name, data.data(), data.sizeInBytes());
+    storage_it = storageMap.insert({key, name}).first;
+  }
+  auto* data = tensor_proto->mutable_data();
+  data->set_key(storage_it->second);
+  // handle device case, set the device_detail and load to CUDA device
+  std::stringstream ss;
+  ss << tensor.device();
+  tensor_proto->set_device(ss.str());
+}
+
 namespace {
 namespace onnx_torch = ::torch::onnx;
 namespace onnx = ::ONNX_NAMESPACE;
@@ -525,45 +564,6 @@ void GraphEncoder::EncodeTensor(
     tensor_proto->set_raw_data(std::string(
         static_cast<char*>(t.data_ptr()), t.element_size() * t.numel()));
   }
-}
-
-// write the content of the tensor to the file/stream, and save the
-// offset in the storageMap_
-void convertAndWriteTensor(
-    size_t tensor_id,
-    const at::Tensor& tensor,
-    torch::TensorDef* tensor_proto,
-    std::unordered_map<const void*, std::string>& storageMap,
-    caffe2::serialize::PyTorchStreamWriter& writer) {
-  for (auto d : tensor.sizes()) {
-    tensor_proto->add_dims(d);
-  }
-  for (auto s : tensor.strides()) {
-    tensor_proto->add_strides(s);
-  }
-  tensor_proto->set_data_type(caffe2::TypeMetaToDataType(
-      at::scalarTypeToTypeMeta(tensor.scalar_type())));
-  tensor_proto->set_offset(tensor.storage_offset());
-  tensor_proto->set_requires_grad(tensor.requires_grad());
-  tensor_proto->set_is_quantized(tensor.is_quantized());
-  if (tensor.is_quantized()) {
-    tensor_proto->set_scale(tensor.q_scale());
-    tensor_proto->set_zero_point(tensor.q_zero_point());
-  }
-  auto* key = tensor.storage().unsafeGetStorageImpl();
-  auto storage_it = storageMap.find(key);
-  if (storage_it == storageMap.end()) {
-    WriteableTensorData data = getWriteableTensorData(tensor);
-    std::string name = "tensors/" + std::to_string(tensor_id);
-    writer.writeRecord(name, data.data(), data.sizeInBytes());
-    storage_it = storageMap.insert({key, name}).first;
-  }
-  auto* data = tensor_proto->mutable_data();
-  data->set_key(storage_it->second);
-  // handle device case, set the device_detail and load to CUDA device
-  std::stringstream ss;
-  ss << tensor.device();
-  tensor_proto->set_device(ss.str());
 }
 
 // this is a serializer class which saves script modules to pt files. the

--- a/torch/csrc/jit/instruction.cpp
+++ b/torch/csrc/jit/instruction.cpp
@@ -1,0 +1,43 @@
+#include <torch/csrc/jit/instruction.h>
+#include <iostream>
+
+namespace torch {
+namespace jit {
+std::ostream& operator<<(std::ostream& out, OperatorCode op) {
+  switch (op) {
+#define OP_STRING(x, _) \
+  case x:               \
+    return out << #x;
+    FORALL_OPCODES(OP_STRING)
+#undef OP_STRING
+  }
+  return out;
+}
+
+const char* OpInfo(OperatorCode op) {
+  switch (op) {
+#define OP_INFO(x, info) \
+  case x:                \
+    return info;
+    FORALL_OPCODES(OP_INFO)
+#undef OP_INFO
+  }
+  return nullptr;
+}
+
+static_assert(sizeof(Instruction) == 8, "Instructions should be 8 bytes");
+
+std::ostream& operator<<(std::ostream& out, Instruction inst) {
+  // TODO: use op info to print out the op in a more user-friendly way
+  int nargs = strlen(OpInfo(inst.op));
+  out << inst.op;
+  if (nargs > 0) {
+    out << " " << inst.X;
+  }
+  if (nargs > 1) {
+    out << " " << inst.N;
+  }
+  return out;
+}
+}
+}

--- a/torch/csrc/jit/instruction.h
+++ b/torch/csrc/jit/instruction.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <typeinfo>
+#include <iostream>
+
+namespace torch {
+namespace jit {
+// instructs look like:
+// op_code X, N
+// meaning of X, N depend on the op:
+// O - index into operator table
+// R - index into register table
+// I - literal integer
+// C - index into constant table
+// P - jump offset relative to beginning of current instruction
+// F - index into function table
+// T - index into the type table, used for guard instructions
+
+#define FORALL_OPCODES(_)                                                   \
+  _(OP, "O") /* invoke operator X */                                        \
+  _(LOAD, "R") /* push a value from a register X */                         \
+  _(MOVE, "R") /* push a value from register X, clearing the register */    \
+  _(STOREN, "RI") /* store N values to registers [X, X+N) */                \
+  _(STORE, "R") /* store 1 value to registers X */                          \
+  _(DROP, "") /* drop 1 value from the top of the stack */                  \
+  _(DROPR, "R") /* clear register X */                                      \
+  _(LOADC, "C") /* push the constant X */                                   \
+  _(JF, "P") /* pop the top of the stack, if false, branch to P */          \
+  _(JMP, "P") /* unconditional branch to X */                               \
+  _(LOOP, "PI") /* perform a loop, X is where to branch if cond is false */ \
+  _(RET, "") /* exit execution */                                           \
+  _(WAIT, "") /* wait for a future to be complete */                        \
+  _(CALL, "F") /* call function X */                                        \
+  _(GUARD, "T") /* check guard against type_table, true if passes */        \
+  _(TAIL_CALL, "F") /* replace current frame with function F */
+
+enum OperatorCode : uint8_t {
+#define DEFINE_OP(op, _) op,
+  FORALL_OPCODES(DEFINE_OP)
+#undef DEFINE_OP
+};
+
+struct Instruction {
+  OperatorCode op;
+  uint8_t padding; // currently unused
+  uint16_t N;
+  int32_t X;
+  // TODO: check for overflow
+  Instruction(OperatorCode op, int32_t X, uint16_t N)
+      : op(op), padding(0), N(N), X(X) {}
+};
+
+std::ostream& operator<<(std::ostream& out, OperatorCode op);
+std::ostream& operator<<(std::ostream& out, Instruction inst);
+
+}
+}

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -11,8 +11,10 @@
 #include <torch/csrc/jit/exception_message.h>
 #include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/instruction.h>
 #include <torch/csrc/jit/operator.h>
 #include <torch/csrc/jit/passes/bailout_graph.h>
+#include <torch/csrc/liteinterpreter/frameoutput.h>
 #include <torch/csrc/jit/script/compilation_unit.h>
 #include <torch/csrc/jit/script/jit_exception.h>
 
@@ -293,87 +295,6 @@ struct PreprocessGraph {
   std::unordered_map<Node*, bool> can_emit_inline;
 };
 
-// instructs look like:
-// op_code X, N
-// meaning of X, N depend on the op:
-// O - index into operator table
-// R - index into register table
-// I - literal integer
-// C - index into constant table
-// P - jump offset relative to beginning of current instruction
-// F - index into function table
-// T - index into the type table, used for guard instructions
-
-#define FORALL_OPCODES(_)                                                   \
-  _(OP, "O") /* invoke operator X */                                        \
-  _(LOAD, "R") /* push a value from a register X */                         \
-  _(MOVE, "R") /* push a value from register X, clearing the register */    \
-  _(STOREN, "RI") /* store N values to registers [X, X+N) */                \
-  _(STORE, "R") /* store 1 value to registers X */                          \
-  _(DROP, "") /* drop 1 value from the top of the stack */                  \
-  _(DROPR, "R") /* clear register X */                                      \
-  _(LOADC, "C") /* push the constant X */                                   \
-  _(JF, "P") /* pop the top of the stack, if false, branch to P */          \
-  _(JMP, "P") /* unconditional branch to X */                               \
-  _(LOOP, "PI") /* perform a loop, X is where to branch if cond is false */ \
-  _(RET, "") /* exit execution */                                           \
-  _(WAIT, "") /* wait for a future to be complete */                        \
-  _(CALL, "F") /* call function X */                                        \
-  _(GUARD, "T") /* check guard against type_table, true if passes */        \
-  _(TAIL_CALL, "F") /* replace current frame with function F */
-
-enum OpCode : uint8_t {
-#define DEFINE_OP(op, _) op,
-  FORALL_OPCODES(DEFINE_OP)
-#undef DEFINE_OP
-};
-
-std::ostream& operator<<(std::ostream& out, OpCode op) {
-  switch (op) {
-#define OP_STRING(x, _) \
-  case x:               \
-    return out << #x;
-    FORALL_OPCODES(OP_STRING)
-#undef OP_STRING
-  }
-  return out;
-}
-
-const char* OpInfo(OpCode op) {
-  switch (op) {
-#define OP_INFO(x, info) \
-  case x:                \
-    return info;
-    FORALL_OPCODES(OP_INFO)
-#undef OP_INFO
-  }
-  return nullptr;
-}
-
-struct Instruction {
-  OpCode op;
-  uint8_t padding; // currently unused
-  uint16_t N;
-  int32_t X;
-  // TODO: check for overflow
-  Instruction(OpCode op, int32_t X, uint16_t N)
-      : op(op), padding(0), N(N), X(X) {}
-};
-
-static_assert(sizeof(Instruction) == 8, "Instructions should be 8 bytes");
-std::ostream& operator<<(std::ostream& out, Instruction inst) {
-  // TODO: use op info to print out the op in a more user-friendly way
-  int nargs = strlen(OpInfo(inst.op));
-  out << inst.op;
-  if (nargs > 0) {
-    out << " " << inst.X;
-  }
-  if (nargs > 1) {
-    out << " " << inst.N;
-  }
-  return out;
-}
-
 // for keeping track of the current node
 struct WithCurrentNode {
   WithCurrentNode(Node** loc, Node* new_value) : loc_(loc), old_value_(*loc_) {
@@ -409,6 +330,10 @@ struct CodeImpl {
 
   std::vector<IValue> constant_table_;
   std::vector<Operation> operator_table_;
+  // One way to have operator names for debugging/dumping purpose. Because it's only
+  // available from node, we add schema name to the list when operators are emitted.
+  // Any other solutions?
+  std::vector<c10::OperatorName> opname_table_;
   std::vector<Function*> function_table_;
   std::vector<TypePtr> type_table_;
   int register_size_ = 0;
@@ -454,7 +379,7 @@ struct CodeImpl {
     dump(std::cout);
   }
 
-  void insertInstruction(OpCode op, int64_t X = 0, uint64_t N = 0) {
+  void insertInstruction(OperatorCode op, int64_t X = 0, uint64_t N = 0) {
     instructions_.emplace_back(op, X, N);
     instructions_source_.emplace_back(current_node_);
 
@@ -517,7 +442,7 @@ struct CodeImpl {
       int reg = registerFor(input);
       bool moved = input->uses().size() == ++use_count_[input];
 
-      OpCode op;
+      OperatorCode op;
       if (input->node()->kind() == prim::Constant) {
         op = LOADC;
       } else if (drop) {
@@ -541,6 +466,10 @@ struct CodeImpl {
     emitLoadInputs(node->inputs());
     insertInstruction(OP, operator_table_.size());
     operator_table_.emplace_back(getOperation(node));
+    // Looks like all overload_names are empty? If the name is not unique,
+    // use inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)
+    // as a backup.
+    opname_table_.emplace_back(node->schema().operator_name());
   }
 
   void emitWait(Node* node) {
@@ -739,6 +668,16 @@ struct CodeImpl {
       }
     }
     return *grad_executors_;
+  }
+
+  std::unique_ptr<FrameOutput> getFrame() const {
+    std::unique_ptr<FrameOutput> frameptr(new FrameOutput);
+    frameptr->pc = 0;
+    frameptr->instructions = instructions_;
+    frameptr->constants = constant_table_;
+    frameptr->opnames = opname_table_;
+    frameptr->operators = operator_table_;
+    return frameptr;
   }
 
   void dump(std::ostream& out, size_t i) const {
@@ -1113,6 +1052,11 @@ size_t Code::num_inputs() const {
 size_t Code::num_outputs() const {
   return pImpl->n_outputs;
 }
+
+std::unique_ptr<FrameOutput> Code::getFrame() const {
+  return pImpl->getFrame();
+}
+
 
 InterpreterState::InterpreterState(const Code& code)
     : pImpl(c10::make_intrusive<InterpreterStateImpl>(code)) {}

--- a/torch/csrc/jit/interpreter.h
+++ b/torch/csrc/jit/interpreter.h
@@ -25,6 +25,7 @@ struct CodeImpl;
 struct InterpreterStateImpl;
 struct Graph;
 struct Node;
+struct FrameOutput;
 using Stack = std::vector<c10::IValue>;
 using c10::ivalue::Future;
 
@@ -40,6 +41,7 @@ struct TORCH_API Code {
   }
   size_t num_inputs() const;
   size_t num_outputs() const;
+  std::unique_ptr<FrameOutput> getFrame() const;
 
  private:
   std::shared_ptr<CodeImpl> pImpl;

--- a/torch/csrc/liteinterpreter/frameoutput.h
+++ b/torch/csrc/liteinterpreter/frameoutput.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <torch/csrc/jit/instruction.h>
+#include <memory>
+#include <vector>
+#include <string>
+#include <ATen/core/ivalue.h>
+#include <torch/csrc/jit/source_range.h>
+#include <ATen/core/stack.h>
+#include <ATen/core/interned_strings.h>
+#include <ATen/core/function_schema.h>
+
+namespace torch {
+namespace jit {
+
+//struct Variable {
+//  size_t unique_id;
+//  bool free_flag;
+//};
+
+//struct OperatorOutput {
+//  // For C10 dispatcher and debugging
+//  std::string name;
+//  std::string overload_name;
+//};
+
+// A container of necessary structures to be serialized into bytecode.
+// It does not have Function, which depends on graph.
+// It does not have types at this time.
+struct FrameOutput {
+  std::string name;
+  size_t pc;
+  std::vector<Instruction> instructions;
+  std::vector<IValue> constants;
+  std::vector<c10::OperatorName> opnames;
+  std::vector<Operation> operators;
+};
+
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
* Add getFrame() in Code's API to have necessary information (wrapped in FrameOutput) of bytecode. 
* Pull the instruction definition out of interpreter.cpp so that it can be shared by bytecode. 
* Bytecode is dumped through protobuf to Json format. In the later PR25064, the protobuf will be replaced by pickle.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25064 [WIP] Use pickle on bytecode.
* #25063 Add slot number for GetAttr.
* **#25062 Export instruction, operator, constant and tensor tables.**
* #25061 Use pickle to serialize object.
* #25060 Basic framework of bytecode export

