### PR TITLE
Name inference rule for masked select

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -460,6 +460,15 @@ void propagate_names_for_expand(Tensor& result, const Tensor& self) {
   propagate_names(result, std::move(outnames), /*validate_names=*/false);
 }
 
+optional<std::vector<Dimname>> compute_broadcast_outnames(
+    const Tensor& self,
+    const Tensor& other) {
+  if (!self.has_names() && !other.has_names()) {
+    return nullopt;
+  }
+  return unify_from_right(self.names(), other.names());
+}
+
 optional<std::vector<Dimname>> compute_matmul_outnames(
     const Tensor& self,
     const Tensor& other) {

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -73,6 +73,10 @@ void check_names_for_dot(TensorImpl* vec1, TensorImpl* vec2);
 
 void propagate_names_for_expand(Tensor& result, const Tensor& self);
 
+optional<std::vector<Dimname>> compute_broadcast_outnames(
+    const Tensor& self,
+    const Tensor& other);
+
 optional<std::vector<Dimname>> compute_baddbmm_outnames(
     TensorImpl* result,
     TensorImpl* self,

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/LegacyTHFunctionsCPU.h>
+#include <ATen/NamedTensorUtils.h>
 
 namespace at { namespace native {
 
@@ -43,21 +44,30 @@ Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & s
 }
 
 Tensor masked_select_cpu(const Tensor & self, const Tensor & mask) {
+  Tensor result;
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::compute_broadcast_outnames(self, mask);
+#endif
   if (mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cpu::_th_masked_select(self, mask);
+    result = legacy::cpu::_th_masked_select(self, mask);
   } else {
-    return legacy::cpu::_th_masked_select_bool(self, mask);
+    result = legacy::cpu::_th_masked_select_bool(self, mask);
   }
+  return result;
 }
 
 Tensor & masked_select_out_cpu(Tensor & result, const Tensor & self, const Tensor & mask) {
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::compute_broadcast_outnames(self, mask);
+#endif
   if (mask.dtype() == at::ScalarType::Bool) {
-    return legacy::cpu::_th_masked_select_bool_out(result, self, mask);
+    legacy::cpu::_th_masked_select_bool_out(result, self, mask);
   } else {
-    return legacy::cpu::_th_masked_select_out(result, self, mask);
+    legacy::cpu::_th_masked_select_out(result, self, mask);
   }
+  return result;
 }
 
 Tensor argsort(const Tensor & self, int64_t dim, bool descending) {

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -44,18 +44,16 @@ Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & s
 }
 
 Tensor masked_select_cpu(const Tensor & self, const Tensor & mask) {
-  Tensor result;
 #ifdef BUILD_NAMEDTENSOR
-  auto outnames = namedinference::compute_broadcast_outnames(self, mask);
+  namedinference::compute_broadcast_outnames(self, mask);
 #endif
   if (mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    result = legacy::cpu::_th_masked_select(self, mask);
+    return legacy::cpu::_th_masked_select(self, mask);
   } else {
-    result = legacy::cpu::_th_masked_select_bool(self, mask);
+    return legacy::cpu::_th_masked_select_bool(self, mask);
   }
-  return result;
 }
 
 Tensor & masked_select_out_cpu(Tensor & result, const Tensor & self, const Tensor & mask) {
@@ -63,11 +61,10 @@ Tensor & masked_select_out_cpu(Tensor & result, const Tensor & self, const Tenso
   namedinference::compute_broadcast_outnames(self, mask);
 #endif
   if (mask.dtype() == at::ScalarType::Bool) {
-    legacy::cpu::_th_masked_select_bool_out(result, self, mask);
+    return legacy::cpu::_th_masked_select_bool_out(result, self, mask);
   } else {
-    legacy::cpu::_th_masked_select_out(result, self, mask);
+    return legacy::cpu::_th_masked_select_out(result, self, mask);
   }
-  return result;
 }
 
 Tensor argsort(const Tensor & self, int64_t dim, bool descending) {

--- a/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/LegacyTHFunctionsCUDA.h>
+#include <ATen/NamedTensorUtils.h>
 
 namespace at { namespace native {
 
@@ -43,6 +44,9 @@ Tensor & masked_scatter__cuda(Tensor& self, const Tensor & mask, const Tensor & 
 }
 
 Tensor masked_select_cuda(const Tensor & self, const Tensor & mask) {
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::compute_broadcast_outnames(self, mask);
+#endif
   if (mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_select received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
@@ -53,6 +57,9 @@ Tensor masked_select_cuda(const Tensor & self, const Tensor & mask) {
 }
 
 Tensor & masked_select_out_cuda(Tensor & result, const Tensor & self, const Tensor & mask) {
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::compute_broadcast_outnames(self, mask);
+#endif
   if (mask.dtype() == at::ScalarType::Bool) {
     return legacy::cuda::_th_masked_select_bool_out(result, self, mask);
   } else {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3852,12 +3852,14 @@
   dispatch:
     CPU: masked_select_out_cpu
     CUDA: masked_select_out_cuda
+  named_guard: False
 
 - func: masked_select(Tensor self, Tensor mask) -> Tensor
   variants: method, function
   dispatch:
     CPU: masked_select_cpu
     CUDA: masked_select_cuda
+  named_guard: False
 
 - func: nonzero.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -78,6 +78,9 @@ void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
 
 void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask)
 {
+#ifdef BUILD_NAMEDTENSOR
+  at::NoNamesGuard guard;
+#endif
   ptrdiff_t numel = THByteTensor_sumall(mask);
   scalar_t *tensor_data;
 
@@ -102,6 +105,9 @@ void THTensor_(maskedSelect)(THTensor *tensor, THTensor *src, THByteTensor *mask
 
 void THTensor_(maskedSelectBool)(THTensor *tensor, THTensor *src, THBoolTensor *mask)
 {
+#ifdef BUILD_NAMEDTENSOR
+  at::NoNamesGuard guard;
+#endif
   ptrdiff_t numel = THBoolTensor_sumall(mask);
   scalar_t *tensor_data;
 

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -2,6 +2,8 @@
 #define THC_GENERIC_FILE "THC/generic/THCTensorMasked.cu"
 #else
 
+#include <ATen/NamedTensorUtils.h>
+
 
 void THCTensor_(maskedFill)(THCState* state,
                             THCTensor *tensor, THCudaByteTensor *mask, scalar_t value)
@@ -188,6 +190,9 @@ void THCTensor_(maskedCopyByte)(THCState* state,
 
 void THCTensor_(maskedSelect)(THCState* state,
                               THCTensor* tensor, THCTensor* src, THCudaByteTensor* mask) {
+#ifdef BUILD_NAMEDTENSOR
+  at::NoNamesGuard guard;
+#endif
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, tensor, src, mask));
   THArgCheck(THCudaByteTensor_nElement(state, mask) ==
              THCTensor_(nElement)(state, src),
@@ -249,6 +254,9 @@ void THCTensor_(maskedSelect)(THCState* state,
 
 void THCTensor_(maskedSelectBool)(THCState* state,
                                    THCTensor* tensor, THCTensor* src, THCudaBoolTensor* mask) {
+#ifdef BUILD_NAMEDTENSOR
+  at::NoNamesGuard guard;
+#endif
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 3, tensor, src, mask));
   THArgCheck(THCudaBoolTensor_nElement(state, mask) ==
              THCTensor_(nElement)(state, src),

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -730,6 +730,37 @@ class TestNamedTensor(TestCase):
             if testcase.supports_multidim_reduce:
                 test_multidim_reduce(op_name, device)
 
+    def test_masked_select(self):
+        # simple
+        self._test_name_inference(
+            torch.masked_select,
+            (create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C')),
+            expected_names=[None])
+
+        # left broadcast
+        self._test_name_inference(
+            torch.masked_select,
+            (create('C:3'), (create('2,3') > 0).view_names('N', 'C')),
+            expected_names=[None])
+
+        # right broadcast
+        self._test_name_inference(
+            torch.masked_select,
+            (create('N:2,C:3'), (create('3') > 0).view_names('C')),
+            expected_names=[None])
+
+        # error
+        self._test_name_inference(
+            torch.masked_select,
+            (create('N:2,C:3'), (create('3') > 0).view_names('D')),
+            maybe_raises_regex='do not match')
+
+        # out=
+        self._test_name_inference(
+            out_fn(torch.masked_select),
+            (create('0'), create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C')),
+            expected_names=[None])
+
     def test_using_seen_interned_string_doesnt_bump_refcount(self):
         def see_name():
             seen_name = 'N'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25569 Name inference rules for relu/relu_/threshold/threshold_
* #25568 Name inference rule for torch.cat
* #25567 Name inference for masked_fill_ / masked_fill
* **#25566 Name inference rule for masked select**

masked_select returns a tensor with None names. However, it broadcasts
its inputs so we need to perform a check that they are broadcastable.

Test Plan:
- new tests [namedtensor ci]

Differential Revision: [D17159071](https://our.internmc.facebook.com/intern/diff/D17159071)