### PR TITLE
Add tensor observer

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -139,6 +139,31 @@ class MinMaxObserver(ObserverBase):
     def extra_repr(self):
         return 'min_val={}, max_val={}'.format(self.min_val, self.max_val)
 
+class TensorObserver(ObserverBase):
+    r"""Tensor Observer Module
+    The module will record the running value of the output tensor of the module
+    it attaches to. It can be used for debugging of the model numerics.
+    """
+    __annotations__ = {
+        "output": Optional[torch.Tensor],
+    }
+
+    def __init__(self, **kwargs):
+        super(TensorObserver, self).__init__(**kwargs)
+        self.output = None
+
+    def forward(self, x):
+        self.output = x
+        return x
+
+    @torch.jit.export
+    def calculate_qparams(self):
+        return 0
+
+    @torch.jit.export
+    def get_output(self):
+        return self.output
+
 def observer(observer_cls, **kwargs):
     return partial(observer_cls, **kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25864 Add tensor observer**

Add basic tensor observer to record the output of the module it's attached to. Will be used in later diff to collect the intermediate tensor information for debugging numerics.

Differential Revision: [D17263694](https://our.internmc.facebook.com/intern/diff/D17263694/)