### PR TITLE
[JIT] add __getitem__ to class types

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18984,6 +18984,10 @@ class TestClassType(JitTestCase):
                 # type: (int) -> int
                 return self.x ^ other
 
+            def __getitem__(self, other):
+                # type: (int) -> int
+                return other + 1
+
         def add():
             return BinOps(4) + 3
         def sub():  # noqa: E306
@@ -19012,8 +19016,10 @@ class TestClassType(JitTestCase):
             return BinOps(4) | 3
         def _xor():  # noqa: E306
             return BinOps(4) ^ 3
+        def getitem():  # noqa: E306
+            return BinOps(4)[1]
 
-        ops = [add, sub, mul, pow, ne, eq, lt, gt, le, ge, _and, _or, _xor]
+        ops = [add, sub, mul, pow, ne, eq, lt, gt, le, ge, _and, _or, _xor, getitem]
         if not PY2:
             ops.append(truediv)
         for func in ops:

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -302,7 +302,7 @@ std::shared_ptr<SugaredValue> callClassMethod(
                            << desugared_name << " method";
   }
 
-  Value* self = inputs[0].value(*m.graph());
+  Value* self = inputs.at(0).value(*m.graph());
   return MethodValue(self, desugared_name)
       .call(loc, m, inputs.slice(1), attributes, n_binders);
 }

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -289,6 +289,24 @@ Value* SimpleValue::len(const SourceRange& loc, Function& m) {
   }
 }
 
+std::shared_ptr<SugaredValue> callClassMethod(
+    const ClassTypePtr& class_ptr,
+    const std::string& desugared_name,
+    const SourceRange& loc,
+    Function& m,
+    at::ArrayRef<NamedValue> inputs,
+    at::ArrayRef<NamedValue> attributes,
+    size_t n_binders) {
+  if (!class_ptr->getMethod(desugared_name)) {
+    throw ErrorReport(loc) << class_ptr->python_str() << " does not define a "
+                           << desugared_name << " method";
+  }
+
+  Value* self = inputs[0].value(*m.graph());
+  return MethodValue(self, desugared_name)
+      .call(loc, m, inputs.slice(1), attributes, n_binders);
+}
+
 Value* SimpleValue::getitem(const SourceRange& loc, Function& m, Value* idx) {
   Value* val = getValue();
   TypePtr val_type = val->type();
@@ -309,7 +327,11 @@ Value* SimpleValue::getitem(const SourceRange& loc, Function& m, Value* idx) {
     cur_elem = g.insert(aten::__getitem__, {val, idx}, {}, loc);
   } else if (val_type->isSubtypeOf(TensorType::get())) {
     cur_elem = g.insert(aten::select, {val, 0, idx}, {}, loc);
-  } else {
+  } else if (auto class_type = val_type->cast<ClassType>()) {
+    return callClassMethod(class_type, "__getitem__", loc, m, {val, idx}, {}, 1)
+        ->asValue(loc, m);
+  }
+  {
     throw ErrorReport(loc) << "'" << val_type->python_str() << "'"
                            << " object is not subscriptable";
   }
@@ -409,6 +431,21 @@ Value* IterableTree::getitem(const SourceRange& loc, Function& m, Value* idx) {
   return g.insertNode(g.createTuple(child_items))->output();
 }
 
+std::shared_ptr<SugaredValue> MagicMethod::call(
+    const SourceRange& loc,
+    Function& m,
+    at::ArrayRef<NamedValue> inputs,
+    at::ArrayRef<NamedValue> attributes,
+    size_t n_binders) {
+  if (inputs.size() > 0) {
+    Value* self = inputs[0].value(*m.graph());
+    if (auto class_ptr = self->type()->cast<ClassType>()) {
+      return callClassMethod(
+          class_ptr, desugared_name_, loc, m, inputs, attributes, n_binders);
+    }
+  }
+  return base_value_->call(loc, m, inputs, attributes, n_binders);
+}
 std::shared_ptr<SugaredValue> ClassValue::call(
     const SourceRange& loc,
     Function& m,

--- a/torch/csrc/jit/script/sugared_value.h
+++ b/torch/csrc/jit/script/sugared_value.h
@@ -384,23 +384,7 @@ struct TORCH_API MagicMethod : public SugaredValue {
       Function& m,
       at::ArrayRef<NamedValue> inputs,
       at::ArrayRef<NamedValue> attributes,
-      size_t n_binders) override {
-    if (inputs.size() > 0) {
-      Value* self = inputs[0].value(*m.graph());
-
-      if (auto class_ptr = self->type()->cast<ClassType>()) {
-        if (!class_ptr->getMethod(desugared_name_)) {
-          throw ErrorReport(loc)
-              << class_ptr->python_str() << " does not define a "
-              << desugared_name_ << " method";
-        }
-
-        return MethodValue(self, desugared_name_)
-            .call(loc, m, inputs.slice(1), attributes, n_binders);
-      }
-    }
-    return base_value_->call(loc, m, inputs, attributes, n_binders);
-  }
+      size_t n_binders) override;
 
  private:
   SugaredValuePtr base_value_;


### PR DESCRIPTION
Add magic method for `class_type[index]`. Since the compiler has custom logic for indexing this was not included with the other magic methods.

Fix for https://github.com/pytorch/pytorch/issues/25637