### PR TITLE
Use C10_DEPRECATED_MESSAGE instead of TORCH_WARN_ONCE for Tensor.data<T>()

### DIFF
--- a/aten/src/ATen/core/Tensor.h
+++ b/aten/src/ATen/core/Tensor.h
@@ -293,8 +293,8 @@ class CAFFE2_API Tensor {
   T * data_ptr() const;
 
   template<typename T>
+  C10_DEPRECATED_MESSAGE("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.")
   T * data() const {
-    TORCH_WARN_ONCE("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.");
     return data_ptr<T>();
   }
 

--- a/aten/src/ATen/templates/Tensor.h
+++ b/aten/src/ATen/templates/Tensor.h
@@ -293,8 +293,8 @@ class CAFFE2_API Tensor {
   T * data_ptr() const;
 
   template<typename T>
+  C10_DEPRECATED_MESSAGE("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.")
   T * data() const {
-    TORCH_WARN_ONCE("Tensor.data<T>() is deprecated. Please use Tensor.data_ptr<T>() instead.");
     return data_ptr<T>();
   }
 


### PR DESCRIPTION
Using `TORCH_WARN_ONCE` for `Tensor.data<T>()` is still causing deadlocks internally. According to Dima: "So the problem seems to be in TORCH_WARN/c10::Warning::warn which produces a warning - we setup a wrapper that sends the message back to python land. But doing so requires acquiring GIL and it somehow deadlocks. In general using TORCH_WARN in so low-level API is dangerous as there's no guarantee whether we're running under GIL or not."

In order to avoid causing accidental deadlocks in other code including external extensions, the use of `TORCH_WARN_ONCE` in `Tensor.data<T>()` is changed to `C10_DEPRECATED_MESSAGE` in this PR.