### PR TITLE
[iOS][Circle CI] Add PR jobs for iOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,9 @@ pytorch_ios_params: &pytorch_ios_params
     BUILD_ENVIRONMENT: << parameters.build_environment >>
     IOS_ARCH: << parameters.ios_arch >>
     IOS_PLATFORM: << parameters.ios_platform >>
-    USE_NNPACK: << parameters.use_nnpack >>caffe2_params: &caffe2_params
+    USE_NNPACK: << parameters.use_nnpack >>
+
+caffe2_params: &caffe2_params
   parameters:
     build_environment:
       type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1906,18 +1906,19 @@ workflows:
       # Pytorch iOS builds
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_x86_64_build
-          build_environment: "pytorch-ios-10.2.1-x86_64_build"
+          build_environment: "pytorch-ios-10-2-1-x86_64_build"
           ios_platform: "SIMULATOR"
           use_nnpack: "OFF"
           requires: 
             - setup
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_arm64_build
-          build_environment: "pytorch-ios-10.2.1-arm64_build"
+          build_environment: "pytorch-ios-10-2-1-arm64_build"
           ios_arch: "arm64"
           requires: 
             - setup
-        - caffe2_linux_build:
+
+      - caffe2_linux_build:
           name: caffe2_py2_gcc4_8_ubuntu14_04_build
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,17 @@ macos_brew_update: &macos_brew_update
     brew install expect
     brew install libomp
 
-
+ios_brew_update: &ios_brew_update
+  name: Brew update and install iOS toolchains
+  no_output_timeout: "1h"
+  command: |
+    set -ex
+    brew update
+    brew unlink parallel
+    brew install moreutils
+    brew link parallel --overwrite
+    brew install expect
+    brew install libtool
 ##############################################################################
 # Binary build (nightlies nightly build) defaults
 # The binary builds use the docker executor b/c at time of writing the machine
@@ -156,7 +166,25 @@ pytorch_params: &pytorch_params
     USE_CUDA_DOCKER_RUNTIME: << parameters.use_cuda_docker_runtime >>
   resource_class: << parameters.resource_class >>
 
-caffe2_params: &caffe2_params
+pytorch_ios_params: &pytorch_ios_params
+  parameters:
+    build_environment:
+      type: string
+      default: ""
+    ios_arch:
+      type: string
+      default: ""
+    ios_platform:
+      type: string
+      default: ""
+    use_nnpack:
+      type: string
+      default: "ON"
+  environment:
+    BUILD_ENVIRONMENT: << parameters.build_environment >>
+    IOS_ARCH: << parameters.ios_arch >>
+    IOS_PLATFORM: << parameters.ios_platform >>
+    USE_NNPACK: << parameters.use_nnpack >>caffe2_params: &caffe2_params
   parameters:
     build_environment:
       type: string
@@ -1248,7 +1276,61 @@ jobs:
     - store_artifacts:
         path: ~/workspace/build_android_x86_32_artifacts/artifacts.tgz
         destination: artifacts.tgz
-  
+
+  pytorch_ios_build:
+    <<: *pytorch_ios_params  
+    macos:
+      xcode: "10.2.1"
+    steps:
+      # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml
+      - attach_workspace:
+          at: ~/workspace
+      - run:
+          <<: *should_run_job
+      - checkout
+      - run:
+          <<: *ios_brew_update
+      - run:
+          name: Build
+          no_output_timeout: "1h"
+          command: |
+            set -e
+            export IN_CIRCLECI=1
+            WORKSPACE=/Users/distiller/workspace
+            PROJ_ROOT=/Users/distiller/project
+            export TCLLIBPATH="/usr/local/lib" 
+
+            # Install conda
+            curl -o ~/Downloads/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+            chmod +x ~/Downloads/conda.sh
+            /bin/bash ~/Downloads/conda.sh -b -p ~/anaconda
+            export PATH="~/anaconda/bin:${PATH}"
+            source ~/anaconda/bin/activate
+            # Install dependencies
+            conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing requests
+            # sync submodules
+            cd ${PROJ_ROOT}
+            git submodule sync
+            git submodule update --init --recursive
+            # export 
+            export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
+            # run build script
+            chmod a+x ${PROJ_ROOT}/scripts/build_ios.sh
+            CMAKE_ARGS=() 
+            if [ -n "${IOS_ARCH:-}" ]; then
+              CMAKE_ARGS+=("-DIOS_ARCH=${IOS_ARCH}")
+            fi
+            if [ -n "${IOS_PLATFORM:-}" ]; then
+              CMAKE_ARGS+=("-DIOS_PLATFORM=${IOS_PLATFORM}")
+            fi
+            if [ -n "${USE_NNPACK:-}" ]; then 
+              CMAKE_ARGS+=("-DUSE_NNPACK=${USE_NNPACK}")
+            fi
+            CMAKE_ARGS+=("-DBUILD_CAFFE2_MOBILE=OFF")
+            CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
+            CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
+
+            unbuffer ${PROJ_ROOT}/scripts/build_ios.sh ${CMAKE_ARGS[@]} 2>&1 | ts  
   # update_s3_htmls job
   # These jobs create html files for every cpu/cu## folder in s3. The html
   # files just store the names of all the files in that folder (which are
