### PR TITLE
Add shape inference for SliceOp

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -102,6 +102,7 @@ class CAFFE2_API BoundShapeInferencer : public BoundShapeInferencerBase {
   void InferShape(const OperatorDef& op);
   void InferReshape(const OperatorDef& op);
   void InferLengthsRangeFill(const OperatorDef& op);
+  void InferSlice(const OperatorDef& op, const caffe2::Workspace* ws);
 
   // Standard shape/type inference using op schema registered shape inference
   // function


### PR DESCRIPTION
Summary:
ATT. Infer Slice operator output from input params.
This is hacky as it assumes that input shape tensors don't change.

Test Plan: unittest;

Differential Revision: D17068818

