### PR TITLE
move cuda abs to Aten

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -652,18 +652,6 @@
     - bool sorted
 ]]
 [[
-  name: _th_abs
-  cname: abs
-  backends:
-    - CUDA
-  variants: function
-  return: argument 0
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - THTensor* self
-]]
-[[
   name: _th_exp
   cname: exp
   types:

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -61,6 +61,10 @@ Tensor& asin_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(
 Tensor asin(const Tensor& self) { return unary_op_impl(self, at::asin_out); }
 Tensor& asin_(Tensor& self) { return unary_op_impl_(self, at::asin_out); }
 
+Tensor& abs_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, abs_stub); }
+Tensor abs(const Tensor& self) { return unary_op_impl(self, at::abs_out); }
+Tensor& abs_(Tensor& self) { return unary_op_impl_(self, at::abs_out); }
+
 Tensor& bitwise_not_out(Tensor& result, const Tensor& self) { return unary_op_impl_out(result, self, bitwise_not_stub); }
 Tensor bitwise_not(const Tensor& self) { return unary_op_impl(self, at::bitwise_not_out); }
 Tensor& bitwise_not_(Tensor& self) { return unary_op_impl_(self, at::bitwise_not_out); }
@@ -291,7 +295,6 @@ Tensor& mvlgamma_(Tensor& self, int64_t p) {
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cpu, CPU)                         \
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cuda, CUDA)
 
-IMPLEMENT_UNARY_OP_VEC(abs)
 IMPLEMENT_UNARY_OP_VEC(angle)
 IMPLEMENT_UNARY_OP_VEC(real)
 IMPLEMENT_UNARY_OP_VEC(imag)

--- a/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
+++ b/aten/src/ATen/native/cuda/CUDAUnaryOps.cpp
@@ -64,7 +64,6 @@ Tensor& _clamp_min_out_cuda(Tensor& result, const Tensor& self, Scalar min) {
   }
 
 
-IMPLEMENT_UNARY_OP_PREQUEL(abs)
 IMPLEMENT_UNARY_OP_PREQUEL(acos)
 IMPLEMENT_UNARY_OP_PREQUEL(atan)
 IMPLEMENT_UNARY_OP_PREQUEL(cos)

