### PR TITLE
Fix OSS mobile build

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -1,10 +1,11 @@
 #pragma once
 #include <ATen/NamedTensor.h>
+
+#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/Tensor.h>
 #include <ATen/core/DimVector.h>
 #include <functional>
 
-#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25772 [WIP][testing] Turn on BUILD_NAMEDTENSOR permanently
* #25727 Remove more BUILD_NAMEDTENSOR macros, guard mobile builds
* #25728 Quick fixes for named tensor for windows
* #25771 Move BUILD_NAMEDTENSOR in NamedTensorUtils.h
* **#25770 Fix OSS mobile build**

[namedtensor ci]

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25770

Differential Revision: [D17227116](https://our.internmc.facebook.com/intern/diff/D17227116)