### PR TITLE
[UNSTACK] Replace simple if_true / if_false cases in Declarations.cwrap.

### DIFF
--- a/aten/src/ATen/Declarations.cwrap
+++ b/aten/src/ATen/Declarations.cwrap
@@ -1533,14 +1533,12 @@
     - CUDA
   variants: function
   options:
-    - cname: varall
+    - cname: var_all
       return: accreal
       arguments:
         - THTensor* self
-        - arg: bool unbiased
-          if_true: 0
-          if_false: 1
-    - cname: var
+        - bool unbiased
+    - cname: var_single
       return: argument 0
       scalar_check: self_->dim() == 0 || (keepdim == false && self_->dim() == 1)
       arguments:
@@ -1549,9 +1547,7 @@
         - THTensor* self
         - arg: long dim
           wrap_dim: self
-        - arg: bool unbiased
-          if_true: 0
-          if_false: 1
+        - bool unbiased
         - bool keepdim
 ]]
 [[
@@ -1563,14 +1559,12 @@
     - CUDA
   variants: function
   options:
-    - cname: stdall
+    - cname: std_all
       return: accreal
       arguments:
         - THTensor* self
-        - arg: bool unbiased
-          if_true: 0
-          if_false: 1
-    - cname: std
+        - bool unbiased
+    - cname: std_single
       return: argument 0
       scalar_check: self_->dim() == 0 || (keepdim == false && self_->dim() == 1)
       arguments:
@@ -1579,9 +1573,7 @@
         - THTensor* self
         - arg: long dim
           wrap_dim: self
-        - arg: bool unbiased
-          if_true: 0
-          if_false: 1
+        - bool unbiased
         - bool keepdim
 ]]
 [[

--- a/aten/src/TH/generic/THTensorMath.h
+++ b/aten/src/TH/generic/THTensorMath.h
@@ -177,8 +177,8 @@ TH_API void THTensor_(round)(THTensor *r_, THTensor *t);
 TH_API void THTensor_(trunc)(THTensor *r_, THTensor *t);
 TH_API void THTensor_(frac)(THTensor *r_, THTensor *t);
 
-TH_API void THTensor_(std)(THTensor *r_, THTensor *t, int dimension, int biased, int keepdim);
-TH_API void THTensor_(var)(THTensor *r_, THTensor *t, int dimension, int biased, int keepdim);
+TH_API void THTensor_(std_single)(THTensor *r_, THTensor *t, int dimension, bool unbiased, int keepdim);
+TH_API void THTensor_(var_single)(THTensor *r_, THTensor *t, int dimension, bool unbiased, int keepdim);
 TH_API void THTensor_(norm)(THTensor *r_, THTensor *t, scalar_t value, int dimension, int keepdim);
 TH_API void THTensor_(renorm)(THTensor *r_, THTensor *t, scalar_t value, int dimension, scalar_t maxnorm);
 TH_API accreal THTensor_(dist)(THTensor *a, THTensor *b, scalar_t value);
@@ -186,8 +186,8 @@ TH_API void THTensor_(histc)(THTensor *hist, THTensor *tensor, int64_t nbins, sc
 TH_API void THTensor_(bhistc)(THTensor *hist, THTensor *tensor, int64_t nbins, scalar_t minvalue, scalar_t maxvalue);
 
 TH_API accreal THTensor_(meanall)(THTensor *self);
-TH_API accreal THTensor_(varall)(THTensor *self, int biased);
-TH_API accreal THTensor_(stdall)(THTensor *self, int biased);
+TH_API accreal THTensor_(var_all)(THTensor *self, bool unbiased);
+TH_API accreal THTensor_(std_all)(THTensor *self, bool unbiased);
 TH_API accreal THTensor_(normall)(THTensor *t, scalar_t value);
 #endif
 #endif

--- a/aten/src/THC/THCTensorMathReduce.cuh
+++ b/aten/src/THC/THCTensorMathReduce.cuh
@@ -96,17 +96,17 @@ struct ReduceWelford {
 
 template <typename T, typename U>
 struct VarianceWelford {
-  VarianceWelford(const int _biased, const bool _apply_sqrt): biased{_biased}, apply_sqrt(_apply_sqrt) {}
+  VarianceWelford(const int _unbiased, const bool _apply_sqrt): unbiased{_unbiased}, apply_sqrt(_apply_sqrt) {}
 
   inline __device__ T operator()(const WelfordData<T, U> &a) const {
-    T res = THCNumerics<T>::div(a.m_2_n_, biased!=0 ? a.count_ : a.count_-1);
+    T res = THCNumerics<T>::div(a.m_2_n_, unbiased ? a.count_ : a.count_-1);
     if (apply_sqrt) {
       return THCNumerics<T>::sqrt(res);
     }
     return res;
   }
 
-  const int biased;
+  const int unbiased;
   const bool apply_sqrt;
 };
 

--- a/aten/src/THC/generic/THCTensorMathReduce.cu
+++ b/aten/src/THC/generic/THCTensorMathReduce.cu
@@ -148,7 +148,7 @@ void THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, scalar
   THCTensor_(free)(state, data);
 }
 
-void THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dimension, int biased, int keepdim)
+void THCTensor_(std_single)(THCState *state, THCTensor *self_, THCTensor *src, int dimension, bool unbiased, int keepdim)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
 
@@ -157,7 +157,7 @@ void THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dime
   if (!THC_reduceDim<scalar_t>(state, self_, src,
                            ModifyWelford<WelfordData<accreal, scalar_t>>{},
                            ReduceWelford<accreal, scalar_t>{},
-                           VarianceWelford<accreal, scalar_t>{biased, true},
+                           VarianceWelford<accreal, scalar_t>{unbiased, true},
                            init,
                            dimension,
                            keepdim)) {
@@ -167,7 +167,7 @@ void THCTensor_(std)(THCState *state, THCTensor *self_, THCTensor *src, int dime
   THCudaCheck(cudaGetLastError());
 }
 
-void THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dimension, int biased, int keepdim)
+void THCTensor_(var_single)(THCState *state, THCTensor *self_, THCTensor *src, int dimension, bool unbiased, int keepdim)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 2, self_, src));
 
