### PR TITLE
Fix scriptability for Observer

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -58,7 +58,9 @@ class Observer(nn.Module):
         min_val = self.min_val
         max_val = self.max_val
         if max_val is None or min_val is None:
-            raise Exception('must run observer before calling calculate_qparams!')
+            warnings.warn("must run observer before calling calculate_qparams.\
+                                    Returning default scale and zero point ")
+            return torch.tensor([1.0]), torch.tensor([0])
         max_val, min_val = float(max_val), float(min_val)
         min_val = min(0.0, min_val)
         max_val = max(0.0, max_val)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25218 Fix scriptability for Observer**

Ensure that observer code remains scriptable after addition of warnings

Differential Revision: [D17065189](https://our.internmc.facebook.com/intern/diff/D17065189/)