### PR TITLE
[pt1][quant] Fix the convert function issue

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -63,7 +63,7 @@ def test_only_train_fn(model, train_data, loss_fn=_default_loss_fn):
     return train_loss, correct, total
 
 def convert_dynamic(module):
-    convert(module, DEFAULT_DYNAMIC_MODULE_MAPPING)
+    return convert(module, DEFAULT_DYNAMIC_MODULE_MAPPING)
 
 def prepare_dynamic(model, qconfig_dict=None):
     propagate_qconfig(model, qconfig_dict)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -47,7 +47,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         self.checkObservers(model)
 
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.checkNoPrepModules(model)
@@ -75,7 +75,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         self.checkHasPrepModules(model.fc2)
 
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.checkNoPrepModules(model)
@@ -113,7 +113,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         model = prepare(model)
         checkPrepModules(model, True)
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             checkPrepModules(model)
@@ -150,7 +150,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         checkPrepModules(model, True)
 
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             checkPrepModules(model)
@@ -190,7 +190,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         checkPrepModules(model, True)
 
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             checkPrepModules(model)
@@ -215,7 +215,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         self.checkObservers(model)
 
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.checkLinear(model.fc)
@@ -243,7 +243,7 @@ class PostTrainingQuantTest(QuantizationTestCase):
         self.checkObservers(model)
 
         test_only_eval_fn(model, self.calib_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.fc), nnq.Linear)
@@ -273,7 +273,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
             '': default_dynamic_qconfig
         }
         model = prepare_dynamic(model, qconfig_dict)
-        convert_dynamic(model)
+        model = convert_dynamic(model)
 
         def checkQuantized(model):
             self.checkDynamicQuantizedLinear(model.fc1)
@@ -294,7 +294,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         }
         model = prepare_dynamic(model, qconfig_dict)
 
-        convert_dynamic(model)
+        model = convert_dynamic(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.fc1), torch.nn.Linear)
@@ -317,7 +317,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         }
 
         model = prepare_dynamic(model, qconfig_dict)
-        convert_dynamic(model)
+        model = convert_dynamic(model)
 
         def checkQuantized(model):
             self.checkLinear(model.sub1.fc)
@@ -342,7 +342,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         }
         model = prepare_dynamic(model, qconfig_dict)
 
-        convert_dynamic(model)
+        model = convert_dynamic(model)
 
         def checkQuantized(model):
             self.checkLinear(model.sub1.fc)
@@ -374,7 +374,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
         }
         model = prepare_dynamic(model, qconfig_dynamic_dict)
 
-        convert_dynamic(model)
+        model = convert_dynamic(model)
 
         def checkQuantized(model):
             self.checkDynamicQuantizedLinear(model.sub2.fc1)
@@ -400,7 +400,7 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
 
         model = prepare_dynamic(model, qconfig_dict)
         test_only_eval_fn(model, self.calib_data)
-        convert_dynamic(model)
+        model = convert_dynamic(model)
 
         def checkQuantized(model):
             self.checkDynamicQuantizedLinear(model.sub1.fc)
@@ -427,7 +427,7 @@ class QuantizationAwareTrainingTest(QuantizationTestCase):
         model = prepare_qat(model)
         self.checkObservers(model)
         test_only_train_fn(model, self.train_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.fc1), nnq.Linear)
@@ -460,7 +460,7 @@ class QuantizationAwareTrainingTest(QuantizationTestCase):
         self.checkObservers(model)
 
         test_only_train_fn(model, self.img_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.conv), nnq.Conv2d)
@@ -541,7 +541,7 @@ class FusionTest(QuantizationTestCase):
 
         checkQAT(model)
         test_only_train_fn(model, self.img_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.conv1), nniq.ConvReLU2d)
@@ -589,7 +589,7 @@ class FusionTest(QuantizationTestCase):
         model = prepare(model)
         self.checkObservers(model)
         test_only_eval_fn(model, self.img_data)
-        convert(model)
+        model = convert(model)
 
         def checkQuantized(model):
             self.assertEqual(type(model.conv1), nniq.ConvReLU2d)

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -245,7 +245,7 @@ def quantize(model, run_fn, run_args, mapping=DEFAULT_MODULE_MAPPING):
     model.eval()
     model = prepare(model)
     run_fn(model, run_args)
-    convert(model, mapping)
+    model = convert(model, mapping)
     return model
 
 DEFAULT_QCONFIG_DICT = {
@@ -257,7 +257,7 @@ def quantize_dynamic(model, qconfig_dict=DEFAULT_QCONFIG_DICT, mapping=DEFAULT_D
     """
     model.eval()
     propagate_qconfig(model, qconfig_dict)
-    convert(model, mapping)
+    model = convert(model, mapping)
     return model
 
 def prepare_qat(model):
@@ -271,7 +271,7 @@ def quantize_qat(model, run_fn, run_args):
     model.train()
     model = prepare_qat(model)
     run_fn(model, run_args)
-    convert(model)
+    model = convert(model)
     return model
 
 def convert(module, mapping=DEFAULT_MODULE_MAPPING):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25140 [pt1][quant] Fix the convert function issue**

`convert` function doesn't change the model in-place. It returns a new module so need to use
`new_model = convert(model)`
instead of
`convert(model)`

Differential Revision: [D17003306](https://our.internmc.facebook.com/intern/diff/D17003306/)