### PR TITLE
Implementation of constant-then-linear warmup learning rate policy

### DIFF
--- a/caffe2/sgd/learning_rate_op.cc
+++ b/caffe2/sgd/learning_rate_op.cc
@@ -33,6 +33,8 @@ Required:
    `hill`: uses those in both `linearWarmup` and `inv`, plus `end_multiplier`
    `composite`: uses `sub_policy_num_iters` and additional args with format
    `cyclic`: uses `max_lr`, `stepsize`
+   `constantThenLinearWarmup`: uses `start_warmup_multiplier`, `constant_warmup_num_iter`, `linear_warmup_num_iter`
+   `compositeCyclical`: uses `start_warmup_multiplier`, `constant_warmup_num_iter`, `linear_warmup_num_iter`, `cyclical_max_lr`, `cyclical_step_size`, `cyclical_decay`
    sub_policy_{sub_policy_index}_{sub_policy_arg}, for example:
    sub_policy_0_policy: "exp", sub_policy_0_gamma: 0.99,
    sub_policy_0_lr_scale: 1.2
@@ -54,7 +56,12 @@ Optional:
   `m2`: defaults to 0.5, the second piece lr of piece warmup
   `n2`: defaults to 0, iter threshold of the second piece lr
   `m3`: defaults to 0.5, the third piece lr of piece warmup
-
+  `start_warmup_multiplier`: defaults to 0.1, part of constantThenLinearWarmup
+  `constant_warmup_num_iter`: defaults to 10000000, part of constantThenLinearWarmup and constantThenLinearWarmup
+  `linear_warmup_num_iter`: defaults to 10000000, part of constantThenLinearWarmup and CompositeCyclicalLRPolicy
+  `cyclical_max_lr`: defaults to 0.05, part of CompositeCyclicalLRPolicy
+  `cyclical_step_size`: defaults to 1000000, part of CompositeCyclicalLRPolicy
+  `cyclical_decay`: defaults to 1.0, part of CompositeCyclicalLRPolicy
 
 Usage:
   train_net.LearningRate(*iterations*, "*label*", base_lr=*float*,
@@ -101,6 +108,18 @@ Example usage:
     .Arg("m2", "")
     .Arg("n2", "")
     .Arg("m3", "")
+    .Arg("start_warmup_multiplier", "defaults to 0.1")
+    .Arg("constant_warmup_num_iter", "defaults to 10000000")
+    .Arg("linear_warmup_num_iter", "defaults to 10000000")
+    .Arg(
+        "cyclical_max_lr",
+        "defaults to 0.05, part of CompositeCyclicalLRPolicy")
+    .Arg(
+        "cyclical_step_size",
+        "defaults to 1000000, part of CompositeCyclicalLRPolicy")
+    .Arg(
+        "cyclical_decay",
+        "defaults to 0.999, part of CompositeCyclicalLRPolicy")
     .Input(0, "input", "description needed")
     .Output(0, "output", "description needed")
     .DeviceInferenceFunction([](const OperatorDef& def) {
@@ -110,4 +129,4 @@ Example usage:
     });
 
 NO_GRADIENT(LearningRate);
-}  // namespace caffe2
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Constant-then-linear warmup learning rate policy:
* first use a constant warm up
* then ramp up to the fixed learning rate linearly

Test Plan:
* buck test: https://our.intern.facebook.com/intern/testinfra/testconsole/testrun/5910974518377039/
* checked the consistency of learning rates w.r.t. iterations with offline simulation

Differential Revision: D17302632

