### PR TITLE
make python rpc handler to be singleton class

### DIFF
--- a/test/common_distributed.py
+++ b/test/common_distributed.py
@@ -129,7 +129,8 @@ class MultiProcessTestCase(TestCase):
         super(MultiProcessTestCase, self).setUp()
         self.skip_return_code_checks = []
         self.rank = self.MAIN_PROCESS_RANK
-        self.file = tempfile.NamedTemporaryFile(delete=False)
+        # spawn can not pass file handle, so pass file name here
+        self.file = tempfile.NamedTemporaryFile(delete=False).name
         self.processes = [self._spawn_process(rank) for rank in range(int(self.world_size))]
 
     def tearDown(self):
@@ -137,18 +138,30 @@ class MultiProcessTestCase(TestCase):
         for p in self.processes:
             p.terminate()
 
+    def _current_test_name(self):
+        # self.id() == e.g. '__main__.TestDistributed.TestAdditive.test_get_rank'
+        return self.id().split(".")[-1]
+
     def _spawn_process(self, rank):
         name = 'process ' + str(rank)
-        process = multiprocessing.Process(target=self._run, name=name, args=(rank,))
+        test_name = self._current_test_name()
+        process = multiprocessing.Process(
+            target=self.__class__._run,
+            name=name,
+            args=(test_name, rank, self.file)
+        )
         process.start()
         return process
 
-    def _run(self, rank):
-        self.rank = rank
+    @classmethod
+    def _run(cls, test_name, rank, file):
+        self = cls(test_name)
 
-        # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
-        # We're retreiving a corresponding test and executing it.
-        getattr(self, self.id().split(".")[2])()
+        self.rank = rank
+        self.file = file
+
+        # We're retrieving a corresponding test and executing it.
+        getattr(self, test_name)()
         sys.exit(0)
 
     def _join_processes(self, fn):

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -517,7 +517,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         return opts
 
     def test_multi_device_constructor(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         opts = c10d.ProcessGroupGloo.Options()
         opts.timeout = 5.0
         opts.devices = [
@@ -531,7 +531,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             work.wait()
 
     def test_empty_tensors(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         xs = [torch.FloatTensor([])]
@@ -539,7 +539,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self.assertEqual(0, xs[0].numel())
 
     def test_broadcast_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1], dtype=torch.float32)
@@ -589,7 +589,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.broadcast([t1, t3], opts)
 
     def _test_broadcast_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         def broadcast(xs, rootRank, rootTensor):
@@ -632,7 +632,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_broadcast_basics(lambda t: t.clone().cuda())
 
     def _test_broadcast_stress(self, inputs):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         work_handles = [
             pg.broadcast(inputs[i], root=(i % self.world_size))
@@ -659,7 +659,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_broadcast_stress(inputs)
 
     def test_allreduce_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1], dtype=torch.float32)
@@ -679,7 +679,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.allreduce([t1, t3], opts)
 
     def _test_allreduce_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         # Single input tests
@@ -717,7 +717,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_allreduce_basics(lambda t: t.clone().cuda())
 
     def _test_allreduce_stress(self, inputs):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         work_handles = [pg.allreduce(inputs[i]) for i in range(len(inputs))]
         for i, work_handle in enumerate(work_handles):
@@ -742,7 +742,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_allreduce_stress(inputs)
 
     def test_allreduce_coalesced_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros(1, dtype=torch.float32)
@@ -767,7 +767,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
     @skip_if_lt_x_gpu(1)
     def test_allreduce_coalesced_checks_cuda(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros(1, dtype=torch.float32)
@@ -777,7 +777,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.allreduce_coalesced([t1.cuda(), t1.cuda()], opts)
 
     def _test_allreduce_coalesced_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         test_cases = simple_coalesced_reduce_tests(self.rank, self.world_size)
@@ -794,7 +794,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_allreduce_coalesced_basics(lambda t: t.clone())
 
     def _test_allreduce_coalesced_stress(self, inputs):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         work_handles = [pg.allreduce_coalesced(input) for input in inputs]
         for i, work_handle in enumerate(work_handles):
@@ -810,7 +810,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_allreduce_coalesced_stress(inputs)
 
     def test_sparse_allreduce_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1])
