### PR TITLE
[android][circleci] pytorch android circleci integration

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -54,7 +54,14 @@ CONFIG_TREE_DATA = [
             ("10.1", [X("3.6")]),
         ]),
         ("android", [
-            ("r19c", [XImportant("3.6")]),
+            ("r19c", [
+                ("3.6", [
+                    ("android_abi", [XImportant("x86_32")]),
+                    ("android_abi", [X("x86_64")]),
+                    ("android_abi", [X("arm-v7a")]),
+                    ("android_abi", [X("arm-v8a")]),
+                ])
+            ]),
         ]),
     ]),
 ]
@@ -124,6 +131,7 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
             "xla": XlaConfigNode,
             "namedtensor": NamedTensorConfigNode,
             "important": ImportantConfigNode,
+            "android_abi": AndroidAbiConfigNode,
         }
         return next_nodes[experimental_feature]
 
@@ -149,6 +157,13 @@ class NamedTensorConfigNode(TreeConfigNode):
     def child_constructor(self):
         return ImportantConfigNode
 
+class AndroidAbiConfigNode(TreeConfigNode):
+
+    def init2(self, node_name):
+        self.props["android_abi"] = node_name
+
+    def child_constructor(self):
+        return ImportantConfigNode
 
 class ImportantConfigNode(TreeConfigNode):
     def modify_label(self, label):

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -14,13 +14,14 @@ from typing import List, Optional
 
 DOCKER_IMAGE_PATH_BASE = "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/"
 
-DOCKER_IMAGE_VERSION = 336
+DOCKER_IMAGE_VERSION = 339
 
 
 @dataclass
 class Conf:
     distro: str
     parms: List[str]
+    parms_list_ignored_for_docker_image: Optional[List[str]] = None
     pyver: Optional[str] = None
     cuda_version: Optional[str] = None
     # TODO expand this to cover all the USE_* that we want to test for
@@ -51,7 +52,10 @@ class Conf:
         cuda_parms = []
         if self.cuda_version:
             cuda_parms.extend(["cuda" + self.cuda_version, "cudnn7"])
-        return leading + ["linux", self.distro] + cuda_parms + self.parms
+        result = leading + ["linux", self.distro] + cuda_parms + self.parms
+        if (not for_docker and self.parms_list_ignored_for_docker_image is not None):
+            result = result + self.parms_list_ignored_for_docker_image
+        return result
 
     def gen_docker_image_path(self):
 
@@ -194,6 +198,7 @@ def instantiate_configs():
         distro_name = fc.find_prop("distro_name")
         compiler_name = fc.find_prop("compiler_name")
         is_xla = fc.find_prop("is_xla") or False
+        parms_list_ignored_for_docker_image = []
 
         python_version = None
         if compiler_name == "cuda" or compiler_name == "android":
@@ -211,6 +216,8 @@ def instantiate_configs():
             # TODO: do we need clang to compile host binaries like protoc?
             parms_list.append("clang5")
             parms_list.append("android-ndk-" + android_ndk_version)
+            android_abi = fc.find_prop("android_abi")
+            parms_list_ignored_for_docker_image.append(android_abi)
             restrict_phases = ["build"]
 
         elif compiler_name:
