### PR TITLE
[android][ci] CircleCI android nightly (snapshot) build publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1200,6 +1200,42 @@ jobs:
         path: ~/workspace/build_android_artifacts/artifacts.tgz
         destination: artifacts.tgz
 
+  pytorch_android_publish_snapshot:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-publish-snapshot
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - should_run_job
+    - setup_linux_system_environment
+    - checkout
+    - setup_ci_environment
+    - run:
+        name: pytorch android gradle build
+        no_output_timeout: "1h"
+        command: |
+          set -eux
+          docker_image_commit=${DOCKER_IMAGE}-${CIRCLE_SHA1}
+
+          docker_image_libtorch_android_x86_32_gradle=${docker_image_commit}-android-x86_32-gradle
+
+          echo "docker_image_commit: "${docker_image_commit}
+          echo "docker_image_libtorch_android_x86_32_gradle: "${docker_image_libtorch_android_x86_32_gradle}
+
+          # x86_32
+          docker pull ${docker_image_libtorch_android_x86_32_gradle} >/dev/null
+          export id_x86_32=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_32_gradle})
+
+          export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace" && echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "export SONATYPE_NEXUS_USERNAME=${SONATYPE_NEXUS_USERNAME}" && echo "export SONATYPE_NEXUS_PASSWORD=${SONATYPE_NEXUS_PASSWORD}" && echo "export ANDROID_SIGN_KEY=${ANDROID_SIGN_KEY}" && echo "export ANDROID_SIGN_PASS=${ANDROID_SIGN_PASS}" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/publish_android_snapshot.sh") | docker exec -u jenkins -i "$id_x86_32" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+
+          output_image=${docker_image_libtorch_android_x86_32_gradle}-publish-snapshot
+          docker commit "$id_x86_32" ${output_image}
+          docker push ${output_image}
+
   pytorch_android_gradle_build-x86_32:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32
@@ -1239,7 +1275,7 @@ jobs:
           mkdir -p ~/workspace/build_android_x86_32_artifacts
           docker cp $id:/var/lib/jenkins/workspace/android/artifacts.tgz ~/workspace/build_android_x86_32_artifacts/
 
-          output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-gradle-x86_32
+          output_image=${docker_image_libtorch_android_x86_32}-gradle
           docker commit "$id" ${output_image}
           docker push ${output_image}
     - store_artifacts:
@@ -1296,6 +1332,7 @@ jobs:
             CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
 
             unbuffer ${PROJ_ROOT}/scripts/build_ios.sh ${CMAKE_ARGS[@]} 2>&1 | ts
+
   # update_s3_htmls job
   # These jobs create html files for every cpu/cu## folder in s3. The html
   # files just store the names of all the files in that folder (which are
@@ -1849,10 +1886,12 @@ workflows:
           requires:
             - setup
       - pytorch_android_gradle_build-x86_32:
+          name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-x86_32
           requires:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
 
       - pytorch_android_gradle_build:
+          name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build
           requires:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
@@ -3039,6 +3078,44 @@ workflows:
             - setup
             - pytorch_ios_10_2_1_nightly_x86_64_build
             - pytorch_ios_10_2_1_nigthly_arm64_build
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_64"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v7a"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v8a"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+
+      - pytorch_android_gradle_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_android_gradle_build
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
+
+      - pytorch_android_publish_snapshot:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_android_publish_snapshot
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_android_gradle_build
+          context: org-member
 ##############################################################################
 # Nightly tests
 ##############################################################################

