### PR TITLE
Adding ModuleList to modules.h

### DIFF
--- a/test/cpp/api/modulelist.cpp
+++ b/test/cpp/api/modulelist.cpp
@@ -1,14 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <torch/nn/modules.h>
-#include <torch/nn/modules/batchnorm.h>
-#include <torch/nn/modules/conv.h>
-#include <torch/nn/modules/dropout.h>
-#include <torch/nn/modules/linear.h>
-#include <torch/nn/modules/modulelist.h>
-#include <torch/nn/modules/rnn.h>
-#include <torch/types.h>
-#include <torch/utils.h>
+#include <torch/torch.h>
 
 #include <algorithm>
 #include <memory>

--- a/torch/csrc/api/include/torch/nn/modules.h
+++ b/torch/csrc/api/include/torch/nn/modules.h
@@ -7,6 +7,7 @@
 #include <torch/nn/modules/embedding.h>
 #include <torch/nn/modules/functional.h>
 #include <torch/nn/modules/linear.h>
+#include <torch/nn/modules/modulelist.h>
 #include <torch/nn/modules/named_any.h>
 #include <torch/nn/modules/rnn.h>
 #include <torch/nn/modules/sequential.h>


### PR DESCRIPTION
Here is a PR adding ```ModuleList``` to ```modules.h``` so that it can be used by including ```torch/torch.h```.

yf225 edit: Closes https://github.com/pytorch/pytorch/issues/25293.