### PR TITLE
print source code when a function is executed

### DIFF
--- a/torch/csrc/jit/function.cpp
+++ b/torch/csrc/jit/function.cpp
@@ -1,7 +1,5 @@
-#include <sstream>
 #include <torch/csrc/jit/function.h>
-#include <torch/csrc/jit/jit_log.h>
-#include <torch/csrc/jit/passes/python_print.h>
+
 #include <torch/csrc/jit/script/error_report.h>
 
 namespace torch {
@@ -28,20 +26,6 @@ FunctionSchema defaultSchemaFor(const Function& function) {
 struct RecursiveMethodCallError : public std::exception {};
 void placeholderCreator(Function&) {
   throw RecursiveMethodCallError();
-}
-
-std::string Function::toString() const {
-  std::stringstream ss;
-  std::vector<at::Tensor> tensors;
-  std::vector<c10::NamedTypePtr> deps;
-  SourceRangeRecords source_ranges;
-  PythonPrint(ss, source_ranges, *this, false, tensors, deps, false);
-  return ss.str();
-}
-
-void Function::run(Stack &stack) {
-  GRAPH_DUMP("\n\n\n=== Running a function: ===\n\n\n", this);
-  get_executor().run(stack);
 }
 
 void Function::ensure_defined() {

--- a/torch/csrc/jit/function.h
+++ b/torch/csrc/jit/function.h
@@ -21,9 +21,7 @@ struct TORCH_API Function {
         graph_(std::move(graph)),
         function_creator_(std::move(function_creator)) {}
 
-  void run(Stack& stack) {
-    get_executor().run(stack);
-  }
+  void run(Stack &stack);
 
   void run(Stack&& stack) {
     run(stack);
@@ -86,6 +84,8 @@ struct TORCH_API Function {
         graph()->outputs().size() == 1,
         "Method (but not graphs in general) require a single output. Use None/Tuple for 0 or 2+ outputs");
   }
+
+  std::string toString() const;
 
   GraphExecutor& get_executor() {
     ensure_defined();

--- a/torch/csrc/jit/function.h
+++ b/torch/csrc/jit/function.h
@@ -21,7 +21,7 @@ struct TORCH_API Function {
         graph_(std::move(graph)),
         function_creator_(std::move(function_creator)) {}
 
-  void run(Stack &stack);
+  void run(Stack &stack) { get_executor().run(stack); }
 
   void run(Stack&& stack) {
     run(stack);
@@ -84,8 +84,6 @@ struct TORCH_API Function {
         graph()->outputs().size() == 1,
         "Method (but not graphs in general) require a single output. Use None/Tuple for 0 or 2+ outputs");
   }
-
-  std::string toString() const;
 
   GraphExecutor& get_executor() {
     ensure_defined();

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -546,8 +546,7 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
 
   ExecutionPlan compileSpec(const ArgumentSpec& spec) {
     auto opt_graph = graph->copy();
-
-    SOURCE_DUMP(opt_graph);
+    SOURCE_DUMP("Optimizing the following function:", opt_graph);
     arg_spec_creator_.specializeTypes(*opt_graph, spec);
 
     // Phase 0. Inline functions, then clean up any artifacts that the inliner

--- a/torch/csrc/jit/graph_executor.cpp
+++ b/torch/csrc/jit/graph_executor.cpp
@@ -9,6 +9,7 @@
 #include <torch/csrc/jit/graph_executor_impl.h>
 #include <torch/csrc/jit/interpreter.h>
 #include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/pass_manager.h>
 #include <torch/csrc/jit/passes/batch_mm.h>
 #include <torch/csrc/jit/passes/canonicalize_ops.h>
@@ -546,6 +547,7 @@ struct GraphExecutorImpl : public GraphExecutorImplBase {
   ExecutionPlan compileSpec(const ArgumentSpec& spec) {
     auto opt_graph = graph->copy();
 
+    SOURCE_DUMP(opt_graph);
     arg_spec_creator_.specializeTypes(*opt_graph, spec);
 
     // Phase 0. Inline functions, then clean up any artifacts that the inliner

--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -22,8 +22,11 @@ JitLoggingLevels jit_log_level() {
   return log_level;
 }
 
+// Unfortunately, in `GraphExecutor` where `log_function` is invoked
+// we won't have access to an original function, so we have to construct
+// a dummy function to give to PythonPrint
 std::string log_function(const std::shared_ptr<torch::jit::Graph> &graph) {
-  torch::jit::Function func("SOURCE_DUMP", graph, nullptr);
+  torch::jit::Function func("source_dump", graph, nullptr);
   std::stringstream ss;
   std::vector<at::Tensor> tensors;
   std::vector<c10::NamedTypePtr> deps;

--- a/torch/csrc/jit/jit_log.cpp
+++ b/torch/csrc/jit/jit_log.cpp
@@ -1,10 +1,15 @@
-#include <torch/csrc/jit/jit_log.h>
-#include <c10/util/Exception.h>
-#include <torch/csrc/jit/ir.h>
-#include <c10/util/StringUtil.h>
+
 #include <cstdlib>
 #include <iomanip>
 #include <sstream>
+
+#include <c10/util/Exception.h>
+#include <c10/util/StringUtil.h>
+#include <torch/csrc/jit/function.h>
+#include <torch/csrc/jit/ir.h>
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/python_print.h>
+#include <torch/csrc/jit/script/error_report.h>
 
 namespace torch {
 namespace jit {
@@ -15,6 +20,16 @@ JitLoggingLevels jit_log_level() {
       ? static_cast<JitLoggingLevels>(std::atoi(c_log_level))
       : JitLoggingLevels::OFF;
   return log_level;
+}
+
+std::string log_function(const std::shared_ptr<torch::jit::Graph> &graph) {
+  torch::jit::Function func("SOURCE_DUMP", graph, nullptr);
+  std::stringstream ss;
+  std::vector<at::Tensor> tensors;
+  std::vector<c10::NamedTypePtr> deps;
+  SourceRangeRecords source_ranges;
+  PythonPrint(ss, source_ranges, func, false, tensors, deps, false);
+  return ss.str();
 }
 
 std::string debugValueOrDefault(const Node* n) {

--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <string>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
@@ -15,6 +16,7 @@ namespace torch {
 namespace jit {
 
 struct Node;
+struct Graph;
 
 enum class JitLoggingLevels {
   OFF,
@@ -24,6 +26,8 @@ enum class JitLoggingLevels {
 };
 
 std::string debugValueOrDefault(const Node* n);
+
+std::string TORCH_API log_function(const std::shared_ptr<Graph> &graph);
 
 TORCH_API JitLoggingLevels jit_log_level();
 
@@ -46,6 +50,10 @@ TORCH_API std::ostream& operator<<(std::ostream& out, JitLoggingLevels level);
         level, __FILE__, __LINE__, ::c10::str(__VA_ARGS__));                  \
   }
 
+// tries to reconstruct original python source
+#define SOURCE_DUMP(G)                                                         \
+  JIT_LOG(JitLoggingLevels::GRAPH_DUMP,                                        \
+          "Optimizing the following function:\n", log_function(G));
 // use GRAPH_DUMP for dumping graphs after optimization passes
 #define GRAPH_DUMP(MSG, G) \
   JIT_LOG(JitLoggingLevels::GRAPH_DUMP, MSG, "\n", (G)->toString());

--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -51,9 +51,8 @@ TORCH_API std::ostream& operator<<(std::ostream& out, JitLoggingLevels level);
   }
 
 // tries to reconstruct original python source
-#define SOURCE_DUMP(G)                                                         \
-  JIT_LOG(JitLoggingLevels::GRAPH_DUMP,                                        \
-          "Optimizing the following function:\n", log_function(G));
+#define SOURCE_DUMP(MSG, G)                                                    \
+  JIT_LOG(JitLoggingLevels::GRAPH_DUMP, MSG, "\n", log_function(G));
 // use GRAPH_DUMP for dumping graphs after optimization passes
 #define GRAPH_DUMP(MSG, G) \
   JIT_LOG(JitLoggingLevels::GRAPH_DUMP, MSG, "\n", (G)->toString());


### PR DESCRIPTION
While this isn't ideal as it might print out the same source every time a function is run; it's still easier to go and tweak python code to reduce loop counts, than to insert `std::cout` and recompile cpp code.