### PR TITLE
Ports most of test_torch.py to generic device type framework

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -23,7 +23,7 @@ from test_torch import _TestTorchMixin
 from common_methods_invocations import tri_tests_args, tri_large_tests_args, \
     _compare_trilu_indices, _compare_large_trilu_indices
 from common_utils import TestCase, get_gpu_type, to_gpu, freeze_rng_state, run_tests, \
-    PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, TEST_NUMPY, TEST_SCIPY, \
+    PY3, IS_WINDOWS, NO_MULTIPROCESSING_SPAWN, skipIfRocm, \
     TEST_WITH_ROCM, load_tests, slowTest, skipCUDANonDefaultStreamIf
 
 # load_tests from common_utils is used to automatically filter tests for

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1086,18 +1086,6 @@ class TestCuda(TestCase):
             for num in abs_zeros:
                 self.assertGreater(math.copysign(1.0, num), 0.0)
 
-    def test_bitwise_not(self):
-        _TestTorchMixin._test_bitwise_not(self, 'cuda')
-
-    def test_logical_not(self):
-        _TestTorchMixin._test_logical_not(self, 'cuda')
-
-    def test_logical_xor(self):
-        _TestTorchMixin._test_logical_xor(self, 'cuda')
-
-    def test_isinf(self):
-        _TestTorchMixin._test_isinf(self, lambda t: t.cuda())
-
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     def test_arithmetic_large_tensor(self):
         x = torch.empty(2**30, device='cuda')
@@ -1390,9 +1378,6 @@ class TestCuda(TestCase):
         z = torch.cat([x, y], 0)
         self.assertEqual(z.get_device(), x.get_device())
 
-    def test_clamp(self):
-        _TestTorchMixin._test_clamp(self, 'cuda')
-
     def test_cat(self):
         SIZE = 10
         for dim in range(-3, 3):
@@ -1413,12 +1398,6 @@ class TestCuda(TestCase):
         y = torch.randn(1, SIZE, SIZE).cuda()
         z = torch.cat([x, y])
         self.assertEqual(z.size(), (21, SIZE, SIZE))
-
-    def test_cat_empty_legacy(self):
-        _TestTorchMixin._test_cat_empty_legacy(self, use_cuda=True)
-
-    def test_cat_empty(self):
-        _TestTorchMixin._test_cat_empty(self, use_cuda=True)
 
     def test_bernoulli(self):
         _TestTorchMixin._test_bernoulli(self, torch.float32, torch.float64, 'cuda')
@@ -2196,109 +2175,6 @@ class TestCuda(TestCase):
     def _select_broadcastable_dims(dims_full=None):
         return _TestTorchMixin._select_broadcastable_dims(dims_full)
 
-    @slowTest
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_inverse_many_batches(self):
-        _TestTorchMixin._test_inverse_slow(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_pinverse(self):
-        _TestTorchMixin._test_pinverse(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_matrix_rank(self):
-        _TestTorchMixin._test_matrix_rank(self, lambda x: x.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_matrix_power(self):
-        _TestTorchMixin._test_matrix_power(self, conv_fn=lambda t: t.cuda())
-
-    def test_chain_matmul(self):
-        _TestTorchMixin._test_chain_matmul(self, cast=lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_det_logdet_slogdet(self):
-        _TestTorchMixin._test_det_logdet_slogdet(self, 'cuda')
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_det_logdet_slogdet_batched(self):
-        _TestTorchMixin._test_det_logdet_slogdet_batched(self, 'cuda')
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_solve(self):
-        _TestTorchMixin._test_solve(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_solve_batched(self):
-        _TestTorchMixin._test_solve_batched(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_solve_batched_non_contiguous(self):
-        _TestTorchMixin._test_solve_batched_non_contiguous(self, lambda t: t.cuda())
-
-    @slowTest
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_solve_batched_many_batches(self):
-        _TestTorchMixin._test_solve_batched_many_batches(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_solve_batched_broadcasting(self):
-        _TestTorchMixin._test_solve_batched_broadcasting(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky_solve(self):
-        _TestTorchMixin._test_cholesky_solve(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky_solve_batched(self):
-        _TestTorchMixin._test_cholesky_solve_batched(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_cholesky_solve_batched_non_contiguous(self):
-        _TestTorchMixin._test_cholesky_solve_batched_non_contiguous(self, lambda t: t.cuda())
-
-    @slowTest
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky_solve_batched_many_batches(self):
-        _TestTorchMixin._test_cholesky_solve_batched_many_batches(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_cholesky_solve_batched_broadcasting(self):
-        _TestTorchMixin._test_cholesky_solve_batched_broadcasting(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky_inverse(self):
-        _TestTorchMixin._test_cholesky_inverse(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky(self):
-        _TestTorchMixin._test_cholesky(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky_batched(self):
-        _TestTorchMixin._test_cholesky_batched(self, lambda t: t.cuda())
-
-    @slowTest
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_cholesky_batched_many_batches(self):
-        _TestTorchMixin._test_cholesky_batched_many_batches(self, lambda t: t.cuda())
-
-    def test_view(self):
-        _TestTorchMixin._test_view(self, lambda t: t.cuda())
-
-    def test_flip(self):
-        _TestTorchMixin._test_flip(self, use_cuda=True)
-
-    def test_rot90(self):
-        _TestTorchMixin._test_rot90(self, use_cuda=True)
-
-    def test_signal_window_functions(self):
-        _TestTorchMixin._test_signal_window_functions(self, device=torch.device('cuda'))
-
     @skipIfRocm
     def test_fft_ifft_rfft_irfft(self):
         _TestTorchMixin._test_fft_ifft_rfft_irfft(self, device=torch.device('cuda'))
@@ -2411,10 +2287,6 @@ class TestCuda(TestCase):
         samples = probs.multinomial(1000000, replacement=True)
         self.assertGreater(probs[samples].min().item(), 0)
 
-    @skipCUDANonDefaultStreamIf(True)
-    def test_multinomial_alias(self):
-        _TestTorchMixin._test_multinomial_alias(self, lambda t: t.cuda())
-
     @staticmethod
     def mute():
         os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stderr.fileno())
@@ -2451,25 +2323,6 @@ class TestCuda(TestCase):
         self._spawn_method(test_method, torch.Tensor([1, -inf, 1]))
         self._spawn_method(test_method, torch.Tensor([1, 1, nan]))
         self._spawn_method(test_method, torch.Tensor([0, 1, 0]))
-
-    def test_broadcast(self):
-        _TestTorchMixin._test_broadcast(self, lambda t: t.cuda())
-
-    def test_contiguous(self):
-        _TestTorchMixin._test_contiguous(self, lambda t: t.cuda())
-
-    def test_broadcast_fused_matmul(self):
-        _TestTorchMixin._test_broadcast_fused_matmul(self, lambda t: t.cuda())
-
-    def test_broadcast_batched_matmul(self):
-        _TestTorchMixin._test_broadcast_batched_matmul(self, lambda t: t.cuda())
-
-    def test_index(self):
-        _TestTorchMixin._test_index(self, lambda t: t.cuda())
-
-    @skipCUDANonDefaultStreamIf(True)
-    def test_advancedindex(self):
-        _TestTorchMixin._test_advancedindex(self, lambda t: t.cuda())
 
     def test_advancedindex_mixed_cpu_cuda(self):
         def test(x, ia, ib):
@@ -2519,9 +2372,6 @@ class TestCuda(TestCase):
                 ib = ib.to(other_device)
                 test(x, ia, ib)
 
-    def test_advancedindex_big(self):
-        _TestTorchMixin._test_advancedindex_big(self, lambda t: t.cuda())
-
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")
     def test_huge_index(self):
@@ -2530,9 +2380,6 @@ class TestCuda(TestCase):
         res = src[idx]
         res_cpu = src.cpu()[idx.cpu()]
         self.assertEqual(res.cpu(), res_cpu)
-
-    def test_kthvalue(self):
-        _TestTorchMixin._test_kthvalue(self, device='cuda')
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_lu(self):
@@ -2550,27 +2397,9 @@ class TestCuda(TestCase):
         _TestTorchMixin._test_lu_solve_batched(self, lambda t: t.cuda(), pivot=True)
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_lu_solve_batched_non_contiguous(self):
-        _TestTorchMixin._test_lu_solve_batched_non_contiguous(self, lambda t: t.cuda())
-
-    @slowTest
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_lu_solve_batched_many_batches(self):
-        _TestTorchMixin._test_lu_solve_batched_many_batches(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_lu_solve_batched_broadcasting(self):
-        _TestTorchMixin._test_lu_solve_batched_broadcasting(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_lu_unpack(self):
         _TestTorchMixin._test_lu_unpack(self, lambda t: t.cuda(), pivot=False)
         _TestTorchMixin._test_lu_unpack(self, lambda t: t.cuda(), pivot=True)
-
-    def test_dim_reduction(self):
-        _TestTorchMixin._test_dim_reduction(self, lambda t: t.cuda())
 
     def test_tensor_gather(self):
         _TestTorchMixin._test_gather(self, lambda t: t.cuda(), False)
@@ -2602,12 +2431,6 @@ class TestCuda(TestCase):
 
     def test_min_with_inf(self):
         _TestTorchMixin._test_min_with_inf(self, (torch.half, torch.float, torch.double), 'cuda')
-
-    def test_rpow(self):
-        _TestTorchMixin._test_rpow(self, lambda x: x.cuda())
-
-    def test_remainder_overflow(self):
-        _TestTorchMixin._test_remainder_overflow(self, dtype=torch.int64, device='cuda')
 
     def test_var(self):
         cpu_tensor = torch.randn(2, 3, 3)
@@ -2704,18 +2527,6 @@ class TestCuda(TestCase):
         test(True)
         test(False)
 
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_symeig(self):
-        _TestTorchMixin._test_symeig(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_svd(self):
-        _TestTorchMixin._test_svd(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_svd_no_singularvectors(self):
-        _TestTorchMixin._test_svd_no_singularvectors(self, lambda t: t.cuda())
-
     def test_arange(self):
         for t in ['IntTensor', 'LongTensor', 'FloatTensor', 'DoubleTensor']:
             a = torch.cuda.__dict__[t]()
@@ -2739,63 +2550,10 @@ class TestCuda(TestCase):
         b = torch.logspace(1, 10, 10, 2)
         self.assertEqual(a, b.cuda())
 
-    def test_lerp(self):
-        _TestTorchMixin._test_lerp(self, lambda t: t.cuda())
-
-    def test_diagflat(self):
-        _TestTorchMixin._test_diagflat(self, dtype=torch.float32, device='cuda')
-
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @skipCUDANonDefaultStreamIf(True)
-    def test_norm(self):
-        _TestTorchMixin._test_norm(self, device='cuda')
-
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @skipCUDANonDefaultStreamIf(True)
-    def test_nuclear_norm_axes_small_brute_force(self):
-        _TestTorchMixin._test_nuclear_norm_axes(self, device='cuda')
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @skipCUDANonDefaultStreamIf(True)
-    def test_nuclear_norm_exceptions(self):
-        _TestTorchMixin._test_nuclear_norm_exceptions(self, device='cuda')
-
-    def test_dist(self):
-        _TestTorchMixin._test_dist(self, device='cuda')
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_geqrf(self):
-        _TestTorchMixin._test_geqrf(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @skipCUDANonDefaultStreamIf(True)
-    def test_triangular_solve(self):
-        _TestTorchMixin._test_triangular_solve(self, lambda t: t.cuda())
-
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @unittest.skip("Spuriously failing")
     def test_triangular_solve_batched(self):
         _TestTorchMixin._test_triangular_solve_batched(self, lambda t: t.cuda())
-
-    @slowTest
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_triangular_solve_batched_many_batches(self):
-        _TestTorchMixin._test_triangular_solve_batched_many_batches(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
-    def test_triangular_solve_batched_broadcasting(self):
-        _TestTorchMixin._test_triangular_solve_batched_broadcasting(self, lambda t: t.cuda())
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_lstsq(self):
-        _TestTorchMixin._test_lstsq(self, 'cuda')
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_qr(self):
-        _TestTorchMixin._test_qr(self, lambda t: t.cuda())
 
     @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
     def test_get_set_rng_state_all(self):
@@ -2814,12 +2572,6 @@ class TestCuda(TestCase):
         torch.cuda.nvtx.range_push("foo")
         torch.cuda.nvtx.mark("bar")
         torch.cuda.nvtx.range_pop()
-
-    def test_randperm_cuda(self):
-        _TestTorchMixin._test_randperm(self, device='cuda')
-
-    def test_random_neg_values(self):
-        _TestTorchMixin._test_random_neg_values(self, use_cuda=True)
 
     def test_bincount_cuda(self):
         _TestTorchMixin._test_bincount(self, device='cuda')
@@ -2910,9 +2662,6 @@ class TestCuda(TestCase):
     def test_large_trilu_indices(self):
         for test_args in tri_large_tests_args:
             _compare_large_trilu_indices(self, *test_args, device='cuda')
-
-    def test_triu_tril(self):
-        _TestTorchMixin._test_triu_tril(self, lambda t: t.cuda())
 
     def test_cuda_round(self):
         # test half-to-even

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -30,7 +30,8 @@ from common_methods_invocations import tri_tests_args, run_additional_tri_tests,
 from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
     TEST_LIBROSA, run_tests, download_file, skipIfNoLapack, suppress_warnings, \
     IS_WINDOWS, PY3, NO_MULTIPROCESSING_SPAWN, skipIfRocm, do_test_dtypes, do_test_empty_full, \
-    IS_SANDCASTLE, load_tests, brute_pdist, brute_cdist, slowTest, torchtest
+    IS_SANDCASTLE, load_tests, brute_pdist, brute_cdist, slowTest, torchtest, \
+    skipCUDANonDefaultStreamIf
 from multiprocessing.reduction import ForkingPickler
 from common_device_type import instantiate_device_type_tests, \
     skipCPUIfNoLapack, skipCUDAIfNoMagma
@@ -405,84 +406,6 @@ class _TestTorchMixin(torchtest):
                         res2[i, j] += m1[i, k] * m2[k, j]
             self.assertEqual(res1, res2, prec)
 
-    def test_logical_any(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.zeros([2, 3, 400], dtype=torch.uint8, device=device)
-
-            self.assertEqual(
-                torch.tensor(0, dtype=torch.uint8, device=device),
-                x.any())
-
-            self.assertEqual(
-                torch.zeros([1, 3, 400], dtype=torch.uint8, device=device),
-                x.any(0, keepdim=True))
-
-            self.assertEqual(
-                torch.zeros([2, 1, 400], dtype=torch.uint8, device=device),
-                x.any(1, keepdim=True))
-
-            self.assertEqual(
-                torch.zeros([2, 3, 1], dtype=torch.uint8, device=device),
-                x.any(2, keepdim=True))
-
-            # set the last element to 0
-            x[-1][-1][-1] = 1
-
-            self.assertEqual(
-                torch.tensor(1, dtype=torch.uint8, device=device),
-                x.any())
-
-            y = torch.zeros([1, 3, 400], dtype=torch.uint8, device=device)
-            y[-1][-1][-1] = 1
-            self.assertEqual(y, x.any(0, keepdim=True))
-
-            y = torch.zeros([2, 1, 400], dtype=torch.uint8, device=device)
-            y[-1][-1][-1] = 1
-            self.assertEqual(y, x.any(1, keepdim=True))
-
-            y = torch.zeros([2, 3, 1], dtype=torch.uint8, device=device)
-            y[-1][-1][-1] = 1
-            self.assertEqual(y, x.any(2, keepdim=True))
-
-    def test_logical_all(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.ones([2, 3, 400], dtype=torch.uint8, device=device)
-
-            self.assertEqual(
-                torch.tensor(1, dtype=torch.uint8, device=device),
-                x.all())
-
-            self.assertEqual(
-                torch.ones([1, 3, 400], dtype=torch.uint8, device=device),
-                x.all(0, keepdim=True))
-
-            self.assertEqual(
-                torch.ones([2, 1, 400], dtype=torch.uint8, device=device),
-                x.all(1, keepdim=True))
-
-            self.assertEqual(
-                torch.ones([2, 3, 1], dtype=torch.uint8, device=device),
-                x.all(2, keepdim=True))
-
-            # set the last element to 0
-            x[-1][-1][-1] = 0
-
-            self.assertEqual(
-                torch.tensor(0, dtype=torch.uint8, device=device),
-                x.all())
-
-            y = torch.ones([1, 3, 400], dtype=torch.uint8, device=device)
-            y[-1][-1][-1] = 0
-            self.assertEqual(y, x.all(0, keepdim=True))
-
-            y = torch.ones([2, 1, 400], dtype=torch.uint8, device=device)
-            y[-1][-1][-1] = 0
-            self.assertEqual(y, x.all(1, keepdim=True))
-
-            y = torch.ones([2, 3, 1], dtype=torch.uint8, device=device)
-            y[-1][-1][-1] = 0
-            self.assertEqual(y, x.all(2, keepdim=True))
-
     def test_allclose(self):
         x = torch.tensor([1.0, 2.0, 3.0])
         y = torch.tensor([1.01, 2.01, 3.01])
@@ -780,29 +703,6 @@ class _TestTorchMixin(torchtest):
     def test_erfc(self):
         self._test_math_by_name('erfc')
 
-    @torchtest.for_all_device_types()
-    def test_erfinv(self, device):
-        def checkType(dtype):
-            # general testing. Narrow the range to avoid accuracy issues
-            input_values = torch.randn(4, 4, dtype=dtype, device=device).clamp(-0.3, 0.3)
-            self.assertEqual(input_values.erf().erfinv(), input_values)
-            # test inf
-            self.assertTrue(torch.equal(torch.tensor([-1, 1], dtype=dtype, device=device).erfinv(),
-                            torch.tensor([-inf, inf], dtype=dtype, device=device)))
-            # test nan
-            self.assertEqual(torch.tensor([-2, 2], dtype=dtype, device=device).erfinv(),
-                             torch.tensor([nan, nan], dtype=dtype, device=device))
-
-        if device != 'cpu':
-            checkType(torch.half)
-        checkType(torch.float)
-        checkType(torch.double)
-
-        # double precision
-        a = torch.tensor([0.5, 0.8], dtype=torch.double, device=device).erfinv()
-        self.assertAlmostEqual(a[0].item(), 0.47693627620447, places=13)
-        self.assertAlmostEqual(a[1].item(), 0.90619380243682, places=13)
-
     def test_exp(self):
         def exp(x):
             try:
@@ -951,18 +851,6 @@ class _TestTorchMixin(torchtest):
     def test_max(self):
         self._testSelection(torch.max, max)
 
-    def test_log_normal(self):
-        for device in torch.testing.get_all_device_types():
-            a = torch.tensor([10], dtype=torch.float, device=device).log_normal_()
-            self.assertEqual(a.dtype, torch.float)
-            self.assertEqual(a.size(), torch.Size([1]))
-
-    def test_geometric(self):
-        for device in torch.testing.get_all_device_types():
-            a = torch.tensor([10], dtype=torch.float, device=device).geometric_(0.5)
-            self.assertEqual(a.dtype, torch.float)
-            self.assertEqual(a.size(), torch.Size([1]))
-
     @staticmethod
     def _test_max_with_inf(self, dtypes=(torch.float, torch.double), device='cpu'):
         for dtype in dtypes:
@@ -986,152 +874,6 @@ class _TestTorchMixin(torchtest):
     def test_min_with_inf(self):
         self._test_min_with_inf(self)
 
-    @staticmethod
-    def _test_norm(self, device):
-        # full reduction
-        x = torch.randn(25, device=device)
-        xn = x.cpu().numpy()
-        for p in [0, 1, 2, 3, 4, inf, -inf]:
-            res = x.norm(p).item()
-            expected = np.linalg.norm(xn, p)
-            self.assertEqual(res, expected, "full reduction failed for {}-norm".format(p))
-
-        # one dimension
-        x = torch.randn(25, 25, device=device)
-        xn = x.cpu().numpy()
-        for p in [0, 1, 2, 3, 4, inf, -inf]:
-            res = x.norm(p, 1).cpu().numpy()
-            expected = np.linalg.norm(xn, p, 1)
-            self.assertEqual(res.shape, expected.shape)
-            self.assertTrue(np.allclose(res, expected), "dim reduction failed for {}-norm".format(p))
-
-        # matrix norm
-        for p in ['fro', 'nuc']:
-            res = x.norm(p).cpu().numpy()
-            expected = np.linalg.norm(xn, p)
-            self.assertEqual(res.shape, expected.shape)
-            self.assertTrue(np.allclose(res, expected), "dim reduction failed for {}-norm".format(p))
-
-        # larger tensor sanity check
-        self.assertEqual(2 * torch.norm(torch.ones(10000)), torch.norm(torch.ones(40000)))
-
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    @skipIfNoLapack
-    def test_norm(self):
-        self._test_norm(self, device='cpu')
-
-    @staticmethod
-    def _test_nuclear_norm_axes(self, device='cpu'):
-        def check_single_nuclear_norm(x, axes):
-            if x.is_cuda and randrange(100) < 95:
-                return  # too many cpu <==> gpu copies
-
-            a = np.array(x.cpu(), copy=False)
-            expected = np.linalg.norm(a, "nuc", axis=axes)
-
-            ans = torch.norm(x, "nuc", dim=axes)
-            self.assertTrue(ans.is_contiguous())
-            self.assertEqual(ans.shape, expected.shape)
-            self.assertTrue(np.allclose(ans.cpu(), expected, rtol=1e-02, atol=1e-03, equal_nan=True))
-
-            out = torch.zeros(expected.shape, dtype=x.dtype, device=x.device)
-            ans = torch.norm(x, "nuc", dim=axes, out=out)
-            self.assertIs(ans, out)
-            self.assertTrue(ans.is_contiguous())
-            self.assertEqual(ans.shape, expected.shape)
-            self.assertTrue(np.allclose(ans.cpu(), expected, rtol=1e-02, atol=1e-03, equal_nan=True))
-
-        for n in range(1, 3):
-            for m in range(1, 3):
-                for axes in permutations([0, 1], 2):
-                    # 2d, inner dimensions C
-                    x = torch.randn(n, m, device=device)
-                    check_single_nuclear_norm(x, axes)
-
-                    # 2d, inner dimensions Fortran
-                    x = torch.randn(m, n, device=device).transpose(-1, -2)
-                    check_single_nuclear_norm(x, axes)
-
-                    # 2d, inner dimensions non-contiguous
-                    x = torch.randn(n, 2 * m, device=device)[:, ::2]
-                    check_single_nuclear_norm(x, axes)
-
-                    # 2d, all dimensions non-contiguous
-                    x = torch.randn(7 * n, 2 * m, device=device)[::7, ::2]
-                    check_single_nuclear_norm(x, axes)
-
-                for o in range(1, 3):
-                    for axes in permutations([0, 1, 2], 2):
-                        # 3d, inner dimensions C
-                        x = torch.randn(o, n, m, device=device)
-                        check_single_nuclear_norm(x, axes)
-
-                        # 3d, inner dimensions Fortran
-                        x = torch.randn(o, m, n, device=device).transpose(-1, -2)
-                        check_single_nuclear_norm(x, axes)
-
-                        # 3d, inner dimensions non-contiguous
-                        x = torch.randn(o, n, 2 * m, device=device)[:, :, ::2]
-                        check_single_nuclear_norm(x, axes)
-
-                        # 3d, all dimensions non-contiguous
-                        x = torch.randn(7 * o, 5 * n, 2 * m, device=device)[::7, ::5, ::2]
-                        check_single_nuclear_norm(x, axes)
-
-                    for r in range(1, 3):
-                        for axes in permutations([0, 1, 2, 3], 2):
-                            # 4d, inner dimensions C
-                            x = torch.randn(r, o, n, m, device=device)
-                            check_single_nuclear_norm(x, axes)
-
-                            # 4d, inner dimensions Fortran
-                            x = torch.randn(r, o, n, m, device=device).transpose(-1, -2)
-                            check_single_nuclear_norm(x, axes)
-
-                            # 4d, inner dimensions non-contiguous
-                            x = torch.randn(r, o, n, 2 * m, device=device)[:, :, :, ::2]
-                            check_single_nuclear_norm(x, axes)
-
-                            # 4d, all dimensions non-contiguous
-                            x = torch.randn(7 * r, 5 * o, 11 * n, 2 * m, device=device)[::7, ::5, ::11, ::2]
-                            check_single_nuclear_norm(x, axes)
-
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_nuclear_norm_axes_small_brute_force(self):
-        self._test_nuclear_norm_axes(self)
-
-    @staticmethod
-    def _test_nuclear_norm_exceptions(self, device='cpu'):
-        for lst in [], [1], [1, 2]:
-            for axes in (), (0,), (0, 1):
-                x = torch.tensor(lst, dtype=torch.double, device=device)
-                self.assertRaises(RuntimeError, torch.norm, x, "nuc", axes)
-
-        x = torch.tensor([[0, 1, 2], [3, 4, 5]], dtype=torch.double, device=device)
-        self.assertRaisesRegex(RuntimeError, "duplicate or invalid", torch.norm, x, "nuc", (0, 0))
-        self.assertRaisesRegex(RuntimeError, "duplicate or invalid", torch.norm, x, "nuc", (0, 2))
-
-    def test_nuclear_norm_exceptions(self):
-        self._test_nuclear_norm_exceptions(self)
-
-    @staticmethod
-    def _test_dist(self, device):
-        def run_test(x, y):
-            for p in [0, 1, 2, 3, 4, inf, -inf]:
-                dist_xy = torch.dist(x, y, p)
-                dist_xy_norm = torch.norm(x - y, p)
-                self.assertEqual(dist_xy, dist_xy_norm)
-
-        run_test(torch.randn(5, device=device), torch.randn(5, device=device))
-
-        x = torch.zeros(3, device=device)
-        y = torch.zeros(3, device=device)
-        y[1] = 1.
-        run_test(x, y)
-
-    def test_dist(self):
-        self._test_dist(self, device='cpu')
-
     def test_dim_reduction_uint8_overflow(self):
         example = [[-1, 2, 1], [5, 3, 6]]
         x = torch.tensor(example, dtype=torch.uint8)
@@ -1141,364 +883,6 @@ class _TestTorchMixin(torchtest):
         y = torch.tensor(example, dtype=torch.uint8)
         torch.sum(x, 0, out=y)
         self.assertEqual(x.sum(0, dtype=torch.uint8), y)
-
-    @staticmethod
-    def _test_dim_reduction(self, cast):
-        example = [[-1, 2, 1], [5, 3, 6]]
-
-        types = [torch.double,
-                 torch.float,
-                 torch.int64,
-                 torch.int32,
-                 torch.int16]
-
-        # This won't test for 256bit instructions, since we usually
-        # only work on 1 cacheline (1024bit) at a time and these
-        # examples aren't big enough to trigger that.
-        for dtype in types:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.sum().item(), 16)
-            self.assertEqual(x.sum(0), torch.FloatTensor([4, 5, 7]))
-            self.assertEqual(x.sum(1), torch.FloatTensor([2, 14]))
-            y = cast(torch.tensor(example, dtype=dtype))
-            torch.sum(x, 0, out=y)
-            self.assertEqual(x.sum(0), y)
-
-        # Mean not supported for Int types
-        for dtype in types[:2]:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.mean().item(), 16.0 / 6)
-            self.assertEqual(x.mean(0), torch.FloatTensor([2.0, 2.5, 7.0 / 2]))
-            self.assertEqual(x.mean(1), torch.FloatTensor([2.0 / 3, 14.0 / 3]))
-            self.assertEqual(x.mean(), x.mean((0, 1)))
-
-        for dtype in types:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.prod().item(), -180)
-            self.assertEqual(x.prod(0), torch.FloatTensor([-5, 6, 6]))
-            self.assertEqual(x.prod(1), torch.FloatTensor([-2, 90]))
-
-        for dtype in types:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.max().item(), 6)
-            self.assertEqual(x.max(0), (torch.FloatTensor([5, 3, 6]), torch.FloatTensor([1, 1, 1])))
-            self.assertEqual(x.max(1), (torch.FloatTensor([2, 6]), torch.FloatTensor([1, 2])))
-
-        for dtype in types:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.min().item(), -1)
-            self.assertEqual(x.min(0), (torch.FloatTensor([-1, 2, 1]), torch.FloatTensor([0, 0, 0])))
-            self.assertEqual(x.min(1), (torch.FloatTensor([-1, 3]), torch.FloatTensor([0, 1])))
-
-        for dtype in types:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.argmax().item(), 5)
-            self.assertEqual(x.argmax(dim=None).item(), 5)
-            self.assertEqual(x.argmax(dim=0), torch.FloatTensor([1, 1, 1]))
-            self.assertEqual(x.argmax(dim=1), torch.FloatTensor([1, 2]))
-            self.assertEqual(x.argmax(dim=0, keepdim=True), torch.FloatTensor([[1, 1, 1]]))
-            # test that non-contiguous tensors work
-            self.assertEqual(x[:, :2].argmax().item(), 2)
-
-        for dtype in types:
-            x = cast(torch.tensor(example, dtype=dtype))
-            self.assertEqual(x.argmin().item(), 0)
-            self.assertEqual(x.argmin(dim=None).item(), 0)
-            self.assertEqual(x.argmin(dim=0), torch.FloatTensor([0, 0, 0]))
-            self.assertEqual(x.argmin(dim=1), torch.FloatTensor([0, 1]))
-            self.assertEqual(x.argmin(dim=1, keepdim=True), torch.FloatTensor([[0], [1]]))
-            # test that non-contiguous tensors work
-            self.assertEqual(x[:, :2].argmin().item(), 0)
-
-        dim_red_fns = [
-            "mean", "median", "mode", "norm", "prod",
-            "std", "sum", "var", "max", "min"]
-
-        def normfn_attr(t, dim, keepdim=False, out=None):
-            attr = torch.norm
-            return attr(t, 2, dim, keepdim, out=out)
-
-        for fn_name in dim_red_fns:
-            fn_attr = getattr(torch, fn_name) if fn_name != "norm" else normfn_attr
-
-            def fn(x, dim, keepdim=False, out=None):
-                ans = fn_attr(x, dim, keepdim=keepdim, out=out)
-                return ans if not istuple(ans) else ans[0]
-
-            def fn_tuple(x, dim, keepdim=False, out=None):
-                return fn_attr(x, dim, keepdim=keepdim, out=out)
-
-            def test_multidim(x, dim):
-                self.assertEqual(fn(x, dim).unsqueeze(dim), fn(x, dim, keepdim=True))
-                self.assertEqual(x.ndimension() - 1, fn(x, dim).ndimension())
-                self.assertEqual(x.ndimension(), fn(x, dim, keepdim=True).ndimension())
-
-            # general case
-            x = cast(torch.randn(3, 4, 5))
-            dim = random.randint(0, 2)
-            test_multidim(x, dim)
-
-            # check 1-d behavior
-            x = cast(torch.randn(1))
-            dim = 0
-            self.assertEqual(fn(x, dim).shape, ())
-            self.assertEqual(fn(x, dim, keepdim=True).shape, (1,))
-
-            # check reducing of a singleton dimension
-            dims = [3, 4, 5]
-            singleton_dim = random.randint(0, 2)
-            dims[singleton_dim] = 1
-            x = cast(torch.randn(dims))
-            test_multidim(x, singleton_dim)
-
-            # check reducing with output kwargs
-            if fn_name in ['median', 'mode', 'max', 'min']:
-                y = cast(torch.randn(5, 3))
-                values = cast(torch.randn(5, 3))
-                indices = cast(torch.zeros(5, 3).long() - 1)
-                fn_tuple(y, 1, keepdim=False, out=(values[:, 1], indices[:, 1]))
-                values_expected, indices_expected = fn_tuple(y, 1, keepdim=False)
-                self.assertEqual(values[:, 1], values_expected,
-                                 '{} values with out= kwarg'.format(fn_name))
-                self.assertEqual(indices[:, 1], indices_expected,
-                                 '{} indices with out= kwarg'.format(fn_name))
-                continue
-
-            x = cast(torch.randn(5, 3))
-            y = cast(torch.randn(5, 3))
-            fn(y, 1, keepdim=False, out=x[:, 1])
-            expected = fn(y, 1, keepdim=False)
-            self.assertEqual(x[:, 1], expected, '{} with out= kwarg'.format(fn_name))
-
-    def test_dim_reduction(self):
-        self._test_dim_reduction(self, lambda t: t)
-
-    def test_reduction_empty(self):
-        fns_to_test = [
-            # name, function, identity
-            ('max', torch.max, None),
-            ('kthvalue', lambda *args, **kwargs: torch.kthvalue(*args, k=1, **kwargs), None),
-            ('argmax', torch.argmax, None),
-            ('min', torch.min, None),
-            ('argmin', torch.argmin, None),
-            ('mode', torch.mode, None),
-            ('median', torch.median, None),
-
-            ('prod', torch.prod, 1),
-            ('sum', torch.sum, 0),
-            ('norm', torch.norm, 0),
-            ('mean', torch.mean, nan),
-            ('var', torch.var, nan),
-            ('std', torch.std, nan),
-            ('logsumexp', torch.logsumexp, -inf),
-        ]
-
-        shape = (2, 0, 4)
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(shape, device=device)
-
-            for fn in [torch.max, torch.min]:
-                ident_err = 'operation does not have an identity'
-                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x))
-
-            for item in fns_to_test:
-                name, fn, identity = item
-                if identity is None:
-                    ident_err = 'does not have an identity'
-                    self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2))
-                    self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2, keepdim=True))
-                    self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1))
-                    self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1, keepdim=True))
-                else:
-                    self.assertEqual(torch.empty((2, 0), device=device), fn(x, dim=2))
-                    self.assertEqual(torch.empty((2, 0, 1), device=device), fn(x, dim=2, keepdim=True))
-                    # assertEqual doesn't work with inf, -inf, nan and two tensors.
-                    check = (torch.testing.assert_allclose if math.isnan(identity) or math.isinf(identity) else
-                             self.assertEqual)
-                    check(torch.full((2, 4), identity, device=device), fn(x, dim=1))
-                    check(torch.full((2, 1, 4), identity, device=device), fn(x, dim=1, keepdim=True))
-                    try:
-                        check(torch.full((), identity, device=device), fn(x))
-                    except TypeError as err:
-                        # ignore if there is no allreduce.
-                        self.assertTrue('dim' in str(err))
-
-            # any
-            xb = x.to(torch.uint8)
-            yb = x.to(torch.uint8)
-            self.assertEqual((2, 0), xb.any(2).shape)
-            self.assertEqual((2, 0, 1), xb.any(2, keepdim=True).shape)
-            self.assertEqual(torch.zeros((2, 4), device=device), xb.any(1))
-            self.assertEqual(torch.zeros((2, 1, 4), device=device), xb.any(1, keepdim=True))
-            self.assertEqual(torch.zeros((), device=device), xb.any())
-
-            # all
-            self.assertEqual((2, 0), xb.all(2).shape)
-            self.assertEqual((2, 0, 1), xb.all(2, keepdim=True).shape)
-            self.assertEqual(torch.ones((2, 4), device=device), xb.all(1))
-            self.assertEqual(torch.ones((2, 1, 4), device=device), xb.all(1, keepdim=True))
-            self.assertEqual(torch.ones((), device=device), xb.all())
-
-    def test_pairwise_distance_empty(self):
-        for device in torch.testing.get_all_device_types():
-            shape = (2, 0)
-            x = torch.randn(shape, device=device)
-            y = torch.randn(shape, device=device)
-
-            self.assertEqual(torch.zeros(2, device=device), torch.pairwise_distance(x, y))
-            self.assertEqual(torch.zeros((2, 1), device=device), torch.pairwise_distance(x, y, keepdim=True))
-
-            shape = (0, 2)
-            x = torch.randn(shape, device=device)
-            y = torch.randn(shape, device=device)
-            self.assertEqual(torch.zeros(0, device=device), torch.pairwise_distance(x, y))
-            self.assertEqual(torch.zeros((0, 1), device=device), torch.pairwise_distance(x, y, keepdim=True))
-
-    def test_pdist_empty(self):
-        for device in torch.testing.get_all_device_types():
-            shape = (0, 2)
-            x = torch.randn(shape, device=device)
-            self.assertEqual(torch.empty(0, device=device), torch.pdist(x))
-
-            shape = (1, 2)
-            x = torch.randn(shape, device=device)
-            self.assertEqual(torch.empty(0, device=device), torch.pdist(x))
-
-            shape = (3, 0)
-            x = torch.randn(shape, device=device)
-            self.assertEqual(torch.zeros(3, device=device), torch.pdist(x))
-
-    def test_pdist_norm(self):
-        def test_pdist_single(shape, device, p, dtype, trans):
-            x = torch.randn(shape, dtype=dtype, device=device)
-            if trans:
-                x.transpose_(-2, -1)
-            actual = torch.pdist(x, p=p)
-            expected = brute_pdist(x, p=p)
-            self.assertEqual(expected.shape, actual.shape)
-            self.assertTrue(torch.allclose(expected, actual))
-
-        for device in torch.testing.get_all_device_types():
-            for shape in [(4, 5), (3, 2), (2, 1)]:
-                for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
-                    for trans in [False, True]:
-                        for dtype in [torch.float32, torch.float64]:
-                            test_pdist_single(shape, device, p, dtype, trans)
-
-            # do a simplified comparison with big inputs, see:
-            # https://github.com/pytorch/pytorch/issues/15511
-            for dtype in [torch.float32, torch.float64]:
-                test_pdist_single((1000, 2), device, 2, dtype, False)
-
-    def test_cdist_empty(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn((0, 5), device=device)
-            y = torch.randn((4, 5), device=device)
-            self.assertEqual(torch.empty(0, 4, device=device), torch.cdist(x, y))
-
-            x = torch.randn((2, 5), device=device)
-            y = torch.randn((0, 5), device=device)
-            self.assertEqual(torch.empty(2, 0, device=device), torch.cdist(x, y))
-
-            x = torch.randn((2, 0), device=device)
-            y = torch.randn((3, 0), device=device)
-            self.assertEqual(torch.zeros(2, 3, device=device), torch.cdist(x, y))
-
-            x = torch.randn((2, 0), device=device)
-            y = torch.randn((0, 0), device=device)
-            self.assertEqual(torch.empty(2, 0, device=device), torch.cdist(x, y))
-
-    def test_cdist_norm(self):
-        for device in torch.testing.get_all_device_types():
-            for r1 in [3, 4, 5, 6]:
-                for m in [2, 3, 4, 10]:
-                    for r2 in [4, 6, 7, 8]:
-                        for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
-                            x = torch.randn(r1, m, device=device)
-                            y = torch.randn(r2, m, device=device)
-                            actual = torch.cdist(x, y, p=p)
-                            expected = brute_cdist(x, y, p=p)
-                            self.assertTrue(torch.allclose(expected, actual))
-
-    def test_cdist_norm_batch(self):
-        for device in torch.testing.get_all_device_types():
-            for r1 in [3, 4, 5, 6]:
-                for m in [2, 3, 4, 10]:
-                    for r2 in [4, 6, 7, 8]:
-                        for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
-                            x = torch.randn(2, 3, 6, r1, m, device=device)
-                            y = torch.randn(2, 3, 6, r2, m, device=device)
-                            actual = torch.cdist(x, y, p=p)
-                            expected = brute_cdist(x, y, p=p)
-                            self.assertTrue(torch.allclose(expected, actual))
-
-    def test_cdist_large(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(1000, 10, device=device)
-            y = torch.randn(1000, 10, device=device)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertTrue(torch.allclose(expected, actual))
-
-    def test_cdist_large_batch(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(4, 3, 1000, 10, device=device)
-            y = torch.randn(4, 3, 1000, 10, device=device)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertTrue(torch.allclose(expected, actual))
-
-    def test_cdist_non_contiguous(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(5, 7, device=device).transpose(-1, -2)
-            y = torch.randn(5, 3, device=device).transpose(-1, -2)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertFalse(x.is_contiguous())
-            self.assertFalse(y.is_contiguous())
-            self.assertTrue(torch.allclose(expected, actual))
-
-            x = torch.randn(7, 5, device=device)
-            y = torch.randn(5, 3, device=device).t()
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertTrue(x.is_contiguous())
-            self.assertFalse(y.is_contiguous())
-            self.assertTrue(torch.allclose(expected, actual))
-
-            x = torch.randn(5, 7, device=device).t()
-            y = torch.randn(3, 5, device=device)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertFalse(x.is_contiguous())
-            self.assertTrue(y.is_contiguous())
-            self.assertTrue(torch.allclose(expected, actual))
-
-    def test_cdist_non_contiguous_batch(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(4, 3, 2, 5, 7, device=device).transpose(-1, -2)
-            y = torch.randn(4, 3, 2, 5, 3, device=device).transpose(-1, -2)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertFalse(x.is_contiguous())
-            self.assertFalse(y.is_contiguous())
-            self.assertTrue(torch.allclose(expected, actual))
-
-            x = torch.randn(7, 2, 7, 5, device=device)
-            y = torch.randn(7, 2, 5, 3, device=device).transpose(-1, -2)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertTrue(x.is_contiguous())
-            self.assertFalse(y.is_contiguous())
-            self.assertTrue(torch.allclose(expected, actual))
-
-            x = torch.randn(4, 5, 7, device=device).transpose(-1, -2)
-            y = torch.randn(4, 3, 5, device=device)
-            actual = torch.cdist(x, y, p=2)
-            expected = brute_cdist(x, y, p=2)
-            self.assertFalse(x.is_contiguous())
-            self.assertTrue(y.is_contiguous())
-            self.assertTrue(torch.allclose(expected, actual))
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found")
     def test_logsumexp(self):
@@ -1559,27 +943,6 @@ class _TestTorchMixin(torchtest):
 
     def test_min_elementwise(self):
         self._testCSelection(torch.min, min)
-
-    @staticmethod
-    def _test_lerp(self, cast):
-        start_end_shapes = [(), (5,), (5, 5), (5, 5, 5)]
-        for shapes in product(start_end_shapes, start_end_shapes):
-            start = cast(torch.randn(shapes[0]))
-            end = cast(torch.randn(shapes[1]))
-
-            # Tensor weights
-            for weight in [cast(torch.randn(shapes[0])), random.random()]:
-                actual = torch.lerp(start, end, weight)
-                actual_method = start.lerp(end, weight)
-                self.assertEqual(actual, actual_method)
-                actual_out = cast(torch.Tensor())
-                torch.lerp(start, end, weight, out=actual_out)
-                self.assertEqual(actual, actual_out)
-                expected = start + weight * (end - start)
-                self.assertEqual(expected, actual)
-
-    def test_lerp(self):
-        self._test_lerp(self, lambda t: t)
 
     def test_all_any(self):
         def test(size):
@@ -1662,38 +1025,6 @@ class _TestTorchMixin(torchtest):
             RuntimeError, "multinomial arguments must have the same device",
             lambda: torch.multinomial(x, 2, out=y))
 
-    def test_multinomial_constraints(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.empty(1, 2, 3, dtype=torch.double, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "prob_dist must be 1 or 2 dim",
-                lambda: torch.multinomial(x, 2))
-            x = torch.empty(1, 2, dtype=torch.long, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "multinomial only supports floating-point dtypes for input",
-                lambda: torch.multinomial(x, 2))
-            x = torch.empty(1, 2, dtype=torch.double, device=device)
-            y = torch.empty(1, 2, dtype=torch.double, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "multinomial expects Long tensor out",
-                lambda: torch.multinomial(x, 2, out=y))
-            x = torch.empty(2, dtype=torch.double, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "cannot sample n_sample <= 0 samples",
-                lambda: torch.multinomial(x, 0))
-            x = torch.empty(2, dtype=torch.double, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "cannot sample n_sample <= 0 samples",
-                lambda: torch.multinomial(x, -1))
-            x = torch.empty(2, dtype=torch.double, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "cannot sample n_sample > prob_dist",
-                lambda: torch.multinomial(x, 3, False))
-            x = torch.empty(16777217, dtype=torch.double, device=device)
-            self.assertRaisesRegex(
-                RuntimeError, "number of categories cannot exceed",
-                lambda: torch.multinomial(x, 3))
-
     def test_mv(self):
         def _test_mv(m1, v1):
             res1 = torch.mv(m1, v1)
@@ -1720,129 +1051,6 @@ class _TestTorchMixin(torchtest):
         res1 = x1.sum(dim=(0, 2), keepdim=True)
         res2 = x1.sum(axis=(0, 2), keepdims=True)
         self.assertEqual(res1, res2)
-
-    def test_addcdiv(self):
-        def _test_addcdiv(a, alpha, b, c):
-            actual = torch.addcdiv(a, alpha, b, c)
-            # implementation of addcdiv downcasts alpha. arithmetic ops don't.
-            if not actual.dtype.is_floating_point:
-                alpha = int(alpha)
-            expected = a + (alpha * b) / c
-            self.assertTrue(torch.allclose(expected, actual, equal_nan=True))
-
-        def non_zero_rand(size, dtype, device):
-            if dtype.is_floating_point:
-                a = torch.rand(size=size, dtype=dtype, device=device)
-            elif dtype == torch.uint8:
-                a = torch.randint(1, 5, size=size, dtype=dtype, device=device)
-            else:
-                a = torch.randint(-5, 5, size=size, dtype=dtype, device=device)
-            return a + (a == 0).type(dtype)
-
-        for device in torch.testing.get_all_device_types():
-            for dtype in torch.testing.get_all_math_dtypes(device):
-                _test_addcdiv(
-                    non_zero_rand((2, 2), dtype=dtype, device=device),
-                    0.5,
-                    non_zero_rand((2, 2), dtype=dtype, device=device),
-                    non_zero_rand((2, 2), dtype=dtype, device=device))
-
-    def test_add(self):
-        for device in torch.testing.get_all_device_types():
-            # [res] torch.add([res,] tensor1, tensor2)
-            m1 = torch.randn(100, 100, device=device)
-            v1 = torch.randn(100, device=device)
-
-            # contiguous
-            res1 = torch.add(m1[4], v1)
-            res2 = res1.clone().zero_()
-            for i in range(m1.size(1)):
-                res2[i] = m1[4, i] + v1[i]
-            self.assertEqual(res1, res2)
-
-            m1 = torch.randn(100, 100, device=device)
-            v1 = torch.randn(100, device=device)
-
-            # non-contiguous
-            res1 = torch.add(m1[:, 4], v1)
-            res2 = res1.clone().zero_()
-            for i in range(m1.size(0)):
-                res2[i] = m1[i, 4] + v1[i]
-            self.assertEqual(res1, res2)
-
-            # [res] torch.add([res,] tensor, value)
-            m1 = torch.randn(10, 10, device=device)
-
-            # contiguous
-            res1 = m1.clone()
-            res1[3].add_(2)
-            res2 = m1.clone()
-            for i in range(m1.size(1)):
-                res2[3, i] = res2[3, i] + 2
-            self.assertEqual(res1, res2)
-
-            # non-contiguous
-            m1 = torch.randn(10, 10, device=device)
-            res1 = m1.clone()
-            res1[:, 3].add_(2)
-            res2 = m1.clone()
-            for i in range(m1.size(0)):
-                res2[i, 3] = res2[i, 3] + 2
-            self.assertEqual(res1, res2)
-
-            # inter-type
-            m1 = torch.randn(10, 10, device=device)
-            self.assertEqual(m1 + 3, m1 + torch.tensor(3))
-            self.assertEqual(3 + m1, torch.tensor(3) + m1)
-            one = torch.tensor(1, dtype=torch.uint8, device=device)
-            self.assertEqual(torch.add(one, 1), 2)
-            self.assertEqual(torch.add(one, 1).dtype, torch.uint8)
-
-            # contiguous + non-contiguous
-            m1 = torch.randn(10, 10, device=device)
-            m2 = torch.randn(10, 10, device=device).t()
-            res = m1 + m2
-            self.assertTrue(res.is_contiguous())
-            self.assertEqual(res, m1 + m2.contiguous())
-
-            # 1d + empty
-            m1 = torch.tensor([1.0], dtype=torch.float, device=device)
-            m2 = torch.tensor([], dtype=torch.float, device=device)
-            self.assertEqual(m1 + m2, [])
-
-            # bool
-            m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=device)
-            m2 = torch.tensor([True, True, False, False, False, True], dtype=torch.bool, device=device)
-            expected = torch.tensor([True, True, False, True, False, True], dtype=torch.bool, device=device)
-            self.assertEqual(m1 + m2, expected)
-
-            # fused multiply add
-            a = torch.zeros(2, 3, dtype=torch.bool, device=device)
-            res = torch.add(a, a, alpha=0)
-            expected = torch.zeros(2, 3, device=device).bool()
-            self.assertEqual(res, expected)
-
-            # bfloat16
-            m1 = torch.tensor([1., 2.], dtype=torch.bfloat16)
-            m2 = torch.tensor([3., 4.], dtype=torch.bfloat16)
-            self.assertEqual(m1 + m2, torch.tensor([4., 6.], dtype=torch.bfloat16))
-
-    def test_bool_sub(self):
-        for device in torch.testing.get_all_device_types():
-            m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=device)
-            m2 = torch.tensor([True, True, False, False, False, True], dtype=torch.bool, device=device)
-            self.assertRaisesRegex(RuntimeError,
-                                   r"Subtraction, the `\-` operator, with two bool tensors is not supported. "
-                                   r"Use the `\^` or `logical_xor\(\)` operator instead.",
-                                   lambda: m1 - m2)
-            self.assertRaisesRegex(RuntimeError,
-                                   r"Subtraction, the `\-` operator, with a bool tensor is not supported. "
-                                   r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
-                                   lambda: 1 - m1)
-            self.assertRaisesRegex(RuntimeError,
-                                   r"Subtraction, the `\-` operator, with a bool tensor is not supported. "
-                                   r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
-                                   lambda: m2 - 1)
 
     def test_sub(self):
         for dtype in torch.testing.get_all_dtypes():
@@ -1876,92 +1084,6 @@ class _TestTorchMixin(torchtest):
         res_csub.sub_(scalar)
         self.assertEqual(res_add, res_csub)
 
-    @staticmethod
-    def _test_bitwise_not(self, device):
-        res = 0xffff - torch.arange(127, dtype=torch.int8, device=device)
-        for dtype in (torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
-            if dtype == torch.bool:
-                a = torch.tensor([True, False], device=device)
-                expected_res = torch.tensor([False, True], device=device)
-            else:
-                a = torch.arange(127, dtype=dtype, device=device)
-                expected_res = res.type(dtype)
-            # new tensor
-            self.assertEqual(expected_res, a.bitwise_not())
-            # out
-            b = torch.empty(0, dtype=dtype, device=device)
-            torch.bitwise_not(a, out=b)
-            self.assertEqual(expected_res, b)
-            # in-place
-            a.bitwise_not_()
-            self.assertEqual(expected_res, a)
-
-        # test exceptions
-        for dtype in(torch.half, torch.float, torch.double):
-            a = torch.zeros(10, dtype=dtype, device=device)
-            # new tensor
-            with self.assertRaises(RuntimeError):
-                a.bitwise_not()
-            # out
-            b = torch.empty(0, dtype=dtype, device=device)
-            with self.assertRaises(RuntimeError):
-                torch.bitwise_not(a, out=b)
-            # in-place
-            with self.assertRaises(RuntimeError):
-                a.bitwise_not_()
-
-    def test_bitwise_not(self):
-        self._test_bitwise_not(self, 'cpu')
-
-    @staticmethod
-    def _test_logical_not(self, device):
-        for dtype in torch.testing.get_all_dtypes():
-            a = torch.tensor([10, 1, 0], dtype=dtype, device=device)
-            if dtype == torch.bfloat16:
-                self.assertRaises(RuntimeError, lambda: a.logical_not())
-                continue
-            expected_res = torch.tensor([0, 0, 1], dtype=dtype, device=device)
-            # new tensor
-            self.assertEqual(expected_res.bool(), a.logical_not())
-            # out
-            for out_dtype in torch.testing.get_all_dtypes():
-                b = torch.empty(0, dtype=out_dtype, device=device)
-                if out_dtype == torch.bfloat16:
-                    self.assertRaises(RuntimeError, lambda: torch.logical_not(a, out=b))
-                    continue
-                torch.logical_not(a, out=b)
-                self.assertEqual(expected_res.bool(), b.bool())
-            # in-place
-            a.logical_not_()
-            self.assertEqual(expected_res, a)
-
-    def test_logical_not(self):
-        self._test_logical_not(self, 'cpu')
-
-    @staticmethod
-    def _test_logical_xor(self, device):
-        for dtype in (torch.bool,):  # Will add more dtypes in the future
-            expected_res = torch.tensor([0, 0, 1, 1], dtype=dtype, device=device)
-            a = torch.tensor([10, 0, 1, 0], dtype=dtype, device=device)
-            b = torch.tensor([1, 0, 0, 10], dtype=dtype, device=device)
-            # new tensor
-            self.assertEqual(expected_res, a.logical_xor(b))
-            # out
-            c = torch.empty(0, dtype=dtype, device=device)
-            torch.logical_xor(a, b, out=c)
-            self.assertEqual(expected_res, c)
-            # out is not bool
-            c = torch.empty(0, dtype=torch.uint8, device=device)
-            with self.assertRaisesRegex(RuntimeError,
-                                        r"The output tensor of logical_xor must be a bool tensor\."):
-                torch.logical_xor(a, b, out=c)
-            # in-place
-            a.logical_xor_(b)
-            self.assertEqual(expected_res, a)
-
-    def test_logical_xor(self):
-        self._test_logical_xor(self, 'cpu')
-
     def test_threshold(self):
         for dtype in torch.testing.get_all_math_dtypes('cpu'):
             if dtype != torch.uint8 and dtype != torch.float16:
@@ -1977,26 +1099,6 @@ class _TestTorchMixin(torchtest):
             res_reciprocal = a.clone()
             res_reciprocal.reciprocal_()
             self.assertEqual(res_reciprocal, res_div)
-
-    def test_mul(self):
-        for device in torch.testing.get_all_device_types():
-            m1 = torch.randn(10, 10, device=device)
-            res1 = m1.clone()
-            res1[:, 3].mul_(2)
-            res2 = m1.clone()
-            for i in range(res1.size(0)):
-                res2[i, 3] = res2[i, 3] * 2
-            self.assertEqual(res1, res2)
-
-            a1 = torch.tensor([True, False, False, True], dtype=torch.bool, device=device)
-            a2 = torch.tensor([True, False, True, False], dtype=torch.bool, device=device)
-            self.assertEqual(a1 * a2, torch.tensor([True, False, False, False], dtype=torch.bool, device=device))
-
-            if device == 'cpu':
-                a1 = torch.tensor([0.1, 0.1], dtype=torch.bfloat16, device=device)
-                a2 = torch.tensor([1.1, 0.1], dtype=torch.bfloat16, device=device)
-                self.assertEqual(a1 * a2, torch.tensor([0.11, 0.01], dtype=torch.bfloat16, device=device), 0.01)
-                self.assertEqual(a1.mul(a2), a1 * a2)
 
     def test_div(self):
         m1 = torch.randn(10, 10)
@@ -2082,19 +1184,6 @@ class _TestTorchMixin(torchtest):
             long_res1 = long_m1.clone()
             long_res1.remainder_(long_qs.unsqueeze(0).expand_as(long_res1))
 
-    @staticmethod
-    def _test_remainder_overflow(self, dtype, device):
-        # Check Integer Overflows
-        x = torch.tensor(23500, dtype=dtype, device=device)
-        q = 392486996410368
-        self.assertEqual(x % q, x)
-        self.assertEqual(-x % q, q - x)
-        self.assertEqual(x % -q, x - q)
-        self.assertEqual(-x % -q, -x)
-
-    def test_remainder_overflow(self):
-        self._test_remainder_overflow(self, dtype=torch.int64, device='cpu')
-
     def test_mm(self):
         def _test_mm(n, m, p, dtype, genf):
             # helper function
@@ -2175,43 +1264,6 @@ class _TestTorchMixin(torchtest):
             _test_mm(n, m, p, torch.bfloat16, lambda x, y: torch.randn(x, y, dtype=torch.float32).bfloat16())
 
     @staticmethod
-    def _test_lu(self, cast, pivot=True):
-        from common_utils import random_fullrank_matrix_distinct_singular_value as fullrank
-
-        def run_test(matrix_size, batches, cast):
-            a = cast(fullrank(matrix_size, *batches))
-            a_LU_info, pivots_info, info_ = a.lu(pivot=pivot, get_infos=True)
-            self.assertEqual(a_LU_info.size(), torch.Size(batches + (matrix_size, matrix_size)))
-            self.assertEqual(pivots_info.size(), torch.Size(batches + (matrix_size,)))
-            self.assertEqual(info_.size(), torch.Size(batches))
-            self.assertEqual(info_.abs().sum(), 0)
-            a_LU, pivots = a.lu(pivot=pivot)
-            self.assertEqual(a_LU, a_LU_info)
-            self.assertEqual(pivots_info, pivots)
-            if a.is_cuda:
-                a_LU_info_nopiv, nopiv, info_nopiv = a.lu(pivot=False, get_infos=True)
-                self.assertEqual(nopiv, cast(torch.arange(1, 1 + a.size(-1), dtype=torch.int32).expand(a.shape[:-1])))
-                self.assertEqual(info_, info_nopiv)
-            P, L, U = torch.lu_unpack(a_LU, pivots)
-            self.assertEqual(P.matmul(L.matmul(U)), a)
-
-        for ms, batch in product([3, 5, 7], [(), (2,), (3,), (3, 5)]):
-            run_test(ms, batch, cast)
-
-        # Info should be positive for rank deficient matrices
-        a = cast(torch.ones(5, 3, 3))
-        self.assertGreater(a.lu(pivot=pivot, get_infos=True)[2][0], 0)
-
-        # Error checking, no pivoting variant on CPU
-        with self.assertRaisesRegex(RuntimeError,
-                                    'lu without pivoting is not implemented on the CPU'):
-            torch.lu(torch.empty(1, 2, 2), pivot=False)
-
-    @skipIfNoLapack
-    def test_lu(self):
-        self._test_lu(self, lambda t: t, pivot=True)
-
-    @staticmethod
     def _test_lu_solve(self, cast, pivot=True):
         from common_utils import lu_solve_test_helper
         for k, n in zip([2, 3, 5], [3, 5, 7]):
@@ -2249,71 +1301,6 @@ class _TestTorchMixin(torchtest):
     @skipIfNoLapack
     def test_lu_solve_batched(self):
         self._test_lu_solve_batched(self, lambda t: t)
-
-    @staticmethod
-    def _test_lu_solve_batched_non_contiguous(self, cast):
-        from numpy.linalg import solve
-        from common_utils import random_fullrank_matrix_distinct_singular_value
-
-        A = random_fullrank_matrix_distinct_singular_value(2, 2)
-        b = torch.randn(2, 2, 2)
-        x_exp = torch.as_tensor(solve(A.permute(0, 2, 1).numpy(), b.permute(2, 1, 0).numpy()))
-        A = cast(A).permute(0, 2, 1)
-        b = cast(b).permute(2, 1, 0)
-        assert not A.is_contiguous() and not b.is_contiguous(), "contiguous inputs"
-        LU_data, LU_pivots = torch.lu(A)
-        x = torch.lu_solve(b, LU_data, LU_pivots)
-        self.assertEqual(x, cast(x_exp))
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_lu_solve_batched_non_contiguous(self):
-        self._test_lu_solve_batched_non_contiguous(self, lambda t: t)
-
-    @staticmethod
-    def _test_lu_solve_batched_many_batches(self, cast):
-        from common_utils import lu_solve_test_helper
-
-        def run_test(A_dims, b_dims, cast):
-            b, A, LU_data, LU_pivots = lu_solve_test_helper(self, A_dims, b_dims, cast, True)
-            x = torch.lu_solve(b, LU_data, LU_pivots)
-            b_ = torch.matmul(A, x)
-            self.assertEqual(b_, b.expand_as(b_))
-
-        run_test((5, 65536), (65536, 5, 10), cast)
-        run_test((5, 262144), (262144, 5, 10), cast)
-
-    @skipIfNoLapack
-    @slowTest
-    def test_lu_solve_batched_many_batches(self):
-        self._test_lu_solve_batched_many_batches(self, lambda t: t)
-
-    @staticmethod
-    def _test_lu_solve_batched_broadcasting(self, cast, pivot=True):
-        from numpy.linalg import solve
-        from common_utils import random_fullrank_matrix_distinct_singular_value
-
-        def run_test(A_dims, b_dims, cast, pivot):
-            A_matrix_size = A_dims[-1]
-            A_batch_dims = A_dims[:-2]
-            A = random_fullrank_matrix_distinct_singular_value(A_matrix_size, *A_batch_dims)
-            b = torch.randn(*b_dims)
-            x_exp = torch.as_tensor(solve(A.numpy(), b.numpy()))
-            A, b = cast(A), cast(b)
-            LU_data, LU_pivots = torch.lu(A, pivot=pivot)
-            x = torch.lu_solve(b, LU_data, LU_pivots)
-            self.assertEqual(x, cast(x_exp))
-
-        # test against numpy.linalg.solve
-        run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), cast, pivot)  # no broadcasting
-        run_test((2, 1, 3, 4, 4), (4, 6), cast, pivot)  # broadcasting b
-        run_test((4, 4), (2, 1, 3, 4, 2), cast, pivot)  # broadcasting A
-        run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), cast, pivot)  # broadcasting A & b
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_lu_solve_batched_broadcasting(self):
-        self._test_lu_solve_batched_broadcasting(self, lambda t: t)
 
     @staticmethod
     def _test_lu_unpack(self, cast, pivot=True):
@@ -2406,85 +1393,6 @@ class _TestTorchMixin(torchtest):
         res6 = torch.baddbmm(.1, res2, .5, b1, b2)
         self.assertEqual(res6, res2 * .1 + res * .5)
 
-    @staticmethod
-    def _test_clamp(self, device='cpu'):
-        m1 = torch.rand(100, device=device).mul(5).add(-2.5)  # uniform in [-2.5, 2.5]
-        # just in case we're extremely lucky.
-        min_val = -1
-        max_val = 1
-        m1[1] = min_val
-        m1[2] = max_val
-
-        res1 = m1.clone()
-        res1.clamp_(min_val, max_val)
-        res2 = m1.clone()
-        for i in iter_indices(res2):
-            res2[i] = max(min_val, min(max_val, res2[i]))
-        self.assertEqual(res1, res2)
-
-        out = m1.clone()
-        torch.clamp(m1, min=min_val, max=max_val, out=out)
-        self.assertEqual(out, res1)
-
-        res1 = torch.clamp(m1, min=min_val)
-        res2 = m1.clone()
-        for i in iter_indices(res2):
-            res2[i] = max(min_val, res2[i])
-        self.assertEqual(res1, res2)
-
-        torch.clamp(m1, min=min_val, out=out)
-        self.assertEqual(out, res1)
-
-        res1 = torch.clamp(m1, max=max_val)
-        res2 = m1.clone()
-        for i in iter_indices(res2):
-            res2[i] = min(max_val, res2[i])
-        self.assertEqual(res1, res2)
-
-        torch.clamp(m1, max=max_val, out=out)
-        self.assertEqual(out, res1)
-
-        # if the tensor contains nan case
-        test_tens = torch.tensor([nan], device=device)
-
-        res1 = test_tens.clone()
-        res1.clamp_(min_val, max_val)
-        res2 = test_tens.clone()
-        for i in iter_indices(res2):
-            res2[i] = max(min(res2[i], max_val), min_val)
-        self.assertEqual(torch.isnan(res1), torch.isnan(res2))
-
-        out = test_tens.clone()
-        torch.clamp(test_tens, min=min_val, max=max_val, out=out)
-        self.assertEqual(torch.isnan(out), torch.isnan(res1))
-
-        res1 = torch.clamp(test_tens, min=min_val)
-        res2 = test_tens.clone()
-        for i in iter_indices(res2):
-            res2[i] = max(res2[i], min_val)
-        self.assertEqual(torch.isnan(res1), torch.isnan(res2))
-
-        torch.clamp(test_tens, min=min_val, out=out)
-        self.assertEqual(torch.isnan(out), torch.isnan(res1))
-
-        res1 = torch.clamp(test_tens, max=max_val)
-        res2 = test_tens.clone()
-        for i in iter_indices(res2):
-            res2[i] = min(res2[i], max_val)
-        self.assertEqual(torch.isnan(res1), torch.isnan(res2))
-
-        torch.clamp(test_tens, max=max_val, out=out)
-        self.assertEqual(torch.isnan(out), torch.isnan(res1))
-
-        error_msg = 'At least one of \'min\' or \'max\' must not be None'
-        with self.assertRaisesRegex(RuntimeError, error_msg):
-            m1.clamp()
-        with self.assertRaisesRegex(RuntimeError, error_msg):
-            m1.clamp_()
-
-    def test_clamp(self):
-        self._test_clamp(self)
-
     def test_pow(self):
         # [res] torch.pow([res,] x)
 
@@ -2523,129 +1431,6 @@ class _TestTorchMixin(torchtest):
         for i in range(res2.size(0)):
             res2[i] = math.pow(3, m1[i][4])
         self.assertEqual(res1, res2)
-
-    @staticmethod
-    def _test_rpow(self, cast):
-        m = cast(torch.randn(10, 10))
-        self.assertEqual(torch.pow(2, m), 2**m)
-
-        # test with scalar
-        m = cast(torch.randn(1).squeeze())
-        assert m.dim() == 0, "m is intentionally a scalar"
-        self.assertEqual(torch.pow(2, m), 2**m)
-
-    def test_rpow(self):
-        self._test_rpow(self, lambda x: x)
-
-    def _test_pow(self, base, exponent, np_exponent=None):
-        if np_exponent is None:
-            np_exponent = exponent
-
-        def to_np(value):
-            if isinstance(value, torch.Tensor):
-                return value.cpu().numpy()
-            return value
-
-        try:
-            expected = torch.from_numpy(
-                np.power(to_np(base), to_np(np_exponent)))
-        except ValueError as e:
-            err_msg = "Integers to negative integer powers are not allowed."
-            self.assertEqual(str(e), err_msg)
-            out = torch.empty_like(base)
-            test_cases = [
-                lambda: base.pow(exponent),
-                lambda: base.pow_(exponent),
-                lambda: torch.pow(base, exponent),
-                lambda: torch.pow(base, exponent, out=out)
-            ]
-            for test_case in test_cases:
-                self.assertRaisesRegex(RuntimeError, err_msg, test_case)
-        else:
-            if isinstance(base, torch.Tensor):
-                actual = base.pow(exponent)
-                self.assertEqual(actual, expected, allow_inf=True)
-
-                actual = base.clone()
-                actual2 = actual.pow_(exponent)
-                self.assertEqual(actual, expected, allow_inf=True)
-                self.assertEqual(actual2, expected, allow_inf=True)
-
-            actual = torch.pow(base, exponent)
-            self.assertEqual(actual, expected, allow_inf=True)
-
-            actual2 = torch.pow(base, exponent, out=actual)
-            self.assertEqual(actual, expected, allow_inf=True)
-            self.assertEqual(actual2, expected, allow_inf=True)
-
-    @torchtest.for_all_device_types()
-    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
-    def test_int_pow(self, device):
-
-        def _test_integral_pow(dt, range, dev):
-            tensor = torch.tensor((3, 3), dtype=dt, device=dev).random_(*range)
-            exps = [0, 1, 2, 4,
-                    torch.tensor((3, 3), dtype=dt, device=dev).random_(0, 5)]
-            for exp in exps:
-                self._test_pow(tensor, exp)
-
-        _test_integral_pow(torch.int8, (-3, 4), device)
-        _test_integral_pow(torch.uint8, (0, 4), device)
-        _test_integral_pow(torch.int16, (-5, 5), device)
-        _test_integral_pow(torch.int64, (-10, 10), device)
-        _test_integral_pow(torch.int32, (-10, 10), device)
-
-    @torchtest.for_all_device_types()
-    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
-    def test_int_tensor_pow_neg_ints(self, device):
-        ints = [torch.iinfo(torch.int32).min,
-                -3, -2, -1, 0, 1, 2, 3,
-                torch.iinfo(torch.int32).max]
-        neg_ints = [torch.iinfo(torch.int32).min, -3, -2, -1]
-        tensor = torch.tensor(ints, dtype=torch.int32, device=device)
-        for pow in neg_ints:
-            self._test_pow(tensor, pow)
-
-    @torchtest.for_all_device_types()
-    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
-    def test_long_tensor_pow_floats(self, device):
-        ints = [0, 1, 23, 4567]
-        floats = [0.0, 1 / 3, 1 / 2, 1.0, 3 / 2, 2.0]
-        tensor = torch.tensor(ints, dtype=torch.int64, device=device)
-        for pow in floats:
-            self._test_pow(tensor, pow)
-
-    @torchtest.for_all_device_types()
-    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
-    def test_float_scalar_pow_float_tensor(self, device):
-        floats = [2.0, -3 / 2, -1.0, -1 / 2, -1 / 3, 0.0,
-                  1 / 3, 1 / 2, 1.0, 3 / 2, 2.0]
-        tensor = torch.tensor(floats, dtype=torch.float32, device=device)
-        for base in floats:
-            self._test_pow(base, tensor)
-
-    @torchtest.for_all_device_types()
-    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
-    def test_tensor_pow_tensor(self, dev):
-        def rotate(l, n):
-            return l[-n:] + l[:-n]
-
-        def test_tensor_pow_tensor(values, torch_type, numpy_type):
-            vals_tensor = torch.tensor(values, dtype=torch_type, device=dev)
-            for i in range(len(values)):
-                pows = rotate(values, i)
-                pows_tensor = torch.tensor(pows, dtype=torch_type, device=dev)
-                self._test_pow(vals_tensor, pows_tensor)
-
-        ints = [0, 1, 2, 3]
-        test_tensor_pow_tensor(ints, torch.int32, np.int32)
-        test_tensor_pow_tensor(ints, torch.int64, np.int64)
-
-        floats = [-3.0, -2.0, -1.0, -1 / 2, -1 / 3,
-                  0.0,
-                  1 / 3, 1 / 2, 1.0, 2.0, 3.0]
-        test_tensor_pow_tensor(floats, torch.float32, np.float32)
-        test_tensor_pow_tensor(floats, torch.float64, np.float64)
 
     def _test_cop(self, torchfn, mathfn):
         def reference_implementation(res2):
@@ -2881,58 +1666,6 @@ class _TestTorchMixin(torchtest):
         torch.prod(x, 1, out=res2)
         self.assertEqual(res1, res2)
 
-    def test_cumsum(self):
-        for d in torch.testing.get_all_device_types():
-            x = torch.rand(100, 100, device=d)
-            res1 = torch.cumsum(x, 1)
-            res2 = torch.Tensor().to(d)
-            torch.cumsum(x, 1, out=res2)
-            self.assertEqual(res1, res2)
-
-            a = torch.tensor([[True, False, True],
-                              [False, False, False],
-                              [True, True, True]], device=d)
-            b = a.byte()
-            aRes = torch.cumsum(a, 0)
-            bRes = torch.cumsum(b, 0)
-            self.assertEqual(aRes, bRes)
-            self.assertEqual(aRes, torch.tensor([[1, 0, 1],
-                                                 [1, 0, 1],
-                                                 [2, 1, 2]]))
-
-            aRes = torch.cumsum(a, 1)
-            bRes = torch.cumsum(b, 1)
-            self.assertEqual(aRes, bRes)
-            self.assertEqual(aRes, torch.tensor([[1, 1, 2],
-                                                 [0, 0, 0],
-                                                 [1, 2, 3]]))
-
-    def test_cumprod(self):
-        for d in torch.testing.get_all_device_types():
-            x = torch.rand(100, 100, device=d)
-            res1 = torch.cumprod(x, 1)
-            res2 = torch.Tensor().to(d)
-            torch.cumprod(x, 1, out=res2)
-            self.assertEqual(res1, res2)
-
-            a = torch.tensor([[True, False, True],
-                              [False, False, False],
-                              [True, True, True]], dtype=torch.bool, device=d)
-            b = a.byte()
-            aRes = torch.cumprod(a, 0)
-            bRes = torch.cumprod(b, 0)
-            self.assertEqual(aRes, bRes)
-            self.assertEqual(aRes, torch.tensor([[1, 0, 1],
-                                                 [0, 0, 0],
-                                                 [0, 0, 0]]))
-
-            aRes = torch.cumprod(a, 1)
-            bRes = torch.cumprod(b, 1)
-            self.assertEqual(aRes, bRes)
-            self.assertEqual(aRes, torch.tensor([[1, 0, 0],
-                                                 [0, 0, 0],
-                                                 [1, 1, 1]]))
-
     def _test_reduce_integer_upcast(self, fn, has_out=True):
         shape = (3, 4, 5)
         reduced_shape = fn(torch.ones(shape)).shape
@@ -3039,90 +1772,6 @@ class _TestTorchMixin(torchtest):
         expected = torch.tensor([[0.]], dtype=torch.bfloat16)
         self.assertEqual(bfloat16Tensor, expected)
 
-    def test_std_mean(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.rand(100, 50, 20, device=device)
-            for dim in range(x.dim()):
-                for unbiased in [False, True]:
-                    for keepdim in [False, True]:
-                        std1, mean1 = torch.std_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
-                        std2 = x.std(dim=dim, unbiased=unbiased, keepdim=keepdim)
-                        mean2 = x.mean(dim=dim, keepdim=keepdim)
-                        self.assertEqual(std1, std2)
-                        self.assertEqual(mean1, mean2)
-
-    def test_std_mean_all_dims(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.rand(100, 50, 20, device=device)
-            for unbiased in [False, True]:
-                std1, mean1 = torch.std_mean(x, unbiased=unbiased)
-                std2 = x.std(unbiased=unbiased)
-                mean2 = x.mean()
-                self.assertEqual(std1, std2)
-                self.assertEqual(mean1, mean2)
-
-    def test_var_mean(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.rand(100, 300, 50, device=device)
-            for dim in range(x.dim()):
-                for unbiased in [False, True]:
-                    for keepdim in [False, True]:
-                        var1, mean1 = torch.var_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
-                        var2 = x.var(dim=dim, unbiased=unbiased, keepdim=keepdim)
-                        mean2 = x.mean(dim=dim, keepdim=keepdim)
-                        self.assertEqual(var1, var2)
-                        self.assertEqual(mean1, mean2)
-
-    def test_var_mean_all_dims(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.rand(100, 50, 20, device=device)
-            for unbiased in [False, True]:
-                var1, mean1 = torch.var_mean(x, unbiased=unbiased)
-                var2 = x.var(unbiased=unbiased)
-                mean2 = x.mean()
-                self.assertEqual(var1, var2)
-                self.assertEqual(mean1, mean2)
-
-    def test_std_mean_some_dims(self):
-        sizes = (4, 6, 7, 5, 3)
-        dims = len(sizes)
-        for device in torch.testing.get_all_device_types():
-            x = torch.rand(sizes, device=device)
-            for num_of_dims in range(2, dims):
-                dim_list = list(combinations(list(range(dims)), r=num_of_dims))
-                for dim in dim_list:
-                    for unbiased in [False, True]:
-                        for keepdim in [False, True]:
-                            std1, mean1 = torch.std_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
-                            std2 = x.std(dim=dim, unbiased=unbiased, keepdim=keepdim)
-                            mean2 = x.mean(dim=dim, keepdim=keepdim)
-                            self.assertEqual(std1, std2)
-                            self.assertEqual(mean1, mean2)
-
-    @torchtest.for_all_device_types()
-    def test_var_mean_some_dims(self, device):
-        sizes = (4, 6, 7, 5, 3)
-        dims = len(sizes)
-
-        x = torch.rand(sizes, device=device)
-        for num_of_dims in range(2, dims):
-            dim_list = list(combinations(list(range(dims)), r=num_of_dims))
-            for dim in dim_list:
-                for unbiased in [False, True]:
-                    for keepdim in [False, True]:
-                        var1, mean1 = torch.var_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
-                        var2 = x.var(dim=dim, unbiased=unbiased, keepdim=keepdim)
-                        mean2 = x.mean(dim=dim, keepdim=keepdim)
-                        self.assertEqual(var1, var2)
-                        self.assertEqual(mean1, mean2)
-
-    @torchtest.for_all_device_types()
-    def test_zeros_like(self, device):
-        expected = torch.zeros((100, 100,), device=device)
-
-        res1 = torch.zeros_like(expected)
-        self.assertEqual(res1, expected)
-
     @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
     def test_zeros_like_multiple_device(self):
         expected = torch.zeros(100, 100).cuda()
@@ -3145,96 +1794,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(torch.zeros(shape), torch.zeros(shape, dtype=out.dtype, out=out))
         self.assertEqual(torch.zeros(shape), torch.zeros(shape, layout=torch.strided, out=out))
         self.assertEqual(torch.zeros(shape), torch.zeros(shape, device='cpu', out=out))
-
-    def test_histc(self):
-        for device in torch.testing.get_all_device_types():
-            # negative nbins throws
-            with self.assertRaisesRegex(RuntimeError, 'bins must be > 0'):
-                torch.histc(torch.tensor([1], dtype=torch.float, device=device), bins=-1)
-
-            # without nbins
-            actual = torch.histc(
-                torch.tensor([2, 5], dtype=torch.float, device=device))
-            expected = torch.zeros(100, dtype=torch.float, device=device)
-            expected.data[0] = 1
-            expected.data[99] = 1
-            self.assertEqual(expected, actual)
-            # tensor with the same element
-            actual = torch.histc(torch.ones(5, dtype=torch.float, device=device), bins=5)
-            self.assertEqual(
-                torch.tensor([0, 0, 5, 0, 0], dtype=torch.float, device=device),
-                actual)
-            # no element falls between [min, max]
-            actual = torch.histc(
-                torch.ones(5, dtype=torch.float, device=device), bins=5, min=2, max=3)
-            self.assertEqual(
-                torch.tensor([0, 0, 0, 0, 0], dtype=torch.float, device=device),
-                actual)
-            # element falls below min + integral bin size and
-            actual = torch.histc(
-                torch.tensor([2, 4, 2, 2, 5, 4], dtype=torch.float, device=device),
-                bins=5, min=1, max=5)
-            self.assertEqual(
-                torch.tensor([0, 3, 0, 2, 1], dtype=torch.float, device=device),
-                actual)
-            # non-integral bin size
-            actual = torch.histc(
-                torch.tensor([1, 2, 1], dtype=torch.float, device=device),
-                bins=4, min=0, max=3)
-            self.assertEqual(
-                torch.tensor([0, 2, 1, 0], dtype=torch.float, device=device),
-                actual)
-            # double input
-            actual = torch.histc(
-                torch.tensor([1, 2, 1], dtype=torch.double, device=device), bins=4, min=0, max=3)
-            self.assertEqual(
-                torch.tensor([0, 2, 1, 0], dtype=torch.double, device=device),
-                actual)
-            self.assertEqual(actual.dtype, torch.double)
-            # mixed input
-            actual = torch.histc(
-                torch.tensor([1., 2, 1], dtype=torch.float, device=device),
-                bins=4, min=0, max=3)
-            self.assertEqual(
-                torch.tensor([0, 2, 1, 0], dtype=torch.float, device=device),
-                actual)
-            self.assertEqual(actual.dtype, torch.float)
-            # scalar input and 1 bin -- should return a 1-dimensional tensor, not a scalar.
-            actual = torch.histc(
-                torch.tensor(0, dtype=torch.float, device=device),
-                bins=1, min=0, max=3)
-            self.assertEqual(
-                torch.tensor([1], dtype=torch.float, device=device),
-                actual)
-
-        # test against numpy.histogram()
-        def test_against_np(tensor, bins=100, min=0, max=0):
-            if min == 0 and max == 0:
-                min = tensor.min().item()
-                max = tensor.max().item()
-            nparr = tensor.cpu().numpy()
-            actual = torch.histc(tensor, bins=bins, min=min, max=max)
-            expected = torch.from_numpy(np.histogram(nparr, bins=bins, range=(min, max))[0])
-            self.assertEqual(actual.cpu(), expected)
-
-        if TEST_NUMPY:
-            test_against_np(torch.tensor([1., 2, 1], device=device))
-            test_against_np(torch.randn(5000, device=device))
-
-            # Test bins arg
-            test_against_np(torch.randn(301, device=device), bins=10)
-
-            # Test truncated range
-            test_against_np(torch.randn(201, device=device), min=0.1, max=1)
-
-            noncontig = torch.randn(100, 3, device=device)[:, 2]
-            test_against_np(noncontig)
-
-            multidim = torch.randn(3, 5, 7, 2, device=device)
-            test_against_np(multidim)
-
-            expanded = torch.randn(1, 5, 1, 2, device=device).expand(3, 5, 7, 2)
-            test_against_np(expanded)
 
     def test_ones(self):
         res1 = torch.ones(100, 100)
@@ -3730,180 +2289,6 @@ class _TestTorchMixin(torchtest):
         self.assertTrue(x.is_cuda)
         torch.set_default_tensor_type(saved_type)
 
-    def test_bool_tensor_comparison_ops(self):
-        for device in torch.testing.get_all_device_types():
-            a = torch.tensor([True, False, True, False, True, False], dtype=torch.bool, device=device)
-            b = torch.tensor([True, False, True, True, True, True], dtype=torch.bool, device=device)
-            self.assertEqual(a == b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.bool, device=device))
-            self.assertEqual(a != b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.bool, device=device))
-            self.assertEqual(a < b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.bool, device=device))
-            self.assertEqual(a > b, torch.tensor([0, 0, 0, 0, 0, 0], dtype=torch.bool, device=device))
-            self.assertEqual(a >= b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.bool, device=device))
-            self.assertEqual(a <= b, torch.tensor([1, 1, 1, 1, 1, 1], dtype=torch.bool, device=device))
-            self.assertEqual(a > False, torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.bool, device=device))
-            self.assertEqual(a == torch.tensor(True, dtype=torch.bool, device=device),
-                             torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.bool, device=device))
-            self.assertEqual(a == torch.tensor(0, dtype=torch.bool, device=device),
-                             torch.tensor([0, 1, 0, 1, 0, 1], dtype=torch.bool, device=device))
-            self.assertFalse(a.equal(b))
-
-    def test_bool_tensor_value_change(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.tensor([True, False], dtype=torch.bool, device=device)
-            x[0] = False
-            x[1] = True
-            self.assertEqual(x, torch.tensor([False, True], dtype=torch.bool, device=device))
-
-    @torchtest.for_all_device_types()
-    def test_unfold_all_devices_and_dtypes(self, device):
-        for dt in torch.testing.get_all_dtypes():
-            if dt == torch.bfloat16:
-                self.assertRaises(RuntimeError, lambda: torch.randint(5, (0, 1, 3, 0), dtype=dt, device=device))
-                continue
-
-            if dt == torch.half and device == 'cpu':
-                # fix once random is implemented for Half on CPU
-                self.assertRaises(RuntimeError, lambda: torch.randint(5, (0, 1, 3, 0), dtype=dt, device=device))
-            else:
-                x = torch.randint(5, (0, 1, 3, 0), dtype=dt, device=device)
-                self.assertEqual((0, 1, 1, 0, 3), x.unfold(2, 3, 2).shape)
-
-    def test_copy_all_dtypes_and_devices(self):
-        from copy import copy
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor([1, 2, 3, 4], dtype=dt, device=device)
-                x_clone = x.clone()
-                if (device == 'cuda' and dt == torch.bfloat16):
-                    self.assertRaises(RuntimeError, lambda: copy(x))
-                    continue
-                y = copy(x)
-                y.fill_(1)
-                # copy is a shallow copy, only copies the tensor view,
-                # not the data
-                self.assertEqual(x, y)
-
-    def test_resize_all_dtypes_and_devices(self):
-        shape = (2, 2)
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
-                x.resize_(shape)
-                self.assertEqual(shape, x.shape)
-
-    def test_resize_as_all_dtypes_and_devices(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
-                y = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=dt, device=device)
-                x.resize_as_(y)
-                self.assertEqual(y.shape, x.shape)
-
-    def test_view_all_dtypes_and_devices(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
-                if (device == 'cuda' and dt == torch.bfloat16):
-                    self.assertRaises(RuntimeError, lambda: x.view(6))
-                    continue
-                self.assertEqual(x.view(6).shape, [6])
-
-    def test_fill_all_dtypes_and_devices(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor((1, 1), dtype=dt, device=device)
-                if (device == 'cuda' and dt == torch.bfloat16):
-                    self.assertRaises(RuntimeError, lambda: x.fill_(1))
-                    continue
-                x.fill_(1)
-
-                self.assertEqual(x, torch.tensor([1, 1], dtype=dt, device=device))
-                self.assertEqual(dt, x.dtype)
-
-    def test_clone_all_dtypes_and_devices(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor((1, 1), dtype=dt, device=device)
-                y = x.clone()
-                if (device == 'cuda' and dt == torch.bfloat16):
-                    # `x - y` is used inside of the assertEqual
-                    self.assertRaises(RuntimeError, lambda: x - y)
-                    continue
-                self.assertEqual(x, y)
-
-    def test_cat_all_dtypes_and_devices(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor([[1, 2], [3, 4]], dtype=dt, device=device)
-                if (device == 'cuda' and dt == torch.bfloat16):
-                    self.assertRaises(RuntimeError, lambda: torch.cat((x, x), 0))
-                    continue
-
-                expected1 = torch.tensor([[1, 2], [3, 4], [1, 2], [3, 4]], dtype=dt, device=device)
-                self.assertEqual(torch.cat((x, x), 0), expected1)
-
-                expected2 = torch.tensor([[1, 2, 1, 2], [3, 4, 3, 4]], dtype=dt, device=device)
-                self.assertEqual(torch.cat((x, x), 1), expected2)
-
-    def test_tensor_factories_empty(self):
-        # ensure we can create empty tensors from each factory function
-        shapes = [(5, 0, 1), (0,), (0, 0, 1, 0, 2, 0, 0)]
-
-        for device in torch.testing.get_all_device_types():
-            for shape in shapes:
-                for dt in torch.testing.get_all_dtypes():
-
-                    if (device == 'cuda' and dt == torch.bfloat16):
-                        self.assertRaises(RuntimeError, lambda: torch.zeros(shape, device=device, dtype=dt).shape)
-                        self.assertRaises(RuntimeError, lambda: torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                        self.assertRaises(RuntimeError, lambda: torch.full(shape, 3, device=device, dtype=dt).shape)
-                        self.assertRaises(RuntimeError, lambda: torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3))
-                        self.assertRaises(RuntimeError, lambda: torch.ones(shape, device=device, dtype=dt).shape)
-                        self.assertRaises(RuntimeError, lambda: torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                        self.assertRaises(RuntimeError, lambda: torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                    else:
-                        self.assertEqual(shape, torch.zeros(shape, device=device, dtype=dt).shape)
-                        self.assertEqual(shape, torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                        self.assertEqual(shape, torch.full(shape, 3, device=device, dtype=dt).shape)
-                        self.assertEqual(shape, torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
-                        self.assertEqual(shape, torch.ones(shape, device=device, dtype=dt).shape)
-                        self.assertEqual(shape, torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                        self.assertEqual(shape, torch.empty(shape, device=device, dtype=dt).shape)
-                        self.assertEqual(shape, torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-                        self.assertEqual(shape, torch.empty_strided(shape, (0,) * len(shape), device=device, dtype=dt).shape)
-
-                    if dt == torch.half and device == "cpu":
-                        # update once random is implemented for half on CPU
-                        self.assertRaises(RuntimeError, lambda: torch.randint(6, shape, device=device, dtype=dt).shape)
-                    else:
-                        if dt == torch.bfloat16:
-                            self.assertRaises(RuntimeError, lambda: torch.randint(6, shape, device=device, dtype=dt))
-                            continue  # Remove once random is supported for bfloat16 on cuda
-                        self.assertEqual(shape, torch.randint(6, shape, device=device, dtype=dt).shape)
-                        self.assertEqual(shape, torch.randint_like(torch.zeros(shape, device=device, dtype=dt), 6).shape)
-
-                    if dt != torch.double and dt != torch.float and dt != torch.half:
-                        self.assertRaises(RuntimeError, lambda: torch.rand(shape, device=device, dtype=dt).shape)
-
-                    if dt == torch.double or dt == torch.float:
-                        self.assertEqual(shape, torch.randn(shape, device=device, dtype=dt).shape)
-                        self.assertEqual(shape, torch.randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
-
-            self.assertEqual((0,), torch.arange(0, device=device).shape)
-            self.assertEqual((0, 0), torch.eye(0, device=device).shape)
-            self.assertEqual((0, 0), torch.eye(0, 0, device=device).shape)
-            self.assertEqual((5, 0), torch.eye(5, 0, device=device).shape)
-            self.assertEqual((0, 5), torch.eye(0, 5, device=device).shape)
-            self.assertEqual((0,), torch.linspace(1, 1, 0, device=device).shape)
-            self.assertEqual((0,), torch.logspace(1, 1, 0, device=device).shape)
-            self.assertEqual((0,), torch.randperm(0, device=device).shape)
-            self.assertEqual((0,), torch.bartlett_window(0, device=device).shape)
-            self.assertEqual((0,), torch.bartlett_window(0, periodic=False, device=device).shape)
-            self.assertEqual((0,), torch.hamming_window(0, device=device).shape)
-            self.assertEqual((0,), torch.hann_window(0, device=device).shape)
-            self.assertEqual((1, 1, 0), torch.tensor([[[]]], device=device).shape)
-            self.assertEqual((1, 1, 0), torch.as_tensor([[[]]], device=device).shape)
-
     def test_new_tensor(self):
         expected = torch.autograd.Variable(torch.ByteTensor([1, 1]))
         # test data
@@ -4052,53 +2437,6 @@ class _TestTorchMixin(torchtest):
     def test_diag_embed(self):
         self._test_diag_embed(self, dtype=torch.float32, device='cpu')
 
-    @staticmethod
-    def _test_diagflat(self, dtype, device):
-        # Basic sanity test
-        x = torch.randn((100,), dtype=dtype, device=device)
-        result = torch.diagflat(x)
-        expected = torch.diag(x)
-        self.assertEqual(result, expected)
-
-        # Test offset
-        x = torch.randn((100,), dtype=dtype, device=device)
-        result = torch.diagflat(x, 17)
-        expected = torch.diag(x, 17)
-        self.assertEqual(result, expected)
-
-        # Test where input has more than one dimension
-        x = torch.randn((2, 3, 4), dtype=dtype, device=device)
-        result = torch.diagflat(x)
-        expected = torch.diag(x.contiguous().view(-1))
-        self.assertEqual(result, expected)
-
-        # Noncontig input
-        x = torch.randn((2, 3, 4), dtype=dtype, device=device).transpose(2, 0)
-        self.assertFalse(x.is_contiguous())
-        result = torch.diagflat(x)
-        expected = torch.diag(x.contiguous().view(-1))
-        self.assertEqual(result, expected)
-
-    def test_diagflat(self):
-        self._test_diagflat(self, dtype=torch.float32, device='cpu')
-
-    def test_eye(self):
-        for dtype, device in product(torch.testing.get_all_dtypes(), torch.testing.get_all_device_types()):
-            if dtype == torch.bfloat16:
-                continue
-
-            for n, m in product([3, 5, 7], repeat=2):
-                # Construct identity using diagonal and fill
-                res1 = torch.eye(n, m, device=device, dtype=dtype)
-                naive_eye = torch.zeros(n, m, dtype=dtype, device=device)
-                naive_eye.diagonal(dim1=-2, dim2=-1).fill_(1)
-                self.assertEqual(naive_eye, res1)
-
-                # Check eye_out outputs
-                res2 = torch.empty(0, device=device, dtype=dtype)
-                torch.eye(n, m, out=res2)
-                self.assertEqual(res1, res2)
-
     def test_renorm(self):
         m1 = torch.randn(10, 5)
         res1 = torch.Tensor()
@@ -4228,75 +2566,6 @@ class _TestTorchMixin(torchtest):
     def test_multinomial(self):
         self._test_multinomial(self, torch.FloatTensor)
 
-    @staticmethod
-    def _test_multinomial_alias(self, cast):
-        # Get probs vector to use in setup
-        def get_probs(length, is_contiguous):
-            probs = torch.softmax(torch.randn(length), 0)
-            if not is_contiguous:
-                probs = torch.softmax(torch.randn(length, 2), 0)[:, 1]
-            assert not (is_contiguous ^ probs.is_contiguous()), "contiguity requirement not met"
-            return cast(probs)
-
-        for is_contiguous in [True, False]:
-            probs = get_probs(4, is_contiguous)
-            alias_table, prob_table = torch._multinomial_alias_setup(probs)
-            for n_samples in [-1, 1, 10]:
-                if n_samples > 0:
-                    samples = torch._multinomial_alias_draw(prob_table, alias_table, n_samples)
-                    self.assertEqual(prob_table.size(), torch.Size([4]), "size mismatch: probability table")
-                    self.assertEqual(alias_table.size(), torch.Size([4]), "size mismatch: alias table")
-                    self.assertEqual(samples.size(), torch.Size([n_samples]), "wrong number of samples")
-                else:
-                    with self.assertRaisesRegex(RuntimeError, "cannot sample <= 0 samples"):
-                        torch._multinomial_alias_draw(prob_table, alias_table, n_samples)
-
-            with self.assertRaisesRegex(RuntimeError, "expected 1-D"):
-                probs = probs.view(2, 2)
-                torch._multinomial_alias_setup(probs)
-
-            with self.assertRaisesRegex(RuntimeError, "expected 1-D"):
-                a_t, p_t = torch._multinomial_alias_setup(probs)
-                torch._multinomial_alias_draw(p_t.view(2, 2), a_t.view(2, 2))
-
-        MAX_SAMPLES = 200000
-        for probs in [get_probs(4, True),
-                      cast(torch.tensor([0.8, 0.2])),
-                      cast(torch.tensor([0.7, 0.2, 0.1]))]:
-            # Check how different the alias distribution and the original distribution are
-            alias_dist = torch.zeros_like(probs)
-            alias_table, prob_table = torch._multinomial_alias_setup(probs)
-            alias_samples = torch._multinomial_alias_draw(prob_table, alias_table, MAX_SAMPLES)
-            alias_dist = torch.unique(alias_samples, return_counts=True)[1].to(dtype=probs.dtype) / MAX_SAMPLES
-            self.assertTrue(torch.allclose(alias_dist, probs, rtol=0.02, atol=0.0),
-                            "Actual: {}\nExpected: {}".format(alias_dist, probs))
-
-        for probs in [cast(torch.tensor([0.2501, 0.25, 0.2499, 0.25])),
-                      cast(torch.tensor([0.8, 0.199, 0.001])),
-                      cast(torch.tensor([0.25001, 0.25, 0.24999, 0.25])),
-                      cast(torch.tensor([0.33, 0.34, 0.33])),
-                      cast(torch.tensor([0.8, 0.1999, 0.0001]))]:
-            # Check the difference between the original probabilities and the reconstructed
-            # probabilities from the alias and probability tables output by _multinomial_alias_setup
-            alias_table, prob_table = torch._multinomial_alias_setup(probs)
-            actual = torch.zeros_like(probs)
-            for i, vals in enumerate(zip(alias_table, prob_table)):
-                idx, p = vals
-                actual[i] += p
-                actual[idx] += 1. - p
-            actual = actual / len(probs)
-            self.assertEqual(actual, probs, 1e-6)
-
-        # Some special cases
-        test_cases = [cast(torch.tensor([1.0, 0.0, 0.0])), cast(torch.tensor([0.0, 1.0]))]
-        for probs in test_cases:
-            alias_table, prob_table = torch._multinomial_alias_setup(probs)
-            alias_samples = torch._multinomial_alias_draw(prob_table, alias_table, MAX_SAMPLES)
-            self.assertEqual(alias_samples.unique(), probs.nonzero().squeeze(-1))
-
-    def test_multinomial_alias(self):
-        self._test_multinomial_alias(self, lambda t: t)
-
     def _spawn_method(self, method, arg):
         try:
             mp.set_start_method('spawn')
@@ -4304,27 +2573,6 @@ class _TestTorchMixin(torchtest):
             pass
         with mp.Pool(1) as pool:
             self.assertTrue(pool.map(method, [arg]))
-
-    def test_addcmul(self):
-        def rand_tensor(size, dtype, device):
-            if dtype.is_floating_point:
-                return torch.rand(size=size, dtype=dtype, device=device)
-            if dtype == torch.uint8:
-                return torch.randint(1, 5, size=size, dtype=dtype, device=device)
-            else:
-                return torch.randint(-5, 5, size=size, dtype=dtype, device=device)
-        for device in torch.testing.get_all_device_types():
-            for dtype in torch.testing.get_all_math_dtypes(device):
-                a = rand_tensor((2, 2), dtype=dtype, device=device)
-                b = rand_tensor((2, 2), dtype=dtype, device=device)
-                c = rand_tensor((2, 2), dtype=dtype, device=device)
-                if dtype.is_floating_point:
-                    alpha = 0.1
-                else:
-                    alpha = 3
-                actual = torch.addcmul(a, alpha, b, c)
-                expected = a + alpha * b * c
-                self.assertTrue(torch.allclose(expected, actual))
 
     @staticmethod
     def _test_multinomial_invalid_probs(probs):
@@ -4534,188 +2782,6 @@ class _TestTorchMixin(torchtest):
             self.assertIs(torch.int64, torch.randint(*args, size=size, out=out).dtype)
             self.assertIs(torch.int64, torch.randint(*args, size=size, out=out, dtype=torch.int64).dtype)
 
-    @staticmethod
-    def _select_broadcastable_dims(dims_full=None):
-        # select full dimensionality
-        if dims_full is None:
-            dims_full = []
-            ndims = random.randint(1, 4)
-            dims_full = [random.randint(1, 8) for _ in range(ndims)]
-        else:
-            ndims = len(dims_full)
-
-        # select actual dimensions for ops:
-        # larger: full ndims, individual sizes may be reduced
-        # smaller: possibly reduced ndims, sizes may be reduced
-        smaller_ndims = random.randint(1, ndims)
-        dims_small = []
-        dims_large = []
-        for i in range(ndims - 1, -1, -1):
-            j = random.randint(1, 3)
-            if j == 1:  # no reduced singleton dimension
-                ds = dims_full[i]
-                dl = dims_full[i]
-            elif j == 2:  # larger may have reduced singleton dimension
-                ds = dims_full[i]
-                dl = 1 if len(dims_small) < smaller_ndims else dims_full[i]
-            elif j == 3:  # smaller may have reduced singleton dimension
-                ds = 1
-                dl = dims_full[i]
-            dims_large = [dl] + dims_large
-            if len(dims_small) < smaller_ndims:
-                dims_small = [ds] + dims_small
-        return (dims_small, dims_large, dims_full)
-
-    @staticmethod
-    def _test_broadcast(self, cast):
-
-        # all functions
-        fns = {
-            "dist", "atan2", "pow", "lerp", "add",
-            "sub", "mul", "div", "fmod", "remainder",
-            "eq", "ge", "gt", "le", "lt", "max", "min", "ne",
-            "addcdiv", "addcmul", "masked_scatter", "masked_select", "masked_fill",
-            "map", "map2", "copy"
-        }
-        # functions with three tensor arguments
-        fns_3_args = {"addcdiv", "addcmul", "map2"}
-
-        for fn in fns:
-            (dims_small, dims_large, dims_full) = self._select_broadcastable_dims()
-            full1d = cast(torch.randn(*dims_full).flatten().float())
-            small = cast(torch.randn(*dims_small).float())
-            large = cast(torch.randn(*dims_large).float())
-            small_expanded = small.expand(*dims_full)
-            large_expanded = large.expand(*dims_full)
-            small2 = None
-            small2_expanded = None
-            if fn in fns_3_args:
-                # create another smaller tensor
-                (dims_small2, _, _) = self._select_broadcastable_dims(dims_full)
-                small2 = cast(torch.randn(*dims_small2).float())
-                small2_expanded = small2.expand(*dims_full)
-
-            if small.is_cuda and fn in ['map', 'map2']:
-                # map and map2 are not implementd on CUDA tensors
-                continue
-
-            if hasattr(large_expanded, fn):
-                # run through tensor versions of functions
-                # and verify fully expanded inputs give same results
-                expanded = {large: large_expanded, small: small_expanded, small2: small2_expanded}
-
-                def tensorfn(myfn, t1, t2):
-                    if fn == "lerp":
-                        return myfn(t1, 0.5)
-                    elif fn == "masked_select":
-                        return myfn(t1 < 0)
-                    elif fn == "masked_scatter":
-                        return myfn(t1 < 0.5, full1d)
-                    elif fn == "masked_fill":
-                        return myfn(t1 < 0.5, 1.0)
-                    elif fn in fns_3_args:
-                        return myfn(1, t1, t2)
-                    else:
-                        return myfn(t1)
-
-                # test various orders
-                for first, second, third in [(large, small, small2), (small, large, small2),
-                                             (small2, small, large), (small2, large, small)]:
-                    if first is None:
-                        break  # ignore last iter when small2 is None
-                    method_expanded = getattr(expanded[first], fn)
-                    method = getattr(first, fn)
-                    r1 = tensorfn(method_expanded, expanded[second], expanded[third])
-                    r2 = tensorfn(method, second, third)
-                    self.assertEqual(r1, r2)
-
-            # now for torch. versions of functions
-            if hasattr(torch, fn):
-                fntorch = getattr(torch, fn)
-                expanded = {large: large_expanded, small: small_expanded, small2: small2_expanded}
-
-                def torchfn(t1, t2, t3):
-                    if fn == "lerp":
-                        return fntorch(t1, t2, 0.5)
-                    elif fn == "masked_select":
-                        return fntorch(t1, t2 < 0)
-                    elif fn == "masked_scatter":
-                        return fntorch(t1, t2 < 0.5, full1d)
-                    elif fn == "masked_fill":
-                        return fntorch(t1, t2 < 0.5, 1.0)
-                    elif fn in fns_3_args:
-                        return fntorch(t1, 1.0, t2, t3)
-                    else:
-                        return fntorch(t1, t2)
-
-                # test various orders
-                for first, second, third in [(large, small, small2), (small, large, small2),
-                                             (small2, small, large), (small2, large, small)]:
-                    if first is None:
-                        break  # ignore last iter when small2 is None
-                    r1 = torchfn(expanded[first], expanded[second], expanded[third])
-                    r2 = torchfn(first, second, third)
-                    self.assertEqual(r1, r2)
-
-            # now for in place functions
-            # in-place tensor is not broadcastable; test only guaranteed
-            # to work by broadcasting other argument(s)
-            if not hasattr(large_expanded, fn + "_"):
-                continue
-
-            # need to clone largeExpanded so we can reuse, since functions are in-place
-            large_expanded_clone = large_expanded.clone()
-
-            def tensorfn_inplace(t0, t1, t2=None):
-                t0_fn = getattr(t0, fn + "_")
-                if fn == "lerp":
-                    return t0_fn(t1, 0.5)
-                elif fn == "masked_scatter":
-                    return t0_fn(t1 < 0.5, full1d)
-                elif fn == "masked_fill":
-                    return t0_fn(t1 < 0.5, 1.0)
-                elif fn == "map":
-                    return t0_fn(t1, lambda x, y: x + y)
-                elif fn == "map2":
-                    return t0_fn(t1, t2, lambda x, y, z: x + y + z)
-                elif fn in fns_3_args:
-                    return t0_fn(1.0, t1, t2)
-                else:
-                    return t0_fn(t1)
-            # in-place pointwise operations don't actually work if the in-place
-            # tensor is 0-strided (numpy has the same issue)
-            if (0 not in large_expanded.stride() and 0 not in large_expanded_clone.stride()):
-                r1 = tensorfn_inplace(large_expanded, small_expanded, small2_expanded)
-                r2 = tensorfn_inplace(large_expanded_clone, small, small2)
-                self.assertEqual(r1, r2)
-
-            def broadcastable(t0, t1, t2=None):
-                try:
-                    t1.expand_as(t0)
-                    if t2 is not None:
-                        t2.expand_as(t0)
-                except RuntimeError:
-                    return False
-                return True
-
-            def _test_in_place_broadcastable(t0, t1, t2=None):
-                if not broadcastable(t0, t1, t2):
-                    same_size = t0.numel() == t1.numel() and (t0.numel() == t2.numel() if t2 is not None else True)
-                    if not same_size:
-                        self.assertRaises(RuntimeError, lambda: tensorfn_inplace(t0, t1, t2))
-                else:
-                    tensorfn_inplace(t0, t1, t2)
-
-            if fn not in fns_3_args:
-                _test_in_place_broadcastable(small, large_expanded)
-                _test_in_place_broadcastable(small, large)
-            else:
-                _test_in_place_broadcastable(small2, small_expanded, large_expanded)
-                _test_in_place_broadcastable(small2, small, large)
-
-    def test_broadcast(self):
-        self._test_broadcast(self, lambda t: t)
-
     def test_broadcast_empty(self):
         # empty + empty
         self.assertRaises(RuntimeError, lambda: torch.randn(5, 0) + torch.randn(0, 5))
@@ -4742,30 +2808,6 @@ class _TestTorchMixin(torchtest):
         self.assertTrue(y1.size() == expected_size)
         self.assertTrue(y2.size() == expected_size)
 
-    @staticmethod
-    def _test_contiguous(self, cast):
-        x = cast(torch.randn(1, 16, 5, 5))
-        self.assertTrue(x.is_contiguous())
-        stride = list(x.stride())
-        stride[0] = 20
-        # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
-        x.set_(x.storage(), 0, x.size(), stride)
-        self.assertTrue(x.is_contiguous())
-
-    def test_contiguous(self):
-        return self._test_contiguous(self, lambda t: t)
-
-    def test_empty_tensor_props(self):
-        sizes = [(0,), (0, 3), (5, 0), (5, 0, 3, 0, 2), (0, 3, 0, 2), (0, 5, 0, 2, 0)]
-        for size in sizes:
-            for device in torch.testing.get_all_device_types():
-                x = torch.empty(tuple(size), device=device)
-                self.assertEqual(size, x.shape)
-                self.assertTrue(x.is_contiguous())
-                size_ones_instead_of_zeros = (x if x != 0 else 1 for x in size)
-                y = torch.empty(tuple(size_ones_instead_of_zeros), device=device)
-                self.assertEqual(x.stride(), y.stride())
-
     def test_scalars_as_floats(self):
         "zero-dim variables that don't require grad should bind to scalar arguments"
         x = torch.tensor(2.)
@@ -4776,118 +2818,6 @@ class _TestTorchMixin(torchtest):
         x = torch.tensor(2., requires_grad=True)
         self.assertRaises(Exception, lambda: y.addcmul(y, y, value=x))
 
-    @staticmethod
-    def _test_broadcast_fused_matmul(self, cast):
-        fns = ["baddbmm", "addbmm", "addmm", "addmv", "addr"]
-
-        for fn in fns:
-            batch_dim = random.randint(1, 8)
-            n_dim = random.randint(1, 8)
-            m_dim = random.randint(1, 8)
-            p_dim = random.randint(1, 8)
-
-            def dims_full_for_fn():
-                if fn == "baddbmm":
-                    return ([batch_dim, n_dim, p_dim], [batch_dim, n_dim, m_dim], [batch_dim, m_dim, p_dim])
-                elif fn == "addbmm":
-                    return ([n_dim, p_dim], [batch_dim, n_dim, m_dim], [batch_dim, m_dim, p_dim])
-                elif fn == "addmm":
-                    return ([n_dim, p_dim], [n_dim, m_dim], [m_dim, p_dim])
-                elif fn == "addmv":
-                    return ([n_dim], [n_dim, m_dim], [m_dim])
-                elif fn == "addr":
-                    return ([n_dim, m_dim], [n_dim], [m_dim])
-                else:
-                    raise AssertionError("unknown function")
-
-            (t0_dims_full, t1_dims, t2_dims) = dims_full_for_fn()
-            (t0_dims_small, _, _) = self._select_broadcastable_dims(t0_dims_full)
-
-            t0_small = cast(torch.randn(*t0_dims_small).float())
-            t1 = cast(torch.randn(*t1_dims).float())
-            t2 = cast(torch.randn(*t2_dims).float())
-
-            t0_full = cast(t0_small.expand(*t0_dims_full))
-
-            fntorch = getattr(torch, fn)
-            r0 = fntorch(t0_small, t1, t2)
-            r1 = fntorch(t0_full, t1, t2)
-            self.assertEqual(r0, r1)
-
-    def test_broadcast_fused_matmul(self):
-        self._test_broadcast_fused_matmul(self, lambda t: t)
-
-    @staticmethod
-    def _test_broadcast_batched_matmul(self, cast):
-        n_dim = random.randint(1, 8)
-        m_dim = random.randint(1, 8)
-        p_dim = random.randint(1, 8)
-        full_batch_dims = [random.randint(1, 3) for i in range(random.randint(1, 3))]
-        (batch_dims_small, _, _) = self._select_broadcastable_dims(full_batch_dims)
-
-        def verify_batched_matmul(full_lhs, one_dimensional):
-            if not one_dimensional:
-                lhs_dims = [n_dim, m_dim]
-                rhs_dims = [m_dim, p_dim]
-                result_dims = [n_dim, p_dim]
-            else:
-                lhs_dims = [n_dim, m_dim] if full_lhs else [m_dim]
-                rhs_dims = [m_dim, p_dim] if not full_lhs else [m_dim]
-                result_dims = [n_dim] if full_lhs else [p_dim]
-
-            lhs_mat_dims = lhs_dims if len(lhs_dims) != 1 else [1, m_dim]
-            rhs_mat_dims = rhs_dims if len(rhs_dims) != 1 else [m_dim, 1]
-            full_mat_dims = lhs_mat_dims if full_lhs else rhs_mat_dims
-            dim0_dims = rhs_dims if full_lhs else lhs_dims
-            small_dims = batch_dims_small + (rhs_mat_dims if full_lhs else lhs_mat_dims)
-
-            small = cast(torch.randn(*(small_dims)).float())
-            dim0 = cast(torch.randn(*(dim0_dims)).float())
-            full = cast(torch.randn(*(full_batch_dims + full_mat_dims)).float())
-            if not one_dimensional:
-                (lhsTensors, rhsTensors) = ((full,), (small, dim0)) if full_lhs else ((small, dim0), (full,))
-            else:
-                (lhsTensors, rhsTensors) = ((full,), (dim0,)) if full_lhs else ((dim0,), (full,))
-
-            def maybe_squeeze_result(l, r, result):
-                if len(lhs_dims) == 1 and l.dim() != 1:
-                    return result.squeeze(-2)
-                elif len(rhs_dims) == 1 and r.dim() != 1:
-                    return result.squeeze(-1)
-                else:
-                    return result
-
-            for lhs in lhsTensors:
-                lhs_expanded = lhs.expand(*(torch.Size(full_batch_dims) + torch.Size(lhs_mat_dims)))
-                lhs_expanded_matmul_fn = lhs_expanded.matmul
-                for rhs in rhsTensors:
-                    rhs_expanded = ((rhs if len(rhs_dims) != 1 else rhs.unsqueeze(-1)).
-                                    expand(*(torch.Size(full_batch_dims) + torch.Size(rhs_mat_dims))))
-                    truth = maybe_squeeze_result(lhs_expanded, rhs_expanded, lhs_expanded_matmul_fn(rhs_expanded))
-                    for l in (lhs, lhs_expanded):
-                        for r in (rhs, rhs_expanded):
-                            l_matmul_fn = l.matmul
-                            result = maybe_squeeze_result(l, r, l_matmul_fn(r))
-                            self.assertEqual(truth, result)
-                            # test torch.matmul function as well
-                            torch_result = maybe_squeeze_result(l, r, torch.matmul(l, r))
-                            self.assertEqual(truth, torch_result)
-                            # test torch.matmul with out
-                            out = torch.zeros_like(torch_result)
-                            torch.matmul(l, r, out=out)
-                            self.assertEqual(truth, maybe_squeeze_result(l, r, out))
-
-                # compare to bmm
-                bmm_result = (torch.bmm(lhs_expanded.contiguous().view(-1, *lhs_mat_dims),
-                                        rhs_expanded.contiguous().view(-1, *rhs_mat_dims)))
-                self.assertEqual(truth.view(-1, *result_dims), bmm_result.view(-1, *result_dims))
-
-        for indices in product((True, False), repeat=2):
-            verify_batched_matmul(*indices)
-
-    def test_broadcast_batched_matmul(self):
-        self._test_broadcast_batched_matmul(self, lambda t: t)
-
     def test_copy_broadcast(self):
         torch.zeros(5, 6).copy_(torch.zeros(6))
         self.assertRaises(RuntimeError, lambda: torch.zeros(5, 6).copy_(torch.zeros(30)))
@@ -4896,59 +2826,6 @@ class _TestTorchMixin(torchtest):
         # Testing in-place copy where it attempt to write from many memory
         # storage to a single storage would cause RuntimeError to be thrown
         self.assertRaises(RuntimeError, lambda: torch.zeros(1, 6).expand(5, 6).copy_(torch.zeros(5, 6)))
-
-    @staticmethod
-    def _test_randperm(self, device):
-        if device == 'cpu':
-            rng_device = None
-        else:
-            rng_device = [0]
-
-        # Test core functionality. On CUDA, for small n, randperm is offloaded to CPU instead. For large n, randperm is
-        # executed on GPU.
-        for n in (100, 50000, 100000):
-            # Ensure both integer and floating-point numbers are tested. Half follows an execution path that is
-            # different from others on CUDA.
-            for dtype in (torch.long, torch.half, torch.float):
-                if n > 2049 and dtype == torch.half:  # Large n for torch.half will raise an exception, do not test here.
-                    continue
-                with torch.random.fork_rng(devices=rng_device):
-                    res1 = torch.randperm(n, dtype=dtype, device=device)
-                res2 = torch.empty(0, dtype=dtype, device=device)
-                torch.randperm(n, out=res2, dtype=dtype, device=device)
-                self.assertEqual(res1, res2, 0)
-
-        # Default type is long
-        for n in (100, 10000):
-            self.assertEqual(torch.randperm(n, device=device).dtype, torch.long)
-
-        # randperm of 0 elements is an empty tensor
-        res1 = torch.randperm(0)
-        res2 = torch.tensor(5, dtype=dtype, device=device)
-        torch.randperm(0, out=res2)
-        self.assertEqual(res1.numel(), 0)
-        self.assertEqual(res2.numel(), 0)
-
-        # Test exceptions when n is too large for a floating point type
-        for dtype, small_n, large_n in ((torch.half, 2**11 + 1, 2**11 + 2),
-                                        (torch.float, 2**24 + 1, 2**24 + 2),
-                                        (torch.double, 2**25,  # 2**53 + 1 is too large to run
-                                         2**53 + 2)):
-            res = torch.empty(0, dtype=dtype, device=device)
-            torch.randperm(small_n, out=res)  # No exception expected
-            self.assertRaises(RuntimeError, lambda: torch.randperm(large_n, out=res, device=device))
-
-        # Test non-contiguous tensors
-        for n in (4, 5, 6, 10, 20):
-            non_contiguous_tensor = torch.zeros((2, 3), dtype=torch.long, device=device).t()
-            self.assertFalse(non_contiguous_tensor.is_contiguous())
-            with torch.random.fork_rng(devices=rng_device):
-                res = torch.randperm(n, dtype=torch.long, device=device)
-            torch.randperm(n, out=non_contiguous_tensor)
-            self.assertEqual(non_contiguous_tensor, res)
-
-    def test_randperm(self):
-        self._test_randperm(self, 'cpu')
 
     def test_random(self):
         # This test is flaky with p<=(2/(ub-lb))^200=6e-36
@@ -4970,21 +2847,6 @@ class _TestTorchMixin(torchtest):
         ones = torch.ones(10, dtype=torch.int)
         self.assertRaisesRegex(AssertionError, "0 not greater than or equal to",
                                lambda: self.assertNotEqual(ones, ones))
-
-    @staticmethod
-    def _test_random_neg_values(self, use_cuda=False):
-        signed_types = ['torch.DoubleTensor', 'torch.FloatTensor', 'torch.LongTensor',
-                        'torch.IntTensor', 'torch.ShortTensor']
-        for tname in signed_types:
-            res = torch.rand(SIZE, SIZE).type(tname)
-            if use_cuda:
-                res = res.cuda()
-            res.random_(-10, -1)
-            self.assertLessEqual(res.max().item(), 9)
-            self.assertGreaterEqual(res.min().item(), -10)
-
-    def test_random_neg_values(self):
-        self._test_random_neg_values(self)
 
     def assertIsOrdered(self, order, x, mxx, ixx, task):
         SIZE = 4
@@ -5083,25 +2945,6 @@ class _TestTorchMixin(torchtest):
         self.assertIsOrdered('descending', x, res2val, res2ind,
                              'random with NaNs')
 
-    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
-    def test_tensordot(self):
-        for d in torch.testing.get_all_device_types():
-            a = torch.arange(60., device=d).reshape(3, 4, 5)
-            b = torch.arange(24., device=d).reshape(4, 3, 2)
-            c = torch.tensordot(a, b, dims=([1, 0], [0, 1])).cpu()
-            cn = torch.from_numpy(np.tensordot(a.cpu().numpy(), b.cpu().numpy(),
-                                               axes=([1, 0], [0, 1])))
-            self.assertEqual(c, cn)
-            a = torch.randn(2, 3, 4, 5, device=d)
-            b = torch.randn(4, 5, 6, 7, device=d)
-            c = torch.tensordot(a, b, dims=2).cpu()
-            cn = torch.from_numpy(np.tensordot(a.cpu().numpy(), b.cpu().numpy(),
-                                               axes=2))
-            self.assertEqual(c, cn)
-            c = torch.tensordot(a, b).cpu()
-            cn = torch.from_numpy(np.tensordot(a.cpu().numpy(), b.cpu().numpy()))
-            self.assertEqual(c, cn)
-
     def test_topk(self):
         def topKViaSort(t, k, dim, dir):
             sorted, indices = t.sort(dim, dir)
@@ -5158,65 +3001,6 @@ class _TestTorchMixin(torchtest):
         top2, idx2 = t.contiguous().topk(5)
         self.assertEqual(top1, top2)
         self.assertEqual(idx1, idx2)
-
-    @staticmethod
-    def _test_kthvalue(self, device='cpu'):
-        SIZE = 50
-        x = torch.rand(SIZE, SIZE, SIZE, device=device)
-        x0 = x.clone()
-
-        k = random.randint(1, SIZE)
-        res1val, res1ind = torch.kthvalue(x, k, keepdim=False)
-        res2val, res2ind = torch.sort(x)
-
-        self.assertEqual(res1val[:, :], res2val[:, :, k - 1], 0)
-        self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], 0)
-        # test use of result tensors
-        k = random.randint(1, SIZE)
-        res1val = torch.tensor([], device=device)
-        res1ind = torch.tensor([], dtype=torch.long, device=device)
-        torch.kthvalue(x, k, keepdim=False, out=(res1val, res1ind))
-        res2val, res2ind = torch.sort(x)
-        self.assertEqual(res1val[:, :], res2val[:, :, k - 1], 0)
-        self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], 0)
-
-        # test non-default dim
-        k = random.randint(1, SIZE)
-        res1val, res1ind = torch.kthvalue(x, k, 0, keepdim=False)
-        res2val, res2ind = torch.sort(x, 0)
-        self.assertEqual(res1val, res2val[k - 1], 0)
-        self.assertEqual(res1ind, res2ind[k - 1], 0)
-
-        # non-contiguous
-        y = x.narrow(1, 0, 1)
-        y0 = y.contiguous()
-        k = random.randint(1, SIZE)
-        res1val, res1ind = torch.kthvalue(y, k)
-        res2val, res2ind = torch.kthvalue(y0, k)
-        self.assertEqual(res1val, res2val, 0)
-        self.assertEqual(res1ind, res2ind, 0)
-
-        # check that the input wasn't modified
-        self.assertEqual(x, x0, 0)
-
-        # simple test case (with repetitions)
-        y = torch.tensor((3., 5, 4, 1, 1, 5), device=device)
-        self.assertEqual(torch.kthvalue(y, 3)[0], 3, 0)
-        self.assertEqual(torch.kthvalue(y, 2)[0], 1, 0)
-
-        # simple test case (with NaN)
-        SIZE = 50
-        x = torch.rand(SIZE, SIZE, SIZE, device=device)
-        x[torch.arange(SIZE), :, torch.randint(50, (50,))] = nan
-        ks = [random.randint(1, SIZE), 1, SIZE, SIZE - 1]
-        res2val, res2ind = torch.sort(x)
-        for k in ks:
-            res1val, res1ind = torch.kthvalue(x, k, keepdim=False)
-            self.assertEqual(res1val[:, :], res2val[:, :, k - 1], 0)
-            self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], 0)
-
-    def test_kthvalue(self):
-        self._test_kthvalue(self)
 
     def test_median(self):
         for size in (155, 156):
@@ -5306,99 +3090,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(b.triu(2), output)
         self.assertRaises(RuntimeError, lambda: b.triu_(2))
 
-    @staticmethod
-    def _test_triu_tril(self, cast):
-        def gen_mask(shape, diagonal, cast, upper):
-            mask = torch.zeros(*shape[-2:]).byte()
-            for i in range(shape[-2]):
-                for j in range(shape[-1]):
-                    cond = j - i < diagonal if upper else j - i > diagonal
-                    if cond:
-                        mask[i, j] = 1
-            return cast(mask.expand(*shape))
-
-        torch_functions = {True: torch.triu, False: torch.tril}
-        if TEST_NUMPY:
-            numpy_functions = {True: np.triu, False: np.tril}
-
-        # TODO: remove this when bool and half are supported for torch.where
-        def bool_half_compat_where(pred, true_tensor, false_tensor, dtype):
-            if dtype == torch.bool or dtype == torch.half:
-                return torch.where(pred.byte(), true_tensor.byte(), false_tensor.byte()).to(dtype=dtype)
-            else:
-                return torch.where(pred, true_tensor, false_tensor)
-
-        def run_test(shape, cast, diagonal, dtype):
-            x_cpu = torch.empty(*shape, dtype=dtype).fill_(2)
-            x = cast(x_cpu)
-
-            for upper in [True, False]:
-                # normal test with mask
-                torch_tri_func = torch_functions[upper]
-                res1 = torch_tri_func(x, diagonal=diagonal)
-                res2 = cast(torch.empty(0, dtype=dtype))
-                torch_tri_func(x, diagonal=diagonal, out=res2)
-                exp_mask = gen_mask(shape, diagonal, cast, upper)
-                expected = bool_half_compat_where(exp_mask, torch.tensor(0).type_as(x), x, dtype)
-                self.assertEqual(res1, res2, 0)
-                self.assertEqual(expected, res1, 0)
-
-                # non-contiguous and expanded tensors test
-                if 0 not in shape:
-                    for s in range(-len(shape), -1):
-                        # non-contiguous tensors
-                        x_nc = x.clone().transpose(s, s + 1)
-                        exp_mask = gen_mask(x_nc.size(), diagonal, cast, upper)
-                        if 1 not in shape:
-                            assert not x_nc.is_contiguous(), "x is intentionally non-contiguous"
-                        exp_nc = bool_half_compat_where(exp_mask, torch.tensor(0).type_as(x), x_nc, dtype)
-                        self.assertEqual(torch_tri_func(x_nc, diagonal), exp_nc, 0)
-                        x_nc_is_contiguous = x_nc.is_contiguous()
-                        if upper:
-                            self.assertEqual(x_nc.triu_(diagonal), exp_nc, 0)
-                        else:
-                            self.assertEqual(x_nc.tril_(diagonal), exp_nc, 0)
-
-                        self.assertTrue(x_nc.is_contiguous() == x_nc_is_contiguous,
-                                        "contiguity of x_nc should not be changed")
-
-                    # expanded tensors
-                    expanded_size = (x.size(0),) + x.size()
-                    x_expanded = x.clone().expand(*expanded_size)
-                    if x.size(0) != 1:
-                        assert 0 in x_expanded.stride(), "x intentionally has 0 in its stride"
-                    output = torch_tri_func(x_expanded, diagonal)
-                    self.assertEqual(output, expected.expand(expanded_size), 0)
-                    if x.size(0) != 1:
-                        self.assertTrue(0 in x_expanded.stride(),
-                                        "geometry of x_expanded should be the same")
-                    if upper:
-                        self.assertEqual(output, x_expanded.triu_(diagonal), 0)
-                    else:
-                        self.assertEqual(output, x_expanded.tril_(diagonal), 0)
-
-                if not TEST_NUMPY:
-                    continue
-
-                # numpy test
-                numpy_tri_func = numpy_functions[upper]
-                self.assertEqual(numpy_tri_func(x_cpu.numpy(), diagonal), res1.cpu().numpy())
-
-        diagonals = [-2, -1, 0, 1, 2]
-        shapes = [(3, 3), (5, 3, 3), (7, 5, 3, 3),  # square matrices
-                  (7, 3), (5, 7, 3), (7, 5, 7, 3),  # fat matrices
-                  (3, 7), (5, 3, 7), (7, 5, 3, 7),  # thin matrices
-                  (3, 0), (0, 3, 3), (3, 3, 0, 0),  # no numel matrices
-                  (3, 1), (5, 3, 1), (7, 5, 3, 1),  # very fat matrices
-                  (1, 3), (5, 1, 3), (7, 5, 1, 3),  # very thin matrices
-                  (1, 3, 3, 3), (3, 1, 3, 3, 3)]    # unsqueezed batch dimensions
-        dtypes = [dtype for dtype in torch.testing.get_all_dtypes() if dtype != torch.bfloat16]
-        for s, d, dtype in product(shapes, diagonals, dtypes):
-            run_test(s, cast, d, dtype)
-
-    def test_triu_tril(self):
-        self._test_triu_tril(self, lambda t: t)
-
     def test_cat(self):
         SIZE = 10
         for dtype in (torch.half, torch.double, torch.int):
@@ -5441,72 +3132,6 @@ class _TestTorchMixin(torchtest):
         with self.assertRaisesRegex(RuntimeError, 'zero-dimensional.*cannot be concatenated'):
             torch.cat([x, y])
 
-    @staticmethod
-    def _test_cat_empty_legacy(self, use_cuda=False):
-        # FIXME: this is legacy behavior and should be removed
-        # when we support empty tensors with arbitrary sizes
-        dtype = torch.float32
-        device = 'cuda' if use_cuda else 'cpu'
-
-        x = torch.randn((4, 3, 32, 32), dtype=dtype, device=device)
-        empty = torch.randn((0,), dtype=dtype, device=device)
-
-        res1 = torch.cat([x, empty], dim=1)
-        res2 = torch.cat([empty, x], dim=1)
-        self.assertEqual(res1, res2)
-
-        conv = torch.nn.Conv2d(3, 3, kernel_size=1).float()
-        if use_cuda:
-            conv = conv.cuda()
-        res1 = torch.cat([conv(x), empty], dim=1)
-        res2 = torch.cat([empty, conv(x)], dim=1)
-        self.assertEqual(res1, res2)
-
-        res1 = torch.cat([empty, empty], dim=1)
-        self.assertEqual(res1, empty)
-
-        with self.assertRaisesRegex(RuntimeError,
-                                    'expected a non-empty list of Tensors'):
-            torch.cat([], dim=1)
-
-    def test_cat_empty_legacy(self):
-        self._test_cat_empty_legacy(self)
-
-    @staticmethod
-    def _test_cat_empty(self, use_cuda=False):
-        dtype = torch.float32
-        device = 'cuda' if use_cuda else 'cpu'
-
-        x = torch.randn((4, 3, 32, 32), dtype=dtype, device=device)
-        empty = torch.randn((4, 0, 32, 32), dtype=dtype, device=device)
-
-        res1 = torch.cat([x, empty], dim=1)
-        res2 = torch.cat([empty, x], dim=1)
-        self.assertEqual(res1, res2)
-
-        conv = torch.nn.Conv2d(3, 3, kernel_size=1).float()
-        if use_cuda:
-            conv = conv.cuda()
-        res1 = torch.cat([conv(x), empty], dim=1)
-        res2 = torch.cat([empty, conv(x)], dim=1)
-        self.assertEqual(res1, res2)
-
-        res1 = torch.cat([empty, empty], dim=1)
-        self.assertEqual(res1, empty)
-
-        # check non-legacy-behavior (sizes don't match)
-        empty = torch.randn((4, 0, 31, 32), dtype=dtype, device=device)
-        self.assertRaises(RuntimeError, lambda: torch.cat([x, empty], dim=1))
-        self.assertRaises(RuntimeError, lambda: torch.cat([empty, x], dim=1))
-
-        # check non-legacy-behavior (dimensions don't match)
-        empty = torch.randn((4, 0), dtype=dtype, device=device)
-        self.assertRaises(RuntimeError, lambda: torch.cat([x, empty], dim=1))
-        self.assertRaises(RuntimeError, lambda: torch.cat([empty, x], dim=1))
-
-    def test_cat_empty(self):
-        self._test_cat_empty(self)
-
     @slowTest
     def test_cat_big(self):
         SIZE1 = 6500
@@ -5527,15 +3152,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(x.narrow(0, -3, 3), torch.Tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
         self.assertEqual(x.narrow(-1, -1, 1), torch.Tensor([[2], [5], [8]]))
         self.assertEqual(x.narrow(-2, -1, 1), torch.Tensor([[6, 7, 8]]))
-
-    def test_narrow_empty(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(2, 3, 4, device=device)
-            for d in range(x.dim()):
-                y = x.narrow(d, x.size(d), 0)
-                sz = list(x.size())
-                sz[d] = 0
-                self.assertEqual(sz, y.size())
 
     def test_stack(self):
         for dtype in (torch.half, torch.double, torch.int):
@@ -5583,25 +3199,6 @@ class _TestTorchMixin(torchtest):
             for i in range(dim):
                 self.assertEqual(x.select(dim, i), res[i])
                 self.assertEqual(x.select(dim, i), res2[i])
-
-    def test_linspace(self):
-        for device in torch.testing.get_all_device_types():
-            _from = random.random()
-            to = _from + random.random()
-            res1 = torch.linspace(_from, to, 137, device=device)
-            res2 = torch.tensor((), device=device)
-            torch.linspace(_from, to, 137, out=res2)
-            self.assertEqual(res1, res2, 0)
-            self.assertRaises(RuntimeError, lambda: torch.linspace(0, 1, -1, device=device))
-            self.assertEqual(torch.linspace(0, 1, 1, device=device), torch.zeros(1, device=device), 0)
-
-            # Check linspace for generating with start > end.
-            self.assertEqual(torch.linspace(2, 0, 3, device=device), torch.tensor((2, 1, 0), device=device), 0)
-
-            # Check linspace for non-contiguous tensors.
-            x = torch.zeros(2, 3, device=device)
-            y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2))
-            self.assertEqual(x, torch.tensor(((0, 0, 1), (0, 2, 3)), device=device), 0)
 
     def test_logspace(self):
         _from = random.random()
@@ -5698,96 +3295,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(torch.cuda.FloatTensor(5).is_signed(), True)
         self.assertEqual(torch.cuda.HalfTensor(10).is_signed(), True)
 
-    @staticmethod
-    def _test_solve(self, cast):
-        from common_utils import solve_test_helper
-        for (k, n) in zip([2, 3, 5], [3, 5, 7]):
-            b, A = solve_test_helper((n,), (n, k), cast)
-            x = torch.solve(b, A)[0]
-            self.assertLessEqual(b.dist(A.mm(x)), 1e-12)
-
-    @skipIfNoLapack
-    def test_solve(self):
-        self._test_solve(self, lambda t: t)
-
-    @staticmethod
-    def _test_solve_batched(self, cast):
-        from common_utils import solve_test_helper
-
-        def solve_batch_helper(A_dims, b_dims, cast):
-            b, A = solve_test_helper(A_dims, b_dims, cast)
-            x_exp_list = []
-            for i in range(b_dims[0]):
-                x_exp_list.append(torch.solve(b[i], A[i])[0])
-            x_exp = torch.stack(x_exp_list)  # Stacked output
-            x_act = torch.solve(b, A)[0]  # Actual output
-            self.assertEqual(x_exp, x_act)  # Equality check
-            self.assertLessEqual(b.dist(torch.matmul(A, x_act)), 1e-12)  # Correctness check
-
-        for batchsize in [1, 3, 4]:
-            solve_batch_helper((5, batchsize), (batchsize, 5, 10), cast)
-
-    @skipIfNoLapack
-    def test_solve_batched(self):
-        self._test_solve_batched(self, lambda t: t)
-
-    @staticmethod
-    def _test_solve_batched_non_contiguous(self, cast):
-        from numpy.linalg import solve
-        from common_utils import random_fullrank_matrix_distinct_singular_value
-        A = cast(random_fullrank_matrix_distinct_singular_value(2, 2)).permute(1, 0, 2)
-        b = cast(torch.randn(2, 2, 2)).permute(2, 1, 0)
-        x, _ = torch.solve(b, A)
-        x_exp = torch.Tensor(solve(A.cpu().numpy(), b.cpu().numpy()))
-        self.assertEqual(x.data, cast(x_exp))
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_solve_batched_non_contiguous(self):
-        self._test_solve_batched_non_contiguous(self, lambda t: t)
-
-    @staticmethod
-    def _test_solve_batched_many_batches(self, cast):
-        from common_utils import solve_test_helper
-
-        b, A = solve_test_helper((5, 256, 256), (5, 1), cast)
-        x, _ = torch.solve(b, A)
-        self.assertEqual(torch.matmul(A, x), b.expand(A.shape[:-2] + (5, 1)))
-
-        b, A = solve_test_helper((3,), (512, 512, 3, 1), cast)
-        x, _ = torch.solve(b, A)
-        self.assertEqual(torch.matmul(A, x), b)
-
-    @slowTest
-    @skipIfNoLapack
-    def test_solve_batched_many_batches(self):
-        self._test_solve_batched_many_batches(self, lambda t: t.cuda())
-
-    @staticmethod
-    def _test_solve_batched_broadcasting(self, cast):
-        from numpy.linalg import solve
-        from common_utils import solve_test_helper
-
-        def run_test(A_dims, b_dims, cast):
-            A_matrix_size = A_dims[-1]
-            A_batch_dims = A_dims[:-2]
-            b, A = solve_test_helper((A_matrix_size,) + A_batch_dims, b_dims, cast)
-            x, _ = torch.solve(b, A)
-            x_exp = torch.Tensor(solve(A.cpu().numpy(), b.cpu().numpy()))
-            self.assertEqual(x, cast(x_exp))
-
-        # test against numpy.linalg.solve
-        for upper in [True, False]:
-            run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), cast)  # no broadcasting
-            run_test((2, 1, 3, 4, 4), (4, 6), cast)  # broadcasting b
-            run_test((4, 4), (2, 1, 3, 4, 2), cast)  # broadcasting A
-            run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), cast)  # broadcasting A & b
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_solve_batched_broadcasting(self):
-        self._test_solve_batched_broadcasting(self, lambda t: t)
-
     def test_solve_methods_arg_device(self):
         if not torch.cuda.is_available():
             return
@@ -5819,46 +3326,6 @@ class _TestTorchMixin(torchtest):
             with self.assertRaisesRegex(RuntimeError,
                                         "Expected LU_pivots and LU_data to be on the same device"):
                 torch.lu_solve(b, A, torch.rand(A.shape[:-1], device=b_device).int())
-
-    @staticmethod
-    def _test_qr(self, cast):
-        def run_test(tensor_dims, some):
-            A = cast(torch.randn(*tensor_dims))
-            Q, R = torch.qr(A, some=some)
-
-            # Check0: Q[-2:] = (m, n_columns), R[-2:] = (n_columns, n)
-            m, n = tensor_dims[-2:]
-            n_columns = m if (not some) and m > n else min(m, n)
-            self.assertEqual(Q.size(-2), m)
-            self.assertEqual(R.size(-1), n)
-            self.assertEqual(Q.size(-1), n_columns)
-
-            # Check1: A = QR
-            self.assertEqual(A, torch.matmul(Q, R))
-
-            # Check2: A = QR (with out)
-            Q_out, R_out = cast(torch.Tensor()), cast(torch.Tensor())
-            torch.qr(A, some=some, out=(Q_out, R_out))
-            self.assertEqual(A, torch.matmul(Q_out, R_out))
-
-            # Check3: Q == Q_out, R == R_out
-            self.assertEqual(Q, Q_out)
-            self.assertEqual(R, R_out)
-
-            # Check4: Q^{T}Q = I, triu(R) = R
-            self.assertEqual(torch.matmul(Q.transpose(-2, -1), Q),
-                             cast(torch.eye(n_columns).expand(Q.shape[:-2] + (n_columns, n_columns))))
-            self.assertEqual(R.triu(), R)
-
-        tensor_dims_list = [(3, 5), (5, 5), (5, 3),  # Single matrix
-                            (7, 3, 5), (7, 5, 5), (7, 5, 3),  # 3-dim Tensors
-                            (7, 5, 3, 5), (7, 5, 5, 5), (7, 5, 5, 3)]  # 4-dim Tensors
-        for tensor_dims, some in product(tensor_dims_list, [True, False]):
-            run_test(tensor_dims, some)
-
-    @skipIfNoLapack
-    def test_qr(self):
-        self._test_qr(self, lambda t: t)
 
     @skipIfNoLapack
     def test_ormqr(self):
@@ -5893,35 +3360,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(res2, out_holder)
 
     @staticmethod
-    def _test_geqrf(self, cast):
-        a = cast(torch.randn(5, 5))
-        b, c = torch.geqrf(a)
-        b_placeholder, c_placeholder = torch.empty_like(b), torch.empty_like(c)
-        torch.geqrf(a, out=(b_placeholder, c_placeholder))
-        self.assertEqual(b, b_placeholder)
-        self.assertEqual(c, c_placeholder)
-
-    @skipIfNoLapack
-    def test_geqrf(self):
-        self._test_geqrf(self, lambda t: t)
-
-    @staticmethod
-    def _test_triangular_solve(self, cast):
-        from common_utils import triangular_solve_test_helper
-        for (k, n), (upper, unitriangular, transpose) in product(zip([2, 3, 5], [3, 5, 7]),
-                                                                 product([True, False], repeat=3)):
-            b, A = triangular_solve_test_helper((n, n), (n, k), cast, upper, unitriangular)
-            x = torch.triangular_solve(b, A, upper=upper, unitriangular=unitriangular, transpose=transpose)[0]
-            if transpose:
-                self.assertLessEqual(b.dist(A.t().mm(x)), 4e-12)
-            else:
-                self.assertLessEqual(b.dist(A.mm(x)), 4e-12)
-
-    @skipIfNoLapack
-    def test_triangular_solve(self):
-        self._test_triangular_solve(self, lambda t: t)
-
-    @staticmethod
     def _test_triangular_solve_batched(self, cast):
         from common_utils import triangular_solve_test_helper
 
@@ -5947,193 +3385,6 @@ class _TestTorchMixin(torchtest):
     @skipIfNoLapack
     def test_triangular_solve_batched(self):
         self._test_triangular_solve_batched(self, lambda t: t)
-
-    @staticmethod
-    def _test_triangular_solve_batched_many_batches(self, cast):
-        from common_utils import triangular_solve_test_helper
-
-        for upper, transpose, unitriangular in product([True, False], repeat=3):
-            b, A = triangular_solve_test_helper((256, 256, 5, 5), (5, 1), cast, upper, unitriangular)
-            x, _ = torch.triangular_solve(b, A,
-                                          upper=upper, transpose=transpose, unitriangular=unitriangular)
-            if transpose:
-                A = A.transpose(-2, -1)
-            self.assertEqual(torch.matmul(A, x), b.expand(A.shape[:-2] + (5, 1)))
-
-            b, A = triangular_solve_test_helper((3, 3), (512, 512, 3, 1), cast, upper, unitriangular)
-            x, _ = torch.triangular_solve(b, A,
-                                          upper=upper, transpose=transpose, unitriangular=unitriangular)
-            if transpose:
-                A = A.transpose(-2, -1)
-            self.assertEqual(torch.matmul(A, x), b)
-
-    @slowTest
-    @skipIfNoLapack
-    def test_triangular_solve_batched_many_batches(self):
-        self._test_triangular_solve_batched_many_batches(self, lambda t: t)
-
-    @staticmethod
-    def _test_triangular_solve_batched_broadcasting(self, cast):
-        from scipy.linalg import solve_triangular as tri_solve
-        from common_utils import triangular_solve_test_helper
-
-        def scipy_tri_solve_batched(A, B, upper, trans, diag):
-            batch_dims_A, batch_dims_B = A.shape[:-2], B.shape[:-2]
-            single_dim_A, single_dim_B = A.shape[-2:], B.shape[-2:]
-            expand_dims = tuple(torch._C._infer_size(torch.Size(batch_dims_A),
-                                                     torch.Size(batch_dims_B)))
-            expand_A = np.broadcast_to(A, expand_dims + single_dim_A)
-            expand_B = np.broadcast_to(B, expand_dims + single_dim_B)
-            flat_A = expand_A.reshape((-1,) + single_dim_A)
-            flat_B = expand_B.reshape((-1,) + single_dim_B)
-            flat_X = np.vstack([tri_solve(a, b, lower=(not upper), trans=int(trans), unit_diagonal=diag)
-                                for a, b in zip(flat_A, flat_B)])
-            return flat_X.reshape(expand_B.shape)
-
-        def run_test(A_dims, b_dims, cast, upper, transpose, unitriangular):
-            b, A = triangular_solve_test_helper(A_dims, b_dims, cast, upper, unitriangular)
-            x_exp = torch.as_tensor(scipy_tri_solve_batched(A.cpu().numpy(), b.cpu().numpy(),
-                                                            upper, transpose, unitriangular))
-            x = torch.triangular_solve(b, A, upper=upper, transpose=transpose, unitriangular=unitriangular)[0]
-
-            self.assertEqual(x, cast(x_exp))
-
-        for upper, transpose, unitriangular in product([True, False], repeat=3):
-            # test against scipy.linalg.solve_triangular
-            run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), cast, upper, transpose, unitriangular)  # no broadcasting
-            run_test((2, 1, 3, 4, 4), (4, 6), cast, upper, transpose, unitriangular)  # broadcasting b
-            run_test((4, 4), (2, 1, 3, 4, 2), cast, upper, transpose, unitriangular)  # broadcasting A
-            run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), cast, upper, transpose, unitriangular)  # broadcasting A & b
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
-    def test_triangular_solve_batched_broadcasting(self):
-        self._test_triangular_solve_batched_broadcasting(self, lambda t: t)
-
-    @staticmethod
-    def _test_lstsq(self, device):
-        def cast_fn(tensor):
-            return tensor.to(device=device)
-
-        def _test_underdetermined(a, b, expectedNorm):
-            # underdetermined systems are not supported on the GPU
-            if 'cuda' in device:
-                return
-
-            m = a.size()[0]
-            n = a.size()[1]
-            assert(m <= n)
-
-            a_copy = a.clone()
-            b_copy = b.clone()
-            res1 = torch.lstsq(b, a)[0]
-            self.assertEqual(a, a_copy, 0)
-            self.assertEqual(b, b_copy, 0)
-            self.assertEqual((torch.mm(a, res1) - b).norm(), expectedNorm, 1e-8)
-
-            ta = cast_fn(torch.Tensor())
-            tb = cast_fn(torch.Tensor())
-            res2 = torch.lstsq(b, a, out=(tb, ta))[0]
-            self.assertEqual(a, a_copy, 0)
-            self.assertEqual(b, b_copy, 0)
-            self.assertEqual((torch.mm(a, res1) - b).norm(), expectedNorm, 1e-8)
-
-            res3 = torch.lstsq(b, a, out=(b, a))[0]
-            self.assertEqual((torch.mm(a_copy, b) - b_copy).norm(), expectedNorm, 1e-8)
-            self.assertEqual(res1, tb, 0)
-            self.assertEqual(res1, b, 0)
-            self.assertEqual(res1, res2, 0)
-            self.assertEqual(res1, res3, 0)
-
-        def _test_overdetermined(a, b, expectedNorm):
-            m = a.size()[0]
-            n = a.size()[1]
-            assert(m > n)
-
-            def check_norm(a, b, expected_norm, gels_result):
-                # Checks |ax - b| and the residual info from the result
-
-                # The first n rows is the least square solution.
-                # Rows n to m-1 contain residual information.
-                x = gels_result[:n]
-                resid_info = gels_result[n:]
-
-                resid_norm = (torch.mm(a, x) - b).norm()
-                self.assertEqual(resid_norm, expectedNorm, 1e-8)
-                self.assertEqual(resid_info.norm(), resid_norm, 1e-8)
-
-            a_copy = a.clone()
-            b_copy = b.clone()
-            res1 = torch.lstsq(b, a)[0]
-            self.assertEqual(a, a_copy, 0)
-            self.assertEqual(b, b_copy, 0)
-            check_norm(a, b, expectedNorm, res1)
-
-            ta = cast_fn(torch.Tensor())
-            tb = cast_fn(torch.Tensor())
-            res2 = torch.lstsq(b, a, out=(tb, ta))[0]
-            self.assertEqual(a, a_copy, 0)
-            self.assertEqual(b, b_copy, 0)
-            check_norm(a, b, expectedNorm, res2)
-
-            res3 = torch.lstsq(b, a, out=(b, a))[0]
-            check_norm(a_copy, b_copy, expectedNorm, res3)
-
-            self.assertEqual(res1, tb, 0)
-            self.assertEqual(res1, b, 0)
-            self.assertEqual(res1, res2, 0)
-            self.assertEqual(res1, res3, 0)
-
-        # basic test
-        expectedNorm = 0
-        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55, 8.34),
-                                  (-7.84, -0.28, 3.24, 8.09),
-                                  (-4.39, -3.24, 6.27, 5.28),
-                                  (4.53, 3.83, -6.64, 2.06)))).t()
-        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48, -5.28),
-                                  (9.35, -4.43, -0.70, -0.26)))).t()
-        _test_underdetermined(a, b, expectedNorm)
-
-        # test overdetermined
-        expectedNorm = 17.390200628863
-        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55, 8.34, 7.08, -5.45),
-                                  (-7.84, -0.28, 3.24, 8.09, 2.52, -5.70),
-                                  (-4.39, -3.24, 6.27, 5.28, 0.74, -1.19),
-                                  (4.53, 3.83, -6.64, 2.06, -2.47, 4.70)))).t()
-        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48, -5.28, 5.72, 8.93),
-                                  (9.35, -4.43, -0.70, -0.26, -7.36, -2.52)))).t()
-        _test_overdetermined(a, b, expectedNorm)
-
-        # test underdetermined
-        expectedNorm = 0
-        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55),
-                                  (-7.84, -0.28, 3.24),
-                                  (-4.39, -3.24, 6.27),
-                                  (4.53, 3.83, -6.64)))).t()
-        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48),
-                                  (9.35, -4.43, -0.70)))).t()
-        _test_underdetermined(a, b, expectedNorm)
-
-        # test reuse
-        expectedNorm = 0
-        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55, 8.34),
-                                  (-7.84, -0.28, 3.24, 8.09),
-                                  (-4.39, -3.24, 6.27, 5.28),
-                                  (4.53, 3.83, -6.64, 2.06)))).t()
-        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48, -5.28),
-                                  (9.35, -4.43, -0.70, -0.26)))).t()
-        ta = cast_fn(torch.Tensor())
-        tb = cast_fn(torch.Tensor())
-        torch.lstsq(b, a, out=(tb, ta))
-        self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
-        torch.lstsq(b, a, out=(tb, ta))
-        self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
-        torch.lstsq(b, a, out=(tb, ta))
-        self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
-
-    @skipIfNoLapack
-    def test_lstsq(self):
-        self._test_lstsq(self, 'cpu')
 
     @skipIfNoLapack
     def test_eig(self):
@@ -6177,531 +3428,6 @@ class _TestTorchMixin(torchtest):
         torch.eig(X, True, out=(e, v))
         Xhat = torch.mm(torch.mm(v, torch.diag(e.select(1, 0))), v.t())
         self.assertEqual(X, Xhat, 1e-8, 'VeV\' wrong')
-
-    @staticmethod
-    def _test_symeig(self, conv_fn):
-        from common_utils import random_symmetric_matrix
-
-        def run_test(dims, eigenvectors, upper):
-            x = conv_fn(random_symmetric_matrix(*dims))
-            oute = conv_fn(torch.empty(dims[1:] + dims[:1]))
-            outv = conv_fn(torch.empty(dims[1:] + dims[:1] * 2))
-            torch.symeig(x, eigenvectors=eigenvectors, upper=upper, out=(oute, outv))
-
-            if eigenvectors:
-                x_recon = torch.matmul(torch.matmul(outv, torch.diag_embed(oute)), outv.transpose(-2, -1))
-                self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using V @ diag(e) @ V.T')
-            else:
-                eigvals, _ = torch.symeig(x, eigenvectors=True, upper=upper)
-                self.assertEqual(eigvals, oute, 'Eigenvalues mismatch')
-                self.assertEqual(torch.zeros_like(outv), outv, 'Eigenvector matrix not zero')
-
-            rese, resv = x.symeig(eigenvectors=eigenvectors, upper=upper)
-            self.assertEqual(rese, oute, "outputs of symeig and symeig with out don't match")
-            self.assertEqual(resv, outv, "outputs of symeig and symeig with out don't match")
-
-            # test non-contiguous
-            x = conv_fn(random_symmetric_matrix(*dims))
-            n_dim = len(dims) + 1
-            # Reverse the batch dimensions and the matrix dimensions and then concat them
-            x = x.permute(tuple(range(n_dim - 3, -1, -1)) + (n_dim - 1, n_dim - 2))
-            assert not x.is_contiguous(), "x is intentionally non-contiguous"
-            rese, resv = torch.symeig(x, eigenvectors=eigenvectors, upper=upper)
-            if eigenvectors:
-                x_recon = torch.matmul(torch.matmul(resv, torch.diag_embed(rese)), resv.transpose(-2, -1))
-                self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using V @ diag(e) @ V.T')
-            else:
-                eigvals, _ = torch.symeig(x, eigenvectors=True, upper=upper)
-                self.assertEqual(eigvals, rese, 'Eigenvalues mismatch')
-                self.assertEqual(torch.zeros_like(resv), resv, 'Eigenvector matrix not zero')
-
-        batch_dims_set = [(), (3,), (3, 5), (5, 3, 5)]
-        for batch_dims, eigenvectors, upper in product(batch_dims_set, (True, False), (True, False)):
-            run_test((5,) + batch_dims, eigenvectors, upper)
-
-    @skipIfNoLapack
-    def test_symeig(self):
-        self._test_symeig(self, lambda x: x)
-
-    @staticmethod
-    def _test_svd(self, conv_fn):
-        def run_test(dims, some, compute_uv):
-            x = conv_fn(torch.randn(*dims))
-            outu, outs, outv = conv_fn(torch.Tensor()), conv_fn(torch.Tensor()), conv_fn(torch.Tensor())
-            torch.svd(x, some=some, compute_uv=compute_uv, out=(outu, outs, outv))
-
-            if compute_uv:
-                if some:
-                    x_recon = torch.matmul(outu, torch.matmul(outs.diag_embed(), outv.transpose(-2, -1)))
-                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
-                else:
-                    narrow_u = outu[..., :min(*dims[-2:])]
-                    narrow_v = outv[..., :min(*dims[-2:])]
-                    x_recon = torch.matmul(narrow_u, torch.matmul(outs.diag_embed(), narrow_v.transpose(-2, -1)))
-                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
-            else:
-                _, singvals, _ = torch.svd(x, compute_uv=True)
-                self.assertEqual(singvals, outs, 'Singular values mismatch')
-                self.assertEqual(outu, torch.zeros_like(outu), 'U not zero')
-                self.assertEqual(outv, torch.zeros_like(outv), 'V not zero')
-
-            resu, ress, resv = torch.svd(x, some=some, compute_uv=compute_uv)
-            self.assertEqual(resu, outu, 'outputs of svd and svd with out differ')
-            self.assertEqual(ress, outs, 'outputs of svd and svd with out differ')
-            self.assertEqual(resv, outv, 'outputs of svd and svd with out differ')
-
-            # test non-contiguous
-            x = conv_fn(torch.randn(*dims))
-            n_dim = len(dims)
-            # Reverse the batch dimensions and the matrix dimensions and then concat them
-            x = x.permute(tuple(range(n_dim - 3, -1, -1)) + (n_dim - 1, n_dim - 2))
-            assert not x.is_contiguous(), "x is intentionally non-contiguous"
-            resu, ress, resv = torch.svd(x, some=some, compute_uv=compute_uv)
-            if compute_uv:
-                if some:
-                    x_recon = torch.matmul(resu, torch.matmul(ress.diag_embed(), resv.transpose(-2, -1)))
-                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
-                else:
-                    narrow_u = resu[..., :min(*dims[-2:])]
-                    narrow_v = resv[..., :min(*dims[-2:])]
-                    x_recon = torch.matmul(narrow_u, torch.matmul(ress.diag_embed(), narrow_v.transpose(-2, -1)))
-                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
-            else:
-                _, singvals, _ = torch.svd(x, compute_uv=True)
-                self.assertEqual(singvals, ress, 'Singular values mismatch')
-                self.assertEqual(resu, torch.zeros_like(resu), 'U not zero')
-                self.assertEqual(resv, torch.zeros_like(resv), 'V not zero')
-
-        shapes = [(3, 3), (5, 3, 3), (7, 5, 3, 3),  # square matrices
-                  (7, 3), (5, 7, 3), (7, 5, 7, 3),  # fat matrices
-                  (3, 7), (5, 3, 7), (7, 5, 3, 7)]  # thin matrices
-        for dims, some, compute_uv in product(shapes, [True, False], [True, False]):
-            run_test(dims, some, compute_uv)
-
-    @skipIfNoLapack
-    def test_svd(self):
-        self._test_svd(self, lambda t: t)
-
-    @staticmethod
-    def _test_svd_no_singularvectors(self, cast):
-        for size in [(5, 5), (5, 20), (20, 5)]:
-            a = cast(torch.randn(*size))
-            u, s_expect, v = torch.svd(a)
-            u, s_actual, v = torch.svd(a, compute_uv=False)
-            self.assertEqual(s_expect, s_actual, "Singular values don't match")
-
-    @skipIfNoLapack
-    def test_svd_no_singularvectors(self):
-        self._test_svd_no_singularvectors(self, lambda t: t)
-
-    @staticmethod
-    def _test_matrix_rank(self, conv_fn):
-        a = conv_fn(torch.eye(10))
-        self.assertEqual(torch.matrix_rank(a).item(), 10)
-        self.assertEqual(torch.matrix_rank(a, True).item(), 10)
-
-        a[5, 5] = 0
-        self.assertEqual(torch.matrix_rank(a).item(), 9)
-        self.assertEqual(torch.matrix_rank(a, True).item(), 9)
-
-        a = conv_fn(torch.randn(24, 42))
-        self.assertEqual(torch.matrix_rank(a), torch.matrix_rank(a.t()))
-        aaT = torch.mm(a, a.t())
-        self.assertEqual(torch.matrix_rank(aaT), torch.matrix_rank(aaT, True))
-        aTa = torch.mm(a.t(), a)
-        self.assertEqual(torch.matrix_rank(aTa), torch.matrix_rank(aTa, True))
-
-        if TEST_NUMPY:
-            from numpy.linalg import matrix_rank
-            a = conv_fn(torch.randn(35, 75))
-            self.assertEqual(torch.matrix_rank(a).item(), matrix_rank(a.cpu().numpy()))
-            self.assertEqual(torch.matrix_rank(a, 0.01).item(), matrix_rank(a.cpu().numpy(), 0.01))
-
-            aaT = torch.mm(a, a.t())
-            self.assertEqual(torch.matrix_rank(aaT).item(), matrix_rank(aaT.cpu().numpy()))
-            self.assertEqual(torch.matrix_rank(aaT, 0.01).item(), matrix_rank(aaT.cpu().numpy(), 0.01))
-
-            if np.lib.NumpyVersion(np.__version__) >= '1.14.0':
-                self.assertEqual(torch.matrix_rank(aaT, True).item(), matrix_rank(aaT.cpu().numpy(), True))
-                self.assertEqual(torch.matrix_rank(aaT, 0.01, True).item(),
-                                 matrix_rank(aaT.cpu().numpy(), 0.01, True))
-
-    @skipIfNoLapack
-    def test_matrix_rank(self):
-        self._test_matrix_rank(self, lambda x: x)
-
-    @staticmethod
-    def _test_signal_window_functions(self, device='cpu'):
-        if not TEST_SCIPY:
-            raise unittest.SkipTest('Scipy not found')
-
-        def test(name):
-            torch_method = getattr(torch, name + '_window')
-            for size in [1, 2, 5, 10, 50, 100, 1024, 2048]:
-                for periodic in [True, False]:
-                    res = torch_method(size, periodic=periodic, device=device)
-                    ref = torch.from_numpy(signal.get_window(name, size, fftbins=periodic))
-                    self.assertEqual(res, ref)
-            with self.assertRaisesRegex(RuntimeError, r'not implemented for sparse types'):
-                torch_method(3, layout=torch.sparse_coo)
-            with self.assertRaisesRegex(RuntimeError, r'floating point'):
-                torch_method(3, dtype=torch.long)
-            self.assertTrue(torch_method(3, requires_grad=True).requires_grad)
-            self.assertFalse(torch_method(3).requires_grad)
-
-        for window in ['hann', 'hamming', 'bartlett', 'blackman']:
-            test(window)
-
-    def test_signal_window_functions(self):
-        self._test_signal_window_functions(self)
-
-    @staticmethod
-    def _test_inverse_slow(self, conv_fn):
-        from common_utils import random_fullrank_matrix_distinct_singular_value
-
-        matrices = conv_fn(random_fullrank_matrix_distinct_singular_value(5, 256, 256))
-        matrices_inverse = torch.inverse(matrices)
-        self.assertEqual(torch.matmul(matrices_inverse, matrices),
-                         conv_fn(torch.eye(5)).expand_as(matrices))
-
-        matrices = conv_fn(random_fullrank_matrix_distinct_singular_value(3, 512, 512))
-        matrices_inverse = torch.inverse(matrices)
-        self.assertEqual(torch.matmul(matrices, matrices_inverse),
-                         conv_fn(torch.eye(3)).expand_as(matrices))
-
-    @slowTest
-    @skipIfNoLapack
-    def test_inverse_many_batches(self):
-        self._test_inverse_slow(self, lambda t: t)
-
-    @staticmethod
-    def _test_pinverse(self, conv_fn):
-        def run_test(M):
-            # Testing against definition for pseudo-inverses
-            MPI = torch.pinverse(M)
-            self.assertEqual(M, M.mm(MPI).mm(M), 1e-8, 'pseudo-inverse condition 1')
-            self.assertEqual(MPI, MPI.mm(M).mm(MPI), 1e-8, 'pseudo-inverse condition 2')
-            self.assertEqual(M.mm(MPI), (M.mm(MPI)).t(), 1e-8, 'pseudo-inverse condition 3')
-            self.assertEqual(MPI.mm(M), (MPI.mm(M)).t(), 1e-8, 'pseudo-inverse condition 4')
-
-        # Square matrix
-        M = conv_fn(torch.randn(5, 5))
-        run_test(M)
-
-        # Rectangular matrix
-        M = conv_fn(torch.randn(3, 4))
-        run_test(M)
-
-        # Test inverse and pseudo-inverse for invertible matrix
-        M = torch.randn(5, 5)
-        M = conv_fn(M.mm(M.t()))
-        self.assertEqual(conv_fn(torch.eye(5)), M.pinverse().mm(M), 1e-7, 'pseudo-inverse for invertible matrix')
-
-    @skipIfNoLapack
-    def test_pinverse(self):
-        self._test_pinverse(self, conv_fn=lambda x: x)
-
-    @staticmethod
-    def _test_matrix_power(self, conv_fn):
-        def run_test(M, sign=1):
-            if sign == -1:
-                M = M.inverse()
-            MP2 = torch.matrix_power(M, 2)
-            self.assertEqual(MP2, torch.matmul(M, M))
-
-            MP3 = torch.matrix_power(M, 3)
-            self.assertEqual(MP3, torch.matmul(MP2, M))
-
-            MP4 = torch.matrix_power(M, 4)
-            self.assertEqual(MP4, torch.matmul(MP2, MP2))
-
-            MP6 = torch.matrix_power(M, 6)
-            self.assertEqual(MP6, torch.matmul(MP3, MP3))
-
-            MP0 = torch.matrix_power(M, 0)
-            self.assertEqual(MP0, torch.eye(M.size(-2)).expand_as(M))
-
-        # Single matrix
-        M = conv_fn(torch.randn(5, 5))
-        run_test(M)
-
-        # Batch matrices
-        M = conv_fn(torch.randn(3, 3, 3))
-        run_test(M)
-
-        # Many batch matrices
-        M = conv_fn(torch.randn(2, 3, 3, 3))
-        run_test(M)
-
-        # This is for negative powers
-        from common_utils import random_fullrank_matrix_distinct_singular_value
-        M = conv_fn(random_fullrank_matrix_distinct_singular_value(5))
-        run_test(M, sign=-1)
-
-        M = conv_fn(random_fullrank_matrix_distinct_singular_value(3, 3))
-        run_test(M, sign=-1)
-
-        M = conv_fn(random_fullrank_matrix_distinct_singular_value(3, 2, 3))
-        run_test(M, sign=-1)
-
-    @skipIfNoLapack
-    def test_matrix_power(self):
-        self._test_matrix_power(self, conv_fn=lambda x: x)
-
-    @staticmethod
-    def _test_chain_matmul(self, cast):
-        def product(matrices):
-            for mat in matrices[1:]:
-                matrices[0] = matrices[0].mm(mat)
-            return matrices[0]
-
-        def run_test(p, cast):
-            matrices = []
-            for (pi, pi_1) in zip(p[:-1], p[1:]):
-                matrices.append(cast(torch.randn(pi, pi_1)))
-            self.assertEqual(torch.chain_matmul(*matrices), product(matrices))
-
-        run_test([10, 20, 30, 5], cast)
-        run_test([15, 5, 10, 20, 25], cast)
-
-    def test_chain_matmul(self):
-        self._test_chain_matmul(self, cast=lambda x: x)
-
-    @staticmethod
-    def _test_det_logdet_slogdet(self, device):
-        def reference_slogdet(M):
-            if TEST_NUMPY:
-                sdet, logabsdet = np.linalg.slogdet(M.detach().cpu().numpy())
-                return M.new_tensor(sdet), M.new_tensor(logabsdet)
-            else:
-                # naive row reduction
-                M = M.clone()
-                l = M.size(0)
-                multiplier = 1
-                for i in range(l):
-                    if M[i, 0].item() != 0:
-                        if i != 0:
-                            M[0], M[i] = M[i], M[0]
-                            multiplier = -1
-                        break
-                else:
-                    return 0
-                for i in range(1, l):
-                    row = M[i]
-                    for j in range(i):
-                        row -= row[j] / M[j, j] * M[j]
-                    M[i] = row
-            sdet = M.diag().sign().prod()
-            logabsdet = M.diag().abs_().log_().sum().add_(math.log(multiplier))
-            return sdet, logabsdet
-
-        def test_single_det(M, target, desc):
-            target_sdet, target_logabsdet = target
-
-            det = M.det()
-            logdet = M.logdet()
-            sdet, logabsdet = M.slogdet()
-
-            # Test det
-            self.assertEqual(det, target_sdet * target_logabsdet.exp(), 1e-7, '{} (det)'.format(desc))
-
-            # Test slogdet
-            # Compare the overall value rather than individual parts because of
-            # precision issues when det is near zero.
-            self.assertEqual(sdet * logabsdet.exp(), target_sdet * target_logabsdet.exp(), 1e-7, '{} (slogdet)'.format(desc))
-
-            # Test logdet
-            # Compare logdet against our own pytorch slogdet because they should
-            # be consistent, while it may behave slightly differently with other
-            # slogdet implementations when det is near zero due to precision
-            # issues.
-            if sdet.item() < 0:
-                self.assertTrue(logdet.item() != logdet.item(), '{} (logdet negative case)'.format(desc))
-            else:
-                self.assertEqual(logdet.exp(), target_logabsdet.exp(), 1e-7, '{} (logdet non-negative case)'.format(desc))
-
-        eye = torch.eye(5, device=device)
-        test_single_det(eye, (torch.ones((), device=device), torch.zeros((), device=device)), 'identity')
-
-        def test(M):
-            assert M.size(0) >= 5, 'this helper fn assumes M to be at least 5x5'
-            M = M.to(device)
-
-            ref_M_sdet, ref_M_logabsdet = reference_slogdet(M)
-
-            test_single_det(M, (ref_M_sdet, ref_M_logabsdet), 'basic')
-            if ref_M_logabsdet.exp().item() >= 1e-6:  # skip singular
-                M_inv = M.inverse()
-                test_single_det(M_inv, reference_slogdet(M_inv), 'inverse')
-
-            test_single_det(M, (ref_M_sdet, ref_M_logabsdet), 'transpose')
-
-            for x in [0, 2, 4]:
-                for scale in [-2, -0.1, 0, 10]:
-                    if scale > 0:
-                        target = ref_M_sdet, ref_M_logabsdet + math.log(scale)
-                    elif scale == 0:
-                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
-                    else:
-                        target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-scale)
-
-                    # dim 0
-                    M_clone = M.clone()
-                    M_clone[:, x] *= scale
-                    test_single_det(M_clone, target, 'scale a row')
-                    # dim 1
-                    M_clone = M.clone()
-                    M_clone[x, :] *= scale
-                    test_single_det(M_clone, target, 'scale a column')
-
-            for x1, x2 in [(0, 3), (4, 1), (3, 2)]:
-                assert x1 != x2, 'x1 and x2 needs to be different for this test'
-                target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
-                # dim 0
-                M_clone = M.clone()
-                M_clone[:, x2] = M_clone[:, x1]
-                test_single_det(M_clone, target, 'two rows are same')
-                # dim 1
-                M_clone = M.clone()
-                M_clone[x2, :] = M_clone[x1, :]
-                test_single_det(M_clone, target, 'two columns are same')
-
-                for scale1, scale2 in [(0.3, -1), (0, 2), (10, 0.1)]:
-                    det_scale = scale1 * scale2 * -1
-                    if det_scale > 0:
-                        target = ref_M_sdet, ref_M_logabsdet + math.log(det_scale)
-                    elif det_scale == 0:
-                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
-                    else:
-                        target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-det_scale)
-
-                    # dim 0
-                    M_clone = M.clone()
-                    t = M_clone[:, x1] * scale1
-                    M_clone[:, x1] += M_clone[:, x2] * scale2
-                    M_clone[:, x2] = t
-                    test_single_det(M_clone, target, 'exchanging rows')
-                    # dim 1
-                    M_clone = M.clone()
-                    t = M_clone[x1, :] * scale1
-                    M_clone[x1, :] += M_clone[x2, :] * scale2
-                    M_clone[x2, :] = t
-                    test_single_det(M_clone, target, 'exchanging columns')
-
-        def get_random_mat_scale(n):
-            # For matrices with values i.i.d. with 0 mean, unit variance, and
-            # subexponential tail, we have:
-            #   E[log det(A^2)] \approx log((n-1)!)
-            #
-            # Notice:
-            #   log Var[det(A)] = log E[det(A^2)] >= E[log det(A^2)]
-            #
-            # So:
-            #   stddev[det(A)] >= sqrt( (n-1)! )
-            #
-            # We use this as an intuitive guideline to scale random generated
-            # matrices so our closeness tests can work more robustly:
-            #   scale by sqrt( (n-1)! )^(-1/n) = ( (n-1)! )^(-1/(2n))
-            #
-            # source: https://arxiv.org/pdf/1112.0752.pdf
-
-            # TODO: technically we need subexponential distn for this to hold,
-            #       but we mostly use gaussian entries below. Consider switching
-            #       to Chi-sq if this turns out not stable enough, since Chi-sq
-            #       is easy enough to sample from.
-            return math.factorial(n - 1) ** (-1.0 / (2 * n))
-
-        for n in [5, 10, 25]:
-            scale = get_random_mat_scale(n)
-            test(torch.randn(n, n, device=device) * scale)
-            r = torch.randn(n, n, device=device) * scale
-            # symmetric psd
-            test(r.mm(r.t()))
-            # symmetric pd
-            r = torch.randn(n, n, device=device) * scale
-            test(r.mm(r.t()) + torch.eye(n, device=device) * 1e-6)
-            # symmetric
-            r = torch.randn(n, n, device=device) * scale
-            for i in range(n):
-                for j in range(i):
-                    r[i, j] = r[j, i]
-            test(r)
-            # non-contiguous
-            test((torch.randn(n, n, n + 1, device=device) * scale)[:, 2, 1:])
-            # det = 0
-            r = torch.randn(n, n, device=device) * scale
-            u, s, v = r.svd()
-            if reference_slogdet(u)[0] < 0:
-                u = -u
-            if reference_slogdet(v)[0] < 0:
-                v = -v
-            s[0] *= -1
-            s[-1] = 0
-            test(u.mm(s.diag()).mm(v))
-
-        # Small values to test numerical stability. Note that we don't scale
-        # this matrix.
-        r = torch.randn(512, 512, device=device)
-        u, s, v = r.svd()
-        s.fill_(1. / (100 * s.numel()))
-        test(u.mm(s.diag()).mm(v))
-
-    @skipIfNoLapack
-    def test_det_logdet_slogdet(self):
-        self._test_det_logdet_slogdet(self, 'cpu')
-
-    @staticmethod
-    def _test_det_logdet_slogdet_batched(self, device):
-        from common_utils import (random_symmetric_matrix, random_symmetric_psd_matrix,
-                                  random_symmetric_pd_matrix, random_square_matrix_of_rank)
-
-        # mat_chars denotes matrix characteristics
-        # possible values are: sym, sym_psd, sym_pd, sing, non_sym
-        def run_test(matsize, batchdims, mat_chars):
-            num_matrices = reduce(lambda x, y: x * y, batchdims, 1)
-            list_of_matrices = []
-
-            for idx in range(num_matrices):
-                mat_type = idx % len(mat_chars)
-                if mat_chars[mat_type] == 'sym':
-                    list_of_matrices.append(random_symmetric_matrix(matsize).to(device=device))
-                elif mat_chars[mat_type] == 'sym_psd':
-                    list_of_matrices.append(random_symmetric_psd_matrix(matsize).to(device=device))
-                elif mat_chars[mat_type] == 'sym_pd':
-                    list_of_matrices.append(random_symmetric_pd_matrix(matsize).to(device=device))
-                elif mat_chars[mat_type] == 'sing':
-                    list_of_matrices.append(torch.ones(matsize, matsize, device=device))
-                elif mat_chars[mat_type] == 'non_sing':
-                    list_of_matrices.append(random_square_matrix_of_rank(matsize, matsize).to(device=device))
-            full_tensor = torch.stack(list_of_matrices, dim=0).reshape(batchdims + (matsize, matsize))
-            # Scaling adapted from `get_random_mat_scale` in _test_det_logdet_slogdet
-            full_tensor *= (math.factorial(matsize - 1) ** (-1.0 / (2 * matsize)))
-
-            for fn in [torch.det, torch.logdet, torch.slogdet]:
-                expected_value = []
-                actual_value = fn(full_tensor)
-                for full_idx in product(*map(lambda x: list(range(x)), batchdims)):
-                    expected_value.append(fn(full_tensor[full_idx]))
-
-                if fn == torch.slogdet:
-                    sign_value = torch.stack([tup[0] for tup in expected_value], dim=0).reshape(batchdims)
-                    expected_value = torch.stack([tup[1] for tup in expected_value], dim=0).reshape(batchdims)
-                    self.assertEqual(sign_value, actual_value[0], allow_inf=True)
-                    self.assertEqual(expected_value, actual_value[1], allow_inf=True)
-                else:
-                    expected_value = torch.stack(expected_value, dim=0).reshape(batchdims)
-                    self.assertEqual(actual_value, expected_value, allow_inf=True)
-
-        for matsize, batchdims in product([3, 5], [(3,), (5, 3)]):
-            run_test(matsize, batchdims, mat_chars=['sym_pd'])
-            run_test(matsize, batchdims, mat_chars=['sing'])
-            run_test(matsize, batchdims, mat_chars=['non_sing'])
-            run_test(matsize, batchdims, mat_chars=['sym', 'sym_pd', 'sym_psd'])
-            run_test(matsize, batchdims, mat_chars=['sing', 'non_sing'])
-
-    @skipIfNoLapack
-    def test_det_logdet_slogdet_batched(self):
-        self._test_det_logdet_slogdet_batched(self, 'cpu')
 
     @staticmethod
     def _test_fft_ifft_rfft_irfft(self, device='cpu'):
@@ -6991,84 +3717,6 @@ class _TestTorchMixin(torchtest):
                     o32[i + j - 1].add(torch.conv2(x[i], k[j], 'F'))
         self._test_conv_corr_eq(lambda x, k: torch.conv3(x, k, 'F'), reference)
 
-    def test_logical(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                x = torch.tensor([1, 2, 3, 4], device=device, dtype=dt)
-                b = torch.tensor([2], device=device, dtype=dt)
-
-                if dt == torch.half and device == 'cpu':
-                    self.assertRaises(RuntimeError, lambda: x.lt(2))
-                    continue
-
-                if dt == torch.bool:
-                    # torch.bool is a special case and is being tested later
-                    # in this test
-                    continue
-
-                if device == 'cuda' and dt == torch.bfloat16:
-                    self.assertRaises(RuntimeError, lambda: x > b)
-                    self.assertRaises(RuntimeError, lambda: x < b)
-                    self.assertRaises(RuntimeError, lambda: x == b)
-                    self.assertRaises(RuntimeError, lambda: x != b)
-                    self.assertRaises(RuntimeError, lambda: x >= b)
-                    self.assertRaises(RuntimeError, lambda: x <= b)
-                    continue
-
-                self.assertEqual(x.lt(2), torch.tensor([True, False, False, False]))
-                self.assertEqual(x.le(2), torch.tensor([True, True, False, False]))
-                self.assertEqual(x.ge(2), torch.tensor([False, True, True, True]))
-                self.assertEqual(x.gt(2), torch.tensor([False, False, True, True]))
-                self.assertEqual(x.eq(2), torch.tensor([False, True, False, False]))
-                self.assertEqual(x.ne(2), torch.tensor([True, False, True, True]))
-
-                self.assertEqual(x.lt(b), torch.tensor([True, False, False, False]))
-                self.assertEqual(x.le(b), torch.tensor([True, True, False, False]))
-                self.assertEqual(x.ge(b), torch.tensor([False, True, True, True]))
-                self.assertEqual(x.gt(b), torch.tensor([False, False, True, True]))
-                self.assertEqual(x.eq(b), torch.tensor([False, True, False, False]))
-                self.assertEqual(x.ne(b), torch.tensor([True, False, True, True]))
-
-                with warnings.catch_warnings(record=True) as warningsCount:
-                    byteRes = torch.empty_like(x, device=device).byte()
-                    boolRes = torch.empty_like(x, device=device).bool()
-
-                    torch.lt(x, b, out=byteRes)
-                    torch.lt(x, b, out=boolRes)
-                    self.assertEqual(byteRes.bool(), boolRes)
-
-                    torch.le(x, b, out=byteRes)
-                    torch.le(x, b, out=boolRes)
-                    self.assertEqual(byteRes.bool(), boolRes)
-
-                    torch.ge(x, b, out=byteRes)
-                    torch.ge(x, b, out=boolRes)
-                    self.assertEqual(byteRes.bool(), boolRes)
-
-                    torch.gt(x, b, out=byteRes)
-                    torch.gt(x, b, out=boolRes)
-                    self.assertEqual(byteRes.bool(), boolRes)
-
-                    torch.eq(x, b, out=byteRes)
-                    torch.eq(x, b, out=boolRes)
-                    self.assertEqual(byteRes.bool(), boolRes)
-
-                    torch.ne(x, b, out=byteRes)
-                    torch.ne(x, b, out=boolRes)
-                    self.assertEqual(byteRes.bool(), boolRes)
-
-                    self.assertEquals(len(warningsCount), 6)
-
-            # Bool Tensor
-            x = torch.tensor([True, False, True, False], device=device)
-            self.assertEqual(x.lt(True), torch.tensor([False, True, False, True]))
-            self.assertEqual(x.le(True), torch.tensor([True, True, True, True]))
-            self.assertEqual(x.ge(True), torch.tensor([True, False, True, False]))
-            self.assertEqual(x.gt(True), torch.tensor([False, False, False, False]))
-            self.assertEqual(x.eq(True), torch.tensor([True, False, True, False]))
-            self.assertEqual(x.ne(True), torch.tensor([False, True, False, True]))
-
-
     def test_isfinite(self):
         x = torch.Tensor([1, inf, 2, -inf, nan, -10])
         self.assertEqual(torch.isfinite(x), torch.BoolTensor([True, False, True, False, False, True]))
@@ -7080,24 +3728,6 @@ class _TestTorchMixin(torchtest):
     def test_isfinite_type(self):
         with self.assertRaises(TypeError):
             torch.isfinite(1)  # Parameter must be a tensor
-
-    @staticmethod
-    def _test_isinf(self, cast):
-        t1 = cast(torch.Tensor([1, inf, 2, -inf, nan]))
-        t2 = cast(torch.ByteTensor([1, 2, 3]))
-        t3 = cast(torch.CharTensor([1, 2, 3]))
-        t4 = cast(torch.ShortTensor([1, 2, 3]))
-        t5 = cast(torch.IntTensor([1, 2, 3]))
-        t6 = cast(torch.LongTensor([1, 2, 3]))
-        self.assertEqual(torch.isinf(t1), cast(torch.ByteTensor([0, 1, 0, 1, 0])))
-        self.assertEqual(torch.isinf(t2), cast(torch.ByteTensor([0, 0, 0])))
-        self.assertEqual(torch.isinf(t3), cast(torch.ByteTensor([0, 0, 0])))
-        self.assertEqual(torch.isinf(t4), cast(torch.ByteTensor([0, 0, 0])))
-        self.assertEqual(torch.isinf(t5), cast(torch.ByteTensor([0, 0, 0])))
-        self.assertEqual(torch.isinf(t6), cast(torch.ByteTensor([0, 0, 0])))
-
-    def test_isinf(self):
-        self._test_isinf(self, lambda t: t)
 
     def test_isinf_type(self):
         with self.assertRaises(TypeError):
@@ -7167,200 +3797,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(x, y)
         torch.set_rng_state(rng_state)
 
-    @staticmethod
-    def _test_cholesky(self, cast):
-        x = cast(torch.rand(10, 10) + 1e-1)
-        A = torch.mm(x, x.t())
-
-        # default Case
-        C = torch.cholesky(A)
-        B = torch.mm(C, C.t())
-        self.assertEqual(A, B, 1e-14)
-
-        # test Upper Triangular
-        U = torch.cholesky(A, True)
-        B = torch.mm(U.t(), U)
-        self.assertEqual(A, B, 1e-14, 'cholesky (upper) did not allow rebuilding the original matrix')
-
-        # test Lower Triangular
-        L = torch.cholesky(A, False)
-        B = torch.mm(L, L.t())
-        self.assertEqual(A, B, 1e-14, 'cholesky (lower) did not allow rebuilding the original matrix')
-
-    @skipIfNoLapack
-    def test_cholesky(self):
-        self._test_cholesky(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_batched(self, cast):
-        from common_utils import random_symmetric_pd_matrix
-
-        def cholesky_test_helper(n, batch_dims, cast, upper):
-            A = cast(random_symmetric_pd_matrix(n, *batch_dims))
-            cholesky_exp = torch.stack([m.cholesky(upper=upper) for m in A.reshape(-1, n, n)])
-            cholesky_exp = cholesky_exp.reshape_as(A)
-            self.assertEqual(cholesky_exp, torch.cholesky(A, upper=upper))
-
-        for upper, batchsize in product([True, False], [(3,), (3, 4), (2, 3, 4)]):
-            cholesky_test_helper(3, batchsize, cast, upper)
-
-    @skipIfNoLapack
-    def test_cholesky_batched(self):
-        self._test_cholesky_batched(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_batched_many_batches(self, cast):
-        from common_utils import random_symmetric_pd_matrix
-
-        def cholesky_test_helper(n, batchsize, cast, upper):
-            A = cast(random_symmetric_pd_matrix(n, batchsize))
-            chol_fact = torch.cholesky(A, upper=upper)
-            if upper:
-                # Correctness check
-                self.assertEqual(A, chol_fact.transpose(-2, -1).matmul(chol_fact))
-                # Upper triangular check
-                self.assertEqual(chol_fact, chol_fact.triu())
-            else:
-                # Correctness check
-                self.assertEqual(A, chol_fact.matmul(chol_fact.transpose(-2, -1)))
-                # Lower triangular check
-                self.assertEqual(chol_fact, chol_fact.tril())
-
-        for upper, batchsize in product([True, False], [262144, 524288]):
-            cholesky_test_helper(2, batchsize, cast, upper)
-
-    @skipIfNoLapack
-    @slowTest
-    def test_cholesky_batched_many_batches(self):
-        self._test_cholesky_batched_many_batches(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_solve(self, cast):
-        from common_utils import cholesky_solve_test_helper
-        for (k, n), upper in product(zip([2, 3, 5], [3, 5, 7]), [True, False]):
-            b, A, L = cholesky_solve_test_helper((n,), (n, k), cast, upper)
-            x = torch.cholesky_solve(b, L, upper=upper)
-            self.assertLessEqual(b.dist(A.mm(x)), 1e-12)
-
-    @skipIfNoLapack
-    def test_cholesky_solve(self):
-        self._test_cholesky_solve(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_solve_batched(self, cast):
-        from common_utils import cholesky_solve_test_helper
-
-        def cholesky_solve_batch_helper(A_dims, b_dims, cast, upper):
-            b, A, L = cholesky_solve_test_helper(A_dims, b_dims, cast, upper)
-            x_exp_list = []
-            for i in range(b_dims[0]):
-                x_exp_list.append(torch.cholesky_solve(b[i], L[i], upper=upper))
-            x_exp = torch.stack(x_exp_list)  # Stacked output
-            x_act = torch.cholesky_solve(b, L, upper=upper)  # Actual output
-            self.assertEqual(x_act, x_exp)  # Equality check
-            self.assertLessEqual(b.dist(torch.matmul(A, x_act)), 2e-12)  # Correctness check
-
-        for upper, batchsize in product([True, False], [1, 3, 4]):
-            cholesky_solve_batch_helper((5, batchsize), (batchsize, 5, 10), cast, upper)
-
-    @skipIfNoLapack
-    def test_cholesky_solve_batched(self):
-        self._test_cholesky_solve_batched(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_solve_batched_non_contiguous(self, cast):
-        from numpy.linalg import solve
-        from common_utils import random_symmetric_pd_matrix
-
-        for upper in [True, False]:
-            A = random_symmetric_pd_matrix(2, 2)
-            b = torch.randn(2, 2, 2)
-            x_exp = torch.Tensor(solve(A.permute(0, 2, 1).numpy(), b.permute(2, 1, 0).numpy()))
-            A = cast(A).permute(0, 2, 1)
-            b = cast(b).permute(2, 1, 0)
-            assert not A.is_contiguous() and not b.is_contiguous(), "contiguous inputs"
-            L = torch.cholesky(A, upper)
-            x = torch.cholesky_solve(b, L, upper=upper)
-            self.assertEqual(x, cast(x_exp))
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_cholesky_solve_batched_non_contiguous(self):
-        self._test_cholesky_solve_batched_non_contiguous(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_solve_batched_many_batches(self, cast):
-        from common_utils import cholesky_solve_test_helper
-
-        for upper in [True, False]:
-            b, A, L = cholesky_solve_test_helper((5, 256, 256), (5, 10), cast, upper)
-            x = torch.cholesky_solve(b, L, upper)
-            self.assertEqual(torch.matmul(A, x), b.expand(A.shape[:-2] + (5, 10)))
-
-            b, A, L = cholesky_solve_test_helper((5,), (512, 512, 5, 10), cast, upper)
-            x = torch.cholesky_solve(b, L, upper)
-            self.assertEqual(torch.matmul(A, x), b)
-
-    @skipIfNoLapack
-    @slowTest
-    def test_cholesky_solve_batched_many_batches(self):
-        self._test_cholesky_solve_batched_many_batches(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_solve_batched_broadcasting(self, cast):
-        from numpy.linalg import solve
-        from common_utils import random_symmetric_pd_matrix
-
-        def run_test(A_dims, b_dims, cast, upper):
-            A_matrix_size = A_dims[-1]
-            A_batch_dims = A_dims[:-2]
-            A = random_symmetric_pd_matrix(A_matrix_size, *A_batch_dims)
-            b = torch.randn(*b_dims)
-            x_exp = torch.Tensor(solve(A.numpy(), b.numpy()))
-            A, b = cast(A), cast(b)
-            L = torch.cholesky(A, upper)
-            x = torch.cholesky_solve(b, L, upper=upper)
-            self.assertEqual(x, cast(x_exp))
-
-        # test against numpy.linalg.solve
-        for upper in [True, False]:
-            run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), cast, upper)  # no broadcasting
-            run_test((2, 1, 3, 4, 4), (4, 6), cast, upper)  # broadcasting b
-            run_test((4, 4), (2, 1, 3, 4, 2), cast, upper)  # broadcasting A
-            run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), cast, upper)  # broadcasting A & b
-
-    @skipIfNoLapack
-    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
-    def test_cholesky_solve_batched_broadcasting(self):
-        self._test_cholesky_solve_batched_broadcasting(self, lambda t: t)
-
-    @staticmethod
-    def _test_cholesky_inverse(self, cast):
-        from common_utils import random_symmetric_pd_matrix
-        a = cast(random_symmetric_pd_matrix(5))
-
-        # compute inverse directly
-        inv0 = torch.inverse(a)
-
-        # default case
-        chol = torch.cholesky(a)
-        inv1 = torch.cholesky_inverse(chol, False)
-        self.assertLessEqual(inv0.dist(inv1), 1e-12)
-
-        # upper Triangular Test
-        chol = torch.cholesky(a, True)
-        inv1 = torch.cholesky_inverse(chol, True)
-        self.assertLessEqual(inv0.dist(inv1), 1e-12)
-
-        # lower Triangular Test
-        chol = torch.cholesky(a, False)
-        inv1 = torch.cholesky_inverse(chol, False)
-        self.assertLessEqual(inv0.dist(inv1), 1e-12)
-
-    @skipIfNoLapack
-    def test_cholesky_inverse(self):
-        self._test_cholesky_inverse(self, lambda t: t)
-
     def test_numel(self):
         b = torch.ByteTensor(3, 100, 100)
         self.assertEqual(b.nelement(), 3 * 100 * 100)
@@ -7371,641 +3807,6 @@ class _TestTorchMixin(torchtest):
         sequence.add_(start - 1)
         return sequence.resize_(*size)
 
-    @staticmethod
-    def _test_index(self, conv_fn):
-
-        def consec(size, start=1):
-            sequence = torch.ones(int(torch.Tensor(size).prod(0))).cumsum(0)
-            sequence.add_(start - 1)
-            return sequence.view(*size)
-
-        reference = conv_fn(consec((3, 3, 3)))
-
-        # empty tensor indexing
-        self.assertEqual(reference[conv_fn(torch.LongTensor())], reference.new(0, 3, 3))
-
-        self.assertEqual(reference[0], consec((3, 3)), 0)
-        self.assertEqual(reference[1], consec((3, 3), 10), 0)
-        self.assertEqual(reference[2], consec((3, 3), 19), 0)
-        self.assertEqual(reference[0, 1], consec((3,), 4), 0)
-        self.assertEqual(reference[0:2], consec((2, 3, 3)), 0)
-        self.assertEqual(reference[2, 2, 2], 27, 0)
-        self.assertEqual(reference[:], consec((3, 3, 3)), 0)
-
-        # indexing with Ellipsis
-        self.assertEqual(reference[..., 2], torch.Tensor([[3, 6, 9],
-                                                          [12, 15, 18],
-                                                          [21, 24, 27]]), 0)
-        self.assertEqual(reference[0, ..., 2], torch.Tensor([3, 6, 9]), 0)
-        self.assertEqual(reference[..., 2], reference[:, :, 2], 0)
-        self.assertEqual(reference[0, ..., 2], reference[0, :, 2], 0)
-        self.assertEqual(reference[0, 2, ...], reference[0, 2], 0)
-        self.assertEqual(reference[..., 2, 2, 2], 27, 0)
-        self.assertEqual(reference[2, ..., 2, 2], 27, 0)
-        self.assertEqual(reference[2, 2, ..., 2], 27, 0)
-        self.assertEqual(reference[2, 2, 2, ...], 27, 0)
-        self.assertEqual(reference[...], reference, 0)
-
-        reference_5d = conv_fn(consec((3, 3, 3, 3, 3)))
-        self.assertEqual(reference_5d[..., 1, 0], reference_5d[:, :, :, 1, 0], 0)
-        self.assertEqual(reference_5d[2, ..., 1, 0], reference_5d[2, :, :, 1, 0], 0)
-        self.assertEqual(reference_5d[2, 1, 0, ..., 1], reference_5d[2, 1, 0, :, 1], 0)
-        self.assertEqual(reference_5d[...], reference_5d, 0)
-
-        # LongTensor indexing
-        reference = conv_fn(consec((5, 5, 5)))
-        idx = conv_fn(torch.LongTensor([2, 4]))
-        self.assertEqual(reference[idx], torch.stack([reference[2], reference[4]]))
-        # TODO: enable one indexing is implemented like in numpy
-        # self.assertEqual(reference[2, idx], torch.stack([reference[2, 2], reference[2, 4]]))
-        # self.assertEqual(reference[3, idx, 1], torch.stack([reference[3, 2], reference[3, 4]])[:, 1])
-
-        # None indexing
-        self.assertEqual(reference[2, None], reference[2].unsqueeze(0))
-        self.assertEqual(reference[2, None, None], reference[2].unsqueeze(0).unsqueeze(0))
-        self.assertEqual(reference[2:4, None], reference[2:4].unsqueeze(1))
-        self.assertEqual(reference[None, 2, None, None], reference.unsqueeze(0)[:, 2].unsqueeze(0).unsqueeze(0))
-        self.assertEqual(reference[None, 2:5, None, None], reference.unsqueeze(0)[:, 2:5].unsqueeze(2).unsqueeze(2))
-
-        # indexing 0-length slice
-        self.assertEqual(torch.empty(0, 5, 5), reference[slice(0)])
-        self.assertEqual(torch.empty(0, 5), reference[slice(0), 2])
-        self.assertEqual(torch.empty(0, 5), reference[2, slice(0)])
-        self.assertEqual(torch.tensor([]), reference[2, 1:1, 2])
-
-        # indexing with step
-        reference = consec((10, 10, 10))
-        self.assertEqual(reference[1:5:2], torch.stack([reference[1], reference[3]], 0))
-        self.assertEqual(reference[1:6:2], torch.stack([reference[1], reference[3], reference[5]], 0))
-        self.assertEqual(reference[1:9:4], torch.stack([reference[1], reference[5]], 0))
-        self.assertEqual(reference[2:4, 1:5:2], torch.stack([reference[2:4, 1], reference[2:4, 3]], 1))
-        self.assertEqual(reference[3, 1:6:2], torch.stack([reference[3, 1], reference[3, 3], reference[3, 5]], 0))
-        self.assertEqual(reference[None, 2, 1:9:4], torch.stack([reference[2, 1], reference[2, 5]], 0).unsqueeze(0))
-        self.assertEqual(reference[:, 2, 1:6:2],
-                         torch.stack([reference[:, 2, 1], reference[:, 2, 3], reference[:, 2, 5]], 1))
-
-        lst = [list(range(i, i + 10)) for i in range(0, 100, 10)]
-        tensor = conv_fn(torch.DoubleTensor(lst))
-        for _i in range(100):
-            idx1_start = random.randrange(10)
-            idx1_end = idx1_start + random.randrange(1, 10 - idx1_start + 1)
-            idx1_step = random.randrange(1, 8)
-            idx1 = slice(idx1_start, idx1_end, idx1_step)
-            if random.randrange(2) == 0:
-                idx2_start = random.randrange(10)
-                idx2_end = idx2_start + random.randrange(1, 10 - idx2_start + 1)
-                idx2_step = random.randrange(1, 8)
-                idx2 = slice(idx2_start, idx2_end, idx2_step)
-                lst_indexed = list(map(lambda l: l[idx2], lst[idx1]))
-                tensor_indexed = tensor[idx1, idx2]
-            else:
-                lst_indexed = lst[idx1]
-                tensor_indexed = tensor[idx1]
-            self.assertEqual(torch.DoubleTensor(lst_indexed), tensor_indexed)
-
-        self.assertRaises(ValueError, lambda: reference[1:9:0])
-        self.assertRaises(ValueError, lambda: reference[1:9:-1])
-
-        self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1])
-        self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1:1])
-        self.assertRaises(IndexError, lambda: reference[3, 3, 3, 3, 3, 3, 3, 3])
-
-        self.assertRaises(IndexError, lambda: reference[0.0])
-        self.assertRaises(TypeError, lambda: reference[0.0:2.0])
-        self.assertRaises(IndexError, lambda: reference[0.0, 0.0:2.0])
-        self.assertRaises(IndexError, lambda: reference[0.0, :, 0.0:2.0])
-        self.assertRaises(IndexError, lambda: reference[0.0, ..., 0.0:2.0])
-        self.assertRaises(IndexError, lambda: reference[0.0, :, 0.0])
-
-        def delitem():
-            del reference[0]
-
-        self.assertRaises(TypeError, delitem)
-
-    def test_index(self):
-        self._test_index(self, lambda x: x)
-
-    @staticmethod
-    def _test_advancedindex(self, conv_fn):
-        # Tests for Integer Array Indexing, Part I - Purely integer array
-        # indexing
-
-        def consec(size, start=1):
-            numel = reduce(lambda x, y: x * y, size, 1)
-            sequence = torch.ones(numel).cumsum(0)
-            sequence.add_(start - 1)
-            return sequence.view(*size)
-
-        # pick a random valid indexer type
-        def ri(indices):
-            choice = random.randint(0, 2)
-            if choice == 0:
-                return conv_fn(torch.LongTensor(indices))
-            elif choice == 1:
-                return list(indices)
-            else:
-                return tuple(indices)
-
-        def validate_indexing(x):
-            self.assertEqual(x[[0]], consec((1,)))
-            self.assertEqual(x[ri([0]), ], consec((1,)))
-            self.assertEqual(x[ri([3]), ], consec((1,), 4))
-            self.assertEqual(x[[2, 3, 4]], consec((3,), 3))
-            self.assertEqual(x[ri([2, 3, 4]), ], consec((3,), 3))
-            self.assertEqual(x[ri([0, 2, 4]), ], torch.Tensor([1, 3, 5]))
-
-        def validate_setting(x):
-            dtype = x.type()
-            x[[0]] = -2
-            self.assertEqual(x[[0]], torch.Tensor([-2]).type(dtype))
-            x[[0]] = -1
-            self.assertEqual(x[ri([0]), ], torch.Tensor([-1]).type(dtype))
-            x[[2, 3, 4]] = 4
-            self.assertEqual(x[[2, 3, 4]], torch.Tensor([4, 4, 4]).type(dtype))
-            x[ri([2, 3, 4]), ] = 3
-            self.assertEqual(x[ri([2, 3, 4]), ], torch.Tensor([3, 3, 3]).type(dtype))
-            x[ri([0, 2, 4]), ] = conv_fn(torch.Tensor([5, 4, 3])).type(dtype)
-            self.assertEqual(x[ri([0, 2, 4]), ], torch.Tensor([5, 4, 3]).type(dtype))
-
-        # First, we will test indexing to generate return values
-
-        # Case 1: Purely Integer Array Indexing
-        reference = conv_fn(consec((10,)))
-        validate_indexing(reference)
-        validate_indexing(reference.type(torch.half))
-
-        # setting values
-        validate_setting(reference)
-        validate_setting(reference.type(torch.half))
-
-        # Tensor with stride != 1
-
-        # strided is [1, 3, 5, 7]
-        reference = conv_fn(consec((10,)))
-        strided = conv_fn(torch.Tensor())
-        strided.set_(reference.storage(), storage_offset=0,
-                     size=torch.Size([4]), stride=[2])
-
-        self.assertEqual(strided[[0]], torch.Tensor([1]))
-        self.assertEqual(strided[ri([0]), ], torch.Tensor([1]))
-        self.assertEqual(strided[ri([3]), ], torch.Tensor([7]))
-        self.assertEqual(strided[[1, 2]], torch.Tensor([3, 5]))
-        self.assertEqual(strided[ri([1, 2]), ], torch.Tensor([3, 5]))
-        self.assertEqual(strided[ri([[2, 1], [0, 3]]), ],
-                         torch.Tensor([[5, 3], [1, 7]]))
-
-        # stride is [4, 8]
-        strided = conv_fn(torch.Tensor())
-        strided.set_(reference.storage(), storage_offset=4,
-                     size=torch.Size([2]), stride=[4])
-        self.assertEqual(strided[[0]], torch.Tensor([5]))
-        self.assertEqual(strided[ri([0]), ], torch.Tensor([5]))
-        self.assertEqual(strided[ri([1]), ], torch.Tensor([9]))
-        self.assertEqual(strided[[0, 1]], torch.Tensor([5, 9]))
-        self.assertEqual(strided[ri([0, 1]), ], torch.Tensor([5, 9]))
-        self.assertEqual(strided[ri([[0, 1], [1, 0]]), ],
-                         torch.Tensor([[5, 9], [9, 5]]))
-
-        # reference is 1 2
-        #              3 4
-        #              5 6
-        reference = conv_fn(consec((3, 2)))
-        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([1, 3, 5]))
-        self.assertEqual(reference[ri([0, 1, 2]), ri([1])], torch.Tensor([2, 4, 6]))
-        self.assertEqual(reference[ri([0]), ri([0])], consec((1,)))
-        self.assertEqual(reference[ri([2]), ri([1])], consec((1,), 6))
-        self.assertEqual(reference[[ri([0, 0]), ri([0, 1])]], torch.Tensor([1, 2]))
-        self.assertEqual(reference[[ri([0, 1, 1, 0, 2]), ri([1])]],
-                         torch.Tensor([2, 4, 4, 2, 6]))
-        self.assertEqual(reference[[ri([0, 0, 1, 1]), ri([0, 1, 0, 0])]],
-                         torch.Tensor([1, 2, 3, 3]))
-
-        rows = ri([[0, 0],
-                   [1, 2]])
-        columns = [0],
-        self.assertEqual(reference[rows, columns], torch.Tensor([[1, 1],
-                                                                [3, 5]]))
-
-        rows = ri([[0, 0],
-                   [1, 2]])
-        columns = ri([1, 0])
-        self.assertEqual(reference[rows, columns], torch.Tensor([[2, 1],
-                                                                [4, 5]]))
-        rows = ri([[0, 0],
-                   [1, 2]])
-        columns = ri([[0, 1],
-                      [1, 0]])
-        self.assertEqual(reference[rows, columns], torch.Tensor([[1, 2],
-                                                                [4, 5]]))
-
-        # setting values
-        reference[ri([0]), ri([1])] = -1
-        self.assertEqual(reference[ri([0]), ri([1])], torch.Tensor([-1]))
-        reference[ri([0, 1, 2]), ri([0])] = conv_fn(torch.Tensor([-1, 2, -4]))
-        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([-1,
-                         2, -4]))
-        reference[rows, columns] = conv_fn(torch.Tensor([[4, 6], [2, 3]]))
-        self.assertEqual(reference[rows, columns],
-                         torch.Tensor([[4, 6], [2, 3]]))
-
-        # Verify still works with Transposed (i.e. non-contiguous) Tensors
-
-        reference = conv_fn(torch.Tensor([[0, 1, 2, 3],
-                                          [4, 5, 6, 7],
-                                          [8, 9, 10, 11]])).t_()
-
-        # Transposed: [[0, 4, 8],
-        #              [1, 5, 9],
-        #              [2, 6, 10],
-        #              [3, 7, 11]]
-
-        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([0, 1,
-                         2]))
-        self.assertEqual(reference[ri([0, 1, 2]), ri([1])], torch.Tensor([4, 5,
-                         6]))
-        self.assertEqual(reference[ri([0]), ri([0])], torch.Tensor([0]))
-        self.assertEqual(reference[ri([2]), ri([1])], torch.Tensor([6]))
-        self.assertEqual(reference[[ri([0, 0]), ri([0, 1])]], torch.Tensor([0, 4]))
-        self.assertEqual(reference[[ri([0, 1, 1, 0, 3]), ri([1])]],
-                         torch.Tensor([4, 5, 5, 4, 7]))
-        self.assertEqual(reference[[ri([0, 0, 1, 1]), ri([0, 1, 0, 0])]],
-                         torch.Tensor([0, 4, 1, 1]))
-
-        rows = ri([[0, 0],
-                   [1, 2]])
-        columns = [0],
-        self.assertEqual(reference[rows, columns], torch.Tensor([[0, 0],
-                                                                [1, 2]]))
-
-        rows = ri([[0, 0],
-                   [1, 2]])
-        columns = ri([1, 0])
-        self.assertEqual(reference[rows, columns], torch.Tensor([[4, 0],
-                                                                [5, 2]]))
-        rows = ri([[0, 0],
-                   [1, 3]])
-        columns = ri([[0, 1],
-                      [1, 2]])
-        self.assertEqual(reference[rows, columns], torch.Tensor([[0, 4],
-                                                                [5, 11]]))
-
-        # setting values
-        reference[ri([0]), ri([1])] = -1
-        self.assertEqual(reference[ri([0]), ri([1])], torch.Tensor([-1]))
-        reference[ri([0, 1, 2]), ri([0])] = conv_fn(torch.Tensor([-1, 2, -4]))
-        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([-1,
-                         2, -4]))
-        reference[rows, columns] = conv_fn(torch.Tensor([[4, 6], [2, 3]]))
-        self.assertEqual(reference[rows, columns],
-                         torch.Tensor([[4, 6], [2, 3]]))
-
-        # stride != 1
-
-        # strided is [[1 3 5 7],
-        #             [9 11 13 15]]
-
-        reference = conv_fn(torch.arange(0., 24).view(3, 8))
-        strided = conv_fn(torch.Tensor())
-        strided.set_(reference.storage(), 1, size=torch.Size([2, 4]),
-                     stride=[8, 2])
-
-        self.assertEqual(strided[ri([0, 1]), ri([0])], torch.Tensor([1, 9]))
-        self.assertEqual(strided[ri([0, 1]), ri([1])], torch.Tensor([3, 11]))
-        self.assertEqual(strided[ri([0]), ri([0])], torch.Tensor([1]))
-        self.assertEqual(strided[ri([1]), ri([3])], torch.Tensor([15]))
-        self.assertEqual(strided[[ri([0, 0]), ri([0, 3])]], torch.Tensor([1, 7]))
-        self.assertEqual(strided[[ri([1]), ri([0, 1, 1, 0, 3])]],
-                         torch.Tensor([9, 11, 11, 9, 15]))
-        self.assertEqual(strided[[ri([0, 0, 1, 1]), ri([0, 1, 0, 0])]],
-                         torch.Tensor([1, 3, 9, 9]))
-
-        rows = ri([[0, 0],
-                   [1, 1]])
-        columns = [0],
-        self.assertEqual(strided[rows, columns], torch.Tensor([[1, 1],
-                                                              [9, 9]]))
-
-        rows = ri([[0, 1],
-                   [1, 0]])
-        columns = ri([1, 2])
-        self.assertEqual(strided[rows, columns], torch.Tensor([[3, 13],
-                                                              [11, 5]]))
-        rows = ri([[0, 0],
-                   [1, 1]])
-        columns = ri([[0, 1],
-                      [1, 2]])
-        self.assertEqual(strided[rows, columns], torch.Tensor([[1, 3],
-                                                              [11, 13]]))
-
-        # setting values
-
-        # strided is [[10, 11],
-        #             [17, 18]]
-
-        reference = conv_fn(torch.arange(0., 24).view(3, 8))
-        strided = conv_fn(torch.Tensor())
-        strided.set_(reference.storage(), 10, size=torch.Size([2, 2]),
-                     stride=[7, 1])
-        self.assertEqual(strided[ri([0]), ri([1])], torch.Tensor([11]))
-        strided[ri([0]), ri([1])] = -1
-        self.assertEqual(strided[ri([0]), ri([1])], torch.Tensor([-1]))
-
-        reference = conv_fn(torch.arange(0., 24).view(3, 8))
-        strided = conv_fn(torch.Tensor())
-        strided.set_(reference.storage(), 10, size=torch.Size([2, 2]),
-                     stride=[7, 1])
-        self.assertEqual(strided[ri([0, 1]), ri([1, 0])], torch.Tensor([11,
-                         17]))
-        strided[ri([0, 1]), ri([1, 0])] = conv_fn(torch.Tensor([-1, 2]))
-        self.assertEqual(strided[ri([0, 1]), ri([1, 0])], torch.Tensor([-1,
-                         2]))
-
-        reference = conv_fn(torch.arange(0., 24).view(3, 8))
-        strided = conv_fn(torch.Tensor())
-        strided.set_(reference.storage(), 10, size=torch.Size([2, 2]),
-                     stride=[7, 1])
-
-        rows = ri([[0],
-                   [1]])
-        columns = ri([[0, 1],
-                      [0, 1]])
-        self.assertEqual(strided[rows, columns],
-                         torch.Tensor([[10, 11], [17, 18]]))
-        strided[rows, columns] = conv_fn(torch.Tensor([[4, 6], [2, 3]]))
-        self.assertEqual(strided[rows, columns],
-                         torch.Tensor([[4, 6], [2, 3]]))
-
-        # Tests using less than the number of dims, and ellipsis
-
-        # reference is 1 2
-        #              3 4
-        #              5 6
-        reference = conv_fn(consec((3, 2)))
-        self.assertEqual(reference[ri([0, 2]), ], torch.Tensor([[1, 2], [5, 6]]))
-        self.assertEqual(reference[ri([1]), ...], torch.Tensor([[3, 4]]))
-        self.assertEqual(reference[..., ri([1])], torch.Tensor([[2], [4], [6]]))
-
-        # verify too many indices fails
-        with self.assertRaises(IndexError):
-            reference[ri([1]), ri([0, 2]), ri([3])]
-
-        # test invalid index fails
-        reference = conv_fn(torch.empty(10))
-        # can't test cuda because it is a device assert
-        if not reference.is_cuda:
-            for err_idx in (10, -11):
-                with self.assertRaisesRegex(IndexError, r'out of'):
-                    reference[err_idx]
-                with self.assertRaisesRegex(IndexError, r'out of'):
-                    reference[conv_fn(torch.LongTensor([err_idx]))]
-                with self.assertRaisesRegex(IndexError, r'out of'):
-                    reference[[err_idx]]
-
-        if TEST_NUMPY:
-            # we use numpy to compare against, to verify that our advanced
-            # indexing semantics are the same, and also for ease of test
-            # writing
-
-            def tensor_indices_to_np(tensor, indices):
-                # convert the Torch Tensor to a numpy array
-                if (tensor.is_cuda):
-                    tensor = tensor.cpu()
-                npt = tensor.numpy()
-
-                # convert indices
-                idxs = tuple(i.tolist() if isinstance(i, torch.LongTensor) else
-                             i for i in indices)
-
-                return npt, idxs
-
-            def get_numpy(tensor, indices):
-                npt, idxs = tensor_indices_to_np(tensor, indices)
-
-                # index and return as a Torch Tensor
-                return torch.Tensor(npt[idxs])
-
-            def set_numpy(tensor, indices, value):
-                if not isinstance(value, int):
-                    if value.is_cuda:
-                        value = value.cpu()
-                    value = value.numpy()
-
-                npt, idxs = tensor_indices_to_np(tensor, indices)
-                npt[idxs] = value
-                return npt
-
-            def assert_get_eq(tensor, indexer):
-                self.assertEqual(tensor[indexer],
-                                 conv_fn(get_numpy(tensor, indexer)))
-
-            def assert_set_eq(tensor, indexer, val):
-                pyt = tensor.clone()
-                numt = tensor.clone()
-                pyt[indexer] = val
-                numt = conv_fn(torch.Tensor(set_numpy(numt, indexer, val)))
-                self.assertEqual(pyt, numt)
-
-            def assert_backward_eq(tensor, indexer):
-                cpu = tensor.float().clone().detach().requires_grad_(True)
-                outcpu = cpu[indexer]
-                gOcpu = torch.rand_like(outcpu)
-                outcpu.backward(gOcpu)
-                gpu = cpu.cuda().detach().requires_grad_(True)
-                outgpu = gpu[indexer]
-                outgpu.backward(gOcpu.cuda())
-                self.assertEqual(cpu.grad, gpu.grad)
-
-            def get_set_tensor(indexed, indexer):
-                set_size = indexed[indexer].size()
-                set_count = indexed[indexer].numel()
-                set_tensor = conv_fn(torch.randperm(set_count).view(set_size).double())
-                return set_tensor
-
-            # Tensor is  0  1  2  3  4
-            #            5  6  7  8  9
-            #           10 11 12 13 14
-            #           15 16 17 18 19
-            reference = conv_fn(torch.arange(0., 20).view(4, 5))
-
-            indices_to_test = [
-                # grab the second, fourth columns
-                [slice(None), [1, 3]],
-
-                # first, third rows,
-                [[0, 2], slice(None)],
-
-                # weird shape
-                [slice(None), [[0, 1],
-                               [2, 3]]],
-                # negatives
-                [[-1], [0]],
-                [[0, 2], [-1]],
-                [slice(None), [-1]],
-            ]
-
-            # only test dupes on gets
-            get_indices_to_test = indices_to_test + [[slice(None), [0, 1, 1, 2, 2]]]
-
-            for indexer in get_indices_to_test:
-                assert_get_eq(reference, indexer)
-                if torch.cuda.is_available():
-                    assert_backward_eq(reference, indexer)
-
-            for indexer in indices_to_test:
-                assert_set_eq(reference, indexer, 44)
-                assert_set_eq(reference,
-                              indexer,
-                              get_set_tensor(reference, indexer))
-
-            reference = conv_fn(torch.arange(0., 160).view(4, 8, 5))
-
-            indices_to_test = [
-                [slice(None), slice(None), [0, 3, 4]],
-                [slice(None), [2, 4, 5, 7], slice(None)],
-                [[2, 3], slice(None), slice(None)],
-                [slice(None), [0, 2, 3], [1, 3, 4]],
-                [slice(None), [0], [1, 2, 4]],
-                [slice(None), [0, 1, 3], [4]],
-                [slice(None), [[0, 1], [1, 0]], [[2, 3]]],
-                [slice(None), [[0, 1], [2, 3]], [[0]]],
-                [slice(None), [[5, 6]], [[0, 3], [4, 4]]],
-                [[0, 2, 3], [1, 3, 4], slice(None)],
-                [[0], [1, 2, 4], slice(None)],
-                [[0, 1, 3], [4], slice(None)],
-                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None)],
-                [[[0, 1], [1, 0]], [[2, 3]], slice(None)],
-                [[[0, 1], [2, 3]], [[0]], slice(None)],
-                [[[2, 1]], [[0, 3], [4, 4]], slice(None)],
-                [[[2]], [[0, 3], [4, 1]], slice(None)],
-                # non-contiguous indexing subspace
-                [[0, 2, 3], slice(None), [1, 3, 4]],
-
-                # less dim, ellipsis
-                [[0, 2], ],
-                [[0, 2], slice(None)],
-                [[0, 2], Ellipsis],
-                [[0, 2], slice(None), Ellipsis],
-                [[0, 2], Ellipsis, slice(None)],
-                [[0, 2], [1, 3]],
-                [[0, 2], [1, 3], Ellipsis],
-                [Ellipsis, [1, 3], [2, 3]],
-                [Ellipsis, [2, 3, 4]],
-                [Ellipsis, slice(None), [2, 3, 4]],
-                [slice(None), Ellipsis, [2, 3, 4]],
-
-                # ellipsis counts for nothing
-                [Ellipsis, slice(None), slice(None), [0, 3, 4]],
-                [slice(None), Ellipsis, slice(None), [0, 3, 4]],
-                [slice(None), slice(None), Ellipsis, [0, 3, 4]],
-                [slice(None), slice(None), [0, 3, 4], Ellipsis],
-                [Ellipsis, [[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None)],
-                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], Ellipsis, slice(None)],
-                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None), Ellipsis],
-            ]
-
-            for indexer in indices_to_test:
-                assert_get_eq(reference, indexer)
-                assert_set_eq(reference, indexer, 212)
-                assert_set_eq(reference,
-                              indexer,
-                              get_set_tensor(reference, indexer))
-                if torch.cuda.is_available():
-                    assert_backward_eq(reference, indexer)
-
-            reference = conv_fn(torch.arange(0., 1296).view(3, 9, 8, 6))
-
-            indices_to_test = [
-                [slice(None), slice(None), slice(None), [0, 3, 4]],
-                [slice(None), slice(None), [2, 4, 5, 7], slice(None)],
-                [slice(None), [2, 3], slice(None), slice(None)],
-                [[1, 2], slice(None), slice(None), slice(None)],
-                [slice(None), slice(None), [0, 2, 3], [1, 3, 4]],
-                [slice(None), slice(None), [0], [1, 2, 4]],
-                [slice(None), slice(None), [0, 1, 3], [4]],
-                [slice(None), slice(None), [[0, 1], [1, 0]], [[2, 3]]],
-                [slice(None), slice(None), [[0, 1], [2, 3]], [[0]]],
-                [slice(None), slice(None), [[5, 6]], [[0, 3], [4, 4]]],
-                [slice(None), [0, 2, 3], [1, 3, 4], slice(None)],
-                [slice(None), [0], [1, 2, 4], slice(None)],
-                [slice(None), [0, 1, 3], [4], slice(None)],
-                [slice(None), [[0, 1], [3, 4]], [[2, 3], [0, 1]], slice(None)],
-                [slice(None), [[0, 1], [3, 4]], [[2, 3]], slice(None)],
-                [slice(None), [[0, 1], [3, 2]], [[0]], slice(None)],
-                [slice(None), [[2, 1]], [[0, 3], [6, 4]], slice(None)],
-                [slice(None), [[2]], [[0, 3], [4, 2]], slice(None)],
-                [[0, 1, 2], [1, 3, 4], slice(None), slice(None)],
-                [[0], [1, 2, 4], slice(None), slice(None)],
-                [[0, 1, 2], [4], slice(None), slice(None)],
-                [[[0, 1], [0, 2]], [[2, 4], [1, 5]], slice(None), slice(None)],
-                [[[0, 1], [1, 2]], [[2, 0]], slice(None), slice(None)],
-                [[[2, 2]], [[0, 3], [4, 5]], slice(None), slice(None)],
-                [[[2]], [[0, 3], [4, 5]], slice(None), slice(None)],
-                [slice(None), [3, 4, 6], [0, 2, 3], [1, 3, 4]],
-                [slice(None), [2, 3, 4], [1, 3, 4], [4]],
-                [slice(None), [0, 1, 3], [4], [1, 3, 4]],
-                [slice(None), [6], [0, 2, 3], [1, 3, 4]],
-                [slice(None), [2, 3, 5], [3], [4]],
-                [slice(None), [0], [4], [1, 3, 4]],
-                [slice(None), [6], [0, 2, 3], [1]],
-                [slice(None), [[0, 3], [3, 6]], [[0, 1], [1, 3]], [[5, 3], [1, 2]]],
-                [[2, 2, 1], [0, 2, 3], [1, 3, 4], slice(None)],
-                [[2, 0, 1], [1, 2, 3], [4], slice(None)],
-                [[0, 1, 2], [4], [1, 3, 4], slice(None)],
-                [[0], [0, 2, 3], [1, 3, 4], slice(None)],
-                [[0, 2, 1], [3], [4], slice(None)],
-                [[0], [4], [1, 3, 4], slice(None)],
-                [[1], [0, 2, 3], [1], slice(None)],
-                [[[1, 2], [1, 2]], [[0, 1], [2, 3]], [[2, 3], [3, 5]], slice(None)],
-
-                # less dim, ellipsis
-                [Ellipsis, [0, 3, 4]],
-                [Ellipsis, slice(None), [0, 3, 4]],
-                [Ellipsis, slice(None), slice(None), [0, 3, 4]],
-                [slice(None), Ellipsis, [0, 3, 4]],
-                [slice(None), slice(None), Ellipsis, [0, 3, 4]],
-                [slice(None), [0, 2, 3], [1, 3, 4]],
-                [slice(None), [0, 2, 3], [1, 3, 4], Ellipsis],
-                [Ellipsis, [0, 2, 3], [1, 3, 4], slice(None)],
-                [[0], [1, 2, 4]],
-                [[0], [1, 2, 4], slice(None)],
-                [[0], [1, 2, 4], Ellipsis],
-                [[0], [1, 2, 4], Ellipsis, slice(None)],
-                [[1], ],
-                [[0, 2, 1], [3], [4]],
-                [[0, 2, 1], [3], [4], slice(None)],
-                [[0, 2, 1], [3], [4], Ellipsis],
-                [Ellipsis, [0, 2, 1], [3], [4]],
-            ]
-
-            for indexer in indices_to_test:
-                assert_get_eq(reference, indexer)
-                assert_set_eq(reference, indexer, 1333)
-                assert_set_eq(reference,
-                              indexer,
-                              get_set_tensor(reference, indexer))
-            indices_to_test += [
-                [slice(None), slice(None), [[0, 1], [1, 0]], [[2, 3], [3, 0]]],
-                [slice(None), slice(None), [[2]], [[0, 3], [4, 4]]],
-            ]
-            for indexer in indices_to_test:
-                assert_get_eq(reference, indexer)
-                assert_set_eq(reference, indexer, 1333)
-                if torch.cuda.is_available():
-                    assert_backward_eq(reference, indexer)
-
-    def test_advancedindex(self):
-        self._test_advancedindex(self, lambda x: x)
-
-    @staticmethod
-    def _test_advancedindex_big(self, conv_fn):
-        reference = conv_fn(torch.arange(0, 123344).int())
-
-        self.assertEqual(reference[[0, 123, 44488, 68807, 123343], ],
-                         torch.LongTensor([0, 123, 44488, 68807, 123343]))
-
-    def test_advancedindex_big(self):
-        self._test_advancedindex_big(self, lambda x: x)
-
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_empty_storage_view(self):
         # we should be able to "modify" slices of a 0-element
@@ -8013,40 +3814,6 @@ class _TestTorchMixin(torchtest):
         # trying to resize its storage
         t = torch.from_numpy(np.empty((0, 4)))
         t[:, 1::2] *= 1
-
-    def test_atan2(self):
-        def _test_atan2_with_size(size, device):
-            a = torch.rand(size=size, device=device, dtype=torch.double)
-            b = torch.rand(size=size, device=device, dtype=torch.double)
-            actual = a.atan2(b)
-            x = a.view(-1)
-            y = b.view(-1)
-            expected = torch.tensor([math.atan2(x[i].item(), y[i].item()) for i in range(x.numel())],
-                                    device=device, dtype=torch.double)
-            self.assertTrue(torch.allclose(expected, actual.view(-1), rtol=0, atol=0.02))
-        for device in torch.testing.get_all_device_types():
-            _test_atan2_with_size((2, 2), device)
-            _test_atan2_with_size((3, 3), device)
-            _test_atan2_with_size((5, 5), device)
-
-    def test_atan2_edgecases(self):
-        def _test_atan2(x, y, expected, device, dtype):
-            expected_tensor = torch.tensor([expected], dtype=dtype, device=device)
-            x_tensor = torch.tensor([x], dtype=dtype, device=device)
-            y_tensor = torch.tensor([y], dtype=dtype, device=device)
-            actual = torch.atan2(y_tensor, x_tensor)
-            self.assertTrue(torch.allclose(expected_tensor, actual, rtol=0, atol=0.02))
-        for device in torch.testing.get_all_device_types():
-            for dtype in [torch.float, torch.double]:
-                _test_atan2(0, 0, 0, device, dtype)
-                _test_atan2(0, 1, math.pi / 2, device, dtype)
-                _test_atan2(0, -1, math.pi / -2, device, dtype)
-                _test_atan2(-1, 0, math.pi, device, dtype)
-                _test_atan2(1, 0, 0, device, dtype)
-                _test_atan2(-1, -1, math.pi * -3 / 4 , device, dtype)
-                _test_atan2(1, 1, math.pi / 4 , device, dtype)
-                _test_atan2(1, -1, math.pi / -4 , device, dtype)
-                _test_atan2(-1, 1, math.pi * 3 / 4 , device, dtype)
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_newaxis_numpy_comparison(self):
@@ -8143,39 +3910,6 @@ class _TestTorchMixin(torchtest):
         with self.assertRaises(IndexError):
             reference[0.0, :, 0.0] = 1
 
-    def test_index_copy(self):
-        for device in torch.testing.get_all_device_types():
-            num_copy, num_dest = 3, 20
-            dest = torch.randn(num_dest, 4, 5, device=device)
-            src = torch.randn(num_copy, 4, 5, device=device)
-            idx = torch.randperm(num_dest, device=device).narrow(0, 0, num_copy)
-            dest2 = dest.clone()
-            dest.index_copy_(0, idx, src)
-            for i in range(idx.size(0)):
-                dest2[idx[i]] = src[i]
-            self.assertEqual(dest, dest2, 0)
-
-            dest = torch.randn(num_dest, device=device)
-            src = torch.randn(num_copy, device=device)
-            idx = torch.randperm(num_dest, device=device).narrow(0, 0, num_copy)
-            dest2 = dest.clone()
-            dest.index_copy_(0, idx, src)
-            for i in range(idx.size(0)):
-                dest2[idx[i]] = src[i]
-            self.assertEqual(dest, dest2, 0)
-
-            # Bool tensor
-            dest = torch.zeros(2, 2, dtype=torch.bool, device=device)
-            src = torch.tensor([[True, True], [True, True]], device=device)
-            index = torch.tensor([0, 1], device=device)
-            dest.index_copy_(0, index, src)
-            self.assertEqual(dest, torch.tensor([[True, True], [True, True]], device=device))
-
-            # Error cases
-            a = torch.randn(3, 5)
-            c = torch.zeros(3)
-            self.assertRaises(IndexError, lambda: a.index_copy_(dim=1, index=torch.tensor([3]), source=c))
-
     def test_index_add(self):
         num_copy, num_dest = 3, 3
         dest = torch.randn(num_dest, 4, 5)
@@ -8195,42 +3929,6 @@ class _TestTorchMixin(torchtest):
         for i in range(idx.size(0)):
             dest2[idx[i]] = dest2[idx[i]] + src[i]
         self.assertEqual(dest, dest2)
-
-    def test_index_fill(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                if dt == torch.half or dt == torch.bfloat16:
-                    continue
-
-                x = torch.tensor([[1, 2], [4, 5]], dtype=dt, device=device)
-                index = torch.tensor([0], device=device)
-                x.index_fill_(1, index, 0)
-                self.assertEqual(x, torch.tensor([[0, 2], [0, 5]], dtype=dt, device=device))
-
-    def test_index_select(self):
-        for device in torch.testing.get_all_device_types():
-            src = torch.randn(3, 4, 5, device=device)
-            # Index can be duplicated.
-            idx = torch.tensor([2, 1, 0, 1, 2], dtype=torch.long, device=device)
-            dest = torch.index_select(src, 0, idx)
-            self.assertEqual(dest.shape, (5, 4, 5))
-            for i in range(idx.size(0)):
-                self.assertEqual(dest[i], src[idx[i]])
-
-            # Check that 'out' is used correctly.
-            out = torch.randn(5 * 4 * 5, device=device)
-            dest = torch.index_select(src, 0, idx, out=out.view(5, 4, 5))
-            self.assertEqual(dest.shape, (5, 4, 5))
-            for i in range(idx.size(0)):
-                self.assertEqual(dest[i], src[idx[i]])
-            out.fill_(0.123)
-            self.assertEqual(out, dest.view(-1))  # Must point to the same storage.
-
-            # Bool tensor
-            src = torch.tensor([False, True, False, False], device=device, dtype=torch.bool)
-            idx = torch.tensor([1], dtype=torch.long, device=device)
-            dest = torch.index_select(src, 0, idx)
-            self.assertEqual(torch.tensor([True]), dest)
 
     def test_t(self):
         # Test 0D tensors
@@ -8273,14 +3971,6 @@ class _TestTorchMixin(torchtest):
         check(src.transpose(1, 2), idx)
         check(src.bool(), idx)
 
-    def test_take_empty(self):
-        for device in torch.testing.get_all_device_types():
-            for input_shape in [(0,), (0, 1, 2, 0), (1, 2, 3)]:
-                for indices_shape in [(0,), (0, 1, 2, 0)]:
-                    input = torch.empty(input_shape, device=device)
-                    indices = torch.empty(indices_shape, dtype=torch.int64, device=device)
-                    self.assertEqual(indices, torch.take(input, indices))
-
     def test_put_(self):
         def check(dst, idx, value):
             expected = dst.clone().view(-1).index_copy_(
@@ -8304,16 +3994,6 @@ class _TestTorchMixin(torchtest):
         src = torch.Tensor([1, 2, 3, 4])
         dst.put_(idx, src, accumulate=True)
         self.assertEqual(dst.tolist(), [[5, 7], [1, 1]])
-
-    def test_put_empty(self):
-        for device in torch.testing.get_all_device_types():
-            for dst_shape in [(0,), (0, 1, 2, 0), (1, 2, 3)]:
-                for indices_shape in [(0,), (0, 1, 2, 0)]:
-                    for accumulate in [False, True]:
-                        dst = torch.randn(dst_shape, device=device)
-                        indices = torch.empty(indices_shape, dtype=torch.int64, device=device)
-                        src = torch.randn(indices_shape, device=device)
-                        self.assertEqual(dst, dst.put_(indices, src, accumulate=accumulate))
 
     # Fill idx with valid indices.
     @staticmethod
@@ -8476,46 +4156,6 @@ class _TestTorchMixin(torchtest):
     def test_scatterFill(self):
         self._test_scatter_base(self, lambda t: t, 'scatter_', True)
 
-    def test_scatter_to_large_input(self):
-        for device in torch.testing.get_all_device_types():
-            input = torch.zeros(4, 4, device=device)
-            src = torch.ones(2, 2, device=device)
-            index = torch.tensor([[1], [2]], device=device, dtype=torch.long)
-            input.scatter_(0, index, src)
-            self.assertEqual(input, torch.tensor([[0, 0, 0, 0],
-                                                  [1, 0, 0, 0],
-                                                  [1, 0, 0, 0],
-                                                  [0, 0, 0, 0]], device=device))
-
-    def test_scatter_add_to_large_input(self):
-        for device in torch.testing.get_all_device_types():
-            input = torch.zeros(4, 4, device=device)
-            src = torch.ones(2, 2, device=device)
-            index = torch.tensor([[1], [2]], device=device, dtype=torch.long)
-            input.scatter_add_(0, index, src)
-            self.assertEqual(input, torch.tensor([[0, 0, 0, 0],
-                                                  [1, 0, 0, 0],
-                                                  [1, 0, 0, 0],
-                                                  [0, 0, 0, 0]], device=device))
-
-    def test_scatter_bool(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.tensor([[True, True, True], [True, True, True]], device=device)
-            res = torch.zeros(3, 3, dtype=torch.bool, device=device)
-            res = res.scatter_(0, torch.tensor([[0, 1, 2], [0, 1, 2]], device=device), x)
-            self.assertEqual(res, torch.tensor([[True, False, False],
-                                                [False, True, False],
-                                                [False, False, True]], device=device))
-
-    def test_scatter_add_bool(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.tensor([[True, True, True, True, True], [True, True, True, True, True]], device=device)
-            res = torch.zeros(3, 5, dtype=torch.bool, device=device)
-            res = res.scatter_add_(0, torch.tensor([[0, 1, 2, 0, 0], [2, 0, 0, 1, 2]], device=device), x)
-            self.assertEqual(res, torch.tensor([[True, True, True, True, True],
-                                                [False, True, False, True, False],
-                                                [True, False, True, False, True]], device=device))
-
     def test_masked_scatter(self):
         with warnings.catch_warnings(record=True) as w:
             for maskType in [torch.uint8, torch.bool]:
@@ -8557,52 +4197,6 @@ class _TestTorchMixin(torchtest):
         for wi in w:
             self.assertEqual(str(wi.message)[0:55], str(warn))
 
-    def test_masked_scatter_bool_tensor(self):
-        for device in torch.testing.get_all_device_types():
-            src = torch.tensor([True, True, True], device=device)
-            dst = torch.tensor([False, False, False], device=device)
-            mask = torch.tensor([False, True, False], device=device)
-
-            dst.masked_scatter_(mask, src)
-            self.assertEqual(dst, torch.tensor([False, True, False], device=device))
-
-            mask = torch.tensor([True, False, True], device=device)
-            dst = dst.masked_scatter(mask, src)
-            self.assertEqual(dst, torch.tensor([True, True, True], device=device))
-
-    def test_masked_select(self):
-        for device in torch.testing.get_all_device_types():
-            for dt in torch.testing.get_all_dtypes():
-                with warnings.catch_warnings(record=True) as w:
-                    for maskType in [torch.uint8, torch.bool]:
-                        num_src = 10
-                        src = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=dt, device=device)
-                        mask = torch.rand(num_src, device=device).clamp(0, 1).mul(2).floor().to(maskType)
-
-                        if dt == torch.bfloat16 and device == 'cuda':
-                            # remove once bfloat16 implemented on CUDA
-                            self.assertRaises(RuntimeError, lambda: src.masked_select(mask))
-                            continue
-
-                        if dt == torch.half and device == 'cpu':
-                            self.assertRaises(RuntimeError, lambda: src.masked_select(mask))
-                            continue
-
-                        dst = src.masked_select(mask)
-                        dst2 = []
-                        for i in range(num_src):
-                            if mask[i]:
-                                dst2 += [src[i]]
-                        self.assertEqual(dst, torch.tensor(dst2), 0)
-
-                        dst3 = torch.empty_like(src, device=device)
-                        torch.masked_select(src, mask, out=dst3)
-                        self.assertEqual(dst3, torch.Tensor(dst2), 0)
-            self.assertEqual(len(w), 1)
-
-            warn = 'masked_select received a mask with dtype torch.uint8,'
-            self.assertEqual(str(w[0].message)[0:53], str(warn))
-
     def test_masked_fill(self):
         with warnings.catch_warnings(record=True) as w:
             for dt in torch.testing.get_all_dtypes():
@@ -8634,17 +4228,6 @@ class _TestTorchMixin(torchtest):
             warn = 'masked_fill_ received a mask with dtype torch.uint8,'
             for wi in w:
                 self.assertEqual(str(wi.message)[0:52], str(warn))
-
-    def test_masked_fill_bool_tensor(self):
-        for device in torch.testing.get_all_device_types():
-            dst = torch.tensor([True, False, True], device=device)
-            mask = torch.tensor([False, True, False], device=device)
-
-            dst.masked_fill_(mask, True)
-            self.assertEqual(dst, torch.tensor([True, True, True], device=device))
-
-            dst = dst.masked_fill(mask, False)
-            self.assertEqual(dst, torch.tensor([True, False, True], device=device))
 
     def test_abs(self):
         def _test_abs(tensors_dict):
@@ -8766,85 +4349,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(tensor.var(dim=0), 0.03125)
         self.assertEqual(tensor.var(), 0.03125)
 
-    @staticmethod
-    def _test_view(self, cast):
-        tensor = cast(torch.rand(15))
-        template = cast(torch.rand(3, 5))
-        empty = cast(torch.empty(0))
-        target = template.size()
-        self.assertEqual(tensor.view_as(template).size(), target)
-        self.assertEqual(tensor.view(3, 5).size(), target)
-        self.assertEqual(tensor.view(torch.Size([3, 5])).size(), target)
-        self.assertEqual(tensor.view(-1, 5).size(), target)
-        self.assertEqual(tensor.view(3, -1).size(), target)
-        tensor_view = tensor.view(5, 3)
-        tensor_view.fill_(random.uniform(0, 1))
-        self.assertEqual(empty.view_as(empty), empty)
-        self.assertEqual(empty.view(0), empty)
-        self.assertEqual(empty.view(0, 3, 0, 1).size(), torch.Size([0, 3, 0, 1]))
-        self.assertEqual(empty.view(0, 3, 0, 1).view(0), empty)
-
-        # test size inference with empty tensors
-        self.assertEqual(empty.view(-1).size(), torch.Size([0]))
-        self.assertEqual(empty.view(10, 3, -1).size(), torch.Size([10, 3, 0]))
-
-        with self.assertRaisesRegex(RuntimeError, r"because the unspecified dimension size -1 can be any value"):
-            empty.view(-1, 0)
-
-        with self.assertRaisesRegex(RuntimeError, r"because the unspecified dimension size -1 can be any value"):
-            empty.view(3, 0, -1, 0)
-
-        self.assertRaises(RuntimeError, lambda: tensor.view(15, 0))
-        self.assertRaises(RuntimeError, lambda: tensor.view(7, -1))
-        self.assertRaises(RuntimeError, lambda: tensor.view(15, -1, -1))
-
-        # test view when tensor is not contiguous in every dimension, but only
-        # contiguous dimensions are touched.
-        tensor = cast(torch.rand(4, 2, 5, 1, 6, 2, 9, 3)).transpose(-1, 2).transpose(-2, 3)
-        # size:                      [   4,    2,    3,    9,    6,    2,    1,    5]
-        # stride:                    [3840, 1620,    1,    3,   54,   27,  324,  324]
-        # contiguous dim chunks:     [__________, ____, ____, __________, ____, ____]
-        # merging 1 to chunk after:  [__________, ____, ____, __________, __________]
-        contig_tensor = tensor.clone()
-        # [4, 2] => [8, 1]
-        # [3] => [3]
-        # [9] => [3, 3]
-        # [6, 2] => [4, 1, 3]
-        # [1, 5] => [5]
-        view_size = [8, 1, 3, 3, 3, 4, 1, 3, 5]
-        self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
-        # [4, 2] => [2, 4]
-        # [3] => [3]
-        # [9] => [1, 9]
-        # [6, 2] => [2, 2, 3]
-        # [1, 5] => [5, 1]
-        view_size = [2, 4, 3, 1, 9, 2, 2, 3, 5, 1]
-        self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
-        # adding size 1 dims
-        view_size = [1, 1, 2, 1, 4, 3, 1, 1, 9, 1, 2, 1, 2, 3, 1, 5, 1, 1]
-        self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
-
-        # invalid views
-        self.assertRaises(RuntimeError, lambda: tensor.view(-1))
-        # crossing [4, 2], [3]
-        self.assertRaises(RuntimeError, lambda: tensor.view(24, 9, 6, 2, 1, 5))
-        # crossing [6, 2], [1, 5]
-        self.assertRaises(RuntimeError, lambda: tensor.view(8, 3, 9, 6, 10))
-        # crossing [9], [6, 2]
-        self.assertRaises(RuntimeError, lambda: tensor.view(8, 3, 54, 2, 1, 5))
-
-        # view with stride 0 dims
-        tensor = cast(torch.empty(1, 1)).expand(3, 4)  # all dims are contiguous
-        contig_tensor = tensor.clone()
-        self.assertEqual(tensor.view(-1), contig_tensor.view(-1))
-        self.assertEqual(tensor.view(1, -1, 1), contig_tensor.view(1, -1, 1))
-        self.assertEqual(tensor.view(-1, 1), contig_tensor.view(-1, 1))
-        self.assertEqual(tensor.view(6, 2, 1), contig_tensor.view(6, 2, 1))
-        self.assertEqual(tensor.view(1, 6, 2, 1), contig_tensor.view(1, 6, 2, 1))
-
-    def test_view(self):
-        _TestTorchMixin._test_view(self, lambda x: x)
-
     def test_view_empty(self):
         x = torch.randn(0, 6)
         self.assertEqual((1, 0, 6, 1, 1), x.view(1, 0, 6, 1, 1).shape)
@@ -8887,196 +4391,6 @@ class _TestTorchMixin(torchtest):
 
         # match NumPy semantics -- don't infer the size of dimension with a degree of freedom
         self.assertRaises(RuntimeError, lambda: x.reshape(0, -1))
-
-    def test_tensor_shape_empty(self):
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn((0, 1, 3, 0), device=device)
-            # flatten
-            self.assertEqual((0,), torch.flatten(x, 0, 3).shape)
-            self.assertEqual((0, 0), torch.flatten(x, 0, 2).shape)
-            self.assertEqual((0, 3, 0), torch.flatten(x, 1, 2).shape)
-
-            # squeeze, unsqueeze
-            self.assertEqual((0, 1, 1, 3, 0), torch.unsqueeze(x, 1).shape)
-            self.assertEqual((0, 3, 0), torch.squeeze(x, 1).shape)
-            self.assertEqual((0, 3, 0), torch.squeeze(x).shape)
-
-            # transpose, t
-            self.assertEqual((0, 0, 3, 1), torch.transpose(x, 1, 3).shape)
-            y = torch.randn((5, 0), device=device)
-            self.assertEqual((0, 5), y.t().shape)
-
-            # select
-            self.assertEqual((0, 1, 0), torch.select(x, 2, 2).shape)
-
-            # repeat, permute
-            self.assertEqual((9, 0, 5, 6, 0), x.repeat(9, 7, 5, 2, 3).shape)
-            self.assertEqual((3, 0, 0, 1), x.permute(2, 3, 0, 1).shape)
-
-            # diagonal, diagflat
-            self.assertEqual((0,), torch.diagonal(torch.randn((5, 0), device=device)).shape)
-            self.assertEqual((0,), torch.diagonal(torch.randn((0, 5), device=device)).shape)
-            # off the end offsets are valid
-            self.assertEqual((0,), torch.diagonal(torch.randn((5, 0), device=device), offset=1).shape)
-            self.assertEqual((0,), torch.diagonal(torch.randn((0, 5), device=device), offset=1).shape)
-            # check non-zero sized offsets off the end
-            self.assertEqual((5, 6, 0), torch.diagonal(torch.randn((3, 4, 5, 6), device=device), offset=45252).shape)
-            self.assertEqual((5, 6, 0), torch.diagonal(torch.randn((3, 4, 5, 6), device=device), offset=-45252).shape)
-
-            self.assertEqual((0, 0), torch.diagflat(torch.tensor([], device=device)).shape)
-            self.assertEqual(torch.zeros(1, 1), torch.diagflat(torch.tensor([], device=device), offset=1))
-            self.assertEqual((0, 0), torch.diagflat(torch.tensor([[]], device=device)).shape)
-            self.assertEqual(torch.zeros(1, 1), torch.diagflat(torch.tensor([[]], device=device), offset=1))
-
-            # stack, split, chunk
-            self.assertEqual((4, 0, 1, 3, 0), torch.stack((x, x, x, x)).shape)
-            self.assertEqual([(0, 1, 3, 0)],
-                             [z.shape for z in torch.chunk(x, 1, dim=0)])
-
-            self.assertEqual([(0, 1, 3, 0), ] * 3, [z.shape for z in torch.chunk(x, 3, dim=0)])
-            self.assertEqual([(0, 1, 1, 0), ] * 3, [z.shape for z in torch.chunk(x, 3, dim=2)])
-
-            # NOTE: split_with_sizes behaves differently than NumPy in that it
-            # takes sizes rather than offsets
-            self.assertEqual([(0, 1, 0, 0), (0, 1, 1, 0), (0, 1, 2, 0)],
-                             [z.shape for z in torch.split(x, (0, 1, 2), dim=2)])
-
-            self.assertRaises(RuntimeError, lambda: torch.split(x, 0, dim=1))
-            # This is strange because the split size is larger than the dim size, but consistent with
-            # how split handles that case generally (when no 0s are involved).
-            self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 1, dim=0)])
-            self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 0, dim=0)])
-
-    # functions that operate over a dimension but don't reduce.
-    def test_dim_function_empty(self):
-        for device in torch.testing.get_all_device_types():
-            shape = (0, 1, 2, 0)
-            x = torch.randn(shape, device=device)
-
-            # size stride
-            self.assertEqual(0, x.size(3))
-            self.assertEqual(2, x.size(2))
-            self.assertEqual(2, x.stride(0))
-            self.assertEqual(1, x.stride(2))
-
-            self.assertEqual(x, torch.nn.functional.glu(x, 0))
-            self.assertEqual((0, 1, 1, 0), torch.nn.functional.glu(x, 2).shape)
-
-            # softmax, logsoftmax
-            self.assertEqual(x, torch.nn.functional.softmax(x, 0))
-            self.assertEqual(x, torch.nn.functional.softmax(x, 2))
-            self.assertEqual(x, torch.nn.functional.softmax(x, 3))
-
-            self.assertEqual(x, torch.nn.functional.log_softmax(x, 0))
-            self.assertEqual(x, torch.nn.functional.log_softmax(x, 2))
-            self.assertEqual(x, torch.nn.functional.log_softmax(x, 3))
-
-            # cumsum, cumprod
-            self.assertEqual(shape, torch.cumsum(x, 0).shape)
-            self.assertEqual(shape, torch.cumsum(x, 2).shape)
-            self.assertEqual(shape, torch.cumprod(x, 0).shape)
-            self.assertEqual(shape, torch.cumprod(x, 2).shape)
-
-            # flip
-            self.assertEqual(x, x.flip(0))
-            self.assertEqual(x, x.flip(2))
-
-            # roll
-            self.assertEqual(x, x.roll(0, 1).roll(0, -1))
-            self.assertEqual(x, x.roll(1, x.size(1)))
-            self.assertEqual(x, x.roll(1))
-            self.assertEqual(x, x.roll((1, 1), (3, 1)))
-
-            # unbind
-            self.assertEqual((), x.unbind(0))
-            self.assertEqual((torch.empty((0, 1, 0), device=device), torch.empty((0, 1, 0), device=device)),
-                             x.unbind(2))
-
-            # cross
-            y = torch.randn((0, 1, 3, 0), device=device)
-            self.assertEqual(y.shape, torch.cross(y, y).shape)
-
-            # renorm
-            self.assertEqual(shape, torch.renorm(x, 1, 0, 5).shape)
-            self.assertEqual(shape, torch.renorm(x, 1, 2, 5).shape)
-
-            # sort
-            self.assertEqual([shape, shape], [z.shape for z in torch.sort(x, dim=0)])
-            self.assertEqual([shape, shape], [z.shape for z in torch.sort(x, dim=2)])
-
-            # topk
-            self.assertEqual([shape, shape], [z.shape for z in torch.topk(x, 0, dim=0)])
-            self.assertEqual([(0, 1, 1, 0), (0, 1, 1, 0)], [z.shape for z in torch.topk(x, 1, dim=2)])
-
-            y = torch.randn((2, 3, 4), device=device)
-            self.assertEqual([(2, 3, 0), (2, 3, 0)], [z.shape for z in torch.topk(y, 0)])
-
-            # gather
-            self.assertEqual(shape, torch.gather(x, 0, torch.empty(shape, dtype=torch.int64, device=device)).shape)
-            self.assertEqual(shape, torch.gather(x, 2, torch.empty(shape, dtype=torch.int64, device=device)).shape)
-            larger_shape = torch.empty((0, 1, 3, 0), dtype=torch.int64, device=device)
-            self.assertEqual(larger_shape.shape, torch.gather(x, 2, larger_shape).shape)
-            smaller_shape = torch.empty((0, 1, 0, 0), dtype=torch.int64, device=device)
-            self.assertEqual(smaller_shape.shape, torch.gather(x, 2, smaller_shape).shape)
-            y = torch.randn((2, 3, 4), device=device)
-            self.assertEqual((0, 3, 4),
-                             torch.gather(y, 0, torch.empty((0, 3, 4), dtype=torch.int64, device=device)).shape)
-
-            # scatter, scatter_add
-            for dim in [0, 2]:
-                y = torch.randn(shape, device=device)
-                y_src = torch.randn(shape, device=device)
-                ind = torch.empty(shape, dtype=torch.int64, device=device)
-                self.assertEqual(shape, y.scatter_(dim, ind, y_src).shape)
-                self.assertEqual(shape, y.scatter_add_(dim, ind, y_src).shape)
-
-            z = torch.randn((2, 3, 4), device=device)
-            z_src = torch.randn((2, 3, 4), device=device)
-            self.assertEqual(z, z.scatter_(2, torch.empty((2, 3, 0), dtype=torch.int64, device=device), z_src))
-            self.assertEqual(z, z.scatter_add_(2, torch.empty((2, 3, 0), dtype=torch.int64, device=device), z_src))
-
-            # index_fill, index_copy, index_add
-            c = x.clone()
-            c_clone = c.clone()
-            ind_empty = torch.tensor([], dtype=torch.int64, device=device)
-            ind_01 = torch.tensor([0, 1], dtype=torch.int64, device=device)
-            self.assertEqual(c_clone, c.index_fill_(0, ind_empty, -1))
-            self.assertEqual(c_clone, c.index_fill_(2, ind_empty, -1))
-            self.assertEqual(c_clone, c.index_fill_(2, torch.tensor([0, 1], dtype=torch.int64, device=device), -1))
-            self.assertEqual(c_clone, c.index_copy_(0, ind_empty, torch.empty((0, 1, 2, 0), device=device)))
-            self.assertEqual(c_clone, c.index_copy_(2, ind_empty, torch.empty((0, 1, 0, 0), device=device)))
-            self.assertEqual(c_clone, c.index_copy_(2, ind_01, torch.empty((0, 1, 2, 0), device=device)))
-            self.assertEqual(c_clone, c.index_add_(0, ind_empty, torch.empty((0, 1, 2, 0), device=device)))
-            self.assertEqual(c_clone, c.index_add_(2, ind_empty, torch.empty((0, 1, 0, 0), device=device)))
-            self.assertEqual(c_clone, c.index_add_(2, ind_01, torch.empty((0, 1, 2, 0), device=device)))
-
-            c = torch.randn((0, 1, 2), device=device)
-            c_clone = c.clone()
-            self.assertEqual(c_clone, c.index_fill_(0, ind_empty, -1))
-            self.assertEqual(c_clone, c.index_copy_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
-            self.assertEqual(c_clone, c.index_add_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
-            self.assertEqual(c_clone, c.index_fill_(0, ind_empty, -1))
-            self.assertEqual(c_clone, c.index_copy_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
-            self.assertEqual(c_clone, c.index_add_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
-
-            # index fill/copy/add non-empty
-            z = torch.randn((2, 3, 4), device=device)
-            self.assertEqual(z, z.index_fill_(0, ind_empty, -1))
-            z = torch.randn((2, 3, 4), device=device)
-            self.assertEqual(z, z.index_copy_(0, ind_empty, torch.empty((0, 3, 4), device=device)))
-            z = torch.randn((2, 3, 4), device=device)
-            self.assertEqual(z, z.index_add_(0, ind_empty, torch.empty((0, 3, 4), device=device)))
-
-            # index_select
-            self.assertEqual(x, x.index_select(0, ind_empty))
-            self.assertEqual((0, 1, 0, 0), x.index_select(2, ind_empty).shape)
-            self.assertEqual(x, x.index_select(2, ind_01))
-            z = torch.randn((2, 3, 4), device=device)  # non-empty
-            self.assertEqual((0, 3, 4), z.index_select(0, ind_empty).shape)
-            c = torch.randn((0, 1, 2), device=device)
-            self.assertEqual(c, c.index_select(0, ind_empty))
-            c = torch.randn((0, 1, 2), device=device)
-            self.assertEqual(c, c.index_select(0, ind_empty))
 
     @skipIfRocm
     def test_blas_empty(self):
@@ -9263,54 +4577,6 @@ class _TestTorchMixin(torchtest):
                              torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
             self.assertEqual(torch.full((2, 3), beta * value, device=device),
                              torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out))
-
-    @skipIfNoLapack
-    def test_lapack_empty(self):
-        # FIXME: these are just a selection of LAPACK functions -- we need a general strategy here.
-        # The LAPACK functions themselves generally do NOT work with zero sized dimensions, although
-        # numpy/sci often has a direct wrapper (e.g. lu_factor) and a wrapper that "does the right thing"
-        # (e.g. lu).  We often name our functions identically to the lapack function, so it will take work
-        # to name / migrate-to better wrappers.
-        for device in torch.testing.get_all_device_types():
-
-            # need to init cuda to check has_magma
-            empty = torch.randn((0, 0), device=device)
-            if device == 'cuda' and not torch.cuda.has_magma:
-                continue
-
-            def fn(torchfn, *args):
-                return torchfn(*tuple(torch.randn(shape, device=device) if isinstance(shape, tuple) else shape
-                                      for shape in args))
-
-            # inverse, pinverse
-            self.assertEqual((0, 0), fn(torch.inverse, (0, 0)).shape)
-            self.assertEqual((5, 0), fn(torch.pinverse, (0, 5)).shape)
-            self.assertEqual((0, 5), fn(torch.pinverse, (5, 0)).shape)
-            self.assertEqual((0, 0), fn(torch.pinverse, (0, 0)).shape)
-
-            # det, logdet, slogdet
-            self.assertEqual(torch.tensor(1., device=device), fn(torch.det, (0, 0)))
-            self.assertEqual(torch.tensor(0., device=device), fn(torch.logdet, (0, 0)))
-            self.assertEqual((torch.tensor(1., device=device), torch.tensor(0., device=device)),
-                             fn(torch.slogdet, (0, 0)))
-
-            # eig, symeig
-            evalues, evectors = fn(torch.eig, (0, 0), True)
-            self.assertEqual([(0, 2), (0, 0)], [evalues.shape, evectors.shape])
-            evalues, evectors = fn(torch.symeig, (0, 0), True)
-            self.assertEqual([(0,), (0, 0)], [evalues.shape, evectors.shape])
-
-            # qr
-            q, r = fn(torch.qr, (3, 0), True)
-            self.assertEqual([(3, 0), (0, 0)], [q.shape, r.shape])
-            q, r = fn(torch.qr, (0, 3), True)
-            self.assertEqual([(0, 0), (0, 3)], [q.shape, r.shape])
-            q, r = fn(torch.qr, (3, 0), False)
-            self.assertEqual([(3, 3), (3, 0)], [q.shape, r.shape])
-
-            # lstsq
-            self.assertRaises(RuntimeError, lambda: torch.lstsq(torch.randn(0, 0), torch.randn(0, 0)))
-            self.assertRaises(RuntimeError, lambda: torch.lstsq(torch.randn(0,), torch.randn(0, 0)))
 
     def test_expand(self):
         tensor = torch.rand(1, 8, 1)
@@ -9694,118 +4960,6 @@ class _TestTorchMixin(torchtest):
         self.assertEqual(perm, new)
         self.assertEqual(x.size(), orig)
 
-    @staticmethod
-    def _test_flip(self, use_cuda=False):
-        device = torch.device('cuda') if use_cuda else torch.device('cpu')
-        data = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], device=device).view(2, 2, 2)
-
-        self.assertEqual(torch.tensor([5, 6, 7, 8, 1, 2, 3, 4]).view(2, 2, 2), data.flip(0))
-        self.assertEqual(torch.tensor([3, 4, 1, 2, 7, 8, 5, 6]).view(2, 2, 2), data.flip(1))
-        self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(2))
-        self.assertEqual(torch.tensor([7, 8, 5, 6, 3, 4, 1, 2]).view(2, 2, 2), data.flip(0, 1))
-        self.assertEqual(torch.tensor([8, 7, 6, 5, 4, 3, 2, 1]).view(2, 2, 2), data.flip(0, 1, 2))
-
-        # check for wrap dim
-        self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(-1))
-        # check for permute
-        self.assertEqual(torch.tensor([6, 5, 8, 7, 2, 1, 4, 3]).view(2, 2, 2), data.flip(0, 2))
-        self.assertEqual(torch.tensor([6, 5, 8, 7, 2, 1, 4, 3]).view(2, 2, 2), data.flip(2, 0))
-
-        # not allow flip on the same dim more than once
-        self.assertRaises(RuntimeError, lambda: data.flip(0, 1, 1))
-        # not allow empty list as input
-        self.assertRaises(TypeError, lambda: data.flip())
-
-        # not allow size of flip dim > total dims
-        self.assertRaises(IndexError, lambda: data.flip(0, 1, 2, 3))
-        # not allow dim > max dim
-        self.assertRaises(IndexError, lambda: data.flip(3))
-
-        # test for non-contiguous case
-        expanded_data = torch.arange(1, 4, device=device).view(3, 1).expand(3, 2)
-        transposed_data = torch.arange(1, 9, device=device).view(2, 2, 2).transpose(0, 1)
-        self.assertEqual(torch.tensor([3, 3, 2, 2, 1, 1]).view(3, 2), expanded_data.flip(0))
-        self.assertEqual(torch.tensor([8, 7, 4, 3, 6, 5, 2, 1]).view(2, 2, 2), transposed_data.flip(0, 1, 2))
-
-        # test for shape
-        data = torch.randn(2, 3, 4, device=device)
-        size = [2, 3, 4]
-        test_dims = []
-        for i in range(1, 3):
-            test_dims += combinations(range(len(size)), i)
-
-        for ds in test_dims:
-            self.assertEqual(size, list(data.flip(ds).size()))
-
-        # test rectangular case
-        data = torch.tensor([1, 2, 3, 4, 5, 6]).view(2, 3)
-        flip0_result = torch.tensor([[4, 5, 6], [1, 2, 3]])
-        flip1_result = torch.tensor([[3, 2, 1], [6, 5, 4]])
-        if use_cuda:
-            data = data.cuda()
-            flip0_result = flip0_result.cuda()
-            flip1_result = flip1_result.cuda()
-        self.assertEqual(flip0_result, data.flip(0))
-        self.assertEqual(flip1_result, data.flip(1))
-
-        # test empty tensor, should just return an empty tensor of the same shape
-        data = torch.tensor([])
-        self.assertEqual(data, data.flip(0))
-
-    def test_flip(self):
-        self._test_flip(self, use_cuda=False)
-
-    def test_roll(self):
-        for device in torch.testing.get_all_device_types():
-            numbers = torch.arange(1, 9, device=device)
-
-            single_roll = numbers.roll(1, 0)
-            expected = torch.tensor([8, 1, 2, 3, 4, 5, 6, 7], device=device)
-            self.assertEqual(single_roll, expected, "{} did not equal expected result".format(single_roll))
-
-            roll_backwards = numbers.roll(-2, 0)
-            expected = torch.tensor([3, 4, 5, 6, 7, 8, 1, 2], device=device)
-            self.assertEqual(roll_backwards, expected, "{} did not equal expected result".format(roll_backwards))
-
-            data = numbers.view(2, 2, 2)
-            rolled = data.roll(1, 0)
-            expected = torch.tensor([5, 6, 7, 8, 1, 2, 3, 4], device=device).view(2, 2, 2)
-            self.assertEqual(expected, rolled, "{} did not equal expected result: {}".format(rolled, expected))
-
-            data = data.view(2, 4)
-            # roll a loop until back where started
-            loop_rolled = data.roll(2, 0).roll(4, 1)
-            self.assertEqual(data, loop_rolled, "{} did not equal the original: {}".format(loop_rolled, data))
-            # multiple inverse loops
-            self.assertEqual(data, data.roll(-20, 0).roll(-40, 1))
-            self.assertEqual(torch.tensor([8, 1, 2, 3, 4, 5, 6, 7], device=device), numbers.roll(1, 0))
-
-            # test non-contiguous
-            # strided equivalent to numbers.as_strided(size=(4, 2), stride=(1, 4))
-            strided = numbers.view(2, 4).transpose(0, 1)
-            self.assertFalse(strided.is_contiguous(), "this test needs a non-contiguous tensor")
-            expected = torch.tensor([4, 8, 1, 5, 2, 6, 3, 7]).view(4, 2)
-            rolled = strided.roll(1, 0)
-            self.assertEqual(expected, rolled,
-                             "non contiguous tensor rolled to {} instead of {} ".format(rolled, expected))
-
-            # test roll with no dimension specified
-            expected = numbers.roll(1, 0).view(2, 4)
-            self.assertEqual(expected, data.roll(1), "roll with no dims should flatten and roll.")
-            self.assertEqual(expected, data.roll(1, dims=None), "roll with no dims should flatten and roll.")
-
-            # test roll over multiple dimensions
-            expected = torch.tensor([[7, 8, 5, 6], [3, 4, 1, 2]], device=device)
-            double_rolled = data.roll(shifts=(2, -1), dims=(1, 0))
-            self.assertEqual(double_rolled, expected,
-                             "should be able to roll over two dimensions, got {}".format(double_rolled))
-
-            self.assertRaisesRegex(RuntimeError, "required", lambda: data.roll(shifts=(), dims=()))
-            self.assertRaisesRegex(RuntimeError, "required", lambda: data.roll(shifts=(), dims=1))
-            # shifts/dims should align
-            self.assertRaisesRegex(RuntimeError, "align", lambda: data.roll(shifts=(1, 2), dims=(1,)))
-            self.assertRaisesRegex(RuntimeError, "align", lambda: data.roll(shifts=(1,), dims=(1, 2)))
-
     def test_reversed(self):
         val = torch.arange(0, 10)
         self.assertEqual(reversed(val), torch.arange(9, -1, -1))
@@ -9836,168 +4990,10 @@ class _TestTorchMixin(torchtest):
             "Tensor.__contains__ only supports Tensor or scalar, but you passed in a {}.".format(type([1, 2])),
             lambda: [1, 2] in x)
 
-    @staticmethod
-    def _test_rot90(self, use_cuda=False):
-        device = torch.device("cuda" if use_cuda else "cpu")
-        data = torch.arange(1, 5, device=device).view(2, 2)
-        self.assertEqual(torch.tensor([1, 2, 3, 4]).view(2, 2), data.rot90(0, [0, 1]))
-        self.assertEqual(torch.tensor([2, 4, 1, 3]).view(2, 2), data.rot90(1, [0, 1]))
-        self.assertEqual(torch.tensor([4, 3, 2, 1]).view(2, 2), data.rot90(2, [0, 1]))
-        self.assertEqual(torch.tensor([3, 1, 4, 2]).view(2, 2), data.rot90(3, [0, 1]))
-
-        # test for default args k=1, dims=[0, 1]
-        self.assertEqual(data.rot90(), data.rot90(1, [0, 1]))
-
-        # test for reversed order of dims
-        self.assertEqual(data.rot90(3, [0, 1]), data.rot90(1, [1, 0]))
-
-        # test for modulo of k
-        self.assertEqual(data.rot90(5, [0, 1]), data.rot90(1, [0, 1]))
-        self.assertEqual(data.rot90(3, [0, 1]), data.rot90(-1, [0, 1]))
-        self.assertEqual(data.rot90(-5, [0, 1]), data.rot90(-1, [0, 1]))
-
-        # test for dims out-of-range error
-        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, -3]))
-        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, 2]))
-
-        # test tensor with more than 2D
-        data = torch.arange(1, 9, device=device).view(2, 2, 2)
-        self.assertEqual(torch.tensor([2, 4, 1, 3, 6, 8, 5, 7]).view(2, 2, 2), data.rot90(1, [1, 2]))
-        self.assertEqual(data.rot90(1, [1, -1]), data.rot90(1, [1, 2]))
-
-        # test for errors
-        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, 3]))
-        self.assertRaises(RuntimeError, lambda: data.rot90(1, [1, 1]))
-        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, 1, 2]))
-        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0]))
-
-    def test_rot90(self):
-        self._test_rot90(self, use_cuda=False)
-
     def test_storage(self):
         v = torch.randn(3, 5)
         self.assertEqual(v.storage()[0], v.data[0][0])
         self.assertEqual(v.storage()[14], v.data[2][4])
-
-    def test_nonzero(self):
-        devices = torch.testing.get_all_device_types()
-        num_srcs = [
-            12, 12, 12, 12, 12, 125,
-        ]
-
-        types = [
-            'torch.ByteTensor',
-            'torch.CharTensor',
-            'torch.ShortTensor',
-            'torch.IntTensor',
-            'torch.FloatTensor',
-            'torch.DoubleTensor',
-            'torch.LongTensor',
-        ]
-
-        shapes = [
-            torch.Size((12,)),
-            torch.Size((12, 1)),
-            torch.Size((1, 12)),
-            torch.Size((6, 2)),
-            torch.Size((3, 2, 2)),
-            torch.Size((5, 5, 5)),
-        ]
-
-        def is_lexicographically_sorted(inds):
-            """Check sorted ascending with
-            i -> j -> k changing slowest to fastest"""
-            assert inds.size(1) == 3
-            if inds.size(0) > 1:
-                i0, j0, k0 = inds[:-1].t()
-                i1, j1, k1 = inds[+1:].t()
-                i_ok = (i1 >= i0)
-                j_ok = (j1 >= j0) | (i1 > i0)
-                k_ok = (k1 >= k0) | (j1 > j0) | (i1 > i0)
-                lex = torch.stack((i_ok, j_ok, k_ok), dim=1)
-                return lex
-            return torch.full_like(inds, 1)
-
-        def gen_nontrivial_input(num_src, dtype, device):
-            while True:
-                tensor = torch.rand(num_src).mul(2).floor().type(dtype).to(device)
-                if tensor.sum() > 0:
-                    return tensor
-
-        for device in devices:
-            for dtype in types:
-                for shape, num_src in zip(shapes, num_srcs):
-                    tensor = gen_nontrivial_input(num_src, dtype, device)
-                    tensor = tensor.clone().resize_(shape)
-                    dst1 = torch.nonzero(tensor)
-                    dst2 = tensor.nonzero()
-                    dst3 = torch.LongTensor().to(device)
-                    torch.nonzero(tensor, out=dst3)
-
-                    self.assertRaisesRegex(
-                        TypeError,
-                        "received an invalid combination of arguments",
-                        lambda: torch.nonzero(tensor, as_tuple=True, out=dst3))
-                    if len(shape) == 1:
-                        dst = []
-                        for i in range(num_src):
-                            if tensor[i] != 0:
-                                dst += [i]
-                        dst = torch.LongTensor(dst).to(device)
-                        self.assertEqual(dst1.select(1, 0), dst, 0)
-                        self.assertEqual(dst2.select(1, 0), dst, 0)
-                        self.assertEqual(dst3.select(1, 0), dst, 0)
-                    elif len(shape) == 2:
-                        # This test will allow through some False positives. It only checks
-                        # that the elements flagged positive are indeed non-zero.
-                        for i in range(dst1.size(0)):
-                            self.assertNotEqual(tensor[dst1[i, 0], dst1[i, 1]].item(), 0)
-                    elif len(shape) == 3:
-                        # This test will allow through some False positives. It only checks
-                        # that the elements flagged positive are indeed non-zero.
-                        for i in range(dst1.size(0)):
-                            self.assertNotEqual(tensor[dst1[i, 0], dst1[i, 1], dst1[i, 2]].item(), 0)
-                        lex = is_lexicographically_sorted(dst1)
-                        self.assertEqual(torch.ones_like(lex), lex)
-                    if TEST_NUMPY:
-                        tup1 = torch.nonzero(tensor, as_tuple=True)
-                        tup2 = tensor.nonzero(as_tuple=True)
-                        tup3 = torch.where(tensor)
-                        np1 = tensor.cpu().numpy().nonzero()
-                        for t in (tup1, tup2, tup3):
-                            self.assertEqual(len(t), len(np1))
-                            for i in range(len(t)):
-                                self.assertEqual(t[i].cpu().numpy(), np1[i])
-
-    def test_nonzero_empty(self):
-        def assert_tuple_empty(tup, dim):
-            self.assertEqual(dim, len(tup))
-            for t in tup:
-                self.assertEqual(torch.Size([0]), t.shape)
-        for device in torch.testing.get_all_device_types():
-            x = torch.randn(0, 2, 0, 5, 0, device=device)
-            y = torch.nonzero(x)
-            z = torch.nonzero(x, as_tuple=True)
-
-            self.assertEqual(0, y.numel())
-            self.assertEqual(torch.Size([0, 5]), y.shape)
-            assert_tuple_empty(z, 5)
-
-            x = torch.tensor(0.5, device=device)
-            y = torch.nonzero(x)
-            # nonzero with as_tuple returns a
-            # tuple of len 1 for a zero-dim tensor.
-            # This is done to match Numpy behavior.
-            z = torch.nonzero(x, as_tuple=True)
-            self.assertEqual(1, len(z))
-            self.assertEqual(torch.zeros(1, dtype=torch.long), z[0])
-
-            x = torch.zeros((), device=device)
-            y = torch.nonzero(x)
-            z = torch.nonzero(x, as_tuple=True)
-            self.assertEqual(torch.Size([0, 0]), y.shape)
-            self.assertEqual(1, len(z))
-            self.assertEqual(torch.empty(0, dtype=torch.long), z[0])
 
     def test_deepcopy(self):
         from copy import deepcopy
@@ -10162,55 +5158,6 @@ class _TestTorchMixin(torchtest):
         self._test_bernoulli(self, torch.uint8, torch.float64, 'cpu')
         # test that it works with bool tensors
         self._test_bernoulli(self, torch.bool, torch.float32, 'cpu')
-
-    def test_normal(self):
-        for device in torch.testing.get_all_device_types():
-            q = torch.empty(100, 100, device=device).normal_()
-            self.assertEqual(q.mean(), 0, 0.2)
-            self.assertEqual(q.std(), 1, 0.2)
-
-            q.normal_(2, 3)
-            self.assertEqual(q.mean(), 2, 0.3)
-            self.assertEqual(q.std(), 3, 0.3)
-
-            q = torch.empty(100, 100, device=device)
-            q_row1 = q[0:1].clone()
-            q[99:100].normal_()
-            self.assertEqual(q[99:100].mean(), 0, 0.2)
-            self.assertEqual(q[99:100].std(), 1, 0.2)
-            self.assertEqual(q[0:1].clone(), q_row1)
-
-            mean = torch.empty(100, 100, device=device)
-            std = torch.empty(100, 100, device=device)
-            mean[:50] = 0
-            mean[50:] = 1
-            std[:, :50] = 4
-            std[:, 50:] = 1
-
-            r = torch.normal(mean)
-            self.assertEqual(r[:50].mean(), 0, 0.2)
-            self.assertEqual(r[50:].mean(), 1, 0.2)
-            self.assertEqual(r.std(), 1, 0.2)
-
-            r = torch.normal(mean, 3)
-            self.assertEqual(r[:50].mean(), 0, 0.2)
-            self.assertEqual(r[50:].mean(), 1, 0.2)
-            self.assertEqual(r.std(), 3, 0.2)
-
-            r = torch.normal(2, std)
-            self.assertEqual(r.mean(), 2, 0.2)
-            self.assertEqual(r[:, :50].std(), 4, 0.3)
-            self.assertEqual(r[:, 50:].std(), 1, 0.2)
-
-            r = torch.normal(mean, std)
-            self.assertEqual(r[:50].mean(), 0, 0.2)
-            self.assertEqual(r[50:].mean(), 1, 0.2)
-            self.assertEqual(r[:, :50].std(), 4, 0.3)
-            self.assertEqual(r[:, 50:].std(), 1, 0.2)
-
-        r = torch.normal(2, 3, (100, 100))
-        self.assertEqual(r.mean(), 2, 0.2)
-        self.assertEqual(r.std(), 3, 0.2)
 
     def test_generator_cpu(self):
         # test default generators are equal
@@ -11342,21 +6289,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertEqual(torch.empty_like(a).shape, a.shape)
             self.assertEqual(torch.empty_like(a).type(), a.type())
 
-    def test_empty_strided(self):
-        for device in torch.testing.get_all_device_types():
-            for shape in [(2, 3, 4), (0, 2, 0)]:
-                # some of these cases are pretty strange, just verifying that if as_strided
-                # allows them then empty_strided can as well.
-                for strides in [(12, 4, 1), (2, 4, 6), (0, 0, 0)]:
-                    empty_strided = torch.empty_strided(shape, strides, device=device)
-                    # as_strided checks the storage size is big enough to support such a strided tensor;
-                    # instead of repeating this calculation, we just use empty_strided which does the same
-                    # calculation when setting the storage size.
-                    as_strided = torch.empty(empty_strided.storage().size(),
-                                             device=device).as_strided(shape, strides)
-                    self.assertEqual(empty_strided.shape, as_strided.shape)
-                    self.assertEqual(empty_strided.stride(), as_strided.stride())
-
     def test_pin_memory(self):
         x = torch.randn(3, 5)
         self.assertFalse(x.is_pinned())
@@ -11780,44 +6712,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
                 self.assertIsInstance(r2, torch.Tensor)
                 self.assertTrue(r2.dtype == t_dtype)
                 self.assertTrue(r2.requires_grad)
-
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_trapz(self):
-        def test_dx(sizes, dim, dx, device):
-            t = torch.randn(sizes, device=device)
-            actual = torch.trapz(t, dx=dx, dim=dim)
-            expected = np.trapz(t.cpu().numpy(), dx=dx, axis=dim)
-            self.assertEqual(expected.shape, actual.shape)
-            self.assertTrue(np.allclose(expected, actual.cpu().numpy()))
-
-        def test_x(sizes, dim, x, device):
-            t = torch.randn(sizes, device=device)
-            actual = torch.trapz(t, x=torch.tensor(x, device=device), dim=dim)
-            expected = np.trapz(t.cpu().numpy(), x=x, axis=dim)
-            self.assertEqual(expected.shape, actual.shape)
-            self.assertTrue(np.allclose(expected, actual.cpu().numpy()))
-
-        for device in torch.testing.get_all_device_types():
-            test_dx((2, 3, 4), 1, 1, device)
-            test_dx((10, 2), 0, 0.1, device)
-            test_dx((1, 10), 0, 2.3, device)
-            test_dx((0, 2), 0, 1.0, device)
-            test_dx((0, 2), 1, 1.0, device)
-            test_x((2, 3, 4), 1, [1.0, 2.0, 3.0], device)
-            test_x((10, 2), 0, [2.0, 3.0, 4.0, 7.0, 11.0, 14.0, 22.0, 26.0, 26.1, 30.3], device)
-            test_x((1, 10), 0, [1.0], device)
-            test_x((0, 2), 0, [], device)
-            test_x((0, 2), 1, [1.0, 2.0], device)
-            with self.assertRaisesRegex(
-                    IndexError,
-                    'Dimension out of range'):
-                test_x((2, 3), 2, [], device)
-                test_dx((2, 3), 2, 1.0, device)
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    'There must be one `x` value for each sample point'):
-                test_x((2, 3), 1, [1.0, 2.0], device)
-                test_x((2, 3), 1, [1.0, 2.0, 3.0, 4.0], device)
 
     def test_error_msg_type_translation(self):
         with self.assertRaisesRegex(
@@ -12794,278 +7688,9 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         e1.fill_diagonal_(v, wrap=True)
         self.assertEqual(e1, e2)
 
-    def test_sign(self):
-        for device in torch.testing.get_all_device_types():
-            for dtype in torch.testing.get_all_math_dtypes(device):
-
-                # Include NaN for floating point numbers
-                if dtype.is_floating_point:
-                    dt_info = torch.finfo(dtype)
-
-                    # Create tensor (with NaN checking)
-                    a = torch.tensor([float('nan'), -12, 0, 71, dt_info.min, dt_info.max], device=device, dtype=dtype)
-                    a_target = torch.tensor([0, -1, 0, 1, -1, 1], device=device, dtype=dtype)
-
-                else:
-                    dt_info = torch.iinfo(dtype)
-
-                    # If unsigned type, everything should be >= 0
-                    if dt_info.min == 0:
-                        a = torch.tensor([12, 0, 71, dt_info.min, dt_info.max], device=device, dtype=dtype)
-                        a_target = torch.tensor([1, 0, 1, 0, 1], device=device, dtype=dtype)
-                    else:
-                        a = torch.tensor([-12, 0, 71, dt_info.min, dt_info.max], device=device, dtype=dtype)
-                        a_target = torch.tensor([-1, 0, 1, -1, 1], device=device, dtype=dtype)
-
-                self.assertEqual(a.sign(), a_target, 'sign device={} dtype={}'.format(device, dtype))
-                self.assertEqual(torch.sign(a), a_target, 'sign device={} dtype={}'.format(device, dtype))
-
-                out = torch.empty_like(a)
-                torch.sign(a, out=out)
-                self.assertEqual(out, a_target, 'sign_out device={} dtype={}'.format(device, dtype))
-
-                a.sign_()
-                self.assertEqual(a, a_target, 'sign_ device={} dtype={}'.format(device, dtype))
-
-            # Include test for bool dtype
-            a_bool = torch.tensor([True, True, False, float('nan')], device=device).bool()
-            a_bool_target = torch.tensor([True, True, False, True], device=device).bool()
-            self.assertEqual(a_bool.sign(), a_bool_target, 'sign device={} dtype=bool'.format(device))
-            self.assertEqual(torch.sign(a_bool), a_bool_target, 'sign device={} dtype=bool'.format(device))
-
-            a_out = torch.empty_like(a_bool)
-            torch.sign(a_bool, out=a_out)
-            self.assertEqual(a_out, a_bool_target, 'sign_out device={} dtype=bool'.format(device))
-
-            a_bool.sign_()
-            self.assertEqual(a_bool, a_bool_target, 'sign_ device={} dtype=bool'.format(device))
-
     def test_function_unwrap_message(self):
         self.assertRaisesRegex(RuntimeError, ' call to _th_lt',
                                lambda: torch.ones(1, dtype=torch.float) < torch.ones(1, dtype=torch.double))
-
-    def check_internal_mem_overlap(self, inplace_op, num_inputs, device,
-                                   expected_failure=False):
-        if isinstance(inplace_op, str):
-            inplace_op = getattr(torch.Tensor, inplace_op)
-        input = torch.randn(1, device=device).expand(3, 3)
-        inputs = [input] + [torch.randn_like(input)
-                            for i in range(num_inputs - 1)]
-        if not expected_failure:
-            with self.assertRaisesRegex(RuntimeError, 'single memory location'):
-                inplace_op(*inputs)
-        else:
-            with self.assertRaises(AssertionError):
-                with self.assertRaisesRegex(RuntimeError, 'single memory location'):
-                    inplace_op(*inputs)
-
-    def unary_check_input_output_mem_overlap(self, data, sz, op,
-                                             expected_failure=False):
-
-        def _test(op, output, input):
-            output_exp = torch.empty_like(output)
-            op(input, out=output_exp)
-            self.assertEqual(op(input, out=output), output_exp, op.__name__)
-
-        # output is identical to input:
-        _test(op, output=data[0:sz], input=data[0:sz])
-        # output and input are independent:
-        _test(op, output=data[0:sz], input=data[sz:2 * sz])
-        # output partially overlaps with input:
-        if not expected_failure:
-            with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
-                _test(op, data[0:sz], data[1:sz + 1])
-        else:
-            with self.assertRaises(AssertionError):
-                with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
-                    _test(op, data[0:sz], data[1:sz + 1])
-
-    @torchtest.for_all_device_types()
-    def test_unary_out_op_mem_overlap(self, device):
-        sz = 3
-        doubles = torch.randn(2 * sz, device=device)
-        positives = torch.randint(1, 100, (2 * sz,), device=device).double()
-        ints = torch.randint(-100, 100, (2 * sz,), device=device)
-        unary_mem_overlap_cases = [
-            ("abs", doubles, True, True, 'cpu'),
-            ("abs", doubles, False, True, 'cuda'),
-            ("acos", doubles, True, True, 'cpu'),
-            ("acos", doubles, False, True, 'cuda'),
-            ("asin", doubles, True, True, 'cpu'),
-            ("asin", doubles, False, True, 'cuda'),
-            ("atan", doubles, True, True, 'cpu'),
-            ("atan", doubles, False, True, 'cuda'),
-            ("bitwise_not", ints, True, True, 'cpu'),
-            ("bitwise_not", ints, True, True, 'cuda'),
-            ("ceil", doubles, True, True, 'cpu'),
-            ("ceil", doubles, True, True, 'cuda'),
-            ("cos", doubles, True, True, 'cpu'),
-            ("cos", doubles, False, True, 'cuda'),
-            ("cosh", doubles, True, True, 'cpu'),
-            ("cosh", doubles, False, True, 'cuda'),
-            ("digamma", doubles, True, True, 'cpu'),
-            ("erf", doubles, True, True, 'cpu'),
-            ("erf", doubles, False, True, 'cuda'),
-            ("erfc", doubles, True, True, 'cpu'),
-            ("erfc", doubles, False, True, 'cuda'),
-            ("erfinv", doubles, True, True, 'cpu'),
-            ("erfinv", doubles, True, True, 'cuda'),
-            ("exp", doubles, True, True, 'cpu'),
-            ("exp", doubles, False, True, 'cuda'),
-            ("expm1", doubles, True, True, 'cpu'),
-            ("expm1", doubles, False, True, 'cuda'),
-            ("floor", doubles, True, True, 'cpu'),
-            ("floor", doubles, False, True, 'cuda'),
-            ("frac", doubles, True, True, 'cpu'),
-            ("frac", doubles, False, True, 'cuda'),
-            ("log", positives, True, True, 'cpu'),
-            ("log", positives, False, True, 'cuda'),
-            ("log10", positives, True, True, 'cpu'),
-            ("log10", positives, False, True, 'cuda'),
-            ("log1p", positives, True, True, 'cpu'),
-            ("log1p", positives, False, True, 'cuda'),
-            ("log2", positives, True, True, 'cpu'),
-            ("log2", positives, False, True, 'cuda'),
-            ("neg", doubles, True, True, 'cpu'),
-            ("neg", doubles, True, True, 'cuda'),
-            ("reciprocal", doubles, True, True, 'cpu'),
-            ("reciprocal", doubles, False, True, 'cuda'),
-            ("round", doubles, True, True, 'cpu'),
-            ("round", doubles, False, True, 'cuda'),
-            ("rsqrt", positives, True, True, 'cpu'),
-            ("rsqrt", positives, False, True, 'cuda'),
-            ("sin", doubles, True, True, 'cpu'),
-            ("sin", doubles, False, True, 'cuda'),
-            ("sinh", doubles, True, True, 'cpu'),
-            ("sinh", doubles, False, True, 'cuda'),
-            ("sigmoid", doubles, True, True, 'cpu'),
-            ("sigmoid", doubles, False, False, 'cuda'),
-            ("sqrt", doubles, True, True, 'cpu'),
-            ("sqrt", doubles, False, True, 'cuda'),
-            ("tan", doubles, True, True, 'cpu'),
-            ("tan", doubles, False, True, 'cuda'),
-            ("tanh", doubles, True, True, 'cpu'),
-            ("tanh", doubles, False, True, 'cuda'),
-            ("trunc", doubles, True, True, 'cpu'),
-            ("trunc", doubles, False, True, 'cuda')
-        ]
-
-        for (fn, inputs, has_input_output_mem_overlap_check,
-             has_internal_mem_overlap_check, dev) in unary_mem_overlap_cases:
-            if dev != device:
-                continue
-            out_fn = getattr(torch, fn)
-            in_fn = getattr(torch.Tensor, fn + '_')
-
-            self.unary_check_input_output_mem_overlap(inputs, sz, out_fn,
-                                                      expected_failure=not has_input_output_mem_overlap_check)
-
-            self.check_internal_mem_overlap(in_fn, num_inputs=1, device=dev,
-                                            expected_failure=not has_internal_mem_overlap_check)
-
-    def binary_check_input_output_mem_overlap(self, op, device,
-                                              expected_failure=False):
-        sz = 3
-        data = torch.randn(2 * sz, device=device)
-        other = torch.randn(sz, device=device)
-
-        self.unary_check_input_output_mem_overlap(
-            data, sz, lambda input, out: op(other, input, out=out),
-            expected_failure=expected_failure)
-
-        self.unary_check_input_output_mem_overlap(
-            data, sz, lambda input, out: op(input, other, out=out),
-            expected_failure=expected_failure)
-
-    @torchtest.for_all_device_types()
-    def test_binary_op_mem_overlap(self, device):
-        ops = [
-            ("add", True, True, 'cpu'),
-            ("add", True, True, 'cuda'),
-            ("mul", True, True, 'cpu'),
-            ("mul", True, True, 'cuda'),
-            ("sub", True, True, 'cpu'),
-            ("sub", True, True, 'cuda'),
-            ("div", True, True, 'cpu'),
-            ("div", True, True, 'cuda'),
-            ("pow", True, True, 'cpu'),
-            ("pow", True, True, 'cuda')
-        ]
-
-        for (fn, has_input_output_mem_overlap_check,
-             has_internal_mem_overlap_check, dev) in ops:
-            if dev != device:
-                continue
-            out_op = getattr(torch, fn)
-            inplace_op = getattr(torch.Tensor, fn + '_')
-            self.check_internal_mem_overlap(
-                inplace_op, num_inputs=2, device=device,
-                expected_failure=not has_internal_mem_overlap_check)
-
-            self.binary_check_input_output_mem_overlap(out_op, device,
-                                                       expected_failure=not has_input_output_mem_overlap_check)
-
-    def ternary_check_input_output_mem_overlap(self, op, device,
-                                               expected_failure=False):
-        sz = 3
-        data = torch.randn(2 * sz, device=device)
-        other1 = torch.randn(sz, device=device)
-        other2 = torch.randn(sz, device=device)
-
-        self.unary_check_input_output_mem_overlap(
-            data, sz, lambda input, out: op(input, other1, other2, out=out),
-            expected_failure=expected_failure)
-
-        self.unary_check_input_output_mem_overlap(
-            data, sz, lambda input, out: op(other1, input, other2, out=out),
-            expected_failure=expected_failure)
-
-        self.unary_check_input_output_mem_overlap(
-            data, sz, lambda input, out: op(other1, other2, input, out=out),
-            expected_failure=expected_failure)
-
-    @torchtest.for_all_device_types()
-    def test_ternary_op_mem_overlap(self, device):
-        ops = [
-            ("addcmul", True, True, 'cpu'),
-            ("addcmul", True, True, 'cuda'),
-            ("addcdiv", True, True, 'cpu'),
-            ("addcdiv", True, True, 'cuda'),
-            ("lerp", True, True, 'cpu'),
-            ("lerp", False, False, 'cuda')
-        ]
-
-        for (fn, has_input_output_mem_overlap_check,
-             has_internal_mem_overlap_check, dev) in ops:
-            if dev != device:
-                continue
-            out_op = getattr(torch, fn)
-            inplace_op = getattr(torch.Tensor, fn + '_')
-            self.check_internal_mem_overlap(
-                inplace_op, num_inputs=3, device=device,
-                expected_failure=not has_internal_mem_overlap_check)
-            self.ternary_check_input_output_mem_overlap(out_op, dev,
-                                                        expected_failure=not has_input_output_mem_overlap_check)
-
-    @torchtest.for_all_device_types()
-    def test_copy_mem_overlap(self, device):
-        self.check_internal_mem_overlap(
-            torch.Tensor.copy_, num_inputs=2, device=device)
-        sz = 3
-        doubles = torch.randn(2 * sz, device=device)
-        self.unary_check_input_output_mem_overlap(
-            doubles, sz, lambda input, out: out.copy_(input))
-
-    @torchtest.for_all_device_types()
-    def test_pow_scalar_overloads_mem_overlap(self, device):
-        sz = 3
-        doubles = torch.randn(2 * sz, device=device)
-        self.check_internal_mem_overlap(
-            lambda t: t.pow_(42), num_inputs=1, device=device)
-        self.unary_check_input_output_mem_overlap(
-            doubles, sz, lambda input, out: torch.pow(input, 42, out=out))
-        self.unary_check_input_output_mem_overlap(
-            doubles, sz, lambda input, out: torch.pow(42, input, out=out))
 
 
 # Functions to test negative dimension wrapping
@@ -13170,8 +7795,153 @@ def add_neg_dim_tests():
         assert not hasattr(_TestTorchMixin, test_name), "Duplicated test name: " + test_name
         setattr(_TestTorchMixin, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
 
+# Helpers for device-generic tests.
+# Must be in a different, inherited class for Python2 compat.
+class GenericDeviceTypeHelpers(object):
+    @staticmethod
+    def _select_broadcastable_dims(dims_full=None):
+        # select full dimensionality
+        if dims_full is None:
+            dims_full = []
+            ndims = random.randint(1, 4)
+            dims_full = [random.randint(1, 8) for _ in range(ndims)]
+        else:
+            ndims = len(dims_full)
+
+        # select actual dimensions for ops:
+        # larger: full ndims, individual sizes may be reduced
+        # smaller: possibly reduced ndims, sizes may be reduced
+        smaller_ndims = random.randint(1, ndims)
+        dims_small = []
+        dims_large = []
+        for i in range(ndims - 1, -1, -1):
+            j = random.randint(1, 3)
+            if j == 1:  # no reduced singleton dimension
+                ds = dims_full[i]
+                dl = dims_full[i]
+            elif j == 2:  # larger may have reduced singleton dimension
+                ds = dims_full[i]
+                dl = 1 if len(dims_small) < smaller_ndims else dims_full[i]
+            elif j == 3:  # smaller may have reduced singleton dimension
+                ds = 1
+                dl = dims_full[i]
+            dims_large = [dl] + dims_large
+            if len(dims_small) < smaller_ndims:
+                dims_small = [ds] + dims_small
+        return (dims_small, dims_large, dims_full)
+
+    def check_internal_mem_overlap(self, inplace_op, num_inputs, device,
+                                   expected_failure=False):
+        if isinstance(inplace_op, str):
+            inplace_op = getattr(torch.Tensor, inplace_op)
+        input = torch.randn(1, device=device).expand(3, 3)
+        inputs = [input] + [torch.randn_like(input)
+                            for i in range(num_inputs - 1)]
+        if not expected_failure:
+            with self.assertRaisesRegex(RuntimeError, 'single memory location'):
+                inplace_op(*inputs)
+        else:
+            with self.assertRaises(AssertionError):
+                with self.assertRaisesRegex(RuntimeError, 'single memory location'):
+                    inplace_op(*inputs)
+
+    def unary_check_input_output_mem_overlap(self, data, sz, op,
+                                             expected_failure=False):
+
+        def _test(op, output, input):
+            output_exp = torch.empty_like(output)
+            op(input, out=output_exp)
+            self.assertEqual(op(input, out=output), output_exp, op.__name__)
+
+        # output is identical to input:
+        _test(op, output=data[0:sz], input=data[0:sz])
+        # output and input are independent:
+        _test(op, output=data[0:sz], input=data[sz:2 * sz])
+        # output partially overlaps with input:
+        if not expected_failure:
+            with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
+                _test(op, data[0:sz], data[1:sz + 1])
+        else:
+            with self.assertRaises(AssertionError):
+                with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
+                    _test(op, data[0:sz], data[1:sz + 1])
+
+    def binary_check_input_output_mem_overlap(self, op, device,
+                                              expected_failure=False):
+        sz = 3
+        data = torch.randn(2 * sz, device=device)
+        other = torch.randn(sz, device=device)
+
+        self.unary_check_input_output_mem_overlap(
+            data, sz, lambda input, out: op(other, input, out=out),
+            expected_failure=expected_failure)
+
+        self.unary_check_input_output_mem_overlap(
+            data, sz, lambda input, out: op(input, other, out=out),
+            expected_failure=expected_failure)
+
+    def ternary_check_input_output_mem_overlap(self, op, device,
+                                               expected_failure=False):
+        sz = 3
+        data = torch.randn(2 * sz, device=device)
+        other1 = torch.randn(sz, device=device)
+        other2 = torch.randn(sz, device=device)
+
+        self.unary_check_input_output_mem_overlap(
+            data, sz, lambda input, out: op(input, other1, other2, out=out),
+            expected_failure=expected_failure)
+
+        self.unary_check_input_output_mem_overlap(
+            data, sz, lambda input, out: op(other1, input, other2, out=out),
+            expected_failure=expected_failure)
+
+        self.unary_check_input_output_mem_overlap(
+            data, sz, lambda input, out: op(other1, other2, input, out=out),
+            expected_failure=expected_failure)
+
+    def _test_pow(self, base, exponent, np_exponent=None):
+        if np_exponent is None:
+            np_exponent = exponent
+
+        def to_np(value):
+            if isinstance(value, torch.Tensor):
+                return value.cpu().numpy()
+            return value
+
+        try:
+            expected = torch.from_numpy(
+                np.power(to_np(base), to_np(np_exponent)))
+        except ValueError as e:
+            err_msg = "Integers to negative integer powers are not allowed."
+            self.assertEqual(str(e), err_msg)
+            out = torch.empty_like(base)
+            test_cases = [
+                lambda: base.pow(exponent),
+                lambda: base.pow_(exponent),
+                lambda: torch.pow(base, exponent),
+                lambda: torch.pow(base, exponent, out=out)
+            ]
+            for test_case in test_cases:
+                self.assertRaisesRegex(RuntimeError, err_msg, test_case)
+        else:
+            if isinstance(base, torch.Tensor):
+                actual = base.pow(exponent)
+                self.assertEqual(actual, expected, allow_inf=True)
+
+                actual = base.clone()
+                actual2 = actual.pow_(exponent)
+                self.assertEqual(actual, expected, allow_inf=True)
+                self.assertEqual(actual2, expected, allow_inf=True)
+
+            actual = torch.pow(base, exponent)
+            self.assertEqual(actual, expected, allow_inf=True)
+
+            actual2 = torch.pow(base, exponent, out=actual)
+            self.assertEqual(actual, expected, allow_inf=True)
+            self.assertEqual(actual2, expected, allow_inf=True)
+
 # Device-generic tests. Instantiated below and not run directly.
-class TestTorchDeviceType(TestCase):
+class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
     def test_diagonal(self, device):
         x = torch.randn((100, 100), device=device)
         result = torch.diagonal(x)
@@ -13220,6 +7990,7 @@ class TestTorchDeviceType(TestCase):
 
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
     def test_inverse(self, device):
         from common_utils import random_fullrank_matrix_distinct_singular_value
 
@@ -13287,6 +8058,4930 @@ class TestTorchDeviceType(TestCase):
         matrices_inverse = torch.inverse(matrices)
         expected_inv = torch.as_tensor(inv(matrices.cpu().numpy()))
         self.assertEqual(matrices_inverse, expected_inv.to(device))
+
+    def test_bitwise_not(self, device):
+        res = 0xffff - torch.arange(127, dtype=torch.int8, device=device)
+        for dtype in (torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64):
+            if dtype == torch.bool:
+                a = torch.tensor([True, False], device=device)
+                expected_res = torch.tensor([False, True], device=device)
+            else:
+                a = torch.arange(127, dtype=dtype, device=device)
+                expected_res = res.type(dtype)
+            # new tensor
+            self.assertEqual(expected_res, a.bitwise_not())
+            # out
+            b = torch.empty(0, dtype=dtype, device=device)
+            torch.bitwise_not(a, out=b)
+            self.assertEqual(expected_res, b)
+            # in-place
+            a.bitwise_not_()
+            self.assertEqual(expected_res, a)
+
+        # test exceptions
+        for dtype in(torch.half, torch.float, torch.double):
+            a = torch.zeros(10, dtype=dtype, device=device)
+            # new tensor
+            with self.assertRaises(RuntimeError):
+                a.bitwise_not()
+            # out
+            b = torch.empty(0, dtype=dtype, device=device)
+            with self.assertRaises(RuntimeError):
+                torch.bitwise_not(a, out=b)
+            # in-place
+            with self.assertRaises(RuntimeError):
+                a.bitwise_not_()
+
+    def test_logical_not(self, device):
+        for dtype in torch.testing.get_all_dtypes():
+            a = torch.tensor([10, 1, 0], dtype=dtype, device=device)
+            if dtype == torch.bfloat16:
+                self.assertRaises(RuntimeError, lambda: a.logical_not())
+                continue
+            expected_res = torch.tensor([0, 0, 1], dtype=dtype, device=device)
+            # new tensor
+            self.assertEqual(expected_res.bool(), a.logical_not())
+            # out
+            for out_dtype in torch.testing.get_all_dtypes():
+                b = torch.empty(0, dtype=out_dtype, device=device)
+                if out_dtype == torch.bfloat16:
+                    self.assertRaises(RuntimeError, lambda: torch.logical_not(a, out=b))
+                    continue
+                torch.logical_not(a, out=b)
+                self.assertEqual(expected_res.bool(), b.bool())
+            # in-place
+            a.logical_not_()
+            self.assertEqual(expected_res, a)
+
+    def test_logical_xor(self, device):
+        for dtype in (torch.bool,):  # Will add more dtypes in the future
+            expected_res = torch.tensor([0, 0, 1, 1], dtype=dtype, device=device)
+            a = torch.tensor([10, 0, 1, 0], dtype=dtype, device=device)
+            b = torch.tensor([1, 0, 0, 10], dtype=dtype, device=device)
+            # new tensor
+            self.assertEqual(expected_res, a.logical_xor(b))
+            # out
+            c = torch.empty(0, dtype=dtype, device=device)
+            torch.logical_xor(a, b, out=c)
+            self.assertEqual(expected_res, c)
+            # out is not bool
+            c = torch.empty(0, dtype=torch.uint8, device=device)
+            with self.assertRaisesRegex(RuntimeError,
+                                        r"The output tensor of logical_xor must be a bool tensor\."):
+                torch.logical_xor(a, b, out=c)
+            # in-place
+            a.logical_xor_(b)
+            self.assertEqual(expected_res, a)
+
+    def test_isinf(self, device):
+        t1 = torch.Tensor([1, inf, 2, -inf, nan]).to(device)
+        t2 = torch.ByteTensor([1, 2, 3]).to(device)
+        t3 = torch.CharTensor([1, 2, 3]).to(device)
+        t4 = torch.ShortTensor([1, 2, 3]).to(device)
+        t5 = torch.IntTensor([1, 2, 3]).to(device)
+        t6 = torch.LongTensor([1, 2, 3]).to(device)
+        self.assertEqual(torch.isinf(t1), torch.ByteTensor([0, 1, 0, 1, 0]).to(device))
+        self.assertEqual(torch.isinf(t2), torch.ByteTensor([0, 0, 0]).to(device))
+        self.assertEqual(torch.isinf(t3), torch.ByteTensor([0, 0, 0]).to(device))
+        self.assertEqual(torch.isinf(t4), torch.ByteTensor([0, 0, 0]).to(device))
+        self.assertEqual(torch.isinf(t5), torch.ByteTensor([0, 0, 0]).to(device))
+        self.assertEqual(torch.isinf(t6), torch.ByteTensor([0, 0, 0]).to(device))
+
+    def test_clamp(self, device):
+        m1 = torch.rand(100, device=device).mul(5).add(-2.5)  # uniform in [-2.5, 2.5]
+        # just in case we're extremely lucky.
+        min_val = -1
+        max_val = 1
+        m1[1] = min_val
+        m1[2] = max_val
+
+        res1 = m1.clone()
+        res1.clamp_(min_val, max_val)
+        res2 = m1.clone()
+        for i in iter_indices(res2):
+            res2[i] = max(min_val, min(max_val, res2[i]))
+        self.assertEqual(res1, res2)
+
+        out = m1.clone()
+        torch.clamp(m1, min=min_val, max=max_val, out=out)
+        self.assertEqual(out, res1)
+
+        res1 = torch.clamp(m1, min=min_val)
+        res2 = m1.clone()
+        for i in iter_indices(res2):
+            res2[i] = max(min_val, res2[i])
+        self.assertEqual(res1, res2)
+
+        torch.clamp(m1, min=min_val, out=out)
+        self.assertEqual(out, res1)
+
+        res1 = torch.clamp(m1, max=max_val)
+        res2 = m1.clone()
+        for i in iter_indices(res2):
+            res2[i] = min(max_val, res2[i])
+        self.assertEqual(res1, res2)
+
+        torch.clamp(m1, max=max_val, out=out)
+        self.assertEqual(out, res1)
+
+        # if the tensor contains nan case
+        test_tens = torch.tensor([nan], device=device)
+
+        res1 = test_tens.clone()
+        res1.clamp_(min_val, max_val)
+        res2 = test_tens.clone()
+        for i in iter_indices(res2):
+            res2[i] = max(min(res2[i], max_val), min_val)
+        self.assertEqual(torch.isnan(res1), torch.isnan(res2))
+
+        out = test_tens.clone()
+        torch.clamp(test_tens, min=min_val, max=max_val, out=out)
+        self.assertEqual(torch.isnan(out), torch.isnan(res1))
+
+        res1 = torch.clamp(test_tens, min=min_val)
+        res2 = test_tens.clone()
+        for i in iter_indices(res2):
+            res2[i] = max(res2[i], min_val)
+        self.assertEqual(torch.isnan(res1), torch.isnan(res2))
+
+        torch.clamp(test_tens, min=min_val, out=out)
+        self.assertEqual(torch.isnan(out), torch.isnan(res1))
+
+        res1 = torch.clamp(test_tens, max=max_val)
+        res2 = test_tens.clone()
+        for i in iter_indices(res2):
+            res2[i] = min(res2[i], max_val)
+        self.assertEqual(torch.isnan(res1), torch.isnan(res2))
+
+        torch.clamp(test_tens, max=max_val, out=out)
+        self.assertEqual(torch.isnan(out), torch.isnan(res1))
+
+        error_msg = 'At least one of \'min\' or \'max\' must not be None'
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            m1.clamp()
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            m1.clamp_()
+
+    def test_cat_empty_legacy(self, device):
+        # FIXME: this is legacy behavior and should be removed
+        # when we support empty tensors with arbitrary sizes
+        dtype = torch.float32
+
+        x = torch.randn((4, 3, 32, 32), dtype=dtype, device=device)
+        empty = torch.randn((0,), dtype=dtype, device=device)
+
+        res1 = torch.cat([x, empty], dim=1)
+        res2 = torch.cat([empty, x], dim=1)
+        self.assertEqual(res1, res2)
+
+        conv = torch.nn.Conv2d(3, 3, kernel_size=1).float().to(device)
+        res1 = torch.cat([conv(x), empty], dim=1)
+        res2 = torch.cat([empty, conv(x)], dim=1)
+        self.assertEqual(res1, res2)
+
+        res1 = torch.cat([empty, empty], dim=1)
+        self.assertEqual(res1, empty)
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    'expected a non-empty list of Tensors'):
+            torch.cat([], dim=1)
+
+    def test_cat_empty(self, device):
+        dtype = torch.float32
+
+        x = torch.randn((4, 3, 32, 32), dtype=dtype, device=device)
+        empty = torch.randn((4, 0, 32, 32), dtype=dtype, device=device)
+
+        res1 = torch.cat([x, empty], dim=1)
+        res2 = torch.cat([empty, x], dim=1)
+        self.assertEqual(res1, res2)
+
+        conv = torch.nn.Conv2d(3, 3, kernel_size=1).float().to(device)
+        res1 = torch.cat([conv(x), empty], dim=1)
+        res2 = torch.cat([empty, conv(x)], dim=1)
+        self.assertEqual(res1, res2)
+
+        res1 = torch.cat([empty, empty], dim=1)
+        self.assertEqual(res1, empty)
+
+        # check non-legacy-behavior (sizes don't match)
+        empty = torch.randn((4, 0, 31, 32), dtype=dtype, device=device)
+        self.assertRaises(RuntimeError, lambda: torch.cat([x, empty], dim=1))
+        self.assertRaises(RuntimeError, lambda: torch.cat([empty, x], dim=1))
+
+        # check non-legacy-behavior (dimensions don't match)
+        empty = torch.randn((4, 0), dtype=dtype, device=device)
+        self.assertRaises(RuntimeError, lambda: torch.cat([x, empty], dim=1))
+        self.assertRaises(RuntimeError, lambda: torch.cat([empty, x], dim=1))
+
+    @slowTest
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_inverse_many_batches(self, device):
+        from common_utils import random_fullrank_matrix_distinct_singular_value
+
+        matrices = random_fullrank_matrix_distinct_singular_value(5, 256, 256).to(device)
+        matrices_inverse = torch.inverse(matrices)
+        self.assertEqual(torch.matmul(matrices_inverse, matrices),
+                         torch.eye(5).to(device).expand_as(matrices))
+
+        matrices = random_fullrank_matrix_distinct_singular_value(3, 512, 512).to(device)
+        matrices_inverse = torch.inverse(matrices)
+        self.assertEqual(torch.matmul(matrices, matrices_inverse),
+                         torch.eye(3).to(device).expand_as(matrices))
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_pinverse(self, device):
+        def run_test(M):
+            # Testing against definition for pseudo-inverses
+            MPI = torch.pinverse(M)
+            self.assertEqual(M, M.mm(MPI).mm(M), 1e-8, 'pseudo-inverse condition 1')
+            self.assertEqual(MPI, MPI.mm(M).mm(MPI), 1e-8, 'pseudo-inverse condition 2')
+            self.assertEqual(M.mm(MPI), (M.mm(MPI)).t(), 1e-8, 'pseudo-inverse condition 3')
+            self.assertEqual(MPI.mm(M), (MPI.mm(M)).t(), 1e-8, 'pseudo-inverse condition 4')
+
+        # Square matrix
+        M = torch.randn(5, 5, device=device)
+        run_test(M)
+
+        # Rectangular matrix
+        M = torch.randn(3, 4, device=device)
+        run_test(M)
+
+        # Test inverse and pseudo-inverse for invertible matrix
+        M = torch.randn(5, 5)
+        M = M.mm(M.t()).to(device)
+        self.assertEqual(torch.eye(5, device=device), M.pinverse().mm(M), 1e-7, 'pseudo-inverse for invertible matrix')
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_matrix_rank(self, device):
+        a = torch.eye(10, device=device)
+        self.assertEqual(torch.matrix_rank(a).item(), 10)
+        self.assertEqual(torch.matrix_rank(a, True).item(), 10)
+
+        a[5, 5] = 0
+        self.assertEqual(torch.matrix_rank(a).item(), 9)
+        self.assertEqual(torch.matrix_rank(a, True).item(), 9)
+
+        a = torch.randn(24, 42, device=device)
+        self.assertEqual(torch.matrix_rank(a), torch.matrix_rank(a.t()))
+        aaT = torch.mm(a, a.t())
+        self.assertEqual(torch.matrix_rank(aaT), torch.matrix_rank(aaT, True))
+        aTa = torch.mm(a.t(), a)
+        self.assertEqual(torch.matrix_rank(aTa), torch.matrix_rank(aTa, True))
+
+        if TEST_NUMPY:
+            from numpy.linalg import matrix_rank
+            a = torch.randn(35, 75, device=device)
+            self.assertEqual(torch.matrix_rank(a).item(), matrix_rank(a.cpu().numpy()))
+            self.assertEqual(torch.matrix_rank(a, 0.01).item(), matrix_rank(a.cpu().numpy(), 0.01))
+
+            aaT = torch.mm(a, a.t())
+            self.assertEqual(torch.matrix_rank(aaT).item(), matrix_rank(aaT.cpu().numpy()))
+            self.assertEqual(torch.matrix_rank(aaT, 0.01).item(), matrix_rank(aaT.cpu().numpy(), 0.01))
+
+            if np.lib.NumpyVersion(np.__version__) >= '1.14.0':
+                self.assertEqual(torch.matrix_rank(aaT, True).item(), matrix_rank(aaT.cpu().numpy(), True))
+                self.assertEqual(torch.matrix_rank(aaT, 0.01, True).item(),
+                                 matrix_rank(aaT.cpu().numpy(), 0.01, True))
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_matrix_power(self, device):
+        def run_test(M, sign=1):
+            if sign == -1:
+                M = M.inverse()
+            MP2 = torch.matrix_power(M, 2)
+            self.assertEqual(MP2, torch.matmul(M, M))
+
+            MP3 = torch.matrix_power(M, 3)
+            self.assertEqual(MP3, torch.matmul(MP2, M))
+
+            MP4 = torch.matrix_power(M, 4)
+            self.assertEqual(MP4, torch.matmul(MP2, MP2))
+
+            MP6 = torch.matrix_power(M, 6)
+            self.assertEqual(MP6, torch.matmul(MP3, MP3))
+
+            MP0 = torch.matrix_power(M, 0)
+            self.assertEqual(MP0, torch.eye(M.size(-2)).expand_as(M))
+
+        # Single matrix
+        M = torch.randn(5, 5, device=device)
+        run_test(M)
+
+        # Batch matrices
+        M = torch.randn(3, 3, 3, device=device)
+        run_test(M)
+
+        # Many batch matrices
+        M = torch.randn(2, 3, 3, 3, device=device)
+        run_test(M)
+
+        # This is for negative powers
+        from common_utils import random_fullrank_matrix_distinct_singular_value
+        M = random_fullrank_matrix_distinct_singular_value(5).to(device)
+        run_test(M, sign=-1)
+
+        M = random_fullrank_matrix_distinct_singular_value(3, 3).to(device)
+        run_test(M, sign=-1)
+
+        M = random_fullrank_matrix_distinct_singular_value(3, 2, 3).to(device)
+        run_test(M, sign=-1)
+
+    def test_chain_matmul(self, device):
+        def product(matrices):
+            for mat in matrices[1:]:
+                matrices[0] = matrices[0].mm(mat)
+            return matrices[0]
+
+        def run_test(p, device):
+            matrices = []
+            for (pi, pi_1) in zip(p[:-1], p[1:]):
+                matrices.append(torch.randn(pi, pi_1, device=device))
+            self.assertEqual(torch.chain_matmul(*matrices), product(matrices))
+
+        run_test([10, 20, 30, 5], device)
+        run_test([15, 5, 10, 20, 25], device)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_det_logdet_slogdet(self, device):
+        def reference_slogdet(M):
+            if TEST_NUMPY:
+                sdet, logabsdet = np.linalg.slogdet(M.detach().cpu().numpy())
+                return M.new_tensor(sdet), M.new_tensor(logabsdet)
+            else:
+                # naive row reduction
+                M = M.clone()
+                l = M.size(0)
+                multiplier = 1
+                for i in range(l):
+                    if M[i, 0].item() != 0:
+                        if i != 0:
+                            M[0], M[i] = M[i], M[0]
+                            multiplier = -1
+                        break
+                else:
+                    return 0
+                for i in range(1, l):
+                    row = M[i]
+                    for j in range(i):
+                        row -= row[j] / M[j, j] * M[j]
+                    M[i] = row
+            sdet = M.diag().sign().prod()
+            logabsdet = M.diag().abs_().log_().sum().add_(math.log(multiplier))
+            return sdet, logabsdet
+
+        def test_single_det(M, target, desc):
+            target_sdet, target_logabsdet = target
+
+            det = M.det()
+            logdet = M.logdet()
+            sdet, logabsdet = M.slogdet()
+
+            # Test det
+            self.assertEqual(det, target_sdet * target_logabsdet.exp(), 1e-7, '{} (det)'.format(desc))
+
+            # Test slogdet
+            # Compare the overall value rather than individual parts because of
+            # precision issues when det is near zero.
+            self.assertEqual(sdet * logabsdet.exp(), target_sdet * target_logabsdet.exp(), 1e-7, '{} (slogdet)'.format(desc))
+
+            # Test logdet
+            # Compare logdet against our own pytorch slogdet because they should
+            # be consistent, while it may behave slightly differently with other
+            # slogdet implementations when det is near zero due to precision
+            # issues.
+            if sdet.item() < 0:
+                self.assertTrue(logdet.item() != logdet.item(), '{} (logdet negative case)'.format(desc))
+            else:
+                self.assertEqual(logdet.exp(), target_logabsdet.exp(), 1e-7, '{} (logdet non-negative case)'.format(desc))
+
+        eye = torch.eye(5, device=device)
+        test_single_det(eye, (torch.ones((), device=device), torch.zeros((), device=device)), 'identity')
+
+        def test(M):
+            assert M.size(0) >= 5, 'this helper fn assumes M to be at least 5x5'
+            M = M.to(device)
+
+            ref_M_sdet, ref_M_logabsdet = reference_slogdet(M)
+
+            test_single_det(M, (ref_M_sdet, ref_M_logabsdet), 'basic')
+            if ref_M_logabsdet.exp().item() >= 1e-6:  # skip singular
+                M_inv = M.inverse()
+                test_single_det(M_inv, reference_slogdet(M_inv), 'inverse')
+
+            test_single_det(M, (ref_M_sdet, ref_M_logabsdet), 'transpose')
+
+            for x in [0, 2, 4]:
+                for scale in [-2, -0.1, 0, 10]:
+                    if scale > 0:
+                        target = ref_M_sdet, ref_M_logabsdet + math.log(scale)
+                    elif scale == 0:
+                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                    else:
+                        target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-scale)
+
+                    # dim 0
+                    M_clone = M.clone()
+                    M_clone[:, x] *= scale
+                    test_single_det(M_clone, target, 'scale a row')
+                    # dim 1
+                    M_clone = M.clone()
+                    M_clone[x, :] *= scale
+                    test_single_det(M_clone, target, 'scale a column')
+
+            for x1, x2 in [(0, 3), (4, 1), (3, 2)]:
+                assert x1 != x2, 'x1 and x2 needs to be different for this test'
+                target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                # dim 0
+                M_clone = M.clone()
+                M_clone[:, x2] = M_clone[:, x1]
+                test_single_det(M_clone, target, 'two rows are same')
+                # dim 1
+                M_clone = M.clone()
+                M_clone[x2, :] = M_clone[x1, :]
+                test_single_det(M_clone, target, 'two columns are same')
+
+                for scale1, scale2 in [(0.3, -1), (0, 2), (10, 0.1)]:
+                    det_scale = scale1 * scale2 * -1
+                    if det_scale > 0:
+                        target = ref_M_sdet, ref_M_logabsdet + math.log(det_scale)
+                    elif det_scale == 0:
+                        target = torch.zeros_like(ref_M_sdet), torch.full_like(ref_M_logabsdet, -inf)
+                    else:
+                        target = ref_M_sdet.neg(), ref_M_logabsdet + math.log(-det_scale)
+
+                    # dim 0
+                    M_clone = M.clone()
+                    t = M_clone[:, x1] * scale1
+                    M_clone[:, x1] += M_clone[:, x2] * scale2
+                    M_clone[:, x2] = t
+                    test_single_det(M_clone, target, 'exchanging rows')
+                    # dim 1
+                    M_clone = M.clone()
+                    t = M_clone[x1, :] * scale1
+                    M_clone[x1, :] += M_clone[x2, :] * scale2
+                    M_clone[x2, :] = t
+                    test_single_det(M_clone, target, 'exchanging columns')
+
+        def get_random_mat_scale(n):
+            # For matrices with values i.i.d. with 0 mean, unit variance, and
+            # subexponential tail, we have:
+            #   E[log det(A^2)] \approx log((n-1)!)
+            #
+            # Notice:
+            #   log Var[det(A)] = log E[det(A^2)] >= E[log det(A^2)]
+            #
+            # So:
+            #   stddev[det(A)] >= sqrt( (n-1)! )
+            #
+            # We use this as an intuitive guideline to scale random generated
+            # matrices so our closeness tests can work more robustly:
+            #   scale by sqrt( (n-1)! )^(-1/n) = ( (n-1)! )^(-1/(2n))
+            #
+            # source: https://arxiv.org/pdf/1112.0752.pdf
+
+            # TODO: technically we need subexponential distn for this to hold,
+            #       but we mostly use gaussian entries below. Consider switching
+            #       to Chi-sq if this turns out not stable enough, since Chi-sq
+            #       is easy enough to sample from.
+            return math.factorial(n - 1) ** (-1.0 / (2 * n))
+
+        for n in [5, 10, 25]:
+            scale = get_random_mat_scale(n)
+            test(torch.randn(n, n, device=device) * scale)
+            r = torch.randn(n, n, device=device) * scale
+            # symmetric psd
+            test(r.mm(r.t()))
+            # symmetric pd
+            r = torch.randn(n, n, device=device) * scale
+            test(r.mm(r.t()) + torch.eye(n, device=device) * 1e-6)
+            # symmetric
+            r = torch.randn(n, n, device=device) * scale
+            for i in range(n):
+                for j in range(i):
+                    r[i, j] = r[j, i]
+            test(r)
+            # non-contiguous
+            test((torch.randn(n, n, n + 1, device=device) * scale)[:, 2, 1:])
+            # det = 0
+            r = torch.randn(n, n, device=device) * scale
+            u, s, v = r.svd()
+            if reference_slogdet(u)[0] < 0:
+                u = -u
+            if reference_slogdet(v)[0] < 0:
+                v = -v
+            s[0] *= -1
+            s[-1] = 0
+            test(u.mm(s.diag()).mm(v))
+
+        # Small values to test numerical stability. Note that we don't scale
+        # this matrix.
+        r = torch.randn(512, 512, device=device)
+        u, s, v = r.svd()
+        s.fill_(1. / (100 * s.numel()))
+        test(u.mm(s.diag()).mm(v))
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_det_logdet_slogdet_batched(self, device):
+        from common_utils import (random_symmetric_matrix, random_symmetric_psd_matrix,
+                                  random_symmetric_pd_matrix, random_square_matrix_of_rank)
+
+        # mat_chars denotes matrix characteristics
+        # possible values are: sym, sym_psd, sym_pd, sing, non_sym
+        def run_test(matsize, batchdims, mat_chars):
+            num_matrices = reduce(lambda x, y: x * y, batchdims, 1)
+            list_of_matrices = []
+
+            for idx in range(num_matrices):
+                mat_type = idx % len(mat_chars)
+                if mat_chars[mat_type] == 'sym':
+                    list_of_matrices.append(random_symmetric_matrix(matsize).to(device=device))
+                elif mat_chars[mat_type] == 'sym_psd':
+                    list_of_matrices.append(random_symmetric_psd_matrix(matsize).to(device=device))
+                elif mat_chars[mat_type] == 'sym_pd':
+                    list_of_matrices.append(random_symmetric_pd_matrix(matsize).to(device=device))
+                elif mat_chars[mat_type] == 'sing':
+                    list_of_matrices.append(torch.ones(matsize, matsize, device=device))
+                elif mat_chars[mat_type] == 'non_sing':
+                    list_of_matrices.append(random_square_matrix_of_rank(matsize, matsize).to(device=device))
+            full_tensor = torch.stack(list_of_matrices, dim=0).reshape(batchdims + (matsize, matsize))
+            # Scaling adapted from `get_random_mat_scale` in _test_det_logdet_slogdet
+            full_tensor *= (math.factorial(matsize - 1) ** (-1.0 / (2 * matsize)))
+
+            for fn in [torch.det, torch.logdet, torch.slogdet]:
+                expected_value = []
+                actual_value = fn(full_tensor)
+                for full_idx in product(*map(lambda x: list(range(x)), batchdims)):
+                    expected_value.append(fn(full_tensor[full_idx]))
+
+                if fn == torch.slogdet:
+                    sign_value = torch.stack([tup[0] for tup in expected_value], dim=0).reshape(batchdims)
+                    expected_value = torch.stack([tup[1] for tup in expected_value], dim=0).reshape(batchdims)
+                    self.assertEqual(sign_value, actual_value[0], allow_inf=True)
+                    self.assertEqual(expected_value, actual_value[1], allow_inf=True)
+                else:
+                    expected_value = torch.stack(expected_value, dim=0).reshape(batchdims)
+                    self.assertEqual(actual_value, expected_value, allow_inf=True)
+
+        for matsize, batchdims in product([3, 5], [(3,), (5, 3)]):
+            run_test(matsize, batchdims, mat_chars=['sym_pd'])
+            run_test(matsize, batchdims, mat_chars=['sing'])
+            run_test(matsize, batchdims, mat_chars=['non_sing'])
+            run_test(matsize, batchdims, mat_chars=['sym', 'sym_pd', 'sym_psd'])
+            run_test(matsize, batchdims, mat_chars=['sing', 'non_sing'])
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_solve(self, device):
+        from common_utils import solve_test_helper
+        for (k, n) in zip([2, 3, 5], [3, 5, 7]):
+            b, A = solve_test_helper((n,), (n, k), lambda t: t.to(device))
+            x = torch.solve(b, A)[0]
+            self.assertLessEqual(b.dist(A.mm(x)), 1e-12)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_solve_batched(self, device):
+        from common_utils import solve_test_helper
+
+        def solve_batch_helper(A_dims, b_dims, device):
+            b, A = solve_test_helper(A_dims, b_dims, lambda t: t.to(device))
+            x_exp_list = []
+            for i in range(b_dims[0]):
+                x_exp_list.append(torch.solve(b[i], A[i])[0])
+            x_exp = torch.stack(x_exp_list)  # Stacked output
+            x_act = torch.solve(b, A)[0]  # Actual output
+            self.assertEqual(x_exp, x_act)  # Equality check
+            self.assertLessEqual(b.dist(torch.matmul(A, x_act)), 1e-12)  # Correctness check
+
+        for batchsize in [1, 3, 4]:
+            solve_batch_helper((5, batchsize), (batchsize, 5, 10), device)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_solve_batched_non_contiguous(self, device):
+        from numpy.linalg import solve
+        from common_utils import random_fullrank_matrix_distinct_singular_value
+        A = random_fullrank_matrix_distinct_singular_value(2, 2).to(device).permute(1, 0, 2)
+        b = torch.randn(2, 2, 2, device=device).permute(2, 1, 0)
+        x, _ = torch.solve(b, A)
+        x_exp = torch.Tensor(solve(A.cpu().numpy(), b.cpu().numpy())).to(device)
+        self.assertEqual(x.data, x_exp)
+
+    @slowTest
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_solve_batched_many_batches(self, device):
+        from common_utils import solve_test_helper
+
+        b, A = solve_test_helper((5, 256, 256), (5, 1), lambda t: t.to(device))
+        x, _ = torch.solve(b, A)
+        self.assertEqual(torch.matmul(A, x), b.expand(A.shape[:-2] + (5, 1)))
+
+        b, A = solve_test_helper((3,), (512, 512, 3, 1), lambda t: t.to(device))
+        x, _ = torch.solve(b, A)
+        self.assertEqual(torch.matmul(A, x), b)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_solve_batched_broadcasting(self, device):
+        from numpy.linalg import solve
+        from common_utils import solve_test_helper
+
+        def cast(t):
+            return t.to(device)
+
+        def run_test(A_dims, b_dims, cast):
+            A_matrix_size = A_dims[-1]
+            A_batch_dims = A_dims[:-2]
+            b, A = solve_test_helper((A_matrix_size,) + A_batch_dims, b_dims, cast)
+            x, _ = torch.solve(b, A)
+            x_exp = torch.Tensor(solve(A.cpu().numpy(), b.cpu().numpy()))
+            self.assertEqual(x, cast(x_exp))
+
+        # test against numpy.linalg.solve
+        for upper in [True, False]:
+            run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), cast)  # no broadcasting
+            run_test((2, 1, 3, 4, 4), (4, 6), cast)  # broadcasting b
+            run_test((4, 4), (2, 1, 3, 4, 2), cast)  # broadcasting A
+            run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), cast)  # broadcasting A & b
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky_solve(self, device):
+        from common_utils import cholesky_solve_test_helper
+        for (k, n), upper in product(zip([2, 3, 5], [3, 5, 7]), [True, False]):
+            b, A, L = cholesky_solve_test_helper((n,), (n, k), lambda t: t.to(device), upper)
+            x = torch.cholesky_solve(b, L, upper=upper)
+            self.assertLessEqual(b.dist(A.mm(x)), 1e-12)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky_solve_batched(self, device):
+        from common_utils import cholesky_solve_test_helper
+
+        def cholesky_solve_batch_helper(A_dims, b_dims, cast, upper):
+            b, A, L = cholesky_solve_test_helper(A_dims, b_dims, cast, upper)
+            x_exp_list = []
+            for i in range(b_dims[0]):
+                x_exp_list.append(torch.cholesky_solve(b[i], L[i], upper=upper))
+            x_exp = torch.stack(x_exp_list)  # Stacked output
+            x_act = torch.cholesky_solve(b, L, upper=upper)  # Actual output
+            self.assertEqual(x_act, x_exp)  # Equality check
+            self.assertLessEqual(b.dist(torch.matmul(A, x_act)), 2e-12)  # Correctness check
+
+        for upper, batchsize in product([True, False], [1, 3, 4]):
+            cholesky_solve_batch_helper((5, batchsize), (batchsize, 5, 10), lambda t: t.to(device), upper)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_cholesky_solve_batched_non_contiguous(self, device):
+        from numpy.linalg import solve
+        from common_utils import random_symmetric_pd_matrix
+
+        for upper in [True, False]:
+            A = random_symmetric_pd_matrix(2, 2)
+            b = torch.randn(2, 2, 2)
+            x_exp = torch.Tensor(solve(A.permute(0, 2, 1).numpy(), b.permute(2, 1, 0).numpy())).to(device)
+            A = A.to(device).permute(0, 2, 1)
+            b = b.to(device).permute(2, 1, 0)
+            assert not A.is_contiguous() and not b.is_contiguous(), "contiguous inputs"
+            L = torch.cholesky(A, upper)
+            x = torch.cholesky_solve(b, L, upper=upper)
+            self.assertEqual(x, x_exp)
+
+    @slowTest
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky_solve_batched_many_batches(self, device):
+        from common_utils import cholesky_solve_test_helper
+
+        for upper in [True, False]:
+            b, A, L = cholesky_solve_test_helper((5, 256, 256), (5, 10), lambda t: t.to(device), upper)
+            x = torch.cholesky_solve(b, L, upper)
+            self.assertEqual(torch.matmul(A, x), b.expand(A.shape[:-2] + (5, 10)))
+
+            b, A, L = cholesky_solve_test_helper((5,), (512, 512, 5, 10), lambda t: t.to(device), upper)
+            x = torch.cholesky_solve(b, L, upper)
+            self.assertEqual(torch.matmul(A, x), b)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_cholesky_solve_batched_broadcasting(self, device):
+        from numpy.linalg import solve
+        from common_utils import random_symmetric_pd_matrix
+
+        def cast(t):
+            return t.to(device)
+
+        def run_test(A_dims, b_dims, cast, upper):
+            A_matrix_size = A_dims[-1]
+            A_batch_dims = A_dims[:-2]
+            A = random_symmetric_pd_matrix(A_matrix_size, *A_batch_dims)
+            b = torch.randn(*b_dims)
+            x_exp = torch.Tensor(solve(A.numpy(), b.numpy()))
+            A, b = cast(A), cast(b)
+            L = torch.cholesky(A, upper)
+            x = torch.cholesky_solve(b, L, upper=upper)
+            self.assertEqual(x, cast(x_exp))
+
+        # test against numpy.linalg.solve
+        for upper in [True, False]:
+            run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), cast, upper)  # no broadcasting
+            run_test((2, 1, 3, 4, 4), (4, 6), cast, upper)  # broadcasting b
+            run_test((4, 4), (2, 1, 3, 4, 2), cast, upper)  # broadcasting A
+            run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), cast, upper)  # broadcasting A & b
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky_inverse(self, device):
+        from common_utils import random_symmetric_pd_matrix
+        a = random_symmetric_pd_matrix(5).to(device)
+
+        # compute inverse directly
+        inv0 = torch.inverse(a)
+
+        # default case
+        chol = torch.cholesky(a)
+        inv1 = torch.cholesky_inverse(chol, False)
+        self.assertLessEqual(inv0.dist(inv1), 1e-12)
+
+        # upper Triangular Test
+        chol = torch.cholesky(a, True)
+        inv1 = torch.cholesky_inverse(chol, True)
+        self.assertLessEqual(inv0.dist(inv1), 1e-12)
+
+        # lower Triangular Test
+        chol = torch.cholesky(a, False)
+        inv1 = torch.cholesky_inverse(chol, False)
+        self.assertLessEqual(inv0.dist(inv1), 1e-12)
+
+    @slowTest
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky_batched_many_batches(self, device):
+        from common_utils import random_symmetric_pd_matrix
+
+        def cholesky_test_helper(n, batchsize, device, upper):
+            A = random_symmetric_pd_matrix(n, batchsize).to(device)
+            chol_fact = torch.cholesky(A, upper=upper)
+            if upper:
+                # Correctness check
+                self.assertEqual(A, chol_fact.transpose(-2, -1).matmul(chol_fact))
+                # Upper triangular check
+                self.assertEqual(chol_fact, chol_fact.triu())
+            else:
+                # Correctness check
+                self.assertEqual(A, chol_fact.matmul(chol_fact.transpose(-2, -1)))
+                # Lower triangular check
+                self.assertEqual(chol_fact, chol_fact.tril())
+
+        for upper, batchsize in product([True, False], [262144, 524288]):
+            cholesky_test_helper(2, batchsize, device, upper)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky_batched(self, device):
+        from common_utils import random_symmetric_pd_matrix
+
+        def cholesky_test_helper(n, batch_dims, device, upper):
+            A = random_symmetric_pd_matrix(n, *batch_dims).to(device)
+            cholesky_exp = torch.stack([m.cholesky(upper=upper) for m in A.reshape(-1, n, n)])
+            cholesky_exp = cholesky_exp.reshape_as(A)
+            self.assertEqual(cholesky_exp, torch.cholesky(A, upper=upper))
+
+        for upper, batchsize in product([True, False], [(3,), (3, 4), (2, 3, 4)]):
+            cholesky_test_helper(3, batchsize, device, upper)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_cholesky(self, device):
+        x = torch.rand(10, 10, device=device) + 1e-1
+        A = torch.mm(x, x.t())
+
+        # default Case
+        C = torch.cholesky(A)
+        B = torch.mm(C, C.t())
+        self.assertEqual(A, B, 1e-14)
+
+        # test Upper Triangular
+        U = torch.cholesky(A, True)
+        B = torch.mm(U.t(), U)
+        self.assertEqual(A, B, 1e-14, 'cholesky (upper) did not allow rebuilding the original matrix')
+
+        # test Lower Triangular
+        L = torch.cholesky(A, False)
+        B = torch.mm(L, L.t())
+        self.assertEqual(A, B, 1e-14, 'cholesky (lower) did not allow rebuilding the original matrix')
+
+    def test_view(self, device):
+        tensor = torch.rand(15, device=device)
+        template = torch.rand(3, 5, device=device)
+        empty = torch.empty(0, device=device)
+        target = template.size()
+        self.assertEqual(tensor.view_as(template).size(), target)
+        self.assertEqual(tensor.view(3, 5).size(), target)
+        self.assertEqual(tensor.view(torch.Size([3, 5])).size(), target)
+        self.assertEqual(tensor.view(-1, 5).size(), target)
+        self.assertEqual(tensor.view(3, -1).size(), target)
+        tensor_view = tensor.view(5, 3)
+        tensor_view.fill_(random.uniform(0, 1))
+        self.assertEqual(empty.view_as(empty), empty)
+        self.assertEqual(empty.view(0), empty)
+        self.assertEqual(empty.view(0, 3, 0, 1).size(), torch.Size([0, 3, 0, 1]))
+        self.assertEqual(empty.view(0, 3, 0, 1).view(0), empty)
+
+        # test size inference with empty tensors
+        self.assertEqual(empty.view(-1).size(), torch.Size([0]))
+        self.assertEqual(empty.view(10, 3, -1).size(), torch.Size([10, 3, 0]))
+
+        with self.assertRaisesRegex(RuntimeError, r"because the unspecified dimension size -1 can be any value"):
+            empty.view(-1, 0)
+
+        with self.assertRaisesRegex(RuntimeError, r"because the unspecified dimension size -1 can be any value"):
+            empty.view(3, 0, -1, 0)
+
+        self.assertRaises(RuntimeError, lambda: tensor.view(15, 0))
+        self.assertRaises(RuntimeError, lambda: tensor.view(7, -1))
+        self.assertRaises(RuntimeError, lambda: tensor.view(15, -1, -1))
+
+        # test view when tensor is not contiguous in every dimension, but only
+        # contiguous dimensions are touched.
+        tensor = torch.rand(4, 2, 5, 1, 6, 2, 9, 3, device=device).transpose(-1, 2).transpose(-2, 3)
+        # size:                      [   4,    2,    3,    9,    6,    2,    1,    5]
+        # stride:                    [3840, 1620,    1,    3,   54,   27,  324,  324]
+        # contiguous dim chunks:     [__________, ____, ____, __________, ____, ____]
+        # merging 1 to chunk after:  [__________, ____, ____, __________, __________]
+        contig_tensor = tensor.clone()
+        # [4, 2] => [8, 1]
+        # [3] => [3]
+        # [9] => [3, 3]
+        # [6, 2] => [4, 1, 3]
+        # [1, 5] => [5]
+        view_size = [8, 1, 3, 3, 3, 4, 1, 3, 5]
+        self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
+        # [4, 2] => [2, 4]
+        # [3] => [3]
+        # [9] => [1, 9]
+        # [6, 2] => [2, 2, 3]
+        # [1, 5] => [5, 1]
+        view_size = [2, 4, 3, 1, 9, 2, 2, 3, 5, 1]
+        self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
+        # adding size 1 dims
+        view_size = [1, 1, 2, 1, 4, 3, 1, 1, 9, 1, 2, 1, 2, 3, 1, 5, 1, 1]
+        self.assertEqual(tensor.view(*view_size), contig_tensor.view(*view_size))
+
+        # invalid views
+        self.assertRaises(RuntimeError, lambda: tensor.view(-1))
+        # crossing [4, 2], [3]
+        self.assertRaises(RuntimeError, lambda: tensor.view(24, 9, 6, 2, 1, 5))
+        # crossing [6, 2], [1, 5]
+        self.assertRaises(RuntimeError, lambda: tensor.view(8, 3, 9, 6, 10))
+        # crossing [9], [6, 2]
+        self.assertRaises(RuntimeError, lambda: tensor.view(8, 3, 54, 2, 1, 5))
+
+        # view with stride 0 dims
+        tensor = torch.empty(1, 1, device=device).expand(3, 4)  # all dims are contiguous
+        contig_tensor = tensor.clone()
+        self.assertEqual(tensor.view(-1), contig_tensor.view(-1))
+        self.assertEqual(tensor.view(1, -1, 1), contig_tensor.view(1, -1, 1))
+        self.assertEqual(tensor.view(-1, 1), contig_tensor.view(-1, 1))
+        self.assertEqual(tensor.view(6, 2, 1), contig_tensor.view(6, 2, 1))
+        self.assertEqual(tensor.view(1, 6, 2, 1), contig_tensor.view(1, 6, 2, 1))
+
+    def test_flip(self, device):
+        data = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8], device=device).view(2, 2, 2)
+
+        self.assertEqual(torch.tensor([5, 6, 7, 8, 1, 2, 3, 4]).view(2, 2, 2), data.flip(0))
+        self.assertEqual(torch.tensor([3, 4, 1, 2, 7, 8, 5, 6]).view(2, 2, 2), data.flip(1))
+        self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(2))
+        self.assertEqual(torch.tensor([7, 8, 5, 6, 3, 4, 1, 2]).view(2, 2, 2), data.flip(0, 1))
+        self.assertEqual(torch.tensor([8, 7, 6, 5, 4, 3, 2, 1]).view(2, 2, 2), data.flip(0, 1, 2))
+
+        # check for wrap dim
+        self.assertEqual(torch.tensor([2, 1, 4, 3, 6, 5, 8, 7]).view(2, 2, 2), data.flip(-1))
+        # check for permute
+        self.assertEqual(torch.tensor([6, 5, 8, 7, 2, 1, 4, 3]).view(2, 2, 2), data.flip(0, 2))
+        self.assertEqual(torch.tensor([6, 5, 8, 7, 2, 1, 4, 3]).view(2, 2, 2), data.flip(2, 0))
+
+        # not allow flip on the same dim more than once
+        self.assertRaises(RuntimeError, lambda: data.flip(0, 1, 1))
+        # not allow empty list as input
+        self.assertRaises(TypeError, lambda: data.flip())
+
+        # not allow size of flip dim > total dims
+        self.assertRaises(IndexError, lambda: data.flip(0, 1, 2, 3))
+        # not allow dim > max dim
+        self.assertRaises(IndexError, lambda: data.flip(3))
+
+        # test for non-contiguous case
+        expanded_data = torch.arange(1, 4, device=device).view(3, 1).expand(3, 2)
+        transposed_data = torch.arange(1, 9, device=device).view(2, 2, 2).transpose(0, 1)
+        self.assertEqual(torch.tensor([3, 3, 2, 2, 1, 1]).view(3, 2), expanded_data.flip(0))
+        self.assertEqual(torch.tensor([8, 7, 4, 3, 6, 5, 2, 1]).view(2, 2, 2), transposed_data.flip(0, 1, 2))
+
+        # test for shape
+        data = torch.randn(2, 3, 4, device=device)
+        size = [2, 3, 4]
+        test_dims = []
+        for i in range(1, 3):
+            test_dims += combinations(range(len(size)), i)
+
+        for ds in test_dims:
+            self.assertEqual(size, list(data.flip(ds).size()))
+
+        # test rectangular case
+        data = torch.tensor([1, 2, 3, 4, 5, 6]).view(2, 3).to(device)
+        flip0_result = torch.tensor([[4, 5, 6], [1, 2, 3]]).to(device)
+        flip1_result = torch.tensor([[3, 2, 1], [6, 5, 4]]).to(device)
+
+        self.assertEqual(flip0_result, data.flip(0))
+        self.assertEqual(flip1_result, data.flip(1))
+
+        # test empty tensor, should just return an empty tensor of the same shape
+        data = torch.tensor([])
+        self.assertEqual(data, data.flip(0))
+
+    def test_rot90(self, device):
+        data = torch.arange(1, 5, device=device).view(2, 2)
+        self.assertEqual(torch.tensor([1, 2, 3, 4]).view(2, 2), data.rot90(0, [0, 1]))
+        self.assertEqual(torch.tensor([2, 4, 1, 3]).view(2, 2), data.rot90(1, [0, 1]))
+        self.assertEqual(torch.tensor([4, 3, 2, 1]).view(2, 2), data.rot90(2, [0, 1]))
+        self.assertEqual(torch.tensor([3, 1, 4, 2]).view(2, 2), data.rot90(3, [0, 1]))
+
+        # test for default args k=1, dims=[0, 1]
+        self.assertEqual(data.rot90(), data.rot90(1, [0, 1]))
+
+        # test for reversed order of dims
+        self.assertEqual(data.rot90(3, [0, 1]), data.rot90(1, [1, 0]))
+
+        # test for modulo of k
+        self.assertEqual(data.rot90(5, [0, 1]), data.rot90(1, [0, 1]))
+        self.assertEqual(data.rot90(3, [0, 1]), data.rot90(-1, [0, 1]))
+        self.assertEqual(data.rot90(-5, [0, 1]), data.rot90(-1, [0, 1]))
+
+        # test for dims out-of-range error
+        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, -3]))
+        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, 2]))
+
+        # test tensor with more than 2D
+        data = torch.arange(1, 9, device=device).view(2, 2, 2)
+        self.assertEqual(torch.tensor([2, 4, 1, 3, 6, 8, 5, 7]).view(2, 2, 2), data.rot90(1, [1, 2]))
+        self.assertEqual(data.rot90(1, [1, -1]), data.rot90(1, [1, 2]))
+
+        # test for errors
+        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, 3]))
+        self.assertRaises(RuntimeError, lambda: data.rot90(1, [1, 1]))
+        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0, 1, 2]))
+        self.assertRaises(RuntimeError, lambda: data.rot90(1, [0]))
+
+    def test_signal_window_functions(self, device):
+        if not TEST_SCIPY:
+            raise unittest.SkipTest('Scipy not found')
+
+        def test(name):
+            torch_method = getattr(torch, name + '_window')
+            for size in [1, 2, 5, 10, 50, 100, 1024, 2048]:
+                for periodic in [True, False]:
+                    res = torch_method(size, periodic=periodic, device=device)
+                    ref = torch.from_numpy(signal.get_window(name, size, fftbins=periodic))
+                    self.assertEqual(res, ref)
+            with self.assertRaisesRegex(RuntimeError, r'not implemented for sparse types'):
+                torch_method(3, layout=torch.sparse_coo)
+            with self.assertRaisesRegex(RuntimeError, r'floating point'):
+                torch_method(3, dtype=torch.long)
+            self.assertTrue(torch_method(3, requires_grad=True).requires_grad)
+            self.assertFalse(torch_method(3).requires_grad)
+
+        for window in ['hann', 'hamming', 'bartlett', 'blackman']:
+            test(window)
+
+    def test_broadcast(self, device):
+
+        # all functions
+        fns = {
+            "dist", "atan2", "pow", "lerp", "add",
+            "sub", "mul", "div", "fmod", "remainder",
+            "eq", "ge", "gt", "le", "lt", "max", "min", "ne",
+            "addcdiv", "addcmul", "masked_scatter", "masked_select", "masked_fill",
+            "map", "map2", "copy"
+        }
+        # functions with three tensor arguments
+        fns_3_args = {"addcdiv", "addcmul", "map2"}
+
+        for fn in fns:
+            (dims_small, dims_large, dims_full) = self._select_broadcastable_dims()
+            full1d = torch.randn(*dims_full, device=device).flatten().float()
+            small = torch.randn(*dims_small, device=device).float()
+            large = torch.randn(*dims_large, device=device).float()
+            small_expanded = small.expand(*dims_full)
+            large_expanded = large.expand(*dims_full)
+            small2 = None
+            small2_expanded = None
+            if fn in fns_3_args:
+                # create another smaller tensor
+                (dims_small2, _, _) = self._select_broadcastable_dims(dims_full)
+                small2 = torch.randn(*dims_small2, device=device).float()
+                small2_expanded = small2.expand(*dims_full)
+
+            if small.is_cuda and fn in ['map', 'map2']:
+                # map and map2 are not implementd on CUDA tensors
+                continue
+
+            if hasattr(large_expanded, fn):
+                # run through tensor versions of functions
+                # and verify fully expanded inputs give same results
+                expanded = {large: large_expanded, small: small_expanded, small2: small2_expanded}
+
+                def tensorfn(myfn, t1, t2):
+                    if fn == "lerp":
+                        return myfn(t1, 0.5)
+                    elif fn == "masked_select":
+                        return myfn(t1 < 0)
+                    elif fn == "masked_scatter":
+                        return myfn(t1 < 0.5, full1d)
+                    elif fn == "masked_fill":
+                        return myfn(t1 < 0.5, 1.0)
+                    elif fn in fns_3_args:
+                        return myfn(1, t1, t2)
+                    else:
+                        return myfn(t1)
+
+                # test various orders
+                for first, second, third in [(large, small, small2), (small, large, small2),
+                                             (small2, small, large), (small2, large, small)]:
+                    if first is None:
+                        break  # ignore last iter when small2 is None
+                    method_expanded = getattr(expanded[first], fn)
+                    method = getattr(first, fn)
+                    r1 = tensorfn(method_expanded, expanded[second], expanded[third])
+                    r2 = tensorfn(method, second, third)
+                    self.assertEqual(r1, r2)
+
+            # now for torch. versions of functions
+            if hasattr(torch, fn):
+                fntorch = getattr(torch, fn)
+                expanded = {large: large_expanded, small: small_expanded, small2: small2_expanded}
+
+                def torchfn(t1, t2, t3):
+                    if fn == "lerp":
+                        return fntorch(t1, t2, 0.5)
+                    elif fn == "masked_select":
+                        return fntorch(t1, t2 < 0)
+                    elif fn == "masked_scatter":
+                        return fntorch(t1, t2 < 0.5, full1d)
+                    elif fn == "masked_fill":
+                        return fntorch(t1, t2 < 0.5, 1.0)
+                    elif fn in fns_3_args:
+                        return fntorch(t1, 1.0, t2, t3)
+                    else:
+                        return fntorch(t1, t2)
+
+                # test various orders
+                for first, second, third in [(large, small, small2), (small, large, small2),
+                                             (small2, small, large), (small2, large, small)]:
+                    if first is None:
+                        break  # ignore last iter when small2 is None
+                    r1 = torchfn(expanded[first], expanded[second], expanded[third])
+                    r2 = torchfn(first, second, third)
+                    self.assertEqual(r1, r2)
+
+            # now for in place functions
+            # in-place tensor is not broadcastable; test only guaranteed
+            # to work by broadcasting other argument(s)
+            if not hasattr(large_expanded, fn + "_"):
+                continue
+
+            # need to clone largeExpanded so we can reuse, since functions are in-place
+            large_expanded_clone = large_expanded.clone()
+
+            def tensorfn_inplace(t0, t1, t2=None):
+                t0_fn = getattr(t0, fn + "_")
+                if fn == "lerp":
+                    return t0_fn(t1, 0.5)
+                elif fn == "masked_scatter":
+                    return t0_fn(t1 < 0.5, full1d)
+                elif fn == "masked_fill":
+                    return t0_fn(t1 < 0.5, 1.0)
+                elif fn == "map":
+                    return t0_fn(t1, lambda x, y: x + y)
+                elif fn == "map2":
+                    return t0_fn(t1, t2, lambda x, y, z: x + y + z)
+                elif fn in fns_3_args:
+                    return t0_fn(1.0, t1, t2)
+                else:
+                    return t0_fn(t1)
+            # in-place pointwise operations don't actually work if the in-place
+            # tensor is 0-strided (numpy has the same issue)
+            if (0 not in large_expanded.stride() and 0 not in large_expanded_clone.stride()):
+                r1 = tensorfn_inplace(large_expanded, small_expanded, small2_expanded)
+                r2 = tensorfn_inplace(large_expanded_clone, small, small2)
+                self.assertEqual(r1, r2)
+
+            def broadcastable(t0, t1, t2=None):
+                try:
+                    t1.expand_as(t0)
+                    if t2 is not None:
+                        t2.expand_as(t0)
+                except RuntimeError:
+                    return False
+                return True
+
+            def _test_in_place_broadcastable(t0, t1, t2=None):
+                if not broadcastable(t0, t1, t2):
+                    same_size = t0.numel() == t1.numel() and (t0.numel() == t2.numel() if t2 is not None else True)
+                    if not same_size:
+                        self.assertRaises(RuntimeError, lambda: tensorfn_inplace(t0, t1, t2))
+                else:
+                    tensorfn_inplace(t0, t1, t2)
+
+            if fn not in fns_3_args:
+                _test_in_place_broadcastable(small, large_expanded)
+                _test_in_place_broadcastable(small, large)
+            else:
+                _test_in_place_broadcastable(small2, small_expanded, large_expanded)
+                _test_in_place_broadcastable(small2, small, large)
+
+    def test_broadcast_fused_matmul(self, device):
+        fns = ["baddbmm", "addbmm", "addmm", "addmv", "addr"]
+
+        for fn in fns:
+            batch_dim = random.randint(1, 8)
+            n_dim = random.randint(1, 8)
+            m_dim = random.randint(1, 8)
+            p_dim = random.randint(1, 8)
+
+            def dims_full_for_fn():
+                if fn == "baddbmm":
+                    return ([batch_dim, n_dim, p_dim], [batch_dim, n_dim, m_dim], [batch_dim, m_dim, p_dim])
+                elif fn == "addbmm":
+                    return ([n_dim, p_dim], [batch_dim, n_dim, m_dim], [batch_dim, m_dim, p_dim])
+                elif fn == "addmm":
+                    return ([n_dim, p_dim], [n_dim, m_dim], [m_dim, p_dim])
+                elif fn == "addmv":
+                    return ([n_dim], [n_dim, m_dim], [m_dim])
+                elif fn == "addr":
+                    return ([n_dim, m_dim], [n_dim], [m_dim])
+                else:
+                    raise AssertionError("unknown function")
+
+            (t0_dims_full, t1_dims, t2_dims) = dims_full_for_fn()
+            (t0_dims_small, _, _) = self._select_broadcastable_dims(t0_dims_full)
+
+            t0_small = torch.randn(*t0_dims_small, device=device).float()
+            t1 = torch.randn(*t1_dims, device=device).float()
+            t2 = torch.randn(*t2_dims, device=device).float()
+
+            t0_full = t0_small.expand(*t0_dims_full).to(device)
+
+            fntorch = getattr(torch, fn)
+            r0 = fntorch(t0_small, t1, t2)
+            r1 = fntorch(t0_full, t1, t2)
+            self.assertEqual(r0, r1)
+
+    def test_broadcast_batched_matmul(self, device):
+        n_dim = random.randint(1, 8)
+        m_dim = random.randint(1, 8)
+        p_dim = random.randint(1, 8)
+        full_batch_dims = [random.randint(1, 3) for i in range(random.randint(1, 3))]
+        (batch_dims_small, _, _) = self._select_broadcastable_dims(full_batch_dims)
+
+        def verify_batched_matmul(full_lhs, one_dimensional):
+            if not one_dimensional:
+                lhs_dims = [n_dim, m_dim]
+                rhs_dims = [m_dim, p_dim]
+                result_dims = [n_dim, p_dim]
+            else:
+                lhs_dims = [n_dim, m_dim] if full_lhs else [m_dim]
+                rhs_dims = [m_dim, p_dim] if not full_lhs else [m_dim]
+                result_dims = [n_dim] if full_lhs else [p_dim]
+
+            lhs_mat_dims = lhs_dims if len(lhs_dims) != 1 else [1, m_dim]
+            rhs_mat_dims = rhs_dims if len(rhs_dims) != 1 else [m_dim, 1]
+            full_mat_dims = lhs_mat_dims if full_lhs else rhs_mat_dims
+            dim0_dims = rhs_dims if full_lhs else lhs_dims
+            small_dims = batch_dims_small + (rhs_mat_dims if full_lhs else lhs_mat_dims)
+
+            small = torch.randn(*(small_dims), device=device).float()
+            dim0 = torch.randn(*(dim0_dims), device=device).float()
+            full = torch.randn(*(full_batch_dims + full_mat_dims), device=device).float()
+            if not one_dimensional:
+                (lhsTensors, rhsTensors) = ((full,), (small, dim0)) if full_lhs else ((small, dim0), (full,))
+            else:
+                (lhsTensors, rhsTensors) = ((full,), (dim0,)) if full_lhs else ((dim0,), (full,))
+
+            def maybe_squeeze_result(l, r, result):
+                if len(lhs_dims) == 1 and l.dim() != 1:
+                    return result.squeeze(-2)
+                elif len(rhs_dims) == 1 and r.dim() != 1:
+                    return result.squeeze(-1)
+                else:
+                    return result
+
+            for lhs in lhsTensors:
+                lhs_expanded = lhs.expand(*(torch.Size(full_batch_dims) + torch.Size(lhs_mat_dims)))
+                lhs_expanded_matmul_fn = lhs_expanded.matmul
+                for rhs in rhsTensors:
+                    rhs_expanded = ((rhs if len(rhs_dims) != 1 else rhs.unsqueeze(-1)).
+                                    expand(*(torch.Size(full_batch_dims) + torch.Size(rhs_mat_dims))))
+                    truth = maybe_squeeze_result(lhs_expanded, rhs_expanded, lhs_expanded_matmul_fn(rhs_expanded))
+                    for l in (lhs, lhs_expanded):
+                        for r in (rhs, rhs_expanded):
+                            l_matmul_fn = l.matmul
+                            result = maybe_squeeze_result(l, r, l_matmul_fn(r))
+                            self.assertEqual(truth, result)
+                            # test torch.matmul function as well
+                            torch_result = maybe_squeeze_result(l, r, torch.matmul(l, r))
+                            self.assertEqual(truth, torch_result)
+                            # test torch.matmul with out
+                            out = torch.zeros_like(torch_result)
+                            torch.matmul(l, r, out=out)
+                            self.assertEqual(truth, maybe_squeeze_result(l, r, out))
+
+                # compare to bmm
+                bmm_result = (torch.bmm(lhs_expanded.contiguous().view(-1, *lhs_mat_dims),
+                                        rhs_expanded.contiguous().view(-1, *rhs_mat_dims)))
+                self.assertEqual(truth.view(-1, *result_dims), bmm_result.view(-1, *result_dims))
+
+        for indices in product((True, False), repeat=2):
+            verify_batched_matmul(*indices)
+
+    def test_contiguous(self, device):
+        x = torch.randn(1, 16, 5, 5, device=device)
+        self.assertTrue(x.is_contiguous())
+        stride = list(x.stride())
+        stride[0] = 20
+        # change the stride in dimension 0. the tensor is still contiguous because size[0] is 1
+        x.set_(x.storage(), 0, x.size(), stride)
+        self.assertTrue(x.is_contiguous())
+
+    def test_index(self, device):
+
+        def consec(size, start=1):
+            sequence = torch.ones(int(torch.Tensor(size).prod(0))).cumsum(0)
+            sequence.add_(start - 1)
+            return sequence.view(*size)
+
+        reference = consec((3, 3, 3)).to(device)
+
+        # empty tensor indexing
+        self.assertEqual(reference[torch.LongTensor().to(device)], reference.new(0, 3, 3))
+
+        self.assertEqual(reference[0], consec((3, 3)), 0)
+        self.assertEqual(reference[1], consec((3, 3), 10), 0)
+        self.assertEqual(reference[2], consec((3, 3), 19), 0)
+        self.assertEqual(reference[0, 1], consec((3,), 4), 0)
+        self.assertEqual(reference[0:2], consec((2, 3, 3)), 0)
+        self.assertEqual(reference[2, 2, 2], 27, 0)
+        self.assertEqual(reference[:], consec((3, 3, 3)), 0)
+
+        # indexing with Ellipsis
+        self.assertEqual(reference[..., 2], torch.Tensor([[3, 6, 9],
+                                                          [12, 15, 18],
+                                                          [21, 24, 27]]), 0)
+        self.assertEqual(reference[0, ..., 2], torch.Tensor([3, 6, 9]), 0)
+        self.assertEqual(reference[..., 2], reference[:, :, 2], 0)
+        self.assertEqual(reference[0, ..., 2], reference[0, :, 2], 0)
+        self.assertEqual(reference[0, 2, ...], reference[0, 2], 0)
+        self.assertEqual(reference[..., 2, 2, 2], 27, 0)
+        self.assertEqual(reference[2, ..., 2, 2], 27, 0)
+        self.assertEqual(reference[2, 2, ..., 2], 27, 0)
+        self.assertEqual(reference[2, 2, 2, ...], 27, 0)
+        self.assertEqual(reference[...], reference, 0)
+
+        reference_5d = consec((3, 3, 3, 3, 3)).to(device)
+        self.assertEqual(reference_5d[..., 1, 0], reference_5d[:, :, :, 1, 0], 0)
+        self.assertEqual(reference_5d[2, ..., 1, 0], reference_5d[2, :, :, 1, 0], 0)
+        self.assertEqual(reference_5d[2, 1, 0, ..., 1], reference_5d[2, 1, 0, :, 1], 0)
+        self.assertEqual(reference_5d[...], reference_5d, 0)
+
+        # LongTensor indexing
+        reference = consec((5, 5, 5)).to(device)
+        idx = torch.LongTensor([2, 4]).to(device)
+        self.assertEqual(reference[idx], torch.stack([reference[2], reference[4]]))
+        # TODO: enable one indexing is implemented like in numpy
+        # self.assertEqual(reference[2, idx], torch.stack([reference[2, 2], reference[2, 4]]))
+        # self.assertEqual(reference[3, idx, 1], torch.stack([reference[3, 2], reference[3, 4]])[:, 1])
+
+        # None indexing
+        self.assertEqual(reference[2, None], reference[2].unsqueeze(0))
+        self.assertEqual(reference[2, None, None], reference[2].unsqueeze(0).unsqueeze(0))
+        self.assertEqual(reference[2:4, None], reference[2:4].unsqueeze(1))
+        self.assertEqual(reference[None, 2, None, None], reference.unsqueeze(0)[:, 2].unsqueeze(0).unsqueeze(0))
+        self.assertEqual(reference[None, 2:5, None, None], reference.unsqueeze(0)[:, 2:5].unsqueeze(2).unsqueeze(2))
+
+        # indexing 0-length slice
+        self.assertEqual(torch.empty(0, 5, 5), reference[slice(0)])
+        self.assertEqual(torch.empty(0, 5), reference[slice(0), 2])
+        self.assertEqual(torch.empty(0, 5), reference[2, slice(0)])
+        self.assertEqual(torch.tensor([]), reference[2, 1:1, 2])
+
+        # indexing with step
+        reference = consec((10, 10, 10)).to(device)
+        self.assertEqual(reference[1:5:2], torch.stack([reference[1], reference[3]], 0))
+        self.assertEqual(reference[1:6:2], torch.stack([reference[1], reference[3], reference[5]], 0))
+        self.assertEqual(reference[1:9:4], torch.stack([reference[1], reference[5]], 0))
+        self.assertEqual(reference[2:4, 1:5:2], torch.stack([reference[2:4, 1], reference[2:4, 3]], 1))
+        self.assertEqual(reference[3, 1:6:2], torch.stack([reference[3, 1], reference[3, 3], reference[3, 5]], 0))
+        self.assertEqual(reference[None, 2, 1:9:4], torch.stack([reference[2, 1], reference[2, 5]], 0).unsqueeze(0))
+        self.assertEqual(reference[:, 2, 1:6:2],
+                         torch.stack([reference[:, 2, 1], reference[:, 2, 3], reference[:, 2, 5]], 1))
+
+        lst = [list(range(i, i + 10)) for i in range(0, 100, 10)]
+        tensor = torch.DoubleTensor(lst).to(device)
+        for _i in range(100):
+            idx1_start = random.randrange(10)
+            idx1_end = idx1_start + random.randrange(1, 10 - idx1_start + 1)
+            idx1_step = random.randrange(1, 8)
+            idx1 = slice(idx1_start, idx1_end, idx1_step)
+            if random.randrange(2) == 0:
+                idx2_start = random.randrange(10)
+                idx2_end = idx2_start + random.randrange(1, 10 - idx2_start + 1)
+                idx2_step = random.randrange(1, 8)
+                idx2 = slice(idx2_start, idx2_end, idx2_step)
+                lst_indexed = list(map(lambda l: l[idx2], lst[idx1]))
+                tensor_indexed = tensor[idx1, idx2]
+            else:
+                lst_indexed = lst[idx1]
+                tensor_indexed = tensor[idx1]
+            self.assertEqual(torch.DoubleTensor(lst_indexed), tensor_indexed)
+
+        self.assertRaises(ValueError, lambda: reference[1:9:0])
+        self.assertRaises(ValueError, lambda: reference[1:9:-1])
+
+        self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1])
+        self.assertRaises(IndexError, lambda: reference[1, 1, 1, 1:1])
+        self.assertRaises(IndexError, lambda: reference[3, 3, 3, 3, 3, 3, 3, 3])
+
+        self.assertRaises(IndexError, lambda: reference[0.0])
+        self.assertRaises(TypeError, lambda: reference[0.0:2.0])
+        self.assertRaises(IndexError, lambda: reference[0.0, 0.0:2.0])
+        self.assertRaises(IndexError, lambda: reference[0.0, :, 0.0:2.0])
+        self.assertRaises(IndexError, lambda: reference[0.0, ..., 0.0:2.0])
+        self.assertRaises(IndexError, lambda: reference[0.0, :, 0.0])
+
+        def delitem():
+            del reference[0]
+
+        self.assertRaises(TypeError, delitem)
+
+    @skipCUDANonDefaultStreamIf(True)
+    def test_advancedindex(self, device):
+        # Tests for Integer Array Indexing, Part I - Purely integer array
+        # indexing
+
+        def consec(size, start=1):
+            numel = reduce(lambda x, y: x * y, size, 1)
+            sequence = torch.ones(numel).cumsum(0)
+            sequence.add_(start - 1)
+            return sequence.view(*size)
+
+        # pick a random valid indexer type
+        def ri(indices):
+            choice = random.randint(0, 2)
+            if choice == 0:
+                return torch.LongTensor(indices).to(device)
+            elif choice == 1:
+                return list(indices)
+            else:
+                return tuple(indices)
+
+        def validate_indexing(x):
+            self.assertEqual(x[[0]], consec((1,)))
+            self.assertEqual(x[ri([0]), ], consec((1,)))
+            self.assertEqual(x[ri([3]), ], consec((1,), 4))
+            self.assertEqual(x[[2, 3, 4]], consec((3,), 3))
+            self.assertEqual(x[ri([2, 3, 4]), ], consec((3,), 3))
+            self.assertEqual(x[ri([0, 2, 4]), ], torch.Tensor([1, 3, 5]))
+
+        def validate_setting(x):
+            dtype = x.type()
+            x[[0]] = -2
+            self.assertEqual(x[[0]], torch.Tensor([-2]).type(dtype))
+            x[[0]] = -1
+            self.assertEqual(x[ri([0]), ], torch.Tensor([-1]).type(dtype))
+            x[[2, 3, 4]] = 4
+            self.assertEqual(x[[2, 3, 4]], torch.Tensor([4, 4, 4]).type(dtype))
+            x[ri([2, 3, 4]), ] = 3
+            self.assertEqual(x[ri([2, 3, 4]), ], torch.Tensor([3, 3, 3]).type(dtype))
+            x[ri([0, 2, 4]), ] = torch.Tensor([5, 4, 3]).type(dtype).to(device)
+            self.assertEqual(x[ri([0, 2, 4]), ], torch.Tensor([5, 4, 3]).type(dtype))
+
+        # First, we will test indexing to generate return values
+
+        # Case 1: Purely Integer Array Indexing
+        reference = consec((10,)).to(device)
+        validate_indexing(reference)
+        validate_indexing(reference.type(torch.half))
+
+        # setting values
+        validate_setting(reference)
+        validate_setting(reference.type(torch.half))
+
+        # Tensor with stride != 1
+
+        # strided is [1, 3, 5, 7]
+        reference = consec((10,)).to(device)
+        strided = torch.Tensor().to(device)
+        strided.set_(reference.storage(), storage_offset=0,
+                     size=torch.Size([4]), stride=[2])
+
+        self.assertEqual(strided[[0]], torch.Tensor([1]))
+        self.assertEqual(strided[ri([0]), ], torch.Tensor([1]))
+        self.assertEqual(strided[ri([3]), ], torch.Tensor([7]))
+        self.assertEqual(strided[[1, 2]], torch.Tensor([3, 5]))
+        self.assertEqual(strided[ri([1, 2]), ], torch.Tensor([3, 5]))
+        self.assertEqual(strided[ri([[2, 1], [0, 3]]), ],
+                         torch.Tensor([[5, 3], [1, 7]]))
+
+        # stride is [4, 8]
+        strided = torch.Tensor().to(device)
+        strided.set_(reference.storage(), storage_offset=4,
+                     size=torch.Size([2]), stride=[4])
+        self.assertEqual(strided[[0]], torch.Tensor([5]))
+        self.assertEqual(strided[ri([0]), ], torch.Tensor([5]))
+        self.assertEqual(strided[ri([1]), ], torch.Tensor([9]))
+        self.assertEqual(strided[[0, 1]], torch.Tensor([5, 9]))
+        self.assertEqual(strided[ri([0, 1]), ], torch.Tensor([5, 9]))
+        self.assertEqual(strided[ri([[0, 1], [1, 0]]), ],
+                         torch.Tensor([[5, 9], [9, 5]]))
+
+        # reference is 1 2
+        #              3 4
+        #              5 6
+        reference = consec((3, 2)).to(device)
+        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([1, 3, 5]))
+        self.assertEqual(reference[ri([0, 1, 2]), ri([1])], torch.Tensor([2, 4, 6]))
+        self.assertEqual(reference[ri([0]), ri([0])], consec((1,)))
+        self.assertEqual(reference[ri([2]), ri([1])], consec((1,), 6))
+        self.assertEqual(reference[[ri([0, 0]), ri([0, 1])]], torch.Tensor([1, 2]))
+        self.assertEqual(reference[[ri([0, 1, 1, 0, 2]), ri([1])]],
+                         torch.Tensor([2, 4, 4, 2, 6]))
+        self.assertEqual(reference[[ri([0, 0, 1, 1]), ri([0, 1, 0, 0])]],
+                         torch.Tensor([1, 2, 3, 3]))
+
+        rows = ri([[0, 0],
+                   [1, 2]])
+        columns = [0],
+        self.assertEqual(reference[rows, columns], torch.Tensor([[1, 1],
+                                                                [3, 5]]))
+
+        rows = ri([[0, 0],
+                   [1, 2]])
+        columns = ri([1, 0])
+        self.assertEqual(reference[rows, columns], torch.Tensor([[2, 1],
+                                                                [4, 5]]))
+        rows = ri([[0, 0],
+                   [1, 2]])
+        columns = ri([[0, 1],
+                      [1, 0]])
+        self.assertEqual(reference[rows, columns], torch.Tensor([[1, 2],
+                                                                [4, 5]]))
+
+        # setting values
+        reference[ri([0]), ri([1])] = -1
+        self.assertEqual(reference[ri([0]), ri([1])], torch.Tensor([-1]))
+        reference[ri([0, 1, 2]), ri([0])] = torch.Tensor([-1, 2, -4]).to(device)
+        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([-1,
+                         2, -4]))
+        reference[rows, columns] = torch.Tensor([[4, 6], [2, 3]]).to(device)
+        self.assertEqual(reference[rows, columns],
+                         torch.Tensor([[4, 6], [2, 3]]))
+
+        # Verify still works with Transposed (i.e. non-contiguous) Tensors
+
+        reference = torch.Tensor([[0, 1, 2, 3],
+                                          [4, 5, 6, 7],
+                                          [8, 9, 10, 11]]).to(device).t_()
+
+        # Transposed: [[0, 4, 8],
+        #              [1, 5, 9],
+        #              [2, 6, 10],
+        #              [3, 7, 11]]
+
+        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([0, 1,
+                         2]))
+        self.assertEqual(reference[ri([0, 1, 2]), ri([1])], torch.Tensor([4, 5,
+                         6]))
+        self.assertEqual(reference[ri([0]), ri([0])], torch.Tensor([0]))
+        self.assertEqual(reference[ri([2]), ri([1])], torch.Tensor([6]))
+        self.assertEqual(reference[[ri([0, 0]), ri([0, 1])]], torch.Tensor([0, 4]))
+        self.assertEqual(reference[[ri([0, 1, 1, 0, 3]), ri([1])]],
+                         torch.Tensor([4, 5, 5, 4, 7]))
+        self.assertEqual(reference[[ri([0, 0, 1, 1]), ri([0, 1, 0, 0])]],
+                         torch.Tensor([0, 4, 1, 1]))
+
+        rows = ri([[0, 0],
+                   [1, 2]])
+        columns = [0],
+        self.assertEqual(reference[rows, columns], torch.Tensor([[0, 0],
+                                                                [1, 2]]))
+
+        rows = ri([[0, 0],
+                   [1, 2]])
+        columns = ri([1, 0])
+        self.assertEqual(reference[rows, columns], torch.Tensor([[4, 0],
+                                                                [5, 2]]))
+        rows = ri([[0, 0],
+                   [1, 3]])
+        columns = ri([[0, 1],
+                      [1, 2]])
+        self.assertEqual(reference[rows, columns], torch.Tensor([[0, 4],
+                                                                [5, 11]]))
+
+        # setting values
+        reference[ri([0]), ri([1])] = -1
+        self.assertEqual(reference[ri([0]), ri([1])], torch.Tensor([-1]))
+        reference[ri([0, 1, 2]), ri([0])] = torch.Tensor([-1, 2, -4]).to(device)
+        self.assertEqual(reference[ri([0, 1, 2]), ri([0])], torch.Tensor([-1,
+                         2, -4]))
+        reference[rows, columns] = torch.Tensor([[4, 6], [2, 3]]).to(device)
+        self.assertEqual(reference[rows, columns],
+                         torch.Tensor([[4, 6], [2, 3]]))
+
+        # stride != 1
+
+        # strided is [[1 3 5 7],
+        #             [9 11 13 15]]
+
+        reference = torch.arange(0., 24).view(3, 8).to(device)
+        strided = torch.Tensor().to(device)
+        strided.set_(reference.storage(), 1, size=torch.Size([2, 4]),
+                     stride=[8, 2])
+
+        self.assertEqual(strided[ri([0, 1]), ri([0])], torch.Tensor([1, 9]))
+        self.assertEqual(strided[ri([0, 1]), ri([1])], torch.Tensor([3, 11]))
+        self.assertEqual(strided[ri([0]), ri([0])], torch.Tensor([1]))
+        self.assertEqual(strided[ri([1]), ri([3])], torch.Tensor([15]))
+        self.assertEqual(strided[[ri([0, 0]), ri([0, 3])]], torch.Tensor([1, 7]))
+        self.assertEqual(strided[[ri([1]), ri([0, 1, 1, 0, 3])]],
+                         torch.Tensor([9, 11, 11, 9, 15]))
+        self.assertEqual(strided[[ri([0, 0, 1, 1]), ri([0, 1, 0, 0])]],
+                         torch.Tensor([1, 3, 9, 9]))
+
+        rows = ri([[0, 0],
+                   [1, 1]])
+        columns = [0],
+        self.assertEqual(strided[rows, columns], torch.Tensor([[1, 1],
+                                                              [9, 9]]))
+
+        rows = ri([[0, 1],
+                   [1, 0]])
+        columns = ri([1, 2])
+        self.assertEqual(strided[rows, columns], torch.Tensor([[3, 13],
+                                                              [11, 5]]))
+        rows = ri([[0, 0],
+                   [1, 1]])
+        columns = ri([[0, 1],
+                      [1, 2]])
+        self.assertEqual(strided[rows, columns], torch.Tensor([[1, 3],
+                                                              [11, 13]]))
+
+        # setting values
+
+        # strided is [[10, 11],
+        #             [17, 18]]
+
+        reference = torch.arange(0., 24).view(3, 8).to(device)
+        strided = torch.Tensor().to(device)
+        strided.set_(reference.storage(), 10, size=torch.Size([2, 2]),
+                     stride=[7, 1])
+        self.assertEqual(strided[ri([0]), ri([1])], torch.Tensor([11]))
+        strided[ri([0]), ri([1])] = -1
+        self.assertEqual(strided[ri([0]), ri([1])], torch.Tensor([-1]))
+
+        reference = torch.arange(0., 24).view(3, 8).to(device)
+        strided = torch.Tensor().to(device)
+        strided.set_(reference.storage(), 10, size=torch.Size([2, 2]),
+                     stride=[7, 1])
+        self.assertEqual(strided[ri([0, 1]), ri([1, 0])], torch.Tensor([11,
+                         17]))
+        strided[ri([0, 1]), ri([1, 0])] = torch.Tensor([-1, 2]).to(device)
+        self.assertEqual(strided[ri([0, 1]), ri([1, 0])], torch.Tensor([-1,
+                         2]))
+
+        reference = torch.arange(0., 24).view(3, 8).to(device)
+        strided = torch.Tensor().to(device)
+        strided.set_(reference.storage(), 10, size=torch.Size([2, 2]),
+                     stride=[7, 1])
+
+        rows = ri([[0],
+                   [1]])
+        columns = ri([[0, 1],
+                      [0, 1]])
+        self.assertEqual(strided[rows, columns],
+                         torch.Tensor([[10, 11], [17, 18]]))
+        strided[rows, columns] = torch.Tensor([[4, 6], [2, 3]]).to(device)
+        self.assertEqual(strided[rows, columns],
+                         torch.Tensor([[4, 6], [2, 3]]))
+
+        # Tests using less than the number of dims, and ellipsis
+
+        # reference is 1 2
+        #              3 4
+        #              5 6
+        reference = consec((3, 2)).to(device)
+        self.assertEqual(reference[ri([0, 2]), ], torch.Tensor([[1, 2], [5, 6]]))
+        self.assertEqual(reference[ri([1]), ...], torch.Tensor([[3, 4]]))
+        self.assertEqual(reference[..., ri([1])], torch.Tensor([[2], [4], [6]]))
+
+        # verify too many indices fails
+        with self.assertRaises(IndexError):
+            reference[ri([1]), ri([0, 2]), ri([3])]
+
+        # test invalid index fails
+        reference = torch.empty(10, device=device)
+        # can't test cuda because it is a device assert
+        if not reference.is_cuda:
+            for err_idx in (10, -11):
+                with self.assertRaisesRegex(IndexError, r'out of'):
+                    reference[err_idx]
+                with self.assertRaisesRegex(IndexError, r'out of'):
+                    reference[torch.LongTensor([err_idx]).to(device)]
+                with self.assertRaisesRegex(IndexError, r'out of'):
+                    reference[[err_idx]]
+
+        if TEST_NUMPY:
+            # we use numpy to compare against, to verify that our advanced
+            # indexing semantics are the same, and also for ease of test
+            # writing
+
+            def tensor_indices_to_np(tensor, indices):
+                # convert the Torch Tensor to a numpy array
+                if (tensor.is_cuda):
+                    tensor = tensor.cpu()
+                npt = tensor.numpy()
+
+                # convert indices
+                idxs = tuple(i.tolist() if isinstance(i, torch.LongTensor) else
+                             i for i in indices)
+
+                return npt, idxs
+
+            def get_numpy(tensor, indices):
+                npt, idxs = tensor_indices_to_np(tensor, indices)
+
+                # index and return as a Torch Tensor
+                return torch.Tensor(npt[idxs])
+
+            def set_numpy(tensor, indices, value):
+                if not isinstance(value, int):
+                    if value.is_cuda:
+                        value = value.cpu()
+                    value = value.numpy()
+
+                npt, idxs = tensor_indices_to_np(tensor, indices)
+                npt[idxs] = value
+                return npt
+
+            def assert_get_eq(tensor, indexer):
+                self.assertEqual(tensor[indexer],
+                                 get_numpy(tensor, indexer).to(device))
+
+            def assert_set_eq(tensor, indexer, val):
+                pyt = tensor.clone()
+                numt = tensor.clone()
+                pyt[indexer] = val
+                numt = torch.Tensor(set_numpy(numt, indexer, val)).to(device)
+                self.assertEqual(pyt, numt)
+
+            def assert_backward_eq(tensor, indexer):
+                cpu = tensor.float().clone().detach().requires_grad_(True)
+                outcpu = cpu[indexer]
+                gOcpu = torch.rand_like(outcpu)
+                outcpu.backward(gOcpu)
+                gpu = cpu.cuda().detach().requires_grad_(True)
+                outgpu = gpu[indexer]
+                outgpu.backward(gOcpu.cuda())
+                self.assertEqual(cpu.grad, gpu.grad)
+
+            def get_set_tensor(indexed, indexer):
+                set_size = indexed[indexer].size()
+                set_count = indexed[indexer].numel()
+                set_tensor = torch.randperm(set_count).view(set_size).double().to(device)
+                return set_tensor
+
+            # Tensor is  0  1  2  3  4
+            #            5  6  7  8  9
+            #           10 11 12 13 14
+            #           15 16 17 18 19
+            reference = torch.arange(0., 20).view(4, 5).to(device)
+
+            indices_to_test = [
+                # grab the second, fourth columns
+                [slice(None), [1, 3]],
+
+                # first, third rows,
+                [[0, 2], slice(None)],
+
+                # weird shape
+                [slice(None), [[0, 1],
+                               [2, 3]]],
+                # negatives
+                [[-1], [0]],
+                [[0, 2], [-1]],
+                [slice(None), [-1]],
+            ]
+
+            # only test dupes on gets
+            get_indices_to_test = indices_to_test + [[slice(None), [0, 1, 1, 2, 2]]]
+
+            for indexer in get_indices_to_test:
+                assert_get_eq(reference, indexer)
+                if torch.cuda.is_available():
+                    assert_backward_eq(reference, indexer)
+
+            for indexer in indices_to_test:
+                assert_set_eq(reference, indexer, 44)
+                assert_set_eq(reference,
+                              indexer,
+                              get_set_tensor(reference, indexer))
+
+            reference = torch.arange(0., 160).view(4, 8, 5).to(device)
+
+            indices_to_test = [
+                [slice(None), slice(None), [0, 3, 4]],
+                [slice(None), [2, 4, 5, 7], slice(None)],
+                [[2, 3], slice(None), slice(None)],
+                [slice(None), [0, 2, 3], [1, 3, 4]],
+                [slice(None), [0], [1, 2, 4]],
+                [slice(None), [0, 1, 3], [4]],
+                [slice(None), [[0, 1], [1, 0]], [[2, 3]]],
+                [slice(None), [[0, 1], [2, 3]], [[0]]],
+                [slice(None), [[5, 6]], [[0, 3], [4, 4]]],
+                [[0, 2, 3], [1, 3, 4], slice(None)],
+                [[0], [1, 2, 4], slice(None)],
+                [[0, 1, 3], [4], slice(None)],
+                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None)],
+                [[[0, 1], [1, 0]], [[2, 3]], slice(None)],
+                [[[0, 1], [2, 3]], [[0]], slice(None)],
+                [[[2, 1]], [[0, 3], [4, 4]], slice(None)],
+                [[[2]], [[0, 3], [4, 1]], slice(None)],
+                # non-contiguous indexing subspace
+                [[0, 2, 3], slice(None), [1, 3, 4]],
+
+                # less dim, ellipsis
+                [[0, 2], ],
+                [[0, 2], slice(None)],
+                [[0, 2], Ellipsis],
+                [[0, 2], slice(None), Ellipsis],
+                [[0, 2], Ellipsis, slice(None)],
+                [[0, 2], [1, 3]],
+                [[0, 2], [1, 3], Ellipsis],
+                [Ellipsis, [1, 3], [2, 3]],
+                [Ellipsis, [2, 3, 4]],
+                [Ellipsis, slice(None), [2, 3, 4]],
+                [slice(None), Ellipsis, [2, 3, 4]],
+
+                # ellipsis counts for nothing
+                [Ellipsis, slice(None), slice(None), [0, 3, 4]],
+                [slice(None), Ellipsis, slice(None), [0, 3, 4]],
+                [slice(None), slice(None), Ellipsis, [0, 3, 4]],
+                [slice(None), slice(None), [0, 3, 4], Ellipsis],
+                [Ellipsis, [[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None)],
+                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], Ellipsis, slice(None)],
+                [[[0, 1], [1, 0]], [[2, 1], [3, 5]], slice(None), Ellipsis],
+            ]
+
+            for indexer in indices_to_test:
+                assert_get_eq(reference, indexer)
+                assert_set_eq(reference, indexer, 212)
+                assert_set_eq(reference,
+                              indexer,
+                              get_set_tensor(reference, indexer))
+                if torch.cuda.is_available():
+                    assert_backward_eq(reference, indexer)
+
+            reference = torch.arange(0., 1296).view(3, 9, 8, 6).to(device)
+
+            indices_to_test = [
+                [slice(None), slice(None), slice(None), [0, 3, 4]],
+                [slice(None), slice(None), [2, 4, 5, 7], slice(None)],
+                [slice(None), [2, 3], slice(None), slice(None)],
+                [[1, 2], slice(None), slice(None), slice(None)],
+                [slice(None), slice(None), [0, 2, 3], [1, 3, 4]],
+                [slice(None), slice(None), [0], [1, 2, 4]],
+                [slice(None), slice(None), [0, 1, 3], [4]],
+                [slice(None), slice(None), [[0, 1], [1, 0]], [[2, 3]]],
+                [slice(None), slice(None), [[0, 1], [2, 3]], [[0]]],
+                [slice(None), slice(None), [[5, 6]], [[0, 3], [4, 4]]],
+                [slice(None), [0, 2, 3], [1, 3, 4], slice(None)],
+                [slice(None), [0], [1, 2, 4], slice(None)],
+                [slice(None), [0, 1, 3], [4], slice(None)],
+                [slice(None), [[0, 1], [3, 4]], [[2, 3], [0, 1]], slice(None)],
+                [slice(None), [[0, 1], [3, 4]], [[2, 3]], slice(None)],
+                [slice(None), [[0, 1], [3, 2]], [[0]], slice(None)],
+                [slice(None), [[2, 1]], [[0, 3], [6, 4]], slice(None)],
+                [slice(None), [[2]], [[0, 3], [4, 2]], slice(None)],
+                [[0, 1, 2], [1, 3, 4], slice(None), slice(None)],
+                [[0], [1, 2, 4], slice(None), slice(None)],
+                [[0, 1, 2], [4], slice(None), slice(None)],
+                [[[0, 1], [0, 2]], [[2, 4], [1, 5]], slice(None), slice(None)],
+                [[[0, 1], [1, 2]], [[2, 0]], slice(None), slice(None)],
+                [[[2, 2]], [[0, 3], [4, 5]], slice(None), slice(None)],
+                [[[2]], [[0, 3], [4, 5]], slice(None), slice(None)],
+                [slice(None), [3, 4, 6], [0, 2, 3], [1, 3, 4]],
+                [slice(None), [2, 3, 4], [1, 3, 4], [4]],
+                [slice(None), [0, 1, 3], [4], [1, 3, 4]],
+                [slice(None), [6], [0, 2, 3], [1, 3, 4]],
+                [slice(None), [2, 3, 5], [3], [4]],
+                [slice(None), [0], [4], [1, 3, 4]],
+                [slice(None), [6], [0, 2, 3], [1]],
+                [slice(None), [[0, 3], [3, 6]], [[0, 1], [1, 3]], [[5, 3], [1, 2]]],
+                [[2, 2, 1], [0, 2, 3], [1, 3, 4], slice(None)],
+                [[2, 0, 1], [1, 2, 3], [4], slice(None)],
+                [[0, 1, 2], [4], [1, 3, 4], slice(None)],
+                [[0], [0, 2, 3], [1, 3, 4], slice(None)],
+                [[0, 2, 1], [3], [4], slice(None)],
+                [[0], [4], [1, 3, 4], slice(None)],
+                [[1], [0, 2, 3], [1], slice(None)],
+                [[[1, 2], [1, 2]], [[0, 1], [2, 3]], [[2, 3], [3, 5]], slice(None)],
+
+                # less dim, ellipsis
+                [Ellipsis, [0, 3, 4]],
+                [Ellipsis, slice(None), [0, 3, 4]],
+                [Ellipsis, slice(None), slice(None), [0, 3, 4]],
+                [slice(None), Ellipsis, [0, 3, 4]],
+                [slice(None), slice(None), Ellipsis, [0, 3, 4]],
+                [slice(None), [0, 2, 3], [1, 3, 4]],
+                [slice(None), [0, 2, 3], [1, 3, 4], Ellipsis],
+                [Ellipsis, [0, 2, 3], [1, 3, 4], slice(None)],
+                [[0], [1, 2, 4]],
+                [[0], [1, 2, 4], slice(None)],
+                [[0], [1, 2, 4], Ellipsis],
+                [[0], [1, 2, 4], Ellipsis, slice(None)],
+                [[1], ],
+                [[0, 2, 1], [3], [4]],
+                [[0, 2, 1], [3], [4], slice(None)],
+                [[0, 2, 1], [3], [4], Ellipsis],
+                [Ellipsis, [0, 2, 1], [3], [4]],
+            ]
+
+            for indexer in indices_to_test:
+                assert_get_eq(reference, indexer)
+                assert_set_eq(reference, indexer, 1333)
+                assert_set_eq(reference,
+                              indexer,
+                              get_set_tensor(reference, indexer))
+            indices_to_test += [
+                [slice(None), slice(None), [[0, 1], [1, 0]], [[2, 3], [3, 0]]],
+                [slice(None), slice(None), [[2]], [[0, 3], [4, 4]]],
+            ]
+            for indexer in indices_to_test:
+                assert_get_eq(reference, indexer)
+                assert_set_eq(reference, indexer, 1333)
+                if torch.cuda.is_available():
+                    assert_backward_eq(reference, indexer)
+
+    def test_advancedindex_big(self, device):
+        reference = torch.arange(0, 123344).int().to(device)
+
+        self.assertEqual(reference[[0, 123, 44488, 68807, 123343], ],
+                         torch.LongTensor([0, 123, 44488, 68807, 123343]))
+
+    def test_kthvalue(self, device):
+        SIZE = 50
+        x = torch.rand(SIZE, SIZE, SIZE, device=device)
+        x0 = x.clone()
+
+        k = random.randint(1, SIZE)
+        res1val, res1ind = torch.kthvalue(x, k, keepdim=False)
+        res2val, res2ind = torch.sort(x)
+
+        self.assertEqual(res1val[:, :], res2val[:, :, k - 1], 0)
+        self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], 0)
+        # test use of result tensors
+        k = random.randint(1, SIZE)
+        res1val = torch.tensor([], device=device)
+        res1ind = torch.tensor([], dtype=torch.long, device=device)
+        torch.kthvalue(x, k, keepdim=False, out=(res1val, res1ind))
+        res2val, res2ind = torch.sort(x)
+        self.assertEqual(res1val[:, :], res2val[:, :, k - 1], 0)
+        self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], 0)
+
+        # test non-default dim
+        k = random.randint(1, SIZE)
+        res1val, res1ind = torch.kthvalue(x, k, 0, keepdim=False)
+        res2val, res2ind = torch.sort(x, 0)
+        self.assertEqual(res1val, res2val[k - 1], 0)
+        self.assertEqual(res1ind, res2ind[k - 1], 0)
+
+        # non-contiguous
+        y = x.narrow(1, 0, 1)
+        y0 = y.contiguous()
+        k = random.randint(1, SIZE)
+        res1val, res1ind = torch.kthvalue(y, k)
+        res2val, res2ind = torch.kthvalue(y0, k)
+        self.assertEqual(res1val, res2val, 0)
+        self.assertEqual(res1ind, res2ind, 0)
+
+        # check that the input wasn't modified
+        self.assertEqual(x, x0, 0)
+
+        # simple test case (with repetitions)
+        y = torch.tensor((3., 5, 4, 1, 1, 5), device=device)
+        self.assertEqual(torch.kthvalue(y, 3)[0], 3, 0)
+        self.assertEqual(torch.kthvalue(y, 2)[0], 1, 0)
+
+        # simple test case (with NaN)
+        SIZE = 50
+        x = torch.rand(SIZE, SIZE, SIZE, device=device)
+        x[torch.arange(SIZE), :, torch.randint(50, (50,))] = nan
+        ks = [random.randint(1, SIZE), 1, SIZE, SIZE - 1]
+        res2val, res2ind = torch.sort(x)
+        for k in ks:
+            res1val, res1ind = torch.kthvalue(x, k, keepdim=False)
+            self.assertEqual(res1val[:, :], res2val[:, :, k - 1], 0)
+            self.assertEqual(res1ind[:, :], res2ind[:, :, k - 1], 0)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_lu_solve_batched_non_contiguous(self, device):
+        from numpy.linalg import solve
+        from common_utils import random_fullrank_matrix_distinct_singular_value
+
+        A = random_fullrank_matrix_distinct_singular_value(2, 2)
+        b = torch.randn(2, 2, 2)
+        x_exp = torch.as_tensor(solve(A.permute(0, 2, 1).numpy(), b.permute(2, 1, 0).numpy())).to(device)
+        A = A.to(device).permute(0, 2, 1)
+        b = b.to(device).permute(2, 1, 0)
+        assert not A.is_contiguous() and not b.is_contiguous(), "contiguous inputs"
+        LU_data, LU_pivots = torch.lu(A)
+        x = torch.lu_solve(b, LU_data, LU_pivots)
+        self.assertEqual(x, x_exp)
+
+    @slowTest
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_lu_solve_batched_many_batches(self, device):
+        from common_utils import lu_solve_test_helper
+
+        def cast(t):
+            return t.to(device)
+
+        def run_test(A_dims, b_dims, cast):
+            b, A, LU_data, LU_pivots = lu_solve_test_helper(self, A_dims, b_dims, cast, True)
+            x = torch.lu_solve(b, LU_data, LU_pivots)
+            b_ = torch.matmul(A, x)
+            self.assertEqual(b_, b.expand_as(b_))
+
+        run_test((5, 65536), (65536, 5, 10), cast)
+        run_test((5, 262144), (262144, 5, 10), cast)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
+    def test_lu_solve_batched_broadcasting(self, device):
+        from numpy.linalg import solve
+        from common_utils import random_fullrank_matrix_distinct_singular_value
+
+        def run_test(A_dims, b_dims, device, pivot=True):
+            A_matrix_size = A_dims[-1]
+            A_batch_dims = A_dims[:-2]
+            A = random_fullrank_matrix_distinct_singular_value(A_matrix_size, *A_batch_dims)
+            b = torch.randn(*b_dims)
+            x_exp = torch.as_tensor(solve(A.numpy(), b.numpy())).to(device)
+            A, b = A.to(device), b.to(device)
+            LU_data, LU_pivots = torch.lu(A, pivot=pivot)
+            x = torch.lu_solve(b, LU_data, LU_pivots)
+            self.assertEqual(x, x_exp)
+
+        # test against numpy.linalg.solve
+        run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), device)  # no broadcasting
+        run_test((2, 1, 3, 4, 4), (4, 6), device)  # broadcasting b
+        run_test((4, 4), (2, 1, 3, 4, 2), device)  # broadcasting A
+        run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), device)  # broadcasting A & b
+
+    def test_dim_reduction(self, device):
+        example = [[-1, 2, 1], [5, 3, 6]]
+
+        types = [torch.double,
+                 torch.float,
+                 torch.int64,
+                 torch.int32,
+                 torch.int16]
+
+        # This won't test for 256bit instructions, since we usually
+        # only work on 1 cacheline (1024bit) at a time and these
+        # examples aren't big enough to trigger that.
+        for dtype in types:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.sum().item(), 16)
+            self.assertEqual(x.sum(0), torch.FloatTensor([4, 5, 7]))
+            self.assertEqual(x.sum(1), torch.FloatTensor([2, 14]))
+            y = torch.tensor(example, device=device, dtype=dtype)
+            torch.sum(x, 0, out=y)
+            self.assertEqual(x.sum(0), y)
+
+        # Mean not supported for Int types
+        for dtype in types[:2]:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.mean().item(), 16.0 / 6)
+            self.assertEqual(x.mean(0), torch.FloatTensor([2.0, 2.5, 7.0 / 2]))
+            self.assertEqual(x.mean(1), torch.FloatTensor([2.0 / 3, 14.0 / 3]))
+            self.assertEqual(x.mean(), x.mean((0, 1)))
+
+        for dtype in types:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.prod().item(), -180)
+            self.assertEqual(x.prod(0), torch.FloatTensor([-5, 6, 6]))
+            self.assertEqual(x.prod(1), torch.FloatTensor([-2, 90]))
+
+        for dtype in types:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.max().item(), 6)
+            self.assertEqual(x.max(0), (torch.FloatTensor([5, 3, 6]), torch.FloatTensor([1, 1, 1])))
+            self.assertEqual(x.max(1), (torch.FloatTensor([2, 6]), torch.FloatTensor([1, 2])))
+
+        for dtype in types:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.min().item(), -1)
+            self.assertEqual(x.min(0), (torch.FloatTensor([-1, 2, 1]), torch.FloatTensor([0, 0, 0])))
+            self.assertEqual(x.min(1), (torch.FloatTensor([-1, 3]), torch.FloatTensor([0, 1])))
+
+        for dtype in types:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.argmax().item(), 5)
+            self.assertEqual(x.argmax(dim=None).item(), 5)
+            self.assertEqual(x.argmax(dim=0), torch.FloatTensor([1, 1, 1]))
+            self.assertEqual(x.argmax(dim=1), torch.FloatTensor([1, 2]))
+            self.assertEqual(x.argmax(dim=0, keepdim=True), torch.FloatTensor([[1, 1, 1]]))
+            # test that non-contiguous tensors work
+            self.assertEqual(x[:, :2].argmax().item(), 2)
+
+        for dtype in types:
+            x = torch.tensor(example, device=device, dtype=dtype)
+            self.assertEqual(x.argmin().item(), 0)
+            self.assertEqual(x.argmin(dim=None).item(), 0)
+            self.assertEqual(x.argmin(dim=0), torch.FloatTensor([0, 0, 0]))
+            self.assertEqual(x.argmin(dim=1), torch.FloatTensor([0, 1]))
+            self.assertEqual(x.argmin(dim=1, keepdim=True), torch.FloatTensor([[0], [1]]))
+            # test that non-contiguous tensors work
+            self.assertEqual(x[:, :2].argmin().item(), 0)
+
+        dim_red_fns = [
+            "mean", "median", "mode", "norm", "prod",
+            "std", "sum", "var", "max", "min"]
+
+        def normfn_attr(t, dim, keepdim=False, out=None):
+            attr = torch.norm
+            return attr(t, 2, dim, keepdim, out=out)
+
+        for fn_name in dim_red_fns:
+            fn_attr = getattr(torch, fn_name) if fn_name != "norm" else normfn_attr
+
+            def fn(x, dim, keepdim=False, out=None):
+                ans = fn_attr(x, dim, keepdim=keepdim, out=out)
+                return ans if not istuple(ans) else ans[0]
+
+            def fn_tuple(x, dim, keepdim=False, out=None):
+                return fn_attr(x, dim, keepdim=keepdim, out=out)
+
+            def test_multidim(x, dim):
+                self.assertEqual(fn(x, dim).unsqueeze(dim), fn(x, dim, keepdim=True))
+                self.assertEqual(x.ndimension() - 1, fn(x, dim).ndimension())
+                self.assertEqual(x.ndimension(), fn(x, dim, keepdim=True).ndimension())
+
+            # general case
+            x = torch.randn(3, 4, 5, device=device)
+            dim = random.randint(0, 2)
+            test_multidim(x, dim)
+
+            # check 1-d behavior
+            x = torch.randn(1, device=device)
+            dim = 0
+            self.assertEqual(fn(x, dim).shape, ())
+            self.assertEqual(fn(x, dim, keepdim=True).shape, (1,))
+
+            # check reducing of a singleton dimension
+            dims = [3, 4, 5]
+            singleton_dim = random.randint(0, 2)
+            dims[singleton_dim] = 1
+            x = torch.randn(dims, device=device)
+            test_multidim(x, singleton_dim)
+
+            # check reducing with output kwargs
+            if fn_name in ['median', 'mode', 'max', 'min']:
+                y = torch.randn(5, 3, device=device)
+                values = torch.randn(5, 3, device=device)
+                indices = torch.zeros(5, 3, device=device).long() - 1
+                fn_tuple(y, 1, keepdim=False, out=(values[:, 1], indices[:, 1]))
+                values_expected, indices_expected = fn_tuple(y, 1, keepdim=False)
+                self.assertEqual(values[:, 1], values_expected,
+                                 '{} values with out= kwarg'.format(fn_name))
+                self.assertEqual(indices[:, 1], indices_expected,
+                                 '{} indices with out= kwarg'.format(fn_name))
+                continue
+
+            x = torch.randn(5, 3, device=device)
+            y = torch.randn(5, 3, device=device)
+            fn(y, 1, keepdim=False, out=x[:, 1])
+            expected = fn(y, 1, keepdim=False)
+            self.assertEqual(x[:, 1], expected, '{} with out= kwarg'.format(fn_name))
+
+    def test_remainder_overflow(self, device):
+        # Check Integer Overflows
+        x = torch.tensor(23500, dtype=torch.int64, device=device)
+        q = 392486996410368
+        self.assertEqual(x % q, x)
+        self.assertEqual(-x % q, q - x)
+        self.assertEqual(x % -q, x - q)
+        self.assertEqual(-x % -q, -x)
+
+    def test_rpow(self, device):
+        m = torch.randn(10, 10, device=device)
+        self.assertEqual(torch.pow(2, m), 2**m)
+
+        # test with scalar
+        m = torch.randn(1, device=device).squeeze()
+        assert m.dim() == 0, "m is intentionally a scalar"
+        self.assertEqual(torch.pow(2, m), 2**m)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_symeig(self, device):
+        from common_utils import random_symmetric_matrix
+
+        def run_test(dims, eigenvectors, upper):
+            x = random_symmetric_matrix(*dims).to(device)
+            oute = torch.empty(dims[1:] + dims[:1], device=device)
+            outv = torch.empty(dims[1:] + dims[:1] * 2, device=device)
+            torch.symeig(x, eigenvectors=eigenvectors, upper=upper, out=(oute, outv))
+
+            if eigenvectors:
+                x_recon = torch.matmul(torch.matmul(outv, torch.diag_embed(oute)), outv.transpose(-2, -1))
+                self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using V @ diag(e) @ V.T')
+            else:
+                eigvals, _ = torch.symeig(x, eigenvectors=True, upper=upper)
+                self.assertEqual(eigvals, oute, 'Eigenvalues mismatch')
+                self.assertEqual(torch.zeros_like(outv), outv, 'Eigenvector matrix not zero')
+
+            rese, resv = x.symeig(eigenvectors=eigenvectors, upper=upper)
+            self.assertEqual(rese, oute, "outputs of symeig and symeig with out don't match")
+            self.assertEqual(resv, outv, "outputs of symeig and symeig with out don't match")
+
+            # test non-contiguous
+            x = random_symmetric_matrix(*dims).to(device)
+            n_dim = len(dims) + 1
+            # Reverse the batch dimensions and the matrix dimensions and then concat them
+            x = x.permute(tuple(range(n_dim - 3, -1, -1)) + (n_dim - 1, n_dim - 2))
+            assert not x.is_contiguous(), "x is intentionally non-contiguous"
+            rese, resv = torch.symeig(x, eigenvectors=eigenvectors, upper=upper)
+            if eigenvectors:
+                x_recon = torch.matmul(torch.matmul(resv, torch.diag_embed(rese)), resv.transpose(-2, -1))
+                self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using V @ diag(e) @ V.T')
+            else:
+                eigvals, _ = torch.symeig(x, eigenvectors=True, upper=upper)
+                self.assertEqual(eigvals, rese, 'Eigenvalues mismatch')
+                self.assertEqual(torch.zeros_like(resv), resv, 'Eigenvector matrix not zero')
+
+        batch_dims_set = [(), (3,), (3, 5), (5, 3, 5)]
+        for batch_dims, eigenvectors, upper in product(batch_dims_set, (True, False), (True, False)):
+            run_test((5,) + batch_dims, eigenvectors, upper)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_svd(self, device):
+        def run_test(dims, some, compute_uv):
+            x = torch.randn(*dims, device=device)
+            outu, outs, outv = torch.Tensor().to(device), torch.Tensor().to(device), torch.Tensor().to(device)
+            torch.svd(x, some=some, compute_uv=compute_uv, out=(outu, outs, outv))
+
+            if compute_uv:
+                if some:
+                    x_recon = torch.matmul(outu, torch.matmul(outs.diag_embed(), outv.transpose(-2, -1)))
+                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
+                else:
+                    narrow_u = outu[..., :min(*dims[-2:])]
+                    narrow_v = outv[..., :min(*dims[-2:])]
+                    x_recon = torch.matmul(narrow_u, torch.matmul(outs.diag_embed(), narrow_v.transpose(-2, -1)))
+                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
+            else:
+                _, singvals, _ = torch.svd(x, compute_uv=True)
+                self.assertEqual(singvals, outs, 'Singular values mismatch')
+                self.assertEqual(outu, torch.zeros_like(outu), 'U not zero')
+                self.assertEqual(outv, torch.zeros_like(outv), 'V not zero')
+
+            resu, ress, resv = torch.svd(x, some=some, compute_uv=compute_uv)
+            self.assertEqual(resu, outu, 'outputs of svd and svd with out differ')
+            self.assertEqual(ress, outs, 'outputs of svd and svd with out differ')
+            self.assertEqual(resv, outv, 'outputs of svd and svd with out differ')
+
+            # test non-contiguous
+            x = torch.randn(*dims, device=device)
+            n_dim = len(dims)
+            # Reverse the batch dimensions and the matrix dimensions and then concat them
+            x = x.permute(tuple(range(n_dim - 3, -1, -1)) + (n_dim - 1, n_dim - 2))
+            assert not x.is_contiguous(), "x is intentionally non-contiguous"
+            resu, ress, resv = torch.svd(x, some=some, compute_uv=compute_uv)
+            if compute_uv:
+                if some:
+                    x_recon = torch.matmul(resu, torch.matmul(ress.diag_embed(), resv.transpose(-2, -1)))
+                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
+                else:
+                    narrow_u = resu[..., :min(*dims[-2:])]
+                    narrow_v = resv[..., :min(*dims[-2:])]
+                    x_recon = torch.matmul(narrow_u, torch.matmul(ress.diag_embed(), narrow_v.transpose(-2, -1)))
+                    self.assertEqual(x, x_recon, 1e-8, 'Incorrect reconstruction using U @ diag(S) @ V.T')
+            else:
+                _, singvals, _ = torch.svd(x, compute_uv=True)
+                self.assertEqual(singvals, ress, 'Singular values mismatch')
+                self.assertEqual(resu, torch.zeros_like(resu), 'U not zero')
+                self.assertEqual(resv, torch.zeros_like(resv), 'V not zero')
+
+        shapes = [(3, 3), (5, 3, 3), (7, 5, 3, 3),  # square matrices
+                  (7, 3), (5, 7, 3), (7, 5, 7, 3),  # fat matrices
+                  (3, 7), (5, 3, 7), (7, 5, 3, 7)]  # thin matrices
+        for dims, some, compute_uv in product(shapes, [True, False], [True, False]):
+            run_test(dims, some, compute_uv)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_svd_no_singularvectors(self, device):
+        for size in [(5, 5), (5, 20), (20, 5)]:
+            a = torch.randn(*size, device=device)
+            u, s_expect, v = torch.svd(a)
+            u, s_actual, v = torch.svd(a, compute_uv=False)
+            self.assertEqual(s_expect, s_actual, "Singular values don't match")
+
+    def test_lerp(self, device):
+        start_end_shapes = [(), (5,), (5, 5), (5, 5, 5)]
+        for shapes in product(start_end_shapes, start_end_shapes):
+            start = torch.randn(shapes[0], device=device)
+            end = torch.randn(shapes[1], device=device)
+
+            # Tensor weights
+            for weight in [torch.randn(shapes[0], device=device), random.random()]:
+                actual = torch.lerp(start, end, weight)
+                actual_method = start.lerp(end, weight)
+                self.assertEqual(actual, actual_method)
+                actual_out = torch.Tensor().to(device)
+                torch.lerp(start, end, weight, out=actual_out)
+                self.assertEqual(actual, actual_out)
+                expected = start + weight * (end - start)
+                self.assertEqual(expected, actual)
+
+    def test_diagflat(self, device):
+        dtype=torch.float32
+        # Basic sanity test
+        x = torch.randn((100,), dtype=dtype, device=device)
+        result = torch.diagflat(x)
+        expected = torch.diag(x)
+        self.assertEqual(result, expected)
+
+        # Test offset
+        x = torch.randn((100,), dtype=dtype, device=device)
+        result = torch.diagflat(x, 17)
+        expected = torch.diag(x, 17)
+        self.assertEqual(result, expected)
+
+        # Test where input has more than one dimension
+        x = torch.randn((2, 3, 4), dtype=dtype, device=device)
+        result = torch.diagflat(x)
+        expected = torch.diag(x.contiguous().view(-1))
+        self.assertEqual(result, expected)
+
+        # Noncontig input
+        x = torch.randn((2, 3, 4), dtype=dtype, device=device).transpose(2, 0)
+        self.assertFalse(x.is_contiguous())
+        result = torch.diagflat(x)
+        expected = torch.diag(x.contiguous().view(-1))
+        self.assertEqual(result, expected)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_norm(self, device):
+        # full reduction
+        x = torch.randn(25, device=device)
+        xn = x.cpu().numpy()
+        for p in [0, 1, 2, 3, 4, inf, -inf]:
+            res = x.norm(p).item()
+            expected = np.linalg.norm(xn, p)
+            self.assertEqual(res, expected, "full reduction failed for {}-norm".format(p))
+
+        # one dimension
+        x = torch.randn(25, 25, device=device)
+        xn = x.cpu().numpy()
+        for p in [0, 1, 2, 3, 4, inf, -inf]:
+            res = x.norm(p, 1).cpu().numpy()
+            expected = np.linalg.norm(xn, p, 1)
+            self.assertEqual(res.shape, expected.shape)
+            self.assertTrue(np.allclose(res, expected), "dim reduction failed for {}-norm".format(p))
+
+        # matrix norm
+        for p in ['fro', 'nuc']:
+            res = x.norm(p).cpu().numpy()
+            expected = np.linalg.norm(xn, p)
+            self.assertEqual(res.shape, expected.shape)
+            self.assertTrue(np.allclose(res, expected), "dim reduction failed for {}-norm".format(p))
+
+        # larger tensor sanity check
+        self.assertEqual(2 * torch.norm(torch.ones(10000)), torch.norm(torch.ones(40000)))
+
+    @skipCUDAIfNoMagma
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_nuclear_norm_axes_small_brute_force(self, device):
+        def check_single_nuclear_norm(x, axes):
+            if x.is_cuda and randrange(100) < 95:
+                return  # too many cpu <==> gpu copies
+
+            a = np.array(x.cpu(), copy=False)
+            expected = np.linalg.norm(a, "nuc", axis=axes)
+
+            ans = torch.norm(x, "nuc", dim=axes)
+            self.assertTrue(ans.is_contiguous())
+            self.assertEqual(ans.shape, expected.shape)
+            self.assertTrue(np.allclose(ans.cpu(), expected, rtol=1e-02, atol=1e-03, equal_nan=True))
+
+            out = torch.zeros(expected.shape, dtype=x.dtype, device=x.device)
+            ans = torch.norm(x, "nuc", dim=axes, out=out)
+            self.assertIs(ans, out)
+            self.assertTrue(ans.is_contiguous())
+            self.assertEqual(ans.shape, expected.shape)
+            self.assertTrue(np.allclose(ans.cpu(), expected, rtol=1e-02, atol=1e-03, equal_nan=True))
+
+        for n in range(1, 3):
+            for m in range(1, 3):
+                for axes in permutations([0, 1], 2):
+                    # 2d, inner dimensions C
+                    x = torch.randn(n, m, device=device)
+                    check_single_nuclear_norm(x, axes)
+
+                    # 2d, inner dimensions Fortran
+                    x = torch.randn(m, n, device=device).transpose(-1, -2)
+                    check_single_nuclear_norm(x, axes)
+
+                    # 2d, inner dimensions non-contiguous
+                    x = torch.randn(n, 2 * m, device=device)[:, ::2]
+                    check_single_nuclear_norm(x, axes)
+
+                    # 2d, all dimensions non-contiguous
+                    x = torch.randn(7 * n, 2 * m, device=device)[::7, ::2]
+                    check_single_nuclear_norm(x, axes)
+
+                for o in range(1, 3):
+                    for axes in permutations([0, 1, 2], 2):
+                        # 3d, inner dimensions C
+                        x = torch.randn(o, n, m, device=device)
+                        check_single_nuclear_norm(x, axes)
+
+                        # 3d, inner dimensions Fortran
+                        x = torch.randn(o, m, n, device=device).transpose(-1, -2)
+                        check_single_nuclear_norm(x, axes)
+
+                        # 3d, inner dimensions non-contiguous
+                        x = torch.randn(o, n, 2 * m, device=device)[:, :, ::2]
+                        check_single_nuclear_norm(x, axes)
+
+                        # 3d, all dimensions non-contiguous
+                        x = torch.randn(7 * o, 5 * n, 2 * m, device=device)[::7, ::5, ::2]
+                        check_single_nuclear_norm(x, axes)
+
+                    for r in range(1, 3):
+                        for axes in permutations([0, 1, 2, 3], 2):
+                            # 4d, inner dimensions C
+                            x = torch.randn(r, o, n, m, device=device)
+                            check_single_nuclear_norm(x, axes)
+
+                            # 4d, inner dimensions Fortran
+                            x = torch.randn(r, o, n, m, device=device).transpose(-1, -2)
+                            check_single_nuclear_norm(x, axes)
+
+                            # 4d, inner dimensions non-contiguous
+                            x = torch.randn(r, o, n, 2 * m, device=device)[:, :, :, ::2]
+                            check_single_nuclear_norm(x, axes)
+
+                            # 4d, all dimensions non-contiguous
+                            x = torch.randn(7 * r, 5 * o, 11 * n, 2 * m, device=device)[::7, ::5, ::11, ::2]
+                            check_single_nuclear_norm(x, axes)
+
+    @skipCUDAIfNoMagma
+    @skipCUDANonDefaultStreamIf(True)
+    def test_nuclear_norm_exceptions(self, device):
+        for lst in [], [1], [1, 2]:
+            for axes in (), (0,), (0, 1):
+                x = torch.tensor(lst, dtype=torch.double, device=device)
+                self.assertRaises(RuntimeError, torch.norm, x, "nuc", axes)
+
+        x = torch.tensor([[0, 1, 2], [3, 4, 5]], dtype=torch.double, device=device)
+        self.assertRaisesRegex(RuntimeError, "duplicate or invalid", torch.norm, x, "nuc", (0, 0))
+        self.assertRaisesRegex(RuntimeError, "duplicate or invalid", torch.norm, x, "nuc", (0, 2))
+
+    def test_dist(self, device):
+        def run_test(x, y):
+            for p in [0, 1, 2, 3, 4, inf, -inf]:
+                dist_xy = torch.dist(x, y, p)
+                dist_xy_norm = torch.norm(x - y, p)
+                self.assertEqual(dist_xy, dist_xy_norm)
+
+        run_test(torch.randn(5, device=device), torch.randn(5, device=device))
+
+        x = torch.zeros(3, device=device)
+        y = torch.zeros(3, device=device)
+        y[1] = 1.
+        run_test(x, y)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_geqrf(self, device):
+        a = torch.randn(5, 5, device=device)
+        b, c = torch.geqrf(a)
+        b_placeholder, c_placeholder = torch.empty_like(b), torch.empty_like(c)
+        torch.geqrf(a, out=(b_placeholder, c_placeholder))
+        self.assertEqual(b, b_placeholder)
+        self.assertEqual(c, c_placeholder)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_triangular_solve(self, device):
+        from common_utils import triangular_solve_test_helper
+        for (k, n), (upper, unitriangular, transpose) in product(zip([2, 3, 5], [3, 5, 7]),
+                                                                 product([True, False], repeat=3)):
+            b, A = triangular_solve_test_helper((n, n), (n, k), lambda t: t.to(device), upper, unitriangular)
+            x = torch.triangular_solve(b, A, upper=upper, unitriangular=unitriangular, transpose=transpose)[0]
+            if transpose:
+                self.assertLessEqual(b.dist(A.t().mm(x)), 4e-12)
+            else:
+                self.assertLessEqual(b.dist(A.mm(x)), 4e-12)
+
+    @slowTest
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_triangular_solve_batched_many_batches(self, device):
+        from common_utils import triangular_solve_test_helper
+
+        def cast(t):
+            return t.to(device)
+
+        for upper, transpose, unitriangular in product([True, False], repeat=3):
+            b, A = triangular_solve_test_helper((256, 256, 5, 5), (5, 1), cast, upper, unitriangular)
+            x, _ = torch.triangular_solve(b, A,
+                                          upper=upper, transpose=transpose, unitriangular=unitriangular)
+            if transpose:
+                A = A.transpose(-2, -1)
+            self.assertEqual(torch.matmul(A, x), b.expand(A.shape[:-2] + (5, 1)))
+
+            b, A = triangular_solve_test_helper((3, 3), (512, 512, 3, 1), cast, upper, unitriangular)
+            x, _ = torch.triangular_solve(b, A,
+                                          upper=upper, transpose=transpose, unitriangular=unitriangular)
+            if transpose:
+                A = A.transpose(-2, -1)
+            self.assertEqual(torch.matmul(A, x), b)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
+    def test_triangular_solve_batched_broadcasting(self, device):
+        from scipy.linalg import solve_triangular as tri_solve
+        from common_utils import triangular_solve_test_helper
+
+        def scipy_tri_solve_batched(A, B, upper, trans, diag):
+            batch_dims_A, batch_dims_B = A.shape[:-2], B.shape[:-2]
+            single_dim_A, single_dim_B = A.shape[-2:], B.shape[-2:]
+            expand_dims = tuple(torch._C._infer_size(torch.Size(batch_dims_A),
+                                                     torch.Size(batch_dims_B)))
+            expand_A = np.broadcast_to(A, expand_dims + single_dim_A)
+            expand_B = np.broadcast_to(B, expand_dims + single_dim_B)
+            flat_A = expand_A.reshape((-1,) + single_dim_A)
+            flat_B = expand_B.reshape((-1,) + single_dim_B)
+            flat_X = np.vstack([tri_solve(a, b, lower=(not upper), trans=int(trans), unit_diagonal=diag)
+                                for a, b in zip(flat_A, flat_B)])
+            return flat_X.reshape(expand_B.shape)
+
+        def run_test(A_dims, b_dims, device, upper, transpose, unitriangular):
+            b, A = triangular_solve_test_helper(A_dims, b_dims, lambda t: t.to(device), upper, unitriangular)
+            x_exp = torch.as_tensor(scipy_tri_solve_batched(A.cpu().numpy(), b.cpu().numpy(),
+                                                            upper, transpose, unitriangular))
+            x = torch.triangular_solve(b, A, upper=upper, transpose=transpose, unitriangular=unitriangular)[0]
+
+            self.assertEqual(x, x_exp.to(device))
+
+        for upper, transpose, unitriangular in product([True, False], repeat=3):
+            # test against scipy.linalg.solve_triangular
+            run_test((2, 1, 3, 4, 4), (2, 1, 3, 4, 6), device, upper, transpose, unitriangular)  # no broadcasting
+            run_test((2, 1, 3, 4, 4), (4, 6), device, upper, transpose, unitriangular)  # broadcasting b
+            run_test((4, 4), (2, 1, 3, 4, 2), device, upper, transpose, unitriangular)  # broadcasting A
+            run_test((1, 3, 1, 4, 4), (2, 1, 3, 4, 5), device, upper, transpose, unitriangular)  # broadcasting A & b
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_lstsq(self, device):
+        def cast_fn(tensor):
+            return tensor.to(device=device)
+
+        def _test_underdetermined(a, b, expectedNorm):
+            # underdetermined systems are not supported on the GPU
+            if 'cuda' in device:
+                return
+
+            m = a.size()[0]
+            n = a.size()[1]
+            assert(m <= n)
+
+            a_copy = a.clone()
+            b_copy = b.clone()
+            res1 = torch.lstsq(b, a)[0]
+            self.assertEqual(a, a_copy, 0)
+            self.assertEqual(b, b_copy, 0)
+            self.assertEqual((torch.mm(a, res1) - b).norm(), expectedNorm, 1e-8)
+
+            ta = cast_fn(torch.Tensor())
+            tb = cast_fn(torch.Tensor())
+            res2 = torch.lstsq(b, a, out=(tb, ta))[0]
+            self.assertEqual(a, a_copy, 0)
+            self.assertEqual(b, b_copy, 0)
+            self.assertEqual((torch.mm(a, res1) - b).norm(), expectedNorm, 1e-8)
+
+            res3 = torch.lstsq(b, a, out=(b, a))[0]
+            self.assertEqual((torch.mm(a_copy, b) - b_copy).norm(), expectedNorm, 1e-8)
+            self.assertEqual(res1, tb, 0)
+            self.assertEqual(res1, b, 0)
+            self.assertEqual(res1, res2, 0)
+            self.assertEqual(res1, res3, 0)
+
+        def _test_overdetermined(a, b, expectedNorm):
+            m = a.size()[0]
+            n = a.size()[1]
+            assert(m > n)
+
+            def check_norm(a, b, expected_norm, gels_result):
+                # Checks |ax - b| and the residual info from the result
+
+                # The first n rows is the least square solution.
+                # Rows n to m-1 contain residual information.
+                x = gels_result[:n]
+                resid_info = gels_result[n:]
+
+                resid_norm = (torch.mm(a, x) - b).norm()
+                self.assertEqual(resid_norm, expectedNorm, 1e-8)
+                self.assertEqual(resid_info.norm(), resid_norm, 1e-8)
+
+            a_copy = a.clone()
+            b_copy = b.clone()
+            res1 = torch.lstsq(b, a)[0]
+            self.assertEqual(a, a_copy, 0)
+            self.assertEqual(b, b_copy, 0)
+            check_norm(a, b, expectedNorm, res1)
+
+            ta = cast_fn(torch.Tensor())
+            tb = cast_fn(torch.Tensor())
+            res2 = torch.lstsq(b, a, out=(tb, ta))[0]
+            self.assertEqual(a, a_copy, 0)
+            self.assertEqual(b, b_copy, 0)
+            check_norm(a, b, expectedNorm, res2)
+
+            res3 = torch.lstsq(b, a, out=(b, a))[0]
+            check_norm(a_copy, b_copy, expectedNorm, res3)
+
+            self.assertEqual(res1, tb, 0)
+            self.assertEqual(res1, b, 0)
+            self.assertEqual(res1, res2, 0)
+            self.assertEqual(res1, res3, 0)
+
+        # basic test
+        expectedNorm = 0
+        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55, 8.34),
+                                  (-7.84, -0.28, 3.24, 8.09),
+                                  (-4.39, -3.24, 6.27, 5.28),
+                                  (4.53, 3.83, -6.64, 2.06)))).t()
+        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48, -5.28),
+                                  (9.35, -4.43, -0.70, -0.26)))).t()
+        _test_underdetermined(a, b, expectedNorm)
+
+        # test overdetermined
+        expectedNorm = 17.390200628863
+        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55, 8.34, 7.08, -5.45),
+                                  (-7.84, -0.28, 3.24, 8.09, 2.52, -5.70),
+                                  (-4.39, -3.24, 6.27, 5.28, 0.74, -1.19),
+                                  (4.53, 3.83, -6.64, 2.06, -2.47, 4.70)))).t()
+        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48, -5.28, 5.72, 8.93),
+                                  (9.35, -4.43, -0.70, -0.26, -7.36, -2.52)))).t()
+        _test_overdetermined(a, b, expectedNorm)
+
+        # test underdetermined
+        expectedNorm = 0
+        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55),
+                                  (-7.84, -0.28, 3.24),
+                                  (-4.39, -3.24, 6.27),
+                                  (4.53, 3.83, -6.64)))).t()
+        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48),
+                                  (9.35, -4.43, -0.70)))).t()
+        _test_underdetermined(a, b, expectedNorm)
+
+        # test reuse
+        expectedNorm = 0
+        a = cast_fn(torch.Tensor(((1.44, -9.96, -7.55, 8.34),
+                                  (-7.84, -0.28, 3.24, 8.09),
+                                  (-4.39, -3.24, 6.27, 5.28),
+                                  (4.53, 3.83, -6.64, 2.06)))).t()
+        b = cast_fn(torch.Tensor(((8.58, 8.26, 8.48, -5.28),
+                                  (9.35, -4.43, -0.70, -0.26)))).t()
+        ta = cast_fn(torch.Tensor())
+        tb = cast_fn(torch.Tensor())
+        torch.lstsq(b, a, out=(tb, ta))
+        self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
+        torch.lstsq(b, a, out=(tb, ta))
+        self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
+        torch.lstsq(b, a, out=(tb, ta))
+        self.assertEqual((torch.mm(a, tb) - b).norm(), expectedNorm, 1e-8)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_qr(self, device):
+        def run_test(tensor_dims, some):
+            A = torch.randn(*tensor_dims, device=device)
+            Q, R = torch.qr(A, some=some)
+
+            # Check0: Q[-2:] = (m, n_columns), R[-2:] = (n_columns, n)
+            m, n = tensor_dims[-2:]
+            n_columns = m if (not some) and m > n else min(m, n)
+            self.assertEqual(Q.size(-2), m)
+            self.assertEqual(R.size(-1), n)
+            self.assertEqual(Q.size(-1), n_columns)
+
+            # Check1: A = QR
+            self.assertEqual(A, torch.matmul(Q, R))
+
+            # Check2: A = QR (with out)
+            Q_out, R_out = torch.Tensor().to(device), torch.Tensor().to(device)
+            torch.qr(A, some=some, out=(Q_out, R_out))
+            self.assertEqual(A, torch.matmul(Q_out, R_out))
+
+            # Check3: Q == Q_out, R == R_out
+            self.assertEqual(Q, Q_out)
+            self.assertEqual(R, R_out)
+
+            # Check4: Q^{T}Q = I, triu(R) = R
+            self.assertEqual(torch.matmul(Q.transpose(-2, -1), Q),
+                             torch.eye(n_columns, device=device).expand(Q.shape[:-2] + (n_columns, n_columns)))
+            self.assertEqual(R.triu(), R)
+
+        tensor_dims_list = [(3, 5), (5, 5), (5, 3),  # Single matrix
+                            (7, 3, 5), (7, 5, 5), (7, 5, 3),  # 3-dim Tensors
+                            (7, 5, 3, 5), (7, 5, 5, 5), (7, 5, 5, 3)]  # 4-dim Tensors
+        for tensor_dims, some in product(tensor_dims_list, [True, False]):
+            run_test(tensor_dims, some)
+
+    def test_randperm(self, device):
+        if device == 'cpu':
+            rng_device = None
+        else:
+            rng_device = [0]
+
+        # Test core functionality. On CUDA, for small n, randperm is offloaded to CPU instead. For large n, randperm is
+        # executed on GPU.
+        for n in (100, 50000, 100000):
+            # Ensure both integer and floating-point numbers are tested. Half follows an execution path that is
+            # different from others on CUDA.
+            for dtype in (torch.long, torch.half, torch.float):
+                if n > 2049 and dtype == torch.half:  # Large n for torch.half will raise an exception, do not test here.
+                    continue
+                with torch.random.fork_rng(devices=rng_device):
+                    res1 = torch.randperm(n, dtype=dtype, device=device)
+                res2 = torch.empty(0, dtype=dtype, device=device)
+                torch.randperm(n, out=res2, dtype=dtype, device=device)
+                self.assertEqual(res1, res2, 0)
+
+        # Default type is long
+        for n in (100, 10000):
+            self.assertEqual(torch.randperm(n, device=device).dtype, torch.long)
+
+        # randperm of 0 elements is an empty tensor
+        res1 = torch.randperm(0)
+        res2 = torch.tensor(5, dtype=dtype, device=device)
+        torch.randperm(0, out=res2)
+        self.assertEqual(res1.numel(), 0)
+        self.assertEqual(res2.numel(), 0)
+
+        # Test exceptions when n is too large for a floating point type
+        for dtype, small_n, large_n in ((torch.half, 2**11 + 1, 2**11 + 2),
+                                        (torch.float, 2**24 + 1, 2**24 + 2),
+                                        (torch.double, 2**25,  # 2**53 + 1 is too large to run
+                                         2**53 + 2)):
+            res = torch.empty(0, dtype=dtype, device=device)
+            torch.randperm(small_n, out=res)  # No exception expected
+            self.assertRaises(RuntimeError, lambda: torch.randperm(large_n, out=res, device=device))
+
+        # Test non-contiguous tensors
+        for n in (4, 5, 6, 10, 20):
+            non_contiguous_tensor = torch.zeros((2, 3), dtype=torch.long, device=device).t()
+            self.assertFalse(non_contiguous_tensor.is_contiguous())
+            with torch.random.fork_rng(devices=rng_device):
+                res = torch.randperm(n, dtype=torch.long, device=device)
+            torch.randperm(n, out=non_contiguous_tensor)
+            self.assertEqual(non_contiguous_tensor, res)
+
+    def test_random_neg_values(self, device):
+        signed_types = ['torch.DoubleTensor', 'torch.FloatTensor', 'torch.LongTensor',
+                        'torch.IntTensor', 'torch.ShortTensor']
+        for tname in signed_types:
+            res = torch.rand(SIZE, SIZE).type(tname).to(device)
+            res.random_(-10, -1)
+            self.assertLessEqual(res.max().item(), 9)
+            self.assertGreaterEqual(res.min().item(), -10)
+
+    def test_triu_tril(self, device):
+        def gen_mask(shape, diagonal, device, upper):
+            mask = torch.zeros(*shape[-2:]).byte()
+            for i in range(shape[-2]):
+                for j in range(shape[-1]):
+                    cond = j - i < diagonal if upper else j - i > diagonal
+                    if cond:
+                        mask[i, j] = 1
+            return mask.expand(*shape).to(device)
+
+        torch_functions = {True: torch.triu, False: torch.tril}
+        if TEST_NUMPY:
+            numpy_functions = {True: np.triu, False: np.tril}
+
+        # TODO: remove this when bool and half are supported for torch.where
+        def bool_half_compat_where(pred, true_tensor, false_tensor, dtype):
+            if dtype == torch.bool or dtype == torch.half:
+                return torch.where(pred.byte(), true_tensor.byte(), false_tensor.byte()).to(dtype=dtype)
+            else:
+                return torch.where(pred, true_tensor, false_tensor)
+
+        def run_test(shape, device, diagonal, dtype):
+            x = torch.empty(*shape, device=device, dtype=dtype).fill_(2)
+
+            for upper in [True, False]:
+                # normal test with mask
+                torch_tri_func = torch_functions[upper]
+                res1 = torch_tri_func(x, diagonal=diagonal)
+                res2 = torch.empty(0, device=device, dtype=dtype)
+                torch_tri_func(x, diagonal=diagonal, out=res2)
+                exp_mask = gen_mask(shape, diagonal, device, upper)
+                expected = bool_half_compat_where(exp_mask, torch.tensor(0).type_as(x), x, dtype)
+                self.assertEqual(res1, res2, 0)
+                self.assertEqual(expected, res1, 0)
+
+                # non-contiguous and expanded tensors test
+                if 0 not in shape:
+                    for s in range(-len(shape), -1):
+                        # non-contiguous tensors
+                        x_nc = x.clone().transpose(s, s + 1)
+                        exp_mask = gen_mask(x_nc.size(), diagonal, device, upper)
+                        if 1 not in shape:
+                            assert not x_nc.is_contiguous(), "x is intentionally non-contiguous"
+                        exp_nc = bool_half_compat_where(exp_mask, torch.tensor(0).type_as(x), x_nc, dtype)
+                        self.assertEqual(torch_tri_func(x_nc, diagonal), exp_nc, 0)
+                        x_nc_is_contiguous = x_nc.is_contiguous()
+                        if upper:
+                            self.assertEqual(x_nc.triu_(diagonal), exp_nc, 0)
+                        else:
+                            self.assertEqual(x_nc.tril_(diagonal), exp_nc, 0)
+
+                        self.assertTrue(x_nc.is_contiguous() == x_nc_is_contiguous,
+                                        "contiguity of x_nc should not be changed")
+
+                    # expanded tensors
+                    expanded_size = (x.size(0),) + x.size()
+                    x_expanded = x.clone().expand(*expanded_size)
+                    if x.size(0) != 1:
+                        assert 0 in x_expanded.stride(), "x intentionally has 0 in its stride"
+                    output = torch_tri_func(x_expanded, diagonal)
+                    self.assertEqual(output, expected.expand(expanded_size), 0)
+                    if x.size(0) != 1:
+                        self.assertTrue(0 in x_expanded.stride(),
+                                        "geometry of x_expanded should be the same")
+                    if upper:
+                        self.assertEqual(output, x_expanded.triu_(diagonal), 0)
+                    else:
+                        self.assertEqual(output, x_expanded.tril_(diagonal), 0)
+
+                if not TEST_NUMPY:
+                    continue
+
+                # numpy test
+                numpy_tri_func = numpy_functions[upper]
+                self.assertEqual(numpy_tri_func(x.to('cpu').numpy(), diagonal), res1.cpu().numpy())
+
+        diagonals = [-2, -1, 0, 1, 2]
+        shapes = [(3, 3), (5, 3, 3), (7, 5, 3, 3),  # square matrices
+                  (7, 3), (5, 7, 3), (7, 5, 7, 3),  # fat matrices
+                  (3, 7), (5, 3, 7), (7, 5, 3, 7),  # thin matrices
+                  (3, 0), (0, 3, 3), (3, 3, 0, 0),  # no numel matrices
+                  (3, 1), (5, 3, 1), (7, 5, 3, 1),  # very fat matrices
+                  (1, 3), (5, 1, 3), (7, 5, 1, 3),  # very thin matrices
+                  (1, 3, 3, 3), (3, 1, 3, 3, 3)]    # unsqueezed batch dimensions
+        dtypes = [dtype for dtype in torch.testing.get_all_dtypes() if dtype != torch.bfloat16]
+        for s, d, dtype in product(shapes, diagonals, dtypes):
+            run_test(s, device, d, dtype)
+
+    @skipCUDANonDefaultStreamIf(True)
+    def test_multinomial_alias(self, device):
+        # Get probs vector to use in setup
+        def get_probs(length, is_contiguous):
+            probs = torch.softmax(torch.randn(length), 0)
+            if not is_contiguous:
+                probs = torch.softmax(torch.randn(length, 2), 0)[:, 1]
+            assert not (is_contiguous ^ probs.is_contiguous()), "contiguity requirement not met"
+            return probs.to(device)
+
+        for is_contiguous in [True, False]:
+            probs = get_probs(4, is_contiguous)
+            alias_table, prob_table = torch._multinomial_alias_setup(probs)
+            for n_samples in [-1, 1, 10]:
+                if n_samples > 0:
+                    samples = torch._multinomial_alias_draw(prob_table, alias_table, n_samples)
+                    self.assertEqual(prob_table.size(), torch.Size([4]), "size mismatch: probability table")
+                    self.assertEqual(alias_table.size(), torch.Size([4]), "size mismatch: alias table")
+                    self.assertEqual(samples.size(), torch.Size([n_samples]), "wrong number of samples")
+                else:
+                    with self.assertRaisesRegex(RuntimeError, "cannot sample <= 0 samples"):
+                        torch._multinomial_alias_draw(prob_table, alias_table, n_samples)
+
+            with self.assertRaisesRegex(RuntimeError, "expected 1-D"):
+                probs = probs.view(2, 2)
+                torch._multinomial_alias_setup(probs)
+
+            with self.assertRaisesRegex(RuntimeError, "expected 1-D"):
+                a_t, p_t = torch._multinomial_alias_setup(probs)
+                torch._multinomial_alias_draw(p_t.view(2, 2), a_t.view(2, 2))
+
+        MAX_SAMPLES = 200000
+        for probs in [get_probs(4, True),
+                      torch.tensor([0.8, 0.2], device=device),
+                      torch.tensor([0.7, 0.2, 0.1], device=device)]:
+            # Check how different the alias distribution and the original distribution are
+            alias_dist = torch.zeros_like(probs)
+            alias_table, prob_table = torch._multinomial_alias_setup(probs)
+            alias_samples = torch._multinomial_alias_draw(prob_table, alias_table, MAX_SAMPLES)
+            alias_dist = torch.unique(alias_samples, return_counts=True)[1].to(dtype=probs.dtype) / MAX_SAMPLES
+            self.assertTrue(torch.allclose(alias_dist, probs, rtol=0.02, atol=0.0),
+                            "Actual: {}\nExpected: {}".format(alias_dist, probs))
+
+        for probs in [torch.tensor([0.2501, 0.25, 0.2499, 0.25], device=device),
+                      torch.tensor([0.8, 0.199, 0.001], device=device),
+                      torch.tensor([0.25001, 0.25, 0.24999, 0.25], device=device),
+                      torch.tensor([0.33, 0.34, 0.33], device=device),
+                      torch.tensor([0.8, 0.1999, 0.0001], device=device)]:
+            # Check the difference between the original probabilities and the reconstructed
+            # probabilities from the alias and probability tables output by _multinomial_alias_setup
+            alias_table, prob_table = torch._multinomial_alias_setup(probs)
+            actual = torch.zeros_like(probs)
+            for i, vals in enumerate(zip(alias_table, prob_table)):
+                idx, p = vals
+                actual[i] += p
+                actual[idx] += 1. - p
+            actual = actual / len(probs)
+            self.assertEqual(actual, probs, 1e-6)
+
+        # Some special cases
+        test_cases = [torch.tensor([1.0, 0.0, 0.0], device=device), torch.tensor([0.0, 1.0], device=device)]
+        for probs in test_cases:
+            alias_table, prob_table = torch._multinomial_alias_setup(probs)
+            alias_samples = torch._multinomial_alias_draw(prob_table, alias_table, MAX_SAMPLES)
+            self.assertEqual(alias_samples.unique(), probs.nonzero().squeeze(-1))
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    @skipCUDANonDefaultStreamIf(True)
+    def test_lapack_empty(self, device):
+        # FIXME: these are just a selection of LAPACK functions -- we need a general strategy here.
+        # The LAPACK functions themselves generally do NOT work with zero sized dimensions, although
+        # numpy/sci often has a direct wrapper (e.g. lu_factor) and a wrapper that "does the right thing"
+        # (e.g. lu).  We often name our functions identically to the lapack function, so it will take work
+        # to name / migrate-to better wrappers.
+        def fn(torchfn, *args):
+            return torchfn(*tuple(torch.randn(shape, device=device) if isinstance(shape, tuple) else shape
+                                    for shape in args))
+
+        # inverse, pinverse
+        self.assertEqual((0, 0), fn(torch.inverse, (0, 0)).shape)
+        self.assertEqual((5, 0), fn(torch.pinverse, (0, 5)).shape)
+        self.assertEqual((0, 5), fn(torch.pinverse, (5, 0)).shape)
+        self.assertEqual((0, 0), fn(torch.pinverse, (0, 0)).shape)
+
+        # det, logdet, slogdet
+        self.assertEqual(torch.tensor(1., device=device), fn(torch.det, (0, 0)))
+        self.assertEqual(torch.tensor(0., device=device), fn(torch.logdet, (0, 0)))
+        self.assertEqual((torch.tensor(1., device=device), torch.tensor(0., device=device)),
+                            fn(torch.slogdet, (0, 0)))
+
+        # eig, symeig
+        evalues, evectors = fn(torch.eig, (0, 0), True)
+        self.assertEqual([(0, 2), (0, 0)], [evalues.shape, evectors.shape])
+        evalues, evectors = fn(torch.symeig, (0, 0), True)
+        self.assertEqual([(0,), (0, 0)], [evalues.shape, evectors.shape])
+
+        # qr
+        q, r = fn(torch.qr, (3, 0), True)
+        self.assertEqual([(3, 0), (0, 0)], [q.shape, r.shape])
+        q, r = fn(torch.qr, (0, 3), True)
+        self.assertEqual([(0, 0), (0, 3)], [q.shape, r.shape])
+        q, r = fn(torch.qr, (3, 0), False)
+        self.assertEqual([(3, 3), (3, 0)], [q.shape, r.shape])
+
+        # lstsq
+        self.assertRaises(RuntimeError, lambda: torch.lstsq(torch.randn(0, 0), torch.randn(0, 0)))
+        self.assertRaises(RuntimeError, lambda: torch.lstsq(torch.randn(0,), torch.randn(0, 0)))
+
+    def test_roll(self, device):
+        numbers = torch.arange(1, 9, device=device)
+
+        single_roll = numbers.roll(1, 0)
+        expected = torch.tensor([8, 1, 2, 3, 4, 5, 6, 7], device=device)
+        self.assertEqual(single_roll, expected, "{} did not equal expected result".format(single_roll))
+
+        roll_backwards = numbers.roll(-2, 0)
+        expected = torch.tensor([3, 4, 5, 6, 7, 8, 1, 2], device=device)
+        self.assertEqual(roll_backwards, expected, "{} did not equal expected result".format(roll_backwards))
+
+        data = numbers.view(2, 2, 2)
+        rolled = data.roll(1, 0)
+        expected = torch.tensor([5, 6, 7, 8, 1, 2, 3, 4], device=device).view(2, 2, 2)
+        self.assertEqual(expected, rolled, "{} did not equal expected result: {}".format(rolled, expected))
+
+        data = data.view(2, 4)
+        # roll a loop until back where started
+        loop_rolled = data.roll(2, 0).roll(4, 1)
+        self.assertEqual(data, loop_rolled, "{} did not equal the original: {}".format(loop_rolled, data))
+        # multiple inverse loops
+        self.assertEqual(data, data.roll(-20, 0).roll(-40, 1))
+        self.assertEqual(torch.tensor([8, 1, 2, 3, 4, 5, 6, 7], device=device), numbers.roll(1, 0))
+
+        # test non-contiguous
+        # strided equivalent to numbers.as_strided(size=(4, 2), stride=(1, 4))
+        strided = numbers.view(2, 4).transpose(0, 1)
+        self.assertFalse(strided.is_contiguous(), "this test needs a non-contiguous tensor")
+        expected = torch.tensor([4, 8, 1, 5, 2, 6, 3, 7]).view(4, 2)
+        rolled = strided.roll(1, 0)
+        self.assertEqual(expected, rolled,
+                            "non contiguous tensor rolled to {} instead of {} ".format(rolled, expected))
+
+        # test roll with no dimension specified
+        expected = numbers.roll(1, 0).view(2, 4)
+        self.assertEqual(expected, data.roll(1), "roll with no dims should flatten and roll.")
+        self.assertEqual(expected, data.roll(1, dims=None), "roll with no dims should flatten and roll.")
+
+        # test roll over multiple dimensions
+        expected = torch.tensor([[7, 8, 5, 6], [3, 4, 1, 2]], device=device)
+        double_rolled = data.roll(shifts=(2, -1), dims=(1, 0))
+        self.assertEqual(double_rolled, expected,
+                            "should be able to roll over two dimensions, got {}".format(double_rolled))
+
+        self.assertRaisesRegex(RuntimeError, "required", lambda: data.roll(shifts=(), dims=()))
+        self.assertRaisesRegex(RuntimeError, "required", lambda: data.roll(shifts=(), dims=1))
+        # shifts/dims should align
+        self.assertRaisesRegex(RuntimeError, "align", lambda: data.roll(shifts=(1, 2), dims=(1,)))
+        self.assertRaisesRegex(RuntimeError, "align", lambda: data.roll(shifts=(1,), dims=(1, 2)))
+
+    def test_nonzero_empty(self, device):
+        def assert_tuple_empty(tup, dim):
+            self.assertEqual(dim, len(tup))
+            for t in tup:
+                self.assertEqual(torch.Size([0]), t.shape)
+
+        x = torch.randn(0, 2, 0, 5, 0, device=device)
+        y = torch.nonzero(x)
+        z = torch.nonzero(x, as_tuple=True)
+
+        self.assertEqual(0, y.numel())
+        self.assertEqual(torch.Size([0, 5]), y.shape)
+        assert_tuple_empty(z, 5)
+
+        x = torch.tensor(0.5, device=device)
+        y = torch.nonzero(x)
+        # nonzero with as_tuple returns a
+        # tuple of len 1 for a zero-dim tensor.
+        # This is done to match Numpy behavior.
+        z = torch.nonzero(x, as_tuple=True)
+        self.assertEqual(1, len(z))
+        self.assertEqual(torch.zeros(1, dtype=torch.long), z[0])
+
+        x = torch.zeros((), device=device)
+        y = torch.nonzero(x)
+        z = torch.nonzero(x, as_tuple=True)
+        self.assertEqual(torch.Size([0, 0]), y.shape)
+        self.assertEqual(1, len(z))
+        self.assertEqual(torch.empty(0, dtype=torch.long), z[0])
+
+    def test_normal(self, device):
+        q = torch.empty(100, 100, device=device).normal_()
+        self.assertEqual(q.mean(), 0, 0.2)
+        self.assertEqual(q.std(), 1, 0.2)
+
+        q.normal_(2, 3)
+        self.assertEqual(q.mean(), 2, 0.3)
+        self.assertEqual(q.std(), 3, 0.3)
+
+        q = torch.empty(100, 100, device=device)
+        q_row1 = q[0:1].clone()
+        q[99:100].normal_()
+        self.assertEqual(q[99:100].mean(), 0, 0.2)
+        self.assertEqual(q[99:100].std(), 1, 0.2)
+        self.assertEqual(q[0:1].clone(), q_row1)
+
+        mean = torch.empty(100, 100, device=device)
+        std = torch.empty(100, 100, device=device)
+        mean[:50] = 0
+        mean[50:] = 1
+        std[:, :50] = 4
+        std[:, 50:] = 1
+
+        r = torch.normal(mean)
+        self.assertEqual(r[:50].mean(), 0, 0.2)
+        self.assertEqual(r[50:].mean(), 1, 0.2)
+        self.assertEqual(r.std(), 1, 0.2)
+
+        r = torch.normal(mean, 3)
+        self.assertEqual(r[:50].mean(), 0, 0.2)
+        self.assertEqual(r[50:].mean(), 1, 0.2)
+        self.assertEqual(r.std(), 3, 0.2)
+
+        r = torch.normal(2, std)
+        self.assertEqual(r.mean(), 2, 0.2)
+        self.assertEqual(r[:, :50].std(), 4, 0.3)
+        self.assertEqual(r[:, 50:].std(), 1, 0.2)
+
+        r = torch.normal(mean, std)
+        self.assertEqual(r[:50].mean(), 0, 0.2)
+        self.assertEqual(r[50:].mean(), 1, 0.2)
+        self.assertEqual(r[:, :50].std(), 4, 0.3)
+        self.assertEqual(r[:, 50:].std(), 1, 0.2)
+
+        r = torch.normal(2, 3, (100, 100))
+        self.assertEqual(r.mean(), 2, 0.2)
+        self.assertEqual(r.std(), 3, 0.2)
+
+    def test_empty_strided(self, device):
+        for shape in [(2, 3, 4), (0, 2, 0)]:
+            # some of these cases are pretty strange, just verifying that if as_strided
+            # allows them then empty_strided can as well.
+            for strides in [(12, 4, 1), (2, 4, 6), (0, 0, 0)]:
+                empty_strided = torch.empty_strided(shape, strides, device=device)
+                # as_strided checks the storage size is big enough to support such a strided tensor;
+                # instead of repeating this calculation, we just use empty_strided which does the same
+                # calculation when setting the storage size.
+                as_strided = torch.empty(empty_strided.storage().size(),
+                                            device=device).as_strided(shape, strides)
+                self.assertEqual(empty_strided.shape, as_strided.shape)
+                self.assertEqual(empty_strided.stride(), as_strided.stride())
+
+    def test_sign(self, device):
+        for dtype in torch.testing.get_all_math_dtypes(device):
+
+            # Include NaN for floating point numbers
+            if dtype.is_floating_point:
+                dt_info = torch.finfo(dtype)
+
+                # Create tensor (with NaN checking)
+                a = torch.tensor([float('nan'), -12, 0, 71, dt_info.min, dt_info.max], device=device, dtype=dtype)
+                a_target = torch.tensor([0, -1, 0, 1, -1, 1], device=device, dtype=dtype)
+
+            else:
+                dt_info = torch.iinfo(dtype)
+
+                # If unsigned type, everything should be >= 0
+                if dt_info.min == 0:
+                    a = torch.tensor([12, 0, 71, dt_info.min, dt_info.max], device=device, dtype=dtype)
+                    a_target = torch.tensor([1, 0, 1, 0, 1], device=device, dtype=dtype)
+                else:
+                    a = torch.tensor([-12, 0, 71, dt_info.min, dt_info.max], device=device, dtype=dtype)
+                    a_target = torch.tensor([-1, 0, 1, -1, 1], device=device, dtype=dtype)
+
+            self.assertEqual(a.sign(), a_target, 'sign device={} dtype={}'.format(device, dtype))
+            self.assertEqual(torch.sign(a), a_target, 'sign device={} dtype={}'.format(device, dtype))
+
+            out = torch.empty_like(a)
+            torch.sign(a, out=out)
+            self.assertEqual(out, a_target, 'sign_out device={} dtype={}'.format(device, dtype))
+
+            a.sign_()
+            self.assertEqual(a, a_target, 'sign_ device={} dtype={}'.format(device, dtype))
+
+        # Include test for bool dtype
+        a_bool = torch.tensor([True, True, False, float('nan')], device=device).bool()
+        a_bool_target = torch.tensor([True, True, False, True], device=device).bool()
+        self.assertEqual(a_bool.sign(), a_bool_target, 'sign device={} dtype=bool'.format(device))
+        self.assertEqual(torch.sign(a_bool), a_bool_target, 'sign device={} dtype=bool'.format(device))
+
+        a_out = torch.empty_like(a_bool)
+        torch.sign(a_bool, out=a_out)
+        self.assertEqual(a_out, a_bool_target, 'sign_out device={} dtype=bool'.format(device))
+
+        a_bool.sign_()
+        self.assertEqual(a_bool, a_bool_target, 'sign_ device={} dtype=bool'.format(device))
+
+    def test_logical_any(self, device):
+        x = torch.zeros([2, 3, 400], dtype=torch.uint8, device=device)
+
+        self.assertEqual(
+            torch.tensor(0, dtype=torch.uint8, device=device),
+            x.any())
+
+        self.assertEqual(
+            torch.zeros([1, 3, 400], dtype=torch.uint8, device=device),
+            x.any(0, keepdim=True))
+
+        self.assertEqual(
+            torch.zeros([2, 1, 400], dtype=torch.uint8, device=device),
+            x.any(1, keepdim=True))
+
+        self.assertEqual(
+            torch.zeros([2, 3, 1], dtype=torch.uint8, device=device),
+            x.any(2, keepdim=True))
+
+        # set the last element to 0
+        x[-1][-1][-1] = 1
+
+        self.assertEqual(
+            torch.tensor(1, dtype=torch.uint8, device=device),
+            x.any())
+
+        y = torch.zeros([1, 3, 400], dtype=torch.uint8, device=device)
+        y[-1][-1][-1] = 1
+        self.assertEqual(y, x.any(0, keepdim=True))
+
+        y = torch.zeros([2, 1, 400], dtype=torch.uint8, device=device)
+        y[-1][-1][-1] = 1
+        self.assertEqual(y, x.any(1, keepdim=True))
+
+        y = torch.zeros([2, 3, 1], dtype=torch.uint8, device=device)
+        y[-1][-1][-1] = 1
+        self.assertEqual(y, x.any(2, keepdim=True))
+
+    def test_logical_all(self, device):
+        x = torch.ones([2, 3, 400], dtype=torch.uint8, device=device)
+
+        self.assertEqual(
+            torch.tensor(1, dtype=torch.uint8, device=device),
+            x.all())
+
+        self.assertEqual(
+            torch.ones([1, 3, 400], dtype=torch.uint8, device=device),
+            x.all(0, keepdim=True))
+
+        self.assertEqual(
+            torch.ones([2, 1, 400], dtype=torch.uint8, device=device),
+            x.all(1, keepdim=True))
+
+        self.assertEqual(
+            torch.ones([2, 3, 1], dtype=torch.uint8, device=device),
+            x.all(2, keepdim=True))
+
+        # set the last element to 0
+        x[-1][-1][-1] = 0
+
+        self.assertEqual(
+            torch.tensor(0, dtype=torch.uint8, device=device),
+            x.all())
+
+        y = torch.ones([1, 3, 400], dtype=torch.uint8, device=device)
+        y[-1][-1][-1] = 0
+        self.assertEqual(y, x.all(0, keepdim=True))
+
+        y = torch.ones([2, 1, 400], dtype=torch.uint8, device=device)
+        y[-1][-1][-1] = 0
+        self.assertEqual(y, x.all(1, keepdim=True))
+
+        y = torch.ones([2, 3, 1], dtype=torch.uint8, device=device)
+        y[-1][-1][-1] = 0
+        self.assertEqual(y, x.all(2, keepdim=True))
+
+    def test_log_normal(self, device):
+        a = torch.tensor([10], dtype=torch.float, device=device).log_normal_()
+        self.assertEqual(a.dtype, torch.float)
+        self.assertEqual(a.size(), torch.Size([1]))
+
+    def test_geometric(self, device):
+        a = torch.tensor([10], dtype=torch.float, device=device).geometric_(0.5)
+        self.assertEqual(a.dtype, torch.float)
+        self.assertEqual(a.size(), torch.Size([1]))
+
+    def test_pairwise_distance_empty(self, device):
+        shape = (2, 0)
+        x = torch.randn(shape, device=device)
+        y = torch.randn(shape, device=device)
+
+        self.assertEqual(torch.zeros(2, device=device), torch.pairwise_distance(x, y))
+        self.assertEqual(torch.zeros((2, 1), device=device), torch.pairwise_distance(x, y, keepdim=True))
+
+        shape = (0, 2)
+        x = torch.randn(shape, device=device)
+        y = torch.randn(shape, device=device)
+        self.assertEqual(torch.zeros(0, device=device), torch.pairwise_distance(x, y))
+        self.assertEqual(torch.zeros((0, 1), device=device), torch.pairwise_distance(x, y, keepdim=True))
+
+    def test_pdist_empty(self, device):
+        shape = (0, 2)
+        x = torch.randn(shape, device=device)
+        self.assertEqual(torch.empty(0, device=device), torch.pdist(x))
+
+        shape = (1, 2)
+        x = torch.randn(shape, device=device)
+        self.assertEqual(torch.empty(0, device=device), torch.pdist(x))
+
+        shape = (3, 0)
+        x = torch.randn(shape, device=device)
+        self.assertEqual(torch.zeros(3, device=device), torch.pdist(x))
+
+    def test_cdist_empty(self, device):
+        x = torch.randn((0, 5), device=device)
+        y = torch.randn((4, 5), device=device)
+        self.assertEqual(torch.empty(0, 4, device=device), torch.cdist(x, y))
+
+        x = torch.randn((2, 5), device=device)
+        y = torch.randn((0, 5), device=device)
+        self.assertEqual(torch.empty(2, 0, device=device), torch.cdist(x, y))
+
+        x = torch.randn((2, 0), device=device)
+        y = torch.randn((3, 0), device=device)
+        self.assertEqual(torch.zeros(2, 3, device=device), torch.cdist(x, y))
+
+        x = torch.randn((2, 0), device=device)
+        y = torch.randn((0, 0), device=device)
+        self.assertEqual(torch.empty(2, 0, device=device), torch.cdist(x, y))
+
+    def test_cdist_norm(self, device):
+        for r1 in [3, 4, 5, 6]:
+            for m in [2, 3, 4, 10]:
+                for r2 in [4, 6, 7, 8]:
+                    for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+                        x = torch.randn(r1, m, device=device)
+                        y = torch.randn(r2, m, device=device)
+                        actual = torch.cdist(x, y, p=p)
+                        expected = brute_cdist(x, y, p=p)
+                        self.assertTrue(torch.allclose(expected, actual))
+
+    def test_cdist_norm_batch(self, device):
+        for r1 in [3, 4, 5, 6]:
+            for m in [2, 3, 4, 10]:
+                for r2 in [4, 6, 7, 8]:
+                    for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+                        x = torch.randn(2, 3, 6, r1, m, device=device)
+                        y = torch.randn(2, 3, 6, r2, m, device=device)
+                        actual = torch.cdist(x, y, p=p)
+                        expected = brute_cdist(x, y, p=p)
+                        self.assertTrue(torch.allclose(expected, actual))
+
+    def test_cdist_large(self, device):
+        x = torch.randn(1000, 10, device=device)
+        y = torch.randn(1000, 10, device=device)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertTrue(torch.allclose(expected, actual))
+
+    def test_cdist_large_batch(self, device):
+        x = torch.randn(4, 3, 1000, 10, device=device)
+        y = torch.randn(4, 3, 1000, 10, device=device)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertTrue(torch.allclose(expected, actual))
+
+    def test_cdist_non_contiguous(self, device):
+        x = torch.randn(5, 7, device=device).transpose(-1, -2)
+        y = torch.randn(5, 3, device=device).transpose(-1, -2)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertFalse(x.is_contiguous())
+        self.assertFalse(y.is_contiguous())
+        self.assertTrue(torch.allclose(expected, actual))
+
+        x = torch.randn(7, 5, device=device)
+        y = torch.randn(5, 3, device=device).t()
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertTrue(x.is_contiguous())
+        self.assertFalse(y.is_contiguous())
+        self.assertTrue(torch.allclose(expected, actual))
+
+        x = torch.randn(5, 7, device=device).t()
+        y = torch.randn(3, 5, device=device)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertFalse(x.is_contiguous())
+        self.assertTrue(y.is_contiguous())
+        self.assertTrue(torch.allclose(expected, actual))
+
+    def test_cdist_non_contiguous_batch(self, device):
+        x = torch.randn(4, 3, 2, 5, 7, device=device).transpose(-1, -2)
+        y = torch.randn(4, 3, 2, 5, 3, device=device).transpose(-1, -2)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertFalse(x.is_contiguous())
+        self.assertFalse(y.is_contiguous())
+        self.assertTrue(torch.allclose(expected, actual))
+
+        x = torch.randn(7, 2, 7, 5, device=device)
+        y = torch.randn(7, 2, 5, 3, device=device).transpose(-1, -2)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertTrue(x.is_contiguous())
+        self.assertFalse(y.is_contiguous())
+        self.assertTrue(torch.allclose(expected, actual))
+
+        x = torch.randn(4, 5, 7, device=device).transpose(-1, -2)
+        y = torch.randn(4, 3, 5, device=device)
+        actual = torch.cdist(x, y, p=2)
+        expected = brute_cdist(x, y, p=2)
+        self.assertFalse(x.is_contiguous())
+        self.assertTrue(y.is_contiguous())
+        self.assertTrue(torch.allclose(expected, actual))
+
+    def test_multinomial_constraints(self, device):
+        x = torch.empty(1, 2, 3, dtype=torch.double, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "prob_dist must be 1 or 2 dim",
+            lambda: torch.multinomial(x, 2))
+        x = torch.empty(1, 2, dtype=torch.long, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "multinomial only supports floating-point dtypes for input",
+            lambda: torch.multinomial(x, 2))
+        x = torch.empty(1, 2, dtype=torch.double, device=device)
+        y = torch.empty(1, 2, dtype=torch.double, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "multinomial expects Long tensor out",
+            lambda: torch.multinomial(x, 2, out=y))
+        x = torch.empty(2, dtype=torch.double, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "cannot sample n_sample <= 0 samples",
+            lambda: torch.multinomial(x, 0))
+        x = torch.empty(2, dtype=torch.double, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "cannot sample n_sample <= 0 samples",
+            lambda: torch.multinomial(x, -1))
+        x = torch.empty(2, dtype=torch.double, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "cannot sample n_sample > prob_dist",
+            lambda: torch.multinomial(x, 3, False))
+        x = torch.empty(16777217, dtype=torch.double, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "number of categories cannot exceed",
+            lambda: torch.multinomial(x, 3))
+
+    def test_add(self, device):
+        # [res] torch.add([res,] tensor1, tensor2)
+        m1 = torch.randn(100, 100, device=device)
+        v1 = torch.randn(100, device=device)
+
+        # contiguous
+        res1 = torch.add(m1[4], v1)
+        res2 = res1.clone().zero_()
+        for i in range(m1.size(1)):
+            res2[i] = m1[4, i] + v1[i]
+        self.assertEqual(res1, res2)
+
+        m1 = torch.randn(100, 100, device=device)
+        v1 = torch.randn(100, device=device)
+
+        # non-contiguous
+        res1 = torch.add(m1[:, 4], v1)
+        res2 = res1.clone().zero_()
+        for i in range(m1.size(0)):
+            res2[i] = m1[i, 4] + v1[i]
+        self.assertEqual(res1, res2)
+
+        # [res] torch.add([res,] tensor, value)
+        m1 = torch.randn(10, 10, device=device)
+
+        # contiguous
+        res1 = m1.clone()
+        res1[3].add_(2)
+        res2 = m1.clone()
+        for i in range(m1.size(1)):
+            res2[3, i] = res2[3, i] + 2
+        self.assertEqual(res1, res2)
+
+        # non-contiguous
+        m1 = torch.randn(10, 10, device=device)
+        res1 = m1.clone()
+        res1[:, 3].add_(2)
+        res2 = m1.clone()
+        for i in range(m1.size(0)):
+            res2[i, 3] = res2[i, 3] + 2
+        self.assertEqual(res1, res2)
+
+        # inter-type
+        m1 = torch.randn(10, 10, device=device)
+        self.assertEqual(m1 + 3, m1 + torch.tensor(3))
+        self.assertEqual(3 + m1, torch.tensor(3) + m1)
+        one = torch.tensor(1, dtype=torch.uint8, device=device)
+        self.assertEqual(torch.add(one, 1), 2)
+        self.assertEqual(torch.add(one, 1).dtype, torch.uint8)
+
+        # contiguous + non-contiguous
+        m1 = torch.randn(10, 10, device=device)
+        m2 = torch.randn(10, 10, device=device).t()
+        res = m1 + m2
+        self.assertTrue(res.is_contiguous())
+        self.assertEqual(res, m1 + m2.contiguous())
+
+        # 1d + empty
+        m1 = torch.tensor([1.0], dtype=torch.float, device=device)
+        m2 = torch.tensor([], dtype=torch.float, device=device)
+        self.assertEqual(m1 + m2, [])
+
+        # bool
+        m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=device)
+        m2 = torch.tensor([True, True, False, False, False, True], dtype=torch.bool, device=device)
+        expected = torch.tensor([True, True, False, True, False, True], dtype=torch.bool, device=device)
+        self.assertEqual(m1 + m2, expected)
+
+        # fused multiply add
+        a = torch.zeros(2, 3, dtype=torch.bool, device=device)
+        res = torch.add(a, a, alpha=0)
+        expected = torch.zeros(2, 3, device=device).bool()
+        self.assertEqual(res, expected)
+
+        # bfloat16
+        m1 = torch.tensor([1., 2.], dtype=torch.bfloat16)
+        m2 = torch.tensor([3., 4.], dtype=torch.bfloat16)
+        self.assertEqual(m1 + m2, torch.tensor([4., 6.], dtype=torch.bfloat16))
+
+    def test_bool_sub(self, device):
+        m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=device)
+        m2 = torch.tensor([True, True, False, False, False, True], dtype=torch.bool, device=device)
+        self.assertRaisesRegex(RuntimeError,
+                                r"Subtraction, the `\-` operator, with two bool tensors is not supported. "
+                                r"Use the `\^` or `logical_xor\(\)` operator instead.",
+                                lambda: m1 - m2)
+        self.assertRaisesRegex(RuntimeError,
+                                r"Subtraction, the `\-` operator, with a bool tensor is not supported. "
+                                r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
+                                lambda: 1 - m1)
+        self.assertRaisesRegex(RuntimeError,
+                                r"Subtraction, the `\-` operator, with a bool tensor is not supported. "
+                                r"If you are trying to invert a mask, use the `\~` or `logical_not\(\)` operator instead.",
+                                lambda: m2 - 1)
+
+    def test_mul(self, device):
+        m1 = torch.randn(10, 10, device=device)
+        res1 = m1.clone()
+        res1[:, 3].mul_(2)
+        res2 = m1.clone()
+        for i in range(res1.size(0)):
+            res2[i, 3] = res2[i, 3] * 2
+        self.assertEqual(res1, res2)
+
+        a1 = torch.tensor([True, False, False, True], dtype=torch.bool, device=device)
+        a2 = torch.tensor([True, False, True, False], dtype=torch.bool, device=device)
+        self.assertEqual(a1 * a2, torch.tensor([True, False, False, False], dtype=torch.bool, device=device))
+
+        if device == 'cpu':
+            a1 = torch.tensor([0.1, 0.1], dtype=torch.bfloat16, device=device)
+            a2 = torch.tensor([1.1, 0.1], dtype=torch.bfloat16, device=device)
+            self.assertEqual(a1 * a2, torch.tensor([0.11, 0.01], dtype=torch.bfloat16, device=device), 0.01)
+            self.assertEqual(a1.mul(a2), a1 * a2)
+
+    def test_cumsum(self, device):
+        x = torch.rand(100, 100, device=device)
+        res1 = torch.cumsum(x, 1)
+        res2 = torch.Tensor().to(device)
+        torch.cumsum(x, 1, out=res2)
+        self.assertEqual(res1, res2)
+
+        a = torch.tensor([[True, False, True],
+                            [False, False, False],
+                            [True, True, True]], device=device)
+        b = a.byte()
+        aRes = torch.cumsum(a, 0)
+        bRes = torch.cumsum(b, 0)
+        self.assertEqual(aRes, bRes)
+        self.assertEqual(aRes, torch.tensor([[1, 0, 1],
+                                                [1, 0, 1],
+                                                [2, 1, 2]]))
+
+        aRes = torch.cumsum(a, 1)
+        bRes = torch.cumsum(b, 1)
+        self.assertEqual(aRes, bRes)
+        self.assertEqual(aRes, torch.tensor([[1, 1, 2],
+                                                [0, 0, 0],
+                                                [1, 2, 3]]))
+
+    def test_cumprod(self, device):
+        x = torch.rand(100, 100, device=device)
+        res1 = torch.cumprod(x, 1)
+        res2 = torch.Tensor().to(device)
+        torch.cumprod(x, 1, out=res2)
+        self.assertEqual(res1, res2)
+
+        a = torch.tensor([[True, False, True],
+                            [False, False, False],
+                            [True, True, True]], dtype=torch.bool, device=device)
+        b = a.byte()
+        aRes = torch.cumprod(a, 0)
+        bRes = torch.cumprod(b, 0)
+        self.assertEqual(aRes, bRes)
+        self.assertEqual(aRes, torch.tensor([[1, 0, 1],
+                                                [0, 0, 0],
+                                                [0, 0, 0]]))
+
+        aRes = torch.cumprod(a, 1)
+        bRes = torch.cumprod(b, 1)
+        self.assertEqual(aRes, bRes)
+        self.assertEqual(aRes, torch.tensor([[1, 0, 0],
+                                                [0, 0, 0],
+                                                [1, 1, 1]]))
+
+    def test_std_mean(self, device):
+        x = torch.rand(100, 50, 20, device=device)
+        for dim in range(x.dim()):
+            for unbiased in [False, True]:
+                for keepdim in [False, True]:
+                    std1, mean1 = torch.std_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
+                    std2 = x.std(dim=dim, unbiased=unbiased, keepdim=keepdim)
+                    mean2 = x.mean(dim=dim, keepdim=keepdim)
+                    self.assertEqual(std1, std2)
+                    self.assertEqual(mean1, mean2)
+
+    def test_std_mean_all_dims(self, device):
+        x = torch.rand(100, 50, 20, device=device)
+        for unbiased in [False, True]:
+            std1, mean1 = torch.std_mean(x, unbiased=unbiased)
+            std2 = x.std(unbiased=unbiased)
+            mean2 = x.mean()
+            self.assertEqual(std1, std2)
+            self.assertEqual(mean1, mean2)
+
+    def test_var_mean(self, device):
+        x = torch.rand(100, 300, 50, device=device)
+        for dim in range(x.dim()):
+            for unbiased in [False, True]:
+                for keepdim in [False, True]:
+                    var1, mean1 = torch.var_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
+                    var2 = x.var(dim=dim, unbiased=unbiased, keepdim=keepdim)
+                    mean2 = x.mean(dim=dim, keepdim=keepdim)
+                    self.assertEqual(var1, var2)
+                    self.assertEqual(mean1, mean2)
+
+    def test_var_mean_all_dims(self, device):
+        x = torch.rand(100, 50, 20, device=device)
+        for unbiased in [False, True]:
+            var1, mean1 = torch.var_mean(x, unbiased=unbiased)
+            var2 = x.var(unbiased=unbiased)
+            mean2 = x.mean()
+            self.assertEqual(var1, var2)
+            self.assertEqual(mean1, mean2)
+
+    def test_std_mean_some_dims(self, device):
+        sizes = (4, 6, 7, 5, 3)
+        dims = len(sizes)
+        x = torch.rand(sizes, device=device)
+        for num_of_dims in range(2, dims):
+            dim_list = list(combinations(list(range(dims)), r=num_of_dims))
+            for dim in dim_list:
+                for unbiased in [False, True]:
+                    for keepdim in [False, True]:
+                        std1, mean1 = torch.std_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
+                        std2 = x.std(dim=dim, unbiased=unbiased, keepdim=keepdim)
+                        mean2 = x.mean(dim=dim, keepdim=keepdim)
+                        self.assertEqual(std1, std2)
+                        self.assertEqual(mean1, mean2)
+
+    def test_zeros_like(self, device):
+        expected = torch.zeros((100, 100,), device=device)
+
+        res1 = torch.zeros_like(expected)
+        self.assertEqual(res1, expected)
+
+    def test_histc(self, device):
+        # negative nbins throws
+        with self.assertRaisesRegex(RuntimeError, 'bins must be > 0'):
+            torch.histc(torch.tensor([1], dtype=torch.float, device=device), bins=-1)
+
+        # without nbins
+        actual = torch.histc(
+            torch.tensor([2, 5], dtype=torch.float, device=device))
+        expected = torch.zeros(100, dtype=torch.float, device=device)
+        expected.data[0] = 1
+        expected.data[99] = 1
+        self.assertEqual(expected, actual)
+        # tensor with the same element
+        actual = torch.histc(torch.ones(5, dtype=torch.float, device=device), bins=5)
+        self.assertEqual(
+            torch.tensor([0, 0, 5, 0, 0], dtype=torch.float, device=device),
+            actual)
+        # no element falls between [min, max]
+        actual = torch.histc(
+            torch.ones(5, dtype=torch.float, device=device), bins=5, min=2, max=3)
+        self.assertEqual(
+            torch.tensor([0, 0, 0, 0, 0], dtype=torch.float, device=device),
+            actual)
+        # element falls below min + integral bin size and
+        actual = torch.histc(
+            torch.tensor([2, 4, 2, 2, 5, 4], dtype=torch.float, device=device),
+            bins=5, min=1, max=5)
+        self.assertEqual(
+            torch.tensor([0, 3, 0, 2, 1], dtype=torch.float, device=device),
+            actual)
+        # non-integral bin size
+        actual = torch.histc(
+            torch.tensor([1, 2, 1], dtype=torch.float, device=device),
+            bins=4, min=0, max=3)
+        self.assertEqual(
+            torch.tensor([0, 2, 1, 0], dtype=torch.float, device=device),
+            actual)
+        # double input
+        actual = torch.histc(
+            torch.tensor([1, 2, 1], dtype=torch.double, device=device), bins=4, min=0, max=3)
+        self.assertEqual(
+            torch.tensor([0, 2, 1, 0], dtype=torch.double, device=device),
+            actual)
+        self.assertEqual(actual.dtype, torch.double)
+        # mixed input
+        actual = torch.histc(
+            torch.tensor([1., 2, 1], dtype=torch.float, device=device),
+            bins=4, min=0, max=3)
+        self.assertEqual(
+            torch.tensor([0, 2, 1, 0], dtype=torch.float, device=device),
+            actual)
+        self.assertEqual(actual.dtype, torch.float)
+        # scalar input and 1 bin -- should return a 1-dimensional tensor, not a scalar.
+        actual = torch.histc(
+            torch.tensor(0, dtype=torch.float, device=device),
+            bins=1, min=0, max=3)
+        self.assertEqual(
+            torch.tensor([1], dtype=torch.float, device=device),
+            actual)
+
+        # test against numpy.histogram()
+        def test_against_np(tensor, bins=100, min=0, max=0):
+            if min == 0 and max == 0:
+                min = tensor.min().item()
+                max = tensor.max().item()
+            nparr = tensor.cpu().numpy()
+            actual = torch.histc(tensor, bins=bins, min=min, max=max)
+            expected = torch.from_numpy(np.histogram(nparr, bins=bins, range=(min, max))[0])
+            self.assertEqual(actual.cpu(), expected)
+
+        if TEST_NUMPY:
+            test_against_np(torch.tensor([1., 2, 1], device=device))
+            test_against_np(torch.randn(5000, device=device))
+
+            # Test bins arg
+            test_against_np(torch.randn(301, device=device), bins=10)
+
+            # Test truncated range
+            test_against_np(torch.randn(201, device=device), min=0.1, max=1)
+
+            noncontig = torch.randn(100, 3, device=device)[:, 2]
+            test_against_np(noncontig)
+
+            multidim = torch.randn(3, 5, 7, 2, device=device)
+            test_against_np(multidim)
+
+            expanded = torch.randn(1, 5, 1, 2, device=device).expand(3, 5, 7, 2)
+            test_against_np(expanded)
+
+    def test_bool_tensor_comparison_ops(self, device):
+        a = torch.tensor([True, False, True, False, True, False], dtype=torch.bool, device=device)
+        b = torch.tensor([True, False, True, True, True, True], dtype=torch.bool, device=device)
+        self.assertEqual(a == b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.bool, device=device))
+        self.assertEqual(a != b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.bool, device=device))
+        self.assertEqual(a < b, torch.tensor([0, 0, 0, 1, 0, 1], dtype=torch.bool, device=device))
+        self.assertEqual(a > b, torch.tensor([0, 0, 0, 0, 0, 0], dtype=torch.bool, device=device))
+        self.assertEqual(a >= b, torch.tensor([1, 1, 1, 0, 1, 0], dtype=torch.bool, device=device))
+        self.assertEqual(a <= b, torch.tensor([1, 1, 1, 1, 1, 1], dtype=torch.bool, device=device))
+        self.assertEqual(a > False, torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.bool, device=device))
+        self.assertEqual(a == torch.tensor(True, dtype=torch.bool, device=device),
+                            torch.tensor([1, 0, 1, 0, 1, 0], dtype=torch.bool, device=device))
+        self.assertEqual(a == torch.tensor(0, dtype=torch.bool, device=device),
+                            torch.tensor([0, 1, 0, 1, 0, 1], dtype=torch.bool, device=device))
+        self.assertFalse(a.equal(b))
+
+    def test_bool_tensor_value_change(self, device):
+        x = torch.tensor([True, False], dtype=torch.bool, device=device)
+        x[0] = False
+        x[1] = True
+        self.assertEqual(x, torch.tensor([False, True], dtype=torch.bool, device=device))
+
+    def test_unfold_all_devices_and_dtypes(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            if dt == torch.bfloat16:
+                self.assertRaises(RuntimeError, lambda: torch.randint(5, (0, 1, 3, 0), dtype=dt, device=device))
+                continue
+
+            if dt == torch.half and device == 'cpu':
+                # fix once random is implemented for Half on CPU
+                self.assertRaises(RuntimeError, lambda: torch.randint(5, (0, 1, 3, 0), dtype=dt, device=device))
+            else:
+                x = torch.randint(5, (0, 1, 3, 0), dtype=dt, device=device)
+                self.assertEqual((0, 1, 1, 0, 3), x.unfold(2, 3, 2).shape)
+
+    def test_copy_all_dtypes_and_devices(self, device):
+        from copy import copy
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor([1, 2, 3, 4], dtype=dt, device=device)
+            x_clone = x.clone()
+            if (device == 'cuda' and dt == torch.bfloat16):
+                self.assertRaises(RuntimeError, lambda: copy(x))
+                continue
+            y = copy(x)
+            y.fill_(1)
+            # copy is a shallow copy, only copies the tensor view,
+            # not the data
+            self.assertEqual(x, y)
+
+    def test_resize_all_dtypes_and_devices(self, device):
+        shape = (2, 2)
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
+            x.resize_(shape)
+            self.assertEqual(shape, x.shape)
+
+    def test_resize_as_all_dtypes_and_devices(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
+            y = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=dt, device=device)
+            x.resize_as_(y)
+            self.assertEqual(y.shape, x.shape)
+
+    def test_view_all_dtypes_and_devices(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)
+            if (device == 'cuda' and dt == torch.bfloat16):
+                self.assertRaises(RuntimeError, lambda: x.view(6))
+                continue
+            self.assertEqual(x.view(6).shape, [6])
+
+    def test_fill_all_dtypes_and_devices(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor((1, 1), dtype=dt, device=device)
+            if (device == 'cuda' and dt == torch.bfloat16):
+                self.assertRaises(RuntimeError, lambda: x.fill_(1))
+                continue
+            x.fill_(1)
+
+            self.assertEqual(x, torch.tensor([1, 1], dtype=dt, device=device))
+            self.assertEqual(dt, x.dtype)
+
+    def test_clone_all_dtypes_and_devices(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor((1, 1), dtype=dt, device=device)
+            y = x.clone()
+            if (device == 'cuda' and dt == torch.bfloat16):
+                # `x - y` is used inside of the assertEqual
+                self.assertRaises(RuntimeError, lambda: x - y)
+                continue
+            self.assertEqual(x, y)
+
+    def test_cat_all_dtypes_and_devices(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor([[1, 2], [3, 4]], dtype=dt, device=device)
+            if (device == 'cuda' and dt == torch.bfloat16):
+                self.assertRaises(RuntimeError, lambda: torch.cat((x, x), 0))
+                continue
+
+            expected1 = torch.tensor([[1, 2], [3, 4], [1, 2], [3, 4]], dtype=dt, device=device)
+            self.assertEqual(torch.cat((x, x), 0), expected1)
+
+            expected2 = torch.tensor([[1, 2, 1, 2], [3, 4, 3, 4]], dtype=dt, device=device)
+            self.assertEqual(torch.cat((x, x), 1), expected2)
+
+    def test_tensor_factories_empty(self, device):
+        # ensure we can create empty tensors from each factory function
+        shapes = [(5, 0, 1), (0,), (0, 0, 1, 0, 2, 0, 0)]
+
+        for shape in shapes:
+            for dt in torch.testing.get_all_dtypes():
+
+                if (device == 'cuda' and dt == torch.bfloat16):
+                    self.assertRaises(RuntimeError, lambda: torch.zeros(shape, device=device, dtype=dt).shape)
+                    self.assertRaises(RuntimeError, lambda: torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: torch.full(shape, 3, device=device, dtype=dt).shape)
+                    self.assertRaises(RuntimeError, lambda: torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3))
+                    self.assertRaises(RuntimeError, lambda: torch.ones(shape, device=device, dtype=dt).shape)
+                    self.assertRaises(RuntimeError, lambda: torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertRaises(RuntimeError, lambda: torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                else:
+                    self.assertEqual(shape, torch.zeros(shape, device=device, dtype=dt).shape)
+                    self.assertEqual(shape, torch.zeros_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, torch.full(shape, 3, device=device, dtype=dt).shape)
+                    self.assertEqual(shape, torch.full_like(torch.zeros(shape, device=device, dtype=dt), 3).shape)
+                    self.assertEqual(shape, torch.ones(shape, device=device, dtype=dt).shape)
+                    self.assertEqual(shape, torch.ones_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, torch.empty(shape, device=device, dtype=dt).shape)
+                    self.assertEqual(shape, torch.empty_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+                    self.assertEqual(shape, torch.empty_strided(shape, (0,) * len(shape), device=device, dtype=dt).shape)
+
+                if dt == torch.half and device == "cpu":
+                    # update once random is implemented for half on CPU
+                    self.assertRaises(RuntimeError, lambda: torch.randint(6, shape, device=device, dtype=dt).shape)
+                else:
+                    if dt == torch.bfloat16:
+                        self.assertRaises(RuntimeError, lambda: torch.randint(6, shape, device=device, dtype=dt))
+                        continue  # Remove once random is supported for bfloat16 on cuda
+                    self.assertEqual(shape, torch.randint(6, shape, device=device, dtype=dt).shape)
+                    self.assertEqual(shape, torch.randint_like(torch.zeros(shape, device=device, dtype=dt), 6).shape)
+
+                if dt != torch.double and dt != torch.float and dt != torch.half:
+                    self.assertRaises(RuntimeError, lambda: torch.rand(shape, device=device, dtype=dt).shape)
+
+                if dt == torch.double or dt == torch.float:
+                    self.assertEqual(shape, torch.randn(shape, device=device, dtype=dt).shape)
+                    self.assertEqual(shape, torch.randn_like(torch.zeros(shape, device=device, dtype=dt)).shape)
+
+        self.assertEqual((0,), torch.arange(0, device=device).shape)
+        self.assertEqual((0, 0), torch.eye(0, device=device).shape)
+        self.assertEqual((0, 0), torch.eye(0, 0, device=device).shape)
+        self.assertEqual((5, 0), torch.eye(5, 0, device=device).shape)
+        self.assertEqual((0, 5), torch.eye(0, 5, device=device).shape)
+        self.assertEqual((0,), torch.linspace(1, 1, 0, device=device).shape)
+        self.assertEqual((0,), torch.logspace(1, 1, 0, device=device).shape)
+        self.assertEqual((0,), torch.randperm(0, device=device).shape)
+        self.assertEqual((0,), torch.bartlett_window(0, device=device).shape)
+        self.assertEqual((0,), torch.bartlett_window(0, periodic=False, device=device).shape)
+        self.assertEqual((0,), torch.hamming_window(0, device=device).shape)
+        self.assertEqual((0,), torch.hann_window(0, device=device).shape)
+        self.assertEqual((1, 1, 0), torch.tensor([[[]]], device=device).shape)
+        self.assertEqual((1, 1, 0), torch.as_tensor([[[]]], device=device).shape)
+
+    def test_eye(self, device):
+        for dtype in torch.testing.get_all_dtypes():
+            if dtype == torch.bfloat16:
+                continue
+
+            for n, m in product([3, 5, 7], repeat=2):
+                # Construct identity using diagonal and fill
+                res1 = torch.eye(n, m, device=device, dtype=dtype)
+                naive_eye = torch.zeros(n, m, dtype=dtype, device=device)
+                naive_eye.diagonal(dim1=-2, dim2=-1).fill_(1)
+                self.assertEqual(naive_eye, res1)
+
+                # Check eye_out outputs
+                res2 = torch.empty(0, device=device, dtype=dtype)
+                torch.eye(n, m, out=res2)
+                self.assertEqual(res1, res2)
+
+    def test_addcmul(self, device):
+        def rand_tensor(size, dtype, device):
+            if dtype.is_floating_point:
+                return torch.rand(size=size, dtype=dtype, device=device)
+            if dtype == torch.uint8:
+                return torch.randint(1, 5, size=size, dtype=dtype, device=device)
+            else:
+                return torch.randint(-5, 5, size=size, dtype=dtype, device=device)
+
+        for dtype in torch.testing.get_all_math_dtypes(device):
+            a = rand_tensor((2, 2), dtype=dtype, device=device)
+            b = rand_tensor((2, 2), dtype=dtype, device=device)
+            c = rand_tensor((2, 2), dtype=dtype, device=device)
+            if dtype.is_floating_point:
+                alpha = 0.1
+            else:
+                alpha = 3
+            actual = torch.addcmul(a, alpha, b, c)
+            expected = a + alpha * b * c
+            self.assertTrue(torch.allclose(expected, actual))
+
+    def test_empty_tensor_props(self, device):
+        sizes = [(0,), (0, 3), (5, 0), (5, 0, 3, 0, 2), (0, 3, 0, 2), (0, 5, 0, 2, 0)]
+        for size in sizes:
+            x = torch.empty(tuple(size), device=device)
+            self.assertEqual(size, x.shape)
+            self.assertTrue(x.is_contiguous())
+            size_ones_instead_of_zeros = (x if x != 0 else 1 for x in size)
+            y = torch.empty(tuple(size_ones_instead_of_zeros), device=device)
+            self.assertEqual(x.stride(), y.stride())
+
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_tensordot(self, device):
+        a = torch.arange(60., device=device).reshape(3, 4, 5)
+        b = torch.arange(24., device=device).reshape(4, 3, 2)
+        c = torch.tensordot(a, b, dims=([1, 0], [0, 1])).cpu()
+        cn = torch.from_numpy(np.tensordot(a.cpu().numpy(), b.cpu().numpy(),
+                                           axes=([1, 0], [0, 1])))
+        self.assertEqual(c, cn)
+        a = torch.randn(2, 3, 4, 5, device=device)
+        b = torch.randn(4, 5, 6, 7, device=device)
+        c = torch.tensordot(a, b, dims=2).cpu()
+        cn = torch.from_numpy(np.tensordot(a.cpu().numpy(), b.cpu().numpy(),
+                                           axes=2))
+        self.assertEqual(c, cn)
+        c = torch.tensordot(a, b).cpu()
+        cn = torch.from_numpy(np.tensordot(a.cpu().numpy(), b.cpu().numpy()))
+        self.assertEqual(c, cn)
+
+    def test_narrow_empty(self, device):
+        x = torch.randn(2, 3, 4, device=device)
+        for d in range(x.dim()):
+            y = x.narrow(d, x.size(d), 0)
+            sz = list(x.size())
+            sz[d] = 0
+            self.assertEqual(sz, y.size())
+
+    def test_linspace(self, device):
+        _from = random.random()
+        to = _from + random.random()
+        res1 = torch.linspace(_from, to, 137, device=device)
+        res2 = torch.tensor((), device=device)
+        torch.linspace(_from, to, 137, out=res2)
+        self.assertEqual(res1, res2, 0)
+        self.assertRaises(RuntimeError, lambda: torch.linspace(0, 1, -1, device=device))
+        self.assertEqual(torch.linspace(0, 1, 1, device=device), torch.zeros(1, device=device), 0)
+
+        # Check linspace for generating with start > end.
+        self.assertEqual(torch.linspace(2, 0, 3, device=device), torch.tensor((2, 1, 0), device=device), 0)
+
+        # Check linspace for non-contiguous tensors.
+        x = torch.zeros(2, 3, device=device)
+        y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2))
+        self.assertEqual(x, torch.tensor(((0, 0, 1), (0, 2, 3)), device=device), 0)
+
+    def test_logical(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            x = torch.tensor([1, 2, 3, 4], device=device, dtype=dt)
+            b = torch.tensor([2], device=device, dtype=dt)
+
+            if dt == torch.half and device == 'cpu':
+                self.assertRaises(RuntimeError, lambda: x.lt(2))
+                continue
+
+            if dt == torch.bool:
+                # torch.bool is a special case and is being tested later
+                # in this test
+                continue
+
+            if device == 'cuda' and dt == torch.bfloat16:
+                self.assertRaises(RuntimeError, lambda: x > b)
+                self.assertRaises(RuntimeError, lambda: x < b)
+                self.assertRaises(RuntimeError, lambda: x == b)
+                self.assertRaises(RuntimeError, lambda: x != b)
+                self.assertRaises(RuntimeError, lambda: x >= b)
+                self.assertRaises(RuntimeError, lambda: x <= b)
+                continue
+
+            self.assertEqual(x.lt(2), torch.tensor([True, False, False, False]))
+            self.assertEqual(x.le(2), torch.tensor([True, True, False, False]))
+            self.assertEqual(x.ge(2), torch.tensor([False, True, True, True]))
+            self.assertEqual(x.gt(2), torch.tensor([False, False, True, True]))
+            self.assertEqual(x.eq(2), torch.tensor([False, True, False, False]))
+            self.assertEqual(x.ne(2), torch.tensor([True, False, True, True]))
+
+            self.assertEqual(x.lt(b), torch.tensor([True, False, False, False]))
+            self.assertEqual(x.le(b), torch.tensor([True, True, False, False]))
+            self.assertEqual(x.ge(b), torch.tensor([False, True, True, True]))
+            self.assertEqual(x.gt(b), torch.tensor([False, False, True, True]))
+            self.assertEqual(x.eq(b), torch.tensor([False, True, False, False]))
+            self.assertEqual(x.ne(b), torch.tensor([True, False, True, True]))
+
+            with warnings.catch_warnings(record=True) as warningsCount:
+                byteRes = torch.empty_like(x, device=device).byte()
+                boolRes = torch.empty_like(x, device=device).bool()
+
+                torch.lt(x, b, out=byteRes)
+                torch.lt(x, b, out=boolRes)
+                self.assertEqual(byteRes.bool(), boolRes)
+
+                torch.le(x, b, out=byteRes)
+                torch.le(x, b, out=boolRes)
+                self.assertEqual(byteRes.bool(), boolRes)
+
+                torch.ge(x, b, out=byteRes)
+                torch.ge(x, b, out=boolRes)
+                self.assertEqual(byteRes.bool(), boolRes)
+
+                torch.gt(x, b, out=byteRes)
+                torch.gt(x, b, out=boolRes)
+                self.assertEqual(byteRes.bool(), boolRes)
+
+                torch.eq(x, b, out=byteRes)
+                torch.eq(x, b, out=boolRes)
+                self.assertEqual(byteRes.bool(), boolRes)
+
+                torch.ne(x, b, out=byteRes)
+                torch.ne(x, b, out=boolRes)
+                self.assertEqual(byteRes.bool(), boolRes)
+
+                self.assertEquals(len(warningsCount), 6)
+
+        # Bool Tensor
+        x = torch.tensor([True, False, True, False], device=device)
+        self.assertEqual(x.lt(True), torch.tensor([False, True, False, True]))
+        self.assertEqual(x.le(True), torch.tensor([True, True, True, True]))
+        self.assertEqual(x.ge(True), torch.tensor([True, False, True, False]))
+        self.assertEqual(x.gt(True), torch.tensor([False, False, False, False]))
+        self.assertEqual(x.eq(True), torch.tensor([True, False, True, False]))
+        self.assertEqual(x.ne(True), torch.tensor([False, True, False, True]))
+
+    def test_index_copy(self, device):
+        num_copy, num_dest = 3, 20
+        dest = torch.randn(num_dest, 4, 5, device=device)
+        src = torch.randn(num_copy, 4, 5, device=device)
+        idx = torch.randperm(num_dest, device=device).narrow(0, 0, num_copy)
+        dest2 = dest.clone()
+        dest.index_copy_(0, idx, src)
+        for i in range(idx.size(0)):
+            dest2[idx[i]] = src[i]
+        self.assertEqual(dest, dest2, 0)
+
+        dest = torch.randn(num_dest, device=device)
+        src = torch.randn(num_copy, device=device)
+        idx = torch.randperm(num_dest, device=device).narrow(0, 0, num_copy)
+        dest2 = dest.clone()
+        dest.index_copy_(0, idx, src)
+        for i in range(idx.size(0)):
+            dest2[idx[i]] = src[i]
+        self.assertEqual(dest, dest2, 0)
+
+        # Bool tensor
+        dest = torch.zeros(2, 2, dtype=torch.bool, device=device)
+        src = torch.tensor([[True, True], [True, True]], device=device)
+        index = torch.tensor([0, 1], device=device)
+        dest.index_copy_(0, index, src)
+        self.assertEqual(dest, torch.tensor([[True, True], [True, True]], device=device))
+
+        # Error cases
+        a = torch.randn(3, 5)
+        c = torch.zeros(3)
+        self.assertRaises(IndexError, lambda: a.index_copy_(dim=1, index=torch.tensor([3]), source=c))
+
+    def test_index_fill(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            if dt == torch.half or dt == torch.bfloat16:
+                continue
+
+            x = torch.tensor([[1, 2], [4, 5]], dtype=dt, device=device)
+            index = torch.tensor([0], device=device)
+            x.index_fill_(1, index, 0)
+            self.assertEqual(x, torch.tensor([[0, 2], [0, 5]], dtype=dt, device=device))
+
+    def test_index_select(self, device):
+        src = torch.randn(3, 4, 5, device=device)
+        # Index can be duplicated.
+        idx = torch.tensor([2, 1, 0, 1, 2], dtype=torch.long, device=device)
+        dest = torch.index_select(src, 0, idx)
+        self.assertEqual(dest.shape, (5, 4, 5))
+        for i in range(idx.size(0)):
+            self.assertEqual(dest[i], src[idx[i]])
+
+        # Check that 'out' is used correctly.
+        out = torch.randn(5 * 4 * 5, device=device)
+        dest = torch.index_select(src, 0, idx, out=out.view(5, 4, 5))
+        self.assertEqual(dest.shape, (5, 4, 5))
+        for i in range(idx.size(0)):
+            self.assertEqual(dest[i], src[idx[i]])
+        out.fill_(0.123)
+        self.assertEqual(out, dest.view(-1))  # Must point to the same storage.
+
+        # Bool tensor
+        src = torch.tensor([False, True, False, False], device=device, dtype=torch.bool)
+        idx = torch.tensor([1], dtype=torch.long, device=device)
+        dest = torch.index_select(src, 0, idx)
+        self.assertEqual(torch.tensor([True]), dest)
+
+    def test_take_empty(self, device):
+        for input_shape in [(0,), (0, 1, 2, 0), (1, 2, 3)]:
+            for indices_shape in [(0,), (0, 1, 2, 0)]:
+                input = torch.empty(input_shape, device=device)
+                indices = torch.empty(indices_shape, dtype=torch.int64, device=device)
+                self.assertEqual(indices, torch.take(input, indices))
+
+    def test_put_empty(self, device):
+        for dst_shape in [(0,), (0, 1, 2, 0), (1, 2, 3)]:
+            for indices_shape in [(0,), (0, 1, 2, 0)]:
+                for accumulate in [False, True]:
+                    dst = torch.randn(dst_shape, device=device)
+                    indices = torch.empty(indices_shape, dtype=torch.int64, device=device)
+                    src = torch.randn(indices_shape, device=device)
+                    self.assertEqual(dst, dst.put_(indices, src, accumulate=accumulate))
+
+    def test_scatter_to_large_input(self, device):
+        input = torch.zeros(4, 4, device=device)
+        src = torch.ones(2, 2, device=device)
+        index = torch.tensor([[1], [2]], device=device, dtype=torch.long)
+        input.scatter_(0, index, src)
+        self.assertEqual(input, torch.tensor([[0, 0, 0, 0],
+                                                [1, 0, 0, 0],
+                                                [1, 0, 0, 0],
+                                                [0, 0, 0, 0]], device=device))
+
+    def test_scatter_add_to_large_input(self, device):
+        input = torch.zeros(4, 4, device=device)
+        src = torch.ones(2, 2, device=device)
+        index = torch.tensor([[1], [2]], device=device, dtype=torch.long)
+        input.scatter_add_(0, index, src)
+        self.assertEqual(input, torch.tensor([[0, 0, 0, 0],
+                                                [1, 0, 0, 0],
+                                                [1, 0, 0, 0],
+                                                [0, 0, 0, 0]], device=device))
+
+    def test_scatter_bool(self, device):
+        x = torch.tensor([[True, True, True], [True, True, True]], device=device)
+        res = torch.zeros(3, 3, dtype=torch.bool, device=device)
+        res = res.scatter_(0, torch.tensor([[0, 1, 2], [0, 1, 2]], device=device), x)
+        self.assertEqual(res, torch.tensor([[True, False, False],
+                                            [False, True, False],
+                                            [False, False, True]], device=device))
+
+    def test_scatter_add_bool(self, device):
+        x = torch.tensor([[True, True, True, True, True], [True, True, True, True, True]], device=device)
+        res = torch.zeros(3, 5, dtype=torch.bool, device=device)
+        res = res.scatter_add_(0, torch.tensor([[0, 1, 2, 0, 0], [2, 0, 0, 1, 2]], device=device), x)
+        self.assertEqual(res, torch.tensor([[True, True, True, True, True],
+                                            [False, True, False, True, False],
+                                            [True, False, True, False, True]], device=device))
+
+    def test_masked_scatter_bool_tensor(self, device):
+        src = torch.tensor([True, True, True], device=device)
+        dst = torch.tensor([False, False, False], device=device)
+        mask = torch.tensor([False, True, False], device=device)
+
+        dst.masked_scatter_(mask, src)
+        self.assertEqual(dst, torch.tensor([False, True, False], device=device))
+
+        mask = torch.tensor([True, False, True], device=device)
+        dst = dst.masked_scatter(mask, src)
+        self.assertEqual(dst, torch.tensor([True, True, True], device=device))
+
+    def test_masked_select(self, device):
+        for dt in torch.testing.get_all_dtypes():
+            with warnings.catch_warnings(record=True) as w:
+                for maskType in [torch.uint8, torch.bool]:
+                    num_src = 10
+                    src = torch.tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=dt, device=device)
+                    mask = torch.rand(num_src, device=device).clamp(0, 1).mul(2).floor().to(maskType)
+
+                    if dt == torch.bfloat16 and device == 'cuda':
+                        # remove once bfloat16 implemented on CUDA
+                        self.assertRaises(RuntimeError, lambda: src.masked_select(mask))
+                        continue
+
+                    if dt == torch.half and device == 'cpu':
+                        self.assertRaises(RuntimeError, lambda: src.masked_select(mask))
+                        continue
+
+                    dst = src.masked_select(mask)
+                    dst2 = []
+                    for i in range(num_src):
+                        if mask[i]:
+                            dst2 += [src[i]]
+                    self.assertEqual(dst, torch.tensor(dst2), 0)
+
+                    dst3 = torch.empty_like(src, device=device)
+                    torch.masked_select(src, mask, out=dst3)
+                    self.assertEqual(dst3, torch.Tensor(dst2), 0)
+        self.assertEqual(len(w), 1)
+
+        warn = 'masked_select received a mask with dtype torch.uint8,'
+        self.assertEqual(str(w[0].message)[0:53], str(warn))
+
+    def test_masked_fill_bool_tensor(self, device):
+        dst = torch.tensor([True, False, True], device=device)
+        mask = torch.tensor([False, True, False], device=device)
+
+        dst.masked_fill_(mask, True)
+        self.assertEqual(dst, torch.tensor([True, True, True], device=device))
+
+        dst = dst.masked_fill(mask, False)
+        self.assertEqual(dst, torch.tensor([True, False, True], device=device))
+
+    def test_tensor_shape_empty(self, device):
+        x = torch.randn((0, 1, 3, 0), device=device)
+        # flatten
+        self.assertEqual((0,), torch.flatten(x, 0, 3).shape)
+        self.assertEqual((0, 0), torch.flatten(x, 0, 2).shape)
+        self.assertEqual((0, 3, 0), torch.flatten(x, 1, 2).shape)
+
+        # squeeze, unsqueeze
+        self.assertEqual((0, 1, 1, 3, 0), torch.unsqueeze(x, 1).shape)
+        self.assertEqual((0, 3, 0), torch.squeeze(x, 1).shape)
+        self.assertEqual((0, 3, 0), torch.squeeze(x).shape)
+
+        # transpose, t
+        self.assertEqual((0, 0, 3, 1), torch.transpose(x, 1, 3).shape)
+        y = torch.randn((5, 0), device=device)
+        self.assertEqual((0, 5), y.t().shape)
+
+        # select
+        self.assertEqual((0, 1, 0), torch.select(x, 2, 2).shape)
+
+        # repeat, permute
+        self.assertEqual((9, 0, 5, 6, 0), x.repeat(9, 7, 5, 2, 3).shape)
+        self.assertEqual((3, 0, 0, 1), x.permute(2, 3, 0, 1).shape)
+
+        # diagonal, diagflat
+        self.assertEqual((0,), torch.diagonal(torch.randn((5, 0), device=device)).shape)
+        self.assertEqual((0,), torch.diagonal(torch.randn((0, 5), device=device)).shape)
+        # off the end offsets are valid
+        self.assertEqual((0,), torch.diagonal(torch.randn((5, 0), device=device), offset=1).shape)
+        self.assertEqual((0,), torch.diagonal(torch.randn((0, 5), device=device), offset=1).shape)
+        # check non-zero sized offsets off the end
+        self.assertEqual((5, 6, 0), torch.diagonal(torch.randn((3, 4, 5, 6), device=device), offset=45252).shape)
+        self.assertEqual((5, 6, 0), torch.diagonal(torch.randn((3, 4, 5, 6), device=device), offset=-45252).shape)
+
+        self.assertEqual((0, 0), torch.diagflat(torch.tensor([], device=device)).shape)
+        self.assertEqual(torch.zeros(1, 1), torch.diagflat(torch.tensor([], device=device), offset=1))
+        self.assertEqual((0, 0), torch.diagflat(torch.tensor([[]], device=device)).shape)
+        self.assertEqual(torch.zeros(1, 1), torch.diagflat(torch.tensor([[]], device=device), offset=1))
+
+        # stack, split, chunk
+        self.assertEqual((4, 0, 1, 3, 0), torch.stack((x, x, x, x)).shape)
+        self.assertEqual([(0, 1, 3, 0)],
+                            [z.shape for z in torch.chunk(x, 1, dim=0)])
+
+        self.assertEqual([(0, 1, 3, 0), ] * 3, [z.shape for z in torch.chunk(x, 3, dim=0)])
+        self.assertEqual([(0, 1, 1, 0), ] * 3, [z.shape for z in torch.chunk(x, 3, dim=2)])
+
+        # NOTE: split_with_sizes behaves differently than NumPy in that it
+        # takes sizes rather than offsets
+        self.assertEqual([(0, 1, 0, 0), (0, 1, 1, 0), (0, 1, 2, 0)],
+                            [z.shape for z in torch.split(x, (0, 1, 2), dim=2)])
+
+        self.assertRaises(RuntimeError, lambda: torch.split(x, 0, dim=1))
+        # This is strange because the split size is larger than the dim size, but consistent with
+        # how split handles that case generally (when no 0s are involved).
+        self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 1, dim=0)])
+        self.assertEqual([(0, 1, 3, 0)], [z.shape for z in torch.split(x, 0, dim=0)])
+
+    # functions that operate over a dimension but don't reduce.
+    def test_dim_function_empty(self, device):
+        shape = (0, 1, 2, 0)
+        x = torch.randn(shape, device=device)
+
+        # size stride
+        self.assertEqual(0, x.size(3))
+        self.assertEqual(2, x.size(2))
+        self.assertEqual(2, x.stride(0))
+        self.assertEqual(1, x.stride(2))
+
+        self.assertEqual(x, torch.nn.functional.glu(x, 0))
+        self.assertEqual((0, 1, 1, 0), torch.nn.functional.glu(x, 2).shape)
+
+        # softmax, logsoftmax
+        self.assertEqual(x, torch.nn.functional.softmax(x, 0))
+        self.assertEqual(x, torch.nn.functional.softmax(x, 2))
+        self.assertEqual(x, torch.nn.functional.softmax(x, 3))
+
+        self.assertEqual(x, torch.nn.functional.log_softmax(x, 0))
+        self.assertEqual(x, torch.nn.functional.log_softmax(x, 2))
+        self.assertEqual(x, torch.nn.functional.log_softmax(x, 3))
+
+        # cumsum, cumprod
+        self.assertEqual(shape, torch.cumsum(x, 0).shape)
+        self.assertEqual(shape, torch.cumsum(x, 2).shape)
+        self.assertEqual(shape, torch.cumprod(x, 0).shape)
+        self.assertEqual(shape, torch.cumprod(x, 2).shape)
+
+        # flip
+        self.assertEqual(x, x.flip(0))
+        self.assertEqual(x, x.flip(2))
+
+        # roll
+        self.assertEqual(x, x.roll(0, 1).roll(0, -1))
+        self.assertEqual(x, x.roll(1, x.size(1)))
+        self.assertEqual(x, x.roll(1))
+        self.assertEqual(x, x.roll((1, 1), (3, 1)))
+
+        # unbind
+        self.assertEqual((), x.unbind(0))
+        self.assertEqual((torch.empty((0, 1, 0), device=device), torch.empty((0, 1, 0), device=device)),
+                            x.unbind(2))
+
+        # cross
+        y = torch.randn((0, 1, 3, 0), device=device)
+        self.assertEqual(y.shape, torch.cross(y, y).shape)
+
+        # renorm
+        self.assertEqual(shape, torch.renorm(x, 1, 0, 5).shape)
+        self.assertEqual(shape, torch.renorm(x, 1, 2, 5).shape)
+
+        # sort
+        self.assertEqual([shape, shape], [z.shape for z in torch.sort(x, dim=0)])
+        self.assertEqual([shape, shape], [z.shape for z in torch.sort(x, dim=2)])
+
+        # topk
+        self.assertEqual([shape, shape], [z.shape for z in torch.topk(x, 0, dim=0)])
+        self.assertEqual([(0, 1, 1, 0), (0, 1, 1, 0)], [z.shape for z in torch.topk(x, 1, dim=2)])
+
+        y = torch.randn((2, 3, 4), device=device)
+        self.assertEqual([(2, 3, 0), (2, 3, 0)], [z.shape for z in torch.topk(y, 0)])
+
+        # gather
+        self.assertEqual(shape, torch.gather(x, 0, torch.empty(shape, dtype=torch.int64, device=device)).shape)
+        self.assertEqual(shape, torch.gather(x, 2, torch.empty(shape, dtype=torch.int64, device=device)).shape)
+        larger_shape = torch.empty((0, 1, 3, 0), dtype=torch.int64, device=device)
+        self.assertEqual(larger_shape.shape, torch.gather(x, 2, larger_shape).shape)
+        smaller_shape = torch.empty((0, 1, 0, 0), dtype=torch.int64, device=device)
+        self.assertEqual(smaller_shape.shape, torch.gather(x, 2, smaller_shape).shape)
+        y = torch.randn((2, 3, 4), device=device)
+        self.assertEqual((0, 3, 4),
+                            torch.gather(y, 0, torch.empty((0, 3, 4), dtype=torch.int64, device=device)).shape)
+
+        # scatter, scatter_add
+        for dim in [0, 2]:
+            y = torch.randn(shape, device=device)
+            y_src = torch.randn(shape, device=device)
+            ind = torch.empty(shape, dtype=torch.int64, device=device)
+            self.assertEqual(shape, y.scatter_(dim, ind, y_src).shape)
+            self.assertEqual(shape, y.scatter_add_(dim, ind, y_src).shape)
+
+        z = torch.randn((2, 3, 4), device=device)
+        z_src = torch.randn((2, 3, 4), device=device)
+        self.assertEqual(z, z.scatter_(2, torch.empty((2, 3, 0), dtype=torch.int64, device=device), z_src))
+        self.assertEqual(z, z.scatter_add_(2, torch.empty((2, 3, 0), dtype=torch.int64, device=device), z_src))
+
+        # index_fill, index_copy, index_add
+        c = x.clone()
+        c_clone = c.clone()
+        ind_empty = torch.tensor([], dtype=torch.int64, device=device)
+        ind_01 = torch.tensor([0, 1], dtype=torch.int64, device=device)
+        self.assertEqual(c_clone, c.index_fill_(0, ind_empty, -1))
+        self.assertEqual(c_clone, c.index_fill_(2, ind_empty, -1))
+        self.assertEqual(c_clone, c.index_fill_(2, torch.tensor([0, 1], dtype=torch.int64, device=device), -1))
+        self.assertEqual(c_clone, c.index_copy_(0, ind_empty, torch.empty((0, 1, 2, 0), device=device)))
+        self.assertEqual(c_clone, c.index_copy_(2, ind_empty, torch.empty((0, 1, 0, 0), device=device)))
+        self.assertEqual(c_clone, c.index_copy_(2, ind_01, torch.empty((0, 1, 2, 0), device=device)))
+        self.assertEqual(c_clone, c.index_add_(0, ind_empty, torch.empty((0, 1, 2, 0), device=device)))
+        self.assertEqual(c_clone, c.index_add_(2, ind_empty, torch.empty((0, 1, 0, 0), device=device)))
+        self.assertEqual(c_clone, c.index_add_(2, ind_01, torch.empty((0, 1, 2, 0), device=device)))
+
+        c = torch.randn((0, 1, 2), device=device)
+        c_clone = c.clone()
+        self.assertEqual(c_clone, c.index_fill_(0, ind_empty, -1))
+        self.assertEqual(c_clone, c.index_copy_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
+        self.assertEqual(c_clone, c.index_add_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
+        self.assertEqual(c_clone, c.index_fill_(0, ind_empty, -1))
+        self.assertEqual(c_clone, c.index_copy_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
+        self.assertEqual(c_clone, c.index_add_(0, ind_empty, torch.empty((0, 1, 2), device=device)))
+
+        # index fill/copy/add non-empty
+        z = torch.randn((2, 3, 4), device=device)
+        self.assertEqual(z, z.index_fill_(0, ind_empty, -1))
+        z = torch.randn((2, 3, 4), device=device)
+        self.assertEqual(z, z.index_copy_(0, ind_empty, torch.empty((0, 3, 4), device=device)))
+        z = torch.randn((2, 3, 4), device=device)
+        self.assertEqual(z, z.index_add_(0, ind_empty, torch.empty((0, 3, 4), device=device)))
+
+        # index_select
+        self.assertEqual(x, x.index_select(0, ind_empty))
+        self.assertEqual((0, 1, 0, 0), x.index_select(2, ind_empty).shape)
+        self.assertEqual(x, x.index_select(2, ind_01))
+        z = torch.randn((2, 3, 4), device=device)  # non-empty
+        self.assertEqual((0, 3, 4), z.index_select(0, ind_empty).shape)
+        c = torch.randn((0, 1, 2), device=device)
+        self.assertEqual(c, c.index_select(0, ind_empty))
+        c = torch.randn((0, 1, 2), device=device)
+        self.assertEqual(c, c.index_select(0, ind_empty))
+
+    def test_nonzero(self, device):
+        num_srcs = [
+            12, 12, 12, 12, 12, 125,
+        ]
+
+        types = [
+            'torch.ByteTensor',
+            'torch.CharTensor',
+            'torch.ShortTensor',
+            'torch.IntTensor',
+            'torch.FloatTensor',
+            'torch.DoubleTensor',
+            'torch.LongTensor',
+        ]
+
+        shapes = [
+            torch.Size((12,)),
+            torch.Size((12, 1)),
+            torch.Size((1, 12)),
+            torch.Size((6, 2)),
+            torch.Size((3, 2, 2)),
+            torch.Size((5, 5, 5)),
+        ]
+
+        def is_lexicographically_sorted(inds):
+            """Check sorted ascending with
+            i -> j -> k changing slowest to fastest"""
+            assert inds.size(1) == 3
+            if inds.size(0) > 1:
+                i0, j0, k0 = inds[:-1].t()
+                i1, j1, k1 = inds[+1:].t()
+                i_ok = (i1 >= i0)
+                j_ok = (j1 >= j0) | (i1 > i0)
+                k_ok = (k1 >= k0) | (j1 > j0) | (i1 > i0)
+                lex = torch.stack((i_ok, j_ok, k_ok), dim=1)
+                return lex
+            return torch.full_like(inds, 1)
+
+        def gen_nontrivial_input(num_src, dtype, device):
+            while True:
+                tensor = torch.rand(num_src).mul(2).floor().type(dtype).to(device)
+                if tensor.sum() > 0:
+                    return tensor
+
+        for dtype in types:
+            for shape, num_src in zip(shapes, num_srcs):
+                tensor = gen_nontrivial_input(num_src, dtype, device)
+                tensor = tensor.clone().resize_(shape)
+                dst1 = torch.nonzero(tensor)
+                dst2 = tensor.nonzero()
+                dst3 = torch.LongTensor().to(device)
+                torch.nonzero(tensor, out=dst3)
+
+                self.assertRaisesRegex(
+                    TypeError,
+                    "received an invalid combination of arguments",
+                    lambda: torch.nonzero(tensor, as_tuple=True, out=dst3))
+                if len(shape) == 1:
+                    dst = []
+                    for i in range(num_src):
+                        if tensor[i] != 0:
+                            dst += [i]
+                    dst = torch.LongTensor(dst).to(device)
+                    self.assertEqual(dst1.select(1, 0), dst, 0)
+                    self.assertEqual(dst2.select(1, 0), dst, 0)
+                    self.assertEqual(dst3.select(1, 0), dst, 0)
+                elif len(shape) == 2:
+                    # This test will allow through some False positives. It only checks
+                    # that the elements flagged positive are indeed non-zero.
+                    for i in range(dst1.size(0)):
+                        self.assertNotEqual(tensor[dst1[i, 0], dst1[i, 1]].item(), 0)
+                elif len(shape) == 3:
+                    # This test will allow through some False positives. It only checks
+                    # that the elements flagged positive are indeed non-zero.
+                    for i in range(dst1.size(0)):
+                        self.assertNotEqual(tensor[dst1[i, 0], dst1[i, 1], dst1[i, 2]].item(), 0)
+                    lex = is_lexicographically_sorted(dst1)
+                    self.assertEqual(torch.ones_like(lex), lex)
+                if TEST_NUMPY:
+                    tup1 = torch.nonzero(tensor, as_tuple=True)
+                    tup2 = tensor.nonzero(as_tuple=True)
+                    tup3 = torch.where(tensor)
+                    np1 = tensor.cpu().numpy().nonzero()
+                    for t in (tup1, tup2, tup3):
+                        self.assertEqual(len(t), len(np1))
+                        for i in range(len(t)):
+                            self.assertEqual(t[i].cpu().numpy(), np1[i])
+
+    def test_pdist_norm(self, device):
+        def test_pdist_single(shape, device, p, dtype, trans):
+            x = torch.randn(shape, dtype=dtype, device=device)
+            if trans:
+                x.transpose_(-2, -1)
+            actual = torch.pdist(x, p=p)
+            expected = brute_pdist(x, p=p)
+            self.assertEqual(expected.shape, actual.shape)
+            self.assertTrue(torch.allclose(expected, actual))
+
+        for shape in [(4, 5), (3, 2), (2, 1)]:
+            for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+                for trans in [False, True]:
+                    for dtype in [torch.float32, torch.float64]:
+                        test_pdist_single(shape, device, p, dtype, trans)
+
+        # do a simplified comparison with big inputs, see:
+        # https://github.com/pytorch/pytorch/issues/15511
+        for dtype in [torch.float32, torch.float64]:
+            test_pdist_single((1000, 2), device, 2, dtype, False)
+
+    def test_atan2(self, device):
+        def _test_atan2_with_size(size, device):
+            a = torch.rand(size=size, device=device, dtype=torch.double)
+            b = torch.rand(size=size, device=device, dtype=torch.double)
+            actual = a.atan2(b)
+            x = a.view(-1)
+            y = b.view(-1)
+            expected = torch.tensor([math.atan2(x[i].item(), y[i].item()) for i in range(x.numel())],
+                                    device=device, dtype=torch.double)
+            self.assertTrue(torch.allclose(expected, actual.view(-1), rtol=0, atol=0.02))
+
+        _test_atan2_with_size((2, 2), device)
+        _test_atan2_with_size((3, 3), device)
+        _test_atan2_with_size((5, 5), device)
+
+    def test_atan2_edgecases(self, device):
+        def _test_atan2(x, y, expected, device, dtype):
+            expected_tensor = torch.tensor([expected], dtype=dtype, device=device)
+            x_tensor = torch.tensor([x], dtype=dtype, device=device)
+            y_tensor = torch.tensor([y], dtype=dtype, device=device)
+            actual = torch.atan2(y_tensor, x_tensor)
+            self.assertTrue(torch.allclose(expected_tensor, actual, rtol=0, atol=0.02))
+
+        for dtype in [torch.float, torch.double]:
+            _test_atan2(0, 0, 0, device, dtype)
+            _test_atan2(0, 1, math.pi / 2, device, dtype)
+            _test_atan2(0, -1, math.pi / -2, device, dtype)
+            _test_atan2(-1, 0, math.pi, device, dtype)
+            _test_atan2(1, 0, 0, device, dtype)
+            _test_atan2(-1, -1, math.pi * -3 / 4 , device, dtype)
+            _test_atan2(1, 1, math.pi / 4 , device, dtype)
+            _test_atan2(1, -1, math.pi / -4 , device, dtype)
+            _test_atan2(-1, 1, math.pi * 3 / 4 , device, dtype)
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_trapz(self, device):
+        def test_dx(sizes, dim, dx, device):
+            t = torch.randn(sizes, device=device)
+            actual = torch.trapz(t, dx=dx, dim=dim)
+            expected = np.trapz(t.cpu().numpy(), dx=dx, axis=dim)
+            self.assertEqual(expected.shape, actual.shape)
+            self.assertTrue(np.allclose(expected, actual.cpu().numpy()))
+
+        def test_x(sizes, dim, x, device):
+            t = torch.randn(sizes, device=device)
+            actual = torch.trapz(t, x=torch.tensor(x, device=device), dim=dim)
+            expected = np.trapz(t.cpu().numpy(), x=x, axis=dim)
+            self.assertEqual(expected.shape, actual.shape)
+            self.assertTrue(np.allclose(expected, actual.cpu().numpy()))
+
+        test_dx((2, 3, 4), 1, 1, device)
+        test_dx((10, 2), 0, 0.1, device)
+        test_dx((1, 10), 0, 2.3, device)
+        test_dx((0, 2), 0, 1.0, device)
+        test_dx((0, 2), 1, 1.0, device)
+        test_x((2, 3, 4), 1, [1.0, 2.0, 3.0], device)
+        test_x((10, 2), 0, [2.0, 3.0, 4.0, 7.0, 11.0, 14.0, 22.0, 26.0, 26.1, 30.3], device)
+        test_x((1, 10), 0, [1.0], device)
+        test_x((0, 2), 0, [], device)
+        test_x((0, 2), 1, [1.0, 2.0], device)
+        with self.assertRaisesRegex(
+                IndexError,
+                'Dimension out of range'):
+            test_x((2, 3), 2, [], device)
+            test_dx((2, 3), 2, 1.0, device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                'There must be one `x` value for each sample point'):
+            test_x((2, 3), 1, [1.0, 2.0], device)
+            test_x((2, 3), 1, [1.0, 2.0, 3.0, 4.0], device)
+
+    def test_reduction_empty(self, device):
+        fns_to_test = [
+            # name, function, identity
+            ('max', torch.max, None),
+            ('kthvalue', lambda *args, **kwargs: torch.kthvalue(*args, k=1, **kwargs), None),
+            ('argmax', torch.argmax, None),
+            ('min', torch.min, None),
+            ('argmin', torch.argmin, None),
+            ('mode', torch.mode, None),
+            ('median', torch.median, None),
+
+            ('prod', torch.prod, 1),
+            ('sum', torch.sum, 0),
+            ('norm', torch.norm, 0),
+            ('mean', torch.mean, nan),
+            ('var', torch.var, nan),
+            ('std', torch.std, nan),
+            ('logsumexp', torch.logsumexp, -inf),
+        ]
+
+        shape = (2, 0, 4)
+        x = torch.randn(shape, device=device)
+
+        for fn in [torch.max, torch.min]:
+            ident_err = 'operation does not have an identity'
+            self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x))
+
+        for item in fns_to_test:
+            name, fn, identity = item
+            if identity is None:
+                ident_err = 'does not have an identity'
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2))
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=2, keepdim=True))
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1))
+                self.assertRaisesRegex(RuntimeError, ident_err, lambda: fn(x, dim=1, keepdim=True))
+            else:
+                self.assertEqual(torch.empty((2, 0), device=device), fn(x, dim=2))
+                self.assertEqual(torch.empty((2, 0, 1), device=device), fn(x, dim=2, keepdim=True))
+                # assertEqual doesn't work with inf, -inf, nan and two tensors.
+                check = (torch.testing.assert_allclose if math.isnan(identity) or math.isinf(identity) else
+                            self.assertEqual)
+                check(torch.full((2, 4), identity, device=device), fn(x, dim=1))
+                check(torch.full((2, 1, 4), identity, device=device), fn(x, dim=1, keepdim=True))
+                try:
+                    check(torch.full((), identity, device=device), fn(x))
+                except TypeError as err:
+                    # ignore if there is no allreduce.
+                    self.assertTrue('dim' in str(err))
+
+        # any
+        xb = x.to(torch.uint8)
+        yb = x.to(torch.uint8)
+        self.assertEqual((2, 0), xb.any(2).shape)
+        self.assertEqual((2, 0, 1), xb.any(2, keepdim=True).shape)
+        self.assertEqual(torch.zeros((2, 4), device=device), xb.any(1))
+        self.assertEqual(torch.zeros((2, 1, 4), device=device), xb.any(1, keepdim=True))
+        self.assertEqual(torch.zeros((), device=device), xb.any())
+
+        # all
+        self.assertEqual((2, 0), xb.all(2).shape)
+        self.assertEqual((2, 0, 1), xb.all(2, keepdim=True).shape)
+        self.assertEqual(torch.ones((2, 4), device=device), xb.all(1))
+        self.assertEqual(torch.ones((2, 1, 4), device=device), xb.all(1, keepdim=True))
+        self.assertEqual(torch.ones((), device=device), xb.all())
+
+    def test_addcdiv(self, device):
+        def _test_addcdiv(a, alpha, b, c):
+            actual = torch.addcdiv(a, alpha, b, c)
+            # implementation of addcdiv downcasts alpha. arithmetic ops don't.
+            if not actual.dtype.is_floating_point:
+                alpha = int(alpha)
+            expected = a + (alpha * b) / c
+            self.assertTrue(torch.allclose(expected, actual, equal_nan=True))
+
+        def non_zero_rand(size, dtype, device):
+            if dtype.is_floating_point:
+                a = torch.rand(size=size, dtype=dtype, device=device)
+            elif dtype == torch.uint8:
+                a = torch.randint(1, 5, size=size, dtype=dtype, device=device)
+            else:
+                a = torch.randint(-5, 5, size=size, dtype=dtype, device=device)
+            return a + (a == 0).type(dtype)
+
+        for dtype in torch.testing.get_all_math_dtypes(device):
+            _test_addcdiv(
+                non_zero_rand((2, 2), dtype=dtype, device=device),
+                0.5,
+                non_zero_rand((2, 2), dtype=dtype, device=device),
+                non_zero_rand((2, 2), dtype=dtype, device=device))
+
+    def test_unary_out_op_mem_overlap(self, device):
+        sz = 3
+        doubles = torch.randn(2 * sz, device=device)
+        positives = torch.randint(1, 100, (2 * sz,), device=device).double()
+        ints = torch.randint(-100, 100, (2 * sz,), device=device)
+        unary_mem_overlap_cases = [
+            ("abs", doubles, True, True, 'cpu'),
+            ("abs", doubles, False, True, 'cuda'),
+            ("acos", doubles, True, True, 'cpu'),
+            ("acos", doubles, False, True, 'cuda'),
+            ("asin", doubles, True, True, 'cpu'),
+            ("asin", doubles, False, True, 'cuda'),
+            ("atan", doubles, True, True, 'cpu'),
+            ("atan", doubles, False, True, 'cuda'),
+            ("bitwise_not", ints, True, True, 'cpu'),
+            ("bitwise_not", ints, True, True, 'cuda'),
+            ("ceil", doubles, True, True, 'cpu'),
+            ("ceil", doubles, True, True, 'cuda'),
+            ("cos", doubles, True, True, 'cpu'),
+            ("cos", doubles, False, True, 'cuda'),
+            ("cosh", doubles, True, True, 'cpu'),
+            ("cosh", doubles, False, True, 'cuda'),
+            ("digamma", doubles, True, True, 'cpu'),
+            ("erf", doubles, True, True, 'cpu'),
+            ("erf", doubles, False, True, 'cuda'),
+            ("erfc", doubles, True, True, 'cpu'),
+            ("erfc", doubles, False, True, 'cuda'),
+            ("erfinv", doubles, True, True, 'cpu'),
+            ("erfinv", doubles, True, True, 'cuda'),
+            ("exp", doubles, True, True, 'cpu'),
+            ("exp", doubles, False, True, 'cuda'),
+            ("expm1", doubles, True, True, 'cpu'),
+            ("expm1", doubles, False, True, 'cuda'),
+            ("floor", doubles, True, True, 'cpu'),
+            ("floor", doubles, False, True, 'cuda'),
+            ("frac", doubles, True, True, 'cpu'),
+            ("frac", doubles, False, True, 'cuda'),
+            ("log", positives, True, True, 'cpu'),
+            ("log", positives, False, True, 'cuda'),
+            ("log10", positives, True, True, 'cpu'),
+            ("log10", positives, False, True, 'cuda'),
+            ("log1p", positives, True, True, 'cpu'),
+            ("log1p", positives, False, True, 'cuda'),
+            ("log2", positives, True, True, 'cpu'),
+            ("log2", positives, False, True, 'cuda'),
+            ("neg", doubles, True, True, 'cpu'),
+            ("neg", doubles, True, True, 'cuda'),
+            ("reciprocal", doubles, True, True, 'cpu'),
+            ("reciprocal", doubles, False, True, 'cuda'),
+            ("round", doubles, True, True, 'cpu'),
+            ("round", doubles, False, True, 'cuda'),
+            ("rsqrt", positives, True, True, 'cpu'),
+            ("rsqrt", positives, False, True, 'cuda'),
+            ("sin", doubles, True, True, 'cpu'),
+            ("sin", doubles, False, True, 'cuda'),
+            ("sinh", doubles, True, True, 'cpu'),
+            ("sinh", doubles, False, True, 'cuda'),
+            ("sigmoid", doubles, True, True, 'cpu'),
+            ("sigmoid", doubles, False, False, 'cuda'),
+            ("sqrt", doubles, True, True, 'cpu'),
+            ("sqrt", doubles, False, True, 'cuda'),
+            ("tan", doubles, True, True, 'cpu'),
+            ("tan", doubles, False, True, 'cuda'),
+            ("tanh", doubles, True, True, 'cpu'),
+            ("tanh", doubles, False, True, 'cuda'),
+            ("trunc", doubles, True, True, 'cpu'),
+            ("trunc", doubles, False, True, 'cuda')
+        ]
+
+        for (fn, inputs, has_input_output_mem_overlap_check,
+             has_internal_mem_overlap_check, dev) in unary_mem_overlap_cases:
+            if dev != device:
+                continue
+            out_fn = getattr(torch, fn)
+            in_fn = getattr(torch.Tensor, fn + '_')
+
+            self.unary_check_input_output_mem_overlap(inputs, sz, out_fn,
+                                                      expected_failure=not has_input_output_mem_overlap_check)
+
+            self.check_internal_mem_overlap(in_fn, num_inputs=1, device=dev,
+                                            expected_failure=not has_internal_mem_overlap_check)
+
+    def test_binary_op_mem_overlap(self, device):
+        ops = [
+            ("add", True, True, 'cpu'),
+            ("add", True, True, 'cuda'),
+            ("mul", True, True, 'cpu'),
+            ("mul", True, True, 'cuda'),
+            ("sub", True, True, 'cpu'),
+            ("sub", True, True, 'cuda'),
+            ("div", True, True, 'cpu'),
+            ("div", True, True, 'cuda'),
+            ("pow", True, True, 'cpu'),
+            ("pow", True, True, 'cuda')
+        ]
+
+        for (fn, has_input_output_mem_overlap_check,
+             has_internal_mem_overlap_check, dev) in ops:
+            if dev != device:
+                continue
+            out_op = getattr(torch, fn)
+            inplace_op = getattr(torch.Tensor, fn + '_')
+            self.check_internal_mem_overlap(
+                inplace_op, num_inputs=2, device=device,
+                expected_failure=not has_internal_mem_overlap_check)
+
+            self.binary_check_input_output_mem_overlap(out_op, device,
+                                                       expected_failure=not has_input_output_mem_overlap_check)
+
+    def test_ternary_op_mem_overlap(self, device):
+        ops = [
+            ("addcmul", True, True, 'cpu'),
+            ("addcmul", True, True, 'cuda'),
+            ("addcdiv", True, True, 'cpu'),
+            ("addcdiv", True, True, 'cuda'),
+            ("lerp", True, True, 'cpu'),
+            ("lerp", False, False, 'cuda')
+        ]
+
+        for (fn, has_input_output_mem_overlap_check,
+             has_internal_mem_overlap_check, dev) in ops:
+            if dev != device:
+                continue
+            out_op = getattr(torch, fn)
+            inplace_op = getattr(torch.Tensor, fn + '_')
+            self.check_internal_mem_overlap(
+                inplace_op, num_inputs=3, device=device,
+                expected_failure=not has_internal_mem_overlap_check)
+            self.ternary_check_input_output_mem_overlap(out_op, dev,
+                                                        expected_failure=not has_input_output_mem_overlap_check)
+
+    def test_copy_mem_overlap(self, device):
+        self.check_internal_mem_overlap(
+            torch.Tensor.copy_, num_inputs=2, device=device)
+        sz = 3
+        doubles = torch.randn(2 * sz, device=device)
+        self.unary_check_input_output_mem_overlap(
+            doubles, sz, lambda input, out: out.copy_(input))
+
+    def test_pow_scalar_overloads_mem_overlap(self, device):
+        sz = 3
+        doubles = torch.randn(2 * sz, device=device)
+        self.check_internal_mem_overlap(
+            lambda t: t.pow_(42), num_inputs=1, device=device)
+        self.unary_check_input_output_mem_overlap(
+            doubles, sz, lambda input, out: torch.pow(input, 42, out=out))
+        self.unary_check_input_output_mem_overlap(
+            doubles, sz, lambda input, out: torch.pow(42, input, out=out))
+
+    def test_erfinv(self, device):
+        def checkType(dtype):
+            # general testing. Narrow the range to avoid accuracy issues
+            input_values = torch.randn(4, 4, dtype=dtype, device=device).clamp(-0.3, 0.3)
+            self.assertEqual(input_values.erf().erfinv(), input_values)
+            # test inf
+            self.assertTrue(torch.equal(torch.tensor([-1, 1], dtype=dtype, device=device).erfinv(),
+                            torch.tensor([-inf, inf], dtype=dtype, device=device)))
+            # test nan
+            self.assertEqual(torch.tensor([-2, 2], dtype=dtype, device=device).erfinv(),
+                             torch.tensor([nan, nan], dtype=dtype, device=device))
+
+        if device != 'cpu':
+            checkType(torch.half)
+        checkType(torch.float)
+        checkType(torch.double)
+
+        # double precision
+        a = torch.tensor([0.5, 0.8], dtype=torch.double, device=device).erfinv()
+        self.assertAlmostEqual(a[0].item(), 0.47693627620447, places=13)
+        self.assertAlmostEqual(a[1].item(), 0.90619380243682, places=13)
+
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_int_pow(self, device):
+
+        def _test_integral_pow(dt, range, dev):
+            tensor = torch.tensor((3, 3), dtype=dt, device=dev).random_(*range)
+            exps = [0, 1, 2, 4,
+                    torch.tensor((3, 3), dtype=dt, device=dev).random_(0, 5)]
+            for exp in exps:
+                self._test_pow(tensor, exp)
+
+        _test_integral_pow(torch.int8, (-3, 4), device)
+        _test_integral_pow(torch.uint8, (0, 4), device)
+        _test_integral_pow(torch.int16, (-5, 5), device)
+        _test_integral_pow(torch.int64, (-10, 10), device)
+        _test_integral_pow(torch.int32, (-10, 10), device)
+
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_int_tensor_pow_neg_ints(self, device):
+        ints = [torch.iinfo(torch.int32).min,
+                -3, -2, -1, 0, 1, 2, 3,
+                torch.iinfo(torch.int32).max]
+        neg_ints = [torch.iinfo(torch.int32).min, -3, -2, -1]
+        tensor = torch.tensor(ints, dtype=torch.int32, device=device)
+        for pow in neg_ints:
+            self._test_pow(tensor, pow)
+
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_long_tensor_pow_floats(self, device):
+        ints = [0, 1, 23, 4567]
+        floats = [0.0, 1 / 3, 1 / 2, 1.0, 3 / 2, 2.0]
+        tensor = torch.tensor(ints, dtype=torch.int64, device=device)
+        for pow in floats:
+            self._test_pow(tensor, pow)
+
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_float_scalar_pow_float_tensor(self, device):
+        floats = [2.0, -3 / 2, -1.0, -1 / 2, -1 / 3, 0.0,
+                  1 / 3, 1 / 2, 1.0, 3 / 2, 2.0]
+        tensor = torch.tensor(floats, dtype=torch.float32, device=device)
+        for base in floats:
+            self._test_pow(base, tensor)
+
+    @unittest.skipIf(not TEST_NUMPY, 'Numpy not found')
+    def test_tensor_pow_tensor(self, dev):
+        def rotate(l, n):
+            return l[-n:] + l[:-n]
+
+        def test_tensor_pow_tensor(values, torch_type, numpy_type):
+            vals_tensor = torch.tensor(values, dtype=torch_type, device=dev)
+            for i in range(len(values)):
+                pows = rotate(values, i)
+                pows_tensor = torch.tensor(pows, dtype=torch_type, device=dev)
+                self._test_pow(vals_tensor, pows_tensor)
+
+        ints = [0, 1, 2, 3]
+        test_tensor_pow_tensor(ints, torch.int32, np.int32)
+        test_tensor_pow_tensor(ints, torch.int64, np.int64)
+
+        floats = [-3.0, -2.0, -1.0, -1 / 2, -1 / 3,
+                  0.0,
+                  1 / 3, 1 / 2, 1.0, 2.0, 3.0]
+        test_tensor_pow_tensor(floats, torch.float32, np.float32)
+        test_tensor_pow_tensor(floats, torch.float64, np.float64)
+
+    def test_var_mean_some_dims(self, device):
+        sizes = (4, 6, 7, 5, 3)
+        dims = len(sizes)
+
+        x = torch.rand(sizes, device=device)
+        for num_of_dims in range(2, dims):
+            dim_list = list(combinations(list(range(dims)), r=num_of_dims))
+            for dim in dim_list:
+                for unbiased in [False, True]:
+                    for keepdim in [False, True]:
+                        var1, mean1 = torch.var_mean(x, dim=dim, unbiased=unbiased, keepdim=keepdim)
+                        var2 = x.var(dim=dim, unbiased=unbiased, keepdim=keepdim)
+                        mean2 = x.mean(dim=dim, keepdim=keepdim)
+                        self.assertEqual(var1, var2)
+                        self.assertEqual(mean1, mean2)
 
 add_neg_dim_tests()
 instantiate_device_type_tests(TestTorchDeviceType, globals())


### PR DESCRIPTION
This PR moves many tests in test_torch.py to the generic device type framework. This means that many CUDA tests now run in test_torch.py and there is greater consistency in how tests for many device types are written.

One change is that all MAGMA tests are run on the default stream due to intermittent instability running MAGMA on the non-default stream. This is a known issue. 