### PR TITLE
Fixed masking warnings in tests

### DIFF
--- a/test/common_methods_invocations.py
+++ b/test/common_methods_invocations.py
@@ -41,7 +41,7 @@ def gather_variable(shape, index_dim, max_indices, duplicate=False):
 
 
 def bernoulli_scalar():
-    return torch.tensor(0, dtype=torch.uint8).bernoulli_()
+    return torch.tensor(0, dtype=torch.bool).bernoulli_()
 
 
 def mask_not_all_zeros(shape):
@@ -810,22 +810,22 @@ def method_tests():
         ('masked_select', (M,), (mask_not_all_zeros((M, M)),), 'broadcast_lhs'),
         ('masked_select', (M, 1, M), (mask_not_all_zeros((M, M)),),
          'broadcast_all'),
-        ('masked_select', (), (torch.tensor(1, dtype=torch.uint8),), 'scalar'),
-        ('masked_select', (M, M), (torch.tensor(1, dtype=torch.uint8),), 'scalar_broadcast_rhs'),
+        ('masked_select', (), (torch.tensor(1, dtype=torch.bool),), 'scalar'),
+        ('masked_select', (M, M), (torch.tensor(1, dtype=torch.bool),), 'scalar_broadcast_rhs'),
         ('masked_select', (), (mask_not_all_zeros((M, M)),), 'scalar_broadcast_lhs'),
-        ('masked_fill', (M, M), (torch.ByteTensor(M, M).bernoulli_(), 10)),
-        ('masked_fill', (M, M), (torch.ByteTensor(M, M).bernoulli_(), ()), 'tensor'),
-        ('masked_fill', (M,), (torch.ByteTensor(M, M).bernoulli_(), 10), 'broadcast_lhs'),
-        ('masked_fill', (M, M), (torch.ByteTensor(M,).bernoulli_(), 10), 'broadcast_rhs'),
-        ('masked_fill', (), (torch.tensor(0, dtype=torch.uint8).bernoulli_(), 10), 'scalar'),
-        ('masked_fill', (), (torch.tensor(0, dtype=torch.uint8).bernoulli_(), ()),
+        ('masked_fill', (M, M), (torch.BoolTensor(M, M).bernoulli_(), 10)),
+        ('masked_fill', (M, M), (torch.BoolTensor(M, M).bernoulli_(), ()), 'tensor'),
+        ('masked_fill', (M,), (torch.BoolTensor(M, M).bernoulli_(), 10), 'broadcast_lhs'),
+        ('masked_fill', (M, M), (torch.BoolTensor(M,).bernoulli_(), 10), 'broadcast_rhs'),
+        ('masked_fill', (), (torch.tensor(0, dtype=torch.bool).bernoulli_(), 10), 'scalar'),
+        ('masked_fill', (), (torch.tensor(0, dtype=torch.bool).bernoulli_(), ()),
          'scalar_variable'),
-        ('masked_fill', (M, M), (torch.tensor(0, dtype=torch.uint8).bernoulli_(), 10),
+        ('masked_fill', (M, M), (torch.tensor(0, dtype=torch.bool).bernoulli_(), 10),
          'scalar_broadcast_rhs'),
-        ('masked_scatter', (M, M), (torch.ByteTensor(M, M).bernoulli_(), (M, M))),
-        ('masked_scatter', (M,), (torch.ByteTensor(M, M).bernoulli_(), (M, M)),
+        ('masked_scatter', (M, M), (torch.BoolTensor(M, M).bernoulli_(), (M, M))),
+        ('masked_scatter', (M,), (torch.BoolTensor(M, M).bernoulli_(), (M, M)),
          'broadcast_lhs'),
-        ('masked_scatter', (M, M), (torch.ByteTensor(M,).bernoulli_(), (M, M)),
+        ('masked_scatter', (M, M), (torch.BoolTensor(M,).bernoulli_(), (M, M)),
          'broadcast_rhs'),
         ('masked_scatter', (M, M), (bernoulli_scalar(), (M, M)), 'scalar'),
         ('masked_scatter', (M, M), (bernoulli_scalar(), (M, M)),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -964,7 +964,7 @@ class TestAutograd(TestCase):
         check_index(x, y, (1, slice(2, None)))
         check_index(x, y, (slice(None, None), slice(2, None)))
         check_index(x, y, torch.LongTensor([0, 2]))
-        check_index(x, y, torch.rand(4, 4).bernoulli().byte())
+        check_index(x, y, torch.rand(4, 4).bernoulli().bool())
         check_index(x, y, (Ellipsis, slice(2, None)))
         check_index(x, y, ([0], [0]))
         check_index(x, y, ([1, 2, 3], [0]))
@@ -1504,7 +1504,7 @@ class TestAutograd(TestCase):
                                               3]), requires_grad=False), [2, 4], slice(None)])
 
     def test_setitem_mask(self):
