### PR TITLE
fix clang-tidy failing all the time on random lines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,3 +104,6 @@ jobs:
   - script: git branch master origin/master
   - script: pip install pyyaml
   - script: tools/run-clang-tidy-in-ci.sh
+    env:
+      TARGET_BRANCH: $(System.PullRequest.TargetBranch)
+      AZURE_CI: 1

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -4,10 +4,10 @@ set -ex
 
 BASE_BRANCH=master
 # From https://docs.travis-ci.com/user/environment-variables
-if [[ $TRAVIS ]]; then
+if [[ $AZURE_CI ]]; then
   git remote add upstream https://github.com/pytorch/pytorch
-  git fetch upstream "$TRAVIS_BRANCH"
-  BASE_BRANCH="upstream/$TRAVIS_BRANCH"
+  git fetch upstream "$TARGET_BRANCH"
+  BASE_BRANCH="upstream/$TARGET_BRANCH"
 fi
 
 if [[ ! -d build ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25082 [wip] show clang-tidy as github annotations
* **#25078 fix clang-tidy failing all the time on random lines**

Our script is set up to only run on lines generated by diffing your branch against the base branch.

But we were using `$TRAVIS_BRANCH` to refer to the target branch, which was causing the script to diff against master, generating many spurious lines of diff output to be clang-tidy'd

Differential Revision: [D16993054](https://our.internmc.facebook.com/intern/diff/D16993054)