### PR TITLE
Remove superfluous check for POLLIN in TCPStore

### DIFF
--- a/torch/lib/c10d/TCPStore.cpp
+++ b/torch/lib/c10d/TCPStore.cpp
@@ -104,13 +104,6 @@ void TCPStoreDaemon::run() {
         continue;
       }
 
-      if (fds[fdIdx].revents ^ POLLIN) {
-        throw std::system_error(
-            ECONNABORTED,
-            std::system_category(),
-            "Unexpected poll revent: " + std::to_string(fds[fdIdx].revents) +
-                " on socket: " + std::to_string(fds[fdIdx].fd));
-      }
       // Now query the socket that has the event
       try {
         query(fds[fdIdx].fd);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25911 Remove superfluous check for POLLIN in TCPStore**

The check is practically equivalent to checking for equivalence with
POLLIN (because the constant is a single bit and poll(2) is asked to
check for POLLIN). On macOS, if a client disconnects, POLLHUP will be
set as well, and the check fails. Instead of performing the check and
letting it fail, we can simply run the `query` function and catch
exceptions, in case we see EOF.

Differential Revision: [D17313301](https://our.internmc.facebook.com/intern/diff/D17313301)