### PR TITLE
Puts ROCm tests on default stream

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -537,7 +537,7 @@ class TestCase(expecttest.TestCase):
 
         # Wraps the tested method if we should enforce non default CUDA stream.
         self._do_cuda_non_default_stream &= getattr(test_method, '_do_cuda_non_default_stream', True)
-        if self._do_cuda_non_default_stream and not IS_WINDOWS:
+        if self._do_cuda_non_default_stream and not IS_WINDOWS and not TEST_WITH_ROCM:
             self.wrap_with_cuda_policy(method_name, self.enforceNonDefaultStream)
 
     def assertLeaksNoCudaTensors(self, name=None):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2247,9 +2247,9 @@ class TestCuda(TestCase):
                         self.assertEqual(torch.backends.cuda.cufft_plan_cache.max_size, 11)  # default is cuda:1
 
     # passes on ROCm w/ python 2.7, fails w/ python 3.6
-    @skipIfRocm
-    def test_stft(self):
-        _TestTorchMixin._test_stft(self, device=torch.device('cuda'))
+    # @skipIfRocm
+    # def test_stft(self):
+    #     _TestTorchMixin._test_stft(self, device=torch.device('cuda'))
 
     def test_multinomial(self):
         _TestTorchMixin._test_multinomial(self, torch.cuda.FloatTensor)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2247,9 +2247,9 @@ class TestCuda(TestCase):
                         self.assertEqual(torch.backends.cuda.cufft_plan_cache.max_size, 11)  # default is cuda:1
 
     # passes on ROCm w/ python 2.7, fails w/ python 3.6
-    # @skipIfRocm
-    # def test_stft(self):
-    #     _TestTorchMixin._test_stft(self, device=torch.device('cuda'))
+    @skipIfRocm
+    def test_stft(self):
+        _TestTorchMixin._test_stft(self, device=torch.device('cuda'))
 
     def test_multinomial(self):
         _TestTorchMixin._test_multinomial(self, torch.cuda.FloatTensor)


### PR DESCRIPTION
This PR has been updated. Since ORIGINAL PR comment below.

ROCm CI builds have been hanging as we've been refactoring tests, even when these refactors seem entirely innocuous. This PR started by commenting out test_stft, for example, a Python test never run on ROCm, and that was sufficient to reliably hang the ROCm build in CI.

Putting ROCm tests back on the default stream appears to remove this hang. So this PR now does that. This is likely to unblock development. 

ORIGINAL: Some test changes appear to be causing ROCm builds to hang in CI. This PR is an attempt to diagnose the source of the hang. 