### PR TITLE
Delete deprecated Tensor::type() method.

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -216,12 +216,6 @@ class CAFFE2_API Tensor {
     return impl_->itemsize();
   }
 
-  DeprecatedTypeProperties & type() const {
-    return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-        tensorTypeIdToBackend(type_id()),
-        scalar_type(),
-        is_variable());
-  }
   TensorTypeId type_id() const {
     return impl_->type_id();
   }

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -216,12 +216,6 @@ class CAFFE2_API Tensor {
     return impl_->itemsize();
   }
 
-  DeprecatedTypeProperties & type() const {
-    return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
-        tensorTypeIdToBackend(type_id()),
-        scalar_type(),
-        is_variable());
-  }
   TensorTypeId type_id() const {
     return impl_->type_id();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25306 Delete deprecated Tensor::type() method.**

Use Tensor::options() instead.

Differential Revision: [D17092763](https://our.internmc.facebook.com/intern/diff/D17092763/)