### PR TITLE
Make ProcessGroupAgent take num_threads as constructor argument

### DIFF
--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -26,7 +26,8 @@ if is_available():
         def init_model_parallel(self_name,
                                 backend=RpcBackend.PROCESS_GROUP,
                                 self_rank=-1,
-                                init_method=None):
+                                init_method=None,
+                                num_send_recv_threads=4):
             r"""
             Initializes model parallel primitives such as the local rpc agent
             and distributed autograd.
@@ -49,7 +50,8 @@ if is_available():
                             128 characters.
                 self_rank (int): a globally unique id/rank of this node.
                 init_method(str): backend specific init arguments.
+                num_send_recv_threads(int): Number of threads for send/recv work.
             """
-            _init_rpc(backend, self_name, self_rank, init_method)
+            _init_rpc(backend, self_name, self_rank, init_method, num_send_recv_threads)
             from .rpc import _agent
             autograd._init(_agent.get_worker_id().id)

--- a/torch/distributed/rpc.py
+++ b/torch/distributed/rpc.py
@@ -56,7 +56,8 @@ class RpcBackend(Enum):
 def _init_rpc(backend=RpcBackend.PROCESS_GROUP,
               self_name=None,
               self_rank=-1,
-              init_method=None):
+              init_method=None,
+              num_send_recv_threads=4):
     if sys.version_info < (3, 0):
         raise RuntimeError("RPC package does not support Python2.")
 
@@ -73,7 +74,7 @@ def _init_rpc(backend=RpcBackend.PROCESS_GROUP,
             raise RuntimeError("self_rank argument {} doesn't match pg rank {}".format(
                                self_rank, group.rank()))
         # TODO: add try-except and destroy _agent in all processes if any fails.
-        _agent = ProcessGroupAgent(self_name, group)
+        _agent = ProcessGroupAgent(self_name, group, num_send_recv_threads)
         init_rref_context(_agent)
     elif is_backend_registered(rpc_backend):
         _agent = registered_init_rpc(rpc_backend,


### PR DESCRIPTION
Summary:
# Problem

If there is not enough number of thread in the RPC Agent thread pool. Some circular dependent works could cause deadlock.

The current to way to get around this deadlock is to provide abundant number of threads.

# Solution

as titled

Differential Revision: D17405491

