### PR TITLE
fix clang-tidy failing on master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,6 +104,3 @@ jobs:
   - script: git branch master origin/master
   - script: pip install pyyaml
   - script: tools/run-clang-tidy-in-ci.sh
-    env:
-      TARGET_BRANCH: $(System.PullRequest.TargetBranch)
-      AZURE_CI: 1

--- a/tools/run-clang-tidy-in-ci.sh
+++ b/tools/run-clang-tidy-in-ci.sh
@@ -3,11 +3,10 @@
 set -ex
 
 BASE_BRANCH=master
-# From https://docs.travis-ci.com/user/environment-variables
-if [[ $AZURE_CI ]]; then
+if [[ $SYSTEM_PULLREQUEST_TARGETBRANCH ]]; then
   git remote add upstream https://github.com/pytorch/pytorch
-  git fetch upstream "$TARGET_BRANCH"
-  BASE_BRANCH="upstream/$TARGET_BRANCH"
+  git fetch upstream "$SYSTEM_PULLREQUEST_TARGETBRANCH"
+  BASE_BRANCH="upstream/$SYSTEM_PULLREQUEST_TARGETBRANCH"
 fi
 
 if [[ ! -d build ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25121 fix clang-tidy failing on master**

Turns out there is a more idiomatic way to use azure variables. This
also fixes clang-tidy failing on master

Differential Revision: [D16994595](https://our.internmc.facebook.com/intern/diff/D16994595)