### PR TITLE
Move most BUILD_NAMEDTENSOR macros out of header areas

### DIFF
--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -10,9 +10,7 @@
 #include <ATen/DynamicLibrary.h>
 #include <ATen/Formatting.h>
 #include <ATen/Functions.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensor.h>
-#endif
 #include <ATen/ScalarOps.h>
 #include <ATen/Tensor.h>
 #include <ATen/TensorGeometry.h>

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -1,9 +1,8 @@
-#ifdef BUILD_NAMEDTENSOR
-
 #include <ATen/NamedTensorUtils.h>
 #include <bitset>
 #include <sstream>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 // Returns "Tensor['N', 'C', 'H', 'W']" for a tensor with names ('N', 'C', 'H', 'W').

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -1,11 +1,10 @@
 #pragma once
-#ifdef BUILD_NAMEDTENSOR
-
 #include <ATen/NamedTensor.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/core/DimVector.h>
 #include <functional>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;

--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -1,7 +1,7 @@
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/Dimname.h>
 #include <c10/util/Exception.h>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 std::ostream& operator<<(std::ostream& out, const Dimname& dimname) {

--- a/aten/src/ATen/core/Dimname.h
+++ b/aten/src/ATen/core/Dimname.h
@@ -1,6 +1,5 @@
 #pragma once
 #ifdef BUILD_NAMEDTENSOR
-
 #include <ATen/core/interned_strings.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>

--- a/aten/src/ATen/core/NamedTensor.cpp
+++ b/aten/src/ATen/core/NamedTensor.cpp
@@ -1,5 +1,6 @@
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/NamedTensor.h>
+
+#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/Tensor.h>
 #include <c10/util/C++17.h>
 

--- a/aten/src/ATen/core/NamedTensor.h
+++ b/aten/src/ATen/core/NamedTensor.h
@@ -1,10 +1,10 @@
 #pragma once
-#ifdef BUILD_NAMEDTENSOR
 
 #include <ATen/core/Dimname.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/util/C++17.h>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 // XXX: This file exists because TensorImpl is in c10, but Dimname is in ATen.

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -7,9 +7,7 @@
 #include <ATen/native/quantized/Copy.h>
 #include <ATen/quantized/Quantizer.h>
 #include <ATen/MemoryOverlap.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace {
 

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -12,9 +12,7 @@
 #include <ATen/native/Distributions.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/UnaryOps.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 #include <type_traits>
 #include <functional>

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -10,9 +10,7 @@
 #include <numeric>
 #include <vector>
 #include <limits>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/NamedTensor.cpp
