### PR TITLE
Add interface declarations to JIT

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -236,6 +236,12 @@ public:
     }
     return false;
   }
+
+  // can a function with this schema be substituted for a function of rhs's 
+  // schema and have the program typecheck?
+  // as_method - if true, treat this schema as a method and ignore 
+  // the first argument, which will be the object in both cases
+  bool isSubtypeOf(const FunctionSchema& rhs, bool as_method) const;
 };
 
 inline bool operator==(const FunctionSchema& lhs, const FunctionSchema& rhs) {

--- a/aten/src/ATen/core/function_schema_inl.h
+++ b/aten/src/ATen/core/function_schema_inl.h
@@ -197,6 +197,33 @@ inline bool operator!=(const OperatorName& lhs, const OperatorName& rhs) {
   return !operator==(lhs, rhs);
 }
 
+// covariant subtyping of list of Arguments
+inline bool isSubtypeOfList(ArrayRef<Argument> child, ArrayRef<Argument> parent) {
+  if (child.size() != parent.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < child.size(); ++i) {
+    const Argument& c = child[i];
+    const Argument& p = parent[i];
+    if (c.name() != p.name()) {
+      return false;
+    }
+    if (!c.type()->isSubtypeOf(p.type())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool FunctionSchema::isSubtypeOf(const FunctionSchema& rhs, bool as_method) const {
+  size_t start = as_method ? 1 : 0;
+  // functions are covariant in arguments but contravariant in returns
+  return isSubtypeOfList(
+             ArrayRef<Argument>(arguments()).slice(start),
+             ArrayRef<Argument>(rhs.arguments()).slice(start)) &&
+      isSubtypeOfList(rhs.returns(), returns());
+}
+
 } // namespace c10
 
 namespace std {

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -46,7 +46,8 @@ using OptNameList = c10::optional<std::vector<std::string>>;
   _(DeviceObjType)          \
   _(FunctionType)           \
   _(ClassType)              \
-  _(CapsuleType)
+  _(CapsuleType)            \
+  _(InterfaceType)
 
 enum class TypeKind {
 #define DEFINE_TYPE(T) T,
@@ -1426,6 +1427,8 @@ struct CAFFE2_API ClassType : public NamedType {
         is_module(), "asking for parameterSlots of non-Module");
     return parameterSlots_->at(slot);
   }
+
+  bool isSubtypeOf(const TypePtr rhs) const override;
   static const TypeKind Kind = TypeKind::ClassType;
 
  private:
@@ -1452,6 +1455,50 @@ struct CAFFE2_API ClassType : public NamedType {
   // List of methods associated with this class.
   std::vector<Function*> methods_;
 
+};
+
+
+struct InterfaceType;
+using InterfaceTypePtr = std::shared_ptr<InterfaceType>;
+using ::torch::jit::script::CompilationUnit;
+using ::torch::jit::Function;
+
+// Interfaces are a list of abstract methods that a class might meet.
+// If a class provides those methods, it implicitly meets the interface.
+struct CAFFE2_API InterfaceType : public NamedType {
+  friend struct ClassType; // for isSubclassOf
+  static InterfaceTypePtr create(
+      QualifiedName qualifiedName);
+
+  bool operator==(const Type& rhs) const override {
+    if (auto user_rhs = rhs.cast<InterfaceType>()) {
+      return name() == user_rhs->name();
+    }
+    return false;
+  }
+
+  std::string str() const override {
+    return std::string("InterfaceType<") + name()->name() + ">";
+  }
+
+  std::string python_str() const override {
+    return name()->qualifiedName();
+  }
+  
+  bool isSubtypeOf(const TypePtr rhs) const override;
+
+  // try to find a method of this interface,
+  // returns nullptr if not found.
+  const FunctionSchema* getMethod(const std::string& name) const;
+  void addMethod(FunctionSchema schema);
+  static const TypeKind Kind = TypeKind::InterfaceType;
+  ~InterfaceType() override;
+ private:
+  InterfaceType(QualifiedName name);
+
+  // shared_ptr so that this header does not have to depend on 
+  // FunctionSchema.h
+  std::shared_ptr<std::vector<FunctionSchema>> methods_;
 };
 
 } // namespace c10

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -633,4 +633,40 @@ bool TensorType::isSubtypeOf(const TypePtr rhs) const {
   return Type::isSubtypeOf(rhs);
 }
 
+InterfaceTypePtr InterfaceType::create(QualifiedName qualifiedName) {
+  return InterfaceTypePtr(
+      new InterfaceType(std::move(qualifiedName)));
+}
+
+bool InterfaceType::isSubtypeOf(const TypePtr rhs) const {
+  // to improve performance this check can be cached
+  if (auto iface = rhs->cast<InterfaceType>()) {
+    for (const FunctionSchema& schema : *iface->methods_) {
+      auto self_schema = getMethod(schema.name());
+      if (!self_schema || !self_schema->isSubtypeOf(schema, /*is_method=*/true)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return Type::isSubtypeOf(rhs);
+}
+
+const FunctionSchema* InterfaceType::getMethod(const std::string& name) const {
+  for (const FunctionSchema& method : *methods_) {
+    if (method.name() == name) {
+      return &method;
+    }
+  }
+  return nullptr;
+}
+void InterfaceType::addMethod(FunctionSchema schema) {
+  methods_->emplace_back(std::move(schema));
+}
+InterfaceType::InterfaceType(QualifiedName name)
+    : NamedType(InterfaceType::Kind, std::move(name)),
+      methods_(std::make_shared<std::vector<FunctionSchema>>()) {}
+
+InterfaceType::~InterfaceType() = default;
+
 } // namespace c10

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -150,8 +150,8 @@ inline constexpr typename std::remove_reference<T>::type&& constexpr_move(
 
 namespace detail_ {
 
-// VS 2015 doesn't handle constexpr well, so we need to skip these stuff.
-#if (defined _MSC_VER) && (_MSC_VER <= 1900)
+// VS doesn't handle constexpr well, so we need to skip these stuff.
+#if (defined _MSC_VER)
 template <typename T>
 T* static_addressof(T& ref) {
   return std::addressof(ref);

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18419,6 +18419,51 @@ class TestClassType(JitTestCase):
         output = m_loaded(input)
         self.assertEqual(3 * input, output)
 
+    def test_interface(self):
+        with torch.jit._disable_emit_hooks():
+            @torch.jit.script
+            class Foo(object):
+                def __init__(self):
+                    pass
+
+                def one(self, x, y):
+                    return x + y
+
+                def two(self, x):
+                    return 2 * x
+
+            @torch.jit.script
+            class Bar(object):
+                def __init__(self):
+                    pass
+
+                def one(self, x, y):
+                    return x * y
+
+                def two(self, x):
+                    return 2 / x
+
+            @torch.jit.interface
+            class OneTwo(object):
+                def one(self, x, y):
+                    # type: (Tensor, Tensor) -> Tensor
+                    pass
+
+                def two(self, x):
+                    # type: (Tensor) -> Tensor
+                    pass
+
+            def use_them(x):
+                a = Foo()
+                b = Bar()
+                c = torch.jit.annotate(List[OneTwo], [a, b])
+                for i in range(len(c)):
+                    x = c[i].one(x, x)
+                    x = c[i].two(x)
+                return x
+            self.checkScript(use_them, (torch.rand(3, 4),))
+
+
     def test_overloaded_fn(self):
         @torch.jit.script
         class Foo(object):

--- a/torch/csrc/jit/interpreter.cpp
+++ b/torch/csrc/jit/interpreter.cpp
@@ -320,7 +320,8 @@ struct PreprocessGraph {
   _(WAIT, "") /* wait for a future to be complete */                        \
   _(CALL, "F") /* call function X */                                        \
   _(GUARD, "T") /* check guard against type_table, true if passes */        \
-  _(TAIL_CALL, "F") /* replace current frame with function F */
+  _(TAIL_CALL, "F") /* replace current frame with function F */             \
+  _(INTERFACE_CALL, "CI") /* call method X on the first argument (of N) */
 
 enum OpCode : uint8_t {
 #define DEFINE_OP(op, _) op,
@@ -679,7 +680,13 @@ struct CodeImpl {
           instructions_source_[block.jf_instruction_index]);
     }
   }
-
+  void emitInterfaceCall(
+      std::string method_name_str,
+      c10::ArrayRef<Value*> inputs) {
+    emitLoadInputs(inputs);
+    auto method_name = insertConstant(std::move(method_name_str));
+    insertInstruction(INTERFACE_CALL, method_name, inputs.size());
+  }
   void emitNode(Node* node) {
     WithCurrentNode guard(&current_node_, node);
     switch (node->kind()) {
@@ -709,10 +716,11 @@ struct CodeImpl {
             node->inputs().slice(1));
         break;
       case prim::CallMethod:
-        emitCall(
-            node->inputs().at(0)->type()->expect<ClassType>()->getMethod(
-                node->s(attr::name)),
-            node->inputs());
+        if (auto class_type = node->inputs().at(0)->type()->cast<ClassType>()) {
+          emitCall(class_type->getMethod(node->s(attr::name)), node->inputs());
+        } else {
+          emitInterfaceCall(node->s(attr::name), node->inputs());
+        }
         break;
       case prim::BailOut:
         emitBailOut(node);
@@ -934,6 +942,20 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
                 af.functions[inst.X]->get_executor().getPlanFor(stack).code;
             frames.back().pc = af.pc + 1;
             enterFrame(code, stack.size() - code.num_inputs());
+            af = ActiveFrame(frames.back());
+          } break;
+          case INTERFACE_CALL: {
+            // note the hash table lookup to find the function
+            // this can be more optimized if necessary, caching parts
+            // of the hashing computation or storing the offset when
+            // the object is turned into an interface
+            auto function = peek(stack, 0, inst.N)
+                                .toObject()
+                                ->type()
+                                ->getMethod(af.constants[inst.X].toStringRef());
+            const Code& code = function->get_executor().getPlanFor(stack).code;
+            frames.back().pc = af.pc + 1;
+            enterFrame(code, stack.size() - inst.N);
             af = ActiveFrame(frames.back());
           } break;
           case RET:

--- a/torch/csrc/jit/passes/inliner.cpp
+++ b/torch/csrc/jit/passes/inliner.cpp
@@ -27,9 +27,10 @@ void inlineCalls(Block* block) {
       } break;
       case prim::CallMethod: {
         const std::string& name = cur->s(attr::name);
-        auto function =
-            cur->input(0)->type()->expect<ClassType>()->getMethod(name);
-        inlineCallTo(cur, *function->graph());
+        if (auto class_type = cur->input(0)->type()->cast<ClassType>()) {
+          auto function = class_type->getMethod(name);
+          inlineCallTo(cur, *function->graph());
+        }
       } break;
       default: {
         for (auto b : cur->blocks()) {

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -453,6 +453,7 @@ inline IValue toIValue(
     case TypeKind::GeneratorType:
     case TypeKind::VarType:
     case TypeKind::FutureType:
+    case TypeKind::InterfaceType:
       break;
     case TypeKind::FunctionType:
       AT_ERROR("Function Values aren't yet supported");

--- a/torch/csrc/jit/script/class_type.cpp
+++ b/torch/csrc/jit/script/class_type.cpp
@@ -93,4 +93,21 @@ ClassType::ClassType(
   }
 }
 
+bool ClassType::isSubtypeOf(const TypePtr rhs) const {
+  // to improve performance, this check can be cached
+  if (auto iface = rhs->cast<InterfaceType>()) {
+    for (const FunctionSchema& schema : *iface->methods_) {
+      auto self_method = getMethod(schema.name());
+      if (!self_method) {
+        return false;
+      }
+      if (!self_method->getSchema().isSubtypeOf(schema, /*is_method=*/true)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return Type::isSubtypeOf(rhs);
+}
+
 } // namespace c10

--- a/torch/csrc/jit/script/compilation_unit.h
+++ b/torch/csrc/jit/script/compilation_unit.h
@@ -26,6 +26,7 @@ namespace jit {
 namespace script {
 
 struct Def;
+struct ClassDef;
 struct SugaredValue;
 struct Resolver;
 
@@ -102,6 +103,11 @@ struct TORCH_API CompilationUnit {
       const std::string& source,
       const ResolverPtr& resolver,
       const Self* self);
+
+  void define_interface(
+      const std::string& qualifiedName,
+      const ClassDef& classDef,
+      ResolverPtr rcb);
 
   Function* create_function(
       c10::QualifiedName name,

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -602,7 +602,7 @@ struct to_ir {
   }
 
   FunctionSchema emitDef(const Def& def, const Self* self, Block* block) {
-    auto schema = extractSchemaFromDef(def, self);
+    auto schema = typeParser_.parseSchemaFromDef(def, bool(self));
     // TODO need guards on init returning none
     if (schema.returns().size() == 1) {
       def_stack_.back().declared_return_type_ = schema.returns().at(0).type();
@@ -616,135 +616,6 @@ struct to_ir {
     handleMaybeNoReturn(def, block);
     std::vector<Argument> returns = {emitOutput(def.range(), schema, block)};
     return {def.name().name(), "", std::move(arguments), std::move(returns)};
-  }
-
-  std::vector<IValue> evaluateDefaults(
-      const SourceRange& r,
-      const std::vector<Expr>& default_types,
-      const std::vector<Expr>& default_exprs) {
-    std::vector<IValue> default_values;
-    if (default_exprs.empty())
-      return default_values;
-    // To evaluate the default expressions, we create a graph with no inputs,
-    // and whose returns are the default values we need.
-    // We then run constant prop on this graph and check the results are
-    // constant. This approach avoids having to have separate handling of
-    // default arguments from standard expressions by piecing together existing
-    // machinery for graph generation, constant propgation, and constant
-    // extraction.
-    auto tuple_type = Subscript::create(
-        r,
-        Var::create(r, Ident::create(r, "Tuple")),
-        List<Expr>::create(r, default_types));
-    auto blank_decl = Decl::create(
-        r, List<Param>::create(r, {}), Maybe<Expr>::create(r, tuple_type));
-
-    auto tuple_expr =
-        TupleLiteral::create(r, List<Expr>::create(r, default_exprs));
-    auto ret = Return::create(r, tuple_expr);
-    auto def = Def::create(
-        r,
-        Ident::create(r, "defaults"),
-        blank_decl,
-        List<Stmt>::create(r, {ret}));
-
-    CompilationUnit cu;
-    cu.define(c10::nullopt, {def}, {resolver}, nullptr);
-    Stack stack;
-    // XXX: We need to turn optimization off here because otherwise we try to
-    // recursively initialize stuff in DecomposeOps.
-    GraphOptimizerEnabledGuard guard(false);
-    cu.get_function(def.name().name()).run(stack);
-    return stack.at(0).toTuple()->elements();
-  }
-
-  std::vector<Argument> parseArgsFromDecl(const Decl& decl, const Self* self) {
-    auto params_begin = decl.params().begin();
-    auto params_end = decl.params().end();
-    if (self) {
-      ++params_begin;
-    }
-    std::vector<Argument> retval;
-
-    std::vector<Expr> default_types;
-    std::vector<Expr> default_exprs;
-    // gather any non-empty default arguments
-    for (auto it = params_begin; it != params_end; ++it) {
-      auto param = *it;
-      auto def = param.defaultValue();
-      if (def.present()) {
-        default_types.emplace_back(param.type().get());
-        default_exprs.emplace_back(def.get());
-      }
-    }
-    auto default_values =
-        evaluateDefaults(decl.range(), default_types, default_exprs);
-
-    auto defaults_it = default_values.begin();
-    for (auto it = params_begin; it != params_end; ++it) {
-      auto decl_arg = *it;
-
-      TypePtr type;
-      c10::optional<int32_t> N;
-      bool is_inferred_type = false;
-      if (!decl_arg.type().present()) {
-        // If this param doesn't have a type, default to "tensor"
-        is_inferred_type = true;
-        type = TensorType::get();
-        N = c10::nullopt;
-      } else {
-        // BroadcastList list can only appear at the argument level
-        if (auto maybe_broad_list =
-                typeParser_.parseBroadcastList(decl_arg.type().get())) {
-          type = maybe_broad_list->first;
-          N = maybe_broad_list->second;
-        } else {
-          type = typeParser_.parseTypeFromExpr(decl_arg.type().get());
-          N = c10::nullopt;
-        }
-      }
-      c10::optional<IValue> default_value = c10::nullopt;
-      if (decl_arg.defaultValue().present()) {
-        default_value = *defaults_it++;
-      }
-      auto arg = Argument(
-          decl_arg.ident().name(),
-          type,
-          N,
-          default_value,
-          decl_arg.kwarg_only(),
-          /*alias_info=*/c10::nullopt,
-          is_inferred_type);
-      retval.push_back(arg);
-    }
-    return retval;
-  }
-
-  std::vector<Argument> parseReturnFromDecl(const Decl& decl) {
-    // we represent no annoation on a return type as having no values in the
-    // schema's return() list
-    // in emitReturn we take the actual return value to be the value of the
-    // return statement if no one was provided here
-    if (!decl.return_type().present())
-      return {};
-
-    if (typeParser_.parseBroadcastList(decl.return_type().get()))
-      throw ErrorReport(decl.return_type().range())
-          << "Broadcastable lists cannot appear as a return type";
-    auto parsed_type = typeParser_.parseTypeFromExpr(decl.return_type().get());
-    return {Argument(
-        "",
-        parsed_type,
-        /*N =*/c10::nullopt,
-        /*default_value =*/c10::nullopt,
-        /*kwarg_only =*/false)};
-  }
-  FunctionSchema extractSchemaFromDef(const Def& def, const Self* self) {
-    const auto name = def.name().name();
-    std::vector<Argument> args = parseArgsFromDecl(def.decl(), self);
-    std::vector<Argument> returns = parseReturnFromDecl(def.decl());
-    return FunctionSchema(
-        name, "", std::move(args), std::move(returns), false, false);
   }
 
   // see [setstate type]
@@ -2749,7 +2620,8 @@ struct to_ir {
           if (!v->type()->isSubtypeOf(elem_type)) {
             throw ErrorReport(tree)
                 << "Lists must contain only a single type, expected: "
-                << *elem_type << " but found " << *v->type() << " instead";
+                << elem_type->python_str() << " but found "
+                << v->type()->python_str() << " instead";
           }
         }
         Value* result =
@@ -3419,6 +3291,41 @@ void lambdaLiftFork(Node* fork_node) {
   // Separate the subgraph and clean up the orignal one
   fork_node->g_(attr::Subgraph, forked_graph);
   fork_node->eraseBlock(0);
+}
+
+void CompilationUnit::define_interface(
+    const std::string& qualifiedName,
+    const ClassDef& classDef,
+    ResolverPtr rcb) {
+  ScriptTypeParser typeParser(rcb);
+  InterfaceTypePtr iface =
+      InterfaceType::create(c10::QualifiedName(qualifiedName));
+  for (const Stmt& stmt : classDef.body()) {
+    if (stmt.kind() != TK_DEF) {
+      throw ErrorReport(stmt)
+          << "interface declartions can only contain method definitions";
+    }
+    auto method_def = Def(stmt);
+    if (!method_def.decl().return_type().present()) {
+      throw ErrorReport(method_def)
+          << "interface declarations must have a return type annotated.";
+    }
+    FunctionSchema schema =
+        typeParser.parseSchemaFromDef(method_def, /* skip_self*/ true);
+    // need to add self as the first because we skipped it
+    std::vector<Argument> arguments;
+    arguments.emplace_back(
+        Argument(method_def.decl().params()[0].ident().name(), iface));
+    arguments.insert(
+        arguments.end(), schema.arguments().begin(), schema.arguments().end());
+    iface->addMethod(schema.cloneWithArguments(std::move(arguments)));
+    if (method_def.statements().size() != 1 ||
+        method_def.statements()[0].kind() != TK_PASS) {
+      throw ErrorReport(method_def.range())
+          << "interfaces declarations should only contain a single 'pass' statement.";
+    }
+  }
+  this->register_type(iface);
 }
 
 } // namespace script

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -157,7 +157,6 @@ struct PythonResolver : public Resolver {
             tt->python_str());
             return type;
       }
-
       get_python_cu()->register_type(tt);
       return tt;
     }
@@ -799,6 +798,14 @@ void initJitScriptBindings(PyObject* module) {
         }
         const auto self = SimpleSelf(classType);
         cu->define(classname, methodDefs, rcbs, &self);
+      });
+  m.def(
+      "_jit_script_interface_compile",
+      [](const std::string& qualifiedName,
+         const ClassDef& classDef,
+         ResolutionCallback rcb) {
+        get_python_cu()->define_interface(
+            qualifiedName, classDef, pythonResolver(rcb));
       });
 
   m.def("parse_type_comment", [](const std::string& comment) {

--- a/torch/csrc/jit/script/schema_type_parser.cpp
+++ b/torch/csrc/jit/script/schema_type_parser.cpp
@@ -251,6 +251,7 @@ void SchemaTypeParser::parseList(
   if (end != TK_NOTHING)
     L.expect(end);
 }
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/script_type_parser.cpp
+++ b/torch/csrc/jit/script/script_type_parser.cpp
@@ -198,6 +198,140 @@ TypePtr ScriptTypeParser::parseType(const std::string& str) {
   Parser p(std::make_shared<Source>(str));
   return parseTypeFromExpr(p.parseExp());
 }
+
+std::vector<IValue> ScriptTypeParser::evaluateDefaults(
+    const SourceRange& r,
+    const std::vector<Expr>& default_types,
+    const std::vector<Expr>& default_exprs) {
+  std::vector<IValue> default_values;
+  if (default_exprs.empty())
+    return default_values;
+  // To evaluate the default expressions, we create a graph with no inputs,
+  // and whose returns are the default values we need.
+  // We then run constant prop on this graph and check the results are
+  // constant. This approach avoids having to have separate handling of
+  // default arguments from standard expressions by piecing together existing
+  // machinery for graph generation, constant propgation, and constant
+  // extraction.
+  auto tuple_type = Subscript::create(
+      r,
+      Var::create(r, Ident::create(r, "Tuple")),
+      List<Expr>::create(r, default_types));
+  auto blank_decl = Decl::create(
+      r, List<Param>::create(r, {}), Maybe<Expr>::create(r, tuple_type));
+
+  auto tuple_expr =
+      TupleLiteral::create(r, List<Expr>::create(r, default_exprs));
+  auto ret = Return::create(r, tuple_expr);
+  auto def = Def::create(
+      r,
+      Ident::create(r, "defaults"),
+      blank_decl,
+      List<Stmt>::create(r, {ret}));
+
+  CompilationUnit cu;
+  cu.define(c10::nullopt, {def}, {resolver_}, nullptr);
+  Stack stack;
+  // XXX: We need to turn optimization off here because otherwise we try to
+  // recursively initialize stuff in DecomposeOps.
+  GraphOptimizerEnabledGuard guard(false);
+  cu.get_function(def.name().name()).run(stack);
+  return stack.at(0).toTuple()->elements();
+}
+
+std::vector<Argument> ScriptTypeParser::parseArgsFromDecl(
+    const Decl& decl,
+    bool skip_self) {
+  auto params_begin = decl.params().begin();
+  auto params_end = decl.params().end();
+  if (skip_self) {
+    ++params_begin;
+  }
+  std::vector<Argument> retval;
+
+  std::vector<Expr> default_types;
+  std::vector<Expr> default_exprs;
+  // gather any non-empty default arguments
+  for (auto it = params_begin; it != params_end; ++it) {
+    auto param = *it;
+    auto def = param.defaultValue();
+    if (def.present()) {
+      default_types.emplace_back(param.type().get());
+      default_exprs.emplace_back(def.get());
+    }
+  }
+
+  auto default_values =
+      evaluateDefaults(decl.range(), default_types, default_exprs);
+
+  auto defaults_it = default_values.begin();
+  for (auto it = params_begin; it != params_end; ++it) {
+    auto decl_arg = *it;
+
+    TypePtr type;
+    c10::optional<int32_t> N;
+    bool is_inferred_type = false;
+    if (!decl_arg.type().present()) {
+      // If this param doesn't have a type, default to "tensor"
+      is_inferred_type = true;
+      type = TensorType::get();
+      N = c10::nullopt;
+    } else {
+      // BroadcastList list can only appear at the argument level
+      if (auto maybe_broad_list = parseBroadcastList(decl_arg.type().get())) {
+        type = maybe_broad_list->first;
+        N = maybe_broad_list->second;
+      } else {
+        type = parseTypeFromExpr(decl_arg.type().get());
+        N = c10::nullopt;
+      }
+    }
+    c10::optional<IValue> default_value = c10::nullopt;
+    if (decl_arg.defaultValue().present()) {
+      default_value = *defaults_it++;
+    }
+    auto arg = Argument(
+        decl_arg.ident().name(),
+        type,
+        N,
+        default_value,
+        decl_arg.kwarg_only(),
+        /*alias_info=*/c10::nullopt,
+        is_inferred_type);
+    retval.push_back(arg);
+  }
+  return retval;
+}
+
+std::vector<Argument> ScriptTypeParser::parseReturnFromDecl(const Decl& decl) {
+  // we represent no annoation on a return type as having no values in the
+  // schema's return() list
+  // in emitReturn we take the actual return value to be the value of the
+  // return statement if no one was provided here
+  if (!decl.return_type().present())
+    return {};
+
+  if (parseBroadcastList(decl.return_type().get()))
+    throw ErrorReport(decl.return_type().range())
+        << "Broadcastable lists cannot appear as a return type";
+  auto parsed_type = parseTypeFromExpr(decl.return_type().get());
+  return {Argument(
+      "",
+      parsed_type,
+      /*N =*/c10::nullopt,
+      /*default_value =*/c10::nullopt,
+      /*kwarg_only =*/false)};
+}
+FunctionSchema ScriptTypeParser::parseSchemaFromDef(
+    const Def& def,
+    bool skip_self) {
+  const auto name = def.name().name();
+  std::vector<Argument> args = parseArgsFromDecl(def.decl(), skip_self);
+  std::vector<Argument> returns = parseReturnFromDecl(def.decl());
+  return FunctionSchema(
+      name, "", std::move(args), std::move(returns), false, false);
+}
+
 } // namespace script
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/script/script_type_parser.h
+++ b/torch/csrc/jit/script/script_type_parser.h
@@ -28,10 +28,20 @@ class TORCH_API ScriptTypeParser {
 
   c10::TypePtr parseType(const std::string& str);
 
+  FunctionSchema parseSchemaFromDef(const Def& def, bool skip_self);
+
  private:
   at::TypePtr subscriptToType(
       const std::string& typeName,
       const Subscript& subscript) const;
+  std::vector<IValue> evaluateDefaults(
+      const SourceRange& r,
+      const std::vector<Expr>& default_types,
+      const std::vector<Expr>& default_exprs);
+  std::vector<Argument> parseArgsFromDecl(const Decl& decl, bool skip_self);
+
+  std::vector<Argument> parseReturnFromDecl(const Decl& decl);
+
   ResolverPtr resolver_ = nullptr;
 };
 } // namespace script

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -123,6 +123,12 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
     return std::make_shared<SimpleValue>(n->output());
   }
 
+  if (auto iface = value_->type()->cast<InterfaceType>()) {
+    if (auto schema = iface->getMethod(field)) {
+      return std::make_shared<MethodValue>(getValue(), field);
+    }
+  }
+
   return std::make_shared<BuiltinFunction>(
       Symbol::aten(field), NamedValue(loc, "self", value_));
 }

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -305,11 +305,20 @@ struct MethodValue : public SugaredValue {
       size_t n_binders) override {
     std::vector<NamedValue> inputsWithSelf = {self_};
     inputsWithSelf.insert(inputsWithSelf.end(), inputs.begin(), inputs.end());
-    auto method = self_->type()->expect<ClassType>()->getMethod(method_name_);
-    TORCH_INTERNAL_ASSERT(method);
-    method->ensure_defined();
-    MatchedSchema match = matchSchema(
-        method->getSchema(), loc, *f.graph(), inputsWithSelf, attributes);
+    const FunctionSchema* schema = nullptr;
+    if (auto class_type = self_->type()->cast<ClassType>()) {
+      auto method = class_type->getMethod(method_name_);
+      TORCH_INTERNAL_ASSERT(method);
+      method->ensure_defined();
+      schema = &method->getSchema();
+    } else if (auto interface_type = self_->type()->cast<InterfaceType>()) {
+      schema = interface_type->getMethod(method_name_);
+    } else {
+      TORCH_INTERNAL_ASSERT(
+          false, "method constructed that is not a class or interface");
+    }
+    MatchedSchema match =
+        matchSchema(*schema, loc, *f.graph(), inputsWithSelf, attributes);
     Value* output = f.graph()->insertMethodCall(method_name_, match);
     output->node()->setSourceRange(loc);
     return std::make_shared<SimpleValue>(output);

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1033,7 +1033,6 @@ def whichmodule(obj):
             pass
     return '__main__'
 
-
 def _compile_and_register_class(obj, rcb, qualified_name):
     ast = get_jit_class_def(obj, obj.__name__)
     _jit_script_class_compile(qualified_name, ast, rcb)
@@ -1201,6 +1200,18 @@ def _gen_rcb(obj, _frames_up):
         return stack_rcb(name)
 
     return _rcb
+
+
+def interface(obj):
+    if not inspect.isclass(obj):
+        raise RuntimeError("interface must be applied to a class")
+    if not _is_new_style_class(obj):
+        raise RuntimeError("TorchScript interfaces must inherit from 'object'")
+    qualified_name = _qualified_name(obj)
+    ast = get_jit_class_def(obj, obj.__name__)
+    rcb = _jit_internal.createResolutionCallback(1)
+    torch._C._jit_script_interface_compile(qualified_name, ast, rcb)
+    return obj
 
 ScriptMethodStub = namedtuple('ScriptMethodStub', ('resolution_callback', 'def_', 'original_method'))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25228 [jit] improve interface error messages
* #25227 [jit] add serialization of interface
* #25226 Remove PythonPrint's is_method_ member
* **#25258 Add interface declarations to JIT**

Summary: this is the first commit in a series to add interfaces to JIT.
Interfaces allow the specification through a blank python class of an
abstract interface that can be used in type annotations for Script functions.
If a TorchScript class implements all the methods in the interface with
the appropriate types, then it is implicitly considered to implement
that interface.

Follows required:
* implementation of serialization
* implementation in the parser frontend
* better error reporting for explaining why a class does not meet an
  interface specification.

Differential Revision: [D17079963](https://our.internmc.facebook.com/intern/diff/D17079963)