### PR TITLE
Enabled bfloat16 dtype on CUDA

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -6,6 +6,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   device_guard: False
   return: argument 0
   options:
@@ -44,6 +45,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   options:
     - arguments:
       - THTensor* self
@@ -62,6 +64,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   device_guard: False
   return: bool
   arguments:
@@ -73,6 +76,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   cname: maskedFill
   variants: function
   return: self
@@ -94,6 +98,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   cname: maskedFillBool
   variants: function
   return: self
@@ -115,6 +120,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   cname: maskedCopy
   variants: function
   return: self
@@ -129,6 +135,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   cname: maskedCopyBool
   variants: function
   return: self
@@ -144,6 +151,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -160,6 +168,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -177,6 +186,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -196,6 +206,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   arguments:
     - THTensor* self
 ]]
@@ -206,6 +217,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: self
@@ -318,6 +330,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   device_guard: False
   return: argument 0
   arguments:
@@ -611,6 +624,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -634,6 +648,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -657,6 +672,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   variants: function
   options:
@@ -677,6 +693,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -700,6 +717,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -723,6 +741,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   variants: function
   options:
@@ -743,6 +762,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -766,6 +786,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -789,6 +810,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   variants: function
   options:
@@ -809,6 +831,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -832,6 +855,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -855,6 +879,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   variants: function
   options:
@@ -875,6 +900,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -898,6 +924,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -921,6 +948,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   variants: function
   options:
@@ -941,6 +969,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -964,6 +993,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   return: argument 0
@@ -987,6 +1017,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   variants: function
   options:
@@ -1670,6 +1701,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   variants:
     - function
   arguments:
@@ -2433,6 +2465,7 @@
   cpu_bool: True
   cuda_bool: True
   cpu_bfloat16: True
+  cuda_bfloat16: True
   return: self
   arguments:
     - arg: THTensor* self

--- a/aten/src/ATen/cuda/NumericLimits.cuh
+++ b/aten/src/ATen/cuda/NumericLimits.cuh
@@ -95,6 +95,14 @@ struct numeric_limits<at::Half> {
 };
 
 template <>
