### PR TITLE
Do not pass down USE_GLOO_IBVERBS to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,9 +192,6 @@ cmake_dependent_option(
 cmake_dependent_option(
     USE_GLOO "Use Gloo. Only available if USE_DISTRIBUTED is on." ON
     "USE_DISTRIBUTED" OFF)
-cmake_dependent_option(
-    USE_GLOO_IBVERBS "Use Gloo IB verbs for distributed. Only available if USE_GLOO is on." OFF
-    "USE_GLOO" OFF)
 option(USE_TBB "Use TBB" OFF)
 
 # Used when building Caffe2 through setup.py

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -127,7 +127,6 @@ function (caffe2_print_configuration_summary)
   if(${USE_DISTRIBUTED})
     message(STATUS "    USE_MPI             : ${USE_MPI}")
     message(STATUS "    USE_GLOO            : ${USE_GLOO}")
-    message(STATUS "    USE_GLOO_IBVERBS    : ${USE_GLOO_IBVERBS}")
   endif()
   message(STATUS "  BUILD_NAMEDTENSOR   : ${BUILD_NAMEDTENSOR}")
 

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -287,7 +287,7 @@ class CMake:
                       **build_options)
 
         if USE_GLOO_IBVERBS:
-            CMake.defines(args, USE_IBVERBS="1", USE_GLOO_IBVERBS="1")
+            CMake.defines(args, USE_IBVERBS="1")
 
         expected_wrapper = '/usr/local/opt/ccache/libexec'
         if IS_DARWIN and os.path.exists(expected_wrapper):


### PR DESCRIPTION
It doesn't seem to be used anywhere once down to CMake in this repo or any submodules