### PR TITLE
Remove duplicate logs

### DIFF
--- a/caffe2/contrib/tensorboard/tensorboard_exporter.py
+++ b/caffe2/contrib/tensorboard/tensorboard_exporter.py
@@ -27,6 +27,9 @@ except ImportError:
         from tensorflow.core.framework.graph_pb2 import NodeDef, GraphDef
 
 
+logger = logging.getLogger(__name__)
+
+
 def _make_unique_name(seen, name, min_version=0):
     assert name is not None
     i = min_version
@@ -317,7 +320,7 @@ def _try_get_shapes(nets):
         shapes, _ = workspace.InferShapesAndTypes(nets)
         return shapes
     except Exception as e:
-        logging.warning('Failed to compute shapes: %s', e)
+        logger.warning('Failed to compute shapes: %s', e)
         return {}
 
 

--- a/caffe2/python/_import_c_extension.py
+++ b/caffe2/python/_import_c_extension.py
@@ -15,6 +15,8 @@ from caffe2.python import extension_loader
 #    expected caffe2.NetDef got caffe2.NetDef."
 import caffe2.proto
 
+logger = logging.getLogger(__name__)
+
 # We will first try to load the gpu-enabled caffe2. If it fails, we will then
 # attempt to load the cpu version. The cpu backend is the minimum required, so
 # if that still fails, we will exit loud.
@@ -28,22 +30,22 @@ with extension_loader.DlopenGuard():
         if num_cuda_devices():  # noqa
             has_gpu_support = has_cuda_support = True
     except ImportError as gpu_e:
-        logging.info('Failed to import cuda module: {}'.format(gpu_e))
+        logger.info('Failed to import cuda module: {}'.format(gpu_e))
         try:
             from caffe2.python.caffe2_pybind11_state_hip import *  # noqa
             if num_hip_devices():
                 has_gpu_support = has_hip_support = True
-                logging.info('This caffe2 python run has AMD GPU support!')
+                logger.info('This caffe2 python run has AMD GPU support!')
         except ImportError as hip_e:
-            logging.info('Failed to import AMD hip module: {}'.format(hip_e))
+            logger.info('Failed to import AMD hip module: {}'.format(hip_e))
 
