### PR TITLE
fix base_lr overridden in cyclic lr

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1283,5 +1283,26 @@ class TestLRScheduler(TestCase):
                         msg='Momentum is wrong in batch_num {}: expected {}, got {}'.format(
                             batch_num, momentum_target[batch_num], param_group['momentum']), delta=1e-5)
 
+    def test_cosine_then_cyclic(self):
+        # https://github.com/pytorch/pytorch/issues/21965
+
+        model = torch.nn.Linear(2, 1)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.5)
+        lr_scheduler_1 = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=20, eta_min=0.1)
+        lr_scheduler_2 = torch.optim.lr_scheduler.CyclicLR(optimizer, base_lr=0.1, max_lr=0.3, step_size_up=1, step_size_down=3)
+
+        lrs = []
+
+        for i in range(40):
+            if i <= lr_scheduler_1.T_max:
+                lr_scheduler_1.step()
+            else:
+                lr_scheduler_2.step()
+            lrs.append(
+                optimizer.param_groups[0]["lr"]
+            )
+
+        self.assertLessEqual(lrs[-1], 0.3)
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -611,6 +611,7 @@ class CyclicLR(_LRScheduler):
             self.max_momentums = self._format_param('max_momentum', optimizer, max_momentum)
 
         super(CyclicLR, self).__init__(optimizer, last_epoch)
+        self.base_lrs = base_lrs
 
     def _format_param(self, name, optimizer, param):
         """Return correctly formatted lr/momentum for each param group."""


### PR DESCRIPTION
base_lr parameter was being overridden by super `__init__`, see #21965.
