### PR TITLE
[jit] Allow `Optional[Module]` type annotations

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14955,6 +14955,22 @@ class TestRecursiveScript(JitTestCase):
         m = torch.jit.script(MyModule())
         FileCheck().check("ClassType<MyModule>").run(m.graph)
 
+    def test_optional_module(self):
+        class MyModule(torch.nn.Module):
+            __annotations__ = {'sub': Optional[torch.nn.Module]}
+
+            def __init__(self, submodule):
+                super(MyModule, self).__init__()
+                self.sub = submodule
+
+            def forward(self, t):
+                if self.sub is not None:
+                    t += self.sub(t)
+                return t
+
+        self.checkModule(MyModule(torch.nn.ReLU()), (torch.randn(20),))
+        self.checkModule(MyModule(None), (torch.randn(20),))
+
     def test_repeated_error_stack(self):
         def d(x):
             return "a" - 2


### PR DESCRIPTION


Since these can be de-sugared when copying from an `nn.Module` in
recursive script, we can add these annotations for optional modules
instead of putting them into `__constants__`. It still adds it to
`__constants__` behind the scenes so everything still works.

Fixes #26067

Differential Revision: [D17347325](https://our.internmc.facebook.com/intern/diff/17347325/)