### PR TITLE
fix composite learning rate

### DIFF
--- a/caffe2/python/operator_test/learning_rate_op_test.py
+++ b/caffe2/python/operator_test/learning_rate_op_test.py
@@ -112,9 +112,11 @@ class TestLearningRate(serial.SerializedTestCase):
 
         self.assertReferenceChecks(gc, op, [iter], ref)
 
-    @given(gc=hu.gcs['gc'],
-            min_num_iter=st.integers(min_value=10, max_value=20),
-            max_num_iter=st.integers(min_value=50, max_value=100))
+    @given(
+        gc=hu.gcs['gc'],
+        min_num_iter=st.integers(min_value=10, max_value=20),
+        max_num_iter=st.integers(min_value=50, max_value=100),
+    )
     def test_composite_learning_rate_op(self, gc, min_num_iter, max_num_iter):
         np.random.seed(65535)
         # Generate the iteration numbers for sub policy
@@ -128,7 +130,7 @@ class TestLearningRate(serial.SerializedTestCase):
             accu_iter_num[i] += accu_iter_num[i - 1]
         total_iter_nums = accu_iter_num[-1]
 
-        policy_lr_scale = np.random.uniform(low=2.0, high=2.0, size=num_lr_policy)
+        policy_lr_scale = np.random.uniform(low=0.1, high=2.0, size=num_lr_policy)
 
         # args for StepLRPolicy
         step_size = np.random.randint(low=2, high=min_num_iter // 2)


### PR DESCRIPTION
Summary:
In the previous implementation of composite lr, the lr_scale for each sub policy will be rewritten by the last lr_scale.

Due to another bug in unittest (where policy_lr_scale being the same for all sub policies), this bug was not detected by unittest...

Fix: add an additional field in CompositeLearningRateItem so that we store  lr_scale values for all sub policies

If fix unittest, the error in previous implementation:
https://fburl.com/testinfra/ikdbnmey

With the fix,
https://fburl.com/testinfra/m694ehl1

Test Plan:
unittest

buck test  caffe2/caffe2/python/operator_test:learning_rate_op_test -- test_composite_learning_rate_op

Differential Revision: D17380363

