### PR TITLE
Disable flaky test_invalid_names in test_rpc.py

### DIFF
--- a/test/test_rpc.py
+++ b/test/test_rpc.py
@@ -131,6 +131,7 @@ class RpcTest(MultiProcessTestCase):
             dist.init_model_parallel("duplicated_name")
         dist.join_rpc()
 
+    @unittest.skip("Test is flaky, see https://github.com/pytorch/pytorch/issues/25912")
     def test_invalid_names(self):
         store = dist.FileStore(self.file.name, self.world_size)
         dist.init_process_group(backend="gloo", rank=self.rank,


### PR DESCRIPTION
@pietern discovered that `test_invalid_names` is flaky on master. #25656 is potentially the fix. Disable this test for now and will try to add it again when #25656 is in.