### PR TITLE
Prepend all PyTorch QNNPACK symbols with pytorch_ to avoid symbol collision.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/hgemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/hgemm.cc
@@ -53,7 +53,7 @@ class HGEMM : public benchmark::Fixture {
     std::generate(b_.begin(), b_.end(), std::ref(rng));
     w_.resize(ncStride() * kcStride() + ncStride());
     std::fill(w_.begin(), w_.end(), 0);
-    pack_hgemm_w(nc(), kc(), nr(), kr(), k(), b(), w());
+    pytorch_pack_hgemm_w(nc(), kc(), nr(), kr(), k(), b(), w());
     c_.resize(mc() * nc());
     std::fill(c_.begin(), c_.end(), UINT16_C(0x7E00) /* NaN */);
   }
@@ -325,7 +325,7 @@ BENCHMARK_TEMPLATE_F(HGEMM_L1, 8x8__aarch32_neonfp16arith, 8, 8, 1)
     state.SkipWithError("NEON FP16 compute is not supported");
   }
   for (auto _ : state) {
-    hgemm_ukernel_8x8__aarch32_neonfp16arith(
+    pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith(
         mr(),
         nr(),
         kc(),
@@ -348,7 +348,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(HGEMM_Op, 8x8__aarch32_neonfp16arith, 8, 8, 1)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        hgemm_ukernel_8x8__aarch32_neonfp16arith(
+        pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith(
             mrr,
             nrr,
             kc(),

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/q8gemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/q8gemm.cc
@@ -98,7 +98,7 @@ class Q8GEMM : public benchmark::Fixture {
         kcStride() * ncStride() +
         ncStride() * sizeof(int32_t) / sizeof(uint8_t));
     std::fill(w_.begin(), w_.end(), 127);
-    pack_q8gemm_w(
+    pytorch_pack_q8gemm_w(
         nc(),
         kc(),
         nr(),
@@ -259,7 +259,7 @@ class Q8GEMM_XZP : public Q8GEMM {
     std::generate(b_.begin(), b_.end(), std::ref(s32rng));
     w_.resize(ncStride() * (kcStride() + sizeof(int32_t) / sizeof(uint8_t)));
     std::fill(w_.begin(), w_.end(), 127);
-    pack_swizzle_q8gemm_b(
+    pytorch_pack_swizzle_q8gemm_b(
         nc(),
         kc(),
         np(),
@@ -593,7 +593,7 @@ static void q8gemm_compute_row_sum(
     int32_t* row_sum) {
   const size_t block_size = 4;
   for (size_t block_start = 0; block_start < m; block_start += block_size) {
-    q8sumrows_ukernel_4x__neon(
+    pytorch_q8sumrows_ukernel_4x__neon(
         a + block_start * stride,
         std::min(block_size, m - block_start),
         k,
@@ -608,7 +608,7 @@ static void q8gemm_compute_row_sum(
 BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 4x8__aarch32_neon, 4, 8, 8, 1)
 (benchmark::State& state) {
   for (auto _ : state) {
-    q8gemm_ukernel_4x8__aarch32_neon(
+    pytorch_q8gemm_ukernel_4x8__aarch32_neon(
         mr(),
         nr(),
         kc(),
@@ -628,7 +628,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_Op, 4x8__aarch32_neon, 4, 8, 8, 1)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_ukernel_4x8__aarch32_neon(
+        pytorch_q8gemm_ukernel_4x8__aarch32_neon(
             mrr,
             nrr,
             kc(),
@@ -654,7 +654,7 @@ BENCHMARK_TEMPLATE_F(Q8GEMM_XZP_L1, 4x8c2__aarch32_neon, 4, 8, 8, 2)
 (benchmark::State& state) {
   for (auto _ : state) {
     q8gemm_compute_row_sum(a(), mr(), kc(), kc(), -64, aRowSums());
-    q8gemm_xzp_ukernel_4x8c2__aarch32_neon(
+    pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon(
         mr(),
         nr(),
         kc(),
@@ -676,7 +676,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_XZP_Op, 4x8c2__aarch32_neon, 4, 8, 8, 2)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_xzp_ukernel_4x8c2__aarch32_neon(
+        pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon(
             mrr,
             nrr,
             kc(),
@@ -705,7 +705,7 @@ BENCHMARK_REGISTER_F(Q8GEMM_XZP_Op, 4x8c2__aarch32_neon)->Apply(GemmArguments);
 BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 8x8__aarch64_neon, 8, 8, 8, 1)
 (benchmark::State& state) {
   for (auto _ : state) {
-    q8gemm_ukernel_8x8__aarch64_neon(
+    pytorch_q8gemm_ukernel_8x8__aarch64_neon(
         mr(),
         nr(),
         kc(),
@@ -725,7 +725,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_Op, 8x8__aarch64_neon, 8, 8, 8, 1)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_ukernel_8x8__aarch64_neon(
+        pytorch_q8gemm_ukernel_8x8__aarch64_neon(
             mrr,
             nrr,
             kc(),
@@ -753,7 +753,7 @@ BENCHMARK_REGISTER_F(Q8GEMM_Op, 8x8__aarch64_neon)->Apply(GemmArguments);
 BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 4x8__neon, 4, 8, 8, 1)
 (benchmark::State& state) {
   for (auto _ : state) {
-    q8gemm_ukernel_4x8__neon(
+    pytorch_q8gemm_ukernel_4x8__neon(
         mr(),
         nr(),
         kc(),
@@ -769,7 +769,7 @@ BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 4x8__neon, 4, 8, 8, 1)
 BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 8x8__neon, 8, 8, 8, 1)
 (benchmark::State& state) {
   for (auto _ : state) {
-    q8gemm_ukernel_8x8__neon(
+    pytorch_q8gemm_ukernel_8x8__neon(
         mr(),
         nr(),
         kc(),
@@ -789,7 +789,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_Op, 4x8__neon, 4, 8, 8, 1)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_ukernel_4x8__neon(
+        pytorch_q8gemm_ukernel_4x8__neon(
             mrr,
             nrr,
             kc(),
@@ -816,7 +816,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_Op, 8x8__neon, 8, 8, 8, 1)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_ukernel_8x8__neon(
+        pytorch_q8gemm_ukernel_8x8__neon(
             mrr,
             nrr,
             kc(),
@@ -840,7 +840,7 @@ BENCHMARK_TEMPLATE_F(Q8GEMM_XZP_L1, 4x8c2_neon, 4, 8, 8, 2)
 (benchmark::State& state) {
   for (auto _ : state) {
     q8gemm_compute_row_sum(a(), mr(), kc(), kc(), -64, aRowSums());
-    q8gemm_xzp_ukernel_4x8c2__neon(
+    pytorch_q8gemm_xzp_ukernel_4x8c2__neon(
         mr(),
         nr(),
         kc(),
@@ -862,7 +862,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_XZP_Op, 4x8c2_neon, 4, 8, 8, 2)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_xzp_ukernel_4x8c2__neon(
+        pytorch_q8gemm_xzp_ukernel_4x8c2__neon(
             mrr,
             nrr,
             kc(),
@@ -898,7 +898,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(
     const size_t block_size = 4;
     for (size_t block_start = 0; block_start < mc();
          block_start += block_size) {
-      q8sumrows_ukernel_4x__neon(
+      pytorch_q8sumrows_ukernel_4x__neon(
           a() + block_start * kc(),
           min(block_size, mc() - block_start),
           kc(),
@@ -924,7 +924,7 @@ BENCHMARK_REGISTER_F(COMPUTE_ROW_SUM_Op, compute_row_sum_neon)
 BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 2x4c8__sse2, 2, 4, 1, 8)
 (benchmark::State& state) {
   for (auto _ : state) {
-    q8gemm_ukernel_2x4c8__sse2(
+    pytorch_q8gemm_ukernel_2x4c8__sse2(
         mr(),
         nr(),
         kc(),
@@ -940,7 +940,7 @@ BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 2x4c8__sse2, 2, 4, 1, 8)
 BENCHMARK_TEMPLATE_F(Q8GEMM_L1, 4x4c2__sse2, 4, 4, 4, 2)
 (benchmark::State& state) {
   for (auto _ : state) {
-    q8gemm_ukernel_4x4c2__sse2(
+    pytorch_q8gemm_ukernel_4x4c2__sse2(
         mr(),
         nr(),
         kc(),
@@ -960,7 +960,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_Op, 2x4c8__sse2, 2, 4, 1, 8)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_ukernel_2x4c8__sse2(
+        pytorch_q8gemm_ukernel_2x4c8__sse2(
             mrr,
             nrr,
             kc(),
@@ -988,7 +988,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(Q8GEMM_Op, 4x4c2__sse2, 4, 4, 4, 2)
       const uint32_t mrr = min(mc() - m, mr());
       for (uint32_t n = 0; n < nc(); n += nr()) {
         const uint32_t nrr = min(nc() - n, nr());
-        q8gemm_ukernel_4x4c2__sse2(
+        pytorch_q8gemm_ukernel_4x4c2__sse2(
             mrr,
             nrr,
             kc(),

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/bench/sgemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/bench/sgemm.cc
@@ -33,7 +33,7 @@ inline uint32_t roundUp(uint32_t x, uint32_t q) {
 
 static void sgemmBenchmark(
     benchmark::State& state,
-    sgemm_ukernel_function sgemm,
+    pytorch_sgemm_ukernel_function sgemm,
     uint32_t mc,
     uint32_t nc,
     uint32_t kc,
@@ -57,7 +57,7 @@ static void sgemmBenchmark(
   std::vector<float, AlignedAllocator<float, 32>> w(
       ncStride * kcStride + ncStride);
   std::fill(w.begin(), w.end(), 0.0f);
-  pack_sgemm_w(nc, kc, nr, kr, k.data(), b.data(), w.data());
+  pytorch_pack_sgemm_w(nc, kc, nr, kr, k.data(), b.data(), w.data());
   std::vector<float> c(mc * nc);
   std::fill(c.begin(), c.end(), std::nanf(""));
 
@@ -89,7 +89,7 @@ static void sgemmBenchmark(
 
 static void sgemm_in_l1(
     benchmark::State& state,
-    sgemm_ukernel_function sgemm,
+    pytorch_sgemm_ukernel_function sgemm,
     uint32_t mr,
     uint32_t nr,
     uint32_t np,
@@ -109,7 +109,7 @@ static void sgemm_in_l1(
 
 static void sgemm(
     benchmark::State& state,
-    sgemm_ukernel_function sgemm,
+    pytorch_sgemm_ukernel_function sgemm,
     uint32_t mr,
     uint32_t nr,
     uint32_t np,
@@ -493,18 +493,18 @@ static void VGG(benchmark::internal::Benchmark* b) {
 BENCHMARK_CAPTURE(
     sgemm_in_l1,
     6x8__psimd,
-    sgemm_ukernel_6x8__psimd,
+    pytorch_sgemm_ukernel_6x8__psimd,
     6,
     8,
     8,
     1);
 #if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
-BENCHMARK_CAPTURE(sgemm_in_l1, 5x8__neon, sgemm_ukernel_5x8__neon, 5, 8, 8, 1);
-BENCHMARK_CAPTURE(sgemm_in_l1, 6x8__neon, sgemm_ukernel_6x8__neon, 6, 8, 8, 1);
+BENCHMARK_CAPTURE(sgemm_in_l1, 5x8__neon, pytorch_sgemm_ukernel_5x8__neon, 5, 8, 8, 1);
+BENCHMARK_CAPTURE(sgemm_in_l1, 6x8__neon, pytorch_sgemm_ukernel_6x8__neon, 6, 8, 8, 1);
 #endif
 
 static void sgemm_6x8__psimd(benchmark::State& state, const char* net) {
-  sgemm(state, sgemm_ukernel_6x8__psimd, 6, 8, 8, 1);
+  sgemm(state, pytorch_sgemm_ukernel_6x8__psimd, 6, 8, 8, 1);
 }
 
 BENCHMARK_CAPTURE(sgemm_6x8__psimd, mobilenet_v1, "MobileNet v1")
@@ -551,11 +551,11 @@ BENCHMARK_CAPTURE(sgemm_6x8__psimd, vgg, "VGG")->Apply(VGG);
 
 #if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 static void sgemm_5x8__neon(benchmark::State& state, const char* net) {
-  sgemm(state, sgemm_ukernel_5x8__neon, 5, 8, 8, 1);
+  sgemm(state, pytorch_sgemm_ukernel_5x8__neon, 5, 8, 8, 1);
 }
 
 static void sgemm_6x8__neon(benchmark::State& state, const char* net) {
-  sgemm(state, sgemm_ukernel_6x8__neon, 6, 8, 8, 1);
+  sgemm(state, pytorch_sgemm_ukernel_6x8__neon, 6, 8, 8, 1);
 }
 
 BENCHMARK_CAPTURE(sgemm_5x8__neon, mobilenet_v1, "MobileNet v1")

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/configure.py
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/configure.py
@@ -72,7 +72,7 @@ def main(args):
                     build.cc("requantization/gemmlowp-neon.c"),
                 ]
 
-        qnnpack_objects = [
+        qnnpytorch_pack_objects = [
             # Common parts
             build.cc("init.c"),
             build.cc("operator-delete.c"),
@@ -97,7 +97,7 @@ def main(args):
         ]
 
         with build.options(isa=arm.neon if build.target.is_arm else None):
-            qnnpack_objects += [
+            qnnpytorch_pack_objects += [
                 build.cc("sconv/6x8-psimd.c"),
                 build.cc("sdwconv/up4x9-psimd.c"),
                 build.cc("sgemm/6x8-psimd.c"),
@@ -105,7 +105,7 @@ def main(args):
 
         with build.options(isa=arm.neon if build.target.is_arm else None):
             if build.target.is_arm or build.target.is_arm64:
-                qnnpack_objects += [
+                qnnpytorch_pack_objects += [
                     build.cc("q8avgpool/mp8x9p8q-neon.c"),
                     build.cc("q8avgpool/up8x9-neon.c"),
                     build.cc("q8avgpool/up8xm-neon.c"),
@@ -134,7 +134,7 @@ def main(args):
                     build.cc("x8zip/xm-neon.c"),
                 ]
             if build.target.is_arm:
-                qnnpack_objects += [
+                qnnpytorch_pack_objects += [
                     build.cc("hgemm/8x8-aarch32-neonfp16arith.S"),
                     build.cc("q8conv/4x8-aarch32-neon.S"),
                     build.cc("q8dwconv/up8x9-aarch32-neon.S"),
@@ -142,13 +142,13 @@ def main(args):
                     build.cc("q8gemm/4x8c2-xzp-aarch32-neon.S"),
                 ]
             if build.target.is_arm64:
-                qnnpack_objects += [
+                qnnpytorch_pack_objects += [
                     build.cc("q8gemm/8x8-aarch64-neon.S"),
                     build.cc("q8conv/8x8-aarch64-neon.S"),
                 ]
             if build.target.is_x86 or build.target.is_x86_64:
                 with build.options(isa=x86.sse2):
-                    qnnpack_objects += [
+                    qnnpytorch_pack_objects += [
                         build.cc("q8avgpool/mp8x9p8q-sse2.c"),
                         build.cc("q8avgpool/up8x9-sse2.c"),
                         build.cc("q8avgpool/up8xm-sse2.c"),
@@ -170,7 +170,7 @@ def main(args):
                         build.cc("x8zip/x4-sse2.c"),
                         build.cc("x8zip/xm-sse2.c"),
                     ]
-            build.static_library("qnnpack", qnnpack_objects)
+            build.static_library("qnnpack", qnnpytorch_pack_objects)
 
     with build.options(
         source_dir="test",

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/convolution.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/convolution.c
@@ -257,7 +257,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
 
       switch (kernel_size) {
         case 9:
-          pack_q8dw_w(
+          pytorch_pack_q8dw_w(
               kernel_height,
               kernel_width,
               groups,
@@ -272,7 +272,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
           break;
         case 25:
           /* change this later */
-          pack_q8dw_w_dilation(
+          pytorch_pack_q8dw_w_dilation(
               kernel_height,
               kernel_width,
               groups,
@@ -285,7 +285,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
               bias,
               convolution->packed_weights,
               true);
-          pack_q8dw_w_dilation(
+          pytorch_pack_q8dw_w_dilation(
               kernel_height,
               kernel_width,
               groups,
@@ -299,7 +299,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
               (char*)convolution->packed_weights +
                   (10 + sizeof(int32_t) / sizeof(uint8_t)) * c_stride,
               false);
-          pack_q8dw_w_dilation(
+          pytorch_pack_q8dw_w_dilation(
               kernel_height,
               kernel_width,
               groups,
@@ -349,7 +349,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
           convolution->packed_weights, 0, packed_group_weights_size * groups);
 
       for (uint32_t group = 0; group < groups; group++) {
-        pack_swizzle_q8gemm_b(
+        pytorch_pack_swizzle_q8gemm_b(
             group_output_channels,
             group_input_channels,
             nr,
@@ -390,7 +390,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
       switch (ukernel_type) {
         case pytorch_qnnp_ukernel_type_gemm:
           for (uint32_t group = 0; group < groups; group++) {
-            pack_q8gemm_w(
+            pytorch_pack_q8gemm_w(
                 group_output_channels,
                 group_input_channels,
                 nr,
@@ -407,7 +407,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_convolution2d_nhwc_q8(
           break;
         case pytorch_qnnp_ukernel_type_conv:
           for (uint32_t group = 0; group < groups; group++) {
-            pack_q8conv_w(
+            pytorch_pack_q8conv_w(
                 group_output_channels,
                 kernel_size,
                 group_input_channels,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/deconvolution.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/deconvolution.c
@@ -169,7 +169,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_deconvolution2d_nhwc_q8(
       packed_group_weights_size * groups);
 
   for (uint32_t group = 0; group < groups; group++) {
-    pack_q8deconv_w(
+    pytorch_pack_q8deconv_w(
         group_output_channels,
         kernel_size,
         group_input_channels,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/fully-connected.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/fully-connected.c
@@ -111,7 +111,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_fully_connected_nc_q8(
       kernel_zero_point,
       n_stride * (k_stride * sizeof(uint8_t) + sizeof(int32_t)));
 
-  pack_q8gemm_w(
+  pytorch_pack_q8gemm_w(
       output_channels,
       input_channels,
       nr,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/hgemm/8x8-aarch32-neonfp16arith.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/hgemm/8x8-aarch32-neonfp16arith.S
@@ -10,7 +10,7 @@
 
 .syntax unified
 
-# void hgemm_ukernel_8x8__aarch32_neonfp16arith(
+# void pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith(
 #     size_t mr,
 #     size_t nr,
 #     size_t k,
@@ -20,7 +20,7 @@
 #     __fp16*restrict c,
 #     size_t c_stride,
 #     const struct pytorch_qnnp_fp16_clamping_params clamping_params[restrict static 1])
-BEGIN_FUNCTION hgemm_ukernel_8x8__aarch32_neonfp16arith
+BEGIN_FUNCTION pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith
     .arm
 #ifndef __APPLE__
     .arch armv7-a
@@ -505,7 +505,7 @@ BEGIN_FUNCTION hgemm_ukernel_8x8__aarch32_neonfp16arith
     VPOP {d8-d15}
     POP {r4, r5, r6, r7, r8, r9, r10, r11}
     BX lr
-END_FUNCTION hgemm_ukernel_8x8__aarch32_neonfp16arith
+END_FUNCTION pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/hgemm/8x8-neonfp16arith.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/hgemm/8x8-neonfp16arith.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/hgemm.h>
 
-void hgemm_ukernel_8x8__neonfp16arith(
+void pytorch_hgemm_ukernel_8x8__neonfp16arith(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/init.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/init.c
@@ -50,16 +50,16 @@ static void init(void) {
         "QNNPACK initialization failed: NEON is not supported");
     return;
   }
-  pytorch_qnnp_params.q8conv = (struct q8conv_parameters){
-      .gemm = q8gemm_ukernel_4x8__aarch32_neon,
-      .conv = q8conv_ukernel_4x8__aarch32_neon,
+  pytorch_qnnp_params.q8conv = (struct pytorch_q8conv_parameters){
+      .gemm = pytorch_q8gemm_ukernel_4x8__aarch32_neon,
+      .conv = pytorch_q8conv_ukernel_4x8__aarch32_neon,
       .mr = 4,
       .nr = 8,
       .kr = 1,
   };
 #if !PYTORCH_QNNPACK_RUNTIME_QUANTIZATION
-  pytorch_qnnp_params.q8conv_xzp = (struct q8conv_xzp_parameters){
-      .gemm = q8gemm_xzp_ukernel_4x8c2__aarch32_neon,
+  pytorch_qnnp_params.q8conv_xzp = (struct pytorch_q8conv_xzp_parameters){
+      .gemm = pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon,
       .mr = 4,
       .nr = 8,
       .kr = 2,
@@ -84,164 +84,164 @@ static void init(void) {
       break;
   }
 #else
-  pytorch_qnnp_params.q8conv_xzp = (struct q8conv_xzp_parameters){
+  pytorch_qnnp_params.q8conv_xzp = (struct pytorch_q8conv_xzp_parameters){
       .kthreshold = SIZE_MAX,
   };
 #endif
-  pytorch_qnnp_params.q8dw9 = (struct q8dwconv_up_parameters){
-      .updw = q8dwconv_ukernel_up8x9__aarch32_neon,
+  pytorch_qnnp_params.q8dw9 = (struct pytorch_q8dwconv_up_parameters){
+      .updw = pytorch_q8dwconv_ukernel_up8x9__aarch32_neon,
       .cr = 8,
   };
-  pytorch_qnnp_params.q8dw25 = (struct q8dwconv_mp_parameters){
-      .mpdw = q8dwconv_ukernel_mp8x25__neon,
+  pytorch_qnnp_params.q8dw25 = (struct pytorch_q8dwconv_mp_parameters){
+      .mpdw = pytorch_q8dwconv_ukernel_mp8x25__neon,
       .cr = 8,
   };
-  pytorch_qnnp_params.q8sum_rows = (struct q8sum_rows_parameters){
-      .sum_rows = q8sumrows_ukernel_4x__neon,
+  pytorch_qnnp_params.q8sum_rows = (struct pytorch_q8sum_rows_parameters){
+      .sum_rows = pytorch_q8sumrows_ukernel_4x__neon,
       .m = 4,
   };
-  pytorch_qnnp_params.q8vadd = q8vadd_ukernel__neon;
-  pytorch_qnnp_params.q8gavgpool = (struct q8gavgpool_parameters){
-      .ltnr = q8gavgpool_ukernel_up8xm__neon,
-      .genr_lemr = q8gavgpool_ukernel_up8x7__neon,
-      .genr_gtmr = q8gavgpool_ukernel_mp8x7p7q__neon,
+  pytorch_qnnp_params.q8vadd = pytorch_q8vadd_ukernel__neon;
+  pytorch_qnnp_params.q8gavgpool = (struct pytorch_q8gavgpool_parameters){
+      .ltnr = pytorch_q8gavgpool_ukernel_up8xm__neon,
+      .genr_lemr = pytorch_q8gavgpool_ukernel_up8x7__neon,
+      .genr_gtmr = pytorch_q8gavgpool_ukernel_mp8x7p7q__neon,
       .mr = 7,
       .nr = 8,
   };
-  pytorch_qnnp_params.q8avgpool = (struct q8avgpool_parameters){
-      .ltkr = q8avgpool_ukernel_up8xm__neon,
-      .gekr_lemr = q8avgpool_ukernel_up8x9__neon,
-      .gekr_gtmr = q8avgpool_ukernel_mp8x9p8q__neon,
+  pytorch_qnnp_params.q8avgpool = (struct pytorch_q8avgpool_parameters){
+      .ltkr = pytorch_q8avgpool_ukernel_up8xm__neon,
+      .gekr_lemr = pytorch_q8avgpool_ukernel_up8x9__neon,
+      .gekr_gtmr = pytorch_q8avgpool_ukernel_mp8x9p8q__neon,
       .mr = 9,
       .qr = 8,
       .kr = 8,
   };
-  pytorch_qnnp_params.u8maxpool = (struct u8maxpool_parameters){
-      .ltkr = u8maxpool_ukernel_sub16__neon,
-      .gekr = u8maxpool_ukernel_16x9p8q__neon,
+  pytorch_qnnp_params.u8maxpool = (struct pytorch_u8maxpool_parameters){
+      .ltkr = pytorch_u8maxpool_ukernel_sub16__neon,
+      .gekr = pytorch_u8maxpool_ukernel_16x9p8q__neon,
       .mr = 9,
       .qr = 8,
       .kr = 16,
   };
-  pytorch_qnnp_params.x8zip = (struct x8zip_parameters){
+  pytorch_qnnp_params.x8zip = (struct pytorch_x8zip_parameters){
       .x2 = pytorch_qnnp_x8zip_x2__neon,
       .x3 = pytorch_qnnp_x8zip_x3__neon,
       .x4 = pytorch_qnnp_x8zip_x4__neon,
       .xm = pytorch_qnnp_x8zip_xm__neon,
   };
-  pytorch_qnnp_params.u8clamp = u8clamp_ukernel__neon;
-  pytorch_qnnp_params.u8rmax = u8rmax_ukernel__neon;
-  pytorch_qnnp_params.u8lut32norm = u8lut32norm_ukernel__scalar;
-  pytorch_qnnp_params.x8lut = x8lut_ukernel__scalar;
+  pytorch_qnnp_params.u8clamp = pytorch_u8clamp_ukernel__neon;
+  pytorch_qnnp_params.u8rmax = pytorch_u8rmax_ukernel__neon;
+  pytorch_qnnp_params.u8lut32norm = pytorch_u8lut32norm_ukernel__scalar;
+  pytorch_qnnp_params.x8lut = pytorch_x8lut_ukernel__scalar;
 #elif CPUINFO_ARCH_ARM64
-  pytorch_qnnp_params.q8conv = (struct q8conv_parameters){
-      .gemm = q8gemm_ukernel_8x8__aarch64_neon,
-      .conv = q8conv_ukernel_8x8__aarch64_neon,
+  pytorch_qnnp_params.q8conv = (struct pytorch_q8conv_parameters){
+      .gemm = pytorch_q8gemm_ukernel_8x8__aarch64_neon,
+      .conv = pytorch_q8conv_ukernel_8x8__aarch64_neon,
       .mr = 8,
       .nr = 8,
       .kr = 1,
   };
-  pytorch_qnnp_params.q8conv_xzp = (struct q8conv_xzp_parameters){
+  pytorch_qnnp_params.q8conv_xzp = (struct pytorch_q8conv_xzp_parameters){
       .kthreshold = SIZE_MAX,
   };
-  pytorch_qnnp_params.q8dw9 = (struct q8dwconv_up_parameters){
-      .updw = q8dwconv_ukernel_up8x9__neon,
+  pytorch_qnnp_params.q8dw9 = (struct pytorch_q8dwconv_up_parameters){
+      .updw = pytorch_q8dwconv_ukernel_up8x9__neon,
       .cr = 8,
   };
-  pytorch_qnnp_params.q8dw25 = (struct q8dwconv_mp_parameters){
-      .mpdw = q8dwconv_ukernel_mp8x25__neon,
+  pytorch_qnnp_params.q8dw25 = (struct pytorch_q8dwconv_mp_parameters){
+      .mpdw = pytorch_q8dwconv_ukernel_mp8x25__neon,
       .cr = 8,
   };
-  pytorch_qnnp_params.q8vadd = q8vadd_ukernel__neon;
-  pytorch_qnnp_params.q8gavgpool = (struct q8gavgpool_parameters){
-      .ltnr = q8gavgpool_ukernel_up8xm__neon,
-      .genr_lemr = q8gavgpool_ukernel_up8x7__neon,
-      .genr_gtmr = q8gavgpool_ukernel_mp8x7p7q__neon,
+  pytorch_qnnp_params.q8vadd = pytorch_q8vadd_ukernel__neon;
+  pytorch_qnnp_params.q8gavgpool = (struct pytorch_q8gavgpool_parameters){
+      .ltnr = pytorch_q8gavgpool_ukernel_up8xm__neon,
+      .genr_lemr = pytorch_q8gavgpool_ukernel_up8x7__neon,
+      .genr_gtmr = pytorch_q8gavgpool_ukernel_mp8x7p7q__neon,
       .mr = 7,
       .nr = 8,
   };
-  pytorch_qnnp_params.q8avgpool = (struct q8avgpool_parameters){
-      .ltkr = q8avgpool_ukernel_up8xm__neon,
-      .gekr_lemr = q8avgpool_ukernel_up8x9__neon,
-      .gekr_gtmr = q8avgpool_ukernel_mp8x9p8q__neon,
+  pytorch_qnnp_params.q8avgpool = (struct pytorch_q8avgpool_parameters){
+      .ltkr = pytorch_q8avgpool_ukernel_up8xm__neon,
+      .gekr_lemr = pytorch_q8avgpool_ukernel_up8x9__neon,
+      .gekr_gtmr = pytorch_q8avgpool_ukernel_mp8x9p8q__neon,
       .mr = 9,
       .qr = 8,
       .kr = 8,
   };
-  pytorch_qnnp_params.u8maxpool = (struct u8maxpool_parameters){
-      .ltkr = u8maxpool_ukernel_sub16__neon,
-      .gekr = u8maxpool_ukernel_16x9p8q__neon,
+  pytorch_qnnp_params.u8maxpool = (struct pytorch_u8maxpool_parameters){
+      .ltkr = pytorch_u8maxpool_ukernel_sub16__neon,
+      .gekr = pytorch_u8maxpool_ukernel_16x9p8q__neon,
       .mr = 9,
       .qr = 8,
       .kr = 16,
   };
-  pytorch_qnnp_params.x8zip = (struct x8zip_parameters){
+  pytorch_qnnp_params.x8zip = (struct pytorch_x8zip_parameters){
       .x2 = pytorch_qnnp_x8zip_x2__neon,
       .x3 = pytorch_qnnp_x8zip_x3__neon,
       .x4 = pytorch_qnnp_x8zip_x4__neon,
       .xm = pytorch_qnnp_x8zip_xm__neon,
   };
-  pytorch_qnnp_params.u8clamp = u8clamp_ukernel__neon;
-  pytorch_qnnp_params.u8rmax = u8rmax_ukernel__neon;
-  pytorch_qnnp_params.u8lut32norm = u8lut32norm_ukernel__scalar;
-  pytorch_qnnp_params.x8lut = x8lut_ukernel__scalar;
+  pytorch_qnnp_params.u8clamp = pytorch_u8clamp_ukernel__neon;
+  pytorch_qnnp_params.u8rmax = pytorch_u8rmax_ukernel__neon;
+  pytorch_qnnp_params.u8lut32norm = pytorch_u8lut32norm_ukernel__scalar;
+  pytorch_qnnp_params.x8lut = pytorch_x8lut_ukernel__scalar;
 #elif CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
   if (!cpuinfo_has_x86_sse2()) {
     pytorch_qnnp_log_error(
         "QNNPACK initialization failed: SSE2 is not supported");
     return;
   }
-  pytorch_qnnp_params.q8conv = (struct q8conv_parameters){
-      .gemm = q8gemm_ukernel_4x4c2__sse2,
-      .conv = q8conv_ukernel_4x4c2__sse2,
+  pytorch_qnnp_params.q8conv = (struct pytorch_q8conv_parameters){
+      .gemm = pytorch_q8gemm_ukernel_4x4c2__sse2,
+      .conv = pytorch_q8conv_ukernel_4x4c2__sse2,
       .mr = 4,
       .nr = 4,
       .kr = 2,
   };
-  pytorch_qnnp_params.q8conv_xzp = (struct q8conv_xzp_parameters){
+  pytorch_qnnp_params.q8conv_xzp = (struct pytorch_q8conv_xzp_parameters){
       .kthreshold = SIZE_MAX,
   };
-  pytorch_qnnp_params.q8dw9 = (struct q8dwconv_up_parameters){
-      .updw = q8dwconv_ukernel_up8x9__sse2,
+  pytorch_qnnp_params.q8dw9 = (struct pytorch_q8dwconv_up_parameters){
+      .updw = pytorch_q8dwconv_ukernel_up8x9__sse2,
       .cr = 8,
   };
-  pytorch_qnnp_params.q8dw25 = (struct q8dwconv_mp_parameters){
-      .mpdw = q8dwconv_ukernel_mp8x25__sse2,
+  pytorch_qnnp_params.q8dw25 = (struct pytorch_q8dwconv_mp_parameters){
+      .mpdw = pytorch_q8dwconv_ukernel_mp8x25__sse2,
       .cr = 8,
   };
-  pytorch_qnnp_params.q8vadd = q8vadd_ukernel__sse2;
-  pytorch_qnnp_params.q8gavgpool = (struct q8gavgpool_parameters){
-      .ltnr = q8gavgpool_ukernel_up8xm__sse2,
-      .genr_lemr = q8gavgpool_ukernel_up8x7__sse2,
-      .genr_gtmr = q8gavgpool_ukernel_mp8x7p7q__sse2,
+  pytorch_qnnp_params.q8vadd = pytorch_q8vadd_ukernel__sse2;
+  pytorch_qnnp_params.q8gavgpool = (struct pytorch_q8gavgpool_parameters){
+      .ltnr = pytorch_q8gavgpool_ukernel_up8xm__sse2,
+      .genr_lemr = pytorch_q8gavgpool_ukernel_up8x7__sse2,
+      .genr_gtmr = pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2,
       .mr = 7,
       .nr = 8,
   };
-  pytorch_qnnp_params.q8avgpool = (struct q8avgpool_parameters){
-      .ltkr = q8avgpool_ukernel_up8xm__sse2,
-      .gekr_lemr = q8avgpool_ukernel_up8x9__sse2,
-      .gekr_gtmr = q8avgpool_ukernel_mp8x9p8q__sse2,
+  pytorch_qnnp_params.q8avgpool = (struct pytorch_q8avgpool_parameters){
+      .ltkr = pytorch_q8avgpool_ukernel_up8xm__sse2,
+      .gekr_lemr = pytorch_q8avgpool_ukernel_up8x9__sse2,
+      .gekr_gtmr = pytorch_q8avgpool_ukernel_mp8x9p8q__sse2,
       .mr = 9,
       .qr = 8,
       .kr = 8,
   };
-  pytorch_qnnp_params.u8maxpool = (struct u8maxpool_parameters){
-      .ltkr = u8maxpool_ukernel_sub16__sse2,
-      .gekr = u8maxpool_ukernel_16x9p8q__sse2,
+  pytorch_qnnp_params.u8maxpool = (struct pytorch_u8maxpool_parameters){
+      .ltkr = pytorch_u8maxpool_ukernel_sub16__sse2,
+      .gekr = pytorch_u8maxpool_ukernel_16x9p8q__sse2,
       .mr = 9,
       .qr = 8,
       .kr = 16,
   };
-  pytorch_qnnp_params.x8zip = (struct x8zip_parameters){
+  pytorch_qnnp_params.x8zip = (struct pytorch_x8zip_parameters){
       .x2 = pytorch_qnnp_x8zip_x2__sse2,
       .x3 = pytorch_qnnp_x8zip_x3__sse2,
       .x4 = pytorch_qnnp_x8zip_x4__sse2,
       .xm = pytorch_qnnp_x8zip_xm__sse2,
   };
-  pytorch_qnnp_params.u8clamp = u8clamp_ukernel__sse2;
-  pytorch_qnnp_params.u8rmax = u8rmax_ukernel__sse2;
-  pytorch_qnnp_params.u8lut32norm = u8lut32norm_ukernel__scalar;
-  pytorch_qnnp_params.x8lut = x8lut_ukernel__scalar;
+  pytorch_qnnp_params.u8clamp = pytorch_u8clamp_ukernel__sse2;
+  pytorch_qnnp_params.u8rmax = pytorch_u8rmax_ukernel__sse2;
+  pytorch_qnnp_params.u8lut32norm = pytorch_u8lut32norm_ukernel__scalar;
+  pytorch_qnnp_params.x8lut = pytorch_x8lut_ukernel__scalar;
 #else
 #error "Unsupported architecture"
 #endif

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/operator-run.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/operator-run.c
@@ -33,7 +33,7 @@ struct q8gemm_context {
   uint8_t* c;
   size_t c_stride;
   union pytorch_qnnp_conv_quantization_params quantization_params;
-  const q8gemm_ukernel_function ukernel;
+  const pytorch_q8gemm_ukernel_function ukernel;
 };
 
 static void compute_q8gemm(
@@ -78,7 +78,7 @@ struct q8sum_rows_context {
   const int32_t multiplier;
   int32_t* a_sum;
   size_t a_sum_stride;
-  const q8sum_rows_ukernel_function ukernel;
+  const pytorch_q8sum_rows_ukernel_function ukernel;
 };
 
 static void compute_sum_rows(
@@ -123,7 +123,7 @@ struct q8gemm_xzp_context {
   size_t batch_size;
   size_t a_sum_stride;
   union pytorch_qnnp_q31_requantization_params requantization_params;
-  const q8gemm_xzp_ukernel_function ukernel;
+  const pytorch_q8gemm_xzp_ukernel_function ukernel;
 };
 
 static void compute_q8gemm_xzp(
@@ -178,7 +178,7 @@ struct q8conv_context {
   uint8_t* c;
   size_t c_stride;
   union pytorch_qnnp_conv_quantization_params quantization_params;
-  const q8conv_ukernel_function ukernel;
+  const pytorch_q8conv_ukernel_function ukernel;
 };
 
 static void compute_q8conv(
@@ -232,8 +232,8 @@ struct q8dwconv_context {
   size_t output_col_increment;
   union pytorch_qnnp_conv_quantization_params quantization_params;
   union {
-    const q8dwconv_up_ukernel_function unipass_ukernel;
-    const q8dwconv_mp_ukernel_function multipass_ukernel;
+    const pytorch_q8dwconv_up_ukernel_function unipass_ukernel;
+    const pytorch_q8dwconv_mp_ukernel_function multipass_ukernel;
   };
 };
 
@@ -301,7 +301,7 @@ struct max_pooling_context {
   size_t input_increment;
   size_t output_increment;
   union pytorch_qnnp_u8_clamping_params params;
-  u8maxpool_ukernel_function ukernel;
+  pytorch_u8maxpool_ukernel_function ukernel;
 };
 
 static void compute_max_pooling(
@@ -341,8 +341,8 @@ struct average_pooling_context {
   size_t output_increment;
   union pytorch_qnnp_avgpool_quantization_params quantization_params;
   union {
-    q8avgpool_up_ukernel_function unipass_ukernel;
-    q8avgpool_mp_ukernel_function multipass_ukernel;
+    pytorch_q8avgpool_up_ukernel_function unipass_ukernel;
+    pytorch_q8avgpool_mp_ukernel_function multipass_ukernel;
   };
 };
 
@@ -414,8 +414,8 @@ struct global_average_pooling_context {
   size_t output_batch_stride;
   union pytorch_qnnp_avgpool_quantization_params quantization_params;
   union {
-    q8gavgpool_up_ukernel_function unipass_ukernel;
-    q8gavgpool_mp_ukernel_function multipass_ukernel;
+    pytorch_q8gavgpool_up_ukernel_function unipass_ukernel;
+    pytorch_q8gavgpool_mp_ukernel_function multipass_ukernel;
   };
 };
 
@@ -476,7 +476,7 @@ struct q8add_strided_context {
   const uint8_t* y;
   size_t y_stride;
   union pytorch_qnnp_add_quantization_params quantization_params;
-  q8vadd_ukernel_function ukernel;
+  pytorch_q8vadd_ukernel_function ukernel;
 };
 
 static void compute_q8add_strided(
@@ -503,7 +503,7 @@ struct q8add_contiguous_context {
   const uint8_t* b;
   uint8_t* y;
   union pytorch_qnnp_add_quantization_params quantization_params;
-  q8vadd_ukernel_function ukernel;
+  pytorch_q8vadd_ukernel_function ukernel;
 };
 
 static void compute_q8add_contiguous(
@@ -524,8 +524,8 @@ struct channel_shuffle_context {
   size_t n;
   size_t m;
   union {
-    xzipc_ukernel_function fixed_ukernel;
-    xzipv_ukernel_function variable_ukernel;
+    pytorch_xzipc_ukernel_function fixed_ukernel;
+    pytorch_xzipv_ukernel_function variable_ukernel;
   };
 };
 
@@ -556,7 +556,7 @@ struct lut_strided_context {
   const void* t;
   void* y;
   size_t y_stride;
-  x8lut_ukernel_function ukernel;
+  pytorch_x8lut_ukernel_function ukernel;
 };
 
 static void compute_lut_strided(
@@ -575,7 +575,7 @@ struct lut_contiguous_context {
   const void* t;
   void* y;
   size_t y_stride;
-  x8lut_ukernel_function ukernel;
+  pytorch_x8lut_ukernel_function ukernel;
 };
 
 static void compute_lut_contiguous(
@@ -594,7 +594,7 @@ struct clamp_strided_context {
   size_t x_stride;
   void* y;
   size_t y_stride;
-  u8clamp_ukernel_function ukernel;
+  pytorch_u8clamp_ukernel_function ukernel;
   union pytorch_qnnp_u8_clamping_params params;
 };
 
@@ -612,7 +612,7 @@ struct clamp_contiguous_context {
   size_t x_stride;
   void* y;
   size_t y_stride;
-  u8clamp_ukernel_function ukernel;
+  pytorch_u8clamp_ukernel_function ukernel;
   union pytorch_qnnp_u8_clamping_params params;
 };
 
@@ -632,8 +632,8 @@ struct u8softargmax_context {
   const uint32_t* t;
   uint8_t* y;
   size_t y_stride;
-  u8rmax_ukernel_function rmax_ukernel;
-  u8lut32norm_ukernel_function lut_norm_ukernel;
+  pytorch_u8rmax_ukernel_function rmax_ukernel;
+  pytorch_u8lut32norm_ukernel_function lut_norm_ukernel;
 };
 
 static void compute_u8softargmax(

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/mp8x9p8q-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/mp8x9p8q-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8avgpool.h>
 
-void q8avgpool_ukernel_mp8x9p8q__neon(
+void pytorch_q8avgpool_ukernel_mp8x9p8q__neon(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/mp8x9p8q-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/mp8x9p8q-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8avgpool.h>
 
-void q8avgpool_ukernel_mp8x9p8q__sse2(
+void pytorch_q8avgpool_ukernel_mp8x9p8q__sse2(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8x9-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8x9-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8avgpool.h>
 
-void q8avgpool_ukernel_up8x9__neon(
+void pytorch_q8avgpool_ukernel_up8x9__neon(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8x9-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8x9-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8avgpool.h>
 
-void q8avgpool_ukernel_up8x9__sse2(
+void pytorch_q8avgpool_ukernel_up8x9__sse2(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8xm-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8xm-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8avgpool.h>
 
-void q8avgpool_ukernel_up8xm__neon(
+void pytorch_q8avgpool_ukernel_up8xm__neon(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8xm-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8avgpool/up8xm-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8avgpool.h>
 
-void q8avgpool_ukernel_up8xm__sse2(
+void pytorch_q8avgpool_ukernel_up8xm__sse2(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x4c2-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x4c2-sse2.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8conv.h>
 #include <requantization/runtime-sse2.h>
 
-void q8conv_ukernel_4x4c2__sse2(
+void pytorch_q8conv_ukernel_4x4c2__sse2(
     size_t mr,
     size_t nr,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x8-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x8-aarch32-neon.S
@@ -11,7 +11,7 @@
 
 .syntax unified
 
-# void q8conv_ukernel_4x8__aarch32_neon(
+# void pytorch_q8conv_ukernel_4x8__aarch32_neon(
 #     size_t mr,
 #     size_t nr,
 #     size_t kc,
@@ -21,7 +21,7 @@
 #     uint8_t*restrict c,
 #     size_t c_stride,
 #     const union pytorch_qnnp_conv_quantization_params quantization_params[restrict static 1])
-BEGIN_FUNCTION q8conv_ukernel_4x8__aarch32_neon
+BEGIN_FUNCTION pytorch_q8conv_ukernel_4x8__aarch32_neon
     .arm
 #ifndef __APPLE__
     .arch armv7-a
@@ -786,7 +786,7 @@ BEGIN_FUNCTION q8conv_ukernel_4x8__aarch32_neon
     VPOP {d8-d15}
     POP {r4, r5, r6, r7, r8, r9, r10, r11}
     BX lr
-END_FUNCTION q8conv_ukernel_4x8__aarch32_neon
+END_FUNCTION pytorch_q8conv_ukernel_4x8__aarch32_neon
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/4x8-neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8conv.h>
 #include <requantization/runtime-neon.h>
 
-void q8conv_ukernel_4x8__neon(
+void pytorch_q8conv_ukernel_4x8__neon(
     size_t mr,
     size_t nr,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-aarch64-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-aarch64-neon.S
@@ -10,7 +10,7 @@
 #include <requantization/runtime-assembly.h>
 
 
-# void q8conv_ukernel_8x8__aarch64_neon(
+# void pytorch_q8conv_ukernel_8x8__aarch64_neon(
 #    size_t mr,
 #    size_t nr,
 #    size_t kc,
@@ -20,7 +20,7 @@
 #    uint8_t* restrict c,
 #    size_t c_stride,
 #    const union pytorch_qnnp_q31_requantization_params quantization_params[restrict static 1])
-BEGIN_FUNCTION q8conv_ukernel_8x8__aarch64_neon
+BEGIN_FUNCTION pytorch_q8conv_ukernel_8x8__aarch64_neon
     # Load params
     LDR x8, [sp]
 
@@ -758,7 +758,7 @@ BEGIN_FUNCTION q8conv_ukernel_8x8__aarch64_neon
 
     RET
 
-END_FUNCTION q8conv_ukernel_8x8__aarch64_neon
+END_FUNCTION pytorch_q8conv_ukernel_8x8__aarch64_neon
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8conv/8x8-neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8conv.h>
 #include <requantization/runtime-neon.h>
 
-void q8conv_ukernel_8x8__neon(
+void pytorch_q8conv_ukernel_8x8__neon(
     size_t mr,
     size_t nr,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/mp8x25-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/mp8x25-neon.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/q8dwconv.h>
 
-void q8dwconv_ukernel_mp8x25__neon(
+void pytorch_q8dwconv_ukernel_mp8x25__neon(
     size_t channels,
     size_t output_width,
     const uint8_t** input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/mp8x25-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/mp8x25-sse2.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/q8dwconv.h>
 
-void q8dwconv_ukernel_mp8x25__sse2(
+void pytorch_q8dwconv_ukernel_mp8x25__sse2(
     size_t channels,
     size_t output_width,
     const uint8_t** input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-aarch32-neon.S
@@ -11,7 +11,7 @@
 
 .syntax unified
 
-# void q8dwconv_ukernel_up8x9__aarch32_neon(
+# void pytorch_q8dwconv_ukernel_up8x9__aarch32_neon(
 #     size_t channels,
 #     size_t output_width,
 #     const uint8_t** input,
@@ -20,7 +20,7 @@
 #     size_t input_stride,
 #     size_t output_increment,
 #     const union pytorch_qnnp_conv_quantization_params quantization_params[restrict static 1])
-BEGIN_FUNCTION q8dwconv_ukernel_up8x9__aarch32_neon
+BEGIN_FUNCTION pytorch_q8dwconv_ukernel_up8x9__aarch32_neon
     .arm
 #ifndef __APPLE__
     .arch armv7-a
@@ -390,7 +390,7 @@ BEGIN_FUNCTION q8dwconv_ukernel_up8x9__aarch32_neon
 
     VPOP {d8-d15}
     POP {r4, r5, r6, r7, r8, r9, r10, r11, pc}
-END_FUNCTION q8dwconv_ukernel_up8x9__aarch32_neon
+END_FUNCTION pytorch_q8dwconv_ukernel_up8x9__aarch32_neon
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8dwconv.h>
 #include <requantization/runtime-neon.h>
 
-void q8dwconv_ukernel_up8x9__neon(
+void pytorch_q8dwconv_ukernel_up8x9__neon(
     size_t channels,
     size_t output_width,
     const uint8_t** input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8dwconv/up8x9-sse2.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8dwconv.h>
 #include <requantization/runtime-sse2.h>
 
-void q8dwconv_ukernel_up8x9__sse2(
+void pytorch_q8dwconv_ukernel_up8x9__sse2(
     size_t channels,
     size_t output_width,
     const uint8_t** input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/mp8x7p7q-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/mp8x7p7q-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8gavgpool.h>
 
-void q8gavgpool_ukernel_mp8x7p7q__neon(
+void pytorch_q8gavgpool_ukernel_mp8x7p7q__neon(
     size_t m,
     size_t n,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/mp8x7p7q-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/mp8x7p7q-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8gavgpool.h>
 
-void q8gavgpool_ukernel_mp8x7p7q__sse2(
+void pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2(
     size_t m,
     size_t n,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8x7-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8x7-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8gavgpool.h>
 
-void q8gavgpool_ukernel_up8x7__neon(
+void pytorch_q8gavgpool_ukernel_up8x7__neon(
     size_t m,
     size_t n,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8x7-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8x7-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8gavgpool.h>
 
-void q8gavgpool_ukernel_up8x7__sse2(
+void pytorch_q8gavgpool_ukernel_up8x7__sse2(
     size_t m,
     size_t n,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8xm-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8xm-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8gavgpool.h>
 
-void q8gavgpool_ukernel_up8xm__neon(
+void pytorch_q8gavgpool_ukernel_up8xm__neon(
     size_t m,
     size_t n,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8xm-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gavgpool/up8xm-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/q8gavgpool.h>
 
-void q8gavgpool_ukernel_up8xm__sse2(
+void pytorch_q8gavgpool_ukernel_up8xm__sse2(
     size_t m,
     size_t n,
     const uint8_t* input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/2x4c8-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/2x4c8-sse2.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8gemm.h>
 #include <requantization/runtime-sse2.h>
 
-static inline __m128i sse_reduce4_i32(
+static inline __m128i pytorch_sse_reduce4_i32(
     __m128i x,
     __m128i y,
     __m128i z,
@@ -38,7 +38,7 @@ static inline __m128i sse_reduce4_i32(
 #endif
 }
 
-void q8gemm_ukernel_2x4c8__sse2(
+void pytorch_q8gemm_ukernel_2x4c8__sse2(
     size_t mr,
     size_t nr,
     size_t k,
@@ -161,8 +161,8 @@ void q8gemm_ukernel_2x4c8__sse2(
     vacc13 = _mm_add_epi32(vacc13, _mm_madd_epi16(vxa1, vxb3));
   }
 
-  __m128i vacc0x0123 = sse_reduce4_i32(vacc00, vacc01, vacc02, vacc03);
-  __m128i vacc1x0123 = sse_reduce4_i32(vacc10, vacc11, vacc12, vacc13);
+  __m128i vacc0x0123 = pytorch_sse_reduce4_i32(vacc00, vacc01, vacc02, vacc03);
+  __m128i vacc1x0123 = pytorch_sse_reduce4_i32(vacc10, vacc11, vacc12, vacc13);
 
   const __m128i vmultiplier =
       _mm_load_si128((const __m128i*)quantization_params->sse2.multiplier);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x-sumrows-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x-sumrows-neon.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/q8gemm.h>
 
-void q8sumrows_ukernel_4x__neon(
+void pytorch_q8sumrows_ukernel_4x__neon(
     const uint8_t* restrict a,
     size_t m,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x4c2-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x4c2-sse2.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8gemm.h>
 #include <requantization/runtime-sse2.h>
 
-void q8gemm_ukernel_4x4c2__sse2(
+void pytorch_q8gemm_ukernel_4x4c2__sse2(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-aarch32-neon.S
@@ -11,7 +11,7 @@
 
 .syntax unified
 
-# void q8gemm_ukernel_4x8__aarch32_neon(
+# void pytorch_q8gemm_ukernel_4x8__aarch32_neon(
 #     size_t mr,
 #     size_t nr,
 #     size_t k,
@@ -21,7 +21,7 @@
 #     uint8_t*restrict c,
 #     size_t c_stride,
 #     const union pytorch_qnnp_conv_quantization_params quantization_params[restrict static 1])
-BEGIN_FUNCTION q8gemm_ukernel_4x8__aarch32_neon
+BEGIN_FUNCTION pytorch_q8gemm_ukernel_4x8__aarch32_neon
     .arm
 #ifndef __APPLE__
     .arch armv7-a
@@ -788,7 +788,7 @@ BEGIN_FUNCTION q8gemm_ukernel_4x8__aarch32_neon
     VPOP {d8-d15}
     POP {r4, r5, r6, r7}
     BX lr
-END_FUNCTION q8gemm_ukernel_4x8__aarch32_neon
+END_FUNCTION pytorch_q8gemm_ukernel_4x8__aarch32_neon
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8-neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8gemm.h>
 #include <requantization/runtime-neon.h>
 
-void q8gemm_ukernel_4x8__neon(
+void pytorch_q8gemm_ukernel_4x8__neon(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8c2-xzp-aarch32-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8c2-xzp-aarch32-neon.S
@@ -10,7 +10,7 @@
 
 .syntax unified
 
-# void q8gemm_xzp_ukernel_4x8c2__neon(
+# void pytorch_q8gemm_xzp_ukernel_4x8c2__neon(
 #     size_t mr,
 #     size_t nr,
 #     size_t k,
@@ -21,7 +21,7 @@
 #     uint8_t* restrict c,
 #     size_t c_stride,
 #     const union pytorch_qnnp_q31_requantization_params requantization_params[restrict static 1])
-BEGIN_FUNCTION q8gemm_xzp_ukernel_4x8c2__aarch32_neon
+BEGIN_FUNCTION pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon
     .arm
 #ifndef __APPLE__
     .arch armv7-a
@@ -611,7 +611,7 @@ BEGIN_FUNCTION q8gemm_xzp_ukernel_4x8c2__aarch32_neon
     POP {r4, r5, r6, r7, r8, r9, r10, r11}
     BX lr
 
-END_FUNCTION q8gemm_xzp_ukernel_4x8c2__aarch32_neon
+END_FUNCTION pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8c2-xzp-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/4x8c2-xzp-neon.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/q8gemm.h>
 
-void q8gemm_xzp_ukernel_4x8c2__neon(
+void pytorch_q8gemm_xzp_ukernel_4x8c2__neon(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/6x4-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/6x4-neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8gemm.h>
 #include <requantization/runtime-neon.h>
 
-void q8gemm_ukernel_6x4__neon(
+void pytorch_q8gemm_ukernel_6x4__neon(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-aarch64-neon.S
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-aarch64-neon.S
@@ -10,7 +10,7 @@
 #include <requantization/runtime-assembly.h>
 
 
-# void q8gemm_ukernel_8x8__aarch64_neon(
+# void pytorch_q8gemm_ukernel_8x8__aarch64_neon(
 #     size_t mr,
 #     size_t nr,
 #     size_t k,
@@ -20,7 +20,7 @@
 #     uint8_t*restrict c,
 #     size_t c_stride,
 #     const union pytorch_qnnp_conv_quantization_params quantization_params[restrict static 1])
-BEGIN_FUNCTION q8gemm_ukernel_8x8__aarch64_neon
+BEGIN_FUNCTION pytorch_q8gemm_ukernel_8x8__aarch64_neon
 
     STP d15, d14, [sp, -16]
     STP d13, d12, [sp, -32]
@@ -773,7 +773,7 @@ BEGIN_FUNCTION q8gemm_ukernel_8x8__aarch64_neon
 
     RET
 
-END_FUNCTION q8gemm_ukernel_8x8__aarch64_neon
+END_FUNCTION pytorch_q8gemm_ukernel_8x8__aarch64_neon
 
 #ifdef __ELF__
 .section ".note.GNU-stack","",%progbits

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8gemm/8x8-neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/q8gemm.h>
 #include <requantization/runtime-neon.h>
 
-void q8gemm_ukernel_8x8__neon(
+void pytorch_q8gemm_ukernel_8x8__neon(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8vadd/neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8vadd/neon.c
@@ -11,7 +11,7 @@
 #include <qnnpack/common.h>
 #include <qnnpack/q8vadd.h>
 
-void q8vadd_ukernel__neon(
+void pytorch_q8vadd_ukernel__neon(
     size_t n,
     const uint8_t* a,
     const uint8_t* b,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8vadd/sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/q8vadd/sse2.c
@@ -12,7 +12,7 @@
 #include <qnnpack/q8vadd.h>
 #include <qnnpack/scalar-utils.h>
 
-void q8vadd_ukernel__sse2(
+void pytorch_q8vadd_ukernel__sse2(
     size_t n,
     const uint8_t* a,
     const uint8_t* b,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/hgemm.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/hgemm.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_HGEMM_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_HGEMM_UKERNEL_FUNCTION(fn_name) \
   void fn_name(                                 \
       size_t mr,                                \
       size_t nr,                                \
@@ -29,8 +29,8 @@ extern "C" {
       size_t c_stride,                          \
       const struct pytorch_qnnp_fp16_clamping_params* clamping_params);
 
-DECLARE_HGEMM_UKERNEL_FUNCTION(hgemm_ukernel_8x8__neonfp16arith)
-DECLARE_HGEMM_UKERNEL_FUNCTION(hgemm_ukernel_8x8__aarch32_neonfp16arith)
+PYTORCH_DECLARE_HGEMM_UKERNEL_FUNCTION(pytorch_hgemm_ukernel_8x8__neonfp16arith)
+PYTORCH_DECLARE_HGEMM_UKERNEL_FUNCTION(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/pack.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/pack.h
@@ -13,7 +13,7 @@
 //  dq: Design-time Quantization
 //  rq: Run-time Quantization
 
-static inline void pack_q8gemm_wdq(
+static inline void pytorch_pack_q8gemm_wdq(
     size_t nc,
     size_t kc,
     uint32_t nr,
@@ -59,7 +59,7 @@ static inline void pack_q8gemm_wdq(
   }
 }
 
-static inline void pack_q8gemm_wrq(
+static inline void pytorch_pack_q8gemm_wrq(
     const size_t nc,
     const size_t kc,
     const uint32_t nr,
@@ -99,7 +99,7 @@ static inline void pack_q8gemm_wrq(
   }
 }
 
-static inline void pack_q8conv_wdq(
+static inline void pytorch_pack_q8conv_wdq(
     size_t n,
     size_t ks,
     size_t kc,
@@ -148,7 +148,7 @@ static inline void pack_q8conv_wdq(
   }
 }
 
-static inline void pack_q8conv_wrq(
+static inline void pytorch_pack_q8conv_wrq(
     const size_t n,
     const size_t ks,
     const size_t kc,
@@ -191,7 +191,7 @@ static inline void pack_q8conv_wrq(
   }
 }
 
-static inline void pack_q8deconv_wdq(
+static inline void pytorch_pack_q8deconv_wdq(
     size_t n,
     size_t ks,
     size_t kc,
@@ -240,7 +240,7 @@ static inline void pack_q8deconv_wdq(
   }
 }
 
-static inline void pack_q8deconv_wrq(
+static inline void pytorch_pack_q8deconv_wrq(
     const size_t n,
     const size_t ks,
     const size_t kc,
@@ -283,7 +283,7 @@ static inline void pack_q8deconv_wrq(
   }
 }
 
-static inline void pack_q8dw_wdq(
+static inline void pytorch_pack_q8dw_wdq(
     size_t h,
     size_t w,
     size_t c,
@@ -321,7 +321,7 @@ static inline void pack_q8dw_wdq(
   }
 }
 
-static inline void pack_q8dw_wrq(
+static inline void pytorch_pack_q8dw_wrq(
     const size_t h,
     const size_t w,
     const size_t c,
@@ -356,7 +356,7 @@ static inline void pack_q8dw_wrq(
   }
 }
 
-static inline void pack_q8dw_w_dilation(
+static inline void pytorch_pack_q8dw_w_dilation(
     size_t h,
     size_t w,
     size_t c,
@@ -368,10 +368,10 @@ static inline void pack_q8dw_w_dilation(
     const uint8_t* k,
     const int32_t* b,
     void* packed_w,
-    bool pack_b) {
+    bool pytorch_pack_b) {
   for (size_t cr_block_start = 0; cr_block_start < c; cr_block_start += cr) {
     const size_t cr_block_size = min(c - cr_block_start, cr);
-    if (pack_b) {
+    if (pytorch_pack_b) {
       for (size_t cr_block_offset = 0; cr_block_offset < cr_block_size;
            cr_block_offset++) {
         *((int32_t*)packed_w) = b[cr_block_start + cr_block_offset];
@@ -395,7 +395,7 @@ static inline void pack_q8dw_w_dilation(
   }
 }
 
-static inline void pack_swizzle_q8gemm_bdq(
+static inline void pytorch_pack_swizzle_q8gemm_bdq(
     size_t n,
     size_t kc,
     uint32_t nr,
@@ -461,7 +461,7 @@ static inline void pack_swizzle_q8gemm_bdq(
   }
 }
 
-static inline void pack_swizzle_q8gemm_brq(
+static inline void pytorch_pack_swizzle_q8gemm_brq(
     const size_t n,
     const size_t kc,
     const uint32_t nr,
@@ -521,7 +521,7 @@ static inline void pack_swizzle_q8gemm_brq(
   }
 }
 
-static inline void pack_hgemm_w(
+static inline void pytorch_pack_hgemm_w(
     size_t nc,
     size_t kc,
     size_t nr,
@@ -553,7 +553,7 @@ static inline void pack_hgemm_w(
   }
 }
 
-static inline void pack_sgemm_w(
+static inline void pytorch_pack_sgemm_w(
     size_t nc,
     size_t kc,
     size_t nr,
@@ -585,7 +585,7 @@ static inline void pack_sgemm_w(
   }
 }
 
-static inline void pack_sconv_w(
+static inline void pytorch_pack_sconv_w(
     size_t n,
     size_t ks,
     size_t kc,
@@ -623,18 +623,18 @@ static inline void pack_sconv_w(
 
 #if PYTORCH_QNNPACK_RUNTIME_QUANTIZATION
 
-#define pack_q8gemm_w pack_q8gemm_wrq
-#define pack_q8conv_w pack_q8conv_wrq
-#define pack_q8deconv_w pack_q8deconv_wrq
-#define pack_q8dw_w pack_q8dw_wrq
-#define pack_swizzle_q8gemm_b pack_swizzle_q8gemm_brq
+#define pytorch_pack_q8gemm_w pytorch_pack_q8gemm_wrq
+#define pytorch_pack_q8conv_w pytorch_pack_q8conv_wrq
+#define pytorch_pack_q8deconv_w pytorch_pack_q8deconv_wrq
+#define pytorch_pack_q8dw_w pytorch_pack_q8dw_wrq
+#define pytorch_pack_swizzle_q8gemm_b pytorch_pack_swizzle_q8gemm_brq
 
 #else
 
-#define pack_q8gemm_w pack_q8gemm_wdq
-#define pack_q8conv_w pack_q8conv_wdq
-#define pack_q8deconv_w pack_q8deconv_wdq
-#define pack_q8dw_w pack_q8dw_wdq
-#define pack_swizzle_q8gemm_b pack_swizzle_q8gemm_bdq
+#define pytorch_pack_q8gemm_w pytorch_pack_q8gemm_wdq
+#define pytorch_pack_q8conv_w pytorch_pack_q8conv_wdq
+#define pytorch_pack_q8deconv_w pytorch_pack_q8deconv_wdq
+#define pytorch_pack_q8dw_w pytorch_pack_q8dw_wdq
+#define pytorch_pack_swizzle_q8gemm_b pytorch_pack_swizzle_q8gemm_bdq
 
 #endif

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/params.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/params.h
@@ -263,7 +263,7 @@ union pytorch_qnnp_u8_clamping_params {
 #endif /* CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64 */
 };
 
-typedef void (*q8gemm_ukernel_function)(
+typedef void (*pytorch_q8gemm_ukernel_function)(
     size_t mr,
     size_t nr,
     size_t k,
@@ -274,7 +274,7 @@ typedef void (*q8gemm_ukernel_function)(
     size_t c_stride,
     const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-typedef void (*q8conv_ukernel_function)(
+typedef void (*pytorch_q8conv_ukernel_function)(
     size_t mr,
     size_t nr,
     size_t kc,
@@ -285,7 +285,7 @@ typedef void (*q8conv_ukernel_function)(
     size_t c_stride,
     const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-typedef void (*q8gemm_xzp_ukernel_function)(
+typedef void (*pytorch_q8gemm_xzp_ukernel_function)(
     size_t mr,
     size_t nr,
     size_t k,
@@ -297,7 +297,7 @@ typedef void (*q8gemm_xzp_ukernel_function)(
     size_t c_stride,
     const union pytorch_qnnp_q31_requantization_params* requantization_params);
 
-typedef void (*q8sum_rows_ukernel_function)(
+typedef void (*pytorch_q8sum_rows_ukernel_function)(
     const uint8_t* a,
     size_t m,
     size_t k,
@@ -305,18 +305,18 @@ typedef void (*q8sum_rows_ukernel_function)(
     int32_t multiplier,
     int32_t* sums);
 
-typedef void (*xzipc_ukernel_function)(size_t n, const void* x, void* y);
+typedef void (*pytorch_xzipc_ukernel_function)(size_t n, const void* x, void* y);
 
 typedef void (
-    *xzipv_ukernel_function)(size_t n, size_t m, const void* x, void* y);
+    *pytorch_xzipv_ukernel_function)(size_t n, size_t m, const void* x, void* y);
 
-typedef void (*x8lut_ukernel_function)(
+typedef void (*pytorch_x8lut_ukernel_function)(
     size_t n,
     const uint8_t* x,
     const uint8_t* t,
     uint8_t* y);
 
-typedef void (*sgemm_ukernel_function)(
+typedef void (*pytorch_sgemm_ukernel_function)(
     size_t mr,
     size_t nr,
     size_t k,
@@ -327,7 +327,7 @@ typedef void (*sgemm_ukernel_function)(
     size_t c_stride,
     const struct pytorch_qnnp_fp32_clamping_params* clamping_params);
 
-typedef void (*sconv_ukernel_function)(
+typedef void (*pytorch_sconv_ukernel_function)(
     size_t mr,
     size_t nr,
     size_t kc,
@@ -338,7 +338,7 @@ typedef void (*sconv_ukernel_function)(
     size_t c_stride,
     const struct pytorch_qnnp_fp32_clamping_params* clamping_params);
 
-typedef void (*hgemm_ukernel_function)(
+typedef void (*pytorch_hgemm_ukernel_function)(
     size_t mr,
     size_t nr,
     size_t k,
@@ -349,7 +349,7 @@ typedef void (*hgemm_ukernel_function)(
     size_t c_stride,
     const struct pytorch_qnnp_fp16_clamping_params* clamping_params);
 
-typedef void (*q8dwconv_up_ukernel_function)(
+typedef void (*pytorch_q8dwconv_up_ukernel_function)(
     size_t channels,
     size_t output_width,
     const uint8_t** input,
@@ -359,7 +359,7 @@ typedef void (*q8dwconv_up_ukernel_function)(
     size_t output_increment,
     const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-typedef void (*q8dwconv_mp_ukernel_function)(
+typedef void (*pytorch_q8dwconv_mp_ukernel_function)(
     size_t channels,
     size_t output_width,
     const uint8_t** input,
@@ -370,7 +370,7 @@ typedef void (*q8dwconv_mp_ukernel_function)(
     size_t output_increment,
     const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-typedef void (*q8gavgpool_up_ukernel_function)(
+typedef void (*pytorch_q8gavgpool_up_ukernel_function)(
     size_t m,
     size_t n,
     const uint8_t* x,
@@ -379,7 +379,7 @@ typedef void (*q8gavgpool_up_ukernel_function)(
     uint8_t* y,
     const union pytorch_qnnp_avgpool_quantization_params* quantization_params);
 
-typedef void (*q8gavgpool_mp_ukernel_function)(
+typedef void (*pytorch_q8gavgpool_mp_ukernel_function)(
     size_t m,
     size_t n,
     const uint8_t* x,
@@ -389,7 +389,7 @@ typedef void (*q8gavgpool_mp_ukernel_function)(
     uint8_t* y,
     const union pytorch_qnnp_avgpool_quantization_params* quantization_params);
 
-typedef void (*q8avgpool_up_ukernel_function)(
+typedef void (*pytorch_q8avgpool_up_ukernel_function)(
     size_t n,
     size_t ks,
     size_t kc,
@@ -400,7 +400,7 @@ typedef void (*q8avgpool_up_ukernel_function)(
     size_t y_increment,
     const union pytorch_qnnp_avgpool_quantization_params* quantization_params);
 
-typedef void (*q8avgpool_mp_ukernel_function)(
+typedef void (*pytorch_q8avgpool_mp_ukernel_function)(
     size_t n,
     size_t ks,
     size_t kc,
@@ -412,7 +412,7 @@ typedef void (*q8avgpool_mp_ukernel_function)(
     size_t y_increment,
     const union pytorch_qnnp_avgpool_quantization_params* quantization_params);
 
-typedef void (*u8maxpool_ukernel_function)(
+typedef void (*pytorch_u8maxpool_ukernel_function)(
     size_t n,
     size_t ks,
     size_t kc,
@@ -422,37 +422,37 @@ typedef void (*u8maxpool_ukernel_function)(
     size_t y_increment,
     const union pytorch_qnnp_u8_clamping_params* params);
 
-typedef void (*u8clamp_ukernel_function)(
+typedef void (*pytorch_u8clamp_ukernel_function)(
     size_t n,
     const uint8_t* x,
     uint8_t* y,
     const union pytorch_qnnp_u8_clamping_params* params);
 
-typedef uint8_t (*u8rmax_ukernel_function)(size_t n, const uint8_t* x);
+typedef uint8_t (*pytorch_u8rmax_ukernel_function)(size_t n, const uint8_t* x);
 
-typedef void (*u8lut32norm_ukernel_function)(
+typedef void (*pytorch_u8lut32norm_ukernel_function)(
     size_t n,
     const uint8_t* x,
     const uint32_t* t,
     uint8_t* y);
 
-typedef void (*q8vadd_ukernel_function)(
+typedef void (*pytorch_q8vadd_ukernel_function)(
     size_t n,
     const uint8_t* a,
     const uint8_t* b,
     uint8_t* y,
     const union pytorch_qnnp_add_quantization_params* quantization_params);
 
-struct q8conv_parameters {
-  q8gemm_ukernel_function gemm;
-  q8conv_ukernel_function conv;
+struct pytorch_q8conv_parameters {
+  pytorch_q8gemm_ukernel_function gemm;
+  pytorch_q8conv_ukernel_function conv;
   uint8_t mr;
   uint8_t nr;
   uint8_t kr;
 };
 
-struct q8conv_xzp_parameters {
-  q8gemm_xzp_ukernel_function gemm;
+struct pytorch_q8conv_xzp_parameters {
+  pytorch_q8gemm_xzp_ukernel_function gemm;
   /* no conv ukernel */
   uint8_t mr;
   uint8_t nr;
@@ -461,68 +461,68 @@ struct q8conv_xzp_parameters {
   size_t kthreshold;
 };
 
-struct q8dwconv_up_parameters {
-  q8dwconv_up_ukernel_function updw;
+struct pytorch_q8dwconv_up_parameters {
+  pytorch_q8dwconv_up_ukernel_function updw;
   uint8_t cr;
 };
 
-struct q8dwconv_mp_parameters {
-  q8dwconv_mp_ukernel_function mpdw;
+struct pytorch_q8dwconv_mp_parameters {
+  pytorch_q8dwconv_mp_ukernel_function mpdw;
   uint8_t cr;
 };
 
-struct q8sum_rows_parameters {
-  q8sum_rows_ukernel_function sum_rows;
+struct pytorch_q8sum_rows_parameters {
+  pytorch_q8sum_rows_ukernel_function sum_rows;
   uint32_t m;
 };
 
-struct q8gavgpool_parameters {
-  q8gavgpool_up_ukernel_function ltnr;
-  q8gavgpool_up_ukernel_function genr_lemr;
-  q8gavgpool_mp_ukernel_function genr_gtmr;
+struct pytorch_q8gavgpool_parameters {
+  pytorch_q8gavgpool_up_ukernel_function ltnr;
+  pytorch_q8gavgpool_up_ukernel_function genr_lemr;
+  pytorch_q8gavgpool_mp_ukernel_function genr_gtmr;
   uint8_t mr;
   uint8_t nr;
 };
 
-struct q8avgpool_parameters {
-  q8avgpool_up_ukernel_function ltkr;
-  q8avgpool_up_ukernel_function gekr_lemr;
-  q8avgpool_mp_ukernel_function gekr_gtmr;
+struct pytorch_q8avgpool_parameters {
+  pytorch_q8avgpool_up_ukernel_function ltkr;
+  pytorch_q8avgpool_up_ukernel_function gekr_lemr;
+  pytorch_q8avgpool_mp_ukernel_function gekr_gtmr;
   uint8_t mr;
   uint8_t qr;
   uint8_t kr;
 };
 
-struct u8maxpool_parameters {
-  u8maxpool_ukernel_function ltkr;
-  u8maxpool_ukernel_function gekr;
+struct pytorch_u8maxpool_parameters {
+  pytorch_u8maxpool_ukernel_function ltkr;
+  pytorch_u8maxpool_ukernel_function gekr;
   uint8_t mr;
   uint8_t qr;
   uint8_t kr;
 };
 
-struct x8zip_parameters {
-  xzipc_ukernel_function x2;
-  xzipc_ukernel_function x3;
-  xzipc_ukernel_function x4;
-  xzipv_ukernel_function xm;
+struct pytorch_x8zip_parameters {
+  pytorch_xzipc_ukernel_function x2;
+  pytorch_xzipc_ukernel_function x3;
+  pytorch_xzipc_ukernel_function x4;
+  pytorch_xzipv_ukernel_function xm;
 };
 
 struct pytorch_qnnp_parameters {
-  struct q8conv_parameters q8conv;
-  struct q8conv_xzp_parameters q8conv_xzp;
-  struct q8dwconv_up_parameters q8dw9;
-  struct q8dwconv_mp_parameters q8dw25;
-  struct q8sum_rows_parameters q8sum_rows;
-  q8vadd_ukernel_function q8vadd;
-  struct q8gavgpool_parameters q8gavgpool;
-  struct q8avgpool_parameters q8avgpool;
-  struct u8maxpool_parameters u8maxpool;
-  u8lut32norm_ukernel_function u8lut32norm;
-  u8clamp_ukernel_function u8clamp;
-  u8rmax_ukernel_function u8rmax;
-  struct x8zip_parameters x8zip;
-  x8lut_ukernel_function x8lut;
+  struct pytorch_q8conv_parameters q8conv;
+  struct pytorch_q8conv_xzp_parameters q8conv_xzp;
+  struct pytorch_q8dwconv_up_parameters q8dw9;
+  struct pytorch_q8dwconv_mp_parameters q8dw25;
+  struct pytorch_q8sum_rows_parameters q8sum_rows;
+  pytorch_q8vadd_ukernel_function q8vadd;
+  struct pytorch_q8gavgpool_parameters q8gavgpool;
+  struct pytorch_q8avgpool_parameters q8avgpool;
+  struct pytorch_u8maxpool_parameters u8maxpool;
+  pytorch_u8lut32norm_ukernel_function u8lut32norm;
+  pytorch_u8clamp_ukernel_function u8clamp;
+  pytorch_u8rmax_ukernel_function u8rmax;
+  struct pytorch_x8zip_parameters x8zip;
+  pytorch_x8lut_ukernel_function x8lut;
   bool initialized;
 };
 

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8avgpool.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8avgpool.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(fn_name)       \
+#define PYTORCH_DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(fn_name)       \
   PYTORCH_QNNP_INTERNAL void fn_name(                       \
       size_t n,                                             \
       size_t ks,                                            \
@@ -32,10 +32,10 @@ extern "C" {
       const union pytorch_qnnp_avgpool_quantization_params* \
           quantization_params);
 
-DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_mp8x9p8q__neon)
-DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_mp8x9p8q__sse2)
+PYTORCH_DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(pytorch_q8avgpool_ukernel_mp8x9p8q__neon)
+PYTORCH_DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2)
 
-#define DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(fn_name)       \
+#define PYTORCH_DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(fn_name)       \
   PYTORCH_QNNP_INTERNAL void fn_name(                       \
       size_t n,                                             \
       size_t ks,                                            \
@@ -48,10 +48,10 @@ DECLARE_Q8MPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_mp8x9p8q__sse2)
       const union pytorch_qnnp_avgpool_quantization_params* \
           quantization_params);
 
-DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_up8x9__neon)
-DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_up8xm__neon)
-DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_up8x9__sse2)
-DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(q8avgpool_ukernel_up8xm__sse2)
+PYTORCH_DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(pytorch_q8avgpool_ukernel_up8x9__neon)
+PYTORCH_DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(pytorch_q8avgpool_ukernel_up8xm__neon)
+PYTORCH_DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(pytorch_q8avgpool_ukernel_up8x9__sse2)
+PYTORCH_DECLARE_Q8UPAVGPOOL_UKERNEL_FUNCTION(pytorch_q8avgpool_ukernel_up8xm__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8conv.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8conv.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_Q8CONV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_Q8CONV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(            \
       size_t mr,                                 \
       size_t nr,                                 \
@@ -30,11 +30,11 @@ extern "C" {
       size_t c_stride,                           \
       const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-DECLARE_Q8CONV_UKERNEL_FUNCTION(q8conv_ukernel_4x8__neon)
-DECLARE_Q8CONV_UKERNEL_FUNCTION(q8conv_ukernel_4x8__aarch32_neon)
-DECLARE_Q8CONV_UKERNEL_FUNCTION(q8conv_ukernel_8x8__aarch64_neon)
-DECLARE_Q8CONV_UKERNEL_FUNCTION(q8conv_ukernel_8x8__neon)
-DECLARE_Q8CONV_UKERNEL_FUNCTION(q8conv_ukernel_4x4c2__sse2)
+PYTORCH_DECLARE_Q8CONV_UKERNEL_FUNCTION(pytorch_q8conv_ukernel_4x8__neon)
+PYTORCH_DECLARE_Q8CONV_UKERNEL_FUNCTION(pytorch_q8conv_ukernel_4x8__aarch32_neon)
+PYTORCH_DECLARE_Q8CONV_UKERNEL_FUNCTION(pytorch_q8conv_ukernel_8x8__aarch64_neon)
+PYTORCH_DECLARE_Q8CONV_UKERNEL_FUNCTION(pytorch_q8conv_ukernel_8x8__neon)
+PYTORCH_DECLARE_Q8CONV_UKERNEL_FUNCTION(pytorch_q8conv_ukernel_4x4c2__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8dwconv.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8dwconv.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(                \
       size_t channels,                               \
       size_t output_width,                           \
@@ -29,11 +29,11 @@ extern "C" {
       size_t output_increment,                       \
       const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(q8dwconv_ukernel_up8x9__neon)
-DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(q8dwconv_ukernel_up8x9__aarch32_neon)
-DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(q8dwconv_ukernel_up8x9__sse2)
+PYTORCH_DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(pytorch_q8dwconv_ukernel_up8x9__neon)
+PYTORCH_DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon)
+PYTORCH_DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(pytorch_q8dwconv_ukernel_up8x9__sse2)
 
-#define DECLARE_Q8MPDWCONV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_Q8MPDWCONV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(                \
       size_t channels,                               \
       size_t output_width,                           \
@@ -45,8 +45,8 @@ DECLARE_Q8UPDWCONV_UKERNEL_FUNCTION(q8dwconv_ukernel_up8x9__sse2)
       size_t output_increment,                       \
       const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-DECLARE_Q8MPDWCONV_UKERNEL_FUNCTION(q8dwconv_ukernel_mp8x25__neon)
-DECLARE_Q8MPDWCONV_UKERNEL_FUNCTION(q8dwconv_ukernel_mp8x25__sse2)
+PYTORCH_DECLARE_Q8MPDWCONV_UKERNEL_FUNCTION(pytorch_q8dwconv_ukernel_mp8x25__neon)
+PYTORCH_DECLARE_Q8MPDWCONV_UKERNEL_FUNCTION(pytorch_q8dwconv_ukernel_mp8x25__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8gavgpool.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8gavgpool.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(fn_name)      \
+#define PYTORCH_DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(fn_name)      \
   PYTORCH_QNNP_INTERNAL void fn_name(                       \
       size_t m,                                             \
       size_t n,                                             \
@@ -30,10 +30,10 @@ extern "C" {
       const union pytorch_qnnp_avgpool_quantization_params* \
           quantization_params);
 
-DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_mp8x7p7q__neon)
-DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_mp8x7p7q__sse2)
+PYTORCH_DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon)
+PYTORCH_DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2)
 
-#define DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(fn_name)      \
+#define PYTORCH_DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(fn_name)      \
   PYTORCH_QNNP_INTERNAL void fn_name(                       \
       size_t m,                                             \
       size_t n,                                             \
@@ -44,10 +44,10 @@ DECLARE_Q8MPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_mp8x7p7q__sse2)
       const union pytorch_qnnp_avgpool_quantization_params* \
           quantization_params);
 
-DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_up8x7__neon)
-DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_up8xm__neon)
-DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_up8x7__sse2)
-DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(q8gavgpool_ukernel_up8xm__sse2)
+PYTORCH_DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(pytorch_q8gavgpool_ukernel_up8x7__neon)
+PYTORCH_DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(pytorch_q8gavgpool_ukernel_up8xm__neon)
+PYTORCH_DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(pytorch_q8gavgpool_ukernel_up8x7__sse2)
+PYTORCH_DECLARE_Q8UPGAVGPOOL_UKERNEL_FUNCTION(pytorch_q8gavgpool_ukernel_up8xm__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8gemm.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8gemm.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_Q8GEMM_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(            \
       size_t mr,                                 \
       size_t nr,                                 \
@@ -30,20 +30,20 @@ extern "C" {
       size_t c_stride,                           \
       const union pytorch_qnnp_conv_quantization_params* quantization_params);
 
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_3x3c8__neon)
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_2x4c8__neon)
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_4x8__neon)
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_6x4__neon)
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_8x8__neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_3x3c8__neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_2x4c8__neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_4x8__neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_6x4__neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_8x8__neon)
 
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_4x8__aarch32_neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_4x8__aarch32_neon)
 
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_8x8__aarch64_neon)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_8x8__aarch64_neon)
 
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_2x4c8__sse2)
-DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_4x4c2__sse2)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_2x4c8__sse2)
+PYTORCH_DECLARE_Q8GEMM_UKERNEL_FUNCTION(pytorch_q8gemm_ukernel_4x4c2__sse2)
 
-#define DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(fn_name)      \
+#define PYTORCH_DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(fn_name)      \
   PYTORCH_QNNP_INTERNAL void fn_name(                     \
       size_t mr,                                          \
       size_t nr,                                          \
@@ -56,10 +56,10 @@ DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_4x4c2__sse2)
       size_t c_stride,                                    \
       const union pytorch_qnnp_q31_requantization_params* \
           requantization_params);
-DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(q8gemm_xzp_ukernel_4x8c2__neon)
-DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(q8gemm_xzp_ukernel_4x8c2__aarch32_neon)
+PYTORCH_DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(pytorch_q8gemm_xzp_ukernel_4x8c2__neon)
+PYTORCH_DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon)
 
-PYTORCH_QNNP_INTERNAL void q8sumrows_ukernel_4x__neon(
+PYTORCH_QNNP_INTERNAL void pytorch_q8sumrows_ukernel_4x__neon(
     const uint8_t* a,
     size_t m,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8vadd.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/q8vadd.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_Q8VADD_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_Q8VADD_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(            \
       size_t n,                                  \
       const uint8_t* a,                          \
@@ -26,8 +26,8 @@ extern "C" {
       uint8_t* y,                                \
       const union pytorch_qnnp_add_quantization_params* quantization_params);
 
-DECLARE_Q8VADD_UKERNEL_FUNCTION(q8vadd_ukernel__neon)
-DECLARE_Q8VADD_UKERNEL_FUNCTION(q8vadd_ukernel__sse2)
+PYTORCH_DECLARE_Q8VADD_UKERNEL_FUNCTION(pytorch_q8vadd_ukernel__neon)
+PYTORCH_DECLARE_Q8VADD_UKERNEL_FUNCTION(pytorch_q8vadd_ukernel__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/requantization-stubs.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/requantization-stubs.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-typedef void (*requantization_function)(
+typedef void (*pytorch_requantization_function)(
     size_t n,
     const int32_t* input,
     float scale,
@@ -28,7 +28,7 @@ typedef void (*requantization_function)(
     uint8_t qmax,
     uint8_t* output);
 
-#define DECLARE_REQUANTIZATION_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(fn_name) \
   void fn_name(                                  \
       size_t n,                                  \
       const int32_t* input,                      \
@@ -38,36 +38,36 @@ typedef void (*requantization_function)(
       uint8_t qmax,                              \
       uint8_t* output);
 
-DECLARE_REQUANTIZATION_FUNCTION(
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(
     pytorch_qnnp_requantize_precise__scalar_unsigned32)
-DECLARE_REQUANTIZATION_FUNCTION(
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(
     pytorch_qnnp_requantize_precise__scalar_unsigned64)
-DECLARE_REQUANTIZATION_FUNCTION(
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(
     pytorch_qnnp_requantize_precise__scalar_signed64)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__sse2)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__ssse3)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__sse4)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__neon)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__psimd)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__sse2)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__ssse3)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__sse4)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__neon)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_precise__psimd)
 
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__scalar_lrintf)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__scalar_magic)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__sse2)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__neon)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__psimd)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__scalar_lrintf)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__scalar_magic)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__sse2)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__neon)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_fp32__psimd)
 
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__scalar)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__sse2)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__ssse3)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__sse4)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__neon)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__psimd)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__scalar)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__sse2)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__ssse3)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__sse4)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__neon)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_q31__psimd)
 
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__scalar)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__sse2)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__ssse3)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__sse4)
-DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__neon)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__scalar)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__sse2)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__ssse3)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__sse4)
+PYTORCH_DECLARE_REQUANTIZATION_FUNCTION(pytorch_qnnp_requantize_gemmlowp__neon)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/scalar-utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/scalar-utils.h
@@ -61,7 +61,7 @@ inline static int64_t asr_s64(int64_t x, uint32_t n) {
 #endif
 }
 
-inline static uint8_t scalar_requantize_precise(
+inline static uint8_t pytorch_scalar_requantize_precise(
     int32_t value,
     float scale,
     uint8_t zero_point,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/sconv.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/sconv.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_SCONV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_SCONV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(           \
       size_t mr,                                \
       size_t nr,                                \
@@ -30,7 +30,7 @@ extern "C" {
       size_t c_stride,                          \
       const struct pytorch_qnnp_fp32_clamping_params* params);
 
-DECLARE_SCONV_UKERNEL_FUNCTION(sconv_ukernel_6x8__psimd)
+PYTORCH_DECLARE_SCONV_UKERNEL_FUNCTION(pytorch_sconv_ukernel_6x8__psimd)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/sdwconv.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/sdwconv.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_SUPDWCONV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_SUPDWCONV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(               \
       size_t channels,                              \
       size_t output_width,                          \
@@ -29,9 +29,9 @@ extern "C" {
       size_t output_increment,                      \
       const struct pytorch_qnnp_fp32_clamping_params* clamping_params);
 
-DECLARE_SUPDWCONV_UKERNEL_FUNCTION(sdwconv_ukernel_up4x9__psimd)
+PYTORCH_DECLARE_SUPDWCONV_UKERNEL_FUNCTION(pytorch_sdwconv_ukernel_up4x9__psimd)
 
-#define DECLARE_SMPDWCONV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_SMPDWCONV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(               \
       size_t channels,                              \
       size_t output_width,                          \

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/sgemm.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/sgemm.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_SGEMM_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_SGEMM_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(           \
       size_t mr,                                \
       size_t nr,                                \
@@ -29,10 +29,9 @@ extern "C" {
       size_t c_stride,                          \
       const struct pytorch_qnnp_fp32_clamping_params* clamping_params);
 
-DECLARE_SGEMM_UKERNEL_FUNCTION(sgemm_ukernel_5x8__neon)
-DECLARE_SGEMM_UKERNEL_FUNCTION(sgemm_ukernel_6x8__neon)
-
-DECLARE_SGEMM_UKERNEL_FUNCTION(sgemm_ukernel_6x8__psimd)
+PYTORCH_DECLARE_SGEMM_UKERNEL_FUNCTION(pytorch_sgemm_ukernel_5x8__neon)
+PYTORCH_DECLARE_SGEMM_UKERNEL_FUNCTION(pytorch_sgemm_ukernel_6x8__neon)
+PYTORCH_DECLARE_SGEMM_UKERNEL_FUNCTION(pytorch_sgemm_ukernel_6x8__psimd)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8clamp.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8clamp.h
@@ -18,15 +18,15 @@
 extern "C" {
 #endif
 
-#define DECLARE_U8CLAMP_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_U8CLAMP_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(             \
       size_t n,                                   \
       const uint8_t* x,                           \
       uint8_t* y,                                 \
       const union pytorch_qnnp_u8_clamping_params* params);
 
-DECLARE_U8CLAMP_UKERNEL_FUNCTION(u8clamp_ukernel__neon)
-DECLARE_U8CLAMP_UKERNEL_FUNCTION(u8clamp_ukernel__sse2)
+PYTORCH_DECLARE_U8CLAMP_UKERNEL_FUNCTION(pytorch_u8clamp_ukernel__neon)
+PYTORCH_DECLARE_U8CLAMP_UKERNEL_FUNCTION(pytorch_u8clamp_ukernel__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8lut32norm.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8lut32norm.h
@@ -18,11 +18,11 @@
 extern "C" {
 #endif
 
-#define DECLARE_X8LUT32NORM_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_X8LUT32NORM_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(                 \
       size_t n, const uint8_t* x, const uint32_t* t, uint8_t* y);
 
-DECLARE_X8LUT32NORM_UKERNEL_FUNCTION(u8lut32norm_ukernel__scalar)
+PYTORCH_DECLARE_X8LUT32NORM_UKERNEL_FUNCTION(pytorch_u8lut32norm_ukernel__scalar)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8maxpool.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8maxpool.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(               \
       size_t n,                                     \
       size_t ks,                                    \
@@ -29,10 +29,10 @@ extern "C" {
       size_t y_increment,                           \
       const union pytorch_qnnp_u8_clamping_params* params);
 
-DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(u8maxpool_ukernel_16x9p8q__neon)
-DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(u8maxpool_ukernel_16x9p8q__sse2)
-DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(u8maxpool_ukernel_sub16__neon)
-DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(u8maxpool_ukernel_sub16__sse2)
+PYTORCH_DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(pytorch_u8maxpool_ukernel_16x9p8q__neon)
+PYTORCH_DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(pytorch_u8maxpool_ukernel_16x9p8q__sse2)
+PYTORCH_DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(pytorch_u8maxpool_ukernel_sub16__neon)
+PYTORCH_DECLARE_U8MAXPOOL_UKERNEL_FUNCTION(pytorch_u8maxpool_ukernel_sub16__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8rmax.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/u8rmax.h
@@ -18,11 +18,11 @@
 extern "C" {
 #endif
 
-#define DECLARE_U8RMAX_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_U8RMAX_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL uint8_t fn_name(size_t n, const uint8_t* x);
 
-DECLARE_U8RMAX_UKERNEL_FUNCTION(u8rmax_ukernel__neon)
-DECLARE_U8RMAX_UKERNEL_FUNCTION(u8rmax_ukernel__sse2)
+PYTORCH_DECLARE_U8RMAX_UKERNEL_FUNCTION(pytorch_u8rmax_ukernel__neon)
+PYTORCH_DECLARE_U8RMAX_UKERNEL_FUNCTION(pytorch_u8rmax_ukernel__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/x8lut.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/x8lut.h
@@ -18,11 +18,11 @@
 extern "C" {
 #endif
 
-#define DECLARE_X8LUT_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_X8LUT_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(           \
       size_t n, const uint8_t* x, const uint8_t* t, uint8_t* y);
 
-DECLARE_X8LUT_UKERNEL_FUNCTION(x8lut_ukernel__scalar)
+PYTORCH_DECLARE_X8LUT_UKERNEL_FUNCTION(pytorch_x8lut_ukernel__scalar)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/x8zip.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/qnnpack/x8zip.h
@@ -18,22 +18,22 @@
 extern "C" {
 #endif
 
-#define DECLARE_XZIPC_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(size_t n, const void* x, void* y);
 
-DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x2__neon)
-DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x2__sse2)
-DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x3__neon)
-DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x3__sse2)
-DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x4__neon)
-DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x4__sse2)
+PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x2__neon)
+PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x2__sse2)
+PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x3__neon)
+PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x3__sse2)
+PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x4__neon)
+PYTORCH_DECLARE_XZIPC_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_x4__sse2)
 
-#define DECLARE_XZIPV_UKERNEL_FUNCTION(fn_name) \
+#define PYTORCH_DECLARE_XZIPV_UKERNEL_FUNCTION(fn_name) \
   PYTORCH_QNNP_INTERNAL void fn_name(           \
       size_t n, size_t m, const void* x, void* y);
 
-DECLARE_XZIPV_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_xm__neon)
-DECLARE_XZIPV_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_xm__sse2)
+PYTORCH_DECLARE_XZIPV_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_xm__neon)
+PYTORCH_DECLARE_XZIPV_UKERNEL_FUNCTION(pytorch_qnnp_x8zip_xm__sse2)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/sconv/6x8-psimd.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/sconv/6x8-psimd.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/sconv.h>
 
-void sconv_ukernel_6x8__psimd(
+void pytorch_sconv_ukernel_6x8__psimd(
     size_t mr,
     size_t nr,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/sdwconv/up4x9-psimd.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/sdwconv/up4x9-psimd.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/sdwconv.h>
 
-void sdwconv_ukernel_up4x9__psimd(
+void pytorch_sdwconv_ukernel_up4x9__psimd(
     size_t channels,
     size_t output_width,
     const float** input,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/sgemm/5x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/sgemm/5x8-neon.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/sgemm.h>
 
-void sgemm_ukernel_5x8__neon(
+void pytorch_sgemm_ukernel_5x8__neon(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/sgemm/6x8-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/sgemm/6x8-neon.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/sgemm.h>
 
-void sgemm_ukernel_6x8__neon(
+void pytorch_sgemm_ukernel_6x8__neon(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/sgemm/6x8-psimd.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/sgemm/6x8-psimd.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/sgemm.h>
 
-void sgemm_ukernel_6x8__psimd(
+void pytorch_sgemm_ukernel_6x8__psimd(
     size_t mr,
     size_t nr,
     size_t k,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8clamp/neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8clamp/neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8clamp.h>
 
-void u8clamp_ukernel__neon(
+void pytorch_u8clamp_ukernel__neon(
     size_t n,
     const uint8_t* x,
     uint8_t* y,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8clamp/sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8clamp/sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8clamp.h>
 
-void u8clamp_ukernel__sse2(
+void pytorch_u8clamp_ukernel__sse2(
     size_t n,
     const uint8_t* x,
     uint8_t* y,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8lut32norm/scalar.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8lut32norm/scalar.c
@@ -26,7 +26,7 @@ static inline uint32_t compute_sum(
   return vsum;
 }
 
-void u8lut32norm_ukernel__scalar(
+void pytorch_u8lut32norm_ukernel__scalar(
     size_t n,
     const uint8_t* x,
     const uint32_t* t,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/16x9p8q-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/16x9p8q-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8maxpool.h>
 
-void u8maxpool_ukernel_16x9p8q__neon(
+void pytorch_u8maxpool_ukernel_16x9p8q__neon(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/16x9p8q-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/16x9p8q-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8maxpool.h>
 
-void u8maxpool_ukernel_16x9p8q__sse2(
+void pytorch_u8maxpool_ukernel_16x9p8q__sse2(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/sub16-neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/sub16-neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8maxpool.h>
 
-void u8maxpool_ukernel_sub16__neon(
+void pytorch_u8maxpool_ukernel_sub16__neon(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/sub16-sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8maxpool/sub16-sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8maxpool.h>
 
-void u8maxpool_ukernel_sub16__sse2(
+void pytorch_u8maxpool_ukernel_sub16__sse2(
     size_t n,
     size_t ks,
     size_t kc,

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8rmax/neon.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8rmax/neon.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8rmax.h>
 
-uint8_t u8rmax_ukernel__neon(size_t n, const uint8_t* x) {
+uint8_t pytorch_u8rmax_ukernel__neon(size_t n, const uint8_t* x) {
   assert(n != 0);
 
   if

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8rmax/sse2.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/u8rmax/sse2.c
@@ -12,7 +12,7 @@
 
 #include <qnnpack/u8rmax.h>
 
-uint8_t u8rmax_ukernel__sse2(size_t n, const uint8_t* x) {
+uint8_t pytorch_u8rmax_ukernel__sse2(size_t n, const uint8_t* x) {
   assert(n != 0);
 
   if

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/x8lut/scalar.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/x8lut/scalar.c
@@ -10,7 +10,7 @@
 
 #include <qnnpack/x8lut.h>
 
-void x8lut_ukernel__scalar(
+void pytorch_x8lut_ukernel__scalar(
     size_t n,
     const uint8_t* x,
     const uint8_t t[RESTRICT_STATIC 256],

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/avgpool-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/avgpool-microkernel-tester.h
@@ -220,7 +220,7 @@ class AvgPoolMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(q8avgpool_up_ukernel_function q8avgpool) const {
+  void test(pytorch_q8avgpool_up_ukernel_function q8avgpool) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
@@ -313,7 +313,7 @@ class AvgPoolMicrokernelTester {
     }
   }
 
-  void test(q8avgpool_mp_ukernel_function q8avgpool) const {
+  void test(pytorch_q8avgpool_mp_ukernel_function q8avgpool) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/clamp-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/clamp-microkernel-tester.h
@@ -67,7 +67,7 @@ class ClampMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(u8clamp_ukernel_function u8clamp) const {
+  void test(pytorch_u8clamp_ukernel_function u8clamp) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/dwconv-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/dwconv-microkernel-tester.h
@@ -168,7 +168,7 @@ class DWConvMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(q8dwconv_up_ukernel_function q8dwconv) const {
+  void test(pytorch_q8dwconv_up_ukernel_function q8dwconv) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto s32rng =
@@ -205,7 +205,7 @@ class DWConvMicrokernelTester {
 
       std::fill(packedWeights.begin(), packedWeights.end(), 0xA5);
 
-      pack_q8dw_w(
+      pytorch_pack_q8dw_w(
           kernelHeight(),
           kernelWidth(),
           channels(),
@@ -307,7 +307,7 @@ class DWConvMicrokernelTester {
     }
   }
 
-  void test(q8dwconv_mp_ukernel_function q8dwconv) const {
+  void test(pytorch_q8dwconv_mp_ukernel_function q8dwconv) const {
     ASSERT_EQ(25, kernelSize())
         << "only 5x5 microkernel is currently supported";
 
@@ -351,7 +351,7 @@ class DWConvMicrokernelTester {
 
       ASSERT_EQ(25, kernelSize())
           << "only 5x5 microkernel is currently supported";
-      pack_q8dw_w_dilation(
+      pytorch_pack_q8dw_w_dilation(
           kernelHeight(),
           kernelWidth(),
           channels(),
@@ -364,7 +364,7 @@ class DWConvMicrokernelTester {
           bias.data(),
           packedWeights.data(),
           true);
-      pack_q8dw_w_dilation(
+      pytorch_pack_q8dw_w_dilation(
           kernelHeight(),
           kernelWidth(),
           channels(),
@@ -378,7 +378,7 @@ class DWConvMicrokernelTester {
           packedWeights.data() +
               (10 + sizeof(int32_t) / sizeof(uint8_t)) * packedChannels(),
           false);
-      pack_q8dw_w_dilation(
+      pytorch_pack_q8dw_w_dilation(
           kernelHeight(),
           kernelWidth(),
           channels(),

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gavgpool-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gavgpool-microkernel-tester.h
@@ -139,7 +139,7 @@ class GAvgPoolMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(q8gavgpool_up_ukernel_function q8gavgpool) const {
+  void test(pytorch_q8gavgpool_up_ukernel_function q8gavgpool) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
@@ -211,7 +211,7 @@ class GAvgPoolMicrokernelTester {
     }
   }
 
-  void test(q8gavgpool_mp_ukernel_function q8gavgpool) const {
+  void test(pytorch_q8gavgpool_mp_ukernel_function q8gavgpool) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-microkernel-tester.h
@@ -173,7 +173,7 @@ class GemmMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(q8gemm_ukernel_function qgemm) const {
+  void test(pytorch_q8gemm_ukernel_function qgemm) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
     ASSERT_GE(k(), kr());
@@ -203,7 +203,7 @@ class GemmMicrokernelTester {
 
       std::fill(packedW.begin(), packedW.end(), bZeroPoint());
 
-      pack_q8gemm_w(
+      pytorch_pack_q8gemm_w(
           n(),
           k(),
           nr(),
@@ -310,7 +310,7 @@ class GemmMicrokernelTester {
     }
   }
 
-  void test(q8conv_ukernel_function qconv) const {
+  void test(pytorch_q8conv_ukernel_function qconv) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
     ASSERT_GE(k(), kr());
@@ -342,7 +342,7 @@ class GemmMicrokernelTester {
 
       std::fill(packedW.begin(), packedW.end(), bZeroPoint());
 
-      pack_q8conv_w(
+      pytorch_pack_q8conv_w(
           n(),
           ks(),
           k(),
@@ -480,7 +480,7 @@ class GemmMicrokernelTester {
       size_t stride,
       const int32_t multiplier,
       int32_t* row_sum,
-      q8sum_rows_ukernel_function q8sum_rows) {
+      pytorch_q8sum_rows_ukernel_function q8sum_rows) {
     const size_t block_size = 4;
     for (size_t block_start = 0; block_start < m; block_start += block_size) {
       q8sum_rows(
@@ -493,7 +493,7 @@ class GemmMicrokernelTester {
     }
   }
 
-  void test(q8gemm_xzp_ukernel_function qgemm) const {
+  void test(pytorch_q8gemm_xzp_ukernel_function qgemm) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
     ASSERT_GE(k(), kr());
@@ -522,7 +522,7 @@ class GemmMicrokernelTester {
       std::generate(bias.begin(), bias.end(), std::ref(s32rng));
 
       std::fill(packedW.begin(), packedW.end(), 0);
-      pack_swizzle_q8gemm_b(
+      pytorch_pack_swizzle_q8gemm_b(
           n(),
           k(),
           np(),
@@ -630,7 +630,7 @@ class GemmMicrokernelTester {
     }
   }
 
-  void test(hgemm_ukernel_function hgemm) const {
+  void test(pytorch_hgemm_ukernel_function hgemm) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
     ASSERT_GE(k(), kr());
@@ -665,7 +665,7 @@ class GemmMicrokernelTester {
       std::fill(cRef.begin(), cRef.end(), 0.0f);
 
       std::fill(packedW.begin(), packedW.end(), 0);
-      pack_hgemm_w(n(), k(), np(), kr(), b.data(), bias.data(), packedW.data());
+      pytorch_pack_hgemm_w(n(), k(), np(), kr(), b.data(), bias.data(), packedW.data());
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
@@ -748,7 +748,7 @@ class GemmMicrokernelTester {
     }
   }
 
-  void test(sgemm_ukernel_function sgemm) const {
+  void test(pytorch_sgemm_ukernel_function sgemm) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
     ASSERT_GE(k(), kr());
@@ -775,7 +775,7 @@ class GemmMicrokernelTester {
       std::fill(cRef.begin(), cRef.end(), 0.0f);
 
       std::fill(packedW.begin(), packedW.end(), 0.0f);
-      pack_sgemm_w(n(), k(), np(), kr(), b.data(), bias.data(), packedW.data());
+      pytorch_pack_sgemm_w(n(), k(), np(), kr(), b.data(), bias.data(), packedW.data());
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
@@ -849,7 +849,7 @@ class GemmMicrokernelTester {
     }
   }
 
-  void test(sconv_ukernel_function sconv) const {
+  void test(pytorch_sconv_ukernel_function sconv) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
     ASSERT_GE(k(), kr());
@@ -876,7 +876,7 @@ class GemmMicrokernelTester {
       std::fill(cRef.begin(), cRef.end(), 0.0f);
 
       std::fill(packedW.begin(), packedW.end(), 0.0f);
-      pack_sconv_w(
+      pytorch_pack_sconv_w(
           n(), ks(), k(), np(), kr(), b.data(), bias.data(), packedW.data());
 
       ASSERT_NE(

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/hgemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/hgemm.cc
@@ -18,7 +18,7 @@
 TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4) {
   TEST_REQUIRES_ARM_NEON_FP16_ARITH;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(4).test(
-      hgemm_ukernel_8x8__aarch32_neonfp16arith);
+      pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
 }
 
 TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4_strided_a) {
@@ -32,7 +32,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4_strided_a) {
       .n(8)
       .k(4)
       .aStride(37)
-      .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+      .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
 }
 
 TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4_strided_c) {
@@ -46,26 +46,26 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4_strided_c) {
       .n(8)
       .k(4)
       .cStride(17)
-      .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+      .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
 }
 
 TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4_qmin128) {
   TEST_REQUIRES_ARM_NEON_FP16_ARITH;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(4).qmin(128).test(
-      hgemm_ukernel_8x8__aarch32_neonfp16arith);
+      pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
 }
 
 TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_eq_4_qmax128) {
   TEST_REQUIRES_ARM_NEON_FP16_ARITH;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(4).qmax(128).test(
-      hgemm_ukernel_8x8__aarch32_neonfp16arith);
+      pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
 }
 
 TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_gt_4) {
   TEST_REQUIRES_ARM_NEON_FP16_ARITH;
   for (size_t k = 5; k < 8; k++) {
     GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(k).test(
-        hgemm_ukernel_8x8__aarch32_neonfp16arith);
+        pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
   }
 }
 
@@ -81,7 +81,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_gt_4_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+        .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
   }
 }
 
@@ -97,7 +97,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_gt_4_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+        .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
   }
 }
 
@@ -115,7 +115,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_gt_4_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+            .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
       }
     }
   }
@@ -125,7 +125,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_div_4) {
   TEST_REQUIRES_ARM_NEON_FP16_ARITH;
   for (size_t k = 8; k < 64; k += 4) {
     GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(k).test(
-        hgemm_ukernel_8x8__aarch32_neonfp16arith);
+        pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
   }
 }
 
@@ -141,7 +141,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_div_4_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+        .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
   }
 }
 
@@ -157,7 +157,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_div_4_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+        .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
   }
 }
 
@@ -175,7 +175,7 @@ TEST(HGEMM_8x8__AARCH32_NEONFP16ARITH, k_div_4_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(hgemm_ukernel_8x8__aarch32_neonfp16arith);
+            .test(pytorch_hgemm_ukernel_8x8__aarch32_neonfp16arith);
       }
     }
   }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/lut-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/lut-microkernel-tester.h
@@ -48,7 +48,7 @@ class LUTMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(x8lut_ukernel_function x8lut) const {
+  void test(pytorch_x8lut_ukernel_function x8lut) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/lut-norm-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/lut-norm-microkernel-tester.h
@@ -48,7 +48,7 @@ class LUTNormMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(u8lut32norm_ukernel_function u8lut32norm) const {
+  void test(pytorch_u8lut32norm_ukernel_function u8lut32norm) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/maxpool-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/maxpool-microkernel-tester.h
@@ -178,7 +178,7 @@ class MaxPoolMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(u8maxpool_ukernel_function u8maxpool) const {
+  void test(pytorch_u8maxpool_ukernel_function u8maxpool) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8avgpool.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8avgpool.cc
@@ -23,7 +23,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_small_ks) {
         for (size_t kw = 1; kw <= ks; kw++) {
           if (kh * kw == ks) {
             AvgPoolMicrokernelTester().kr(8).kh(kh).kw(kw).kc(kc).test(
-                q8avgpool_ukernel_up8xm__neon);
+                pytorch_q8avgpool_ukernel_up8xm__neon);
           }
         }
       }
@@ -36,9 +36,9 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_large_ks) {
   for (size_t kc = 1; kc < 8; kc++) {
     for (size_t ks = 8; ks < 16; ks++) {
       AvgPoolMicrokernelTester().kr(8).kh(ks).kw(1).kc(kc).test(
-          q8avgpool_ukernel_up8xm__neon);
+          pytorch_q8avgpool_ukernel_up8xm__neon);
       AvgPoolMicrokernelTester().kr(8).kh(1).kw(ks).kc(kc).test(
-          q8avgpool_ukernel_up8xm__neon);
+          pytorch_q8avgpool_ukernel_up8xm__neon);
     }
   }
 }
@@ -57,7 +57,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_with_x_scale) {
               .kc(kc)
               .xScale(xScale)
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__neon);
+              .test(pytorch_q8avgpool_ukernel_up8xm__neon);
         }
       }
     }
@@ -78,7 +78,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_with_x_zero_point) {
               .kc(kc)
               .xZeroPoint(uint8_t(xZeroPoint))
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__neon);
+              .test(pytorch_q8avgpool_ukernel_up8xm__neon);
         }
       }
     }
@@ -99,7 +99,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_with_y_scale) {
               .kc(kc)
               .yScale(yScale)
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__neon);
+              .test(pytorch_q8avgpool_ukernel_up8xm__neon);
         }
       }
     }
@@ -120,7 +120,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_with_y_zero_point) {
               .kc(kc)
               .yZeroPoint(uint8_t(yZeroPoint))
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__neon);
+              .test(pytorch_q8avgpool_ukernel_up8xm__neon);
         }
       }
     }
@@ -144,7 +144,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_with_y_max) {
             .yScale(1.0f)
             .yMax(128)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8avgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -167,7 +167,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, kc_lt_8_with_y_min) {
             .yScale(1.0f)
             .yMin(128)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8avgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -185,7 +185,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, small_n) {
             .kw(ks)
             .kc(kc)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8avgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -204,7 +204,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, small_n_with_x_stride) {
             .kc(kc)
             .xStride(11)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8avgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -223,7 +223,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, small_n_with_y_stride) {
             .kc(kc)
             .yStride(13)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8avgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -243,7 +243,7 @@ TEST(Q8AVGPOOL_UP8xM__NEON, small_n_with_s) {
               .kc(kc)
               .s(s)
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__neon);
+              .test(pytorch_q8avgpool_ukernel_up8xm__neon);
         }
       }
     }
@@ -256,7 +256,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_eq_8_fulltile) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).test(q8avgpool_ukernel_up8x9__neon);
+        tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -269,7 +269,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_eq_8_subtile) {
     for (size_t kh = 1; kh <= ks; kh++) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
-          tester.kh(kh).kw(kw).test(q8avgpool_ukernel_up8x9__neon);
+          tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_up8x9__neon);
         }
       }
     }
@@ -283,7 +283,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 8; kc < 128; kc += 24) {
-          tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__neon);
         }
       }
     }
@@ -298,7 +298,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_subtile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 8; kc < 128; kc += 24) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__neon);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__neon);
           }
         }
       }
@@ -314,7 +314,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 8; kc < 128; kc += 24) {
           tester.kh(kh).kw(kw).kc(kc).xStride(131).test(
-              q8avgpool_ukernel_up8x9__neon);
+              pytorch_q8avgpool_ukernel_up8x9__neon);
         }
       }
     }
@@ -328,7 +328,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_gt_8_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 9; kc < 16; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__neon);
         }
       }
     }
@@ -343,7 +343,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_gt_8_subtile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 9; kc < 16; kc++) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__neon);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__neon);
           }
         }
       }
@@ -359,7 +359,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_gt_8_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 9; kc < 16; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(23).test(
-              q8avgpool_ukernel_up8x9__neon);
+              pytorch_q8avgpool_ukernel_up8x9__neon);
         }
       }
     }
@@ -380,7 +380,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_with_x_scale) {
             .kc(kc)
             .xScale(xScale)
             .iterations(2)
-            .test(q8avgpool_ukernel_up8x9__neon);
+            .test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -400,7 +400,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_with_x_zero_point) {
             .kc(kc)
             .xZeroPoint(uint8_t(xZeroPoint))
             .iterations(3)
-            .test(q8avgpool_ukernel_up8x9__neon);
+            .test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -420,7 +420,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_with_y_scale) {
             .kc(kc)
             .yScale(yScale)
             .iterations(2)
-            .test(q8avgpool_ukernel_up8x9__neon);
+            .test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -440,7 +440,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_with_y_zero_point) {
             .kc(kc)
             .yZeroPoint(uint8_t(yZeroPoint))
             .iterations(3)
-            .test(q8avgpool_ukernel_up8x9__neon);
+            .test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -462,7 +462,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_with_y_max) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMax(128)
-          .test(q8avgpool_ukernel_up8x9__neon);
+          .test(pytorch_q8avgpool_ukernel_up8x9__neon);
     }
   }
 }
@@ -483,7 +483,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, kc_div_8_with_y_min) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMin(128)
-          .test(q8avgpool_ukernel_up8x9__neon);
+          .test(pytorch_q8avgpool_ukernel_up8x9__neon);
     }
   }
 }
@@ -494,7 +494,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, small_n) {
     for (size_t ks : std::vector<size_t>{{2, 3}}) {
       for (size_t kc = 8; kc < 25; kc += 5) {
         AvgPoolMicrokernelTester().kr(8).mr(9).n(n).kh(ks).kw(ks).kc(kc).test(
-            q8avgpool_ukernel_up8x9__neon);
+            pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -513,7 +513,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, small_n_with_x_stride) {
             .kw(ks)
             .kc(kc)
             .xStride(29)
-            .test(q8avgpool_ukernel_up8x9__neon);
+            .test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -532,7 +532,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, small_n_with_y_stride) {
             .kw(ks)
             .kc(kc)
             .yStride(31)
-            .test(q8avgpool_ukernel_up8x9__neon);
+            .test(pytorch_q8avgpool_ukernel_up8x9__neon);
       }
     }
   }
@@ -552,7 +552,7 @@ TEST(Q8AVGPOOL_UP8x9__NEON, small_n_with_s) {
               .kw(ks)
               .kc(kc)
               .s(s)
-              .test(q8avgpool_ukernel_up8x9__neon);
+              .test(pytorch_q8avgpool_ukernel_up8x9__neon);
         }
       }
     }
@@ -566,7 +566,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_eq_8_twopass_fulltile) {
   for (size_t kh = 1; kh <= ks; kh++) {
     for (size_t kw = 1; kw <= ks; kw++) {
       if (kh * kw == ks) {
-        tester.kh(kh).kw(kw).test(q8avgpool_ukernel_mp8x9p8q__neon);
+        tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -576,8 +576,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_eq_8_twopass_subtile) {
   TEST_REQUIRES_ARM_NEON;
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).kc(8);
   for (size_t ks = 10; ks < tester.mr() + tester.qr(); ks++) {
-    tester.kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-    tester.kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+    tester.kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+    tester.kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
   }
 }
 
@@ -588,7 +588,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_eq_8_multipass_fulltile) {
     for (size_t kh = 1; kh <= ks; kh++) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
-          tester.kh(kh).kw(kw).test(q8avgpool_ukernel_mp8x9p8q__neon);
+          tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
         }
       }
     }
@@ -600,8 +600,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_eq_8_multipass_subtile) {
   for (size_t ksMax : std::vector<size_t>{{25, 49}}) {
     auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).kc(8);
     for (size_t ks = ksMax - tester.qr() + 1; ks < ksMax; ks++) {
-      tester.kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-      tester.kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+      tester.kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+      tester.kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
     }
   }
 }
@@ -611,8 +611,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_twopass_fulltile) {
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
   const size_t ks = 17;
   for (size_t kc = 8; kc < 128; kc += 24) {
-    tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-    tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+    tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+    tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
   }
 }
 
@@ -621,8 +621,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_twopass_subtile) {
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
   for (size_t ks = 10; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 8; kc < 128; kc += 24) {
-      tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-      tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+      tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+      tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
     }
   }
 }
@@ -636,7 +636,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_twopass_fulltile_with_x_stride) {
       if (kh * kw == ks) {
         for (size_t kc = 8; kc < 128; kc += 24) {
           tester.kh(kh).kw(kw).kc(kc).xStride(131).test(
-              q8avgpool_ukernel_mp8x9p8q__neon);
+              pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
         }
       }
     }
@@ -651,7 +651,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_multipass_fulltile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 8; kc < 128; kc += 24) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_mp8x9p8q__neon);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
           }
         }
       }
@@ -665,8 +665,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_multipass_subtile) {
     auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
     for (size_t ks = ksMax - tester.qr() + 1; ks < ksMax; ks++) {
       for (size_t kc = 8; kc < 128; kc += 24) {
-        tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-        tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+        tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+        tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -681,7 +681,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_multipass_fulltile_with_x_stride) {
         if (kh * kw == ks) {
           for (size_t kc = 8; kc < 128; kc += 24) {
             tester.kh(kh).kw(kw).kc(kc).xStride(131).test(
-                q8avgpool_ukernel_mp8x9p8q__neon);
+                pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
           }
         }
       }
@@ -697,7 +697,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_gt_8_twopass_fulltile) {
     for (size_t kw = 1; kw <= ks; kw++) {
       if (kh * kw == ks) {
         for (size_t kc = 9; kc < 16; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_mp8x9p8q__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
         }
       }
     }
@@ -709,8 +709,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_gt_8_twopass_subtile) {
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
   for (size_t ks = 10; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 9; kc < 16; kc++) {
-      tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-      tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+      tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+      tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
     }
   }
 }
@@ -724,7 +724,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_gt_8_twopass_fulltile_with_x_stride) {
       if (kh * kw == ks) {
         for (size_t kc = 9; kc < 16; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(23).test(
-              q8avgpool_ukernel_mp8x9p8q__neon);
+              pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
         }
       }
     }
@@ -739,7 +739,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_gt_8_multipass_fulltile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 9; kc < 16; kc++) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_mp8x9p8q__neon);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
           }
         }
       }
@@ -753,8 +753,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_gt_8_multipass_subtile) {
     auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
     for (size_t ks = ksMax - tester.qr() + 1; ks < ksMax; ks++) {
       for (size_t kc = 9; kc < 16; kc++) {
-        tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__neon);
-        tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__neon);
+        tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
+        tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -769,7 +769,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_gt_8_multipass_fulltile_with_x_stride) {
         if (kh * kw == ks) {
           for (size_t kc = 9; kc < 16; kc++) {
             tester.kh(kh).kw(kw).kc(kc).xStride(23).test(
-                q8avgpool_ukernel_mp8x9p8q__neon);
+                pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
           }
         }
       }
@@ -792,7 +792,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_with_x_scale) {
             .kc(kc)
             .xScale(xScale)
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -813,7 +813,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_with_x_zero_point) {
             .kc(kc)
             .xZeroPoint(uint8_t(xZeroPoint))
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -834,7 +834,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_with_y_scale) {
             .kc(kc)
             .yScale(yScale)
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -855,7 +855,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_with_y_zero_point) {
             .kc(kc)
             .yZeroPoint(uint8_t(yZeroPoint))
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -879,7 +879,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_with_y_max) {
           .yScale(1.0f)
           .yMax(128)
           .iterations(3)
-          .test(q8avgpool_ukernel_mp8x9p8q__neon);
+          .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
     }
   }
 }
@@ -902,7 +902,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, kc_div_8_with_y_min) {
           .yScale(1.0f)
           .yMin(128)
           .iterations(3)
-          .test(q8avgpool_ukernel_mp8x9p8q__neon);
+          .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
     }
   }
 }
@@ -920,7 +920,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, small_n) {
             .kh(ks)
             .kw(ks)
             .kc(kc)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -940,7 +940,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, small_n_with_x_stride) {
             .kw(ks)
             .kc(kc)
             .xStride(29)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -960,7 +960,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, small_n_with_y_stride) {
             .kw(ks)
             .kc(kc)
             .yStride(31)
-            .test(q8avgpool_ukernel_mp8x9p8q__neon);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
       }
     }
   }
@@ -981,7 +981,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__NEON, small_n_with_s) {
               .kw(ks)
               .kc(kc)
               .s(s)
-              .test(q8avgpool_ukernel_mp8x9p8q__neon);
+              .test(pytorch_q8avgpool_ukernel_mp8x9p8q__neon);
         }
       }
     }
@@ -998,7 +998,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_small_ks) {
         for (size_t kw = 1; kw <= ks; kw++) {
           if (kh * kw == ks) {
             AvgPoolMicrokernelTester().kr(8).kh(kh).kw(kw).kc(kc).test(
-                q8avgpool_ukernel_up8xm__sse2);
+                pytorch_q8avgpool_ukernel_up8xm__sse2);
           }
         }
       }
@@ -1011,9 +1011,9 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_large_ks) {
   for (size_t kc = 1; kc < 8; kc++) {
     for (size_t ks = 8; ks < 16; ks++) {
       AvgPoolMicrokernelTester().kr(8).kh(ks).kw(1).kc(kc).test(
-          q8avgpool_ukernel_up8xm__sse2);
+          pytorch_q8avgpool_ukernel_up8xm__sse2);
       AvgPoolMicrokernelTester().kr(8).kh(1).kw(ks).kc(kc).test(
-          q8avgpool_ukernel_up8xm__sse2);
+          pytorch_q8avgpool_ukernel_up8xm__sse2);
     }
   }
 }
@@ -1032,7 +1032,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_with_x_scale) {
               .kc(kc)
               .xScale(xScale)
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__sse2);
+              .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
         }
       }
     }
@@ -1053,7 +1053,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_with_x_zero_point) {
               .kc(kc)
               .xZeroPoint(uint8_t(xZeroPoint))
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__sse2);
+              .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
         }
       }
     }
@@ -1074,7 +1074,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_with_y_scale) {
               .kc(kc)
               .yScale(yScale)
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__sse2);
+              .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
         }
       }
     }
@@ -1095,7 +1095,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_with_y_zero_point) {
               .kc(kc)
               .yZeroPoint(uint8_t(yZeroPoint))
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__sse2);
+              .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
         }
       }
     }
@@ -1119,7 +1119,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_with_y_max) {
             .yScale(1.0f)
             .yMax(128)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1142,7 +1142,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, kc_lt_8_with_y_min) {
             .yScale(1.0f)
             .yMin(128)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1160,7 +1160,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, small_n) {
             .kw(ks)
             .kc(kc)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1179,7 +1179,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, small_n_with_x_stride) {
             .kc(kc)
             .xStride(11)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1198,7 +1198,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, small_n_with_y_stride) {
             .kc(kc)
             .yStride(13)
             .iterations(3)
-            .test(q8avgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1218,7 +1218,7 @@ TEST(Q8AVGPOOL_UP8xM__SSE2, small_n_with_s) {
               .kc(kc)
               .s(s)
               .iterations(1)
-              .test(q8avgpool_ukernel_up8xm__sse2);
+              .test(pytorch_q8avgpool_ukernel_up8xm__sse2);
         }
       }
     }
@@ -1231,7 +1231,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_eq_8_fulltile) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).test(q8avgpool_ukernel_up8x9__sse2);
+        tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1244,7 +1244,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_eq_8_subtile) {
     for (size_t kh = 1; kh <= ks; kh++) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
-          tester.kh(kh).kw(kw).test(q8avgpool_ukernel_up8x9__sse2);
+          tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_up8x9__sse2);
         }
       }
     }
@@ -1258,7 +1258,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 8; kc < 128; kc += 24) {
-          tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__sse2);
         }
       }
     }
@@ -1273,7 +1273,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_subtile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 8; kc < 128; kc += 24) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__sse2);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__sse2);
           }
         }
       }
@@ -1289,7 +1289,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 8; kc < 128; kc += 24) {
           tester.kh(kh).kw(kw).kc(kc).xStride(131).test(
-              q8avgpool_ukernel_up8x9__sse2);
+              pytorch_q8avgpool_ukernel_up8x9__sse2);
         }
       }
     }
@@ -1303,7 +1303,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_gt_8_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 9; kc < 16; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__sse2);
         }
       }
     }
@@ -1318,7 +1318,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_gt_8_subtile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 9; kc < 16; kc++) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_up8x9__sse2);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_up8x9__sse2);
           }
         }
       }
@@ -1334,7 +1334,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_gt_8_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 9; kc < 16; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(23).test(
-              q8avgpool_ukernel_up8x9__sse2);
+              pytorch_q8avgpool_ukernel_up8x9__sse2);
         }
       }
     }
@@ -1355,7 +1355,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_with_x_scale) {
             .kc(kc)
             .xScale(xScale)
             .iterations(2)
-            .test(q8avgpool_ukernel_up8x9__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1375,7 +1375,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_with_x_zero_point) {
             .kc(kc)
             .xZeroPoint(uint8_t(xZeroPoint))
             .iterations(3)
-            .test(q8avgpool_ukernel_up8x9__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1395,7 +1395,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_with_y_scale) {
             .kc(kc)
             .yScale(yScale)
             .iterations(2)
-            .test(q8avgpool_ukernel_up8x9__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1415,7 +1415,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_with_y_zero_point) {
             .kc(kc)
             .yZeroPoint(uint8_t(yZeroPoint))
             .iterations(3)
-            .test(q8avgpool_ukernel_up8x9__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1437,7 +1437,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_with_y_max) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMax(128)
-          .test(q8avgpool_ukernel_up8x9__sse2);
+          .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
     }
   }
 }
@@ -1458,7 +1458,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, kc_div_8_with_y_min) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMin(128)
-          .test(q8avgpool_ukernel_up8x9__sse2);
+          .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
     }
   }
 }
@@ -1469,7 +1469,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, small_n) {
     for (size_t ks : std::vector<size_t>{{2, 3}}) {
       for (size_t kc = 8; kc < 25; kc += 5) {
         AvgPoolMicrokernelTester().kr(8).mr(9).n(n).kh(ks).kw(ks).kc(kc).test(
-            q8avgpool_ukernel_up8x9__sse2);
+            pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1488,7 +1488,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, small_n_with_x_stride) {
             .kw(ks)
             .kc(kc)
             .xStride(29)
-            .test(q8avgpool_ukernel_up8x9__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1507,7 +1507,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, small_n_with_y_stride) {
             .kw(ks)
             .kc(kc)
             .yStride(31)
-            .test(q8avgpool_ukernel_up8x9__sse2);
+            .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
       }
     }
   }
@@ -1527,7 +1527,7 @@ TEST(Q8AVGPOOL_UP8x9__SSE2, small_n_with_s) {
               .kw(ks)
               .kc(kc)
               .s(s)
-              .test(q8avgpool_ukernel_up8x9__sse2);
+              .test(pytorch_q8avgpool_ukernel_up8x9__sse2);
         }
       }
     }
@@ -1541,7 +1541,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_eq_8_twopass_fulltile) {
   for (size_t kh = 1; kh <= ks; kh++) {
     for (size_t kw = 1; kw <= ks; kw++) {
       if (kh * kw == ks) {
-        tester.kh(kh).kw(kw).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+        tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1551,8 +1551,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_eq_8_twopass_subtile) {
   TEST_REQUIRES_X86_SSE2;
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).kc(8);
   for (size_t ks = 10; ks < tester.mr() + tester.qr(); ks++) {
-    tester.kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-    tester.kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+    tester.kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+    tester.kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
   }
 }
 
@@ -1563,7 +1563,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_eq_8_multipass_fulltile) {
     for (size_t kh = 1; kh <= ks; kh++) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
-          tester.kh(kh).kw(kw).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+          tester.kh(kh).kw(kw).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
         }
       }
     }
@@ -1575,8 +1575,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_eq_8_multipass_subtile) {
   for (size_t ksMax : std::vector<size_t>{{25, 49}}) {
     auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).kc(8);
     for (size_t ks = ksMax - tester.qr() + 1; ks < ksMax; ks++) {
-      tester.kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-      tester.kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+      tester.kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+      tester.kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
     }
   }
 }
@@ -1586,8 +1586,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_twopass_fulltile) {
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
   const size_t ks = 17;
   for (size_t kc = 8; kc < 128; kc += 24) {
-    tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-    tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+    tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+    tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
   }
 }
 
@@ -1596,8 +1596,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_twopass_subtile) {
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
   for (size_t ks = 10; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 8; kc < 128; kc += 24) {
-      tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-      tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+      tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+      tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
     }
   }
 }
@@ -1611,7 +1611,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_twopass_fulltile_with_x_stride) {
       if (kh * kw == ks) {
         for (size_t kc = 8; kc < 128; kc += 24) {
           tester.kh(kh).kw(kw).kc(kc).xStride(131).test(
-              q8avgpool_ukernel_mp8x9p8q__sse2);
+              pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
         }
       }
     }
@@ -1626,7 +1626,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_multipass_fulltile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 8; kc < 128; kc += 24) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
           }
         }
       }
@@ -1640,8 +1640,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_multipass_subtile) {
     auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
     for (size_t ks = ksMax - tester.qr() + 1; ks < ksMax; ks++) {
       for (size_t kc = 8; kc < 128; kc += 24) {
-        tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-        tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+        tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+        tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1656,7 +1656,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_multipass_fulltile_with_x_stride) {
         if (kh * kw == ks) {
           for (size_t kc = 8; kc < 128; kc += 24) {
             tester.kh(kh).kw(kw).kc(kc).xStride(131).test(
-                q8avgpool_ukernel_mp8x9p8q__sse2);
+                pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
           }
         }
       }
@@ -1672,7 +1672,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_gt_8_twopass_fulltile) {
     for (size_t kw = 1; kw <= ks; kw++) {
       if (kh * kw == ks) {
         for (size_t kc = 9; kc < 16; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
         }
       }
     }
@@ -1684,8 +1684,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_gt_8_twopass_subtile) {
   auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
   for (size_t ks = 10; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 9; kc < 16; kc++) {
-      tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-      tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+      tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+      tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
     }
   }
 }
@@ -1699,7 +1699,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_gt_8_twopass_fulltile_with_x_stride) {
       if (kh * kw == ks) {
         for (size_t kc = 9; kc < 16; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(23).test(
-              q8avgpool_ukernel_mp8x9p8q__sse2);
+              pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
         }
       }
     }
@@ -1714,7 +1714,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_gt_8_multipass_fulltile) {
       for (size_t kw = 1; kw <= ks; kw++) {
         if (kh * kw == ks) {
           for (size_t kc = 9; kc < 16; kc++) {
-            tester.kh(kh).kw(kw).kc(kc).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            tester.kh(kh).kw(kw).kc(kc).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
           }
         }
       }
@@ -1728,8 +1728,8 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_gt_8_multipass_subtile) {
     auto tester = AvgPoolMicrokernelTester().kr(8).mr(9).qr(8).iterations(3);
     for (size_t ks = ksMax - tester.qr() + 1; ks < ksMax; ks++) {
       for (size_t kc = 9; kc < 16; kc++) {
-        tester.kc(kc).kh(ks).kw(1).test(q8avgpool_ukernel_mp8x9p8q__sse2);
-        tester.kc(kc).kh(1).kw(ks).test(q8avgpool_ukernel_mp8x9p8q__sse2);
+        tester.kc(kc).kh(ks).kw(1).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
+        tester.kc(kc).kh(1).kw(ks).test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1744,7 +1744,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_gt_8_multipass_fulltile_with_x_stride) {
         if (kh * kw == ks) {
           for (size_t kc = 9; kc < 16; kc++) {
             tester.kh(kh).kw(kw).kc(kc).xStride(23).test(
-                q8avgpool_ukernel_mp8x9p8q__sse2);
+                pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
           }
         }
       }
@@ -1767,7 +1767,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_with_x_scale) {
             .kc(kc)
             .xScale(xScale)
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1788,7 +1788,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_with_x_zero_point) {
             .kc(kc)
             .xZeroPoint(uint8_t(xZeroPoint))
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1809,7 +1809,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_with_y_scale) {
             .kc(kc)
             .yScale(yScale)
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1830,7 +1830,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_with_y_zero_point) {
             .kc(kc)
             .yZeroPoint(uint8_t(yZeroPoint))
             .iterations(1)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1854,7 +1854,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_with_y_max) {
           .yScale(1.0f)
           .yMax(128)
           .iterations(3)
-          .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+          .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
     }
   }
 }
@@ -1877,7 +1877,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, kc_div_8_with_y_min) {
           .yScale(1.0f)
           .yMin(128)
           .iterations(3)
-          .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+          .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
     }
   }
 }
@@ -1895,7 +1895,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, small_n) {
             .kh(ks)
             .kw(ks)
             .kc(kc)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1915,7 +1915,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, small_n_with_x_stride) {
             .kw(ks)
             .kc(kc)
             .xStride(29)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1935,7 +1935,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, small_n_with_y_stride) {
             .kw(ks)
             .kc(kc)
             .yStride(31)
-            .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+            .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
       }
     }
   }
@@ -1956,7 +1956,7 @@ TEST(Q8AVGPOOL_MP8x9P8Q__SSE2, small_n_with_s) {
               .kw(ks)
               .kc(kc)
               .s(s)
-              .test(q8avgpool_ukernel_mp8x9p8q__sse2);
+              .test(pytorch_q8avgpool_ukernel_mp8x9p8q__sse2);
         }
       }
     }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8conv.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8conv.cc
@@ -26,7 +26,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8conv_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_strided_c) {
@@ -41,19 +41,19 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_strided_c) {
       .k(8)
       .aStride(37)
       .cStride(17)
-      .test(q8conv_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmin(128).test(
-      q8conv_ukernel_4x8__aarch32_neon);
+      pytorch_q8conv_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmax(128).test(
-      q8conv_ukernel_4x8__aarch32_neon);
+      pytorch_q8conv_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_azp_only) {
@@ -68,7 +68,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_azp_only) {
       .k(8)
       .aZeroPoint(255)
       .bZeroPoint(0)
-      .test(q8conv_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_bzp_only) {
@@ -83,7 +83,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_eq_8_bzp_only) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(255)
-      .test(q8conv_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8CONV_4x8__AARCH32_NEON, k_gt_8) {
@@ -98,7 +98,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_gt_8) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8conv_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -115,7 +115,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_gt_8_strided_c) {
         .k(k)
         .aStride(37)
         .cStride(17)
-        .test(q8conv_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -133,7 +133,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_gt_8_azp_only) {
         .aStride(37)
         .aZeroPoint(255)
         .bZeroPoint(0)
-        .test(q8conv_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -151,7 +151,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_gt_8_bzp_only) {
         .aStride(37)
         .aZeroPoint(0)
         .bZeroPoint(255)
-        .test(q8conv_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -170,7 +170,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_gt_8_subtile) {
             .k(k)
             .aStride(37)
             .iterations(3)
-            .test(q8conv_ukernel_4x8__aarch32_neon);
+            .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
       }
     }
   }
@@ -188,7 +188,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_div_8) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8conv_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -205,7 +205,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_div_8_strided_c) {
         .k(k)
         .aStride(171)
         .cStride(17)
-        .test(q8conv_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -224,7 +224,7 @@ TEST(Q8CONV_4x8__AARCH32_NEON, k_div_8_subtile) {
             .k(k)
             .aStride(171)
             .iterations(3)
-            .test(q8conv_ukernel_4x8__aarch32_neon);
+            .test(pytorch_q8conv_ukernel_4x8__aarch32_neon);
       }
     }
   }
@@ -242,7 +242,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8conv_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_strided_c) {
@@ -256,17 +256,17 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_strided_c) {
       .k(8)
       .aStride(37)
       .cStride(17)
-      .test(q8conv_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_qmin128) {
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmin(128).test(
-      q8conv_ukernel_8x8__aarch64_neon);
+      pytorch_q8conv_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_qmax128) {
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmax(128).test(
-      q8conv_ukernel_8x8__aarch64_neon);
+      pytorch_q8conv_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_azp_only) {
@@ -280,7 +280,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_azp_only) {
       .k(8)
       .aZeroPoint(255)
       .bZeroPoint(0)
-      .test(q8conv_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_bzp_only) {
@@ -294,7 +294,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_eq_8_bzp_only) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(255)
-      .test(q8conv_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8CONV_8x8__AARCH64_NEON, k_gt_8) {
@@ -308,7 +308,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_gt_8) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8conv_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -324,7 +324,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_gt_8_strided_c) {
         .k(k)
         .aStride(37)
         .cStride(17)
-        .test(q8conv_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -341,7 +341,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_gt_8_azp_only) {
         .aStride(37)
         .aZeroPoint(255)
         .bZeroPoint(0)
-        .test(q8conv_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -358,7 +358,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_gt_8_bzp_only) {
         .aStride(37)
         .aZeroPoint(0)
         .bZeroPoint(255)
-        .test(q8conv_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -376,7 +376,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_gt_8_subtile) {
             .k(k)
             .aStride(37)
             .iterations(3)
-            .test(q8conv_ukernel_8x8__aarch64_neon);
+            .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
       }
     }
   }
@@ -393,7 +393,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_div_8) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8conv_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -409,7 +409,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_div_8_strided_c) {
         .k(k)
         .aStride(171)
         .cStride(17)
-        .test(q8conv_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -427,7 +427,7 @@ TEST(Q8CONV_8x8__AARCH64_NEON, k_div_8_subtile) {
             .k(k)
             .aStride(171)
             .iterations(3)
-            .test(q8conv_ukernel_8x8__aarch64_neon);
+            .test(pytorch_q8conv_ukernel_8x8__aarch64_neon);
       }
     }
   }
@@ -446,7 +446,7 @@ TEST(Q8CONV_4x8__NEON, k_eq_8) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8conv_ukernel_4x8__neon);
+      .test(pytorch_q8conv_ukernel_4x8__neon);
 }
 
 TEST(Q8CONV_4x8__NEON, k_eq_8_strided_c) {
@@ -461,19 +461,19 @@ TEST(Q8CONV_4x8__NEON, k_eq_8_strided_c) {
       .k(8)
       .aStride(37)
       .cStride(17)
-      .test(q8conv_ukernel_4x8__neon);
+      .test(pytorch_q8conv_ukernel_4x8__neon);
 }
 
 TEST(Q8CONV_4x8__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmin(128).test(
-      q8conv_ukernel_4x8__neon);
+      pytorch_q8conv_ukernel_4x8__neon);
 }
 
 TEST(Q8CONV_4x8__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmax(128).test(
-      q8conv_ukernel_4x8__neon);
+      pytorch_q8conv_ukernel_4x8__neon);
 }
 
 TEST(Q8CONV_4x8__NEON, k_eq_8_azp_only) {
@@ -488,7 +488,7 @@ TEST(Q8CONV_4x8__NEON, k_eq_8_azp_only) {
       .k(8)
       .aZeroPoint(255)
       .bZeroPoint(0)
-      .test(q8conv_ukernel_4x8__neon);
+      .test(pytorch_q8conv_ukernel_4x8__neon);
 }
 
 TEST(Q8CONV_4x8__NEON, k_eq_8_bzp_only) {
@@ -503,7 +503,7 @@ TEST(Q8CONV_4x8__NEON, k_eq_8_bzp_only) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(255)
-      .test(q8conv_ukernel_4x8__neon);
+      .test(pytorch_q8conv_ukernel_4x8__neon);
 }
 
 TEST(Q8CONV_4x8__NEON, k_gt_8) {
@@ -518,7 +518,7 @@ TEST(Q8CONV_4x8__NEON, k_gt_8) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8conv_ukernel_4x8__neon);
+        .test(pytorch_q8conv_ukernel_4x8__neon);
   }
 }
 
@@ -535,7 +535,7 @@ TEST(Q8CONV_4x8__NEON, k_gt_8_strided_c) {
         .k(k)
         .aStride(37)
         .cStride(17)
-        .test(q8conv_ukernel_4x8__neon);
+        .test(pytorch_q8conv_ukernel_4x8__neon);
   }
 }
 
@@ -553,7 +553,7 @@ TEST(Q8CONV_4x8__NEON, k_gt_8_azp_only) {
         .aStride(37)
         .aZeroPoint(255)
         .bZeroPoint(0)
-        .test(q8conv_ukernel_4x8__neon);
+        .test(pytorch_q8conv_ukernel_4x8__neon);
   }
 }
 
@@ -571,7 +571,7 @@ TEST(Q8CONV_4x8__NEON, k_gt_8_bzp_only) {
         .aStride(37)
         .aZeroPoint(0)
         .bZeroPoint(255)
-        .test(q8conv_ukernel_4x8__neon);
+        .test(pytorch_q8conv_ukernel_4x8__neon);
   }
 }
 
@@ -590,7 +590,7 @@ TEST(Q8CONV_4x8__NEON, k_gt_8_subtile) {
             .k(k)
             .aStride(37)
             .iterations(3)
-            .test(q8conv_ukernel_4x8__neon);
+            .test(pytorch_q8conv_ukernel_4x8__neon);
       }
     }
   }
@@ -608,7 +608,7 @@ TEST(Q8CONV_4x8__NEON, k_div_8) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8conv_ukernel_4x8__neon);
+        .test(pytorch_q8conv_ukernel_4x8__neon);
   }
 }
 
@@ -625,7 +625,7 @@ TEST(Q8CONV_4x8__NEON, k_div_8_strided_c) {
         .k(k)
         .aStride(171)
         .cStride(17)
-        .test(q8conv_ukernel_4x8__neon);
+        .test(pytorch_q8conv_ukernel_4x8__neon);
   }
 }
 
@@ -644,7 +644,7 @@ TEST(Q8CONV_4x8__NEON, k_div_8_subtile) {
             .k(k)
             .aStride(171)
             .iterations(3)
-            .test(q8conv_ukernel_4x8__neon);
+            .test(pytorch_q8conv_ukernel_4x8__neon);
       }
     }
   }
@@ -661,7 +661,7 @@ TEST(Q8CONV_8x8__NEON, k_eq_8) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8conv_ukernel_8x8__neon);
+      .test(pytorch_q8conv_ukernel_8x8__neon);
 }
 
 TEST(Q8CONV_8x8__NEON, k_eq_8_strided_c) {
@@ -676,19 +676,19 @@ TEST(Q8CONV_8x8__NEON, k_eq_8_strided_c) {
       .k(8)
       .aStride(37)
       .cStride(17)
-      .test(q8conv_ukernel_8x8__neon);
+      .test(pytorch_q8conv_ukernel_8x8__neon);
 }
 
 TEST(Q8CONV_8x8__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmin(128).test(
-      q8conv_ukernel_8x8__neon);
+      pytorch_q8conv_ukernel_8x8__neon);
 }
 
 TEST(Q8CONV_8x8__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmax(128).test(
-      q8conv_ukernel_8x8__neon);
+      pytorch_q8conv_ukernel_8x8__neon);
 }
 
 TEST(Q8CONV_8x8__NEON, k_eq_8_azp_only) {
@@ -703,7 +703,7 @@ TEST(Q8CONV_8x8__NEON, k_eq_8_azp_only) {
       .k(8)
       .aZeroPoint(255)
       .bZeroPoint(0)
-      .test(q8conv_ukernel_8x8__neon);
+      .test(pytorch_q8conv_ukernel_8x8__neon);
 }
 
 TEST(Q8CONV_8x8__NEON, k_eq_8_bzp_only) {
@@ -718,7 +718,7 @@ TEST(Q8CONV_8x8__NEON, k_eq_8_bzp_only) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(255)
-      .test(q8conv_ukernel_8x8__neon);
+      .test(pytorch_q8conv_ukernel_8x8__neon);
 }
 
 TEST(Q8CONV_8x8__NEON, k_gt_8) {
@@ -733,7 +733,7 @@ TEST(Q8CONV_8x8__NEON, k_gt_8) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8conv_ukernel_8x8__neon);
+        .test(pytorch_q8conv_ukernel_8x8__neon);
   }
 }
 
@@ -750,7 +750,7 @@ TEST(Q8CONV_8x8__NEON, k_gt_8_strided_c) {
         .k(k)
         .aStride(37)
         .cStride(17)
-        .test(q8conv_ukernel_8x8__neon);
+        .test(pytorch_q8conv_ukernel_8x8__neon);
   }
 }
 
@@ -768,7 +768,7 @@ TEST(Q8CONV_8x8__NEON, k_gt_8_azp_only) {
         .aStride(37)
         .aZeroPoint(255)
         .bZeroPoint(0)
-        .test(q8conv_ukernel_8x8__neon);
+        .test(pytorch_q8conv_ukernel_8x8__neon);
   }
 }
 
@@ -786,7 +786,7 @@ TEST(Q8CONV_8x8__NEON, k_gt_8_bzp_only) {
         .aStride(37)
         .aZeroPoint(0)
         .bZeroPoint(255)
-        .test(q8conv_ukernel_8x8__neon);
+        .test(pytorch_q8conv_ukernel_8x8__neon);
   }
 }
 
@@ -805,7 +805,7 @@ TEST(Q8CONV_8x8__NEON, k_gt_8_subtile) {
             .k(k)
             .aStride(37)
             .iterations(3)
-            .test(q8conv_ukernel_8x8__neon);
+            .test(pytorch_q8conv_ukernel_8x8__neon);
       }
     }
   }
@@ -823,7 +823,7 @@ TEST(Q8CONV_8x8__NEON, k_div_8) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8conv_ukernel_8x8__neon);
+        .test(pytorch_q8conv_ukernel_8x8__neon);
   }
 }
 
@@ -840,7 +840,7 @@ TEST(Q8CONV_8x8__NEON, k_div_8_strided_c) {
         .k(k)
         .aStride(171)
         .cStride(17)
-        .test(q8conv_ukernel_8x8__neon);
+        .test(pytorch_q8conv_ukernel_8x8__neon);
   }
 }
 
@@ -859,7 +859,7 @@ TEST(Q8CONV_8x8__NEON, k_div_8_subtile) {
             .k(k)
             .aStride(171)
             .iterations(3)
-            .test(q8conv_ukernel_8x8__neon);
+            .test(pytorch_q8conv_ukernel_8x8__neon);
       }
     }
   }
@@ -878,7 +878,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_eq_8) {
       .n(4)
       .k(8)
       .aStride(37)
-      .test(q8conv_ukernel_4x4c2__sse2);
+      .test(pytorch_q8conv_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8CONV_4x4c2__SSE2, k_eq_8_strided_c) {
@@ -893,19 +893,19 @@ TEST(Q8CONV_4x4c2__SSE2, k_eq_8_strided_c) {
       .k(8)
       .aStride(37)
       .cStride(17)
-      .test(q8conv_ukernel_4x4c2__sse2);
+      .test(pytorch_q8conv_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8CONV_4x4c2__SSE2, k_eq_8_qmin128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(8).qmin(128).test(
-      q8conv_ukernel_4x4c2__sse2);
+      pytorch_q8conv_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8CONV_4x4c2__SSE2, k_eq_8_qmax128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(8).qmax(128).test(
-      q8conv_ukernel_4x4c2__sse2);
+      pytorch_q8conv_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8CONV_4x4c2__SSE2, k_eq_8_azp_only) {
@@ -920,7 +920,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_eq_8_azp_only) {
       .k(8)
       .aZeroPoint(255)
       .bZeroPoint(0)
-      .test(q8conv_ukernel_4x4c2__sse2);
+      .test(pytorch_q8conv_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8CONV_4x4c2__SSE2, k_eq_8_bzp_only) {
@@ -935,7 +935,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_eq_8_bzp_only) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(255)
-      .test(q8conv_ukernel_4x4c2__sse2);
+      .test(pytorch_q8conv_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8CONV_4x4c2__SSE2, k_gt_8) {
@@ -950,7 +950,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_gt_8) {
         .n(4)
         .k(k)
         .aStride(37)
-        .test(q8conv_ukernel_4x4c2__sse2);
+        .test(pytorch_q8conv_ukernel_4x4c2__sse2);
   }
 }
 
@@ -967,7 +967,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_gt_8_strided_c) {
         .k(k)
         .aStride(37)
         .cStride(17)
-        .test(q8conv_ukernel_4x4c2__sse2);
+        .test(pytorch_q8conv_ukernel_4x4c2__sse2);
   }
 }
 
@@ -985,7 +985,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_gt_8_azp_only) {
         .aStride(37)
         .aZeroPoint(255)
         .bZeroPoint(0)
-        .test(q8conv_ukernel_4x4c2__sse2);
+        .test(pytorch_q8conv_ukernel_4x4c2__sse2);
   }
 }
 
@@ -1003,7 +1003,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_gt_8_bzp_only) {
         .aStride(37)
         .aZeroPoint(0)
         .bZeroPoint(255)
-        .test(q8conv_ukernel_4x4c2__sse2);
+        .test(pytorch_q8conv_ukernel_4x4c2__sse2);
   }
 }
 
@@ -1022,7 +1022,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_gt_8_subtile) {
             .k(k)
             .aStride(37)
             .iterations(3)
-            .test(q8conv_ukernel_4x4c2__sse2);
+            .test(pytorch_q8conv_ukernel_4x4c2__sse2);
       }
     }
   }
@@ -1040,7 +1040,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_div_8) {
         .n(4)
         .k(k)
         .aStride(171)
-        .test(q8conv_ukernel_4x4c2__sse2);
+        .test(pytorch_q8conv_ukernel_4x4c2__sse2);
   }
 }
 
@@ -1057,7 +1057,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_div_8_strided_c) {
         .k(k)
         .aStride(171)
         .cStride(17)
-        .test(q8conv_ukernel_4x4c2__sse2);
+        .test(pytorch_q8conv_ukernel_4x4c2__sse2);
   }
 }
 
@@ -1076,7 +1076,7 @@ TEST(Q8CONV_4x4c2__SSE2, k_div_8_subtile) {
             .k(k)
             .aStride(171)
             .iterations(3)
-            .test(q8conv_ukernel_4x4c2__sse2);
+            .test(pytorch_q8conv_ukernel_4x4c2__sse2);
       }
     }
   }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8dwconv.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8dwconv.cc
@@ -23,7 +23,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(1)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_eq_8_with_qmin) {
@@ -35,7 +35,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_eq_8_with_qmin) {
       .channels(8)
       .width(1)
       .qmin(128)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_eq_8_with_qmax) {
@@ -47,7 +47,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_eq_8_with_qmax) {
       .channels(8)
       .width(1)
       .qmax(128)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(
@@ -62,7 +62,7 @@ TEST(
       .width(1)
       .inputZeroPoint(255)
       .kernelZeroPoint(0)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(
@@ -77,7 +77,7 @@ TEST(
       .width(1)
       .inputZeroPoint(0)
       .kernelZeroPoint(255)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8) {
@@ -88,7 +88,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8_with_subsampling) {
@@ -100,7 +100,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8_with_subsampling) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8_with_input_stride) {
@@ -112,7 +112,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8_with_input_stride) {
       .channels(8)
       .width(5)
       .inputStride(17)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8_with_output_stride) {
@@ -124,7 +124,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_eq_8_with_output_stride) {
       .channels(8)
       .width(5)
       .outputStride(19)
-      .test(q8dwconv_ukernel_up8x9__neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__neon);
 }
 
 TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_div_8) {
@@ -136,7 +136,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -149,7 +149,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -163,7 +163,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_div_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(171)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -176,7 +176,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -190,7 +190,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_gt_8_with_qmin) {
         .channels(channels)
         .width(1)
         .qmin(128)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -204,7 +204,7 @@ TEST(Q8DWCONV_UP8x9__NEON, single_output_channels_gt_8_with_qmax) {
         .channels(channels)
         .width(1)
         .qmax(128)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -221,7 +221,7 @@ TEST(
         .width(1)
         .inputZeroPoint(255)
         .kernelZeroPoint(0)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -238,7 +238,7 @@ TEST(
         .width(1)
         .inputZeroPoint(0)
         .kernelZeroPoint(255)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -251,7 +251,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -265,7 +265,7 @@ TEST(Q8DWCONV_UP8x9__NEON, multi_output_channels_gt_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(17)
-        .test(q8dwconv_ukernel_up8x9__neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__neon);
   }
 }
 
@@ -277,7 +277,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(1)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8_with_subsampling) {
@@ -289,7 +289,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8_with_subsampling) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8_with_input_stride) {
@@ -301,7 +301,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8_with_input_stride) {
       .channels(8)
       .width(5)
       .inputStride(17)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8_with_output_stride) {
@@ -313,7 +313,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8_with_output_stride) {
       .channels(8)
       .width(5)
       .outputStride(19)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_eq_8_with_qmin) {
@@ -325,7 +325,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_eq_8_with_qmin) {
       .channels(8)
       .width(1)
       .qmin(128)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_eq_8_with_qmax) {
@@ -337,7 +337,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_eq_8_with_qmax) {
       .channels(8)
       .width(1)
       .qmax(128)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(
@@ -352,7 +352,7 @@ TEST(
       .width(1)
       .inputZeroPoint(255)
       .kernelZeroPoint(0)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(
@@ -367,7 +367,7 @@ TEST(
       .width(1)
       .inputZeroPoint(0)
       .kernelZeroPoint(255)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8) {
@@ -378,7 +378,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(3)
-      .test(q8dwconv_ukernel_mp8x25__neon);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
 }
 
 TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_div_8) {
@@ -390,7 +390,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -403,7 +403,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -417,7 +417,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_div_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(171)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -430,7 +430,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -444,7 +444,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_gt_8_with_qmin) {
         .channels(channels)
         .width(1)
         .qmin(128)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -458,7 +458,7 @@ TEST(Q8DWCONV_MP8x25__NEON, single_output_channels_gt_8_with_qmax) {
         .channels(channels)
         .width(1)
         .qmax(128)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -471,7 +471,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 
@@ -485,7 +485,7 @@ TEST(Q8DWCONV_MP8x25__NEON, multi_output_channels_gt_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(17)
-        .test(q8dwconv_ukernel_mp8x25__neon);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__neon);
   }
 }
 #endif /* CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 */
@@ -499,7 +499,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(1)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_eq_8_with_qmin) {
@@ -511,7 +511,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_eq_8_with_qmin) {
       .channels(8)
       .width(1)
       .qmin(128)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_eq_8_with_qmax) {
@@ -523,7 +523,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_eq_8_with_qmax) {
       .channels(8)
       .width(1)
       .qmax(128)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(
@@ -538,7 +538,7 @@ TEST(
       .width(1)
       .inputZeroPoint(255)
       .kernelZeroPoint(0)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(
@@ -553,7 +553,7 @@ TEST(
       .width(1)
       .inputZeroPoint(0)
       .kernelZeroPoint(255)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(Q8DWCONV_UP8x9__AARCH32_NEON, multi_output_channels_eq_8) {
@@ -564,7 +564,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, multi_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(
@@ -578,7 +578,7 @@ TEST(
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(
@@ -592,7 +592,7 @@ TEST(
       .channels(8)
       .width(5)
       .inputStride(17)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(
@@ -606,7 +606,7 @@ TEST(
       .channels(8)
       .width(5)
       .outputStride(19)
-      .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+      .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
 }
 
 TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_div_8) {
@@ -618,7 +618,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -631,7 +631,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, multi_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -647,7 +647,7 @@ TEST(
         .channels(channels)
         .width(5)
         .outputStride(171)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -660,7 +660,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -674,7 +674,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_gt_8_with_qmin) {
         .channels(channels)
         .width(1)
         .qmin(128)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -688,7 +688,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, single_output_channels_gt_8_with_qmax) {
         .channels(channels)
         .width(1)
         .qmax(128)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -705,7 +705,7 @@ TEST(
         .width(1)
         .inputZeroPoint(255)
         .kernelZeroPoint(0)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -722,7 +722,7 @@ TEST(
         .width(1)
         .inputZeroPoint(0)
         .kernelZeroPoint(255)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -735,7 +735,7 @@ TEST(Q8DWCONV_UP8x9__AARCH32_NEON, multi_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 
@@ -751,7 +751,7 @@ TEST(
         .channels(channels)
         .width(5)
         .outputStride(17)
-        .test(q8dwconv_ukernel_up8x9__aarch32_neon);
+        .test(pytorch_q8dwconv_ukernel_up8x9__aarch32_neon);
   }
 }
 #endif /* CPUINFO_ARCH_ARM */
@@ -765,7 +765,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(1)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_eq_8_with_qmin) {
@@ -777,7 +777,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_eq_8_with_qmin) {
       .channels(8)
       .width(1)
       .qmin(128)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_eq_8_with_qmax) {
@@ -789,7 +789,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_eq_8_with_qmax) {
       .channels(8)
       .width(1)
       .qmax(128)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(
@@ -804,7 +804,7 @@ TEST(
       .width(1)
       .inputZeroPoint(255)
       .kernelZeroPoint(0)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(
@@ -819,7 +819,7 @@ TEST(
       .width(1)
       .inputZeroPoint(0)
       .kernelZeroPoint(255)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8) {
@@ -830,7 +830,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8_with_subsampling) {
@@ -842,7 +842,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8_with_subsampling) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8_with_input_stride) {
@@ -854,7 +854,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8_with_input_stride) {
       .channels(8)
       .width(5)
       .inputStride(17)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8_with_output_stride) {
@@ -866,7 +866,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_eq_8_with_output_stride) {
       .channels(8)
       .width(5)
       .outputStride(19)
-      .test(q8dwconv_ukernel_up8x9__sse2);
+      .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
 }
 
 TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_div_8) {
@@ -878,7 +878,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -891,7 +891,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -905,7 +905,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_div_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(171)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -918,7 +918,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -932,7 +932,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_gt_8_with_qmin) {
         .channels(channels)
         .width(1)
         .qmin(128)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -946,7 +946,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, single_output_channels_gt_8_with_qmax) {
         .channels(channels)
         .width(1)
         .qmax(128)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -963,7 +963,7 @@ TEST(
         .width(1)
         .inputZeroPoint(255)
         .kernelZeroPoint(0)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -980,7 +980,7 @@ TEST(
         .width(1)
         .inputZeroPoint(0)
         .kernelZeroPoint(255)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -993,7 +993,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -1007,7 +1007,7 @@ TEST(Q8DWCONV_UP8x9__SSE2, multi_output_channels_gt_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(17)
-        .test(q8dwconv_ukernel_up8x9__sse2);
+        .test(pytorch_q8dwconv_ukernel_up8x9__sse2);
   }
 }
 
@@ -1019,7 +1019,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(1)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_eq_8_with_qmin) {
@@ -1031,7 +1031,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_eq_8_with_qmin) {
       .channels(8)
       .width(1)
       .qmin(128)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_eq_8_with_qmax) {
@@ -1043,7 +1043,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_eq_8_with_qmax) {
       .channels(8)
       .width(1)
       .qmax(128)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(
@@ -1058,7 +1058,7 @@ TEST(
       .width(1)
       .inputZeroPoint(255)
       .kernelZeroPoint(0)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(
@@ -1073,7 +1073,7 @@ TEST(
       .width(1)
       .inputZeroPoint(0)
       .kernelZeroPoint(255)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8) {
@@ -1084,7 +1084,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8_with_subsampling) {
@@ -1096,7 +1096,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8_with_subsampling) {
       .cr(8)
       .channels(8)
       .width(5)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8_with_input_stride) {
@@ -1108,7 +1108,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8_with_input_stride) {
       .channels(8)
       .width(5)
       .inputStride(17)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8_with_output_stride) {
@@ -1120,7 +1120,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_eq_8_with_output_stride) {
       .channels(8)
       .width(5)
       .outputStride(19)
-      .test(q8dwconv_ukernel_mp8x25__sse2);
+      .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
 }
 
 TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_div_8) {
@@ -1132,7 +1132,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1145,7 +1145,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_div_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1159,7 +1159,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_div_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(171)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1172,7 +1172,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(1)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1186,7 +1186,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_gt_8_with_qmin) {
         .channels(channels)
         .width(1)
         .qmin(128)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1200,7 +1200,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, single_output_channels_gt_8_with_qmax) {
         .channels(channels)
         .width(1)
         .qmax(128)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1217,7 +1217,7 @@ TEST(
         .width(1)
         .inputZeroPoint(255)
         .kernelZeroPoint(0)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1234,7 +1234,7 @@ TEST(
         .width(1)
         .inputZeroPoint(0)
         .kernelZeroPoint(255)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1247,7 +1247,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_gt_8) {
         .cr(8)
         .channels(channels)
         .width(5)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 
@@ -1261,7 +1261,7 @@ TEST(Q8DWCONV_MP8x25__SSE2, multi_output_channels_gt_8_with_output_stride) {
         .channels(channels)
         .width(5)
         .outputStride(17)
-        .test(q8dwconv_ukernel_mp8x25__sse2);
+        .test(pytorch_q8dwconv_ukernel_mp8x25__sse2);
   }
 }
 #endif /* CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64 */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8gavgpool.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8gavgpool.cc
@@ -17,27 +17,27 @@
 #if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m) {
   TEST_REQUIRES_ARM_NEON;
-  GAvgPoolMicrokernelTester().m(7).n(8).test(q8gavgpool_ukernel_up8x7__neon);
+  GAvgPoolMicrokernelTester().m(7).n(8).test(pytorch_q8gavgpool_ukernel_up8x7__neon);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_few_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t m = 1; m < 7; m++) {
-    GAvgPoolMicrokernelTester().m(m).n(8).test(q8gavgpool_ukernel_up8x7__neon);
+    GAvgPoolMicrokernelTester().m(m).n(8).test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_x_stride) {
   TEST_REQUIRES_ARM_NEON;
   GAvgPoolMicrokernelTester().m(7).n(8).xStride(11).test(
-      q8gavgpool_ukernel_up8x7__neon);
+      pytorch_q8gavgpool_ukernel_up8x7__neon);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_x_scale) {
   TEST_REQUIRES_ARM_NEON;
   for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(7).n(8).xScale(xScale).test(
-        q8gavgpool_ukernel_up8x7__neon);
+        pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -48,7 +48,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_x_zero_point) {
         .m(7)
         .n(8)
         .xZeroPoint(xZeroPoint)
-        .test(q8gavgpool_ukernel_up8x7__neon);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -56,7 +56,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_y_scale) {
   TEST_REQUIRES_ARM_NEON;
   for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(7).n(8).yScale(yScale).test(
-        q8gavgpool_ukernel_up8x7__neon);
+        pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -67,7 +67,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_y_zero_point) {
         .m(7)
         .n(8)
         .yZeroPoint(yZeroPoint)
-        .test(q8gavgpool_ukernel_up8x7__neon);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -81,7 +81,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_y_max) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMax(128)
-      .test(q8gavgpool_ukernel_up8x7__neon);
+      .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_y_min) {
@@ -94,13 +94,13 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_eq_8_all_m_with_y_min) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMin(128)
-      .test(q8gavgpool_ukernel_up8x7__neon);
+      .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_div_8_all_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 8; n < 128; n += 24) {
-    GAvgPoolMicrokernelTester().m(7).n(n).test(q8gavgpool_ukernel_up8x7__neon);
+    GAvgPoolMicrokernelTester().m(7).n(n).test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -109,7 +109,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_div_8_few_m) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8x7__neon);
+          pytorch_q8gavgpool_ukernel_up8x7__neon);
     }
   }
 }
@@ -117,7 +117,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_div_8_few_m) {
 TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 9; n < 16; n++) {
-    GAvgPoolMicrokernelTester().m(7).n(n).test(q8gavgpool_ukernel_up8x7__neon);
+    GAvgPoolMicrokernelTester().m(7).n(n).test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -126,7 +126,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_few_m) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8x7__neon);
+          pytorch_q8gavgpool_ukernel_up8x7__neon);
     }
   }
 }
@@ -136,7 +136,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m_with_x_scale) {
   for (size_t n = 9; n < 16; n++) {
     for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
       GAvgPoolMicrokernelTester().m(7).n(n).xScale(xScale).test(
-          q8gavgpool_ukernel_up8x7__neon);
+          pytorch_q8gavgpool_ukernel_up8x7__neon);
     }
   }
 }
@@ -149,7 +149,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m_with_x_zero_point) {
           .m(7)
           .n(n)
           .xZeroPoint(xZeroPoint)
-          .test(q8gavgpool_ukernel_up8x7__neon);
+          .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
     }
   }
 }
@@ -159,7 +159,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m_with_y_scale) {
   for (size_t n = 9; n < 16; n++) {
     for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
       GAvgPoolMicrokernelTester().m(7).n(n).yScale(yScale).test(
-          q8gavgpool_ukernel_up8x7__neon);
+          pytorch_q8gavgpool_ukernel_up8x7__neon);
     }
   }
 }
@@ -172,7 +172,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m_with_y_zero_point) {
           .m(7)
           .n(n)
           .yZeroPoint(yZeroPoint)
-          .test(q8gavgpool_ukernel_up8x7__neon);
+          .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
     }
   }
 }
@@ -188,7 +188,7 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m_with_y_max) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMax(128)
-        .test(q8gavgpool_ukernel_up8x7__neon);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
@@ -203,27 +203,27 @@ TEST(Q8GAVGPOOL_UP8x7__NEON, n_gt_8_all_m_with_y_min) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMin(128)
-        .test(q8gavgpool_ukernel_up8x7__neon);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__neon);
   }
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m) {
   TEST_REQUIRES_ARM_NEON;
   GAvgPoolMicrokernelTester().m(14).n(8).nr(8).test(
-      q8gavgpool_ukernel_mp8x7p7q__neon);
+      pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_x_stride) {
   TEST_REQUIRES_ARM_NEON;
   GAvgPoolMicrokernelTester().m(14).n(8).nr(8).xStride(11).test(
-      q8gavgpool_ukernel_mp8x7p7q__neon);
+      pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_x_scale) {
   TEST_REQUIRES_ARM_NEON;
   for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(14).n(8).nr(8).xScale(xScale).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -235,7 +235,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_x_zero_point) {
         .n(8)
         .nr(8)
         .xZeroPoint(xZeroPoint)
-        .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -243,7 +243,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_y_scale) {
   TEST_REQUIRES_ARM_NEON;
   for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(14).n(8).nr(8).yScale(yScale).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -255,7 +255,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_y_zero_point) {
         .n(8)
         .nr(8)
         .yZeroPoint(yZeroPoint)
-        .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -270,7 +270,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_y_max) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMax(128)
-      .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+      .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_y_min) {
@@ -284,14 +284,14 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_all_m_with_y_min) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMin(128)
-      .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+      .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_few_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t m = 1; m < 7; m++) {
     GAvgPoolMicrokernelTester().m(7 + m).n(8).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -299,7 +299,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_2pass_few_m_with_x_stride) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t m = 1; m < 7; m++) {
     GAvgPoolMicrokernelTester().m(7 + m).n(8).nr(8).xStride(11).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -307,7 +307,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_multipass_all_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t m = 14; m <= 35; m += 7) {
     GAvgPoolMicrokernelTester().m(m).n(8).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -315,7 +315,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_eq_8_multipass_all_m_with_x_stride) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t m = 14; m <= 35; m += 7) {
     GAvgPoolMicrokernelTester().m(m).n(8).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -323,7 +323,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_div_8_2pass_all_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 8; n < 128; n += 24) {
     GAvgPoolMicrokernelTester().m(14).n(n).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -332,7 +332,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_div_8_2pass_few_m) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(7 + m).n(n).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -342,7 +342,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_div_8_multipass_all_m) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -352,7 +352,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_div_8_multipass_all_m_with_x_stride) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).nr(8).xStride(131).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -361,7 +361,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 9; n < 16; n++) {
     GAvgPoolMicrokernelTester().m(14).n(n).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__neon);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -370,7 +370,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m_with_x_scale) {
   for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
     for (size_t n = 9; n < 16; n++) {
       GAvgPoolMicrokernelTester().m(14).n(n).nr(8).xScale(xScale).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -384,7 +384,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m_with_x_zero_point) {
           .n(n)
           .nr(8)
           .xZeroPoint(xZeroPoint)
-          .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+          .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -394,7 +394,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m_with_y_scale) {
   for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
     for (size_t n = 9; n < 16; n++) {
       GAvgPoolMicrokernelTester().m(14).n(n).nr(8).yScale(yScale).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -408,7 +408,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m_with_y_zero_point) {
           .n(n)
           .nr(8)
           .yZeroPoint(yZeroPoint)
-          .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+          .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -425,7 +425,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m_with_y_max) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMax(128)
-        .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -441,7 +441,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_all_m_with_y_min) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMin(128)
-        .test(q8gavgpool_ukernel_mp8x7p7q__neon);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
   }
 }
 
