### PR TITLE
[ONNX] Export masked_select and masked_scatter in opset 11

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1092,6 +1092,26 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.arange(16).view(2, 2, 4).to(torch.float32)
         self.run_test(MaskedFillModel2(), x)
 
+    @unittest.skip("Enable this once ScatterND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_masked_scatter(self):
+        class MaskedScatterModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.masked_scatter(x, x.ge(0.5), torch.ones(100, 100)*5)
+
+        x = torch.randn(3, 4, 5, requires_grad=True)
+        self.run_test(MaskedScatterModel(), x)
+
+    @unittest.skip("Enable this once GatherND is supported in ORT")
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_masked_select(self):
+        class MaskedSelectModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.masked_select(x, x.ge(0.5))
+
+        x = torch.randn(3, 4, 5, requires_grad=True)
+        self.run_test(MaskedSelectModel(), x)
+
     @unittest.skip("Enable this once depthToSpace attr 'mode' is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_pixel_shuffle(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1092,7 +1092,6 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.arange(16).view(2, 2, 4).to(torch.float32)
         self.run_test(MaskedFillModel2(), x)
 
-    @unittest.skip("Enable this once ScatterND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_masked_scatter(self):
         class MaskedScatterModel(torch.nn.Module):
@@ -1102,7 +1101,6 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(3, 4, 5, requires_grad=True)
         self.run_test(MaskedScatterModel(), x)
 
-    @unittest.skip("Enable this once GatherND is supported in ORT")
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_masked_select(self):
         class MaskedSelectModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1097,7 +1097,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_masked_scatter(self):
         class MaskedScatterModel(torch.nn.Module):
             def forward(self, x):
-                return torch.masked_scatter(x, x.ge(0.5), torch.ones(100, 100)*5)
+                return torch.masked_scatter(x, x.ge(0.5), torch.ones(100, 100) * 5)
 
         x = torch.randn(3, 4, 5, requires_grad=True)
         self.run_test(MaskedScatterModel(), x)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -113,7 +113,7 @@ def masked_select(g, self, mask):
 
 
 def masked_scatter(g, self, mask, source):
-    from torch.onnx.symbolic_opset9 import nonzero, expand_as, view, size, add
+    from torch.onnx.symbolic_opset9 import nonzero, expand_as, view, size
     index = nonzero(g, expand_as(g, mask, self))
     # NOTE: source can have more elements than needed.
     # It could also have arbitrary shape.

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -106,6 +106,27 @@ def cumsum(g, self, dim, dtype=None):
     return csum
 
 
+def masked_select(g, self, mask):
+    from torch.onnx.symbolic_opset9 import nonzero, expand_as
+    index = nonzero(g, expand_as(g, mask, self))
+    return g.op('GatherND', self, index)
+
+
+def masked_scatter(g, self, mask, source):
+    from torch.onnx.symbolic_opset9 import nonzero, expand_as, view, size, add
+    index = nonzero(g, expand_as(g, mask, self))
+    # NOTE: source can have more elements than needed.
+    # It could also have arbitrary shape.
+    # This is not supported by ONNX::ScatterND, so we need to flatten and slice source tensor.
+    source = view(g, source, torch.LongTensor([-1]))
+    source = sym_help._slice_helper(g, source,
+                                    axes=torch.LongTensor([0]),
+                                    starts=torch.LongTensor([0]),
+                                    ends=size(g, index, torch.LongTensor([0])),
+                                    dynamic_slice=True)
+    return g.op('ScatterND', self, index, source)
+
+
 @parse_args('v', 'i', 'i', 'i')
 def _unique2(g, self, sorted, return_inverse, return_counts):
     u, indices, inverse_indices, counts = g.op("Unique", self, sorted_i=sorted, outputs=4)


### PR DESCRIPTION
- masked_select is exported as ONNX::GatherND
- masked_scatter is exported as ONNX::ScatterND