### PR TITLE
Delay external imports until we're ready to test tensorboard

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -44,8 +44,6 @@ skipIfNoMatplotlib = unittest.skipIf(not TEST_MATPLOTLIB, "no matplotlib")
 
 import torch
 from common_utils import TestCase, run_tests, TEST_WITH_ASAN
-from google.protobuf import text_format
-from PIL import Image
 
 def tensor_N(shape, dtype=float):
     numel = np.prod(shape)
@@ -66,6 +64,8 @@ if TEST_TENSORBOARD:
     from torch.utils.tensorboard._utils import _prepare_video, convert_to_HWC
     from torch.utils.tensorboard._convert_np import make_np
     from torch.utils.tensorboard import _caffe2_graph as c2_graph
+    from google.protobuf import text_format
+    from PIL import Image
 
     class TestTensorBoardPyTorchNumpy(BaseTestCase):
         def test_pytorch_np(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26033 Skip TestHub on macOS
* **#25993 Delay external imports until we're ready to test tensorboard**
* #25942 Skip TestAutograd.test_deep_reentrant on macOS
* #25930 Refactor macOS build and test
* #25988 Change brew update logic to run much faster
* #25987 Remove trailing whitespace in CircleCI configuration files

These imports fail the test suite if they're not installed, even if we
don't end up testing tensorboard.

[test macos]

Differential Revision: [D17318588](https://our.internmc.facebook.com/intern/diff/D17318588)