### PR TITLE
Fix implicit fallthrough warnings in FeatureLPPooling.cu

### DIFF
--- a/aten/src/THCUNN/FeatureLPPooling.cu
+++ b/aten/src/THCUNN/FeatureLPPooling.cu
@@ -447,7 +447,8 @@ runFeatureLPPoolingUpdateOutput(THCState* state,
       L2_STRIDE_CASE(2, WIDTH);                 \
       L2_STRIDE_CASE(3, WIDTH);                 \
       L2_STRIDE_CASE(4, WIDTH);                 \
-    }
+    }                                           \
+    break;
 
 #define LP_STRIDE_CASE(STRIDE, WIDTH)                                   \
   case STRIDE:                                                          \
@@ -467,7 +468,8 @@ runFeatureLPPoolingUpdateOutput(THCState* state,
       LP_STRIDE_CASE(2, WIDTH);                 \
       LP_STRIDE_CASE(3, WIDTH);                 \
       LP_STRIDE_CASE(4, WIDTH);                 \
-    }
+    }                                           \
+    break;
 
   if (power == 2.0f) {
     switch (width) {
@@ -583,7 +585,8 @@ runFeatureLPPoolingUpdateGradInput(THCState* state,
       L2_STRIDE_CASE(2, WIDTH);                 \
       L2_STRIDE_CASE(3, WIDTH);                 \
       L2_STRIDE_CASE(4, WIDTH);                 \
-    }
+    }                                           \
+    break;
 
 #define LP_STRIDE_CASE(STRIDE, WIDTH)                                   \
   case STRIDE:                                                          \
@@ -601,7 +604,8 @@ runFeatureLPPoolingUpdateGradInput(THCState* state,
       LP_STRIDE_CASE(2, WIDTH);                 \
       LP_STRIDE_CASE(3, WIDTH);                 \
       LP_STRIDE_CASE(4, WIDTH);                 \
-    }
+    }                                           \
+    break;
 
   if (power == 2.0f) {
     switch (width) {


### PR DESCRIPTION
`-Wimplicit-fallthrough` is enabled for recent GCC versions, and there's about 1000 lines of warnings in the build output with GCC 9.1 like:

```
/home/rgommers/code/pytorch/aten/src/THCUNN/FeatureLPPooling.cu: In function ‘bool runFeatureLPPoolingUpdateOutput(THCState*, const THCDeviceTensor<T, 4>&, THCDeviceTensor<T, 4>&, float, int, int) [with T = c10::Half]’:
/home/rgommers/code/pytorch/aten/src/THCUNN/FeatureLPPooling.cu:474:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
  474 |       L2_WIDTH_CASE(2);
      |          ^~~~~~
/home/rgommers/code/pytorch/aten/src/THCUNN/FeatureLPPooling.cu:475:1: note: here
  475 |       L2_WIDTH_CASE(3);
      | ^

...

/home/rgommers/code/pytorch/aten/src/THCUNN/FeatureLPPooling.cu:639:11: warning: this statement may fall through [-Wimplicit-fallthrough=]
  639 |       LP_WIDTH_CASE(15);
      |           ^~~~~~
/home/rgommers/code/pytorch/aten/src/THCUNN/FeatureLPPooling.cu:640:1: note: here
  640 |       LP_WIDTH_CASE(16);
      | ^
```

Fix by ending each case statement with `break;`

