### PR TITLE
make c10::Dict ordered by default

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -5,6 +5,7 @@
 #include <c10/util/TypeList.h>
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/order_preserving_flat_hash_map.h>
 #include <c10/util/Optional.h>
 #include <ATen/core/Tensor.h>
 
@@ -39,7 +40,7 @@ struct DictKeyEqualTo {
 };
 
 struct DictImpl final : public c10::intrusive_ptr_target {
-  using dict_map_type = ska::flat_hash_map<IValue, IValue, DictKeyHash, DictKeyEqualTo>;
+  using dict_map_type = ska_ordered::order_preserving_flat_hash_map<IValue, IValue, DictKeyHash, DictKeyEqualTo>;
   struct DictElementTypes final {
     TypePtr keyType;
     TypePtr valueType;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25952 make c10::Dict ordered by default**
* #25675 flat hash map that preserves insertion and deletion order
* #25674 [JIT] make copy of flat has map

