### PR TITLE
Fix the API for record observer

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -7,10 +7,10 @@ import torch.nn._intrinsic as nni
 import torch.nn._intrinsic.quantized as nniq
 import torch.nn._intrinsic.qat as nniqat
 from torch.quantization import \
-    QConfig_dynamic, default_weight_observer, dump_tensor,\
+    QConfig_dynamic, default_weight_observer, get_observer_dict,\
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules, \
     quantize_dynamic, default_qconfig, default_debug_qconfig, default_qat_qconfig, \
-    default_dynamic_qconfig, HistogramObserver, MinMaxObserver, PerChannelMinMaxObserver, TensorObserver, QuantWrapper
+    default_dynamic_qconfig, HistogramObserver, MinMaxObserver, PerChannelMinMaxObserver, RecordingObserver, QuantWrapper
 
 from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
@@ -872,25 +872,26 @@ class ObserverTest(QuantizationTestCase):
                  ' well with UBSAN at the moment, so we skip the test if'
                  ' we are in a UBSAN environment.')
 class QuantizationDebugTest(QuantizationTestCase):
-    def test_tensor_observer(self):
+    def test_record_observer(self):
         model = SingleLayerLinearModel()
         model.qconfig = default_debug_qconfig
         prepare(model)
         # run the evaluation and dump all tensors
         test_only_eval_fn(model, self.calib_data)
         test_only_eval_fn(model, self.calib_data)
-        tensor_dict = {}
-        dump_tensor(model, tensor_dict)
+        observer_dict = {}
+        get_observer_dict(model, observer_dict)
 
-        # we can torch,save() and torch_load() in bento for further analysis
-        self.assertTrue('fc1.module.activation' in tensor_dict.keys(),
-                        'activation is not recorded in the dict')
-        self.assertEqual(len(tensor_dict['fc1.module.activation']), 2 * len(self.calib_data))
+        self.assertTrue('fc1.module.observer' in observer_dict.keys(),
+                        'observer is not recorded in the dict')
+        self.assertEqual(len(observer_dict['fc1.module.observer'].get_tensor_value()), 2 * len(self.calib_data))
+        self.assertEqual(observer_dict['fc1.module.observer'].get_tensor_value()[0], model(self.calib_data[0][0]))
+
 
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_tensor_affine, torch.per_tensor_symmetric)))
-    def test_tensor_observer_scriptable(self, qdtype, qscheme):
-        obs = TensorObserver(dtype=qdtype, qscheme=qscheme)
+    def test_observer_observer_scriptable(self, qdtype, qscheme):
+        obs = RecordingObserver(dtype=qdtype, qscheme=qscheme)
         scripted = torch.jit.script(obs)
 
         x = torch.rand(3, 4)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -6,10 +6,10 @@ import torch.nn._intrinsic as nni
 import torch.nn._intrinsic.quantized as nniq
 import torch.nn._intrinsic.qat as nniqat
 from torch.quantization import \
-    QConfig_dynamic, default_weight_observer, dump_tensor,\
+    QConfig_dynamic, default_weight_observer, get_observer_dict,\
     quantize, prepare, convert, prepare_qat, quantize_qat, fuse_modules, \
     quantize_dynamic, default_qconfig, default_debug_qconfig, default_qat_qconfig, \
-    default_dynamic_qconfig, HistogramObserver, MinMaxObserver, TensorObserver, QuantWrapper
+    default_dynamic_qconfig, HistogramObserver, MinMaxObserver, RecordingObserver, QuantWrapper
 
 from common_utils import run_tests
 from common_quantization import QuantizationTestCase, SingleLayerLinearModel, \
@@ -797,25 +797,24 @@ class ObserverTest(QuantizationTestCase):
                  ' well with UBSAN at the moment, so we skip the test if'
                  ' we are in a UBSAN environment.')
 class QuantizationDebugTest(QuantizationTestCase):
-    def test_tensor_observer(self):
+    def test_record_observer(self):
         model = SingleLayerLinearModel()
         model.qconfig = default_debug_qconfig
         prepare(model)
         # run the evaluation and dump all tensors
         test_only_eval_fn(model, self.calib_data)
         test_only_eval_fn(model, self.calib_data)
-        tensor_dict = {}
-        dump_tensor(model, tensor_dict)
+        observer_dict = {}
+        get_observer_dict(model, observer_dict)
 
-        # we can torch,save() and torch_load() in bento for further analysis
-        self.assertTrue('fc1.module.activation' in tensor_dict.keys(),
-                        'activation is not recorded in the dict')
-        self.assertEqual(len(tensor_dict['fc1.module.activation']), 2 * len(self.calib_data))
+        self.assertTrue('fc1.module.observer' in observer_dict.keys(),
+                        'observer is not recorded in the dict')
+        self.assertEqual(len(observer_dict['fc1.module.observer'].get_tensor_value()), 2 * len(self.calib_data))
 
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_tensor_affine, torch.per_tensor_symmetric)))
-    def test_tensor_observer_scriptable(self, qdtype, qscheme):
-        obs = TensorObserver(dtype=qdtype, qscheme=qscheme)
+    def test_observer_observer_scriptable(self, qdtype, qscheme):
+        obs = RecordingObserver(dtype=qdtype, qscheme=qscheme)
         scripted = torch.jit.script(obs)
 
         x = torch.rand(3, 4)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -810,6 +810,8 @@ class QuantizationDebugTest(QuantizationTestCase):
         self.assertTrue('fc1.module.observer' in observer_dict.keys(),
                         'observer is not recorded in the dict')
         self.assertEqual(len(observer_dict['fc1.module.observer'].get_tensor_value()), 2 * len(self.calib_data))
