### PR TITLE
[iOS] Cocoapods for iOS OSS release

### DIFF
--- a/ios/LibTorch.h
+++ b/ios/LibTorch.h
@@ -1,0 +1,7 @@
+#include <torch/script.h>
+
+#if TARGET_OS_IPHONE
+    #define AT_NNPACK_ENABLED() 1
+    #define USE_NNPACK ON
+    #undef CAFFE2_PERF_WITH_AVX512
+#endif

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,0 +1,36 @@
+Pod::Spec.new do |s|
+    s.name             = 'LibTorch'
+    s.version          = '0.0.1'
+    s.authors          = 'PyTorch Team'
+    s.license          = { :type => 'BSD' }
+    s.homepage         = 'https://github.com/pytorch/pytorch'
+    s.source           = { :http => 'http://ossci-macos.s3.amazonaws.com/libtorch_x86_arm64.zip' }
+    s.summary          = 'PyTorch C++ library for iOS'
+    s.description      = <<-DESC
+        PyTorch C++ library for iOS
+    DESC
+
+    s.default_subspec = 'Core'
+    s.subspec 'Core' do |ss|
+        ss.dependency 'LibTorch/Torch'
+        ss.source_files = 'src/*.{h,cpp,cc}'
+        ss.public_header_files = ['src/LibTorch.h']
+    end
+    
+    s.subspec 'Torch' do |ss|
+        ss.header_mappings_dir = 'install/include/'
+        ss.preserve_paths = 'install/include/**/*.{h,cpp,cc,c}' 
+        ss.vendored_libraries = 'install/lib/libtorch.a'
+        ss.libraries = ['c++', 'stdc++']
+    end
+    s.user_target_xcconfig = {
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
+        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/LibTorch/install/lib/libtorch.a"',
+        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
+        'CLANG_CXX_LIBRARY' => 'libc++'
+    }
+    s.pod_target_xcconfig = { 'VALID_ARCHS' => 'x86_64 armv7s arm64' }
+    s.module_name='LibTorch'
+    s.module_map = 'src/framework.modulemap'
+    s.library = ['c++', 'stdc++']
+end

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -5,18 +5,16 @@ Pod::Spec.new do |s|
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'
     s.source           = { :http => 'http://ossci-macos.s3.amazonaws.com/libtorch_x86_arm64.zip' }
-    s.summary          = 'PyTorch C++ library for iOS'
+    s.summary          = 'The PyTorch C++ library for iOS'
     s.description      = <<-DESC
-        PyTorch C++ library for iOS
+        The PyTorch C++ library for iOS.
     DESC
-
     s.default_subspec = 'Core'
     s.subspec 'Core' do |ss|
         ss.dependency 'LibTorch/Torch'
         ss.source_files = 'src/*.{h,cpp,cc}'
         ss.public_header_files = ['src/LibTorch.h']
     end
-    
     s.subspec 'Torch' do |ss|
         ss.header_mappings_dir = 'install/include/'
         ss.preserve_paths = 'install/include/**/*.{h,cpp,cc,c}' 

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,3 @@
+## LibTorch
+
+The PyTorch C++ static library for iOS.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,3 +1,5 @@
 ## LibTorch
 
-The PyTorch C++ static library for iOS.
+The PyTorch C++ static library for iOS. 
+
+(Detailed documentation  will be added soon)

--- a/ios/framework.modulemap
+++ b/ios/framework.modulemap
@@ -1,0 +1,4 @@
+framework module LibTorch {
+    umbrella header "LibTorch.h"
+    export *
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25847 [iOS] Cocoapods for iOS OSS release**

### Summary

The Podspec file for iOS OSS release. This podspec contains the C++ header files and a static library that supports three architectures.

Please ignore the link for `s.source` for now, as I'm still working on the CI nightly build. This is a temporary link for testing purpose.

### Note

Previously I have a cocoapods release proposal  -  https://github.com/pytorch/pytorch/pull/25543 which contains two podspec files. However, for the time being, we haven't decided whether we want to release the Objective-C API wrapper or not. Please review and refer to this one if you have questions.

Differential Revision: [D17262459](https://our.internmc.facebook.com/intern/diff/D17262459)