### PR TITLE
Use `constructor` in test_params for C++ API parity test

### DIFF
--- a/test/cpp_api_parity/__init__.py
+++ b/test/cpp_api_parity/__init__.py
@@ -5,11 +5,11 @@ TorchNNTestParams = namedtuple(
     [
         'module_name',
         'module_variant_name',
+        'python_constructor',
         'python_constructor_args',
         'cpp_constructor_args',
         'example_inputs',
         'has_parity',
-        'python_module_class',
         'cpp_sources',
         'num_attrs_recursive',
         'device',

--- a/test/cpp_api_parity/sample_module.py
+++ b/test/cpp_api_parity/sample_module.py
@@ -92,7 +92,7 @@ module_tests = [
     ),
     dict(
         module_name='SampleModule',
-        constructor_args=(False, True),
+        constructor=lambda: SampleModule(False, True),
         cpp_constructor_args='(true)',
         input_size=(3, 4),
         desc='no_parity',

--- a/test/cpp_api_parity/sample_module.py
+++ b/test/cpp_api_parity/sample_module.py
@@ -84,18 +84,17 @@ TORCH_MODULE(SampleModule);
 module_tests = [
     dict(
         module_name='SampleModule',
+        desc='has_parity',
         constructor_args=(True, True),
         cpp_constructor_args='(true)',
         input_size=(3, 4),
-        desc='has_parity',
         has_parity=True,
     ),
     dict(
-        module_name='SampleModule',
+        fullname='SampleModule_no_parity',
         constructor=lambda: SampleModule(False, True),
         cpp_constructor_args='(true)',
         input_size=(3, 4),
-        desc='no_parity',
         has_parity=False,
     ),
 ]


### PR DESCRIPTION
This PR changes the C++ API parity test script so that `test_params` such as the following is understood:
https://github.com/pytorch/pytorch/blob/88e4cee3e70aac95dd2c18b898808ce3426cb3c9/test/common_nn.py#L2194-L2200