@@ -450,7 +450,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_2pass_few_m) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(7 + m).n(n).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -460,7 +460,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_multipass_all_m) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -470,7 +470,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__NEON, n_gt_8_multipass_all_m_with_x_stride) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).xStride(23).test(
-          q8gavgpool_ukernel_mp8x7p7q__neon);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__neon);
     }
   }
 }
@@ -480,7 +480,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_small_m) {
   for (size_t n = 1; n < 8; n++) {
     for (size_t m = 1; m < 8; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8xm__neon);
+          pytorch_q8gavgpool_ukernel_up8xm__neon);
     }
   }
 }
@@ -490,7 +490,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_large_m) {
   for (size_t n = 1; n < 8; n++) {
     for (size_t m = 8; m < 16; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8xm__neon);
+          pytorch_q8gavgpool_ukernel_up8xm__neon);
     }
   }
 }
@@ -501,7 +501,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_x_scale) {
     for (size_t m = 1; m < 16; m += 5) {
       for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
         GAvgPoolMicrokernelTester().m(m).n(n).xScale(xScale).test(
-            q8gavgpool_ukernel_up8xm__neon);
+            pytorch_q8gavgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -516,7 +516,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_x_zero_point) {
             .m(m)
             .n(n)
             .xZeroPoint(xZeroPoint)
-            .test(q8gavgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8gavgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -528,7 +528,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_y_scale) {
     for (size_t m = 1; m < 16; m += 5) {
       for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
         GAvgPoolMicrokernelTester().m(m).n(n).yScale(yScale).test(
-            q8gavgpool_ukernel_up8xm__neon);
+            pytorch_q8gavgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -543,7 +543,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_y_zero_point) {
             .m(m)
             .n(n)
             .yZeroPoint(yZeroPoint)
-            .test(q8gavgpool_ukernel_up8xm__neon);
+            .test(pytorch_q8gavgpool_ukernel_up8xm__neon);
       }
     }
   }
@@ -561,7 +561,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_y_max) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMax(128)
-          .test(q8gavgpool_ukernel_up8xm__neon);
+          .test(pytorch_q8gavgpool_ukernel_up8xm__neon);
     }
   }
 }
