### PR TITLE
Creates generic device type testing framework

### DIFF
--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -1,0 +1,299 @@
+import unittest
+
+import torch
+from common_utils import TestCase
+
+# Note: Generic Device-Type Testing
+#
+# [WRITING TESTS]
+#
+# To write a test that runs on a variety of devices do the following:
+#
+#   (1) Create a class, class _<name>(object):
+#       Tests defined in this class will not be discoverable by unittest.
+#   (2) Write tests as usual, except they take a 'device' argument,
+#       def test_X(self, device):
+#       The device will be a string, like 'cpu' or 'cuda,' and the test
+#       should move tensors to and perform operations on this device.
+#   (3) Write tests as usual, except they take a 'device' and 'dtype'
+#       argument. These tests must also specify a list of dtypes using
+#       the dtypes, dtypesIfCPU, or dtypesIfCUDA decorators,
+#       @dtypes(torch.float, torch.long)
+#       def test_X(self, device, dtype):
+#       Tests should create tensors and perform operations using this dtype.
+#   (4) Call instantiate_device_type_tests(_<name>, globals()) in your test
+#       test script. This will create the device-specific test cases from
+#       the generic test case, and make them discoverable by unittest by
+#       putting them into the global scope of your script.
+#
+# See test_torch.py for an example.
+#
+# [RUNNING TESTS]
+#
+# The above will create test classes with names <name><device_type.upper()>,
+# e.g. if the generic class is called _TestTorchDevice then the created test
+# classes will TestTorchDeviceTypeCPU and TestTorchDeviceTypeCUDA.
+#
+# Tests like test_diag will have "_<device_type>" appended. So an instantiated
+# test can be run directly with the command
+# "python test_torch.py TestTorchDeviceTypeCPU.test_diag_cpu"
+#
+# If a test takes dtypes, then the dtype will also be appended, so the test
+# name will be <name>_<device_type>_<dtype>, and can be run directly with
+# "python test_torch.py TestTorchDeviceTypeCPU.test_neg_cpu_torch.float"
+#
+# Particular test suites can be run using pytest filtering. For example,
+# "pytest test_torch.py -k 'test_diag'"
+# will run test_diag on every device (and with every dtype, if applicable).
+# To specify particular device types or dtypes the 'and' keyword can be used:
+# "pytest test_torch.py -k 'test_diag and cpu'"
+# "pytest test_torch.py -k 'test_neg and cuda and float"
+# pytest filtering also makes it easy to run all tests on a particular device
+# type or all tests for a particular dtype.
+#
+# [ADDING A DEVICE TYPE]
+#
+# To add a device type:
+#
+#   (1) Create a new "TestBase" extending DeviceTypeTestBase.
+#       See CPUTestBase and CUDATestBase below.
+#   (2) Define the "device_type" attribute of the base to be the
+#       appropriate string.
+#   (3) Add logic to this file that appends your base class to
+#       device_type_test_bases when your device type is available.
+#   (4) (Optional) Define the "supported_dtypes" attribute to
+#       a list of dtypes your device type supports.
+#   (5) (Optional) Write setUpClass/tearDownClass class methods.
+#   (6) (Optional) Override the _check_if_skip method.
+#
+# Device type tests are created BEFORE setUpClass is called. setUpClass
+# is only called if those tests are being run, and so can initialize
+# devices. The setUpClass method might be used, for example, to inspect
+# the available software and hardware and change the supported_dtypes attribute
+# or dynamically exclude some tests.
+#
+# Before each test is run the _check_if_skip method is called. This method
+# can use the information defined in setUpClass to determine if a test should
+# be run. See below for examples.
+#
+
+# List of device type test bases that can be used to instantiate tests
+device_type_test_bases = []
+
+# List of all Torch dtypes
+all_dtypes = [torch.float, torch.double, torch.half, torch.uint8,
+              torch.int8, torch.short, torch.int, torch.long, torch.bool]
+
+# Holds dtype metadata that applies to all device types (unless overriden)
+# test_name : str -> iterable of Torch dtypes
+_generic_test_dtypes = {}
+
+# Holds dependency metadata that applies to all device types
+# test_name : str -> list of (dependency : [bool, str], skip reason : str) tuples
+_generic_test_deps = {}
+
+class DeviceTypeTestBase(TestCase):
+    device_type = "generic_device_type"
+    supported_dtypes = all_dtypes
+
+    @classmethod
+    def _get_dtypes(cls, test):
+        if hasattr(cls, 'dtypes') and test.__name__ in cls.dtypes:
+            return cls.dtypes[test.__name__]
+        return _generic_test_dtypes.get(test.__name__, None)
+
+    def _check_if_skip(self, test, dtype=None):
+        # Checks if dtype is supported
+        if dtype is not None and dtype not in self.supported_dtypes:
+            reason = "unsupported dtype '{0}'".format(str(dtype))
+            raise unittest.SkipTest(reason)
+
+        # Checks dependencies
+        if hasattr(self, 'deps'):
+            deps = self.deps.get(test.__name__, [])
+            deps.extend(_generic_test_deps.get(test.__name__, []))
+            for dep, reason in deps:
+                if isinstance(dep, int) and dep:
+                    raise unittest.SkipTest(reason)
+                elif isinstance(dep, str) and hasattr(self, dep) and not getattr(self, dep):
+                    raise unittest.SkipTest(reason)
+
+    # Creates device-specific tests.
+    # Note: called after all non-test members of the generic class have
+    # been ported.
+    @classmethod
+    def instantiate_test(cls, test):
+        test_name = test.__name__ + "_" + cls.device_type
+
+        dtypes = cls._get_dtypes(test)
+        if dtypes is None or len(dtypes) == 0:
+            # Test has no dtype variants
+            def instantiated_test(self, test=test):
+                self._check_if_skip(test)
+                return test(self, cls.device_type)
+
+            setattr(cls, test_name, instantiated_test)
+        else:
+            # Test has dtype variants
+            for dtype in dtypes:
+                dtype_test_name = test_name + "_" + str(dtype)
+
+                def instantiated_test(self, test=test, dtype=dtype):
+                    self._check_if_skip(test, dtype=dtype)
+                    return test(self, cls.device_type, dtype)
+
+                setattr(cls, dtype_test_name, instantiated_test)
+
+class CPUTestBase(DeviceTypeTestBase):
+    device_type = "cpu"
+    dtypes = {}  # Holds device-specific dtype metadata
+    deps = {}  # Holds device-specific dependency metadata
+
+    @classmethod
+    def setUpClass(cls):
+        cls.lapack = torch._C.has_lapack
+
+class CUDATestBase(DeviceTypeTestBase):
+    device_type = "cuda"
+    dtypes = {}  # Holds device-specific dtype metadata
+    deps = {}  # Holds device-specific dependency metadata
+
+    @classmethod
+    def setUpClass(cls):
+        # has_magma shows up after cuda is initialized
+        torch.ones(1).cuda()
+        cls.magma = torch.cuda.has_magma
+
+# Adds available device-type-specific classes
+device_type_test_bases.append(CPUTestBase)
+if torch.cuda.is_available():
+    device_type_test_bases.append(CUDATestBase)
+
+# Adds 'instantiated' device-specific test cases to the given scope.
+# The tests in these test cases are derived from the generic tests in
+# generic_test_class.
+# See note "Generic Device Type Testing."
+def instantiate_device_type_tests(generic_test_class, scope):
+    assert generic_test_class.__name__.startswith('_'), \
+        "Generic device type test class name should start with _"
+
+    # Creates an 'empty' version of the generic_test_class
+    empty_name = generic_test_class.__name__[1:] + "_base"
+    empty_class = type(empty_name, (generic_test_class.__base__,), {})
+
+    generic_members = set(dir(generic_test_class)) - set(dir(empty_class))
+    generic_tests = [x for x in generic_members if x.startswith('test_')]
+    generic_nontests = generic_members - set(generic_tests)
+    for base in device_type_test_bases:
+        # Creates the device-specific test case
+        class_name = generic_test_class.__name__[1:] + base.device_type.upper()
+        device_type_test_class = type(class_name, (base, empty_class), {})
+
+        # Ports non_tests from the generic_test_class
+        for name in generic_nontests:
+            nontest = getattr(generic_test_class, name)
+            assert not hasattr(device_type_test_class, name), \
+                "Device-specific test class attribute redefinition"
+            setattr(device_type_test_class, name, nontest)
+
+        # Instantiates device-specific tests
+        for name in generic_tests:
+            test = getattr(generic_test_class, name)
+            assert not hasattr(device_type_test_class, name), \
+                "Device-specific test class attribute redefinition"
+            device_type_test_class.instantiate_test(test)
+
+        # Mimics defining the instantiated class in the caller's file
+        # by setting its module to the given class's and adding
+        # the module to the given scope.
+        # This lets the instantiated class be discovered by unittest.
+        device_type_test_class.__module__ = generic_test_class.__module__
+        scope[class_name] = device_type_test_class
+
+def _get_base(device_type):
+    for base in device_type_test_bases:
+        if device_type == base.device_type:
+            return base
+    return None
+
+# Decorator that specifies a variant of the test for each of the given
+# dtypes should be instantiated. If device_type is None then the
+# variants are instantiated for all device types (unless overridden).
+# for all device types (unless overridden). Setting device_type
+# will override previous @dtypes decorations for that device type.
+class dtypes(object):
+
+    def __init__(self, *args, device_type=None):
+        self.args = args
+        self.device_type = device_type
+
+    def __call__(self, fn):
+        if self.device_type is None:
+            _generic_test_dtypes[fn.__name__] = self.args
+        else:
+            base = _get_base(self.device_type)
+            if base is not None:
+                base.dtypes[fn.__name__] = self.args
+        return fn
+
+# Sugar for @dtypes(..., device_type='cpu')
+class dtypesIfCPU(dtypes):
+
+    def __init__(self, *args):
+        super(dtypesIfCPU, self).__init__(*args, device_type='cpu')
+
+# Sugar for @dtypes(..., device_type='cuda')
+class dtypesIfCUDA(dtypes):
+
+    def __init__(self, *args):
+        super(dtypesIfCUDA, self).__init__(*args, device_type='cuda')
+
+# Decorator that specifes when to skip a test. If device_type is None
+# then the dependency is required for all device_types. Unlike @dtypes,
+# dependencies are extended, not overwritten, by later calls.
+# Dependencies can either be booleans or strings specifiying an
+# attribute. If the latter, the test is skipped if the class has the attribute
+# and it's false.
+class skipIf(object):
+
+    def __init__(self, dep, reason, device_type=None):
+        self.dep = dep
+        self.reason = reason
+        self.device_type = device_type
+
+    def __call__(self, fn):
+        if self.device_type is None:
+            if fn.__name__ not in _generic_test_deps:
+                _generic_test_deps[fn.__name__] = []
+            _generic_test_deps[fn.__name__].append((self.dep, self.reason))
+        else:
+            base = _get_base(self.device_type)
+            if base is not None:
+                if fn.__name__ not in base.deps:
+                    base.deps[fn.__name__] = []
+                base.deps[fn.__name__].append((self.dep, self.reason))
+        return fn
+
+# Sugar for @skipIf(..., device_type='cpu')
+class skipCPUIf(skipIf):
+
+    def __init__(self, dep, reason):
+        super(skipCPUIf, self).__init__(dep, reason, device_type='cpu')
+
+# Sugar for @skipIf(..., device_type='cuda')
+class skipCUDAIf(skipIf):
+
+    def __init__(self, dep, reason):
+        super(skipCUDAIf, self).__init__(dep, reason, device_type='cuda')
+
+# Sugar for @skipCPUIf('lapack', "PyTorch compiled without Lapack")
+def skipCPUIfNoLapack(fn):
+    skipper = skipCPUIf('lapack', "PyTorch compiled without Lapack")
+    skipper(fn)
+    return fn
+
+# Sugar for @skipCUDAIf('magma', "no MAGMA library detected")
+def skipCUDAIfNoMagma(fn):
+    skipper = skipCUDAIf('magma', "no MAGMA library detected")
+    skipper(fn)
+    return fn