@@ -237,6 +244,7 @@ def instantiate_configs():
         c = Conf(
             distro_name,
             parms_list,
+            parms_list_ignored_for_docker_image,
             python_version,
             cuda_version,
             is_xla,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,6 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         if [[ ${BUILD_ENVIRONMENT} == *"android"* ]]; then
           NAMED_FLAG="export USE_STATIC_DISPATCH=1"
         fi
-
         export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$NAMED_FLAG"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -119,6 +118,14 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
             export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
           elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-xla
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-x86_64"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-x86_64
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-arm-v7a"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-arm-v7a
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-arm-v8a"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-arm-v8a
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-x86_32"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-x86_32
           else
             export COMMIT_DOCKER_IMAGE=$output_image
           fi
@@ -712,118 +719,118 @@ jobs:
   pytorch_linux_xenial_py2_7_9_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py2.7.9-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py2_7_9_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py2.7.9-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7.9:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py2_7_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py2.7-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py2_7_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py2.7-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py2.7:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py3_5_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.5-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py3_5_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.5-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.5:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_pynightly_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-pynightly-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_pynightly_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-pynightly-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-pynightly:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py3_6_gcc4_8_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.6-gcc4.8-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc4.8:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc4.8:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py3_6_gcc4_8_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.6-gcc4.8-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc4.8:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc4.8:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py3_6_gcc5_4_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.6-gcc5.4-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py3_6_gcc5_4_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.6-gcc5.4-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-py3.6-gcc5.4-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_namedtensor_linux_xenial_py3_6_gcc5_4_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-py3.6-gcc5.4-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc5.4:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py3_6_gcc7_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.6-gcc7-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc7:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py3_6_gcc7_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3.6-gcc7-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-gcc7:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_py3_clang5_asan_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-asan-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_py3_clang5_asan_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-asan-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:339"
       PYTHON_VERSION: "3.6"
     resource_class: large
     <<: *pytorch_linux_test_defaults
@@ -831,14 +838,14 @@ jobs:
   pytorch_namedtensor_linux_xenial_py3_clang5_asan_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-py3-clang5-asan-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_namedtensor_linux_xenial_py3_clang5_asan_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-py3-clang5-asan-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-asan:339"
       PYTHON_VERSION: "3.6"
     resource_class: large
     <<: *pytorch_linux_test_defaults
@@ -846,27 +853,27 @@ jobs:
   pytorch_xla_linux_xenial_py3_6_clang7_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-xla-linux-xenial-py3.6-clang7-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:339"
     <<: *pytorch_linux_build_defaults
 
   pytorch_xla_linux_xenial_py3_6_clang7_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-xla-linux-xenial-py3.6-clang7-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3.6-clang7:339"
     resource_class: large
     <<: *pytorch_linux_test_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py2_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:339"
       PYTHON_VERSION: "2.7"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py2_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py2-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:339"
       PYTHON_VERSION: "2.7"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -875,14 +882,14 @@ jobs:
   pytorch_linux_xenial_cuda9_cudnn7_py3_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_cudnn7_py3_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -891,7 +898,7 @@ jobs:
   pytorch_linux_xenial_cuda9_cudnn7_py3_multigpu_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-multigpu-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
       MULTI_GPU: "1"
@@ -901,7 +908,7 @@ jobs:
   pytorch_linux_xenial_cuda9_cudnn7_py3_NO_AVX2_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-NO_AVX2-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -910,7 +917,7 @@ jobs:
   pytorch_linux_xenial_cuda9_cudnn7_py3_NO_AVX_NO_AVX2_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-NO_AVX-NO_AVX2-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -919,7 +926,7 @@ jobs:
   pytorch_linux_xenial_cuda9_cudnn7_py3_slow_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-slow-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -928,7 +935,7 @@ jobs:
   pytorch_linux_xenial_cuda9_cudnn7_py3_nogpu_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9-cudnn7-py3-nogpu-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
     resource_class: large
     <<: *pytorch_linux_test_defaults
@@ -936,14 +943,14 @@ jobs:
   pytorch_namedtensor_linux_xenial_cuda9_cudnn7_py2_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-cuda9-cudnn7-py2-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:339"
       PYTHON_VERSION: "2.7"
     <<: *pytorch_linux_build_defaults
 
   pytorch_namedtensor_linux_xenial_cuda9_cudnn7_py2_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-namedtensor-linux-xenial-cuda9-cudnn7-py2-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py2:339"
       PYTHON_VERSION: "2.7"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -952,14 +959,14 @@ jobs:
   pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -968,30 +975,51 @@ jobs:
   pytorch_linux_xenial_cuda10_cudnn7_py3_gcc7_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda10_1_cudnn7_py3_gcc7_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
   pytorch_linux_xenial_cuda10_1_cudnn7_py3_gcc7_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7-test
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
     <<: *pytorch_linux_test_defaults
 
-  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_build:
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build:
     environment:
-      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:336"
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_64-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v7a-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v8a-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
 
@@ -1032,7 +1060,7 @@ jobs:
   pytorch_short_perf_test_gpu:
     environment:
       BUILD_ENVIRONMENT: pytorch-short-perf-test-gpu
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -1073,7 +1101,7 @@ jobs:
     environment:
       BUILD_ENVIRONMENT: pytorch-python-doc-push
       # TODO: stop hardcoding this
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -1123,7 +1151,7 @@ jobs:
   pytorch_cpp_doc_push:
     environment:
       BUILD_ENVIRONMENT: pytorch-cpp-doc-push
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -1296,6 +1324,142 @@ jobs:
             git submodule sync && git submodule update -q --init --recursive
             chmod a+x .jenkins/pytorch/macos-build.sh
             unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
+
+  pytorch_android_gradle_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - attach_workspace:
+        at: ~/workspace
+    - run:
+        <<: *should_run_job
+    - run:
+        <<: *setup_linux_system_environment
+    - checkout
+    - run:
+        <<: *setup_ci_environment
+    - run:
+        name: PytorchAndroidGradleBuild
+        no_output_timeout: "1h"
+        command: |
+          set -e
+          docker_image_commit=${DOCKER_IMAGE}-${CIRCLE_SHA1}
+
+          docker_image_libtorch_android_x86_32=${docker_image_commit}-android-x86_32
+          docker_image_libtorch_android_x86_64=${docker_image_commit}-android-x86_64
+          docker_image_libtorch_android_arm_v7a=${docker_image_commit}-android-arm-v7a
+          docker_image_libtorch_android_arm_v8a=${docker_image_commit}-android-arm-v8a
+
+          echo "docker_image_commit: "${docker_image_commit}
+          echo "docker_image_libtorch_android_x86_32: "${docker_image_libtorch_android_x86_32}
+          echo "docker_image_libtorch_android_x86_64: "${docker_image_libtorch_android_x86_64}
+          echo "docker_image_libtorch_android_arm_v7a: "${docker_image_libtorch_android_arm_v7a}
+          echo "docker_image_libtorch_android_arm_v8a: "${docker_image_libtorch_android_arm_v8a}
+
+          # x86_32
+          docker pull ${docker_image_libtorch_android_x86_32} >/dev/null
+          export id_x86_32=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_32})
+          mkdir ~/workspace/build_android_install_x86_32
+          docker cp $id_x86_32:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_x86_32
+
+          # arm-v7a
+          docker pull ${docker_image_libtorch_android_arm_v7a} >/dev/null
+          export id_arm_v7a=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_arm_v7a})
+          mkdir ~/workspace/build_android_install_arm_v7a
+          docker cp $id_arm_v7a:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_arm_v7a
+
+          # x86_64
+          docker pull ${docker_image_libtorch_android_x86_64} >/dev/null
+          export id_x86_64=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_64})
+          mkdir ~/workspace/build_android_install_x86_64
+          docker cp $id_x86_64:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_x86_64
+
+          # arm-v8a
+          docker pull ${docker_image_libtorch_android_arm_v8a} >/dev/null
+          export id_arm_v8a=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_arm_v8a})
+          mkdir ~/workspace/build_android_install_arm_v8a
+          docker cp $id_arm_v8a:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_arm_v8a
+
+          #docker_image_for_gradle=${docker_image_libtorch_android_x86_32}
+          #docker pull ${docker_image_for_gradle} >/dev/null
+          #export id=$(docker run -t -d -w /var/lib/jenkins ${docker_image_for_gradle})
+
+          export id=id_x86_32
+
+          docker cp ~/workspace/build_android_install_x86_32 $id:/var/lib/jenkins/workspace/build_android_install_x86_32
+          docker cp ~/workspace/build_android_install_arm_v7a $id:/var/lib/jenkins/workspace/build_android_install_arm_v7a
+          docker cp ~/workspace/build_android_install_x86_64 $id:/var/lib/jenkins/workspace/build_android_install_x86_64
+          docker cp ~/workspace/build_android_install_arm_v8a $id:/var/lib/jenkins/workspace/build_android_install_arm_v8a
+
+          # run gradle buildRelease
+          export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh || true") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts || true
+
+          mkdir -p ~/workspace/build_android_aar
+          docker cp $id:/var/lib/jenkins/workspace/android/pytorch_android/build/outputs/aar/pytorch_android.aar ~/workspace/build_android_aar/
+
+          output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-gradle
+          docker commit "$id" ${output_image}
+          docker push ${output_image}
+#    - store_artifacts:
+#        path: ~/workspace/build_android_aar/pytorch_android.aar
+#        destination: pytorch_android.aar
+
+  pytorch_android_gradle_build-x86_32:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - attach_workspace:
+        at: ~/workspace
+    - run:
+        <<: *should_run_job
+    - run:
+        name: filter_run_only_on_pr
+        no_output_timeout: "5m"
+        command: |
+          echo "CIRCLE_PULL_REQUEST: ${CIRCLE_PULL_REQUEST:-}"
+          if [ -z "${CIRCLE_PULL_REQUEST:-}" ]; then
+            circleci step halt
+          fi
+    - run:
+        <<: *setup_linux_system_environment
+    - checkout
+    - run:
+        <<: *setup_ci_environment
+    - run:
+        name: PytorchAndroidGradleBuildX86
+        no_output_timeout: "1h"
+        command: |
+          set -e
+          docker_image_libtorch_android_x86_32=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-x86_32
+          echo "docker_image_libtorch_android_x86_32: "${docker_image_libtorch_android_x86_32}
+
+          # x86
+          docker pull ${docker_image_libtorch_android_x86_32} >/dev/null
+          export id=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_32})
+
+          export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh || true") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts || true
+
+          mkdir -p ~/workspace/build_android_aar_x86_32
+          docker cp $id:/var/lib/jenkins/workspace/android/pytorch_android/build/outputs/aar/pytorch_android.aar ~/workspace/build_android_aar_x86_32/
+
+          output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-gradle-x86_32
+          docker commit "$id" ${output_image}
+          docker push ${output_image}
+#    - store_artifacts:
+#        path: ~/workspace/build_android_aar_x86_32/pytorch_android.aar
+#        destination: pytorch_android_x86.aar
   caffe2_py2_gcc4_8_ubuntu14_04_build:
     environment:
       BUILD_ENVIRONMENT: "caffe2-py2-gcc4.8-ubuntu14.04-build"