@@ -578,7 +578,7 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_y_min) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMin(128)
-          .test(q8gavgpool_ukernel_up8xm__neon);
+          .test(pytorch_q8gavgpool_ukernel_up8xm__neon);
     }
   }
 }
@@ -587,27 +587,27 @@ TEST(Q8GAVGPOOL_UP8xM__NEON, n_lt_8_with_y_min) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m) {
   TEST_REQUIRES_X86_SSE2;
-  GAvgPoolMicrokernelTester().m(7).n(8).test(q8gavgpool_ukernel_up8x7__sse2);
+  GAvgPoolMicrokernelTester().m(7).n(8).test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_few_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t m = 1; m < 7; m++) {
-    GAvgPoolMicrokernelTester().m(m).n(8).test(q8gavgpool_ukernel_up8x7__sse2);
+    GAvgPoolMicrokernelTester().m(m).n(8).test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_x_stride) {
   TEST_REQUIRES_X86_SSE2;
   GAvgPoolMicrokernelTester().m(7).n(8).xStride(11).test(
-      q8gavgpool_ukernel_up8x7__sse2);
+      pytorch_q8gavgpool_ukernel_up8x7__sse2);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_x_scale) {
   TEST_REQUIRES_X86_SSE2;
   for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(7).n(8).xScale(xScale).test(
-        q8gavgpool_ukernel_up8x7__sse2);
+        pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -618,7 +618,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_x_zero_point) {
         .m(7)
         .n(8)
         .xZeroPoint(xZeroPoint)
-        .test(q8gavgpool_ukernel_up8x7__sse2);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -626,7 +626,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_y_scale) {
   TEST_REQUIRES_X86_SSE2;
   for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(7).n(8).yScale(yScale).test(
-        q8gavgpool_ukernel_up8x7__sse2);
+        pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -637,7 +637,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_y_zero_point) {
         .m(7)
         .n(8)
         .yZeroPoint(yZeroPoint)
-        .test(q8gavgpool_ukernel_up8x7__sse2);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -651,7 +651,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_y_max) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMax(128)
-      .test(q8gavgpool_ukernel_up8x7__sse2);
+      .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_y_min) {
@@ -664,13 +664,13 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_eq_8_all_m_with_y_min) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMin(128)
-      .test(q8gavgpool_ukernel_up8x7__sse2);
+      .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
 }
 
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_div_8_all_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 8; n < 128; n += 24) {
-    GAvgPoolMicrokernelTester().m(7).n(n).test(q8gavgpool_ukernel_up8x7__sse2);
+    GAvgPoolMicrokernelTester().m(7).n(n).test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -679,7 +679,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_div_8_few_m) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8x7__sse2);
+          pytorch_q8gavgpool_ukernel_up8x7__sse2);
     }
   }
 }
