### PR TITLE
Use whitelist instead of blacklist for USE_DISTRIBUTED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,21 +83,13 @@ else ()
   set(CPU_INTEL OFF)
 endif ()
 
-# For Windows, turn USE_DISTRIBUTED off by default.
+# For non-supported platforms, turn USE_DISTRIBUTED off by default.
 # It is not tested and likely won't work without additional changes.
-if(MSVC)
+if(NOT LINUX)
   set(USE_DISTRIBUTED OFF CACHE STRING "Use distributed")
-endif()
-
-# For macOS, turn USE_DISTRIBUTED off by default.
-# Gloo depends on libuv, which has to be installed by the user first.
-# Therefore, the user should explicitly specify -DUSE_DISTRIBUTED=1
-# to build torch.distributed, after installing the dependency.
-if(APPLE)
-  set(USE_DISTRIBUTED OFF CACHE STRING "Use distributed")
-  # If USE_DISTRIBUTED is set, also set USE_LIBUV=1 for Gloo.
-  # It is the only transport that can be built on macOS.
-  if(USE_DISTRIBUTED)
+  # On macOS, if USE_DISTRIBUTED is enabled (specified by the user),
+  # then make Gloo build with the libuv transport.
+  if(APPLE AND USE_DISTRIBUTED)
     set(USE_LIBUV ON CACHE STRING "")
   endif()
 endif()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25759 Use whitelist instead of blacklist for USE_DISTRIBUTED**

In #25260, USE_DISTRIBUTED was defaulted to OFF for Windows and macOS
only. The Android builds didn't run for the PR and started to fail
when it was merged to master. It turns out the mobile builds
explicitly disable USE_DISTRIBUTED but only after the USE_DISTRIBUTED
option, and derivative dependent options were defined. The result
being that USE_GLOO was enabled while USE_DISTRIBUTED was disabled.

This commit ensures that USE_DISTRIBUTED defaults to OFF unless the
build is for a supported platform.

Differential Revision: [D17224842](https://our.internmc.facebook.com/intern/diff/D17224842/)