### PR TITLE
Update derivatives.yaml docs to refer to Declarations.yaml rather than Declarations.cwrap.

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -49,7 +49,7 @@
 #     'output_differentiability' entry (see above).
 #
 #   - Any of the input arguments, tensor or non-tensor, including
-#     argument names that only appear in Declarations.cwrap, e.g. 'output'.
+#     argument names that only appear in Declarations.yaml, e.g. 'output'.
 #
 #   - 'result', representing the result of evaluating the forward
 #     expression for ATen native function declarations. If the forward
@@ -92,7 +92,7 @@
 # OpName.apply to see if it's still using a legacy Python style API.
 #
 # NB: The parameter names here MUST be consistent with the parameter names
-# in ./torch/lib/ATen/Declarations.cwrap
+# in Decalarations.yaml
 - name: abs(Tensor self) -> Tensor
   self: grad * self.sign()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25358 Kill non-shared cwrap tools.
* **#25357 Update derivatives.yaml docs to refer to Declarations.yaml rather than Declarations.cwrap.**
* #25356 Get rid of extract_cwarp.
* #25355 Get rid of more unused plugins.
* #25354 Get rid of torch._thnn.
* #25353 Stop doing nn wrap.
* #25352 Stop initializing THNN backend.
* #25343 [JIT] Attempt to enable CrossMapLRN2d, as it no longer uses Module._backend.
* #25342 Remove Module._backend as it's not used anymore.
* #25339 Move autograd function for CrossMapLRN2d from being backend specific to modules/_functions.
* #25331 Kill backend-specific lookup in CrossMapLRN2d, as it never succeeds.
* #25326 Kill ConvTransposeMixin.forward, which doesn't seem to be used.
* #25323 Remove THNN sparse autograd Functions.
* #25322 Kill THNN function auto generation.

Declarations.cwrap is no longer hooked up derivatives.yaml directly.

Differential Revision: [D17101570](https://our.internmc.facebook.com/intern/diff/D17101570)