### PR TITLE
Fully deprecate variadic inputs of checkpoint_sequential

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -197,11 +197,8 @@ class TestCheckpoint(TestCase):
         a = torch.randn(1, 100, requires_grad=True)
         b = torch.randn(1, 100, requires_grad=True)
 
-        self.assertWarnsRegex(
-            lambda: checkpoint_sequential(model, 1, a, b),
-            'deprecated',
-            'checkpoint_sequential with multiple args should be deprecated',
-        )
+        with self.assertRaises(TypeError):
+            checkpoint_sequential(model, 1, a, b)
 
     def test_checkpoint_sequential_deprecated_no_args(self):
         class Noop(nn.Module):
@@ -210,11 +207,8 @@ class TestCheckpoint(TestCase):
 
         model = nn.Sequential(Noop())
 
-        self.assertWarnsRegex(
-            lambda: checkpoint_sequential(model, 1),
-            'deprecated',
-            'checkpoint_sequential with no args should be deprecated',
-        )
+        with self.assertRaises(TypeError):
+            checkpoint_sequential(model, 1)
 
     def test_checkpoint_rng_cpu(self):
         for _ in range(5):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -49,14 +49,14 @@ class TestCheckpoint(TestCase):
 
         # not checkpointed
         out = model(input)
-        out_not_checkpointed = out.data.clone()
+        out_not_checkpointed = out.detach().clone()
         model.zero_grad()
         out.sum().backward()
         grad_not_checkpointed = {
-            name: param.grad.data.clone()
+            name: param.grad.detach().clone()
             for name, param in model.named_parameters()
         }
-        input_grad_not_checkpointed = input.grad.data.clone()
+        input_grad_not_checkpointed = input.grad.detach().clone()
         for model_to_compare in module_lists_to_compare:
             # checkpointed model by passing list of modules
             detached = input.detach()
@@ -64,14 +64,14 @@ class TestCheckpoint(TestCase):
 
             # pass list of modules to checkpoint
             out = checkpoint_sequential(model_to_compare, num_chunks, detached)
-            out_checkpointed = out.data.clone()
+            out_checkpointed = out.detach().clone()
             model.zero_grad()
             out.sum().backward()
             grad_checkpointed = {
-                name: param.grad.data.clone()
+                name: param.grad.detach().clone()
                 for name, param in model.named_parameters()
             }
-            input_grad_checkpointed = detached.grad.data.clone()
+            input_grad_checkpointed = detached.grad.detach().clone()
             # compare outputs as well as the gradients of input and parameters
             self.assertEqual(out_checkpointed, out_not_checkpointed)
             self.assertEqual(input_grad_not_checkpointed, input_grad_checkpointed)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -201,13 +201,10 @@ def checkpoint_sequential(functions, segments, input, **kwargs):
         raise ValueError("Unexpected keyword arguments: " + ",".join(arg for arg in kwargs))
 
     def run_function(start, end, functions):
-        def forward(*inputs):
+        def forward(input):
             for j in range(start, end + 1):
-                if isinstance(inputs, tuple):
-                    inputs = functions[j](*inputs)
-                else:
-                    inputs = functions[j](inputs)
-            return inputs
+                input = functions[j](input)
+            return input
         return forward
 
     if isinstance(functions, torch.nn.Sequential):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -176,11 +176,15 @@ def checkpoint_sequential(functions, segments, input, preserve_rng_state=True):
         grads are needed for model inputs, otherwise the checkpointed part of the
         model won't have gradients.
 
+    .. warning:
+        Since PyTorch 1.3, it allows only one Tensor as the input and
+        intermediate outputs, just like :class:`torch.nn.Sequential`.
+
     Args:
         functions: A :class:`torch.nn.Sequential` or the list of modules or
             functions (comprising the model) to run sequentially.
         segments: Number of chunks to create in the model
-        inputs: tuple of Tensors that are inputs to :attr:`functions`
+        input: A Tensor that is input to :attr:`functions`
         preserve_rng_state(bool, optional, default=True):  Omit stashing and restoring
             the RNG state during each checkpoint.
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -177,7 +177,7 @@ def checkpoint_sequential(functions, segments, input, **kwargs):
         model won't have gradients.
 
     .. warning:
-        Since PyTorch 1.3, it allows only one Tensor as the input and
+        Since PyTorch 1.4, it allows only one Tensor as the input and
         intermediate outputs, just like :class:`torch.nn.Sequential`.
 
     Args:


### PR DESCRIPTION
To support variadic inputs of `checkpoint_sequential` was deprecated at #21006. This case should be warned with `DeprecationWarning` for PyTorch 1.2, but it should be simply failed with `TypeError` since PyTorch 1.3. This patch removes the `DeprecationWarning` for PyTorch 1.2.