--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -1,9 +1,7 @@
-import sys
-from functools import wraps
 import unittest
 
 import torch
-from common_utils import TestCase, CudaMemoryLeakCheck
+from common_utils import TestCase
 
 # Note: Generic Device-Type Testing
 #

--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -1,6 +1,6 @@
-import types
+import inspect
+from functools import wraps
 import unittest
-
 import torch
 from common_utils import TestCase
 
@@ -8,47 +8,69 @@ from common_utils import TestCase
 #
 # [WRITING TESTS]
 #
-# To write a test that runs on a variety of devices do the following:
+# Write your test class as usual except:
+#   (1) Only define test methods in the test class itself. Helper methods
+#       and non-methods must be inherited. This limitation is for Python2
+#       compatibility.
+#   (2) Each test method should have have the signature
+#           testX(self, device)
+#       OR
+#           testX(self, device, dtype)
+#       The device argument will be a string like 'cpu' or 'cuda.'
+#       If the dtype argument is in the signature the test must be decorated
+#       with a dtypes decorator (see below). This will instantiate a variant
+#       of the test for each dtype.
+#   (3) Prefer using test decorators defined in this file to others.
+#       For example, using the @skipIfNoLapack decorator instead of the
+#       @skipCPUIfNoLapack will cause the test to not run on CUDA if
+#       LAPACK is not available, which is wrong. If you need to use a
+#       decorator you may have to port it.
 #
