### PR TITLE
[iOS] Clean up the iOS build script

### DIFF
--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -17,7 +17,7 @@ cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 
-if [ -n "${BUILD_PYTORCH_MOBILE}" ]; then 
+if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then 
   CMAKE_ARGS+=("-DBUILD_CAFFE2_MOBILE=OFF")
   CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
   CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -47,7 +47,7 @@ fi
 if [ -n "${IOS_PLATFORM:-}" ]; then
   CMAKE_ARGS+=("-DIOS_PLATFORM=${IOS_PLATFORM}")
   if [ "${IOS_PLATFORM}" == "SIMULATOR" ]; then
-      # iOS Simulator build is not suppored by NNPACK
+      # iOS Simulator build is not supported by NNPACK
       CMAKE_ARGS+=("-DUSE_NNPACK=OFF")
   fi
 else

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -9,11 +9,6 @@
 
 CAFFE2_ROOT="$( cd "$(dirname "$0")"/.. ; pwd -P)"
 
-# Build protobuf from third_party so we have a host protoc binary.
-echo "Building protoc"
-BITCODE_FLAGS="-DCMAKE_C_FLAGS=-fembed-bitcode -DCMAKE_CXX_FLAGS=-fembed-bitcode "
-$CAFFE2_ROOT/scripts/build_host_protoc.sh --other-flags $BITCODE_FLAGS
-
 # Now, actually build the iOS target.
 BUILD_ROOT=${BUILD_ROOT:-"$CAFFE2_ROOT/build_ios"}
 INSTALL_PREFIX=${BUILD_ROOT}/install
@@ -22,9 +17,20 @@ cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 
-# Use locally built protoc because we'll build libprotobuf for the
-# target architecture and need an exact version match.
-CMAKE_ARGS+=("-DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=$CAFFE2_ROOT/build_host_protoc/bin/protoc")
+if [ -n "${BUILD_PYTORCH_MOBILE}" ]; then 
+  CMAKE_ARGS+=("-DBUILD_CAFFE2_MOBILE=OFF")
+  CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
+  CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
+  CMAKE_ARGS+=("-DBUILD_CUSTOM_PROTOBUF=OFF")
+else
+  # Build protobuf from third_party so we have a host protoc binary.
+  echo "Building protoc"
+  BITCODE_FLAGS="-DCMAKE_C_FLAGS=-fembed-bitcode -DCMAKE_CXX_FLAGS=-fembed-bitcode "
+  $CAFFE2_ROOT/scripts/build_host_protoc.sh --other-flags $BITCODE_FLAGS
+  # Use locally built protoc because we'll build libprotobuf for the
+  # target architecture and need an exact version match.
+  CMAKE_ARGS+=("-DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=$CAFFE2_ROOT/build_host_protoc/bin/protoc")
+fi
 
 # Use ios-cmake to build iOS project from CMake.
 # This projects sets CMAKE_C_COMPILER to /usr/bin/gcc and
@@ -40,9 +46,17 @@ fi
 # IOS_PLATFORM controls type of iOS platform (see ios-cmake)
 if [ -n "${IOS_PLATFORM:-}" ]; then
   CMAKE_ARGS+=("-DIOS_PLATFORM=${IOS_PLATFORM}")
+  if [ "${IOS_PLATFORM}" == "SIMULATOR" ]; then
+      # iOS Simulator build is not suppored by NNPACK
+      CMAKE_ARGS+=("-DUSE_NNPACK=OFF")
+  fi
 else
   # IOS_PLATFORM is not set, default to OS, which builds iOS.
   CMAKE_ARGS+=("-DIOS_PLATFORM=OS")
+fi
+
+if [ -n "${IOS_ARCH:-}" ]; then
+  CMAKE_ARGS+=("-DIOS_ARCH=${IOS_ARCH}")
 fi
 
 # Don't build binaries or tests (only the library)
@@ -57,6 +71,7 @@ CMAKE_ARGS+=("-DUSE_OPENCV=OFF")
 CMAKE_ARGS+=("-DUSE_LMDB=OFF")
 CMAKE_ARGS+=("-DUSE_LEVELDB=OFF")
 CMAKE_ARGS+=("-DUSE_MPI=OFF")
+CMAKE_ARGS+=("-DUSE_NUMPY=OFF")
 
 # pthreads
 CMAKE_ARGS+=("-DCMAKE_THREAD_LIBS_INIT=-lpthread")
@@ -72,7 +87,7 @@ CMAKE_ARGS+=("-DCMAKE_C_FLAGS=-fembed-bitcode")
 CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-fembed-bitcode")
 cmake "$CAFFE2_ROOT" \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DBUILD_SHARED_LIBS=OFF \
     ${CMAKE_ARGS[@]} \
     $@


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25822 [iOS] Clean up the iOS build script**

### Summary

Since protobuf has been removed from mobile, the `build_host_protoc.sh` can be removed from `build_ios.sh` as well. However, the old caffe2 mobile build  still depend on it, therefore, I introduced this `BUILD_PYTORCH_MOBILE` flag to gate the build.

- iOS device build

```
BUILD_PYTORCH_MOBILE=1 IOS_ARCH=arm64 ./scripts/build_ios.sh
BUILD_PYTORCH_MOBILE=1 IOS_ARCH=armv7s ./scripts/build_ios.sh
```

- iOS simulator build

```
BUILD_PYTORCH_MOBILE=1 IOS_PLATFORM=SIMULATOR ./scripts/build_ios.sh
```

### Test Plan

All device and simulator builds run successfully

Differential Revision: [D17264469](https://our.internmc.facebook.com/intern/diff/D17264469)