### PR TITLE
[jit] improve interface error messages

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -241,7 +241,7 @@ public:
   // schema and have the program typecheck?
   // as_method - if true, treat this schema as a method and ignore 
   // the first argument, which will be the object in both cases
-  bool isSubtypeOf(const FunctionSchema& rhs, bool as_method) const;
+  bool isSubtypeOf(const FunctionSchema& rhs, bool as_method, std::ostream* why_not=nullptr) const;
 };
 
 inline bool operator==(const FunctionSchema& lhs, const FunctionSchema& rhs) {

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -198,7 +198,7 @@ inline bool operator!=(const OperatorName& lhs, const OperatorName& rhs) {
 }
 
 // covariant subtyping of list of Arguments
-inline bool isSubtypeOfList(ArrayRef<Argument> child, ArrayRef<Argument> parent) {
+inline bool isSubtypeOfList(ArrayRef<Argument> child, ArrayRef<Argument> parent, std::ostream* why_not) {
   if (child.size() != parent.size()) {
     return false;
   }
@@ -208,20 +208,20 @@ inline bool isSubtypeOfList(ArrayRef<Argument> child, ArrayRef<Argument> parent)
     if (c.name() != p.name()) {
       return false;
     }
-    if (!c.type()->isSubtypeOf(p.type())) {
+    if (!c.type()->isSubtypeOfExt(p.type(), why_not)) {
       return false;
     }
   }
   return true;
 }
 
-inline bool FunctionSchema::isSubtypeOf(const FunctionSchema& rhs, bool as_method) const {
+inline bool FunctionSchema::isSubtypeOf(const FunctionSchema& rhs, bool as_method, std::ostream* why_not) const {
   size_t start = as_method ? 1 : 0;
   // functions are covariant in arguments but contravariant in returns
   return isSubtypeOfList(
              ArrayRef<Argument>(arguments()).slice(start),
-             ArrayRef<Argument>(rhs.arguments()).slice(start)) &&
-      isSubtypeOfList(rhs.returns(), returns());
+             ArrayRef<Argument>(rhs.arguments()).slice(start), why_not) &&
+      isSubtypeOfList(rhs.returns(), returns(), why_not);
 }
 
 } // namespace c10

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1590,7 +1590,6 @@ graph(%Ra, %Rb):
     @unittest.skipIf(IS_SANDCASTLE, "gtest runs these in sandcastle")
     @unittest.skipIf(RUN_CUDA, "covered by test_cpp_cuda")
     @skipIfRocm
-    @unittest.skipIf(True, "yep")
     def test_cpp(self):
         from cpp.jit import tests_setup
         tests_setup.setup()

--- a/torch/csrc/jit/script/schema_matching.cpp
+++ b/torch/csrc/jit/script/schema_matching.cpp
@@ -158,8 +158,9 @@ static Value* tryMatchArgument(
   // Check if the value can be matched to the arg through any implicit
   // conversions
   value = tryConvertToType(loc, graph, concrete_type, value, allow_conversions);
-
-  if (!value->type()->isSubtypeOf(concrete_type)) {
+  std::stringstream ss;
+  if (!value->type()->isSubtypeOfExt(
+          concrete_type, /*why_not=*/(failure_messages) ? &ss : nullptr)) {
     if (failure_messages) {
       auto& ostream = err()
           << arg.formatTypeMismatchMsg(value->type()->python_str());
@@ -177,6 +178,7 @@ static Value* tryMatchArgument(
         ostream << "Use int(tensor) or float(tensor) to retrieve item() from a "
                 << "tensor with the appropriate type.\n";
       }
+      ostream << ss.str();
     }
 
     return nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25228 [jit] improve interface error messages**
* #25227 [jit] add serialization of interface
* #25226 Remove PythonPrint's is_method_ member
* #25258 Add interface declarations to JIT

This adds a facility to isSubtypeOf for it to explain why a type is
not a subtype of something else. It is used in situations where it
is not clear from the types python_str alone why the relationship
is now true. Because of subtle interaction between default arguments,
overloads, and virtual methods, it uses isSubtypeOfExt for the extended
version to avoid requiring readers to understand the interaction.

Differential Revision: [D17066673](https://our.internmc.facebook.com/intern/diff/D17066673)