-#   (1) Create a class, "class <name>(<base>)"
-#   (2) Write tests as usual, except they must take a 'device' argument
-#       and may take a 'dtype' argument. If the test takes the 'dtype'
-#       argument then it must specify a set of dtypes using the @dtypes
-#       decorator. Additional decorators can specialize the set of dtypes
-#       for CPU or CUDA device types.
-#
-#       The device will be a string, like 'cpu' or 'cuda,' and dtype will be a
-#       member of the set passed to @dtypes, like torch.float.
-#       The test should use the given device and dtype. See test_torch.py's
-#       TestTorchDeviceType for an example.
-#   (3) Non-test attributes, like helper methods, must go in the base class.
-#       This quirk is for Python 2 compatibility.
-#   (5) Call instantiate_device_type_tests(_<name>, globals()) in your test
-#       test script. This will create the device-specific test cases from
-#       the generic test case and make them discoverable.
-#
-# See test_torch.py for an example.
+#   See the TestTorchDeviceType class in test_torch.py for an example.
 #
 # [RUNNING TESTS]
 #
-# The above will create test classes with names <name><device_type.upper()>,
-# e.g. if the generic class is called _TestTorchDevice then the created test
-# classes will TestTorchDeviceTypeCPU and TestTorchDeviceTypeCUDA.
+# After defining your test class call instantiate_device_type_tests on it
+# and pass in globals() for the second argument. This will instantiate
+# discoverable device-specific test classes from your generic class. It will
+# also hide the tests in your generic class so they're not run directly.
 #
