### PR TITLE
Produce a proper error when scripting an unsupported UnaryOp.

### DIFF
--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -505,7 +505,8 @@ class ExprBuilder(Builder):
         sub_expr = build_expr(ctx, expr.operand)
         op = type(expr.op)
         op_token = ExprBuilder.unop_map.get(op)
-        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + len(op_token))
+        token_len = len(op_token) if op_token is not None else 0
+        r = ctx.make_range(expr.lineno, expr.col_offset, expr.col_offset + token_len)
         if op_token is None:
             err_range = ctx.make_raw_range(r.start, sub_expr.range().end)
             raise NotSupportedError(err_range, "unsupported unary operator: " + op.__name__)


### PR DESCRIPTION
If the unary op was not supported, `len(op_token)` would throw an exception since `op_token` would be None. This would hide the actual error message which would point to the unsupported op in the source.

Fixes #25360

