### PR TITLE
[pytorch][dev setup] remove "build_deps" arg from setup.py command in
onnx_c2_setup.sh

### DIFF
--- a/scripts/fbcode-dev-setup/onnx_c2_setup.sh
+++ b/scripts/fbcode-dev-setup/onnx_c2_setup.sh
@@ -140,7 +140,7 @@ with_proxy python setup.py develop
 # Build PyTorch and Caffe2
 cd "$onnx_root/pytorch"
 with_proxy pip install -r "requirements.txt"
-with_proxy python setup.py build_deps develop
+with_proxy python setup.py develop
 
 # Sanity checks and useful info
 cd "$onnx_root"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26113 [pytorch][dev setup] remove "build_deps" arg from setup.py command in
onnx_c2_setup.sh**


This diff removes the `build_deps` arg passed into `setup.py` in `onnx_c2_setup.sh`. 

After https://github.com/pytorch/pytorch/pull/16914, passing in an
argument such as "build_deps" (i.e. `python setup.py build_deps develop`) is
invalid since it gets picked up as an invalid argument in `setup.py`. There is already a flag `RUN_BUILD_DEPS` set to true in `setup.py`, so the script's functionality shouldn't change.

Test plan: Before, this script would execute "python setup.py build_deps
develop", which errored. Now it executes "python setup.py develop" without an
error. Verified by successfully running the script on devgpu.

Differential Revision: [D17350359](https://our.internmc.facebook.com/intern/diff/D17350359/)