### PR TITLE
[JIT] fix closures which always throw.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12885,6 +12885,7 @@ a")
                     a = 0
                     def backward(grad_output):
                         raise "Hi"
+                    a = a + 1
                 else:
                     return x
                 return a + 1

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12891,7 +12891,7 @@ a")
                 return a + 1
         ''')
         func = torch.jit.CompilationUnit(code).test_exit_pair_reset
-        self.assertEqual(func(1,), 1)
+        self.assertEqual(func(1,), 2)
         self.assertEqual(func(-1,), -1)
         FileCheck().check_count("prim::If", 2, exactly=True).check("aten::add")\
             .run(func.graph)  # if added to guard a + 1

--- a/torch/csrc/jit/script/exit_transforms.cpp
+++ b/torch/csrc/jit/script/exit_transforms.cpp
@@ -415,7 +415,8 @@ struct ExitTransformer {
           exit_pair = transformIf(node);
         } break;
         case prim::Function: {
-          exit_pair = transformExits(node->blocks().at(0));
+          // exits of closure declaration stay local to the closure
+          transformExits(node->blocks().at(0));
         } break;
         case prim::Loop: {
           exit_pair = transformLoop(node);


### PR DESCRIPTION
When a closure was declared that always throw'd we would erroneously propagate the ExitThrows status to the block in which it was declared, causing us to remove the subsequent code in the block. [this code](https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/script/exit_transforms.cpp#L462) was meant to handle this case, however it didn't handle the case when we were transforming Loops and the prim::Function wasn't a target block.
