### PR TITLE
Spell out the legacy::cuda_th_ functions that are used.

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -56,41 +56,41 @@ Tensor& _clamp_min_out_cuda(Tensor& result, const Tensor& self, Scalar min) {
 
 // These are just forwarding stubs
 
-#define IMPLEMENT_UNARY_OP_PREQUEL(op)                           \
+#define IMPLEMENT_UNARY_OP_PREQUEL(op, _th_op)                   \
   Tensor& _##op##__cuda(Tensor& self) {                          \
-    return legacy::cuda::_th_##op##_out(self, self);         \
+    return _th_op##_out(self, self);                             \
   }                                                              \
   Tensor& _##op##_out_cuda(Tensor& result, const Tensor& self) { \
-    return legacy::cuda::_th_##op##_out(result, self);       \
+    return _th_##op##_out(result, self);                         \
   }
 
 
-IMPLEMENT_UNARY_OP_PREQUEL(abs)
-IMPLEMENT_UNARY_OP_PREQUEL(acos)
-IMPLEMENT_UNARY_OP_PREQUEL(asin)
-IMPLEMENT_UNARY_OP_PREQUEL(atan)
-IMPLEMENT_UNARY_OP_PREQUEL(ceil)
-IMPLEMENT_UNARY_OP_PREQUEL(cos)
-IMPLEMENT_UNARY_OP_PREQUEL(cosh)
-IMPLEMENT_UNARY_OP_PREQUEL(erf)
-IMPLEMENT_UNARY_OP_PREQUEL(erfc)
-IMPLEMENT_UNARY_OP_PREQUEL(exp)
-IMPLEMENT_UNARY_OP_PREQUEL(expm1)
-IMPLEMENT_UNARY_OP_PREQUEL(frac)
-IMPLEMENT_UNARY_OP_PREQUEL(floor)
-IMPLEMENT_UNARY_OP_PREQUEL(log)
-IMPLEMENT_UNARY_OP_PREQUEL(log10)
-IMPLEMENT_UNARY_OP_PREQUEL(log1p)
-IMPLEMENT_UNARY_OP_PREQUEL(log2)
-IMPLEMENT_UNARY_OP_PREQUEL(reciprocal)
-IMPLEMENT_UNARY_OP_PREQUEL(round)
-IMPLEMENT_UNARY_OP_PREQUEL(rsqrt)
-IMPLEMENT_UNARY_OP_PREQUEL(sigmoid)
-IMPLEMENT_UNARY_OP_PREQUEL(sin)
-IMPLEMENT_UNARY_OP_PREQUEL(sinh)
-IMPLEMENT_UNARY_OP_PREQUEL(sqrt)
-IMPLEMENT_UNARY_OP_PREQUEL(tan)
-IMPLEMENT_UNARY_OP_PREQUEL(tanh)
-IMPLEMENT_UNARY_OP_PREQUEL(trunc)
+IMPLEMENT_UNARY_OP_PREQUEL(abs, legacy::cuda::_th_abs_out)
+IMPLEMENT_UNARY_OP_PREQUEL(acos, legacy::cuda::_th_acos_out)
+IMPLEMENT_UNARY_OP_PREQUEL(asin, legacy::cuda::_th_asin_out)
+IMPLEMENT_UNARY_OP_PREQUEL(atan, legacy::cuda::_th_atan_out)
+IMPLEMENT_UNARY_OP_PREQUEL(ceil, legacy::cuda::_th_ceil_out)
+IMPLEMENT_UNARY_OP_PREQUEL(cos, legacy::cuda::_th_cos_out)
+IMPLEMENT_UNARY_OP_PREQUEL(cosh, legacy::cuda::_th_cosh_out)
+IMPLEMENT_UNARY_OP_PREQUEL(erf, legacy::cuda::_th_erf_out)
+IMPLEMENT_UNARY_OP_PREQUEL(erfc, legacy::cuda::_th_erfc_out)
+IMPLEMENT_UNARY_OP_PREQUEL(exp, legacy::cuda::_th_exp_out)
+IMPLEMENT_UNARY_OP_PREQUEL(expm1, legacy::cuda::_th_expm1_out)
+IMPLEMENT_UNARY_OP_PREQUEL(frac, legacy::cuda::_th_frac_out)
+IMPLEMENT_UNARY_OP_PREQUEL(floor, legacy::cuda::_th_floor_out)
+IMPLEMENT_UNARY_OP_PREQUEL(log, legacy::cuda::_th_log_out)
+IMPLEMENT_UNARY_OP_PREQUEL(log10, legacy::cuda::_th_log10_out)
+IMPLEMENT_UNARY_OP_PREQUEL(log1p, legacy::cuda::_th_log1p_out)
+IMPLEMENT_UNARY_OP_PREQUEL(log2, legacy::cuda::_th_log2_out)
+IMPLEMENT_UNARY_OP_PREQUEL(reciprocal, legacy::cuda::_th_reciprocal_out)
+IMPLEMENT_UNARY_OP_PREQUEL(round, legacy::cuda::_th_round_out)
+IMPLEMENT_UNARY_OP_PREQUEL(rsqrt, legacy::cuda::_th_rqsrt_out)
+IMPLEMENT_UNARY_OP_PREQUEL(sigmoid, legacy::cuda::_th_sigmoid_out)
+IMPLEMENT_UNARY_OP_PREQUEL(sin, legacy::cuda::_th_sin_out)
+IMPLEMENT_UNARY_OP_PREQUEL(sinh, legacy::cuda::_th_sinh_out)
+IMPLEMENT_UNARY_OP_PREQUEL(sqrt, legacy::cuda::_th_sqrt_out)
+IMPLEMENT_UNARY_OP_PREQUEL(tan, legacy::cuda::_th_tan_out)
+IMPLEMENT_UNARY_OP_PREQUEL(tanh, legacy::cuda::_th_tanh_out)
+IMPLEMENT_UNARY_OP_PREQUEL(trunc, legacy::cuda::_th_trunc_out)
 
 }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25787 Spell out the legacy::cuda_th_ functions that are used.**
* #25358 Kill non-shared cwrap tools.
* #25357 Update derivatives.yaml docs to refer to Declarations.yaml rather than Declarations.cwrap.
* #25356 Get rid of extract_cwrap
* #25355 Get rid of more unused plugins.
* #25354 Get rid of torch._thnn.
* #25353 Stop doing nn wrap.
* #25352 Stop initializing THNN backend.
* #25343 [JIT] Attempt to enable CrossMapLRN2d, as it no longer uses Module._backend.
* #25342 Remove Module._backend as it's not used anymore.
* #25339 Move autograd function for CrossMapLRN2d from being backend specific to modules/_functions.
* #25331 Kill backend-specific lookup in CrossMapLRN2d, as it never succeeds.
* #25326 Kill ConvTransposeMixin.forward, which doesn't seem to be used.
* #25323 Remove THNN sparse autograd Functions.
* #25322 Kill THNN function auto generation.

Since we are actively trying to kill this layer, hiding the calls behind macros really slows down figuring out what is used.

Differential Revision: [D17233904](https://our.internmc.facebook.com/intern/diff/D17233904)