### PR TITLE
[android] javadocs for Tensor, IValue, Module

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/IValue.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/IValue.java
@@ -3,6 +3,12 @@ package org.pytorch;
 import java.util.Locale;
 import java.util.Map;
 
+/**
+ * Java representation of a torchscript variable, which is implemented as tagged union that can be
+ * one of the supported types: https://pytorch.org/docs/stable/jit.html#types.
+ * <p>
+ * Calling getters for inappropriate types will throw IllegalStateException.
+ */
 public class IValue {
   private static final int TYPE_CODE_NULL = 1;
 
@@ -84,54 +90,81 @@ public class IValue {
     return new IValue(TYPE_CODE_NULL);
   }
 
+  /**
+   * Creates a new IValue instance of torchscript Tensor type.
+   */
   public static IValue tensor(Tensor tensor) {
     final IValue iv = new IValue(TYPE_CODE_TENSOR);
     iv.mData = tensor;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript bool type.
+   */
   public static IValue bool(boolean value) {
     final IValue iv = new IValue(TYPE_CODE_BOOL);
     iv.mData = value;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript int type.
+   */
   public static IValue long64(long value) {
     final IValue iv = new IValue(TYPE_CODE_LONG);
     iv.mData = value;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript float type.
+   */
   public static IValue double64(double value) {
     final IValue iv = new IValue(TYPE_CODE_DOUBLE);
     iv.mData = value;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript List[bool] type.
+   */
   public static IValue boolList(boolean... list) {
     final IValue iv = new IValue(TYPE_CODE_BOOL_LIST);
     iv.mData = list;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript List[int] type.
+   */
   public static IValue longList(long... list) {
     final IValue iv = new IValue(TYPE_CODE_LONG_LIST);
     iv.mData = list;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript List[float] type.
+   */
   public static IValue doubleList(double... list) {
     final IValue iv = new IValue(TYPE_CODE_DOUBLE_LIST);
     iv.mData = list;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript List[Tensor] type.
+   */
   public static IValue tensorList(Tensor... list) {
     final IValue iv = new IValue(TYPE_CODE_TENSOR_LIST);
     iv.mData = list;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript List[T] type. All elements must have the same type.
+   */
   public static IValue list(IValue... array) {
     final int size = array.length;
     if (size > 0) {
@@ -148,18 +181,27 @@ public class IValue {
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript Tuple[T0, T1, ...] type.
+   */
   public static IValue tuple(IValue... array) {
     final IValue iv = new IValue(TYPE_CODE_TUPLE);
     iv.mData = array;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance oftorchscript Dict[Str, V] type.
+   */
   public static IValue dictStringKey(Map<String, IValue> map) {
     final IValue iv = new IValue(TYPE_CODE_DICT_STRING_KEY);
     iv.mData = map;
     return iv;
   }
 
+  /**
+   * Creates a new IValue instance of torchscript Dict[int, V] type.
+   */
   public static IValue dictLongKey(Map<Long, IValue> map) {
     final IValue iv = new IValue(TYPE_CODE_DICT_LONG_KEY);
     iv.mData = map;

--- a/android/pytorch_android/src/main/java/org/pytorch/Module.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Module.java
@@ -4,10 +4,20 @@ package org.pytorch;
 
 import com.facebook.jni.HybridData;
 
+/**
+ * Java holder for torch::jit::script::Module which owns it on jni side.
+ */
 public class Module {
 
   private NativePeer mNativePeer;
 
+  /**
+   * Loads serialized torchscript module from the specified absolute path on the disk.
+   *
+   * @param modelAbsolutePath absolute path to file that contains the serialized torchscript module.
+   * @return new {@link org.pytorch.Module} object which owns torch::jit::script::Module on jni
+   * side.
+   */
   public static Module load(final String modelAbsolutePath) {
     return new Module(modelAbsolutePath);
   }
@@ -16,10 +26,23 @@ public class Module {
     this.mNativePeer = new NativePeer(moduleAbsolutePath);
   }
 
+  /**
+   * Runs 'forward' method of loaded torchscript module with specified arguments.
+   *
+   * @param inputs arguments for torchscript module 'forward' method.
+   * @return result of torchscript module 'forward' method evaluation
+   */
   public IValue forward(IValue... inputs) {
     return mNativePeer.forward(inputs);
   }
 
+  /**
+   * Runs specified method of loaded torchscript module with specified arguments.
+   *
+   * @param methodName torchscript module method to run
+   * @param inputs     arguments that will be specified to torchscript module method call
+   * @return result of torchscript module specified method evaluation
+   */
   public IValue runMethod(String methodName, IValue... inputs) {
     return mNativePeer.runMethod(methodName, inputs);
   }

--- a/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/Tensor.java
@@ -10,12 +10,23 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 import java.util.Locale;
 
+/**
+ * Representation of Tensor. Tensor shape is stored in {@link Tensor#shape}, elements are stored as
+ * {@link java.nio.DirectByteBuffer} of one of the supported types.
+ */
 public abstract class Tensor {
+
+  /** Code for dtype torch.uint8. {@link Tensor#dtype()} */
   public static final int DTYPE_UINT8 = 1;
+  /** Code for dtype torch.int8. {@link Tensor#dtype()} */
   public static final int DTYPE_INT8 = 2;
+  /** Code for dtype torch.int32. {@link Tensor#dtype()} */
   public static final int DTYPE_INT32 = 3;
+  /** Code for dtype torch.float32. {@link Tensor#dtype()} */
   public static final int DTYPE_FLOAT32 = 4;
+  /** Code for dtype torch.int64. {@link Tensor#dtype()} */
   public static final int DTYPE_INT64 = 5;
+  /** Code for dtype torch.float64. {@link Tensor#dtype()} */
   public static final int DTYPE_FLOAT64 = 6;
 
   private static final String ERROR_MSG_DATA_BUFFER_NOT_NULL = "Data buffer must be not null";
@@ -28,6 +39,7 @@ public abstract class Tensor {
   private static final String ERROR_MSG_DATA_BUFFER_MUST_BE_DIRECT =
       "Data buffer must be direct (java.nio.ByteBuffer#allocateDirect)";
 
+  /** Shape of current tensor. */
   public final long[] shape;
 
   private static final int INT_SIZE_BYTES = 4;
@@ -35,6 +47,13 @@ public abstract class Tensor {
   private static final int LONG_SIZE_BYTES = 8;
   private static final int DOUBLE_SIZE_BYTES = 8;
 
+  /**
+   * Allocates a new direct {@link java.nio.ByteBuffer} with native byte order with specified
+   * capacity that can be used in {@link Tensor#newInt8Tensor(long[], ByteBuffer)}, {@link
+   * Tensor#newUInt8Tensor(long[], ByteBuffer)}.
+   *
+   * @param numElements capacity (number of elements) of result buffer.
+   */
   public static ByteBuffer allocateByteBuffer(int numElements) {
     return ByteBuffer.allocateDirect(numElements).order(ByteOrder.nativeOrder());
   }
@@ -45,24 +64,49 @@ public abstract class Tensor {
         .asIntBuffer();
   }
 
+  /**
+   * Allocates a new direct {@link java.nio.FloatBuffer} with native byte order with specified
+   * capacity that can be used in {@link Tensor#newFloat32Tensor(long[], FloatBuffer)}.
+   *
+   * @param numElements capacity (number of elements) of result buffer.
+   */
   public static FloatBuffer allocateFloatBuffer(int numElements) {
     return ByteBuffer.allocateDirect(numElements * FLOAT_SIZE_BYTES)
         .order(ByteOrder.nativeOrder())
         .asFloatBuffer();
   }
 
+  /**
+   * Allocates a new direct {@link java.nio.LongBuffer} with native byte order with specified
+   * capacity that can be used in {@link Tensor#newInt64Tensor(long[], LongBuffer)}.
+   *
+   * @param numElements capacity (number of elements) of result buffer.
+   */
   public static LongBuffer allocateLongBuffer(int numElements) {
     return ByteBuffer.allocateDirect(numElements * LONG_SIZE_BYTES)
         .order(ByteOrder.nativeOrder())
         .asLongBuffer();
   }
 
+  /**
+   * Allocates a new direct {@link java.nio.DoubleBuffer} with native byte order with specified
+   * capacity that can be used in {@link Tensor#newFloat64Tensor(long[], DoubleBuffer)}.
+   *
+   * @param numElements capacity (number of elements) of result buffer.
+   */
   public static DoubleBuffer allocateDoubleBuffer(int numElements) {
     return ByteBuffer.allocateDirect(numElements * DOUBLE_SIZE_BYTES)
         .order(ByteOrder.nativeOrder())
         .asDoubleBuffer();
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.uint8 with specified shape and data as array of
+   * bytes.
+   *
+   * @param shape Tensor shape
+   * @param data Tensor elements
+   */
   public static Tensor newUInt8Tensor(long[] shape, byte[] data) {
     checkArgument(data != null, ERROR_MSG_DATA_ARRAY_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -73,6 +117,13 @@ public abstract class Tensor {
     return new Tensor_uint8(byteBuffer, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.int8 with specified shape and data as array of
+   * bytes.
+   *
+   * @param shape Tensor shape
+   * @param data Tensor elements
+   */
   public static Tensor newInt8Tensor(long[] shape, byte[] data) {
     checkArgument(data != null, ERROR_MSG_DATA_ARRAY_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -83,6 +134,13 @@ public abstract class Tensor {
     return new Tensor_int8(byteBuffer, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.int32 with specified shape and data as array of
+   * ints.
+   *
+   * @param shape Tensor shape
+   * @param data Tensor elements
+   */
   public static Tensor newInt32Tensor(long[] shape, int[] data) {
     checkArgument(data != null, ERROR_MSG_DATA_ARRAY_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -93,6 +151,13 @@ public abstract class Tensor {
     return new Tensor_int32(intBuffer, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.float32 with specified shape and data as array
+   * of floats.
+   *
+   * @param shape Tensor shape
+   * @param data Tensor elements
+   */
   public static Tensor newFloat32Tensor(long[] shape, float[] data) {
     checkArgument(data != null, ERROR_MSG_DATA_ARRAY_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -103,6 +168,13 @@ public abstract class Tensor {
     return new Tensor_float32(floatBuffer, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.int64 with specified shape and data as array of
+   * longs.
+   *
+   * @param shape Tensor shape
+   * @param data Tensor elements
+   */
   public static Tensor newInt64Tensor(long[] shape, long[] data) {
     checkArgument(data != null, ERROR_MSG_DATA_ARRAY_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -113,6 +185,13 @@ public abstract class Tensor {
     return new Tensor_int64(longBuffer, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.float64 with specified shape and data as array
+   * of doubles.
+   *
+   * @param shape Tensor shape
+   * @param data Tensor elements
+   */
   public static Tensor newFloat64Tensor(long[] shape, double[] data) {
     checkArgument(data != null, ERROR_MSG_DATA_ARRAY_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -123,6 +202,14 @@ public abstract class Tensor {
     return new Tensor_float64(doubleBuffer, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.uint8 with specified shape and data.
+   *
+   * @param shape Tensor shape
+   * @param data Direct buffer with native byte order that contains {@code Tensor#numel(shape)}
+   *     elements. The buffer is used directly without copying, and changes to its content will
+   *     change the tensor.
+   */
   public static Tensor newUInt8Tensor(long[] shape, ByteBuffer data) {
     checkArgument(data != null, ERROR_MSG_DATA_BUFFER_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -135,6 +222,14 @@ public abstract class Tensor {
     return new Tensor_uint8(data, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.int8 with specified shape and data.
+   *
+   * @param shape Tensor shape
+   * @param data Direct buffer with native byte order that contains {@code Tensor#numel(shape)}
+   *     elements. The buffer is used directly without copying, and changes to its content will
+   *     change the tensor.
+   */
   public static Tensor newInt8Tensor(long[] shape, ByteBuffer data) {
     checkArgument(data != null, ERROR_MSG_DATA_BUFFER_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -147,6 +242,14 @@ public abstract class Tensor {
     return new Tensor_int8(data, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.int32 with specified shape and data.
+   *
+   * @param shape Tensor shape
+   * @param data Direct buffer with native byte order that contains {@code Tensor#numel(shape)}
+   *     elements. The buffer is used directly without copying, and changes to its content will
+   *     change the tensor.
+   */
   public static Tensor newInt32Tensor(long[] shape, IntBuffer data) {
     checkArgument(data != null, ERROR_MSG_DATA_BUFFER_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -159,6 +262,14 @@ public abstract class Tensor {
     return new Tensor_int32(data, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.float32 with specified shape and data.
+   *
+   * @param shape Tensor shape
+   * @param data Direct buffer with native byte order that contains {@code Tensor#numel(shape)}
+   *     elements. The buffer is used directly without copying, and changes to its content will
+   *     change the tensor.
+   */
   public static Tensor newFloat32Tensor(long[] shape, FloatBuffer data) {
     checkArgument(data != null, ERROR_MSG_DATA_BUFFER_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -171,6 +282,14 @@ public abstract class Tensor {
     return new Tensor_float32(data, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.int64 with specified shape and data.
+   *
+   * @param shape Tensor shape
+   * @param data Direct buffer with native byte order that contains {@code Tensor#numel(shape)}
+   *     elements. The buffer is used directly without copying, and changes to its content will
+   *     change the tensor.
+   */
   public static Tensor newInt64Tensor(long[] shape, LongBuffer data) {
     checkArgument(data != null, ERROR_MSG_DATA_BUFFER_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -183,6 +302,14 @@ public abstract class Tensor {
     return new Tensor_int64(data, shape);
   }
 
+  /**
+   * Creates a new Tensor instance with dtype torch.float64 with specified shape and data.
+   *
+   * @param shape Tensor shape
+   * @param data Direct buffer with native byte order that contains {@code Tensor#numel(shape)}
+   *     elements. The buffer is used directly without copying, and changes to its content will
+   *     change the tensor.
+   */
   public static Tensor newFloat64Tensor(long[] shape, DoubleBuffer data) {
     checkArgument(data != null, ERROR_MSG_DATA_BUFFER_NOT_NULL);
     checkArgument(shape != null, ERROR_MSG_SHAPE_NOT_NULL);
@@ -200,10 +327,12 @@ public abstract class Tensor {
     this.shape = Arrays.copyOf(shape, shape.length);
   }
 
+  /** Calculates number of elements in current tensor instance. */
   public long numel() {
     return numel(this.shape);
   }
 
+  /** Calculates number of elements in tensor with specified shape. */
   public static long numel(long[] shape) {
     checkShape(shape);
     int result = 1;
@@ -213,33 +342,68 @@ public abstract class Tensor {
     return result;
   }
 
+  /**
+   * Returns dtype of current tensor. Can be one of {@link Tensor#DTYPE_UINT8}, {@link
+   * Tensor#DTYPE_INT8}, {@link Tensor#DTYPE_INT32},{@link Tensor#DTYPE_FLOAT32}, {@link
+   * Tensor#DTYPE_INT64}, {@link Tensor#DTYPE_FLOAT64}.
+   */
   public abstract int dtype();
 
+  /**
+   * Returns newly allocated java byte array that contains a copy of tensor data.
+   *
+   * @throws IllegalStateException if it is called for a non-int8 tensor.
+   */
   public byte[] getDataAsByteArray() {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot return data as byte array.");
   }
 
+  /**
+   * Returns newly allocated java byte array that contains a copy of tensor data.
+   *
+   * @throws IllegalStateException if it is called for a non-uint8 tensor.
+   */
   public byte[] getDataAsUnsignedByteArray() {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot return data as byte array.");
   }
 
+  /**
+   * Returns newly allocated java byte array that contains a copy of tensor data.
+   *
+   * @throws IllegalStateException if it is called for a non-int32 tensor.
+   */
   public int[] getDataAsIntArray() {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot return data as int array.");
   }
 
+  /**
+   * Returns newly allocated java byte array that contains a copy of tensor data.
+   *
+   * @throws IllegalStateException if it is called for a non-float32 tensor.
+   */
   public float[] getDataAsFloatArray() {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot return data as float array.");
   }
 
+  /**
+   * Returns newly allocated java byte array that contains a copy of tensor data.
+   *
+   * @throws IllegalStateException if it is called for a non-int64 tensor.
+   */
   public long[] getDataAsLongArray() {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot return data as float array.");
   }
 
+  /**
+   * Returns newly allocated java byte array that contains a copy of tensor data.
+   *
+   * @throws IllegalStateException if it is called for a non-float64 tensor.
+   */
   public double[] getDataAsDoubleArray() {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot return data as double array.");


### PR DESCRIPTION
At the moment it includes https://github.com/pytorch/pytorch/pull/26219 changes. That PR is landing at the moment, afterwards this PR will contain only javadocs.

Applied all @dreiss comments from previous version.