### PR TITLE
bind OrderedDict() and Dict constructor

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -649,6 +649,7 @@ struct CAFFE2_API DictType : public Type {
       case TypeKind::FloatType:
       case TypeKind::StringType:
       case TypeKind::TensorType:
+      case TypeKind::VarType:
         return DictTypePtr(new DictType(key, value));
       default:
         AT_ERROR(

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1204,6 +1204,7 @@ RegisterOperators reg(
            TypePtr value_type = static_cast<const DictType*>(output_type.get())->getValueType();
            return [=](Stack& stack) {
              auto vals = c10::impl::GenericDict(key_type, value_type);
+             vals.reserve(stack.size() / 2);
              for (size_t i = 0; i < num_inputs; i += 2) {
                auto val = pop(stack);
                auto key = pop(stack);
@@ -1214,6 +1215,38 @@ RegisterOperators reg(
            };
          },
          aliasAnalysisSpecialCase()),
+     Operator(
+         "aten::dict((tKey, tVal)[] inputs) -> Dict(tKey, tVal)",
+         [](const Node* node) -> Operation {
+           TypePtr output_type = node->outputs()[0]->type();
+           TypePtr key_type =
+               static_cast<const DictType*>(output_type.get())->getKeyType();
+           TypePtr value_type =
+               static_cast<const DictType*>(output_type.get())->getValueType();
+           return [key_type, value_type](Stack& stack) {
+             auto input_list = pop(stack);
+             auto list_ref = input_list.toGenericListRef();
+             auto dict = c10::impl::GenericDict(key_type, value_type);
+             dict.reserve(list_ref.size());
+             for (const auto& input : list_ref) {
+               const auto tup = input.toTuple()->elements();
+               dict.insert_or_assign(tup[0], tup[1]);
+             }
+             push(stack, dict);
+             return 0;
+           };
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "aten::dict() -> Dict(str, Tensor)",
+         [](const Node* node) -> Operation {
+           return [](Stack& stack) {
+             auto dict =
+                 c10::impl::GenericDict(StringType::get(), TensorType::get());
+             push(stack, dict);
+             return 0;
+           };
+         }),
      Operator(
          "aten::_unwrap_optional(t(a)? optional) -> t(a)",
          [](Stack& stack) {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1767,6 +1767,8 @@ _builtin_ops = [
     (_triple, "aten::_triple"),
     (_unwrap_optional, "aten::_unwrap_optional"),
     (_wait, 'aten::wait'),
+    (OrderedDict, "aten::dict"),
+    (dict, "aten::dict"),
     (cudnn.is_acceptable, "aten::cudnn_is_acceptable"),
     (math.ceil, "aten::ceil"),
     (math.copysign, "aten::copysign"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26170 bind OrderedDict() and Dict constructor**
* #26066 make c10 dict order preserving
* #25675 flat hash map that preserves insertion and deletion order
* #25674 [JIT] make copy of flat has map

Binds the OrderedDict() and dict() constructor into torchscript. For the case of the empty constructor `dict()` i typed it as [str, Tensor] because:
• we're almost dropping support for python 2, at which point all dicts are ordered
• then it's more conventional to write ` x : Dict[int, int] = {} ` which is already supported
• It is possible to construct an arbitrarily typed empty OrderedDict through
` OrderedDict(torch.jit.annotate(List[Tuple[key, value]], [])`

We could consider dropping the no inputs `aten::dict` constructor since then the types would be more explicit.
