### PR TITLE
Add a torch function similar to numpy.in1d

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9950,6 +9950,22 @@ class _TestTorchMixin(torchtest):
         val += 10
         self.assertEqual(val in x, False)
 
+    def test_isin(self):
+        a = torch.LongTensor([[1, 2, 3], [1, 1, 2], [3, 5, 1]])
+        result = torch.ByteTensor([[1, 1, 0], [1, 1, 1], [0, 1, 1]])
+
+        self.assertEqual(a.isin(torch.LongTensor([1, 2, 5])), result)
+
+        a = torch.LongTensor([[1, 2, 3], [1, 1, 2], [3, 5, 1]])
+        result = torch.ByteTensor([[1, 0, 0], [1, 1, 0], [0, 0, 1]])
+
+        self.assertEqual(a.isin(torch.LongTensor([1])), result)
+
+        a = torch.LongTensor([[6, 7, 8], [9, 0, 3], [4, 6, 7]])
+        result = torch.ByteTensor([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+        self.assertEqual(a.isin(torch.LongTensor([1, 2, 5])), result)
+
     @staticmethod
     def _test_rot90(self, use_cuda=False):
         device = torch.device("cuda" if use_cuda else "cpu")

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     'typename', 'is_tensor', 'is_storage', 'set_default_tensor_type',
     'set_rng_state', 'get_rng_state', 'manual_seed', 'initial_seed', 'seed',
     'save', 'load', 'set_printoptions', 'chunk', 'split', 'stack', 'matmul',
-    'no_grad', 'enable_grad', 'rand', 'randn',
+    'no_grad', 'enable_grad', 'rand', 'randn', 'isin',
     'DoubleStorage', 'FloatStorage', 'LongStorage', 'IntStorage',
     'ShortStorage', 'CharStorage', 'ByteStorage', 'BoolStorage',
     'DoubleTensor', 'FloatTensor', 'LongTensor', 'IntTensor',

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -318,6 +318,14 @@ class Tensor(torch._C._TensorBase):
         """
         return torch.unique_consecutive(self, return_inverse=return_inverse, return_counts=return_counts, dim=dim)
 
+    def isin(self, other):
+        r""" Compares a tensor element-wise with a list of possible values.
+
+        See :func:`torch.isin`
+        """
+        result = (self[..., None] == other).any(-1)
+        return result.type(torch.ByteTensor)
+
     def __rsub__(self, other):
         return _C._VariableFunctions.rsub(self, other)
 


### PR DESCRIPTION
PR to have a function similar to https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.in1d.html, that compares a tensor element-wise with a list of possible values.

```
>>> a = torch.LongTensor([[1,2,3],[1,1,2],[3,5,1]])
>>> a
 1  2  3
 1  1  2
 3  5  1
[torch.LongTensor of size 3x3]
>>> a.in(torch.LongTensor([1, 2, 5]))
 1 1 0
 1 1 1
 0 1 1
[torch.ByteTensor of size 3x3]
```

resolve #3025