### PR TITLE
Cpu strided complex unaryop support

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -146,6 +146,21 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
     switch (_st) {                                                                                               \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                            \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)                     \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)                       \
+      default:                                                                                                   \
+        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");                                           \
+    }                                                                                                            \
+  }()
+
+ #define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND_HALF(TYPE, NAME, ...)                                        \
+  [&] {                                                                                                          \
+    const auto& the_type = TYPE;                                                                                 \
+    /* don't use TYPE again in case it is an expensive or side-effect op */                                      \
+    at::ScalarType _st = ::detail::scalar_type(the_type);                                                        \
+    switch (_st) {                                                                                               \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Double, double, __VA_ARGS__)                                          \
+      AT_PRIVATE_CASE_TYPE(at::ScalarType::Float, float, __VA_ARGS__)                                            \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::Half, at::Half, __VA_ARGS__)                                          \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexDouble, std::complex<double>, __VA_ARGS__)                     \
       AT_PRIVATE_CASE_TYPE(at::ScalarType::ComplexFloat, std::complex<float>, __VA_ARGS__)                       \

--- a/aten/src/ATen/core/TensorBody.h
+++ b/aten/src/ATen/core/TensorBody.h
@@ -410,6 +410,8 @@ class CAFFE2_API Tensor {
   #endif
   Tensor abs() const;
   Tensor & abs_() const;
+  Tensor real() const;
+  Tensor imag() const;
   Tensor acos() const;
   Tensor & acos_() const;
   Tensor add(const Tensor & other, Scalar alpha=1) const;

--- a/aten/src/ATen/core/TensorBody.h
+++ b/aten/src/ATen/core/TensorBody.h
@@ -410,6 +410,7 @@ class CAFFE2_API Tensor {
   #endif
   Tensor abs() const;
   Tensor & abs_() const;
+  Tensor angle() const;
   Tensor real() const;
   Tensor imag() const;
   Tensor acos() const;

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -127,6 +127,22 @@ inline Tensor & Tensor::abs_() const {
     return table->getOp<Tensor & (Tensor &)>(type_set(), is_variable())(const_cast<Tensor&>(*this));
 #endif
 }
+inline Tensor Tensor::real() const {
+#ifdef USE_STATIC_DISPATCH
+    return TypeDefault::real(const_cast<Tensor&>(*this));
+#else
+    static auto table = globalATenDispatch().getOpTable("aten::real(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(type_set(), is_variable())(const_cast<Tensor&>(*this));
+#endif
+}
+inline Tensor Tensor::imag() const {
+#ifdef USE_STATIC_DISPATCH
+    return TypeDefault::imag(const_cast<Tensor&>(*this));
+#else
+    static auto table = globalATenDispatch().getOpTable("aten::imag(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(type_set(), is_variable())(const_cast<Tensor&>(*this));
+#endif
+}
 inline Tensor Tensor::acos() const {
 #ifdef USE_STATIC_DISPATCH
     return TypeDefault::acos(const_cast<Tensor&>(*this));

--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -127,6 +127,14 @@ inline Tensor & Tensor::abs_() const {
     return table->getOp<Tensor & (Tensor &)>(type_set(), is_variable())(const_cast<Tensor&>(*this));
 #endif
 }
+inline Tensor Tensor::angle() const {
+#ifdef USE_STATIC_DISPATCH
+    return TypeDefault::angle(const_cast<Tensor&>(*this));
+#else
+    static auto table = globalATenDispatch().getOpTable("aten::angle(Tensor self) -> Tensor");
+    return table->getOp<Tensor (const Tensor &)>(type_set(), is_variable())(const_cast<Tensor&>(*this));
+#endif
+}
 inline Tensor Tensor::real() const {
 #ifdef USE_STATIC_DISPATCH
     return TypeDefault::real(const_cast<Tensor&>(*this));

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -7,6 +7,8 @@
 #include <ATen/cpu/vec256/vec256_double.h>
 #include <ATen/cpu/vec256/vec256_int.h>
 #include <ATen/cpu/vec256/vec256_qint.h>
+#include <ATen/cpu/vec256/vec256_complex_float_no_vec.h>
+#include <ATen/cpu/vec256/vec256_complex_double_no_vec.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -7,8 +7,8 @@
 #include <ATen/cpu/vec256/vec256_double.h>
 #include <ATen/cpu/vec256/vec256_int.h>
 #include <ATen/cpu/vec256/vec256_qint.h>
-//#include <ATen/cpu/vec256/vec256_complex_float_no_vec.h>
-#include <ATen/cpu/vec256/vec256_complex_double.h>
+//#include <ATen/cpu/vec256/vec256_complex_double_rrii.h>
+#include <ATen/cpu/vec256/vec256_complex_double_riri.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -7,8 +7,8 @@
 #include <ATen/cpu/vec256/vec256_double.h>
 #include <ATen/cpu/vec256/vec256_int.h>
 #include <ATen/cpu/vec256/vec256_qint.h>
-#include <ATen/cpu/vec256/vec256_complex_float_no_vec.h>
-#include <ATen/cpu/vec256/vec256_complex_double_no_vec.h>
+//#include <ATen/cpu/vec256/vec256_complex_float_no_vec.h>
+#include <ATen/cpu/vec256/vec256_complex_double.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -7,7 +7,6 @@
 #include <ATen/cpu/vec256/vec256_double.h>
 #include <ATen/cpu/vec256/vec256_int.h>
 #include <ATen/cpu/vec256/vec256_qint.h>
-//#include <ATen/cpu/vec256/vec256_complex_double_rrii.h>
 #include <ATen/cpu/vec256/vec256_complex_double_riri.h>
 
 #include <algorithm>

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -175,6 +175,12 @@ public:
     }
     return ret;
   }
+  Vec256<T> real() const {
+    return *this;
+  }
+  Vec256<T> imag() const {
+    return *this;
+  }
   Vec256<T> acos() const {
     return map(std::acos);
   }

--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -183,6 +183,9 @@ public:
     }
     return ret;
   }
+  Vec256<T> angle() const {
+    return *this;
+  }
   Vec256<T> real() const {
     return *this;
   }
@@ -400,24 +403,30 @@ inline T minimum(const T& a, const T& b) {
 // To save BC, it will not propagate NaN based on IEEE 754 201X
 template <class T> Vec256<T> inline clamp(const Vec256<T> &a, const Vec256<T> &min_vec, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
+  using value_t = typename at::native::ztype<T>::value_t;
+  value_t (*zabs_)(T) = at::native::zabs;
   for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = a[i] < min_vec[i] ? min_vec[i] : (a[i] > max_vec[i] ? max_vec[i] : a[i]);
+    c[i] = zabs_(a[i]) < zabs_(min_vec[i]) ? min_vec[i] : (zabs_(a[i]) > zabs_(max_vec[i]) ? max_vec[i] : a[i]);
   }
   return c;
 }
 
 template <class T> Vec256<T> inline clamp_max(const Vec256<T> &a, const Vec256<T> &max_vec) {
   Vec256<T> c = Vec256<T>();
+  using value_t = typename at::native::ztype<T>::value_t;
+  value_t (*zabs_)(T) = at::native::zabs;
   for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = a[i] > max_vec[i] ? max_vec[i] : a[i];
+    c[i] = zabs_(a[i]) > zabs_(max_vec[i]) ? max_vec[i] : a[i];
   }
   return c;
 }
 
 template <class T> Vec256<T> inline clamp_min(const Vec256<T> &a, const Vec256<T> &min_vec) {
   Vec256<T> c = Vec256<T>();
+  using value_t = typename at::native::ztype<T>::value_t;
+  value_t (*zabs_)(T) = at::native::zabs;
   for (int i = 0; i != Vec256<T>::size(); i++) {
-    c[i] = a[i] < min_vec[i] ? min_vec[i] : a[i];
+    c[i] = zabs_(a[i]) < zabs_(min_vec[i]) ? min_vec[i] : a[i];
   }
   return c;
 }

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double.h
@@ -1,0 +1,259 @@
+#pragma once
+
+#include <ATen/cpu/vec256/intrinsics.h>
+#include <ATen/cpu/vec256/vec256_base.h>
+#if defined(__AVX__) && !defined(_MSC_VER)
+#include <sleef.h>
+#endif
+
+namespace at {
+namespace vec256 {
+// See Note [Acceptable use of anonymous namespace in header]
+namespace {
+
+#if defined(__AVX__) && !defined(_MSC_VER)
+
+template <> class Vec256<std::complex<double>> {
+private:
+  __m256d real_values;
+  __m256d imag_values;
+public:
+  using value_type = std::complex<double>;
+  static constexpr int size() {
+    return 4;
+  }
+  Vec256() {}
+  Vec256(__m256d real) : real_values(real), imag_values(_mm256_setzero_pd()) {}
+  Vec256(__m256d real, __m256d imag) : real_values(real), imag_values(imag) {}
+  Vec256(std::complex<double> val) {
+    real_values = _mm256_set1_pd(val.real());
+    imag_values = _mm256_set1_pd(val.imag());
+  }
+  Vec256(std::complex<double> val1, std::complex<double> val2, std::complex<double> val3, std::complex<double> val4) {
+    real_values = _mm256_setr_pd(val1.real(), val2.real(), val3.real(), val4.real());
+    imag_values = _mm256_setr_pd(val1.imag(), val2.imag(), val3.imag(), val4.imag());\
+  }
+  operator __m256d() const {
+    return real_values;
+  }
+  template <int64_t mask>
+  static Vec256<std::complex<double>> blend(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+    return Vec256<std::complex<double>>(
+      _mm256_blend_pd(a.real_values, b.imag_values, mask),
+      _mm256_blend_pd(b.real_values, b.imag_values, mask)
+    );
+  }
+  static Vec256<std::complex<double>> blendv(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
+                               const Vec256<std::complex<double>>& mask) {
+    return Vec256<std::complex<double>>(
+      _mm256_blendv_pd(a.real_values, b.real_values, mask.real_values),
+      _mm256_blendv_pd(a.imag_values, b.imag_values, mask.imag_values)
+    );
+  }
+  static Vec256<std::complex<double>> arange(std::complex<double> base = 0., std::complex<double> step = 1.) {
+    return Vec256<std::complex<double>>(base, base + step, base + 2.0 * step, base + 3.0 * step);
+  }
+  static Vec256<std::complex<double>> set(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
+                            int64_t count = size()) {
+    switch (count) {
+      case 0:
+        return a;
+      case 1:
+        return blend<1>(a, b);
+      case 2:
+        return blend<3>(a, b);
+      case 3:
+        return blend<7>(a, b);
+    }
+    return b;
+  }
+  static Vec256<std::complex<double>> loadu(const void* ptr, int64_t count = size()) {
+    __at_align32__ double tmp_reals[size()];
+    __at_align32__ double tmp_imags[size()];
+
+    const double * tmp = reinterpret_cast<const double *>(ptr);
+    for (int i=0; i<count; i++)
+    {
+      tmp_reals[i] = tmp[2*i];
+      tmp_imags[i] = tmp[2*i+1];
+    }
+    return Vec256<std::complex<double>>(_mm256_loadu_pd(tmp_reals), _mm256_loadu_pd(tmp_imags));
+  }
+  void store(void* ptr, int count = size()) const {
+    double tmp[2*size()];
+    _mm256_storeu_pd(tmp, real_values);
+    _mm256_storeu_pd(tmp + size(), imag_values);
+
+    // permute to correct order
+    double *tmp_ptr = reinterpret_cast<double *>(ptr);
+    for (int i=0; i<count; i++)
+    {
+      tmp_ptr[2*i] = tmp[i];
+      tmp_ptr[2*i+1] = tmp[i + size()];
+    }
+  }
+  const std::complex<double>& operator[](int idx) const  = delete;
+  std::complex<double>& operator[](int idx) = delete;
+  Vec256<std::complex<double>> map(std::complex<double> (*f)(std::complex<double>)) const {
+    __at_align32__ std::complex<double> tmp[size()];
+    store(tmp);
+    for (int i = 0; i < size(); i++) {
+      tmp[i] = f(tmp[i]);
+    }
+    return loadu(tmp);
+  }
+  Vec256<std::complex<double>> map(std::complex<double> (*f)(const std::complex<double> &)) const {
+    __at_align32__ std::complex<double> tmp[size()];
+    store(tmp);
+    for (int i = 0; i < size(); i++) {
+      tmp[i] = f(tmp[i]);
+    }
+    return loadu(tmp);
+  }
+  Vec256<std::complex<double>> abs() const {
+   auto real = _mm256_mul_pd(real_values, real_values);
+   auto imag = _mm256_mul_pd(imag_values, imag_values);
+   auto abs_2 = _mm256_add_pd(real, imag);
+   return Vec256<std::complex<double>>(_mm256_sqrt_pd(abs_2));
+  }
+  Vec256<std::complex<double>> real() const {
+    return Vec256<std::complex<double>>(real_values);
+  }
+  __m256d real_() const {return real_values;}
+  Vec256<std::complex<double>> imag() const {
+    return Vec256<std::complex<double>>(imag_values);
+  }
+  __m256d imag_() const {return imag_values;}
+  Vec256<std::complex<double>> acos() const {
+    return map(std::acos);
+  }
+  Vec256<std::complex<double>> asin() const {
+    return map(std::asin);
+  }
+  Vec256<std::complex<double>> atan() const {
+    return map(std::atan);
+  }
+  Vec256<std::complex<double>> atan2(const Vec256<std::complex<double>> &b) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> erf() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> erfc() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> exp() const {
+    return map(std::exp);
+  }
+  Vec256<std::complex<double>> expm1() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log2() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log1p() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log() const {
+    return map(std::log);
+  }
+  Vec256<std::complex<double>> log10() const {
+    return map(std::log10);
+  }
+  Vec256<std::complex<double>> ceil() const {
+    return Vec256<std::complex<double>>(_mm256_ceil_pd(real_values), _mm256_ceil_pd(imag_values));
+  }
+  Vec256<std::complex<double>> cos() const {
+    return map(std::cos);
+  }
+  Vec256<std::complex<double>> cosh() const {
+    return map(std::cosh);
+  }
+  Vec256<std::complex<double>> floor() const {
+    return Vec256<std::complex<double>>(_mm256_floor_pd(real_values), _mm256_floor_pd(imag_values));
+  }
+  Vec256<std::complex<double>> neg() const {
+    auto zero = _mm256_setzero_pd();
+    return Vec256<std::complex<double>>(_mm256_sub_pd(zero, real_values), _mm256_sub_pd(zero, imag_values));
+  }
+  Vec256<std::complex<double>> round() const {
+    return Vec256<std::complex<double>>(_mm256_round_pd(real_values, 0), _mm256_round_pd(imag_values, 0));
+  }
+  Vec256<std::complex<double>> sin() const {
+    return map(std::sin);
+  }
+  Vec256<std::complex<double>> sinh() const {
+    return map(std::sinh);
+  }
+  Vec256<std::complex<double>> tan() const {
+    return map(std::tan);
+  }
+  Vec256<std::complex<double>> tanh() const {
+    return map(std::tanh);
+  }
+  Vec256<std::complex<double>> trunc() const {
+    return map(at::native::trunc_impl);
+  }
+  Vec256<std::complex<double>> sqrt() const {
+    return map(std::sqrt);
+  }
+  Vec256<std::complex<double>> reciprocal() const {
+    return map([](const std::complex<double> &x) { return (std::complex<double>)(1)/x; });
+  }
+  Vec256<std::complex<double>> rsqrt() const {
+    return map([](const std::complex<double> &x) { return (std::complex<double>)(1)/std::sqrt(x); });
+  }
+  Vec256<std::complex<double>> pow(const Vec256<std::complex<double>> &exp) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  // Comparison using the _CMP_**_OQ predicate.
+  //   `O`: get false if an operand is NaN
+  //   `Q`: do not raise if an operand is NaN
+  Vec256<std::complex<double>> operator==(const Vec256<std::complex<double>>& other) const {
+    auto real_cmp = _mm256_cmp_pd(real_values, other.real_values, _CMP_EQ_OQ);
+    auto imag_cmp = _mm256_cmp_pd(imag_values, other.imag_values, _CMP_EQ_OQ);
+    return Vec256<std::complex<double>>(_mm256_and_pd(real_cmp, imag_cmp), _mm256_setzero_pd());
+  }
+  Vec256<std::complex<double>> operator!=(const Vec256<std::complex<double>>& other) const {
+    auto real_cmp = _mm256_cmp_pd(real_values, other.real_values, _CMP_NEQ_OQ);
+    auto imag_cmp = _mm256_cmp_pd(imag_values, other.imag_values, _CMP_NEQ_OQ);
+    return Vec256<std::complex<double>>(_mm256_and_pd(real_cmp, imag_cmp), _mm256_setzero_pd());
+  }
+  Vec256<std::complex<double>> operator<(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> operator<=(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> operator>(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> operator>=(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+};
+
+template <> Vec256<std::complex<double>> inline operator+(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
+  return Vec256<std::complex<double>>(_mm256_add_pd(a.real_(), b.real_()), _mm256_add_pd(a.imag_(), b.imag_()));
+}
+
+template <> Vec256<std::complex<double>> inline operator-(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
+  return Vec256<std::complex<double>>(_mm256_sub_pd(a.real_(), b.real_()), _mm256_sub_pd(a.imag_(), b.imag_()));
+}
+
+template <> Vec256<std::complex<double>> inline operator*(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
+  //(a + bi)*(c + di) = (ac - bd) + (ad + bc)i.
+  auto ac = _mm256_mul_pd(a.real_(), b.real_());
+  auto bd = _mm256_mul_pd(a.imag_(), b.imag_());
+  auto ad = _mm256_mul_pd(a.real_(), b.imag_());
+  auto bc = _mm256_mul_pd(a.imag_(), b.real_());
+  return Vec256<std::complex<double>>(_mm256_sub_pd(ac, bd), _mm256_add_pd(ad, bc));
+}
+
+template <> Vec256<std::complex<double>> inline operator/(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) __ubsan_ignore_float_divide_by_zero__ {
+  AT_ERROR("not supported for complex numbers");
+}
+
+#endif
+
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double_no_vec.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double_no_vec.h
@@ -1,0 +1,328 @@
+#pragma once
+
+#include <ATen/cpu/vec256/intrinsics.h>
+#include <ATen/cpu/vec256/vec256_base.h>
+#if defined(__AVX__) && !defined(_MSC_VER)
+#include <sleef.h>
+#endif
+
+namespace at {
+namespace vec256 {
+// See Note [Acceptable use of anonymous namespace in header]
+namespace {
+
+template <> class Vec256<std::complex<double>> {
+private:
+  std::complex<double> values[2] = {0};
+public:
+  using value_type = std::complex<double>;
+  static constexpr int size() {
+    return 2;
+  }
+  Vec256() {}
+  Vec256(std::complex<double> val) {
+    for (int i = 0; i != size(); i++) {
+      values[i] = val;
+    }
+  }
+  Vec256(std::complex<double> val1, std::complex<double> val2) {
+    values[0] = val1;
+    values[1] = val2;
+  }
+  template <int64_t mask>
+  static Vec256<std::complex<double>> blend(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+    int64_t mask_ = mask;
+    Vec256 vec;
+    for (int i = 0; i < size(); i++) {
+      if (mask & 0x01) {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+      mask_ = mask_ >> 1;
+    }
+    return vec;
+  }
+  static Vec256<std::complex<double>> blendv(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
+                               const Vec256<std::complex<double>>& mask) {
+    Vec256 vec;
+    int64_t buffer[size()];
+    mask.store(buffer);
+    for (int i = 0; i < size(); i++) {
+      if (buffer[i] & 0x01)
+       {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+    }
+    return vec;
+  }
+  static Vec256<std::complex<double>> arange(std::complex<double> base = 0., std::complex<double> step = 1.) {
+    return Vec256(base, base + step);
+  }
+  static Vec256<std::complex<double>> set(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
+                            int64_t count = size()) {
+    Vec256 vec;
+    for (int i = 0; i < size(); i++) {
+      if (i < count) {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+    }
+    return vec;
+  }
+  static Vec256<std::complex<double>> loadu(const void* ptr, int64_t count = size()) {
+    Vec256 vec;
+    std::memcpy(vec.values, ptr, count * sizeof(std::complex<double>));
+    return vec;
+  }
+  void store(void* ptr, int count = size()) const {
+    std::memcpy(ptr, values, count * sizeof(std::complex<double>));
+  }
+  const std::complex<double>& operator[](int idx) const {
+    return values[idx];
+  }
+  std::complex<double>& operator[](int idx) {
+    return values[idx];
+  }
+  Vec256<std::complex<double>> map(std::complex<double> (*f)(const std::complex<double> &)) const {
+    Vec256<std::complex<double>> ret;
+    for (int i = 0; i != size(); i++) {
+      ret[i] = f(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<double>> abs() const {
+    Vec256<std::complex<double>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::abs(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<double>> real() const {
+    Vec256<std::complex<double>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::real(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<double>> imag() const {
+    Vec256<std::complex<double>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::imag(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<double>> acos() const {
+    return map(std::acos);
+  }
+  Vec256<std::complex<double>> asin() const {
+    return map(std::asin);
+  }
+  Vec256<std::complex<double>> atan() const {
+    return map(std::atan);
+  }
+  Vec256<std::complex<double>> atan2(const Vec256<std::complex<double>> &b) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> erf() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> erfc() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> exp() const {
+    return map(std::exp);
+  }
+  Vec256<std::complex<double>> expm1() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log() const {
+    return map(std::log);
+  }
+  Vec256<std::complex<double>> log2() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log10() const {
+    return map(std::log10);
+  }
+  Vec256<std::complex<double>> log1p() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> sin() const {
+    return map(std::sin);
+  }
+  Vec256<std::complex<double>> sinh() const {
+    return map(std::sinh);
+  }
+  Vec256<std::complex<double>> cos() const {
+    return map(std::cos);
+  }
+  Vec256<std::complex<double>> cosh() const {
+    return map(std::cosh);
+  }
+  Vec256<std::complex<double>> ceil() const {
+    return map([](const std::complex<double> &x) {
+      return std::complex<double>(std::ceil(std::real(x)), std::ceil(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<double>> floor() const {
+    return map([](const std::complex<double> &x) {
+      return std::complex<double>(std::floor(std::real(x)), std::floor(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<double>> frac() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> neg() const {
+    return map([](const std::complex<double> &x) { return -x; });
+  }
+  Vec256<std::complex<double>> round() const {
+    return map([](const std::complex<double> &x) {
+        return std::complex<double>(std::round(std::real(x)), std::round(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<double>> tan() const {
+    return map(std::tan);
+  }
+  Vec256<std::complex<double>> tanh() const {
+      return map(std::tanh);
+  }
+  Vec256<std::complex<double>> trunc() const {
+    return map([](const std::complex<double> &x) {
+        return std::complex<double>(std::trunc(std::real(x)), std::trunc(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<double>> sqrt() const {
+    return map(std::sqrt);
+  }
+  Vec256<std::complex<double>> reciprocal() const {
+    return map([](const std::complex<double> &x) { return std::complex<double>(1) / x; });
+  }
+  Vec256<std::complex<double>> rsqrt() const {
+    return map([](const std::complex<double> &x) { return std::complex<double>(1., 0.) / std::sqrt(x); });
+  }
+  Vec256<std::complex<double>> pow(const Vec256<std::complex<double>> &b) const {
+    Vec256<std::complex<double>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::pow(values[i], b[i]);
+    }
+    return ret;
+  }
+
+#define DEFINE_COMPLEX_DOUBLE_COMP(binary_pred)                                                                                    \
+  Vec256<std::complex<double>> operator binary_pred(const Vec256<std::complex<double>> &other) const {              \
+    Vec256<std::complex<double>> vec;                                                                               \
+    for (int i = 0; i != size(); i++) {                                                                             \
+      if (values[i] binary_pred other.values[i]) {                                                                  \
+        std::memset(static_cast<void*>(vec.values + i), 0xFF, sizeof(std::complex<double>));                        \
+      } else {                                                                                                      \
+        std::memset(static_cast<void*>(vec.values + i), 0, sizeof(std::complex<double>));                           \
+      }                                                                                                             \
+    }                                                                                                               \
+    return vec;                                                                                                     \
+  }
+  DEFINE_COMPLEX_DOUBLE_COMP(==)
+  DEFINE_COMPLEX_DOUBLE_COMP(!=)
+  Vec256<std::complex<double>> operator<(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+  Vec256<std::complex<double>> operator<=(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+  Vec256<std::complex<double>> operator>(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+  Vec256<std::complex<double>> operator>=(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+};
+
+template <>
+Vec256<std::complex<double>> inline operator+(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  Vec256<std::complex<double>> ret;
+  for (int i = 0; i < Vec256<std::complex<double>>::size(); i++) {
+    ret[i] = a[i] + b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<double>> inline operator-(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  Vec256<std::complex<double>> ret;
+  for (int i = 0; i < Vec256<std::complex<double>>::size(); i++) {
+    ret[i] = a[i] + b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<double>> inline operator*(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  Vec256<std::complex<double>> ret;
+  for (int i = 0; i < Vec256<std::complex<double>>::size(); i++) {
+    ret[i] = a[i] * b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<double>> inline operator/(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  Vec256<std::complex<double>> ret;
+  for (int i = 0; i < Vec256<std::complex<double>>::size(); i++) {
+    ret[i] = a[i] / b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<double>> inline maximum(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline minimum(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline clamp(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& min, const Vec256<std::complex<double>>& max) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline clamp_min(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& min) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline clamp_max(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& max) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline operator&(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline operator|(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<double>> inline operator^(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+inline void convert(const std::complex<double>* src, std::complex<double>* dst, int64_t n) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double_no_vec.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double_no_vec.h
@@ -2,9 +2,6 @@
 
 #include <ATen/cpu/vec256/intrinsics.h>
 #include <ATen/cpu/vec256/vec256_base.h>
-#if defined(__AVX__) && !defined(_MSC_VER)
-#include <sleef.h>
-#endif
 
 namespace at {
 namespace vec256 {
@@ -59,7 +56,11 @@ public:
     return vec;
   }
   static Vec256<std::complex<double>> arange(std::complex<double> base = 0., std::complex<double> step = 1.) {
-    return Vec256(base, base + step);
+    Vec256 vec;
+    for (int i = 0; i < size(); i++) {
+      vec.values[i] = base + static_cast<std::complex<double>>(i)*step;
+    }
+    return vec;
   }
   static Vec256<std::complex<double>> set(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
                             int64_t count = size()) {
@@ -98,6 +99,13 @@ public:
     Vec256<std::complex<double>> ret;
     for (int i = 0; i < size(); i++) {
       ret[i] = std::abs(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<double>> angle() const {
+    Vec256<std::complex<double>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::arg(values[i]);
     }
     return ret;
   }

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double_riri.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double_riri.h
@@ -41,9 +41,9 @@ public:
       case 0:
         return a;
       case 1:
-        return Vec256<std::complex<double>>(_mm256_blend_pd(a.values, b.values, 0x3));
+        return _mm256_blend_pd(a.values, b.values, 0x3);
       case 2:
-        return Vec256<std::complex<double>>(_mm256_blend_pd(a.values, b.values, 0xc));
+        return _mm256_blend_pd(a.values, b.values, 0xc);
       case 3:
         return b;
       default:
@@ -54,7 +54,7 @@ public:
                                const Vec256<std::complex<double>>& mask) {
     // convert std::complex<V> index mask to V index mask: xy -> xxyy
     auto mask_ = _mm256_unpacklo_pd(mask.values, mask.values);
-    return Vec256<std::complex<double>>(_mm256_blendv_pd(a.values, b.values, mask_));
+    return _mm256_blendv_pd(a.values, b.values, mask_);
 
   }
   static Vec256<std::complex<double>> arange(std::complex<double> base = 0., std::complex<double> step = 1.) {
@@ -110,7 +110,7 @@ public:
     return _mm256_mul_pd(abs, mask);                // abs     0
   }
   Vec256<std::complex<double>> abs() const {
-   return Vec256<std::complex<double>>(abs_());     // abs     0
+   return abs_();     // abs     0
   }
   __m256d angle_() const {
     auto b_a = _mm256_permute_pd(values, 0x5);      //b        a
@@ -119,21 +119,21 @@ public:
     return _mm256_mul_pd(angle, mask);              //0        angle
   }
   Vec256<std::complex<double>> angle() const {
-    return Vec256<std::complex<double>>(_mm256_permute_pd(angle_(), 0x5));  // angle     0
+    return _mm256_permute_pd(angle_(), 0x5);        // angle     0
   }
   __m256d real_() const {
     auto mask = _mm256_setr_pd(1.0, 0.0, 1.0, 0.0);
     return _mm256_mul_pd(values, mask);
   }
   Vec256<std::complex<double>> real() const {
-    return Vec256<std::complex<double>>(real_());
+    return real_();
   }
   __m256d imag_() const {
     auto mask = _mm256_setr_pd(0.0, 1.0, 0.0, 1.0);
     return _mm256_mul_pd(values, mask);
     }
   Vec256<std::complex<double>> imag() const {
-    return Vec256<std::complex<double>>(_mm256_permute_pd(imag_(), 0x5)); //b        a
+    return _mm256_permute_pd(imag_(), 0x5);        //b        a
   }
   Vec256<std::complex<double>> acos() const {
     return map(std::acos);
@@ -184,17 +184,17 @@ public:
     return map(std::cosh);
   }
   Vec256<std::complex<double>> ceil() const {
-    return Vec256<std::complex<double>>(_mm256_ceil_pd(values));
+    return _mm256_ceil_pd(values);
   }
   Vec256<std::complex<double>> floor() const {
-    return Vec256<std::complex<double>>(_mm256_floor_pd(values));
+    return _mm256_floor_pd(values);
   }
   Vec256<std::complex<double>> neg() const {
     auto zero = _mm256_setzero_pd();
-    return Vec256<std::complex<double>>(_mm256_sub_pd(zero, values));
+    return _mm256_sub_pd(zero, values);
   }
   Vec256<std::complex<double>> round() const {
-    return Vec256<std::complex<double>>(_mm256_round_pd(values, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
+    return _mm256_round_pd(values, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
   }
   Vec256<std::complex<double>> tan() const {
     return map(std::tan);
@@ -203,7 +203,7 @@ public:
     return map(std::tanh);
   }
   Vec256<std::complex<double>> trunc() const {
-    return Vec256<std::complex<double>>(_mm256_round_pd(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
+    return _mm256_round_pd(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC));
   }
   Vec256<std::complex<double>> sqrt() const {
     return map(std::sqrt);
@@ -221,10 +221,10 @@ public:
   //   `O`: get false if an operand is NaN
   //   `Q`: do not raise if an operand is NaN
   Vec256<std::complex<double>> operator==(const Vec256<std::complex<double>>& other) const {
-    return Vec256<std::complex<double>>(_mm256_cmp_pd(values, other.values, _CMP_EQ_OQ));
+    return _mm256_cmp_pd(values, other.values, _CMP_EQ_OQ);
   }
   Vec256<std::complex<double>> operator!=(const Vec256<std::complex<double>>& other) const {
-    return Vec256<std::complex<double>>(_mm256_cmp_pd(values, other.values, _CMP_NEQ_OQ));
+    return _mm256_cmp_pd(values, other.values, _CMP_NEQ_OQ);
   }
   Vec256<std::complex<double>> operator<(const Vec256<std::complex<double>>& other) const {
     AT_ERROR("not supported for complex numbers");
@@ -241,11 +241,11 @@ public:
 };
 
 template <> Vec256<std::complex<double>> inline operator+(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
-  return Vec256<std::complex<double>>(_mm256_add_pd(a, b));
+  return _mm256_add_pd(a, b);
 }
 
 template <> Vec256<std::complex<double>> inline operator-(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
-  return Vec256<std::complex<double>>(_mm256_sub_pd(a, b));
+  return _mm256_sub_pd(a, b);
 }
 
 template <> Vec256<std::complex<double>> inline operator*(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
@@ -258,7 +258,7 @@ template <> Vec256<std::complex<double>> inline operator*(const Vec256<std::comp
   auto ad_bc = _mm256_mul_pd(a, d_c);       //ad      -bc
 
   auto ret = _mm256_hsub_pd(ac_bd, ad_bc);  //ac - bd  ad + bc
-  return Vec256<std::complex<double>>(ret);
+  return ret;
 }
 
 template <> Vec256<std::complex<double>> inline operator/(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) __ubsan_ignore_float_divide_by_zero__ {
@@ -273,7 +273,7 @@ Vec256<std::complex<double>> inline maximum(const Vec256<std::complex<double>>& 
   auto abs_a = a.abs_2_();
   auto abs_b = b.abs_2_();
   auto mask = _mm256_cmp_pd(abs_a, abs_b, _CMP_LT_OQ);
-  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, b, mask));
+  return _mm256_blendv_pd(a, b, mask);
 }
 
 template <>
@@ -281,7 +281,7 @@ Vec256<std::complex<double>> inline minimum(const Vec256<std::complex<double>>& 
   auto abs_a = a.abs_2_();
   auto abs_b = b.abs_2_();
   auto mask = _mm256_cmp_pd(abs_a, abs_b, _CMP_GT_OQ);
-  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, b, mask));
+  return _mm256_blendv_pd(a, b, mask);
 }
 
 template <>
@@ -291,7 +291,7 @@ Vec256<std::complex<double>> inline clamp(const Vec256<std::complex<double>>& a,
   auto max_mask = _mm256_cmp_pd(abs_a, abs_min, _CMP_LT_OQ);
   auto abs_max = max.abs_2_();
   auto min_mask = _mm256_cmp_pd(abs_a, abs_max, _CMP_GT_OQ);
-  return Vec256<std::complex<double>>(_mm256_blendv_pd(_mm256_blendv_pd(a, min, max_mask), max, min_mask));
+  return _mm256_blendv_pd(_mm256_blendv_pd(a, min, max_mask), max, min_mask);
 }
 
 template <>
@@ -299,7 +299,7 @@ Vec256<std::complex<double>> inline clamp_min(const Vec256<std::complex<double>>
   auto abs_a = a.abs_2_();
   auto abs_min = min.abs_2_();
   auto max_mask = _mm256_cmp_pd(abs_a, abs_min, _CMP_LT_OQ);
-  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, min, max_mask));
+  return _mm256_blendv_pd(a, min, max_mask);
 }
 
 template <>
@@ -307,7 +307,7 @@ Vec256<std::complex<double>> inline clamp_max(const Vec256<std::complex<double>>
   auto abs_a = a.abs_2_();
   auto abs_max = max.abs_2_();
   auto min_mask = _mm256_cmp_pd(abs_a, abs_max, _CMP_GT_OQ);
-  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, max, min_mask));
+  return _mm256_blendv_pd(a, max, min_mask);
 }
 
 template <>

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double_riri.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double_riri.h
@@ -1,0 +1,336 @@
+#pragma once
+
+#include <ATen/cpu/vec256/intrinsics.h>
+#include <ATen/cpu/vec256/vec256_base.h>
+#if defined(__AVX__) && !defined(_MSC_VER)
+#include <sleef.h>
+#endif
+
+namespace at {
+namespace vec256 {
+// See Note [Acceptable use of anonymous namespace in header]
+namespace {
+
+#if defined(__AVX__) && !defined(_MSC_VER)
+
+template <> class Vec256<std::complex<double>> {
+private:
+  __m256d values;
+public:
+  using value_type = std::complex<double>;
+  static constexpr int size() {
+    return 2;
+  }
+  Vec256() {}
+  Vec256(__m256d v) : values(v) {}
+  Vec256(std::complex<double> val) {
+    double real_value = std::real(val);
+    double imag_value = std::imag(val);
+    values = _mm256_setr_pd(real_value, imag_value, real_value, imag_value);
+  }
+  Vec256(std::complex<double> val1, std::complex<double> val2) {
+    values = _mm256_setr_pd(std::real(val1), std::imag(val1), std::real(val2), std::imag(val2));
+  }
+  operator __m256d() const {
+    return values;
+  }
+  template <int64_t mask>
+  static Vec256<std::complex<double>> blend(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+     // convert std::complex<V> index mask to V index mask: xy -> xxyy
+    switch (mask) {
+      case 0:
+        return a;
+      case 1:
+        return Vec256<std::complex<double>>(_mm256_blend_pd(a.values, b.values, 0x3));
+      case 2:
+        return Vec256<std::complex<double>>(_mm256_blend_pd(a.values, b.values, 0xc));
+      case 3:
+        return b;
+      default:
+        AT_ERROR("unsupported Vec256<complex> blend mask");
+    }
+  }
+  static Vec256<std::complex<double>> blendv(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
+                               const Vec256<std::complex<double>>& mask) {
+    // convert std::complex<V> index mask to V index mask: xy -> xxyy
+    auto mask_ = _mm256_unpacklo_pd(mask.values, mask.values);
+    return Vec256<std::complex<double>>(_mm256_blendv_pd(a.values, b.values, mask_));
+
+  }
+  static Vec256<std::complex<double>> arange(std::complex<double> base = 0., std::complex<double> step = 1.) {
+    return Vec256<std::complex<double>>(base, base + step);
+  }
+  static Vec256<std::complex<double>> set(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b,
+                            int64_t count = size()) {
+    switch (count) {
+      case 0:
+        return a;
+      case 1:
+        return blend<1>(a, b);
+    }
+    return b;
+  }
+  static Vec256<std::complex<double>> loadu(const void* ptr, int64_t count = size()) {
+    if (count == size())
+      return _mm256_loadu_pd(reinterpret_cast<const double*>(ptr));
+
+    __at_align32__ double tmp_values[2*size()];
+    std::memcpy(
+        tmp_values,
+        reinterpret_cast<const double*>(ptr),
+        count * sizeof(std::complex<double>));
+    return _mm256_load_pd(tmp_values);
+  }
+  void store(void* ptr, int count = size()) const {
+    if (count == size()) {
+      _mm256_storeu_pd(reinterpret_cast<double*>(ptr), values);
+    } else if (count > 0) {
+      double tmp_values[2*size()];
+      _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
+      std::memcpy(ptr, tmp_values, count * sizeof(std::complex<double>));
+    }
+  }
+  const std::complex<double>& operator[](int idx) const  = delete;
+  std::complex<double>& operator[](int idx) = delete;
+  Vec256<std::complex<double>> map(std::complex<double> (*f)(const std::complex<double> &)) const {
+    __at_align32__ std::complex<double> tmp[size()];
+    store(tmp);
+    for (int i = 0; i < size(); i++) {
+      tmp[i] = f(tmp[i]);
+    }
+    return loadu(tmp);
+  }
+  __m256d abs_2_() const {
+    auto val_2 = _mm256_mul_pd(values, values);     // a*a     b*b
+    return _mm256_hadd_pd(val_2, val_2);            // a*a+b*b a*a+b*b
+  }
+  __m256d abs_() const {
+    auto abs = _mm256_sqrt_pd(abs_2_());            // abs     abs
+    auto mask = _mm256_setr_pd(1.0, 0.0, 1.0, 0.0);
+    return _mm256_mul_pd(abs, mask);                // abs     0
+  }
+  Vec256<std::complex<double>> abs() const {
+   return Vec256<std::complex<double>>(abs_());     // abs     0
+  }
+  __m256d angle_() const {
+    auto b_a = _mm256_permute_pd(values, 0x5);      //b        a
+    auto angle = Sleef_atan2d4_u10(values, b_a);    //-angle   angle
+    auto mask = _mm256_setr_pd(0.0, 1.0, 0.0, 1.0);
+    return _mm256_mul_pd(angle, mask);              //0        angle
+  }
+  Vec256<std::complex<double>> angle() const {
+    return Vec256<std::complex<double>>(_mm256_permute_pd(angle_(), 0x5));  // angle     0
+  }
+  __m256d real_() const {
+    auto mask = _mm256_setr_pd(1.0, 0.0, 1.0, 0.0);
+    return _mm256_mul_pd(values, mask);
+  }
+  Vec256<std::complex<double>> real() const {
+    return Vec256<std::complex<double>>(real_());
+  }
+  __m256d imag_() const {
+    auto mask = _mm256_setr_pd(0.0, 1.0, 0.0, 1.0);
+    return _mm256_mul_pd(values, mask);
+    }
+  Vec256<std::complex<double>> imag() const {
+    return Vec256<std::complex<double>>(_mm256_permute_pd(imag_(), 0x5)); //b        a
+  }
+  Vec256<std::complex<double>> acos() const {
+    return map(std::acos);
+  }
+  Vec256<std::complex<double>> asin() const {
+    return map(std::asin);
+  }
+  Vec256<std::complex<double>> atan() const {
+    return map(std::atan);
+  }
+  Vec256<std::complex<double>> atan2(const Vec256<std::complex<double>> &b) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> erf() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> erfc() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> exp() const {
+    return map(std::exp);
+  }
+  Vec256<std::complex<double>> expm1() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log() const {
+    return map(std::log);
+  }
+  Vec256<std::complex<double>> log2() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> log10() const {
+    return map(std::log10);
+  }
+  Vec256<std::complex<double>> log1p() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> sin() const {
+    return map(std::sin);
+  }
+  Vec256<std::complex<double>> sinh() const {
+    return map(std::sinh);
+  }
+  Vec256<std::complex<double>> cos() const {
+    return map(std::cos);
+  }
+  Vec256<std::complex<double>> cosh() const {
+    return map(std::cosh);
+  }
+  Vec256<std::complex<double>> ceil() const {
+    return Vec256<std::complex<double>>(_mm256_ceil_pd(values));
+  }
+  Vec256<std::complex<double>> floor() const {
+    return Vec256<std::complex<double>>(_mm256_floor_pd(values));
+  }
+  Vec256<std::complex<double>> neg() const {
+    auto zero = _mm256_setzero_pd();
+    return Vec256<std::complex<double>>(_mm256_sub_pd(zero, values));
+  }
+  Vec256<std::complex<double>> round() const {
+    return Vec256<std::complex<double>>(_mm256_round_pd(values, (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
+  }
+  Vec256<std::complex<double>> tan() const {
+    return map(std::tan);
+  }
+  Vec256<std::complex<double>> tanh() const {
+    return map(std::tanh);
+  }
+  Vec256<std::complex<double>> trunc() const {
+    return Vec256<std::complex<double>>(_mm256_round_pd(values, (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
+  }
+  Vec256<std::complex<double>> sqrt() const {
+    return map(std::sqrt);
+  }
+  Vec256<std::complex<double>> reciprocal() const {
+    return map([](const std::complex<double> &x) { return (std::complex<double>)(1)/x; });
+  }
+  Vec256<std::complex<double>> rsqrt() const {
+    return map([](const std::complex<double> &x) { return (std::complex<double>)(1)/std::sqrt(x); });
+  }
+  Vec256<std::complex<double>> pow(const Vec256<std::complex<double>> &exp) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  // Comparison using the _CMP_**_OQ predicate.
+  //   `O`: get false if an operand is NaN
+  //   `Q`: do not raise if an operand is NaN
+  Vec256<std::complex<double>> operator==(const Vec256<std::complex<double>>& other) const {
+    return Vec256<std::complex<double>>(_mm256_cmp_pd(values, other.values, _CMP_EQ_OQ));
+  }
+  Vec256<std::complex<double>> operator!=(const Vec256<std::complex<double>>& other) const {
+    return Vec256<std::complex<double>>(_mm256_cmp_pd(values, other.values, _CMP_NEQ_OQ));
+  }
+  Vec256<std::complex<double>> operator<(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> operator<=(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> operator>(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<double>> operator>=(const Vec256<std::complex<double>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+};
+
+template <> Vec256<std::complex<double>> inline operator+(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
+  return Vec256<std::complex<double>>(_mm256_add_pd(a, b));
+}
+
+template <> Vec256<std::complex<double>> inline operator-(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
+  return Vec256<std::complex<double>>(_mm256_sub_pd(a, b));
+}
+
+template <> Vec256<std::complex<double>> inline operator*(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
+  //(a + bi)  * (c + di) = (ac - bd) + (ad + bc)i
+  auto neg = _mm256_setr_pd(1.0, -1.0, 1.0, -1.0);
+  auto ac_bd = _mm256_mul_pd(a, b);         //ac       bd
+
+  auto d_c = _mm256_permute_pd(b, 0x5);     //d        c
+  d_c = _mm256_mul_pd(neg, d_c);            //d       -c
+  auto ad_bc = _mm256_mul_pd(a, d_c);       //ad      -bc
+
+  auto ret = _mm256_hsub_pd(ac_bd, ad_bc);  //ac - bd  ad + bc
+  return Vec256<std::complex<double>>(ret);
+}
+
+template <> Vec256<std::complex<double>> inline operator/(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) __ubsan_ignore_float_divide_by_zero__ {
+  auto mask = _mm256_setr_pd(0.0, 1.0, 0.0, 1.0);
+  Vec256<std::complex<double>> abs = Vec256<std::complex<double>>(_mm256_div_pd(a.abs_(), _mm256_add_pd(b.abs_(), mask)));
+  Vec256<std::complex<double>> i_angle = Vec256<std::complex<double>>(_mm256_sub_pd(a.angle_(), b.angle_()));
+  return abs*i_angle.exp();
+}
+
+template <>
+Vec256<std::complex<double>> inline maximum(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  auto abs_a = a.abs_2_();
+  auto abs_b = b.abs_2_();
+  auto mask = _mm256_cmp_pd(abs_a, abs_b, _CMP_LT_OQ);
+  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, b, mask));
+}
+
+template <>
+Vec256<std::complex<double>> inline minimum(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  auto abs_a = a.abs_2_();
+  auto abs_b = b.abs_2_();
+  auto mask = _mm256_cmp_pd(abs_a, abs_b, _CMP_GT_OQ);
+  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, b, mask));
+}
+
+template <>
+Vec256<std::complex<double>> inline clamp(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& min, const Vec256<std::complex<double>>& max) {
+  auto abs_a = a.abs_2_();
+  auto abs_min = min.abs_2_();
+  auto max_mask = _mm256_cmp_pd(abs_a, abs_min, _CMP_LT_OQ);
+  auto abs_max = max.abs_2_();
+  auto min_mask = _mm256_cmp_pd(abs_a, abs_max, _CMP_GT_OQ);
+  return Vec256<std::complex<double>>(_mm256_blendv_pd(_mm256_blendv_pd(a, min, max_mask), max, min_mask));
+}
+
+template <>
+Vec256<std::complex<double>> inline clamp_min(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& min) {
+  auto abs_a = a.abs_2_();
+  auto abs_min = min.abs_2_();
+  auto max_mask = _mm256_cmp_pd(abs_a, abs_min, _CMP_LT_OQ);
+  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, min, max_mask));
+}
+
+template <>
+Vec256<std::complex<double>> inline clamp_max(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& max) {
+  auto abs_a = a.abs_2_();
+  auto abs_max = max.abs_2_();
+  auto min_mask = _mm256_cmp_pd(abs_a, abs_max, _CMP_GT_OQ);
+  return Vec256<std::complex<double>>(_mm256_blendv_pd(a, max, min_mask));
+}
+
+template <>
+Vec256<std::complex<double>> inline operator&(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  return _mm256_and_pd(a, b);
+}
+
+template <>
+Vec256<std::complex<double>> inline operator|(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  return _mm256_or_pd(a, b);
+}
+
+template <>
+Vec256<std::complex<double>> inline operator^(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b) {
+  return _mm256_xor_pd(a, b);
+}
+
+#ifdef __AVX2__
+template <> inline Vec256<std::complex<double>> fmadd(const Vec256<std::complex<double>>& a, const Vec256<std::complex<double>>& b, const Vec256<std::complex<double>>& c) {
+  return a * b + c;
+}
+#endif
+
+#endif
+
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_complex_double_rrii.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_double_rrii.h
@@ -111,19 +111,19 @@ public:
     return _mm256_sqrt_pd(abs_2_());
   }
   Vec256<std::complex<double>> abs() const {
-   return Vec256<std::complex<double>>(abs_());
+   return abs_();
   }
   __m256d angle_() const {return Sleef_atan2d4_u10(imag_values, real_values);}
   Vec256<std::complex<double>> angle() const {
-    return Vec256<std::complex<double>>(angle_());
+    return angle_();
   }
   __m256d real_() const {return real_values;}
   Vec256<std::complex<double>> real() const {
-    return Vec256<std::complex<double>>(real_());
+    return real_();
   }
   __m256d imag_() const {return imag_values;}
   Vec256<std::complex<double>> imag() const {
-    return Vec256<std::complex<double>>(imag_());
+    return imag_();
   }
   Vec256<std::complex<double>> acos() const {
     return map(std::acos);
@@ -174,14 +174,15 @@ public:
     return map(std::cosh);
   }
   Vec256<std::complex<double>> ceil() const {
-    return Vec256<std::complex<double>>(_mm256_ceil_pd(real_values), _mm256_ceil_pd(imag_values));
+    return _mm256_ceil_pd(real_values), _mm256_ceil_pd(imag_values);
   }
   Vec256<std::complex<double>> floor() const {
-    return Vec256<std::complex<double>>(_mm256_floor_pd(real_values), _mm256_floor_pd(imag_values));
+    return _mm256_floor_pd(real_values), _mm256_floor_pd(imag_values);
   }
   Vec256<std::complex<double>> neg() const {
     auto zero = _mm256_setzero_pd();
-    return Vec256<std::complex<double>>(_mm256_sub_pd(zero, real_values), _mm256_sub_pd(zero, imag_values));
+    return Vec256<std::complex<double>>(_mm256_sub_pd(zero, real_values),
+                                        _mm256_sub_pd(zero, imag_values));
   }
   Vec256<std::complex<double>> round() const {
     return Vec256<std::complex<double>>(
@@ -224,7 +225,8 @@ public:
   Vec256<std::complex<double>> operator!=(const Vec256<std::complex<double>>& other) const {
     auto real_cmp = _mm256_cmp_pd(real_values, other.real_values, _CMP_NEQ_OQ);
     auto imag_cmp = _mm256_cmp_pd(imag_values, other.imag_values, _CMP_NEQ_OQ);
-    return Vec256<std::complex<double>>(_mm256_and_pd(real_cmp, imag_cmp), _mm256_setzero_pd());
+    return Vec256<std::complex<double>>(_mm256_and_pd(real_cmp, imag_cmp),
+                                        _mm256_setzero_pd());
   }
   Vec256<std::complex<double>> operator<(const Vec256<std::complex<double>>& other) const {
     AT_ERROR("not supported for complex numbers");
@@ -241,11 +243,13 @@ public:
 };
 
 template <> Vec256<std::complex<double>> inline operator+(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
-  return Vec256<std::complex<double>>(_mm256_add_pd(a.real_(), b.real_()), _mm256_add_pd(a.imag_(), b.imag_()));
+  return Vec256<std::complex<double>>(_mm256_add_pd(a.real_(), b.real_()),
+                                      _mm256_add_pd(a.imag_(), b.imag_()));
 }
 
 template <> Vec256<std::complex<double>> inline operator-(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
-  return Vec256<std::complex<double>>(_mm256_sub_pd(a.real_(), b.real_()), _mm256_sub_pd(a.imag_(), b.imag_()));
+  return Vec256<std::complex<double>>(_mm256_sub_pd(a.real_(), b.real_()),
+                                      _mm256_sub_pd(a.imag_(), b.imag_()));
 }
 
 template <> Vec256<std::complex<double>> inline operator*(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) {
@@ -254,7 +258,8 @@ template <> Vec256<std::complex<double>> inline operator*(const Vec256<std::comp
   auto bd = _mm256_mul_pd(a.imag_(), b.imag_());
   auto ad = _mm256_mul_pd(a.real_(), b.imag_());
   auto bc = _mm256_mul_pd(a.imag_(), b.real_());
-  return Vec256<std::complex<double>>(_mm256_sub_pd(ac, bd), _mm256_add_pd(ad, bc));
+  return Vec256<std::complex<double>>(_mm256_sub_pd(ac, bd),
+                                      _mm256_add_pd(ad, bc));
 }
 
 template <> Vec256<std::complex<double>> inline operator/(const Vec256<std::complex<double>> &a, const Vec256<std::complex<double>> &b) __ubsan_ignore_float_divide_by_zero__ {

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float_no_vec.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float_no_vec.h
@@ -1,0 +1,331 @@
+#pragma once
+
+#include <ATen/cpu/vec256/intrinsics.h>
+#include <ATen/cpu/vec256/vec256_base.h>
+#include <complex>
+
+namespace at {
+namespace vec256 {
+// See Note [Acceptable use of anonymous namespace in header]
+namespace {
+
+template <> class Vec256<std::complex<float>> {
+private:
+  std::complex<float> values[4] = {0};
+public:
+  using value_type = std::complex<float>;
+  static constexpr int size() {
+    return 2;
+  }
+  Vec256() {}
+  Vec256(std::complex<float> val) {
+    for (int i = 0; i != size(); i++) {
+      values[i] = val;
+    }
+  }
+  Vec256(std::complex<float> val1, std::complex<float> val2, std::complex<float> val3, std::complex<float> val4) {
+    values[0] = val1;
+    values[1] = val2;
+    values[2] = val3;
+    values[3] = val4;
+  }
+  template <int64_t mask>
+  static Vec256<std::complex<float>> blend(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+    int64_t mask_ = mask;
+    Vec256 vec;
+    for (int i = 0; i < size(); i++) {
+      if (mask & 0x01) {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+      mask_ = mask_ >> 1;
+    }
+    return vec;
+  }
+  static Vec256<std::complex<float>> blendv(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b,
+                               const Vec256<std::complex<float>>& mask) {
+    Vec256 vec;
+    int64_t buffer[size()];
+    mask.store(buffer);
+    for (int i = 0; i < size(); i++) {
+      if (buffer[i] & 0x01)
+       {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+    }
+    return vec;
+  }
+  static Vec256<std::complex<float>> arange(std::complex<float> base = 0., std::complex<float> step = 1.) {
+    Vec256 vec;
+    for (int i = 0; i < size(); i++) {
+      vec.values[i] = base + static_cast<std::complex<float>>(i)*step;
+    }
+    return vec;
+  }
+  static Vec256<std::complex<float>> set(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b,
+                            int64_t count = size()) {
+    Vec256 vec;
+    for (int i = 0; i < size(); i++) {
+      if (i < count) {
+        vec[i] = b[i];
+      } else {
+        vec[i] = a[i];
+      }
+    }
+    return vec;
+  }
+  static Vec256<std::complex<float>> loadu(const void* ptr, int64_t count = size()) {
+    Vec256 vec;
+    std::memcpy(vec.values, ptr, count * sizeof(std::complex<float>));
+    return vec;
+  }
+  void store(void* ptr, int count = size()) const {
+    std::memcpy(ptr, values, count * sizeof(std::complex<float>));
+  }
+  const std::complex<float>& operator[](int idx) const {
+    return values[idx];
+  }
+  std::complex<float>& operator[](int idx) {
+    return values[idx];
+  }
+  Vec256<std::complex<float>> map(std::complex<float> (*f)(const std::complex<float> &)) const {
+    Vec256<std::complex<float>> ret;
+    for (int i = 0; i != size(); i++) {
+      ret[i] = f(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<float>> abs() const {
+    Vec256<std::complex<float>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::abs(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<float>> real() const {
+    Vec256<std::complex<float>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::real(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<float>> imag() const {
+    Vec256<std::complex<float>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::imag(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<float>> acos() const {
+    return map(std::acos);
+  }
+  Vec256<std::complex<float>> asin() const {
+    return map(std::asin);
+  }
+  Vec256<std::complex<float>> atan() const {
+    return map(std::atan);
+  }
+  Vec256<std::complex<float>> atan2(const Vec256<std::complex<float>> &b) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> erf() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> erfc() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> exp() const {
+    return map(std::exp);
+  }
+  Vec256<std::complex<float>> expm1() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> log() const {
+    return map(std::log);
+  }
+  Vec256<std::complex<float>> log2() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> log10() const {
+    return map(std::log10);
+  }
+  Vec256<std::complex<float>> log1p() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> sin() const {
+    return map(std::sin);
+  }
+  Vec256<std::complex<float>> sinh() const {
+    return map(std::sinh);
+  }
+  Vec256<std::complex<float>> cos() const {
+    return map(std::cos);
+  }
+  Vec256<std::complex<float>> cosh() const {
+    return map(std::cosh);
+  }
+  Vec256<std::complex<float>> ceil() const {
+    return map([](const std::complex<float> &x) {
+      return std::complex<float>(std::ceil(std::real(x)), std::ceil(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<float>> floor() const {
+    return map([](const std::complex<float> &x) {
+      return std::complex<float>(std::floor(std::real(x)), std::floor(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<float>> frac() const {
+    AT_ERROR("not supported for complex numbers");
+  }
+  Vec256<std::complex<float>> neg() const {
+    return map([](const std::complex<float> &x) { return -x; });
+  }
+  Vec256<std::complex<float>> round() const {
+    return map([](const std::complex<float> &x) {
+      return std::complex<float>(std::round(std::real(x)), std::round(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<float>> tan() const {
+    return map(std::tan);
+  }
+  Vec256<std::complex<float>> tanh() const {
+      return map(std::tanh);
+  }
+  Vec256<std::complex<float>> trunc() const {
+    return map([](const std::complex<float> &x) {
+      return std::complex<float>(std::trunc(std::real(x)), std::trunc(std::imag(x)));
+    });
+  }
+  Vec256<std::complex<float>> sqrt() const {
+    return map(std::sqrt);
+  }
+  Vec256<std::complex<float>> reciprocal() const {
+    return map([](const std::complex<float> &x) { return std::complex<float>(1) / x; });
+  }
+  Vec256<std::complex<float>> rsqrt() const {
+    return map([](const std::complex<float> &x) { return std::complex<float>(1., 0.) / std::sqrt(x); });
+  }
+  Vec256<std::complex<float>> pow(const Vec256<std::complex<float>> &b) const {
+    Vec256<std::complex<float>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::pow(values[i], b[i]);
+    }
+    return ret;
+  }
+
+#define DEFINE_COMPLEX_FLOAT_COMP(binary_pred)                                                                                    \
+  Vec256<std::complex<float>> operator binary_pred(const Vec256<std::complex<float>> &other) const {              \
+    Vec256<std::complex<float>> vec;                                                                               \
+    for (int i = 0; i != size(); i++) {                                                                             \
+      if (values[i] binary_pred other.values[i]) {                                                                  \
+        std::memset(static_cast<void*>(vec.values + i), 0xFF, sizeof(std::complex<float>));                        \
+      } else {                                                                                                      \
+        std::memset(static_cast<void*>(vec.values + i), 0, sizeof(std::complex<float>));                           \
+      }                                                                                                             \
+    }                                                                                                               \
+    return vec;                                                                                                     \
+  }
+  DEFINE_COMPLEX_FLOAT_COMP(==)
+  DEFINE_COMPLEX_FLOAT_COMP(!=)
+  Vec256<std::complex<float>> operator<(const Vec256<std::complex<float>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+  Vec256<std::complex<float>> operator<=(const Vec256<std::complex<float>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+  Vec256<std::complex<float>> operator>(const Vec256<std::complex<float>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+
+  Vec256<std::complex<float>> operator>=(const Vec256<std::complex<float>>& other) const {
+    AT_ERROR("not supported for complex numbers");
+  }
+};
+
+template <>
+Vec256<std::complex<float>> inline operator+(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  Vec256<std::complex<float>> ret;
+  for (int i = 0; i < Vec256<std::complex<float>>::size(); i++) {
+    ret[i] = a[i] + b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<float>> inline operator-(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  Vec256<std::complex<float>> ret;
+  for (int i = 0; i < Vec256<std::complex<float>>::size(); i++) {
+    ret[i] = a[i] + b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<float>> inline operator*(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  Vec256<std::complex<float>> ret;
+  for (int i = 0; i < Vec256<std::complex<float>>::size(); i++) {
+    ret[i] = a[i] * b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<float>> inline operator/(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  Vec256<std::complex<float>> ret;
+  for (int i = 0; i < Vec256<std::complex<float>>::size(); i++) {
+    ret[i] = a[i] / b[i];
+  }
+  return ret;
+}
+
+template <>
+Vec256<std::complex<float>> inline maximum(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline minimum(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline clamp(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& min, const Vec256<std::complex<float>>& max) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline clamp_min(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& min) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline clamp_max(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& max) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline operator&(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline operator|(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+Vec256<std::complex<float>> inline operator^(const Vec256<std::complex<float>>& a, const Vec256<std::complex<float>>& b) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+template <>
+inline void convert(const std::complex<float>* src, std::complex<float>* dst, int64_t n) {
+  AT_ERROR("not supported for complex numbers");
+}
+
+}}}

--- a/aten/src/ATen/cpu/vec256/vec256_complex_float_no_vec.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float_no_vec.h
@@ -2,7 +2,6 @@
 
 #include <ATen/cpu/vec256/intrinsics.h>
 #include <ATen/cpu/vec256/vec256_base.h>
-#include <complex>
 
 namespace at {
 namespace vec256 {
@@ -102,6 +101,13 @@ public:
     Vec256<std::complex<float>> ret;
     for (int i = 0; i < size(); i++) {
       ret[i] = std::abs(values[i]);
+    }
+    return ret;
+  }
+  Vec256<std::complex<float>> angle() const {
+    Vec256<std::complex<float>> ret;
+    for (int i = 0; i < size(); i++) {
+      ret[i] = std::arg(values[i]);
     }
     return ret;
   }

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -91,6 +91,12 @@ public:
     auto mask = _mm256_set1_pd(-0.f);
     return _mm256_andnot_pd(mask, values);
   }
+  Vec256<double> real() const {
+    return *this;
+  }
+  Vec256<double> imag() const {
+    return _mm256_set1_pd(0);
+  }
   Vec256<double> acos() const {
     return Vec256<double>(Sleef_acosd4_u10(values));
   }

--- a/aten/src/ATen/cpu/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec256/vec256_double.h
@@ -91,6 +91,9 @@ public:
     auto mask = _mm256_set1_pd(-0.f);
     return _mm256_andnot_pd(mask, values);
   }
+  Vec256<double> angle() const {
+    return _mm256_set1_pd(0);
+  }
   Vec256<double> real() const {
     return *this;
   }

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -99,6 +99,12 @@ public:
     auto mask = _mm256_set1_ps(-0.f);
     return _mm256_andnot_ps(mask, values);
   }
+  Vec256<float> real() const {
+    return *this;
+  }
+  Vec256<float> imag() const {
+    return _mm256_set1_ps(0);
+  }
   Vec256<float> acos() const {
     return Vec256<float>(Sleef_acosf8_u10(values));
   }

--- a/aten/src/ATen/cpu/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float.h
@@ -99,6 +99,9 @@ public:
     auto mask = _mm256_set1_ps(-0.f);
     return _mm256_andnot_ps(mask, values);
   }
+  Vec256<float> angle() const {
+    return _mm256_set1_ps(0);
+  }
   Vec256<float> real() const {
     return *this;
   }

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -97,6 +97,12 @@ struct Vec256<int64_t> : public Vec256i {
     auto inverse = _mm256_xor_si256(values, is_larger);
     return _mm256_sub_epi64(inverse, is_larger);
   }
+  Vec256<int64_t> real() const {
+    return *this;
+  }
+  Vec256<int64_t> imag() const {
+    return _mm256_set1_epi64x(0);
+  }
   Vec256<int64_t> frac() const;
   Vec256<int64_t> neg() const;
   Vec256<int64_t> operator==(const Vec256<int64_t>& other) const {
@@ -188,6 +194,12 @@ struct Vec256<int32_t> : public Vec256i {
   int32_t& operator[](int idx)  = delete;
   Vec256<int32_t> abs() const {
     return _mm256_abs_epi32(values);
+  }
+  Vec256<int32_t> real() const {
+    return *this;
+  }
+  Vec256<int32_t> imag() const {
+    return _mm256_set1_epi32(0);
   }
   Vec256<int32_t> frac() const;
   Vec256<int32_t> neg() const;
@@ -375,6 +387,12 @@ struct Vec256<int16_t> : public Vec256i {
   int16_t& operator[](int idx)  = delete;
   Vec256<int16_t> abs() const {
     return _mm256_abs_epi16(values);
+  }
+  Vec256<int16_t> real() const {
+    return *this;
+  }
+  Vec256<int16_t> imag() const {
+    return _mm256_set1_epi16(0);
   }
   Vec256<int16_t> frac() const;
   Vec256<int16_t> neg() const;

--- a/aten/src/ATen/cpu/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec256/vec256_int.h
@@ -97,6 +97,9 @@ struct Vec256<int64_t> : public Vec256i {
     auto inverse = _mm256_xor_si256(values, is_larger);
     return _mm256_sub_epi64(inverse, is_larger);
   }
+  Vec256<int64_t> angle() const {
+    return _mm256_set1_epi64x(0);
+  }
   Vec256<int64_t> real() const {
     return *this;
   }
@@ -194,6 +197,9 @@ struct Vec256<int32_t> : public Vec256i {
   int32_t& operator[](int idx)  = delete;
   Vec256<int32_t> abs() const {
     return _mm256_abs_epi32(values);
+  }
+  Vec256<int32_t> angle() const {
+    return _mm256_set1_epi32(0);
   }
   Vec256<int32_t> real() const {
     return *this;
@@ -387,6 +393,9 @@ struct Vec256<int16_t> : public Vec256i {
   int16_t& operator[](int idx)  = delete;
   Vec256<int16_t> abs() const {
     return _mm256_abs_epi16(values);
+  }
+  Vec256<int16_t> angle() const {
+    return _mm256_set1_epi16(0);
   }
   Vec256<int16_t> real() const {
     return *this;

--- a/aten/src/ATen/cpu/vml.h
+++ b/aten/src/ATen/cpu/vml.h
@@ -39,9 +39,22 @@
 // https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1663280. Calling zeroall
 // when using AVX/AVX2 code resolves this.
 #if defined(__AVX__) && defined(__GLIBC__) && __GLIBC_MINOR__ == 23
-#define DL_RUNTIME_BUG(op, type) \
-  volatile type x = (type)(1);   \
-  x = std::op(x);                \
+template <typename TYPE>
+struct ztype {
+  using value_t = TYPE;
+};
+template <>
+struct ztype<std::complex<double>> {
+  using value_t = double;
+};
+template <>
+struct ztype<std::complex<float>> {
+  using value_t = float;
+};
+#define DL_RUNTIME_BUG(op, type)                  \
+  using value_t = typename ztype<type>::value_t;  \
+  volatile value_t x = (value_t)(1);        \
+  x = std::op(x);                                 \
   _mm256_zeroall();
 #else
 #define DL_RUNTIME_BUG(op, type)

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -239,9 +239,9 @@ inline void propagate_names_if_namedtensor_enabled(Tensor& result, const Tensor&
     return at::op##_out(self, self);                                   \
   }                                                                    \
   Tensor& _##op##_out_##prefix(Tensor& result, const Tensor& self) {   \
-    checkBackend(#op, result, Backend::device);                        \
     auto iter = TensorIterator::unary_op(result, self,                 \
       /*check_mem_overlap=*/true);                                     \
+    AT_ASSERT(iter.device_type() == DeviceType::CPU);                  \
     op##_stub(iter.device_type(), iter);                               \
     return result;                                                     \
   }

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -255,6 +255,8 @@ inline void propagate_names_if_namedtensor_enabled(Tensor& result, const Tensor&
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cuda, CUDA)
 
 IMPLEMENT_UNARY_OP_VEC(abs)
+IMPLEMENT_UNARY_OP_VEC(real)
+IMPLEMENT_UNARY_OP_VEC(imag)
 IMPLEMENT_UNARY_OP_VEC(acos)
 IMPLEMENT_UNARY_OP_VEC(asin)
 IMPLEMENT_UNARY_OP_VEC(atan)
@@ -282,6 +284,8 @@ IMPLEMENT_UNARY_OP_VEC(tanh)
 IMPLEMENT_UNARY_OP_VEC(trunc)
 
 DEFINE_DISPATCH(abs_stub);
+DEFINE_DISPATCH(real_stub);
+DEFINE_DISPATCH(imag_stub);
 DEFINE_DISPATCH(acos_stub);
 DEFINE_DISPATCH(asin_stub);
 DEFINE_DISPATCH(atan_stub);

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -255,6 +255,7 @@ inline void propagate_names_if_namedtensor_enabled(Tensor& result, const Tensor&
   IMPLEMENT_UNARY_OP_OUT_INPLACE(op, cuda, CUDA)
 
 IMPLEMENT_UNARY_OP_VEC(abs)
+IMPLEMENT_UNARY_OP_VEC(angle)
 IMPLEMENT_UNARY_OP_VEC(real)
 IMPLEMENT_UNARY_OP_VEC(imag)
 IMPLEMENT_UNARY_OP_VEC(acos)
@@ -284,6 +285,7 @@ IMPLEMENT_UNARY_OP_VEC(tanh)
 IMPLEMENT_UNARY_OP_VEC(trunc)
 
 DEFINE_DISPATCH(abs_stub);
+DEFINE_DISPATCH(angle_stub);
 DEFINE_DISPATCH(real_stub);
 DEFINE_DISPATCH(imag_stub);
 DEFINE_DISPATCH(acos_stub);

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -13,6 +13,8 @@ using unary_fn = void(*)(TensorIterator&);
 using unary_fn_with_scalar = void(*)(TensorIterator&, Scalar a);
 
 DECLARE_DISPATCH(unary_fn, abs_stub);
+DECLARE_DISPATCH(unary_fn, real_stub);
+DECLARE_DISPATCH(unary_fn, imag_stub);
 DECLARE_DISPATCH(unary_fn, acos_stub);
 DECLARE_DISPATCH(unary_fn, asin_stub);
 DECLARE_DISPATCH(unary_fn, atan_stub);

--- a/aten/src/ATen/native/UnaryOps.h
+++ b/aten/src/ATen/native/UnaryOps.h
@@ -13,6 +13,7 @@ using unary_fn = void(*)(TensorIterator&);
 using unary_fn_with_scalar = void(*)(TensorIterator&, Scalar a);
 
 DECLARE_DISPATCH(unary_fn, abs_stub);
+DECLARE_DISPATCH(unary_fn, angle_stub);
 DECLARE_DISPATCH(unary_fn, real_stub);
 DECLARE_DISPATCH(unary_fn, imag_stub);
 DECLARE_DISPATCH(unary_fn, acos_stub);

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -14,14 +14,13 @@ namespace {
 using namespace vec256;
 
 void add_kernel(TensorIterator& iter, Scalar alpha_scalar) {
-  if (iter.dtype() == ScalarType::Bool || isComplexType(iter.dtype())) {
-    AT_DISPATCH_COMPLEX_TYPES_AND(kBool, iter.dtype(), "add_cpu/sub_cpu", [&]() {
+  if (iter.dtype() == ScalarType::Bool) {
+      using scalar_t = bool;
       auto alpha = alpha_scalar.to<scalar_t>();
       cpu_kernel(iter,
         [=](scalar_t a, scalar_t b) -> scalar_t { return a + alpha * b; });
-      });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "add_cpu/sub_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "add_cpu/sub_cpu", [&]() {
       auto alpha = alpha_scalar.to<scalar_t>();
       auto alpha_vec = Vec256<scalar_t>(alpha);
       cpu_kernel_vec(iter,
@@ -51,13 +50,8 @@ void sub_kernel(TensorIterator& iter, Scalar alpha_scalar) {
 void mul_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     cpu_kernel(iter, [=](bool a, bool b) -> bool { return a && b; });
-  } else if (isComplexType(iter.dtype())) {
-      AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "mul_cpu", [&]() {
-        cpu_kernel(iter,
-          [=](scalar_t a, scalar_t b) -> scalar_t { return a * b; });
-     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.dtype(), "mul_cpu", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16, iter.dtype(), "mul_cpu", [&]() {
       cpu_kernel_vec(iter,
         [=](scalar_t a, scalar_t b) -> scalar_t { return a * b; },
         [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
@@ -78,9 +72,12 @@ void div_kernel(TensorIterator& iter) {
     });
   } else if (isComplexType(iter.dtype())) {
       AT_DISPATCH_COMPLEX_TYPES(iter.dtype(), "div_cpu", [&]() {
-        cpu_kernel(iter,
+        cpu_kernel_vec(iter,
           [=](scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
              return a / b;
+          },
+          [=](Vec256<scalar_t> a, Vec256<scalar_t> b) {
+            return a / b;
           });
       });
     } else {

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -62,6 +62,24 @@ static void abs_kernel(TensorIterator& iter) {
   });
 }
 
+static void real_kernel(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "real_cpu", [&]() {
+    cpu_kernel_vec(
+        iter,
+        [=](scalar_t a) -> scalar_t { return real_impl(a); },
+        [=](Vec256<scalar_t> a) { return a.real(); });
+  });
+}
+
+static void imag_kernel(TensorIterator& iter) {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "imag_cpu", [&]() {
+    cpu_kernel_vec(
+        iter,
+        [=](scalar_t a) -> scalar_t { return imag_impl(a); },
+        [=](Vec256<scalar_t> a) { return a.imag(); });
+  });
+}
+
 static void bitwise_not_kernel(TensorIterator& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     // Boolean type does not work with ~ (bitwise NOT) in C++. bitwise_not wraps this operation for both Boolean and
@@ -330,6 +348,8 @@ REGISTER_DISPATCH(rsqrt_stub, &rsqrt_kernel);
 REGISTER_DISPATCH(sigmoid_stub, &sigmoid_kernel);
 REGISTER_DISPATCH(bernoulli_mkl_stub, &bernoulli_mkl_kernel);
 REGISTER_DISPATCH(abs_stub, &abs_kernel);
+REGISTER_DISPATCH(real_stub, &real_kernel);
+REGISTER_DISPATCH(imag_stub, &imag_kernel);
 REGISTER_DISPATCH(bitwise_not_stub, &bitwise_not_kernel);
 REGISTER_DISPATCH(logical_not_stub, &logical_not_kernel);
 REGISTER_DISPATCH(frac_stub, &frac_kernel);

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// Complex number math operations that act as no-ops for other dtypes.
+#include <complex.h>
+
+namespace at { namespace native {
+namespace {
+
+template <typename TYPE>
+struct ztype {
+  using value_t = TYPE;
+};
+
+template <>
+struct ztype<std::complex<double>> {
+  using value_t = double;
+};
+
+template <>
+struct ztype<std::complex<float>> {
+  using value_t = float;
+};
+
+template <typename TYPE>
+inline TYPE real_impl (TYPE z) {
+  return z; //No-Op
+}
+
+template<>
+inline std::complex<float> real_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(std::real(z), 0.0);
+}
+
+template<>
+inline std::complex<double> real_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(std::real(z), 0.0);
+}
+
+template <typename TYPE>
+inline TYPE imag_impl (TYPE z) {
+  return 0;
+}
+
+template<>
+inline std::complex<float> imag_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(0.0, std::imag(z));
+}
+
+template<>
+inline std::complex<double> imag_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(0.0, std::imag(z));
+}
+
+} // end namespace
+}} //end at::native

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -21,6 +21,36 @@ struct ztype<std::complex<float>> {
   using value_t = float;
 };
 
+template <typename SCALAR_TYPE, typename VALUE_TYPE>
+inline VALUE_TYPE zabs (SCALAR_TYPE z) {
+  return z;
+}
+
+template<>
+inline float zabs <std::complex<float>> (std::complex<float> z) {
+  return std::abs(z);
+}
+
+template<>
+inline double zabs <std::complex<double>> (std::complex<double> z) {
+  return std::abs(z);
+}
+
+template <typename TYPE>
+inline TYPE angle_impl (TYPE z) {
+  return 0;
+}
+
+template<>
+inline std::complex<float> angle_impl <std::complex<float>> (std::complex<float> z) {
+  return std::complex<float>(std::arg(z), 0.0);
+}
+
+template<>
+inline std::complex<double> angle_impl <std::complex<double>> (std::complex<double> z) {
+  return std::complex<double>(std::arg(z), 0.0);
+}
+
 template <typename TYPE>
 inline TYPE real_impl (TYPE z) {
   return z; //No-Op

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -43,12 +43,72 @@ inline TYPE imag_impl (TYPE z) {
 
 template<>
 inline std::complex<float> imag_impl <std::complex<float>> (std::complex<float> z) {
-  return std::complex<float>(0.0, std::imag(z));
+  return std::complex<float>(std::imag(z), 0.0);
 }
 
 template<>
 inline std::complex<double> imag_impl <std::complex<double>> (std::complex<double> z) {
-  return std::complex<double>(0.0, std::imag(z));
+  return std::complex<double>(std::imag(z), 0.0);
+}
+
+template <typename TYPE>
+inline TYPE ceil_impl (TYPE z) {
+  return std::ceil(z);
+}
+
+template <>
+inline std::complex<float> ceil_impl (std::complex<float> z) {
+  return std::complex<float>(std::ceil(std::real(z)), std::ceil(std::imag(z)));
+}
+
+template <>
+inline std::complex<double> ceil_impl (std::complex<double> z) {
+  return std::complex<double>(std::ceil(std::real(z)), std::ceil(std::imag(z)));
+}
+
+template <typename TYPE>
+inline TYPE floor_impl (TYPE z) {
+  return std::floor(z);
+}
+
+template <>
+inline std::complex<float> floor_impl (std::complex<float> z) {
+  return std::complex<float>(std::floor(std::real(z)), std::floor(std::imag(z)));
+}
+
+template <>
+inline std::complex<double> floor_impl (std::complex<double> z) {
+  return std::complex<double>(std::floor(std::real(z)), std::floor(std::imag(z)));
+}
+
+template <typename TYPE>
+inline TYPE round_impl (TYPE z) {
+  return std::nearbyint(z);
+}
+
+template <>
+inline std::complex<float> round_impl (std::complex<float> z) {
+  return std::complex<float>(std::nearbyint(std::real(z)), std::nearbyint(std::imag(z)));
+}
+
+template <>
+inline std::complex<double> round_impl (std::complex<double> z) {
+  return std::complex<double>(std::nearbyint(std::real(z)), std::nearbyint(std::imag(z)));
+}
+
+template <typename TYPE>
+inline TYPE trunc_impl (TYPE z) {
+  return std::trunc(z);
+}
+
+template <>
+inline std::complex<float> trunc_impl (std::complex<float> z) {
+  return std::complex<float>(std::trunc(std::real(z)), std::trunc(std::imag(z)));
+}
+
+template <>
+inline std::complex<double> trunc_impl (std::complex<double> z) {
+  return std::complex<double>(std::trunc(std::real(z)), std::trunc(std::imag(z)));
 }
 
 } // end namespace

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -131,6 +131,26 @@
     CPU: _abs_out_cpu
     CUDA: _abs_out_cuda
 
+- func: real(Tensor self) -> Tensor
+  variants: function, method
+  named_guard: False
+
+- func: real.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  named_guard: False
+  dispatch:
+    CPU: _real_out_cpu
+    CUDA: _abs_out_cuda
+
+- func: imag(Tensor self) -> Tensor
+  variants: function, method
+  named_guard: False
+
+- func: imag.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  named_guard: False
+  dispatch:
+    CPU: _imag_out_cpu
+    CUDA: _abs_out_cuda
+
 - func: acos(Tensor self) -> Tensor
   named_guard: False
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -131,6 +131,16 @@
     CPU: _abs_out_cpu
     CUDA: _abs_out_cuda
 
+- func: angle(Tensor self) -> Tensor
+  variants: function, method
+  named_guard: False
+
+- func: angle.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  named_guard: False
+  dispatch:
+    CPU: _angle_out_cpu
+    CUDA: _abs_out_cuda
+
 - func: real(Tensor self) -> Tensor
   variants: function, method
   named_guard: False

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -365,10 +365,6 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
   if (a == ud || b == ud) {
     return ScalarType::Undefined;
   }
-  if (isComplexType(a) || isComplexType(b)) {
-    AT_ERROR(
-        "promoteTypes with complex numbers is not handled yet; figure out what the correct rules should be for ", toString(a), " and ", toString(b));
-  }
 
   // For QInt types, we only allow exact match
   if (isQIntType(a) && a == b) {

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -277,6 +277,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: hardshrink
    .. automethod:: histc
    .. automethod:: ifft
+   .. automethod:: imag
    .. automethod:: index_add_
    .. automethod:: index_add
    .. automethod:: index_copy_
@@ -381,6 +382,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: register_hook
    .. automethod:: remainder
    .. automethod:: remainder_
+   .. automethod:: real
    .. automethod:: renorm
    .. automethod:: renorm_
    .. automethod:: repeat

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -170,6 +170,7 @@ view of a storage and defines numeric operations on it.
    .. automethod:: addr
    .. automethod:: addr_
    .. automethod:: allclose
+   .. automethod:: angle
    .. automethod:: apply_
    .. automethod:: argmax
    .. automethod:: argmin

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -206,6 +206,7 @@ Pointwise Ops
 .. autofunction:: floor
 .. autofunction:: fmod
 .. autofunction:: frac
+.. autofunction:: imag
 .. autofunction:: lerp
 .. autofunction:: log
 .. autofunction:: log10
@@ -217,6 +218,7 @@ Pointwise Ops
 .. autofunction:: mvlgamma
 .. autofunction:: neg
 .. autofunction:: pow
+.. autofunction:: real
 .. autofunction:: reciprocal
 .. autofunction:: remainder
 .. autofunction:: round

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -188,6 +188,7 @@ Pointwise Ops
 .. autofunction:: add
 .. autofunction:: addcdiv
 .. autofunction:: addcmul
+.. autofunction:: angle
 .. autofunction:: asin
 .. autofunction:: atan
 .. autofunction:: atan2

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -999,6 +999,13 @@ flip(dims) -> Tensor
 See :func:`torch.flip`
 """)
 
+add_docstr_all('real',
+               r"""
+real() -> Tensor
+
+See :func:`torch.real`
+""")
+
 add_docstr_all('roll',
                r"""
 roll(shifts, dims) -> Tensor
@@ -1093,6 +1100,13 @@ add_docstr_all('ger',
 ger(vec2) -> Tensor
 
 See :func:`torch.ger`
+""")
+
+add_docstr_all('imag',
+               r"""
+imag() -> Tensor
+
+See :func:`torch.imag`
 """)
 
 add_docstr_all('indices',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -332,6 +332,13 @@ allclose(other, rtol=1e-05, atol=1e-08, equal_nan=False) -> Tensor
 See :func:`torch.allclose`
 """)
 
+add_docstr_all('angle',
+               r"""
+angle() -> Tensor
+
+See :func:`torch.angle`
+""")
+
 add_docstr_all('any',
                r"""
 .. function:: any() -> bool

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -930,6 +930,25 @@ Example::
     tensor([-0., -1., -1.,  1.])
 """.format(**common_args))
 
+add_docstr(torch.real,
+           r"""
+real(input, out=None) -> Tensor
+
+Computes the element-wise real value of the given :attr:`input` tensor.
+
+.. math::
+    \text{out}_{i} = real(\text{input}_{i})
+""" + r"""
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> torch.real(torch.tensor([-1 + 1j, -2 + 2j, 3 - 3j]))
+    tensor([ -1,  -2,  3])
+""".format(**common_args))
+
 add_docstr(torch.reciprocal,
            r"""
 reciprocal(input, out=None) -> Tensor
@@ -2240,6 +2259,25 @@ Example::
 
     >>> torch.histc(torch.tensor([1., 2, 1]), bins=4, min=0, max=3)
     tensor([ 0.,  2.,  1.,  0.])
+""".format(**common_args))
+
+add_docstr(torch.imag,
+           r"""
+imag(input, out=None) -> Tensor
+
+Computes the element-wise imag value of the given :attr:`input` tensor.
+
+.. math::
+    \text{out}_{i} = imag(\text{input}_{i})
+""" + r"""
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> torch.imag(torch.tensor([-1 + 1j, -2 + 2j, 3 - 3j]))
+    tensor([ 1,  2,  -3])
 """.format(**common_args))
 
 add_docstr(torch.index_select,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -473,6 +473,25 @@ Example::
     True
 """)
 
+add_docstr(torch.angle,
+           r"""
+angle(input, out=None) -> Tensor
+
+Computes the element-wise angle (in radians) of the given :attr:`input` tensor.
+
+.. math::
+    \text{out}_{i} = |\text{input}_{i}|
+""" + r"""
+Args:
+    {input}
+    {out}
+
+Example::
+
+    >>> torch.real(torch.tensor([-1 + 1j, -2 + 2j, 3 - 3j]))*180/3.14159
+    tensor([ 135.,  135,  -45])
+""".format(**common_args))
+
 add_docstr(torch.as_strided,
            r"""
 as_strided(input, size, stride, storage_offset=0) -> Tensor

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -123,7 +123,7 @@ static PyObject* THPDTypeInfo_bits(THPDTypeInfo* self, void*) {
 }
 
 static PyObject* THPFInfo_eps(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND_HALF(
       self->type, "epsilon", [] {
         return PyFloat_FromDouble(
             std::numeric_limits<
@@ -132,14 +132,14 @@ static PyObject* THPFInfo_eps(THPFInfo* self, void*) {
 }
 
 static PyObject* THPFInfo_max(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self->type, "max", [] {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND_HALF(self->type, "max", [] {
     return PyFloat_FromDouble(
         std::numeric_limits<at::scalar_value_type<scalar_t>::type>::max());
   });
 }
 
 static PyObject* THPFInfo_min(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self->type, "min", [] {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND_HALF(self->type, "min", [] {
     return PyFloat_FromDouble(
         std::numeric_limits<at::scalar_value_type<scalar_t>::type>::lowest());
   });
@@ -170,7 +170,7 @@ static PyObject* THPIInfo_min(THPFInfo* self, void*) {
 }
 
 static PyObject* THPFInfo_tiny(THPFInfo* self, void*) {
-  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self->type, "min", [] {
+  return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND_HALF(self->type, "min", [] {
     return PyFloat_FromDouble(
         std::numeric_limits<at::scalar_value_type<scalar_t>::type>::min());
   });


### PR DESCRIPTION
Fixed the CI failures in #25850. There was a minor problem with the `DL_RUNTIME_BUG` in `vml.h`.

In-tree changes to pytorch to support complex numbers are being submitted here.
Out-of-tree support for complex numbers is here: [pytorch-cpu-strided-complex extension](https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex)

Changes in this PR.

- [x]  Added complex support of UnaryOp kernels.