@@ -176,7 +176,7 @@ void THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dime
   if (!THC_reduceDim<scalar_t>(state, self_, src,
                            ModifyWelford<WelfordData<accreal, scalar_t>>{},
                            ReduceWelford<accreal, scalar_t>{},
-                           VarianceWelford<accreal, scalar_t>{biased, false},
+                           VarianceWelford<accreal, scalar_t>{unbiased, false},
                            init,
                            dimension,
                            keepdim)) {
@@ -186,13 +186,13 @@ void THCTensor_(var)(THCState *state, THCTensor *self_, THCTensor *src, int dime
   THCudaCheck(cudaGetLastError());
 }
 
-accreal THCTensor_(stdall)(THCState *state, THCTensor *self, int biased)
+accreal THCTensor_(std_all)(THCState *state, THCTensor *self, bool unbiased)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
-  return THCNumerics<accreal>::sqrt((THCTensor_(varall)(state, self, biased)));
+  return THCNumerics<accreal>::sqrt((THCTensor_(var_all)(state, self, unbiased)));
 }
 
-accreal THCTensor_(varall)(THCState *state, THCTensor *self, int biased)
+accreal THCTensor_(var_all)(THCState *state, THCTensor *self, bool unbiased)
 {
   THCAssertSameGPU(THCTensor_(checkGPU)(state, 1, self));
   accreal mean = THCTensor_(meanall)(state, self);
@@ -208,7 +208,7 @@ accreal THCTensor_(varall)(THCState *state, THCTensor *self, int biased)
 
   val = THCNumerics<accreal>::div(
     val,
-    scalar_cast<accreal>(std::max<int64_t>(0, THCTensor_(nElement)(state, self) - (biased ? 0 : 1)))
+    scalar_cast<accreal>(std::max<int64_t>(0, THCTensor_(nElement)(state, self) - (unbiased ? 1 : 0)))
   );
 
   THCudaCheck(cudaGetLastError());

--- a/aten/src/THC/generic/THCTensorMathReduce.h
+++ b/aten/src/THC/generic/THCTensorMathReduce.h
@@ -21,13 +21,13 @@ THC_API scalar_t THCTensor_(maxall)(THCState *state, THCTensor *self);
 #if defined(THC_REAL_IS_FLOAT) || defined(THC_REAL_IS_DOUBLE) || defined(THC_REAL_IS_HALF)
 
 THC_API void THCTensor_(renorm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, scalar_t max_norm);
-THC_API void THCTensor_(std)(THCState *state, THCTensor *self, THCTensor *src, int dim, int biased, int keepdim);
+THC_API void THCTensor_(std_single)(THCState *state, THCTensor *self, THCTensor *src, int dim, bool unbiased, int keepdim);
 THC_API void THCTensor_(norm)(THCState *state, THCTensor* self, THCTensor* src, scalar_t value, int dimension, int keepdim);
-THC_API void THCTensor_(var)(THCState *state, THCTensor *self, THCTensor *src, int dim, int biased, int keepdim);
+THC_API void THCTensor_(var_single)(THCState *state, THCTensor *self, THCTensor *src, int dim, bool unbiased, int keepdim);
 
-THC_API accreal THCTensor_(stdall)(THCState *state, THCTensor *self, int biased);
+THC_API accreal THCTensor_(std_all)(THCState *state, THCTensor *self, bool unbiased);
 THC_API accreal THCTensor_(normall)(THCState *state, THCTensor *self, scalar_t value);
-THC_API accreal THCTensor_(varall)(THCState *state, THCTensor *self, int biased);
+THC_API accreal THCTensor_(var_all)(THCState *state, THCTensor *self, bool unbiased);
 
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26346 [RESTACK] Kill if_true / if_false in Declarations.cwrap.
* **#26285 [UNSTACK] Replace simple if_true / if_false cases in Declarations.cwrap.**

I renamed:
THTensor_(std / var) -> THTensor(std_single / var_single)
THTensor(stdall / varall) -> THTensor(std_all, var_all)

because I reversed the meaning of the bias/unbiased parameters (to match ATen) and type checking wouldn't catch failures.

Differential Revision: [D17397227](https://our.internmc.facebook.com/intern/diff/D17397227)