### PR TITLE
prevent generating caffe2::mkldnn for multiple times

### DIFF
--- a/cmake/public/mkldnn.cmake
+++ b/cmake/public/mkldnn.cmake
@@ -2,7 +2,10 @@ set(MKLDNN_USE_NATIVE_ARCH ${USE_NATIVE_ARCH})
 
 find_package(MKLDNN QUIET)
 
-add_library(caffe2::mkldnn INTERFACE IMPORTED)
+if(NOT TARGET caffe2::mkldnn)
+  add_library(caffe2::mkldnn INTERFACE IMPORTED)
+endif()
+
 set_property(
   TARGET caffe2::mkldnn PROPERTY INTERFACE_INCLUDE_DIRECTORIES
   ${MKLDNN_INCLUDE_DIR})


### PR DESCRIPTION
This is a similar problem to #25004. After the merge of #25167, I recompiled torch and discovered another similar bug.

@ezyang please take a look