### PR TITLE
Add missing argument for failing function call

### DIFF
--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -470,7 +470,7 @@ class QuantizedLSTM(QuantizedRNNBase):
         assert batch_sizes is None
         result = _VF.quantized_lstm(input, hx, self._get_all_weights(), self.bias, self.num_layers,
                                     float(self.dropout), self.training, self.bidirectional,
-                                    self.batch_first, dtype=self.dtype)
+                                    self.batch_first, dtype=self.dtype, use_dynamic=False)
         output = result[0]
         hidden = result[1:]
 


### PR DESCRIPTION
Summary:
We are currently unable to deploy models due to D16955662 changing function signature of ```quantized_lstm(``` but the function call here (https://fburl.com/diffusion/e4wrmx83) not passing the newly added ```use_dynamic``` param.

Here is the details of the error: P111215482

```
E0916 12:36:16.423516 1149877 ExceptionTracer.cpp:214] exception stack complete
terminate called after throwing an instance of 'torch::jit::script::ErrorReport'
  what():
Arguments for call are not valid.
The following operator variants are available:

  aten::quantized_lstm(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first, *, int? dtype=None) -> (Tensor, Tensor, Tensor):
  Keyword argument use_dynamic unknown.
```

This diff fixes that.

Test Plan:
Running quantization tests after.

```buck test mode/dev caffe2/test:jit -- 'test_quantization_modules \(test_jit\.TestScript\)'```

https://our.intern.facebook.com/intern/testinfra/testrun/5910974518872494

Also, currently building a package and testing this.

Differential Revision: D17404451

