### PR TITLE
[jit] Add `in` membership checks for lists

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17524,7 +17524,6 @@ class TestList(JitTestCase):
         self.checkScript(str_in, (['hi', 'bye'],))
         self.checkScript(str_in, ([],))
 
-
     def test_list_literal(self):
         def reassign():
             x = [1]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -17501,6 +17501,30 @@ class TestDataParallel(JitTestCase):
 
 
 class TestList(JitTestCase):
+    def test_in_check(self):
+        def int_in(x):
+            # type: (List[int]) -> bool
+            return 2 in x
+
+        self.checkScript(int_in, ([1, 2, 3],))
+        self.checkScript(int_in, ([1, 3, 3],))
+
+        def float_in(x):
+            # type: (List[float]) -> bool
+            return 2. in x
+
+        self.checkScript(float_in, ([1., 2., 3.],))
+        self.checkScript(float_in, ([1., 3., 3.],))
+
+        def str_in(x):
+            # type: (List[str]) -> bool
+            return 'hi' in x
+
+        self.checkScript(str_in, (['not', 'here'],))
+        self.checkScript(str_in, (['hi', 'bye'],))
+        self.checkScript(str_in, ([],))
+
+
     def test_list_literal(self):
         def reassign():
             x = [1]

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1748,18 +1748,6 @@ int listContains(Stack& stack) {
   return 0;
 }
 
-Operation listContainsStr(const Node* node) {
-  auto list = node->inputs().at(0)->type()->expect<ListType>();
-
-  if (!list->getElementType()->isSubtypeOf(StringType::get())) {
-    throw script::ErrorReport(node->sourceRange())
-        << "'in' checks can only be"
-           " used on List[str], List[int], and List[float]";
-  }
-
-  return listContains<std::string>;
-}
-
 template <class T>
 int listAdd(Stack& stack) {
   c10::List<T> b = pop(stack).to<c10::List<T>>();
@@ -2398,6 +2386,7 @@ RegisterOperators reg2({
     CREATE_LIST_OPS("t", c10::List<IValue>),
 
     // `listContains<T>` is not implemented for non-primitive types
+    // TODO: Add List[bool] once .to<c10::List<bool>> doesn't throw an error
     Operator(
         "aten::__contains__(int[] l, int item) -> bool",
         listContains<int64_t>,
@@ -2408,7 +2397,7 @@ RegisterOperators reg2({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::__contains__(str[] l, str item) -> bool",
-        listContainsStr,
+        listContains<std::string>,
         aliasAnalysisFromSchema()),
 #undef CREATE_LIST_OPS
     Operator(


### PR DESCRIPTION


Since it requires an equality operator, it's only implemented for lists
of `int`, `float`, and `str`.

Fixes some of #25758

Differential Revision: [D17296216](https://our.internmc.facebook.com/intern/diff/17296216/)