### PR TITLE
make c10 dict order preserving

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -5,6 +5,7 @@
 #include <c10/util/TypeList.h>
 #include <c10/util/flat_hash_map.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/order_preserving_flat_hash_map.h>
 #include <c10/util/Optional.h>
 #include <ATen/core/TensorBody.h>
 
@@ -39,7 +40,7 @@ struct DictKeyEqualTo {
 };
 
 struct DictImpl final : public c10::intrusive_ptr_target {
-  using dict_map_type = ska::flat_hash_map<IValue, IValue, DictKeyHash, DictKeyEqualTo>;
+  using dict_map_type = ska_ordered::order_preserving_flat_hash_map<IValue, IValue, DictKeyHash, DictKeyEqualTo>;
   struct DictElementTypes final {
     TypePtr keyType;
     TypePtr valueType;

--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -3,7 +3,6 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/TypeTraits.h>
 #include <c10/util/TypeList.h>
-#include <c10/util/flat_hash_map.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/order_preserving_flat_hash_map.h>
 #include <c10/util/Optional.h>
@@ -208,9 +207,9 @@ class Dict final {
 private:
   static_assert((std::is_same<IValue, Key>::value && std::is_same<IValue, Value>::value) || guts::typelist::contains<impl::valid_dict_key_types, Key>::value, "Invalid Key type for Dict. We only support int64_t, double, bool, and string.");
 
-  // impl_ stores the underlying map as a ska::flat_hash_map.
+  // impl_ stores the underlying map as a ska_ordered::order_preserving_flat_hash_map.
   // We intentionally don't offer conversion from/to
-  // ska::flat_hash_map, return references to it or something like that,
+  // order_preserving_flat_hash_map, return references to it or something like that,
   // because such operations would get expensive if we switch out
   // the actual map implementation.
   // This is an intrusive_ptr because Dict is a pointer type.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26372 make c10 dict order preserving**
* #25675 flat hash map that preserves insertion and deletion order
* #26371 make copy

From python 3.6 onward python dictionaries preserve insertion order.

replaces https://github.com/pytorch/pytorch/pull/26066 bc ghstack was poisoned and i had to resubmit