### PR TITLE
tvm operator dynolog

### DIFF
--- a/caffe2/core/operator.h
+++ b/caffe2/core/operator.h
@@ -532,6 +532,10 @@ class CAFFE2_API OperatorBase : public Observable<OperatorBase> {
     }
   }
 
+  virtual std::string debug_info_string() const {
+    return "";
+  }
+
   inline const OperatorDef& debug_def() const {
     CAFFE_ENFORCE(has_debug_def(), "operator_def was null!");
     return *operator_def_;


### PR DESCRIPTION
Summary:
Log the following in scuba caffe2_tvm_operator_stats:
1. everything in caffe2_operator_stats
2. fallback netdef
3. tvm module graph_json
4. whether compilation triggered this round
5. number of compilations stored in tvm_runtime_map
6. (not yet logged) last compilation time if any
7. (not yet logged) total bytes occupied by compilation
8. whether this compilation is fallback
9. batch size as observed by tvm op

Test Plan:
```
buck run mode/dbg //tvm/sparse:tvm_bbpredictor_benchmark -- --init_net ~/tmp/ads/84480054_204/init_net.pb --input_init_net ~/tmp/ads/84480054_204/input_init_net.pb --pred_net ~/tmp/ads/84480054_204/pred_net.pb --warmup 1000 --iter 1000 --num_cycles 5 --caffe2_logging_operator_dyno_sampling_rate=1 --vmodule=Logger=
2
```

Logs show up in the scuba:
https://our.intern.facebook.com/intern/scuba/query/?dataset=caffe2_tvm_operator_stats

https://fburl.com/scuba/lq2h22e4

Reviewed By: yinghai

Differential Revision: D17358412

