### PR TITLE
Rename tensor.view_names -> tensor.renamed

### DIFF
--- a/aten/src/ATen/core/TensorBody.h
+++ b/aten/src/ATen/core/TensorBody.h
@@ -376,7 +376,7 @@ class CAFFE2_API Tensor {
   Tensor & names_(c10::optional<DimnameList> names) const;
   #endif
   #ifdef BUILD_NAMEDTENSOR
-  Tensor view_names(c10::optional<DimnameList> names) const;
+  Tensor renamed(c10::optional<DimnameList> names) const;
   #endif
   #ifdef BUILD_NAMEDTENSOR
   Tensor align_to(DimnameList names) const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -86,11 +86,11 @@ inline Tensor & Tensor::names_(c10::optional<DimnameList> names) const {
 }
 #endif
 #ifdef BUILD_NAMEDTENSOR
-inline Tensor Tensor::view_names(c10::optional<DimnameList> names) const {
+inline Tensor Tensor::renamed(c10::optional<DimnameList> names) const {
 #ifdef USE_STATIC_DISPATCH
-    return TypeDefault::view_names(const_cast<Tensor&>(*this), names);
+    return TypeDefault::renamed(const_cast<Tensor&>(*this), names);
 #else
-    static auto table = globalATenDispatch().getOpTable("aten::view_names(Tensor(a) self, Dimname[]? names) -> Tensor(a)");
+    static auto table = globalATenDispatch().getOpTable("aten::renamed(Tensor(a) self, Dimname[]? names) -> Tensor(a)");
     return table->getOp<Tensor (const Tensor &, c10::optional<DimnameList>)>(tensorTypeIdToBackend(type_id()), is_variable())(const_cast<Tensor&>(*this), names);
 #endif
 }

--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -10,7 +10,7 @@ Tensor& names_(Tensor& self, optional<DimnameList> names) {
   return at::internal_set_names_inplace(self, names);
 }
 
-Tensor view_names(const Tensor& self, optional<DimnameList> names) {
+Tensor renamed(const Tensor& self, optional<DimnameList> names) {
   auto result = self.alias();
   at::internal_set_names_inplace(result, names);
   return result;
@@ -104,7 +104,7 @@ static Tensor align(const Tensor& tensor, DimnameList names, bool is_aligning_tw
         tensor.names(),
         names,
         is_aligning_two_tensors);
-  auto result = tensor.view_names(nullopt).view(expanded_sizes);
+  auto result = tensor.renamed(nullopt).view(expanded_sizes);
   at::internal_set_names_inplace(result, names);
   return result;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -39,7 +39,7 @@
   variants: method
   named_guard: False
 
-- func: view_names(Tensor(a) self, Dimname[]? names) -> Tensor(a)
+- func: renamed(Tensor(a) self, Dimname[]? names) -> Tensor(a)
   variants: method
   named_guard: False
 

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -89,8 +89,8 @@ class TestNamedTensor(TestCase):
     # Right now I don't know what it should look like.
     def assertTensorDataAndNamesEqual(self, x, y):
         self.assertEqual(x.names, y.names)
-        unnamed_x = x.view_names(None)
-        unnamed_y = y.view_names(None)
+        unnamed_x = x.renamed(None)
+        unnamed_y = y.renamed(None)
         self.assertEqual(unnamed_x, unnamed_y)
 
     def _test_factory(self, factory, device):
@@ -186,7 +186,7 @@ class TestNamedTensor(TestCase):
 
     def test_big_tensor_repr(self):
         def check_repr(named_tensor):
-            unnamed_tensor = named_tensor.view_names(None)
+            unnamed_tensor = named_tensor.renamed(None)
             expected = "{}, names={})".format(repr(unnamed_tensor)[:-1], named_tensor.names)
             self.assertEqual(repr(named_tensor), expected)
 
@@ -218,82 +218,82 @@ class TestNamedTensor(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'duplicate names'):
             tensor.names_('N', 'N')
 
-    def test_view_names(self):
+    def test_renamed(self):
         tensor = torch.empty(1, 1, names=('N', 'C'))
 
-        self.assertEqual(tensor.view_names(None).names, (None, None))
-        self.assertEqual(tensor.view_names('H', 'W').names, ('H', 'W'))
+        self.assertEqual(tensor.renamed(None).names, (None, None))
+        self.assertEqual(tensor.renamed('H', 'W').names, ('H', 'W'))
 
         # Check that we didn't modify tensor.names
         self.assertEqual(tensor.names, ('N', 'C'))
 
         with self.assertRaisesRegex(RuntimeError, 'Number of names'):
-            tensor.view_names('N', 'C', 'W')
+            tensor.renamed('N', 'C', 'W')
         with self.assertRaisesRegex(RuntimeError, 'duplicate names'):
-            tensor.view_names('N', 'N')
+            tensor.renamed('N', 'N')
 
         with self.assertRaisesRegex(RuntimeError, 'either positional args or keyword args'):
-            tensor.view_names(None, N='batch')
+            tensor.renamed(None, N='batch')
 
-        # view_names returns a view on the tensor
-        self.assertEqual(tensor.view_names('H', 'W').data_ptr(), tensor.data_ptr())
-        self.assertEqual(tensor.view_names(None).data_ptr(), tensor.data_ptr())
+        # renamed returns a view on the tensor
+        self.assertEqual(tensor.renamed('H', 'W').data_ptr(), tensor.data_ptr())
+        self.assertEqual(tensor.renamed(None).data_ptr(), tensor.data_ptr())
 
-    def test_view_names_globber(self):
+    def test_renamed_globber(self):
         scalar = torch.randn([])
         unnamed_tensor = torch.empty(1, 1, 1, 1)
         named_tensor = torch.empty(1, 1, 1, 1, names=('N', 'C', 'H', 'W'))
 
-        self.assertEqual(scalar.view_names(None).names, [])
-        self.assertEqual(scalar.view_names('*').names, [])
+        self.assertEqual(scalar.renamed(None).names, [])
+        self.assertEqual(scalar.renamed('*').names, [])
 
         # Check that it works with unnamed tensors
-        self.assertEqual(unnamed_tensor.view_names('*').names, unnamed_tensor.names)
-        self.assertEqual(unnamed_tensor.view_names('*', 'H', 'W').names,
+        self.assertEqual(unnamed_tensor.renamed('*').names, unnamed_tensor.names)
+        self.assertEqual(unnamed_tensor.renamed('*', 'H', 'W').names,
                          [None, None, 'H', 'W'])
-        self.assertEqual(unnamed_tensor.view_names('N', '*', 'W').names,
+        self.assertEqual(unnamed_tensor.renamed('N', '*', 'W').names,
                          ['N', None, None, 'W'])
-        self.assertEqual(unnamed_tensor.view_names('N', 'C', '*').names,
+        self.assertEqual(unnamed_tensor.renamed('N', 'C', '*').names,
                          ['N', 'C', None, None])
 
         # Check that it works with named tensors
-        self.assertEqual(named_tensor.view_names('*').names, named_tensor.names)
-        self.assertEqual(named_tensor.view_names('*', 'width').names,
+        self.assertEqual(named_tensor.renamed('*').names, named_tensor.names)
+        self.assertEqual(named_tensor.renamed('*', 'width').names,
                          ['N', 'C', 'H', 'width'])
-        self.assertEqual(named_tensor.view_names('batch', 'channels', '*', 'width').names,
+        self.assertEqual(named_tensor.renamed('batch', 'channels', '*', 'width').names,
                          ['batch', 'channels', 'H', 'width'])
-        self.assertEqual(named_tensor.view_names('batch', '*').names,
+        self.assertEqual(named_tensor.renamed('batch', '*').names,
                          ['batch', 'C', 'H', 'W'])
 
         # Test empty glob
-        self.assertEqual(unnamed_tensor.view_names('*', None, None, None, None).names,
+        self.assertEqual(unnamed_tensor.renamed('*', None, None, None, None).names,
                          [None, None, None, None])
-        self.assertEqual(named_tensor.view_names('N', 'C', 'H', '*', 'W').names,
+        self.assertEqual(named_tensor.renamed('N', 'C', 'H', '*', 'W').names,
                          ['N', 'C', 'H', 'W'])
 
         # Multiple globs throw
         with self.assertRaisesRegex(RuntimeError, 'More than one '):
-            named_tensor.view_names('*', 'channels', '*')
+            named_tensor.renamed('*', 'channels', '*')
 
-    def test_view_names_rename_map(self):
+    def test_renamed_rename_map(self):
         scalar = torch.randn([])
         unnamed_tensor = torch.empty(1, 1, 1, 1)
         named_tensor = torch.empty(1, 1, 1, 1, names=('N', 'C', 'H', 'W'))
 
         with self.assertRaisesRegex(RuntimeError, "dim 'N' does not exist"):
-            scalar.view_names(N='batch')
+            scalar.renamed(N='batch')
         with self.assertRaisesRegex(RuntimeError, "dim 'N' does not exist"):
-            unnamed_tensor.view_names(N='batch')
+            unnamed_tensor.renamed(N='batch')
         with self.assertRaisesRegex(RuntimeError, "dim 'B' does not exist"):
-            named_tensor.view_names(B='batch')
+            named_tensor.renamed(B='batch')
         with self.assertRaisesRegex(RuntimeError, "dim 'B' does not exist"):
-            named_tensor.view_names(H='height', B='batch')
+            named_tensor.renamed(H='height', B='batch')
 
-        self.assertEqual(named_tensor.view_names(N='batch').data_ptr(),
+        self.assertEqual(named_tensor.renamed(N='batch').data_ptr(),
                          named_tensor.data_ptr())
-        self.assertEqual(named_tensor.view_names(N='batch').names,
+        self.assertEqual(named_tensor.renamed(N='batch').names,
                          ['batch', 'C', 'H', 'W'])
-        self.assertEqual(named_tensor.view_names(N='batch', H='height').names,
+        self.assertEqual(named_tensor.renamed(N='batch', H='height').names,
                          ['batch', 'C', 'height', 'W'])
 
     def test_set_names_property(self):
@@ -763,31 +763,31 @@ class TestNamedTensor(TestCase):
         # simple
         self._test_name_inference(
             torch.masked_select,
-            (create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C')),
+            (create('N:2,C:3'), (create('2,3') > 0).renamed('N', 'C')),
             expected_names=[None])
 
         # left broadcast
         self._test_name_inference(
             torch.masked_select,
-            (create('C:3'), (create('2,3') > 0).view_names('N', 'C')),
+            (create('C:3'), (create('2,3') > 0).renamed('N', 'C')),
             expected_names=[None])
 
         # right broadcast
         self._test_name_inference(
             torch.masked_select,
-            (create('N:2,C:3'), (create('3') > 0).view_names('C')),
+            (create('N:2,C:3'), (create('3') > 0).renamed('C')),
             expected_names=[None])
 
         # error
         self._test_name_inference(
             torch.masked_select,
-            (create('N:2,C:3'), (create('3') > 0).view_names('D')),
+            (create('N:2,C:3'), (create('3') > 0).renamed('D')),
             maybe_raises_regex='do not match')
 
         # out=
         self._test_name_inference(
             out_fn(torch.masked_select),
-            (create('0'), create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C')),
+            (create('0'), create('N:2,C:3'), (create('2,3') > 0).renamed('N', 'C')),
             expected_names=[None])
 
     def test_cat(self):
@@ -825,37 +825,37 @@ class TestNamedTensor(TestCase):
         # simple
         self._test_name_inference(
             Tensor.masked_fill,
-            (create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C'), 3.14),
+            (create('N:2,C:3'), (create('2,3') > 0).renamed('N', 'C'), 3.14),
             expected_names=['N', 'C'])
 
         # left broadcast
         self._test_name_inference(
             Tensor.masked_fill,
-            (create('C:3'), (create('2,3') > 0).view_names('N', 'C'), 3.14),
+            (create('C:3'), (create('2,3') > 0).renamed('N', 'C'), 3.14),
             maybe_raises_regex="must be less than or equal to")
 
         # right broadcast
         self._test_name_inference(
             Tensor.masked_fill,
-            (create('N:2,C:3'), (create('3') > 0).view_names('C'), 3.14),
+            (create('N:2,C:3'), (create('3') > 0).renamed('C'), 3.14),
             expected_names=['N', 'C'])
 
         # error
         self._test_name_inference(
             Tensor.masked_fill,
-            (create('N:2,C:3'), (create('3') > 0).view_names('D'), 3.14),
+            (create('N:2,C:3'), (create('3') > 0).renamed('D'), 3.14),
             maybe_raises_regex='do not match')
 
         # inplace
         self._test_name_inference(
             Tensor.masked_fill_,
-            (create('N:2,C:3'), (create('2,3') > 0).view_names('N', 'C'), 3.14),
+            (create('N:2,C:3'), (create('2,3') > 0).renamed('N', 'C'), 3.14),
             expected_names=['N', 'C'])
 
         # inplace, computed names don't match output tensor names
         self._test_name_inference(
             Tensor.masked_fill_,
-            (create('N:2,None:3'), (create('2,3') > 0).view_names('N', 'C'), 3.14),
+            (create('N:2,None:3'), (create('2,3') > 0).renamed('N', 'C'), 3.14),
             maybe_raises_regex="not the same as the computed output names")
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -239,7 +239,7 @@ class _TestTorchMixin(torchtest):
                        'sparse_resize_',
                        'sparse_resize_and_clear_',
                        'align_to',  # BUILD_NAMEDTENSOR only
-                       'view_names',  # BUILD_NAMEDTENSOR only
+                       'renamed',  # BUILD_NAMEDTENSOR only
                        'names_',  # BUILD_NAMEDTENSOR only
                        'has_names',  # BUILD_NAMEDTENSOR only
                        'rename',  # BUILD_NAMEDTENSOR only

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -201,7 +201,7 @@ def _tensor_str(self, indent):
         # - tensor data needs to be summarized
         # Some of the codepaths don't fully support named tensors, so we send in
         # an unnamed tensor to the formatting code as a workaround.
-        self = self.view_names(None)
+        self = self.renamed(None)
 
     summarize = self.numel() > PRINT_OPTS.threshold
     if self.dtype is torch.float16 or self.dtype is torch.bfloat16:

--- a/torch/namedtensor.py
+++ b/torch/namedtensor.py
@@ -32,7 +32,7 @@ def _namer_api_name(inplace):
     if inplace:
         return 'names_'
     else:
-        return 'view_names'
+        return 'renamed'
 
 
 def _expand_single_glob(numel_pre_glob, numel_post_glob, names):
@@ -40,7 +40,7 @@ def _expand_single_glob(numel_pre_glob, numel_post_glob, names):
 
 
 def _update_names_with_list(tensor, names, inplace):
-    # Special case for tensor.view_names(None)
+    # Special case for tensor.renamed(None)
     if len(names) == 1 and names[0] is None:
         return tensor._update_names(None, inplace)
 
@@ -75,7 +75,7 @@ def _update_names_with_mapping(tensor, rename_map, inplace):
 def _update_names(tensor, names, rename_map, inplace):
     """There are two usages:
 
-    tensor.view_names(*names) returns a view on tensor with named dims `names`.
+    tensor.renamed(*names) returns a view on tensor with named dims `names`.
     `names` must be of length `tensor.dim()`; otherwise, if '*' is in `names`,
     then it is expanded greedily to be equal to the corresponding names from
     `tensor.names`.
@@ -83,24 +83,24 @@ def _update_names(tensor, names, rename_map, inplace):
     For example,
     ```
     >>> x = torch.empty(2, 3, 5, 7, names=('N', 'C', 'H', 'W'))
-    >>> x.view_names('*', 'height', 'width').names
+    >>> x.renamed('*', 'height', 'width').names
     ('N', 'C', 'height', 'width')
 
-    >>> x.view_names('batch', '*', 'width').names
+    >>> x.renamed('batch', '*', 'width').names
     ('batch', 'C', 'H', 'width')
     ```
 
-    tensor.view_names(**rename_map) returns a view on tensor that has renamed dims
+    tensor.renamed(**rename_map) returns a view on tensor that has renamed dims
         as specified in the mapping `rename_map`.
 
     For example,
     ```
     >>> x = torch.empty(2, 3, 5, 7, names=('N', 'C', 'H', 'W'))
-    >>> x.view_names(W='width', H='height').names
+    >>> x.renamed(W='width', H='height').names
     ('N', 'C', 'height', 'width')
     ```
 
-    Finally, tensor.view_names has an in-place version called tensor.names_.
+    Finally, tensor.renamed has an in-place version called tensor.names_.
     """
     _assert_namedtensor_build(_namer_api_name(inplace))
 
@@ -112,7 +112,7 @@ def _update_names(tensor, names, rename_map, inplace):
                            'to name dims and tensor.{api_name}(**rename_map) to rename '
                            'dims.'.format(api_name=_namer_api_name(inplace)))
 
-    # Special case for tensor.view_names(*[]), which is valid for a 0 dim tensor.
+    # Special case for tensor.renamed(*[]), which is valid for a 0 dim tensor.
     if not has_names and not has_rename_pairs:
         return _update_names_with_list(tensor, names, inplace)
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -482,22 +482,22 @@ class Tensor(torch._C._TensorBase):
         return dict(typestr=typestr, shape=shape, strides=strides, data=data, version=1)
 
     def names_(self, *names, **rename_map):
-        # Note [names_ / view_names API]
+        # Note [names_ / renamed API]
         # The Python API for these is different from the C++ API. In Python:
-        # 1) tensor.view_names(*names) takes a vararglist of names
-        # 2) tensor.view_names(**rename_map) takes a map of names to rename.
+        # 1) tensor.renamed(*names) takes a vararglist of names
+        # 2) tensor.renamed(**rename_map) takes a map of names to rename.
         # C++ is static, making it difficult to implement similar behavior.
         return _update_names(self, names, rename_map, inplace=True)
 
-    def view_names(self, *names, **rename_map):
-        # See Note [names_ / view_names API]
+    def renamed(self, *names, **rename_map):
+        # See Note [names_ / renamed API]
         return _update_names(self, names, rename_map, inplace=False)
 
     def _update_names(self, names, inplace):
-        # See Note [names_ / view_names API]
+        # See Note [names_ / renamed API]
         if inplace:
             return super(Tensor, self).names_(names)
         else:
-            return super(Tensor, self).view_names(names)
+            return super(Tensor, self).renamed(names)
 
     __module__ = 'torch'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25711 Rename tensor.view_names -> tensor.renamed**

This function renames the dimensions of a tensor out-of-place. Because
of that, I think `tensor.renamed(...)` is a clearer name: `view_names`
has the connotation that we can use names to `view` our tensors with a
"different shape", but what this function really does is let us rename a
tensor no matter the previous names.

`tensor.names_`, the in-place version of this, is unchanged for now.
However, we might delete this or not advertise it if it has no use case
and also because its naming is a little inconsistent with `tensor.renamed`.

Test Plan:
- [namedtensor ci]

Differential Revision: [D17206515](https://our.internmc.facebook.com/intern/diff/D17206515)