+++ b/aten/src/ATen/native/NamedTensor.cpp
@@ -1,9 +1,9 @@
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 
 #include <ATen/NamedTensorUtils.h>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at { namespace native {
 
 Tensor& names_(Tensor& self, optional<DimnameList> names) {

--- a/aten/src/ATen/native/PointwiseOps.cpp
+++ b/aten/src/ATen/native/PointwiseOps.cpp
@@ -6,9 +6,7 @@
 #include <ATen/MemoryOverlap.h>
 #include <ATen/native/TensorIterator.h>
 
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -8,9 +8,7 @@
 #include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/TensorIterator.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 #include <algorithm>
 #include <functional>

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -5,9 +5,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/native/cpu/SoftmaxKernel.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -17,9 +17,7 @@
 #include <TH/THAllocator.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <c10/util/Exception.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 #include <algorithm>
 #include <cctype>

--- a/aten/src/ATen/native/TensorIterator.h
+++ b/aten/src/ATen/native/TensorIterator.h
@@ -7,9 +7,7 @@
 #include <bitset>
 #include <c10/util/Optional.h>
 #include <ATen/MemoryOverlap.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 // TensorIterator is a helper class for element-wise operations, such as
 // arithmetic, comparisions, and trigonometric functions. It handles

--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -2,9 +2,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/detail/CUDAHooksInterface.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 #include <ATen/Config.h>
 namespace at {

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -13,9 +13,7 @@
 #include <ATen/quantized/QTensorImpl.h>
 #include <algorithm>
 #include <vector>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -16,9 +16,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/TensorIterator.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 #include <algorithm>
 #include <cmath>

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -1,8 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/LegacyTHFunctionsCUDA.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace at { namespace native {
 

--- a/aten/src/ATen/templates/LegacyTHFunctions.cpp
+++ b/aten/src/ATen/templates/LegacyTHFunctions.cpp
@@ -4,9 +4,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/Utils.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 #include <ATen/${Generator}.h>
 #include <ATen/ExpandUtils.h>
 ${th_headers}

--- a/aten/src/ATen/templates/TypeDefault.cpp
+++ b/aten/src/ATen/templates/TypeDefault.cpp
@@ -5,9 +5,7 @@
 #include <ATen/DeviceGuard.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/Functions.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 #include <ATen/NativeFunctions.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/Storage.h>

--- a/aten/src/ATen/templates/TypeDefault.h
+++ b/aten/src/ATen/templates/TypeDefault.h
@@ -9,9 +9,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 namespace c10 {
 struct Storage;

--- a/aten/src/ATen/templates/TypeDerived.cpp
+++ b/aten/src/ATen/templates/TypeDerived.cpp
@@ -12,9 +12,7 @@ $storage_tensor_headers
 #include <c10/core/Allocator.h>
 #include <ATen/DeviceGuard.h>
 #include <ATen/NativeFunctions.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 #include <ATen/Utils.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/Dispatch.h>

--- a/aten/src/ATen/test/Dimname_test.cpp
+++ b/aten/src/ATen/test/Dimname_test.cpp
@@ -1,10 +1,10 @@
-#ifdef BUILD_NAMEDTENSOR
 #include <gtest/gtest.h>
 
 #include <ATen/Dimname.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 
+#ifdef BUILD_NAMEDTENSOR
 using at::is_valid_identifier;
 using at::NameType;
 using at::Symbol;

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -1,4 +1,3 @@
-#ifdef BUILD_NAMEDTENSOR
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
@@ -6,6 +5,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/C++17.h>
 
+#ifdef BUILD_NAMEDTENSOR
 using at::Dimname;
 using at::DimnameList;
 using at::NamedTensorMeta;

--- a/aten/src/TH/generic/THTensor.cpp
+++ b/aten/src/TH/generic/THTensor.cpp
@@ -5,9 +5,7 @@
 #include <ATen/InferSize.h>
 #include <ATen/NativeFunctions.h>
 #include <new>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 /**** access methods ****/
 THStorage *THTensor_(storage)(const THTensor *self)

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -3,9 +3,7 @@
 #else
 
 #include <TH/generic/THTensorApply.hpp>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 // Finds non-zero elements of a tensor and returns their subscripts
 void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)

--- a/aten/src/TH/generic/THTensorMath.cpp
+++ b/aten/src/TH/generic/THTensorMath.cpp
@@ -3,9 +3,7 @@
 #else
 
 #include <TH/generic/THTensorApply.hpp>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 // HEY YOU!
 //

--- a/aten/src/THC/generic/THCTensorMathBlas.cu
+++ b/aten/src/THC/generic/THCTensorMathBlas.cu
@@ -3,9 +3,7 @@
 #else
 
 #include "ATen/cuda/CUDAContext.h"
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 #define ERROR_ONLY_FP_TYPES(func) \
   THError("%s for CUDA tensors only supports floating-point types. Try converting the tensors with .float()", func);

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -3,9 +3,7 @@
 #else
 
 #include <ATen/MemoryOverlap.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/NamedTensorUtils.h>
-#endif
 
 void THCTensor_(cbitand)(THCState* state, THCTensor *self_, THCTensor *src1, THCTensor *src2)
 {

--- a/torch/csrc/python_dimname.cpp
+++ b/torch/csrc/python_dimname.cpp
@@ -1,9 +1,9 @@
-#ifdef BUILD_NAMEDTENSOR
 #include <torch/csrc/python_dimname.h>
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <c10/util/flat_hash_map.h>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace torch {
 
 struct InternedStringsTable {

--- a/torch/csrc/python_dimname.h
+++ b/torch/csrc/python_dimname.h
@@ -1,8 +1,8 @@
 #pragma once
-#ifdef BUILD_NAMEDTENSOR
 #include <torch/csrc/python_headers.h>
 #include <ATen/Dimname.h>
 
+#ifdef BUILD_NAMEDTENSOR
 at::Dimname THPDimname_parse(PyObject* obj);
 bool THPUtils_checkDimname(PyObject* obj);
 bool THPUtils_checkDimnameList(PyObject* obj);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25727 Remove more BUILD_NAMEDTENSOR macros, guard mobile builds
* **#25721 Move most BUILD_NAMEDTENSOR macros out of header areas**

Context: I am starting to work on removing the BUILD_NAMEDTENSOR flag.
Here is the approach:
- Move the macro out of header areas
- Include a new `enable_namedtensor.h` header that does a `#ifndef
BUILD_NAMEDTENSOR #define BUILD_NAMEDTENSOR`.
- Include `enable_namedtensor.h` where necessary. This only really needs
to happen in two files (c10/TensorImpl.h, ATen/Dimname.h).
- Incrementally delete usages of the BUILD_NAMEDTENSOR macro later.

The alternative is to straight up delete all instances of
BUILD_NAMEDTENSOR. This alternative could be disruptive, lead to merge
conflicts, and isn't incremental.

Along with the above, some work needs to be done on feature flagging
named tensors, and merging the namedtensor CI with the regular CI, and
communicating with devs. This work will too be done incrementally.

Test Plan
- [namedtensor ci]

Differential Revision: [D17210913](https://our.internmc.facebook.com/intern/diff/D17210913)