@@ -837,7 +837,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 pg.allreduce([t3], opts)
 
     def _test_sparse_allreduce_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         for num_inputs_per_rank in [1, 2]:
@@ -858,7 +858,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_sparse_allreduce_basics(lambda t: t.clone().cuda())
 
     def test_scatter_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1], dtype=torch.float32)
@@ -926,7 +926,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.scatter([t1], [[t1] * self.world_size], opts)
 
     def _test_scatter_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         # Preallocate tensors for input/output
@@ -956,7 +956,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_scatter_basics(lambda t: t.clone().cuda())
 
     def _test_scatter_stress(self, inputs, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         outputs = [
             [fn(torch.Tensor([-1])) for _ in range(self.world_size)]
@@ -1002,7 +1002,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_scatter_stress(inputs, lambda t: t.clone().cuda())
 
     def test_gather_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1], dtype=torch.float32)
@@ -1065,7 +1065,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.gather([[t1] * self.world_size], [t1], opts)
 
     def _test_gather_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         # Preallocate tensors for input/output
@@ -1097,7 +1097,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_gather_basics(lambda t: t.clone().cuda())
 
     def _test_gather_stress(self, inputs, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         work_handles = []
         outputs = [
@@ -1142,7 +1142,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_gather_stress(inputs, lambda t: t.clone().cuda())
 
     def test_allgather_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1], dtype=torch.float32)
@@ -1177,7 +1177,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.allgather([([t1, t3] * (self.world_size))[:self.world_size]], [t1])
 
     def _test_allgather_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         # Run with N input tensor per rank
