### PR TITLE
Add int8 resize nearest 3d op in DNNLOWP

### DIFF
--- a/caffe2/quantization/server/resize_nearest_3d_dnnlowp_op.cc
+++ b/caffe2/quantization/server/resize_nearest_3d_dnnlowp_op.cc
@@ -1,0 +1,65 @@
+#include "caffe2/quantization/server/resize_nearest_3d_dnnlowp_op.h"
+
+namespace caffe2 {
+
+template <typename T>
+bool ResizeNearest3DDNNLowPOp<T>::RunOnDevice() {
+  using namespace dnnlowp;
+
+  this->ParseDNNLowPOperatorArguments_();
+
+  // Choose quantization params
+  in_qparams_[0] = GetInputTensorQuantizationParamsOf(this, 0, qfactory_.get());
+
+  const auto& X = InputTensorCPU_(0);
+  auto* Y = OutputTensorCPU_(0);
+
+  CAFFE_ENFORCE_EQ(X.ndim(), 5);
+  const int N = X.dim32(0);
+  // input frames
+  const int IF = X.dim32(1);
+  const int IH = X.dim32(2);
+  const int IW = X.dim32(3);
+  const int C = X.dim32(4);
+  const int OF = IF * temporal_scale_;
+  const int OH = IH * height_scale_;
+  const int OW = IW * width_scale_;
+
+  vector<int> buffer_shape{N, OF, OH, OW, C};
+  Y->Resize(buffer_shape);
+  const T* X_data = X.template data<T>();
+  T* Y_data = Y->template mutable_data<T>();
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int n = 0; n < N; ++n) {
+    for (int t = 0; t < OF; ++t) {
+      const int in_f = std::min((int)(t / temporal_scale_), (IF - 1));
+      for (int y = 0; y < OH; ++y) {
+        const int in_y = std::min((int)(y / height_scale_), (IH - 1));
+        for (int x = 0; x < OW; ++x) {
+          const int in_x = std::min((int)(x / width_scale_), (IW - 1));
+          std::memcpy(
+              &Y_data[((((n * OF) + t) * OH + y) * OW + x) * C],
+              &X_data[((((n * IF) + in_f) * IH + in_y) * IW + in_x) * C],
+              C * sizeof(T));
+        }
+      }
+    }
+  }
+
+  // Even if there is a pre-chosen quantization parameters for the output,
+  // it is ignored because resize nearest output quantization should be same
+  // as the input.
+  PropagateOutputTensorQuantizationParams(this, 0, in_qparams_[0]);
+
+  return true;
+}
+
+REGISTER_CPU_OPERATOR_WITH_ENGINE(
+    Int8ResizeNearest3D,
+    DNNLOWP,
+    ResizeNearest3DDNNLowPOp<uint8_t>);
+
+} // namespace caffe2

--- a/caffe2/quantization/server/resize_nearest_3d_dnnlowp_op.h
+++ b/caffe2/quantization/server/resize_nearest_3d_dnnlowp_op.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "caffe2/quantization/server/dnnlowp_op.h"
+#include "vision/video_modeling/experimental/abc/ops/resize_3d_op.h"
+
+namespace caffe2 {
+
+using ResizeNearest3DFP32Op = ResizeNearest3DOp<float, CPUContext>;
+
+template <typename T>
+class ResizeNearest3DDNNLowPOp final
+    : public DNNLowPOp<T, ResizeNearest3DFP32Op> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CPUContext);
+  USE_DNNLOWP_OPERATOR_BASE_FUNCTIONS(T, ResizeNearest3DFP32Op);
+
+  ResizeNearest3DDNNLowPOp(const OperatorDef& operator_def, Workspace* ws)
+      : BaseType(operator_def, ws),
+        temporal_scale_(
+            this->template GetSingleArgument<float>("temporal_scale", 1)),
+        width_scale_(this->template GetSingleArgument<float>("width_scale", 1)),
+        height_scale_(
+            this->template GetSingleArgument<float>("height_scale", 1)) {
+    CAFFE_ENFORCE_GT(temporal_scale_, 0);
+    CAFFE_ENFORCE_GT(width_scale_, 0);
+    CAFFE_ENFORCE_GT(height_scale_, 0);
+
+    const auto& order = StringToStorageOrder(
+        this->template GetSingleArgument<std::string>("order", "NHWC"));
+    CAFFE_ENFORCE_EQ(order, StorageOrder::NHWC);
+  }
+
+  bool RunOnDevice() override;
+
+ private:
+  float temporal_scale_;
+  float width_scale_;
+  float height_scale_;
+};
+
+} // namespace caffe2

--- a/caffe2/quantization/server/resize_nearest_3d_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/resize_nearest_3d_dnnlowp_op_test.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import caffe2.python.hypothesis_test_util as hu
+import hypothesis.strategies as st
+import numpy as np
+from caffe2.python import core, dyndep, workspace
+from hypothesis import given
+
+
+dyndep.InitOpsLibrary("//caffe2/caffe2/quantization/server:dnnlowp_ops")
+workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
+
+
+class DNNLowPResizeNearest3DOpTest(hu.HypothesisTestCase):
+    @given(
+        N=st.integers(1, 3),
+        T=st.integers(1, 16),
+        H=st.integers(10, 300),
+        W=st.integers(10, 300),
+        C=st.integers(1, 32),
+        scale_t=st.floats(0.25, 4.0) | st.just(2.0),
+        scale_w=st.floats(0.25, 4.0) | st.just(2.0),
+        scale_h=st.floats(0.25, 4.0) | st.just(2.0),
+        **hu.gcs_cpu_only
+    )
+    def test_resize_nearest(self, N, T, H, W, C, scale_t, scale_w, scale_h, gc, dc):
+        X = np.round(np.random.rand(N, T, H, W, C) * 255).astype(np.float32)
+
+        quantize = core.CreateOperator("Quantize", ["X"], ["X_q"], engine="DNNLOWP")
+        resize_nearest = core.CreateOperator(
+            "Int8ResizeNearest3D",
+            ["X_q"],
+            ["Y_q"],
+            temporal_scale=scale_t,
+            width_scale=scale_w,
+            height_scale=scale_h,
+            engine="DNNLOWP",
+        )
+
+        net = core.Net("test_net")
+        net.Proto().op.extend([quantize, resize_nearest])
+
+        workspace.FeedBlob("X", X)
+        workspace.RunNetOnce(net)
+        X_q = workspace.FetchInt8Blob("X_q").data
+        Y_q = workspace.FetchInt8Blob("Y_q").data
+
+        def resize_nearest_ref(X):
+            outT = np.int32(T * scale_t)
+            outH = np.int32(H * scale_h)
+            outW = np.int32(W * scale_w)
+            outT_idxs, outH_idxs, outW_idxs = np.meshgrid(
+                np.arange(outT), np.arange(outH), np.arange(outW), indexing="ij"
+            )
+            inT_idxs = np.minimum(outT_idxs / scale_t, T - 1).astype(np.int32)
+            inH_idxs = np.minimum(outH_idxs / scale_h, H - 1).astype(np.int32)
+            inW_idxs = np.minimum(outW_idxs / scale_w, W - 1).astype(np.int32)
+            Y = X[:, inT_idxs, inH_idxs, inW_idxs, :]
+            return Y
+
+        Y_q_ref = resize_nearest_ref(X_q)
+        np.testing.assert_allclose(Y_q, Y_q_ref)


### PR DESCRIPTION
Summary: As title

Test Plan: buck test mode/opt caffe2/caffe2/quantization/server:resize_nearest_3d_dnnlowp_op_test

Differential Revision: D17330625

