### PR TITLE
[nocommit] Test torch.distributed support for nightly builds

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -41,6 +41,9 @@ popd
 # Clone the Builder master repo
 git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
+git remote add pietern https://github.com/pietern/builder.git
+git fetch pietern
+git reset --hard pietern/macos-distributed
 echo "Using builder from "
 git --no-pager log --max-count 1
 popd


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26164 [nocommit] Test torch.distributed support for nightly builds**
* #26163 Turn setup_ci_environment into command
* #26162 Turn setup_linux_system_environment into command
* #26160 Turn should_run_job into command
* #26159 Use CircleCI commands for brew update/install

[test conda]
[test wheel]