### PR TITLE
[pt][qconv] Improve error message when input is not in the right format

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -112,6 +112,13 @@ class QConv2dInt8 final : public c10::OperatorKernel {
     int kernel_h = kernel[0];
     int kernel_w = kernel[1];
 
+    TORCH_CHECK(C == (packB->inputChannels() * groups),
+        "[QConv2D] Given groups=", groups, ", weight of size ",
+        K, ", ",  kernel_h, ", ", kernel_w, ", ", packB->inputChannels(),
+        ", expected input (NHWC) ", N, ", ", H, ", ", W, ", ", C,
+        " to have ", (packB->inputChannels() * groups),
+        " channels, but got ", C, " channels instead");
+
     fbgemm::conv_param_t<> conv_p(
         N, // Batch size
         C, // Number of input channels

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -111,7 +111,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
     int kernel_h = kernel[0];
     int kernel_w = kernel[1];
 
-    TORCH_CHECK(C == (packB->inputChannels() * groups),
+    TORCH_CHECK(C == (packB->inputChannels()),
         "[QConv2D] Given groups=", groups, ", weight of size ",
         K, ", ",  kernel_h, ", ", kernel_w, ", ", packB->inputChannels(),
         ", expected input (NHWC) ", N, ", ", H, ", ", W, ", ", C,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25928 [pt][qconv] Improve error message when input is not in the right format**

Improved error message

Differential Revision: [D17287290](https://our.internmc.facebook.com/intern/diff/D17287290/)