### PR TITLE
Get rid of _th_reciprocal_.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1733,20 +1733,6 @@
         - THTensor* self
 ]]
 [[
-  name: _th_reciprocal_
-  types:
-    - floating_point
-  backends:
-    - CUDA
-  variants: function
-  options:
-    - cname: cinv
-      return: self
-      arguments:
-        - THTensor* self
-        - THTensor* self
-]]
-[[
   name: _th_pow
   backends:
     - CUDA


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25507 Get rid of _th_reciprocal_.**

It doesn't seem to be used.

Differential Revision: [D17163584](https://our.internmc.facebook.com/intern/diff/D17163584)