-# Tests like test_diag will have "_<device_type>" appended. So an instantiated
-# test can be run directly with the command
-# "python test_torch.py TestTorchDeviceTypeCPU.test_diag_cpu"
+# For each generic testX, a new test textX_<device_type> or a suite of tests
+# testX_<device_type>_<dtype> will be created, depending on whether the generic
+# test used type in its signature. These tests will be put in classes named
+# GenericTestClassName<DEVICE_TYPE>. For example, test_diagonal in TestTorchDeviceType
+# becomes test_diagonal_cpu in TestTorchDeviceTypeCPU and test_diagonal_cuda in
+# TestTorchDeviceTypeCUDA. Tests with datatypes have the "torch." part of the
+# dtype name removed, so tests instantiated from a dtype test like test_neg are
+# named test_neg_cpu_float32, test_neg_cuda_int64... These tests receive the
+# device_type and dtype corresponding to their names as arguments.
 #
-# If a test takes dtypes, then the dtype will also be appended, so the test
-# name will be <name>_<device_type>_<dtype>, and can be run directly with
-# "python test_torch.py TestTorchDeviceTypeCPU.test_neg_cpu_torch.float"
+# In short, if you write a test signature like
+#   def textX(self, device)
+# You are effectively writing
+#   def testX_cpu(self, device='cpu')
+#   def textX_cuda(self, device='cuda')
+#   def testX_xla(self, device='xla')
+#   ...
+# And if you accept a dtype
+#   @dtypes(torch.float, torch.double)
+#   def testX(self, device, dtype)
+# It becomes
+#   def testX_cpu_float32(self, device='cpu', dtype=torch.float32)
+#   def testX_cpu_float64(self, device='cpu', dtype=torch.float64)
+#   def testX_cuda_float32(self, device='cuda', dtype=torch.float32)
+#   ...
 #
-# Particular test suites can be run using pytest filtering. For example,
+# These tests can be run directly like normal tests:
+# "python test_torch.py TestTorchDeviceTypeCPU.test_diagonal_cpu"
+# "python test_torch.py TestTorchDeviceTypeCUDA.test_neg_cuda_float64"
+#
+# Collections of tests can be run using pytest filtering. For example,
 # "pytest test_torch.py -k 'test_diag'"
 # will run test_diag on every device (and with every dtype, if applicable).
 # To specify particular device types or dtypes the 'and' keyword can be used:
 # "pytest test_torch.py -k 'test_diag and cpu'"
-# "pytest test_torch.py -k 'test_neg and cuda and float"
+# "pytest test_torch.py -k 'test_neg and cuda and float'"
 # pytest filtering also makes it easy to run all tests on a particular device
 # type or all tests for a particular dtype.
 #
@@ -64,65 +86,45 @@ from common_utils import TestCase
 #       device_type_test_bases when your device type is available.
 #   (4) (Optional) Define the "supported_dtypes" attribute to
 #       a list of dtypes your device type supports.
-#   (5) (Optional) Write setUpClass/tearDownClass class methods.
-#   (6) (Optional) Override the _check_if_skip method.
+#   (5) (Optional) Write setUpClass/tearDownClass class methods that
+#       instantiate dependencies (see MAGMA in CUDATestBase).
 #
-# Device type tests are created and discovered BEFORE setUpClass is called.
-# setUpClass is called before tests are run, however.
-# setupClass is also only called if its tests are being run, and so can
-# it can initialize devices. The setUpClass method might be used, for example,
-# to inspect the available software and hardware and change the
-# supported_dtypes attribute or dynamically exclude some tests.
-#
-# Before each test is run the _check_if_skip method is called. This method
-# can use the information defined in setUpClass to determine if a test should
-# be run. See below for examples.
+# setUpClass is called AFTER tests have been created and BEFORE and ONLY IF
+# they are run. This makes it useful for initializing devices and dependencies.
 #
 
-# List of device type test bases that can be used to instantiate tests
+# List of device type test bases that can be used to instantiate tests.
+# See below for how this list is populated. If you're adding a device type
+# you should check if it's available and (if it is) and it to this list.
 device_type_test_bases = []
 
-# List of all Torch dtypes
-all_dtypes = [torch.float, torch.double, torch.half, torch.uint8,
-              torch.int8, torch.short, torch.int, torch.long, torch.bool]
-
-# Holds dtype metadata that applies to all device types (unless overriden)
-# test_name : str -> iterable of Torch dtypes
-_generic_test_dtypes = {}
-
-# Holds dependency metadata that applies to all device types
-# test_name : str -> list of (dependency : [bool, str], skip reason : str) tuples
-_generic_test_deps = {}
+# List of all Torch dtypes.
+all_dtypes = [torch.float64, torch.float32, torch.float16,
+              torch.int64, torch.int32, torch.int16, torch.int8,
+              torch.uint8, torch.bool]
 
 class DeviceTypeTestBase(TestCase):
     device_type = "generic_device_type"
     supported_dtypes = all_dtypes
 
+    # Returns the dtypes the test has requested.
+    # Prefers device-specific dtype specifications over generic ones.
     @classmethod
     def _get_dtypes(cls, test):
