### PR TITLE
[bc breaking] Fix AliasAnalysisKind::PURE on MSVC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -524,6 +524,11 @@ static_assert(std::is_same(A*, decltype(A::singleton()))::value, "hmm");
   This causes preprocessor tokens inside the literal like an`#endif`  to be incorrectly
   treated as preprocessor directives. See https://godbolt.org/z/eVTIJq as an example.
 
+* Either MSVC or the Windows headers have a PURE macro defined and will replace
+  any occurrences of the PURE token in code with an empty string. This is why
+  we have AliasAnalysisKind::PURE_FUNCTION and not AliasAnalysisKind::PURE.
+  The same is likely true for other identifiers that we just didn't try to use yet.
+
 ### Running Clang-Tidy
 
 [Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/index.html) is a C++

--- a/aten/src/ATen/core/dispatch/OperatorOptions.h
+++ b/aten/src/ATen/core/dispatch/OperatorOptions.h
@@ -12,7 +12,7 @@ enum class AliasAnalysisKind : uint8_t {
   CONSERVATIVE, // The most conservative alias analysis type, assumes
                 // side-effects. This is the default analysis.
   FROM_SCHEMA,
-  PURE
+  PURE_FUNCTION
 };
 
 constexpr inline const char* toString(AliasAnalysisKind aliasAnalysisKind) {
@@ -20,8 +20,8 @@ constexpr inline const char* toString(AliasAnalysisKind aliasAnalysisKind) {
       ? "CONSERVATIVE"
       : (aliasAnalysisKind == AliasAnalysisKind::FROM_SCHEMA)
           ? "FROM_SCHEMA"
-          : (aliasAnalysisKind == AliasAnalysisKind::PURE)
-              ? "PURE"
+          : (aliasAnalysisKind == AliasAnalysisKind::PURE_FUNCTION)
+              ? "PURE_FUNCTION"
               : (aliasAnalysisKind == AliasAnalysisKind::INTERNAL_SPECIAL_CASE)
                   ? "INTERNAL_SPECIAL_CASE"
                   : "UNKNOWN";

--- a/test/cpp/jit/test_alias_analysis.cpp
+++ b/test/cpp/jit/test_alias_analysis.cpp
@@ -830,7 +830,7 @@ graph():
             .catchAllKernel([](torch::List<at::Tensor> in) {
               return torch::rand({2, 3});
             })
-            .aliasAnalysis(AliasAnalysisKind::PURE));
+            .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
     // Write to the inside of a list. Check that we can't reorder a
     // print across it.
     auto graph = std::make_shared<Graph>();
@@ -872,7 +872,7 @@ graph():
             .catchAllKernel([](torch::List<at::Tensor> in) {
               return torch::rand({2, 3});
             })
-            .aliasAnalysis(AliasAnalysisKind::PURE));
+            .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
     // Write to the inside of a list. Check that we can't reorder a
     // print across it.
     auto graph = std::make_shared<Graph>();
@@ -1191,7 +1191,7 @@ void testAliasRegistration() {
             .catchAllKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
-            .aliasAnalysis(AliasAnalysisKind::PURE));
+            .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
     const auto rand_op = Symbol::fromQualString("foo::rand9");
     auto graph = std::make_shared<Graph>();
     auto a = graph->addInput();
@@ -1207,7 +1207,7 @@ void testAliasRegistration() {
             .catchAllKernel([](at::Tensor) -> at::Tensor {
               return at::rand({2, 2});
             })
-            .aliasAnalysis(AliasAnalysisKind::PURE));
+            .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
     const auto rand_op = Symbol::fromQualString("foo::rand10");
     auto graph = std::make_shared<Graph>();
     auto a = graph->addInput();
@@ -1224,7 +1224,7 @@ void testAliasRegistration() {
               torch::RegisterOperators::options()
                   .catchAllKernel(
                       [](at::Tensor t) -> at::Tensor { return t * 2; })
-                  .aliasAnalysis(AliasAnalysisKind::PURE));
+                  .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
         },
         "Tried to register operator foo::rand11(Tensor(a) arg1) -> Tensor(a) with aliasing information in the schema but without AliasAnalysisKind::FROM_SCHEMA");
   }
@@ -1236,7 +1236,7 @@ void testAliasRegistration() {
               torch::RegisterOperators::options()
                   .catchAllKernel(
                       [](at::Tensor t) -> at::Tensor { return t * 2; })
-                  .aliasAnalysis(AliasAnalysisKind::PURE));
+                  .aliasAnalysis(AliasAnalysisKind::PURE_FUNCTION));
         },
         "Tried to register operator foo::rand12(Tensor(a) arg1) -> Tensor(b) with aliasing information in the schema but without AliasAnalysisKind::FROM_SCHEMA");
   }

--- a/torch/csrc/jit/ir.cpp
+++ b/torch/csrc/jit/ir.cpp
@@ -936,7 +936,7 @@ bool Node::hasSideEffects() const {
   }
 
   switch (op->aliasAnalysisKind()) {
-    case AliasAnalysisKind::PURE:
+    case AliasAnalysisKind::PURE_FUNCTION:
       return false;
     case AliasAnalysisKind::FROM_SCHEMA:
       return false;

--- a/torch/csrc/jit/passes/alias_analysis.cpp
+++ b/torch/csrc/jit/passes/alias_analysis.cpp
@@ -266,7 +266,7 @@ void AliasDb::analyze(Node* node) {
 bool AliasDb::tryRegisteredAnalysis(Node* node) {
   const Operator& op = node->getOperator();
   auto analysis = op.aliasAnalysisKind();
-  if (AliasAnalysisKind::PURE == analysis) {
+  if (AliasAnalysisKind::PURE_FUNCTION == analysis) {
     analyzeCreator(node);
     return true;
   }
@@ -416,7 +416,7 @@ void AliasDb::analyzeImpl(Node* node) {
 
   TORCH_INTERNAL_ASSERT(
       analysis == AliasAnalysisKind::FROM_SCHEMA,
-      "AliasAnalysisKind::CONSERVATIVE/PURE/INTERNAL_SPECIAL_CASE should already have been handled above");
+      "AliasAnalysisKind::CONSERVATIVE/PURE_FUNCTION/INTERNAL_SPECIAL_CASE should already have been handled above");
   const auto& schema = node->schema();
 
   // Bind the schema's "formal" alias annotation to the actual values those


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #23888 Allow TensorMethods.h to include Dispatcher.h (alternative)
* **#25375 [bc breaking] Fix AliasAnalysisKind::PURE on MSVC**

Either MSVC or the Windows headers have a PURE macro defined and will replace
any occurrences of the PURE token in code with an empty string. Replace
AliasAnalysisKind::PURE with AliasAnalysisKind::PURE_FUNCTION.

Note: this is bc breaking.

Differential Revision: [D17107743](https://our.internmc.facebook.com/intern/diff/D17107743/)