### PR TITLE
Fix jit/pass/peephole.cpp fuse addmm

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -914,6 +914,14 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         m2 = torch.randn(4, 5)
         self.run_model_test(MyModel(), train=False, input=(ma, m1, m2), batch_size=BATCH_SIZE, use_gpu=False)
 
+    def test_fuse_addmm(self):
+        class AddmmModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.mm(x, x) + x
+
+        x = torch.randn(3, 3)
+        self.run_model_test(AddmmModel(), train=False, input=x, batch_size=BATCH_SIZE, use_gpu=False)
+
     def test_scalar_type(self):
         class ArithmeticModel(torch.nn.Module):
             def forward(self, x):
@@ -937,21 +945,20 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         y = torch.ones(2, 3, dtype=torch.float32)
         self.run_model_test(ComparisonModel(), input=(x, y), train=False, batch_size=BATCH_SIZE)
 
-        # TODO: re-enable the two tests after https://github.com/pytorch/pytorch/issues/26328 is resolved.
         class MatMulModel(torch.nn.Module):
             def forward(self, x, y):
                 return torch.mm(x, y)
 
         x = torch.ones(3, 4)
         y = torch.ones(4, 5)
-        # self.run_model_test(MatMulModel(), input=(x, y), train=False, batch_size=BATCH_SIZE)
+        self.run_model_test(MatMulModel(), input=(x, y), train=False, batch_size=BATCH_SIZE)
 
         class AddMMModel(torch.nn.Module):
             def forward(self, x):
                 return torch.mm(x, x) + x
 
         x = torch.ones(3, 3)
-        # self.run_model_test(AddMMModel(), input=x, train=False, batch_size=BATCH_SIZE)
+        self.run_model_test(AddMMModel(), input=x, train=False, batch_size=BATCH_SIZE)
 
     # test for a pytorch optimization pass, see https://github.com/pytorch/pytorch/pull/7872
     def test_consecutive_transposes(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -214,6 +214,14 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor(12)
         self.run_test(FullModelScripting(), x)
 
+    def test_fuse_addmm(self):
+        class AddmmModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.mm(x, x) + x
+
+        x = torch.ones(3, 3)
+        self.run_test(AddmmModel(), x)
+
     def test_maxpool(self):
         model = torch.nn.MaxPool1d(2, stride=1)
         x = torch.randn(20, 16, 50)
@@ -862,20 +870,19 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.ones(2, 3, dtype=torch.float32)
         self.run_test(ComparisonModel(), (x, y))
 
-        # TODO: re-enable the two tests after https://github.com/pytorch/pytorch/issues/26328 is resolved.
         class MatMulModel(torch.nn.Module):
             def forward(self, x):
                 return (torch.mm(x, x) + x + torch.mm(x, x) + x)
 
         x = torch.ones(3, 3)
-        # self.run_test(MatMulModel(), x)
+        self.run_test(MatMulModel(), x)
 
         class AddMMModel(torch.nn.Module):
             def forward(self, x):
                 return torch.mm(x, x) + x
 
         x = torch.ones(3, 3)
-        # self.run_test(AddMMModel(), x)
+        self.run_test(AddMMModel(), x)
 
         class FullModel(torch.nn.Module):
             # add is used for exporting full

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2463,6 +2463,15 @@ graph(%Ra, %Rb):
         does_decompose()
         doesnt_decompose()
 
+    def test_fuse_addmm(self):
+        class AddmmModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.mm(x, x) + x
+
+        x = torch.ones(3, 3)
+        f = io.BytesIO()
+        torch.onnx._export(AddmmModel(), x, f, verbose=False)
+
     def test_index_put(self):
         ten = torch.zeros(3, 3)
         mask = torch.tensor([[True, True, True],

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -152,8 +152,8 @@ void PeepholeOptimizeImpl(Block* block, bool addmm_fusion_enabled) {
               }
             }
 
-            auto* addmm_node = graph->insertNode(graph->create(aten::addmm, 1));
             auto* cOne = graph->insertConstant(1);
+            auto* addmm_node = graph->insertNode(graph->create(aten::addmm, 1));
             addmm_node->addInput(add_mat);
             addmm_node->addInput(mat1);
             addmm_node->addInput(mat2);


### PR DESCRIPTION
Fix #26328. Reversing the order of inserting nodes. Previously the IR graph looks like

```
graph(%0 : Float(3, 3)):
  %5 : Float(3, 3) = aten::addmm(%0, %0, %0, %6, %6)
  %6 : int = prim::Constant[value=1]()
  return (%5)
```
where %6 is used before created. Now
```
graph(%0 : Float(3, 3)):
  %5 : int = prim::Constant[value=1]()
  %6 : Float(3, 3) = aten::addmm(%0, %0, %0, %5, %5)
  return (%6)
```