### PR TITLE
Fix int32 overflow in SummaryOps.cu getBin  #25747

### DIFF
--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -2,6 +2,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 
+
 namespace at {
 namespace cuda {
 #define THRESH_NUMBER_BINS_FOR_MULTI_BLOCK_MEM 100
@@ -17,8 +18,8 @@ namespace cuda {
 enum class CUDAHistogramMemoryType { SHARED, MULTI_BLOCK, GLOBAL };
 namespace {
   template<typename input_t, typename IndexType>
-  __device__ static IndexType getBin(input_t bVal, input_t minvalue, input_t maxvalue, int nbins) {
-    IndexType bin = (int)(int64_t(bVal - minvalue) * nbins / (maxvalue - minvalue));
+  __device__ static IndexType getBin(input_t bVal, input_t minvalue, input_t maxvalue, int64_t nbins) {
+    IndexType bin = (int)((bVal - minvalue) * nbins / (maxvalue - minvalue));
     // (only applicable for histc)
     // while each bin is inclusive at the lower end and exclusive at the higher, i.e. [start, end)
     // the last bin is inclusive at both, i.e. [start, end], in order to include maxvalue if exists
@@ -47,7 +48,7 @@ __global__ void kernelHistogram1D(
     detail::TensorInfo<output_t, IndexType> a, /* output */
     detail::TensorInfo<output_t, IndexType> p, /* partial output */
     detail::TensorInfo<input_t, IndexType> b, /* input */
-    int nbins,
+    int64_t nbins,
     input_t minvalue,
     input_t maxvalue,
     IndexType totalElements,

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -18,7 +18,7 @@ enum class CUDAHistogramMemoryType { SHARED, MULTI_BLOCK, GLOBAL };
 namespace {
   template<typename input_t, typename IndexType>
   __device__ static IndexType getBin(input_t bVal, input_t minvalue, input_t maxvalue, int nbins) {
-    IndexType bin = (int)((bVal - minvalue) * nbins / (maxvalue - minvalue));
+    IndexType bin = (int)(int64_t(bVal - minvalue) * nbins / (maxvalue - minvalue));
     // (only applicable for histc)
     // while each bin is inclusive at the lower end and exclusive at the higher, i.e. [start, end)
     // the last bin is inclusive at both, i.e. [start, end], in order to include maxvalue if exists

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -2,7 +2,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 
-
 namespace at {
 namespace cuda {
 #define THRESH_NUMBER_BINS_FOR_MULTI_BLOCK_MEM 100

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2855,12 +2855,6 @@ class TestCuda(TestCase):
         counted = t.bincount(minlength=65536)
         self.assertEqual(T.sum(counted), 10)
 
-        t = torch.zeros()
-        t = torch.randint(2000, input_size, dtype=torch.int32, device='cuda')
-        self.assertEqual(t.cpu().bincount(), t.bincount())
-        self.assertEqual(t.cpu().bincount(w_cpu), t.bincount(w))
-
-
     def test_tiny_half_norm_(self):
         a = torch.arange(25).cuda().float()
         a /= 100000000

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2848,6 +2848,19 @@ class TestCuda(TestCase):
         self.assertEqual(t.cpu().bincount(), t.bincount())
         self.assertEqual(t.cpu().bincount(w_cpu), t.bincount(w))
 
+        t = torch.zeros([10], dtype=torch.int32, device='cuda')
+        # 35488 * 65536 as int32 would cause overflow to negative value
+        # giving negative bin offset
+        t[0] = 35488
+        counted = t.bincount(minlength=65536)
+        self.assertEqual(T.sum(counted), 10)
+
+        t = torch.zeros()
+        t = torch.randint(2000, input_size, dtype=torch.int32, device='cuda')
+        self.assertEqual(t.cpu().bincount(), t.bincount())
+        self.assertEqual(t.cpu().bincount(w_cpu), t.bincount(w))
+
+
     def test_tiny_half_norm_(self):
         a = torch.arange(25).cuda().float()
         a /= 100000000

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2853,7 +2853,7 @@ class TestCuda(TestCase):
         # giving negative bin offset
         t[0] = 35488
         counted = t.bincount(minlength=65536)
-        self.assertEqual(T.sum(counted), 10)
+        self.assertEqual(torch.sum(counted), 10)
 
     def test_tiny_half_norm_(self):
         a = torch.arange(25).cuda().float()


### PR DESCRIPTION
Fixes issue #25747 by upcasting to int64 before multiplication. Should be good enough for all reasonable nbins