-            logging.warning(
+            logger.warning(
                 'This caffe2 python run does not have GPU support. '
                 'Will run in CPU only mode.')
             try:
                 from caffe2.python.caffe2_pybind11_state import *  # noqa
             except ImportError as cpu_e:
-                logging.critical(
+                logger.critical(
                     'Cannot load caffe2.python. Error: {0}'.format(str(cpu_e)))
                 sys.exit(1)
 

--- a/caffe2/python/cnn.py
+++ b/caffe2/python/cnn.py
@@ -11,6 +11,9 @@ from caffe2.proto import caffe2_pb2
 import logging
 
 
+logger = logging.getLogger(__name__)
+
+
 class CNNModelHelper(ModelHelper):
     """A helper model so we can write CNN models more easily, without having to
     manually define parameter initializations and operators separately.
@@ -21,7 +24,7 @@ class CNNModelHelper(ModelHelper):
                  ws_nbytes_limit=None, init_params=True,
                  skip_sparse_optim=False,
                  param_model=None):
-        logging.warning(
+        logger.warning(
             "[====DEPRECATE WARNING====]: you are creating an "
             "object from CNNModelHelper class which will be deprecated soon. "
             "Please use ModelHelper object with brew module. For more "

--- a/caffe2/python/model_helper.py
+++ b/caffe2/python/model_helper.py
@@ -23,6 +23,8 @@ import logging
 import six
 
 
+logger = logging.getLogger(__name__)
+
 # _known_working_ops are operators that do not need special care.
 _known_working_ops = [
     "Accuracy",
@@ -240,7 +242,7 @@ class ModelHelper(object):
     # This method is deprecated, use create_param method which
     # also does parameter initialization when needed
     def add_param_DEPRECATED(self, param, key=None, shape=None, length=None):
-        logging.warning("add_param method is DEPRECATED")
+        logger.warning("add_param method is DEPRECATED")
         self._update_param_info_deprecated()
         self.AddParameter(param)
         if key is not None and self.net.input_record() is not None:
@@ -438,7 +440,7 @@ class ModelHelper(object):
                 raise AttributeError(
                     "Operator {} is not known to be safe".format(op_type))
 
-            logging.warning("You are creating an op that the ModelHelper "
+            logger.warning("You are creating an op that the ModelHelper "
                             "does not recognize: {}.".format(op_type))
         return self.net.__getattr__(op_type)
 
@@ -617,7 +619,7 @@ def ExtractPredictorNet(
             )
 
         else:
-            logging.debug(
+            logger.debug(
                 "Op {} had unknown inputs: {}".format(
                     op.type, set(op.input).difference(known_blobs)
                 )

--- a/caffe2/python/rnn_cell.py
+++ b/caffe2/python/rnn_cell.py
@@ -29,6 +29,9 @@ from caffe2.python.modeling.initializers import Initializer
 from caffe2.python.model_helper import ModelHelper
 
 
+logger = logging.getLogger(__name__)
+
+
 def _RectifyName(blob_reference_or_name):
     if blob_reference_or_name is None:
         return None
@@ -1652,7 +1655,7 @@ class UnrolledCell(RNNCell):
             outputs_with_grads)
         for i in outputs_without_grad:
             model.net.ZeroGradient(outputs[i], [])
-        logging.debug("Added 0 gradients for blobs:",
+        logger.debug("Added 0 gradients for blobs:",
                       [outputs[i] for i in outputs_without_grad])
 
         final_output = self.cell._prepare_output_sequence(model, outputs)

--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -23,6 +23,8 @@ from ._convert_np import make_np
 from ._utils import _prepare_video, convert_to_HWC
 
 
+logger = logging.getLogger(__name__)
+
 _INVALID_TAG_CHARACTERS = _re.compile(r'[^-/\w\.]')
 
 
@@ -43,7 +45,7 @@ def _clean_tag(name):
         new_name = _INVALID_TAG_CHARACTERS.sub('_', name)
         new_name = new_name.lstrip('/')  # Remove leading slashes
         if new_name != name:
-            logging.info(
+            logger.info(
                 'Summary name %s is illegal; using %s instead.' % (name, new_name))
             name = new_name
     return name
@@ -115,10 +117,10 @@ def hparams(hparam_dict=None, metric_dict=None):
     # hparam_infos=[hp], metric_infos=[mt], user='tw')
 
     if not isinstance(hparam_dict, dict):
-        logging.warning('parameter: hparam_dict should be a dictionary, nothing logged.')
+        logger.warning('parameter: hparam_dict should be a dictionary, nothing logged.')
         raise TypeError('parameter: hparam_dict should be a dictionary, nothing logged.')
     if not isinstance(metric_dict, dict):
-        logging.warning('parameter: metric_dict should be a dictionary, nothing logged.')
+        logger.warning('parameter: metric_dict should be a dictionary, nothing logged.')
         raise TypeError('parameter: metric_dict should be a dictionary, nothing logged.')
 
     hps = [HParamInfo(name=k) for k in hparam_dict.keys()]
@@ -425,7 +427,7 @@ def make_video(tensor, fps):
     try:
         os.remove(filename)
     except OSError:
-        logging.warning('The temporary file used by moviepy cannot be deleted.')
+        logger.warning('The temporary file used by moviepy cannot be deleted.')
 
     return Summary.Image(height=h, width=w, colorspace=c, encoded_image_string=tensor_string)
 


### PR DESCRIPTION
# Problem description

There are a few call to `logging.info()`, `logging.debug()`, etc in the library. Such calls add an `logging.StreamHandler` to the `RootLogger`.
This is annoying because since all other loggers inherit from this logger, which mean that if a client code sets up another logger, with another handler, the logs will be output twice (once through the client handler and once by the root logger handler added by Pytorch)

# Solution

I replaced in the library code, the calls to `logging.info()`, `logging.debug()` and `logging.warning()` to `logger = logging.getLogger(__name__);logger.info()` which don't add an handler to the `RootLogger`.

There are a few remaining calls to `logging.debug()`, `logging.info()`, `logging.warning()` and `logging.BasicConfig()` (which also adds an handler to the `RootLogger`)  in the tests or scripts, which shouldn't be a problem since client code won't use these files.