### PR TITLE
Throw runtime exception for integer div by zero

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -73,6 +73,9 @@ void div_kernel(TensorIterator& iter) {
     // TODO: if the divisor is a scalar, rewrite as multiplication by a constant.
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "div_cpu", [&]() {
       cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
+        if (b == 0) {
+            throw std::runtime_error("ZeroDivisionError: integer division by zero");
+        }
         return a / b;
       });
     });

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <iostream>
+#include <stdexcept>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec256/vec256.h>

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -1,6 +1,5 @@
 #include <cmath>
 #include <iostream>
-#include <stdexcept>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec256/vec256.h>
@@ -74,9 +73,7 @@ void div_kernel(TensorIterator& iter) {
     // TODO: if the divisor is a scalar, rewrite as multiplication by a constant.
     AT_DISPATCH_INTEGRAL_TYPES(iter.dtype(), "div_cpu", [&]() {
       cpu_kernel(iter, [](scalar_t a, scalar_t b) -> scalar_t {
-        if (b == 0) {
-            throw std::runtime_error("ZeroDivisionError: integer division by zero");
-        }
+        TORCH_CHECK(b != 0, "ZeroDivisionError: integer division by zero");
         return a / b;
       });
     });

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -39,7 +39,7 @@ void div_kernel_cuda(TensorIterator& iter) {
       });
     });
   } else {
-    auto isInt = isIntegralType(iter.dtype(), /*includeBool* false);
+    auto isInt = isIntegralType(iter.dtype(), /*includeBool*/ false);
     AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [isInt]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         TORCH_CHECK(b != 0 || !isInt, "ZeroDivisionError: integer division by zero");

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -39,10 +39,10 @@ void div_kernel_cuda(TensorIterator& iter) {
       });
     });
   } else {
+    auto isInt = isIntegralType(iter.dtype(), /*includeBool* false);
     AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, [&iter]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        TORCH_CHECK(b != 0 || !isIntegralType(iter.dtype(), /*includeBool*/ false),
-        "ZeroDivisionError: integer division by zero");
+      gpu_kernel_with_scalars(iter, [isInt]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        TORCH_CHECK(b != 0 || !isInt, "ZeroDivisionError: integer division by zero");
         return a / b;
       });
     });

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -6,6 +6,7 @@
 #include <ATen/native/BinaryOps.h>
 #include <THC/THCNumerics.cuh>
 #include <limits>
+#include <stdexcept>
 
 
 // NOTE: CUDA on Windows requires that the enclosing function
@@ -41,6 +42,9 @@ void div_kernel_cuda(TensorIterator& iter) {
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        if (b == 0) {
+            throw std::runtime_error("ZeroDivisionError: integer division by zero");
+        }
         return a / b;
       });
     });

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -42,7 +42,7 @@ void div_kernel_cuda(TensorIterator& iter) {
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        if (b == 0) {
+        if (b == 0 && isIntegralType(iter.dtype(), /*includeBool*/ false)) {
             throw std::runtime_error("ZeroDivisionError: integer division by zero");
         }
         return a / b;

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -6,7 +6,6 @@
 #include <ATen/native/BinaryOps.h>
 #include <THC/THCNumerics.cuh>
 #include <limits>
-#include <stdexcept>
 
 
 // NOTE: CUDA on Windows requires that the enclosing function
@@ -42,9 +41,8 @@ void div_kernel_cuda(TensorIterator& iter) {
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-        if (b == 0 && isIntegralType(iter.dtype(), /*includeBool*/ false)) {
-            throw std::runtime_error("ZeroDivisionError: integer division by zero");
-        }
+        TORCH_CHECK(b != 0 || !isIntegralType(iter.dtype(), /*includeBool*/ false),
+        "ZeroDivisionError: integer division by zero");
         return a / b;
       });
     });

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -40,7 +40,7 @@ void div_kernel_cuda(TensorIterator& iter) {
     });
   } else {
     AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(), "div_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+      gpu_kernel_with_scalars(iter, [&iter]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
         TORCH_CHECK(b != 0 || !isIntegralType(iter.dtype(), /*includeBool*/ false),
         "ZeroDivisionError: integer division by zero");
         return a / b;


### PR DESCRIPTION
Update CPU and GPU paths to throw run time exception instead of crashing with FP-exception when integer division by zero is encountered.

  #25829  