### PR TITLE
[Pytorch-iOS] Fix iOS x86(Simulator) build

### DIFF
--- a/caffe2/perfkernels/CMakeLists.txt
+++ b/caffe2/perfkernels/CMakeLists.txt
@@ -89,3 +89,14 @@ set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
 set(Caffe2_DEPENDENCY_WHOLE_LINK_LIBS
     ${Caffe2_DEPENDENCY_WHOLE_LINK_LIBS}
     PARENT_SCOPE)
+
+# For iOS x86_64 build, the libCaffe2_perfkernels_avx2.a is not installed properly.
+# In the future, this file might be removed from mobile.  This is just a temporary fix 
+# until we find a better solution.
+
+if (IOS)
+    if (${IOS_PLATFORM} STREQUAL "SIMULATOR")
+        install (TARGETS Caffe2_perfkernels_avx2 EXPORT Caffe2Targets DESTINATION lib)
+    endif()
+endif()
+

--- a/caffe2/perfkernels/CMakeLists.txt
+++ b/caffe2/perfkernels/CMakeLists.txt
@@ -89,14 +89,3 @@ set(Caffe2_CPU_SRCS ${Caffe2_CPU_SRCS} PARENT_SCOPE)
 set(Caffe2_DEPENDENCY_WHOLE_LINK_LIBS
     ${Caffe2_DEPENDENCY_WHOLE_LINK_LIBS}
     PARENT_SCOPE)
-
-# For iOS x86_64 build, the libCaffe2_perfkernels_avx2.a is not installed properly.
-# In the future, this file might be removed from mobile.  This is just a temporary fix 
-# until we find a better solution.
-
-if (IOS)
-    if (${IOS_PLATFORM} STREQUAL "SIMULATOR")
-        install (TARGETS Caffe2_perfkernels_avx2 EXPORT Caffe2Targets DESTINATION lib)
-    endif()
-endif()
-

--- a/cmake/MiscCheck.cmake
+++ b/cmake/MiscCheck.cmake
@@ -154,30 +154,32 @@ endif()
 cmake_pop_check_state()
 
 # ---[ Check if the compiler has AVX/AVX2 support. We only check AVX2.
