### PR TITLE
fix clang-tidy failing all the time on random lines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,3 +104,5 @@ jobs:
   - script: git branch master origin/master
   - script: pip install pyyaml
   - script: tools/run-clang-tidy-in-ci.sh
+    env: 
+      TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)


### PR DESCRIPTION
Our script is set up to only run on lines generated by diffing your branch against the base branch.

But we were using `$TRAVIS_BRANCH` to refer to the target branch, which was causing the script to diff against master, generating many spurious lines of diff output to be clang-tidy'd

This PR bind $TRAVIS_BRANCH to its azure equivalent variable and I think fixes things