### PR TITLE
Revert D17097735: [quantization] Rename fbgemm quantized operators to generic `quantized` ops

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -240,10 +240,10 @@ class QConv2dInt8 final : public c10::OperatorKernel {
 
 static auto registry =
     c10::RegisterOperators()
-        .op("quantized::conv2d",
+        .op("quantized::fbgemm_conv2d",
             c10::RegisterOperators::options().kernel<QConv2dInt8<false>>(
                 TensorTypeId::QuantizedCPUTensorId))
-        .op("quantized::conv2d_relu",
+        .op("quantized::fbgemm_conv2d_relu",
             c10::RegisterOperators::options().kernel<QConv2dInt8<true>>(
                 TensorTypeId::QuantizedCPUTensorId));
 

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -132,7 +132,7 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
 };
 
 static auto registry = c10::RegisterOperators().op(
-    "quantized::conv_prepack",
+    "quantized::fbgemm_conv_prepack",
     c10::RegisterOperators::options().kernel<QConvPackWeightInt8>(
         TensorTypeId::QuantizedCPUTensorId));
 

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -79,7 +79,7 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
 };
 
 static auto registry = c10::RegisterOperators().op(
-    "quantized::conv_unpack(Tensor packed_weights)"
+    "quantized::fbgemm_conv_unpack(Tensor packed_weights)"
     " -> Tensor unpacked_weights",
     c10::RegisterOperators::options().kernel<QConvUnpackWeightsInt8>(
         TensorTypeId::CPUTensorId));

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -218,10 +218,10 @@ class QLinearInt8 final : public torch::OperatorKernel {
 
 static auto registry =
     torch::RegisterOperators()
-        .op("quantized::linear(Tensor X, Tensor W_prepack, Tensor? b, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
+        .op("quantized::fbgemm_linear(Tensor X, Tensor W_prepack, Tensor? b, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
             torch::RegisterOperators::options().kernel<QLinearInt8<false>>(
                 TensorTypeId::QuantizedCPUTensorId))
-        .op("quantized::linear_relu(Tensor X, Tensor W_prepack, Tensor? b, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
+        .op("quantized::fbgemm_linear_relu(Tensor X, Tensor W_prepack, Tensor? b, float Y_scale_i, int Y_zero_point_i) -> Tensor Y",
             torch::RegisterOperators::options().kernel<QLinearInt8<true>>(
                 TensorTypeId::QuantizedCPUTensorId));
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -119,7 +119,7 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
 };
 
 static auto registry = c10::RegisterOperators().op(
-    "quantized::linear_prepack(Tensor W) -> Tensor W_prepack",
+    "quantized::fbgemm_linear_prepack(Tensor W) -> Tensor W_prepack",
     c10::RegisterOperators::options().kernel<QLinearPackWeightInt8>(
         TensorTypeId::QuantizedCPUTensorId));
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -64,7 +64,7 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
 };
 
 static auto registry = c10::RegisterOperators().op(
-    "quantized::linear_unpack(Tensor W_prepack) -> Tensor W_origin",
+    "quantized::fbgemm_linear_unpack(Tensor W_prepack) -> Tensor W_origin",
     c10::RegisterOperators::options().kernel<QLinearUnpackWeightInt8>(
         TensorTypeId::CPUTensorId));
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1132,8 +1132,8 @@ graph(%a, %w, %b, %a_scale, %a_zero_point, %a_dtype, %w_scale, %w_zero_point, %w
         %b_intrepr = aten::int_repr(%b_quant)
         # CHECK-NOT: aten::_dequantize_linear
         %b_dequant = aten::_dequantize_linear(%b_intrepr, %b_scale, %b_zero_point, %b_dtype)
-        # CHECK: quantized::conv_prepack
-        # CHECK: quantized::conv2d
+        # CHECK: quantized::fbgemm_conv_prepack
+        # CHECK: quantized::fbgemm_conv2d
         # CHECK-NOT: aten::conv2d
         %r = aten::conv2d(%a_dequant, %w_dequant, %b_dequant, %c, %d, %e, %f)
         # CHECK-NOT: aten::quantize_linear
@@ -14615,11 +14615,11 @@ a")
                     [out_features, in_features], scale=1, zero_point=0,
                     dtype=torch.qint8)
                 self.register_buffer('_packed_weight',
-                                     torch.ops.quantized.linear_prepack(qweight))
+                                     torch.ops.quantized.fbgemm_linear_prepack(qweight))
 
             @torch.jit.export
             def __getstate__(self):
-                return torch.ops.quantized.linear_unpack(self._packed_weight)
+                return torch.ops.quantized.fbgemm_linear_unpack(self._packed_weight)
 
             def forward(self):
                 return self._packed_weight
@@ -14627,15 +14627,15 @@ a")
             @torch.jit.export
             def __setstate__(self, state):
                 self._packed_weight.set_(
-                    torch.ops.quantized.linear_prepack(state))
+                    torch.ops.quantized.fbgemm_linear_prepack(state))
 
             @property
             def weight(self):