-        if hasattr(cls, 'dtypes') and test.__name__ in cls.dtypes:
-            return cls.dtypes[test.__name__]
-        return _generic_test_dtypes.get(test.__name__, None)
+        if not hasattr(test, 'dtypes'):
+            return None
+        d = getattr(test, 'dtypes')
+        if cls.device_type in d:
+            return d[cls.device_type]
+        return d.get('all', None)
 
-    def _check_if_skip(self, test, dtype=None):
-        # Checks if dtype is supported
-        if dtype is not None and dtype not in self.supported_dtypes:
+    # Raises unittest.SkipTest if the dtype in not in supported_dtypes.
+    def _skip_if_unsupported_dtype(self, dtype):
+        if dtype not in self.supported_dtypes:
             reason = "unsupported dtype '{0}'".format(str(dtype))
             raise unittest.SkipTest(reason)
 
-        # Checks dependencies
-        if hasattr(self, 'deps'):
-            deps = self.deps.get(test.__name__, [])
-            deps.extend(_generic_test_deps.get(test.__name__, []))
-            for dep, reason in deps:
-                if isinstance(dep, int) and dep:
-                    raise unittest.SkipTest(reason)
-                elif isinstance(dep, str) and hasattr(self, dep) and not getattr(self, dep):
-                    raise unittest.SkipTest(reason)
-
     # Creates device-specific tests.
-    # Note: called after all non-test members of the generic class have
-    # been ported. Called
     @classmethod
     def instantiate_test(cls, test):
         test_name = test.__name__ + "_" + cls.device_type
@@ -130,44 +132,43 @@ class DeviceTypeTestBase(TestCase):
         dtypes = cls._get_dtypes(test)
         if dtypes is None or len(dtypes) == 0:
             # Test has no dtype variants
+            @wraps(test)
             def instantiated_test(self, test=test):
-                self._check_if_skip(test)
                 return test(self, cls.device_type)
 
             setattr(cls, test_name, instantiated_test)
         else:
             # Test has dtype variants
             for dtype in dtypes:
-                dtype_test_name = test_name + "_" + str(dtype)
+                dtype_str = str(dtype).rsplit('.', maxsplit=1)[1]
+                dtype_test_name = test_name + "_" + dtype_str
 
+                @wraps(test)
                 def instantiated_test(self, test=test, dtype=dtype):
-                    self._check_if_skip(test, dtype=dtype)
+                    self._skip_if_unsupported_dtype(dtype)
                     return test(self, cls.device_type, dtype)
 
                 setattr(cls, dtype_test_name, instantiated_test)
 
 class CPUTestBase(DeviceTypeTestBase):
     device_type = "cpu"
-    dtypes = {}  # Holds device-specific dtype metadata
-    deps = {}  # Holds device-specific dependency metadata
 
     @classmethod
     def setUpClass(cls):
-        cls.lapack = torch._C.has_lapack
+        cls.has_lapack = torch._C.has_lapack
 
 class CUDATestBase(DeviceTypeTestBase):
     device_type = "cuda"
-    dtypes = {}  # Holds device-specific dtype metadata
-    deps = {}  # Holds device-specific dependency metadata
     _do_cuda_memory_leak_check = True
+    _do_cuda_non_default_stream = True
 
     @classmethod
     def setUpClass(cls):
         # has_magma shows up after cuda is initialized
         torch.ones(1).cuda()
-        cls.magma = torch.cuda.has_magma
+        cls.has_magma = torch.cuda.has_magma
 
-# Adds available device-type-specific classes
+# Adds available device-type-specific test base classes
 device_type_test_bases.append(CPUTestBase)
 if torch.cuda.is_available():
     device_type_test_bases.append(CUDATestBase)
@@ -182,34 +183,37 @@ def instantiate_device_type_tests(generic_test_class, scope):
     del scope[generic_test_class.__name__]
 
     # Creates an 'empty' version of the generic_test_class
+    # Note: we don't inherit from the generic_test_class directly because
+    #   that would add its tests to our test classes and they would be
+    #   discovered (despite not being runnable). Inherited methods also
+    #   can't be removed later, and we can't rely on load_tests because
+    #   pytest doesn't support it (as of this writing).
     empty_name = generic_test_class.__name__ + "_base"
-    empty_class = type(empty_name, (generic_test_class.__base__,), {})
+    empty_class = type(empty_name, generic_test_class.__bases__, {})
 
-    # Acquires member names
+    # Acquires members names
     generic_members = set(dir(generic_test_class)) - set(dir(empty_class))
-    generic_tests = [x for x in generic_members if x.startswith('test_')]
+    generic_tests = [x for x in generic_members if x.startswith('test')]
+
+    # Checks that the generic test suite only has test members
+    # Note: for Python2 compat.
+    # Note: Nontest members can be inherited, so if you want to use a helper
+    #   function you can put it in a base class.
     generic_nontests = generic_members - set(generic_tests)
