### PR TITLE
adds sync to flaky test_events_multi_gpu_query

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1965,6 +1965,7 @@ class TestCuda(TestCase):
         with torch.cuda.device(d0):
             s0 = torch.cuda.current_stream()
             e0 = s0.record_event()
+            s0.synchronize()
 
         with torch.cuda.device(d1):
             s1 = torch.cuda.current_stream()


### PR DESCRIPTION
This test can sometimes fail in CI. 

I suspect this flakiness is because the test asks a CUDA stream to record an event, fails to synchronize the CPU with that stream, then checks if the event is recorded on the CPU. There is no guarantee this will have happened.

This one-line change preserves the intent of the test while ensuring the GPU has recorded the event before the CPU queries it. 