-                return torch.ops.quantized.linear_unpack(self._packed_weight)
+                return torch.ops.quantized.fbgemm_linear_unpack(self._packed_weight)
 
             @weight.setter
             def weight(self, w):
-                self._packed_weight = torch.ops.quantized.linear_prepack(w)
+                self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(w)
 
         with torch.jit._disable_emit_hooks():
             x = torch.jit.script(Linear(10, 10))

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -619,7 +619,7 @@ class TestDynamicQuantizedLinear(TestCase):
         use_channelwise=st.booleans())
     def test_qlinear(self, batch_size, input_channels, output_channels,
                      use_bias, use_relu, use_multi_dim_input, use_channelwise):
-        qlinear_prepack = torch.ops.quantized.linear_prepack
+        qlinear_prepack = torch.ops.quantized.fbgemm_linear_prepack
         if use_relu:
             qlinear_dynamic = torch.ops.quantized.fbgemm_linear_relu_dynamic
         else:
@@ -736,11 +736,11 @@ class TestQuantizedLinear(unittest.TestCase):
            use_channelwise=st.booleans())
     def test_qlinear(self, batch_size, input_channels, output_channels, use_bias,
                      use_relu, use_multi_dim_input, use_channelwise):
-        qlinear_prepack = torch.ops.quantized.linear_prepack
+        qlinear_prepack = torch.ops.quantized.fbgemm_linear_prepack
         if use_relu:
-            qlinear = torch.ops.quantized.linear_relu
+            qlinear = torch.ops.quantized.fbgemm_linear_relu
         else:
-            qlinear = torch.ops.quantized.linear
+            qlinear = torch.ops.quantized.fbgemm_linear
 
         if use_multi_dim_input:
             batch_size *= 3  # Test the multi-dim input tensor
@@ -864,8 +864,8 @@ class TestQuantizedLinear(unittest.TestCase):
             W_zps = torch.round(torch.rand(output_channels)
                                 * 100 - 50).to(torch.int64)
 
-        qlinear_prepack = torch.ops.quantized.linear_prepack
-        qlinear_unpack = torch.ops.quantized.linear_unpack
+        qlinear_prepack = torch.ops.quantized.fbgemm_linear_prepack
+        qlinear_unpack = torch.ops.quantized.fbgemm_linear_unpack
 
         W = torch.from_numpy(W)
 
@@ -952,10 +952,10 @@ class TestQuantizedConv(unittest.TestCase):
             use_channelwise
     ):
 
-        qconv = torch.ops.quantized.conv2d
+        qconv = torch.ops.quantized.fbgemm_conv2d
         if use_relu:
-            qconv = torch.ops.quantized.conv2d_relu
-        qconv_prepack = torch.ops.quantized.conv_prepack
+            qconv = torch.ops.quantized.fbgemm_conv2d_relu
+        qconv_prepack = torch.ops.quantized.fbgemm_conv_prepack
 
         # C
         input_channels = input_channels_per_group * groups
@@ -1116,8 +1116,8 @@ class TestQuantizedConv(unittest.TestCase):
             filters_scale = torch.tensor([filters_scale] * output_channels).to(torch.double)
             filters_zero_point = torch.tensor([filters_zero_point] * output_channels).to(torch.long)
 
