### PR TITLE
[tensorboard] Fix empty graph problem

### DIFF
--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -151,6 +151,11 @@ class GraphPy(object):
                 self.unique_name_to_scoped_name[input_node_id] = node.scopeName + '/' + input_node_id
 
         for key, node in self.nodes_io.items():
+            if type(node) == NodeBase:
+                self.unique_name_to_scoped_name[key] = node.scope + '/' + node.debugName
+            if hasattr(node, 'input_or_output'):
+                self.unique_name_to_scoped_name[key] = node.input_or_output + '/' + node.debugName
+
             if hasattr(node, 'scope') and node.scope is not None:
                 self.unique_name_to_scoped_name[key] = node.scope + '/' + node.debugName
                 if node.scope == '' and self.shallowest_scope_name:


### PR DESCRIPTION
This fixes the empty graph problem since pytorch 1.2

To prevent such things happen, we have to make the test harder.

There 3 levels of verification.
lv 1. make sure that the graph is saved to some event file.  <--currently here
lv 2. make sure the file can be read by tensorboard.
lv 3. make sure the graph in tensorboard is human-friendly.

I think (3) must be involved by a human. 
(2) is possible, but it will be useless if we want to use lv 3 directly.

cc @orionr 