### PR TITLE
Fixes an endian swap bug on big endian machines.

### DIFF
--- a/torch/csrc/generic/serialization.cpp
+++ b/torch/csrc/generic/serialization.cpp
@@ -6,6 +6,15 @@
 #include <c10/cuda/CUDAGuard.h>
 #endif
 
+#if defined(__s390x__)
+// add any big endian arch here
+#include <endian.h>
+#define swap_on_big_endian_arch(s) do {s = __bswap_64(s);} while(0)
+#else
+// no-op
+#define swap_on_big_endian_arch(s) ((void)0)
+#endif
+
 template <class io>
 void THPStorage_(writeFileRaw)(THWStorage *self, io fd)
 {
@@ -22,7 +31,9 @@ void THPStorage_(writeFileRaw)(THWStorage *self, io fd)
   data = (scalar_t*)cpu_data.get();
   THCudaCheck(cudaMemcpy(data, THWStorage_(data)(LIBRARY_STATE self), size * sizeof(scalar_t), cudaMemcpyDeviceToHost));
 #endif
+  swap_on_big_endian_arch(size);
   doWrite(fd, &size, sizeof(int64_t));
+  swap_on_big_endian_arch(size);
   // fast track for bytes and little endian
   if (sizeof(scalar_t) == 1 || THP_nativeByteOrder() == THPByteOrder::THP_LITTLE_ENDIAN) {
     doWrite(fd, data, sizeof(scalar_t) * size);
@@ -68,6 +79,7 @@ THWStorage * THPStorage_(readFileRaw)(io file, THWStorage *_storage)
   scalar_t *data;
   int64_t size;
   doRead(file, &size, sizeof(int64_t));
+  swap_on_big_endian_arch(size);
   THWStoragePtr storage;
   if (_storage == nullptr) {
     storage = THWStorage_(newWithSize)(LIBRARY_STATE size);


### PR DESCRIPTION
Endian conversion of the variable 'size' was forgotten in
serialization.cpp. Throws an assertion in serialization.py
on big endian machines.

Additionally the patch reads and writes torch files in the native
little endian format so that the model files are portable across x86 and s390.

Details:
A torch model file produced on x86 was loaded on to a big endian s390 arch machine.
The very large integer 2305843009213693952 is read with doRead() from file.
It should have been read as 32.  If you endian swap the large int it is actually 32

loaded_model = torch.load( opt.model_file, map_location=torch.device("cpu"))
File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 422, in load
return _load(f, map_location, pickle_module, **pickle_load_args)
File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 616, in _load
deserialized_objects[key]._set_from_file(f, offset, f_should_read_directly)
RuntimeError: storage has wrong size: expected 2305843009213693952 got 32

