### PR TITLE
Move BUILD_NAMEDTENSOR in NamedTensorUtils.h

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <ATen/NamedTensor.h>
 
-#ifdef BUILD_NAMEDTENSOR
-#include <ATen/core/Tensor.h>
+#include <ATen/core/TensorBody.h>
 #include <ATen/core/DimVector.h>
 #include <functional>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25772 [WIP][testing] Turn on BUILD_NAMEDTENSOR permanently
* #25727 Remove more BUILD_NAMEDTENSOR macros, guard mobile builds
* #25778 Fix assertion if NamedTensorMeta's num_names != tensor.dim
* #25728 Quick fixes for named tensor
* **#25779 Move BUILD_NAMEDTENSOR in NamedTensorUtils.h**

