### PR TITLE
register HeatmapMaxKeypoint with C10

### DIFF
--- a/caffe2/operators/heatmap_max_keypoint_op.cc
+++ b/caffe2/operators/heatmap_max_keypoint_op.cc
@@ -158,3 +158,17 @@ bool HeatmapMaxKeypointOp<float, CPUContext>::RunOnDevice() {
 }
 
 } // namespace caffe2
+
+using HeatmapMaxKeypointOpFloatCPU =
+    caffe2::HeatmapMaxKeypointOp<float, caffe2::CPUContext>;
+
+// clang-format off
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    HeatmapMaxKeypoint,
+    "_caffe2::HeatmapMaxKeypoint("
+      "Tensor heatmaps, "
+      "Tensor bboxes_in, "
+      "bool should_output_softmax = True"
+    ") -> Tensor keypoints",
+    HeatmapMaxKeypointOpFloatCPU);
+// clang-format on

--- a/caffe2/operators/heatmap_max_keypoint_op.h
+++ b/caffe2/operators/heatmap_max_keypoint_op.h
@@ -4,9 +4,12 @@
 #define HEATMAP_MAX_KEYPOINT_OP_H_
 
 #include "caffe2/core/context.h"
+#include "caffe2/core/export_caffe2_op_to_c10.h"
 #include "caffe2/core/logging.h"
 #include "caffe2/core/operator.h"
 #include "caffe2/utils/math.h"
+
+C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(HeatmapMaxKeypoint)
 
 namespace caffe2 {
 

--- a/caffe2/python/operator_test/heatmap_max_keypoint_op_test.py
+++ b/caffe2/python/operator_test/heatmap_max_keypoint_op_test.py
@@ -4,9 +4,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+import torch
+import sys
 import unittest
 from scipy import interpolate
-import sys
 
 import caffe2.python.hypothesis_test_util as hu
 from caffe2.python import core, utils
@@ -25,6 +26,15 @@ def heatmap_FAIR_keypoint_ref(maps, rois):
 
 def heatmap_approx_keypoint_ref(maps, rois):
     return [keypoint_utils.approx_heatmap_keypoint(maps, rois)]
+
+
+def c10_op_ref(maps, rois):
+    keypoints = torch.ops._caffe2.HeatmapMaxKeypoint(
+        torch.Tensor(maps),
+        torch.Tensor(rois),
+        should_output_softmax=True,
+    )
+    return [keypoints.numpy()]
 
 
 class TestHeatmapMaxKeypointOp(hu.HypothesisTestCase):
@@ -52,8 +62,9 @@ class TestHeatmapMaxKeypointOp(hu.HypothesisTestCase):
             NUM_KEYPOINTS,
             HEATMAP_SMALL_SIZE,
             HEATMAP_SMALL_SIZE).astype(np.float32)
-        heatmaps_in = np.zeros((NUM_TEST_ROI, NUM_KEYPOINTS,
-            HEATMAP_SIZE, HEATMAP_SIZE)).astype(np.float32)
+        heatmaps_in = np.zeros(
+            (NUM_TEST_ROI, NUM_KEYPOINTS, HEATMAP_SIZE, HEATMAP_SIZE)
+        ).astype(np.float32)
         for roi in range(NUM_TEST_ROI):
             for keyp in range(NUM_KEYPOINTS):
                 f = interpolate.interp2d(
@@ -120,6 +131,14 @@ class TestHeatmapMaxKeypointOp(hu.HypothesisTestCase):
                 inputs=[heatmap_test, example_bboxes],
                 reference=heatmap_approx_keypoint_ref,
             )
+
+    def test_caffe2_pytorch_eq(self):
+        self.assertReferenceChecks(
+            device_option=caffe2_pb2.DeviceOption(),
+            op=self.op,
+            inputs=[self.heatmaps_in, self.bboxes_in],
+            reference=c10_op_ref,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: registering as C10.

Test Plan: buck test mode/dev-nosan caffe2/caffe2/python/operator_test:heatmap_max_keypoint_op_test

Differential Revision: D17056321

