### PR TITLE
Kill discover_sparse_tensor_operations.

### DIFF
--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -207,18 +207,6 @@ def discover_zero_dim_tensor_operations(declaration):
                     # print("SHARED "+names[i])
 
 
-def discover_sparse_tensor_operations(declaration):
-    def exclude(arg):
-        return arg.get('ignore_check')
-
-    def signature(option, i=None, value=None):
-        elements = [TYPE_FORMAL_GENERIC.get(arg['type'], arg['type'])
-                    if i is None or j != i else value
-                    for j, arg in enumerate(option['arguments'])
-                    if not exclude(arg)]
-        return '#'.join(elements)
-
-
 def is_extended_method(option):
     if 'method' in option['variants']:
         return False
@@ -241,7 +229,6 @@ def run(declarations):
         common_with_cwrap.sort_by_number_of_options(declaration)
 
         discover_zero_dim_tensor_operations(declaration)
-        discover_sparse_tensor_operations(declaration)
 
         for option in declaration['options']:
             set_mode(option)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25655 Kill declared_type and ignore_check from THFormal.
* #25615 Kill if_true / if_false in Declarations.cwarp.
* #25614 Replace simple if_true / if_false cases in Declarations.cwrap.
* #25613 Kill aten_custom_call.
* #25612 Kill remaining defaults in Declarations.cwrap.
* #25611 Get rid of more defaults in Declarations.cwrap.
* #25610 Kill most defaults in Declarations.cwrap.
* #25609 Kill kwarg_only declarations in Declarations.cwrap.
* #25608 Stop reordering TH random function arguments.
* #25607 Kill TH(C)Blas kwarg_only declarations.
* #25606 Stop re-ordering TH(C)Blas arguments.
* **#25589 Kill discover_sparse_tensor_operations.**
* #25588 Kill unused enumerate_options_due_to_default.

It's not used anymore.

Differential Revision: [D17172501](https://our.internmc.facebook.com/intern/diff/D17172501)