### PR TITLE
cuda devices should have same dtype

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -766,7 +766,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
         with self.assertRaisesRegex(ValueError, "unsupported device type"):
             opts = c10d.AllreduceCoalescedOptions()
-            pg.allreduce_coalesced([t1.cuda(), t2.cuda()], opts)
+            pg.allreduce_coalesced([t1.cuda(), t1.cuda()], opts)
 
     def _test_allreduce_coalesced_basics(self, fn):
         store = c10d.FileStore(self.file.name, self.world_size)


### PR DESCRIPTION
addresses #25465

was passing in two tensors of different dtypes for a check making sure the two tensors were on the same device.