### PR TITLE
[JIT] Fix missing newline in compiled from source range highlihgt

### DIFF
--- a/torch/csrc/jit/source_range.cpp
+++ b/torch/csrc/jit/source_range.cpp
@@ -66,8 +66,9 @@ C10_EXPORT void SourceRange::highlight(std::ostream& out) const {
   size_t len = std::min(size(), end_line - start());
   out << std::string(len, '~')
       << (len < size() ? "...  <--- HERE" : " <--- HERE");
-  out << str.substr(end_line, end_highlight - end_line);
-  if (!str.empty() && str.back() != '\n')
+  auto line_substr = str.substr(end_line, end_highlight - end_line);
+  out << line_substr;
+  if (!line_substr.empty() && line_substr.back() != '\n')
     out << "\n";
   // Retrieve original SourceRange, if present.
   if (auto orig_source_range = findSourceRangeThatGenerated()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25802 [JIT] Fix missing newline in compiled from source range highlihgt**

Test script

```
import torch


def foo(x, y):
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    return x

scripted = torch.jit.script(foo)
scripted.save('foo.zip')

loaded = torch.jit.load('foo.zip')
loaded(torch.rand(3, 4), torch.rand(4, 5))
```

Before this change
```
RuntimeError: The size of tensor a (4) must match the size of tensor b (5) at non-singleton dimension 1
The above operation failed in interpreter, with the following stack trace:
at code/__torch__.py:7:9
op_version_set = 1
class PlaceholderModule(Module):
  __parameters__ = []
  def forward(self: __torch__.PlaceholderModule,
    x: Tensor,
    y: Tensor) -> Tensor:
    x0 = torch.add(x, y, alpha=1)
         ~~~~~~~~~ <--- HERE
    x1 = torch.add(x0, y, alpha=1)
    x2 = torch.add(x1, y, alpha=1)
    x3 = torch.add(x2, y, alpha=1)
    x4 = torch.add(x3, y, alpha=1)
    x5 = torch.add(x4, y, alpha=1)
    x6 = torch.add(x5, y, alpha=1)
    x7 = torch.add(x6, y, alpha=1)
    x8 = torch.add(x7, y, alpha=1)
    x9 = torch.add(x8, y, alpha=1)Compiled from code at /home/jamesreed/print_test.py:5:8
def foo(x, y):
    x = x + y
        ~~~~~ <--- HERE
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
```

After this change
```
RuntimeError: The size of tensor a (4) must match the size of tensor b (5) at non-singleton dimension 1
The above operation failed in interpreter, with the following stack trace:
at code/__torch__.py:7:9
op_version_set = 1
class PlaceholderModule(Module):
  __parameters__ = []
  def forward(self: __torch__.PlaceholderModule,
    x: Tensor,
    y: Tensor) -> Tensor:
    x0 = torch.add(x, y, alpha=1)
         ~~~~~~~~~ <--- HERE
    x1 = torch.add(x0, y, alpha=1)
    x2 = torch.add(x1, y, alpha=1)
    x3 = torch.add(x2, y, alpha=1)
    x4 = torch.add(x3, y, alpha=1)
    x5 = torch.add(x4, y, alpha=1)
    x6 = torch.add(x5, y, alpha=1)
    x7 = torch.add(x6, y, alpha=1)
    x8 = torch.add(x7, y, alpha=1)
    x9 = torch.add(x8, y, alpha=1)
Compiled from code at /home/jamesreed/print_test.py:5:8
def foo(x, y):
    x = x + y
        ~~~~~ <--- HERE
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
    x = x + y
```

Differential Revision: [D17250599](https://our.internmc.facebook.com/intern/diff/D17250599)