### PR TITLE
[android][circleci] Add libtorch android build with shared lib for 4 android abis

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -54,7 +54,14 @@ CONFIG_TREE_DATA = [
             ("10.1", [X("3.6")]),
         ]),
         ("android", [
-            ("r19c", [XImportant("3.6")]),
+            ("r19c", [
+                ("3.6", [
+                    ("android_abi", [XImportant("x86_32")]),
+                    ("android_abi", [X("x86_64")]),
+                    ("android_abi", [X("arm-v7a")]),
+                    ("android_abi", [X("arm-v8a")]),
+                ])
+            ]),
         ]),
     ]),
 ]
@@ -124,6 +131,7 @@ class ExperimentalFeatureConfigNode(TreeConfigNode):
             "xla": XlaConfigNode,
             "namedtensor": NamedTensorConfigNode,
             "important": ImportantConfigNode,
+            "android_abi": AndroidAbiConfigNode,
         }
         return next_nodes[experimental_feature]
 
@@ -149,6 +157,13 @@ class NamedTensorConfigNode(TreeConfigNode):
     def child_constructor(self):
         return ImportantConfigNode
 
+class AndroidAbiConfigNode(TreeConfigNode):
+
+    def init2(self, node_name):
+        self.props["android_abi"] = node_name
+
+    def child_constructor(self):
+        return ImportantConfigNode
 
 class ImportantConfigNode(TreeConfigNode):
     def modify_label(self, label):

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -988,9 +988,30 @@ jobs:
     resource_class: gpu.medium
     <<: *pytorch_linux_test_defaults
 
-  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_build:
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build:
     environment:
-      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:336"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_64-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:336"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v7a-build
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:336"
+      PYTHON_VERSION: "3.6"
+    <<: *pytorch_linux_build_defaults
+
+  pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v8a-build
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:336"
       PYTHON_VERSION: "3.6"
     <<: *pytorch_linux_build_defaults
@@ -3417,9 +3438,33 @@ workflows:
               only:
                 - master
                 - /ci-all\/.*/
-      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_build:
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build:
           requires:
             - setup
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+      - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build:
+          requires:
+            - setup
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
       # Warning: indentation here matters!
 
       # Pytorch MacOS builds

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -43,7 +43,7 @@ default_set = [
     # PyTorch OSX
     'pytorch-macos-10.13-cuda9.2-cudnn7-py3',
     # PyTorch Android
-    'pytorch-linux-xenial-py3-clang5-android-ndk-r19c',
+    'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32-build',
 
     # XLA
     'pytorch-xla-linux-xenial-py3.6-clang7',

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -66,6 +66,18 @@ if [[ "${BUILD_ENVIRONMENT}" == *-android* ]]; then
   export ANDROID_NDK=/opt/ndk
   build_args=()
   build_args+=("-DBUILD_CAFFE2_MOBILE=OFF")
+
+  build_args+=("-DBUILD_SHARED_LIBS=ON")
+  if [[ "${BUILD_ENVIRONMENT}" == *-arm-v7a* ]]; then
+    build_args+=("-DANDROID_ABI=armeabi-v7a")
+  elif [[ "${BUILD_ENVIRONMENT}" == *-arm-v8a* ]]; then
+    build_args+=("-DANDROID_ABI=arm64-v8a")
+  elif [[ "${BUILD_ENVIRONMENT}" == *-x86_32* ]]; then
+    build_args+=("-DANDROID_ABI=x86")
+  elif [[ "${BUILD_ENVIRONMENT}" == *-x86_64* ]]; then
+    build_args+=("-DANDROID_ABI=x86_64")
+  fi
+
   build_args+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
   build_args+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
   exec ./scripts/build_android.sh "${build_args[@]}" "$@"


### PR DESCRIPTION
In current  pytorch/master we have only libtorch android build for static libraries for armv7

This change adds the same builds with shared library to circleCI, abis: x86, x86_64, arm
-v7a, arm-v8a

In pytorch_build_data.py I added new AndroidAbiConfigNode:
class AndroidAbiConfigNode(TreeConfigNode):
def init2(self, node_name):
self.props["android_abi"] = node_name
def child_constructor(self):
return ImportantConfigNode
That can be children of
ExperimentalFeatureConfigNode
And it results:

    ("android", [
        ("r19c", [
            ("3.6", [
                ("android_abi", [XImportant("x86")]),
                ("android_abi", [XImportant("x86_64")]),
                ("android_abi", [XImportant("arm-v7a")]),
                ("android_abi", [XImportant("arm-v8a")]),
            ])
        ]),
    ]),

As all parameters are used for docker_image_name generation, while I wanted to use the same docker image for all android jobs - I introduced in  Conf.parms_list_ignored_for_docker_image in pytorch_build_definitions.py

It contains parameters that will not be joined to docker_image but used for job name generation and build_environment generation

