### PR TITLE
[pytorch] fix OSS mobile CI

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -1,10 +1,11 @@
 #pragma once
 #include <ATen/NamedTensor.h>
+
+#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/Tensor.h>
 #include <ATen/core/DimVector.h>
 #include <functional>
 
-#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25697 [pytorch] introduce INTERN_DISABLE_AUTOGRAD flag to create inference only library for mobile
* #25650 [pytorch][cmake] get rid of protobuf dependencies
* #25670 [pytorch] remove caffe2.pb.h dependency for embedding_lookup_idx.cc
* **#25755 [pytorch] fix OSS mobile CI**

Summary:
PR #25721 breaks mobile CI (with USE_STATIC_DISPATCH=1) due to circular
header dependency.
Move 'ATen/core/Tensor.h' back into '#ifdef BUILD_NAMEDTENSOR' to work
around the CI issue.

Test Plan:
- build android library locally

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25755

Differential Revision: [D17223997](https://our.internmc.facebook.com/intern/diff/D17223997)