### PR TITLE
Unify treatment of warp size / wave size

### DIFF
--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -5,18 +5,13 @@
 
 #include <ATen/native/Distance.h>
 
+#include <c10/macros/Macros.h>
 
 namespace at { namespace native {
 
 namespace {
 
 static const int forward_threads = 256;
-
-#ifdef __HIP_PLATFORM_HCC__
-static const int WARP_SIZE = 64;
-#else
-static const int WARP_SIZE = 32;
-#endif
 
 template <typename scalar_t>
 static __forceinline__ __device__ scalar_t device_sqrt(scalar_t val);

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -3,6 +3,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/util/Exception.h>
+#include <c10/macros/Macros.h>
 
 #include <THC/THCDeviceUtils.cuh>
 #include <THC/THCTensorMathReduce.cuh>
@@ -21,10 +22,8 @@ namespace at { namespace native {
 namespace {
 
 #ifdef __HIP_PLATFORM_HCC__
-static const int WARP_SIZE = 64;
 static const int BLOCKDIMY = 16;
 #else
-static const int WARP_SIZE = 32;
 static const int BLOCKDIMY = 32;
 #endif
 
@@ -41,8 +40,8 @@ __global__ void embedding_backward_feature_kernel
 {
   extern __shared__ char buf[];
   accscalar_t* smem = (accscalar_t*)buf;
-  accscalar_t* my_s = smem + WARP_SIZE*threadIdx.y;
-  int* indices_batch = (int*)(buf + sizeof(accscalar_t)*WARP_SIZE*blockDim.y);
+  accscalar_t* my_s = smem + C10_WARP_SIZE*threadIdx.y;
+  int* indices_batch = (int*)(buf + sizeof(accscalar_t)*C10_WARP_SIZE*blockDim.y);
 
   const int s = (int)stride; // OK to make int, we don't expect 2 billion+ embedding row size
 
@@ -106,7 +105,7 @@ __global__ void embedding_backward_feature_kernel
 #else
             first_remaining_peer = __ffs(matchmask) - 1;
 #endif
-            my_s[threadIdx.x] += smem[threadIdx.x + WARP_SIZE*first_remaining_peer];
+            my_s[threadIdx.x] += smem[threadIdx.x + C10_WARP_SIZE*first_remaining_peer];
             matchmask ^= (1 << first_remaining_peer);
           }
           if(f < s)
@@ -154,7 +153,7 @@ __global__ void embedding_backward_kernel(
 
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++) {
-        int feature_dim = start_feature + ii * WARP_SIZE;
+        int feature_dim = start_feature + ii * C10_WARP_SIZE;
         if (feature_dim < stride) {
           gradient[ii] = static_cast<accscalar_t>(grad_output[grad_row + feature_dim]);
           weight[ii] = static_cast<accscalar_t>(grad_weight[weight_row + feature_dim]);
@@ -168,7 +167,7 @@ __global__ void embedding_backward_kernel(
 
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++) {
-        int feature_dim = start_feature + ii * WARP_SIZE;
+        int feature_dim = start_feature + ii * C10_WARP_SIZE;
         if (feature_dim < stride) {
             grad_weight[weight_row + feature_dim] = static_cast<scalar_t>(weight[ii]);
         }
@@ -240,8 +239,8 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
     auto indices_contig = indices.contiguous();
     auto grad_weight = at::zeros({num_weights, grad_.size(-1)}, grad_.options());
     int64_t stride = grad_weight.stride(0);
-    dim3 grid(THCCeilDiv(stride, (int64_t)WARP_SIZE));
-    dim3 block(WARP_SIZE, BLOCKDIMY);
+    dim3 grid(THCCeilDiv(stride, (int64_t)C10_WARP_SIZE));
+    dim3 block(C10_WARP_SIZE, BLOCKDIMY);
 
     AT_DISPATCH_FLOATING_TYPES_AND_HALF
       (grad.scalar_type(),
@@ -252,7 +251,7 @@ Tensor embedding_dense_backward_cuda(const Tensor & grad_, const Tensor & indice
          embedding_backward_feature_kernel<scalar_t, accscalar_t>
            <<<grid,
               block,
-              sizeof(accscalar_t)*WARP_SIZE*BLOCKDIMY + sizeof(int)*WARP_SIZE*BLOCKDIMY,
+              sizeof(accscalar_t)*C10_WARP_SIZE*BLOCKDIMY + sizeof(int)*C10_WARP_SIZE*BLOCKDIMY,
               stream>>>
            (indices_contig.data_ptr<int64_t>(),
             grad.data_ptr<scalar_t>(),

--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -14,6 +14,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/unique.h>
 
+#include <c10/macros/Macros.h>
 
 namespace at {
 namespace native {
@@ -32,12 +33,6 @@ constexpr int MAX_BLOCK_SIZE = 1024;
   make the size of the thread blocks in the final sum in step 2) too small.
 */
 constexpr int NROWS_PER_THREAD = 10;
-
-#ifdef __HIP_PLATFORM_HCC__
-    constexpr int WARP_SIZE = 64;
-#else
-    constexpr int WARP_SIZE = 32;
-#endif
 
 // Fast ceil division (no overflow checking)
 __host__ __device__ __forceinline__
@@ -266,7 +261,7 @@ Tensor embedding_backward_cuda_kernel(
             num_of_segments);
   }
 
-  const int stride_warped = ceil_div(stride, WARP_SIZE)*WARP_SIZE;
+  const int stride_warped = ceil_div(stride, C10_WARP_SIZE)*C10_WARP_SIZE;
   const int block = std::min(stride_warped, MAX_BLOCK_SIZE);
   const int grid = ceil_div(num_of_partial_segments*stride_warped, block);
 

--- a/aten/src/ATen/native/cuda/EmbeddingBag.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBag.cu
@@ -18,6 +18,8 @@
 
 #include <ATen/native/cuda/EmbeddingBackwardKernel.cuh>
 
+#include <c10/macros/Macros.h>
+
 namespace at {
 namespace native {
 
@@ -26,13 +28,6 @@ namespace {
 constexpr int MODE_SUM = 0;
 constexpr int MODE_MEAN = 1;
 constexpr int MODE_MAX = 2;
-
-#ifdef __HIP_PLATFORM_HCC__
-constexpr int WARP_SIZE = 64;
-#else
-constexpr int WARP_SIZE = 32;
-#endif
-
 
 // This kernel assumes that all input tensors except `weight` and
 // per_sample_weights are contiguous.
@@ -352,7 +347,7 @@ Tensor _embedding_bag_dense_backward_cuda(const Tensor &grad_, const Tensor &ind
 template <typename scalar_t>
 __inline__ __device__
 static scalar_t warpReduceSum(scalar_t val) {
-  for (int offset = WARP_SIZE/2; offset > 0; offset /= 2)
+  for (int offset = C10_WARP_SIZE/2; offset > 0; offset /= 2)
     val += WARP_SHFL_DOWN(val, offset);
   return val;
 }
@@ -368,9 +363,9 @@ __global__ static void _embedding_bag_per_sample_weights_backward_kernel(
     scalar_t* output) {
   using accscalar_t = acc_type<scalar_t, true>;
   const int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  const int warp = idx / WARP_SIZE;
-  const int thread_in_warp = idx % WARP_SIZE;
-  const int num_warps = blockDim.x * gridDim.x / WARP_SIZE;
+  const int warp = idx / C10_WARP_SIZE;
+  const int thread_in_warp = idx % C10_WARP_SIZE;
+  const int num_warps = blockDim.x * gridDim.x / C10_WARP_SIZE;
 
   // Each warp is responsible for the accumulation of one sample.
   // This involves doing one dot product between grad[bag_idx] and weight[embedding_idx].
@@ -379,7 +374,7 @@ __global__ static void _embedding_bag_per_sample_weights_backward_kernel(
     const int bag_idx = (int)offset2bag[sample_idx];
     const int embedding_idx = (int)indices[sample_idx];
     for (int feature_idx = thread_in_warp; feature_idx < embedding_features;
-        feature_idx += WARP_SIZE) {
+        feature_idx += C10_WARP_SIZE) {
       result +=
           grad[grad_stride0 * bag_idx + grad_stride1 * feature_idx] *
           weight[weight_stride0 * embedding_idx + weight_stride1 * feature_idx];
@@ -412,7 +407,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cuda(
   AT_ASSERT(weight.size(1) == embedding_features);
 
   const int threads_per_block = 1024;
-  const int warps_per_block = threads_per_block / WARP_SIZE;
+  const int warps_per_block = threads_per_block / C10_WARP_SIZE;
 
   dim3 block(threads_per_block);
   dim3 grid((num_samples + warps_per_block - 1) / warps_per_block);

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -15,19 +15,10 @@
 #include <thrust/execution_policy.h>
 #include <thrust/sort.h>
 
+#include <c10/macros/Macros.h>
 
 namespace {
 
-#ifdef __HIP_PLATFORM_HCC__
-static const int WARP_SIZE = 64;
-#else
-static const int WARP_SIZE = 32;
-#endif
-
-
-
-
-template <typename scalar_t, int SZ>
 __global__ void indexing_backward_kernel(
   int64_t* sorted_indices, int64_t* indices, scalar_t* grad_output, scalar_t* grad_weight,
   int64_t numel, int64_t stride, int64_t stride_before, int64_t outer_dim) {
@@ -66,7 +57,7 @@ __global__ void indexing_backward_kernel(
         while (start_feature < stride) {
           #pragma unroll
           for (int ii = 0; ii < SZ; ii++) {
-            int feature_dim = start_feature + ii * WARP_SIZE;
+            int feature_dim = start_feature + ii * C10_WARP_SIZE;
             if (feature_dim < stride) {
               gradient[ii] = static_cast<accscalar_t>(grad_output[grad_row + feature_dim]);
               weight[ii] = static_cast<accscalar_t>(grad_weight[weight_row + feature_dim]);
@@ -80,7 +71,7 @@ __global__ void indexing_backward_kernel(
 
           #pragma unroll
           for (int ii = 0; ii < SZ; ii++) {
-            int feature_dim = start_feature + ii * WARP_SIZE;
+            int feature_dim = start_feature + ii * C10_WARP_SIZE;
             if (feature_dim < stride) {
                 grad_weight[weight_row + feature_dim] = static_cast<scalar_t>(weight[ii]);
             }
@@ -229,9 +220,9 @@ void index_put_accum_kernel(Tensor & self, TensorList indices, const Tensor & va
       const int UNROLL = 4;
       const int indices_per_block = 4;
       dim3 grid(THCCeilDiv(num_indices, (int64_t) indices_per_block),
-           std::min<int>(at::cuda::getCurrentDeviceProperties()->maxGridSize[1], THCCeilDiv(sliceSize, (int64_t) (WARP_SIZE*UNROLL))),
+           std::min<int>(at::cuda::getCurrentDeviceProperties()->maxGridSize[1], THCCeilDiv(sliceSize, (int64_t) (C10_WARP_SIZE*UNROLL))),
            std::min(std::max<int>(1,nElemBefore), at::cuda::getCurrentDeviceProperties()->maxGridSize[2]));
-      dim3 block(WARP_SIZE, indices_per_block);
+      dim3 block(C10_WARP_SIZE, indices_per_block);
   
       AT_DISPATCH_FLOATING_TYPES_AND_HALF(value_.scalar_type(), "embedding_backward", [&] {
       indexing_backward_kernel<scalar_t, UNROLL><<<grid, block, 0, stream>>>(

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -19,6 +19,7 @@
 
 namespace {
 
+template <typename scalar_t, int SZ>
 __global__ void indexing_backward_kernel(
   int64_t* sorted_indices, int64_t* indices, scalar_t* grad_output, scalar_t* grad_weight,
   int64_t numel, int64_t stride, int64_t stride_before, int64_t outer_dim) {

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -8,14 +8,9 @@
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
 #include <ATen/native/cuda/LaunchUtils.h>
+#include <c10/macros/Macros.h>
 
 namespace at { namespace native {
-
-#if defined(__HIP_PLATFORM_HCC__)
-constexpr int WARP_SIZE = 64;
-#else
-constexpr int WARP_SIZE = 32;
-#endif
 
 // The maximum number of threads in a block
 #if defined(__HIP_PLATFORM_HCC__)
@@ -94,8 +89,8 @@ struct GradOp {
 // Sum across all threads within a warp
 template <typename T>
 static __device__ __forceinline__ T warpSum(T val) {
-  for (int i = 0; i < getMSB(WARP_SIZE); ++i) {
-    val += WARP_SHFL_XOR(val, 1 << i, WARP_SIZE);
+  for (int i = 0; i < getMSB(C10_WARP_SIZE); ++i) {
+    val += WARP_SHFL_XOR(val, 1 << i, C10_WARP_SIZE);
   }
   return val;
 }
@@ -110,12 +105,12 @@ static __device__ __forceinline__ Float2<scalar_t, accscalar_t> warpSum(Float2<s
 // Sum across (batch, x/y/z) applying Op() pointwise
 // this works by first having each thread sum it's part
 // of the data. Then there is a double-shuffeling reduction.
-// First each warp (of WARP_SIZE threads) uses warpSum to reduce its
+// First each warp (of C10_WARP_SIZE threads) uses warpSum to reduce its
 // data to the "warp leader", who writes its value into shared memory.
-// Then a single warp reads the remaining (at most WARP_SIZE) items
+// Then a single warp reads the remaining (at most C10_WARP_SIZE) items
 // and reduces them using another warpSum.
 // The implicit assumption is that there are no more
-// than WARP_SIZE**2 threads.
+// than C10_WARP_SIZE**2 threads.
 template<typename scalar_t, typename Op, typename PTA>
 __device__ scalar_t reduce(Op op, PTA tensor, int plane) {
   // first the reductions each thread does separately
@@ -131,15 +126,15 @@ __device__ scalar_t reduce(Op op, PTA tensor, int plane) {
   sum = warpSum(sum);
 
   // this writes each warps  item into shared memory
-  // there are at most WARP_SIZE items left because
-  // there are at most WARP_SIZE**2 threads at the beginning
-  __shared__ scalar_t shared[WARP_SIZE];
+  // there are at most C10_WARP_SIZE items left because
+  // there are at most C10_WARP_SIZE**2 threads at the beginning
+  __shared__ scalar_t shared[C10_WARP_SIZE];
   __syncthreads();
   int tid = threadIdx.x + threadIdx.y * blockDim.x;
-  if (tid % WARP_SIZE == 0) {
-    shared[tid / WARP_SIZE] = sum;
+  if (tid % C10_WARP_SIZE == 0) {
+    shared[tid / C10_WARP_SIZE] = sum;
   }
-  if (tid >= blockDim.x * blockDim.y / WARP_SIZE && tid < WARP_SIZE) {
+  if (tid >= blockDim.x * blockDim.y / C10_WARP_SIZE && tid < C10_WARP_SIZE) {
     // zero out the other entries in shared
     shared[tid] = (scalar_t)0;
   }
@@ -148,7 +143,7 @@ __device__ scalar_t reduce(Op op, PTA tensor, int plane) {
   // from shared memory to a single number. The very first
   // thread writes it to shared memory.
 
-  if (tid / WARP_SIZE == 0) {
+  if (tid / C10_WARP_SIZE == 0) {
     sum = warpSum(shared[tid]);
     if (tid == 0) {
       shared[0] = sum;
@@ -227,7 +222,7 @@ __global__ void batch_norm_collect_statistics_kernel(
     PackedTensorAccessor<stat_accscalar_t, 1, RestrictPtrTraits, index_t> save_mean,
     PackedTensorAccessor<stat_accscalar_t, 1, RestrictPtrTraits, index_t> save_transformed_var) {
 
-  __shared__ int shared_n[2 * 2 * WARP_SIZE + WARP_SIZE];
+  __shared__ int shared_n[2 * 2 * C10_WARP_SIZE + C10_WARP_SIZE];
 
   int plane = blockIdx.x;
   int N = input.size(0) * input.size(2);
@@ -239,7 +234,7 @@ __global__ void batch_norm_collect_statistics_kernel(
   // and the parallel algorithm on the same page.
   // We use two shuffles to reduce across the entire block.
   // https://devblogs.nvidia.com/faster-parallel-reductions-kepler/ has a description.
-  stat_accscalar_t* shared_avg_var = (stat_accscalar_t*) &shared_n[WARP_SIZE];
+  stat_accscalar_t* shared_avg_var = (stat_accscalar_t*) &shared_n[C10_WARP_SIZE];
 
   // first the reductions each thread does separately
   stat_accscalar_t avg = 0;
@@ -257,39 +252,39 @@ __global__ void batch_norm_collect_statistics_kernel(
 
   // first warpSum to get one value per thread to
   // one value per warp
-  for (int i = 0; i < getMSB(WARP_SIZE); ++i) {
-    stat_accscalar_t o_avg = WARP_SHFL_XOR(avg, 1 << i, WARP_SIZE);
-    int o_n = WARP_SHFL_XOR(n, 1 << i, WARP_SIZE);
+  for (int i = 0; i < getMSB(C10_WARP_SIZE); ++i) {
+    stat_accscalar_t o_avg = WARP_SHFL_XOR(avg, 1 << i, C10_WARP_SIZE);
+    int o_n = WARP_SHFL_XOR(n, 1 << i, C10_WARP_SIZE);
     stat_accscalar_t factor = 1.0 / fmaxf(1.0, n+o_n);
-    var_n += WARP_SHFL_XOR(var_n, 1 << i, WARP_SIZE) + (avg - o_avg) * (avg - o_avg) * n * o_n * factor;
+    var_n += WARP_SHFL_XOR(var_n, 1 << i, C10_WARP_SIZE) + (avg - o_avg) * (avg - o_avg) * n * o_n * factor;
     avg = (n * avg + o_n * o_avg) * factor;
     n += o_n;
   }
 
   // this writes each warps  item into shared memory
-  // there are at most WARP_SIZE items left because
-  // there are at most WARP_SIZE**2 threads at the beginning
+  // there are at most C10_WARP_SIZE items left because
+  // there are at most C10_WARP_SIZE**2 threads at the beginning
   __syncthreads();
-  if (tid % WARP_SIZE == 0) {
-    shared_n[tid / WARP_SIZE] = n;
-    shared_avg_var[tid / WARP_SIZE * 2] = avg;
-    shared_avg_var[tid / WARP_SIZE * 2 + 1] = var_n;
+  if (tid % C10_WARP_SIZE == 0) {
+    shared_n[tid / C10_WARP_SIZE] = n;
+    shared_avg_var[tid / C10_WARP_SIZE * 2] = avg;
+    shared_avg_var[tid / C10_WARP_SIZE * 2 + 1] = var_n;
   }
   __syncthreads();
   // now have a second warpSum to reduce the intermediate values
   // from shared memory to a single number. The very first
   // thread writes it to shared memory.
 
-  if (tid < WARP_SIZE) {
-    n = (tid < blockDim.x * blockDim.y / WARP_SIZE ? shared_n[tid] : 0);
-    avg = (tid < blockDim.x * blockDim.y  / WARP_SIZE ? shared_avg_var[2 * tid] : stat_accscalar_t(0));
-    var_n = (tid < blockDim.x * blockDim.y  / WARP_SIZE ? shared_avg_var[2 * tid + 1] : stat_accscalar_t(0));
+  if (tid < C10_WARP_SIZE) {
+    n = (tid < blockDim.x * blockDim.y / C10_WARP_SIZE ? shared_n[tid] : 0);
+    avg = (tid < blockDim.x * blockDim.y  / C10_WARP_SIZE ? shared_avg_var[2 * tid] : stat_accscalar_t(0));
+    var_n = (tid < blockDim.x * blockDim.y  / C10_WARP_SIZE ? shared_avg_var[2 * tid + 1] : stat_accscalar_t(0));
   }
-  for (int i = 0; i < getMSB(WARP_SIZE); ++i) {
-    stat_accscalar_t o_avg = WARP_SHFL_XOR(avg, 1 << i, WARP_SIZE);
-    int o_n = WARP_SHFL_XOR(n, 1 << i, WARP_SIZE);
+  for (int i = 0; i < getMSB(C10_WARP_SIZE); ++i) {
+    stat_accscalar_t o_avg = WARP_SHFL_XOR(avg, 1 << i, C10_WARP_SIZE);
+    int o_n = WARP_SHFL_XOR(n, 1 << i, C10_WARP_SIZE);
     stat_accscalar_t factor = 1.0 / fmaxf(1.0, n+o_n);
-    var_n += WARP_SHFL_XOR(var_n, 1 << i, WARP_SIZE) + (avg - o_avg) * (avg - o_avg) * n * o_n * factor;
+    var_n += WARP_SHFL_XOR(var_n, 1 << i, C10_WARP_SIZE) + (avg - o_avg) * (avg - o_avg) * n * o_n * factor;
     avg = (n * avg + o_n * o_avg) * factor;
     n += o_n;
   }

--- a/aten/src/ATen/native/cuda/SortingCommon.cuh
+++ b/aten/src/ATen/native/cuda/SortingCommon.cuh
@@ -14,11 +14,9 @@ namespace at {
 namespace native {
 
 #if defined(__HIP_PLATFORM_HCC__)
-constexpr int WARP_SIZE = 64;
 constexpr int MAX_BLOCK_SIZE = 256;
 
 #else
-constexpr int WARP_SIZE = 32;
 constexpr int MAX_BLOCK_SIZE = 1024;
 #endif
 

--- a/aten/src/ATen/native/cuda/SortingKthValue.cu
+++ b/aten/src/ATen/native/cuda/SortingKthValue.cu
@@ -40,7 +40,7 @@ __global__ void gatherKthValue(
     cuda::detail::TensorInfo<int64_t, index_t> indices) {
   // Indices are limited to integer fp precision, so counts can fit in
   // int32, regardless of index_t
-  __shared__ int smem[WARP_SIZE]; // one per each warp, up to warp limit
+  __shared__ int smem[C10_WARP_SIZE]; // one per each warp, up to warp limit
 
   index_t slice = getLinearBlockId<index_t>();
   if (slice >= numInputSlices) {
@@ -117,7 +117,7 @@ struct KthValueLauncher {
     }
 
     dim3 block(
-        std::min(THCRoundUp(slice_size, (int64_t)WARP_SIZE), (int64_t)1024));
+        std::min(THCRoundUp(slice_size, (int64_t)C10_WARP_SIZE), (int64_t)1024));
     auto stream = at::cuda::getCurrentCUDAStream();
     gatherKthValue<scalar_t, index_t, all_dims><<<grid, block, 0, stream>>>(
         self_info,

--- a/aten/src/ATen/native/cuda/SortingKthValue.cu
+++ b/aten/src/ATen/native/cuda/SortingKthValue.cu
@@ -21,6 +21,7 @@
 #include <THC/THCThrustAllocator.cuh>
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/native/cuda/SortingRadixSelect.cuh>
+#include <c10/macros/Macros.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/cuda/SortingKthValue.cu
+++ b/aten/src/ATen/native/cuda/SortingKthValue.cu
@@ -21,7 +21,6 @@
 #include <THC/THCThrustAllocator.cuh>
 #include <ATen/native/cuda/SortingCommon.cuh>
 #include <ATen/native/cuda/SortingRadixSelect.cuh>
-#include <c10/macros/Macros.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
+++ b/aten/src/ATen/native/cuda/SortingRadixSelect.cuh
@@ -229,7 +229,7 @@ __device__ scalar_t findPattern(
     index_t withinSliceStride,
     bitwise_t desired,
     bitwise_t desiredMask) {
-  if (threadIdx.x < WARP_SIZE) {
+  if (threadIdx.x < C10_WARP_SIZE) {
     smem[threadIdx.x] = static_cast<scalar_t>(0);
   }
   __syncthreads();

--- a/aten/src/THCUNN/LookupTableBag.cu
+++ b/aten/src/THCUNN/LookupTableBag.cu
@@ -13,12 +13,8 @@
 #include <thrust/unique.h>
 #include <TH/THHalf.h>
 #include <THC/THCTensorSort.cuh>
+#include <c10/macros/Macros.h>
 
-#if defined(__HIP_PLATFORM_HCC__)
-const int WARP_SIZE = 64;
-#else
-const int WARP_SIZE = 32;
-#endif
 const int MODE_SUM = 0;
 const int MODE_MEAN = 1;
 
@@ -109,7 +105,7 @@ __global__ void cunn_LookupTableBag_accGradParametersKernel(
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++)
       {
-        int featureDim = startFeature + ii * WARP_SIZE;
+        int featureDim = startFeature + ii * C10_WARP_SIZE;
         if (featureDim < stride)
         {
           gradient[ii] = ScalarConvert<Dtype, Acctype>::to(gradOutput[gradOutputRow + featureDim]);
@@ -129,7 +125,7 @@ __global__ void cunn_LookupTableBag_accGradParametersKernel(
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++)
       {
-        int featureDim = startFeature + ii * WARP_SIZE;
+        int featureDim = startFeature + ii * C10_WARP_SIZE;
         if (featureDim < stride)
         {
           gradWeight[weightRow + featureDim] = ScalarConvert<Acctype, Dtype>::to(weight[ii]);

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -194,9 +194,9 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #endif
 
 #ifdef __HIP_PLATFORM_HCC__
-#define C10_WARP_SIZE = 64;
+#define C10_WARP_SIZE 64
 #else
-#define C10_WARP_SIZE = 32;
+#define C10_WARP_SIZE 32
 #endif
 
 #ifdef __APPLE__

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -193,6 +193,12 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 #define C10_HIP_HOST_DEVICE
 #endif
 
+#ifdef __HIP_PLATFORM_HCC__
+#define C10_WARP_SIZE = 64;
+#else
+#define C10_WARP_SIZE = 32;
+#endif
+
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif


### PR DESCRIPTION
Introduce a C10_WARP_SIZE define in Macros.h

For kernels that had ifdef-ing of WARP_SIZE for ROCm vs CUDA, use said macro. This is no functional change - we merely refactor to unify on one WARP_SIZE definition.

I hope we can encourage use of this macro over more WARP_SIZE definitions being sprinkled across the code base (or numerically hard-coded).

Some kernels remain that have their own WARP_SIZE definitions but did not satisfy above condition. They will be fixed in follow-up PRs.