### PR TITLE
Return a message instead of void from rpc udf

### DIFF
--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -33,7 +33,7 @@ Message processRequestBlocking(Message&& request) {
         response.setId(request.id());
         return response;
       } catch (std::exception& e) {
-        return createException(std::move(request), e);
+        return createException(request, e);
       }
       break;
     }

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -4,26 +4,17 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-void sendException(
-    const std::string& from,
-    const Message& request,
-    RpcAgent& agent,
-    const std::exception& e) {
+Message createException(const Message& request, const std::exception& e) {
   const char* err = e.what();
   std::vector<char> payload(err, err + strlen(err));
-  agent.send(
-      from,
-      Message(
-          std::move(payload),
-          std::vector<torch::Tensor>(),
-          MessageType::EXCEPTION,
-          request.id()));
+  return Message(
+      std::move(payload),
+      std::vector<torch::Tensor>(),
+      MessageType::EXCEPTION,
+      request.id());
 }
 
-void processRequestBlocking(
-    const std::string& from,
-    Message&& request,
-    RpcAgent& agent) {
+Message processRequestBlocking(Message&& request) {
   switch (request.type()) {
     case MessageType::SCRIPT_CALL: {
       try {
@@ -40,24 +31,22 @@ void processRequestBlocking(
 
         auto response = ScriptRet(std::move(stack.front())).toMessage();
         response.setId(request.id());
-        agent.send(from, std::move(response));
+        return response;
       } catch (std::exception& e) {
-        sendException(from, request, agent, e);
+        return createException(std::move(request), e);
       }
       break;
     }
     case MessageType::PYTHON_CALL: {
       try {
         auto payload = PythonRpcHandler::generatePythonUDFResult(request);
-        agent.send(
-            from,
-            Message(
-                std::move(payload),
-                std::vector<torch::Tensor>(),
-                MessageType::PYTHON_RET,
-                request.id()));
+        return Message(
+            std::move(payload),
+            std::vector<torch::Tensor>(),
+            MessageType::PYTHON_RET,
+            request.id());
       } catch (std::exception& e) {
-        sendException(from, request, agent, e);
+        return createException(request, e);
       }
       break;
     }

--- a/torch/csrc/distributed/rpc/functions.h
+++ b/torch/csrc/distributed/rpc/functions.h
@@ -11,16 +11,9 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-void processRequestBlocking(
-    const std::string& from,
-    Message&& message,
-    RpcAgent& agent);
+Message processRequestBlocking(Message&& message);
 
-void sendException(
-    const std::string& from,
-    const Message& request,
-    RpcAgent& agent,
-    const std::exception& e);
+Message createException(const Message& request, const std::exception& e);
 
 } // namespace rpc
 } // namespace distributed

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -197,7 +197,8 @@ void ProcessGroupAgent::enqueueRecv(RecvWork work) {
       Message message = deserialize(work.type_, ss);
 
       if (message.isRequest()) {
-        cb_(names_[work.from_], std::move(message), *this);
+        auto response = cb_(std::move(message));
+        send(names_[work.from_], std::move(response));
       } else if (message.isResponse()) {
         auto id = message.id();
         {

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -17,12 +17,12 @@ class RpcAgent;
 
 // RpcAgent implementation should invoke ``RequestCallback`` to process received
 // requests. There is no restriction on the implementation's threading model.
-// This function takes the name of the request sender, the an rvalue reference
-// of the Message object, and a reference to the RpcAgent itself. Having a
-// reference to the RpcAgent allows the ``RequestCallback`` implementation to
-// be both stateless and non-blocking. It may enqueue the message and the
-// RpcAgent reference, and use a different set of threads to process them later.
-using RequestCallback = std::function<void(std::string, Message&&, RpcAgent&)>;
+// This function takes an rvalue reference of the Message object.
+// It is expected to return the response message or message containing an
+// exception. Different rpc agent implementations are expected to ensure
+// delivery of the response/exception based on their implementation specific
+// mechanisms.
+using RequestCallback = std::function<Message(Message&&)>;
 
 class RpcAgent {
  public:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25283 Return a message instead of void from rpc udf**

Return a message instead of void from rpc udf
This is to help thrift style rpc where there is no need for explicit send for a response.
We need to figure out how to solve the non-blocking callback case but don't want to block the thrift backed rpc agent implementation till then.

Differential Revision: [D16825072](https://our.internmc.facebook.com/intern/diff/D16825072/)