### PR TITLE
Fix cpp_extensions test failures with GCC 9.1 from ArrayRef(initializer_list)

### DIFF
--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -100,7 +100,7 @@ class ArrayRef final {
 
   /// Construct an ArrayRef from a std::initializer_list.
   /* implicit */ constexpr ArrayRef(const std::initializer_list<T>& Vec)
-      : Data(Vec.begin() == Vec.end() ? static_cast<T*>(nullptr) : Vec.begin()),
+      : Data(std::begin(Vec) == std::end(Vec) ? static_cast<T*>(nullptr) : std::begin(Vec)),
         Length(Vec.size()) {}
 
   /// @}


### PR DESCRIPTION
These are test failures due to `-Werror` in `test/cpp_extensions/setup.py` that look like:
```
$ python test/run_test.py -i cpp_extensions
Test executor: ['/home/rgommers/anaconda3/envs/pytorch-gcc91/bin/python']
Running test_cpp_extensions ... [2019-08-29 02:19:03.421117]
running install
running build
running build_py
creating build
creating build/lib.linux-x86_64-3.6
creating build/lib.linux-x86_64-3.6/torch_test_cpp_extension
copying torch_test_cpp_extension/__init__.py -> build/lib.linux-x86_64-3.6/torch_test_cpp_extension
running build_ext
building 'torch_test_cpp_extension.cpp' extension
creating build/temp.linux-x86_64-3.6
gcc -pthread -B /home/rgommers/anaconda3/envs/pytorch-gcc91/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/home/rgommers/code/pytorch/torch/include -I/home/rgommers/code/pytorch/torch/include/torch/csrc/api/include -I/home/rgommers/code/pytorch/torch/include/TH -I/home/rgommers/code/pytorch/torch/include/THC -I/home/rgommers/anaconda3/envs/pytorch-gcc91/include/python3.6m -c extension.cpp -o build/temp.linux-x86_64-3.6/extension.o -g -Werror -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=cpp -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
In file included from /home/rgommers/code/pytorch/torch/include/c10/core/MemoryFormat.h:5,
                 from /home/rgommers/code/pytorch/torch/include/ATen/core/Tensor.h:5,
                 from /home/rgommers/code/pytorch/torch/include/ATen/Tensor.h:2,
                 from /home/rgommers/code/pytorch/torch/include/ATen/Context.h:4,
                 from /home/rgommers/code/pytorch/torch/include/ATen/ATen.h:5,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/types.h:3,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/data/dataloader_options.h:4,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/data/dataloader/base.h:3,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/data/dataloader/stateful.h:3,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/data/dataloader.h:3,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/data.h:3,
                 from /home/rgommers/code/pytorch/torch/include/torch/csrc/api/include/torch/all.h:4,
                 from /home/rgommers/code/pytorch/torch/include/torch/extension.h:4,
                 from extension.cpp:1:
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = long int]’:
/home/rgommers/code/pytorch/torch/include/c10/core/TensorImpl.h:1464:34:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<long int>::Data’ from ‘std::initializer_list<long int>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
  103 |       : Data(Vec.begin() == Vec.end() ? static_cast<T*>(nullptr) : Vec.begin()),
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = unsigned char]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<unsigned char>::Data’ from ‘std::initializer_list<unsigned char>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = signed char]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<signed char>::Data’ from ‘std::initializer_list<signed char>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = short int]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<short int>::Data’ from ‘std::initializer_list<short int>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = int]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<int>::Data’ from ‘std::initializer_list<int>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = float]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<float>::Data’ from ‘std::initializer_list<float>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = double]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<double>::Data’ from ‘std::initializer_list<double>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = bool]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<bool>::Data’ from ‘std::initializer_list<bool>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = c10::Half]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<c10::Half>::Data’ from ‘std::initializer_list<c10::Half>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h: In instantiation of ‘constexpr c10::ArrayRef<T>::ArrayRef(const std::initializer_list<_Tp>&) [with T = c10::BFloat16]’:
/home/rgommers/code/pytorch/torch/include/ATen/NativeFunctions.h:47:1:   required from here
/home/rgommers/code/pytorch/torch/include/c10/util/ArrayRef.h:103:39: error: initializing ‘c10::ArrayRef<c10::BFloat16>::Data’ from ‘std::initializer_list<c10::BFloat16>::begin’ does not extend the lifetime of the underlying array [-Werror=init-list-lifetime]
cc1plus: all warnings being treated as errors
error: command 'gcc' failed with exit status 1
Traceback (most recent call last):
  File "test/run_test.py", line 438, in <module>
    main()
  File "test/run_test.py", line 430, in main
    raise RuntimeError(message)
RuntimeError: test_cpp_extensions failed!
```

The warnings look valid, the code isn't guaranteed to work (although in practice it does seem to).  Using `std::begin` keeps the underlying array for the `initializer_list` going out of scope.

Note that the same warning is reported in https://github.com/pytorch/vision/issues/1173#issuecomment-517308733 (Cc @ShahriarSS)

