### PR TITLE
Fix c10 tracing

### DIFF
--- a/torch/csrc/jit/register_c10_ops.cpp
+++ b/torch/csrc/jit/register_c10_ops.cpp
@@ -46,15 +46,16 @@ IValue wrap(IValue&& ivalue) {
 Operator createOperatorFromC10(const c10::OperatorHandle& op) {
   return Operator(op, [op](Stack& stack) {
       RECORD_FUNCTION(op.schema().name(), stack);
-
       const auto input_size = op.schema().arguments().size();
       const auto output_size = op.schema().returns().size();
 
       Node* node = nullptr;
+      std::shared_ptr<jit::tracer::TracingState> tracer_state;
 
       // trace the input before unwrapping, otherwise we may lose
       // the input information
       if (jit::tracer::isTracing()) {
+        tracer_state = jit::tracer::getTracingState();
         auto symbol = Symbol::fromQualString(op.schema().name());
         const auto& graph = tracer::getTracingState()->graph;
         node = graph->create(symbol, 0);
@@ -130,6 +131,8 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
           }
         }
         graph->insertNode(node);
+
+        jit::tracer::setTracingState(nullptr);
       }
 
       c10::Dispatcher::singleton().lookup(op, &stack).call(&stack);
@@ -139,7 +142,8 @@ Operator createOperatorFromC10(const c10::OperatorHandle& op) {
         *iter = wrap(std::move(*iter));
       }
 
-      if (jit::tracer::isTracing()) {
+      if (tracer_state) {
+        jit::tracer::setTracingState(std::move(tracer_state));
         int i = 0;
         for (auto iter = stack.end() - output_size; iter != stack.end();
              ++iter, ++i) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25877 [quantization] TorchScript Serialization for dynamic LSTM module
* #25870 [quantzation] Test scripting and tracing for dynamic linear modules
* **#25869 Fix c10 tracing**

The c10 code for tracing was not disabling tracing when calling the op like it should have. This caused really weird errors where we were recording tensors for ops called within a given c10 op implementation, and making tracing fail

Differential Revision: [D17275748](https://our.internmc.facebook.com/intern/diff/D17275748)