### PR TITLE
Fix possible deadlock in SharedCache inside a forked child proc

### DIFF
--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -4,6 +4,7 @@ import os
 import threading
 import errno
 import multiprocessing
+from multiprocessing.util import register_after_fork
 from multiprocessing.reduction import ForkingPickler
 import sys
 try:
@@ -43,6 +44,13 @@ class SharedCache(dict):
         # free_dead_references() is called if the len exceeds the current
         # limit. The limit scales with the number of remaining live objects.
         self.limit = 128
+        # `fork` inherits lock state, so in case we fork when the lock is held,
+        # we register a function to reset the lock to a new object to avoid
+        # possible deadlocks, following python multiprocessing library design.
+        self._after_fork()
+        register_after_fork(self, SharedCache._after_fork)
+
+    def _after_fork(self):
         self.lock = threading.Lock()
 
     def __setitem__(self, key, storage_ref):


### PR DESCRIPTION
Related: https://github.com/pytorch/pytorch/issues/24927#issuecomment-524608021

`fork` inherits lock state. So if we happen to unfortunately fork when the `SharedCache` lock is held. We could deadlock in the child process when some code tries to acquire it. 

Following pytorch multiprocessing library design, this patch resets the lock to a new object after fork. A similar example from python core lib for `multiprocessing.Queue` is : 

```py
class Queue(object):
    def __init__(self, ...):
        ...
        self._after_fork()
        if sys.platform != 'win32':
            register_after_fork(self, Queue._after_fork)

    def _after_fork(self):
        debug('Queue._after_fork()')
        self._notempty = threading.Condition(threading.Lock())
        self._buffer = collections.deque()
        self._thread = None
        self._jointhread = None
        self._joincancelled = False
        self._closed = False
        self._close = None
        self._send_bytes = self._writer.send_bytes
        self._recv_bytes = self._reader.recv_bytes
        self._poll = self._reader.poll
```

https://github.com/python/cpython/blob/d4d60134b29290049e28df54f23493de4f1824b6/Lib/multiprocessing/queues.py#L54-L78