### PR TITLE
Rewrite argmax and argmin as TensorIterator reductions

### DIFF
--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#ifdef __HIPCC__
+#include <hip/hip_runtime.h>
+#endif
+
 #include <cmath>
 #include <type_traits>
 #include <c10/util/BFloat16.h>

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <cmath>
 #include <type_traits>
 #include <c10/util/BFloat16.h>

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <type_traits>
 #include <c10/util/BFloat16.h>
+#include <c10/macros/Macros.h>
 
 namespace at {
 
@@ -11,16 +12,22 @@ namespace at {
 
 template <typename T,
           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-inline bool _isnan(T val) {
+inline C10_HOST_DEVICE bool _isnan(T val) {
   return false;
 }
 
 template <typename T,
           typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
-inline bool _isnan(T val) {
+inline C10_HOST_DEVICE bool _isnan(T val) {
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  return ::isnan(val);
+#else
   return std::isnan(val);
+#endif
 }
 
-inline bool _isnan(at::BFloat16 val) { return std::isnan(float(val)); }
+inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
+  return at::_isnan(float(val));
+}
 
 } // namespace at

--- a/aten/src/ATen/detail/FunctionTraits.h
+++ b/aten/src/ATen/detail/FunctionTraits.h
@@ -32,6 +32,12 @@ template <typename ClassType, typename ReturnType, typename... Args>
 struct function_traits<ReturnType(ClassType::*)(Args...) const> : public function_traits<ReturnType(Args...)> {
 };
 
+// Reference types
+template <typename T>
+struct function_traits<T&> : public function_traits<T> {};
+template <typename T>
+struct function_traits<T*> : public function_traits<T> {};
+
 // Free functions
 template <typename ReturnType, typename... Args>
 struct function_traits<ReturnType(Args...)> {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -625,21 +625,18 @@ Tensor max_values(const Tensor& self, DimnameList dims, bool keepdim) {
 
 Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
   TORCH_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
-  "argmax only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
+      "argmax only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
   TORCH_CHECK(self.numel() > 0, "cannot perform argmax of an empty tensor");
+  Tensor in;
   if (dim) {
-    auto dim_wrapped = maybe_wrap_dim(dim.value(), self.dim());
-    auto itr = make_reduction("argmax", result, self, dim_wrapped, keepdim,
-        self.scalar_type(), at::kLong);
-    argmax_stub(itr.device_type(), itr);
+    in = self;
+  } else {
+    in = self.reshape({-1});
+    keepdim = false;
   }
-  else
-  {
-    auto x = self.reshape({-1});
-    auto itr = make_reduction("argmax", result, x, 0, false, self.scalar_type(),
-        at::kLong);
-    argmax_stub(itr.device_type(), itr);
-  }
+  auto itr = make_reduction("argmax", result, in, dim.value_or(0), keepdim,
+      self.scalar_type(), at::kLong);
+  argmax_stub(itr.device_type(), itr);
   return result;
 }
 
@@ -650,21 +647,18 @@ Tensor argmax(const Tensor& self, c10::optional<int64_t> dim, bool keepdims) {
 
 Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
   TORCH_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
-  "argmin only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
+      "argmin only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
   TORCH_CHECK(self.numel() > 0, "cannot perform argmin of an empty tensor");
+  Tensor in;
   if (dim) {
-    auto dim_wrapped = maybe_wrap_dim(dim.value(), self.dim());
-    auto itr = make_reduction("argmin", result, self, dim_wrapped, keepdim,
-        self.scalar_type(), at::kLong);
-    argmin_stub(itr.device_type(), itr);
+    in = self;
+  } else {
+    in = self.reshape({-1});
+    keepdim = false;
   }
-  else
-  {
-    auto x = self.reshape({-1});
-    auto itr = make_reduction("argmin", result, x, 0, false,
-        self.scalar_type(), at::kLong);
-    argmin_stub(itr.device_type(), itr);
-  }
+  auto itr = make_reduction("argmin", result, in, dim.value_or(0), keepdim,
+      self.scalar_type(), at::kLong);
+  argmin_stub(itr.device_type(), itr);
   return result;
 }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -624,8 +624,6 @@ Tensor max_values(const Tensor& self, DimnameList dims, bool keepdim) {
 #endif
 
 Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
-  TORCH_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
-      "argmax only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
   TORCH_CHECK(self.numel() > 0, "cannot perform reduction function argmax on a "
       "tensor with no elements because the operation does not have an identity");
   Tensor in;
@@ -634,6 +632,10 @@ Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
   } else {
     in = self.reshape({-1});
     keepdim = false;
+  }
+  if (self.type().backend() != Backend::CPU && self.type().backend() != Backend::CUDA) {
+    Tensor ignored = at::empty({0}, self.options());
+    return std::get<1>(at::max_out(ignored, result, in, dim.value_or(0), keepdim));
   }
   auto itr = make_reduction("argmax", result, in, dim.value_or(0), keepdim,
       self.scalar_type(), at::kLong);
@@ -647,8 +649,6 @@ Tensor argmax(const Tensor& self, c10::optional<int64_t> dim, bool keepdims) {
 }
 
 Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
-  TORCH_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
-      "argmin only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
   TORCH_CHECK(self.numel() > 0, "cannot perform reduction function argmin on a "
       "tensor with no elements because the operation does not have an identity");
   Tensor in;
@@ -657,6 +657,10 @@ Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> di
   } else {
     in = self.reshape({-1});
     keepdim = false;
+  }
+  if (self.type().backend() != Backend::CPU && self.type().backend() != Backend::CUDA) {
+    Tensor ignored = at::empty({0}, self.options());
+    return std::get<1>(at::min_out(ignored, result, in, dim.value_or(0), keepdim));
   }
   auto itr = make_reduction("argmin", result, in, dim.value_or(0), keepdim,
       self.scalar_type(), at::kLong);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -626,7 +626,8 @@ Tensor max_values(const Tensor& self, DimnameList dims, bool keepdim) {
 Tensor& argmax_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
   TORCH_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
       "argmax only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
-  TORCH_CHECK(self.numel() > 0, "cannot perform argmax of an empty tensor");
+  TORCH_CHECK(self.numel() > 0, "cannot perform reduction function argmax on a "
+      "tensor with no elements because the operation does not have an identity");
   Tensor in;
   if (dim) {
     in = self;
@@ -648,7 +649,8 @@ Tensor argmax(const Tensor& self, c10::optional<int64_t> dim, bool keepdims) {
 Tensor& argmin_out(Tensor& result, const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
   TORCH_CHECK(self.type().backend() == Backend::CPU || self.type().backend() == Backend::CUDA,
       "argmin only supports CPU AND CUDA backend, got: ", toString(self.type().backend()));
-  TORCH_CHECK(self.numel() > 0, "cannot perform argmin of an empty tensor");
+  TORCH_CHECK(self.numel() > 0, "cannot perform reduction function argmin on a "
+      "tensor with no elements because the operation does not have an identity");
   Tensor in;
   if (dim) {
     in = self;

--- a/aten/src/ATen/native/ReduceOps.h
+++ b/aten/src/ATen/native/ReduceOps.h
@@ -19,6 +19,8 @@ DECLARE_DISPATCH(reduce_fn, and_stub);
 DECLARE_DISPATCH(reduce_fn, or_stub);
 DECLARE_DISPATCH(reduce_fn, min_values_stub);
 DECLARE_DISPATCH(reduce_fn, max_values_stub);
+DECLARE_DISPATCH(reduce_fn, argmax_stub);
+DECLARE_DISPATCH(reduce_fn, argmin_stub);
 
 using reduce_std_var_function =
   void (*)(TensorIterator&, bool unbiased, bool take_sqrt);

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -3,16 +3,22 @@
 // used across both CPU and GPU.
 
 #include <c10/macros/Macros.h>
+#include <ATen/detail/FunctionTraits.h>
 #if defined(__CUDACC__)
 #include <THC/THCDeviceUtils.cuh>
+#include <THC/THCNumerics.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
-#include <thrust/tuple.h>
 #elif defined(__HIPCC__)
 #include <THH/THHDeviceUtils.cuh>
+#include <THH/THHNumerics.cuh>
 #include <ATen/native/hip/DeviceSqrt.cuh>
+#endif
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #include <thrust/tuple.h>
+#include <thrust/pair.h>
 #else
 #include <cmath>
+#include <ATen/NumericUtils.h>
 #define device_sqrt std::sqrt
 #endif
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -246,6 +252,76 @@ struct NormOneOps {
     return WARP_SHFL_DOWN(data, offset);
   }
 #endif
+};
+
+namespace detail {
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+template <typename T1, typename T2> using pair = thrust::pair<T1, T2>;
+
+template <typename scalar_t>
+bool C10_DEVICE isnan(scalar_t x) {
+  return THCNumerics<scalar_t>::isnan(x);
+}
+#else
+template <typename T1, typename T2> using pair = std::pair<T1, T2>;
+
+template <typename scalar_t>
+bool isnan(scalar_t x) {
+  return at::_isnan(x);
+}
+#endif
+
+template <typename scalar_t>
+struct LessOrNan {
+  C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
+    return isnan(a) || a < b;
+  }
+};
+
+template <typename scalar_t>
+struct GreaterOrNan {
+  C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
+    return isnan(a) || a > b;
+  }
+};
+
+template <typename comp_t>
+struct ArgReductionOps {
+  using scalar_t = typename binary_function_traits<comp_t>::arg1_t;
+  using index_t = int64_t;
+  using arg_t = detail::pair<scalar_t, index_t>;
+
+  static C10_DEVICE index_t project(arg_t arg) {
+    return arg.second;
+  }
+
+  static C10_DEVICE arg_t reduce(arg_t arg, scalar_t val, int64_t idx) {
+    return comp_t{}(arg.first, val) ? arg : arg_t(val, idx);
+  }
+
+  static C10_DEVICE arg_t combine(arg_t a, arg_t b) {
+    return comp_t{}(a.first, b.first) ? a : b;
+  }
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  static C10_DEVICE arg_t warp_shfl_down(arg_t arg, int offset) {
+    return arg_t(WARP_SHFL_DOWN(arg.first, offset),
+                 WARP_SHFL_DOWN(arg.second, offset));
+  }
+#endif
+};
+
+} // namespace detail
+
+template <typename scalar_t>
+struct ArgMaxOps :
+  public detail::ArgReductionOps<detail::GreaterOrNan<scalar_t>> {
+};
+
+template <typename scalar_t>
+struct ArgMinOps :
+  public detail::ArgReductionOps<detail::LessOrNan<scalar_t>> {
 };
 
 }} // namespace at::native

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -50,7 +50,7 @@ struct WelfordOps {
   bool take_sqrt;
  public:
   using acc_t = WelfordData<acc_scalar_t, index_t, combine_t>;
-  inline C10_DEVICE acc_t reduce(acc_t acc, scalar_t data) const {
+  inline C10_DEVICE acc_t reduce(acc_t acc, scalar_t data, index_t /*idx*/) const {
     acc_scalar_t delta = data - acc.mean;
     // using acc.nf(combine_t) here, as acc.n(index_t) would still be converted
     // accumulation in reduce is done through index_T
@@ -114,12 +114,12 @@ template <typename acc_t, typename factor_t>
 struct MeanOps {
   factor_t factor;
 
-  inline C10_DEVICE acc_t reduce(acc_t a, acc_t b) const {
-    return a + b;
+  inline C10_DEVICE acc_t reduce(acc_t a, acc_t b, int64_t /*idx*/) const {
+    return combine(a, b);
   }
 
   inline C10_DEVICE acc_t combine(acc_t a, acc_t b) const {
-    return reduce(a, b);
+    return a + b;
   }
 
   inline C10_DEVICE acc_t project(acc_t a) const {
@@ -139,7 +139,7 @@ struct MeanOps {
 template <typename acc_t>
 struct AbsMinOps {
 
-  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data) const {
+  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data, int64_t /*idx*/) const {
     return MIN(acc, std::abs(data));
   }
 
@@ -161,7 +161,7 @@ struct AbsMinOps {
 template <typename acc_t>
 struct AbsMaxOps {
 
-  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data) const {
+  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data, int64_t /*idx*/) const {
     return MAX(acc, std::abs(data));
   }
 
@@ -184,7 +184,7 @@ template <typename acc_t>
 struct NormOps {
   acc_t norm;
 
-  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data) const {
+  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data, int64_t /*idx*/) const {
     return acc + compat_pow(std::abs(data), norm);
   }
 
@@ -208,7 +208,7 @@ struct NormOps {
 
 template <typename acc_t>
 struct NormZeroOps {
-  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data) const {
+  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data, int64_t /*idx*/) const {
     return acc + (data==acc_t(0) ? acc_t(0) : acc_t(1));
   }
 
@@ -229,7 +229,7 @@ struct NormZeroOps {
 
 template <typename acc_t>
 struct NormOneOps {
-  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data) const {
+  inline C10_DEVICE acc_t reduce(acc_t acc, acc_t data, int64_t /*idx*/) const {
     return acc + std::abs(data);
   }
 

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -4,13 +4,12 @@
 
 #include <c10/macros/Macros.h>
 #include <ATen/detail/FunctionTraits.h>
+#include <ATen/NumericUtils.h>
 #if defined(__CUDACC__)
 #include <THC/THCDeviceUtils.cuh>
-#include <THC/THCNumerics.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
 #elif defined(__HIPCC__)
 #include <THH/THHDeviceUtils.cuh>
-#include <THH/THHNumerics.cuh>
 #include <ATen/native/hip/DeviceSqrt.cuh>
 #endif
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -18,7 +17,6 @@
 #include <thrust/pair.h>
 #else
 #include <cmath>
-#include <ATen/NumericUtils.h>
 #define device_sqrt std::sqrt
 #endif
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -258,31 +256,21 @@ namespace detail {
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 template <typename T1, typename T2> using pair = thrust::pair<T1, T2>;
-
-template <typename scalar_t>
-bool C10_DEVICE isnan(scalar_t x) {
-  return THCNumerics<scalar_t>::isnan(x);
-}
 #else
 template <typename T1, typename T2> using pair = std::pair<T1, T2>;
-
-template <typename scalar_t>
-bool isnan(scalar_t x) {
-  return at::_isnan(x);
-}
 #endif
 
 template <typename scalar_t>
 struct LessOrNan {
   C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
-    return isnan(a) || a < b;
+    return at::_isnan(a) || a < b;
   }
 };
 
 template <typename scalar_t>
 struct GreaterOrNan {
   C10_DEVICE bool operator () (scalar_t a, scalar_t b) const {
-    return isnan(a) || a > b;
+    return at::_isnan(a) || a > b;
   }
 };
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -281,20 +281,6 @@ std::tuple<Tensor&,Tensor&> min_out(Tensor& min, Tensor& min_indices,
 }
 
 
-// argmax and argmin
-
-Tensor argmax(const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
-  if (dim)
-    return std::get<1>(self.max(dim.value(), keepdim));
-  return std::get<1>(self.reshape({-1}).max(/*dim=*/0));
-}
-
-Tensor argmin(const Tensor& self, c10::optional<int64_t> dim, bool keepdim) {
-  if (dim)
-    return std::get<1>(self.min(dim.value(), keepdim));
-  return std::get<1>(self.reshape({-1}).min(/*dim=*/0));
-}
-
 #ifdef BUILD_NAMEDTENSOR
 // Named tensor overloads
 

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -647,6 +647,8 @@ TensorIterator TensorIterator::reduce_op(Tensor& out, const Tensor& a) {
   iter.promote_gpu_output_dtypes_ = true;
   iter.resize_outputs_ = false;
   iter.is_reduction_ = true;
+  // TODO: This is only really necessary for arg{min,max}
+  iter.compute_common_dtype_only_for_inputs();
   iter.build();
   return iter;
 }
@@ -670,8 +672,6 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
   iter.promote_gpu_output_dtypes_ = true;
   iter.resize_outputs_ = false;
   iter.is_reduction_ = true;
-  // TODO: This is only really necessary for arg{min,max}
-  iter.compute_common_dtype_only_for_inputs();
   iter.build();
   return iter;
 }

--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -670,6 +670,8 @@ TensorIterator TensorIterator::reduce_op(Tensor& out1, Tensor& out2, const Tenso
   iter.promote_gpu_output_dtypes_ = true;
   iter.resize_outputs_ = false;
   iter.is_reduction_ = true;
+  // TODO: This is only really necessary for arg{min,max}
+  iter.compute_common_dtype_only_for_inputs();
   iter.build();
   return iter;
 }

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -1,6 +1,7 @@
 #include <numeric>
 #include <iterator>
 #include <algorithm>
+#include <limits>
 
 #include <ATen/Dispatch.h>
 #include <ATen/cpu/vec256/vec256.h>
@@ -166,6 +167,72 @@ static void max_values_kernel_impl(TensorIterator& iter) {
   });
 }
 
+template <typename func_t>
+struct arg_reduce_wrapper_t {
+  using scalar_t = typename binary_function_traits<func_t>::arg1_t;
+  using index_t = int64_t;
+  using arg_t = std::pair<scalar_t, index_t>;
+
+  func_t comp;
+
+  arg_reduce_wrapper_t(const func_t& op) : comp(op) {
+  }
+
+  static index_t project(arg_t arg) {
+    return arg.second;
+  }
+
+  arg_t reduce(arg_t arg, scalar_t val, int64_t idx) const {
+    return comp(arg.first, val) ? arg : arg_t(val, idx);
+  }
+
+  arg_t combine(arg_t a, arg_t b) const {
+    return comp(a.first, b.first) ? a : b;
+  }
+};
+
+// Wrap a comparator(scalar_t, scalar_t) to perform index reduction like arg{max,min}
+template <typename func_t>
+arg_reduce_wrapper_t<func_t> arg_reduce_wrapper(const func_t& op) {
+  return arg_reduce_wrapper_t<func_t>{ op };
+}
+
+// Maximum and minimum possible scalar values, including infinities
+
+template <typename scalar_t>
+constexpr scalar_t upper_bound() {
+  using lim = std::numeric_limits<scalar_t>;
+  return lim::has_infinity ? lim::infinity() : lim::max();
+}
+
+template <typename scalar_t>
+constexpr scalar_t lower_bound() {
+  using lim = std::numeric_limits<scalar_t>;
+  return lim::has_infinity ? -lim::infinity() : lim::lowest();
+}
+
+static void argmax_kernel_impl(TensorIterator &iter) {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "argmax_cpu", [&] {
+    binary_kernel_reduce(
+      iter,
+      arg_reduce_wrapper([](scalar_t a, scalar_t b) {
+        return std::isnan(a) || a > b;
+      }),
+      std::pair<scalar_t, int64_t>(lower_bound<scalar_t>(), 0));
+  });
+}
+
+static void argmin_kernel_impl(TensorIterator &iter) {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(), "argmin_cpu", [&] {
+    binary_kernel_reduce(
+      iter,
+      arg_reduce_wrapper([](scalar_t a, scalar_t b) {
+        return std::isnan(a) || a < b;
+      }),
+      std::pair<scalar_t, int64_t>(upper_bound<scalar_t>(), 0));
+  });
+}
+
 }  // anonymous namespace
 
 REGISTER_DISPATCH(sum_stub, &sum_kernel_impl);
@@ -177,5 +244,7 @@ REGISTER_DISPATCH(and_stub, &and_kernel_impl);
 REGISTER_DISPATCH(or_stub, &or_kernel_impl);
 REGISTER_DISPATCH(min_values_stub, &min_values_kernel_impl);
 REGISTER_DISPATCH(max_values_stub, &max_values_kernel_impl);
+REGISTER_DISPATCH(argmax_stub, &argmax_kernel_impl);
+REGISTER_DISPATCH(argmin_stub, &argmin_kernel_impl);
 
 }}  // namespace at::native

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -212,7 +212,7 @@ constexpr scalar_t lower_bound() {
 }
 
 static void argmax_kernel_impl(TensorIterator &iter) {
-  AT_DISPATCH_ALL_TYPES(iter.dtype(), "argmax_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmax_cpu", [&] {
     binary_kernel_reduce(
       iter,
       arg_reduce_wrapper([](scalar_t a, scalar_t b) {
@@ -223,7 +223,7 @@ static void argmax_kernel_impl(TensorIterator &iter) {
 }
 
 static void argmin_kernel_impl(TensorIterator &iter) {
-  AT_DISPATCH_ALL_TYPES(iter.dtype(), "argmin_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmin_cpu", [&] {
     binary_kernel_reduce(
       iter,
       arg_reduce_wrapper([](scalar_t a, scalar_t b) {

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -17,6 +17,7 @@
 #include <type_traits>
 #include <utility>
 #include <thrust/tuple.h>
+#include <thrust/pair.h>
 
 namespace at { namespace native {
 
@@ -241,8 +242,9 @@ __device__ void strided_iterate(func_t f, index_t begin, index_t end, index_t st
 
 template <typename out_scalar_t, typename func_t>
 struct func_wrapper_t {
-  using arg_t = typename binary_function_traits<func_t>::arg2_t;
-  func_t reduce;
+  using arg_t = typename binary_function_traits<func_t>::arg1_t;
+  using scalar_t = typename binary_function_traits<func_t>::arg2_t;
+
   func_t combine;
   static inline __device__ out_scalar_t project(arg_t arg) {
     return (out_scalar_t) arg;
@@ -251,20 +253,61 @@ struct func_wrapper_t {
     return WARP_SHFL_DOWN(arg, offset);
   }
 
-  func_wrapper_t(const func_t& op) : reduce(op), combine(op) {
+  func_wrapper_t(const func_t& op) : combine(op) {
   }
+
+  // wrap a normal reduction that ignores the index
+  __device__ arg_t reduce(arg_t acc, scalar_t val, int64_t idx) const {
+    return combine(acc, val);
+  }
+
 };
 
 template <typename scalar_t, typename func_t>
 func_wrapper_t<scalar_t, func_t> func_wrapper(const func_t& op) {
-  using arg_t = typename binary_function_traits<func_t>::arg2_t;
   return func_wrapper_t<scalar_t, func_t> { op };
 }
 
+template <typename func_t>
+struct arg_reduce_wrapper_t {
+  using scalar_t = typename binary_function_traits<func_t>::arg1_t;
+  using index_t = int64_t;
+  using arg_t = thrust::pair<scalar_t, index_t>;
+
+  func_t comp;
+
+  arg_reduce_wrapper_t(const func_t& op) : comp(op) {
+  }
+
+  static __device__ index_t project(arg_t arg) {
+    return arg.second;
+  }
+
+  static __device__ arg_t warp_shfl_down(arg_t arg, int offset) {
+    return arg_t(WARP_SHFL_DOWN(arg.first, offset),
+                 WARP_SHFL_DOWN(arg.second, offset));
+  }
+
+  __device__ arg_t reduce(arg_t arg, scalar_t val, int64_t idx) const {
+    return comp(arg.first, val) ? arg : arg_t(val, idx);
+  }
+
+  __device__ arg_t combine(arg_t a, arg_t b) const {
+    return comp(a.first, b.first) ? a : b;
+  }
+};
+
+// Wrap a comparator(scalar_t, scalar_t) to perform index reduction like arg{max,min}
+template <typename func_t>
+arg_reduce_wrapper_t<func_t> arg_reduce_wrapper(const func_t& op) {
+  return arg_reduce_wrapper_t<func_t>{ op };
+}
+
+
 template <typename scalar_t, typename ops_t, typename index_t, typename out_scalar_t=scalar_t, int vt0=4>
 struct ReduceOp {
-  using traits = binary_function_traits<decltype(&ops_t::reduce)>;
-  using arg_t = typename std::remove_const<typename std::remove_reference<typename traits::arg1_t>::type>::type;
+  using traits = function_traits<decltype(&ops_t::reduce)>;
+  using arg_t = typename std::decay<typename traits::template arg<0>::type>::type;
 
   using InputCalculator = OffsetCalculator<1, index_t>;
   using OutputCalculator = OffsetCalculator<2, index_t>;
@@ -321,7 +364,7 @@ struct ReduceOp {
       auto input_slice = (const char*)src + base_offsets[1];
       value = thread_reduce((const scalar_t*)input_slice);
     }
-    
+
     if (config.should_block_y_reduce()) {
       value = block_y_reduce(value, shared_memory);
     }
@@ -391,7 +434,7 @@ struct ReduceOp {
       }
       // compute
       strided_iterate<vt0, index_t>([&](index_t i, index_t idx) {
-        value_list[i] = ops.reduce(value_list[i], values[i]);
+        value_list[i] = ops.reduce(value_list[i], values[i], idx);
       }, idx, config.num_inputs, config.step_input);
       // step offset
       idx += config.step_input * vt0;
@@ -640,8 +683,8 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
                               AccumulationBuffer* acc_buf_ptr=nullptr) {
   AT_ASSERT(iter.numel() > 0 && iter.ntensors() - iter.noutputs() == 1 && iter.noutputs() >= 1);
 
-  using traits = binary_function_traits<decltype(&ops_t::reduce)>;
-  using arg_t = typename traits::arg1_t;
+  using traits = function_traits<decltype(&ops_t::reduce)>;
+  using arg_t = typename traits::template arg<0>::type;
   static constexpr bool can_accumulate_in_output =
     std::is_convertible<arg_t, out_scalar_t>::value;
 
@@ -712,13 +755,13 @@ inline void gpu_reduce_kernel(TensorIterator& iter, const ops_t& ops, ident_t id
   // We try to max out dim1 so that we have enough threads per CTA to deliver
   // performance for larger problem size.
   if (reduction_on_fastest_striding_dimension) {
-    // Map block.x to the fastest reducing dimension. It implies: 
+    // Map block.x to the fastest reducing dimension. It implies:
     //   1. block_x_reduce is required.
     //   2. block.y now max out to num_outputs.
     dim0 = iter.shape()[0];
     dim1 = num_outputs;
   } else {
-    // Map block.x to the fastest non reducing dimension. It implies: 
+    // Map block.x to the fastest non reducing dimension. It implies:
     //   1. block_x_reduce is turned off.
     //   2. block.y now max out to inputs_per_output.
     dim0 = iter.shape()[iter.num_reduce_dims()];

--- a/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
@@ -172,18 +172,18 @@ void min_values_kernel_cuda(TensorIterator& iter) {
 void argmax_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmax_cuda", [&]() {
     gpu_reduce_kernel<scalar_t, int64_t>(
-    iter, arg_reduce_wrapper([]GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
-      return (THCNumerics<scalar_t>::isnan(a) || a > b);
-    }), thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::lower_bound(), 0));
+      iter,
+      ArgMaxOps<scalar_t>{},
+      thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::lower_bound(), 0));
   });
 }
 
 void argmin_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmin_cuda", [&]() {
-    gpu_reduce_kernel<scalar_t, scalar_t>(
-    iter, arg_reduce_wrapper([]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-      return (THCNumerics<scalar_t>::isnan(a) || a < b);
-    }), thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
+    gpu_reduce_kernel<scalar_t, int64_t>(
+      iter,
+      ArgMinOps<scalar_t>{},
+      thrust::pair<scalar_t, int64_t>(at::numeric_limits<scalar_t>::upper_bound(), 0));
   });
 }
 

--- a/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceOpsKernel.cu
@@ -170,7 +170,7 @@ void min_values_kernel_cuda(TensorIterator& iter) {
 }
 
 void argmax_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.dtype(), "argmax_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmax_cuda", [&]() {
     gpu_reduce_kernel<scalar_t, int64_t>(
     iter, arg_reduce_wrapper([]GPU_LAMBDA(scalar_t a, scalar_t b) -> bool {
       return (THCNumerics<scalar_t>::isnan(a) || a > b);
@@ -179,7 +179,7 @@ void argmax_kernel_cuda(TensorIterator& iter) {
 }
 
 void argmin_kernel_cuda(TensorIterator& iter) {
-  AT_DISPATCH_ALL_TYPES(iter.dtype(), "argmin_cuda", [&]() {
+  AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmin_cuda", [&]() {
     gpu_reduce_kernel<scalar_t, scalar_t>(
     iter, arg_reduce_wrapper([]GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
       return (THCNumerics<scalar_t>::isnan(a) || a < b);

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2123,13 +2123,13 @@ class TestCuda(TestCase):
     def test_sum_cpu_gpu_mismatch(self):
         x = torch.randn(20, dtype=torch.float32, device='cuda:0')
         y = torch.randn(1, dtype=torch.float32)
-        with self.assertRaisesRegex(RuntimeError,
-                                    'expected device cpu but got device cuda:0'):
+        with self.assertRaisesRegex(RuntimeError, "output with device cpu "
+                                    "doesn't match the desired device cuda:0"):
             torch.sum(x, dim=[0], dtype=torch.float32, out=y)
         # makeing sure half to float promotion is also properly working.
         x = x.half()
-        with self.assertRaisesRegex(RuntimeError,
-                                    'expected dtype Float but got dtype Half'):
+        with self.assertRaisesRegex(RuntimeError, "output with device cpu "
+                                    "doesn't match the desired device cuda:0"):
             torch.sum(x, dim=[0], dtype=torch.float32, out=y)
 
     @skipIfRocm


### PR DESCRIPTION
Fixes #8817

This rewrites `argmax` and `argmin` to use `TensorIterator` as suggested by @ngimel in #8817. To support this, the reduction operation is now passed the index along with the current element. I also had to change a few places where the input and output tensor `dtype`s were assumed to be the same.

Unfortunatley, this isn't enough to reimplement the variants of `min` and `max` that return indices. There are several places where multiple tensor outputs are assumed to all have the same `dtype` and so returning `pair<scalar_t, int64_t>` for `ops.project` isn't possible.

#### Performance Results
**Edit:** These timings are invalid, see below for a better perf comparison
Timings reported by [`argmax.py`](https://gist.github.com/SsnL/6898c240d22faa91da16fc41359756a2):
```
cuda : 0.1432
cpu  : 26.976
numpy: 2.1350
```

So, the `TensorIterator` reductions are much faster on the GPU but significantly slower on the CPU. `htop` shows the cpu kernel using 4 cores for the cpu reduction so it's not clear what the issue is there. 
Should I just revert to the old implementation on CPU or is it worth investigating further? I see that other `TensorIterator` cpu reductions are similarly faster in `numpy`  e.g. `max`, `mean` `std`.