### PR TITLE
Compare shapes of outputs and grad_outputs in autograd.grad

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -323,6 +323,18 @@ class TestAutograd(TestCase):
         self.assertEqual(x.grad.data, x_grad)
         self.assertEqual(y.grad.data, y_grad)
 
+        # Test that grad_outputs and outputs have the same shape
+        grad_out = torch.ones(2)
+        try:
+            torch.autograd.grad(
+                outputs=[grad_sum], grad_outputs=[grad_out],
+                inputs=[x], create_graph=True)
+            self.assertFail()
+        except RuntimeError as error:
+            self.assertEqual(str(error), "Mismatch in shape: grad_output[0] has a shape of "
+                             + str(grad_out.shape) + " and output[0] has a shape of "
+                             + str(grad_sum.shape) + ".")
+
     def test_grad_nonleaf(self):
         x_init = torch.randn(2, 2, requires_grad=True)
         x = x_init

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -21,6 +21,12 @@ def _make_grads(outputs, grads):
     new_grads = []
     for out, grad in zip(outputs, grads):
         if isinstance(grad, torch.Tensor):
+            if not out.shape == grad.shape:
+                raise RuntimeError("Mismatch in shape: grad_output["
+                                   + str(grads.index(grad)) + "] has a shape of "
+                                   + str(grad.shape) + " and output["
+                                   + str(outputs.index(out)) + "] has a shape of "
+                                   + str(out.shape) + ".")
             new_grads.append(grad)
         elif grad is None:
             if out.requires_grad:
@@ -133,6 +139,7 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
 
     outputs = (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
     inputs = (inputs,) if isinstance(inputs, torch.Tensor) else tuple(inputs)
+
     if grad_outputs is None:
         grad_outputs = [None] * len(outputs)
     elif isinstance(grad_outputs, torch.Tensor):
@@ -141,6 +148,7 @@ def grad(outputs, inputs, grad_outputs=None, retain_graph=None, create_graph=Fal
         grad_outputs = list(grad_outputs)
 
     grad_outputs = _make_grads(outputs, grad_outputs)
+
     if retain_graph is None:
         retain_graph = create_graph
 
@@ -170,7 +178,6 @@ def _is_checkpoint_valid():
 def variable(*args, **kwargs):
     warnings.warn("torch.autograd.variable(...) is deprecated, use torch.tensor(...) instead")
     return torch.tensor(*args, **kwargs)
-
 
 if not torch._C._autograd_init():
     raise RuntimeError("autograd initialization failed")


### PR DESCRIPTION
PR to compare shapes of `outputs` and `grad_outputs` in `torch.autograd.grad()`. 

> grad_outputs should be a sequence of length matching output containing the pre-computed gradients w.r.t. each of the outputs.

resolve #17893