### PR TITLE
[ROCm] make sparse coalesce warp size aware

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/cuda/detail/TensorInfo.cuh>
+#include <c10/macros/Macros.h>
 
 namespace at { namespace native {
 
@@ -8,8 +9,6 @@ namespace apply {
 
 using at::cuda::detail::TensorInfo;
 using indexT = int64_t;
-
-const int WARP_SIZE = 32;
 
 template <typename IndexType, typename Real, typename Op>
 __device__ void applyOp2(
@@ -324,7 +323,7 @@ __global__ void coalesceValuesKernel(
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++)
       {
-        int featureDim = startFeature + ii * WARP_SIZE;
+        int featureDim = startFeature + ii * C10_WARP_SIZE;
         if (featureDim < stride)
         {
           tmp[ii] += static_cast<Acctype>(values[valueRow + featureDim]);
@@ -334,7 +333,7 @@ __global__ void coalesceValuesKernel(
     #pragma unroll
     for (int ii = 0; ii < SZ; ii++)
     {
-      int featureDim = startFeature + ii * WARP_SIZE;
+      int featureDim = startFeature + ii * C10_WARP_SIZE;
       if (featureDim < stride)
       {
         newValues[newValueRow + featureDim] = static_cast<Dtype>(tmp[ii]);


### PR DESCRIPTION
Use the new C10_WARP_SIZE macro to make the sparse coalesce kernel warp size aware.