### PR TITLE
Make various improvements to C++ API parity test harness

### DIFF
--- a/test/cpp_api_parity/__init__.py
+++ b/test/cpp_api_parity/__init__.py
@@ -12,7 +12,6 @@ TorchNNTestParams = namedtuple(
         'has_parity',
         'cpp_sources',
         'num_attrs_recursive',
-        'options_args',
         'device',
     ]
 )
@@ -26,11 +25,10 @@ TorchNNModuleMetadata = namedtuple(
     [
         'cpp_default_constructor_args',
         'num_attrs_recursive',
-        'options_args',
         'cpp_sources',
     ]
 )
-TorchNNModuleMetadata.__new__.__defaults__ = (None, None, [], '')
+TorchNNModuleMetadata.__new__.__defaults__ = (None, None, '')
 
 '''
 This function expects the parity tracker Markdown file to have the following format:

--- a/test/cpp_api_parity/sample_module.py
+++ b/test/cpp_api_parity/sample_module.py
@@ -113,14 +113,6 @@ module_tests = [
 torch_nn_modules.module_metadata_map['SampleModule'] = TorchNNModuleMetadata(
     cpp_default_constructor_args='(true)',
     num_attrs_recursive=18,
-    options_args=[
-        'has_submodule',
-        'int_option',
-        'double_option',
-        'bool_option',
-        'string_option',
-        'tensor_option',
-    ],
     cpp_sources=SAMPLE_MODULE_CPP_SOURCE,
 )
 

--- a/test/cpp_api_parity/sample_module.py
+++ b/test/cpp_api_parity/sample_module.py
@@ -15,7 +15,8 @@ When `SampleModule.has_parity` is false, behavior of `reset_parameters` / `forwa
 
 class SampleModule(torch.nn.Module):
     def __init__(self, has_parity, has_submodule, int_option=0, double_option=0.1,
-                 bool_option=False, string_option='0', tensor_option=torch.zeros(1)):
+                 bool_option=False, string_option='0', tensor_option=torch.zeros(1),
+                 int_or_tuple_option=0):
         super(SampleModule, self).__init__()
         self.has_parity = has_parity
         if has_submodule:
@@ -28,6 +29,7 @@ class SampleModule(torch.nn.Module):
         self.bool_option = bool_option
         self.string_option = string_option
         self.tensor_option = tensor_option
+        self.int_or_tuple_option = int_or_tuple_option
         self.register_parameter('param', torch.nn.Parameter(torch.empty(3, 4)))
         self.register_buffer('buffer', torch.empty(4, 5))
         self.attr = 0
@@ -62,6 +64,7 @@ struct C10_EXPORT SampleModuleOptions {
   TORCH_ARG(bool, bool_option) = false;
   TORCH_ARG(std::string, string_option) = "0";
   TORCH_ARG(torch::Tensor, tensor_option) = torch::zeros({1});
+  TORCH_ARG(ExpandingArray<2>, int_or_tuple_option) = 0;
 };
 
 struct C10_EXPORT SampleModuleImpl : public torch::nn::Cloneable<SampleModuleImpl> {
@@ -112,7 +115,7 @@ module_tests = [
 
 torch_nn_modules.module_metadata_map['SampleModule'] = TorchNNModuleMetadata(
     cpp_default_constructor_args='(true)',
-    num_attrs_recursive=18,
+    num_attrs_recursive=20,
     cpp_sources=SAMPLE_MODULE_CPP_SOURCE,
 )
 

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -272,6 +272,7 @@ class TestCppApiParity(common.TestCase):
             module_option=cpp_module_option,
             extra_stmts=''.join(extra_stmts))
         cpp_test_name = module_name + '_test_ctor_args'
+        print(cpp_sources)
         cpp_module = self._compile_cpp_code_inline(
             name=cpp_test_name, cpp_sources=cpp_sources, functions=cpp_test_name)
 

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -272,7 +272,6 @@ class TestCppApiParity(common.TestCase):
             module_option=cpp_module_option,
             extra_stmts=''.join(extra_stmts))
         cpp_test_name = module_name + '_test_ctor_args'
-        print(cpp_sources)
         cpp_module = self._compile_cpp_code_inline(
             name=cpp_test_name, cpp_sources=cpp_sources, functions=cpp_test_name)
 

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -42,7 +42,7 @@ bool check_ivalue_equality(const c10::IValue& ivalue_python, const c10::IValue& 
   // are multidimensional but have the same value in all dimensions. The corresponding
   // data type for C++ modules is `ExpandingArray` (which is converted to `IntList` by the
   // `IValue` constructor), and here we check that all elements in the `ExpandingArray`
-  // equal to the Python `int` attribute.
+  // are equal to the Python `int` attribute.
   if (ivalue_python.isInt() && ivalue_cpp.isIntList()) {
     auto ivalue_cpp_list = ivalue_cpp.toIntListRef();
     std::vector<int64_t> ivalue_python_vec(ivalue_cpp_list.size());
@@ -381,7 +381,7 @@ class TestCppApiParity(common.TestCase):
                         if type(value) == tuple:
                             assert all(isinstance(x, type(value[0])) for x in value), \
                                 "All elements in a tuple attribute of a Python torch.nn module must have the same type."
-                            # Here, we set the Python attribute's type to `ListType` in the ScriptModule,
+                            # Here, we set the Python tuple attribute's type to `ListType` in the ScriptModule,
                             # which will automatically be converted to `IntList` later and match the type
                             # of the corresponding attribute in C++ module (which is initially an `ExpandingArray`
                             # and is converted to `IntList` by the `IValue` constructor).
@@ -486,6 +486,9 @@ def _process_test_params(test_params_dict, module_metadata, device):
     else:
         raise RuntimeError("Unexpected input type: {}".format(type(example_inputs)))
 
+    # We set all inputs to torch.nn module to requires grad, so that the backward test can always be run.
+    # However, we skip embedding layers for now, becuase they only accept LongTensor as inputs,
+    # And LongTensor cannot require grad.
     if module_name not in ["Embedding", "Embedding_sparse", "EmbeddingBag", "EmbeddingBag_sparse"]:
         example_inputs = [x.requires_grad_() for x in example_inputs]
 

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -235,7 +235,8 @@ class TestCppApiParity(common.TestCase):
         init_arg_spec = self._get_python_module_init_arg_spec(module_name)
         init_kwargs_defaults = init_arg_spec.defaults
         python_default_constructor_arg_names = [x for x in init_arg_spec.args[1:-len(init_kwargs_defaults)] if x != 'has_parity']
-        cpp_default_constructor_arg_values = re.findall(r'{[^}]*}|[^,\s]+', cpp_default_constructor_args_str.strip('()'))
+        # NOTE: the regex is used here to split up e.g. `(1, {2, 3}, 4)` into `['1', '{2, 3}', '4']`
+        cpp_default_constructor_arg_values = re.findall(r'{[^}]*}|[^,\s()]+', cpp_default_constructor_args_str)
         self.assertEqual(
             len(cpp_default_constructor_arg_values),
             len(python_default_constructor_arg_names),

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -265,7 +265,7 @@ class TestCppApiParity(common.TestCase):
 
         # Step 3: Generate code to check existence of all Python module constructor args in the C++ module options.
         extra_stmts = [TORCH_NN_MODULE_TEST_OPTIONS_ARG.substitute(options_arg_name=arg_name)
-            for arg_name in python_default_constructor_arg_names + init_kwargs]
+                       for arg_name in python_default_constructor_arg_names + init_kwargs]
 
         # Step 4: Compile the test code and run the tests.
         cpp_sources = TORCH_NN_MODULE_COMMON_TEST_HARNESS + module_metadata.cpp_sources


### PR DESCRIPTION
This PR makes the following improvements to C++ API parity test harness:
1. Remove `options_args` since we can get the list of options from the Python module constructor args.
2. Add test for mapping `int` or `tuple` in Python module constructor args to `ExpandingArray` in C++ module options.
3. Use regex to split up e.g. `(1, {2, 3}, 4)` into `['1', '{2, 3}', '4']` for `cpp_default_constructor_args`.
4. Add options arg accessor tests in `_test_torch_nn_module_ctor_args`.

We will be able to merge https://github.com/pytorch/pytorch/pull/24160 and https://github.com/pytorch/pytorch/pull/24860 after these improvements.