### PR TITLE
use avx2 for Add without broadcast and when inputs are uint8_t

### DIFF
--- a/caffe2/quantization/server/elementwise_sum_dnnlowp_op.cc
+++ b/caffe2/quantization/server/elementwise_sum_dnnlowp_op.cc
@@ -73,6 +73,8 @@ bool SumDNNLowPOp<T, ReluFused>::RunOnDevice() {
     if (InputSize() == 2 && is_same<T, uint8_t>::value && GetCpuId().avx2() &&
         GetCpuId().fma()) {
       // fast path when we have 2 uint8_t inputs with AVX2 / FMA support
+      // NOTE: this path does addition in floating point unlike slow path that
+      // does everything in fixed-point. So they are numerically different.
       array<const T*, 2> input_data;
       for (int i = 0; i < 2; ++i) {
         input_data[i] = InputTensorCPU_(i).template data<T>();


### PR DESCRIPTION
Summary:
Use the same optimization we used for Sum operator in Add when broadcast is not used and inputs are uint8_t.
The optimization uses AVX2 instruction and use fp32 (instead of pure fixed point arithmetic). It does introduce numerical difference but only for minor cases like tie-breaking when rounding.

Test Plan: buck test caffe2/caffe2/quantization/server:elementwise_add_dnnlowp_op_test

Differential Revision: D16985776

