### PR TITLE
Switch to using requests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -352,8 +352,7 @@ install_requires = []
 if sys.version_info <= (2, 7):
     install_requires += ['future']
 
-if sys.version_info[0] == 2:
-    install_requires += ['requests']
+install_requires += ['requests']
 
 missing_pydep = '''
 Missing build dependency: Unable to `import {importname}`.

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -9,13 +9,8 @@ import tempfile
 import torch
 import warnings
 import zipfile
-
-if sys.version_info[0] == 2:
-    from urlparse import urlparse
-    import requests
-else:
-    from urllib.request import urlopen
-    from urllib.parse import urlparse  # noqa: F401
+import requests
+from urlparse import urlparse
 
 try:
     from tqdm import tqdm
@@ -93,12 +88,7 @@ def _git_archive_link(repo_owner, repo_name, branch):
 
 def _download_archive_zip(url, filename):
     sys.stderr.write('Downloading: \"{}\" to {}\n'.format(url, filename))
-    # We use a different API for python2 since urllib(2) doesn't recognize the CA
-    # certificates in older Python
-    if sys.version_info[0] == 2:
-        response = requests.get(url, stream=True).raw
-    else:
-        response = urlopen(url)
+    response = requests.get(url, stream=True).raw
     with open(filename, 'wb') as f:
         while True:
             data = response.read(READ_DATA_CHUNK)
@@ -374,24 +364,11 @@ def load(github, model, *args, **kwargs):
 
 def _download_url_to_file(url, dst, hash_prefix, progress):
     file_size = None
-    # We use a different API for python2 since urllib(2) doesn't recognize the CA
-    # certificates in older Python
-    if sys.version_info[0] == 2:
-        response = requests.get(url, stream=True)
+    response = requests.get(url, stream=True)
 
-        content_length = response.headers['Content-Length']
-        file_size = int(content_length)
-        u = response.raw
-    else:
-        u = urlopen(url)
-
-        meta = u.info()
-        if hasattr(meta, 'getheaders'):
-            content_length = meta.getheaders("Content-Length")
-        else:
-            content_length = meta.get_all("Content-Length")
-        if content_length is not None and len(content_length) > 0:
-            file_size = int(content_length[0])
+    content_length = response.headers['Content-Length']
+    file_size = int(content_length)
+    u = response.raw
 
     # We deliberately save it in a temp file and move it after
     # download is complete. This prevents a local working checkpoint


### PR DESCRIPTION
Summary:
We are running into ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate
verify failed (_ssl.c:852), while using urrlib. Switching to requests instead.

Differential Revision: D17327704

