### PR TITLE
[wip][jit] Decorator for compiling functions while tracing

### DIFF
--- a/torch/csrc/jit/init.cpp
+++ b/torch/csrc/jit/init.cpp
@@ -518,6 +518,8 @@ void initJITBindings(PyObject* module) {
     }
   });
 
+  m.def("_is_tracing", []() { return jit::tracer::isTracing(); });
+
   m.def("wait", [](PythonFutureWrapper& fut) {
     if (jit::tracer::isTracing()) {
       auto graph = jit::tracer::getTracingState()->graph;

--- a/torch/csrc/jit/tracer.cpp
+++ b/torch/csrc/jit/tracer.cpp
@@ -145,7 +145,7 @@ Value* TracingState::getValue(const IValue& var) {
       }
       return it->second;
     }
-    std::ostringstream oss; 
+    std::ostringstream oss;
     if (var.isFuture()) {
       oss << "Tried to trace Future or Object that the tracer was not aware of.";
     } else {
@@ -284,7 +284,7 @@ static void gatherParametersAndBuffers(
     Value* self_value,
     const script::Module& self) {
   Graph& g = *self_value->owningGraph();
-  
+
   state->setValue(self.module_object(), self_value);
 
   for (script::Slot s : self.get_slots()) {
@@ -376,6 +376,8 @@ void TracingState::setValue(const IValue& v, Value* value) {
     }
   } else if (v.isFuture() || v.isObject()) {
     env_stack.back()[v] = value;
+  } else if (v.isNone()) {
+    graph->insertNode(graph->createNone());
   } else {
     std::ostringstream os;
     os << "Tracer cannot set value trace for type " << v.tagKind() << ". "

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1186,6 +1186,10 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         fn.__doc__ = obj.__doc__
         return fn
 
+
+torch._jit_internal.jit_script = script
+
+
 def _gen_rcb(obj, _frames_up):
     _frames_up = _frames_up + 1  # for invoking _gen_rcb()
 

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -195,6 +195,10 @@ def make_strong_submodule(field, module, parent):
 
 
 def try_compile_fn(fn, loc):
+    # Un-wrap @delayed_script functions
+    if hasattr(fn, '__original_fn__'):
+        fn = fn.__original_fn__
+
     if _jit_internal.is_ignored_fn(fn):
         # Don't do anything for @ignore'd functions
         return None

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -72,6 +72,12 @@ class DeQuantize(Module):
     def from_float(mod):
         return DeQuantize()
 
+@torch._jit_internal.delayed_script
+def get_bias(packed_params):
+    # type: (Tensor) -> Optional[Tensor]
+    return torch.ops.quantized.linear_unpack(packed_params)[1]
+
+
 class Linear(torch.nn.Module):
     r"""
     A quantized linear module with quantized tensor as inputs and outputs.
@@ -193,8 +199,7 @@ class Linear(torch.nn.Module):
 
     def bias(self):
         # type: () -> Optional[torch.Tensor]
-        (w, b) = torch.ops.quantized.linear_unpack(self._packed_params)
-        return b
+        return get_bias(self._packed_params)
 
     def set_weight_bias(self, w, b):
         # type: (torch.Tensor, Optional[torch.Tensor]) -> None


### PR DESCRIPTION
```
ERROR: test_linear_api (__main__.DynamicModuleAPITest)
test API functionality for nn.quantized.dynamic.Linear
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_quantized_nn_mods.py", line 92, in test_linear_api
    @unittest.skipIf(
  File "/private/home/davidriazati/miniconda/lib/python3.7/site-packages/hypothesis/core.py", line 1012, in wrapped_test
    raise the_error_hypothesis_found
  File "test/test_quantized_nn_mods.py", line 168, in test_linear_api
    self.checkScriptable(qlinear, list(zip([X], [Z_ref])), check_save_load=True)
  File "/scratch/davidriazati/dev/pytorch/test/common_quantization.py", line 148, in checkScriptable
    traced = torch.jit.trace(orig_mod, calib_data[0][0], check_trace=False)
  File "/scratch/davidriazati/dev/pytorch/torch/jit/__init__.py", line 822, in trace
    check_tolerance, _force_outplace, _module_class)
  File "/scratch/davidriazati/dev/pytorch/torch/jit/__init__.py", line 961, in trace_module
    module._c._create_method_from_trace(method_name, func, example_inputs, var_lookup_fn, _force_outplace)
RuntimeError: hasSpecialCase INTERNAL ASSERT FAILED at ../torch/csrc/jit/passes/alias_analysis.cpp:302, please report a bug to PyTorch. We don't have an op for aten::contiguous but it isn't a special case. (analyzeImpl at ../torch/csrc/jit/passes/alias_analysis.cpp:302)
frame #0: <unknown function> + 0x5ebdf (0x7fdb70c1bbdf in /scratch/davidriazati/dev/pytorch/torch/lib/libc10.so)
frame #1: std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > ()>::operator()() const + 0x4d (0x7fdaade7f89d in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #2: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0x43 (0x7fdb70c1b1f3 in /scratch/davidriazati/dev/pytorch/torch/lib/libc10.so)
frame #3: <unknown function> + 0x3e5f5b2 (0x7fdaadc2f5b2 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #4: <unknown function> + 0x3e5efed (0x7fdaadc2efed in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #5: <unknown function> + 0x3e5efb0 (0x7fdaadc2efb0 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #6: <unknown function> + 0x3e5cf0a (0x7fdaadc2cf0a in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #7: torch::jit::AliasDb::AliasDb(std::shared_ptr<torch::jit::Graph>) + 0x131 (0x7fdaadc2ccb1 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #8: <unknown function> + 0x3ea23a6 (0x7fdaadc723a6 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #9: <unknown function> + 0x3ea1fbd (0x7fdaadc71fbd in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #10: torch::jit::EliminateDeadCode(std::shared_ptr<torch::jit::Graph> const&, torch::jit::DCESideEffectPolicy) + 0x43 (0x7fdaadc71983 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #11: torch::jit::LowerSimpleTuples(std::shared_ptr<torch::jit::Graph>&) + 0x30 (0x7fdaadca4ee0 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch.so)
frame #12: torch::jit::tracer::createGraphByTracing(pybind11::function const&, torch::jit::tracer::TypedStack, pybind11::function const&, bool, torch::jit::script::Module*) + 0x837 (0x7fdb758b14f7 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
frame #13: <unknown function> + 0xaced21 (0x7fdb758d4d21 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
frame #14: <unknown function> + 0xacec17 (0x7fdb758d4c17 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
frame #15: <unknown function> + 0xacead6 (0x7fdb758d4ad6 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
frame #16: <unknown function> + 0xacea07 (0x7fdb758d4a07 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
frame #17: <unknown function> + 0xace8f5 (0x7fdb758d48f5 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
frame #18: <unknown function> + 0x5aebc4 (0x7fdb753b4bc4 in /scratch/davidriazati/dev/pytorch/torch/lib/libtorch_python.so)
<omitting python frames>
```