### PR TITLE
[iOS]Cocoapods Release Proposal Part 3 - Podspecs

### DIFF
--- a/ios/cpp/PytorchExp.podspec
+++ b/ios/cpp/PytorchExp.podspec
@@ -1,0 +1,38 @@
+Pod::Spec.new do |s|
+    s.name             = 'Pytorch'
+    s.version          = '0.0.1'
+    s.authors          = 'Facebook'
+    s.license          = { :type => 'BSD' }
+    s.homepage         = 'https://github.com/pytorch/pytorch'
+    s.source           = { :http => 'http://ossci-macos.s3.amazonaws.com/libtorch_x86_arm64.zip' }
+    s.summary          = 'Pytorch for iOS'
+    s.description      = <<-DESC
+    An internal-only pod containing the Pytorch C++ library that the public `PytorchObjC` depends on. This pod is not
+    intended to be used directly. Swift and Objective-C developers should use `PytorchObjC` pod.
+    DESC
+
+    s.default_subspec = 'Core'
+    s.subspec 'Core' do |ss|
+        ss.dependency 'Pytorch/Libtorch'
+        ss.source_files = 'src/*.{h,cpp,cc}'
+        ss.public_header_files = ['src/Pytorch.h']
+    end
+    
+    s.subspec 'Libtorch' do |ss|
+        ss.header_mappings_dir = 'install/include/'
+        ss.preserve_paths = 'install/include/**/*.{h,cpp,cc,c}' 
+        ss.vendored_libraries = 'install/lib/libtorch.a'
+        ss.libraries = ['c++', 'stdc++']
+    end
+    s.user_target_xcconfig = {
+        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Pytorch/install/lib/libtorch.a"',
+        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
+        'CLANG_CXX_LIBRARY' => 'libc++'
+    }
+    s.pod_target_xcconfig = { 
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/Pytorch/install/include/"', 
+        'VALID_ARCHS' => 'x86_64 arm64' }
+    s.module_name='Pytorch'
+    s.module_map = 'src/framework.modulemap'
+    s.library = ['c++', 'stdc++']
+end

--- a/ios/cpp/README.md
+++ b/ios/cpp/README.md
@@ -1,0 +1,3 @@
+## Pytorch C++ Library
+
+This is an internal-only pod containing the Pytorch C++ library that the public `PytorchObjC` depends on. This pod is not intended to be used directly. Swift and Objective-C developers should use `PytorchObjC` pod.

--- a/ios/objc/.gitignore
+++ b/ios/objc/.gitignore
@@ -1,0 +1,57 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+

--- a/ios/objc/PytorchExpObjC.podspec
+++ b/ios/objc/PytorchExpObjC.podspec
@@ -1,0 +1,40 @@
+Pod::Spec.new do |s|
+    s.name             = 'PytorchObjC'
+    s.version          = '0.0.1'
+    s.authors          = 'Facebook'
+    s.license          = { :type => 'BSD' }
+    s.homepage         = 'https://github.com/pytorch/pytorch'
+    s.source           = { :git => 'https://github.com/pytorch/pytorch.git', :branch => "master" }
+    s.summary          = 'Pytorch for Objective-C and Swift'
+    s.description      = <<-DESC
+   Pytorch for Objective-C and Swift developers. 
+                         DESC
+  
+    s.ios.deployment_target = '10.3'
+    s.module_name = 'PytorchObjC'
+    s.static_framework = true
+
+    objc_dir = 'ios/objc/'
+    s.public_header_files = objc_dir + 'apis/*.h'
+    s.source_files = [ objc_dir+'apis/*.{h,m,mm}', objc_dir+'src/*.{h,m,mm}' ]
+    s.module_map = objc_dir+'apis/framework.modulemap'
+    s.dependency 'Pytorch'
+    header = ""
+    s.pod_target_xcconfig = { 
+      'HEADER_SEARCH_PATHS' => 
+      '"${PODS_ROOT}/Pytorch/install/include" ' + 
+      '"${PODS_ROOT}/PytorchObjC/' + objc_dir + 'apis"',
+      'VALID_ARCHS' => 'x86_64 arm64' 
+    }
+    s.library = 'c++', 'stdc++'
+    s.user_target_xcconfig = {
+      'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Pytorch/install/include"'
+    }
+    s.test_spec 'Tests' do |ts| 
+      ts.source_files = objc_dir + 'Tests/*.{h,mm,m}'
+      ts.resources = [ objc_dir + 'Tests/models/*.pt']
+      ts.pod_target_xcconfig = {
+        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Pytorch/install/lib/libtorch.a"'
+      }
+    end
+  end

--- a/ios/objc/README.md
+++ b/ios/objc/README.md
@@ -1,0 +1,29 @@
+## PytorchObjC
+
+PytorchObjc is Pytorch solutions for Objective-C developers.
+
+## Quick start
+
+Add the PytorchObjC to your `podfile`, then run `pod install`. 
+
+```
+pod 'PytorchObjC'
+```
+
+For Swift developers, add 
+
+```
+!use_frameworks!
+pod 'PytorchObjC'
+```
+
+In your Objective-C files, import the umbrella header:
+
+```
+#import <PytorchObjC/PytorchObjC.h>
+```
+For Swift users, import the `PytorchObjC` as a module 
+
+```
+import PytorchObjC
+```


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25543 [iOS]Cocoapods Release Proposal Part 3 - Podspecs**
* #25542 [iOS]Cocoapods Release Proposal Part 2 - Tests App & UnitTests Files
* #25541 [iOS] Cocoapods Release Proposal Part 1 - Objective-C API wrapper

## Summary

iOS cocoapods release proposal

- Part1: Objective-C API wrapper
- Part2: TestApps(Objective-C+Swift) + UnitTests
- Part3: Podspec files
- Part4: CI changes

This PR is the third part of the proposal regarding the podspec files. There are two podspec files included, one is for the Pytorch C++ library which shouldn't be used directly by developers. The other one is an Objective-C wrapper that depends on the first one. Swift and Objective-C developers should use the second podspec file as it provides the high level API interfaces.

## Note

Notice that the source specified in `Pytorch.podspec` - `http://ossci-macos.s3.amazonaws.com/libtorch_x86_arm64.zip` is just a temporary address for testing purposes. It will be replaced by the real address after CI has been done.

## Test Plan

Right now, the tests can't be run as the cocoapods hasn't been released yet. But you can test the demos in my own repo [here]((https://github.com/xta0/PytorchExp/tree/master/ios/objc) for more details.). I made a PytorchExp pod which is just a mirror of the code here.

