### PR TITLE
cleanup tmp name generation

### DIFF
--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -524,7 +524,7 @@ struct to_ir {
   std::vector<DefContext> def_stack_;
   size_t temp_name_count_ = 0;
   std::string createTempName(const std::string& prefix) {
-    return prefix + std::to_string(temp_name_count_);
+    return prefix + std::to_string(temp_name_count_++);
   }
 
   void pushFrame(Block* b, bool starts_def = false) {
@@ -1041,7 +1041,7 @@ struct to_ir {
   }
 
   Value* emitListComprehension(const ListComp& lc) {
-    const auto tmp_name = createTempName("___list_acc");
+    const auto tmp_name = createTempName("$list_acc");
     const auto list_value = emitExpr(lc.iter());
     if (list_value->type()->kind() != TypeKind::ListType) {
       // TODO: constraining iterators to be simple lists for now


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25065 cleanup tmp name generation**

Using global atomic variables is bad because sending the same AST through
the compiler twice will produce different graphs. This makes it a
member of the translation struct.

Differential Revision: [D16975355](https://our.internmc.facebook.com/intern/diff/D16975355)