### PR TITLE
Remove global group name tracking for ProcessGroupNCCL

### DIFF
--- a/test/test_c10d.py
+++ b/test/test_c10d.py
@@ -2993,7 +2993,11 @@ class CommTest(MultiProcessTestCase):
     def _test_nccl_errors_blocking(self, func):
         os.environ["NCCL_BLOCKING_WAIT"] = "1"
         store = c10d.FileStore(self.file.name, self.world_size)
-        process_group = c10d.ProcessGroupNCCL(store, self.rank, self.world_size, "", timeout=timedelta(seconds=self.op_timeout_sec))
+        process_group = c10d.ProcessGroupNCCL(
+            store,
+            self.rank,
+            self.world_size,
+            timeout=timedelta(seconds=self.op_timeout_sec))
         process_group.allreduce(torch.rand(10).cuda(self.rank))
         if self.rank == 0:
             work = process_group.allreduce(torch.rand(10).cuda(self.rank))

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -485,12 +485,10 @@ They are used in specifying strategies for reduction collectives, e.g.,
               const std::shared_ptr<::c10d::Store>&,
               int,
               int,
-              const std::string&,
               const std::chrono::milliseconds&>(),
           py::arg("store"),
           py::arg("rank"),
           py::arg("size"),
-          py::arg("groupName") = "",
           py::arg("timeout") = std::chrono::milliseconds(
               ::c10d::ProcessGroupNCCL::kProcessGroupNCCLOpTimeoutMillis));
 #endif

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -485,8 +485,7 @@ def _new_process_group_helper(world_size,
             pg = ProcessGroupNCCL(
                 prefix_store,
                 rank,
-                world_size,
-                group_name)
+                world_size)
             _pg_map[pg] = (Backend.NCCL, store)
             _pg_names[pg] = group_name
         else:

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -217,21 +217,14 @@ void ProcessGroupNCCL::WorkNCCL::wait() {
   synchronize();
 }
 
-std::unordered_map<std::string, ssize_t> ProcessGroupNCCL::pgUniqueNCCLIDCnt_;
-std::unordered_map<std::string, ssize_t>
-    ProcessGroupNCCL::processGroupCounterMap_;
-
-std::mutex ProcessGroupNCCL::pgTrackingLock_;
-
 ProcessGroupNCCL::ProcessGroupNCCL(
     const std::shared_ptr<Store>& store,
     int rank,
     int size,
-    const std::string& groupName,
     const std::chrono::milliseconds& opTimeout)
     : ProcessGroup(rank, size),
       store_(store),
-      groupName_(groupName),
+      ncclCommCounter_(0),
       terminateWatchdog_(false),
       opTimeout_(opTimeout) {
   char* blockingWait = getenv(NCCL_BLOCKING_WAIT);
@@ -253,25 +246,11 @@ ProcessGroupNCCL::ProcessGroupNCCL(
         std::string(NCCL_BLOCKING_WAIT));
   }
 
