### PR TITLE
[pytorch] turn off BUILD_BINARY for android CI jobs

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -65,7 +65,6 @@ fi
 if [[ "${BUILD_ENVIRONMENT}" == *-android* ]]; then
   export ANDROID_NDK=/opt/ndk
   build_args=()
-  build_args+=("-DBUILD_BINARY=ON")
   build_args+=("-DBUILD_CAFFE2_MOBILE=OFF")
 
   build_args+=("-DBUILD_SHARED_LIBS=ON")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25449 [pytorch] update speed benchmark binary to work in USE_STATIC_DISPATCH mode
* #25486 [pytorch] add speed benchmark binary for torch jit
* **#25485 [pytorch] turn off BUILD_BINARY for android CI jobs**

Summary:
I recently enabled binary build macro for android CI in PR #25368 as I started
adding new binaries for android. But seems it's fragile, e.g.: PR #25230 failed
android-armv8 CI but passed armv7/x86-32/x86-64. Currently it only runs
x86-32 for PR so the armv8 failure was not captured before landing.

Similar problem might happen for other PRs so I think we should just
disable it for now to avoid breaking master CI. The android binaries are
for local testing purpose anyway. We can re-enable it when it becomes
more stable.

Test Plan:
- will check CI;

Reviewers: ivankobzarev, dreiss

Subscribers: pytorch-mobile-dev

Differential Revision: [D17137006](https://our.internmc.facebook.com/intern/diff/D17137006)