### PR TITLE
Name inference rule for torch.cat

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -51,10 +51,11 @@ static void report_positional_error(
     const Dimname& name,
     const Dimname& other_name,
     DimnameList names,
-    DimnameList other_names) {
+    DimnameList other_names,
+    const char* action) {
   // TODO(zou3519): Can improve message by checking if names are alignable and suggesting workarounds
   TORCH_CHECK(false,
-      "Error when attempting to broadcast dims ", names, " and dims ",
+      "Error when attempting to ", action, " dims ", names, " and dims ",
       other_names, ": dim ", name, " and dim ", other_name, " are at the same position "
       "from the right but do not match.")
 }
@@ -62,7 +63,8 @@ static void report_positional_error(
 static void check_for_misalignment(
     const Dimname& name,
     DimnameList names,
-    DimnameList other_names) {
+    DimnameList other_names,
+    const char* action) {
   if (name.is_wildcard()) {
     return;
   }
@@ -70,14 +72,17 @@ static void check_for_misalignment(
       [&](const Dimname& candidate) { return name.can_refer_to(candidate); });
   // TODO(zou3519): Can improve message by checking if names are alignable and suggesting workarounds
   TORCH_CHECK(it == other_names.end(),
-      "Misaligned dims when attempting to broadcast dims ", names, " and dims ",
+      "Misaligned dims when attempting to ", action, " dims ", names, " and dims ",
       other_names, ": dim ", name, " appears in a different position from the right "
       "across both lists");
 }
 
 // Assumption: A DimnameList can have no duplicate full names with
 // the exception of wildcards
-std::vector<Dimname> unify_from_right(DimnameList names, DimnameList other_names) {
+std::vector<Dimname> unify_from_right(
+    DimnameList names,
+    DimnameList other_names,
+    const char* action) {
   const auto wildcard = Dimname::wildcard();
   const auto size = std::max(names.size(), other_names.size());
   auto result = std::vector<Dimname>(size, wildcard);
@@ -97,7 +102,7 @@ std::vector<Dimname> unify_from_right(DimnameList names, DimnameList other_names
     // Step 1: Check that the names match
     const auto maybeName = unify(name, other_name);
     if (!maybeName) {
-      report_positional_error(name, other_name, names, other_names);
+      report_positional_error(name, other_name, names, other_names, action);
     }
     *result_it = *maybeName;
 
@@ -106,8 +111,8 @@ std::vector<Dimname> unify_from_right(DimnameList names, DimnameList other_names
       // Let: N = max(len(names), len(other_names))
       //      K = # of special names among names and other_names.
       // This search (including the outer loop) is O(N*K) but typically # of dims is small.
-      check_for_misalignment(name, names, other_names);
-      check_for_misalignment(other_name, other_names, names);
+      check_for_misalignment(name, names, other_names, action);
+      check_for_misalignment(other_name, other_names, names, action);
     }
 
     if (names_it != names.rend()) {
@@ -485,6 +490,22 @@ optional<std::vector<Dimname>> broadcast_to_outnames(
       ") must be less than or equal to the number of dims in the tensor (",
       reference_names.size(), ")");
   return unify_from_right(reference_names, tensor_names);
+}
+
+optional<std::vector<Dimname>> compute_cat_outnames(TensorList tensors) {
+  if (!at::has_names(tensors)) {
+    return nullopt;
+  }
+  std::vector<Dimname> result;
+  for (const auto& tensor : tensors) {
+    const auto tensor_names = tensor.names();
+    TORCH_CHECK(tensor_names.size() > 0, "zero-dimensional tensor cannot be concatenated");
+    TORCH_CHECK(result.empty() || tensor_names.size() == result.size(),
+        "Tensors must have same number of dimensions: got ", result.size(),
+        " and ", tensor_names.size());
+    result = unify_from_right(result, tensor_names, "cat");
+  }
+  return result;
 }
 
 optional<std::vector<Dimname>> compute_matmul_outnames(

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -29,7 +29,7 @@ CAFFE2_API std::vector<int64_t> dimnames_to_positions(const Tensor& tensor, Dimn
 //    the same index from the right in other.
 // 3) The output names are obtained by unifying the names individually from the right.
 CAFFE2_API std::vector<Dimname>
-unify_from_right(DimnameList names, DimnameList other);
+unify_from_right(DimnameList names, DimnameList other, const char* action = "broadcast");
 
 namespace namedinference {
 
@@ -72,6 +72,8 @@ void propagate_names_for_addmv(
 void check_names_for_dot(TensorImpl* vec1, TensorImpl* vec2);
 
 void propagate_names_for_expand(Tensor& result, const Tensor& self);
+
+optional<std::vector<Dimname>> compute_cat_outnames(TensorList tensors);
 
 optional<std::vector<Dimname>> compute_broadcast_outnames(
     const Tensor& self,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -445,8 +445,16 @@
   device_guard: False
 
 - func: cat(Tensor[] tensors, int dim=0) -> Tensor
+  named_guard: False
 
 - func: cat.out(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
+  named_guard: False
+
+- func: cat.names(Tensor[] tensors, Dimname dim) -> Tensor
+  named_guard: False
+
+- func: cat.names_out(Tensor[] tensors, Dimname dim, *, Tensor(a!) out) -> Tensor(a!)
+  named_guard: False
 
 - func: ceil(Tensor self) -> Tensor
   named_guard: False

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -761,6 +761,37 @@ class TestNamedTensor(TestCase):
             (create('0'), create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C')),
             expected_names=[None])
 
+    def test_cat(self):
+        # simple
+        self._test_name_inference(
+            torch.cat,
+            [[create('N:2,C:3'), create('N:2,C:3')]],
+            expected_names=['N', 'C'])
+
+        # error: zero dim
+        self._test_name_inference(
+            torch.cat,
+            [[create(''), create('')]],
+            maybe_raises_regex='zero-dim')
+
+        # error: names don't match
+        self._test_name_inference(
+            torch.cat,
+            [[create('N:2,C:3'), create('C:3,N:2')]],
+            maybe_raises_regex='do not match')
+
+        # error: different number of dims
+        self._test_name_inference(
+            torch.cat,
+            [[create('N:2,C:3'), create('C:3')]],
+            maybe_raises_regex='must have same number of dimensions')
+
+        # out=
+        self._test_name_inference(
+            out_fn(torch.cat),
+            [create('0'), [create('N:2,C:3'), create('N:2,C:3')]],
+            expected_names=['N', 'C'])
+
     def test_masked_fill(self):
         # simple
         self._test_name_inference(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25569 Name inference rules for relu/relu_/threshold/threshold_
* **#25568 Name inference rule for torch.cat**
* #25567 Name inference for masked_fill_ / masked_fill
* #25566 Name inference rule for masked select

Test Plan
- new test [namedtensor ci]

Differential Revision: [D17159069](https://our.internmc.facebook.com/intern/diff/D17159069)