@@ -687,7 +687,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_div_8_few_m) {
 TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 9; n < 16; n++) {
-    GAvgPoolMicrokernelTester().m(7).n(n).test(q8gavgpool_ukernel_up8x7__sse2);
+    GAvgPoolMicrokernelTester().m(7).n(n).test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -696,7 +696,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_few_m) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8x7__sse2);
+          pytorch_q8gavgpool_ukernel_up8x7__sse2);
     }
   }
 }
@@ -706,7 +706,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m_with_x_scale) {
   for (size_t n = 9; n < 16; n++) {
     for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
       GAvgPoolMicrokernelTester().m(7).n(n).xScale(xScale).test(
-          q8gavgpool_ukernel_up8x7__sse2);
+          pytorch_q8gavgpool_ukernel_up8x7__sse2);
     }
   }
 }
@@ -719,7 +719,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m_with_x_zero_point) {
           .m(7)
           .n(n)
           .xZeroPoint(xZeroPoint)
-          .test(q8gavgpool_ukernel_up8x7__sse2);
+          .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
     }
   }
 }
@@ -729,7 +729,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m_with_y_scale) {
   for (size_t n = 9; n < 16; n++) {
     for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
       GAvgPoolMicrokernelTester().m(7).n(n).yScale(yScale).test(
-          q8gavgpool_ukernel_up8x7__sse2);
+          pytorch_q8gavgpool_ukernel_up8x7__sse2);
     }
   }
 }
