### PR TITLE
Move BUILD_NAMEDTENSOR in NamedTensorUtils.h

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <ATen/NamedTensor.h>
 
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/Tensor.h>
 #include <ATen/core/DimVector.h>
 #include <functional>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;

--- a/aten/src/ATen/templates/TypeDefault.h
+++ b/aten/src/ATen/templates/TypeDefault.h
@@ -9,7 +9,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
-#include <ATen/NamedTensorUtils.h>
+#include <ATen/Dimname.h>
 
 namespace c10 {
 struct Storage;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25798 Turn on BUILD_NAMEDTENSOR permanently
* #25789 Remove more BUILD_NAMEDTENSOR macros, guard mobile builds
* #25778 Fix assertion if NamedTensorMeta's num_names != tensor.dim
* #25728 Quick fixes for named tensor
* **#25781 Move BUILD_NAMEDTENSOR in NamedTensorUtils.h**

To prepare for removing the BUILD_NAMEDTENSOR flag, I am attempting to
remove BUILD_NAMEDTENSOR out of header areas.

Test Plan:
- [namedtensor ci]
- Tested building locally with USE_STATIC_DISPATCH=1. Previously, in
https://github.com/pytorch/pytorch/pull/25721, this change had caused a
dependency cycle while building with that on.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25781

Differential Revision: [D17229490](https://our.internmc.facebook.com/intern/diff/D17229490)