### PR TITLE
[WIP] Add a mode to check input tensor sizes in allreduce_coalesced

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -111,6 +111,7 @@ They are used in specifying strategies for reduction collectives, e.g.,
       module, "AllreduceCoalescedOptions")
       .def(py::init<>())
       .def_readwrite("reduceOp", &::c10d::AllreduceCoalescedOptions::reduceOp)
+      .def_readwrite("checkShapes", &::c10d::AllreduceCoalescedOptions::checkShapes)
       .def_readwrite("timeout", &::c10d::AllreduceCoalescedOptions::timeout);
 
   py::class_<::c10d::ReduceOptions>(module, "ReduceOptions")

--- a/torch/lib/c10d/Types.hpp
+++ b/torch/lib/c10d/Types.hpp
@@ -26,7 +26,9 @@ struct AllreduceOptions {
   std::chrono::milliseconds timeout = kUnsetTimeout;
 };
 
-struct AllreduceCoalescedOptions : AllreduceOptions {};
+struct AllreduceCoalescedOptions : AllreduceOptions {
+  bool checkShapes = true;
+};
 
 struct ReduceOptions {
   ReduceOp reduceOp = ReduceOp::SUM;


### PR DESCRIPTION
addresses #25417

this PR adds cross-node shape checking, which will result in exceptions being thrown at all nodes if any of them send mismatched shapes.

This is accomplished in three steps:
1) root broadcasts its number of tensors and max tensor dimensions, nodes use this to allocate buffer for incoming root shapes
2) root broadcasts shapes in a single tensor of shape (root_n_tensors, root_max_tensor_dims), nodes use this to compare with their own input shapes.
3) allreduce of shapematch status yields product of match status at all nodes, raise exception if this is false.