@@ -742,7 +742,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m_with_y_zero_point) {
           .m(7)
           .n(n)
           .yZeroPoint(yZeroPoint)
-          .test(q8gavgpool_ukernel_up8x7__sse2);
+          .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
     }
   }
 }
@@ -758,7 +758,7 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m_with_y_max) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMax(128)
-        .test(q8gavgpool_ukernel_up8x7__sse2);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
@@ -773,27 +773,27 @@ TEST(Q8GAVGPOOL_UP8x7__SSE2, n_gt_8_all_m_with_y_min) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMin(128)
-        .test(q8gavgpool_ukernel_up8x7__sse2);
+        .test(pytorch_q8gavgpool_ukernel_up8x7__sse2);
   }
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m) {
   TEST_REQUIRES_X86_SSE2;
   GAvgPoolMicrokernelTester().m(14).n(8).nr(8).test(
-      q8gavgpool_ukernel_mp8x7p7q__sse2);
+      pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_x_stride) {
   TEST_REQUIRES_X86_SSE2;
   GAvgPoolMicrokernelTester().m(14).n(8).nr(8).xStride(11).test(
-      q8gavgpool_ukernel_mp8x7p7q__sse2);
+      pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_x_scale) {
   TEST_REQUIRES_X86_SSE2;
   for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(14).n(8).nr(8).xScale(xScale).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -805,7 +805,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_x_zero_point) {
         .n(8)
         .nr(8)
         .xZeroPoint(xZeroPoint)
-        .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -813,7 +813,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_y_scale) {
   TEST_REQUIRES_X86_SSE2;
   for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
     GAvgPoolMicrokernelTester().m(14).n(8).nr(8).yScale(yScale).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -825,7 +825,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_y_zero_point) {
         .n(8)
         .nr(8)
         .yZeroPoint(yZeroPoint)
-        .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -840,7 +840,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_y_max) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMax(128)
-      .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+      .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_y_min) {
@@ -854,14 +854,14 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_all_m_with_y_min) {
       .xScale(1.0f)
       .yScale(1.0f)
       .yMin(128)
-      .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+      .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
 }
 
 TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_few_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t m = 1; m < 7; m++) {
     GAvgPoolMicrokernelTester().m(7 + m).n(8).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -869,7 +869,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_2pass_few_m_with_x_stride) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t m = 1; m < 7; m++) {
     GAvgPoolMicrokernelTester().m(7 + m).n(8).nr(8).xStride(11).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -877,7 +877,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_multipass_all_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t m = 14; m <= 35; m += 7) {
     GAvgPoolMicrokernelTester().m(m).n(8).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -885,7 +885,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_eq_8_multipass_all_m_with_x_stride) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t m = 14; m <= 35; m += 7) {
     GAvgPoolMicrokernelTester().m(m).n(8).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -893,7 +893,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_div_8_2pass_all_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 8; n < 128; n += 24) {
     GAvgPoolMicrokernelTester().m(14).n(n).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -902,7 +902,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_div_8_2pass_few_m) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(7 + m).n(n).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -912,7 +912,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_div_8_multipass_all_m) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -922,7 +922,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_div_8_multipass_all_m_with_x_stride) {
   for (size_t n = 8; n < 128; n += 24) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).nr(8).xStride(131).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -931,7 +931,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 9; n < 16; n++) {
     GAvgPoolMicrokernelTester().m(14).n(n).nr(8).test(
-        q8gavgpool_ukernel_mp8x7p7q__sse2);
+        pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -940,7 +940,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m_with_x_scale) {
   for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
     for (size_t n = 9; n < 16; n++) {
       GAvgPoolMicrokernelTester().m(14).n(n).nr(8).xScale(xScale).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -954,7 +954,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m_with_x_zero_point) {
           .n(n)
           .nr(8)
           .xZeroPoint(xZeroPoint)
-          .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+          .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -964,7 +964,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m_with_y_scale) {
   for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
     for (size_t n = 9; n < 16; n++) {
       GAvgPoolMicrokernelTester().m(14).n(n).nr(8).yScale(yScale).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -978,7 +978,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m_with_y_zero_point) {
           .n(n)
           .nr(8)
           .yZeroPoint(yZeroPoint)
-          .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+          .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -995,7 +995,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m_with_y_max) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMax(128)
-        .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -1011,7 +1011,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_all_m_with_y_min) {
         .xScale(1.0f)
         .yScale(1.0f)
         .yMin(128)
-        .test(q8gavgpool_ukernel_mp8x7p7q__sse2);
+        .test(pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
   }
 }
 
@@ -1020,7 +1020,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_2pass_few_m) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 1; m < 7; m++) {
       GAvgPoolMicrokernelTester().m(7 + m).n(n).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -1030,7 +1030,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_multipass_all_m) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -1040,7 +1040,7 @@ TEST(Q8GAVGPOOL_MP8x7p7q__SSE2, n_gt_8_multipass_all_m_with_x_stride) {
   for (size_t n = 9; n < 16; n++) {
     for (size_t m = 14; m <= 35; m += 7) {
       GAvgPoolMicrokernelTester().m(m).n(n).nr(8).xStride(23).test(
-          q8gavgpool_ukernel_mp8x7p7q__sse2);
+          pytorch_q8gavgpool_ukernel_mp8x7p7q__sse2);
     }
   }
 }
