### PR TITLE
[JIT] Attempt to enable CrossMapLRN2d, as it no longer uses Module._backend.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15443,9 +15443,6 @@ EXCLUDE_SCRIPT_MODULES = {
     'test_nn_AdaptiveAvgPool3d_tuple_none',
     'test_nn_AdaptiveMaxPool2d_tuple_none',
     'test_nn_AdaptiveMaxPool3d_tuple_none',
-
-    # Uses Module._backend, so this is not supported
-    'test_nn_CrossMapLRN2d',
 }
 
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15443,6 +15443,9 @@ EXCLUDE_SCRIPT_MODULES = {
     'test_nn_AdaptiveAvgPool3d_tuple_none',
     'test_nn_AdaptiveMaxPool2d_tuple_none',
     'test_nn_AdaptiveMaxPool3d_tuple_none',
+
+    # Doesn't use future division, so this is not supported
+    'test_nn_CrossMapLRN2d',
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25358 Kill non-shared cwrap tools.
* #25357 Update derivatives.yaml docs to refer to Declarations.yaml rather than Declarations.cwrap.
* #25356 Get rid of extract_cwarp.
* #25355 Get rid of more unused plugins.
* #25354 Get rid of torch._thnn.
* #25353 Stop doing nn wrap.
* #25352 Stop initializing THNN backend.
* **#25343 [JIT] Attempt to enable CrossMapLRN2d, as it no longer uses Module._backend.**
* #25342 Remove Module._backend as it's not used anymore.
* #25339 Move autograd function for CrossMapLRN2d from being backend specific to modules/_functions.
* #25331 Kill backend-specific lookup in CrossMapLRN2d, as it never succeeds.
* #25326 Kill ConvTransposeMixin.forward, which doesn't seem to be used.
* #25323 Remove THNN sparse autograd Functions.
* #25322 Kill THNN function auto generation.

Differential Revision: [D17101574](https://our.internmc.facebook.com/intern/diff/D17101574)