+        self.assertEqual(observer_dict['fc1.module.observer'].get_tensor_value()[0], model(self.calib_data[0][0]))
+
 
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
            qscheme=st.sampled_from((torch.per_tensor_affine, torch.per_tensor_symmetric)))

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -493,14 +493,14 @@ class HistogramObserver(ObserverBase):
         return self._calculate_qparams(new_min.item(), new_max.item())
 
 
-class TensorObserver(ObserverBase):
+class RecordingObserver(ObserverBase):
     r"""
     The module is mainly for debug and records the tensor values during runtime
     """
     __annotations__ = {"tensor_val": List[Optional[torch.Tensor]]}
 
     def __init__(self, **kwargs):
-        super(TensorObserver, self).__init__(**kwargs)
+        super(RecordingObserver, self).__init__(**kwargs)
         self.tensor_val = []
 
     def forward(self, x):
@@ -509,7 +509,7 @@ class TensorObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception("calculate_qparams should not be called for TensorObserver")
+        raise Exception("calculate_qparams should not be called for RecordingObserver")
 
     @torch.jit.export
     def get_tensor_value(self):
@@ -527,7 +527,7 @@ def default_observer(**kwargs):
 
 
 def default_debug_observer(**kwargs):
-    return observer(TensorObserver, **kwargs)
+    return observer(RecordingObserver, **kwargs)
 
 
 def default_weight_observer(**kwargs):

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -411,14 +411,14 @@ class HistogramObserver(ObserverBase):
         return self._calculate_qparams(new_min.item(), new_max.item())
 
 
-class TensorObserver(ObserverBase):
+class RecordingObserver(ObserverBase):
     r"""
     The module is mainly for debug and records the tensor values during runtime
     """
     __annotations__ = {"tensor_val": List[Optional[torch.Tensor]]}
 
     def __init__(self, **kwargs):
-        super(TensorObserver, self).__init__(**kwargs)
+        super(RecordingObserver, self).__init__(**kwargs)
         self.tensor_val = []
 
     def forward(self, x):
@@ -427,7 +427,7 @@ class TensorObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception("calculate_qparams should not be called for TensorObserver")
+        raise Exception("calculate_qparams should not be called for RecordingObserver")
 
     @torch.jit.export
     def get_tensor_value(self):
@@ -445,7 +445,7 @@ def default_observer(**kwargs):
 
 
 def default_debug_observer(**kwargs):
-    return observer(TensorObserver, **kwargs)
+    return observer(RecordingObserver, **kwargs)
 
 
 def default_weight_observer(**kwargs):

--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -334,25 +334,19 @@ def swap_module(mod, mapping):
             new_mod = mapping[type(mod)].from_float(mod)
     return new_mod
 
-def dump_tensor(mod, target_dict, prefix=""):
-    r"""Traverse the modules and save the weight and stored activation to given dict.
+def get_observer_dict(mod, target_dict, prefix=""):
+    r"""Traverse the modules and save all observers into dict.
     This is mainly used for quantization accuracy debug
     Args:
-        mod: the top module we want to save all tensors
+        mod: the top module we want to save all observers
         prefix: the prefix for the current module
-        target_dict: the dictionary used to save the tensors
+        target_dict: the dictionary used to save all the observers
     """
     def get_prefix(prefix):
         return prefix if prefix == "" else prefix + '.'
 
-    weight_unpack = getattr(mod, "weight", None)
-    if weight_unpack is not None and callable(weight_unpack):
-        target_dict[get_prefix(prefix) + 'weight'] = mod.weight()
-    elif hasattr(mod, 'weight'):
-        target_dict[get_prefix(prefix) + 'weight'] = mod.weight
-
     if hasattr(mod, 'observer'):
-        target_dict[get_prefix(prefix) + 'activation'] = mod.observer.get_tensor_value()
+        target_dict[get_prefix(prefix) + 'observer'] = mod.observer
     for name, child in mod.named_children():
         module_prefix = get_prefix(prefix) + name if prefix else name
-        dump_tensor(child, target_dict, module_prefix)
+        get_observer_dict(child, target_dict, module_prefix)


### PR DESCRIPTION
Mainly want to resolve comments from https://github.com/pytorch/pytorch/pull/25830.

Overall, we want to provide a recording observer for recording the runtime tensor values of activation path in order to debug the numerical accuracy loss offline.

According to the feedback from #25830, it might be better to record all the observers in a dict and query the dict to get corresponding tensor values. @hx89 is working on how to insert the recording observers into model under debug.