-cmake_push_check_state(RESET)
-if (MSVC)
-  set(CMAKE_REQUIRED_FLAGS "/arch:AVX2")
-else()
-  set(CMAKE_REQUIRED_FLAGS "-mavx2")
+if(NOT INTERN_BUILD_MOBILE)
+  cmake_push_check_state(RESET)
+  if (MSVC)
+    set(CMAKE_REQUIRED_FLAGS "/arch:AVX2")
+  else()
+    set(CMAKE_REQUIRED_FLAGS "-mavx2")
+  endif()
+  CHECK_CXX_SOURCE_COMPILES(
+      "#include <immintrin.h>
+      int main() {
+        __m256i a, b;
+        a = _mm256_set1_epi8 (1);
+        b = a;
+        _mm256_add_epi8 (a,a);
+        __m256i x;
+        _mm256_extract_epi64(x, 0); // we rely on this in our AVX2 code
+        return 0;
+      }" CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
+  if (CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
+    message(STATUS "Current compiler supports avx2 extension. Will build perfkernels.")
+    # Also see CMakeLists.txt under caffe2/perfkernels.
+    set(CAFFE2_PERF_WITH_AVX 1)
+    set(CAFFE2_PERF_WITH_AVX2 1)
+  endif()
+  cmake_pop_check_state()
 endif()
-CHECK_CXX_SOURCE_COMPILES(
-    "#include <immintrin.h>
-     int main() {
-       __m256i a, b;
-       a = _mm256_set1_epi8 (1);
-       b = a;
-       _mm256_add_epi8 (a,a);
-       __m256i x;
-       _mm256_extract_epi64(x, 0); // we rely on this in our AVX2 code
-       return 0;
-     }" CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
-if (CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
-  message(STATUS "Current compiler supports avx2 extension. Will build perfkernels.")
-  # Also see CMakeLists.txt under caffe2/perfkernels.
-  set(CAFFE2_PERF_WITH_AVX 1)
-  set(CAFFE2_PERF_WITH_AVX2 1)
-endif()
-cmake_pop_check_state()
 
 # ---[ Check if the compiler has AVX512 support.
 cmake_push_check_state(RESET)
@@ -306,13 +308,12 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
               #      dllexport in cc file. The strategy is copied from gflags.
   )
 
+  # Make sure windows.h does not include additional headers.
+  add_definitions("/DWIN32_LEAN_AND_MEAN")
+
   # Make sure windef.h does not define max/min macros.
   # Required by ATen among others.
   add_definitions("/DNOMINMAX")
-
-  # Exception handing for compiler warining C4530, see
-  # https://msdn.microsoft.com/en-us/library/2axwkyt4.aspx
-  add_definitions("/EHsc")
 
   set(CMAKE_SHARED_LINKER_FLAGS
       "${CMAKE_SHARED_LINKER_FLAGS} /ignore:4049 /ignore:4217")

--- a/cmake/iOS.cmake
+++ b/cmake/iOS.cmake
@@ -66,18 +66,11 @@ if (${IOS_PLATFORM} STREQUAL "OS")
     # This causes the installers to properly locate the output libraries
     set (CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos")
 elseif (${IOS_PLATFORM} STREQUAL "SIMULATOR")
-    set (SIMULATOR true)
     set (IOS_PLATFORM_LOCATION "iPhoneSimulator.platform")
     set (XCODE_IOS_PLATFORM iphonesimulator)
 
     # This causes the installers to properly locate the output libraries
     set (CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphonesimulator")
-elseif (${IOS_PLATFORM} STREQUAL "WATCHOS")
-    set (IOS_PLATFORM_LOCATION "WatchOS.platform")
-    set (XCODE_IOS_PLATFORM watchos)
-
-    # This causes the installers to properly locate the output libraries
-    set (CMAKE_XCODE_EFFECTIVE_PLATFORMS "-watchos")
 else (${IOS_PLATFORM} STREQUAL "OS")
     message (FATAL_ERROR
              "Unsupported IOS_PLATFORM value selected. "
@@ -161,16 +154,18 @@ set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS su
 if (IOS_PLATFORM STREQUAL "OS")
     set (DEFAULT_IOS_ARCH "armv7;armv7s;arm64")
 elseif (IOS_PLATFORM STREQUAL "SIMULATOR")
-    set (DEFAULT_IOS_ARCH "i386;x86_64")
-elseif (IOS_PLATFORM STREQUAL "WATCHOS")
-    set (DEFAULT_IOS_ARCH "armv7k")
+    set (DEFAULT_IOS_ARCH "x86_64")
+else()
+    message (FATAL_ERROR 
+             "Unsupported IOS_PLATFORM value selected. "
+             "Please choose OS, SIMULATOR.")
 endif ()
 
-set (IOS_ARCH ${DEFAULT_IOS_ARCH} CACHE string  "Build architecture for iOS")
-set (CMAKE_OSX_ARCHITECTURES ${IOS_ARCH} CACHE string  "Build architecture for iOS")
+set (IOS_ARCH ${DEFAULT_IOS_ARCH} CACHE STRING  "Build architecture for iOS")
+set (CMAKE_OSX_ARCHITECTURES ${IOS_ARCH} CACHE STRING  "Build architecture for iOS")
 
 # Set the find root to the iOS developer roots and to user defined paths
-set (CMAKE_FIND_ROOT_PATH ${CMAKE_IOS_DEVELOPER_ROOT} ${CMAKE_IOS_SDK_ROOT} ${CMAKE_PREFIX_PATH} CACHE string  "iOS find search path root")
+set (CMAKE_FIND_ROOT_PATH ${CMAKE_IOS_DEVELOPER_ROOT} ${CMAKE_IOS_SDK_ROOT} ${CMAKE_PREFIX_PATH} CACHE STRING  "iOS find search path root")
 
 # default to searching for frameworks first
 set (CMAKE_FIND_FRAMEWORK FIRST)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25630 [Pytorch-iOS] Fix iOS x86(Simulator) build**

Summary:

The iOS simulator build (x86_64) is broken right now. The goal of this PR is to fix it and make Pytorch compile and run on iOS Simulators.

Test Plan:

1. The `build_ios.sh` can be run successfully for iOS x86 build. The build script I'm using:

	```shell
   	./scripts/build_ios.sh \
   	-DBUILD_CAFFE2_MOBILE=OFF \
	-DIOS_PLATFORM=SIMULATOR \
   	-DUSE_NNPACK=OFF \
	-DUSE_QNNPACK=OFF \
   	-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())') \
   	-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')
   	```
2. All generated static libs are x86 libs as shown below

	```
	> lipo -i *.a
	Non-fat file: libCaffe2_perfkernels_avx2.a is architecture: x86_64
	Non-fat file: libasmjit.a is architecture: x86_64
	Non-fat file: libc10.a is architecture: x86_64
	Non-fat file: libcaffe2_protos.a is architecture: x86_64
	Non-fat file: libclog.a is architecture: x86_64
	Non-fat file: libcpuinfo.a is architecture: x86_64
	Non-fat file: libfbgemm.a is architecture: x86_64
	Non-fat file: libtorch.a is architecture: x86_64
	```
3. Run Pytorch on iOS simulator
	<img src="https://github.com/xta0/Sat842/blob/master/screenshots-simulator.png?raw=true" with="480">