### PR TITLE
[pytorch] update build_android.sh to not build host protoc for libtorch

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -65,8 +65,6 @@ fi
 if [[ "${BUILD_ENVIRONMENT}" == *-android* ]]; then
   export ANDROID_NDK=/opt/ndk
   build_args=()
-  build_args+=("-DBUILD_CAFFE2_MOBILE=OFF")
-
   build_args+=("-DBUILD_SHARED_LIBS=ON")
   if [[ "${BUILD_ENVIRONMENT}" == *-arm-v7a* ]]; then
     build_args+=("-DANDROID_ABI=armeabi-v7a")
@@ -77,9 +75,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *-android* ]]; then
   elif [[ "${BUILD_ENVIRONMENT}" == *-x86_64* ]]; then
     build_args+=("-DANDROID_ABI=x86_64")
   fi
-
-  build_args+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
-  build_args+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
+  export BUILD_PYTORCH_MOBILE=1
   exec ./scripts/build_android.sh "${build_args[@]}" "$@"
 fi
 

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -17,7 +17,7 @@ cd $BUILD_ROOT
 
 CMAKE_ARGS=()
 
-if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then 
+if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then
   CMAKE_ARGS+=("-DBUILD_CAFFE2_MOBILE=OFF")
   CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
   CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25896 [pytorch] update build_android.sh to not build host protoc for libtorch**
* #25894 [pytorch] remove pthreadpool dependency in aten/CMake
* #25817 [pytorch][mobile] disable backward function codegen if disable_autograd is set
* #25816 [pytorch][mobile] add NO_EXPORT macro to unset __visibility__ attribute
* #25697 [pytorch] introduce INTERN_DISABLE_AUTOGRAD flag to create inference only library for mobile
* #25815 [pytorch][mobile] gate static aten registerer with USE_STATIC_DISPATCH

Summary:
Similar change as PR #25822.

Test Plan:
- Updated CI to use the new script.
- Will check pytorch android CI output to make sure it builds libtorch
  instead of libcaffe2.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25896

Differential Revision: [D17279722](https://our.internmc.facebook.com/intern/diff/D17279722)