@@ -1819,7 +1901,21 @@ workflows:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
-      - caffe2_linux_build:
+      # Pytorch iOS builds
+      - pytorch_ios_build:
+          name: pytorch_ios_10_2_1_x86_64_build
+          build_environment: "pytorch-ios-10.2.1-x86_64_build"
+          ios_platform: "SIMULATOR"
+          use_nnpack: "OFF"
+          requires: 
+            - setup
+      - pytorch_ios_build:
+          name: pytorch_ios_10_2_1_arm64_build
+          build_environment: "pytorch-ios-10.2.1-arm64_build"
+          ios_arch: "arm64"
+          requires: 
+            - setup
+        - caffe2_linux_build:
           name: caffe2_py2_gcc4_8_ubuntu14_04_build
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1906,14 +1906,14 @@ workflows:
       # Pytorch iOS builds
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_x86_64_build
-          build_environment: "pytorch-ios-10-2-1-x86_64_build"
+          build_environment: "pytorch-ios-10.2.1-x86_64_build"
           ios_platform: "SIMULATOR"
           use_nnpack: "OFF"
           requires: 
             - setup
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_arm64_build
-          build_environment: "pytorch-ios-10-2-1-arm64_build"
+          build_environment: "pytorch-ios-10.2.1-arm64_build"
           ios_arch: "arm64"
           requires: 
             - setup

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -91,6 +91,7 @@ YAML_SOURCES = [
     Listgen(pytorch_build_definitions.get_workflow_jobs, 3),
     File("workflows-pytorch-macos-builds.yml"),
     File("workflows-pytorch-android-gradle-build.yml"),
+    File("workflows-pytorch-ios-builds.yml"),
     Listgen(caffe2_build_definitions.get_workflow_jobs, 3),
     File("workflows-binary-builds-smoke-subset.yml"),
     Header("Daily smoke test trigger"),

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -46,6 +46,10 @@ default_set = set([
     'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32-build',
     # PyTorch Android gradle
     'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32',
+    # Pytorch iOS builds
+    'pytorch-ios-10.2.1-x86_64_build"',
+    'pytorch-ios-10.2.1-arm64_build',
+
 
     # XLA
     'pytorch-xla-linux-xenial-py3.6-clang7',

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -47,7 +47,7 @@ default_set = set([
     # PyTorch Android gradle
     'pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32',
     # Pytorch iOS builds
-    'pytorch-ios-10.2.1-x86_64_build"',
+    'pytorch-ios-10.2.1-x86_64_build',
     'pytorch-ios-10.2.1-arm64_build',
 
 

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -63,3 +63,14 @@ macos_brew_update: &macos_brew_update
     brew install expect
     brew install libomp
 
+ios_brew_update: &ios_brew_update
+  name: Brew update and install iOS toolchains
+  no_output_timeout: "1h"
+  command: |
+    set -ex
+    brew update
+    brew unlink parallel
+    brew install moreutils
+    brew link parallel --overwrite
+    brew install expect
+    brew install libtool

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -407,3 +407,58 @@
     - store_artifacts:
         path: ~/workspace/build_android_x86_32_artifacts/artifacts.tgz
         destination: artifacts.tgz
+
+  pytorch_ios_build:
+    <<: *pytorch_ios_params  
+    macos:
+      xcode: "10.2.1"
+    steps:
+      # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml
+      - attach_workspace:
+          at: ~/workspace
+      - run:
+          <<: *should_run_job
+      - checkout
+      - run:
+          <<: *ios_brew_update
+      - run:
+          name: Build
+          no_output_timeout: "1h"
+          command: |
+            set -e
+            export IN_CIRCLECI=1
+            WORKSPACE=/Users/distiller/workspace
+            PROJ_ROOT=/Users/distiller/project
+            export TCLLIBPATH="/usr/local/lib" 
+
+            # Install conda
+            curl -o ~/Downloads/conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+            chmod +x ~/Downloads/conda.sh
+            /bin/bash ~/Downloads/conda.sh -b -p ~/anaconda
+            export PATH="~/anaconda/bin:${PATH}"
+            source ~/anaconda/bin/activate
+            # Install dependencies
+            conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing requests
+            # sync submodules
+            cd ${PROJ_ROOT}
+            git submodule sync
+            git submodule update --init --recursive
+            # export 
+            export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
+            # run build script
+            chmod a+x ${PROJ_ROOT}/scripts/build_ios.sh
+            CMAKE_ARGS=() 
+            if [ -n "${IOS_ARCH:-}" ]; then
+              CMAKE_ARGS+=("-DIOS_ARCH=${IOS_ARCH}")
+            fi
+            if [ -n "${IOS_PLATFORM:-}" ]; then
+              CMAKE_ARGS+=("-DIOS_PLATFORM=${IOS_PLATFORM}")
+            fi
+            if [ -n "${USE_NNPACK:-}" ]; then 
+              CMAKE_ARGS+=("-DUSE_NNPACK=${USE_NNPACK}")
+            fi
+            CMAKE_ARGS+=("-DBUILD_CAFFE2_MOBILE=OFF")
+            CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
+            CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
+
+            unbuffer ${PROJ_ROOT}/scripts/build_ios.sh ${CMAKE_ARGS[@]} 2>&1 | ts

--- a/.circleci/verbatim-sources/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/pytorch-build-params.yml
@@ -18,3 +18,22 @@ pytorch_params: &pytorch_params
     USE_CUDA_DOCKER_RUNTIME: << parameters.use_cuda_docker_runtime >>
   resource_class: << parameters.resource_class >>
 
+pytorch_ios_params: &pytorch_ios_params
+  parameters:
+    build_environment:
+      type: string
+      default: ""
+    ios_arch:
+      type: string
+      default: ""
+    ios_platform:
+      type: string
+      default: ""
+    use_nnpack:
+      type: string
+      default: "ON"
+  environment:
+    BUILD_ENVIRONMENT: << parameters.build_environment >>
+    IOS_ARCH: << parameters.ios_arch >>
+    IOS_PLATFORM: << parameters.ios_platform >>
+    USE_NNPACK: << parameters.use_nnpack >>

--- a/.circleci/verbatim-sources/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/pytorch-build-params.yml
@@ -37,3 +37,4 @@ pytorch_ios_params: &pytorch_ios_params
     IOS_ARCH: << parameters.ios_arch >>
     IOS_PLATFORM: << parameters.ios_platform >>
     USE_NNPACK: << parameters.use_nnpack >>
+

--- a/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
@@ -1,15 +1,15 @@
       # Pytorch iOS builds
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_x86_64_build
-          build_environment: "pytorch-ios-10.2.1-x86_64_build"
+          build_environment: "pytorch-ios-10-2-1-x86_64_build"
           ios_platform: "SIMULATOR"
           use_nnpack: "OFF"
           requires: 
             - setup
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_arm64_build
-          build_environment: "pytorch-ios-10.2.1-arm64_build"
+          build_environment: "pytorch-ios-10-2-1-arm64_build"
           ios_arch: "arm64"
           requires: 
             - setup
-  
+

--- a/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
@@ -1,0 +1,15 @@
+      # Pytorch iOS builds
+      - pytorch_ios_build:
+          name: pytorch_ios_10_2_1_x86_64_build
+          build_environment: "pytorch-ios-10.2.1-x86_64_build"
+          ios_platform: "SIMULATOR"
+          use_nnpack: "OFF"
+          requires: 
+            - setup
+      - pytorch_ios_build:
+          name: pytorch_ios_10_2_1_arm64_build
+          build_environment: "pytorch-ios-10.2.1-arm64_build"
+          ios_arch: "arm64"
+          requires: 
+            - setup
+  

--- a/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-ios-builds.yml
@@ -1,14 +1,14 @@
       # Pytorch iOS builds
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_x86_64_build
-          build_environment: "pytorch-ios-10-2-1-x86_64_build"
+          build_environment: "pytorch-ios-10.2.1-x86_64_build"
           ios_platform: "SIMULATOR"
           use_nnpack: "OFF"
           requires: 
             - setup
       - pytorch_ios_build:
           name: pytorch_ios_10_2_1_arm64_build
-          build_environment: "pytorch-ios-10-2-1-arm64_build"
+          build_environment: "pytorch-ios-10.2.1-arm64_build"
           ios_arch: "arm64"
           requires: 
             - setup


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25840 [iOS][Circle CI] Add PR jobs for iOS builds**

### Summary:

The CI jobs for iOS builds are missing, this PR creates two jobs in Cricle CI's PR workflow

- pytorch_ios_10_2_1_x86_64_build
- pytorch_ios_10_2_1_arm64_build

### Note:

Those two jobs will not store any artifacts nor upload any binary files, which will be done in the next PR.

Test Plan:

- Jobs can be triggered by any PR.
- Jobs can be run successfully.

Differential Revision: [D17255504](https://our.internmc.facebook.com/intern/diff/D17255504)