-
-    assert len(generic_nontests) == 0, "Generic device class has non-test attributes"
-
-    # Makes all tests in generic_test_class staticmethods
-    # Note: necessary for Python 2 compatibility
-    for test in generic_tests:
-        fn = staticmethod(getattr(generic_test_class, test))
-        setattr(generic_test_class, test, fn)
+    assert len(generic_nontests) == 0, "Generic device class has non-test members"
 
     for base in device_type_test_bases:
         # Creates the device-specific test case
         class_name = generic_test_class.__name__ + base.device_type.upper()
         device_type_test_class = type(class_name, (base, empty_class), {})
 
-        # Instantiates device-specific tests
         for name in generic_tests:
-            assert not hasattr(device_type_test_class, name), \
-                "Device-specific test class attribute '{0}' redefinition".format(name)
+            # Attempts to acquire a function from the attribute
             test = getattr(generic_test_class, name)
             if hasattr(test, '__func__'):
                 test = test.__func__
+            assert inspect.isfunction(test), "Couldn't extract function from '{0}'".format(name)
+            # Instantiates the device-specific tests
             device_type_test_class.instantiate_test(test)
 
         # Mimics defining the instantiated class in the caller's file
@@ -219,90 +223,95 @@ def instantiate_device_type_tests(generic_test_class, scope):
         device_type_test_class.__module__ = generic_test_class.__module__
         scope[class_name] = device_type_test_class
 
-def _get_base(device_type):
-    for base in device_type_test_bases:
-        if device_type == base.device_type:
-            return base
-    return None
-
 # Decorator that specifies a variant of the test for each of the given
-# dtypes should be instantiated. If device_type is None then the
-# variants are instantiated for all device types (unless overridden).
-# for all device types (unless overridden). Setting device_type
-# will override previous @dtypes decorations for that device type.
+# dtypes should be instantiated.
+# Notes:
+#   (1) Tests that accept the dtype argument MUST use this decorator, the
+#       allDtypes decorator, or the allDtypesExcept decorator so the test will
+#       work with new device types.
+#   (2) Can be overriden using dtypesIfCPU or dtypesIfCUDA.
+#   (3) Prefer the existing decorators to using kwargs here.
 class dtypes(object):
 
+    # Note: *args, **kwargs for Python2 compat.
+    # Python 3 allows (self, *args, device_type='all).
     def __init__(self, *args, **kwargs):
+        assert all(arg in all_dtypes for arg in args), "Unknown dtype in {0}".format(str(args))
         self.args = args
-        self.device_type = kwargs.get('device_type', None)
+        self.device_type = kwargs.get('device_type', 'all')
 
     def __call__(self, fn):
-        if self.device_type is None:
-            _generic_test_dtypes[fn.__name__] = self.args
-        else:
-            base = _get_base(self.device_type)
-            if base is not None:
-                base.dtypes[fn.__name__] = self.args
+        d = getattr(fn, 'dtypes', {})
+        assert self.device_type not in d, "dtypes redefinition for {0}".format(self.device_type)
+        d[self.device_type] = self.args
+        setattr(fn, 'dtypes', d)
         return fn
 
-# Sugar for @dtypes(..., device_type='cpu')
+# Sugar that requests a variant of the test for each dtype.
+def allDtypes(fn):
+    return dtypes(*all_dtypes)(fn)
+
+# Sugar that requests a variant of the test for each dtype EXCEPT those given.
+class allDtypesExcept(dtypes):
+
+    def __init__(self, *args):
+        filtered = [x for x in all_dtypes if x not in args]
+        super(allDtypesExcept, self).__init__(*filtered)
+
+# Overrides specified dtypes on the CPU.
 class dtypesIfCPU(dtypes):
 
     def __init__(self, *args):
         super(dtypesIfCPU, self).__init__(*args, device_type='cpu')
 
-# Sugar for @dtypes(..., device_type='cuda')
+# Overrides specified dtypes on CUDA.
 class dtypesIfCUDA(dtypes):
 
     def __init__(self, *args):
         super(dtypesIfCUDA, self).__init__(*args, device_type='cuda')
 
-# Decorator that specifes when to skip a test. If device_type is None
-# then the dependency is required for all device_types. Unlike @dtypes,
-# dependencies are extended, not overwritten, by later calls.
-# Dependencies can either be booleans or strings specifiying an
-# attribute. If the latter, the test is skipped if the class has the attribute
-# and it's false.
+# Decorator that specifies a test dependency.
+# Notes:
+#   (1) Dependencies stack. Multiple dependencies are all evaluated.
+#   (2) Dependencies can either be bools or strings. If a string the
+#       test base must have defined the corresponding attribute to be True
+#       for the test to run. If you want to use a string argument you should
+#       probably define a new decorator instead (see below).
+#   (3) Prefer the existing decorators to defining the 'device_type' kwarg.
 class skipIf(object):
 
-    def __init__(self, dep, reason, device_type=None):
+    def __init__(self, dep, reason, device_type='all'):
         self.dep = dep
         self.reason = reason
         self.device_type = device_type
 
     def __call__(self, fn):
