### PR TITLE
Ensure NCCL error handling code is disabled for NCCL versions < 2.4

### DIFF
--- a/test/common_distributed.py
+++ b/test/common_distributed.py
@@ -64,6 +64,18 @@ def requires_gloo():
         "c10d was not compiled with the Gloo backend",
     )
 
+def requires_nccl_version(version, msg):
+    if not c10d.is_nccl_available():
+        return unittest.skip(
+            "c10d was not compiled with the NCCL backend",
+        )
+    elif torch.cuda.nccl.version() >= version:
+        return unittest.skip(
+            "Requires NCCL version greater than or equal to: {}, found: {}, reason: {}".format(
+                version,
+                torch.cuda.nccl.version(), msg
+            ),
+        )
 
 def requires_nccl():
     return unittest.skipUnless(

--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -25,7 +25,7 @@ import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel
 
 from common_distributed import MultiProcessTestCase, \
-    requires_gloo, requires_nccl, \
+    requires_gloo, requires_nccl, requires_nccl_version, \
     skip_if_not_multigpu, skip_if_lt_x_gpu, skip_for_known_issues, get_timeout
 from common_utils import TestCase, load_tests, run_tests
 from common_utils import retry_on_address_already_in_use_error
@@ -2970,6 +2970,7 @@ class CommTest(MultiProcessTestCase):
         pg.allreduce(torch.rand(10).cuda(self.rank))
 
     @requires_nccl()
+    @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_not_multigpu
     def test_nccl_errors_nonblocking(self):
         store = c10d.FileStore(self.file.name, self.world_size)
@@ -3008,26 +3009,31 @@ class CommTest(MultiProcessTestCase):
             func()
 
     @requires_nccl()
+    @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_not_multigpu
     def test_nccl_errors_blocking_clean_exit(self):
         self._test_nccl_errors_blocking(lambda : sys.exit(0))
 
     @requires_nccl()
+    @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_not_multigpu
     def test_nccl_errors_blocking_nonzero_exit(self):
         self._test_nccl_errors_blocking(lambda : sys.exit(1))
 
     @requires_nccl()
+    @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_not_multigpu
     def test_nccl_errors_blocking_abort(self):
         self._test_nccl_errors_blocking(lambda : os.abort())
 
     @requires_nccl()
+    @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_not_multigpu
     def test_nccl_errors_blocking_sigkill(self):
         self._test_nccl_errors_blocking(lambda : os.kill(os.getpid(), signal.SIGKILL))
 
     @requires_nccl()
+    @requires_nccl_version(2400, "Need NCCL 2.4+ for error checking")
     @skip_if_not_multigpu
     def test_nccl_errors_blocking_sigterm(self):
         self._test_nccl_errors_blocking(lambda : os.kill(os.getpid(), signal.SIGTERM))

--- a/torch/lib/c10d/NCCLUtils.hpp
+++ b/torch/lib/c10d/NCCLUtils.hpp
@@ -1,14 +1,16 @@
 #pragma once
 
-#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
-    (NCCL_MINOR < 4)
-#error "Need NCCL version 2.4+"
-#elif defined(NCCL_MAJOR) && (NCCL_MAJOR < 2)
-#error "Need NCCL version 2.4+"
-#endif
-
 #include <nccl.h>
 #include <memory>
+
+// Error checking is enabled only for NCCL versions 2.4+ since ncclCommAbort()
+// and ncclCommGetAsyncError() are not supported in earlier versions.
+#if defined(NCCL_MAJOR) && (NCCL_MAJOR == 2) && defined(NCCL_MINOR) && \
+    (NCCL_MINOR >= 4)
+#define ENABLE_NCCL_ERROR_CHECKING
+#elif defined(NCCL_MAJOR) && (NCCL_MAJOR >= 3)
+#define ENABLE_NCCL_ERROR_CHECKING
+#endif
 
 #define C10D_NCCL_CHECK(cmd)                                              \
   do {                                                                    \
@@ -33,9 +35,14 @@ class NCCLComm {
 
   ~NCCLComm() noexcept(false) {
     if (ncclComm_ && !aborted_) {
-      // Use ncclCommAbort instead of ncclCommDestroy here since ncclCommDestroy
-      // could block forever waiting for work to complete on the communicator.
+#ifdef ENABLE_NCCL_ERROR_CHECKING
+      // Use ncclCommAbort instead of ncclCommDestroy here since
+      // ncclCommDestroy could block forever waiting for work to complete on
+      // the communicator.
       ncclCommAbort();
+#else
+      C10D_NCCL_CHECK(::ncclCommDestroy(ncclComm_));
+#endif
     }
   }
 
@@ -76,6 +83,7 @@ class NCCLComm {
   }
 
   void ncclCommAbort() {
+#ifdef ENABLE_NCCL_ERROR_CHECKING
     if (aborted_) {
       // Should not abort twice.
       return;
@@ -89,6 +97,10 @@ class NCCLComm {
     if (ncclAsyncErr_ == ncclSuccess) {
       ncclAsyncErr_ = ncclSystemError;
     }
+#else
+    // This is a NOOP, if error checks are disabled.
+    return;
+#endif
   }
 
   bool isAborted() const {
@@ -96,11 +108,16 @@ class NCCLComm {
   }
 
   ncclResult_t checkForNcclError() {
+#ifdef ENABLE_NCCL_ERROR_CHECKING
     if (ncclAsyncErr_ != ncclSuccess) {
       return ncclAsyncErr_;
     }
     C10D_NCCL_CHECK(ncclCommGetAsyncError(ncclComm_, &ncclAsyncErr_));
     return ncclAsyncErr_;
+#else
+    // Always return success, if error checks are disabled.
+    return ncclSuccess;
+#endif
   }
 
  protected:

--- a/torch/lib/c10d/test/CMakeLists.txt
+++ b/torch/lib/c10d/test/CMakeLists.txt
@@ -1,3 +1,19 @@
+if(USE_C10D_NCCL)
+  if (MSVC)
+    set(LIBSHM_SUBDIR libshm_windows)
+  else()
+    set(LIBSHM_SUBDIR libshm)
+  endif()
+
+  set(LIBSHM_SRCDIR ${TORCH_SRC_DIR}/lib/${LIBSHM_SUBDIR})
+
+  add_library(nccl_utils SHARED ${TORCH_SRC_DIR}/csrc/cuda/nccl.cpp)
+  target_link_libraries(nccl_utils __caffe2_nccl shm)
+  target_include_directories(nccl_utils PUBLIC
+      ${CMAKE_BINARY_DIR}/caffe2/aten/src ${CMAKE_BINARY_DIR}/nccl/include
+      ${LIBSHM_SRCDIR})
+endif()
+
 if(USE_CUDA)
   cuda_add_library(c10d_cuda_test CUDATest.cu)
   target_link_libraries(c10d_cuda_test c10d)
@@ -23,7 +39,8 @@ if(USE_CUDA)
   endif()
   if(USE_C10D_NCCL)
     c10d_add_test(ProcessGroupNCCLTest.cpp c10d c10d_cuda_test)
-    c10d_add_test(ProcessGroupNCCLErrorsTest.cpp c10d c10d_cuda_test gtest_main)
+    c10d_add_test(ProcessGroupNCCLErrorsTest.cpp nccl_utils c10d c10d_cuda_test
+        gtest_main)
   endif()
 else()
   if(USE_C10D_GLOO)

--- a/torch/lib/c10d/test/ProcessGroupNCCLErrorsTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLErrorsTest.cpp
@@ -3,6 +3,7 @@
 #include <c10d/test/CUDATest.hpp>
 #include <c10d/test/TestUtils.hpp>
 #include <gtest/gtest.h>
+#include <torch/csrc/cuda/nccl.h>
 
 using namespace c10d::test;
 
@@ -71,8 +72,14 @@ class ProcessGroupNCCLSimulateErrors : public c10d::ProcessGroupNCCL {
 class ProcessGroupNCCLErrorsTest : public ::testing::Test {
  protected:
   bool skipTest() {
-    // Skip test if no cuda devices found.
-    return cudaNumDevices() == 0;
+    if (cudaNumDevices() == 0) {
+      return true;
+    }
+#ifdef USE_C10D_NCCL
+    return torch::cuda::nccl::version() < 2400;
+#else
+    return false;
+#endif
   }
 
   void SetUp() override {


### PR DESCRIPTION
Summary:
ncclCommAbort() and ncclGetAsyncError() were two APIs added in NCCL
2.4 to detect errors in NCCL communicators. These were used as part of
ProcesGroupNCCL and we also enforced that only NCCL versions 2.4+ were
supported. Although, there is still legitimate use for older NCCL versions and
hence we should still support those.

For that purpose, in this change I've ensured we disable NCCL error checking
for versions < 2.4.

Test Plan:
1) Test with 2.4.8
2) Test with 2.2.13
3) unit tests.

Differential Revision: D17178988

