### PR TITLE
Don't compile at::NamesMode for caffe2 mobile builds

### DIFF
--- a/aten/src/ATen/core/NamedTensor.cpp
+++ b/aten/src/ATen/core/NamedTensor.cpp
@@ -13,6 +13,11 @@ bool NamedTensorMeta::has_names() const {
       });
 }
 
+/// thread_local is a feature that is not enabled by Caffe2 mobile
+/// build (e.g. iOS). Therefore, we only provide `at::NamesMode`
+/// when we are not in mobile build or when FEATURE_TORCH_MOBILE
+/// is on.
+#if !defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE)
 thread_local bool NamesMode_enabled = true;
 
 bool NamesMode::is_enabled() {
@@ -22,6 +27,17 @@ bool NamesMode::is_enabled() {
 void NamesMode::set_enabled(bool enabled) {
    NamesMode_enabled = enabled;
 }
+
+#else
+
+bool NamesMode::is_enabled() {
+  throw std::runtime_error("NamesMode is not supported on mobile");
+}
+void NamesMode::set_enabled(bool enabled) {
+  throw std::runtime_error("NamesMode is not supported on mobile");
+}
+
+#endif
 
 Tensor& internal_set_names_inplace(Tensor& tensor, optional<DimnameList> names) {
   impl::internal_set_names_inplace(tensor.unsafeGetTensorImpl(), names);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25875 Remove more BUILD_NAMEDTENSOR flags, guard mobile builds
* **#25872 Don't compile at::NamesMode for caffe2 mobile builds**

The caffe2 ios mobile build doesn't support thread_local variables.
Guard against it and raise a runtime error if one tries to use
at::NamesMode in that configuration.

Test Plan:
- [namedtensor ci]

Differential Revision: [D17267285](https://our.internmc.facebook.com/intern/diff/D17267285)