### PR TITLE
Fix typo in TransformerEncoder documentation

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -156,7 +156,7 @@ class TransformerEncoder(Module):
         self.norm = norm
 
     def forward(self, src, mask=None, src_key_padding_mask=None):
-        r"""Pass the input through the endocder layers in turn.
+        r"""Pass the input through the encoder layers in turn.
 
         Args:
             src: the sequnce to the encoder (required).


### PR DESCRIPTION
Just fixes a minor typo in documentation, replacing "endocder" with "encoder".