-        mask = torch.ByteTensor(5, 5).bernoulli_()
+        mask = torch.BoolTensor(5, 5).bernoulli_()
         self._test_setitem((5, 5), Variable(mask))
         self._test_setitem((5,), Variable(mask[0]))
         self._test_setitem((1,), Variable(mask[0, 0:1]))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2047,7 +2047,6 @@ graph(%Ra, %Rb):
                              [True, False, False],
                              [True, True, False]])
 
-        print(mask)
         def test_fn(ten, mask):
             ten[mask] = torch.ones(6)
             return ten
@@ -12886,13 +12885,12 @@ a")
                     a = 0
                     def backward(grad_output):
                         raise "Hi"
-                    a = a + 1
                 else:
                     return x
                 return a + 1
         ''')
         func = torch.jit.CompilationUnit(code).test_exit_pair_reset
-        self.assertEqual(func(1,), 2)
+        self.assertEqual(func(1,), 1)
         self.assertEqual(func(-1,), -1)
         FileCheck().check_count("prim::If", 2, exactly=True).check("aten::add")\
             .run(func.graph)  # if added to guard a + 1
@@ -18420,129 +18418,6 @@ class TestClassType(JitTestCase):
         input = torch.rand(2, 3)
         output = m_loaded(input)
         self.assertEqual(3 * input, output)
-
-    def test_interface(self):
-        @torch.jit.script
-        class Foo(object):
-            def __init__(self):
-                pass
-
-            def one(self, x, y):
-                return x + y
-
-            def two(self, x):
-                return 2 * x
-
-        @torch.jit.script
-        class Bar(object):
-            def __init__(self):
-                pass
-
-            def one(self, x, y):
-                return x * y
-
-            def two(self, x):
-                return 2 / x
-
-        @torch.jit.interface
-        class OneTwo(object):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                pass
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                pass
-
-        @torch.jit.interface
-        class OneTwoThree(object):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                pass
-
-            def two(self, x):
-                # type: (Tensor) -> Tensor
-                pass
-
-            def three(self, x):
-                # type: (Tensor) -> Tensor
-                pass
-
-        @torch.jit.interface
-        class OneTwoWrong(object):
-            def one(self, x, y):
-                # type: (Tensor, Tensor) -> Tensor
-                pass
-
-            def two(self, x):
-                # type: (int) -> int
-                pass            
-
-        @torch.jit.script
-        class NotMember(object):
-            def __init__(self):
-                pass
-
-            def one(self, x, y):
-                return x + y
-            # missing two
-
-        @torch.jit.script
-        class NotMember2(object):
-            def __init__(self):
-                pass
-
-            def one(self, x, y):
-                return x + y
-
-            def two(self, x):
-                # type: (int) -> int
-                return 3
-
-        def use_them(x):
-            a = Foo()
-            b = Bar()
-            c = torch.jit.annotate(List[OneTwo], [a, b])
-            for i in range(len(c)):
-                x = c[i].one(x, x)
-                x = c[i].two(x)
-            return x
-        self.checkScript(use_them, (torch.rand(3, 4),))
-
-        @torch.jit.script
-        def as_interface(x):
-            # type: (OneTwo) -> OneTwo
-            return x
-
-        @torch.jit.script
-        def inherit(x):
-            # type: (OneTwoThree) -> OneTwo
-            return as_interface(x)
-
-        with self.assertRaisesRegex(RuntimeError, "does not have method"):
-            @torch.jit.script
-            def wrong1():
-                return as_interface(NotMember())
-
-        with self.assertRaisesRegex(RuntimeError, "is not compatible with interface"):
-            @torch.jit.script
-            def wrong2():
-                return as_interface(NotMember2())
-
-        with self.assertRaisesRegex(RuntimeError, "does not have method"):
-            @torch.jit.script
-            def wrong3():
-                return inherit(as_interface(Foo()))
-
-        with self.assertRaisesRegex(RuntimeError, "is not compatible with interface"):
-
-            @torch.jit.script
-            def wrong4(x):
-                # type: (OneTwoWrong) -> int
-                return as_interface(x)
-
-    # TODO test: interface-interface class-interface inheritance errors,
-    # NamedTuple inheritance errors
 
     def test_overloaded_fn(self):
         @torch.jit.script

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2043,10 +2043,11 @@ graph(%Ra, %Rb):
 
     def test_index_put(self):
         ten = torch.zeros(3, 3)
-        mask = torch.Tensor([[True, True, True],
+        mask = torch.tensor([[True, True, True],
                              [True, False, False],
-                             [True, True, False]]).byte()
+                             [True, True, False]])
 
+        print(mask)
         def test_fn(ten, mask):
             ten[mask] = torch.ones(6)
             return ten

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12885,12 +12885,13 @@ a")
                     a = 0
                     def backward(grad_output):
                         raise "Hi"
+                    a = a + 1
                 else:
                     return x
                 return a + 1
         ''')
         func = torch.jit.CompilationUnit(code).test_exit_pair_reset
