### PR TITLE
[jit] fix use-after-free bug

### DIFF
--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1990,7 +1990,9 @@ class ShapePropagator {
       if (inferred) {
         SHAPE_ASSERT(size_product != 0);
         size_t numel = 1;
-        for (int64_t s : tensor_types.at(0)->sizes().concrete_sizes().value())
+        auto concrete_sizes =
+            tensor_types.at(0)->sizes().concrete_sizes().value();
+        for (int64_t s : concrete_sizes)
           numel *= s;
         int64_t inferred_size = numel / size_product;
         sizes[inferred_idx] = inferred_size;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25965 [jit] fix use-after-free bug**

Our optional type does not distinguish between lvalue and rvalue `this` when accessing its value because `OPTIONAL_HAS_MOVE_ACCESSORS = 0`.  This means that `for (auto x : optional.value())` will cause `optional` to be freed before the for loop begins.  Lifetime extension for references only works for the captured reference no for recursive references it captures.

Differential Revision: [D17300835](https://our.internmc.facebook.com/intern/diff/D17300835)