--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -9,6 +9,28 @@
 
 namespace at { namespace native {
 
+// We manually overload abs because std::abs does not work with ROCm.
+template<typename scalar_t>
+__host__ __device__ static inline scalar_t abs_wrapper(scalar_t v) {
+  return ::abs(v);
+}
+
+__host__ __device__ static inline uint8_t abs_wrapper(uint8_t v) {
+  return v;
+}
+
+__host__ __device__ static inline bool abs_wrapper(bool v) {
+  return v;
+}
+
+void abs_kernel_cuda(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Half, ScalarType::Bool, iter.dtype(), "abs_cuda", [&]() {
+    gpu_kernel(iter, []GPU_LAMBDA(scalar_t a) -> scalar_t {
+      return abs_wrapper(a);
+    });
+  });
+}
+
 void bitwise_not_kernel_cuda(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     gpu_kernel(iter, []GPU_LAMBDA(bool a) {
@@ -239,6 +261,7 @@ void lgamma_kernel_cuda(TensorIterator& iter) {
   });
 }
 
+REGISTER_DISPATCH(abs_stub, &abs_kernel_cuda);
 REGISTER_DISPATCH(bitwise_not_stub, &bitwise_not_kernel_cuda);
 REGISTER_DISPATCH(logical_not_stub, &logical_not_kernel_cuda);
 REGISTER_DISPATCH(asin_stub, &asin_kernel_cuda);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -185,15 +185,9 @@
 - func: abs_(Tensor(a!) self) -> Tensor(a!)
   variants: function, method
   supports_named_tensor: True
-  dispatch:
-    CPU: _abs__cpu
-    CUDA: _abs__cuda
 
 - func: abs.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
-  dispatch:
-    CPU: _abs_out_cpu
-    CUDA: _abs_out_cuda
 
 - func: angle(Tensor self) -> Tensor
   variants: function, method
@@ -205,7 +199,6 @@
   supports_named_tensor: True
   dispatch:
     CPU: _angle_out_cpu
-    CUDA: _abs_out_cuda
 
 - func: real(Tensor self) -> Tensor
   variants: function, method
@@ -217,7 +210,6 @@
   supports_named_tensor: True
   dispatch:
     CPU: _real_out_cpu
-    CUDA: _abs_out_cuda
 
 - func: imag(Tensor self) -> Tensor
   variants: function, method
@@ -229,7 +221,6 @@
   supports_named_tensor: True
   dispatch:
     CPU: _imag_out_cpu
-    CUDA: _abs_out_cuda
 
 - func: conj(Tensor self) -> Tensor
   variants: function, method
@@ -241,7 +232,6 @@
   supports_named_tensor: True
   dispatch:
     CPU: _conj_out_cpu
-    CUDA: _abs_out_cuda
 
 - func: acos(Tensor self) -> Tensor
   use_c10_dispatcher: full

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -144,7 +144,6 @@ TH_API void THTensor_(diag)(THTensor *r_, THTensor *t, int k);
 TH_API void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder);
 TH_API void THTensor_(triu)(THTensor *r_, THTensor *t, int64_t k);
 
-TH_API void THTensor_(abs)(THTensor *r_, THTensor *t);
 
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 

--- a/aten/src/TH/generic/THVector.h
+++ b/aten/src/TH/generic/THVector.h
@@ -24,10 +24,6 @@ TH_API void THVector_(normal_fill)(scalar_t *data,
 
 #endif /* non bool only part */
 
-#if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_LONG)
-TH_API void THVector_(abs)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
-#endif
-
 /* floating point only now */
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
@@ -42,7 +38,6 @@ TH_API void THVector_(tan)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(atan)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(tanh)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(pow)(scalar_t *y, const scalar_t *x, const scalar_t c, const ptrdiff_t n);
-TH_API void THVector_(abs)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(frac)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 TH_API void THVector_(cinv)(scalar_t *y, const scalar_t *x, const ptrdiff_t n);
 

--- a/aten/src/TH/generic/THVectorDefault.cpp
+++ b/aten/src/TH/generic/THVectorDefault.cpp
@@ -221,19 +221,6 @@ void THVector_(normal_fill_DEFAULT)(scalar_t *data,
       y[i] = CFUNC(x[i], c);  \
   } \
 
-#if defined(TH_REAL_IS_LONG)
-VECTOR_IMPLEMENT_FUNCTION(abs,std::abs)
-#endif /* long only part */
-
-#if defined(TH_REAL_IS_SHORT) || defined(TH_REAL_IS_INT) || defined(TH_REAL_IS_CHAR)
-VECTOR_IMPLEMENT_FUNCTION(abs,abs)
-#endif /* int only part */
-
-#if defined(TH_REAL_IS_BYTE)
-VECTOR_IMPLEMENT_FUNCTION(abs,)
-#endif /* unsigned, so identity */
-
-
 /* floating point only now */
 #if defined(TH_REAL_IS_FLOAT) || defined(TH_REAL_IS_DOUBLE)
 
@@ -258,7 +245,6 @@ VECTOR_IMPLEMENT_FUNCTION(rsqrt,TH_MATH_NAME(TH_rsqrt))
 VECTOR_IMPLEMENT_FUNCTION(ceil,TH_MATH_NAME(ceil))
 VECTOR_IMPLEMENT_FUNCTION(floor,TH_MATH_NAME(floor))
 VECTOR_IMPLEMENT_FUNCTION(round,TH_MATH_NAME(nearbyint))
-VECTOR_IMPLEMENT_FUNCTION(abs,TH_MATH_NAME(fabs))
 VECTOR_IMPLEMENT_FUNCTION(trunc,TH_MATH_NAME(trunc))
 VECTOR_IMPLEMENT_FUNCTION(frac,TH_MATH_NAME(TH_frac))
 VECTOR_IMPLEMENT_FUNCTION(cinv, TH_MATH_NAME(1.0) / )

--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -57,7 +57,6 @@ struct THCNumerics<uint8_t> {
   static inline __host__ __device__  uint8_t mul(uint8_t a, uint8_t b) { return a * b; }
   static inline __host__ __device__  uint8_t sub(uint8_t a, uint8_t b) { return a - b; }
   static inline __host__ __device__  uint8_t div(uint8_t a, uint8_t b) { return a / b; }
-  static inline __host__ __device__  uint8_t abs(uint8_t a) { return a; }
   static inline __host__ __device__  uint8_t pow(uint8_t a, uint8_t b) { return powi<uint8_t>(a, b); }
   static inline __host__ __device__  bool isnan(uint8_t a) { return false; }
   static inline __host__ __device__  bool isinf(uint8_t a) { return false; }
@@ -80,7 +79,6 @@ struct THCNumerics<bool> {
   static inline __host__ __device__ bool mul(bool a, bool b) { return a && b; }
   static inline __host__ __device__ bool sub(bool a, bool b) { return a - b; }
   static inline __host__ __device__ bool div(bool a, bool b) { return a / b; }
-  static inline __host__ __device__ bool abs(bool a) { return a; }
   static inline __host__ __device__ bool isnan(bool a) { return false; }
   static inline __host__ __device__ bool isinf(bool a) { return false; }
 };
@@ -104,7 +102,6 @@ struct THCNumerics<int8_t> {
   static inline __host__ __device__  int8_t mul(int8_t a, int8_t b) { return a * b; }
   static inline __host__ __device__  int8_t sub(int8_t a, int8_t b) { return a - b; }
   static inline __host__ __device__  int8_t div(int8_t a, int8_t b) { return a / b; }
-  static inline __host__ __device__  int8_t abs(int8_t a) { return ::abs((int)a); }
   static inline __host__ __device__  int8_t pow(int8_t a, int8_t b) { return powi<int8_t>(a, b); }
   static inline __host__ __device__  bool isnan(int8_t a) { return false; }
   static inline __host__ __device__  bool isinf(int8_t a) { return false; }
@@ -129,7 +126,6 @@ struct THCNumerics<int16_t> {
   static inline __host__ __device__  int16_t mul(int16_t a, int16_t b) { return a * b; }
   static inline __host__ __device__  int16_t sub(int16_t a, int16_t b) { return a - b; }
   static inline __host__ __device__  int16_t div(int16_t a, int16_t b) { return a / b; }
-  static inline __host__ __device__  int16_t abs(int16_t a) { return ::abs((int)a); }
   static inline __host__ __device__  int16_t pow(int16_t a, int16_t b) { return powi<int16_t>(a, b); }
   static inline __host__ __device__  bool isnan(int16_t a) { return false; }
   static inline __host__ __device__  bool isinf(int16_t a) { return false; }
@@ -154,7 +150,6 @@ struct THCNumerics<int32_t> {
   static inline __host__ __device__  int32_t mul(int32_t a, int32_t b) { return a * b; }
   static inline __host__ __device__  int32_t sub(int32_t a, int32_t b) { return a - b; }
   static inline __host__ __device__  int32_t div(int32_t a, int32_t b) { return a / b; }
-  static inline __host__ __device__  int32_t abs(int32_t a) { return ::abs(a); }
   static inline __host__ __device__  int32_t pow(int32_t a, int32_t b) { return powi<int32_t>(a, b); }
   static inline __host__ __device__  bool isnan(int32_t a) { return false; }
   static inline __host__ __device__  bool isinf(int32_t a) { return false; }
@@ -180,7 +175,6 @@ struct THCNumerics<int64_t> {
   static inline __host__ __device__  int64_t mul(int64_t a, int64_t b) { return a * b; }
   static inline __host__ __device__  int64_t sub(int64_t a, int64_t b) { return a - b; }
   static inline __host__ __device__  int64_t div(int64_t a, int64_t b) { return a / b; };
-  static inline __host__ __device__  int64_t abs(int64_t a) { return labs(a); }
   static inline __host__ __device__  int64_t pow(int64_t a, int64_t b) { return powi<int64_t>(a, b); }
   static inline __host__ __device__  bool isnan(int64_t a) { return false; }
   static inline __host__ __device__  bool isinf(int64_t a) { return false; }
@@ -213,8 +207,6 @@ struct THCNumerics<at::Half> {
   static inline __host__ __device__ at::Half tanh(at::Half a) { return ::tanh(a); }
   static inline __host__ __device__ at::Half erf(at::Half a) { return ::erf(a); }
   static inline __host__ __device__ at::Half erfc(at::Half a) { return ::erfc(a); }
-  static inline __host__ __device__ at::Half abs(at::Half a) { return std::abs(a); }
-
   static inline __host__ __device__ at::Half frac(at::Half a) {
     #if defined(__CUDA_ARCH__) || defined(__HIP_PLATFORM_HCC__)
         return a - ::trunc(a);
@@ -281,7 +273,6 @@ struct THCNumerics<float> {
   static inline __host__ __device__  float tanh (float a) { return  tanhf(a); }
   static inline __host__ __device__  float erf  (float a) { return   erff(a); }
   static inline __host__ __device__  float erfc (float a) { return  erfcf(a); }
-  static inline __host__ __device__  float abs  (float a) { return  fabsf(a); }
   static inline __host__ __device__  float frac (float a) { return a - truncf(a); }
   static inline __host__ __device__  float cinv (float a) { return 1.0f / a; }
   static inline __host__ __device__  float add  (float a, float b) { return a + b; }
@@ -322,7 +313,6 @@ struct THCNumerics<double> {
   static inline __host__ __device__  double tanh (double a) { return  ::tanh(a); }
   static inline __host__ __device__  double erf  (double a) { return   ::erf(a); }
   static inline __host__ __device__  double erfc (double a) { return  ::erfc(a); }
-  static inline __host__ __device__  double abs  (double a) { return   fabs(a); }
   static inline __host__ __device__  double frac (double a) { return a - ::trunc(a); }
   static inline __host__ __device__  double cinv (double a) { return 1.0 / a; }
   static inline __host__ __device__  double add  (double a, double b) { return a + b; }

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -211,7 +211,7 @@ __global__ void THCTensor_kernel_renorm(T *data,
     // get norm of axis
     for (ptrdiff_t i = tx; i < size; i += step) {
       const AccT val = scalar_cast<AccT>(row[i]);
-      buffer[tx] = THCMax<AccT>(buffer[tx], THCNumerics<AccT>::abs(val));
+      buffer[tx] = THCMax<AccT>(buffer[tx], static_cast<AccT>(std::abs(val)));
     }
     // add (reduce)
     for (unsigned int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
@@ -228,7 +228,7 @@ __global__ void THCTensor_kernel_renorm(T *data,
       const AccT val = scalar_cast<AccT>(row[i]);
       buffer[tx] = THCNumerics<AccT>::add(
         buffer[tx],
-        THCNumerics<AccT>::pow(THCNumerics<AccT>::abs(val), value)
+        THCNumerics<AccT>::pow(static_cast<AccT>(std::abs(val)), value)
       );
     }
     // add (reduce)
@@ -273,9 +273,9 @@ struct TensorNormOp {
 
   __host__ __device__ T operator()(const T x) const {
     switch (StaticExp) {
-      case 1: return THCNumerics<T>::abs(x);
+      case 1: return static_cast<T>(std::abs(x));
       case 2: return THCNumerics<T>::mul(x, x);
-      default: return THCNumerics<T>::pow(THCNumerics<T>::abs(x), exponent);
+      default: return THCNumerics<T>::pow(static_cast<T>(std::abs(x)), exponent);
     }
   }
 
@@ -298,13 +298,13 @@ struct ThrustTensorDistOp {
       return scalar_cast<AccT>(1);
     }
     if (THCNumerics<AccT>::eq(exponent, scalar_cast<AccT, float>(1))) {
-      return THCNumerics<AccT>::abs(THCNumerics<AccT>::sub(x, y));
+      return static_cast<AccT>(std::abs(THCNumerics<AccT>::sub(x, y)));
     } else if (THCNumerics<AccT>::eq(exponent, scalar_cast<AccT, float>(2))) {
       return THCNumerics<AccT>::pow(
         THCNumerics<AccT>::sub(x, y), exponent);
     } else {
       return THCNumerics<AccT>::pow(
-        THCNumerics<AccT>::abs(THCNumerics<AccT>::sub(x, y)),
+        static_cast<AccT>(std::abs(THCNumerics<AccT>::sub(x, y))),
         exponent);
     }
   }

--- a/aten/src/THC/generic/THCTensorMathPointwise.cu
+++ b/aten/src/THC/generic/THCTensorMathPointwise.cu
@@ -213,9 +213,6 @@ IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(  frac, THCNumerics<scalar_t>::frac,  Real)
 IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(  cinv, THCNumerics<scalar_t>::cinv,  Real)
 
 #endif
-
-IMPLEMENT_CUDA_TENSOR_BASIC_FUNC(  abs, THCNumerics<scalar_t>::abs,   Real)
-
 #undef IMPLEMENT_CUDA_TENSOR_BASIC_FUNC_
 #undef IMPLEMENT_CUDA_TENSOR_BASIC_FUNC
 

--- a/aten/src/THC/generic/THCTensorMathPointwise.h
+++ b/aten/src/THC/generic/THCTensorMathPointwise.h
@@ -32,7 +32,6 @@ THC_API void THCTensor_(cinv)(THCState *state, THCTensor *self, THCTensor *src);
 
 #endif
 
-THC_API void THCTensor_(abs)(THCState *state, THCTensor *self, THCTensor *src);
 THC_API void THCTensor_(clamp)(THCState *state, THCTensor *self, THCTensor *src, scalar_t min_value, scalar_t max_value);
 THC_API void THCTensor_(crossKernel)(THCState *state, THCTensor *self, THCTensor *src1, THCTensor *src2, int dimension);
 

--- a/aten/src/THCUNN/THCHalfAutoNumerics.cuh
+++ b/aten/src/THCUNN/THCHalfAutoNumerics.cuh
@@ -31,10 +31,6 @@ inline __host__ __device__ double fmaxType(double x, double y) {
 
 // arithmetic functions
 
-inline __host__ __device__ THHalf abs(THHalf a) {
-  return THCNumerics<THHalf>::abs(a);
-}
-
 inline __host__ __device__ THHalf exp(THHalf a) {
   return THCNumerics<THHalf>::exp(a);
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -10994,7 +10994,7 @@ class TestTorchDeviceType(TestCase):
         ints = torch.randint(-100, 100, (2 * sz,), device=device)
         unary_mem_overlap_cases = [
             ("abs", doubles, True, True, 'cpu'),
-            ("abs", doubles, False, True, 'cuda'),
+            ("abs", doubles, True, True, 'cuda'),
             ("acos", doubles, True, True, 'cpu'),
             ("acos", doubles, False, True, 'cuda'),
             ("asin", doubles, True, True, 'cpu'),
@@ -11410,7 +11410,7 @@ class TestTorchDeviceType(TestCase):
                                                   [2., 1.]]],
                                                 dtype=dtype,
                                                 device=device)
-            expected_unique_dim1_bool = torch.tensor([[[False, True], [True, True]], 
+            expected_unique_dim1_bool = torch.tensor([[[False, True], [True, True]],
                                                       [[False, True], [True, True]]],
                                                      dtype=torch.bool,
                                                      device=device)
@@ -11472,7 +11472,7 @@ class TestTorchDeviceType(TestCase):
                 x,
                 return_inverse=True,
                 dim=1)
-            if x.dtype == torch.bool:   
+            if x.dtype == torch.bool:
                 self.assertEqual(expected_unique_dim1_bool, x_unique)
                 self.assertEqual(expected_inverse_dim1_bool, x_inverse)
             else:
@@ -11484,7 +11484,7 @@ class TestTorchDeviceType(TestCase):
                 return_inverse=False,
                 return_counts=True,
                 dim=1)
-            if x.dtype == torch.bool:   
+            if x.dtype == torch.bool:
                 self.assertEqual(expected_unique_dim1_bool, x_unique)
                 self.assertEqual(expected_counts_dim1_bool, x_counts)
             else:
@@ -11496,7 +11496,7 @@ class TestTorchDeviceType(TestCase):
                 return_inverse=True,
                 return_counts=True,
                 dim=1)
-            if x.dtype == torch.bool:   
+            if x.dtype == torch.bool:
                 self.assertEqual(expected_unique_dim1_bool, x_unique)
                 self.assertEqual(expected_inverse_dim1_bool, x_inverse)
                 self.assertEqual(expected_counts_dim1_bool, x_counts)
@@ -11590,7 +11590,7 @@ class TestTorchDeviceType(TestCase):
             expected_y_inverse_bool = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 3, 3], dtype=dtype, device=device)
             expected_y_counts_bool = torch.tensor([3, 3, 2, 2], dtype=dtype, device=device)
             y_unique, y_inverse, y_counts = torch.unique_consecutive(y, return_inverse=True, return_counts=True, dim=0)
-            if x.dtype == torch.bool:   
+            if x.dtype == torch.bool:
                 self.assertEqual(expected_y_inverse_bool, y_inverse)
                 self.assertEqual(expected_y_counts_bool, y_counts)
             else:


### PR DESCRIPTION
@VitalyFedyunin, this PR fix the https://github.com/pytorch/pytorch/issues/24531

Benchmark script :
```
import timeit

device = "cuda"
for n, t in [(10, 100000),(1000, 10000)]:
    print('a.abs() (a.numel() == {}) for {} times'.format(n, t))
    for dtype in ('torch.int8', 'torch.uint8', 'torch.int16', 'torch.int32', 'torch.int64', 'torch.float', 'torch.double', 'torch.half'):
        print(f'device: {device}, dtype: {dtype}, {t} times', end='\t\t')
        print(timeit.timeit(f'a.abs()\nif "{device}" == "cuda": torch.cuda.synchronize()', setup=f'import torch; a = torch.ones({n}, device="{device}", dtype={dtype})', number=t))
```
Device: **Tesla P4**
Cuda verison: **9.0.176**

Before this change:
```
a.abs() (a.numel() == 10) for 100000 times
device: cuda, dtype: torch.int8, 100000 times           1.8391285985708237
device: cuda, dtype: torch.uint8, 100000 times          1.8831938095390797
device: cuda, dtype: torch.int16, 100000 times          1.8131775446236134
device: cuda, dtype: torch.int32, 100000 times          1.832334715873003
device: cuda, dtype: torch.int64, 100000 times          1.8218239657580853
device: cuda, dtype: torch.float, 100000 times          1.7942761108279228
device: cuda, dtype: torch.double, 100000 times         1.8193779103457928
device: cuda, dtype: torch.half, 100000 times           1.796515878289938
a.abs() (a.numel() == 1000) for 10000 times
device: cuda, dtype: torch.int8, 10000 times            0.18348361551761627
device: cuda, dtype: torch.uint8, 10000 times           0.1892806850373745
device: cuda, dtype: torch.int16, 10000 times           0.18253886327147484
device: cuda, dtype: torch.int32, 10000 times           0.18509215489029884
device: cuda, dtype: torch.int64, 10000 times           0.18291602283716202
device: cuda, dtype: torch.float, 10000 times           0.1796952784061432
device: cuda, dtype: torch.double, 10000 times          0.18088893592357635
device: cuda, dtype: torch.half, 10000 times            0.18222836777567863
```
After change:
```a.abs() (a.numel() == 10) for 100000 times
device: cuda, dtype: torch.int8, 100000 times           1.7365420907735825
device: cuda, dtype: torch.uint8, 100000 times          1.7433889284729958
device: cuda, dtype: torch.int16, 100000 times          1.7034666128456593
device: cuda, dtype: torch.int32, 100000 times          1.6825932636857033
device: cuda, dtype: torch.int64, 100000 times          1.6896217577159405
device: cuda, dtype: torch.float, 100000 times          1.7211194895207882
device: cuda, dtype: torch.double, 100000 times         1.6823345720767975
device: cuda, dtype: torch.half, 100000 times           1.7027524448931217
a.abs() (a.numel() == 1000) for 10000 times
device: cuda, dtype: torch.int8, 10000 times            0.17180879414081573
device: cuda, dtype: torch.uint8, 10000 times           0.17316896095871925
device: cuda, dtype: torch.int16, 10000 times           0.16990498825907707
device: cuda, dtype: torch.int32, 10000 times           0.1681906059384346
device: cuda, dtype: torch.int64, 10000 times           0.16994905844330788
device: cuda, dtype: torch.float, 10000 times           0.1719626784324646
device: cuda, dtype: torch.double, 10000 times          0.16886932775378227
device: cuda, dtype: torch.half, 10000 times            0.16957201063632965
```