### PR TITLE
Revert "Switch hub to use `requests` because of SSL (#25083)"

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -106,11 +106,6 @@ if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
   export LC_ALL=C.UTF-8
   export LANG=C.UTF-8
 fi
-
-if [[ "$BUILD_ENVIRONMENT" == *py2* ]]; then
-  pip install --user requests
-fi
-
 pip install --user pytest-sugar
 "$PYTHON" \
   -m pytest \
@@ -142,4 +137,3 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   fi
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi
-

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -56,10 +56,6 @@ if [[ "$BUILD_ENVIRONMENT" != *ppc64le* ]]; then
   pip_install --user mypy || true
 fi
 
-if [[ $PYTHON_VERSION == "2" ]]; then
-  pip_install --user requests
-fi
-
 # faulthandler become built-in since 3.3
 if [[ ! $(python -c "import sys; print(int(sys.version_info >= (3, 3)))") == "1" ]]; then
   pip_install --user faulthandler

--- a/setup.py
+++ b/setup.py
@@ -352,9 +352,6 @@ install_requires = []
 if sys.version_info <= (2, 7):
     install_requires += ['future']
 
-if sys.version_info[0] == 2:
-    install_requires += ['requests']
-
 missing_pydep = '''
 Missing build dependency: Unable to `import {importname}`.
 Please install it via `conda install {module}` or `pip install {module}`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25250 Revert "Switch hub to use `requests` because of SSL (#25083)"**

This reverts commit f71ddd42927999e533ada0ba5655efec3986e941.

Differential Revision: [D17071638](https://our.internmc.facebook.com/intern/diff/D17071638)