### PR TITLE
allow building docker without torchvision

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ ccmake build  # or cmake-gui build
 
 Dockerfile is supplied to build images with cuda support and cudnn v7. You can pass `-e PYTHON_VERSION=x.y` flag to specify which Python version is to be used by Miniconda, or leave it unset to use the default. Build from pytorch repo directory as docker needs to copy git repo into docker filesystem while building the image.
 ```
-docker build -t pytorch -f docker/pytorch/Dockerfile .
+docker build -t pytorch -f docker/pytorch/Dockerfile .  # [optional] --build-arg WITH_TORCHVISION=0
 ```
 
 You can also pull a pre-built docker image from Docker Hub and run with nvidia-docker,

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -1,5 +1,6 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 ARG PYTHON_VERSION=3.6
+ARG WITH_TORCHVISION=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
          build-essential \
          cmake \
@@ -28,7 +29,7 @@ RUN TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX" TORCH_NVCC_FLAGS="-Xfatbin -c
     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
     pip install -v .
 
-RUN git clone https://github.com/pytorch/vision.git && cd vision && pip install -v .
+RUN if [ "$WITH_TORCHVISION" = "1" ] ; then git clone https://github.com/pytorch/vision.git && cd vision && pip install -v . ; else echo "building without torchvision" ; fi
 
 WORKDIR /workspace
 RUN chmod -R a+w .


### PR DESCRIPTION
There is an issue with the torchvision version not matching the pytorch version if one builds the docker from a tag, see issue #25917.  The current solution requires one to re-init the submodules or manually change the version of torchvision.  This PR allows one to build the docker image without torchvision, which not only fixes the above mentioned bug but also frees non-image pytorch users from the tyranny of torchvision :laughing:.  

In all seriousness, for NLP researchers especially torchvision isn't a necessity for pytorch and all non-essential items shouldn't be in the docker.  This option removes one extra thing that can go wrong.