### PR TITLE
Don't include ATen/core/Tensor.h from caffe2/tensor.h.

### DIFF
--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -6,7 +6,6 @@
 
 #include <ATen/core/UndefinedTensorImpl.h>
 #include <c10/util/intrusive_ptr.h>
-#include "ATen/core/Tensor.h"
 #include <c10/core/TensorOptions.h>
 
 #include <ATen/core/grad_mode.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25200 Remove some unused plugins.
* **#25198 Don't include ATen/core/Tensor.h from caffe2/tensor.h.**

This shouldn't be necessary, and simplifies the checked-in Tensor.h.