### PR TITLE
Name inference for masked_fill_ / masked_fill

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -469,6 +469,24 @@ optional<std::vector<Dimname>> compute_broadcast_outnames(
   return unify_from_right(self.names(), other.names());
 }
 
+optional<std::vector<Dimname>> broadcast_to_outnames(
+    const Tensor& tensor,
+    const Tensor& reference_tensor,
+    const char* op_name) {
+  if (!tensor.has_names() && !reference_tensor.has_names()) {
+    return nullopt;
+  }
+  auto reference_names = reference_tensor.names();
+  auto tensor_names = tensor.names();
+  TORCH_CHECK(
+      reference_names.size() >= tensor_names.size(),
+      op_name, ": attempted to broadcast Tensor", tensor_names, " to Tensor",
+      reference_names, " but the number of dims (", tensor_names.size(),
+      ") must be less than or equal to the number of dims in the tensor (",
+      reference_names.size(), ")");
+  return unify_from_right(reference_names, tensor_names);
+}
+
 optional<std::vector<Dimname>> compute_matmul_outnames(
     const Tensor& self,
     const Tensor& other) {

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -77,6 +77,11 @@ optional<std::vector<Dimname>> compute_broadcast_outnames(
     const Tensor& self,
     const Tensor& other);
 
+optional<std::vector<Dimname>> broadcast_to_outnames(
+    const Tensor& tensor,
+    const Tensor& reference_tensor,
+    const char* op_name);
+
 optional<std::vector<Dimname>> compute_baddbmm_outnames(
     TensorImpl* result,
     TensorImpl* self,

--- a/aten/src/ATen/native/Indexing.cpp
+++ b/aten/src/ATen/native/Indexing.cpp
@@ -344,15 +344,39 @@ Tensor masked_scatter(const Tensor & self, const Tensor & mask, const Tensor & s
 }
 
 Tensor masked_fill(const Tensor & self, const Tensor & mask, Scalar source) {
-  Tensor _mask, _self;
-  std::tie(_mask, _self) = expand_outplace(mask, self);
-  return _self.clone().masked_fill_(mask, source);
+  Tensor result;
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::broadcast_to_outnames(mask, self, "masked_fill");
+  {
+    NoNamesGuard guard;
+#endif
+    Tensor _mask, _self;
+    std::tie(_mask, _self) = expand_outplace(mask, self);
+    result = _self.clone();
+    result.masked_fill_(mask, source);
+#ifdef BUILD_NAMEDTENSOR
+  }
+  namedinference::propagate_names(result, std::move(outnames), /*validate_names=*/false);
+#endif
+  return result;
 }
 
 Tensor masked_fill(const Tensor & self, const Tensor & mask, const Tensor & source) {
+  Tensor result;
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::broadcast_to_outnames(mask, self, "masked_fill");
+  {
+    NoNamesGuard guard;
+#endif
   Tensor _mask, _self;
   std::tie(_mask, _self) = expand_outplace(mask, self);
-  return _self.clone().masked_fill_(mask, source);
+  result = _self.clone();
+  result.masked_fill_(mask, source);
+#ifdef BUILD_NAMEDTENSOR
+  }
+  namedinference::propagate_names(result, std::move(outnames), /*validate_names=*/false);
+#endif
+  return result;
 }
 
 Tensor _gather_sparse_backward(const Tensor& self, int64_t dim, const Tensor& index, const Tensor& grad){

--- a/aten/src/ATen/native/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/LegacyDefinitions.cpp
@@ -8,27 +8,41 @@ namespace at { namespace native {
 // Methods
 
 Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, Scalar value) {
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+#endif
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cpu::_th_masked_fill_(self, mask, value);
+    legacy::cpu::_th_masked_fill_(self, mask, value);
   } else {
-    return legacy::cpu::_th_masked_fill_bool_(self, mask, value);
+    legacy::cpu::_th_masked_fill_bool_(self, mask, value);
   }
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::propagate_names(self, std::move(outnames), /*validate_names=*/false);
+#endif
+  return self;
 }
 
 Tensor & masked_fill__cpu(Tensor& self, const Tensor & mask, const Tensor & value) {
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+#endif
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cpu::_th_masked_fill_(self, mask, value);
+    legacy::cpu::_th_masked_fill_(self, mask, value);
   } else {
-    return legacy::cpu::_th_masked_fill_bool_(self, mask, value);
+    legacy::cpu::_th_masked_fill_bool_(self, mask, value);
   }
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::propagate_names(self, std::move(outnames), /*validate_names=*/false);
+#endif
+  return self;
 }
 
 Tensor & masked_scatter__cpu(Tensor& self, const Tensor & mask, const Tensor & source) {

--- a/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
+++ b/aten/src/ATen/native/cuda/LegacyDefinitions.cpp
@@ -8,18 +8,28 @@ namespace at { namespace native {
 // Methods
 
 Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, Scalar value) {
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+#endif
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (mask.dtype() == at::ScalarType::Byte) {
     AT_WARN("masked_fill_ received a mask with dtype torch.uint8, this behavior is now deprecated," \
             "please use a mask with dtype torch.bool instead.");
-    return legacy::cuda::_th_masked_fill_(self, mask, value);
+    legacy::cuda::_th_masked_fill_(self, mask, value);
   } else {
-    return legacy::cuda::_th_masked_fill_bool_(self, mask, value);
+    legacy::cuda::_th_masked_fill_bool_(self, mask, value);
   }
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::propagate_names(self, std::move(outnames), /*validate_names=*/false);
+#endif
+  return self;
 }
 
 Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, const Tensor & value) {
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
+#endif
   // As we dispatch on self and TH is type-checked, we need different definitions.
   // This can be fixed by moving to ATen.
   if (mask.dtype() == at::ScalarType::Byte) {
@@ -29,6 +39,9 @@ Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, const Tensor & val
   } else {
     return legacy::cuda::_th_masked_fill_bool_(self, mask, value);
   }
+#ifdef BUILD_NAMEDTENSOR
+  namedinference::propagate_names(self, std::move(outnames), /*validate_names=*/false);
+#endif
 }
 
 Tensor & masked_scatter__cuda(Tensor& self, const Tensor & mask, const Tensor & source) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3164,18 +3164,22 @@
   dispatch:
     CPU: masked_fill__cpu
     CUDA: masked_fill__cuda
+  named_guard: False
 
 - func: masked_fill.Scalar(Tensor self, Tensor mask, Scalar value) -> Tensor
   variants: function, method
+  named_guard: False
 
 - func: masked_fill_.Tensor(Tensor(a!) self, Tensor mask, Tensor value) -> Tensor(a!)
   variants: method
   dispatch:
     CPU: masked_fill__cpu
     CUDA: masked_fill__cuda
+  named_guard: False
 
 - func: masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor
   variants: function, method
+  named_guard: False
 
 - func: masked_scatter_(Tensor(a!) self, Tensor mask, Tensor source) -> Tensor(a!)
   variants: method

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -154,6 +154,9 @@ void THTensor_(scatterFill)(THTensor *tensor, int dim, THLongTensor *index, scal
 
 void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
 {
+#ifdef BUILD_NAMEDTENSOR
+  at::NoNamesGuard guard;
+#endif
   int64_t tensor_size = THTensor_(nElement)(tensor);
   int tensor_contig = THTensor_(isContiguous)(tensor);
   int mask_contig = THTensor_(isContiguous)(mask);
@@ -180,6 +183,9 @@ void THTensor_(maskedFill)(THTensor *tensor, THByteTensor *mask, scalar_t value)
 
 void THTensor_(maskedFillBool)(THTensor *tensor, THBoolTensor *mask, scalar_t value)
 {
+#ifdef BUILD_NAMEDTENSOR
+  at::NoNamesGuard guard;
+#endif
   int64_t tensor_size = THTensor_(nElement)(tensor);
   int tensor_contig = THTensor_(isContiguous)(tensor);
   int mask_contig = THTensor_(isContiguous)(mask);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25569 Name inference rules for relu/relu_/threshold/threshold_
* #25568 Name inference rule for torch.cat
* **#25567 Name inference for masked_fill_ / masked_fill**
* #25566 Name inference rule for masked select

Test Plan:
- new tests [namedtensor ci]

Differential Revision: [D17159070](https://our.internmc.facebook.com/intern/diff/D17159070)