### PR TITLE
Turn on BUILD_NAMEDTENSOR permanently

### DIFF
--- a/aten/src/ATen/core/Dimname.h
+++ b/aten/src/ATen/core/Dimname.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <c10/core/EnableNamedTensor.h>
+
 #ifdef BUILD_NAMEDTENSOR
 #include <ATen/core/interned_strings.h>
 #include <c10/util/ArrayRef.h>

--- a/aten/src/ATen/env.py
+++ b/aten/src/ATen/env.py
@@ -9,4 +9,4 @@ def check_env_flag(name, default=''):
 def check_negative_env_flag(name, default=''):
     return os.getenv(name, default).upper() in ['OFF', '0', 'NO', 'FALSE', 'N']
 
-BUILD_NAMEDTENSOR = check_env_flag('BUILD_NAMEDTENSOR')
+BUILD_NAMEDTENSOR = True

--- a/c10/core/EnableNamedTensor.h
+++ b/c10/core/EnableNamedTensor.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// We are working on removing the BUILD_NAMEDTENSOR flag from the codebase.
+//
+// PyTorch's codegen also uses a similar flag. You can find it in
+// - aten/src/ATen/env.py
+#if !defined(CAFFE2_IS_XPLAT_BUILD) && (!defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE))
+#ifndef BUILD_NAMEDTENSOR
+#define BUILD_NAMEDTENSOR
+#endif
+#endif

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -17,6 +17,8 @@
 #include <c10/util/Logging.h>
 #include <c10/util/python_stub.h>
 
+#include <c10/core/EnableNamedTensor.h>
+
 // A global boolean variable to control whether we free memory when a Tensor
 // is shrinked to a smaller size. As a result, a Tensor is always going to
 // keep the memory allocated for its maximum capacity reshaped to so far.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26264 Turn on BUILD_NAMEDTENSOR permanently**

This PR enables BUILD_NAMEDTENSOR by default. This is done via including
a header, `c10/core/EnableNamedTensor`, that sets `BUILD_NAMEDTENSOR`.
In the future, the plan is to get rid of the flag entirely: we can
incrementally delete usages after this PR goes in.

This PR also maintains the namedtensor ci vs regular ci distinction.
`test/test_namedtensor.py` only runs if TEST_NAMEDTENSOR=1 is specified.
TEST_NAMEDTENSOR=1 is set on the namedtensor ci. I'll remove this
distinction later and send out an announcement about it; devs will be
responsible for named tensor failures after that.

The initial reason why we had the BUILD_NAMEDTENSOR flag was so that we
could quickly prototype named tensor features without worrying about
adding overhead to the framework. The overheads can be categorized as
memory overhead and performance overhead.

Memory overhead: named tensors adds 1 additional word per Tensor. This
is because TensorImpl stores a `unique_ptr<NamedTensorMetaInterface>`
field. This is not a lot of overhead.

Performance overhead: At all entry points to name inference, we check
if inputs to an op are named. If inputs are not named, we short-circuit
and don't do name inference. These calls should therefore be as
efficient as error-checking code and not take up a lot of time.

My plan is to benchmark a few functions and then post the results in a
comment to this PR.

Test Plan:
- [namedtensor ci]

Differential Revision: [D17392428](https://our.internmc.facebook.com/intern/diff/D17392428)