### PR TITLE
[RFC] add is_python_module to CppExtension/CUDAExtension

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -431,7 +431,15 @@ class CppExtension(setuptools.Extension):
                     'build_ext': BuildExtension
                 })
     '''
-    def __init__(self, name, sources, *args, cuda=False, is_python_module=True, **kwargs):
+    def __init__(self, name, sources, *args, **kwargs):
+        # works around Python2 not having key word args after *args
+        cuda = kwargs.get('cuda', False)
+        if 'cuda' in kwargs:
+            del kwargs['cuda']
+        is_python_module = kwargs.get('is_python_module', True)
+        if 'is_python_module' in kwargs:
+            del kwargs['is_python_module']
+
         include_dirs = kwargs.get('include_dirs', [])
         include_dirs += include_paths(cuda=cuda)
         kwargs['include_dirs'] = include_dirs


### PR DESCRIPTION
So this would add a keyword argument `is_python_module` to CppExtension/CUDAExtension.
This would be handy to build extensions and non-Python custom op libraries and have the latter not get the python version bits as part of the filename. (In https://github.com/pytorch/vision/pull/1267 we tried to get rid of the funny filename but gave up.)

It also unifies the CppExtension/CUDAExtension linking (possibly adding options in the pure C++ case), I'm not 100% sure this is acceptable, but the duplication did feel wrong.
