### PR TITLE
bind OrderedDict() and Dict constructor

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -645,6 +645,7 @@ struct CAFFE2_API DictType : public Type {
       case TypeKind::FloatType:
       case TypeKind::StringType:
       case TypeKind::TensorType:
+      case TypeKind::VarType:
         return DictTypePtr(new DictType(key, value));
       default:
         AT_ERROR(

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -645,7 +645,6 @@ struct CAFFE2_API DictType : public Type {
       case TypeKind::FloatType:
       case TypeKind::StringType:
       case TypeKind::TensorType:
-      case TypeKind::VarType:
         return DictTypePtr(new DictType(key, value));
       default:
         AT_ERROR(
@@ -1287,7 +1286,7 @@ struct MatchTypeReturn {
   }
 
  private:
-  MatchTypeReturn() 
+  MatchTypeReturn()
   : reason_(c10::nullopt) {}
   c10::optional<std::string> reason_; // is there is no match, this contains the reason
 };
@@ -1297,13 +1296,13 @@ struct MatchTypeReturn {
 // and a r.reason() that describes why it could not match.
 // note: It is possible to successfully match a formal, but for type variables
 // in the formal to still not be defined. In particular, None matches Optional[T]
-// but does not define the value of T. 
+// but does not define the value of T.
 CAFFE2_API MatchTypeReturn
 matchTypeVariables(TypePtr formal, TypePtr actual, TypeEnv& type_env);
 
-// replace type variables appearing in `type` with the values in 
-// `type_env`. Returns nullptr if a variable used in `type` 
-// does not appear in `type_env` 
+// replace type variables appearing in `type` with the values in
+// `type_env`. Returns nullptr if a variable used in `type`
+// does not appear in `type_env`
 CAFFE2_API TypePtr tryEvalTypeVariables(TypePtr type, TypeEnv& type_env);
 
 /**

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -39,7 +39,7 @@ from test_module.future_div import div_int_future, div_float_future
 from test_module.no_future_div import div_int_nofuture, div_float_nofuture
 
 # Standard library
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from copy import deepcopy
 from functools import wraps
 from itertools import product, chain
@@ -18740,6 +18740,36 @@ class TestDict(JitTestCase):
         a_dict = {'a': torch.ones(1), 'b': torch.ones(1) + 1, 'c': torch.ones(1) + 2}
         self.checkScript(fn, (a_dict, ('a', 'c')))
 
+    def test_func(self, fn, inputs):
+        self.assertEqual(fn(*inputs), torch.jit.script(fn)(*inputs))
+
+    def test_ordered_dict(self):
+        def repeated_key():
+            return OrderedDict([(1, 2), (2, 3), (1, 4)])
+
+        self.test_func(repeated_key, ())
+
+        def no_args():
+            a = OrderedDict()
+            a["one"] = torch.tensor(1)
+            a["two"] = torch.tensor(2)
+
+        self.test_func(no_args, ())
+
+        def test_dict_constructor():
+            a = dict()
+            a["one"] = torch.tensor(1)
+            return a, dict([(1, 2), (2, 3), (1, 4)])  # noqa: C406
+
+        self.test_func(test_dict_constructor, ())
+
+        def test_dict_error():
+            a = dict()
+            a[1] = 2
+            return a
+
+        with self.assertRaisesRegex(Exception, "Arguments for call are not"):
+            torch.jit.script(test_dict_error)
 
 class TestClassType(JitTestCase):
     def test_get_with_method(self):

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1221,28 +1221,6 @@ RegisterOperators reg(
          },
          aliasAnalysisSpecialCase()),
      Operator(
-         "aten::dict((tKey, tVal)[] inputs) -> Dict(tKey, tVal)",
-         [](const Node* node) -> Operation {
-           TypePtr output_type = node->outputs()[0]->type();
-           TypePtr key_type =
-               static_cast<const DictType*>(output_type.get())->getKeyType();
-           TypePtr value_type =
-               static_cast<const DictType*>(output_type.get())->getValueType();
-           return [key_type, value_type](Stack& stack) {
-             auto input_list = pop(stack);
-             auto list_ref = input_list.toGenericListRef();
-             auto dict = c10::impl::GenericDict(key_type, value_type);
-             dict.reserve(list_ref.size());
-             for (const auto& input : list_ref) {
-               const auto tup = input.toTuple()->elements();
-               dict.insert_or_assign(tup[0], tup[1]);
-             }
-             push(stack, dict);
-             return 0;
-           };
-         },
-         aliasAnalysisFromSchema()),
-     Operator(
          "aten::dict() -> Dict(str, Tensor)",
          [](const Node* node) -> Operation {
            return [](Stack& stack) {
@@ -2167,6 +2145,26 @@ int dictCopy(Stack& stack) {
   return 0;
 }
 
+Operation dictConstructFromList(const Node* node) {
+  TypePtr output_type = node->outputs()[0]->type();
+  TypePtr key_type =
+      static_cast<const DictType*>(output_type.get())->getKeyType();
+  TypePtr value_type =
+      static_cast<const DictType*>(output_type.get())->getValueType();
+  return [key_type, value_type](Stack& stack) {
+    auto input_list = pop(stack);
+    auto list_ref = input_list.toGenericListRef();
+    auto dict = c10::impl::GenericDict(key_type, value_type);
+    dict.reserve(list_ref.size());
+    for (const auto& input : list_ref) {
+      const auto tup = input.toTuple()->elements();
+      dict.insert_or_assign(tup[0], tup[1]);
+    }
+    push(stack, dict);
+    return 0;
+  };
+}
+
 template <typename T>
 int hashValue(Stack& stack) {
   auto value = pop(stack);
@@ -2934,6 +2932,11 @@ RegisterOperators reg2({
           "aten::_set_item(Dict(" key_type ", t)(a!) l, " key_type            \
           " idx, t(b -> *) v) -> ()",                                         \
           dictSetItem,                                                        \
+          aliasAnalysisFromSchema()),                                         \
+      Operator(                                                               \
+          "aten::dict((" key_type ", tVal)[] inputs) -> Dict(" key_type       \
+          ", tVal)",                                                          \
+          dictConstructFromList,                                              \
           aliasAnalysisFromSchema())
 
     CREATE_DICT_OPS("str"),

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -1209,6 +1209,7 @@ RegisterOperators reg(
            TypePtr value_type = static_cast<const DictType*>(output_type.get())->getValueType();
            return [=](Stack& stack) {
              auto vals = c10::impl::GenericDict(key_type, value_type);
+             vals.reserve(stack.size() / 2);
              for (size_t i = 0; i < num_inputs; i += 2) {
                auto val = pop(stack);
                auto key = pop(stack);
@@ -1219,6 +1220,38 @@ RegisterOperators reg(
            };
          },
          aliasAnalysisSpecialCase()),
+     Operator(
+         "aten::dict((tKey, tVal)[] inputs) -> Dict(tKey, tVal)",
+         [](const Node* node) -> Operation {
+           TypePtr output_type = node->outputs()[0]->type();
+           TypePtr key_type =
+               static_cast<const DictType*>(output_type.get())->getKeyType();
+           TypePtr value_type =
+               static_cast<const DictType*>(output_type.get())->getValueType();
+           return [key_type, value_type](Stack& stack) {
+             auto input_list = pop(stack);
+             auto list_ref = input_list.toGenericListRef();
+             auto dict = c10::impl::GenericDict(key_type, value_type);
+             dict.reserve(list_ref.size());
+             for (const auto& input : list_ref) {
+               const auto tup = input.toTuple()->elements();
+               dict.insert_or_assign(tup[0], tup[1]);
+             }
+             push(stack, dict);
+             return 0;
+           };
+         },
+         aliasAnalysisFromSchema()),
+     Operator(
+         "aten::dict() -> Dict(str, Tensor)",
+         [](const Node* node) -> Operation {
+           return [](Stack& stack) {
+             auto dict =
+                 c10::impl::GenericDict(StringType::get(), TensorType::get());
+             push(stack, dict);
+             return 0;
+           };
+         }),
      Operator(
          "aten::_unwrap_optional(t(a)? optional) -> t(a)",
          [](Stack& stack) {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1868,6 +1868,8 @@ _builtin_ops = [
     (_unwrap_optional, "aten::_unwrap_optional"),
     (_wait, 'aten::wait'),
     (is_scripting, "aten::is_scripting"),
+    (OrderedDict, "aten::dict"),
+    (dict, "aten::dict"),
     (cudnn.is_acceptable, "aten::cudnn_is_acceptable"),
     (math.ceil, "aten::ceil"),
     (math.copysign, "aten::copysign"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26373 bind OrderedDict() and Dict constructor**
* #26372 make c10 dict order preserving
* #25675 flat hash map that preserves insertion and deletion order
* #26371 make copy

Binds the OrderedDict() and dict() constructor into torchscript. For the case of the empty constructor dict() i typed it as [str, Tensor] because:
• we're almost dropping support for python 2, at which point all dicts are ordered
• then it's more conventional to write x : Dict[int, int] = {} which is already supported
• It is possible to construct an arbitrarily typed empty OrderedDict through
OrderedDict(torch.jit.annotate(List[Tuple[key, value]], [])

We could consider dropping the no inputs aten::dict constructor since then the types would be more explicit.

This replaces https://github.com/pytorch/pytorch/pull/26170 b/c ghstack was poisioned and i had to resubmit