### PR TITLE
change shape for some ops to reduce variance

### DIFF
--- a/benchmarks/operator_benchmark/pt/pool_test.py
+++ b/benchmarks/operator_benchmark/pt/pool_test.py
@@ -20,7 +20,7 @@ pool_1d_configs_short = op_bench.config_list(
         'kernel', 'stride', 'N', 'C', 'L'
     ],
     attrs=[
-        [3, 1, 1, 3, 32],
+        [3, 1, 8, 256, 256],
     ],
     tags=['short']
 )
@@ -47,7 +47,7 @@ pool_1d_ops_list = op_bench.op_list(
 
 class Pool1dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, kernel, stride, N, C, L, op_func):
-        self.input = torch.rand(N, C, L) 
+        self.input = torch.rand(N, C, L)
         self.kernel = kernel
         self.stride = stride
         self.op_func = op_func(self.kernel, stride=self.stride)
@@ -56,8 +56,8 @@ class Pool1dBenchmark(op_bench.TorchBenchmarkBase):
         return self.op_func(self.input)
 
 
-op_bench.generate_pt_tests_from_op_list(pool_1d_ops_list, 
-                                        pool_1d_configs_short + pool_1d_configs_long, 
+op_bench.generate_pt_tests_from_op_list(pool_1d_ops_list,
+                                        pool_1d_configs_short + pool_1d_configs_long,
                                         Pool1dBenchmark)
 
 
@@ -99,7 +99,7 @@ pool_2d_ops_list = op_bench.op_list(
 
 class Pool2dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, kernel, stride, N, C, H, W, op_func):
-        self.input = torch.rand(N, C, H, W) 
+        self.input = torch.rand(N, C, H, W)
         self.kernel = kernel
         self.stride = stride
         self.op_func = op_func(self.kernel, stride=self.stride)
@@ -108,8 +108,8 @@ class Pool2dBenchmark(op_bench.TorchBenchmarkBase):
         return self.op_func(self.input)
 
 
-op_bench.generate_pt_tests_from_op_list(pool_2d_ops_list, 
-                                        pool_2d_configs_short + pool_2d_configs_long, 
+op_bench.generate_pt_tests_from_op_list(pool_2d_ops_list,
+                                        pool_2d_configs_short + pool_2d_configs_long,
                                         Pool2dBenchmark)
 
 
@@ -152,7 +152,7 @@ pool_3d_ops_list = op_bench.op_list(
 
 class Pool3dBenchmark(op_bench.TorchBenchmarkBase):
     def init(self, kernel, stride, N, C, D, H, W, op_func):
-        self.input = torch.rand(N, C, D, H, W) 
+        self.input = torch.rand(N, C, D, H, W)
         self.kernel = kernel
         self.stride = stride
         self.op_func = op_func(self.kernel, stride=self.stride)
@@ -161,7 +161,7 @@ class Pool3dBenchmark(op_bench.TorchBenchmarkBase):
         return self.op_func(self.input)
 
 
-op_bench.generate_pt_tests_from_op_list(pool_3d_ops_list, 
+op_bench.generate_pt_tests_from_op_list(pool_3d_ops_list,
                                         pool_3d_configs_short + pool_3d_configs_long,
                                         Pool3dBenchmark)
 

--- a/benchmarks/operator_benchmark/pt/unary_test.py
+++ b/benchmarks/operator_benchmark/pt/unary_test.py
@@ -110,7 +110,6 @@ unary_ops_list = op_bench.op_list(
         ['zero_', torch.zero_],
         ['bernoulli_', lambda t: t.bernoulli_()],
         ['cauchy_', lambda t: t.cauchy_()],
-        ['contiguous', lambda t: t.contiguous()],
         ['digamma_', lambda t: t.digamma_()],
         ['erfinv_', lambda t: t.erfinv_()],
         ['exponential_', lambda t: t.exponential_()],


### PR DESCRIPTION
Summary: From the new runs, we found some ops that we can increase the shape size to reduce the variance

Test Plan:
```
[huaminli@devvm2388.ftw3 ~/fbsource/fbcode] buck run mode/dev-nosan caffe2/benchmarks/operator_benchmark:benchmark_all_test -- --operators None --iterations 3
```

Reviewed By: mingzhe09088

Differential Revision: D17199623

