### PR TITLE
[JIT] don't throw in constant prop

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2302,6 +2302,18 @@ graph(%Ra, %Rb):
         # testing that 1 // 0 error is not thrownn
         self.run_pass('constant_propagation', constant_prop.graph)
 
+    def test_constant_prop_excption(self):
+        # checking y = a[4] does not error in constant propagation
+        def bad_index(x):
+            # type: (bool)
+            y = 0
+            if x:
+                a = [1, 2, 3]
+                y = a[4]
+            return y
+
+        self.checkScript(bad_index, (False,))
+
     def test_short_circuit_optimization(self):
         @torch.jit.script
         def const_expressions(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2302,7 +2302,7 @@ graph(%Ra, %Rb):
         # testing that 1 // 0 error is not thrownn
         self.run_pass('constant_propagation', constant_prop.graph)
 
-    def test_constant_prop_excption(self):
+    def test_constant_prop_exception(self):
         # checking y = a[4] does not error in constant propagation
         def bad_index(x):
             # type: (bool)
@@ -17215,14 +17215,14 @@ class TestList(JitTestCase):
             a = [1, 2, 3]
             return a[4]
 
-        self.checkScriptRaisesRegex(bad_index, (), IndexError,
+        self.checkScriptRaisesRegex(bad_index, (), Exception,
                                     "list index out of range")
 
         def bad_negative_index():
             a = [1, 2, 3]
             return a[-5]
 
-        self.checkScriptRaisesRegex(bad_negative_index, (), IndexError,
+        self.checkScriptRaisesRegex(bad_negative_index, (), Exception,
                                     "list index out of range")
 
     def test_list_len(self):

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -111,8 +111,8 @@ struct ConstantPropagator {
     std::vector<IValue> outputs;
     try {
       outputs = runNode(n);
-    } catch (const c10::Error& e) {
-      // catch AT_ASSERT errors. This op may not be run reached,
+    } catch (...) {
+      // Catch exceptions. This op may not be run,
       // so catch the error here & leave the op in the graph
       return;
     }


### PR DESCRIPTION
Don't throw in constant propagation, since the op we're running may not be reached. Previously we would only only catch `C10::Error`; however it's hard to maintain that the entire codebase doesn't throw any other types of errors, and some errors map nicely to python errors, like `std::index_error` to IndexError.

