### PR TITLE
Update mapping dictionary to support functionalmodules and pooling operations

### DIFF
--- a/test/common_quantization.py
+++ b/test/common_quantization.py
@@ -471,3 +471,27 @@ class ModForWrapping(torch.nn.Module):
         new_mod.mycat = new_mod.mycat.from_float(mod.mycat)
         new_mod.myadd = new_mod.myadd.from_float(mod.myadd)
         return new_mod
+
+class ResNetBase(torch.nn.Module):
+    def __init__(self):
+        super(ResNetBase, self).__init__()
+        norm_layer = nn.BatchNorm2d
+        inplanes = 3
+        self.conv1 = nn.Conv2d(inplanes, inplanes, (1, 1), bias=False)
+        self.bn1 = norm_layer(inplanes)
+        self.relu1 = nn.ReLU()
+        self.relu2 = nn.ReLU()
+        self.downsample = torch.nn.Identity()
+        self.myop = nn.quantized.FloatFunctional()
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu1(out)
+        identity = self.downsample(x)
+        out = self.myop.add(out, identity)
+        out = self.relu2(out)
+        out = self.avgpool(out)
+        return out

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -11,7 +11,7 @@ from torch.quantization import \
     QConfig_dynamic, default_weight_observer, \
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules, \
     quantize_dynamic, default_qconfig, default_qat_qconfig, \
-    default_dynamic_qconfig, Observer
+    default_dynamic_qconfig, Observer, QuantWrapper
 
 from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
@@ -19,7 +19,8 @@ from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
     ModelForFusion, ManualLinearQATModel, ManualConvLinearQATModel, \
     ModForWrapping, \
     test_only_eval_fn, test_only_train_fn, \
-    prepare_dynamic, convert_dynamic, SingleLayerLinearDynamicModel, TwoLayerLinearModel, NestedModel
+    prepare_dynamic, convert_dynamic, SingleLayerLinearDynamicModel, \
+    TwoLayerLinearModel, NestedModel, ResNetBase
 
 from common_quantization import AnnotatedTwoLayerLinearModel, AnnotatedNestedModel, \
     AnnotatedSubNestedModel, AnnotatedCustomConfigNestedModel
@@ -256,6 +257,27 @@ class PostTrainingQuantTest(QuantizationTestCase):
         model = quantize(QuantStubModel(), test_only_eval_fn, self.calib_data)
         checkQuantized(model)
 
+    def test_resnet_base(self):
+        r"""Test quantization for bottleneck topology used in resnet/resnext
+        and add coverage for conversion of average pool and float functional
+        """
+        model = ResNetBase().float().eval()
+        model = QuantWrapper(model)
+        model.qconfig = default_qconfig
+        fuse_list = [['module.conv1', 'module.bn1', 'module.relu1']]
+        fuse_modules(model, fuse_list)
+        prepare(model)
+        self.checkObservers(model)
+        test_only_eval_fn(model, self.img_data)
+        convert(model)
+
+        def checkQuantized(model):
+            self.assertEqual(type(model.module.conv1), nn._intrinsic.quantized.ConvReLU2d)
+            self.assertEqual(type(model.module.myop), nn.quantized.QFunctional)
+            self.assertEqual(type(model.module.avgpool), nn.AdaptiveAvgPool2d)
+            test_only_eval_fn(model, self.img_data)
+
+        checkQuantized(model)
 
 @unittest.skipIf(
     not torch.fbgemm_is_cpu_supported(),

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -9,7 +9,7 @@ from .QConfig import default_dynamic_qconfig
 import torch.nn.qat as nnqat
 
 
-DEFAULT_SKIP_LIST = [nn.Identity, nn.MaxPool2d]
+DEFAULT_SKIP_LIST = [nn.Identity, nn.MaxPool2d, nn.AvgPool2d, nn.AdaptiveAvgPool2d]
 
 def propagate_qconfig_helper(module, qconfig_dict, skip_list=DEFAULT_SKIP_LIST, qconfig_parent=None, prefix=''):
     r"""This is a helper function for `propagate_qconfig`
@@ -198,6 +198,7 @@ DEFAULT_MODULE_MAPPING = {
     nn.Conv2d: nnq.Conv2d,
     QuantStub: nnq.Quantize,
     DeQuantStub: nnq.DeQuantize,
+    nnq.FloatFunctional: nnq.QFunctional,
     # Intrinsic modules:
     nni.ConvReLU2d: nniq.ConvReLU2d,
     nni.LinearReLU: nniq.LinearReLU,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25216 Update mapping dictionary to support functionalmodules and pooling operations**

Differential Revision: [D17065029](https://our.internmc.facebook.com/intern/diff/D17065029/)