### PR TITLE
contrib-tensorboard: removed external tensorboardX dependency

### DIFF
--- a/caffe2/contrib/tensorboard/tensorboard.py
+++ b/caffe2/contrib/tensorboard/tensorboard.py
@@ -12,8 +12,21 @@ import os
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 import caffe2.contrib.tensorboard.tensorboard_exporter as tb_exporter
-import tensorflow as tf
 
+try:
+    # tensorboard>=1.14.0
+    from tensorboard.compat.proto.summary_pb2 import Summary, HistogramProto
+    from tensorboard.compat.proto.event_pb2 import Event
+    from tensorboard.summary.writer.event_file_writer import EventFileWriter as FileWriter
+except ImportError:
+    from tensorflow.core.framework.summary_pb2 import Summary, HistogramProto
+    from tensorflow.core.util.event_pb2 import Event
+    try:
+        # tensorflow>=1.0.0
+        from tensorflow.summary import FileWriter
+    except ImportError:
+        # tensorflow<=0.12.1
+        from tensorflow.train import SummaryWriter as FileWriter
 
 class Config(object):
     HEIGHT = 600
@@ -81,13 +94,7 @@ def cli():
 
 
 def write_events(tf_dir, events):
-    # tf.summary.FileWriter exists in the current Tensorflow release
-    # tf.train.SummaryWriter is the way in older versions
-    if hasattr(tf.summary, 'FileWriter'):
-        writer = tf.summary.FileWriter(logdir=tf_dir, max_queue=len(events))
-    else:
-        writer = tf.train.SummaryWriter(logdir=tf_dir, max_queue=len(events))
-
+    writer = FileWriter(tf_dir, len(events))
     for event in events:
         writer.add_event(event)
     writer.flush()
@@ -95,7 +102,7 @@ def write_events(tf_dir, events):
 
 
 def graph_def_to_event(step, graph_def):
