### PR TITLE
Disable QNNPACK tests if pytorch is not built with it.

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -185,7 +185,7 @@ TEST_WITH_ASAN = os.getenv('PYTORCH_TEST_WITH_ASAN', '0') == '1'
 TEST_WITH_TSAN = os.getenv('PYTORCH_TEST_WITH_TSAN', '0') == '1'
 TEST_WITH_UBSAN = os.getenv('PYTORCH_TEST_WITH_UBSAN', '0') == '1'
 TEST_WITH_ROCM = os.getenv('PYTORCH_TEST_WITH_ROCM', '0') == '1'
-
+TEST_WITH_QNNPACK = os.getenv('PYTORCH_TEST_WITH_QNNPACK', '0') == '1'
 # Enables tests that are slow to run (disabled by default)
 TEST_WITH_SLOW = os.getenv('PYTORCH_TEST_WITH_SLOW', '0') == '1'
 

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -11,7 +11,8 @@ from hypothesis import strategies as st
 import hypothesis_utils as hu
 from hypothesis_utils import no_deadline
 
-from common_utils import TEST_WITH_UBSAN, TestCase, run_tests, IS_WINDOWS, IS_PPC
+from common_utils import TEST_WITH_UBSAN, TestCase, run_tests, IS_WINDOWS, IS_PPC, \
+    TEST_WITH_QNNPACK
 from common_quantized import _quantize, _dequantize, _calculate_dynamic_qparams, \
     enable_mobile_quantized_engine
 
@@ -1211,6 +1212,7 @@ class TestQuantizedConv(unittest.TestCase):
             np.testing.assert_equal(np.float32(W_q.q_scale()), np.float32(W_unpacked.q_scale()))
             np.testing.assert_equal(W_q.q_zero_point(), W_unpacked.q_zero_point())
 
+@unittest.skipIf(not TEST_WITH_QNNPACK, "This Pytorch Build has not been built with QNNPACK")
 @unittest.skipIf(IS_WINDOWS, "QNNPACK has not been built for Windows")
 @unittest.skipIf(IS_PPC, "QNNPACK is not currently supported on ppc64le")
 @unittest.skipIf(TEST_WITH_UBSAN,


### PR DESCRIPTION
Summary: Use the new macro USE_PYTORCH_QNNPACK to enable testing with qnnpack

Test Plan:
test caffe2/test:quantized -- TestQNNPackOps
Summary (total time 4.96s):
  PASS: 0
  FAIL: 0
  SKIP: 4
    caffe2/test:quantized - test_qlinear_qnnpack (test_quantized.TestQNNPackOps)
    caffe2/test:quantized - test_qnnpack_add (test_quantized.TestQNNPackOps)
    caffe2/test:quantized - test_qnnpack_relu (test_quantized.TestQNNPackOps)
    caffe2/test:quantized - test_qnnpack_maxpool2d (test_quantized.TestQNNPackOps)
  FATAL: 0
  TIMEOUT: 0
  OMIT: 0

Reviewed By: ljk53

Differential Revision: D17459791

