### PR TITLE
[pt1][quant] Use BytesIO instead of tempfile

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -11,7 +11,7 @@ from torch.quantization import \
     quantize_dynamic, default_qconfig, default_qat_qconfig, \
     default_dynamic_qconfig, MinMaxObserver, QuantWrapper
 
-from common_utils import run_tests, tempfile
+from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
     SkipQuantModel, QuantStubModel, \
     ModelForFusion, ManualLinearQATModel, ManualConvLinearQATModel, \
@@ -589,10 +589,10 @@ class ScriptabilityTest(QuantizationTestCase):
 
     def test_scriptability_serialization(self):
         # test serialization of quantized functional modules
-        with tempfile.TemporaryFile() as f:
-            torch.save(self.qmodel_under_test, f)
-            f.seek(0)
-            loaded = torch.load(f)
+        b = io.BytesIO()
+        torch.save(self.qmodel_under_test, b)
+        b.seek(0)
+        loaded = torch.load(b)
         self.assertEqual(self.qmodel_under_test.myadd.zero_point, loaded.myadd.zero_point)
         state_dict = self.qmodel_under_test.state_dict()
         self.assertTrue('myadd.zero_point' in state_dict.keys(),

--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -6,7 +6,7 @@ import torch.nn.quantized.functional as qF
 from torch.nn.quantized.modules import Conv2d
 from torch.nn._intrinsic.quantized import ConvReLU2d
 import torch.quantization
-from common_utils import run_tests, tempfile
+from common_utils import run_tests
 from common_quantization import QuantizationTestCase, prepare_dynamic
 from common_quantized import _calculate_dynamic_qparams
 from hypothesis import given
@@ -130,10 +130,10 @@ class DynamicModuleAPITest(QuantizationTestCase):
         self.assertEqual(model_dict['weight'], W_q)
         if use_bias:
             self.assertEqual(model_dict['bias'], B)
-        with tempfile.TemporaryFile() as f:
-            torch.save(model_dict, f)
-            f.seek(0)
-            loaded_dict = torch.load(f)
+        b = io.BytesIO()
+        torch.save(model_dict, b)
+        b.seek(0)
+        loaded_dict = torch.load(b)
         for key in model_dict:
             self.assertEqual(model_dict[key], loaded_dict[key])
         loaded_qlinear = nnqd.Linear(in_features, out_features)
@@ -156,10 +156,10 @@ class DynamicModuleAPITest(QuantizationTestCase):
         self.assertEqual(Z_dq, Z_dq2)
 
         # test serialization of module directly
-        with tempfile.TemporaryFile() as f:
-            torch.save(qlinear, f)
-            f.seek(0)
-            loaded = torch.load(f)
+        b = io.BytesIO()
+        torch.save(qlinear, b)
+        b.seek(0)
+        loaded = torch.load(b)
         # This check is disabled pending an issue in PyTorch serialization:
         # https://github.com/pytorch/pytorch/issues/24045
         # self.assertEqual(qlinear.weight(), loaded.weight())
@@ -256,10 +256,10 @@ class ModuleAPITest(QuantizationTestCase):
         self.assertEqual(model_dict['weight'], W_q)
         if use_bias:
             self.assertEqual(model_dict['bias'], B_q)
-        with tempfile.TemporaryFile() as f:
-            torch.save(model_dict, f)
-            f.seek(0)
-            loaded_dict = torch.load(f)
+        b = io.BytesIO()
+        torch.save(model_dict, b)
+        b.seek(0)
+        loaded_dict = torch.load(b)
         for key in model_dict:
             self.assertEqual(model_dict[key], loaded_dict[key])
         if use_fused:
@@ -286,10 +286,10 @@ class ModuleAPITest(QuantizationTestCase):
         self.assertEqual(Z_q, Z_q2)
 
         # test serialization of module directly
-        with tempfile.TemporaryFile() as f:
-            torch.save(qlinear, f)
-            f.seek(0)
-            loaded = torch.load(f)
+        b = io.BytesIO()
+        torch.save(qlinear, b)
+        b.seek(0)
+        loaded = torch.load(b)
         # This check is disabled pending an issue in PyTorch serialization:
         # https://github.com/pytorch/pytorch/issues/24045
         # self.assertEqual(qlinear.weight(), loaded.weight())
@@ -426,10 +426,10 @@ class ModuleAPITest(QuantizationTestCase):
         self.assertEqual(model_dict['weight'], qw)
         if use_bias:
             self.assertEqual(model_dict['bias'], qb)
-        with tempfile.NamedTemporaryFile() as f:
-            torch.save(model_dict, f)
-            f.seek(0)
-            loaded_dict = torch.load(f)
+        b = io.BytesIO()
+        torch.save(model_dict, b)
+        b.seek(0)
+        loaded_dict = torch.load(b)
         for key in model_dict:
             self.assertEqual(loaded_dict[key], model_dict[key])
         if use_fused:
@@ -468,10 +468,10 @@ class ModuleAPITest(QuantizationTestCase):
         loaded_result = loaded_conv_under_test(qX)
         self.assertEqual(loaded_result, result_reference)
 
-        with tempfile.NamedTemporaryFile() as f:
-            torch.save(conv_under_test, f)
-            f.seek(0)
-            loaded_conv = torch.load(f)
+        b = io.BytesIO()
+        torch.save(conv_under_test, b)
+        b.seek(0)
+        loaded_conv = torch.load(b)
 
         self.assertEqual(conv_under_test.bias, loaded_conv.bias)
         self.assertEqual(conv_under_test.scale, loaded_conv.scale)

--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -13,6 +13,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis_utils import no_deadline
 import unittest
+import io
 
 '''
 Note that tests in this file are just API test, to make sure we wrapped the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#25976 [pt1][quant] Use BytesIO instead of tempfile**

As recommended in https://github.com/pytorch/pytorch/pull/25877/files#r322956051:

> We should move more of these toward using BytesIO. Using files in tests is generally considered bad practice because it introduces syscalls and dependencies on the execution environment, and thus can cause test flakiness/instability.

Differential Revision: [D17310441](https://our.internmc.facebook.com/intern/diff/D17310441/)