### PR TITLE
[JIT] add tuple keyword

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3311,6 +3311,25 @@ def foo(x):
         a = (torch.rand(3), torch.rand(3))
         self.checkScript(stuff, (a,))
 
+    def test_tuple_keyword(self):
+        def bar():
+            f = tuple((1, 2))  # noqa: C409
+            return f
+
+        self.checkScript(bar, ())
+
+        def foo():
+            return tuple(1, 2)
+
+        self.checkScriptRaisesRegex(foo, (), Exception,
+                                    "1 argument")
+
+        def cant_infer_size():
+            return tuple([1, 2, 3])  # noqa: C409
+
+        with self.assertRaisesRegex(Exception, "cannot statically infer the expected"):
+            torch.jit.script(cant_infer_size)
+
     def test_tuple_create_return(self):
         def stuff2(x):
             # type: (int) -> Tuple[Tensor, Tensor]

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -348,6 +348,7 @@ struct Environment {
     if (!retval) {
       static std::unordered_map<std::string, SugaredValuePtr> globals = {
           {"print", std::make_shared<PrintValue>()},
+          {"tuple", std::make_shared<TupleCallValue>()},
           {"float",
            makeMagic(
                "__float__",
@@ -2173,6 +2174,14 @@ struct to_ir {
       auto out = graph->insertNode(graph->createUninitialized(type))
                      ->setSourceRange(loc);
       return std::make_shared<SimpleValue>(out->output());
+    } else if (auto tuple_call = dynamic_cast<TupleCallValue*>(sv.get())) {
+      checkApplyExpr(apply, loc, /*expected_inputs*/ 1);
+      auto arg = emitSugaredExpr(apply.inputs()[0], 1);
+      auto inputs = arg->asTuple(apply.range(), method);
+      auto inp_values = fmap(
+          inputs, [&](SugaredValuePtr sv) { return sv->asValue(loc, method); });
+      return std::make_shared<SimpleValue>(
+          graph->insertNode(graph->createTuple(inp_values))->output());
     } else if (auto isinstance = dynamic_cast<IsInstanceValue*>(sv.get())) {
       // NOTE: for `isinstance` builtin call in JIT, we only check the static
       // types on the inputs to evaluate, and insert the corresponding constant
@@ -3086,7 +3095,8 @@ CompilationUnit::CompilationUnit(const std::string& source)
   define(c10::nullopt, source, nativeResolver(), nullptr);
 }
 
-c10::QualifiedName CompilationUnit::mangle(const c10::QualifiedName& name) const {
+c10::QualifiedName CompilationUnit::mangle(
+    const c10::QualifiedName& name) const {
   static const std::string manglePrefix = "___torch_mangle_";
   std::vector<std::string> atoms = name.atoms();
 

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -2178,8 +2178,9 @@ struct to_ir {
       checkApplyExpr(apply, loc, /*expected_inputs*/ 1);
       auto arg = emitSugaredExpr(apply.inputs()[0], 1);
       auto inputs = arg->asTuple(apply.range(), method);
-      auto inp_values = fmap(
-          inputs, [&](SugaredValuePtr sv) { return sv->asValue(loc, method); });
+      auto inp_values = fmap(inputs, [&](const SugaredValuePtr& sv) {
+        return sv->asValue(loc, method);
+      });
       return std::make_shared<SimpleValue>(
           graph->insertNode(graph->createTuple(inp_values))->output());
     } else if (auto isinstance = dynamic_cast<IsInstanceValue*>(sv.get())) {

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -439,6 +439,14 @@ struct TORCH_API IsInstanceValue : SugaredValue {
   }
 };
 
+// matched against for special handling of tuple() call
+struct TORCH_API TupleCallValue : SugaredValue {
+  TupleCallValue() = default;
+  std::string kind() const override {
+    return "tuple";
+  }
+};
+
 // matched against for special handling of range expressions
 struct TORCH_API RangeValue : SugaredValue {
   RangeValue(const SourceRange& loc, Function& m, std::vector<Value*> inputs);


### PR DESCRIPTION
Doesn't really add much functionality, since inputs to `tuple()` which we can statically infer the output size is pretty much just tuples. Does improve the error message though. 

Fix for https://github.com/pytorch/pytorch/issues/24000