### PR TITLE
[quantization] Memory layout for pooling ops

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -215,8 +215,11 @@ Tensor quantized_adaptive_avg_pool2d(
     IntArrayRef output_size) {
   const auto output_shape = get_output_shape(input, output_size);
   Tensor output = at::_empty_affine_quantized(
-      output_shape, input.options(), input.q_scale(), input.q_zero_point());
-  ;
+      output_shape,
+      input.options(),
+      input.q_scale(),
+      input.q_zero_point(),
+      input.suggest_memory_format());
   adaptive_avg_pool2d_out_template(output, input, output_shape);
   return output;
 }

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -144,7 +144,8 @@ Tensor q_maxpool_2d(
       oSizes,
       qx.options().dtype(toQIntType(qx.scalar_type())),
       qx.q_scale(),
-      qx.q_zero_point());
+      qx.q_zero_point(),
+      qx.suggest_memory_format());
   auto qx_contig = qx.contiguous();
   auto qxd = qx_contig.data_ptr<Q>();
   auto qyd = qy.data_ptr<Q>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25374 [quantization] Memory layout for pooling ops**
* #25271 [quantization] Make quantized relu ops inherit the memory format from input
* #25265 [quantization] Ensure quantized::add stride matches inputs

Differential Revision: [D17107577](https://our.internmc.facebook.com/intern/diff/D17107577)