### PR TITLE
Add note about TORCH_WARN/TORCH_WARN_ONCE and GIL

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -282,8 +282,8 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // Report a warning to the user.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
-// Note that if running under Python, `TORCH_WARN` routes to Python
-// warning handler which tries to acquire GIL. If someone calls `TORCH_WARN`
+// Note that if running under Python, `TORCH_WARN` routes to Python warning handler
+// which tries to acquire GIL. If someone calls the function that uses `TORCH_WARN`
 // without releasing the GIL first it will deadlock badly.
 //
 #define TORCH_WARN(...) \
@@ -292,8 +292,8 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // Report a warning to the user only once.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
-// Note that if running under Python, `TORCH_WARN_ONCE` routes to Python
-// warning handler which tries to acquire GIL. If someone calls `TORCH_WARN_ONCE`
+// Note that if running under Python, `TORCH_WARN_ONCE` routes to Python warning handler
+// which tries to acquire GIL. If someone calls the function that uses `TORCH_WARN_ONCE`
 // without releasing the GIL first it will deadlock badly.
 //
 #define TORCH_WARN_ONCE(...) \

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -282,11 +282,19 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // Report a warning to the user.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
+// Note that if running under Python, `TORCH_WARN` routes to Python
+// warning handler which tries to acquire GIL. If someone calls `TORCH_WARN`
+// without releasing the GIL first it will deadlock badly.
+//
 #define TORCH_WARN(...) \
   ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::str(__VA_ARGS__))
 
 // Report a warning to the user only once.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
+//
+// Note that if running under Python, `TORCH_WARN_ONCE` routes to Python
+// warning handler which tries to acquire GIL. If someone calls `TORCH_WARN_ONCE`
+// without releasing the GIL first it will deadlock badly.
 //
 #define TORCH_WARN_ONCE(...) \
   C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [] { \


### PR DESCRIPTION
When running under Python, `TORCH_WARN` / `TORCH_WARN_ONCE` can cause deadlock if someone is calling it while holding the GIL. This PR adds notes to warn users about this.

cc. @gchanan 