### PR TITLE
[quant] Reducing the test size for adaptive avg pool

### DIFF
--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -417,10 +417,10 @@ class TestQuantizedOps(TestCase):
                          message="ops.quantized.max_pool2d results are off")
 
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=3, max_dims=4,
-                                              min_side=1, max_side=10),
+                                              min_side=1, max_side=5),
                        qparams=hu.qparams()),
-           output_size_h=st.integers(1, 10),
-           output_size_w=st.integers(1, 10))
+           output_size_h=st.integers(1, 5),
+           output_size_w=st.integers(1, 5))
     def test_adaptive_avg_pool2d(self, X, output_size_h, output_size_w):
         X, (scale, zero_point, torch_type) = X
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25195 [quant] Reducing the test size for adaptive avg pool**

The test will fila for large samples adue to deadline constraint in the hypothesis framework.

Differential Revision: [D17059087](https://our.internmc.facebook.com/intern/diff/D17059087)