### PR TITLE
C++ unregister_module function for Module

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -115,6 +115,17 @@ TEST_F(ModuleTest, ReplaceModule) {
   ASSERT_EQ(model->l1.get(), model->named_modules()["l1"]->as<Linear>());
 }
 
+TEST_F(ModuleTest, UnregisterModule) {
+  struct TestModel : public torch::nn::Module {};
+  TestModel model;
+  ASSERT_THROWS_WITH(
+      model.unregister_module("linear"),
+      "No Module with name `linear` is registered");
+  model.register_module("linear", torch::nn::Linear(3, 4));
+  model.unregister_module("linear");
+  ASSERT_TRUE(model.children().empty());
+}
+
 TEST_F(ModuleTest, RegisterParameterThrowsForEmptyOrDottedName) {
   struct TestModel : public torch::nn::Module {};
   ASSERT_THROWS_WITH(

--- a/test/cpp/api/ordered_dict.cpp
+++ b/test/cpp/api/ordered_dict.cpp
@@ -137,6 +137,20 @@ TEST(OrderedDictTest, CanIterateItems) {
   ASSERT_EQ(iterator, dict.end());
 }
 
+TEST(OrderedDictTest, EraseWorks) {
+  OrderedDict<int> dict = {{"a", 1}, {"b", 2}, {"c", 3}};
+  dict.erase("b");
+  ASSERT_FALSE(dict.contains("b"));
+  ASSERT_EQ(dict["a"], 1);
+  ASSERT_EQ(dict["c"], 3);
+  dict.erase("a");
+  ASSERT_FALSE(dict.contains("a"));
+  ASSERT_EQ(dict["c"], 3);
+  dict.erase("c");
+  ASSERT_FALSE(dict.contains("c"));
+  ASSERT_TRUE(dict.is_empty());
+}
+
 TEST(OrderedDictTest, ClearMakesTheDictEmpty) {
   OrderedDict<int> dict = {{"a", 1}, {"b", 2}};
   ASSERT_FALSE(dict.is_empty());

--- a/torch/csrc/api/include/torch/nn/module.h
+++ b/torch/csrc/api/include/torch/nn/module.h
@@ -504,6 +504,10 @@ class TORCH_API Module : public std::enable_shared_from_this<Module> {
       const std::string& name,
       ModuleHolder<ModuleType> module_holder);
 
+  /// Unregisters a submodule from this `Module`. If there is no such module
+  /// with `name` an exception is thrown.
+  void unregister_module(const std::string& name);
+
  private:
   // Friend classes.
 

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -225,7 +225,7 @@ class OrderedDict<Key, Value>::Item {
   }
 
   /// Returns a `(key, value)` pair.
-  const std::pair<const Key, Value>& pair() const noexcept {
+  const std::pair<Key, Value>& pair() const noexcept {
     return pair_;
   }
 

--- a/torch/csrc/api/include/torch/ordered_dict.h
+++ b/torch/csrc/api/include/torch/ordered_dict.h
@@ -146,6 +146,10 @@ class OrderedDict {
   /// `other` is already present in this `OrderedDict`, an exception is thrown.
   void update(const OrderedDict& other);
 
+  /// Removes the item that has `key` from this `OrderedDict` if exists and if
+  /// it doesn't an exception is thrown.
+  void erase(const Key& key);
+
   /// Removes all items from this `OrderedDict`.
   void clear();
 
@@ -228,7 +232,7 @@ class OrderedDict<Key, Value>::Item {
  private:
   /// This is stored as an std::pair because it will make Python binding a lot,
   /// lot easier.
-  ::std::pair<const Key, Value> pair_;
+  ::std::pair<Key, Value> pair_;
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ OrderedDict ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -399,6 +403,20 @@ const Value* OrderedDict<Key, Value>::find(const Key& key) const noexcept {
     return nullptr;
   }
   return &items_[iterator->second].value();
+}
+
+template <typename Key, typename Value>
+void OrderedDict<Key, Value>::erase(const Key& key) {
+  auto it = index_.find(key);
+  TORCH_CHECK(it != index_.end(), "Key '", key, "' doesn't exist");
+
+  auto index = it->second;
+  index_.erase(it);
+  items_.erase(items_.begin() + index);
+
+  for (auto& pair : index_)
+    if (pair.second > index)
+      --pair.second;
 }
 
 template <typename Key, typename Value>

--- a/torch/csrc/api/src/nn/module.cpp
+++ b/torch/csrc/api/src/nn/module.cpp
@@ -330,6 +330,15 @@ Tensor& Module::register_buffer(std::string name, Tensor tensor) {
   return buffers_.insert(std::move(name), std::move(tensor));
 }
 
+void Module::unregister_module(const std::string& name) {
+  TORCH_CHECK(
+      children_.contains(name),
+      "No Module with name `",
+      name,
+      "` is registered");
+  children_.erase(name);
+}
+
 void Module::pretty_print(std::ostream& stream) const {
   stream << name();
 }


### PR DESCRIPTION
This PR adds ```unregister_module``` to ```nn::Module``` and ```erase``` function to ```OrderedDict```.