@@ -1050,7 +1050,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_small_m) {
   for (size_t n = 1; n < 8; n++) {
     for (size_t m = 1; m < 8; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8xm__sse2);
+          pytorch_q8gavgpool_ukernel_up8xm__sse2);
     }
   }
 }
@@ -1060,7 +1060,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_large_m) {
   for (size_t n = 1; n < 8; n++) {
     for (size_t m = 8; m < 16; m++) {
       GAvgPoolMicrokernelTester().m(m).n(n).test(
-          q8gavgpool_ukernel_up8xm__sse2);
+          pytorch_q8gavgpool_ukernel_up8xm__sse2);
     }
   }
 }
@@ -1071,7 +1071,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_with_x_scale) {
     for (size_t m = 1; m < 16; m += 5) {
       for (float xScale = 0.01f; xScale < 100.0f; xScale *= 3.14159265f) {
         GAvgPoolMicrokernelTester().m(m).n(n).xScale(xScale).test(
-            q8gavgpool_ukernel_up8xm__sse2);
+            pytorch_q8gavgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1086,7 +1086,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_with_x_zero_point) {
             .m(m)
             .n(n)
             .xZeroPoint(xZeroPoint)
-            .test(q8gavgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8gavgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1098,7 +1098,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_with_y_scale) {
     for (size_t m = 1; m < 16; m += 5) {
       for (float yScale = 0.01f; yScale < 100.0f; yScale *= 3.14159265f) {
         GAvgPoolMicrokernelTester().m(m).n(n).yScale(yScale).test(
-            q8gavgpool_ukernel_up8xm__sse2);
+            pytorch_q8gavgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1113,7 +1113,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_with_y_zero_point) {
             .m(m)
             .n(n)
             .yZeroPoint(yZeroPoint)
-            .test(q8gavgpool_ukernel_up8xm__sse2);
+            .test(pytorch_q8gavgpool_ukernel_up8xm__sse2);
       }
     }
   }
@@ -1131,7 +1131,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_with_y_max) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMax(128)
-          .test(q8gavgpool_ukernel_up8xm__sse2);
+          .test(pytorch_q8gavgpool_ukernel_up8xm__sse2);
     }
   }
 }
@@ -1148,7 +1148,7 @@ TEST(Q8GAVGPOOL_UP8xM__SSE2, n_lt_8_with_y_min) {
           .xScale(1.0f)
           .yScale(1.0f)
           .yMin(128)
-          .test(q8gavgpool_ukernel_up8xm__sse2);
+          .test(pytorch_q8gavgpool_ukernel_up8xm__sse2);
     }
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8gemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8gemm.cc
@@ -18,7 +18,7 @@
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).test(
-      q8gemm_ukernel_4x8__aarch32_neon);
+      pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_strided_a) {
@@ -32,7 +32,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_strided_a) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_strided_c) {
@@ -46,19 +46,19 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_strided_c) {
       .n(8)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmin(128).test(
-      q8gemm_ukernel_4x8__aarch32_neon);
+      pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmax(128).test(
-      q8gemm_ukernel_4x8__aarch32_neon);
+      pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_azp0) {
@@ -72,7 +72,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_azp0) {
       .n(8)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_bzp0) {
@@ -86,7 +86,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_bzp0) {
       .n(8)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_nozp) {
@@ -101,14 +101,14 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x8__aarch32_neon);
+      .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(k).test(
-        q8gemm_ukernel_4x8__aarch32_neon);
+        pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -124,7 +124,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -140,7 +140,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -156,7 +156,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8_azp0) {
         .n(8)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -172,7 +172,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8_bzp0) {
         .n(8)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -189,7 +189,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -207,7 +207,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_4x8__aarch32_neon);
+            .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
       }
     }
   }
@@ -217,7 +217,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(k).test(
-        q8gemm_ukernel_4x8__aarch32_neon);
+        pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -233,7 +233,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_div_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -249,7 +249,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_div_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_4x8__aarch32_neon);
+        .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
   }
 }
 
@@ -267,7 +267,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_4x8__aarch32_neon);
+            .test(pytorch_q8gemm_ukernel_4x8__aarch32_neon);
       }
     }
   }
@@ -276,7 +276,7 @@ TEST(Q8GEMM_4x8__AARCH32_NEON, k_div_8_subtile) {
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(8).test(
-      q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_strided_a) {
@@ -290,7 +290,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_strided_a) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_strided_c) {
@@ -304,19 +304,19 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_strided_c) {
       .n(8)
       .k(8)
       .cStride(17)
-      .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(8).qmin(128).test(
-      q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(8).qmax(128).test(
-      q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_azp0) {
@@ -330,7 +330,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_azp0) {
       .n(8)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_bzp0) {
@@ -344,7 +344,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_bzp0) {
       .n(8)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_nozp) {
@@ -359,14 +359,14 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(k).test(
-        q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -382,7 +382,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -398,7 +398,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -414,7 +414,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8_azp0) {
         .n(8)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -430,7 +430,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8_bzp0) {
         .n(8)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -447,7 +447,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -465,7 +465,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+            .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
       }
     }
   }
@@ -475,7 +475,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(k).test(
-        q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -491,7 +491,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_div_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -507,7 +507,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_div_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
   }
 }
 
@@ -525,7 +525,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
+            .test(pytorch_q8gemm_xzp_ukernel_4x8c2__aarch32_neon);
       }
     }
   }
@@ -535,7 +535,7 @@ TEST(Q8GEMM_4x8c2_XZP__AARCH32_NEON, k_div_8_subtile) {
 #if CPUINFO_ARCH_ARM64
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8) {
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).test(
-      q8gemm_ukernel_8x8__aarch64_neon);
+      pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_strided_a) {
@@ -548,7 +548,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_strided_a) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_strided_c) {
@@ -561,17 +561,17 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_strided_c) {
       .n(8)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_qmin128) {
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmin(128).test(
-      q8gemm_ukernel_8x8__aarch64_neon);
+      pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_qmax128) {
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmax(128).test(
-      q8gemm_ukernel_8x8__aarch64_neon);
+      pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_azp0) {
@@ -584,7 +584,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_azp0) {
       .n(8)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_bzp0) {
@@ -597,7 +597,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_bzp0) {
       .n(8)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_nozp) {
@@ -611,13 +611,13 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_8x8__aarch64_neon);
+      .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
 }
 
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8) {
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(k).test(
-        q8gemm_ukernel_8x8__aarch64_neon);
+        pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -632,7 +632,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -647,7 +647,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -662,7 +662,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_azp0) {
         .n(8)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -677,7 +677,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_bzp0) {
         .n(8)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -693,7 +693,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -710,7 +710,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_8x8__aarch64_neon);
+            .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
       }
     }
   }
@@ -719,7 +719,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_gt_8_subtile) {
 TEST(Q8GEMM_8x8__AARCH64_NEON, k_div_8) {
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(k).test(
-        q8gemm_ukernel_8x8__aarch64_neon);
+        pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -734,7 +734,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_div_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -749,7 +749,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_div_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_8x8__aarch64_neon);
+        .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
   }
 }
 
@@ -766,7 +766,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_8x8__aarch64_neon);
+            .test(pytorch_q8gemm_ukernel_8x8__aarch64_neon);
       }
     }
   }
@@ -777,7 +777,7 @@ TEST(Q8GEMM_8x8__AARCH64_NEON, k_div_8_subtile) {
 TEST(Q8GEMM_4x8__NEON, k_eq_8) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).test(
-      q8gemm_ukernel_4x8__neon);
+      pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_strided_a) {
@@ -791,7 +791,7 @@ TEST(Q8GEMM_4x8__NEON, k_eq_8_strided_a) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_4x8__neon);
+      .test(pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_strided_c) {
@@ -805,19 +805,19 @@ TEST(Q8GEMM_4x8__NEON, k_eq_8_strided_c) {
       .n(8)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_4x8__neon);
+      .test(pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmin(128).test(
-      q8gemm_ukernel_4x8__neon);
+      pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmax(128).test(
-      q8gemm_ukernel_4x8__neon);
+      pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_azp0) {
@@ -831,7 +831,7 @@ TEST(Q8GEMM_4x8__NEON, k_eq_8_azp0) {
       .n(8)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_4x8__neon);
+      .test(pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_bzp0) {
@@ -845,7 +845,7 @@ TEST(Q8GEMM_4x8__NEON, k_eq_8_bzp0) {
       .n(8)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x8__neon);
+      .test(pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_eq_8_nozp) {
@@ -860,14 +860,14 @@ TEST(Q8GEMM_4x8__NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x8__neon);
+      .test(pytorch_q8gemm_ukernel_4x8__neon);
 }
 
 TEST(Q8GEMM_4x8__NEON, k_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(k).test(
-        q8gemm_ukernel_4x8__neon);
+        pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -883,7 +883,7 @@ TEST(Q8GEMM_4x8__NEON, k_gt_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -899,7 +899,7 @@ TEST(Q8GEMM_4x8__NEON, k_gt_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -915,7 +915,7 @@ TEST(Q8GEMM_4x8__NEON, k_gt_8_azp0) {
         .n(8)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -931,7 +931,7 @@ TEST(Q8GEMM_4x8__NEON, k_gt_8_bzp0) {
         .n(8)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -948,7 +948,7 @@ TEST(Q8GEMM_4x8__NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -966,7 +966,7 @@ TEST(Q8GEMM_4x8__NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_4x8__neon);
+            .test(pytorch_q8gemm_ukernel_4x8__neon);
       }
     }
   }
@@ -976,7 +976,7 @@ TEST(Q8GEMM_4x8__NEON, k_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(k).test(
-        q8gemm_ukernel_4x8__neon);
+        pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -992,7 +992,7 @@ TEST(Q8GEMM_4x8__NEON, k_div_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -1008,7 +1008,7 @@ TEST(Q8GEMM_4x8__NEON, k_div_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_4x8__neon);
+        .test(pytorch_q8gemm_ukernel_4x8__neon);
   }
 }
 
@@ -1026,7 +1026,7 @@ TEST(Q8GEMM_4x8__NEON, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_4x8__neon);
+            .test(pytorch_q8gemm_ukernel_4x8__neon);
       }
     }
   }
@@ -1035,7 +1035,7 @@ TEST(Q8GEMM_4x8__NEON, k_div_8_subtile) {
 TEST(Q8GEMM_8x8__NEON, k_eq_8) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).test(
-      q8gemm_ukernel_8x8__neon);
+      pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_strided_a) {
@@ -1049,7 +1049,7 @@ TEST(Q8GEMM_8x8__NEON, k_eq_8_strided_a) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_8x8__neon);
+      .test(pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_strided_c) {
@@ -1063,19 +1063,19 @@ TEST(Q8GEMM_8x8__NEON, k_eq_8_strided_c) {
       .n(8)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_8x8__neon);
+      .test(pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmin(128).test(
-      q8gemm_ukernel_8x8__neon);
+      pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(8).qmax(128).test(
-      q8gemm_ukernel_8x8__neon);
+      pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_azp0) {
@@ -1089,7 +1089,7 @@ TEST(Q8GEMM_8x8__NEON, k_eq_8_azp0) {
       .n(8)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_8x8__neon);
+      .test(pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_bzp0) {
@@ -1103,7 +1103,7 @@ TEST(Q8GEMM_8x8__NEON, k_eq_8_bzp0) {
       .n(8)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_8x8__neon);
+      .test(pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_eq_8_nozp) {
@@ -1118,14 +1118,14 @@ TEST(Q8GEMM_8x8__NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_8x8__neon);
+      .test(pytorch_q8gemm_ukernel_8x8__neon);
 }
 
 TEST(Q8GEMM_8x8__NEON, k_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(k).test(
-        q8gemm_ukernel_8x8__neon);
+        pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1141,7 +1141,7 @@ TEST(Q8GEMM_8x8__NEON, k_gt_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1157,7 +1157,7 @@ TEST(Q8GEMM_8x8__NEON, k_gt_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1173,7 +1173,7 @@ TEST(Q8GEMM_8x8__NEON, k_gt_8_azp0) {
         .n(8)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1189,7 +1189,7 @@ TEST(Q8GEMM_8x8__NEON, k_gt_8_bzp0) {
         .n(8)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1206,7 +1206,7 @@ TEST(Q8GEMM_8x8__NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1224,7 +1224,7 @@ TEST(Q8GEMM_8x8__NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_8x8__neon);
+            .test(pytorch_q8gemm_ukernel_8x8__neon);
       }
     }
   }
@@ -1234,7 +1234,7 @@ TEST(Q8GEMM_8x8__NEON, k_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(8).nr(8).np(8).kr(1).m(8).n(8).k(k).test(
-        q8gemm_ukernel_8x8__neon);
+        pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1250,7 +1250,7 @@ TEST(Q8GEMM_8x8__NEON, k_div_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1266,7 +1266,7 @@ TEST(Q8GEMM_8x8__NEON, k_div_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_8x8__neon);
+        .test(pytorch_q8gemm_ukernel_8x8__neon);
   }
 }
 
@@ -1284,7 +1284,7 @@ TEST(Q8GEMM_8x8__NEON, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_8x8__neon);
+            .test(pytorch_q8gemm_ukernel_8x8__neon);
       }
     }
   }
@@ -1293,7 +1293,7 @@ TEST(Q8GEMM_8x8__NEON, k_div_8_subtile) {
 TEST(Q8GEMM_6x4__NEON, k_eq_8) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(6).nr(4).np(4).kr(1).m(6).n(4).k(8).test(
-      q8gemm_ukernel_6x4__neon);
+      pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_strided_a) {
@@ -1307,7 +1307,7 @@ TEST(Q8GEMM_6x4__NEON, k_eq_8_strided_a) {
       .n(4)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_6x4__neon);
+      .test(pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_strided_c) {
@@ -1321,19 +1321,19 @@ TEST(Q8GEMM_6x4__NEON, k_eq_8_strided_c) {
       .n(4)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_6x4__neon);
+      .test(pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(6).nr(4).np(4).kr(1).m(6).n(4).k(8).qmin(128).test(
-      q8gemm_ukernel_6x4__neon);
+      pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(6).nr(4).np(4).kr(1).m(6).n(4).k(8).qmax(128).test(
-      q8gemm_ukernel_6x4__neon);
+      pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_azp0) {
@@ -1347,7 +1347,7 @@ TEST(Q8GEMM_6x4__NEON, k_eq_8_azp0) {
       .n(4)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_6x4__neon);
+      .test(pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_bzp0) {
@@ -1361,7 +1361,7 @@ TEST(Q8GEMM_6x4__NEON, k_eq_8_bzp0) {
       .n(4)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_6x4__neon);
+      .test(pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_eq_8_nozp) {
@@ -1376,14 +1376,14 @@ TEST(Q8GEMM_6x4__NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_6x4__neon);
+      .test(pytorch_q8gemm_ukernel_6x4__neon);
 }
 
 TEST(Q8GEMM_6x4__NEON, k_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(6).nr(4).np(4).kr(1).m(6).n(4).k(k).test(
-        q8gemm_ukernel_6x4__neon);
+        pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1399,7 +1399,7 @@ TEST(Q8GEMM_6x4__NEON, k_gt_8_strided_a) {
         .n(4)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1415,7 +1415,7 @@ TEST(Q8GEMM_6x4__NEON, k_gt_8_strided_c) {
         .n(4)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1431,7 +1431,7 @@ TEST(Q8GEMM_6x4__NEON, k_gt_8_azp0) {
         .n(4)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1447,7 +1447,7 @@ TEST(Q8GEMM_6x4__NEON, k_gt_8_bzp0) {
         .n(4)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1464,7 +1464,7 @@ TEST(Q8GEMM_6x4__NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1482,7 +1482,7 @@ TEST(Q8GEMM_6x4__NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_6x4__neon);
+            .test(pytorch_q8gemm_ukernel_6x4__neon);
       }
     }
   }
@@ -1492,7 +1492,7 @@ TEST(Q8GEMM_6x4__NEON, k_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(6).nr(4).np(4).kr(1).m(6).n(4).k(k).test(
-        q8gemm_ukernel_6x4__neon);
+        pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1508,7 +1508,7 @@ TEST(Q8GEMM_6x4__NEON, k_div_8_strided_a) {
         .n(4)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1524,7 +1524,7 @@ TEST(Q8GEMM_6x4__NEON, k_div_8_strided_c) {
         .n(4)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_6x4__neon);
+        .test(pytorch_q8gemm_ukernel_6x4__neon);
   }
 }
 
@@ -1534,7 +1534,7 @@ TEST(Q8GEMM_6x4__NEON, k_div_8_subtile) {
     for (uint32_t m = 1; m <= 6; m++) {
       for (uint32_t n = 1; n <= 4; n++) {
         GemmMicrokernelTester().mr(6).nr(4).np(4).kr(1).m(m).n(n).k(k).test(
-            q8gemm_ukernel_6x4__neon);
+            pytorch_q8gemm_ukernel_6x4__neon);
       }
     }
   }
@@ -1543,7 +1543,7 @@ TEST(Q8GEMM_6x4__NEON, k_div_8_subtile) {
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(8).test(
-      q8gemm_xzp_ukernel_4x8c2__neon);
+      pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_strided_a) {
@@ -1557,7 +1557,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_strided_a) {
       .n(8)
       .k(8)
       .aStride(37)
-      .test(q8gemm_xzp_ukernel_4x8c2__neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_strided_c) {
@@ -1571,19 +1571,19 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_strided_c) {
       .n(8)
       .k(8)
       .cStride(17)
-      .test(q8gemm_xzp_ukernel_4x8c2__neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(8).qmin(128).test(
-      q8gemm_xzp_ukernel_4x8c2__neon);
+      pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(8).qmax(128).test(
-      q8gemm_xzp_ukernel_4x8c2__neon);
+      pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_azp0) {
@@ -1597,7 +1597,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_azp0) {
       .n(8)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_xzp_ukernel_4x8c2__neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_bzp0) {
@@ -1611,7 +1611,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_bzp0) {
       .n(8)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_xzp_ukernel_4x8c2__neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_nozp) {
@@ -1626,14 +1626,14 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_xzp_ukernel_4x8c2__neon);
+      .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
 }
 
 TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(k).test(
-        q8gemm_xzp_ukernel_4x8c2__neon);
+        pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1649,7 +1649,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1665,7 +1665,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1681,7 +1681,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8_azp0) {
         .n(8)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1697,7 +1697,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8_bzp0) {
         .n(8)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1714,7 +1714,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1732,7 +1732,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_xzp_ukernel_4x8c2__neon);
+            .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
       }
     }
   }
@@ -1742,7 +1742,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(4).nr(8).np(8).kr(2).m(4).n(8).k(k).test(
-        q8gemm_xzp_ukernel_4x8c2__neon);
+        pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1758,7 +1758,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_div_8_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1774,7 +1774,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_div_8_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
   }
 }
 
@@ -1792,7 +1792,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_xzp_ukernel_4x8c2__neon);
+            .test(pytorch_q8gemm_xzp_ukernel_4x8c2__neon);
       }
     }
   }
@@ -1803,7 +1803,7 @@ TEST(Q8GEMM_4x8c2_XZP__NEON, k_div_8_subtile) {
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(2).nr(4).np(1).kr(8).m(2).n(4).k(8).test(
-      q8gemm_ukernel_2x4c8__sse2);
+      pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_strided_a) {
@@ -1817,7 +1817,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_strided_a) {
       .n(4)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_2x4c8__sse2);
+      .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_strided_c) {
@@ -1831,19 +1831,19 @@ TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_strided_c) {
       .n(4)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_2x4c8__sse2);
+      .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_qmin128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(2).nr(4).np(1).kr(8).m(2).n(4).k(8).qmin(128).test(
-      q8gemm_ukernel_2x4c8__sse2);
+      pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_qmax128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(2).nr(4).np(1).kr(8).m(2).n(4).k(8).qmax(128).test(
-      q8gemm_ukernel_2x4c8__sse2);
+      pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_azp0) {
@@ -1857,7 +1857,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_azp0) {
       .n(4)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_2x4c8__sse2);
