### PR TITLE
Remove more BUILD_NAMEDTENSOR flags, guard mobile builds

### DIFF
--- a/aten/src/ATen/core/Dimname.h
+++ b/aten/src/ATen/core/Dimname.h
@@ -1,10 +1,10 @@
 #pragma once
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/interned_strings.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
 #include <ostream>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 enum class NameType: uint8_t { NORMAL, WILDCARD, TAGGED };

--- a/aten/src/ATen/core/NamedTensor.cpp
+++ b/aten/src/ATen/core/NamedTensor.cpp
@@ -1,9 +1,9 @@
 #include <ATen/core/NamedTensor.h>
 
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/Tensor.h>
 #include <c10/util/C++17.h>
 
+#ifdef BUILD_NAMEDTENSOR
 namespace at {
 
 bool NamedTensorMeta::has_names() const {

--- a/aten/src/ATen/core/TensorBody.h
+++ b/aten/src/ATen/core/TensorBody.h
@@ -16,9 +16,7 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/NamedTensor.h>
-#endif
 
 namespace caffe2 {
 class Tensor;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -11,9 +11,7 @@
 #if !defined(CAFFE2_IS_XPLAT_BUILD)
 #include <ATen/core/dispatch/Dispatcher.h>
 #endif
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/NamedTensor.h>
-#endif
 #ifdef USE_STATIC_DISPATCH
 #include <ATen/TypeDefault.h>
 #include <ATen/CPUType.h>

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -7,13 +7,13 @@
 
 #include <c10/macros/Macros.h>
 
-#if !defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE)
+#if !defined(CAFFE2_IS_XPLAT_BUILD) && (!defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE))
 #include <ATen/core/aten_interned_strings.h>
 #endif
 
 namespace c10 {
 
-#if !defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE)
+#if !defined(CAFFE2_IS_XPLAT_BUILD) && (!defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE))
 #define FORALL_NS_SYMBOLS(_)         \
   _(namespaces, prim)                \
   _(namespaces, aten)                \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -231,8 +231,7 @@ namespace c10 {
   _(namespaces, dimname)           \
   _(namespaces, namespaces)
 #else
-#define FORALL_NS_SYMBOLS(_) \
-  _(namespaces, namespaces)
+#define FORALL_NS_SYMBOLS(_)
 #endif
 
 // 'prim' symbols are synthetic operators that occur only in the IR

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -16,9 +16,7 @@
 #include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/NamedTensor.h>
-#endif
 
 namespace caffe2 {
 class Tensor;

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -11,9 +11,7 @@
 #if !defined(CAFFE2_IS_XPLAT_BUILD)
 #include <ATen/core/dispatch/Dispatcher.h>
 #endif
-#ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/NamedTensor.h>
-#endif
 #ifdef USE_STATIC_DISPATCH
 #include <ATen/TypeDefault.h>
 #include <ATen/CPUType.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25875 Remove more BUILD_NAMEDTENSOR flags, guard mobile builds**
* #25872 Don't compile at::NamesMode for caffe2 mobile builds

Test Plan:
- [namedtensor ci]

Differential Revision: [D17268394](https://our.internmc.facebook.com/intern/diff/D17268394)