### PR TITLE
Add guard for named tensors in the JIT

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -799,6 +799,15 @@ class TestNamedTensor(TestCase):
     def test_as_strided_cuda(self):
         self._test_as_strided('cuda')
 
+    def test_no_jit_support(self):
+        @torch.jit.script
+        def foo(x):
+            return x + 1
+
+        named_tensor = torch.randn(2, 3, names=('N', 'C'))
+        with self.assertRaisesRegex(RuntimeError, 'NYI'):
+            foo(named_tensor)
+
     def test_align_to(self):
         def _test(tensor_namedshape, align_names, expected_sizes, expected_error):
             tensor_names, tensor_sizes = tensor_namedshape

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -804,9 +804,20 @@ class TestNamedTensor(TestCase):
         def foo(x):
             return x + 1
 
-        named_tensor = torch.randn(2, 3, names=('N', 'C'))
         with self.assertRaisesRegex(RuntimeError, 'NYI'):
-            foo(named_tensor)
+            foo(torch.randn(2, 3, names=('N', 'C')))
+
+        @torch.jit.ignore
+        def add_names(x):
+            x.names = ('N', 'C')
+
+        @torch.jit.script
+        def return_named_tensor(input):
+            add_names(input)
+            return input
+
+        with self.assertRaisesRegex(RuntimeError, "NYI"):
+            return_named_tensor(torch.randn(1, 1))
 
     def test_align_to(self):
         def _test(tensor_namedshape, align_names, expected_sizes, expected_error):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25345 Add guards for using named tensor with serialization and multiprocessing
* **#25344 Add guard for named tensors in the JIT**

Test Plan
- [namedtensor ci]

Differential Revision: [D17101487](https://our.internmc.facebook.com/intern/diff/D17101487)