### PR TITLE
Support host builds for PyTorch "Android" library

### DIFF
--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -4,12 +4,23 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 set(pytorch_android_DIR ${CMAKE_CURRENT_LIST_DIR}/src/main/cpp)
-set(libtorch_include_DIR ${pytorch_android_DIR}/libtorch_include/${ANDROID_ABI})
 
-set(libtorch_SO ${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${ANDROID_ABI}/libtorch.so)
-set(libc10_SO ${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${ANDROID_ABI}/libc10.so)
+if (ANDROID_ABI)
+  set(libtorch_include_DIR ${pytorch_android_DIR}/libtorch_include/${ANDROID_ABI})
 
-message(STATUS "libtorch dir:${libtorch_DIR}")
+  set(libtorch_SO ${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${ANDROID_ABI}/libtorch.so)
+  set(libc10_SO ${CMAKE_CURRENT_LIST_DIR}/src/main/jniLibs/${ANDROID_ABI}/libc10.so)
+else()
+  if (NOT LIBTORCH_ROOT)
+    message(FATAL_ERROR
+      "PyTorch requires LIBTORCH_ROOT to be defined for non-Android builds.")
+  endif()
+
+  set(libtorch_include_DIR ${LIBTORCH_ROOT}/include)
+
+  set(libtorch_SO ${LIBTORCH_ROOT}/lib/libtorch.so)
+  set(libc10_SO ${LIBTORCH_ROOT}/lib/libc10.so)
+endif()
 
 add_library(libtorch SHARED IMPORTED)
 set_property(TARGET libtorch PROPERTY IMPORTED_LOCATION ${libtorch_SO})
@@ -32,6 +43,17 @@ target_compile_options(pytorch PRIVATE
 target_include_directories(pytorch PUBLIC
     ${libtorch_include_DIR}
 )
+
+if (NOT ANDROID_ABI)
+  if (NOT JAVA_HOME)
+    message(FATAL_ERROR
+      "PyTorch requires JAVA_HOME to be defined for non-Android builds.")
+  endif()
+  target_include_directories(pytorch PUBLIC ${JAVA_HOME}/include)
+  if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    target_include_directories(pytorch PUBLIC ${JAVA_HOME}/include/linux)
+  endif()
+endif()
 
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 file(MAKE_DIRECTORY ${BUILD_DIR})


### PR DESCRIPTION
Building this for the host makes it possible to test the Java bindings
from a normal Java environment, which is often more convenient than
testing on Android.

Tested with a nightly libtorch binary on Linux as
```
mkdir android/pytorch_android/build
cd android/pytorch_android/build
cmake \
  -DJAVA_HOME=/path/to/jdk \
  -DLIBTORCH_ROOT=/path/to/libtorch \
  ..
make
```

Then I had to manually compile the Java code for fbjni and
pytorch_android, but the jars on my classpath, and put the native
libraries on my LD_LIBRARY_PATH.

