### PR TITLE
Map module options between Python and C++ in API parity test

### DIFF
--- a/test/cpp_api_parity/__init__.py
+++ b/test/cpp_api_parity/__init__.py
@@ -12,6 +12,7 @@ TorchNNTestParams = namedtuple(
         'has_parity',
         'cpp_sources',
         'num_attrs_recursive',
+        'options_args',
         'device',
     ]
 )
@@ -20,8 +21,16 @@ CppArg = namedtuple('CppArg', ['type', 'value'])
 
 ParityStatus = namedtuple('ParityStatus', ['has_impl_parity', 'has_doc_parity'])
 
-TorchNNModuleMetadata = namedtuple('TorchNNModuleMetadata', ['cpp_default_constructor_args', 'num_attrs_recursive', 'cpp_sources'])
-TorchNNModuleMetadata.__new__.__defaults__ = (None, None, '')
+TorchNNModuleMetadata = namedtuple(
+    'TorchNNModuleMetadata',
+    [
+        'cpp_default_constructor_args',
+        'num_attrs_recursive',
+        'options_args',
+        'cpp_sources',
+    ]
+)
+TorchNNModuleMetadata.__new__.__defaults__ = (None, None, [], '')
 
 '''
 This function expects the parity tracker Markdown file to have the following format:

--- a/test/cpp_api_parity/torch_nn_modules.py
+++ b/test/cpp_api_parity/torch_nn_modules.py
@@ -20,8 +20,8 @@ from cpp_api_parity import TorchNNModuleMetadata
 #     as the Python module constructor.
 #
 # `num_attrs_recursive`: the number of attributes (including parameters, buffers and non-tensor
-#     attributes) of a module. If the module contains any submodule, the submodule's attributes
-#     also need to be counted.
+#     attributes) of the Python module. If the module contains any submodule, the submodule's
+#     attributes also need to be counted.
 module_metadata_map = {
     'Conv1d': TorchNNModuleMetadata(),
     'Conv2d': TorchNNModuleMetadata(),


### PR DESCRIPTION
`torch.nn` modules in Python save their kwarg options directly as module object attributes, while `torch::nn` modules in C++ save their options inside the `options` field of the module object. This PR tries to map between these two (by using the newly added `options_args` list to discover options arguments in Python module), to make sure options equivalence is properly checked.