-  // Generate the Process Group ID for current PG, this needs to be identical
-  // for all processes
-  std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  // Default group is an empty string
-  const auto groupKey = groupName_ + "_";
-  if (processGroupCounterMap_.count(groupKey) == 0) {
-    processGroupCounterMap_[groupKey] = -1;
-  }
-  ++processGroupCounterMap_[groupKey];
-  processGroupID_ = std::to_string(processGroupCounterMap_[groupKey]);
-  groupPgID_ = groupName_ + "_" + processGroupID_;
-  pgUniqueNCCLIDCnt_[groupPgID_] = -1;
   ncclCommWatchdogThread_ =
       std::thread(&ProcessGroupNCCL::ncclCommWatchdog, this);
 }
 
 ProcessGroupNCCL::~ProcessGroupNCCL() {
-  std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  pgUniqueNCCLIDCnt_.erase(groupPgID_);
   terminateWatchdog_.store(true);
   watchdogCV_.notify_one();
   ncclCommWatchdogThread_.join();
@@ -343,36 +322,22 @@ std::exception_ptr ProcessGroupNCCL::checkForNCCLErrorsInternal(
 }
 
 void ProcessGroupNCCL::broadcastUniqueNCCLID(ncclUniqueId* ncclID) {
-  // Every time when we create a new unique NCCL ID, we need to use a new
-  // global key to access/update the store.
-  // The key is a combination of processGroupID_ and the current count of
-  // NCCL unique ID created
-  std::unique_lock<std::mutex> lock(pgTrackingLock_);
-  auto groupPgId = groupName_ + "_" + processGroupID_;
-  const auto uniqueNCCLIDCnt = ++pgUniqueNCCLIDCnt_[groupPgID_];
-
-  lock.unlock();
-
-  std::string storeKey =
-      processGroupID_ + "_" + std::to_string(uniqueNCCLIDCnt);
-
-  // Rank 0 writes to the store as bcast
+  // For every NCCL communicator that we create we need to broadcast
+  // a unique ID from rank 0 to all other ranks. This broadcast is
+  // done by rank 0 setting a key in the store and all other ranks
+  // retrieving the contents of that key. A single process group
+  // may create multiple NCCL communicators, so we use a sequence
+  // number to differentiate between them.
+  std::string storeKey = std::to_string(ncclCommCounter_++);
   if (rank_ == 0) {
-    auto ncclIDVal = std::vector<uint8_t>(
+    auto vec = std::vector<uint8_t>(
         reinterpret_cast<uint8_t*>(ncclID),
         reinterpret_cast<uint8_t*>(ncclID) + NCCL_UNIQUE_ID_BYTES);
-    store_->set(storeKey, ncclIDVal);
-    // Other ranks get to the store
+    store_->set(storeKey, vec);
   } else {
-    auto ncclIDVal = store_->get(storeKey);
-    // Just a sanity check
-    if (ncclIDVal.size() != NCCL_UNIQUE_ID_BYTES) {
-      throw std::runtime_error(
-          "Unexpected NCCL unique ID length received "
-          "from the store");
-    }
-    // Now put the data back to the input pointer
-    memcpy(ncclID, ncclIDVal.data(), NCCL_UNIQUE_ID_BYTES);
+    auto vec = store_->get(storeKey);
+    AT_CHECK(vec.size() == NCCL_UNIQUE_ID_BYTES);
+    std::memcpy(ncclID, vec.data(), vec.size());
   }
 }
 

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -120,27 +120,38 @@ class ProcessGroupNCCL : public ProcessGroup {
     friend class ProcessGroupNCCL;
   };
 
-  // Constructor will also check the number of available GPUs in the system
+  // If you wish to create multiple process groups, each with a potentially
+  // different rank and size, you can do so by passing a new store instance
+  // to each one. If you have only a single store object, you can
+  // use the `c10d::PrefixStore` to derive scoped instances.
+  // This is also what the Python API in torch.distributed does.
   //
-  // Group support:
+  // The process group instance keeps a reference to the store because
+  // it may be used long after the constructor runs. In fact, the constructor
+  // doesn't create any NCCL communicators. A single NCCL communicator can
+  // only be used on a specific set of devices, and are therefore created
+  // on-demand when a collective runs. If another collective is executed later,
+  // against a different set of devices, the process group creates another NCCL
+  // communicator. These NCCL communicators are cached and reused if possible.
   //
-  // In order to support multiple NCCL process groups, each of which has
-  // different group ranks, we need to use groupName to identify each group
-  // to ensure the correct behavior. In other words, each process group that
-  // has different group ranks needs to have a different and unique groupName
-  // to avoid clashing into undefined behaviors.
-  //
-  // In Python frontend API of torch.distributed, it guarantees that each group
-  // will have a unique name to be passed into the ProcessGroupNCCL constructor.
-  // If you would like to use ProcessGroupNCCL constructor directly, it is
-  // your reponsibility to do so as well.
   ProcessGroupNCCL(
       const std::shared_ptr<Store>& store,
       int rank,
       int size,
-      const std::string& groupName = "",
       const std::chrono::milliseconds& opTimeout =
           std::chrono::milliseconds(kProcessGroupNCCLOpTimeoutMillis));
+
+  // This constructor includes the deprecated `groupName` argument.
+  // If you have existing code that uses the `groupName`, you can replace
+  // it by specifying a `c10d::PrefixStore(groupName, store)` for store.
+  C10_DEPRECATED ProcessGroupNCCL(
+      const std::shared_ptr<Store>& store,
+      int rank,
+      int size,
+      const std::string& groupName,
+      const std::chrono::milliseconds& opTimeout =
+          std::chrono::milliseconds(kProcessGroupNCCLOpTimeoutMillis))
+      : ProcessGroupNCCL(store, rank, size, opTimeout) {}
 
   virtual ~ProcessGroupNCCL();
 
@@ -257,11 +268,13 @@ class ProcessGroupNCCL : public ProcessGroup {
  protected:
   static const int64_t kWatchdogThreadSleepMillis;
 
-  // Store that is used to exchange each Ranks's NCCL unique ID
+  // The store is used to broadcast the NCCL unique ID of rank 0.
   std::shared_ptr<Store> store_;
 
-  // The process group name
-  std::string groupName_;
+  // The number of NCCL communicators that have been create during
+  // the lifetime of this process group. This sequence number is
+  // used to scope keys used in the store.
+  uint64_t ncclCommCounter_{0};
 
   // The NCCL communicator that the process group has cached.
   // The key is a list of GPU devices that an operation is operating on
@@ -307,17 +320,8 @@ class ProcessGroupNCCL : public ProcessGroup {
   // The CUDA events used to sync NCCL streams
   std::unordered_map<std::string, std::vector<at::cuda::CUDAEvent>> ncclEvents_;
 
-  // ID of this process group
-  std::string processGroupID_;
-
-  // Group Prefix and ID of this process group
-  std::string groupPgID_;
-
   // Device Indexes used for all collectives in this group
   std::set<int> usedDeviceIdxs_;
-
-  // processGroupID tracking
-  static std::mutex pgTrackingLock_;
 
   // map from the key: "group name + pg counter (ID)" to the
   // unique NCCL ID count. This needs to be group and pg specific

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -271,7 +271,7 @@ class ProcessGroupNCCL : public ProcessGroup {
   // The store is used to broadcast the NCCL unique ID of rank 0.
   std::shared_ptr<Store> store_;
 
-  // The number of NCCL communicators that have been create during
+  // The number of NCCL communicators that have been created during
   // the lifetime of this process group. This sequence number is
   // used to scope keys used in the store.
   uint64_t ncclCommCounter_{0};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25905 Remove global group name tracking for ProcessGroupNCCL**

Now that we can detect and recover from failures in NCCL we should
allow processes that are started at different times (and perhaps have
had previous NCCL process group instances), to eventually be part of
the same process group. Keeping track of group names in global
variables prevents that, because the processes will be out of sync.

This commit removes the global group name maps and defers
responsibility of isolating access to the same store from multiple
process groups to the store itself. Users can use `c10d::PrefixStore`
to derive new store instances whose keyspace is scoped to some
prefix. Functionally, this is identical to keeping a global map and
using a group name, but also gives more flexibility to the front-end
API to reset state and have processes that have started at different
times to join the same process group.

Differential Revision: [D17281416](https://our.internmc.facebook.com/intern/diff/D17281416/)