### PR TITLE
Fix named tensor printing

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -183,6 +183,14 @@ class TestNamedTensor(TestCase):
         with self.assertRaisesRegex(RuntimeError, "NYI"):
             ForkingPickler(buf, pickle.HIGHEST_PROTOCOL).dump(named_tensor)
 
+    def test_big_tensor_repr(self):
+        def check_repr(named_tensor):
+            unnamed_tensor = named_tensor.view_names(None)
+            expected = "{}, names={})".format(repr(unnamed_tensor)[:-1], named_tensor.names)
+            self.assertEqual(repr(named_tensor), expected)
+
+        check_repr(torch.randn(128, 3, 64, 64, names=('N', 'C', 'H', 'W')))
+
     def test_noncontig_contiguous(self):
         # This type of contiguous is special-cased and therefore needs its own test
         for device in torch.testing.get_all_device_types():

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -196,7 +196,11 @@ def _tensor_str(self, indent):
         return '[]'
 
     if torch._C._BUILD_NAMEDTENSOR and self.has_names():
-        # Many fns involved in printing don't support names, so drop them first
+        # There are two main codepaths (possibly more) that tensor printing goes through:
+        # - tensor data can fit comfortably on screen
+        # - tensor data needs to be summarized
+        # Some of the codepaths don't fully support named tensors, so we send in
+        # an unnamed tensor to the formatting code as a workaround.
         self = self.view_names(None)
 
     summarize = self.numel() > PRINT_OPTS.threshold

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -195,6 +195,10 @@ def _tensor_str(self, indent):
     if self.numel() == 0:
         return '[]'
 
+    if torch._C._BUILD_NAMEDTENSOR and self.has_names():
+        # Many fns involved in printing don't support names, so drop them first
+        self = self.view_names(None)
+
     summarize = self.numel() > PRINT_OPTS.threshold
     if self.dtype is torch.float16 or self.dtype is torch.bfloat16:
         self = self.float()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25564 Fix named tensor printing**

There are a number of ops that get called while printing tensors
depending on how large the tensors are. This PR makes it so that before
we attempt to format tensor data for printing, we drop the names of the
tensor (if there are any). This is easier than supporting named tensors
for all of those ops (which should happen eventually).

Test Plan:
- new test [namedtensor ci]

Differential Revision: [D17158872](https://our.internmc.facebook.com/intern/diff/D17158872)