### PR TITLE
Add the build for runtime dispatch for AVX, AVX2 instruction set

### DIFF
--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -12,6 +12,8 @@
 
 #include <caffe2/core/common.h>
 
+#include <ATen/native/DispatchStub.h>
+
 #include <sstream>
 
 namespace at {
@@ -88,6 +90,28 @@ std::string get_openmp_version() {
   return ss.str();
 }
 
+std::string used_cpu_capability() {
+  // It is possible that we override the cpu_capability with
+  // environment variable
+  std::ostringstream ss;
+  ss << "CPU capability usage: ";
+  auto capability = native::get_cpu_capability();
+  switch (capability) {
+    case native::CPUCapability::DEFAULT:
+      ss << "NO AVX";
+      break;
+    case native::CPUCapability::AVX:
+      ss << "AVX";
+      break;
+    case native::CPUCapability::AVX2:
+      ss << "AVX2";
+      break;
+    default:
+      break;
+  }
+  return ss.str();
+}
+
 std::string show_config() {
   std::ostringstream ss;
   ss << "PyTorch built with:\n"; // TODO add the version of PyTorch
@@ -140,6 +164,8 @@ std::string show_config() {
   // TODO: No version; c.f. https://github.com/Maratyszcza/NNPACK/issues/165
   ss << "  - NNPACK is enabled\n";
 #endif
+
+  ss << "  - "<< used_cpu_capability() << "\n";
 
   if (hasCUDA()) {
     ss << detail::getCUDAHooks().showConfig();

--- a/test/cpp/api/dispatch.cpp
+++ b/test/cpp/api/dispatch.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <torch/torch.h>
+#include <ATen/native/Pow.h>
+#include <torch/types.h>
+#include <torch/utils.h>
+#include <test/cpp/api/support.h>
+#include <iostream>
+#include <vector>
+#include <type_traits>
+#include <cstdlib>
+
+using namespace at;
+using namespace torch::test;
+
+struct DispatchTest : torch::test::SeedingFixture {};
+
+TEST_F(DispatchTest, TestAVX2) {
+  const std::vector<int> ints {1, 2, 3, 4};
+  const std::vector<int> result {1, 4, 27, 256};
+  const auto vals_tensor = torch::tensor(ints);
+  const auto pows_tensor = torch::tensor(ints);
+  setenv("ATEN_CPU_CAPABILITY", "avx2", 1);
+  const auto actual_pow_avx2 = vals_tensor.pow(pows_tensor);
+  for (int i = 0; i < 4; i++) {
+    ASSERT_EQ(result[i], actual_pow_avx2[i].item<int>());
+  }
+}
+
+TEST_F(DispatchTest, TestAVX) {
+  const std::vector<int> ints {1, 2, 3, 4};
+  const std::vector<int> result {1, 4, 27, 256};
+  const auto vals_tensor = torch::tensor(ints);
+  const auto pows_tensor = torch::tensor(ints);
+  setenv("ATEN_CPU_CAPABILITY", "avx", 1);
+  const auto actual_pow_avx = vals_tensor.pow(pows_tensor);
+  for (int i = 0; i < 4; i++) {
+    ASSERT_EQ(result[i], actual_pow_avx[i].item<int>());
+  }
+}
+
+TEST_F(DispatchTest, TestDefault) {
+  const std::vector<int> ints {1, 2, 3, 4};
+  const std::vector<int> result {1, 4, 27, 256};
+  const auto vals_tensor = torch::tensor(ints);
+  const auto pows_tensor = torch::tensor(ints);
+  setenv("ATEN_CPU_CAPABILITY", "default", 1);
+  const auto actual_pow_default = vals_tensor.pow(pows_tensor);
+  for (int i = 0; i < 4; i++) {
+    ASSERT_EQ(result[i], actual_pow_default[i].item<int>());
+  }
+}


### PR DESCRIPTION
Summary: We already had some optimization implementation using AVX2 for improve the quantized kernel performance. In this diff, we want to enable the runtime dispatch.

Test Plan: Sandcastle build and test

Differential Revision: D17337251

