### PR TITLE
[iOS] Change the source link in podspec

### DIFF
--- a/ios/LibTorch.h
+++ b/ios/LibTorch.h
@@ -1,7 +1,1 @@
 #include <torch/script.h>
-
-#if TARGET_OS_IPHONE
-    #define AT_NNPACK_ENABLED() 1
-    #define USE_NNPACK ON
-    #undef CAFFE2_PERF_WITH_AVX512
-#endif

--- a/ios/LibTorch.h
+++ b/ios/LibTorch.h
@@ -1,1 +1,6 @@
+#ifndef LibTorch_h
+#define LibTorch_h
+
 #include <torch/script.h>
+
+#endif

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
     s.default_subspec = 'Core'
     s.subspec 'Core' do |ss|
         ss.dependency 'LibTorch/Torch'
-        ss.source_files = 'src/*.{h,cpp,cc}'
+        ss.source_files = 'src/*.{h,cpp,c,cc}'
         ss.public_header_files = ['src/LibTorch.h']
     end
     s.subspec 'Torch' do |ss|

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '0.0.1'
+    s.version          = '0.0.2'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -22,13 +22,13 @@ Pod::Spec.new do |s|
         ss.libraries = ['c++', 'stdc++']
     end
     s.user_target_xcconfig = {
-        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/#{s.name}/install/include/"', 
-        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/#{s.name}/install/lib/libtorch.a"',
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
+        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/LibTorch/install/lib/libtorch.a"',
         'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
         'CLANG_CXX_LIBRARY' => 'libc++'
     }
     s.pod_target_xcconfig = { 
-        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/#{s.name}/install/include/"', 
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
         'VALID_ARCHS' => 'x86_64 armv7s arm64' 
     }
     s.library = ['c++', 'stdc++']

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -22,13 +22,13 @@ Pod::Spec.new do |s|
         ss.libraries = ['c++', 'stdc++']
     end
     s.user_target_xcconfig = {
-        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
-        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/LibTorch/install/lib/libtorch.a"',
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/#{s.name}/install/include/"', 
+        'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/#{s.name}/install/lib/libtorch.a"',
         'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
         'CLANG_CXX_LIBRARY' => 'libc++'
     }
     s.pod_target_xcconfig = { 
-        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/#{s.name}/install/include/"', 
         'VALID_ARCHS' => 'x86_64 armv7s arm64' 
     }
     s.library = ['c++', 'stdc++']

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'
-    s.source           = { :http => 'http://ossci-macos.s3.amazonaws.com/libtorch_x86_arm64.zip' }
+    s.source           = { :http => 'http://ossci-ios-build.s3.amazonaws.com/libtorch_ios_nightly_build.zip' }
     s.summary          = 'The PyTorch C++ library for iOS'
     s.description      = <<-DESC
         The PyTorch C++ library for iOS.
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     s.subspec 'Torch' do |ss|
         ss.header_mappings_dir = 'install/include/'
         ss.preserve_paths = 'install/include/**/*.{h,cpp,cc,c}' 
-        ss.vendored_libraries = 'install/lib/libtorch.a'
+        ss.vendored_libraries = 'install/lib/*.a'
         ss.libraries = ['c++', 'stdc++']
     end
     s.user_target_xcconfig = {
@@ -27,8 +27,9 @@ Pod::Spec.new do |s|
         'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
         'CLANG_CXX_LIBRARY' => 'libc++'
     }
-    s.pod_target_xcconfig = { 'VALID_ARCHS' => 'x86_64 armv7s arm64' }
-    s.module_name='LibTorch'
-    s.module_map = 'src/framework.modulemap'
+    s.pod_target_xcconfig = { 
+        'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
+        'VALID_ARCHS' => 'x86_64 armv7s arm64' 
+    }
     s.library = ['c++', 'stdc++']
 end

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'
-    s.source           = { :http => 'http://ossci-ios-build.s3.amazonaws.com/libtorch_ios_nightly_build.zip' }
+    s.source           = { :http => 'https://ossci-ios-build.s3.amazonaws.com/libtorch_ios_nightly_build.zip' }
     s.summary          = 'The PyTorch C++ library for iOS'
     s.description      = <<-DESC
         The PyTorch C++ library for iOS.

--- a/ios/framework.modulemap
+++ b/ios/framework.modulemap
@@ -1,4 +1,0 @@
-framework module LibTorch {
-    umbrella header "LibTorch.h"
-    export *
-}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26089 [iOS] Change the source link in podspec**

### Summary

A couple of changes

1. Replace the source link with the newly nightly build address
2. Remove module support for Swift and Objective-C
3. Expose all static libraries instead of archiving them into one single library. This is because those static libraries might contain object files that have the same name, e.g. `init.c.o` in both `libcupinfo.a` and `libqnnpack.a`. If we archive them into one using this `libtool -static` command, by default, it only picks one object file and discards the others, which could result in undefined symbols when linking the executable. The change here is to expose all the static libraries and let the linker decide which one to use.

### Test Plan

- pod spec lint succeed
 - `pod spec lint --verbose --allow-warnings --no-clean --use-libraries --skip-import-validation`

Differential Revision: [D17363037](https://our.internmc.facebook.com/intern/diff/D17363037)