### PR TITLE
Use _mm256_rsqrt_ps for rsqrt on CPU for float instead of using division and _mm256_sqrt_ps.

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -194,7 +194,7 @@ public:
     return _mm256_div_ps(_mm256_set1_ps(1), values);
   }
   Vec256<float> rsqrt() const {
-    return _mm256_div_ps(_mm256_set1_ps(1), _mm256_sqrt_ps(values));
+    return _mm256_rsqrt_ps(values);
   }
   Vec256<float> pow(const Vec256<float> &b) const {
     return Vec256<float>(Sleef_powf8_u10(values, b));

--- a/aten/src/ATen/native/cpu/PowKernel.cpp
+++ b/aten/src/ATen/native/cpu/PowKernel.cpp
@@ -66,7 +66,7 @@ void pow_tensor_scalar_kernel(TensorIterator& iter, Scalar exp_scalar) {
           [](scalar_t base) -> scalar_t {
             return 1.0 / std::sqrt(base);
           },
-          [](Vec base) -> Vec { return base.rsqrt(); }
+          [](Vec base) -> Vec { return Vec(static_cast<scalar_t>(1)) / base.sqrt(); }
         );
       } else if (exp == -1) {
         cpu_kernel_vec(iter,
@@ -93,7 +93,7 @@ void pow_tensor_scalar_kernel(TensorIterator& iter, Scalar exp_scalar) {
     });
   } else if (isComplexType(iter.dtype())) {
     const auto exp = exp_scalar.to<std::complex<double>>();
-    // Floating types allow AVX2 vector optimizations for pow/sqrt/rsqrt:
+    // Floating types allow AVX2 vector optimizations for pow/sqrt:
     AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "pow", [&]() {
       using Vec = Vec256<scalar_t>;
       if (exp == 0.5) {
@@ -122,7 +122,7 @@ void pow_tensor_scalar_kernel(TensorIterator& iter, Scalar exp_scalar) {
           [](scalar_t base) -> scalar_t {
             return scalar_t(1.0) / std::sqrt(base);
           },
-          [](Vec base) -> Vec { return base.rsqrt(); }
+          [](Vec base) -> Vec { return Vec(static_cast<scalar_t>(1)) / base.sqrt(); }
         );
       } else if (exp == -1.0) {
         cpu_kernel_vec(iter,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -304,7 +304,7 @@ class _TestTorchMixin(object):
             non_contig = torch.empty(shape + (2,), dtype=dtype)[..., 0]
             non_contig.copy_(contig)
             self.assertFalse(non_contig.is_contiguous())
-            self.assertEqual(torchfn(contig), torchfn(non_contig), 'non-contiguous')
+            torch.testing.assert_allclose(torchfn(contig), torchfn(non_contig), rtol=rtol, atol=atol)
 
         # compare application against contiguous vs. non-contiguous
         check_non_contiguous((5, 7), torch.double)
@@ -580,7 +580,7 @@ class _TestTorchMixin(object):
                 return nan
             return 1.0 / math.sqrt(x)
 
-        self._test_math(torch.rsqrt, rsqrt)
+        self._test_math(torch.rsqrt, rsqrt, rtol=1.5 * 2**-12, atol=0)
 
     def test_frac(self):
         self._test_math(torch.frac, lambda x: math.fmod(x, 1))
@@ -14147,7 +14147,6 @@ tensor_op_tests = [
     ('rot90', 'k1_d12', _small_3d, lambda t, d: [1, [1, 2]], 1e-5, 1e-5, _types, False),
     ('rot90', 'k1_neg_d', _small_3d, lambda t, d: [1, [1, -1]], 1e-5, 1e-5, _types, False),
     ('rot90', 'default', _small_3d, lambda t, d: [], 1e-5, 1e-5, _types, False),
-    ('rsqrt', '', lambda t, d: _small_3d(t, d) + 1, lambda t, d: [], 1e-2, 1e-4, _float_types_no_half),
     ('sinh', '', lambda t, d: _small_3d(t, d).clamp(-1, 1), lambda t, d: [], 1e-3, 1e-5, _float_types),
     ('tan', '', lambda t, d: _small_3d(t, d).clamp(-1, 1), lambda t, d: [], 1e-3, 1e-5, _float_types),
     ('__lshift__', '',

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4644,10 +4644,17 @@ add_docstr(torch.rsqrt,
 rsqrt(input, out=None) -> Tensor
 
 Returns a new tensor with the reciprocal of the square-root of each of
-the elements of :attr:`input`.
+the elements of ``input``.
 
 .. math::
     \text{out}_{i} = \frac{1}{\sqrt{\text{input}_{i}}}
+
+.. note: This function, whenever possible, attempts to use an algorithm that is
+         faster but does not guarantee as much accuracy as
+         ``1/torch.sqrt(input)`` does. The relative error can be as large as
+         :math:`1.5 \times 2^{-12}` (e.g., see the `document of
+         __m256_rsqrt_ps`_ ). If accuracy is critical to your purpose, please
+         use ``1/torch.sqrt(input)`` instead.
 """ + r"""
 Args:
     {input}
@@ -4660,6 +4667,9 @@ Example::
     tensor([-0.0370,  0.2970,  1.5420, -0.9105])
     >>> torch.rsqrt(a)
     tensor([    nan,  1.8351,  0.8053,     nan])
+
+.. _document of __mm256_rsqrt_ps:
+    https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_rsqrt_ps&expand=4804
 """.format(**common_args))
 
 add_docstr(torch.set_flush_denormal,


### PR DESCRIPTION
Currently for single-precision floating-point number, division and
_mm256_sqrt_ps are used. While the current method is more accurate,
using _mm256_rsqrt_ps is faster. See
https://github.com/pytorch/pytorch/pull/8488#discussion_r195911562 .

This commit switches to _mm256_rsqrt_ps, because:

- This is more consistent with the CUDA implementation, which uses
  rsqrt, which is faster but less accurate:
  https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#standard-functions

- Users who call torch.rsqrt() are more likely to seek for speed than
  accuracy. Otherwise, they can use 1/torch.sqrt().

Another possibility would be to add an option to decide which version to
use, as rsqrt has a faster derivative.

Test on small3d is also removed, because test_rsqrt is sufficiently comprehensive, and small3d does not allow specifying max relative error.

Benchmark (RHEL 7.3, Release, g++ 8.3, turbo off):

```python
import timeit

for n, t in [(10_000, 800000),
             (100_000, 80000)]:
    print(f'a.rsqrt() (a.numel() == {n}) for {t} times')
    print(timeit.timeit(f'a.rsqrt()',
                        setup=f'import torch; a = torch.arange({n}, device="cpu", dtype=torch.float)',
                        number=t))
```

Before:

```
a.rsqrt() (a.numel() == 10000) for 800000 times
6.847818954000104
a.rsqrt() (a.numel() == 100000) for 80000 times
4.606836445998852
```

After:

```
a.rsqrt() (a.numel() == 10000) for 800000 times
3.61814929799948
a.rsqrt() (a.numel() == 100000) for 80000 times
2.1390665140006604
```