### PR TITLE
Add __s390x__ compiler define for s390 builds.

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -23,7 +23,7 @@ static CPUCapability compute_cpu_capability() {
     AT_WARN("ignoring invalid value for ATEN_CPU_CAPABILITY: ", envar);
   }
 
-#ifndef __powerpc__
+#if !defined(__powerpc__) && !defined(__s390x__)
   if (cpuinfo_initialize()) {
     if (cpuinfo_has_x86_avx2() && cpuinfo_has_x86_fma3()) {
       return CPUCapability::AVX2;

--- a/aten/src/TH/vector/simd.h
+++ b/aten/src/TH/vector/simd.h
@@ -72,6 +72,13 @@ static inline uint32_t detectHostSIMDExtensions()
 
  #endif
 
+#elif defined(__s390x__)
+
+static inline uint32_t detectHostSIMDExtensions()
+{
+  return SIMDExtension_DEFAULT;
+}
+
 #elif defined(__PPC64__)
 
  #if defined(__VSX__)


### PR DESCRIPTION
pytorch build fails on s390 machines because
in simd.h the if,elif defined statements default
to x86 if the machine architecture is not found.
This patch fixes the build problem.

