### PR TITLE
SubgraphMatcher: add logging to a check missed previously.

### DIFF
--- a/torch/csrc/jit/subgraph_matcher.cpp
+++ b/torch/csrc/jit/subgraph_matcher.cpp
@@ -78,7 +78,20 @@ bool patternGraphIsValid(const Graph& pattern) {
 bool SubgraphMatcher::matchValues(const Value* v1, Value* v2) {
   // Check if we've already visited these values.
   if (values_map_.count(v1)) {
-    return values_map_.at(v1) == v2;
+    if (values_map_.at(v1) != v2) {
+      GRAPH_DEBUG(
+          "Values %",
+          v1->debugName(),
+          " and %",
+          v2->debugName(),
+          " did not match because %",
+          v1->debugName(),
+          " has already been matched with %",
+          values_map_.at(v1)->debugName(),
+          ".\n");
+      return false;
+    }
+    return true;
   }
 
   // When V2 is ANCHOR, we're comparing exiting values, and when V1->node is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25735 SubgraphMatcher: add logging to a check missed previously.**

Differential Revision: [D17216869](https://our.internmc.facebook.com/intern/diff/D17216869)