### PR TITLE
Stop initializing THNN backend.

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -530,15 +530,6 @@ void initModule(PyObject *module);
 }} // namespace torch::cuda
 #endif
 
-namespace torch { namespace nn {
-
-void init__THNN(PyObject*);
-#ifdef USE_CUDA
-void init__THCUNN(PyObject*);
-#endif
-
-}} // namespace torch::nn
-
 bool THDPDoubleStorage_init(PyObject *module);
 bool THDPFloatStorage_init(PyObject *module);
 //bool THDPHalfStorage_init(PyObject *module);
@@ -759,11 +750,6 @@ PyObject* initModule() {
 
 #ifdef USE_NUMPY
   if (_import_array() < 0) return nullptr;
-#endif
-
-  torch::nn::init__THNN(module);
-#ifdef USE_CUDA
-  torch::nn::init__THCUNN(module);
 #endif
 
   return module;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25348 Stop initializing THNN backend.**
* #25343 [JIT] Attempt to enable CrossMapLRN2d, as it no longer uses Module._backend.
* #25342 Remove Module._backend as it's not used anymore.
* #25339 Move autograd function for CrossMapLRN2d from being backend specific to modules/_functions.
* #25331 Kill backend-specific lookup in CrossMapLRN2d, as it never succeeds.
* #25326 Kill ConvTransposeMixin.forward, which doesn't seem to be used.
* #25323 Remove THNN sparse autograd Functions.
* #25322 Kill THNN function auto generation.

It doesn't appear to be necessary anymore; assuming this works I'll kill the codegen in a follow-up PR.