### PR TITLE
Add slot number for GetAttr.

### DIFF
--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -464,7 +464,13 @@ struct CodeImpl {
 
   void emitOperator(Node* node) {
     emitLoadInputs(node->inputs());
-    insertInstruction(OP, operator_table_.size());
+    uint64_t Nn = 0;
+    if (node->kind() == prim::GetAttr) {
+      const auto type = node->input()->type()->expect<ClassType>();
+      const auto& field = node->s(attr::name);
+      Nn = type->getAttributeSlot(field);
+    }
+    insertInstruction(OP, operator_table_.size(), Nn);
     operator_table_.emplace_back(getOperation(node));
     // Looks like all overload_names are empty? If the name is not unique,
     // use inline std::ostream& operator<<(std::ostream& out, const FunctionSchema& schema)


### PR DESCRIPTION
Since the bytecode does not depend on graph/code, put the slot number directly into instruction.N. 

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25064 [WIP] Use pickle on bytecode.
* **#25063 Add slot number for GetAttr.**
* #25062 Export instruction, operator, constant and tensor tables.
* #25061 Use pickle to serialize object.
* #25060 Basic framework of bytecode export

