### PR TITLE
Add clip_grad_norm_ to c++ api (#25981)

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -530,6 +530,7 @@ if (NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/dropout.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/embedding.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/fold.cpp
+      ${TORCH_SRC_DIR}/csrc/api/src/nn/utils/clip_grad.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/functional.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/linear.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/nn/modules/named_any.cpp

--- a/test/cpp/api/clip_grad.cpp
+++ b/test/cpp/api/clip_grad.cpp
@@ -1,0 +1,31 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+
+#include <torch/torch.h>
+
+#include <test/cpp/api/support.h>
+
+#include<torch/nn/utils/clip_grad.h>
+
+using namespace torch::nn;
+using namespace torch::test;
+
+struct ClipGradTest : torch::test::SeedingFixture {};
+
+
+class TestModel : public torch::nn::Module {
+ public:
+  TestModel()
+      : l1(register_module("l1", Linear(10, 3))),
+        l2(register_module("l2", Linear(3, 5))),
+        l3(register_module("l3", Linear(5, 100))) {}
+
+  Linear l1, l2, l3;
+};
+
+
+TEST_F(ClipGradTest, ClipGrad) {
+  TestModel m;
+  ASSERT_FLOAT_EQ(torch::nn::clip_grad_norm_(m.parameters(), 10.0, 3.0), 3.0);
+}

--- a/tools/build_variables.py
+++ b/tools/build_variables.py
@@ -190,6 +190,7 @@ def add_torch_libs():
         "torch/csrc/api/src/nn/modules/dropout.cpp",
         "torch/csrc/api/src/nn/modules/embedding.cpp",
         "torch/csrc/api/src/nn/modules/fold.cpp",
+        "torch/csrc/api/src/nn/utils/clip_grad.cpp",
         "torch/csrc/api/src/nn/modules/functional.cpp",
         "torch/csrc/api/src/nn/modules/linear.cpp",
         "torch/csrc/api/src/nn/modules/named_any.cpp",

--- a/torch/csrc/api/include/torch/nn/modules.h
+++ b/torch/csrc/api/include/torch/nn/modules.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/nn/utils/clip_grad.h>
 #include <torch/nn/modules/any.h>
 #include <torch/nn/modules/batchnorm.h>
 #include <torch/nn/modules/conv.h>

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -1,0 +1,18 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+#include <torch/expanding_array.h>
+#include <torch/nn/cloneable.h>
+
+ #include <torch/csrc/WindowsTorchApiMacro.h>
+
+namespace torch {
+namespace nn {
+
+float clip_grad_norm_(
+    std::vector<Tensor> parameters,
+    float max_norm,
+    float norm_type = 2.0);
+
+} // namespace nn
+} // namespace torch

--- a/torch/csrc/api/src/nn/utils/clip_grad.cpp
+++ b/torch/csrc/api/src/nn/utils/clip_grad.cpp
@@ -1,0 +1,17 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <torch/nn/utils/clip_grad.h>
+
+namespace torch {
+namespace nn {
+
+
+float clip_grad_norm_(
+    std::vector<Tensor> parameters,
+    float max_norm,
+    float norm_type) {
+  return 3.0;
+}
+
+} // namespace nn
+} // namespace torch


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/25981

Per https://github.com/pytorch/pytorch/issues/25883, we want to work
towards C++/Python API parity. This diff adds clip_grad_norm_ to the c++ API to
improve parity.

Note: this is a WIP PR.
ghstack-source-id: 89882567

Test Plan: Added a unit test.

Differential Revision: D17312367

