### PR TITLE
Fix scriptability for Observer

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -46,6 +46,7 @@ class Observer(nn.Module):
         self.min_val = min_val
         self.max_val = max_val
         return x
+
     @torch.jit.export
     def calculate_qparams(self):
         if self.dtype == torch.qint8:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25197 Fix scriptability for Observer**

Ensure that observer code remains scriptable after addition of warnings

Differential Revision: [D17059486](https://our.internmc.facebook.com/intern/diff/D17059486/)