### PR TITLE
checks requiring GPU moved to their own test

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -741,7 +741,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.Tensor([i + self.rank]).cuda() for i in range(1000)]
         self._test_allreduce_stress(inputs)
 
-    @skip_if_lt_x_gpu(1)
     def test_allreduce_coalesced_checks(self):
         store = c10d.FileStore(self.file.name, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
@@ -765,6 +764,13 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         with self.assertRaisesRegex(ValueError, "unsupported layout"):
             opts = c10d.AllreduceCoalescedOptions()
             pg.allreduce_coalesced([t3, t3.clone()], opts)
+
+    @skip_if_lt_x_gpu(1)
+    def test_allreduce_coalesced_checks_cuda(self):
+        store = c10d.FileStore(self.file.name, self.world_size)
+        pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
+
+        t1 = torch.zeros(1, dtype=torch.float32)
 
         with self.assertRaisesRegex(ValueError, "unsupported device type"):
             opts = c10d.AllreduceCoalescedOptions()


### PR DESCRIPTION
`test_allreduce_coalesced_checks` is skipped if no GPU/not compiled with `CUDA` support. This PR moves the checks involving `.cuda()` to their own tests, since the others are still valid with or without CUDA. 

cc @pietern @mrshenli 