-        if self.device_type is None:
-            if fn.__name__ not in _generic_test_deps:
-                _generic_test_deps[fn.__name__] = []
-            _generic_test_deps[fn.__name__].append((self.dep, self.reason))
-        else:
-            base = _get_base(self.device_type)
-            if base is not None:
-                if fn.__name__ not in base.deps:
-                    base.deps[fn.__name__] = []
-                base.deps[fn.__name__].append((self.dep, self.reason))
-        return fn
 
-# Sugar for @skipIf(..., device_type='cpu')
+        @wraps(fn)
+        def dep_fn(slf, device, *args, **kwargs):
+            if self.device_type == 'all' or self.device_type == slf.device_type:
+                if not self.dep or (isinstance(self.dep, str) and not getattr(slf, self.dep, False)):
+                    raise unittest.SkipTest(self.reason)
+
+            return fn(slf, device, *args, **kwargs)
+        return dep_fn
+
+# Specifies a CPU dependency.
 class skipCPUIf(skipIf):
 
     def __init__(self, dep, reason):
         super(skipCPUIf, self).__init__(dep, reason, device_type='cpu')
 
-# Sugar for @skipIf(..., device_type='cuda')
+# Specifies a CUDA dependency.
 class skipCUDAIf(skipIf):
 
     def __init__(self, dep, reason):
         super(skipCUDAIf, self).__init__(dep, reason, device_type='cuda')
 
-# Sugar for @skipCPUIf('lapack', "PyTorch compiled without Lapack")
+# Specifies LAPACK as a CPU dependency.
 def skipCPUIfNoLapack(fn):
-    skipper = skipCPUIf('lapack', "PyTorch compiled without Lapack")
-    skipper(fn)
-    return fn
+    return skipCPUIf(torch._C.has_lapack, "PyTorch compiled without Lapack")(fn)
 
-# Sugar for @skipCUDAIf('magma', "no MAGMA library detected")
+# Specifies MAGMA as a CUDA dependency.
 def skipCUDAIfNoMagma(fn):
-    skipper = skipCUDAIf('magma', "no MAGMA library detected")
-    skipper(fn)
-    return fn
+    return skipCUDAIf('has_magma', "no MAGMA library detected")(fn)

--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -12,7 +12,7 @@ from common_utils import TestCase
 #   (1) Only define test methods in the test class itself. Helper methods
 #       and non-methods must be inherited. This limitation is for Python2
 #       compatibility.
-#   (2) Each test method should have have the signature
+#   (2) Each test method should have the signature
 #           testX(self, device)
 #       The device argument will be a string like 'cpu' or 'cuda.'
 #   (3) Prefer using test decorators defined in this file to others.
@@ -87,6 +87,8 @@ class DeviceTypeTestBase(TestCase):
     def instantiate_test(cls, test):
         test_name = test.__name__ + "_" + cls.device_type
 
+        assert not hasattr(cls, test_name), "Redefinition of test {0}".format(test_name)
+
         @wraps(test)
         def instantiated_test(self, test=test):
             return test(self, cls.device_type)
@@ -121,7 +123,7 @@ if torch.cuda.is_available():
 # generic_test_class.
 # See note "Generic Device Type Testing."
 def instantiate_device_type_tests(generic_test_class, scope):
-    # Removes the generic test class from its enclosing scope so it's tests
+    # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.
     del scope[generic_test_class.__name__]
 
@@ -177,7 +179,7 @@ def instantiate_device_type_tests(generic_test_class, scope):
 #   (3) Prefer the existing decorators to defining the 'device_type' kwarg.
 class skipIf(object):
 
-    def __init__(self, dep, reason, device_type='all'):
+    def __init__(self, dep, reason, device_type=None):
         self.dep = dep
         self.reason = reason
         self.device_type = device_type
@@ -186,7 +188,7 @@ class skipIf(object):
 
         @wraps(fn)
         def dep_fn(slf, device, *args, **kwargs):
-            if self.device_type == 'all' or self.device_type == slf.device_type:
+            if self.device_type is None or self.device_type == slf.device_type:
                 if not self.dep or (isinstance(self.dep, str) and not getattr(slf, self.dep, False)):
                     raise unittest.SkipTest(self.reason)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1094,9 +1094,6 @@ class TestCuda(TestCase):
             for num in abs_zeros:
                 self.assertGreater(math.copysign(1.0, num), 0.0)
 
-    def test_neg(self):
-        _TestTorchMixin._test_neg(self, lambda t: t.cuda())
-
     def test_bitwise_not(self):
         _TestTorchMixin._test_bitwise_not(self, 'cuda')
 
@@ -2206,10 +2203,6 @@ class TestCuda(TestCase):
     def _select_broadcastable_dims(dims_full=None):
         return _TestTorchMixin._select_broadcastable_dims(dims_full)
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_inverse(self):
-        _TestTorchMixin._test_inverse(self, lambda t: t.cuda())
-
     @slowTest
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_inverse_many_batches(self):
@@ -2745,9 +2738,6 @@ class TestCuda(TestCase):
 
     def test_lerp(self):
         _TestTorchMixin._test_lerp(self, lambda t: t.cuda())
