### PR TITLE
[iOS]Fix iOS simulator build

### DIFF
--- a/cmake/iOS.cmake
+++ b/cmake/iOS.cmake
@@ -66,7 +66,6 @@ if (${IOS_PLATFORM} STREQUAL "OS")
     # This causes the installers to properly locate the output libraries
     set (CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos")
 elseif (${IOS_PLATFORM} STREQUAL "SIMULATOR")
-    set (SIMULATOR true)
     set (IOS_PLATFORM_LOCATION "iPhoneSimulator.platform")
     set (XCODE_IOS_PLATFORM iphonesimulator)
 
@@ -161,7 +160,7 @@ set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS su
 if (IOS_PLATFORM STREQUAL "OS")
     set (DEFAULT_IOS_ARCH "armv7;armv7s;arm64")
 elseif (IOS_PLATFORM STREQUAL "SIMULATOR")
-    set (DEFAULT_IOS_ARCH "i386;x86_64")
+    set (DEFAULT_IOS_ARCH "x86_64")
 elseif (IOS_PLATFORM STREQUAL "WATCHOS")
     set (DEFAULT_IOS_ARCH "armv7k")
 endif ()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25633 [iOS]Fix iOS simulator build**

Summary:

The iOS simulator build (x86_64) is broken right now. To fix it:

1. Fix the bug in iOS.cmake
2. Disable avx2 for mobile x86_64 build

Test Plan:

1. The `build_ios.sh` can be run successfully for iOS x86 build. The build script I'm using:

	```shell
   	./scripts/build_ios.sh \
   	-DBUILD_CAFFE2_MOBILE=OFF \
	-DIOS_PLATFORM=SIMULATOR \
   	-DUSE_NNPACK=OFF \
   	-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())') \
   	-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')
   	```
2. All generated static libs are x86 libs as shown below

	```
	> lipo -i *.a
	Non-fat file: libasmjit.a is architecture: x86_64
	Non-fat file: libc10.a is architecture: x86_64
	Non-fat file: libcaffe2_protos.a is architecture: x86_64
	Non-fat file: libclog.a is architecture: x86_64
	Non-fat file: libcpuinfo.a is architecture: x86_64
	Non-fat file: libfbgemm.a is architecture: x86_64
	Non-fat file: libtorch.a is architecture: x86_64

Differential Revision: [D17183803](https://our.internmc.facebook.com/intern/diff/D17183803)