-    return tf.Event(
+    return Event(
         wall_time=step, step=step, graph_def=graph_def.SerializeToString())
 
 
@@ -157,7 +164,7 @@ def tensorboard_events(c2_dir, tf_dir):
         samples = np.clip(samples, a_min=summary.min, a_max=summary.max)
         (hist, edges) = np.histogram(samples)
         upper_edges = edges[1:]
-        r = tf.HistogramProto(
+        r = HistogramProto(
             min=summary.min,
             max=summary.max,
             num=len(samples),
@@ -173,21 +180,21 @@ def tensorboard_events(c2_dir, tf_dir):
         summaries = list(zip(*summaries))
 
         def event(step, values):
-            s = tf.Summary()
+            s = Summary()
             scalar = [
-                tf.Summary.Value(
+                Summary.Value(
                     tag="{}/{}".format(name, field),
                     simple_value=v)
                 for name, value in zip(names, values)
                 for field, v in value._asdict().items()]
             hist = [
-                tf.Summary.Value(
+                Summary.Value(
                     tag="{}/inferred_normal_hist".format(name),
                     histo=inferred_histo(value))
                 for name, value in zip(names, values)
             ]
             s.value.extend(scalar + hist)
-            return tf.Event(wall_time=int(step), step=step, summary=s)
+            return Event(wall_time=int(step), step=step, summary=s)
 
         return [event(step, values)
                 for step, values in enumerate(summaries, start=1)]

--- a/caffe2/contrib/tensorboard/tensorboard_exporter.py
+++ b/caffe2/contrib/tensorboard/tensorboard_exporter.py
@@ -11,9 +11,20 @@ import six
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
-import tensorflow as tf
-from tensorflow.core.framework import tensor_shape_pb2
-from tensorflow.core.framework import graph_pb2
+
+try:
+    # tensorboard>=1.14.0
+    from tensorboard.compat.proto import tensor_shape_pb2
+    from tensorboard.compat.proto.node_def_pb2 import NodeDef
+    from tensorboard.compat.proto.graph_pb2 import GraphDef
+except ImportError:
+    from tensorflow.core.framework import tensor_shape_pb2
+    try:
+        # tensorflow>=1.0.0
+        from tensorflow import NodeDef, GraphDef
+    except ImportError:
+        # tensorflow<=0.12.1
+        from tensorflow.core.framework.graph_pb2 import NodeDef, GraphDef
 
 
 def _make_unique_name(seen, name, min_version=0):
@@ -224,8 +235,7 @@ def _set_tf_attr(m, arg):
 
 def _operator_to_node(shapes, op):
     assert op.name, op
-    # Check for existance of __version__ for backwards compatibility
-    n = tf.NodeDef() if hasattr(tf, '__version__') else graph_pb2.NodeDef()
+    n = NodeDef()
     n.name = op.name
     n.input.extend(op.input)
     n.op = op.type
@@ -243,8 +253,7 @@ def _operator_to_node(shapes, op):
 
 def _blob_to_node(producing_ops, shapes, name):
     assert name
-    # Check for existance of __version__ for backwards compatibility
-    n = tf.NodeDef() if hasattr(tf, '__version__') else graph_pb2.NodeDef()
+    n = NodeDef()
     n.name = name
     inputs = producing_ops.get(name, [])
     if inputs:
@@ -279,8 +288,7 @@ def _operators_to_graph_def(
     if with_gradient_scope:
         _add_gradient_scope(shapes, track_blob_names, ops)
     _fill_missing_operator_names(ops)
-    # Check for existance of __version__ for backwards compatibility
-    g = tf.GraphDef() if hasattr(tf, '__version__') else graph_pb2.GraphDef()
+    g = GraphDef()
     producing_ops = {}
     blobs = set()
     for op in ops:

--- a/caffe2/contrib/tensorboard/tensorboard_test.py
+++ b/caffe2/contrib/tensorboard/tensorboard_test.py
@@ -12,7 +12,23 @@ import unittest
 from caffe2.python import brew, core, model_helper
 import caffe2.contrib.tensorboard.tensorboard as tb
 import caffe2.contrib.tensorboard.tensorboard_exporter as tb_exporter
-import tensorflow as tf
+
+try:
+    # tensorboard>=1.14.0
+    from tensorboard.compat.proto.graph_pb2 import GraphDef
+except ImportError:
+    from tensorflow import GraphDef
+
+
+def load_events(filename):
+    try:
+        # tensorboard>=1.14.0
+        from tensorboard.backend.event_processing import event_file_loader
+        loader = event_file_loader.EventFileLoader(filename)
+        return list(loader.Load())
+    except ImportError:
+        import tensorflow as tf
+        return list(tf.train.summary_iterator(filename))
 
 
 class TensorboardTest(unittest.TestCase):
@@ -43,7 +59,7 @@ class TensorboardTest(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         ((d, _, (fname,)),) = entries
         self.assertEqual(tf_dir, d)
-        events = list(tf.train.summary_iterator(os.path.join(tf_dir, fname)))
+        events = load_events(os.path.join(tf_dir, fname))
         self.assertEqual(len(events), n_iters + 1)
         events = events[1:]
         self.maxDiff = None
@@ -84,14 +100,14 @@ class TensorboardTest(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         ((d, _, (fname,)),) = entries
         self.assertEqual(tf_dir, d)
-        events = list(tf.train.summary_iterator(os.path.join(tf_dir, fname)))
+        events = load_events(os.path.join(tf_dir, fname))
         self.assertEqual(len(events), 3)
         events = events[1:]
         nets = [model.param_init_net, model.net]
         for i, (event, net) in enumerate(zip(events, nets), start=1):
             self.assertEqual(event.step, i)
             self.assertEqual(event.wall_time, i)
-            g = tf.GraphDef()
+            g = GraphDef()
             g.ParseFromString(event.graph_def)
             self.assertMultiLineEqual(
                 str(g),


### PR DESCRIPTION
Summary: Switching to tensorboard instead of tensorflow

Test Plan: went through instructions in [fbsource/fbcode/caffe2/caffe2/contrib/tensorboard/tensorboard.md] to make sure everything is working (using/not using tensorboard/tensorflow)

Reviewed By: orionr

Differential Revision: D17059111

