### PR TITLE
[ROCm] rocBLAS deprecated the last two parameters.

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -217,9 +217,7 @@ void gemm<at::Half>(CUDABLAS_GEMM_ARGTYPES(at::Half)) {
       rocblas_datatype_f32_r,
       rocblas_gemm_algo_standard,
       0,
-      0,
-      NULL,
-      NULL));
+      0));
 #else
 
 # if CUDA_VERSION >= 9000


### PR DESCRIPTION
Fixes warnings.