### PR TITLE
fix bug in assertNotEqual for int tensors

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -731,7 +731,7 @@ class TestCase(expecttest.TestCase):
                 if diff.is_signed():
                     diff = diff.abs()
                 diff[nan_mask] = 0
-                max_err = diff.max()
+                max_err = diff.max().item()
                 self.assertGreaterEqual(max_err, prec, message)
         elif type(x) == str and type(y) == str:
             super(TestCase, self).assertNotEqual(x, y)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -731,6 +731,8 @@ class TestCase(expecttest.TestCase):
                 if diff.is_signed():
                     diff = diff.abs()
                 diff[nan_mask] = 0
+                # Use `item()` to work around:
+                # https://github.com/pytorch/pytorch/issues/22301
                 max_err = diff.max().item()
                 self.assertGreaterEqual(max_err, prec, message)
         elif type(x) == str and type(y) == str:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4834,6 +4834,11 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(t.min(), 0)
         self.assertEqual(t.max(), ub - 1)
 
+    def test_not_equal(self):
+        ones = torch.ones(10, dtype=torch.int)
+        self.assertRaisesRegex(AssertionError, "0 not greater than or equal to",
+                               lambda:self.assertNotEqual(ones, ones))
+
     @staticmethod
     def _test_random_neg_values(self, use_cuda=False):
         signed_types = ['torch.DoubleTensor', 'torch.FloatTensor', 'torch.LongTensor',

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4837,7 +4837,7 @@ class _TestTorchMixin(torchtest):
     def test_not_equal(self):
         ones = torch.ones(10, dtype=torch.int)
         self.assertRaisesRegex(AssertionError, "0 not greater than or equal to",
-                               lambda:self.assertNotEqual(ones, ones))
+                               lambda: self.assertNotEqual(ones, ones))
 
     @staticmethod
     def _test_random_neg_values(self, use_cuda=False):


### PR DESCRIPTION
assertNotEqual was failing to detect differences in int tensors.
