### PR TITLE
Fix binary op name inference to happen before shape checks

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -214,29 +214,34 @@ void TensorIterator::allocate_outputs() {
 }
 
 #ifdef BUILD_NAMEDTENSOR
-void TensorIterator::propagate_names_to_outputs() {
-  bool should_perform_name_inference = std::any_of(
+void TensorIterator::compute_names() {
+  bool should_infer_names = std::any_of(
       operands_.begin(),
       operands_.end(),
       [](const OperandInfo& op) {
         return op.tensor.defined() && op.tensor.has_names();
       });
-  if (!should_perform_name_inference) {
-    return;
-  }
 
-  // build names
-  NameVector names;
   for (auto& op : operands_) {
     if (!op.tensor.defined()) continue;
     // don't include output tensors that are not also input tensors.
     if (resize_outputs_ && op.is_output && !op.is_read_write) continue;
     // perform name inference
-    if (names.empty()) {
-      names = op.tensor.names();
+    if (names_.empty()) {
+      names_ = op.tensor.names();
     } else {
-      names = NameVector(unify_from_right(names, op.tensor.names()));
+      names_ = NameVector(unify_from_right(names_, op.tensor.names()));
     }
+  }
+}
+
+void TensorIterator::propagate_names_to_outputs() {
+  // names_ can be empty for two reasons:
+  // 1. We were performing ops on scalar tensors. Then there should be no names.
+  // 2. All of the defined inputs/outputs had no names. Then we shouldn't
+  //    run name inference.
+  if (names_.empty()) {
+    return;
   }
 
   // propagate names
@@ -244,10 +249,10 @@ void TensorIterator::propagate_names_to_outputs() {
     auto& op = operands_[i];
     // must call propagate_names_to_outputs after outputs have been allocated.
     TORCH_INTERNAL_ASSERT(op.tensor.defined());
-    if (names.empty()) {
+    if (names_.empty()) {
       namedinference::propagate_names(op.tensor, nullopt);
     } else {
-      namedinference::propagate_names(op.tensor, names);
+      namedinference::propagate_names(op.tensor, names_);
     }
   }
 }
@@ -752,6 +757,10 @@ void TensorIterator::build() {
   // Check that the outputs have no internal overlap
   // and do not share memory with inputs.
   check_mem_overlaps();
+#ifdef BUILD_NAMEDTENSOR
+  // Check that input dimensions are aligned correctly & compute outnames.
+  compute_names();
+#endif
   // compute the broadcasted shape
   compute_shape();
   // compute each tensor's stride after broadcasting

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -221,6 +221,9 @@ void TensorIterator::compute_names() {
       [](const OperandInfo& op) {
         return op.tensor.defined() && op.tensor.has_names();
       });
+  if (!should_infer_names) {
+    return;
+  }
 
   for (auto& op : operands_) {
     if (!op.tensor.defined()) continue;

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -302,6 +302,7 @@ protected:
   std::tuple<Device, ScalarType> compute_common_type();
   void allocate_outputs();
 #ifdef BUILD_NAMEDTENSOR
+  void compute_names();
   void propagate_names_to_outputs();
 #endif
   void coalesce_dimensions();
@@ -309,6 +310,9 @@ protected:
 protected:
   DimVector shape_;
   DimVector perm_;
+#ifdef BUILD_NAMEDTENSOR
+  NameVector names_;
+#endif
   SmallVector<OperandInfo, 4> operands_;
   int num_outputs_ = 0;
   bool has_coalesced_dimensions_ = false;

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -419,9 +419,9 @@ class TestNamedTensor(TestCase):
     def test_binary_ops(self):
         def test_basic(op):
             a = torch.empty(2, 3, names=('N', 'C'))
-            b = torch.empty(2, 3, names=('C', 'N'))
+            b = torch.empty(3, 2, names=('C', 'N'))
             c = torch.empty(3, names=('C',))
-            d = torch.empty(3, names=('W',))
+            d = torch.empty(5, names=('W',))
 
             self.assertEqual(op(a, a).names, ('N', 'C'))
             self.assertEqual(op(a, c).names, ('N', 'C'))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25563 Fix binary op name inference to happen before shape checks**

Before, for binary ops, name inference occurred after shape checks. This
defeats the purposes for names because the names are supposed to tell
the user that i.e. their tensors are misaligned or that they are adding
incompatible tensors.

This PR changes TensorIterator so that names are computed before shape checks and
propagated after the binary ops are finished. In order to support this,
this PR makes the following changes:
- adds a `names_` field to TensorIterator, similar to `shape_`. This is
necessary to hold the output names, that are computed in
`compute_names`, until they are used in `propagate_names_to_outputs()`.

Differential Revision: [D17158869](https://our.internmc.facebook.com/intern/diff/D17158869)