### PR TITLE
Fix windows build error when TBB enabled and Windows SDK installed

### DIFF
--- a/aten/src/ATen/ParallelNativeTBB.h
+++ b/aten/src/ATen/ParallelNativeTBB.h
@@ -4,6 +4,9 @@
 #include <cstddef>
 #include <exception>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include "tbb/tbb.h"
 
 #define INTRA_OP_PARALLEL


### PR DESCRIPTION
Fixed #25320 
See the issue for more infomation.