### PR TITLE
Fix invalid function cast warnings that show up with GCC 8/9

### DIFF
--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -302,7 +302,7 @@ PyObject * THPStorage_(_setCdata)(THPStorage *self, PyObject *new_cdata)
 }
 
 static PyMethodDef THPStorage_(methods)[] = {
-  {"copy_", (PyCFunction)THPStorage_(copy_), METH_VARARGS | METH_KEYWORDS, nullptr},
+  {"copy_", (PyCFunction)(void(*)(void))THPStorage_(copy_), METH_VARARGS | METH_KEYWORDS, nullptr},
   {"element_size", (PyCFunction)THPStorage_(elementSize), METH_NOARGS, nullptr},
   {"fill_", (PyCFunction)THPStorage_(fill_), METH_O, nullptr},
   {"new", (PyCFunction)THPStorage_(new), METH_NOARGS, nullptr},
@@ -311,12 +311,12 @@ static PyMethodDef THPStorage_(methods)[] = {
   {"data_ptr", (PyCFunction)THPStorage_(dataPtr), METH_NOARGS, nullptr},
   {"is_pinned", (PyCFunction)THPStorage_(isPinned), METH_NOARGS, nullptr},
   {"_write_file", (PyCFunction)THPStorage_(writeFile), METH_VARARGS, nullptr},
-  {"_new_with_file", (PyCFunction)THPStorage_(newWithFile), METH_O | METH_STATIC, nullptr},
+  {"_new_with_file", (PyCFunction)(void(*)(void))THPStorage_(newWithFile), METH_O | METH_STATIC, nullptr},
   {"_set_from_file", (PyCFunction)THPStorage_(setFromFile), METH_VARARGS, nullptr},
 #if !defined(THC_GENERIC_FILE)
-  {"from_buffer", (PyCFunction)THPStorage_(fromBuffer), METH_VARARGS | METH_KEYWORDS | METH_STATIC, nullptr},
+  {"from_buffer", (PyCFunction)(void(*)(void))THPStorage_(fromBuffer), METH_VARARGS | METH_KEYWORDS | METH_STATIC, nullptr},
 #endif
-  {"from_file", (PyCFunction)THPStorage_(fromFile), METH_VARARGS | METH_KEYWORDS | METH_STATIC, nullptr},
+  {"from_file", (PyCFunction)(void(*)(void))THPStorage_(fromFile), METH_VARARGS | METH_KEYWORDS | METH_STATIC, nullptr},
 #ifdef THC_GENERIC_FILE
   {"get_device", (PyCFunction)THPStorage_(getDevice), METH_NOARGS, nullptr},
 #endif

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -4,14 +4,14 @@
 #include <cuda_runtime.h>
 #endif
 
-static PyObject * THPStorage_(size)(THPStorage *self)
+static PyObject * THPStorage_(size)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   return PyLong_FromLong(THWStorage_(size)(LIBRARY_STATE self->cdata));
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(dataPtr)(THPStorage *self)
+static PyObject * THPStorage_(dataPtr)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   return PyLong_FromVoidPtr(THWStorage_(data)(LIBRARY_STATE self->cdata));
@@ -25,7 +25,7 @@ static PyObject * THPStorage_(copy_)(PyObject *self, PyObject *args, PyObject *k
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(isPinned)(THPStorage *self)
+static PyObject * THPStorage_(isPinned)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
 #if defined(USE_CUDA)
@@ -36,14 +36,14 @@ static PyObject * THPStorage_(isPinned)(THPStorage *self)
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(elementSize)(THPStorage *self)
+static PyObject * THPStorage_(elementSize)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   return PyLong_FromLong(THWStorage_(elementSize)(LIBRARY_STATE_NOARGS));
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(new)(THPStorage *self)
+static PyObject * THPStorage_(new)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   THWStoragePtr new_storage(THWStorage_(new)(LIBRARY_STATE_NOARGS));
@@ -278,7 +278,7 @@ static PyObject *THPStorage_(setFromFile)(THPStorage *self, PyObject *args)
 }
 
 #ifdef THC_GENERIC_FILE
-PyObject * THPStorage_(getDevice)(THPStorage *self)
+PyObject * THPStorage_(getDevice)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   return PyLong_FromLong(THCStorage_(getDevice)(LIBRARY_STATE self->cdata));

--- a/torch/csrc/generic/StorageSharing.cpp
+++ b/torch/csrc/generic/StorageSharing.cpp
@@ -6,7 +6,7 @@
 
 #include <random>
 
-static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
+static PyObject * THPStorage_(sharedDecref)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
@@ -21,7 +21,7 @@ static PyObject * THPStorage_(sharedDecref)(THPStorage *self)
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(sharedIncref)(THPStorage *self)
+static PyObject * THPStorage_(sharedIncref)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
 #ifndef THC_GENERIC_FILE
@@ -69,7 +69,7 @@ static PyObject * THPStorage_(pyNewFilenameStorage)(PyObject *_unused, PyObject 
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(shareFilename)(THPStorage *self)
+static PyObject * THPStorage_(shareFilename)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
@@ -150,7 +150,7 @@ static PyObject * THPStorage_(pyNewFdStorage)(PyObject *_unused, PyObject *args)
   END_HANDLE_TH_ERRORS
 }
 
-static PyObject * THPStorage_(shareFd)(THPStorage *self)
+static PyObject * THPStorage_(shareFd)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
@@ -212,7 +212,7 @@ static PyObject * THPStorage_(newSharedFd)(PyObject *_unused, PyObject *args)
 
 #else // THC_GENERIC_FILE
 
-static PyObject * THPStorage_(shareCuda)(THPStorage *self)
+static PyObject * THPStorage_(shareCuda)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   THWStorage *storage = self->cdata;
@@ -496,7 +496,7 @@ PyObject * THPStorage_(expired)(PyObject *_unused, PyObject *arg)
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THPStorage_(sharedFd)(THPStorage *self)
+PyObject * THPStorage_(sharedFd)(THPStorage *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   THMapAllocator *ctx = nullptr;
@@ -510,7 +510,7 @@ PyObject * THPStorage_(sharedFd)(THPStorage *self)
   END_HANDLE_TH_ERRORS
 }
 
-PyObject * THPStorage_(isShared)(THPStorage *self)
+PyObject * THPStorage_(isShared)(THPStorage *self, PyObject *noargs)
 {
 #ifdef THC_GENERIC_FILE
   Py_RETURN_TRUE;
@@ -525,22 +525,22 @@ PyObject * THPStorage_(isShared)(THPStorage *self)
 }
 
 static PyMethodDef THPStorage_(sharingMethods)[] = {
-  {"_new_with_weak_ptr", (PyCFunction)THPStorage_(newWithWeakPtr), METH_O | METH_CLASS, nullptr},
+  {"_new_with_weak_ptr", (PyCFunction)(void(*)(void))THPStorage_(newWithWeakPtr), METH_O | METH_CLASS, nullptr},
 #ifdef THC_GENERIC_FILE
   {"_share_cuda_", (PyCFunction)THPStorage_(shareCuda), METH_NOARGS, nullptr},
-  {"_new_shared_cuda", (PyCFunction)THPStorage_(newSharedCuda), METH_VARARGS | METH_STATIC, nullptr},
-  {"_release_ipc_counter", (PyCFunction)THPStorage_(releaseIPCCounter), METH_VARARGS | METH_STATIC, nullptr},
+  {"_new_shared_cuda", (PyCFunction)(void(*)(void))THPStorage_(newSharedCuda), METH_VARARGS | METH_STATIC, nullptr},
+  {"_release_ipc_counter", (PyCFunction)(void(*)(void))THPStorage_(releaseIPCCounter), METH_VARARGS | METH_STATIC, nullptr},
 #else
   {"_share_fd_", (PyCFunction)THPStorage_(shareFd), METH_NOARGS, nullptr},
-  {"_new_shared_fd", (PyCFunction)THPStorage_(newSharedFd), METH_VARARGS | METH_STATIC, nullptr},
-  {"_new_using_fd", (PyCFunction)THPStorage_(pyNewFdStorage), METH_VARARGS | METH_STATIC, nullptr},
+  {"_new_shared_fd", (PyCFunction)(void(*)(void))THPStorage_(newSharedFd), METH_VARARGS | METH_STATIC, nullptr},
+  {"_new_using_fd", (PyCFunction)(void(*)(void))THPStorage_(pyNewFdStorage), METH_VARARGS | METH_STATIC, nullptr},
   {"_share_filename_", (PyCFunction)THPStorage_(shareFilename), METH_NOARGS, nullptr},
-  {"_new_shared_filename", (PyCFunction)THPStorage_(newSharedFilename), METH_VARARGS | METH_STATIC, nullptr},
-  {"_new_using_filename", (PyCFunction)THPStorage_(pyNewFilenameStorage), METH_VARARGS | METH_STATIC, nullptr},
+  {"_new_shared_filename", (PyCFunction)(void(*)(void))THPStorage_(newSharedFilename), METH_VARARGS | METH_STATIC, nullptr},
+  {"_new_using_filename", (PyCFunction)(void(*)(void))THPStorage_(pyNewFilenameStorage), METH_VARARGS | METH_STATIC, nullptr},
 #endif
   {"_weak_ref", (PyCFunction)THPStorage_(weakRef), METH_NOARGS, nullptr},
-  {"_free_weak_ref", (PyCFunction)THPStorage_(freeWeakRef), METH_O | METH_STATIC, nullptr},
-  {"_expired", (PyCFunction)THPStorage_(expired), METH_O | METH_STATIC, nullptr},
+  {"_free_weak_ref", (PyCFunction)(void(*)(void))THPStorage_(freeWeakRef), METH_O | METH_STATIC, nullptr},
+  {"_expired", (PyCFunction)(void(*)(void))THPStorage_(expired), METH_O | METH_STATIC, nullptr},
   {"_shared_decref", (PyCFunction)THPStorage_(sharedDecref), METH_NOARGS, nullptr},
   {"_shared_incref", (PyCFunction)THPStorage_(sharedIncref), METH_NOARGS, nullptr},
   {"_get_shared_fd", (PyCFunction)THPStorage_(sharedFd), METH_NOARGS, nullptr},


### PR DESCRIPTION
Fixes ~5000 lines of warnings like:

```
In file included from ../aten/src/TH/TH.h:4,
                 from ../torch/csrc/Storage.cpp:11:
../torch/csrc/Storage.h:6:39: warning: cast between incompatible function types from ‘PyObject* (*)(THPStorage*)’ {aka ‘_object* (*)(THPStorage*)’} to ‘getter’ {aka ‘_object* (*)(_object*, void*)’} [-Wcast-function-type]
    6 | #define THPStorage_(NAME) TH_CONCAT_4(THP,Real,Storage_,NAME)
      |                                       ^~~
caffe2/aten/src/TH/THGeneral.h:154:37: note: in definition of macro ‘TH_CONCAT_4_EXPAND’
  154 | #define TH_CONCAT_4_EXPAND(x,y,z,w) x ## y ## z ## w
      |                                     ^
../torch/csrc/Storage.h:6:27: note: in expansion of macro ‘TH_CONCAT_4’
    6 | #define THPStorage_(NAME) TH_CONCAT_4(THP,Real,Storage_,NAME)
      |                           ^~~~~~~~~~~
../torch/csrc/generic/Storage.cpp:299:22: note: in expansion of macro ‘THPStorage_’
  299 |   {"device", (getter)THPStorage_(device), nullptr, nullptr, nullptr},
      |                      ^~~~~~~~~~~
../torch/csrc/Storage.h:6:39: warning: cast between incompatible function types from ‘PyObject* (*)(THPStorage*)’ {aka ‘_object* (*)(THPStorage*)’} to ‘getter’ {aka ‘_object* (*)(_object*, void*)’} [-Wcast-function-type]
    6 | #define THPStorage_(NAME) TH_CONCAT_4(THP,Real,Storage_,NAME)
      |                                       ^~~
caffe2/aten/src/TH/THGeneral.h:154:37: note: in definition of macro ‘TH_CONCAT_4_EXPAND’
  154 | #define TH_CONCAT_4_EXPAND(x,y,z,w) x ## y ## z ## w
      |                                     ^
../torch/csrc/Storage.h:6:27: note: in expansion of macro ‘TH_CONCAT_4’
    6 | #define THPStorage_(NAME) TH_CONCAT_4(THP,Real,Storage_,NAME)
      |                           ^~~~~~~~~~~
```

This issue and the fix is very similar to how CPython fixed it, see https://bugs.python.org/issue33012.

There's still more of these warnings left, but this fixes the majority of them.
