### PR TITLE
Fix named tensor test

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -175,10 +175,6 @@ Tensor& sign_out(Tensor& result, const Tensor& self) {
     auto iter = TensorIterator::unary_op(result, self,
       /*check_internal_overlap=*/true);
     sign_stub(iter.device_type(), iter);
-
-#ifdef BUILD_NAMEDTENSOR
-    at::namedinference::propagate_names(result, self);
-#endif
     return result;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4114,9 +4114,11 @@
 
 - func: sign(Tensor self) -> Tensor
   variants: function, method
+  named_guard: False
 
 - func: sign_(Tensor(a!) self) -> Tensor(a!)
   variants: method
+  named_guard: False
 
 - func: sign.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   named_guard: False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25181 [WIP][testing] Turn on BUILD_NAMEDTENSOR permanently
* #25256 Move BUILD_NAMEDTENSOR macro out of header areas
* #25280 Fix dependency by moving Dimname.{h,cpp} NamedTensor.{h,cpp} to core/
* #25178 Include the correct header for make_unique in named tensor headers
* #25177 Implement name inference for torch.matmul
* #25123 Implement name inference for torch.bmm
* **#25313 Fix named tensor test**

`sign` was recently ported from TH to ATen, undoing some named tensor
changes and breaking the CI named tensor test. This PR re-enables named tensor
for `sign`.

Test Plan
- [namedtensor ci]

Differential Revision: [D17093439](https://our.internmc.facebook.com/intern/diff/D17093439)