### PR TITLE
Back out "Back out "[Caffe2] Fix device_option propagation""

### DIFF
--- a/caffe2/core/net_dag_utils.cc
+++ b/caffe2/core/net_dag_utils.cc
@@ -381,9 +381,13 @@ std::vector<OperatorNode> prepareOperatorNodes(
     const OperatorDef& op_def = net_def->op(idx);
     VLOG(1) << "Creating operator #" << idx << ": " << op_def.name() << ": "
             << op_def.type();
-    if (!op_def.has_device_option() && net_def_has_device_option) {
+    if (net_def_has_device_option) {
       OperatorDef temp_def(op_def);
-      temp_def.mutable_device_option()->CopyFrom(net_def->device_option());
+
+      DeviceOption temp_dev(net_def->device_option());
+      temp_dev.MergeFrom(op_def.device_option());
+
+      temp_def.mutable_device_option()->CopyFrom(temp_dev);
       operator_nodes[idx].operator_ = CreateOperator(temp_def, ws, idx);
     } else {
       auto op = CreateOperator(op_def, ws, idx);

--- a/caffe2/core/net_simple.cc
+++ b/caffe2/core/net_simple.cc
@@ -31,12 +31,16 @@ SimpleNet::SimpleNet(
     VLOG(1) << "Creating operator " << operator_def.name() << ": "
             << operator_def.type();
     std::unique_ptr<OperatorBase> op{nullptr};
-    if (!operator_def.has_device_option() && net_def_has_device_option) {
-      // In the case that the operator def does not specify a device option but
-      // the net def has a default option, we copy the device option over to the
-      // operator def.
+    if (net_def_has_device_option) {
+      // In the case when net def specifies device option, final device option
+      // will be equal to merge of operator and net def device options, with
+      // preference to settings from the operator.
       OperatorDef temp_def(operator_def);
-      temp_def.mutable_device_option()->CopyFrom(net_def->device_option());
+
+      DeviceOption temp_dev(net_def->device_option());
+      temp_dev.MergeFrom(operator_def.device_option());
+
+      temp_def.mutable_device_option()->CopyFrom(temp_dev);
       op = CreateOperator(temp_def, ws, idx);
     } else {
       op = CreateOperator(operator_def, ws, idx);

--- a/caffe2/operators/rnn/recurrent_network_executor.h
+++ b/caffe2/operators/rnn/recurrent_network_executor.h
@@ -39,13 +39,14 @@ class RecurrentNetworkExecutorBase {
         timestep_blob_(timestep_blob) {
     const bool net_def_has_device_option = step_net_def_.has_device_option();
     for (int i = 0; i < step_net_def_.op_size(); i++) {
-      if (!step_net_def_.op(i).has_device_option() &&
-          net_def_has_device_option) {
-        // In the case that the operator def does not specify a device option
-        // but the net def has a default option, we copy the device option over
-        // to the operator def.
-        step_net_def_.mutable_op(i)->mutable_device_option()->CopyFrom(
-            step_net_def_.device_option());
+      if (net_def_has_device_option) {
+        // In the case when net def specifies device option, final device option
+        // will be equal to merge of operator and net def device options, with
+        // preference to settings from the operator.
+        DeviceOption option;
+        option.CopyFrom(step_net_def_.device_option());
+        option.MergeFrom(step_net_def_.op(i).device_option());
+        step_net_def_.mutable_op(i)->mutable_device_option()->CopyFrom(option);
       }
       op_deps_.push_back(op_deps(i));
     }


### PR DESCRIPTION
Summary:
Original commit changeset: f6e961e88c01

device_option propagation is completely broken in Caffe2 for cases when pass through operators are used. As an example Gather operator don't have gradient and passes through it's inputs, which results in incorrect detection of the components for sparse parameter aggregation (component will be empty instead of the real device).
This diff is trying to fix this issue.

Original diff had a problem, that Caffe2 is not handling cases when device option is present, but contains only metadata (for example one for auto-generated reduction ops in backward pass). This diff is addressing this issue by merging device options during the backward pass

Test Plan:
1. net_transform is finally working with Gather + FloatToHalf transformed model instead of failing because of incorrect number of components.
2. New unit-test.
3. Verify that previously broken benchmark is now passing

ezyang do you have suggestions what else I should test?

Differential Revision: D17281528

