### PR TITLE
[pytorch] remove pthreadpool dependency in aten/CMake

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -210,7 +210,7 @@ endif()
 
 if(AT_NNPACK_ENABLED)
   include_directories(${NNPACK_INCLUDE_DIRS})
-  list(APPEND ATen_CPU_DEPENDENCY_LIBS nnpack pthreadpool) # cpuinfo is added below
+  list(APPEND ATen_CPU_DEPENDENCY_LIBS nnpack) # cpuinfo is added below
 endif()
 
 if(MKLDNN_FOUND)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25896 [pytorch] update build_android.sh to not build host protoc for libtorch
* **#25894 [pytorch] remove pthreadpool dependency in aten/CMake**
* #25817 [pytorch][mobile] disable backward function codegen if disable_autograd is set
* #25816 [pytorch][mobile] add NO_EXPORT macro to unset __visibility__ attribute
* #25697 [pytorch] introduce INTERN_DISABLE_AUTOGRAD flag to create inference only library for mobile
* #25815 [pytorch][mobile] gate static aten registerer with USE_STATIC_DISPATCH

Summary:
NNPack/QNNPack both depend on a third-party library "pthreadpool". There
are two versions of "pthreadpool" implementation, one is the default
implementation under third-party/pthreadpool, the other is caffe2 custom
implementation under caffe2/utils/threadpool. Both implementations share
the same interface (as defined by pthreadpool headers).

Usually only one version of pthreadpool should be linked into libtorch.
If QNNPACK_CUSTOM_THREADPOOL/NNPACK_CUSTOM_THREADPOOL are set to true,
then QNNPack/NNPack will not link third-party/pthreadpool - they will
expect the caller (libtorch) to link correct version of pthreadpool;
otherwise they will bring in the default pthreadpool implementation.

Looks like libtorch cmake already sets both macros to true in
Dependencies.cmake and External/nnpack.cmake. And currently libtorch
mobile build includes the caffe2/utils/threadpool pthreadpool
implementation. So it shouldn't try to explicitly link default
pthreadpool target in aten/CMake in this AT_NNPACK_ENABLED section.

Test Plan:
- Before this diff, libtorch.so links libpthreadpool.a:
```
LINK_LIBRARIES = lib/libc10.so lib/libqnnpack.a lib/libnnpack.a
lib/libcpuinfo.a -llog -ldl -lm lib/libnnpack.a lib/libpthreadpool.a
lib/libcpuinfo.a lib/libclog.a -llog -latomic -lm
```

- After this diff, libtorch.so no longer links libpthreadpool.a:
```
LINK_LIBRARIES = lib/libc10.so lib/libqnnpack.a lib/libnnpack.a
lib/libcpuinfo.a -llog -ldl -lm lib/libnnpack.a lib/libcpuinfo.a
lib/libclog.a -llog -latomic -lm
```

- Tried the following combinations to make sure things work as expected:
* remove caffe2/utils/threadpool, remove libpthreadpool: link error;
* keep caffe2/utils/threadpool, remove libpthreadpool: no link error;
* remove caffe2/utils/threadpool, add back libpthreadpool: no link error;

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25894

Differential Revision: [D17279723](https://our.internmc.facebook.com/intern/diff/D17279723)