--- a/.circleci/generate_config_yml.py
+++ b/.circleci/generate_config_yml.py
@@ -100,6 +100,7 @@ YAML_SOURCES = [
     Header("Daily binary build trigger"),
     Treegen(binary_build_definitions.add_binary_build_jobs, 1),
     File("workflows-nightly-ios-binary-builds.yml"),
+    File("workflows-nightly-android-binary-builds.yml"),
     Header("Nightly tests"),
     Listgen(binary_build_definitions.get_nightly_tests, 3),
     File("workflows-nightly-uploads-header.yml"),

--- a/.circleci/scripts/publish_android_snapshot.sh
+++ b/.circleci/scripts/publish_android_snapshot.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# DO NOT ADD 'set -x' not to reveal CircleCI secret context environment variables
+set -eu -o pipefail
+
+export ANDROID_NDK_HOME=/opt/ndk
+export ANDROID_HOME=/opt/android/sdk
+
+export GRADLE_VERSION_FOR_PUBLISH=4.10.3
+
+echo "GRADLE_VERSION:${GRADLE_VERSION_FOR_PUBLISH}"
+_gradle_home=/opt/gradle
+sudo mkdir -p $_gradle_home
+
+wget --no-verbose --output-document=/tmp/gradle.zip \
+"https://services.gradle.org/distributions/gradle-${GRADLE_VERSION_FOR_PUBLISH}-bin.zip"
+
+sudo unzip -q /tmp/gradle.zip -d $_gradle_home
+rm /tmp/gradle.zip
+
+sudo chmod -R 777 $_gradle_home
+
+export GRADLE_HOME=/opt/gradle/gradle-$GRADLE_VERSION_FOR_PUBLISH
+export GRADLE_PATH=$GRADLE_HOME/bin/gradle
+
+echo "BUILD_ENVIRONMENT:$BUILD_ENVIRONMENT"
+ls -la ~/workspace
+
+GRADLE_PROPERTIES=~/workspace/android/gradle.properties
+
+IS_SNAPSHOT="$(grep 'VERSION_NAME=[0-9\.]\+-SNAPSHOT' "$GRADLE_PROPERTIES")"
+echo "IS_SNAPSHOT:$IS_SNAPSHOT"
+
+if [ -z "$IS_SNAPSHOT" ]; then
+  echo "Error: version is not snapshot."
+elif [ -z "$SONATYPE_NEXUS_USERNAME" ]; then
+  echo "Error: missing env variable SONATYPE_NEXUS_USERNAME."
+elif [ -z "$SONATYPE_NEXUS_PASSWORD" ]; then
+  echo "Error: missing env variable SONATYPE_NEXUS_PASSWORD."
+elif [ -z "$ANDROID_SIGN_KEY" ]; then
+  echo "Error: missing env variable ANDROID_SIGN_KEY."
+elif [ -z "$ANDROID_SIGN_PASS" ]; then
+  echo "Error: missing env variable ANDROID_SIGN_PASS."
+else
+  GRADLE_LOCAL_PROPERTIES=~/workspace/android/local.properties
+  rm -f $GRADLE_LOCAL_PROPERTIES
+
+  echo "sdk.dir=/opt/android/sdk" >> $GRADLE_LOCAL_PROPERTIES
+  echo "ndk.dir=/opt/ndk" >> $GRADLE_LOCAL_PROPERTIES
+
+  echo "SONATYPE_NEXUS_USERNAME=${SONATYPE_NEXUS_USERNAME}" >> $GRADLE_PROPERTIES
+  echo "SONATYPE_NEXUS_PASSWORD=${SONATYPE_NEXUS_PASSWORD}" >> $GRADLE_PROPERTIES
+
+  echo "signing.keyId=${ANDROID_SIGN_KEY}" >> $GRADLE_PROPERTIES
+  echo "signing.password=${ANDROID_SIGN_PASS}" >> $GRADLE_PROPERTIES
+
+  $GRADLE_PATH -p ~/workspace/android/ uploadArchives
+fi

--- a/.circleci/verbatim-sources/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs-custom.yml
@@ -321,6 +321,42 @@
         path: ~/workspace/build_android_artifacts/artifacts.tgz
         destination: artifacts.tgz
 
+  pytorch_android_publish_snapshot:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-publish-snapshot
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      PYTHON_VERSION: "3.6"
+    resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - should_run_job
+    - setup_linux_system_environment
+    - checkout
+    - setup_ci_environment
+    - run:
+        name: pytorch android gradle build
+        no_output_timeout: "1h"
+        command: |
+          set -eux
+          docker_image_commit=${DOCKER_IMAGE}-${CIRCLE_SHA1}
+
+          docker_image_libtorch_android_x86_32_gradle=${docker_image_commit}-android-x86_32-gradle
+
+          echo "docker_image_commit: "${docker_image_commit}
+          echo "docker_image_libtorch_android_x86_32_gradle: "${docker_image_libtorch_android_x86_32_gradle}
+
+          # x86_32
+          docker pull ${docker_image_libtorch_android_x86_32_gradle} >/dev/null
+          export id_x86_32=$(docker run -t -d -w /var/lib/jenkins ${docker_image_libtorch_android_x86_32_gradle})
+
+          export COMMAND='((echo "source ./workspace/env" && echo "sudo chown -R jenkins workspace" && echo "export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}" && echo "export SONATYPE_NEXUS_USERNAME=${SONATYPE_NEXUS_USERNAME}" && echo "export SONATYPE_NEXUS_PASSWORD=${SONATYPE_NEXUS_PASSWORD}" && echo "export ANDROID_SIGN_KEY=${ANDROID_SIGN_KEY}" && echo "export ANDROID_SIGN_PASS=${ANDROID_SIGN_PASS}" && echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/publish_android_snapshot.sh") | docker exec -u jenkins -i "$id_x86_32" bash) 2>&1'
+          echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
+
+          output_image=${docker_image_libtorch_android_x86_32_gradle}-publish-snapshot
+          docker commit "$id_x86_32" ${output_image}
+          docker push ${output_image}
+
   pytorch_android_gradle_build-x86_32:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-only-x86_32
@@ -360,7 +396,7 @@
           mkdir -p ~/workspace/build_android_x86_32_artifacts
           docker cp $id:/var/lib/jenkins/workspace/android/artifacts.tgz ~/workspace/build_android_x86_32_artifacts/
 
-          output_image=${DOCKER_IMAGE}-${CIRCLE_SHA1}-android-gradle-x86_32
+          output_image=${docker_image_libtorch_android_x86_32}-gradle
           docker commit "$id" ${output_image}
           docker push ${output_image}
     - store_artifacts:

--- a/.circleci/verbatim-sources/workflows-nightly-android-binary-builds.yml
+++ b/.circleci/verbatim-sources/workflows-nightly-android-binary-builds.yml
@@ -1,0 +1,38 @@
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_32"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-x86_64"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v7a"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+      - pytorch_linux_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
+          build_environment: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-arm-v8a"
+          requires:
+            - setup
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c:339"
+
+      - pytorch_android_gradle_build:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_android_gradle_build
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v7a_build
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_arm_v8a_build
+
+      - pytorch_android_publish_snapshot:
+          name: pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_android_publish_snapshot
+          requires:
+            - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_android_gradle_build
+          context: org-member

--- a/.circleci/verbatim-sources/workflows-pytorch-android-gradle-build.yml
+++ b/.circleci/verbatim-sources/workflows-pytorch-android-gradle-build.yml
@@ -1,8 +1,10 @@
       - pytorch_android_gradle_build-x86_32:
+          name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build-x86_32
           requires:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
 
       - pytorch_android_gradle_build:
+          name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build
           requires:
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_32_build
             - pytorch_linux_xenial_py3_clang5_android_ndk_r19c_x86_64_build

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,8 +1,8 @@
 ABI_FILTERS=armeabi-v7a,arm64-v8a,x86,x86_64
 
-VERSION_NAME=0.0.4
+VERSION_NAME=0.0.7-SNAPSHOT
 GROUP=org.pytorch
-MAVEN_GROUP=com.facebook
+MAVEN_GROUP=org.pytorch
 POM_URL=https://github.com/pytorch/pytorch/tree/master/android
 POM_SCM_URL=https://github.com/pytorch/pytorch.git
 POM_SCM_CONNECTION=scm:git:https://github.com/pytorch/pytorch
@@ -11,9 +11,14 @@ POM_LICENSE_NAME=BSD 3-Clause
 POM_LICENSE_URL=https://github.com/pytorch/pytorch/blob/master/LICENSE
 POM_ISSUES_URL=https://github.com/pytorch/pytorch/issues
 POM_LICENSE_DIST=repo
-POM_DEVELOPER_ID=facebook
-POM_DEVELOPER_NAME=facebook
+POM_DEVELOPER_ID=pytorch
+POM_DEVELOPER_NAME=pytorch
+syncWithMavenCentral=true
 
 GRADLE_BINTRAY_PLUGIN_VERSION=1.8.0
 GRADLE_VERSIONS_PLUGIN_VERSION=0.15.0
 ANDROID_MAVEN_GRADLE_PLUGIN_VERSION=2.1
+
+# Gradle internals
+org.gradle.internal.repository.max.retries=1
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m

--- a/android/gradle/android_tasks.gradle
+++ b/android/gradle/android_tasks.gradle
@@ -18,12 +18,12 @@ afterEvaluate { project ->
         }
 
         task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-            archiveClassifier.set('javadoc')
+            classifier = 'javadoc'
             from androidJavadoc.destinationDir
         }
 
         task androidSourcesJar(type: Jar) {
-            archiveClassifier.set('sources')
+            classifier = 'sources'
             from android.sourceSets.main.java.srcDirs
         }
 
