### PR TITLE
Fix allreduce_coalesced tests in c10d

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -799,7 +799,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 "Mismatch in interation {}".format(i)
             )
 
-    @unittest.skip("Test is flaky")
+    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/25427")
     def test_allreduce_coalesced_stress(self):
         inputs = [2 * [torch.Tensor([i + self.rank])] for i in range(1000)]
         self._test_allreduce_coalesced_stress(inputs)

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -741,6 +741,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.Tensor([i + self.rank]).cuda() for i in range(1000)]
         self._test_allreduce_stress(inputs)
 
+    @skip_if_lt_x_gpu(1)
     def test_allreduce_coalesced_checks(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
@@ -798,6 +799,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 "Mismatch in interation {}".format(i)
             )
 
+    @unittest.skip("Test is flaky")
     def test_allreduce_coalesced_stress(self):
         inputs = [2 * [torch.Tensor([i + self.rank])] for i in range(1000)]
         self._test_allreduce_coalesced_stress(inputs)


### PR DESCRIPTION
1. `test_allreduce_coalesced_stress` is flaky.
2. `test_allreduce_coalesced_checks` uses GPU but didn't claim so.

cc @jfc4050 
