### PR TITLE
[fix] skip tests if fbgemm is not supported for test_quantizer.py

### DIFF
--- a/test/test_quantizer.py
+++ b/test/test_quantizer.py
@@ -149,7 +149,11 @@ class QuantTemplate:
     def getQParamDict(self):
         return self.qparam_dict
 
-
+@unittest.skipIf(
+    not torch.fbgemm_is_cpu_supported(),
+    " Quantized operations require FBGEMM. FBGEMM is only optimized for CPUs"
+    " with instruction set support avx2 or newer.",
+)
 class QuantizerTestCase(TestCase):
     @_inline_everything
     def test_compare_qparam_eager_script_default(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25209 [fix] skip tests if fbgemm is not supported for test_quantizer.py**

Summary:
att

Test Plan:
ossci

Reviewers:
pt1quant
Subscribers:

Tasks:

Tags:

Differential Revision: [D17063744](https://our.internmc.facebook.com/intern/diff/D17063744)