### PR TITLE
Don't save `self` in `index` backward

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1067,6 +1067,18 @@ class TestAutograd(TestCase):
         expected_grad[1].fill_(3)
         self.assertEqual(y.grad.data, expected_grad)
 
+    def test_index_backward_does_not_save_tensor(self):
+        # Example from https://github.com/pytorch/pytorch/issues/24853.
+        # if `index(tensor, indices)` saves `tensor` for backwards, then it will
+        # trigger a version check on `tensor` during the backward pass, which
+        # will cause the following code to error because `tensor` gets modified
+        # by the indexing line.
+        a = torch.tensor([1., 0, 0])
+        b = torch.zeros(3, requires_grad=True)
+        tensor = b + 0
+        tensor[a != 0] = tensor[a != 0]
+        tensor.backward(torch.zeros_like(tensor))
+
     def test_volatile_deprecated(self):
         v = torch.autograd.torch.randn(3, 3)
         with warnings.catch_warnings(record=True) as w:

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -387,7 +387,7 @@
   self: not_implemented("histc")
 
 - name: index(Tensor self, Tensor?[] indices) -> Tensor
-  self: index_backward(self, indices, grad)
+  self: index_backward(zeros_like(self), indices, grad)
   indices: TensorList()
 
 - name: index_add_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)

--- a/tools/autograd/templates/Functions.cpp
+++ b/tools/autograd/templates/Functions.cpp
@@ -2303,9 +2303,8 @@ Tensor embedding_dense_double_backward(const Tensor & grad, const Tensor & indic
   return gg_weight.view(size);
 }
 
-Tensor index_backward(const Tensor & self, TensorList indices, const Tensor& grad) {
-   auto zeros = at::zeros_like(self);
-   return at::_index_put_impl_(zeros, indices, grad, true, true);
+Tensor index_backward(Tensor zeros_like_self, TensorList indices, const Tensor& grad) {
+   return at::_index_put_impl_(zeros_like_self, indices, grad, true, true);
 }
 
 


### PR DESCRIPTION
`self` isn't necessary for `index` backward, we only need the shape of
`self`. Changing derivatives.yaml to use `zeros_like(self)` triggers a
codepath in the codegen to only save the shape.

Fixes https://github.com/pytorch/pytorch/issues/24853.

Test Plan
- I added a new test that is adapted from the code in
https://github.com/pytorch/pytorch/issues/24853. I'm not sure what a
more minimal example would look like because the bug is hard to trigger
because of how autograd handles differential views.

