### PR TITLE
Return a unique_ptr to message instead of void

### DIFF
--- a/torch/csrc/distributed/rpc/functions.h
+++ b/torch/csrc/distributed/rpc/functions.h
@@ -11,16 +11,9 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-void processRequestBlocking(
-    const std::string& from,
-    Message&& message,
-    RpcAgent& agent);
+std::unique_ptr<Message> processRequestBlocking(Message&& message);
 
-void sendException(
-    const std::string& from,
-    const Message& request,
-    RpcAgent& agent,
-    const std::exception& e);
+Message createException(const Message& request, const std::exception& e);
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -197,7 +197,11 @@ void ProcessGroupAgent::enqueueRecv(RecvWork work) {
       Message message = deserialize(work.type_, ss);
 
       if (message.isRequest()) {
-        cb_(names_[work.from_], std::move(message), *this);
+        auto response = cb_(std::move(message));
+        if (!response) {
+          AT_ERROR("Null response from user callback ", message.type());
+        }
+        send(names_[work.from_], std::move(*response));
       } else if (message.isResponse()) {
         auto id = message.id();
         {

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -17,12 +17,13 @@ class RpcAgent;
 
 // RpcAgent implementation should invoke ``RequestCallback`` to process received
 // requests. There is no restriction on the implementation's threading model.
-// This function takes the name of the request sender, the an rvalue reference
-// of the Message object, and a reference to the RpcAgent itself. Having a
-// reference to the RpcAgent allows the ``RequestCallback`` implementation to
-// be both stateless and non-blocking. It may enqueue the message and the
-// RpcAgent reference, and use a different set of threads to process them later.
-using RequestCallback = std::function<void(std::string, Message&&, RpcAgent&)>;
+// This function takes an rvalue reference of the Message object.
+// It is expected to return the response message or message containing an
+// exception. Different rpc agent implementations are expected to ensure
+// delivery of the response/exception based on their implementation specific
+// mechnisms.
+using RequestCallback =
+    std::function<std::unique_ptr<Message>(Message&&)>;
 
 class RpcAgent {
  public:


### PR DESCRIPTION
Summary:
Return a unique_ptr to message instead of void
This is to help thrift style rpc where there is no need for explicit send for a response.
If unique_ptr isn't intuitive fine with returning message itself. We need to figure out how to solve the non-blocking callback case but don't want to block the thrift based rpc agent implementation till then.

Differential Revision: D16825072

