### PR TITLE
Fix clang-tidy script

### DIFF
--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -126,6 +126,9 @@ def get_changed_lines(revision, filename):
     for chunk in re.finditer(CHUNK_PATTERN, output, re.MULTILINE):
         start = int(chunk.group(1))
         count = int(chunk.group(2) or 1)
+        # If count == 0, a chunk was removed and can be ignored.
+        if count == 0:
+            continue
         changed_lines.append([start, start + count])
 
     return {"name": filename, "lines": changed_lines}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25652 Fix clang-tidy script**

The clang-tidy driver script generates a chunk whitelist per file so
that it only shows errors for lines that were actually changed. If a
change removes the chunk the count is equal to 0. If the chunk happens
to be at the start of the file, and the start position is equal 0,
clang-tidy fails to run. This change filters out those chunks.

Differential Revision: [D17184188](https://our.internmc.facebook.com/intern/diff/D17184188)