-        self.assertEqual(func(1,), 1)
+        self.assertEqual(func(1,), 2)
         self.assertEqual(func(-1,), -1)
         FileCheck().check_count("prim::If", 2, exactly=True).check("aten::add")\
             .run(func.graph)  # if added to guard a + 1
@@ -18418,6 +18419,129 @@ class TestClassType(JitTestCase):
         input = torch.rand(2, 3)
         output = m_loaded(input)
         self.assertEqual(3 * input, output)
+
+    def test_interface(self):
+        @torch.jit.script
+        class Foo(object):
+            def __init__(self):
+                pass
+
+            def one(self, x, y):
+                return x + y
+
+            def two(self, x):
+                return 2 * x
+
+        @torch.jit.script
+        class Bar(object):
+            def __init__(self):
+                pass
+
+            def one(self, x, y):
+                return x * y
+
+            def two(self, x):
+                return 2 / x
+
+        @torch.jit.interface
+        class OneTwo(object):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                pass
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+        @torch.jit.interface
+        class OneTwoThree(object):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                pass
+
+            def two(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+            def three(self, x):
+                # type: (Tensor) -> Tensor
+                pass
+
+        @torch.jit.interface
+        class OneTwoWrong(object):
+            def one(self, x, y):
+                # type: (Tensor, Tensor) -> Tensor
+                pass
+
+            def two(self, x):
+                # type: (int) -> int
+                pass
+
+        @torch.jit.script
+        class NotMember(object):
+            def __init__(self):
+                pass
+
+            def one(self, x, y):
+                return x + y
+            # missing two
+
+        @torch.jit.script
+        class NotMember2(object):
+            def __init__(self):
+                pass
+
+            def one(self, x, y):
+                return x + y
+
+            def two(self, x):
+                # type: (int) -> int
+                return 3
+
+        def use_them(x):
+            a = Foo()
+            b = Bar()
+            c = torch.jit.annotate(List[OneTwo], [a, b])
+            for i in range(len(c)):
+                x = c[i].one(x, x)
+                x = c[i].two(x)
+            return x
+        self.checkScript(use_them, (torch.rand(3, 4),))
+
+        @torch.jit.script
+        def as_interface(x):
+            # type: (OneTwo) -> OneTwo
+            return x
+
+        @torch.jit.script
+        def inherit(x):
+            # type: (OneTwoThree) -> OneTwo
+            return as_interface(x)
+
+        with self.assertRaisesRegex(RuntimeError, "does not have method"):
+            @torch.jit.script
+            def wrong1():
+                return as_interface(NotMember())
+
+        with self.assertRaisesRegex(RuntimeError, "is not compatible with interface"):
+            @torch.jit.script
+            def wrong2():
+                return as_interface(NotMember2())
+
+        with self.assertRaisesRegex(RuntimeError, "does not have method"):
+            @torch.jit.script
+            def wrong3():
+                return inherit(as_interface(Foo()))
+
+        with self.assertRaisesRegex(RuntimeError, "is not compatible with interface"):
+
+            @torch.jit.script
+            def wrong4(x):
+                # type: (OneTwoWrong) -> int
+                return as_interface(x)
+
+    # TODO test: interface-interface class-interface inheritance errors,
+    # NamedTuple inheritance errors
 
     def test_overloaded_fn(self):
         @torch.jit.script


### PR DESCRIPTION
Fixing [deprecation warnings](https://github.com/pytorch/pytorch/issues/24918) in tests related to uint8 masking and indexing.