### PR TITLE
Optimize LeftRight and either

### DIFF
--- a/c10/util/either.h
+++ b/c10/util/either.h
@@ -101,7 +101,7 @@ class either final {
   }
 
   const Left& left() const& {
-    if (!is_left()) {
+    if (C10_UNLIKELY(!is_left())) {
       throw std::logic_error(
           "Tried to get left side of an either which is right.");
     }
@@ -116,7 +116,7 @@ class either final {
   }
 
   const Right& right() const& {
-    if (!is_right()) {
+    if (C10_UNLIKELY(!is_right())) {
       throw std::logic_error(
           "Tried to get right side of an either which is left.");
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25133 Optimize LeftRight and either**

This is driven by benchmarks I did for moving ATen ops to the c10 operator library.
Improvements:
 - tell the compiler that the error cases are unlikely so it can optimize code better
 - optimize cache layout of LeftRight.

Differential Revision: [D16998010](https://our.internmc.facebook.com/intern/diff/D16998010/)