### PR TITLE
Swap 'weight' and 'activation' observers in QConfig.

### DIFF
--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -122,9 +122,9 @@ Node* insertObserver(
   script::Module observer_module;
   if (v->node()->kind() == prim::GetAttr &&
       v->node()->s(attr::name) == "weight") {
-    observer_module = std::get<1>(qconfig);
-  } else {
     observer_module = std::get<0>(qconfig);
+  } else {
+    observer_module = std::get<1>(qconfig);
   }
   std::string observer_name = "observer_for_" + v->debugName();
   script::Module observer = observer_module.clone();

--- a/torch/csrc/jit/passes/quantization.cpp
+++ b/torch/csrc/jit/passes/quantization.cpp
@@ -122,9 +122,9 @@ Node* insertObserver(
   script::Module observer_module;
   if (v->node()->kind() == prim::GetAttr &&
       v->node()->s(attr::name) == "weight") {
-    observer_module = std::get<0>(qconfig);
-  } else {
     observer_module = std::get<1>(qconfig);
+  } else {
+    observer_module = std::get<0>(qconfig);
   }
   std::string observer_name = "observer_for_" + v->debugName();
   script::Module observer = observer_module.clone();

--- a/torch/quantization/QConfig.py
+++ b/torch/quantization/QConfig.py
@@ -4,7 +4,7 @@ from .observer import *
 from .fake_quantize import *
 
 QConfig = namedtuple('QConfig',
-                     ['weight', 'activation'])
+                     ['activation', 'weight'])
 
 default_qconfig = QConfig(default_weight_observer(),
                           default_observer())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25929 Swap 'weight' and 'activation' observers in QConfig.**

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25929

Differential Revision: [D17288317](https://our.internmc.facebook.com/intern/diff/D17288317)