@@ -3417,9 +3581,33 @@ workflows:
               only:
                 - master
                 - /ci-all\/.*/
-      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_build:
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build:
           requires:
             - setup
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
       # Warning: indentation here matters!
 
       # Pytorch MacOS builds
@@ -3439,6 +3627,16 @@ workflows:
       - pytorch_macos_10_13_cuda9_2_cudnn7_py3_build:
           requires:
             - setup
+      - pytorch_android_gradle_build-x86_32:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+
+      - pytorch_android_gradle_build:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
       - caffe2_py2_gcc4_8_ubuntu14_04_build:
           filters:
             branches:

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -103,6 +103,7 @@ YAML_SOURCES = [
     File("workflows.yml"),
     Listgen(pytorch_build_definitions.get_workflow_list, 3),
     File("workflows-pytorch-macos-builds.yml"),
+    File("workflows-pytorch-android-gradle-build.yml"),
     Listgen(caffe2_build_definitions.get_caffe2_workflows, 3),
     File("workflows-binary-builds-smoke-subset.yml"),
     Header("Daily smoke test trigger"),

--- a/.circleci/scripts/build_android_gradle.sh
+++ b/.circleci/scripts/build_android_gradle.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+# sh ./build_android_gradle_dockerpart.sh
+
+echo "$(pwd)"
+echo "HOME:$(~/.)"
+
+export ANDROID_NDK_HOME=/opt/ndk
+export ANDROID_HOME=/opt/android/sdk
+
+export GRADLE_VERSION=5.1.1
+export GRADLE_HOME=/opt/gradle/gradle-$GRADLE_VERSION
+export GRADLE_PATH=$GRADLE_HOME/bin/gradle
+
+PYTORCH_ANDROID_SRC_MAIN_DIR=~/workspace/android/pytorch_android/src/main
+
+JNI_LIBS_DIR=${PYTORCH_ANDROID_SRC_MAIN_DIR}/jniLibs
+mkdir -p $JNI_LIBS_DIR
+JNI_LIBS_DIR_x86=${JNI_LIBS_DIR}/x86
+mkdir -p $JNI_LIBS_DIR_x86
+
+JNI_INCLUDE_DIR=${PYTORCH_ANDROID_SRC_MAIN_DIR}/cpp/libtorch_include
+mkdir -p $JNI_INCLUDE_DIR
+JNI_INCLUDE_DIR_x86=${JNI_INCLUDE_DIR}/x86
+
+if [[ "${BUILD_ENVIRONMENT}" == *-gradle-build-only-x86_32* ]]; then
+    BUILD_ANDROID_INCLUDE_DIR_x86=~/workspace/build_android/install/include
+    BUILD_ANDROID_LIB_DIR_x86=~/workspace/build_android/install/lib
+else
+    BUILD_ANDROID_INCLUDE_DIR_x86=~/workspace/build_android_install_x86_32/install/include
+    BUILD_ANDROID_LIB_DIR_x86=~/workspace/build_android_install_x86_32/install/lib
+
+    BUILD_ANDROID_INCLUDE_DIR_x86_64=~/workspace/build_android_install_x86_64/install/include
+    BUILD_ANDROID_LIB_DIR_x86_64=~/workspace/build_android_install_x86_64/install/lib
+
+    BUILD_ANDROID_INCLUDE_DIR_arm_v7a=~/workspace/build_android_install_arm_v7a/install/include
+    BUILD_ANDROID_LIB_DIR_arm_v7a=~/workspace/build_android_install_arm_v7a/install/lib
+
+    BUILD_ANDROID_INCLUDE_DIR_arm_v8a=~/workspace/build_android_install_arm_v8a/install/include
+    BUILD_ANDROID_LIB_DIR_arm_v8a=~/workspace/build_android_install_arm_v8a/install/lib
+
+    JNI_LIBS_DIR_x86_64=${JNI_LIBS_DIR}/x86_64
+    mkdir -p $JNI_LIBS_DIR_x86_64
+    JNI_LIBS_DIR_arm_v7a=${JNI_LIBS_DIR}/armeabi-v7a
+    mkdir -p $JNI_LIBS_DIR_arm_v7a
+    JNI_LIBS_DIR_arm_v8a=${JNI_LIBS_DIR}/arm64-v8a
+    mkdir -p $JNI_LIBS_DIR_arm_v8a
+
+    JNI_INCLUDE_DIR_x86_64=${JNI_INCLUDE_DIR}/x86_64
+    JNI_INCLUDE_DIR_arm_v7a=${JNI_INCLUDE_DIR}/armeabi-v7a
+    JNI_INCLUDE_DIR_arm_v8a=${JNI_INCLUDE_DIR}/arm64-v8a
+
+    ln -s ${BUILD_ANDROID_INCLUDE_DIR_x86_64} ${JNI_INCLUDE_DIR_x86_64}
+    ln -s ${BUILD_ANDROID_INCLUDE_DIR_arm_v7a} ${JNI_INCLUDE_DIR_arm_v7a}
+    ln -s ${BUILD_ANDROID_INCLUDE_DIR_arm_v8a} ${JNI_INCLUDE_DIR_arm_v8a}
+
+    ln -s ${BUILD_ANDROID_LIB_DIR_x86_64}/libc10.so ${JNI_LIBS_DIR_x86_64}/libc10.so
+    ln -s ${BUILD_ANDROID_LIB_DIR_x86_64}/libtorch.so ${JNI_LIBS_DIR_x86_64}/libtorch.so
+
+    ln -s ${BUILD_ANDROID_LIB_DIR_arm_v7a}/libc10.so ${JNI_LIBS_DIR_arm_v7a}/libc10.so
+    ln -s ${BUILD_ANDROID_LIB_DIR_arm_v7a}/libtorch.so ${JNI_LIBS_DIR_arm_v7a}/libtorch.so
+
+    ln -s ${BUILD_ANDROID_LIB_DIR_arm_v8a}/libc10.so ${JNI_LIBS_DIR_arm_v8a}/libc10.so
+    ln -s ${BUILD_ANDROID_LIB_DIR_arm_v8a}/libtorch.so ${JNI_LIBS_DIR_arm_v8a}/libtorch.so
+fi
+
+ln -s ${BUILD_ANDROID_INCLUDE_DIR_x86} ${JNI_INCLUDE_DIR_x86}
+ln -s ${BUILD_ANDROID_LIB_DIR_x86}/libc10.so ${JNI_LIBS_DIR_x86}/libc10.so
+ln -s ${BUILD_ANDROID_LIB_DIR_x86}/libtorch.so ${JNI_LIBS_DIR_x86}/libtorch.so
+
+export GRADLE_LOCAL_PROPERTIES=~/workspace/android/local.properties
+rm -f $GRADLE_LOCAL_PROPERTIES
+echo "sdk.dir=/opt/android/sdk" >> $GRADLE_LOCAL_PROPERTIES
+echo "ndk.dir=/opt/ndk" >> $GRADLE_LOCAL_PROPERTIES
+
+if [[ "${BUILD_ENVIRONMENT}" == *-gradle-build-only-x86_32* ]]; then
+    $GRADLE_PATH -PABI_FILTERS=x86 -p ~/workspace/android/ assembleRelease
+else
+    $GRADLE_PATH -p ~/workspace/android/ assembleRelease
+fi
+
+find . -type f -name *aar | xargs ls -lah

--- a/.circleci/scripts/build_android_gradle_dockerpart.sh
+++ b/.circleci/scripts/build_android_gradle_dockerpart.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+echo "$(pwd)"
+echo "HOME:$(~/.)"
+
+# ---------------------------------
+# Installing openjdk-8
+# https://hub.docker.com/r/picoded/ubuntu-openjdk-8-jdk/dockerfile/
+
+sudo apt-get update && \
+    sudo apt-get install -y openjdk-8-jdk && \
+    sudo apt-get install -y ant && \
+    sudo apt-get clean && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    sudo rm -rf /var/cache/oracle-jdk8-installer;
+
+sudo apt-get update && \
+    sudo apt-get install -y ca-certificates-java && \
+    sudo apt-get clean && \
+    sudo update-ca-certificates -f && \
+    sudo rm -rf /var/lib/apt/lists/* && \
+    sudo rm -rf /var/cache/oracle-jdk8-installer;
+
+# ---------------------------------
+# Installing android sdk
+# https://github.com/circleci/circleci-images/blob/staging/android/Dockerfile.m4
+
+_sdk_version=sdk-tools-linux-3859397.zip
+_android_home=/opt/android/sdk
+
+rm -rf $_android_home
+sudo mkdir -p $_android_home
+curl --silent --show-error --location --fail --retry 3 --output /tmp/$_sdk_version https://dl.google.com/android/repository/$_sdk_version
+sudo unzip -q /tmp/$_sdk_version -d $_android_home
+rm /tmp/$_sdk_version
+
+sudo chmod -R 777 $_android_home
+
+export ANDROID_HOME=$_android_home
+export ADB_INSTALL_TIMEOUT=120
+
+export PATH="${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+echo "PATH:${PATH}"
+
+alias sdkmanager=${ANDROID_HOME}/tools/bin/sdkmanager
+
+sudo mkdir /var/lib/jenkins/.android/
+sudo chmod -R 777 /var/lib/jenkins/.android/
+echo '### User Sources for Android SDK Manager' > /var/lib/jenkins/.android/repositories.cfg
+sudo chmod -R 777 /var/lib/jenkins/.android/
+
+sudo yes | sudo sdkmanager --update
+sudo yes | sudo sdkmanager --licenses
+
+sdkmanager \
+  "tools" \
+  "platform-tools" \
+  "emulator"
+
+sdkmanager \
+  "build-tools;28.0.3"
+
+sdkmanager "platforms;android-28"
+
+sdkmanager --list
+
+# ---------------------------------
+# Installing android sdk
+# https://github.com/keeganwitt/docker-gradle/blob/a206b4a26547df6d8b29d06dd706358e3801d4a9/jdk8/Dockerfile
+export GRADLE_VERSION=5.1.1
+_gradle_home=/opt/gradle
+sudo rm -rf $_gradle_home
+sudo mkdir -p $_gradle_home
+
+wget --no-verbose --output-document=/tmp/gradle.zip \
+"https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+
+sudo unzip -q /tmp/gradle.zip -d $_gradle_home
+rm /tmp/gradle.zip
+
+sudo chmod -R 777 $_gradle_home
+
+export GRADLE_HOME=$_gradle_home/gradle-$GRADLE_VERSION
+
+export PATH="${GRADLE_HOME}/bin/:${PATH}"
+echo "PATH:${PATH}"
+
+alias gradle=$GRADLE_HOME/bin/gradle
+
+gradle --version

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -13,23 +13,23 @@ default_set = [
     # Selected oldest Python 2 version to ensure Python 2 coverage
     'pytorch-linux-xenial-py2.7.9',
     # PyTorch CUDA
-    'pytorch-linux-xenial-cuda9-cudnn7-py3',
+    #'pytorch-linux-xenial-cuda9-cudnn7-py3',
     # PyTorch ASAN
-    'pytorch-linux-xenial-py3-clang5-asan',
+    #'pytorch-linux-xenial-py3-clang5-asan',
     # PyTorch DEBUG
     'pytorch-linux-xenial-py3.6-gcc5.4',
 
     # Caffe2 CPU
-    'caffe2-py2-mkl-ubuntu16.04',
+    #'caffe2-py2-mkl-ubuntu16.04',
     # Caffe2 CUDA
-    'caffe2-py2-cuda9.1-cudnn7-ubuntu16.04',
+    #'caffe2-py2-cuda9.1-cudnn7-ubuntu16.04',
     # Caffe2 ONNX
-    'caffe2-onnx-py2-gcc5-ubuntu16.04',
-    'caffe2-onnx-py3.6-clang7-ubuntu16.04',
+    #'caffe2-onnx-py2-gcc5-ubuntu16.04',
+    #'caffe2-onnx-py3.6-clang7-ubuntu16.04',
     # Caffe2 Clang
-    'caffe2-py2-clang7-ubuntu16.04',
+    #'caffe2-py2-clang7-ubuntu16.04',
     # Caffe2 CMake
-    'caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04',
+    #'caffe2-cmake-cuda9.0-cudnn7-ubuntu16.04',
 
     # Binaries
     'manywheel 2.7mu cpu devtoolset7',
@@ -37,21 +37,30 @@ default_set = [
     'libtorch 2.7m cpu gcc5.4_cxx11-abi',
 
     # Caffe2 Android
-    'caffe2-py2-android-ubuntu16.04',
+    #'caffe2-py2-android-ubuntu16.04',
     # Caffe2 OSX
-    'caffe2-py2-system-macos10.13',
+    #'caffe2-py2-system-macos10.13',
     # PyTorch OSX
-    'pytorch-macos-10.13-cuda9.2-cudnn7-py3',
+    #'pytorch-macos-10.13-cuda9.2-cudnn7-py3',
     # PyTorch Android
-    'pytorch-linux-xenial-py3-clang5-android-ndk-r19c',
+    'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32-build',
+    # PyTorch Android gradle
+    'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32',
+
+    #NOT_FOR_COMMIT begin
+    #'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_64-build',
+    #'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v7a-build',
+    #'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v8a-build',
+    #'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build',
+    #NOT_FOR_COMMIT_end
 
     # XLA
-    'pytorch-xla-linux-xenial-py3.6-clang7',
+    #'pytorch-xla-linux-xenial-py3.6-clang7',
 
     # Other checks
-    'pytorch-short-perf-test-gpu',
-    'pytorch-python-doc-push',
-    'pytorch-cpp-doc-push',
+    #'pytorch-short-perf-test-gpu',
+    #'pytorch-python-doc-push',
+    #'pytorch-cpp-doc-push',
 ]
 
 # Takes in commit message to analyze via stdin

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -1,7 +1,7 @@
   pytorch_short_perf_test_gpu:
     environment:
       BUILD_ENVIRONMENT: pytorch-short-perf-test-gpu
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
       PYTHON_VERSION: "3.6"
       USE_CUDA_DOCKER_RUNTIME: "1"
     resource_class: gpu.medium
@@ -42,7 +42,7 @@
     environment:
       BUILD_ENVIRONMENT: pytorch-python-doc-push
       # TODO: stop hardcoding this
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -92,7 +92,7 @@
   pytorch_cpp_doc_push:
     environment:
       BUILD_ENVIRONMENT: pytorch-cpp-doc-push
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:336"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9-cudnn7-py3:339"
     resource_class: large
     machine:
       image: ubuntu-1604:201903-01
@@ -265,3 +265,139 @@
             git submodule sync && git submodule update -q --init --recursive
             chmod a+x .jenkins/pytorch/macos-build.sh
             unbuffer .jenkins/pytorch/macos-build.sh 2>&1 | ts
+
+  pytorch_android_gradle_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - attach_workspace:
+        at: ~/workspace
+    - run:
+        <<: *should_run_job
+    - run:
+        <<: *setup_linux_system_environment
+    - checkout
+    - run:
+        <<: *setup_ci_environment
+    - run:
+        name: PytorchAndroidGradleBuild
+        no_output_timeout: "1h"
+        command: |
+          set -e
+          docker_image_commit=${DOCKER_IMAGE}-${CIRCLE_SHA1}
+
+          docker_image_libtorch_android_x86_32=${docker_image_commit}-android-x86_32
+          docker_image_libtorch_android_x86_64=${docker_image_commit}-android-x86_64
+          docker_image_libtorch_android_arm_v7a=${docker_image_commit}-android-arm-v7a
+          docker_image_libtorch_android_arm_v8a=${docker_image_commit}-android-arm-v8a
+
+          echo "docker_image_commit: "${docker_image_commit}
+          echo "docker_image_libtorch_android_x86_32: "${docker_image_libtorch_android_x86_32}
+          echo "docker_image_libtorch_android_x86_64: "${docker_image_libtorch_android_x86_64}
+          echo "docker_image_libtorch_android_arm_v7a: "${docker_image_libtorch_android_arm_v7a}
+          echo "docker_image_libtorch_android_arm_v8a: "${docker_image_libtorch_android_arm_v8a}
+
+          # x86_32
+          docker pull ${docker_image_libtorch_android_x86_32} >/dev/null
+          export id_x86_32=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_32})
+          mkdir ~/workspace/build_android_install_x86_32
+          docker cp $id_x86_32:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_x86_32
+
+          # arm-v7a
+          docker pull ${docker_image_libtorch_android_arm_v7a} >/dev/null
+          export id_arm_v7a=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_arm_v7a})
+          mkdir ~/workspace/build_android_install_arm_v7a
+          docker cp $id_arm_v7a:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_arm_v7a
+
+          # x86_64
+          docker pull ${docker_image_libtorch_android_x86_64} >/dev/null
+          export id_x86_64=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_64})
+          mkdir ~/workspace/build_android_install_x86_64
+          docker cp $id_x86_64:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_x86_64
+
+          # arm-v8a
+          docker pull ${docker_image_libtorch_android_arm_v8a} >/dev/null
+          export id_arm_v8a=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_arm_v8a})
+          mkdir ~/workspace/build_android_install_arm_v8a
+          docker cp $id_arm_v8a:/var/lib/jenkins/workspace/build_android/install ~/workspace/build_android_install_arm_v8a
+
+          #docker_image_for_gradle=${docker_image_libtorch_android_x86_32}
+          #docker pull ${docker_image_for_gradle} >/dev/null
+          #export id=$(docker run -t -d -w /var/lib/jenkins ${docker_image_for_gradle})
+
+          export id=id_x86_32
+
+          docker cp ~/workspace/build_android_install_x86_32 $id:/var/lib/jenkins/workspace/build_android_install_x86_32
+          docker cp ~/workspace/build_android_install_arm_v7a $id:/var/lib/jenkins/workspace/build_android_install_arm_v7a
+          docker cp ~/workspace/build_android_install_x86_64 $id:/var/lib/jenkins/workspace/build_android_install_x86_64
+          docker cp ~/workspace/build_android_install_arm_v8a $id:/var/lib/jenkins/workspace/build_android_install_arm_v8a
+
+          # run gradle buildRelease
+          export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh || true") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts || true
+
+          mkdir -p ~/workspace/build_android_aar
+          docker cp $id:/var/lib/jenkins/workspace/android/pytorch_android/build/outputs/aar/pytorch_android.aar ~/workspace/build_android_aar/
+
+          output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-gradle
+          docker commit "$id" ${output_image}
+          docker push ${output_image}
+#    - store_artifacts:
+#        path: ~/workspace/build_android_aar/pytorch_android.aar
+#        destination: pytorch_android.aar
+
+  pytorch_android_gradle_build-x86_32:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - attach_workspace:
+        at: ~/workspace
+    - run:
+        <<: *should_run_job
+    - run:
+        name: filter_run_only_on_pr
+        no_output_timeout: "5m"
+        command: |
+          echo "CIRCLE_PULL_REQUEST: ${CIRCLE_PULL_REQUEST:-}"
+          if [ -z "${CIRCLE_PULL_REQUEST:-}" ]; then
+            circleci step halt
+          fi
+    - run:
+        <<: *setup_linux_system_environment
+    - checkout
+    - run:
+        <<: *setup_ci_environment
+    - run:
+        name: PytorchAndroidGradleBuildX86
+        no_output_timeout: "1h"
+        command: |
+          set -e
+          docker_image_libtorch_android_x86_32=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-x86_32
+          echo "docker_image_libtorch_android_x86_32: "${docker_image_libtorch_android_x86_32}
+
+          # x86
+          docker pull ${docker_image_libtorch_android_x86_32} >/dev/null
+          export id=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_32})
+
+          export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh || true") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts || true
+
+          mkdir -p ~/workspace/build_android_aar_x86_32
+          docker cp $id:/var/lib/jenkins/workspace/android/pytorch_android/build/outputs/aar/pytorch_android.aar ~/workspace/build_android_aar_x86_32/
+
+          output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-gradle-x86_32
+          docker commit "$id" ${output_image}
+          docker push ${output_image}
+#    - store_artifacts:
+#        path: ~/workspace/build_android_aar_x86_32/pytorch_android.aar
+#        destination: pytorch_android_x86.aar

--- a/.circleci/verbatim-sources/linux-build-defaults.yml
+++ b/.circleci/verbatim-sources/linux-build-defaults.yml
@@ -41,7 +41,6 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
         if [[ ${BUILD_ENVIRONMENT} == *"android"* ]]; then
           NAMED_FLAG="export USE_STATIC_DISPATCH=1"
         fi
-
         export COMMAND='((echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo '"$NAMED_FLAG"' && echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh") | docker exec -u jenkins -i "$id" bash) 2>&1'
         echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -56,6 +55,14 @@ pytorch_linux_build_defaults: &pytorch_linux_build_defaults
             export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
           elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
             export COMMIT_DOCKER_IMAGE=$output_image-xla
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-x86_64"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-x86_64
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-arm-v7a"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-arm-v7a
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-arm-v8a"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-arm-v8a
+          elif [[ ${BUILD_ENVIRONMENT} == *"android-ndk-r19c-x86_32"* ]]; then
+            export COMMIT_DOCKER_IMAGE=$output_image-android-x86_32
           else
             export COMMIT_DOCKER_IMAGE=$output_image
           fi

--- a/.circleci/verbatim-sources/workflows-pytorch-android-gradle-build.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-android-gradle-build.yml
@@ -1,0 +1,10 @@
+      - pytorch_android_gradle_build-x86_32:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+
+      - pytorch_android_gradle_build:
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -66,6 +66,18 @@ if [[ "${BUILD_ENVIRONMENT}" == *-android* ]]; then
   export ANDROID_NDK=/opt/ndk
   build_args=()
   build_args+=("-DBUILD_CAFFE2_MOBILE=OFF")
+
+  build_args+=("-DBUILD_SHARED_LIBS=ON")
+  if [[ "${BUILD_ENVIRONMENT}" == *-arm-v7a* ]]; then
+    build_args+=("-DANDROID_ABI=armeabi-v7a")
+  elif [[ "${BUILD_ENVIRONMENT}" == *-arm-v8a* ]]; then
+    build_args+=("-DANDROID_ABI=arm64-v8a")
+  elif [[ "${BUILD_ENVIRONMENT}" == *-x86_32* ]]; then
+    build_args+=("-DANDROID_ABI=x86")
+  elif [[ "${BUILD_ENVIRONMENT}" == *-x86_64* ]]; then
+    build_args+=("-DANDROID_ABI=x86_64")
+  fi
+
   build_args+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
   build_args+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
   exec ./scripts/build_android.sh "${build_args[@]}" "$@"

--- a/.jenkins/pytorch/buildbuild.sh
+++ b/.jenkins/pytorch/buildbuild.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p /var/lib/jenkins/workspace/build_android/install/include
+mkdir -p /var/lib/jenkins/workspace/build_android/install/lib
+echo includefile > /var/lib/jenkins/workspace/build_android/install/include/includefile
+echo libfile > /var/lib/jenkins/workspace/build_android/install/lib/libfile

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+ABI_FILTERS=armeabi-v7a,arm64-v8a,x86,x86_64

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -12,7 +12,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+            abiFilters ABI_FILTERS.split(",")
         }
     }
     buildTypes {


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/25128 - PR to pytorch with config updates

https://github.com/pietern/pytorch-dockerfiles/pull/35 - PR to pytorch-dockerfiles with update of android docker image

https://github.com/pytorch/pytorch/tree/master/android - pytorch android in pytorch repo.
It is built by gradle, needs builds of libtorch for 4 android_abis: (Arm-v7a, Arm-v8a, X86, X86_64)

General idea:
Introducing 4 jobs for libtorch android_abi’s, based in current android job, that was made by Jiakai, these jobs run in parallel:

      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_build:
          requires:
            - setup
      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build:
          requires:
            - setup
      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build:
          requires:
            - setup
      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build:
          requires:
            - setup

And one job that waits for them 

      - pytorch_android_gradle_build:
          requires:
            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_build
            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build


All jobs use the same base docker_image, libtorch_android_abi commit docker images with different arch-suffixes (like it is now for xla and namedtensor):

          if [[ ${BUILD_ENVIRONMENT} == *"namedtensor"* ]]; then
            export COMMIT_DOCKER_IMAGE=$output_image-namedtensor
          elif [[ ${BUILD_ENVIRONMENT} == *"xla"* ]]; then
            export COMMIT_DOCKER_IMAGE=$output_image-xla
          elif [[ ${BUILD_ENVIRONMENT} == *"-x86"* ]]; then
            export COMMIT_DOCKER_IMAGE=$output_image-android-x86
          elif [[ ${BUILD_ENVIRONMENT} == *"-arm-v7a"* ]]; then
            export COMMIT_DOCKER_IMAGE=$output_image-android-arm-v7a
          elif [[ ${BUILD_ENVIRONMENT} == *"-arm-v8a"* ]]; then
            export COMMIT_DOCKER_IMAGE=$output_image-android-arm-v8a
          elif [[ ${BUILD_ENVIRONMENT} == *"-x86_64"* ]]; then
            export COMMIT_DOCKER_IMAGE=$output_image-android-x86_64
          else
            export COMMIT_DOCKER_IMAGE=$output_image
          fi


Pytorch_android_gradle_build job copies headers and libtorch.so, libc10.so results from libtorch android docker images, to workspace first and to it’s own docker image afterwards

And runs  .circleci/scripts/build_android_gradle.sh which runs gradle assembleRelease to build aar package that will be uploaded to bintray (maven repo)

To build gradle package we need gradle, openjdk, android_sdk, at the moment I put all those installations in build_android_gradle.sh, but that should be in docker image:
https://github.com/pietern/pytorch-dockerfiles/pull/35 

Generation of libtorch android builds for 4 android_abis:

In pytorch_build_data.py I added new AndroidAbiConfigNode:
class AndroidAbiConfigNode(TreeConfigNode):
    def init2(self, node_name):
        self.props["android_abi"] = node_name
    def child_constructor(self):
        return ImportantConfigNode
That can be children of 
ExperimentalFeatureConfigNode
And it results:

        ("android", [
            ("r19c", [
                ("3.6", [
                    ("android_abi", [XImportant("x86")]),
                    ("android_abi", [XImportant("x86_64")]),
                    ("android_abi", [XImportant("arm-v7a")]),
                    ("android_abi", [XImportant("arm-v8a")]),
                ])
            ]),
        ]),




Why introduced pytorch_build_definitions.py Conf.parms_list_ignored_for_docker_image

As all parameters are used for docker_image_name generation - while I wanted to use the same docker image for all android jobs - 
I added to Conf class field Parms_list_ignored_for_docker_image that contains parameters that will not be joined to docker_image but used for job name generation and build_environment generation