-        qconv_prepack = torch.ops.quantized.conv_prepack
-        qconv_unpack = torch.ops.quantized.conv_unpack
+        qconv_prepack = torch.ops.quantized.fbgemm_conv_prepack
+        qconv_unpack = torch.ops.quantized.fbgemm_conv_unpack
 
         # Orig tensor is assumed to be in K(C/G)RS format
         W = torch.from_numpy(filters).to(torch.float)

--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -63,7 +63,7 @@ class FunctionalAPITest(QuantizationTestCase):
 
         b = torch.randn(oC, dtype=torch.float32) if use_bias else None
         q_bias = torch.quantize_linear(b, scale=1.0 / 1024, zero_point=0, dtype=torch.qint32) if use_bias else None
-        q_filters_ref = torch.ops.quantized.conv_prepack(qw.permute([0, 2, 3, 1]),
+        q_filters_ref = torch.ops.quantized.fbgemm_conv_prepack(qw.permute([0, 2, 3, 1]),
                                                                 stride,
                                                                 i_padding,
                                                                 dilation,
@@ -71,7 +71,7 @@ class FunctionalAPITest(QuantizationTestCase):
 
 
         requantized_bias = torch.quantize_linear(q_bias.dequantize(), scale * scale, 0 , torch.qint32) if use_bias else None
-        ref_result = torch.ops.quantized.conv2d(qX.permute([0, 2, 3, 1]), q_filters_ref,
+        ref_result = torch.ops.quantized.fbgemm_conv2d(qX.permute([0, 2, 3, 1]), q_filters_ref,
                                                        requantized_bias, stride,
                                                        i_padding, dilation,
                                                        g, scale, zero_point).permute([0, 3, 1, 2])
@@ -139,7 +139,7 @@ class DynamicModuleAPITest(QuantizationTestCase):
         loaded_qlinear = nnqd.Linear(in_features, out_features)
         loaded_qlinear.load_state_dict(loaded_dict)
 
-        linear_unpack = torch.ops.quantized.linear_unpack
+        linear_unpack = torch.ops.quantized.fbgemm_linear_unpack
         self.assertEqual(linear_unpack(qlinear._packed_weight),
                          linear_unpack(loaded_qlinear._packed_weight))
         if use_bias:
@@ -151,7 +151,7 @@ class DynamicModuleAPITest(QuantizationTestCase):
         self.assertTrue(hasattr(loaded_qlinear, 'weight'))
 
         self.assertEqual(qlinear.weight(), loaded_qlinear.weight())
-        self.assertEqual(qlinear.weight(), torch.ops.quantized.linear_unpack(qlinear._packed_weight))
+        self.assertEqual(qlinear.weight(), torch.ops.quantized.fbgemm_linear_unpack(qlinear._packed_weight))
         Z_dq2 = qlinear(X)
         self.assertEqual(Z_dq, Z_dq2)
 
@@ -246,9 +246,9 @@ class ModuleAPITest(QuantizationTestCase):
         # Check if the module implementation matches calling the
         # ops directly
         if use_fused:
-            Z_ref = torch.ops.quantized.linear_relu(X_q, W_pack, B_q, scale, zero_point)
+            Z_ref = torch.ops.quantized.fbgemm_linear_relu(X_q, W_pack, B_q, scale, zero_point)
         else:
-            Z_ref = torch.ops.quantized.linear(X_q, W_pack, B_q, scale, zero_point)
+            Z_ref = torch.ops.quantized.fbgemm_linear(X_q, W_pack, B_q, scale, zero_point)
         self.assertEqual(Z_ref, Z_q)
 
         # Test serialization of quantized Linear Module using state_dict
@@ -269,7 +269,7 @@ class ModuleAPITest(QuantizationTestCase):
             loaded_qlinear = nnq.Linear(in_features, out_features)
         loaded_qlinear.load_state_dict(loaded_dict)
 
-        linear_unpack = torch.ops.quantized.linear_unpack
+        linear_unpack = torch.ops.quantized.fbgemm_linear_unpack
         self.assertEqual(linear_unpack(qlinear._packed_weight),
                          linear_unpack(loaded_qlinear._packed_weight))
         if use_bias:
@@ -282,7 +282,7 @@ class ModuleAPITest(QuantizationTestCase):
         self.assertTrue(hasattr(qlinear, 'weight'))
         self.assertTrue(hasattr(loaded_qlinear, 'weight'))
         self.assertEqual(qlinear.weight(), loaded_qlinear.weight())
-        self.assertEqual(qlinear.weight(), torch.ops.quantized.linear_unpack(qlinear._packed_weight))
+        self.assertEqual(qlinear.weight(), torch.ops.quantized.fbgemm_linear_unpack(qlinear._packed_weight))
         Z_q2 = loaded_qlinear(X_q)
         self.assertEqual(Z_q, Z_q2)
 

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -622,8 +622,8 @@ graph(%a_quant, %w_quant, %b_quant, %a_scale, %a_zero_point, %a_dtype, %w_scale,
         %in_param : int[] = prim::ListConstruct(%0, %2, %3, %1)
         %a_perm : Tensor = aten::permute(%a_quant, %in_param)
         %w_perm : Tensor = aten::permute(%w_quant, %in_param)
-        %w_packed = quantized::conv_prepack(%w_perm, %stride, %padding, %dilation, %groups)
-        %r = quantized::conv2d(%a_perm, %w_packed, %b_quant, %stride, %padding, %dilation, %groups, %r_scale, %r_zero_point)
+        %w_packed = quantized::fbgemm_conv_prepack(%w_perm, %stride, %padding, %dilation, %groups)
+        %r = quantized::fbgemm_conv2d(%a_perm, %w_packed, %b_quant, %stride, %padding, %dilation, %groups, %r_scale, %r_zero_point)
         %out_param : int[] = prim::ListConstruct(%0, %3, %1, %2)
         %r_perm = aten::permute(%r, %out_param)
         return (%r_perm))";

--- a/torch/nn/_intrinsic/quantized/modules/conv_relu.py
+++ b/torch/nn/_intrinsic/quantized/modules/conv_relu.py
@@ -25,10 +25,10 @@ class ConvReLU2d(nnq.Conv2d):
                                          groups=groups, bias=bias, padding_mode=padding_mode)
 
     def weight(self):
-        return torch.ops.quantized.conv_unpack(self._packed_weight).permute([0, 3, 1, 2])
+        return torch.ops.quantized.fbgemm_conv_unpack(self._packed_weight).permute([0, 3, 1, 2])
 
     def set_weight(self, w):
-        self._packed_weight = torch.ops.quantized.conv_prepack(w.permute([0, 2, 3, 1]),
+        self._packed_weight = torch.ops.quantized.fbgemm_conv_prepack(w.permute([0, 2, 3, 1]),
                                                                       self.stride,
                                                                       self.padding,
                                                                       self.dilation,
@@ -45,7 +45,7 @@ class ConvReLU2d(nnq.Conv2d):
         bias = self.bias
         if bias is not None:
             bias = torch.quantize_linear(bias.dequantize(), float(self.weight_scale) * input.q_scale(), 0, torch.qint32)
-        output = torch.ops.quantized.conv2d_relu(input.permute([0, 2, 3, 1]),
+        output = torch.ops.quantized.fbgemm_conv2d_relu(input.permute([0, 2, 3, 1]),
                                                         self._packed_weight, bias,
                                                         self.stride, self.padding,
                                                         self.dilation, self.groups,

--- a/torch/nn/_intrinsic/quantized/modules/linear_relu.py
+++ b/torch/nn/_intrinsic/quantized/modules/linear_relu.py
@@ -30,7 +30,7 @@ class LinearReLU(nnq.Linear):
         if bias is not None:
             bias = torch.quantize_linear(bias.dequantize(), float(self.weight_scale) * input.q_scale(), 0, torch.qint32)
 
-        Y_q = torch.ops.quantized.linear_relu(
+        Y_q = torch.ops.quantized.fbgemm_linear_relu(
             input, self._packed_weight,
             bias,
             float(self.scale),

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -53,10 +53,10 @@ def linear(input, weight, bias=None, scale=None, zero_point=None):
         scale = input.q_scale()
     if zero_point is None:
         zero_point = input.q_zero_point()
-    _packed_weight = torch.ops.quantized.linear_prepack(weight)
+    _packed_weight = torch.ops.quantized.fbgemm_linear_prepack(weight)
     if bias is not None:
         bias = torch.quantize_linear(bias.dequantize(), weight.q_scale() * input.q_scale(), 0, torch.qint32)
-    return torch.ops.quantized.linear(input, _packed_weight, bias, scale,
+    return torch.ops.quantized.fbgemm_linear(input, _packed_weight, bias, scale,
                                              zero_point)
 
 def conv2d(input, weight, bias,
@@ -116,11 +116,11 @@ def conv2d(input, weight, bias,
     padding = _pair(padding)
     dilation = _pair(dilation)
 
-    prepacked_weight = torch.ops.quantized.conv_prepack(
+    prepacked_weight = torch.ops.quantized.fbgemm_conv_prepack(
         weight.permute([0, 2, 3, 1]), stride, padding, dilation, groups)
     if bias is not None:
         bias = torch.quantize_linear(bias.dequantize(), scale=weight.q_scale() * input.q_scale(), zero_point=0, dtype=torch.qint32)
-    return torch.ops.quantized.conv2d(input.permute([0, 2, 3, 1]),
+    return torch.ops.quantized.fbgemm_conv2d(input.permute([0, 2, 3, 1]),
                                              prepacked_weight, bias,
                                              stride, padding, dilation,
                                              groups, scale, zero_point).permute([0, 3, 1, 2])

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -109,12 +109,12 @@ class Conv2d(torch.nn.Module):
         return s.format(**self.__dict__)
 
     def set_weight(self, w):
-        self._packed_weight = torch.ops.quantized.conv_prepack(
+        self._packed_weight = torch.ops.quantized.fbgemm_conv_prepack(
             w.permute([0, 2, 3, 1]), self.stride, self.padding, self.dilation, self.groups)
         self.weight_scale = w.q_scale()
 
     def weight(self):
-        return torch.ops.quantized.conv_unpack(
+        return torch.ops.quantized.fbgemm_conv_unpack(
             self._packed_weight).permute([0, 3, 1, 2])
 
     def forward(self, input):
@@ -127,7 +127,7 @@ class Conv2d(torch.nn.Module):
         bias = self.bias
         if bias is not None:
             bias = torch.quantize_linear(bias.dequantize(), self.weight_scale * input.q_scale(), 0, torch.qint32)
-        output = ops.quantized.conv2d(input.permute([0, 2, 3, 1]),
+        output = ops.quantized.fbgemm_conv2d(input.permute([0, 2, 3, 1]),
                                              self._packed_weight, bias,
                                              self.stride, self.padding,
                                              self.dilation, self.groups,

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -136,7 +136,7 @@ class Linear(torch.nn.Module):
         if bias is not None:
             bias = torch.quantize_linear(bias.dequantize(), float(self.weight_scale) * x.q_scale(), 0, torch.qint32)
 
-        return torch.ops.quantized.linear(
+        return torch.ops.quantized.fbgemm_linear(
             x, self._packed_weight, bias, self.scale, self.zero_point)
 
     # ===== Serialization methods =====
@@ -195,10 +195,10 @@ class Linear(torch.nn.Module):
     # Function rather than property to make sure that JIT serialization doesn't
     # register this as an attribute
     def weight(self):
-        return torch.ops.quantized.linear_unpack(self._packed_weight)
+        return torch.ops.quantized.fbgemm_linear_unpack(self._packed_weight)
 
     def set_weight(self, w):
-        self._packed_weight = torch.ops.quantized.linear_prepack(w)
+        self._packed_weight = torch.ops.quantized.fbgemm_linear_prepack(w)
         self.weight_scale = w.q_scale()
 
     @classmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Test Plan: revert-hammer

Differential Revision:
D17097735

Original commit changeset: 447112a7a421

fbshipit-source-id: 78368b6f84d96cea70692fb000cebe99602a08c1