### PR TITLE
fix typo: toDense --> to_dense #25706

### DIFF
--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -127,7 +127,7 @@ Therefore, representation of a SparseTensor of sparse_dim = 0 is simply a dense 
     .. method:: sub
     .. method:: sub_
     .. method:: t_
-    .. method:: toDense
+    .. method:: to_dense
     .. method:: transpose
     .. method:: transpose_
     .. method:: zero_


### PR DESCRIPTION
Only fixes a minor typo in [torch.sparse.FloatTensor docs](https://pytorch.org/docs/stable/sparse.html#torch.sparse.FloatTensor.toDense).