### PR TITLE
[pytorch] rename 'mobile' to 'static_dispatch'

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -132,7 +132,7 @@ ${return_type} ${api_name}(${method_formals_with_defaults}) const;
 TENSOR_METHOD_DEFINITION = CodeTemplate("""\
 inline ${return_type} Tensor::${api_name}(${method_formals}) const {
 #ifdef USE_STATIC_DISPATCH
-    ${mobile_method_body}
+    ${static_dispatch_method_body}
 #else
     static auto table = globalATenDispatch().getOpTable("${schema_string}");
     return table->getOp<${return_type} (${formals_types})>(tensorTypeIdToBackend(type_id()), is_variable())(${method_actuals});
@@ -151,7 +151,7 @@ C10_DEPRECATED static inline ${return_type} ${api_name}(${formals_with_defaults}
 FUNCTION_DEFINITION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals}) {
 #ifdef USE_STATIC_DISPATCH
-    ${mobile_function_body}
+    ${static_dispatch_function_body}
 #else
     static auto table = globalATenDispatch().getOpTable("${schema_string}");
     return table->getOp<${return_type} (${formals_types})>(${inferred_backend}, ${inferred_is_variable})(${native_actuals});
@@ -159,19 +159,19 @@ static inline ${return_type} ${api_name}(${formals}) {
 }
 """)
 
