### PR TITLE
[jit] Make `is_optional` check more robust

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -44,7 +44,7 @@ from copy import deepcopy
 from functools import wraps
 from itertools import product, chain
 from textwrap import dedent
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Union
 import copy
 import inspect
 import math
@@ -3403,6 +3403,9 @@ def foo(x):
                 def invalid_prefix_annotation3(a):
                     #     type: (Int) -> Int
                     return a + 2
+    def test_is_optional(self):
+        ann = Union[List[int], List[float]]
+        torch._jit_internal.is_optional(ann)
 
     def test_interpreter_fuzz(self):
         # This test generates random tree-like programs to fuzz test

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -44,7 +44,7 @@ from copy import deepcopy
 from functools import wraps
 from itertools import product, chain
 from textwrap import dedent
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Tuple, Union
 import copy
 import inspect
 import math

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3403,6 +3403,7 @@ def foo(x):
                 def invalid_prefix_annotation3(a):
                     #     type: (Int) -> Int
                     return a + 2
+
     def test_is_optional(self):
         ann = Union[List[int], List[float]]
         torch._jit_internal.is_optional(ann)

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -507,13 +507,20 @@ try:
 
     def is_optional(ann):
         # Optional[T] is just shorthand for Union[T, None], so check for both
+        def safe_is_subclass(the_type, super_type):
+            # Don't throw if `the_type` isn't a class type (e.g. if it is
+            # another type annotation instance)
+            if not inspect.isclass(the_type):
+                return False
+            return issubclass(the_type, super_type)
+
         union_optional = False
         if ann.__module__ == 'typing' and \
            (getattr(ann, '__origin__', None) is typing.Union):
             args = getattr(ann, '__args__', ())
             if len(args) == 2:
-                union_optional = (issubclass(args[1], type(None)) and not issubclass(args[0], type(None))) \
-                    or (issubclass(args[0], type(None)) and not issubclass(args[1], type(None)))
+                union_optional = (safe_is_subclass(args[1], type(None)) and not safe_is_subclass(args[0], type(None))) \
+                    or (safe_is_subclass(args[0], type(None)) and not safe_is_subclass(args[1], type(None)))
 
         optional = ann.__module__ == 'typing' and \
             (getattr(ann, '__origin__', None) is typing.Optional)


### PR DESCRIPTION


If the `Union` contains a non-class type, `issubclass` would fail, this
adds a check for that case

Differential Revision: [D17505206](https://our.internmc.facebook.com/intern/diff/17505206/)