### PR TITLE
Revert "Memory layout for pooling ops"

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -215,11 +215,8 @@ Tensor quantized_adaptive_avg_pool2d(
     IntArrayRef output_size) {
   const auto output_shape = get_output_shape(input, output_size);
   Tensor output = at::_empty_affine_quantized(
-      output_shape,
-      input.options(),
-      input.q_scale(),
-      input.q_zero_point(),
-      input.suggest_memory_format());
+      output_shape, input.options(), input.q_scale(), input.q_zero_point());
+  ;
   adaptive_avg_pool2d_out_template(output, input, output_shape);
   return output;
 }

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -144,8 +144,7 @@ Tensor q_maxpool_2d(
       oSizes,
       qx.options().dtype(toQIntType(qx.scalar_type())),
       qx.q_scale(),
-      qx.q_zero_point(),
-      qx.suggest_memory_format());
+      qx.q_zero_point());
   auto qx_contig = qx.contiguous();
   auto qxd = qx_contig.data_ptr<Q>();
   auto qyd = qy.data_ptr<Q>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25495 Revert "Memory layout for pooling ops"**

This reverts commit 8dcd256201a16827bae3610fe05f6566cce787d0.

Differential Revision: [D17139716](https://our.internmc.facebook.com/intern/diff/D17139716)