### PR TITLE
[pt1][quant] data -> data_ptr: upgrade the deprecated APIs

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -149,9 +149,9 @@ Tensor per_channel_affine_qtensor_cpu(
   Tensor self_contig = self.contiguous();
   AT_DISPATCH_QINT_TYPES(
       dst.scalar_type(), "per_channel_affine_qtensor", [&]() {
-        underlying_t* self_data = self_contig.data<underlying_t>();
+        underlying_t* self_data = self_contig.data_ptr<underlying_t>();
         underlying_t* dst_data =
-            reinterpret_cast<underlying_t*>(dst.data<scalar_t>());
+            reinterpret_cast<underlying_t*>(dst.data_ptr<scalar_t>());
         if (self.numel() > 0) {
           memcpy(dst_data, self_data, self.nbytes());
         }

--- a/aten/src/ATen/native/quantized/TensorFactories.cpp
+++ b/aten/src/ATen/native/quantized/TensorFactories.cpp
@@ -44,8 +44,8 @@ Tensor empty_per_channel_affine_quantized_cpu(
       scales.numel() == zero_points.numel(),
       "number of elements in scales and zero_points must match");
   TORCH_CHECK(axis.size() == 1, "only axis of size 1 is supported right now");
-  double* scales_data = scales.data<double>();
-  int64_t* zero_points_data = zero_points.data<int64_t>();
+  double* scales_data = scales.data_ptr<double>();
+  int64_t* zero_points_data = zero_points.data_ptr<int64_t>();
   std::vector<double> scale_vals(scales_data, scales_data + scales.numel());
   std::vector<int64_t> zero_point_vals(
       zero_points_data, zero_points_data + zero_points.numel());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25223 [pt1][quant] data -> data_ptr: upgrade the deprecated APIs**

Before this PR, it shows the following warning:
```
> caffe2/aten/src/ATen/core/Tensor.h:297: UserWarning: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.
>   TORCH_WARN("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.");
> caffe2/aten/src/ATen/core/Tensor.h:297: UserWarning: Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.
>   TORCH_WARN("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.");
```

After this PR, the warning message should disappear.

Differential Revision: [D17066471](https://our.internmc.facebook.com/intern/diff/D17066471/)