### PR TITLE
[jit] move some methods into function.cpp

### DIFF
--- a/torch/csrc/jit/function.cpp
+++ b/torch/csrc/jit/function.cpp
@@ -4,6 +4,25 @@
 
 namespace torch {
 namespace jit {
+namespace {
+FunctionSchema defaultSchemaFor(const Function& function) {
+  std::vector<Argument> args;
+  std::vector<Argument> returns;
+  Graph& g = *function.graph();
+  size_t num_inputs = function.num_inputs();
+  for (size_t i = 0; i < num_inputs; ++i) {
+    const Value* v = g.inputs().at(i);
+    std::string name = v->hasDebugName() ? v->debugNameBase()
+                                         : ("argument_" + std::to_string(i));
+    args.emplace_back(std::move(name), unshapedType(g.inputs()[i]->type()));
+  }
+  for (size_t i = 0; i < g.outputs().size(); ++i) {
+    returns.emplace_back("", unshapedType(g.outputs()[i]->type()));
+  }
+  return {function.name(), "", std::move(args), std::move(returns)};
+}
+} // namespace
+
 struct RecursiveMethodCallError : public std::exception {};
 void placeholderCreator(Function&) {
   throw RecursiveMethodCallError();
@@ -27,5 +46,11 @@ void Function::ensure_defined() {
   check_single_output();
 }
 
+  const FunctionSchema& Function::getSchema() const {
+    if (schema_ == nullptr) {
+      schema_ = make_unique<FunctionSchema>(defaultSchemaFor(*this));
+    }
+    return *schema_;
+  }
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/function.cpp
+++ b/torch/csrc/jit/function.cpp
@@ -46,11 +46,11 @@ void Function::ensure_defined() {
   check_single_output();
 }
 
-  const FunctionSchema& Function::getSchema() const {
-    if (schema_ == nullptr) {
-      schema_ = make_unique<FunctionSchema>(defaultSchemaFor(*this));
-    }
-    return *schema_;
+const FunctionSchema& Function::getSchema() const {
+  if (schema_ == nullptr) {
+    schema_ = make_unique<FunctionSchema>(defaultSchemaFor(*this));
   }
+  return *schema_;
+}
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/function.h
+++ b/torch/csrc/jit/function.h
@@ -61,12 +61,7 @@ struct TORCH_API Function {
     return *this;
   }
 
-  const FunctionSchema& getSchema() const {
-    if (schema_ == nullptr) {
-      schema_ = make_unique<FunctionSchema>(defaultSchemaFor(*this));
-    }
-    return *schema_;
-  }
+  const FunctionSchema& getSchema() const;
 
   std::string pretty_print_schema() const {
     AT_ASSERT(schema_);
@@ -102,23 +97,6 @@ struct TORCH_API Function {
   }
 
  private:
-  static FunctionSchema defaultSchemaFor(const Function& function) {
-    std::vector<Argument> args;
-    std::vector<Argument> returns;
-    Graph& g = *function.graph();
-    size_t num_inputs = function.num_inputs();
-    for (size_t i = 0; i < num_inputs; ++i) {
-      const Value* v = g.inputs().at(i);
-      std::string name = v->hasDebugName() ? v->debugNameBase()
-                                           : ("argument_" + std::to_string(i));
-      args.emplace_back(std::move(name), unshapedType(g.inputs()[i]->type()));
-    }
-    for (size_t i = 0; i < g.outputs().size(); ++i) {
-      returns.emplace_back("", unshapedType(g.outputs()[i]->type()));
-    }
-    return {function.name(), "", std::move(args), std::move(returns)};
-  }
-
   c10::QualifiedName name_;
   std::shared_ptr<Graph> graph_; // for debugging and for inlining
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25119 [jit] move some methods into function.cpp**

Make `defaultSchemaFor` an anonymous function and move it + its caller
into function.cpp

Purely mechanical changes

Differential Revision: [D16994147](https://our.internmc.facebook.com/intern/diff/D16994147)