### PR TITLE
Use expected_wrapper only if CMAKE_{C,CXX}_COMPILER and/or is not set by user

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -290,9 +290,11 @@ class CMake:
 
         expected_wrapper = '/usr/local/opt/ccache/libexec'
         if IS_DARWIN and os.path.exists(expected_wrapper):
-            CMake.defines(args,
-                          CMAKE_C_COMPILER="{}/gcc".format(expected_wrapper),
-                          CMAKE_CXX_COMPILER="{}/g++".format(expected_wrapper))
+            if 'CMAKE_C_COMPILER' not in build_options and 'CC' not in os.environ:
+                CMake.defines(args, CMAKE_C_COMPILER="{}/gcc".format(expected_wrapper))
+            if 'CMAKE_CXX_COMPILER' not in build_options and 'CXX' not in os.environ:
+                CMake.defines(args, CMAKE_CXX_COMPILER="{}/g++".format(expected_wrapper))
+
         for env_var_name in my_env:
             if env_var_name.startswith('gh'):
                 # github env vars use utf-8, on windows, non-ascii code may


### PR DESCRIPTION
This will honor user's preference.

