### PR TITLE
Remove unnecessary BUILD_NAMEDTENSOR from interned_strings.h

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -297,9 +297,7 @@ struct CAFFE2_API Symbol {
   static Symbol prim(const std::string & s);
   static Symbol user(const std::string & s);
   static Symbol caffe2(const std::string & s);
-#ifdef BUILD_NAMEDTENSOR
   static Symbol dimname(const std::string & s);
-#endif
   // TODO: eliminate me
   static Symbol scope(const std::string & s);
 
@@ -309,9 +307,7 @@ struct CAFFE2_API Symbol {
   bool is_onnx() const;
   bool is_user() const;
   bool is_caffe2() const;
-#ifdef BUILD_NAMEDTENSOR
   bool is_dimname() const;
-#endif
 
   // So we can switch on this
   constexpr operator unique_t() const {
@@ -372,18 +368,14 @@ inline Symbol Symbol::prim(const std::string & s)  { return Symbol::fromQualStri
 inline Symbol Symbol::scope(const std::string & s) { return Symbol::fromQualString("scope::" + s); }
 inline Symbol Symbol::user(const std::string & s) { return Symbol::fromQualString("user::" + s); }
 inline Symbol Symbol::caffe2(const std::string & s) { return Symbol::fromQualString("_caffe2::" + s); }
-#ifdef BUILD_NAMEDTENSOR
 inline Symbol Symbol::dimname(const std::string & s) { return Symbol::fromQualString("dimname::" + s); }
-#endif
 inline bool Symbol::is_attr() const { return ns() == namespaces::attr; }
 inline bool Symbol::is_aten() const { return ns() == namespaces::aten; }
 inline bool Symbol::is_prim() const { return ns() == namespaces::prim; }
 inline bool Symbol::is_onnx() const { return ns() == namespaces::onnx; }
 inline bool Symbol::is_user() const { return ns() == namespaces::user; }
 inline bool Symbol::is_caffe2() const { return ns() == namespaces::_caffe2; }
-#ifdef BUILD_NAMEDTENSOR
 inline bool Symbol::is_dimname() const { return ns() == namespaces::dimname; }
-#endif
 
 } // namespace c10
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25798 Turn on BUILD_NAMEDTENSOR permanently
* #26050 Experimental warning for named tensors
* #26030 Move NamedTensorMetaInterface definitions to TensorImpl.h
* #25948 Add TEST_NAMEDTENSOR flag to namedtensor ci
* **#25938 Remove unnecessary BUILD_NAMEDTENSOR from interned_strings.h**
* #25920 Delete tools/autograd/env.py
* #25919 Remove some more BUILD_NAMEDTENSOR flags

It doesn't matter whether or not we expose these for namedtensor /
non-namedtensor builds.

Test Plan:
- [namedtensor ci]

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25938

Differential Revision: [D17291249](https://our.internmc.facebook.com/intern/diff/D17291249)