-# for mobile builds, we rely on the linker to strip unused ops.
-# this requires us to dispatch statically in Functions.h and TensorMethods.h
-MOBILE_FUNCTION_DEFAULT_BODY = CodeTemplate("""\
+# In order to rely on the linker to strip unused ops, it requires us to dispatch statically
+# in Functions.h and TensorMethods.h.
+STATIC_DISPATCH_FUNCTION_DEFAULT_BODY = CodeTemplate("""\
 ${return_call} TypeDefault::${native_type_method_dispatch}(${native_arguments});
 """)
-MOBILE_FUNCTION_SWITCH_BODY = CodeTemplate("""\
+STATIC_DISPATCH_FUNCTION_SWITCH_BODY = CodeTemplate("""\
 switch(${backend}) {
-    ${mobile_function_switches}
+    ${static_dispatch_function_switches}
     default:
         AT_ERROR("${api_name} not implemented for ", at::toString(${backend}));
 }
 """)
-MOBILE_FUNCTION_SWITCH_STATEMENT = CodeTemplate("""\
+STATIC_DISPATCH_FUNCTION_SWITCH_STATEMENT = CodeTemplate("""\
 case Backend::${backend}:
     ${return_call} ${backend}Type::${api_name}(${native_arguments});
     break;
@@ -186,7 +186,7 @@ CAFFE2_API ${return_type} ${native_type_method_dispatch}(${formals_with_defaults
 FACTORY_DEFINITION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals}) {
 #ifdef USE_STATIC_DISPATCH
-    ${mobile_function_body}
+    ${static_dispatch_function_body}
 #else
     globalLegacyTypeDispatch().initForBackend(${inferred_backend});
     static auto table = globalATenDispatch().getOpTable("${schema_string}");
@@ -236,7 +236,7 @@ scalar_types = [
     ('BFloat16', 'BFloat16', 'BFloat16AccrealNotDefined', True),
 ]
 
-mobile_backends = ['CPU', 'QuantizedCPU', 'SparseCPU']
+static_dispatch_backends = ['CPU', 'QuantizedCPU', 'SparseCPU']
 
 
 class NYIError(Exception):
@@ -1093,25 +1093,25 @@ def create_generic(top_env, declarations):
         def gen_tensor_method(option):
             # type: (Any) -> FunctionCode
             if isinstance(type_method_dispatch, dict):
-                mobile_function_switches = []
-                for backend in mobile_backends:
+                static_dispatch_function_switches = []
+                for backend in static_dispatch_backends:
                     if backend in type_method_dispatch:
-                        mobile_function_switches.append(MOBILE_FUNCTION_SWITCH_STATEMENT.substitute(
+                        static_dispatch_function_switches.append(STATIC_DISPATCH_FUNCTION_SWITCH_STATEMENT.substitute(
                             option,
                             backend=backend,
                             backend_function=type_method_dispatch[backend],
                             native_arguments=option['method_actuals']))
-                mobile_method_body = MOBILE_FUNCTION_SWITCH_BODY.substitute(
+                static_dispatch_method_body = STATIC_DISPATCH_FUNCTION_SWITCH_BODY.substitute(
                     option,
                     backend='tensorTypeIdToBackend(type_id())',
-                    mobile_function_switches=mobile_function_switches)
+                    static_dispatch_function_switches=static_dispatch_function_switches)
             else:
-                mobile_method_body = MOBILE_FUNCTION_DEFAULT_BODY.substitute(
+                static_dispatch_method_body = STATIC_DISPATCH_FUNCTION_DEFAULT_BODY.substitute(
                     option, native_arguments=option['method_actuals'])
 
             return FunctionCode(
-                declaration=TENSOR_METHOD_DECLARATION.substitute(option, mobile_method_body=mobile_method_body),
-                definition=TENSOR_METHOD_DEFINITION.substitute(option, mobile_method_body=mobile_method_body))
+                declaration=TENSOR_METHOD_DECLARATION.substitute(option, static_dispatch_method_body=static_dispatch_method_body),
+                definition=TENSOR_METHOD_DEFINITION.substitute(option, static_dispatch_method_body=static_dispatch_method_body))
 
         def gen_namespace_function(option, dispatch_tensor, dispatch_options):
             # type: (Any, Optional[str], Any) -> FunctionCode
@@ -1129,26 +1129,26 @@ def create_generic(top_env, declarations):
             fn_declaration = declaration.substitute(option)
 
             if isinstance(type_method_dispatch, dict):
-                mobile_function_switches = []
-                for backend in mobile_backends:
+                static_dispatch_function_switches = []
+                for backend in static_dispatch_backends:
                     if backend in type_method_dispatch:
-                        mobile_function_switches.append(MOBILE_FUNCTION_SWITCH_STATEMENT.substitute(
+                        static_dispatch_function_switches.append(STATIC_DISPATCH_FUNCTION_SWITCH_STATEMENT.substitute(
                             option,
                             backend=backend,
                             backend_function=type_method_dispatch[backend],
                             native_arguments=option['native_actuals']))
-                mobile_function_body = MOBILE_FUNCTION_SWITCH_BODY.substitute(
+                static_dispatch_function_body = STATIC_DISPATCH_FUNCTION_SWITCH_BODY.substitute(
                     option,
                     backend=option['inferred_backend'],
-                    mobile_function_switches=mobile_function_switches)
+                    static_dispatch_function_switches=static_dispatch_function_switches)
             else:
-                mobile_function_body = MOBILE_FUNCTION_DEFAULT_BODY.substitute(
+                static_dispatch_function_body = STATIC_DISPATCH_FUNCTION_DEFAULT_BODY.substitute(
                     option, native_arguments=option['native_actuals'])
 
             if is_factory_method:
-                fn_definition = FACTORY_DEFINITION.substitute(option, mobile_function_body=mobile_function_body)
+                fn_definition = FACTORY_DEFINITION.substitute(option, static_dispatch_function_body=static_dispatch_function_body)
             else:
-                fn_definition = FUNCTION_DEFINITION.substitute(option, mobile_function_body=mobile_function_body)
+                fn_definition = FUNCTION_DEFINITION.substitute(option, static_dispatch_function_body=static_dispatch_function_body)
             return FunctionCode(definition=fn_definition, declaration=fn_declaration)
 
         # Emit #ifdef BUILD_NAMEDTENSOR macros for any code generated here


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25697 [pytorch] introduce INTERN_DISABLE_AUTOGRAD flag to create inference only library for mobile
* #25696 [pytorch] move USE_STATIC_DISPATCH from CI script to master cmake
* **#25695 [pytorch] rename 'mobile' to 'static_dispatch'**

Summary:
Rename codegen variables to better reflect its semantics.

As we are going to change other parts of codegen for mobile build, e.g.
autograd, it would be more clear to use more specific names instead of
calling everything 'mobile'.

Test Plan:
- will check CI

Differential Revision: [D17202732](https://our.internmc.facebook.com/intern/diff/D17202732)