### PR TITLE
Make TORCH_WARN_ONCE capture variables by reference

### DIFF
--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -291,7 +291,7 @@ inline std::string if_empty_then(std::string x, std::string y) {
 // arguments which are concatenated into the warning message using operator<<
 //
 #define TORCH_WARN_ONCE(...) \
-  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [] { \
+  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [&] { \
     ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::str(__VA_ARGS__)); \
     return true; \
   }()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26289 Make TORCH_WARN_ONCE capture variables by reference**

It's not possible to refer to values of local variables otherwise.

Differential Revision: [D17397702](https://our.internmc.facebook.com/intern/diff/D17397702/)