@@ -1207,7 +1207,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_allgather_basics(lambda t: t.clone().cuda())
 
     def _test_allgather_stress(self, inputs, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         work_handles = []
         outputs = [
@@ -1243,7 +1243,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_allgather_stress(inputs, lambda t: t.clone().cuda())
 
     def test_reduce_checks(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         t1 = torch.zeros([1], dtype=torch.float32)
@@ -1273,7 +1273,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.reduce([t1, t1], opts)
 
     def _test_reduce_basics(self, fn):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
         for (op, input, output) in simple_reduce_tests(self.rank, self.world_size):
             for root in range(self.world_size):
@@ -1294,7 +1294,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_reduce_basics(lambda t: t.clone().cuda())
 
     def _test_reduce_stress(self, inputs):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts(threads=8))
         work_handles = []
         outputs = []
@@ -1332,7 +1332,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         self._test_reduce_stress(inputs)
 
     def test_send_recv_all_to_all(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size, self.opts())
 
         # Preallocate tensors for input/output
@@ -1370,7 +1370,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             self.assertEqual(torch.Tensor([i]), outputs[i])
 
     def test_timeout_kwarg(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(
             store,
             self.rank,
@@ -1389,7 +1389,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             pg.barrier().wait()
 
     def test_barrier_implies_wait(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         pg = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
 
         # Kick off allreduce operations
@@ -1740,7 +1740,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         # TODO: investigate this test and the test is known to have issues
         # Use this hack to remove files for that test
         try:
-            os.remove(self.file.name)
+            os.remove(self.file)
         except OSError:
             pass
 
@@ -1836,7 +1836,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
             input = input[torch.randperm(global_batch_size)]
 
     def _test_gloo_backend(self, devices, device_ids, multi_device=False):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -1875,7 +1875,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         self._test_gloo_backend(devices, [], multi_device=True)
 
     def _test_nccl_backend(self, devices, device_ids, multi_device=False):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
         self._test_ddp_with_process_group(process_group, devices, device_ids, multi_device)
 
@@ -1914,7 +1914,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
         self.assertTrue(len(gpus) >= 2, "expecting at least 2 gpus per process")
 
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         gpus = gpus[:2]
@@ -1941,7 +1941,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @skip_if_not_multigpu
     @skip_for_known_issues
     def test_dist_broadcast_coalesced_nccl(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         device = torch.device('cuda')
@@ -1978,7 +1978,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @requires_gloo()
     @skip_if_not_multigpu
     def test_dist_broadcast_coalesced_gloo(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -2017,7 +2017,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @requires_gloo()
     @skip_if_not_multigpu
     def test_sync_params_no_buffers(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -2044,7 +2044,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @requires_gloo()
     @skip_if_not_multigpu
     def test_sync_params_with_buffers(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -2082,7 +2082,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_if_not_multigpu
     def test_fp16(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         gpus = gpus_for_rank(self.world_size)[self.rank]
@@ -2114,7 +2114,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @skip_if_not_multigpu
     def test_queue_reduction(self):
         # Set up process group.
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         # Get this process' split of devices.
@@ -2142,7 +2142,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @skip_if_not_multigpu
     def test_sync_reduction(self):
         # Set up process group.
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         # Get this process' split of devices.
@@ -2164,7 +2164,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         class ForwardReturnValueModule(nn.Module):
@@ -2254,7 +2254,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         class FindUnusedParametersModule(nn.Module):
@@ -2330,7 +2330,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         class MultipleOutputModule(nn.Module):
@@ -2380,7 +2380,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         Note: this test can be sped up by only running it on a CPU module
         once DistributedDataParallel supports them.
         """
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         class NoGradModule(nn.Module):
@@ -2427,7 +2427,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         # This is the recommended way to implement accumulate grads
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
         global_batch_size = self.world_size
         local_batch_size = len(devices)
@@ -2482,7 +2482,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         # module.
         int_devices = gpus_for_rank(self.world_size)[self.rank][:1]
         devices = list([torch.device('cuda:' + str(i)) for i in int_devices])
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
         global_batch_size = self.world_size
 
@@ -2532,7 +2532,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         Test that the output of a model can be ignored and that there is no
         implicit requirement that `backward` gets called.
         """
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
 
         class IgnoredOutput(nn.Module):
@@ -2574,7 +2574,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         implicit requirement that `backward` gets called, if not all model
         parameters participated in computing the model output.
         """
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
 
         class IgnoredOutputWithUnusedParameters(nn.Module):
@@ -2615,12 +2615,12 @@ class DistributedDataParallelTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_if_not_multigpu
     def test_failure_recovery(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
         # need to create a separate file for the recovered FileStore, because
         # the original one will be deleted when destructing the first FileStore.
-        recovery_filename = self.file.name + "_recovery"
+        recovery_filename = self.file + "_recovery"
 
         if self.rank == 0:
             # the file will be deleted by the recovered FileStore
@@ -2679,7 +2679,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
 
     @requires_gloo()
     def test_sparse_gradients(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size)
 
         class SparseGradientModule(nn.Module):
@@ -2901,6 +2901,10 @@ class ComputeBucketAssignmentTest(TestCase):
 
 class CommTest(MultiProcessTestCase):
 
+    @property
+    def op_timeout_sec(self):
+        return 1
+
     def setUp(self):
         super(CommTest, self).setUp()
         # Need to skip return code checking for these tests since the child
@@ -2924,13 +2928,9 @@ class CommTest(MultiProcessTestCase):
     def tearDown(self):
         super(CommTest, self).tearDown()
         try:
-            os.remove(self.file.name)
+            os.remove(self.file)
         except OSError:
             pass
-
-    @property
-    def op_timeout_sec(self):
-        return 1
 
     @property
     def world_size(self):
@@ -2970,7 +2970,7 @@ class CommTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_if_not_multigpu
     def test_nccl_errors_nonblocking(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
         process_group.allreduce(torch.rand(10).cuda(self.rank))
         if self.rank == 0:
@@ -2990,7 +2990,7 @@ class CommTest(MultiProcessTestCase):
 
     def _test_nccl_errors_blocking(self, func):
         os.environ["NCCL_BLOCKING_WAIT"] = "1"
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size, "", timeout=timedelta(seconds=self.op_timeout_sec))
         process_group.allreduce(torch.rand(10).cuda(self.rank))
         if self.rank == 0:
@@ -3028,7 +3028,7 @@ class CommTest(MultiProcessTestCase):
 
     def _run_invalid_nccl_blocking_wait_env(self, val):
         os.environ["NCCL_BLOCKING_WAIT"] = val
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         with self.assertRaises(RuntimeError):
             process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
 
@@ -3043,7 +3043,7 @@ class CommTest(MultiProcessTestCase):
     @requires_nccl()
     @skip_if_not_multigpu
     def test_broadcast_coalesced_nccl(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size)
         device = torch.device('cuda:%d' % self.rank)
         self._test_broadcast_coalesced(process_group, device)
@@ -3051,7 +3051,7 @@ class CommTest(MultiProcessTestCase):
     @requires_gloo()
     @skip_if_not_multigpu
     def test_broadcast_coalesced_gloo_cuda(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)
@@ -3060,7 +3060,7 @@ class CommTest(MultiProcessTestCase):
 
     @requires_gloo()
     def test_broadcast_coalesced_gloo_cpu(self):
-        store = c10d.FileStore(self.file.name, self.world_size)
+        store = c10d.FileStore(self.file, self.world_size)
         options = c10d.ProcessGroupGloo.Options()
         options.devices = [c10d.ProcessGroupGloo.create_tcp_device(interface="lo")]
         process_group = c10d.ProcessGroupGloo(store, self.rank, self.world_size, options)

--- a/test/test_dist_autograd.py
+++ b/test/test_dist_autograd.py
@@ -23,7 +23,7 @@ def dist_init(func):
     @wraps(func)
     def wrapper(self):
         self.worker_id = self.rank
-        store = dist.FileStore(self.file.name, self.world_size)
+        store = dist.FileStore(self.file, self.world_size)
         dist.init_process_group(backend='gloo', rank=self.rank,
                                 world_size=self.world_size, store=store)
         dist.init_model_parallel('worker%d' % self.rank)

--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import unittest
+import multiprocessing
+import caffe2.python._import_c_extension as C
 
 import torch
 import torch.distributed as dist
@@ -76,7 +78,7 @@ def _wrap_with_rpc(func):
         'setUp' and 'tearDown' methods of unittest.
     '''
     def wrapper(self):
-        store = dist.FileStore(self.file.name, self.world_size)
+        store = dist.FileStore(self.file, self.world_size)
         dist.init_process_group(backend='gloo', rank=self.rank,
                                 world_size=self.world_size, store=store)
         dist.init_model_parallel('worker%d' % self.rank)
@@ -90,7 +92,13 @@ def _wrap_with_rpc(func):
     sys.version_info < (3, 0),
     "Pytorch distributed rpc package " "does not support python2",
 )
+@unittest.skipIf(C.is_asan, "Skip ASAN since torch + multiprocessing + fbcode doesn't work with asan")
 class RpcTest(MultiProcessTestCase):
+    @classmethod
+    def setUpClass(cls):
+        multiprocessing.set_start_method("spawn")
+        super(RpcTest, cls). setUpClass()
+
     @property
     def world_size(self):
         return 4
@@ -124,7 +132,7 @@ class RpcTest(MultiProcessTestCase):
             dist.rpc(self_worker_name, torch.add, args=(torch.ones(2, 2), 1))
 
     def test_duplicated_names(self):
-        store = dist.FileStore(self.file.name, self.world_size)
+        store = dist.FileStore(self.file, self.world_size)
         dist.init_process_group(backend="gloo", rank=self.rank,
                                 world_size=self.world_size, store=store)
         with self.assertRaisesRegex(RuntimeError, "is not unique"):
@@ -132,7 +140,7 @@ class RpcTest(MultiProcessTestCase):
         dist.join_rpc()
 
     def test_invalid_names(self):
-        store = dist.FileStore(self.file.name, self.world_size)
+        store = dist.FileStore(self.file, self.world_size)
         dist.init_process_group(backend="gloo", rank=self.rank,
                                 world_size=self.world_size, store=store)
 

--- a/torch/csrc/distributed/rpc/functions.cpp
+++ b/torch/csrc/distributed/rpc/functions.cpp
@@ -39,7 +39,8 @@ Message processRequestBlocking(Message&& request) {
     }
     case MessageType::PYTHON_CALL: {
       try {
-        auto payload = PythonRpcHandler::generatePythonUDFResult(request);
+        auto payload =
+            PythonRpcHandler::getInstance().generatePythonUDFResult(request);
         return Message(
             std::move(payload),
             std::vector<torch::Tensor>(),

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -119,7 +119,8 @@ ProcessGroupAgent::ProcessGroupAgent(
     workerIds_.emplace_back(std::move(tmpWorkerIds[rank]), rank);
   }
 
-  PythonRpcHandler::init();
+  // construct PythonRpcHandler singleton here
+  PythonRpcHandler::getInstance();
   listenerThread_ = std::thread(&ProcessGroupAgent::listenLoop, this);
 }
 

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -13,7 +13,7 @@ py::object to_py_obj(const Message& message) {
       return torch::jit::createPyObjectForStack(std::move(stack));
     }
     case MessageType::PYTHON_RET: {
-      return PythonRpcHandler::loadPythonUDFResult(message);
+      return PythonRpcHandler::getInstance().loadPythonUDFResult(message);
     }
     case MessageType::EXCEPTION: {
       std::string err(message.payload().begin(), message.payload().end());

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -3,45 +3,41 @@
 namespace torch {
 namespace distributed {
 namespace rpc {
-namespace {
-  py::object runUDFFunction_ = py::none();
-  py::object loadResultFunction_ = py::none();
-} // anonymous namespace
 
-namespace PythonRpcHandler {
-  void init() {
-    AutoGIL ag;
-    py::object module
-      = py::module::import("torch.distributed.internal_rpc_utils");
-    TORCH_CHECK(!module.is(py::none()), "module is None.");
-    if (runUDFFunction_.is(py::none())) {
-      runUDFFunction_ = module.attr("run_python_udf_internal");
-    }
-    if (loadResultFunction_.is(py::none())) {
-      loadResultFunction_ = module.attr("load_python_udf_result_internal");
-    }
+PythonRpcHandler::PythonRpcHandler() {
+  AutoGIL ag;
+  py::object module =
+      py::module::import("torch.distributed.internal_rpc_utils");
+  if (runUDFFunction_ == nullptr) {
+    runUDFFunction_ = module.attr("run_python_udf_internal");
   }
+  if (loadResultFunction_ == nullptr) {
+    loadResultFunction_ = module.attr("load_python_udf_result_internal");
+  }
+}
 
-  std::vector<char> generatePythonUDFResult(
+PythonRpcHandler& PythonRpcHandler::getInstance() {
+  static PythonRpcHandler handler;
+  return handler;
+}
+
+std::vector<char> PythonRpcHandler::generatePythonUDFResult(
     const Message& request) {
-    AutoGIL ag;
-    auto pargs = py::bytes(request.payload().data(), request.payload().size());
-    TORCH_CHECK(!runUDFFunction_.is(py::none()), "runUDFFunction_ is None.");
-    py::bytes pres = runUDFFunction_(pargs);
-    const auto& presStr = static_cast<std::string>(pres);
-    std::vector<char> payload(presStr.begin(), presStr.end());
-    return payload;
-  }
+  AutoGIL ag;
+  auto pargs = py::bytes(request.payload().data(), request.payload().size());
+  TORCH_CHECK(runUDFFunction_ != nullptr, "runUDFFunction_ is nullptr");
+  py::bytes pres = runUDFFunction_(pargs);
+  const auto& presStr = static_cast<std::string>(pres);
+  std::vector<char> payload(presStr.begin(), presStr.end());
+  return payload;
+}
 
-  py::object loadPythonUDFResult(const Message& message) {
-    AutoGIL ag;
-    auto pargs = py::bytes(message.payload().data(), message.payload().size());
-    TORCH_CHECK(
-        !loadResultFunction_.is(py::none()), "loadResultFunction_ is None.");
-    return loadResultFunction_(pargs);
-  }
-} // PythonRpcHandler
-
+py::object PythonRpcHandler::loadPythonUDFResult(const Message& message) {
+  AutoGIL ag;
+  auto pargs = py::bytes(message.payload().data(), message.payload().size());
+  TORCH_CHECK(loadResultFunction_ != nullptr, "loadResultFunction_ is nullptr");
+  return loadResultFunction_(pargs);
+}
 
 } // rpc
 } // distributed

--- a/torch/csrc/distributed/rpc/python_rpc_handler.cpp
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.cpp
@@ -4,22 +4,21 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 namespace {
-  py::object module_;
-  py::object runUDFFunction_;
-  py::object loadResultFunction_;
+  py::object runUDFFunction_ = py::none();
+  py::object loadResultFunction_ = py::none();
 } // anonymous namespace
 
 namespace PythonRpcHandler {
   void init() {
     AutoGIL ag;
-    if (module_ == nullptr) {
-      module_ = py::module::import("torch.distributed.internal_rpc_utils");
+    py::object module
+      = py::module::import("torch.distributed.internal_rpc_utils");
+    TORCH_CHECK(!module.is(py::none()), "module is None.");
+    if (runUDFFunction_.is(py::none())) {
+      runUDFFunction_ = module.attr("run_python_udf_internal");
     }
-    if (runUDFFunction_ == nullptr) {
-      runUDFFunction_ = module_.attr("run_python_udf_internal");
-    }
-    if (loadResultFunction_ == nullptr) {
-      loadResultFunction_ = module_.attr("load_python_udf_result_internal");
+    if (loadResultFunction_.is(py::none())) {
+      loadResultFunction_ = module.attr("load_python_udf_result_internal");
     }
   }
 
@@ -27,6 +26,7 @@ namespace PythonRpcHandler {
     const Message& request) {
     AutoGIL ag;
     auto pargs = py::bytes(request.payload().data(), request.payload().size());
+    TORCH_CHECK(!runUDFFunction_.is(py::none()), "runUDFFunction_ is None.");
     py::bytes pres = runUDFFunction_(pargs);
     const auto& presStr = static_cast<std::string>(pres);
     std::vector<char> payload(presStr.begin(), presStr.end());
@@ -36,6 +36,8 @@ namespace PythonRpcHandler {
   py::object loadPythonUDFResult(const Message& message) {
     AutoGIL ag;
     auto pargs = py::bytes(message.payload().data(), message.payload().size());
+    TORCH_CHECK(
+        !loadResultFunction_.is(py::none()), "loadResultFunction_ is None.");
     return loadResultFunction_(pargs);
   }
 } // PythonRpcHandler

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -7,17 +7,34 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
-namespace PythonRpcHandler {
-// initialize python module object and function objects in which python user
-// defined function (UDF) will run there
-void init();
-// execute python UDF, result is pickled to binary string
-std::vector<char> generatePythonUDFResult(const Message& request);
-// returned python UDF result is pickled binary string, so run python
-// function to unpickle the python UDF result and return pyObject to user
-py::object loadPythonUDFResult(const Message& message);
-}
+// singleton class provides interface to  execute python UDF remote call
+// and deserialize the returned results by running python function
+// in internal_rpc_utilities
+// the singleton object is constructed at first when RPC agent is
+// constructed, where the python function in internal_rpc_utilities are imported
+// only once
+class PythonRpcHandler {
+ public:
+  static PythonRpcHandler& getInstance();
+  // execute python UDF, result is pickled to binary string
+  std::vector<char> generatePythonUDFResult(const Message& request);
+  // returned python UDF result is pickled binary string, so run python
+  // function to unpickle the python UDF result and return pyObject to user
+  py::object loadPythonUDFResult(const Message& message);
 
-}
-}
-}
+ private:
+  PythonRpcHandler();
+  ~PythonRpcHandler() = default;
+
+  PythonRpcHandler(const PythonRpcHandler&) = delete;
+  PythonRpcHandler& operator=(const PythonRpcHandler&) = delete;
+  PythonRpcHandler(PythonRpcHandler&&) = delete;
+  PythonRpcHandler& operator=(PythonRpcHandler&&) = delete;
+
+  py::object runUDFFunction_;
+  py::object loadResultFunction_;
+};
+
+} // namespace rpc
+} // namespace distributed
+} // namespace torch


### PR DESCRIPTION
Summary: python rpc handler right now is namespace + global variable, changed it to be singleton class as it can gurantee deterministic order of variable destruction. for namespace + global variable, we hit a process exit crash issue because global variables have dependencies and they are not destructed as expected

Test Plan: unit test passed

Differential Revision: D17097999

