### PR TITLE
torch.load default encoding change to 'utf-8'

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4995,9 +4995,6 @@ class _TestTorchMixin(object):
         utf8_bytes = b'\xc5\xbc\xc4\x85\xc4\x85\xc3\xb3\xc5\xbc\xc4\x85\xc5\xbc'
         utf8_str = utf8_bytes.decode('utf-8')
         if PY3:
-            with self.assertRaisesRegex(UnicodeDecodeError, "'ascii' codec can't decode byte"):
-                loaded = torch.load(buf)
-            buf.seek(0)
             loaded_utf8 = torch.load(buf, encoding='utf-8')
             self.assertEqual(loaded_utf8, [utf8_str, torch.zeros(1, dtype=torch.float), 2])
             buf.seek(0)
@@ -5389,6 +5386,21 @@ class _TestTorchMixin(object):
         self.assertEqual(s1[0], 0)
         self.assertEqual(s2[0], 0)
         self.assertEqual(s1.data_ptr() + 4, s2.data_ptr())
+
+    def test_load_unicode_error_msg(self):
+        # This Pickle contains a Python 2 module with Unicode data and the 
+        # loading should fail if the user explicitly specifies ascii encoding!
+        path = download_file('https://download.pytorch.org/test_data/legacy_conv2d.pt')
+        if sys.version_info >= (3, 0):
+            self.assertRaises(UnicodeDecodeError, lambda: torch.load(path, encoding='ascii'))
+        else:
+            # Just checks the module loaded
+            self.assertIsNotNone(torch.load(path)) 
+
+    def test_load_python2_unicode_module(self):
+        # This Pickle contains some Unicode data!
+        path = download_file('https://download.pytorch.org/test_data/legacy_conv2d.pt')
+        self.assertIsNotNone(torch.load(path)) 
 
     def test_load_error_msg(self):
         expected_err_msg = (".*You can only torch.load from a file that is seekable. " +

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -379,7 +379,7 @@ def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
             match the :attr:`pickle_module` used to serialize file)
         pickle_load_args: (Python 3 only) optional keyword arguments passed over to
             :func:`pickle_module.load` and :func:`pickle_module.Unpickler`, e.g.,
-            :attr:`errors=...`. By default only attr:`encoding='utf-8'` is used.
+            :attr:`errors=...`.
 
     .. note::
         When you call :func:`torch.load()` on a file which contains GPU tensors, those tensors
@@ -387,16 +387,13 @@ def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
         and then :meth:`load_state_dict` to avoid GPU RAM surge when loading a model checkpoint.
 
     .. note::
-        In Python 3, when loading files saved by Python 2, you may encounter
-        ``UnicodeDecodeError: 'ascii' codec can't decode byte 0x...``. This is
-        caused by the difference of handling in byte strings in Python2 and
-        Python 3. You may use extra :attr:`encoding` keyword argument to specify how
-        these objects should be loaded, e.g., :attr:`encoding='utf-8'` decodes them
-        to strings using ``utf-8`` encoding, and :attr:`encoding='bytes'` keeps them
+        By default, we decode byte strings as ``utf-8``.  This is to avoid a common error
+        case ``UnicodeDecodeError: 'ascii' codec can't decode byte 0x...``
+        when loading files saved by Python 2 in Python 3.  If this default
+        is incorrect, you may use an extra :attr:`encoding` keyword argument to specify how
+        these objects should be loaded, e.g., :attr:`encoding='latin1'` decodes them
+        to strings using ``latin1`` encoding, and :attr:`encoding='bytes'` keeps them
         as byte arrays which can be decoded later with ``byte_array.decode(...)``.
-        Even though we are defaulting to ``utf-8`` (Python 3) you can still run into
-        this issue e.g. if you try to load a module with specified `encoding='ascii'`
-        and the module has Unicode characters inside.
 
     Example:
         >>> torch.load('tensors.pt')


### PR DESCRIPTION
Default encoding when using torch.load to 'utf-8'
    
This commit provides changes for cases where user tries to torch.load 
a pickled module with non-ASCII characters in the docstring as 
discussed in #21743. The default encoding was changed from 'ascii'
to 'utf-8'. Documentation for `torch.load` was updated and two tests
(loading py2 unicode module with unicode in it; error throwing when
user explicitly sets wrong encoding) were written.


~~This commit provides changes for better error handling in cases
where user tries to `torch.load` a pickled module with non-ASCII
characters in the docstring as discussed in #21743.~~

Ping @ezyang 