@@ -61,12 +61,12 @@ afterEvaluate { project ->
 
     if (POM_PACKAGING == 'jar') {
         task javadocJar(type: Jar, dependsOn: javadoc) {
-            archiveClassifier.set('javadoc')
+            classifier = 'javadoc'
             from javadoc.destinationDir
         }
 
         task sourcesJar(type: Jar, dependsOn: classes) {
-            archiveClassifier.set('sources')
+            classifier = 'sources'
             from sourceSets.main.allSource
         }
 

--- a/android/gradle/release_bintray.gradle
+++ b/android/gradle/release_bintray.gradle
@@ -1,6 +1,6 @@
 ext {
     bintrayRepo = 'maven'
-    bintrayUserOrg = 'facebook'
+    bintrayUserOrg = 'pytorch'
     bintrayName = "${GROUP}:${POM_ARTIFACT_ID}"
     bintrayDescription = POM_DESCRIPTION
     projectUrl = POM_URL

--- a/android/libs/fbjni_local/build.gradle
+++ b/android/libs/fbjni_local/build.gradle
@@ -18,7 +18,14 @@ android {
             }
         }
     }
-
+    buildTypes {
+        debug {
+            minifyEnabled false
+        }
+        release {
+            minifyEnabled false
+        }
+    }
     externalNativeBuild {
         cmake {
             path "../fbjni/CMakeLists.txt"
@@ -31,3 +38,10 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/release.gradle')
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+artifacts.add('archives', sourcesJar)

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -59,7 +59,7 @@ apply from: rootProject.file('gradle/release.gradle')
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set('sources')
+    classifier = 'sources'
 }
 
 artifacts.add('archives', sourcesJar)

--- a/android/pytorch_android_torchvision/build.gradle
+++ b/android/pytorch_android_torchvision/build.gradle
@@ -49,7 +49,7 @@ apply from: rootProject.file('gradle/release.gradle')
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set('sources')
+    classifier = 'sources'
 }
 
 artifacts.add('archives', sourcesJar)


### PR DESCRIPTION
To publish android snapshots to sonatype repository:
1. set gradle properties SONATYPE_NEXUS_USERNAME, SONATYPE_NEXUS_PASSWORD, ANDROID_SIGN_KEY, ANDROID_SIGN_PASS
these variables are stored as context environment variables in 'org-member' circleCI context
2. gradle -p ~/workspace/android/ uploadArchives

Due to gradle bugs in version 5 uploadArchives task works correctly with gradle version 4.10.3
That is also the reason of changes  `archiveClassifier.set('sources')` -> `classifier = 'sources'` as archiveClassifier was introduced in version 5


Registering nightly build job that publishes *-SNAPSHOT version of android api


Testing:
CircleCI successful snapshot publishing run https://circleci.com/gh/pytorch/pytorch/2786503?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
Corresponding published artifacts can be seen: https://oss.sonatype.org/#nexus-search;quick~pytorch_android
<img width="1316" alt="Screenshot 2019-09-16 09 36 14" src="https://user-images.githubusercontent.com/6638825/64976167-7f447480-d865-11e9-95c5-874c5cd62b6d.png">
