### PR TITLE
Kill ConvTransposeMixin.forward, which doesn't seem to be used.

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -481,17 +481,6 @@ class Conv3d(_ConvNd):
 
 
 class _ConvTransposeMixin(object):
-    def forward(self, input, output_size=None):
-        # type(Tensor, Optional[List[int]]) -> Tensor
-        output_padding = self._output_padding(input, output_size, self.stride, self.padding, self.kernel_size)
-        func = self._backend.ConvNd(
-            self.stride, self.padding, self.dilation, self.transposed,
-            output_padding, self.groups)
-        if self.bias is None:
-            return func(input, self.weight)
-        else:
-            return func(input, self.weight, self.bias)
-
     def _output_padding(self, input, output_size, stride, padding, kernel_size):
         # type: (Tensor, Optional[List[int]], List[int], List[int], List[int]) -> List[int]
         if output_size is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25358 Kill non-shared cwrap tools.
* #25357 Update derivatives.yaml docs to refer to Declarations.yaml rather than Declarations.cwrap.
* #25356 Get rid of extract_cwarp.
* #25355 Get rid of more unused plugins.
* #25354 Get rid of torch._thnn.
* #25353 Stop doing nn wrap.
* #25352 Stop initializing THNN backend.
* #25343 [JIT] Attempt to enable CrossMapLRN2d, as it no longer uses Module._backend.
* #25342 Remove Module._backend as it's not used anymore.
* #25339 Move autograd function for CrossMapLRN2d from being backend specific to modules/_functions.
* #25331 Kill backend-specific lookup in CrossMapLRN2d, as it never succeeds.
* **#25326 Kill ConvTransposeMixin.forward, which doesn't seem to be used.**
* #25323 Remove THNN sparse autograd Functions.
* #25322 Kill THNN function auto generation.

And also uses self._backend, which I'm trying to kill or at least drastically reduce.

Differential Revision: [D17097303](https://our.internmc.facebook.com/intern/diff/D17097303)