### PR TITLE
[iOS] Remove armv7s build from iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,7 +812,6 @@ jobs:
     steps:
     - attach_workspace:
         at: ~/workspace
-    
     - should_run_job
     - checkout
     - run_brew_for_ios_build
@@ -835,7 +834,6 @@ jobs:
     steps:
     - attach_workspace:
         at: ~/workspace
-    
     - should_run_job
     - checkout
     - run_brew_for_ios_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,8 +812,8 @@ jobs:
     steps:
     - attach_workspace:
         at: ~/workspace
-    - run:
-        <<: *should_run_job
+    
+    - should_run_job
     - checkout
     - run:
         <<: *ios_brew_update
@@ -836,8 +836,8 @@ jobs:
     steps:
     - attach_workspace:
         at: ~/workspace
-    - run:
-        <<: *should_run_job
+    
+    - should_run_job
     - checkout
     - run:
         <<: *ios_brew_update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3036,13 +3036,6 @@ workflows:
           ios_platform: "OS"
           requires: 
             - setup
-      - binary_ios_build:
-          name: pytorch_ios_10_2_1_nightly_armv7s_build
-          build_environment: "libtorch-ios-10.2.1-nightly-armv7s-build"
-          ios_arch: "armv7s"
-          ios_platform: "OS"
-          requires: 
-            - setup
       - binary_ios_upload:
           build_environment: "libtorch-ios-10.2.1-nightly-binary-build-upload"
           context: org-member
@@ -3050,7 +3043,6 @@ workflows:
             - setup
             - pytorch_ios_10_2_1_nightly_x86_64_build
             - pytorch_ios_10_2_1_nigthly_arm64_build
-            - pytorch_ios_10_2_1_nightly_armv7s_build
 ##############################################################################
 # Nightly tests
 ##############################################################################

--- a/.circleci/scripts/binary_ios_upload.sh
+++ b/.circleci/scripts/binary_ios_upload.sh
@@ -17,11 +17,11 @@ cd ${ZIP_DIR}/install/lib
 target_libs=(libc10.a libclog.a libcpuinfo.a libqnnpack.a libtorch.a)
 for lib in ${target_libs[*]}
 do
-    libs=(${ARTIFACTS_DIR}/x86_64/lib/${lib} ${ARTIFACTS_DIR}/arm64/lib/${lib} ${ARTIFACTS_DIR}/armv7s/lib/${lib} )
+    libs=(${ARTIFACTS_DIR}/x86_64/lib/${lib} ${ARTIFACTS_DIR}/arm64/lib/${lib})
     lipo -create "${libs[@]}" -o ${ZIP_DIR}/install/lib/${lib}
 done
-# for nnpack, we only support arm64/armv7s build
-lipo -create ${ARTIFACTS_DIR}/arm64/lib/libnnpack.a ${ARTIFACTS_DIR}/armv7s/lib/libnnpack.a -o ${ZIP_DIR}/install/lib/libnnpack.a
+# for nnpack, we only support arm64 build
+cp ${ARTIFACTS_DIR}/arm64/lib/libnnpack.a ./
 lipo -i ${ZIP_DIR}/install/lib/*.a
 # copy the umbrella header and license
 cp ${PROJ_ROOT}/ios/LibTorch.h ${ZIP_DIR}/src/

--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -37,7 +37,6 @@ default_set = set([
     'libtorch 2.7m cpu gcc5.4_cxx11-abi',
     'libtorch-ios-10.2.1-nightly-x86_64-build',
     'libtorch-ios-10.2.1-nightly-arm64-build',
-    'libtorch-ios-10.2.1-nightly-armv7s-build',
     'libtorch-ios-10.2.1-nightly-binary-build-upload',
 
     # Caffe2 Android

--- a/.circleci/verbatim-sources/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/binary-job-specs.yml
@@ -223,8 +223,8 @@
     steps:
     - attach_workspace:
         at: ~/workspace
-    - run:
-        <<: *should_run_job
+    
+    - should_run_job
     - checkout
     - run:
         <<: *ios_brew_update
@@ -247,8 +247,8 @@
     steps:
     - attach_workspace:
         at: ~/workspace
-    - run:
-        <<: *should_run_job
+    
+    - should_run_job
     - checkout
     - run:
         <<: *ios_brew_update

--- a/.circleci/verbatim-sources/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/binary-job-specs.yml
@@ -223,7 +223,6 @@
     steps:
     - attach_workspace:
         at: ~/workspace
-    
     - should_run_job
     - checkout
     - run_brew_for_ios_build
@@ -246,7 +245,6 @@
     steps:
     - attach_workspace:
         at: ~/workspace
-    
     - should_run_job
     - checkout
     - run_brew_for_ios_build

--- a/.circleci/verbatim-sources/workflows-nightly-ios-binary-builds.yml
+++ b/.circleci/verbatim-sources/workflows-nightly-ios-binary-builds.yml
@@ -13,13 +13,6 @@
           ios_platform: "OS"
           requires: 
             - setup
-      - binary_ios_build:
-          name: pytorch_ios_10_2_1_nightly_armv7s_build
-          build_environment: "libtorch-ios-10.2.1-nightly-armv7s-build"
-          ios_arch: "armv7s"
-          ios_platform: "OS"
-          requires: 
-            - setup
       - binary_ios_upload:
           build_environment: "libtorch-ios-10.2.1-nightly-binary-build-upload"
           context: org-member
@@ -27,4 +20,3 @@
             - setup
             - pytorch_ios_10_2_1_nightly_x86_64_build
             - pytorch_ios_10_2_1_nigthly_arm64_build
-            - pytorch_ios_10_2_1_nightly_armv7s_build

--- a/cmake/iOS.cmake
+++ b/cmake/iOS.cmake
@@ -158,7 +158,7 @@ set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS su
 
 # set the architecture for iOS 
 if (IOS_PLATFORM STREQUAL "OS")
-    set (DEFAULT_IOS_ARCH "armv7;armv7s;arm64")
+    set (DEFAULT_IOS_ARCH "arm64")
 elseif (IOS_PLATFORM STREQUAL "SIMULATOR")
     set (DEFAULT_IOS_ARCH "x86_64")
 elseif (IOS_PLATFORM STREQUAL "WATCHOS")

--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '0.0.2'
+    s.version          = '0.0.3'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
         The PyTorch C++ library for iOS.
     DESC
+    s.ios.deployment_target = '12.0'
     s.default_subspec = 'Core'
     s.subspec 'Core' do |ss|
         ss.dependency 'LibTorch/Torch'
@@ -29,7 +30,7 @@ Pod::Spec.new do |s|
     }
     s.pod_target_xcconfig = { 
         'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/LibTorch/install/include/"', 
-        'VALID_ARCHS' => 'x86_64 armv7s arm64' 
+        'VALID_ARCHS' => 'x86_64 arm64' 
     }
     s.library = ['c++', 'stdc++']
 end


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26222 [iOS] Remove armv7s build from iOS**

### Summary

The last generation of armv7s device is Phone 5C. As discussed with David offline, we decided not to support iOS armv7s devices.

### Test plan

- CI finishes successfully
- Builds can be run only on X86_64 and arm64 devices

Differential Revision: [D17385308](https://our.internmc.facebook.com/intern/diff/D17385308)