### PR TITLE
Only default USE_DISTRIBUTED=True on Linux

### DIFF
--- a/tools/setup_helpers/dist_check.py
+++ b/tools/setup_helpers/dist_check.py
@@ -2,10 +2,10 @@ import os
 import subprocess
 import glob
 
-from .env import IS_CONDA, IS_WINDOWS, CONDA_DIR, check_env_flag, check_negative_env_flag, gather_paths
+from .env import IS_CONDA, IS_LINUX, CONDA_DIR, check_env_flag, check_negative_env_flag, gather_paths
 
 # On ROCm, RCCL development isn't complete. https://github.com/ROCmSoftwarePlatform/rccl
-USE_DISTRIBUTED = not check_negative_env_flag("USE_DISTRIBUTED") and not IS_WINDOWS
+USE_DISTRIBUTED = not check_negative_env_flag("USE_DISTRIBUTED") and IS_LINUX
 USE_GLOO_IBVERBS = False
 
 IB_DEVINFO_CMD = "ibv_devinfo"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25725 Only default USE_DISTRIBUTED=True on Linux**

After landing #25260 the macOS wheel builds started to fail. It turns
out that if not specified, the setup helpers default USE_DISTRIBUTED
to true on all platforms except Windows.

This commit updates that such that USE_DISTRIBUTED only defaults to
true on Linux. More work is needed to enable it by default on macOS.

[test wheel]

Differential Revision: [D17211695](https://our.internmc.facebook.com/intern/diff/D17211695)