### PR TITLE
[JIT] add torch.jit.is_scripting() api

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -8177,6 +8177,15 @@ a")
 
         self.checkScript(test_if_tracing, (inp,))
 
+    def test_is_scripting(self):
+        def foo():
+            return torch.jit._is_scripting()
+
+        self.assertFalse(foo())
+        scripted = torch.jit.script(foo)
+        FileCheck().check("is_scripting").run(scripted.graph)
+        self.assertTrue(scripted())
+
     def test_script_outputs(self):
         with self.assertRaisesRegex(RuntimeError, "cannot be used as a tuple"):
             @torch.jit.script

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -473,6 +473,13 @@ RegisterOperators reg({
         },
         aliasAnalysisFromSchema()),
     Operator(
+        "aten::_is_scripting() -> bool",
+        [](Stack& stack) {
+          push(stack, true);
+          return 0;
+        },
+        aliasAnalysisFromSchema()),
+    Operator(
         "aten::_no_grad_uniform_(Tensor(a!) tensor, float a, float b) -> Tensor(a!)",
         [](Stack& stack) {
           // TODO: remove when script supports setting grad mode

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1741,6 +1741,10 @@ def _unwrap_optional(x):
     assert x is not None, "Unwrapping null optional"
     return x
 
+# primitive that returns True when in compilation and False otherwise
+def _is_scripting():
+    return False
+
 _builtin_table = None
 
 _modules_containing_builtins = (torch, torch._C._nn)
@@ -1754,6 +1758,7 @@ _builtin_ops = [
     (_triple, "aten::_triple"),
     (_unwrap_optional, "aten::_unwrap_optional"),
     (_wait, 'aten::wait'),
+    (_is_scripting, "aten::_is_scripting"),
     (cudnn.is_acceptable, "aten::cudnn_is_acceptable"),
     (math.ceil, "aten::ceil"),
     (math.copysign, "aten::copysign"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25263 [JIT] add torch.jit.is_scripting() api**
* #25262 [JIT] preserve ignored function return value type

This adds an api to return true in script and false in eager, which together with @ignore allows guarding of not yet supported JIT features. Bikeshedding requested please. 

cc @zou3519 

```
def foo():
   if not torch.jit.is_scripting():
      return torch.linear(...)
   else:
      return addmm(...)
```

Differential Revision: [D17273136](https://our.internmc.facebook.com/intern/diff/D17273136)