### PR TITLE
Correctly gate __CUDA_ARCH__ with defined()

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -70,7 +70,7 @@ inline C10_HOST_DEVICE Half operator/(const Half& a, const Half& b) {
 }
 
 inline C10_HOST_DEVICE Half operator-(const Half& a) {
-#if __CUDA_ARCH__ >= 530 || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530) || defined(__HIP_DEVICE_COMPILE__)
   return __hneg(a);
 #else
   return -static_cast<float>(a);


### PR DESCRIPTION
Summary:
Undefined preprocessor macros being evaluated cause
errors on some compilers/configs. There is an ungated define in caffe2
which is inconsistent with the rest of the file and should be
fixed anyway because it's causing issues in ovrsource.

Test Plan: contbuilds

Differential Revision: D17211552