+struct numeric_limits<at::BFloat16> {
+  static inline __host__ __device__ at::BFloat16 lowest() { return at::BFloat16(0x0080, at::BFloat16::from_bits()); }
+  static inline __host__ __device__ at::BFloat16 max() { return at::BFloat16(0x7F7F, at::BFloat16::from_bits()); }
+  static inline __host__ __device__ at::BFloat16 lower_bound() { return at::BFloat16(0xFF80, at::BFloat16::from_bits()); }
+  static inline __host__ __device__ at::BFloat16 upper_bound() { return at::BFloat16(0x7F80, at::BFloat16::from_bits()); }
+};
+
+template <>
 struct numeric_limits<float> {
   static inline __host__ __device__ float lowest() { return -FLT_MAX; }
   static inline __host__ __device__ float max() { return FLT_MAX; }

--- a/aten/src/ATen/cuda/NumericLimits.cuh
+++ b/aten/src/ATen/cuda/NumericLimits.cuh
@@ -96,7 +96,7 @@ struct numeric_limits<at::Half> {
 
 template <>
 struct numeric_limits<at::BFloat16> {
-  static inline __host__ __device__ at::BFloat16 lowest() { return at::BFloat16(0x0080, at::BFloat16::from_bits()); }
+  static inline __host__ __device__ at::BFloat16 lowest() { return at::BFloat16(0xFF7F, at::BFloat16::from_bits()); }
   static inline __host__ __device__ at::BFloat16 max() { return at::BFloat16(0x7F7F, at::BFloat16::from_bits()); }
   static inline __host__ __device__ at::BFloat16 lower_bound() { return at::BFloat16(0xFF80, at::BFloat16::from_bits()); }
   static inline __host__ __device__ at::BFloat16 upper_bound() { return at::BFloat16(0x7F80, at::BFloat16::from_bits()); }

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -577,6 +577,7 @@ FunctionOption = TypedDict('FunctionOption', {
     'with_gil': bool,
     'cpu_half': bool,
     'cpu_bfloat16': bool,
+    'cuda_bfloat16': bool,
     'deprecated': bool,
     'cpu_bool': bool,
     'cuda_bool': bool,

--- a/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryOpsKernel.cu
@@ -14,7 +14,7 @@
 namespace at { namespace native {
 
 void add_kernel_cuda(TensorIterator& iter, Scalar alpha_scalar) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(), "add_cuda/sub_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(), "add_cuda/sub_cuda", [&]() {
     auto alpha = alpha_scalar.to<scalar_t>();
     gpu_kernel_with_scalars(iter, [alpha]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
       return a + alpha * b;

--- a/aten/src/ATen/native/cuda/CUDAScalar.cu
+++ b/aten/src/ATen/native/cuda/CUDAScalar.cu
@@ -9,8 +9,8 @@ namespace native {
 
 Scalar _local_scalar_dense_cuda(const Tensor& self) {
   Scalar r;
-  AT_DISPATCH_ALL_TYPES_AND2(
-    at::ScalarType::Half, at::ScalarType::Bool, self.scalar_type(), "_local_scalar_dense_cuda", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(
+    at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_local_scalar_dense_cuda", [&] {
         scalar_t value;
         cudaStream_t stream = at::cuda::getCurrentCUDAStream();
         AT_CUDA_CHECK(cudaMemcpyAsync(&value, self.data_ptr<scalar_t>(), sizeof(scalar_t), cudaMemcpyDeviceToHost, stream));

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -65,9 +65,9 @@ static void copy_device_to_device(TensorIterator& iter, bool non_blocking) {
         cudaMemcpyDeviceToDevice,
         copy_stream));
   } else {
-    AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(0), "copy_", [&] {
+    AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(0), "copy_", [&] {
       using dst_t = scalar_t;
-      AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBool, iter.dtype(1), "copy_", [&] {
+      AT_DISPATCH_ALL_TYPES_AND3(kHalf, kBool, kBFloat16, iter.dtype(1), "copy_", [&] {
         copy_kernel_impl<dst_t, scalar_t>(iter);
       });
     });

--- a/aten/src/ATen/native/cuda/FillKernel.cu
+++ b/aten/src/ATen/native/cuda/FillKernel.cu
@@ -7,7 +7,7 @@
 namespace at { namespace native {
 
 void fill_kernel_cuda(TensorIterator& iter, Scalar value) {
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half, iter.dtype(), "fill_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "fill_cuda", [&]() {
     auto value_converted = value.to<scalar_t>();
     gpu_kernel(iter, [value_converted]GPU_LAMBDA() -> scalar_t {
       return value_converted;

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -97,7 +97,7 @@ static void index_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayR
 
 static void index_put_kernel(TensorIterator& iter, IntArrayRef index_size, IntArrayRef index_stride, bool accumulate) {
   AT_ASSERTM(!accumulate, "index_put does not support accumulate=true");
-  AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::Bool, iter.dtype(), "index_put", [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, iter.dtype(), "index_put", [&] {
     using dtype = OpaqueType<sizeof(scalar_t)>;
     index_put_kernel_impl<dtype>(iter, index_size, index_stride);
   });

--- a/aten/src/ATen/native_parse.py
+++ b/aten/src/ATen/native_parse.py
@@ -408,6 +408,7 @@ def run(paths):
                 declaration['matches_jit_signature'] = func.get('matches_jit_signature', True)
                 declaration['cpu_half'] = func.get('cpu_half', False)
                 declaration['cpu_bfloat16'] = func.get('cpu_bfloat16', False)
+                declaration['cuda_bfloat16'] = func.get('cuda_bfloat16', False)
                 declaration['cpu_bool'] = func.get('cpu_bool', False)
                 declaration['cuda_bool'] = func.get('cuda_bool', False)
                 declaration['deprecated'] = func.get('deprecated', False)

--- a/aten/src/ATen/preprocess_declarations.py
+++ b/aten/src/ATen/preprocess_declarations.py
@@ -71,14 +71,14 @@ def process_types_and_backends(option):
         if 'CPU' in backend_types:
             backend_types['CPU'].discard('Half')
 
-    # special case remove BFloat16 for cpu unless it is explicitly enabled
+    # special case remove BFloat16 for cpu and cuda unless it is explicitly enabled
     if not option.get('cpu_bfloat16', False):
         if 'CPU' in backend_types:
             backend_types['CPU'].discard('BFloat16')
 
-    # TODO: remove this hack once support for a bfloat16 tensor for CUDA is enabled
-    if 'CUDA' in backend_types:
-        backend_types['CUDA'].discard('BFloat16')
+    if not option.get('cuda_bfloat16', False):
+        if 'CUDA' in backend_types:
+            backend_types['CUDA'].discard('BFloat16')
 
     # special cases remove bool for cpu and cuda unless it is explicitly enabled
     if not option.get('cpu_bool', False):

--- a/aten/src/THC/CMakeLists.txt
+++ b/aten/src/THC/CMakeLists.txt
@@ -26,6 +26,14 @@ foreach(THC_FILE TensorMathCompareT TensorMathCompare TensorMathReduce TensorMas
    LIST(APPEND extra_src "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}Bool.cu")
 endforeach()
 
+foreach(THC_FILE TensorMathCompareT TensorMathCompare TensorMathReduce TensorMasked)
+   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}BFloat16.cu")
+      FILE(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}BFloat16.cu"
+        "#include <THC/THC${THC_FILE}.cuh>\n#include <THC/THCTensor.hpp>\n\n#include <THC/generic/THC${THC_FILE}.cu>\n#include <THC/THCGenerateBFloat16Type.h>\n")
+   endif()
+   LIST(APPEND extra_src "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}BFloat16.cu")
+endforeach()
+
 set(ATen_CUDA_SRCS ${ATen_CUDA_SRCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/THCCachingHostAllocator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/THCGeneral.cpp

--- a/aten/src/THC/CMakeLists.txt
+++ b/aten/src/THC/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(THC_TYPE Byte Char Short Int Long Half Float Double)
    endforeach()
 endforeach()
 
-foreach(THC_FILE TensorMathCompareT TensorMathCompare TensorMathReduce TensorMasked TensorMathPointwise)
+foreach(THC_FILE TensorMathCompareT TensorMathPointwise TensorMathCompare TensorMathReduce TensorMasked)
    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}Bool.cu")
       FILE(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/generated/THC${THC_FILE}Bool.cu"
         "#include <THC/THC${THC_FILE}.cuh>\n#include <THC/THCTensor.hpp>\n\n#include <THC/generic/THC${THC_FILE}.cu>\n#include <THC/THCGenerateBoolType.h>\n")

--- a/aten/src/THC/THCGenerateBFloat16Type.h
+++ b/aten/src/THC/THCGenerateBFloat16Type.h
@@ -4,6 +4,7 @@
 #include <c10/util/BFloat16.h>
 
 #define scalar_t at::BFloat16
+#define accreal float
 #define Real BFloat16
 
 #define CReal CudaBFloat16
@@ -12,6 +13,7 @@
 #line 1 THC_GENERIC_FILE
 #include THC_GENERIC_FILE
 #undef scalar_t
+#undef accreal
 #undef Real
 
 #undef CReal

--- a/aten/src/THC/THCNumerics.cuh
+++ b/aten/src/THC/THCNumerics.cuh
@@ -321,6 +321,59 @@ struct THCNumerics<float> {
   static inline __host__ __device__  bool isinf(float a) { return ::isinf(a); }
 };
 
+template <>
+struct THCNumerics<at::BFloat16> {
+  static inline __host__ __device__ at::BFloat16 min() { return at::numeric_limits<at::BFloat16>::lowest(); }
+  static inline __host__ __device__ at::BFloat16 max() { return at::numeric_limits<at::BFloat16>::max(); }
+  static inline __host__ __device__ at::BFloat16 lower_bound() { return at::numeric_limits<at::BFloat16>::lower_bound(); }
+  static inline __host__ __device__ at::BFloat16 upper_bound() { return at::numeric_limits<at::BFloat16>::upper_bound(); }
+
+  static inline __host__ __device__ bool lt(at::BFloat16 a, at::BFloat16 b) { return a < b; }
+  static inline __host__ __device__ bool le(at::BFloat16 a, at::BFloat16 b) { return a <= b; }
+  static inline __host__ __device__ bool gt(at::BFloat16 a, at::BFloat16 b) { return a > b; }
+  static inline __host__ __device__ bool ge(at::BFloat16 a, at::BFloat16 b) { return a >= b; }
+  static inline __host__ __device__ bool eq(at::BFloat16 a, at::BFloat16 b) { return a == b; }
+  static inline __host__ __device__ bool ne(at::BFloat16 a, at::BFloat16 b) { return a != b; }
+
+  static inline __host__ __device__  at::BFloat16 lgamma(at::BFloat16 a) { return lgammaf(a);}
+  static inline __host__ __device__  at::BFloat16 exp  (at::BFloat16 a) { return   expf(a); }
+  static inline __host__ __device__  at::BFloat16 exp10(at::BFloat16 a) { return exp10f(a); }
+  static inline __host__ __device__  at::BFloat16 log  (at::BFloat16 a) { return   logf(a); }
+  static inline __host__ __device__  at::BFloat16 log10(at::BFloat16 a) { return log10f(a); }
+  static inline __host__ __device__  at::BFloat16 log1p(at::BFloat16 a) { return log1pf(a); }
+  static inline __host__ __device__  at::BFloat16 log2 (at::BFloat16 a) { return  log2f(a); }
+  static inline __host__ __device__  at::BFloat16 expm1(at::BFloat16 a) { return expm1f(a); }
+  static inline __host__ __device__  at::BFloat16 cos  (at::BFloat16 a) { return   cosf(a); }
+  static inline __host__ __device__  at::BFloat16 sin  (at::BFloat16 a) { return   sinf(a); }
+  static inline __host__ __device__  at::BFloat16 sqrt (at::BFloat16 a) { return  sqrtf(a); }
+  static inline __host__ __device__  at::BFloat16 rsqrt(at::BFloat16 a) { return rsqrtf(a); }
+  static inline __host__ __device__  at::BFloat16 floor(at::BFloat16 a) { return floorf(a); }
+  static inline __host__ __device__  at::BFloat16 trunc(at::BFloat16 a) { return truncf(a); }
+  static inline __host__ __device__  at::BFloat16 acos (at::BFloat16 a) { return  acosf(a); }
+  static inline __host__ __device__  at::BFloat16 cosh (at::BFloat16 a) { return  coshf(a); }
+  static inline __host__ __device__  at::BFloat16 acosh(at::BFloat16 a) { return acoshf(a); }
+  static inline __host__ __device__  at::BFloat16 asin (at::BFloat16 a) { return  asinf(a); }
+  static inline __host__ __device__  at::BFloat16 sinh (at::BFloat16 a) { return  sinhf(a); }
+  static inline __host__ __device__  at::BFloat16 asinh(at::BFloat16 a) { return asinhf(a); }
+  static inline __host__ __device__  at::BFloat16 tan  (at::BFloat16 a) { return   tanf(a); }
+  static inline __host__ __device__  at::BFloat16 atan (at::BFloat16 a) { return  atanf(a); }
+  static inline __host__ __device__  at::BFloat16 tanh (at::BFloat16 a) { return  tanhf(a); }
+  static inline __host__ __device__  at::BFloat16 erf  (at::BFloat16 a) { return   erff(a); }
+  static inline __host__ __device__  at::BFloat16 erfc (at::BFloat16 a) { return  erfcf(a); }
+  static inline __host__ __device__  at::BFloat16 abs  (at::BFloat16 a) { return  fabsf(a); }
+  static inline __host__ __device__  at::BFloat16 round(at::BFloat16 a) { return nearbyintf(a); }
+  static inline __host__ __device__  at::BFloat16 frac (at::BFloat16 a) { return a - truncf(a); }
+  static inline __host__ __device__  at::BFloat16 cinv (at::BFloat16 a) { return 1.0f / a; }
+  static inline __host__ __device__  at::BFloat16 add  (at::BFloat16 a, at::BFloat16 b) { return a + b; }
+  static inline __host__ __device__  at::BFloat16 div  (at::BFloat16 a, at::BFloat16 b) { return a / b; }
+  static inline __host__ __device__  at::BFloat16 mul  (at::BFloat16 a, at::BFloat16 b) { return a * b; }
+  static inline __host__ __device__  at::BFloat16 sub  (at::BFloat16 a, at::BFloat16 b) { return a - b; }
+  static inline __host__ __device__  at::BFloat16 pow  (at::BFloat16 a, at::BFloat16 b) { return powf(a, b); }
+  static inline __host__ __device__  at::BFloat16 atan2(at::BFloat16 a, at::BFloat16 b) { return atan2f(a, b); }
+  static inline __host__ __device__  bool isnan(at::BFloat16 a) { return ::isnan(a); }
+  static inline __host__ __device__  bool isinf(at::BFloat16 a) { return ::isinf(a); }
+};
+
 // DEPRECATED: use math functions from std and cuda math API (if needed)
 //             note that the functions exp10,rsqrt,erfinv,frac and cinv
 //             are not in the std namespace

--- a/aten/src/THC/THCTensorMath.cu
+++ b/aten/src/THC/THCTensorMath.cu
@@ -123,3 +123,6 @@ struct NonZeroOp<bool>
 
 #include <THC/generic/THCTensorMath.cu>
 #include <THC/THCGenerateBoolType.h>
+
+#include <THC/generic/THCTensorMath.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/THCTensorMath.h
+++ b/aten/src/THC/THCTensorMath.h
@@ -10,6 +10,9 @@
 #include <THC/generic/THCTensorMath.h>
 #include <THC/THCGenerateBoolType.h>
 
+#include <THC/generic/THCTensorMath.h>
+#include <THC/THCGenerateBFloat16Type.h>
+
 #include <THC/generic/THCTensorMathBlas.h>
 #include <THC/THCGenerateAllTypes.h>
 
@@ -34,17 +37,26 @@
 #include <THC/generic/THCTensorMathReduce.h>
 #include <THC/THCGenerateBoolType.h>
 
+#include <THC/generic/THCTensorMathReduce.h>
+#include <THC/THCGenerateBFloat16Type.h>
+
 #include <THC/generic/THCTensorMathCompare.h>
 #include <THC/THCGenerateAllTypes.h>
 
 #include <THC/generic/THCTensorMathCompare.h>
 #include <THC/THCGenerateBoolType.h>
 
+#include <THC/generic/THCTensorMathCompare.h>
+#include <THC/THCGenerateBFloat16Type.h>
+
 #include <THC/generic/THCTensorMathCompareT.h>
 #include <THC/THCGenerateAllTypes.h>
 
 #include <THC/generic/THCTensorMathCompareT.h>
 #include <THC/THCGenerateBoolType.h>
+
+#include <THC/generic/THCTensorMathCompareT.h>
+#include <THC/THCGenerateBFloat16Type.h>
 
 #include <THC/generic/THCTensorMathScan.h>
 #include <THC/THCGenerateAllTypes.h>
@@ -57,6 +69,9 @@
 
 #include <THC/generic/THCTensorMasked.h>
 #include <THC/THCGenerateBoolType.h>
+
+#include <THC/generic/THCTensorMasked.h>
+#include <THC/THCGenerateBFloat16Type.h>
 
 #include <THC/generic/THCTensorScatterGather.h>
 #include <THC/THCGenerateAllTypes.h>

--- a/aten/src/THC/generated/THCTensorMaskedBFloat16.cu
+++ b/aten/src/THC/generated/THCTensorMaskedBFloat16.cu
@@ -1,0 +1,5 @@
+#include <THC/THCTensorMasked.cuh>
+#include <THC/THCTensor.hpp>
+
+#include <THC/generic/THCTensorMasked.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/generated/THCTensorMathCompareBFloat16.cu
+++ b/aten/src/THC/generated/THCTensorMathCompareBFloat16.cu
@@ -1,0 +1,5 @@
+#include <THC/THCTensorMathCompare.cuh>
+#include <THC/THCTensor.hpp>
+
+#include <THC/generic/THCTensorMathCompare.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/generated/THCTensorMathCompareTBFloat16.cu
+++ b/aten/src/THC/generated/THCTensorMathCompareTBFloat16.cu
@@ -1,0 +1,5 @@
+#include <THC/THCTensorMathCompareT.cuh>
+#include <THC/THCTensor.hpp>
+
+#include <THC/generic/THCTensorMathCompareT.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/generated/THCTensorMathPointwiseBFloat16.cu
+++ b/aten/src/THC/generated/THCTensorMathPointwiseBFloat16.cu
@@ -1,0 +1,5 @@
+#include <THC/THCTensorMathPointwise.cuh>
+#include <THC/THCTensor.hpp>
+
+#include <THC/generic/THCTensorMathPointwise.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/generated/THCTensorMathPointwiseBFloat16.cu
+++ b/aten/src/THC/generated/THCTensorMathPointwiseBFloat16.cu
@@ -1,5 +1,0 @@
-#include <THC/THCTensorMathPointwise.cuh>
-#include <THC/THCTensor.hpp>
-
-#include <THC/generic/THCTensorMathPointwise.cu>
-#include <THC/THCGenerateBFloat16Type.h>

--- a/aten/src/THC/generated/THCTensorMathReduceBFloat16.cu
+++ b/aten/src/THC/generated/THCTensorMathReduceBFloat16.cu
@@ -1,0 +1,5 @@
+#include <THC/THCTensorMathReduce.cuh>
+#include <THC/THCTensor.hpp>
+
+#include <THC/generic/THCTensorMathReduce.cu>
+#include <THC/THCGenerateBFloat16Type.h>

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -313,7 +313,7 @@ static inline bool isSignedType(ScalarType t) {
       return std::numeric_limits<ctype>::is_signed;
 
     switch (t) {
-      AT_FORALL_SCALAR_TYPES_AND(Half, CASE_SIGNED)
+      AT_FORALL_SCALAR_TYPES_AND2(Half, BFloat16, CASE_SIGNED)
       default:
         AT_ERROR("Unknown ScalarType");
     }

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -684,6 +684,9 @@ class TestCase(expecttest.TestCase):
                     if (a.device.type == 'cpu' and (a.dtype == torch.float16 or a.dtype == torch.bfloat16)):
                         # CPU half and bfloat16 tensors don't have the methods we need below
                         a = a.to(torch.float32)
+                    if (a.device.type == 'cuda' and a.dtype == torch.bfloat16):
+                        # CPU half and bfloat16 tensors don't have the methods we need below
+                        a = a.to(torch.float32)
                     b = b.to(a)
 
                     if (a.dtype == torch.bool) != (b.dtype == torch.bool):

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -684,9 +684,11 @@ class TestCase(expecttest.TestCase):
                     if (a.device.type == 'cpu' and (a.dtype == torch.float16 or a.dtype == torch.bfloat16)):
                         # CPU half and bfloat16 tensors don't have the methods we need below
                         a = a.to(torch.float32)
+
                     if (a.device.type == 'cuda' and a.dtype == torch.bfloat16):
-                        # CPU half and bfloat16 tensors don't have the methods we need below
+                        # CUDA bfloat16 tensors don't have the methods we need below
                         a = a.to(torch.float32)
+
                     b = b.to(a)
 
                     if (a.dtype == torch.bool) != (b.dtype == torch.bool):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6046,9 +6046,6 @@ class _TestTorchMixin(torchtest):
                 continue
             if t.is_cuda and not torch.cuda.is_available():
                 continue
-            if t == torch.cuda.BFloat16Tensor:
-                self.assertRaises(RuntimeError, lambda: t(100, 100).fill_(1))
-                continue
             obj = t(100, 100).fill_(1)
             obj.__repr__()
             str(obj)
@@ -11848,9 +11845,6 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
         for dt in torch.testing.get_all_dtypes():
             x = torch.tensor([1, 2, 3, 4], dtype=dt, device=device)
             x_clone = x.clone()
-            if (device == 'cuda' and dt == torch.bfloat16):
-                self.assertRaises(RuntimeError, lambda: copy(x))
-                continue
             y = copy(x)
             y.fill_(1)
             # copy is a shallow copy, only copies the tensor view,
@@ -11874,17 +11868,11 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
     def test_view_all_dtypes_and_devices(self, device):
         for dt in torch.testing.get_all_dtypes():
             x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
-            if (device == 'cuda' and dt == torch.bfloat16):
-                self.assertRaises(RuntimeError, lambda: x.view(6))
-                continue
             self.assertEqual(x.view(6).shape, [6])
 
     def test_fill_all_dtypes_and_devices(self, device):
         for dt in torch.testing.get_all_dtypes():
             x = torch.tensor((1, 1), dtype=dt, device=device)
-            if (device == 'cuda' and dt == torch.bfloat16):
-                self.assertRaises(RuntimeError, lambda: x.fill_(1))
-                continue
             x.fill_(1)
 
             self.assertEqual(x, torch.tensor([1, 1], dtype=dt, device=device))
@@ -11894,18 +11882,11 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
         for dt in torch.testing.get_all_dtypes():
             x = torch.tensor((1, 1), dtype=dt, device=device)
             y = x.clone()
-            if (device == 'cuda' and dt == torch.bfloat16):
-                # `x - y` is used inside of the assertEqual
-                self.assertRaises(RuntimeError, lambda: x - y)
-                continue
             self.assertEqual(x, y)
 
     def test_cat_all_dtypes_and_devices(self, device):
         for dt in torch.testing.get_all_dtypes():
             x = torch.tensor([[1, 2], [3, 4]], dtype=dt, device=device)
-            if (device == 'cuda' and dt == torch.bfloat16):
-                self.assertRaises(RuntimeError, lambda: torch.cat((x, x), 0))
-                continue
 
             expected1 = torch.tensor([[1, 2], [3, 4], [1, 2], [3, 4]], dtype=dt, device=device)
             self.assertEqual(torch.cat((x, x), 0), expected1)
@@ -11920,24 +11901,15 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
         for shape in shapes:
             for dt in torch.testing.get_all_dtypes():
 
-                if (device == 'cuda' and dt == torch.bfloat16):
-                    self.assertRaises(RuntimeError, lambda: torch.zeros(shape, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.full(shape, 3, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3))
-                    self.assertRaises(RuntimeError, lambda: torch.ones(shape, device=device, dtype=dt).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertRaises(RuntimeError, lambda: torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                else:
-                    self.assertEqual(shape, torch.zeros(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertEqual(shape, torch.full(shape, 3, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
-                    self.assertEqual(shape, torch.ones(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertEqual(shape, torch.empty(shape, device=device, dtype=dt).shape)
-                    self.assertEqual(shape, torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    self.assertEqual(shape, torch.empty_strided(shape, (0,) * len(shape), device=device, dtype=dt).shape)
+                self.assertEqual(shape, torch.zeros(shape, device=device, dtype=dt).shape)
+                self.assertEqual(shape, torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                self.assertEqual(shape, torch.full(shape, 3, device=device, dtype=dt).shape)
+                self.assertEqual(shape, torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
+                self.assertEqual(shape, torch.ones(shape, device=device, dtype=dt).shape)
+                self.assertEqual(shape, torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                self.assertEqual(shape, torch.empty(shape, device=device, dtype=dt).shape)
+                self.assertEqual(shape, torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                self.assertEqual(shape, torch.empty_strided(shape, (0,) * len(shape), device=device, dtype=dt).shape)
 
                 if dt == torch.half and device == "cpu":
                     # update once random is implemented for half on CPU
@@ -12075,15 +12047,6 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
             if dt == torch.bool:
                 # torch.bool is a special case and is being tested later
                 # in this test
-                continue
-
-            if device == 'cuda' and dt == torch.bfloat16:
-                self.assertRaises(RuntimeError, lambda: x > b)
-                self.assertRaises(RuntimeError, lambda: x < b)
-                self.assertRaises(RuntimeError, lambda: x == b)
-                self.assertRaises(RuntimeError, lambda: x != b)
-                self.assertRaises(RuntimeError, lambda: x >= b)
-                self.assertRaises(RuntimeError, lambda: x <= b)
                 continue
 
             self.assertEqual(x.lt(2), torch.tensor([True, False, False, False]))
@@ -12276,11 +12239,6 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
                     num_src = 10
                     src = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=dt, device=device)
                     mask = torch.rand(num_src, device=device).clamp(0, 1).mul(2).floor().to(maskType)
-
-                    if dt == torch.bfloat16 and device == 'cuda':
-                        # remove once bfloat16 implemented on CUDA
-                        self.assertRaises(RuntimeError, lambda: src.masked_select(mask))
-                        continue
 
                     if dt == torch.half and device == 'cpu':
                         self.assertRaises(RuntimeError, lambda: src.masked_select(mask))


### PR DESCRIPTION
Enabled basic functionality for bfloat16 dtype on CUDA. 
Tested via unit tests.