### PR TITLE
Fix CUDA distributions test on Windows

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/test_libtorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_libtorch.bat
@@ -17,8 +17,6 @@ goto :eof
 :: See https://github.com/pytorch/pytorch/issues/25161
 if "%~1" == "c10_metaprogramming_test" goto :eof
 if "%~1" == "module_test" goto :eof
-:: See https://github.com/pytorch/pytorch/issues/25304
-if "%~1" == "cuda_distributions_test" goto :eof
 :: See https://github.com/pytorch/pytorch/issues/25312
 if "%~1" == "converter_nomigraph_test" goto :eof
 

--- a/aten/src/ATen/test/cuda_distributions_test.cu
+++ b/aten/src/ATen/test/cuda_distributions_test.cu
@@ -141,7 +141,7 @@ TEST(DistributionsTest, TestPhiloxIncrementSmallMultinomialTensor) {
   // this will trigger torch.multinomial without replacement
   // which increments philox offset by 4*num_samples times.
   // num_samples in the following call is 4.
-  at::empty({10}, at::TensorOptions(at::kCUDA)).multinomial(4);
+  at::ones({10}, at::TensorOptions(at::kCUDA)).multinomial(4);
 
   // expected uniforms will start from counter offset of 4*4
   assert_with_expected_uniforms(16);


### PR DESCRIPTION
Fixes #25304.

The possible cause for the failure could have been the fact that `at::empty` was creating a tensor with very small values or 0, which led to `cumdist` not summing to a positive number.