### PR TITLE
[pytorch][cmake] remove protobuf from Dependencies.cmake for libtorch mobile build

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -34,7 +34,7 @@ macro(enable_ubsan)
 endmacro()
 
 # ---[ Custom Protobuf
-if(CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
+if(CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO AND (NOT INTERN_BUILD_MOBILE OR BUILD_CAFFE2_MOBILE))
   disable_ubsan()
   include(${CMAKE_CURRENT_LIST_DIR}/ProtoBuf.cmake)
   enable_ubsan()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #25898 DO NOT COMMIT - run full pytorch_android_gradle_build
* #25897 [pytorch] simplify build_android_gradle.sh
* #25817 [pytorch][mobile] disable backward function codegen if disable_autograd is set
* **#25958 [pytorch][cmake] remove protobuf from Dependencies.cmake for libtorch mobile build**

Summary:
Should have cleaned up the remaining protobuf dependencies before landing PR #25896.

Test Plan:
- CI build;

Pull Request resolved: https://github.com/pytorch/pytorch/pull/25958

Differential Revision: [D17296949](https://our.internmc.facebook.com/intern/diff/D17296949)