-
-    def test_diagonal(self):
-        _TestTorchMixin._test_diagonal(self, dtype=torch.float32, device='cuda')
 
     def test_diagflat(self):
         _TestTorchMixin._test_diagflat(self, dtype=torch.float32, device='cuda')

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -33,7 +33,6 @@ from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MK
     IS_SANDCASTLE, load_tests, brute_pdist, brute_cdist, slowTest, torchtest, TEST_WITH_ROCM
 from multiprocessing.reduction import ForkingPickler
 from common_device_type import instantiate_device_type_tests, dtypes, \
-    dtypesIfCPU, dtypesIfCUDA, skipIf, skipCPUIf, skipCUDAIf, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma
 
 # load_tests from common_utils is used to automatically filter tests for

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13327,7 +13327,7 @@ def add_neg_dim_tests():
         setattr(_TestTorchMixin, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
 # Device-agnostic tests. Instantiated below and not run directly.
-class _TestTorchDeviceType(object):
+class TestTorchDeviceType(TestCase):
     def test_diagonal(self, device):
         x = torch.randn((100, 100), device=device)
         result = torch.diagonal(x)
@@ -13445,7 +13445,7 @@ class _TestTorchDeviceType(object):
         self.assertEqual(matrices_inverse, expected_inv.to(device))
 
 add_neg_dim_tests()
-instantiate_device_type_tests(_TestTorchDeviceType, globals())
+instantiate_device_type_tests(TestTorchDeviceType, globals())
 
 class TestTorch(TestCase, _TestTorchMixin):
     pass

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13340,9 +13340,17 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(result, expected)
 
     @dtypes(torch.float, torch.double, torch.long, torch.int, torch.short,
-            torch.uint8, torch.int8)
+            torch.uint8, torch.int8, torch.bool)
     def test_neg(self, device, dtype):
         float_types = [torch.float, torch.double, torch.long]
+
+        if dtype == torch.bool:
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"Negation, the `\-` operator, on a bool tensor is not supported. "
+                r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
+                lambda: - torch.tensor([False, True], device=device))
+            return
 
         if dtype in float_types:
             a = torch.randn(100, 90).type(dtype).to(device)
@@ -13366,13 +13374,6 @@ class TestTorchDeviceType(TestCase):
         # test via __neg__ operator
         res_neg_op = -a.clone()
         self.assertEqual(res_neg_op, res_add)
-
-        # bool
-        self.assertRaisesRegex(
-            RuntimeError,
-            r"Negation, the `\-` operator, on a bool tensor is not supported. "
-            r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
-            lambda: - torch.tensor([False, True], device=device))
 
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13343,12 +13343,12 @@ class TestTorchDeviceType(TestCase):
         int_types = [torch.int, torch.short, torch.int8, torch.uint8]
         float_types = [torch.float, torch.double, torch.long]
 
+        # Tests bool tensor negation raises the correct error
         self.assertRaisesRegex(
             RuntimeError,
             r"Negation, the `\-` operator, on a bool tensor is not supported. "
             r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
             lambda: - torch.tensor([False, True], device=device))
-        return
 
         for dtype in float_types + int_types:
             if dtype in float_types:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -13326,7 +13326,7 @@ def add_neg_dim_tests():
         assert not hasattr(_TestTorchMixin, test_name), "Duplicated test name: " + test_name
         setattr(_TestTorchMixin, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
-# Device-agnostic tests. Instantiated below and not run directly.
+# Device-generic tests. Instantiated below and not run directly.
 class TestTorchDeviceType(TestCase):
     def test_diagonal(self, device):
         x = torch.randn((100, 100), device=device)


### PR DESCRIPTION
This PR addresses #24851 by...

1. lets device types easily register themselves for testing
2. lets tests be written to run on multiple devices and with multiple dtypes
3. provides a mechanism to instantiate those tests so they are discoverable and filterable by unittest and pytest

It refactors three tests from test_torch.py to demonstrate how to use it. 

`test_diagonal` is the simplest example. Most tests just need to be modified to accept 'device' as an argument. The framework will then instantiate `test_diagonal_cpu` and `test_diagonal_cuda` (when CUDA is available) which call `test_diagonal` with the appropriate 'device' argument.

`test_neg` also has dtype variants. It accepts both 'device' and 'dtype' as arguments, and the dtypes it runs with are specified with the 'dtypes' decorator. Dtypes can be specified for all device types and particular device types. The framework instantiates tests like `test_neg_cpu_torch.float`.

`test_inverse` has device-specific dependencies. These dependencies are expressed with the sugary 'skipCUDAIfNoMagma' and 'skipCPUIfNoLapack' decorators. These decorators are device-specific so CPU testing is not skipped if Magma is not installed, and there conditions may be checked after or before the test case has been initialized. This means that skipCUDAIfNoMagma does not initialize CUDA. In fact, CUDA is only initialized if a CUDA test is run.

These instantiated tests may be run as usual and with pytest filtering it's easy to run one test on all device types, run all the tests for a particular device type, or run a device type and dtype combination. 

See the note "Generic Device-Type Testing" for more detail.
