### PR TITLE
Delete a few cases where we directly use Backend/TensorTypeId.

### DIFF
--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -60,8 +60,11 @@ ideep::tensor& itensor_from_mkldnn(const MKLDNNTensor& mkldnn_tensor) {
 
 ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
   AT_ASSERTM(
-      tensor.type_id() == TensorTypeId::CPUTensorId,
-      "itensor_view_from_dense expects dense CPU tensor input");
+      tensor.device().type() == DeviceType::CPU,
+      "itensor_view_from_dense expects CPU tensor input");
+  AT_ASSERTM(
+      tensor.layout() == Layout::Strided,
+      "itensor_view_from_dense expects dense tensor input");
   AT_ASSERTM(tensor.scalar_type() == ScalarType::Float,
              "itensor_view_from_dense expects float tensor input");
   AT_ASSERTM(

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -20,8 +20,10 @@ Tensor mkldnn_to_dense(const Tensor& mkldnn_tensor) {
 }
 
 Tensor dense_to_mkldnn(const Tensor& cpu_tensor) {
-  AT_ASSERTM(cpu_tensor.type_id() == TensorTypeId::CPUTensorId,
-             "dense_to_mkldnn expects dense CPU tensor input");
+  AT_ASSERTM(cpu_tensor.device().type() == DeviceType::CPU,
+             "dense_to_mkldnn expects CPU tensor input");
+  AT_ASSERTM(cpu_tensor.layout() == Layout::Strided,
+             "dense_to_mkldnn expects strided tensor input");
   AT_ASSERTM(cpu_tensor.scalar_type() == ScalarType::Float,
              "dense_to_mkldnn expects float tensor input");
   AT_ASSERTM(cpu_tensor.dim() <= 5,

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -4,7 +4,7 @@
 namespace torch { namespace autograd {
 
 VariableInfo::VariableInfo(const Variable& var)
-  : backend(tensorTypeIdToBackend(var.type_id()))
+  : layout(var.layout())
   , device(var.device())
   , scalar_type(var.scalar_type())
   , size(var.sizes().vec())
@@ -12,10 +12,8 @@ VariableInfo::VariableInfo(const Variable& var)
 }
 
 Variable VariableInfo::zeros(at::OptionalDeviceGuard& device_guard) const {
-  // NB: This will NOT work if we ever get mixed device gradients
-  device_guard.reset_device(device);
   return at::zeros(size,
-    at::TensorOptions(scalar_type).device(backendToDeviceType(backend)).layout(layout_from_backend(backend)).is_variable(true));
+    at::TensorOptions(scalar_type).device(device).layout(layout).is_variable(true));
 }
 
 variable_list _wrap_outputs(const variable_list &input_vars,

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -123,7 +123,7 @@ struct TORCH_API VariableInfo {
 
   Variable zeros(at::OptionalDeviceGuard& device_guard) const;
 
-  at::Backend backend = at::Backend::Undefined;
+  at::Layout layout = at::Layout::Strided;
   at::Device device = at::kCPU;
   at::ScalarType scalar_type = at::kFloat;
   std::vector<int64_t> size;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25467 Delete a few cases where we directly use Backend/TensorTypeId.**

Use Layout/Device more directly in these cases.

Differential Revision: [D17131883](https://our.internmc.facebook.com/intern/diff/D17131883/)