### PR TITLE
Kill unused enumerate_options_due_to_default.

### DIFF
--- a/aten/src/ATen/common_with_cwrap.py
+++ b/aten/src/ATen/common_with_cwrap.py
@@ -94,43 +94,6 @@ def filter_unique_options(options, allow_kwarg, type_to_signature, remove_self):
     return unique
 
 
-def enumerate_options_due_to_default(declaration,
-                                     allow_kwarg=True, type_to_signature=None, remove_self=True):
-
-    if type_to_signature is None:
-        type_to_signature = []
-
-    # Checks to see if an argument with a default keyword is a Tensor that
-    # by default can be NULL. In this case, instead of generating another
-    # option that excludes this argument, we will instead generate a single
-    # function call that allows for the Tensor to be NULL
-    def is_nullable_tensor_arg(arg):
-        return arg['type'] == 'THTensor*' and arg['default'] == 'nullptr'
-
-    # TODO(zach): in cwrap this is shared among all declarations
-    # but seems to assume that all declarations will have the same
-    new_options = []
-    for option in declaration['options']:
-        optional_args = []
-        for i, arg in enumerate(option['arguments']):
-            if 'default' in arg:
-                optional_args.append(i)
-        for permutation in product((True, False), repeat=len(optional_args)):
-            option_copy = deepcopy(option)
-            option_copy['has_full_argument_list'] = sum(permutation) == len(optional_args)
-            for i, bit in zip(optional_args, permutation):
-                arg = option_copy['arguments'][i]
-                # PyYAML interprets NULL as None...
-                arg['default'] = 'NULL' if arg['default'] is None else arg['default']
-                if not bit:
-                    arg['declared_type'] = arg['type']
-                    arg['type'] = 'CONSTANT'
-                    arg['ignore_check'] = True
-            new_options.append(option_copy)
-    declaration['options'] = filter_unique_options(new_options,
-                                                   allow_kwarg, type_to_signature, remove_self)
-
-
 def sort_by_number_of_options(declaration, reverse=True):
     def num_checked_args(option):
         return sum(map(lambda a: not a.get('ignore_check', False), option['arguments']))

--- a/aten/src/ATen/common_with_cwrap.py
+++ b/aten/src/ATen/common_with_cwrap.py
@@ -1,9 +1,6 @@
 # this code should be common among cwrap and ATen preprocessing
 # for now, I have put it in one place but right now is copied out of cwrap
 
-from copy import deepcopy
-from itertools import product
-
 
 def parse_arguments(args):
     new_args = []

--- a/tools/shared/__init__.py
+++ b/tools/shared/__init__.py
@@ -1,2 +1,2 @@
 from .module_loader import import_module  # noqa: F401
-from .cwrap_common import set_declaration_defaults, sort_by_number_of_options, enumerate_options_due_to_default  # noqa: F401
+from .cwrap_common import set_declaration_defaults, sort_by_number_of_options  # noqa: F401


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25655 Kill declared_type and ignore_check from THFormal.
* #25615 Kill if_true / if_false in Declarations.cwarp.
* #25614 Replace simple if_true / if_false cases in Declarations.cwrap.
* #25613 Kill aten_custom_call.
* #25612 Kill remaining defaults in Declarations.cwrap.
* #25611 Get rid of more defaults in Declarations.cwrap.
* #25610 Kill most defaults in Declarations.cwrap.
* #25609 Kill kwarg_only declarations in Declarations.cwrap.
* #25608 Stop reordering TH random function arguments.
* #25607 Kill TH(C)Blas kwarg_only declarations.
* #25606 Stop re-ordering TH(C)Blas arguments.
* #25589 Kill discover_sparse_tensor_operations.
* **#25588 Kill unused enumerate_options_due_to_default.**

Differential Revision: [D17172502](https://our.internmc.facebook.com/intern/diff/D17172502)