+      .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_bzp0) {
@@ -1871,7 +1871,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_bzp0) {
       .n(4)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_2x4c8__sse2);
+      .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_nozp) {
@@ -1886,14 +1886,14 @@ TEST(Q8GEMM_2x4c8__SSE2, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_2x4c8__sse2);
+      .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
 }
 
 TEST(Q8GEMM_2x4c8__SSE2, k_gt_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(2).nr(4).np(1).kr(8).m(2).n(4).k(k).test(
-        q8gemm_ukernel_2x4c8__sse2);
+        pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -1909,7 +1909,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_gt_8_strided_a) {
         .n(4)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -1925,7 +1925,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_gt_8_strided_c) {
         .n(4)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -1941,7 +1941,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_gt_8_azp0) {
         .n(4)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -1957,7 +1957,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_gt_8_bzp0) {
         .n(4)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -1974,7 +1974,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -1992,7 +1992,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_2x4c8__sse2);
+            .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
       }
     }
   }
@@ -2002,7 +2002,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(2).nr(4).np(1).kr(8).m(2).n(4).k(k).test(
-        q8gemm_ukernel_2x4c8__sse2);
+        pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -2018,7 +2018,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_strided_a) {
         .n(4)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -2034,7 +2034,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_strided_c) {
         .n(4)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_2x4c8__sse2);
+        .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
   }
 }
 
@@ -2052,7 +2052,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_2x4c8__sse2);
+            .test(pytorch_q8gemm_ukernel_2x4c8__sse2);
       }
     }
   }
@@ -2072,7 +2072,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .m(4)
       .n(4)
       .k(1)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_strided_a) {
@@ -2086,7 +2086,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .n(4)
       .k(1)
       .aStride(37)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_strided_c) {
@@ -2100,7 +2100,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .n(4)
       .k(1)
       .cStride(17)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_qmin128) {
@@ -2114,7 +2114,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .n(4)
       .k(1)
       .qmin(128)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_qmax128) {
@@ -2128,7 +2128,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .n(4)
       .k(1)
       .qmax(128)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_azp0) {
@@ -2142,7 +2142,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .n(4)
       .k(1)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_bzp0) {
@@ -2156,7 +2156,7 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .n(4)
       .k(1)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 
   TEST(Q8GEMM_4x4c2__SSE2, k_eq_1_nozp) {
@@ -2171,14 +2171,14 @@ TEST(Q8GEMM_2x4c8__SSE2, k_div_8_subtile) {
       .k(1)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 #endif
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(3).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_strided_a) {
@@ -2192,7 +2192,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_strided_a) {
       .n(4)
       .k(3)
       .aStride(37)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_strided_c) {
@@ -2206,19 +2206,19 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_strided_c) {
       .n(4)
       .k(3)
       .cStride(17)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_qmin128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(3).qmin(128).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_qmax128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(3).qmax(128).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_azp0) {
@@ -2232,7 +2232,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_azp0) {
       .n(4)
       .k(3)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_bzp0) {
@@ -2246,7 +2246,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_bzp0) {
       .n(4)
       .k(3)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_nozp) {
@@ -2261,13 +2261,13 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_4_nozp) {
       .k(3)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(5).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_strided_a) {
@@ -2281,7 +2281,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_strided_a) {
       .n(4)
       .k(5)
       .aStride(37)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_strided_c) {
@@ -2295,19 +2295,19 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_strided_c) {
       .n(4)
       .k(5)
       .cStride(17)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_qmin128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(5).qmin(128).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_qmax128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(5).qmax(128).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_azp0) {
@@ -2321,7 +2321,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_azp0) {
       .n(4)
       .k(5)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_bzp0) {
@@ -2335,7 +2335,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_bzp0) {
       .n(4)
       .k(5)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_nozp) {
@@ -2350,13 +2350,13 @@ TEST(Q8GEMM_4x4c2__SSE2, k_lt_8_nozp) {
       .k(5)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(8).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_strided_a) {
@@ -2370,7 +2370,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_strided_a) {
       .n(4)
       .k(8)
       .aStride(37)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_strided_c) {
@@ -2384,19 +2384,19 @@ TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_strided_c) {
       .n(4)
       .k(8)
       .cStride(17)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_qmin128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(8).qmin(128).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_qmax128) {
   TEST_REQUIRES_X86_SSE2;
   GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(8).qmax(128).test(
-      q8gemm_ukernel_4x4c2__sse2);
+      pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_azp0) {
@@ -2410,7 +2410,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_azp0) {
       .n(4)
       .k(8)
       .aZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_bzp0) {
@@ -2424,7 +2424,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_bzp0) {
       .n(4)
       .k(8)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_nozp) {
@@ -2439,14 +2439,14 @@ TEST(Q8GEMM_4x4c2__SSE2, k_eq_8_nozp) {
       .k(8)
       .aZeroPoint(0)
       .bZeroPoint(0)
-      .test(q8gemm_ukernel_4x4c2__sse2);
+      .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
 }
 
 TEST(Q8GEMM_4x4c2__SSE2, k_gt_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t k = 9; k < 16; k++) {
     GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(k).test(
-        q8gemm_ukernel_4x4c2__sse2);
+        pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2462,7 +2462,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_gt_8_strided_a) {
         .n(4)
         .k(k)
         .aStride(37)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2478,7 +2478,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_gt_8_strided_c) {
         .n(4)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2494,7 +2494,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_gt_8_azp0) {
         .n(4)
         .k(k)
         .aZeroPoint(0)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2510,7 +2510,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_gt_8_bzp0) {
         .n(4)
         .k(k)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2527,7 +2527,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_gt_8_nozp) {
         .k(k)
         .aZeroPoint(0)
         .bZeroPoint(0)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2545,7 +2545,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_gt_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_4x4c2__sse2);
+            .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
       }
     }
   }
@@ -2555,7 +2555,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_div_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t k = 16; k < 128; k += 8) {
     GemmMicrokernelTester().mr(4).nr(4).np(4).kr(2).m(4).n(4).k(k).test(
-        q8gemm_ukernel_4x4c2__sse2);
+        pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2571,7 +2571,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_div_8_strided_a) {
         .n(4)
         .k(k)
         .aStride(171)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2587,7 +2587,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_div_8_strided_c) {
         .n(4)
         .k(k)
         .cStride(17)
-        .test(q8gemm_ukernel_4x4c2__sse2);
+        .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
   }
 }
 
@@ -2605,7 +2605,7 @@ TEST(Q8GEMM_4x4c2__SSE2, k_div_8_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(q8gemm_ukernel_4x4c2__sse2);
+            .test(pytorch_q8gemm_ukernel_4x4c2__sse2);
       }
     }
   }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8vadd.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/q8vadd.cc
@@ -17,27 +17,27 @@
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 TEST(Q8VADD__SSE2, n_eq_8) {
   TEST_REQUIRES_X86_SSE2;
-  VAddMicrokernelTester().n(8).test(q8vadd_ukernel__sse2);
+  VAddMicrokernelTester().n(8).test(pytorch_q8vadd_ukernel__sse2);
 }
 
 TEST(Q8VADD__SSE2, n_div_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 8; n < 128; n += 24) {
-    VAddMicrokernelTester().n(n).test(q8vadd_ukernel__sse2);
+    VAddMicrokernelTester().n(n).test(pytorch_q8vadd_ukernel__sse2);
   }
 }
 
 TEST(Q8VADD__SSE2, n_gt_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 9; n < 16; n++) {
-    VAddMicrokernelTester().n(n).test(q8vadd_ukernel__sse2);
+    VAddMicrokernelTester().n(n).test(pytorch_q8vadd_ukernel__sse2);
   }
 }
 
 TEST(Q8VADD__SSE2, n_lt_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 8; n++) {
-    VAddMicrokernelTester().n(n).test(q8vadd_ukernel__sse2);
+    VAddMicrokernelTester().n(n).test(pytorch_q8vadd_ukernel__sse2);
   }
 }
 
@@ -45,7 +45,7 @@ TEST(Q8VADD__SSE2, inplace_a) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).inplaceA(true).test(
-        q8vadd_ukernel__sse2);
+        pytorch_q8vadd_ukernel__sse2);
   }
 }
 
@@ -53,7 +53,7 @@ TEST(Q8VADD__SSE2, inplace_b) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).inplaceB(true).test(
-        q8vadd_ukernel__sse2);
+        pytorch_q8vadd_ukernel__sse2);
   }
 }
 
@@ -65,7 +65,7 @@ TEST(Q8VADD__SSE2, inplace_a_and_b) {
         .n(n)
         .inplaceA(true)
         .inplaceB(true)
-        .test(q8vadd_ukernel__sse2);
+        .test(pytorch_q8vadd_ukernel__sse2);
   }
 }
 
@@ -74,7 +74,7 @@ TEST(Q8VADD__SSE2, a_scale) {
   for (size_t n = 1; n < 128; n += 11) {
     for (float aScale = 1.0e-2; aScale < 1.0e+2; aScale *= 1.7f) {
       VAddMicrokernelTester().iterations(1).n(n).aScale(aScale).test(
-          q8vadd_ukernel__sse2);
+          pytorch_q8vadd_ukernel__sse2);
     }
   }
 }
@@ -84,7 +84,7 @@ TEST(Q8VADD__SSE2, b_scale) {
   for (size_t n = 1; n < 128; n += 11) {
     for (float bScale = 1.0e-2; bScale < 1.0e+2; bScale *= 1.7f) {
       VAddMicrokernelTester().iterations(1).n(n).bScale(bScale).test(
-          q8vadd_ukernel__sse2);
+          pytorch_q8vadd_ukernel__sse2);
     }
   }
 }
@@ -94,7 +94,7 @@ TEST(Q8VADD__SSE2, y_scale) {
   for (size_t n = 1; n < 128; n += 11) {
     for (float yScale = 1.0e-2; yScale < 1.0e+2; yScale *= 1.7f) {
       VAddMicrokernelTester().iterations(1).n(n).yScale(yScale).test(
-          q8vadd_ukernel__sse2);
+          pytorch_q8vadd_ukernel__sse2);
     }
   }
 }
@@ -107,7 +107,7 @@ TEST(Q8VADD__SSE2, a_zero_point) {
           .iterations(1)
           .n(n)
           .aZeroPoint(uint8_t(aZeroPoint))
-          .test(q8vadd_ukernel__sse2);
+          .test(pytorch_q8vadd_ukernel__sse2);
     }
   }
 }
@@ -120,7 +120,7 @@ TEST(Q8VADD__SSE2, b_zero_point) {
           .iterations(1)
           .n(n)
           .bZeroPoint(uint8_t(bZeroPoint))
-          .test(q8vadd_ukernel__sse2);
+          .test(pytorch_q8vadd_ukernel__sse2);
     }
   }
 }
@@ -133,7 +133,7 @@ TEST(Q8VADD__SSE2, y_zero_point) {
           .iterations(1)
           .n(n)
           .yZeroPoint(uint8_t(yZeroPoint))
-          .test(q8vadd_ukernel__sse2);
+          .test(pytorch_q8vadd_ukernel__sse2);
     }
   }
 }
@@ -142,7 +142,7 @@ TEST(Q8VADD__SSE2, qmin) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).qmin(128).test(
-        q8vadd_ukernel__sse2);
+        pytorch_q8vadd_ukernel__sse2);
   }
 }
 
@@ -150,7 +150,7 @@ TEST(Q8VADD__SSE2, qmax) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).qmax(128).test(
-        q8vadd_ukernel__sse2);
+        pytorch_q8vadd_ukernel__sse2);
   }
 }
 #endif /* CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64 */
@@ -158,27 +158,27 @@ TEST(Q8VADD__SSE2, qmax) {
 #if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 TEST(Q8VADD__NEON, n_eq_8) {
   TEST_REQUIRES_ARM_NEON;
-  VAddMicrokernelTester().n(8).test(q8vadd_ukernel__neon);
+  VAddMicrokernelTester().n(8).test(pytorch_q8vadd_ukernel__neon);
 }
 
 TEST(Q8VADD__NEON, n_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 8; n < 128; n += 24) {
-    VAddMicrokernelTester().n(n).test(q8vadd_ukernel__neon);
+    VAddMicrokernelTester().n(n).test(pytorch_q8vadd_ukernel__neon);
   }
 }
 
 TEST(Q8VADD__NEON, n_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 9; n < 16; n++) {
-    VAddMicrokernelTester().n(n).test(q8vadd_ukernel__neon);
+    VAddMicrokernelTester().n(n).test(pytorch_q8vadd_ukernel__neon);
   }
 }
 
 TEST(Q8VADD__NEON, n_lt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 8; n++) {
-    VAddMicrokernelTester().n(n).test(q8vadd_ukernel__neon);
+    VAddMicrokernelTester().n(n).test(pytorch_q8vadd_ukernel__neon);
   }
 }
 
@@ -186,7 +186,7 @@ TEST(Q8VADD__NEON, inplace_a) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).inplaceA(true).test(
-        q8vadd_ukernel__neon);
+        pytorch_q8vadd_ukernel__neon);
   }
 }
 
@@ -194,7 +194,7 @@ TEST(Q8VADD__NEON, inplace_b) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).inplaceB(true).test(
-        q8vadd_ukernel__neon);
+        pytorch_q8vadd_ukernel__neon);
   }
 }
 
@@ -206,7 +206,7 @@ TEST(Q8VADD__NEON, inplace_a_and_b) {
         .n(n)
         .inplaceA(true)
         .inplaceB(true)
-        .test(q8vadd_ukernel__neon);
+        .test(pytorch_q8vadd_ukernel__neon);
   }
 }
 
@@ -215,7 +215,7 @@ TEST(Q8VADD__NEON, a_scale) {
   for (size_t n = 1; n < 128; n += 11) {
     for (float aScale = 1.0e-2; aScale < 1.0e+2; aScale *= 1.7f) {
       VAddMicrokernelTester().iterations(1).n(n).aScale(aScale).test(
-          q8vadd_ukernel__neon);
+          pytorch_q8vadd_ukernel__neon);
     }
   }
 }
@@ -225,7 +225,7 @@ TEST(Q8VADD__NEON, b_scale) {
   for (size_t n = 1; n < 128; n += 11) {
     for (float bScale = 1.0e-2; bScale < 1.0e+2; bScale *= 1.7f) {
       VAddMicrokernelTester().iterations(1).n(n).bScale(bScale).test(
-          q8vadd_ukernel__neon);
+          pytorch_q8vadd_ukernel__neon);
     }
   }
 }
@@ -235,7 +235,7 @@ TEST(Q8VADD__NEON, y_scale) {
   for (size_t n = 1; n < 128; n += 11) {
     for (float yScale = 1.0e-2; yScale < 1.0e+2; yScale *= 1.7f) {
       VAddMicrokernelTester().iterations(1).n(n).yScale(yScale).test(
-          q8vadd_ukernel__neon);
+          pytorch_q8vadd_ukernel__neon);
     }
   }
 }
@@ -248,7 +248,7 @@ TEST(Q8VADD__NEON, a_zero_point) {
           .iterations(1)
           .n(n)
           .aZeroPoint(uint8_t(aZeroPoint))
-          .test(q8vadd_ukernel__neon);
+          .test(pytorch_q8vadd_ukernel__neon);
     }
   }
 }
@@ -261,7 +261,7 @@ TEST(Q8VADD__NEON, b_zero_point) {
           .iterations(1)
           .n(n)
           .bZeroPoint(uint8_t(bZeroPoint))
-          .test(q8vadd_ukernel__neon);
+          .test(pytorch_q8vadd_ukernel__neon);
     }
   }
 }
@@ -274,7 +274,7 @@ TEST(Q8VADD__NEON, y_zero_point) {
           .iterations(1)
           .n(n)
           .yZeroPoint(uint8_t(yZeroPoint))
-          .test(q8vadd_ukernel__neon);
+          .test(pytorch_q8vadd_ukernel__neon);
     }
   }
 }
@@ -283,7 +283,7 @@ TEST(Q8VADD__NEON, qmin) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).qmin(128).test(
-        q8vadd_ukernel__neon);
+        pytorch_q8vadd_ukernel__neon);
   }
 }
 
@@ -291,7 +291,7 @@ TEST(Q8VADD__NEON, qmax) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 128; n += 11) {
     VAddMicrokernelTester().iterations(1).n(n).qmax(128).test(
-        q8vadd_ukernel__neon);
+        pytorch_q8vadd_ukernel__neon);
   }
 }
 #endif /* CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/requantization-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/requantization-tester.h
@@ -81,7 +81,7 @@ class RequantizationTester {
    * produces exactly i, provided that ((i - zero point) * 2**s) does not
    * overflow.
    */
-  void testExactDivideByPO2(requantization_function requantize) const {
+  void testExactDivideByPO2(pytorch_requantization_function requantize) const {
     ASSERT_GE(zeroPoint(), 0);
     ASSERT_LE(zeroPoint(), 255);
 
@@ -125,7 +125,7 @@ class RequantizationTester {
    * produces exactly i, provided that ((i - zero point) * 2**s) does not
    * overflow.
    */
-  void testDivideByPO2WithRoundingUp(requantization_function requantize) {
+  void testDivideByPO2WithRoundingUp(pytorch_requantization_function requantize) {
     ASSERT_GE(zeroPoint(), 0);
     ASSERT_LE(zeroPoint(), 255);
 
@@ -170,7 +170,7 @@ class RequantizationTester {
    * produces exactly i, provided that ((i - zero point) * 2**s) does not
    * overflow.
    */
-  void testDivideByPO2WithRoundingDown(requantization_function requantize) {
+  void testDivideByPO2WithRoundingDown(pytorch_requantization_function requantize) {
     ASSERT_GE(zeroPoint(), 0);
     ASSERT_LE(zeroPoint(), 255);
 
@@ -206,7 +206,7 @@ class RequantizationTester {
     }
   }
 
-  void testDivideByPO2WithRoundingAway(requantization_function requantize) {
+  void testDivideByPO2WithRoundingAway(pytorch_requantization_function requantize) {
     ASSERT_GE(zeroPoint(), 0);
     ASSERT_LE(zeroPoint(), 255);
 
@@ -248,7 +248,7 @@ class RequantizationTester {
     }
   }
 
-  void testSpecialCases(requantization_function requantize) {
+  void testSpecialCases(pytorch_requantization_function requantize) {
     std::vector<int32_t> inputs(256);
     std::vector<uint8_t> outputs(inputs.size());
 
@@ -283,7 +283,7 @@ class RequantizationTester {
     }
   }
 
-  void testRandomCasesPrecise(requantization_function requantize) {
+  void testRandomCasesPrecise(pytorch_requantization_function requantize) {
     std::random_device randomDevice;
     std::mt19937 mtRng(randomDevice());
     for (size_t iteration = 0; iteration < iterations(); iteration++) {
@@ -319,7 +319,7 @@ class RequantizationTester {
           *std::min_element(outputs.cbegin(), outputs.cend()));
 
       for (size_t i = 0; i < inputs.size(); i++) {
-        const uint8_t referenceOutput = scalar_requantize_precise(
+        const uint8_t referenceOutput = pytorch_scalar_requantize_precise(
             inputs[i],
             scale,
             zeroPoint,
@@ -330,7 +330,7 @@ class RequantizationTester {
     }
   }
 
-  void testRandomCasesApproximate(requantization_function requantize) {
+  void testRandomCasesApproximate(pytorch_requantization_function requantize) {
     std::random_device randomDevice;
     std::mt19937 mtRng(randomDevice());
     for (size_t iteration = 0; iteration < iterations(); iteration++) {
@@ -381,8 +381,8 @@ class RequantizationTester {
   }
 
   void testRandomCasesAgainstReference(
-      requantization_function requantize,
-      requantization_function requantizeReference) {
+      pytorch_requantization_function requantize,
+      pytorch_requantization_function requantizeReference) {
     std::random_device randomDevice;
     std::mt19937 mtRng(randomDevice());
     for (size_t iteration = 0; iteration < iterations(); iteration++) {

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/rmax-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/rmax-microkernel-tester.h
@@ -39,7 +39,7 @@ class RMaxMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(u8rmax_ukernel_function u8rmax) const {
+  void test(pytorch_u8rmax_ukernel_function u8rmax) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/sconv.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/sconv.cc
@@ -24,7 +24,7 @@ TEST(SCONV_6x8__PSIMD, k_eq_1) {
       .n(8)
       .k(1)
       .aStride(37)
-      .test(sconv_ukernel_6x8__psimd);
+      .test(pytorch_sconv_ukernel_6x8__psimd);
 }
 
 TEST(SCONV_6x8__PSIMD, k_eq_1_strided_c) {
@@ -38,17 +38,17 @@ TEST(SCONV_6x8__PSIMD, k_eq_1_strided_c) {
       .k(1)
       .aStride(37)
       .cStride(17)
-      .test(sconv_ukernel_6x8__psimd);
+      .test(pytorch_sconv_ukernel_6x8__psimd);
 }
 
 TEST(SCONV_6x8__PSIMD, k_eq_1_qmin128) {
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(1).qmin(128).test(
-      sconv_ukernel_6x8__psimd);
+      pytorch_sconv_ukernel_6x8__psimd);
 }
 
 TEST(SCONV_6x8__PSIMD, k_eq_1_qmax128) {
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(1).qmax(128).test(
-      sconv_ukernel_6x8__psimd);
+      pytorch_sconv_ukernel_6x8__psimd);
 }
 
 TEST(SCONV_6x8__PSIMD, k_gt_1) {
@@ -62,7 +62,7 @@ TEST(SCONV_6x8__PSIMD, k_gt_1) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(sconv_ukernel_6x8__psimd);
+        .test(pytorch_sconv_ukernel_6x8__psimd);
   }
 }
 
@@ -78,7 +78,7 @@ TEST(SCONV_6x8__PSIMD, k_gt_1_strided_c) {
         .k(k)
         .aStride(37)
         .cStride(17)
-        .test(sconv_ukernel_6x8__psimd);
+        .test(pytorch_sconv_ukernel_6x8__psimd);
   }
 }
 
@@ -96,7 +96,7 @@ TEST(SCONV_6x8__PSIMD, k_gt_1_subtile) {
             .k(k)
             .aStride(37)
             .iterations(3)
-            .test(sconv_ukernel_6x8__psimd);
+            .test(pytorch_sconv_ukernel_6x8__psimd);
       }
     }
   }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/sgemm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/sgemm.cc
@@ -18,7 +18,7 @@
 TEST(SGEMM_5x8__NEON, k_eq_2) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(5).nr(8).np(8).kr(1).m(5).n(8).k(2).test(
-      sgemm_ukernel_5x8__neon);
+      pytorch_sgemm_ukernel_5x8__neon);
 }
 
 TEST(SGEMM_5x8__NEON, k_eq_2_strided_a) {
@@ -32,7 +32,7 @@ TEST(SGEMM_5x8__NEON, k_eq_2_strided_a) {
       .n(8)
       .k(2)
       .aStride(37)
-      .test(sgemm_ukernel_5x8__neon);
+      .test(pytorch_sgemm_ukernel_5x8__neon);
 }
 
 TEST(SGEMM_5x8__NEON, k_eq_2_strided_c) {
@@ -46,26 +46,26 @@ TEST(SGEMM_5x8__NEON, k_eq_2_strided_c) {
       .n(8)
       .k(2)
       .cStride(17)
-      .test(sgemm_ukernel_5x8__neon);
+      .test(pytorch_sgemm_ukernel_5x8__neon);
 }
 
 TEST(SGEMM_5x8__NEON, k_eq_8_rmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmin(128).test(
-      sgemm_ukernel_5x8__neon);
+      pytorch_sgemm_ukernel_5x8__neon);
 }
 
 TEST(SGEMM_5x8__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(4).nr(8).np(8).kr(1).m(4).n(8).k(8).qmax(128).test(
-      sgemm_ukernel_5x8__neon);
+      pytorch_sgemm_ukernel_5x8__neon);
 }
 
 TEST(SGEMM_5x8__NEON, k_gt_2) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 3; k < 16; k++) {
     GemmMicrokernelTester().mr(5).nr(8).np(8).kr(1).m(5).n(8).k(k).test(
-        sgemm_ukernel_5x8__neon);
+        pytorch_sgemm_ukernel_5x8__neon);
   }
 }
 
@@ -81,7 +81,7 @@ TEST(SGEMM_5x8__NEON, k_gt_2_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(sgemm_ukernel_5x8__neon);
+        .test(pytorch_sgemm_ukernel_5x8__neon);
   }
 }
 
@@ -97,7 +97,7 @@ TEST(SGEMM_5x8__NEON, k_gt_2_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(sgemm_ukernel_5x8__neon);
+        .test(pytorch_sgemm_ukernel_5x8__neon);
   }
 }
 
@@ -115,7 +115,7 @@ TEST(SGEMM_5x8__NEON, k_gt_2_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(sgemm_ukernel_5x8__neon);
+            .test(pytorch_sgemm_ukernel_5x8__neon);
       }
     }
   }
@@ -125,7 +125,7 @@ TEST(SGEMM_5x8__NEON, k_div_2) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 2; k < 32; k += 2) {
     GemmMicrokernelTester().mr(5).nr(8).np(8).kr(1).m(5).n(8).k(k).test(
-        sgemm_ukernel_5x8__neon);
+        pytorch_sgemm_ukernel_5x8__neon);
   }
 }
 
@@ -141,7 +141,7 @@ TEST(SGEMM_5x8__NEON, k_div_2_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(sgemm_ukernel_5x8__neon);
+        .test(pytorch_sgemm_ukernel_5x8__neon);
   }
 }
 
@@ -157,7 +157,7 @@ TEST(SGEMM_5x8__NEON, k_div_2_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(sgemm_ukernel_5x8__neon);
+        .test(pytorch_sgemm_ukernel_5x8__neon);
   }
 }
 
@@ -175,7 +175,7 @@ TEST(SGEMM_5x8__NEON, k_div_2_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(sgemm_ukernel_5x8__neon);
+            .test(pytorch_sgemm_ukernel_5x8__neon);
       }
     }
   }
@@ -184,7 +184,7 @@ TEST(SGEMM_5x8__NEON, k_div_2_subtile) {
 TEST(SGEMM_6x8__NEON, k_eq_2) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(2).test(
-      sgemm_ukernel_6x8__neon);
+      pytorch_sgemm_ukernel_6x8__neon);
 }
 
 TEST(SGEMM_6x8__NEON, k_eq_2_strided_a) {
@@ -198,7 +198,7 @@ TEST(SGEMM_6x8__NEON, k_eq_2_strided_a) {
       .n(8)
       .k(2)
       .aStride(37)
-      .test(sgemm_ukernel_6x8__neon);
+      .test(pytorch_sgemm_ukernel_6x8__neon);
 }
 
 TEST(SGEMM_6x8__NEON, k_eq_2_strided_c) {
@@ -212,26 +212,26 @@ TEST(SGEMM_6x8__NEON, k_eq_2_strided_c) {
       .n(8)
       .k(2)
       .cStride(17)
-      .test(sgemm_ukernel_6x8__neon);
+      .test(pytorch_sgemm_ukernel_6x8__neon);
 }
 
 TEST(SGEMM_6x8__NEON, k_eq_8_qmin128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(8).qmin(128).test(
-      sgemm_ukernel_6x8__neon);
+      pytorch_sgemm_ukernel_6x8__neon);
 }
 
 TEST(SGEMM_6x8__NEON, k_eq_8_qmax128) {
   TEST_REQUIRES_ARM_NEON;
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(8).qmax(128).test(
-      sgemm_ukernel_6x8__neon);
+      pytorch_sgemm_ukernel_6x8__neon);
 }
 
 TEST(SGEMM_6x8__NEON, k_gt_2) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 3; k < 16; k++) {
     GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(k).test(
-        sgemm_ukernel_6x8__neon);
+        pytorch_sgemm_ukernel_6x8__neon);
   }
 }
 
@@ -247,7 +247,7 @@ TEST(SGEMM_6x8__NEON, k_gt_2_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(sgemm_ukernel_6x8__neon);
+        .test(pytorch_sgemm_ukernel_6x8__neon);
   }
 }
 
@@ -263,7 +263,7 @@ TEST(SGEMM_6x8__NEON, k_gt_2_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(sgemm_ukernel_6x8__neon);
+        .test(pytorch_sgemm_ukernel_6x8__neon);
   }
 }
 
@@ -281,7 +281,7 @@ TEST(SGEMM_6x8__NEON, k_gt_2_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(sgemm_ukernel_6x8__neon);
+            .test(pytorch_sgemm_ukernel_6x8__neon);
       }
     }
   }
@@ -291,7 +291,7 @@ TEST(SGEMM_6x8__NEON, k_div_2) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t k = 2; k < 32; k += 2) {
     GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(k).test(
-        sgemm_ukernel_6x8__neon);
+        pytorch_sgemm_ukernel_6x8__neon);
   }
 }
 
@@ -307,7 +307,7 @@ TEST(SGEMM_6x8__NEON, k_div_2_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(sgemm_ukernel_6x8__neon);
+        .test(pytorch_sgemm_ukernel_6x8__neon);
   }
 }
 
@@ -323,7 +323,7 @@ TEST(SGEMM_6x8__NEON, k_div_2_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(sgemm_ukernel_6x8__neon);
+        .test(pytorch_sgemm_ukernel_6x8__neon);
   }
 }
 
@@ -341,7 +341,7 @@ TEST(SGEMM_6x8__NEON, k_div_2_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(sgemm_ukernel_6x8__neon);
+            .test(pytorch_sgemm_ukernel_6x8__neon);
       }
     }
   }
@@ -350,7 +350,7 @@ TEST(SGEMM_6x8__NEON, k_div_2_subtile) {
 
 TEST(SGEMM_6x8__PSIMD, k_eq_2) {
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(2).test(
-      sgemm_ukernel_6x8__psimd);
+      pytorch_sgemm_ukernel_6x8__psimd);
 }
 
 TEST(SGEMM_6x8__PSIMD, k_eq_2_strided_a) {
@@ -363,7 +363,7 @@ TEST(SGEMM_6x8__PSIMD, k_eq_2_strided_a) {
       .n(8)
       .k(2)
       .aStride(37)
-      .test(sgemm_ukernel_6x8__psimd);
+      .test(pytorch_sgemm_ukernel_6x8__psimd);
 }
 
 TEST(SGEMM_6x8__PSIMD, k_eq_2_strided_c) {
@@ -376,23 +376,23 @@ TEST(SGEMM_6x8__PSIMD, k_eq_2_strided_c) {
       .n(8)
       .k(2)
       .cStride(17)
-      .test(sgemm_ukernel_6x8__psimd);
+      .test(pytorch_sgemm_ukernel_6x8__psimd);
 }
 
 TEST(SGEMM_6x8__PSIMD, k_eq_8_qmin128) {
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(8).qmin(128).test(
-      sgemm_ukernel_6x8__psimd);
+      pytorch_sgemm_ukernel_6x8__psimd);
 }
 
 TEST(SGEMM_6x8__PSIMD, k_eq_8_qmax128) {
   GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(8).qmax(128).test(
-      sgemm_ukernel_6x8__psimd);
+      pytorch_sgemm_ukernel_6x8__psimd);
 }
 
 TEST(SGEMM_6x8__PSIMD, k_gt_2) {
   for (size_t k = 3; k < 16; k++) {
     GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(k).test(
-        sgemm_ukernel_6x8__psimd);
+        pytorch_sgemm_ukernel_6x8__psimd);
   }
 }
 
@@ -407,7 +407,7 @@ TEST(SGEMM_6x8__PSIMD, k_gt_2_strided_a) {
         .n(8)
         .k(k)
         .aStride(37)
-        .test(sgemm_ukernel_6x8__psimd);
+        .test(pytorch_sgemm_ukernel_6x8__psimd);
   }
 }
 
@@ -422,7 +422,7 @@ TEST(SGEMM_6x8__PSIMD, k_gt_2_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(sgemm_ukernel_6x8__psimd);
+        .test(pytorch_sgemm_ukernel_6x8__psimd);
   }
 }
 
@@ -439,7 +439,7 @@ TEST(SGEMM_6x8__PSIMD, k_gt_2_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(sgemm_ukernel_6x8__psimd);
+            .test(pytorch_sgemm_ukernel_6x8__psimd);
       }
     }
   }
@@ -448,7 +448,7 @@ TEST(SGEMM_6x8__PSIMD, k_gt_2_subtile) {
 TEST(SGEMM_6x8__PSIMD, k_div_2) {
   for (size_t k = 2; k < 32; k += 2) {
     GemmMicrokernelTester().mr(6).nr(8).np(8).kr(1).m(6).n(8).k(k).test(
-        sgemm_ukernel_6x8__psimd);
+        pytorch_sgemm_ukernel_6x8__psimd);
   }
 }
 
@@ -463,7 +463,7 @@ TEST(SGEMM_6x8__PSIMD, k_div_2_strided_a) {
         .n(8)
         .k(k)
         .aStride(171)
-        .test(sgemm_ukernel_6x8__psimd);
+        .test(pytorch_sgemm_ukernel_6x8__psimd);
   }
 }
 
@@ -478,7 +478,7 @@ TEST(SGEMM_6x8__PSIMD, k_div_2_strided_c) {
         .n(8)
         .k(k)
         .cStride(17)
-        .test(sgemm_ukernel_6x8__psimd);
+        .test(pytorch_sgemm_ukernel_6x8__psimd);
   }
 }
 
