### PR TITLE
a small fix to `setWildcard`

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12581,6 +12581,18 @@ a")
         FileCheck().check("prim::Loop").check_not("aten::rand").check("aten::__getitem__") \
             .check_count("aten::rand", 1, exactly=True).run(str(foo.graph))
 
+    def test_mutable_dce_indirect_wildcards(self):
+        def fn():
+            x = torch.ones(2, 3)
+            x_1 = x.view(-1)
+            l = []
+            l.append(x_1)
+            x_view = l[0]
+            x.add_(torch.ones(2, 3))
+            return x_view
+        self.checkScript(fn, ())
+
+
     def test_mutable_dce_wildcards(self):
         def fn():
             x = torch.ones(2, 3)

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -455,8 +455,6 @@ void AliasDb::analyzeImpl(Node* node) {
 
     // Record writes
     if (formal->isWrite()) {
-      std::cerr << "registering a write " << actualValue->debugName() 
-        << " to " << *node << std::endl;
       registerWrite(actualValue, node);
     }
 

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -1314,17 +1314,15 @@ void AliasDb::setWildcard(const Value* v) {
   TORCH_INTERNAL_ASSERT(e != nullptr);
   memoryDAG_->makePointerTo(getOrCreateElement(v), e);
 
-  // point everything v aliases to the wildcard 
-  const auto& pointeeSet = getOrCreateElement(v)->getMemoryLocations();
-  for (const auto& pointee : pointeeSet)
-  {  
-      auto fe = memoryDAG_->fromIndex(pointee);
-      // avoid cycles where the wildcard points
-      // to itself
-      if (fe != e)
-      {
-        memoryDAG_->makePointerTo(fe, e);
-      }
+  // point everything v aliases to the wildcard
+  const auto &pointeeSet = getOrCreateElement(v)->getMemoryLocations();
+  for (const auto &pointee : pointeeSet) {
+    auto fe = memoryDAG_->fromIndex(pointee);
+    // avoid cycles where the wildcard points
+    // to itself
+    if (fe != e) {
+      memoryDAG_->makePointerTo(fe, e);
+    }
   }
 }
 

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -112,9 +112,9 @@ Element* MemoryDAG::makeFreshValue(const Value* v) {
 }
 
 const MemoryLocations& Element::getMemoryLocations() const {
-  // if (false && !cachedMemoryLocations_.empty()) {
-  //   return cachedMemoryLocations_;
-  // }
+  if (!cachedMemoryLocations_.empty()) {
+    return cachedMemoryLocations_;
+  }
 
   // Do a BFS in the `points-to` direction, collecting all memory locations
   MemoryLocations ret;

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -16,9 +16,9 @@ const Element* MemoryDAG::fromIndex(unsigned x) const {
   return indexToElementMap[x].get();
 }
 
-Element* MemoryDAG::fromIndex(unsigned x) {
-    TORCH_INTERNAL_ASSERT(x < indexToElementMap.size());
-      return indexToElementMap[x].get();
+Element *MemoryDAG::fromIndex(unsigned x) {
+  TORCH_INTERNAL_ASSERT(x < indexToElementMap.size());
+  return indexToElementMap[x].get();
 }
 
 bool MemoryDAG::mayAlias(Element* a, Element* b) const {

--- a/torch/csrc/jit/passes/utils/memory_dag.cpp
+++ b/torch/csrc/jit/passes/utils/memory_dag.cpp
@@ -16,6 +16,11 @@ const Element* MemoryDAG::fromIndex(unsigned x) const {
   return indexToElementMap[x].get();
 }
 
+Element* MemoryDAG::fromIndex(unsigned x) {
+    TORCH_INTERNAL_ASSERT(x < indexToElementMap.size());
+      return indexToElementMap[x].get();
+}
+
 bool MemoryDAG::mayAlias(Element* a, Element* b) const {
   return mayAliasImpl(a, b);
 }
@@ -107,9 +112,9 @@ Element* MemoryDAG::makeFreshValue(const Value* v) {
 }
 
 const MemoryLocations& Element::getMemoryLocations() const {
-  if (!cachedMemoryLocations_.empty()) {
-    return cachedMemoryLocations_;
-  }
+  // if (false && !cachedMemoryLocations_.empty()) {
+  //   return cachedMemoryLocations_;
+  // }
 
   // Do a BFS in the `points-to` direction, collecting all memory locations
   MemoryLocations ret;

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -64,9 +64,9 @@ class TORCH_API MemoryDAG {
 
   // Converts from the compressed index representation
   const Element* fromIndex(unsigned x) const;
-  Element* fromIndex(unsigned x);
+  Element *fromIndex(unsigned x);
 
- private:
+private:
   bool mayAliasImpl(const Element* a, const Element* b) const;
   bool mayContainAliasImpl(const Element* contained, const Element* container)
       const;

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -64,6 +64,7 @@ class TORCH_API MemoryDAG {
 
   // Converts from the compressed index representation
   const Element* fromIndex(unsigned x) const;
+  Element* fromIndex(unsigned x);
 
  private:
   bool mayAliasImpl(const Element* a, const Element* b) const;


### PR DESCRIPTION
  this fixes a corner case where there's an aliasing chain
  v -> a1 -> a2 -> ... , and now v -> (*).
  if v may alias a wildcard anything v points to
  may **also** alias the wildcard.
  A simple example of this case would be:
  ```python
  def fn():
      x = torch.ones(2, 3)
      x_1 = x.view(-1)
      l = []
      l.append(x_1)
      x_view = l[0]
      x.add_(torch.ones(2, 3))
      return x_view
  ```
  if the fact that x points to (*) isn't recorded,
  `x.add_(torch.ones(2, 3))` will be removed by DCE,
  since x isn't alive at the end of `test_indirect`
  yet x, x_view, x1 all share the same memory
  and x_view is returned to the user.