### PR TITLE
Align AT_FORALL macros with DISPATCH macros wrt Half.

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -173,7 +173,7 @@ Tensor& empty_out(
     return self.to(ScalarType::n, non_blocking);                 \
   }
 
-AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, DEFINE_CAST_OP)
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CAST_OP)
 
 #undef DEFINE_CAST_OP
 
@@ -814,7 +814,7 @@ Tensor tensor_backend(ArrayRef<T> values, const TensorOptions& options) {
       return tensor_cpu(values, options);                           \
     }                                                               \
   }
-AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, TENSOR)
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 
 Tensor from_file(std::string filename, c10::optional<bool> shared, c10::optional<int64_t> size, const TensorOptions& options) {

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -44,7 +44,7 @@ namespace native {
   inline Tensor tensor(T value) {                                             \
     return native::tensor(ArrayRef<T>(value));                                \
   }
-AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, TENSOR)
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 
 ${native_function_declarations}

--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -27,7 +27,7 @@ class C10_API Scalar {
 #define DEFINE_IMPLICIT_CTOR(type, name)      \
   Scalar(type vv) : Scalar(vv, true) { }
 
-  AT_FORALL_SCALAR_TYPES_AND(BFloat16, DEFINE_IMPLICIT_CTOR)
+  AT_FORALL_SCALAR_TYPES_AND2(Half, BFloat16, DEFINE_IMPLICIT_CTOR)
 
 #undef DEFINE_IMPLICIT_CTOR
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -134,22 +134,32 @@ struct ScalarTypeToCPPType<c10::ScalarType::Long> {
   _(int16_t, Short)                                                        \
   _(int, Int)                                                              \
   _(int64_t, Long)                                                         \
-  _(at::Half, Half)                                                        \
   _(float, Float)                                                          \
   _(double, Double)                                                        \
   _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE>::t), SCALARTYPE)
 
-#define AT_FORALL_SCALAR_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _)                              \
-  _(uint8_t, Byte)                                                                            \
-  _(int8_t, Char)                                                                             \
-  _(int16_t, Short)                                                                           \
-  _(int, Int)                                                                                 \
-  _(int64_t, Long)                                                                            \
-  _(at::Half, Half)                                                                           \
-  _(float, Float)                                                                             \
-  _(double, Double)                                                                           \
+#define AT_FORALL_SCALAR_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, _)                                \
+  _(uint8_t, Byte)                                                                              \
+  _(int8_t, Char)                                                                               \
+  _(int16_t, Short)                                                                             \
+  _(int, Int)                                                                                   \
+  _(int64_t, Long)                                                                              \
+  _(float, Float)                                                                               \
+  _(double, Double)                                                                             \
   _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE1>::t), SCALARTYPE1) \
   _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE2>::t), SCALARTYPE2)
+
+#define AT_FORALL_SCALAR_TYPES_AND3(SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, _)                   \
+  _(uint8_t, Byte)                                                                              \
+  _(int8_t, Char)                                                                               \
+  _(int16_t, Short)                                                                             \
+  _(int, Int)                                                                                   \
+  _(int64_t, Long)                                                                              \
+  _(float, Float)                                                                               \
+  _(double, Double)                                                                             \
+  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE1>::t), SCALARTYPE1) \
+  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE2>::t), SCALARTYPE2) \
+  _(decltype(::c10::impl::ScalarTypeToCPPType<::c10::ScalarType::SCALARTYPE3>::t), SCALARTYPE3)
 
 #define AT_FORALL_QINT_TYPES(_)  \
   _(c10::qint8, QInt8)           \

--- a/caffe2/contrib/aten/aten_op_template.h
+++ b/caffe2/contrib/aten/aten_op_template.h
@@ -15,7 +15,7 @@ static std::unordered_map<std::string, int> op_to_key = {
 
 namespace caffe2 {
 
-using at::Half; // for AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, ...)
+using at::Half; // for AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, ...)
 
 template <class Context>
 class ATenOp : public Operator<Context> {
@@ -47,7 +47,7 @@ private:
       case at::k##aten_name: \
         return TypeMeta::Make<ctype>();
     switch(st) {
-      AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, DEFINE_CASE)
+      AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CASE)
     default:
       CAFFE_THROW("Unknown ATen Type");
     }
@@ -139,7 +139,7 @@ private:
           auto value = extract<ctype>(scalar); \
           assignToValue<ctype>(dst, at::convert<ctype,decltype(value)>(value)); \
         } break;
-      AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, DEFINE_CASE)
+      AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, DEFINE_CASE)
 #undef DEFINE_CASE
       default:
         CAFFE_THROW("Unknown ATen Type");

--- a/caffe2/operators/experimental/c10/cpu/cast_cpu.cc
+++ b/caffe2/operators/experimental/c10/cpu/cast_cpu.cc
@@ -80,7 +80,7 @@ void cast_op_cpu(
     int64_t to) {
   switch (input.scalar_type()) {
 #define CASE(ctype,name) case ScalarType:: name : return cast_op_cpu_impl<ctype>(input, output, to);
-    AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, CASE)
+    AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CASE)
 #undef CASE
     default: throw std::runtime_error(string() + "Unsupported scalar type " + toString(input.scalar_type()));
   }

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -44,7 +44,7 @@ namespace torch {
   inline at::Tensor tensor(T value) {                                      \
     return torch::tensor(at::ArrayRef<T>(value));                          \
   }
-AT_FORALL_SCALAR_TYPES_AND2(Bool, BFloat16, TENSOR)
+AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 
 /// A generic deleter function.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25268 Align AT_FORALL macros with DISPATCH macros wrt Half.**

The AT_FORALL AND macros with mistakenly already include Half, which differs from the Dispatch macros.

This change shouldn't have any effect.

Differential Revision: [D17079747](https://our.internmc.facebook.com/intern/diff/D17079747)