### PR TITLE
Add __s390x__ compiler define for s390 builds.

### DIFF
--- a/aten/src/TH/vector/simd.h
+++ b/aten/src/TH/vector/simd.h
@@ -72,6 +72,13 @@ static inline uint32_t detectHostSIMDExtensions()
 
  #endif
 
+#elif defined(__s390x__)
+
+static inline uint32_t detectHostSIMDExtensions()
+{
+  return SIMDExtension_DEFAULT;
+}
+
 #elif defined(__PPC64__)
 
  #if defined(__VSX__)


### PR DESCRIPTION
pytorch builds fail on 390 architecture because
in simd.h the ifdef macros default to an x86 asm instruction.
This patchs adds an ifdef __s390x__ to be able to build on s390.