@@ -495,7 +495,7 @@ TEST(SGEMM_6x8__PSIMD, k_div_2_subtile) {
             .n(n)
             .k(k)
             .iterations(3)
-            .test(sgemm_ukernel_6x8__psimd);
+            .test(pytorch_sgemm_ukernel_6x8__psimd);
       }
     }
   }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8clamp.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8clamp.cc
@@ -17,27 +17,27 @@
 #if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 TEST(U8CLAMP__NEON, n_eq_8) {
   TEST_REQUIRES_ARM_NEON;
-  ClampMicrokernelTester().n(8).test(u8clamp_ukernel__neon);
+  ClampMicrokernelTester().n(8).test(pytorch_u8clamp_ukernel__neon);
 }
 
 TEST(U8CLAMP__NEON, n_div_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 8; n < 512; n += 8) {
-    ClampMicrokernelTester().n(n).test(u8clamp_ukernel__neon);
+    ClampMicrokernelTester().n(n).test(pytorch_u8clamp_ukernel__neon);
   }
 }
 
 TEST(U8CLAMP__NEON, n_gt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 9; n < 16; n++) {
-    ClampMicrokernelTester().n(n).test(u8clamp_ukernel__neon);
+    ClampMicrokernelTester().n(n).test(pytorch_u8clamp_ukernel__neon);
   }
 }
 
 TEST(U8CLAMP__NEON, n_lt_8) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 8; n++) {
-    ClampMicrokernelTester().n(n).test(u8clamp_ukernel__neon);
+    ClampMicrokernelTester().n(n).test(pytorch_u8clamp_ukernel__neon);
   }
 }
 
@@ -45,7 +45,7 @@ TEST(U8CLAMP__NEON, inplace) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 128; n += 5) {
     ClampMicrokernelTester().iterations(1).n(n).inplace(true).test(
-        u8clamp_ukernel__neon);
+        pytorch_u8clamp_ukernel__neon);
   }
 }
 
@@ -54,7 +54,7 @@ TEST(U8CLAMP__NEON, qmin) {
   for (size_t n = 1; n < 128; n += 11) {
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
       ClampMicrokernelTester().iterations(1).n(n).qmin(qmin).test(
-          u8clamp_ukernel__neon);
+          pytorch_u8clamp_ukernel__neon);
     }
   }
 }
@@ -64,7 +64,7 @@ TEST(U8CLAMP__NEON, qmax) {
   for (size_t n = 1; n < 128; n += 11) {
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
       ClampMicrokernelTester().iterations(1).n(n).qmax(qmax).test(
-          u8clamp_ukernel__neon);
+          pytorch_u8clamp_ukernel__neon);
     }
   }
 }
@@ -73,27 +73,27 @@ TEST(U8CLAMP__NEON, qmax) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 TEST(U8CLAMP__SSE2, n_eq_8) {
   TEST_REQUIRES_X86_SSE2;
-  ClampMicrokernelTester().n(8).test(u8clamp_ukernel__sse2);
+  ClampMicrokernelTester().n(8).test(pytorch_u8clamp_ukernel__sse2);
 }
 
 TEST(U8CLAMP__SSE2, n_div_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 8; n < 512; n += 8) {
-    ClampMicrokernelTester().n(n).test(u8clamp_ukernel__sse2);
+    ClampMicrokernelTester().n(n).test(pytorch_u8clamp_ukernel__sse2);
   }
 }
 
 TEST(U8CLAMP__SSE2, n_gt_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 9; n < 16; n++) {
-    ClampMicrokernelTester().n(n).test(u8clamp_ukernel__sse2);
+    ClampMicrokernelTester().n(n).test(pytorch_u8clamp_ukernel__sse2);
   }
 }
 
 TEST(U8CLAMP__SSE2, n_lt_8) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 8; n++) {
-    ClampMicrokernelTester().n(n).test(u8clamp_ukernel__sse2);
+    ClampMicrokernelTester().n(n).test(pytorch_u8clamp_ukernel__sse2);
   }
 }
 
@@ -101,7 +101,7 @@ TEST(U8CLAMP__SSE2, inplace) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 128; n += 5) {
     ClampMicrokernelTester().iterations(1).n(n).inplace(true).test(
-        u8clamp_ukernel__sse2);
+        pytorch_u8clamp_ukernel__sse2);
   }
 }
 
@@ -110,7 +110,7 @@ TEST(U8CLAMP__SSE2, qmin) {
   for (size_t n = 1; n < 128; n += 11) {
     for (uint8_t qmin = 1; qmin < 255; qmin++) {
       ClampMicrokernelTester().iterations(1).n(n).qmin(qmin).test(
-          u8clamp_ukernel__sse2);
+          pytorch_u8clamp_ukernel__sse2);
     }
   }
 }
@@ -120,7 +120,7 @@ TEST(U8CLAMP__SSE2, qmax) {
   for (size_t n = 1; n < 128; n += 11) {
     for (uint8_t qmax = 1; qmax < 255; qmax++) {
       ClampMicrokernelTester().iterations(1).n(n).qmax(qmax).test(
-          u8clamp_ukernel__sse2);
+          pytorch_u8clamp_ukernel__sse2);
     }
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8lut32norm.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8lut32norm.cc
@@ -13,36 +13,36 @@
 #include "lut-norm-microkernel-tester.h"
 
 TEST(U8LUT32NORM__SCALAR, n_eq_1) {
-  LUTNormMicrokernelTester().n(1).test(u8lut32norm_ukernel__scalar);
+  LUTNormMicrokernelTester().n(1).test(pytorch_u8lut32norm_ukernel__scalar);
 }
 
 TEST(U8LUT32NORM__SCALAR, small_n) {
   for (size_t n = 2; n <= 16; n++) {
-    LUTNormMicrokernelTester().n(n).test(u8lut32norm_ukernel__scalar);
+    LUTNormMicrokernelTester().n(n).test(pytorch_u8lut32norm_ukernel__scalar);
   }
 }
 
 TEST(U8LUT32NORM__SCALAR, large_n) {
   for (size_t n = 16; n <= 128; n += 2) {
-    LUTNormMicrokernelTester().n(n).test(u8lut32norm_ukernel__scalar);
+    LUTNormMicrokernelTester().n(n).test(pytorch_u8lut32norm_ukernel__scalar);
   }
 }
 
 TEST(U8LUT32NORM__SCALAR, n_eq_1_inplace) {
   LUTNormMicrokernelTester().n(1).inplace(true).test(
-      u8lut32norm_ukernel__scalar);
+      pytorch_u8lut32norm_ukernel__scalar);
 }
 
 TEST(U8LUT32NORM__SCALAR, small_n_inplace) {
   for (size_t n = 2; n <= 16; n++) {
     LUTNormMicrokernelTester().n(n).inplace(true).test(
-        u8lut32norm_ukernel__scalar);
+        pytorch_u8lut32norm_ukernel__scalar);
   }
 }
 
 TEST(U8LUT32NORM__SCALAR, large_n_inplace) {
   for (size_t n = 16; n <= 128; n += 2) {
     LUTNormMicrokernelTester().n(n).inplace(true).test(
-        u8lut32norm_ukernel__scalar);
+        pytorch_u8lut32norm_ukernel__scalar);
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8maxpool.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8maxpool.cc
@@ -20,7 +20,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_mx1_pool) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(ks).kw(1).kc(kc).test(
-          u8maxpool_ukernel_sub16__neon);
+          pytorch_u8maxpool_ukernel_sub16__neon);
     }
   }
 }
@@ -30,7 +30,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_mx1_pool_with_qmin) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(ks).kw(1).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_sub16__neon);
+          pytorch_u8maxpool_ukernel_sub16__neon);
     }
   }
 }
@@ -40,7 +40,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_mx1_pool_with_qmax) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(ks).kw(1).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_sub16__neon);
+          pytorch_u8maxpool_ukernel_sub16__neon);
     }
   }
 }
@@ -50,7 +50,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_1xm_pool) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(1).kw(ks).kc(kc).test(
-          u8maxpool_ukernel_sub16__neon);
+          pytorch_u8maxpool_ukernel_sub16__neon);
     }
   }
 }
@@ -60,7 +60,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_1xm_pool_with_qmin) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(1).kw(ks).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_sub16__neon);
+          pytorch_u8maxpool_ukernel_sub16__neon);
     }
   }
 }
@@ -70,7 +70,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_1xm_pool_with_qmax) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(1).kw(ks).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_sub16__neon);
+          pytorch_u8maxpool_ukernel_sub16__neon);
     }
   }
 }
@@ -87,7 +87,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_small_n) {
             .kw(ks)
             .kc(kc)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__neon);
+            .test(pytorch_u8maxpool_ukernel_sub16__neon);
       }
     }
   }
@@ -106,7 +106,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_small_n_with_x_stride) {
             .kc(kc)
             .xStride(17)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__neon);
+            .test(pytorch_u8maxpool_ukernel_sub16__neon);
       }
     }
   }
@@ -126,7 +126,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_small_n_with_s) {
               .kc(kc)
               .s(s)
               .iterations(1)
-              .test(u8maxpool_ukernel_sub16__neon);
+              .test(pytorch_u8maxpool_ukernel_sub16__neon);
         }
       }
     }
@@ -146,7 +146,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_small_n_with_qmin) {
             .kc(kc)
             .qmin(192)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__neon);
+            .test(pytorch_u8maxpool_ukernel_sub16__neon);
       }
     }
   }
@@ -165,7 +165,7 @@ TEST(U8MAXPOOL_SUB16__NEON, kc_lt_16_small_n_with_qmax) {
             .kc(kc)
             .qmax(192)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__neon);
+            .test(pytorch_u8maxpool_ukernel_sub16__neon);
       }
     }
   }
@@ -177,7 +177,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_unipass_fulltile) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).test(u8maxpool_ukernel_16x9p8q__neon);
+        tester.kh(kh).kw(kw).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -189,7 +189,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_unipass_fulltile_with_qmin) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).qmin(192).test(u8maxpool_ukernel_16x9p8q__neon);
+        tester.kh(kh).kw(kw).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -201,7 +201,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_unipass_fulltile_with_qmax) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).qmax(192).test(u8maxpool_ukernel_16x9p8q__neon);
+        tester.kh(kh).kw(kw).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -211,8 +211,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_unipass_subtile) {
   TEST_REQUIRES_ARM_NEON;
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).kc(16);
   for (size_t ks = 2; ks < tester.mr(); ks++) {
-    tester.kh(ks).kw(1).test(u8maxpool_ukernel_16x9p8q__neon);
-    tester.kh(1).kw(ks).test(u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(ks).kw(1).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(1).kw(ks).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
   }
 }
 
@@ -223,7 +223,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_unipass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -238,7 +238,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_unipass_fulltile_with_qmin) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -253,7 +253,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_unipass_fulltile_with_qmax) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -268,7 +268,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_unipass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -280,8 +280,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_unipass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).iterations(3);
   for (size_t ks = 2; ks < tester.mr(); ks++) {
     for (size_t kc = 16; kc < 256; kc += 48) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -293,7 +293,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_unipass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -308,7 +308,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_unipass_fulltile_with_qmin) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -323,7 +323,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_unipass_fulltile_with_qmax) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -338,7 +338,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_unipass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -350,8 +350,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_unipass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).iterations(3);
   for (size_t ks = 2; ks < tester.mr(); ks++) {
     for (size_t kc = 17; kc < 32; kc++) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -362,7 +362,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_twopass_fulltile) {
   for (size_t kh = 1; kh <= tester.mr() + tester.qr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
-        tester.kh(kh).kw(kw).test(u8maxpool_ukernel_16x9p8q__neon);
+        tester.kh(kh).kw(kw).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -374,7 +374,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_twopass_fulltile_with_qmin) {
   for (size_t kh = 1; kh <= tester.mr() + tester.qr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
-        tester.kh(kh).kw(kw).qmin(192).test(u8maxpool_ukernel_16x9p8q__neon);
+        tester.kh(kh).kw(kw).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -386,7 +386,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_twopass_fulltile_with_qmax) {
   for (size_t kh = 1; kh <= tester.mr() + tester.qr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
-        tester.kh(kh).kw(kw).qmax(192).test(u8maxpool_ukernel_16x9p8q__neon);
+        tester.kh(kh).kw(kw).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -396,8 +396,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_twopass_subtile) {
   TEST_REQUIRES_ARM_NEON;
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).qr(8).kc(16);
   for (size_t ks = tester.mr() + 1; ks < tester.mr() + tester.qr(); ks++) {
-    tester.kh(ks).kw(1).test(u8maxpool_ukernel_16x9p8q__neon);
-    tester.kh(1).kw(ks).test(u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(ks).kw(1).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(1).kw(ks).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
   }
 }
 
@@ -408,7 +408,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_twopass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -423,7 +423,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_twopass_fulltile_with_qmin) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -438,7 +438,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_twopass_fulltile_with_qmax) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -453,7 +453,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_twopass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -465,8 +465,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_twopass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).qr(8).iterations(3);
   for (size_t ks = tester.mr() + 1; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 16; kc < 256; kc += 48) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -478,7 +478,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_twopass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -493,7 +493,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_twopass_fulltile_with_qmin) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -508,7 +508,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_twopass_fulltile_with_qmax) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -523,7 +523,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_twopass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__neon);
+              pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -535,8 +535,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_twopass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).qr(8).iterations(3);
   for (size_t ks = tester.mr() + 1; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 17; kc < 32; kc++) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -547,8 +547,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_multipass) {
   for (size_t ks = tester.mr() + tester.qr() + 1;
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
-    tester.kh(ks).kw(1).test(u8maxpool_ukernel_16x9p8q__neon);
-    tester.kh(1).kw(ks).test(u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(ks).kw(1).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(1).kw(ks).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
   }
 }
 
@@ -558,8 +558,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_multipass_with_qmin) {
   for (size_t ks = tester.mr() + tester.qr() + 1;
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
-    tester.kh(ks).kw(1).qmin(192).test(u8maxpool_ukernel_16x9p8q__neon);
-    tester.kh(1).kw(ks).qmin(192).test(u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(ks).kw(1).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(1).kw(ks).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
   }
 }
 
@@ -569,8 +569,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_eq_16_multipass_with_qmax) {
   for (size_t ks = tester.mr() + tester.qr() + 1;
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
-    tester.kh(ks).kw(1).qmax(192).test(u8maxpool_ukernel_16x9p8q__neon);
-    tester.kh(1).kw(ks).qmax(192).test(u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(ks).kw(1).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+    tester.kh(1).kw(ks).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
   }
 }
 
@@ -581,8 +581,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_multipass) {
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -595,9 +595,9 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_multipass_with_qmin) {
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
       tester.kh(ks).kw(1).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
       tester.kh(1).kw(ks).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -610,9 +610,9 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_multipass_with_qmax) {
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
       tester.kh(ks).kw(1).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
       tester.kh(1).kw(ks).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -625,9 +625,9 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_div_16_multipass_with_x_stride) {
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
       tester.kh(ks).kw(1).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
       tester.kh(1).kw(ks).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -639,8 +639,8 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_multipass) {
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -653,9 +653,9 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_multipass_with_qmin) {
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
       tester.kh(ks).kw(1).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
       tester.kh(1).kw(ks).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -668,9 +668,9 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_multipass_with_qmax) {
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
       tester.kh(ks).kw(1).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
       tester.kh(1).kw(ks).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -683,9 +683,9 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, kc_gt_16_multipass_with_x_stride) {
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
       tester.kh(ks).kw(1).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
       tester.kh(1).kw(ks).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__neon);
+          pytorch_u8maxpool_ukernel_16x9p8q__neon);
     }
   }
 }
@@ -704,7 +704,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, small_n) {
             .kw(ks)
             .kc(kc)
             .iterations(3)
-            .test(u8maxpool_ukernel_16x9p8q__neon);
+            .test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -725,7 +725,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, small_n_with_x_stride) {
             .kc(kc)
             .xStride(101)
             .iterations(1)
-            .test(u8maxpool_ukernel_16x9p8q__neon);
+            .test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -746,7 +746,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, small_n_with_y_stride) {
             .kc(kc)
             .yStride(103)
             .iterations(1)
-            .test(u8maxpool_ukernel_16x9p8q__neon);
+            .test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
       }
     }
   }
@@ -768,7 +768,7 @@ TEST(U8MAXPOOL_16x9P8Q__NEON, small_n_with_s) {
               .kc(kc)
               .s(s)
               .iterations(1)
-              .test(u8maxpool_ukernel_16x9p8q__neon);
+              .test(pytorch_u8maxpool_ukernel_16x9p8q__neon);
         }
       }
     }
@@ -782,7 +782,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_mx1_pool) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(ks).kw(1).kc(kc).test(
-          u8maxpool_ukernel_sub16__sse2);
+          pytorch_u8maxpool_ukernel_sub16__sse2);
     }
   }
 }
@@ -792,7 +792,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_mx1_pool_with_qmin) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(ks).kw(1).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_sub16__sse2);
+          pytorch_u8maxpool_ukernel_sub16__sse2);
     }
   }
 }
@@ -802,7 +802,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_mx1_pool_with_qmax) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(ks).kw(1).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_sub16__sse2);
+          pytorch_u8maxpool_ukernel_sub16__sse2);
     }
   }
 }
@@ -812,7 +812,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_1xm_pool) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(1).kw(ks).kc(kc).test(
-          u8maxpool_ukernel_sub16__sse2);
+          pytorch_u8maxpool_ukernel_sub16__sse2);
     }
   }
 }
@@ -822,7 +822,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_1xm_pool_with_qmin) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(1).kw(ks).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_sub16__sse2);
+          pytorch_u8maxpool_ukernel_sub16__sse2);
     }
   }
 }
@@ -832,7 +832,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_1xm_pool_with_qmax) {
   for (size_t kc = 1; kc < 16; kc++) {
     for (size_t ks = 2; ks < 16; ks++) {
       MaxPoolMicrokernelTester().kr(16).kh(1).kw(ks).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_sub16__sse2);
+          pytorch_u8maxpool_ukernel_sub16__sse2);
     }
   }
 }
@@ -849,7 +849,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_small_n) {
             .kw(ks)
             .kc(kc)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__sse2);
+            .test(pytorch_u8maxpool_ukernel_sub16__sse2);
       }
     }
   }
@@ -868,7 +868,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_small_n_with_x_stride) {
             .kc(kc)
             .xStride(17)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__sse2);
+            .test(pytorch_u8maxpool_ukernel_sub16__sse2);
       }
     }
   }
@@ -888,7 +888,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_small_n_with_s) {
               .kc(kc)
               .s(s)
               .iterations(1)
-              .test(u8maxpool_ukernel_sub16__sse2);
+              .test(pytorch_u8maxpool_ukernel_sub16__sse2);
         }
       }
     }
@@ -908,7 +908,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_small_n_with_qmin) {
             .kc(kc)
             .qmin(192)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__sse2);
+            .test(pytorch_u8maxpool_ukernel_sub16__sse2);
       }
     }
   }
@@ -927,7 +927,7 @@ TEST(U8MAXPOOL_SUB16__SSE2, kc_lt_16_small_n_with_qmax) {
             .kc(kc)
             .qmax(192)
             .iterations(3)
-            .test(u8maxpool_ukernel_sub16__sse2);
+            .test(pytorch_u8maxpool_ukernel_sub16__sse2);
       }
     }
   }
@@ -939,7 +939,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_unipass_fulltile) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).test(u8maxpool_ukernel_16x9p8q__sse2);
+        tester.kh(kh).kw(kw).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -951,7 +951,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_unipass_fulltile_with_qmin) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).qmin(192).test(u8maxpool_ukernel_16x9p8q__sse2);
+        tester.kh(kh).kw(kw).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -963,7 +963,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_unipass_fulltile_with_qmax) {
   for (size_t kh = 1; kh <= tester.mr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
-        tester.kh(kh).kw(kw).qmax(192).test(u8maxpool_ukernel_16x9p8q__sse2);
+        tester.kh(kh).kw(kw).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -973,8 +973,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_unipass_subtile) {
   TEST_REQUIRES_X86_SSE2;
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).kc(16);
   for (size_t ks = 2; ks < tester.mr(); ks++) {
-    tester.kh(ks).kw(1).test(u8maxpool_ukernel_16x9p8q__sse2);
-    tester.kh(1).kw(ks).test(u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(ks).kw(1).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(1).kw(ks).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
   }
 }
 
@@ -985,7 +985,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_unipass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1000,7 +1000,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_unipass_fulltile_with_qmin) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1015,7 +1015,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_unipass_fulltile_with_qmax) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1030,7 +1030,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_unipass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1042,8 +1042,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_unipass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).iterations(3);
   for (size_t ks = 2; ks < tester.mr(); ks++) {
     for (size_t kc = 16; kc < 256; kc += 48) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1055,7 +1055,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_unipass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr(); kw++) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1070,7 +1070,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_unipass_fulltile_with_qmin) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1085,7 +1085,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_unipass_fulltile_with_qmax) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1100,7 +1100,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_unipass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1112,8 +1112,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_unipass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).iterations(3);
   for (size_t ks = 2; ks < tester.mr(); ks++) {
     for (size_t kc = 17; kc < 32; kc++) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1124,7 +1124,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_twopass_fulltile) {
   for (size_t kh = 1; kh <= tester.mr() + tester.qr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
-        tester.kh(kh).kw(kw).test(u8maxpool_ukernel_16x9p8q__sse2);
+        tester.kh(kh).kw(kw).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -1136,7 +1136,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_twopass_fulltile_with_qmin) {
   for (size_t kh = 1; kh <= tester.mr() + tester.qr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
-        tester.kh(kh).kw(kw).qmin(192).test(u8maxpool_ukernel_16x9p8q__sse2);
+        tester.kh(kh).kw(kw).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -1148,7 +1148,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_twopass_fulltile_with_qmax) {
   for (size_t kh = 1; kh <= tester.mr() + tester.qr(); kh++) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
-        tester.kh(kh).kw(kw).qmax(192).test(u8maxpool_ukernel_16x9p8q__sse2);
+        tester.kh(kh).kw(kw).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -1158,8 +1158,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_twopass_subtile) {
   TEST_REQUIRES_X86_SSE2;
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).qr(8).kc(16);
   for (size_t ks = tester.mr() + 1; ks < tester.mr() + tester.qr(); ks++) {
-    tester.kh(ks).kw(1).test(u8maxpool_ukernel_16x9p8q__sse2);
-    tester.kh(1).kw(ks).test(u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(ks).kw(1).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(1).kw(ks).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
   }
 }
 
@@ -1170,7 +1170,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_twopass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1185,7 +1185,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_twopass_fulltile_with_qmin) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1200,7 +1200,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_twopass_fulltile_with_qmax) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1215,7 +1215,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_twopass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 16; kc < 256; kc += 48) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1227,8 +1227,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_twopass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).qr(8).iterations(3);
   for (size_t ks = tester.mr() + 1; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 16; kc < 256; kc += 48) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1240,7 +1240,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_twopass_fulltile) {
     for (size_t kw = 1; kw <= tester.mr() + tester.qr(); kw++) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
-          tester.kh(kh).kw(kw).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+          tester.kh(kh).kw(kw).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1255,7 +1255,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_twopass_fulltile_with_qmin) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmin(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1270,7 +1270,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_twopass_fulltile_with_qmax) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).qmax(192).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1285,7 +1285,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_twopass_fulltile_with_x_stride) {
       if (kh * kw == tester.mr() + tester.qr()) {
         for (size_t kc = 17; kc < 32; kc++) {
           tester.kh(kh).kw(kw).kc(kc).xStride(257).test(
-              u8maxpool_ukernel_16x9p8q__sse2);
+              pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }
@@ -1297,8 +1297,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_twopass_subtile) {
   auto tester = MaxPoolMicrokernelTester().kr(16).mr(9).qr(8).iterations(3);
   for (size_t ks = tester.mr() + 1; ks < tester.mr() + tester.qr(); ks++) {
     for (size_t kc = 17; kc < 32; kc++) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1309,8 +1309,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_multipass) {
   for (size_t ks = tester.mr() + tester.qr() + 1;
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
-    tester.kh(ks).kw(1).test(u8maxpool_ukernel_16x9p8q__sse2);
-    tester.kh(1).kw(ks).test(u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(ks).kw(1).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(1).kw(ks).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
   }
 }
 
@@ -1320,8 +1320,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_multipass_with_qmin) {
   for (size_t ks = tester.mr() + tester.qr() + 1;
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
-    tester.kh(ks).kw(1).qmin(192).test(u8maxpool_ukernel_16x9p8q__sse2);
-    tester.kh(1).kw(ks).qmin(192).test(u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(ks).kw(1).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(1).kw(ks).qmin(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
   }
 }
 
@@ -1331,8 +1331,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_eq_16_multipass_with_qmax) {
   for (size_t ks = tester.mr() + tester.qr() + 1;
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
-    tester.kh(ks).kw(1).qmax(192).test(u8maxpool_ukernel_16x9p8q__sse2);
-    tester.kh(1).kw(ks).qmax(192).test(u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(ks).kw(1).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+    tester.kh(1).kw(ks).qmax(192).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
   }
 }
 
@@ -1343,8 +1343,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_multipass) {
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1357,9 +1357,9 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_multipass_with_qmin) {
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
       tester.kh(ks).kw(1).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       tester.kh(1).kw(ks).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1372,9 +1372,9 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_multipass_with_qmax) {
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
       tester.kh(ks).kw(1).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       tester.kh(1).kw(ks).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1387,9 +1387,9 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_div_16_multipass_with_x_stride) {
        ks += 3) {
     for (size_t kc = 16; kc < 256; kc += 48) {
       tester.kh(ks).kw(1).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       tester.kh(1).kw(ks).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1401,8 +1401,8 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_multipass) {
        ks < tester.mr() + 3 * tester.qr();
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
-      tester.kh(ks).kw(1).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
-      tester.kh(1).kw(ks).kc(kc).test(u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(ks).kw(1).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
+      tester.kh(1).kw(ks).kc(kc).test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1415,9 +1415,9 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_multipass_with_qmin) {
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
       tester.kh(ks).kw(1).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       tester.kh(1).kw(ks).kc(kc).qmin(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1430,9 +1430,9 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_multipass_with_qmax) {
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
       tester.kh(ks).kw(1).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       tester.kh(1).kw(ks).kc(kc).qmax(192).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1445,9 +1445,9 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, kc_gt_16_multipass_with_x_stride) {
        ks += 3) {
     for (size_t kc = 17; kc < 32; kc++) {
       tester.kh(ks).kw(1).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       tester.kh(1).kw(ks).kc(kc).xStride(257).test(
-          u8maxpool_ukernel_16x9p8q__sse2);
+          pytorch_u8maxpool_ukernel_16x9p8q__sse2);
     }
   }
 }
@@ -1466,7 +1466,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, small_n) {
             .kw(ks)
             .kc(kc)
             .iterations(3)
-            .test(u8maxpool_ukernel_16x9p8q__sse2);
+            .test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -1487,7 +1487,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, small_n_with_x_stride) {
             .kc(kc)
             .xStride(101)
             .iterations(1)
-            .test(u8maxpool_ukernel_16x9p8q__sse2);
+            .test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -1508,7 +1508,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, small_n_with_y_stride) {
             .kc(kc)
             .yStride(103)
             .iterations(1)
-            .test(u8maxpool_ukernel_16x9p8q__sse2);
+            .test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
       }
     }
   }
@@ -1530,7 +1530,7 @@ TEST(U8MAXPOOL_16x9P8Q__SSE2, small_n_with_s) {
               .kc(kc)
               .s(s)
               .iterations(1)
-              .test(u8maxpool_ukernel_16x9p8q__sse2);
+              .test(pytorch_u8maxpool_ukernel_16x9p8q__sse2);
         }
       }
     }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8rmax.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/u8rmax.cc
@@ -18,26 +18,26 @@
 TEST(U8RMAX__NEON, n_lt_16) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 1; n < 16; n++) {
-    RMaxMicrokernelTester().n(n).test(u8rmax_ukernel__neon);
+    RMaxMicrokernelTester().n(n).test(pytorch_u8rmax_ukernel__neon);
   }
 }
 
 TEST(U8RMAX__NEON, n_eq_16) {
   TEST_REQUIRES_ARM_NEON;
-  RMaxMicrokernelTester().n(16).test(u8rmax_ukernel__neon);
+  RMaxMicrokernelTester().n(16).test(pytorch_u8rmax_ukernel__neon);
 }
 
 TEST(U8RMAX__NEON, n_div_16) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 16; n < 128; n += 16) {
-    RMaxMicrokernelTester().n(n).test(u8rmax_ukernel__neon);
+    RMaxMicrokernelTester().n(n).test(pytorch_u8rmax_ukernel__neon);
   }
 }
 
 TEST(U8RMAX__NEON, n_gt_16) {
   TEST_REQUIRES_ARM_NEON;
   for (size_t n = 16; n < 32; n++) {
-    RMaxMicrokernelTester().n(n).test(u8rmax_ukernel__neon);
+    RMaxMicrokernelTester().n(n).test(pytorch_u8rmax_ukernel__neon);
   }
 }
 #endif /* CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 */
@@ -46,26 +46,26 @@ TEST(U8RMAX__NEON, n_gt_16) {
 TEST(U8RMAX__SSE2, n_lt_16) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 1; n < 16; n++) {
-    RMaxMicrokernelTester().n(n).test(u8rmax_ukernel__sse2);
+    RMaxMicrokernelTester().n(n).test(pytorch_u8rmax_ukernel__sse2);
   }
 }
 
 TEST(U8RMAX__SSE2, n_eq_16) {
   TEST_REQUIRES_X86_SSE2;
-  RMaxMicrokernelTester().n(16).test(u8rmax_ukernel__sse2);
+  RMaxMicrokernelTester().n(16).test(pytorch_u8rmax_ukernel__sse2);
 }
 
 TEST(U8RMAX__SSE2, n_div_16) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 16; n < 128; n += 16) {
-    RMaxMicrokernelTester().n(n).test(u8rmax_ukernel__sse2);
+    RMaxMicrokernelTester().n(n).test(pytorch_u8rmax_ukernel__sse2);
   }
 }
 
 TEST(U8RMAX__SSE2, n_gt_16) {
   TEST_REQUIRES_X86_SSE2;
   for (size_t n = 17; n < 32; n++) {
-    RMaxMicrokernelTester().n(n).test(u8rmax_ukernel__sse2);
+    RMaxMicrokernelTester().n(n).test(pytorch_u8rmax_ukernel__sse2);
   }
 }
 #endif /* CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64 */

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/vadd-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/vadd-microkernel-tester.h
@@ -136,7 +136,7 @@ class VAddMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(q8vadd_ukernel_function q8vadd) const {
+  void test(pytorch_q8vadd_ukernel_function q8vadd) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/x8lut.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/x8lut.cc
@@ -13,33 +13,33 @@
 #include "lut-microkernel-tester.h"
 
 TEST(X8LUT__SCALAR, n_eq_1) {
-  LUTMicrokernelTester().n(1).test(x8lut_ukernel__scalar);
+  LUTMicrokernelTester().n(1).test(pytorch_x8lut_ukernel__scalar);
 }
 
 TEST(X8LUT__SCALAR, small_n) {
   for (size_t n = 2; n <= 16; n++) {
-    LUTMicrokernelTester().n(n).test(x8lut_ukernel__scalar);
+    LUTMicrokernelTester().n(n).test(pytorch_x8lut_ukernel__scalar);
   }
 }
 
 TEST(X8LUT__SCALAR, large_n) {
   for (size_t n = 16; n <= 128; n += 2) {
-    LUTMicrokernelTester().n(n).test(x8lut_ukernel__scalar);
+    LUTMicrokernelTester().n(n).test(pytorch_x8lut_ukernel__scalar);
   }
 }
 
 TEST(X8LUT__SCALAR, n_eq_1_inplace) {
-  LUTMicrokernelTester().n(1).inplace(true).test(x8lut_ukernel__scalar);
+  LUTMicrokernelTester().n(1).inplace(true).test(pytorch_x8lut_ukernel__scalar);
 }
 
 TEST(X8LUT__SCALAR, small_n_inplace) {
   for (size_t n = 2; n <= 16; n++) {
-    LUTMicrokernelTester().n(n).inplace(true).test(x8lut_ukernel__scalar);
+    LUTMicrokernelTester().n(n).inplace(true).test(pytorch_x8lut_ukernel__scalar);
   }
 }
 
 TEST(X8LUT__SCALAR, large_n_inplace) {
   for (size_t n = 16; n <= 128; n += 2) {
-    LUTMicrokernelTester().n(n).inplace(true).test(x8lut_ukernel__scalar);
+    LUTMicrokernelTester().n(n).inplace(true).test(pytorch_x8lut_ukernel__scalar);
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/zip-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/zip-microkernel-tester.h
@@ -51,7 +51,7 @@ class ZipMicrokernelTester {
     return this->iterations_;
   }
 
-  void test(xzipc_ukernel_function xzip) const {
+  void test(pytorch_xzipc_ukernel_function xzip) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
@@ -76,7 +76,7 @@ class ZipMicrokernelTester {
     }
   }
 
-  void test(xzipv_ukernel_function xzip) const {
+  void test(pytorch_xzipv_ukernel_function xzip) const {
     std::random_device randomDevice;
     auto rng = std::mt19937(randomDevice());
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);


### PR DESCRIPTION
This probably doesn't catch absolutely everything but it's a good starting point.
