### PR TITLE
Moves more tests to TestTorchDeviceType

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2246,11 +2246,6 @@ class TestCuda(TestCase):
                             self.assertEqual(torch.backends.cuda.cufft_plan_cache.max_size, 10)  # default is cuda:0
                         self.assertEqual(torch.backends.cuda.cufft_plan_cache.max_size, 11)  # default is cuda:1
 
-    # passes on ROCm w/ python 2.7, fails w/ python 3.6
-    @skipIfRocm
-    def test_stft(self):
-        _TestTorchMixin._test_stft(self, device=torch.device('cuda'))
-
     def test_multinomial(self):
         _TestTorchMixin._test_multinomial(self, torch.cuda.FloatTensor)
 
@@ -2380,11 +2375,6 @@ class TestCuda(TestCase):
         res = src[idx]
         res_cpu = src.cpu()[idx.cpu()]
         self.assertEqual(res.cpu(), res_cpu)
-
-    @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
-    def test_lu(self):
-        _TestTorchMixin._test_lu(self, lambda t: t.cuda(), pivot=False)
-        _TestTorchMixin._test_lu(self, lambda t: t.cuda(), pivot=True)
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     def test_lu_solve(self):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -29,12 +29,12 @@ from common_methods_invocations import tri_tests_args, run_additional_tri_tests,
     _compare_trilu_indices
 from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MKL, \
     TEST_LIBROSA, run_tests, download_file, skipIfNoLapack, suppress_warnings, \
-    IS_WINDOWS, PY3, NO_MULTIPROCESSING_SPAWN, skipIfRocm, do_test_dtypes, do_test_empty_full, \
+    IS_WINDOWS, PY3, NO_MULTIPROCESSING_SPAWN, do_test_dtypes, do_test_empty_full, \
     IS_SANDCASTLE, load_tests, brute_pdist, brute_cdist, slowTest, \
-    skipCUDANonDefaultStreamIf
+    skipCUDANonDefaultStreamIf, skipCUDAMemoryLeakCheckIf
 from multiprocessing.reduction import ForkingPickler
 from common_device_type import instantiate_device_type_tests, \
-    skipCPUIfNoLapack, skipCUDAIfNoMagma
+    skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -738,12 +738,6 @@ class _TestTorchMixin(object):
     def test_ceil(self):
         self._test_math_by_name('ceil')
 
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_ceil_out_cpu_cuda(self):
-        a = torch.randn(1)
-        b = torch.randn(1, device="cuda")
-        self.assertRaises(RuntimeError, lambda: torch.ceil(a, out=b))
-
     def test_rsqrt(self):
         def rsqrt(x):
             if x == 0:
@@ -782,23 +776,6 @@ class _TestTorchMixin(object):
         self.assertIsNotNone(torch.Tensor().clone().storage())
         self.assertIsNotNone(torch.Tensor([0, 0, 0]).nonzero().storage())
         self.assertIsNotNone(torch.Tensor().new().storage())
-
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_has_storage_numpy(self):
-        for dtype in [np.float32, np.float64, np.int64,
-                      np.int32, np.int16, np.uint8]:
-            arr = np.array([1], dtype=dtype)
-            self.assertIsNotNone(torch.FloatTensor(arr).storage())
-            self.assertIsNotNone(torch.DoubleTensor(arr).storage())
-            self.assertIsNotNone(torch.IntTensor(arr).storage())
-            self.assertIsNotNone(torch.LongTensor(arr).storage())
-            self.assertIsNotNone(torch.ByteTensor(arr).storage())
-            if torch.cuda.is_available():
-                self.assertIsNotNone(torch.cuda.FloatTensor(arr).storage())
-                self.assertIsNotNone(torch.cuda.DoubleTensor(arr).storage())
-                self.assertIsNotNone(torch.cuda.IntTensor(arr).storage())
-                self.assertIsNotNone(torch.cuda.LongTensor(arr).storage())
-                self.assertIsNotNone(torch.cuda.ByteTensor(arr).storage())
 
     def _testSelection(self, torchfn, mathfn):
         # contiguous
@@ -977,15 +954,6 @@ class _TestTorchMixin(object):
         test((10,))
         test((5, 5))
 
-    def test_all_any_empty(self):
-        x = torch.ByteTensor()
-        self.assertTrue(x.all())
-        self.assertFalse(x.any())
-
-        x = torch.BoolTensor()
-        self.assertTrue(x.all())
-        self.assertFalse(x.any())
-
     def test_all_any_with_dim(self):
         def test(x):
             r1 = x.prod(dim=0, keepdim=False).byte()
@@ -1002,32 +970,6 @@ class _TestTorchMixin(object):
                                [0, 0, 1],
                                [0, 1, 1],
                                [1, 1, 1]]))
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_all_any_empty_cuda(self):
-        x = torch.cuda.ByteTensor()
-        self.assertTrue(x.all())
-        self.assertFalse(x.any())
-
-        x = torch.cuda.BoolTensor()
-        self.assertTrue(x.all())
-        self.assertFalse(x.any())
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_multinomial_device_constrain(self):
-        x = torch.empty(0, device="cpu")
-        y = torch.empty(0, device="cuda")
-        self.assertRaisesRegex(
-            RuntimeError, "multinomial arguments must have the same device",
-            lambda: torch.multinomial(x, 2, out=y))
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
-    def test_multinomial_gpu_device_constrain(self):
-        x = torch.empty(0, device="cuda:0")
-        y = torch.empty(0, device="cuda:1")
-        self.assertRaisesRegex(
-            RuntimeError, "multinomial arguments must have the same device",
-            lambda: torch.multinomial(x, 2, out=y))
 
     def test_mv(self):
         def _test_mv(m1, v1):
@@ -1266,43 +1208,6 @@ class _TestTorchMixin(object):
             _test_mm(n, m, p, torch.int32, lambda x, y: torch.randint(0, 100, (x, y), dtype=torch.int32))
             _test_mm(n, m, p, torch.int64, lambda x, y: torch.randint(0, 100, (x, y), dtype=torch.int64))
             _test_mm(n, m, p, torch.bfloat16, lambda x, y: torch.randn(x, y, dtype=torch.float32).bfloat16())
-
-    @staticmethod
-    def _test_lu(self, cast, pivot=True):
-        from common_utils import random_fullrank_matrix_distinct_singular_value as fullrank
-
-        def run_test(matrix_size, batches, cast):
-            a = cast(fullrank(matrix_size, *batches))
-            a_LU_info, pivots_info, info_ = a.lu(pivot=pivot, get_infos=True)
-            self.assertEqual(a_LU_info.size(), torch.Size(batches + (matrix_size, matrix_size)))
-            self.assertEqual(pivots_info.size(), torch.Size(batches + (matrix_size,)))
-            self.assertEqual(info_.size(), torch.Size(batches))
-            self.assertEqual(info_.abs().sum(), 0)
-            a_LU, pivots = a.lu(pivot=pivot)
-            self.assertEqual(a_LU, a_LU_info)
-            self.assertEqual(pivots_info, pivots)
-            if a.is_cuda:
-                a_LU_info_nopiv, nopiv, info_nopiv = a.lu(pivot=False, get_infos=True)
-                self.assertEqual(nopiv, cast(torch.arange(1, 1 + a.size(-1), dtype=torch.int32).expand(a.shape[:-1])))
-                self.assertEqual(info_, info_nopiv)
-            P, L, U = torch.lu_unpack(a_LU, pivots)
-            self.assertEqual(P.matmul(L.matmul(U)), a)
-
-        for ms, batch in product([3, 5, 7], [(), (2,), (3,), (3, 5)]):
-            run_test(ms, batch, cast)
-
-        # Info should be positive for rank deficient matrices
-        a = cast(torch.ones(5, 3, 3))
-        self.assertGreater(a.lu(pivot=pivot, get_infos=True)[2][0], 0)
-
-        # Error checking, no pivoting variant on CPU
-        with self.assertRaisesRegex(RuntimeError,
-                                    'lu without pivoting is not implemented on the CPU'):
-            torch.lu(torch.empty(1, 2, 2), pivot=False)
-
-    @skipIfNoLapack
-    def test_lu(self):
-        self._test_lu(self, lambda t: t, pivot=True)
 
     @staticmethod
     def _test_lu_solve(self, cast, pivot=True):
@@ -1813,13 +1718,6 @@ class _TestTorchMixin(object):
         expected = torch.tensor([[0.]], dtype=torch.bfloat16)
         self.assertEqual(bfloat16Tensor, expected)
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
-    def test_zeros_like_multiple_device(self):
-        expected = torch.zeros(100, 100).cuda()
-        x = torch.cuda.FloatTensor(100, 100, device=1)
-        output = torch.zeros_like(x)
-        self.assertEqual(output, expected)
-
     def test_zeros_out(self):
         shape = (3, 4)
         out = torch.zeros(shape)
@@ -1857,20 +1755,6 @@ class _TestTorchMixin(object):
         expected = torch.tensor([True, True], dtype=torch.bool)
         res1 = torch.ones_like(expected)
         self.assertEqual(res1, expected)
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_ones_like_cuda(self):
-        expected = torch.ones(100, 100).cuda()
-
-        res1 = torch.ones_like(expected)
-        self.assertEqual(res1, expected)
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
-    def test_ones_like_multiple_device(self):
-        expected = torch.ones(100, 100).cuda()
-        x = torch.cuda.FloatTensor(100, 100, device=1)
-        output = torch.ones_like(x)
-        self.assertEqual(output, expected)
 
     def test_dtypes(self):
         all_dtypes = torch.testing.get_all_dtypes()
@@ -1980,95 +1864,6 @@ class _TestTorchMixin(object):
                 assertEqual('cuda:1', lambda: torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cuda:1'))
                 if TEST_NUMPY:
                     assertEqual('cuda:1', lambda: torch.tensor(np.random.randn(2, 3), device='cuda:1'))
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, 'fewer than 2 GPUs detected')
-    def test_device_guard(self):
-        # verify that all operators with `device_guard: False` behave properly with multiple devices.
-        # TODO: if we had operator introspection we could figure out this set of operators automatically...
-        current_device = torch.cuda.current_device()
-        device = torch.device('cuda:1') if current_device == 0 else torch.device('cuda:0')
-        x = torch.randn((1, 2, 3), device=device)
-        y = torch.zeros((1, 3, 2), device=device)
-        scalar = torch.tensor(5, device=device)
-
-        # property ops
-        torch.cudnn_is_acceptable(x)
-        x.is_distributed()
-        x.is_floating_point()
-        x.is_complex()
-        x.is_same_size(y)
-        x.is_signed()
-        x.size(0)
-        x.stride(0)
-        x.numel()
-        x.is_set_to(y)
-        x.data_ptr()
-        scalar.is_nonzero()
-
-        # sparse property ops
-        y[0][1] = 5
-        y_sparse = y.to_sparse()
-        y_sparse.sparse_dim()
-        y_sparse._dimI()
-        y_sparse.dense_dim()
-        y_sparse._dimV()
-        y_sparse._nnz()
-        y_sparse.is_coalesced()
-        y_sparse._indices()
-        y_sparse._values()
-        y_sparse.indices()
-        y_sparse.values()
-
-        # in-place ops
-        def inplace():
-            return torch.randn((1, 2, 3), device=device)
-        inplace().as_strided_(y.size(), y.stride())
-        inplace().resize_(y.size())
-        inplace().squeeze_()
-        inplace().squeeze_(0)
-        inplace().unsqueeze_(2)
-        inplace().transpose_(1, 2)
-        inplace().squeeze_().t_()
-        inplace().set_(x.storage())
-        inplace().set_(x.storage(), x.storage_offset(), x.size(), x.stride())
-        inplace().set_(x)
-        inplace().set_()
-        y_sparse._coalesced_(True)
-
-        # shape modification
-        x.as_strided(y.size(), y.stride())
-        x.expand((5, 2, 3))
-        x.expand_as(x)
-        x.sum_to_size((1,))
-        torch.broadcast_tensors(x , x)
-        x.reshape((1, 3, 2))
-        x.reshape_as(y)
-        x.squeeze()
-        x.squeeze(0)
-        x.squeeze().t()
-        x.transpose(1, 2)
-        x.unsqueeze(2)
-        x.view((1, 3, 2))
-        x.view_as(y)
-
-        # chunk, split, etc.
-        x.chunk(2, dim=1)
-        x.split(1, dim=2)
-        x.split_with_sizes([1, 2], dim=2)
-        x.unfold(dimension=2, size=1, step=1)
-
-        x.narrow(1, 1, 1)
-        x.select(1, 1)
-        torch.isnan(x)
-
-        torch.empty((1, 3, 2), out=y)
-        torch.empty_like(x)
-        torch.empty_like(x, dtype=torch.int64)
-
-        # to
-        x.to(x)
-        x.to(y)
-        x.to(x, copy=True)
 
     def test_to(self):
         def test_copy_behavior(t, non_blocking=False):
@@ -2305,31 +2100,6 @@ class _TestTorchMixin(object):
         test_inference(torch.float64)
         test_inference(torch.float32)
 
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_tensor_factory_cuda_type_inference(self):
-        saved_type = torch.Tensor().type()
-        torch.set_default_tensor_type(torch.cuda.DoubleTensor)
-        torch.set_default_dtype(torch.float32)
-        self.assertIs(torch.float32, torch.tensor(0.).dtype)
-        self.assertEqual(torch.device('cuda:0'), torch.tensor(0.).device)
-        torch.set_default_dtype(torch.float64)
-        self.assertIs(torch.float64, torch.tensor(0.).dtype)
-        self.assertEqual(torch.device('cuda:0'), torch.tensor(0.).device)
-        torch.set_default_tensor_type(saved_type)
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_tensor_factory_cuda_type(self):
-        saved_type = torch.Tensor().type()
-        torch.set_default_tensor_type(torch.cuda.FloatTensor)
-        x = torch.zeros((5, 5))
-        self.assertIs(torch.float32, x.dtype)
-        self.assertTrue(x.is_cuda)
-        torch.set_default_tensor_type(torch.cuda.DoubleTensor)
-        x = torch.zeros((5, 5))
-        self.assertIs(torch.float64, x.dtype)
-        self.assertTrue(x.is_cuda)
-        torch.set_default_tensor_type(saved_type)
-
     def test_new_tensor(self):
         expected = torch.autograd.Variable(torch.ByteTensor([1, 1]))
         # test data
@@ -2510,23 +2280,6 @@ class _TestTorchMixin(object):
         m3 = m1.transpose(1, 2).contiguous().clone().resize_(15, 4)
         self.assertEqual(m3, m2)
         self.assertEqual(m3.norm(2, 0), m2.norm(2, 0))
-
-    @staticmethod
-    def _test_renorm_ps(self, device):
-        # full reduction
-        x = torch.randn(5, 5)
-        xn = x.numpy()
-        for p in [1, 2, 3, 4, inf]:
-            res = x.renorm(p, 1, 1)
-            expected = x / x.norm(p, 0, keepdim=True).clamp(min=1)
-            self.assertEqual(res.numpy(), expected.numpy(), "renorm failed for {}-norm".format(p))
-
-    def test_renorm_ps(self):
-        self._test_renorm_ps(self, device='cpu')
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_renorm_ps_cuda(self):
-        self._test_renorm_ps(self, device='cuda')
 
     @staticmethod
     def _test_multinomial(self, type):
@@ -3035,14 +2788,6 @@ class _TestTorchMixin(object):
         # Make sure True isn't mistakenly taken as the 2nd dimension (interpreted as 1)
         self.assertRaises(TypeError, lambda: q.topk(4, True))
 
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_topk_noncontiguous_gpu(self):
-        t = torch.randn(20, device="cuda")[::2]
-        top1, idx1 = t.topk(5)
-        top2, idx2 = t.contiguous().topk(5)
-        self.assertEqual(top1, top2)
-        self.assertEqual(idx1, idx2)
-
     def test_median(self):
         for size in (155, 156):
             x = torch.rand(size, size)
@@ -3321,53 +3066,6 @@ class _TestTorchMixin(object):
         self.assertEqual(x[:, -2:3].data.tolist(), [[2], [6], [10], [14]])
         self.assertEqual(x[0:-1:2].data.tolist(), [[0, 1, 2, 3], [8, 9, 10, 11]])
 
-    def test_is_signed(self):
-        self.assertEqual(torch.IntTensor(5).is_signed(), True)
-        self.assertEqual(torch.ByteTensor(5).is_signed(), False)
-        self.assertEqual(torch.CharTensor(5).is_signed(), True)
-        self.assertEqual(torch.FloatTensor(5).is_signed(), True)
-        self.assertEqual(torch.HalfTensor(10).is_signed(), True)
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_is_signed_cuda(self):
-        self.assertEqual(torch.cuda.IntTensor(5).is_signed(), True)
-        self.assertEqual(torch.cuda.ByteTensor(5).is_signed(), False)
-        self.assertEqual(torch.cuda.CharTensor(5).is_signed(), True)
-        self.assertEqual(torch.cuda.FloatTensor(5).is_signed(), True)
-        self.assertEqual(torch.cuda.HalfTensor(10).is_signed(), True)
-
-    def test_solve_methods_arg_device(self):
-        if not torch.cuda.is_available():
-            return
-
-        for b_device, A_device in product(['cpu', 'cuda'], repeat=2):
-            if b_device == A_device:
-                continue
-
-            b = torch.randn(3, 1, device=b_device)
-            A = torch.randn(3, 3, device=A_device)
-            err_str = "Expected b and A to be on the same device"
-            with self.assertRaisesRegex(RuntimeError, err_str):
-                torch.solve(b, A)
-
-            with self.assertRaisesRegex(RuntimeError, err_str):
-                torch.cholesky_solve(b, A)
-
-            with self.assertRaisesRegex(RuntimeError, err_str):
-                torch.triangular_solve(b, A)
-
-            # b and A have to be modified to match accepted inputs sizes for lu_solve
-            b = b.unsqueeze(0)
-            A = A.unsqueeze(0)
-            with self.assertRaisesRegex(RuntimeError, err_str):
-                torch.lu_solve(b, A, torch.rand(A.shape[:-1], device=A_device).int())
-
-            # This checks if a suitable error message is thrown
-            # when LU output and pivots are on the same device
-            with self.assertRaisesRegex(RuntimeError,
-                                        "Expected LU_pivots and LU_data to be on the same device"):
-                torch.lu_solve(b, A, torch.rand(A.shape[:-1], device=b_device).int())
-
     @skipIfNoLapack
     def test_ormqr(self):
         mat1 = torch.randn(7, 7)
@@ -3560,69 +3258,6 @@ class _TestTorchMixin(object):
     @unittest.skipIf(not TEST_MKL, "PyTorch is built without MKL support")
     def test_fft_ifft_rfft_irfft(self):
         self._test_fft_ifft_rfft_irfft(self)
-
-    @staticmethod
-    def _test_stft(self, device='cpu'):
-        if not TEST_LIBROSA:
-            raise unittest.SkipTest('librosa not found')
-
-        def librosa_stft(x, n_fft, hop_length, win_length, window, center):
-            if window is None:
-                window = np.ones(n_fft if win_length is None else win_length)
-            else:
-                window = window.cpu().numpy()
-            input_1d = x.dim() == 1
-            if input_1d:
-                x = x.view(1, -1)
-            result = []
-            for xi in x:
-                ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center)
-                result.append(torch.from_numpy(np.stack([ri.real, ri.imag], -1)))
-            result = torch.stack(result, 0)
-            if input_1d:
-                result = result[0]
-            return result
-
-        def _test(sizes, n_fft, hop_length=None, win_length=None, win_sizes=None,
-                  center=True, expected_error=None):
-            x = torch.randn(*sizes, device=device)
-            if win_sizes is not None:
-                window = torch.randn(*win_sizes, device=device)
-            else:
-                window = None
-            if expected_error is None:
-                result = x.stft(n_fft, hop_length, win_length, window, center=center)
-                ref_result = librosa_stft(x, n_fft, hop_length, win_length, window, center)
-                self.assertEqual(result, ref_result, 7e-6, 'stft comparison against librosa')
-            else:
-                self.assertRaises(expected_error,
-                                  lambda: x.stft(n_fft, hop_length, win_length, window, center=center))
-
-        for center in [True, False]:
-            _test((10,), 7, center=center)
-            _test((10, 4000), 1024, center=center)
-
-            _test((10,), 7, 2, center=center)
-            _test((10, 4000), 1024, 512, center=center)
-
-            _test((10,), 7, 2, win_sizes=(7,), center=center)
-            _test((10, 4000), 1024, 512, win_sizes=(1024,), center=center)
-
-            # spectral oversample
-            _test((10,), 7, 2, win_length=5, center=center)
-            _test((10, 4000), 1024, 512, win_length=100, center=center)
-
-        _test((10, 4, 2), 1, 1, expected_error=RuntimeError)
-        _test((10,), 11, 1, center=False, expected_error=RuntimeError)
-        _test((10,), -1, 1, expected_error=RuntimeError)
-        _test((10,), 3, win_length=5, expected_error=RuntimeError)
-        _test((10,), 5, 4, win_sizes=(11,), expected_error=RuntimeError)
-        _test((10,), 5, 4, win_sizes=(1, 1), expected_error=RuntimeError)
-
-    # passes on ROCm w/ python 2.7, fails w/ python 3.6
-    @skipIfRocm
-    def test_stft(self):
-        self._test_stft(self)
 
     @unittest.skip("Not implemented yet")
     def test_conv2(self):
@@ -4433,76 +4068,6 @@ class _TestTorchMixin(object):
         # match NumPy semantics -- don't infer the size of dimension with a degree of freedom
         self.assertRaises(RuntimeError, lambda: x.reshape(0, -1))
 
-    @skipIfRocm
-    def test_blas_empty(self):
-        for device in torch.testing.get_all_device_types():
-
-            def fn(torchfn, *args):
-                return torchfn(*tuple(torch.randn(shape, device=device) if isinstance(shape, tuple) else shape
-                                      for shape in args))
-
-            # mm, addmm
-            self.assertEqual((0, 0), fn(torch.mm, (0, 0), (0, 0)).shape)
-            self.assertEqual((0, 5), fn(torch.mm, (0, 0), (0, 5)).shape)
-            self.assertEqual((5, 0), fn(torch.mm, (5, 0), (0, 0)).shape)
-            self.assertEqual((3, 0), fn(torch.mm, (3, 2), (2, 0)).shape)
-            self.assertEqual(torch.zeros((5, 6), device=device), fn(torch.mm, (5, 0), (0, 6)))
-
-            self.assertEqual((0, 0), fn(torch.addmm, (0, 0), (0, 0), (0, 0)).shape)
-            self.assertEqual((5, 6), fn(torch.addmm, (5, 6), (5, 0), (0, 6)).shape)
-
-            # mv, addmv
-            self.assertEqual((0,), fn(torch.mv, (0, 0), (0,)).shape)
-            self.assertEqual((0,), fn(torch.mv, (0, 2), (2,)).shape)
-            self.assertEqual(torch.zeros((3,), device=device), fn(torch.mv, (3, 0), (0,)))
-
-            self.assertEqual((0,), fn(torch.addmv, (0,), (0, 0), (0,)).shape)
-            self.assertEqual((3,), fn(torch.addmv, (3,), (3, 0), (0,)).shape)
-
-            # ger, addr
-            self.assertEqual((0, 0), fn(torch.ger, (0,), (0,)).shape)
-            self.assertEqual((5, 0), fn(torch.ger, (5,), (0,)).shape)
-            self.assertEqual((0, 4), fn(torch.ger, (0,), (4,)).shape)
-
-            self.assertEqual((0, 0), fn(torch.addr, (0, 0), (0,), (0,)).shape)
-            self.assertEqual((5, 0), fn(torch.addr, (5, 0), (5,), (0,)).shape)
-            self.assertEqual((0, 4), fn(torch.addr, (0, 4), (0,), (4,)).shape)
-
-            # bmm, baddbmm
-            self.assertEqual((0, 0, 0), fn(torch.bmm, (0, 0, 0), (0, 0, 0)).shape)
-            self.assertEqual((3, 0, 5), fn(torch.bmm, (3, 0, 0), (3, 0, 5)).shape)
-            self.assertEqual((0, 5, 6), fn(torch.bmm, (0, 5, 0), (0, 0, 6)).shape)
-            self.assertEqual(torch.zeros((3, 5, 6), device=device), fn(torch.bmm, (3, 5, 0), (3, 0, 6)))
-
-            self.assertEqual((0, 0, 0), fn(torch.baddbmm, (0, 0, 0), (0, 0, 0), (0, 0, 0)).shape)
-            self.assertEqual((3, 0, 5), fn(torch.baddbmm, (3, 0, 5), (3, 0, 0), (3, 0, 5)).shape)
-            self.assertEqual((0, 5, 6), fn(torch.baddbmm, (0, 5, 6), (0, 5, 0), (0, 0, 6)).shape)
-            self.assertEqual((3, 5, 6), fn(torch.baddbmm, (3, 5, 6), (3, 5, 0), (3, 0, 6)).shape)
-
-            # addbmm
-            self.assertEqual((0, 0), fn(torch.addbmm, (0, 0), (0, 0, 0), (0, 0, 0)).shape)
-            self.assertEqual((0, 5), fn(torch.addbmm, (0, 5), (3, 0, 0), (3, 0, 5)).shape)
-            self.assertEqual((5, 6), fn(torch.addbmm, (5, 6), (0, 5, 0), (0, 0, 6)).shape)
-
-            # matmul
-            self.assertEqual(torch.tensor(0., device=device), fn(torch.matmul, (0,), (0,)))
-            self.assertEqual((0, 0), fn(torch.matmul, (0, 0), (0, 0)).shape)
-            self.assertEqual((0, 0, 0), fn(torch.matmul, (0, 0, 0), (0, 0, 0)).shape)
-            self.assertEqual((5, 0, 0), fn(torch.matmul, (5, 0, 0), (5, 0, 0)).shape)
-            self.assertEqual(torch.zeros((5, 3, 4), device=device), fn(torch.matmul, (5, 3, 0), (5, 0, 4)))
-
-            # dot
-            self.assertEqual(torch.tensor(0., device=device), fn(torch.dot, (0,), (0,)))
-
-            if torch._C.has_lapack:
-                # lu
-                A_LU, pivots = fn(torch.lu, (0, 5, 5))
-                self.assertEqual([(0, 5, 5), (0, 5)], [A_LU.shape, pivots.shape])
-                A_LU, pivots = fn(torch.lu, (0, 0, 0))
-                self.assertEqual([(0, 0, 0), (0, 0)], [A_LU.shape, pivots.shape])
-                A_LU, pivots = fn(torch.lu, (2, 0, 0))
-                self.assertEqual([(2, 0, 0), (2, 0)], [A_LU.shape, pivots.shape])
-
     def check_single_matmul(self, x, y, shape):
         a = np.array(x, copy=False)
         b = np.array(y, copy=False)
@@ -4593,31 +4158,6 @@ class _TestTorchMixin(object):
                             x = torch.arange(n * 2 * m).reshape(n, 2 * m)[:, ::2]
                             y = torch.arange(r * o * m * 2 * p).reshape(r, o, m, 2 * p)[:, :, :, ::2]
                             self.check_single_matmul(x, y, (r, o, n, p))
-
-    @skipIfRocm
-    def test_blas_alpha_beta_empty(self):
-        for device in torch.testing.get_all_device_types():
-            # ensure beta is respected
-            value = 11
-            input = torch.full((2,), value, device=device)
-            mat = torch.ones((2, 0), device=device)
-            vec = torch.ones((0,), device=device)
-            out = torch.randn((2,), device=device)
-            alpha = 6
-            beta = 3
-            self.assertEqual(torch.full((2,), beta * value, device=device),
-                             torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta))
-            self.assertEqual(torch.full((2,), beta * value, device=device),
-                             torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out))
-
-            # torch.addmm
-            input = torch.full((2, 3), value, device=device)
-            mat2 = torch.ones((0, 3), device=device)
-            out = torch.randn((2, 3), device=device)
-            self.assertEqual(torch.full((2, 3), beta * value, device=device),
-                             torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
-            self.assertEqual(torch.full((2, 3), beta * value, device=device),
-                             torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out))
 
     def test_expand(self):
         tensor = torch.rand(1, 8, 1)
@@ -4835,16 +4375,6 @@ class _TestTorchMixin(object):
             self.assertRaises(RuntimeError,
                               lambda: f_cuda.set_(f_cpu.storage(), 0, f_cpu.size(), f_cpu.stride()))
             self.assertRaises(RuntimeError, lambda: f_cuda.set_(f_cpu))
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, 'less than 2 GPUs detected')
-    def test_tensor_set_errors_multigpu(self):
-        f_cuda0 = torch.randn((2, 3), dtype=torch.float32, device='cuda:0')
-        f_cuda1 = torch.randn((2, 3), dtype=torch.float32, device='cuda:1')
-
-        self.assertRaises(RuntimeError, lambda: f_cuda0.set_(f_cuda1.storage()))
-        self.assertRaises(RuntimeError,
-                          lambda: f_cuda0.set_(f_cuda1.storage(), 0, f_cuda1.size(), f_cuda1.stride()))
-        self.assertRaises(RuntimeError, lambda: f_cuda0.set_(f_cuda1))
 
     def test_equal(self):
         # Contiguous, 1D
@@ -5580,43 +5110,6 @@ class _TestTorchMixin(object):
             device_copied = copy.deepcopy(device)
             self.assertEqual(device, device_copied)
 
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_half_tensor_cuda(self):
-        x = torch.randn(5, 5).half()
-        self.assertEqual(x.cuda(), x)
-
-        xc = x.cuda()
-        with tempfile.NamedTemporaryFile() as f:
-            torch.save(xc, f)
-            f.seek(0)
-            xc2 = torch.load(f)
-            self.assertIsInstance(xc2, type(xc))
-            self.assertEqual(xc.float(), xc2.float())
-
-    def _test_serialization_cuda(self, filecontext_lambda):
-        device_count = torch.cuda.device_count()
-        t0 = torch.cuda.FloatTensor(5).fill_(1)
-        torch.cuda.set_device(device_count - 1)
-        tn = torch.cuda.FloatTensor(3).fill_(2)
-        torch.cuda.set_device(0)
-        b = (t0, tn)
-        with filecontext_lambda() as f:
-            torch.save(b, f)
-            f.seek(0)
-            c = torch.load(f)
-            self.assertEqual(b, c, 0)
-            u0, un = c
-            self.assertEqual(u0.get_device(), 0)
-            self.assertEqual(un.get_device(), device_count - 1)
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_serialization_cuda(self):
-        self._test_serialization_cuda(tempfile.NamedTemporaryFile)
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_serialization_cuda_filelike(self):
-        self._test_serialization_cuda(BytesIOContext)
-
     def test_serialization_backwards_compat(self):
         a = [torch.arange(1 + i, 26 + i).view(5, 5).float() for i in range(2)]
         b = [a[i % 2] for i in range(4)]
@@ -5984,19 +5477,6 @@ class _TestTorchMixin(object):
         self.assertEqual(boolStorage.int().tolist(), [1, 0, 1, 1, 1, 1])
         self.assertIs(boolStorage.dtype, torch.bool)
 
-    def test_storage_device(self):
-        devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
-        for device in devices:
-            x = torch.tensor([], device=device)
-            self.assertEqual(x.dtype, x.storage().dtype)
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, 'less than 2 GPUs detected')
-    def test_storage_multigpu(self):
-        devices = ['cuda:0', 'cuda:1']
-        for device in devices:
-            x = torch.tensor([], device=device)
-            self.assertEqual(x.dtype, x.storage().dtype)
-
     @unittest.skipIf(IS_WINDOWS, "TODO: need to fix this test case for Windows")
     def test_from_file(self):
         size = 10000
@@ -6344,40 +5824,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
             self.assertIs(pinned, pinned.pin_memory())
             self.assertEqual(pinned.data_ptr(), pinned.pin_memory().data_ptr())
 
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_pin_memory_from_constructor(self):
-
-        def _get_like(t, **kwargs):
-            return [
-                torch.rand_like(t, **kwargs),
-                torch.randn_like(t, **kwargs),
-                torch.empty_like(t, **kwargs),
-                torch.full_like(t, 4, **kwargs),
-                torch.zeros_like(t, **kwargs),
-                torch.ones_like(t, **kwargs),
-            ]
-
-        def _get_tensors(**kwargs):
-            return [
-                torch.tensor([10, 11], **kwargs),
-                torch.randn(3, 5, **kwargs),
-                torch.rand(3, **kwargs),
-                # torch.randint(3, 5, **kwargs), // unsupported
-                torch.zeros(3, **kwargs),
-                torch.randperm(3, **kwargs),
-                torch.empty(6, **kwargs),
-                torch.ones(6, **kwargs),
-                torch.eye(6, **kwargs),
-                torch.arange(3, 5, **kwargs)]
-
-        pinned_tensors = _get_tensors(pin_memory=True) + _get_like(torch.empty(5, dtype=torch.float64), pin_memory=True)
-        for x in pinned_tensors:
-            self.assertTrue(x.is_pinned())
-
-        tensors = _get_tensors() + _get_like(torch.empty(5, dtype=torch.float64, pin_memory=True))
-        for x in tensors:
-            self.assertFalse(x.is_pinned())
-
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_numpy_unresizable(self):
         x = np.zeros((2, 2))
@@ -6514,17 +5960,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         self.assertEqual(y.dtype, np.bool)
         self.assertEqual(x[0], y[0])
 
-    def test_dlpack_conversion(self):
-        x = torch.randn(1, 2, 3, 4).type('torch.FloatTensor')
-        z = from_dlpack(to_dlpack(x))
-        self.assertEqual(z, x)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "No CUDA")
-    def test_dlpack_cuda(self):
-        x = torch.randn(1, 2, 3, 4).cuda()
-        z = from_dlpack(to_dlpack(x))
-        self.assertEqual(z, x)
-
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_from_numpy(self):
         dtypes = [
@@ -6588,54 +6023,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         x = np.array([3., 5., 8.])
         x.strides = (3,)
         self.assertRaises(ValueError, lambda: torch.from_numpy(x))
-
-    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
-    def test_ctor_with_numpy_array(self):
-        correct_dtypes = [
-            np.double,
-            np.float,
-            np.float16,
-            np.int64,
-            np.int32,
-            np.int16,
-            np.int8,
-            np.uint8,
-            np.bool,
-        ]
-
-        incorrect_byteorder = '>' if sys.byteorder == 'little' else '<'
-        incorrect_dtypes = map(lambda t: incorrect_byteorder + t, ['d', 'f'])
-
-        for dtype in correct_dtypes:
-            array = np.array([1, 2, 3, 4], dtype=dtype)
-
-            # Upcast
-            tensor = torch.DoubleTensor(array)
-            for i in range(len(array)):
-                self.assertEqual(tensor[i], array[i])
-
-            if torch.cuda.is_available():
-                tensor = torch.cuda.DoubleTensor(array)
-                for i in range(len(array)):
-                    self.assertEqual(tensor[i], array[i])
-
-            # Downcast (sometimes)
-            tensor = torch.FloatTensor(array)
-            for i in range(len(array)):
-                self.assertEqual(tensor[i], array[i])
-
-            tensor = torch.HalfTensor(array)
-            for i in range(len(array)):
-                self.assertEqual(tensor[i], array[i])
-
-            if torch.cuda.is_available():
-                tensor = torch.cuda.FloatTensor(array)
-                for i in range(len(array)):
-                    self.assertEqual(tensor[i], array[i])
-
-                tensor = torch.cuda.HalfTensor(array)
-                for i in range(len(array)):
-                    self.assertEqual(tensor[i], array[i])
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_ctor_with_numpy_scalar_ctor(self):
@@ -6985,311 +6372,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         self.assertEqual(double_tensor[2], 0.0, prec=0.0)  # tiny_double to zero
         torch.set_flush_denormal(False)
 
-    def test_unique(self):
-        def run_test(device):
-            x = torch.tensor([1, 2, 3, 2, 8, 5, 2, 3], device=device)
-            expected_unique = torch.tensor([1, 2, 3, 5, 8], device=device)
-            expected_inverse = torch.tensor([0, 1, 2, 1, 4, 3, 1, 2], device=device)
-            expected_counts = torch.tensor([1, 3, 2, 1, 1], device=device)
-
-            x_unique = torch.unique(x)
-            self.assertEqual(
-                expected_unique.tolist(), sorted(x_unique.tolist()))
-
-            x_unique, x_inverse = x.unique(return_inverse=True)
-            self.assertEqual(
-                expected_unique.tolist(), sorted(x_unique.tolist()))
-            self.assertEqual(expected_inverse.numel(), x_inverse.numel())
-
-            x_unique = x.unique(sorted=True)
-            self.assertEqual(expected_unique, x_unique)
-
-            x_unique, x_counts = torch.unique(x, sorted=True, return_counts=True)
-            self.assertEqual(expected_counts, x_counts)
-
-            x_unique, x_inverse = torch.unique(
-                x, sorted=True, return_inverse=True)
-            self.assertEqual(expected_unique, x_unique)
-            self.assertEqual(expected_inverse, x_inverse)
-
-            x_unique, x_inverse, x_counts = torch.unique(
-                x, sorted=True, return_inverse=True, return_counts=True)
-            self.assertEqual(expected_unique, x_unique)
-            self.assertEqual(expected_inverse, x_inverse)
-            self.assertEqual(expected_counts, x_counts)
-
-            # Tests per-element unique on a higher rank tensor.
-            y = x.view(2, 2, 2)
-            y_unique, y_inverse = y.unique(sorted=True, return_inverse=True)
-            self.assertEqual(expected_unique, y_unique)
-            self.assertEqual(expected_inverse.view(y.size()), y_inverse)
-
-            y_unique, y_inverse, y_counts = torch.unique(
-                y, sorted=True, return_inverse=True, return_counts=True)
-            self.assertEqual(expected_unique, y_unique)
-            self.assertEqual(expected_inverse.view(y.size()), y_inverse)
-            self.assertEqual(expected_counts, y_counts)
-
-            # Tests unique on other types.
-            int_unique, int_inverse, int_counts = torch.unique(
-                torch.tensor([2, 1, 2], dtype=torch.int, device=device),
-                sorted=True,
-                return_inverse=True,
-                return_counts=True
-            )
-            self.assertEqual(torch.tensor([1, 2], dtype=torch.int, device=device), int_unique)
-            self.assertEqual(torch.tensor([1, 0, 1], dtype=torch.long, device=device), int_inverse)
-            self.assertEqual(torch.tensor([1, 2], dtype=torch.long, device=device), int_counts)
-
-            double_unique, double_inverse, double_counts = torch.unique(
-                torch.tensor([2., 1.5, 2.1, 2.], dtype=torch.double, device=device),
-                sorted=True,
-                return_inverse=True,
-                return_counts=True
-            )
-            self.assertEqual(torch.tensor([1.5, 2., 2.1], dtype=torch.double, device=device), double_unique)
-            self.assertEqual(torch.tensor([1, 0, 2, 1], dtype=torch.long, device=device), double_inverse)
-            self.assertEqual(torch.tensor([1, 2, 1], dtype=torch.long, device=device), double_counts)
-
-            byte_unique, byte_inverse, byte_counts = torch.unique(
-                torch.tensor([133, 7, 7, 7, 42, 128], dtype=torch.uint8, device=device),
-                sorted=True,
-                return_inverse=True,
-                return_counts=True
-            )
-            self.assertEqual(torch.tensor([7, 42, 128, 133], dtype=torch.uint8, device=device), byte_unique)
-            self.assertEqual(torch.tensor([3, 0, 0, 0, 1, 2], dtype=torch.long, device=device), byte_inverse)
-            self.assertEqual(torch.tensor([3, 1, 1, 1], dtype=torch.long, device=device), byte_counts)
-
-            # test consecutive version
-            z = torch.tensor([1, 2, 2, 2, 5, 5, 2, 2, 3], device=device)
-            expected_z_unique = torch.tensor([1, 2, 5, 2, 3], device=device)
-            expected_z_inverse = torch.tensor([0, 1, 1, 1, 2, 2, 3, 3, 4], device=device)
-            expected_z_counts = torch.tensor([1, 3, 2, 2, 1], device=device)
-
-            z_unique = torch.unique_consecutive(z)
-            self.assertEqual(z_unique, expected_z_unique)
-
-            z_unique, z_inverse = torch.unique_consecutive(z, return_inverse=True)
-            self.assertEqual(z_unique, expected_z_unique)
-            self.assertEqual(z_inverse, expected_z_inverse)
-
-            z_unique, z_counts = torch.unique_consecutive(z, return_counts=True)
-            self.assertEqual(z_unique, expected_z_unique)
-            self.assertEqual(z_counts, expected_z_counts)
-
-            z_unique, z_inverse, z_counts = torch.unique_consecutive(z, return_inverse=True, return_counts=True)
-            self.assertEqual(z_unique, expected_z_unique)
-            self.assertEqual(z_inverse, expected_z_inverse)
-            self.assertEqual(z_counts, expected_z_counts)
-
-        run_test(torch.device('cpu'))
-        if torch.cuda.is_available():
-            run_test(torch.device('cuda'))
-
-    @skipIfRocm
-    def test_unique_dim(self):
-        self.assertFalse(hasattr(torch, 'unique_dim'))
-
-        def run_test(dtype=torch.float, device=torch.device('cpu')):
-            x = torch.tensor([[[1., 1.],
-                               [0., 1.],
-                               [2., 1.],
-                               [0., 1.]],
-                              [[1., 1.],
-                               [0., 1.],
-                               [2., 1.],
-                               [0., 1.]]],
-                             dtype=dtype,
-                             device=device)
-            x_empty = torch.empty(5, 0, dtype=dtype, device=device)
-            x_ill_formed_empty = torch.empty(5, 0, 0, dtype=dtype, device=device)
-            x_ill_formed_empty_another = torch.empty(5, 0, 5, dtype=dtype, device=device)
-            expected_unique_dim0 = torch.tensor([[[1., 1.],
-                                                  [0., 1.],
-                                                  [2., 1.],
-                                                  [0., 1.]]],
-                                                dtype=dtype,
-                                                device=device)
-            expected_inverse_dim0 = torch.tensor([0, 0])
-            expected_counts_dim0 = torch.tensor([2])
-            expected_unique_dim1 = torch.tensor([[[0., 1.],
-                                                  [1., 1.],
-                                                  [2., 1.]],
-                                                 [[0., 1.],
-                                                  [1., 1.],
-                                                  [2., 1.]]],
-                                                dtype=dtype,
-                                                device=device)
-            expected_inverse_dim1 = torch.tensor([1, 0, 2, 0])
-            expected_counts_dim1 = torch.tensor([2, 1, 1])
-            expected_unique_dim2 = torch.tensor([[[1., 1.],
-                                                  [0., 1.],
-                                                  [2., 1.],
-                                                  [0., 1.]],
-                                                 [[1., 1.],
-                                                  [0., 1.],
-                                                  [2., 1.],
-                                                  [0., 1.]]],
-                                                dtype=dtype,
-                                                device=device)
-            expected_inverse_dim2 = torch.tensor([0, 1])
-            expected_counts_dim2 = torch.tensor([1, 1])
-            expected_unique_empty = torch.tensor([], dtype=dtype, device=device)
-            expected_inverse_empty = torch.tensor([], dtype=torch.long, device=device)
-            expected_counts_empty = torch.tensor([], dtype=torch.long, device=device)
-            # dim0
-            x_unique = torch.unique(x, dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-
-            x_unique, x_inverse = torch.unique(
-                x,
-                return_inverse=True,
-                dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-            self.assertEqual(expected_inverse_dim0, x_inverse)
-
-            x_unique, x_counts = torch.unique(
-                x,
-                return_inverse=False,
-                return_counts=True,
-                dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-            self.assertEqual(expected_counts_dim0, x_counts)
-
-            x_unique, x_inverse, x_counts = torch.unique(
-                x,
-                return_inverse=True,
-                return_counts=True,
-                dim=0)
-            self.assertEqual(expected_unique_dim0, x_unique)
-            self.assertEqual(expected_inverse_dim0, x_inverse)
-            self.assertEqual(expected_counts_dim0, x_counts)
-
-            # dim1
-            x_unique = torch.unique(x, dim=1)
-            self.assertEqual(expected_unique_dim1, x_unique)
-
-            x_unique, x_inverse = torch.unique(
-                x,
-                return_inverse=True,
-                dim=1)
-            self.assertEqual(expected_unique_dim1, x_unique)
-            self.assertEqual(expected_inverse_dim1, x_inverse)
-
-            x_unique, x_counts = torch.unique(
-                x,
-                return_inverse=False,
-                return_counts=True,
-                dim=1)
-            self.assertEqual(expected_unique_dim1, x_unique)
-            self.assertEqual(expected_counts_dim1, x_counts)
-
-            x_unique, x_inverse, x_counts = torch.unique(
-                x,
-                return_inverse=True,
-                return_counts=True,
-                dim=1)
-            self.assertEqual(expected_unique_dim1, x_unique)
-            self.assertEqual(expected_inverse_dim1, x_inverse)
-            self.assertEqual(expected_counts_dim1, x_counts)
-
-            # dim2
-            x_unique = torch.unique(x, dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-
-            x_unique, x_inverse = torch.unique(
-                x,
-                return_inverse=True,
-                dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-            self.assertEqual(expected_inverse_dim2, x_inverse)
-
-            x_unique, x_counts = torch.unique(
-                x,
-                return_inverse=False,
-                return_counts=True,
-                dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-            self.assertEqual(expected_counts_dim2, x_counts)
-
-            x_unique, x_inverse, x_counts = torch.unique(
-                x,
-                return_inverse=True,
-                return_counts=True,
-                dim=2)
-            self.assertEqual(expected_unique_dim2, x_unique)
-            self.assertEqual(expected_inverse_dim2, x_inverse)
-            self.assertEqual(expected_counts_dim2, x_counts)
-
-            # test empty tensor
-            x_unique, x_inverse, x_counts = torch.unique(
-                x_empty,
-                return_inverse=True,
-                return_counts=True,
-                dim=1)
-            self.assertEqual(expected_unique_empty, x_unique)
-            self.assertEqual(expected_inverse_empty, x_inverse)
-            self.assertEqual(expected_counts_empty, x_counts)
-
-            # test not a well formed tensor
-            # Checking for runtime error, as this is the expected behaviour
-            with self.assertRaises(RuntimeError):
-                torch.unique(
-                    x_ill_formed_empty,
-                    return_inverse=True,
-                    return_counts=True,
-                    dim=1)
-
-            # test along dim2
-            with self.assertRaises(RuntimeError):
-                torch.unique(
-                    x_ill_formed_empty_another,
-                    return_inverse=True,
-                    return_counts=True,
-                    dim=2)
-
-            # test consecutive version
-            y = torch.tensor(
-                [[0, 1],
-                 [0, 1],
-                 [0, 1],
-                 [1, 2],
-                 [1, 2],
-                 [3, 4],
-                 [0, 1],
-                 [0, 1],
-                 [3, 4],
-                 [1, 2]],
-                dtype=dtype,
-                device=device
-            )
-            expected_y_unique = torch.tensor(
-                [[0, 1],
-                 [1, 2],
-                 [3, 4],
-                 [0, 1],
-                 [3, 4],
-                 [1, 2]],
-                dtype=dtype,
-                device=device
-            )
-            expected_y_inverse = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3, 4, 5], dtype=dtype, device=device)
-            expected_y_counts = torch.tensor([3, 2, 1, 2, 1, 1], dtype=dtype, device=device)
-            y_unique, y_inverse, y_counts = torch.unique_consecutive(y, return_inverse=True, return_counts=True, dim=0)
-            self.assertEqual(expected_y_inverse, y_inverse)
-            self.assertEqual(expected_y_counts, y_counts)
-
-        run_test(torch.float)
-        run_test(torch.double)
-        run_test(torch.long)
-        run_test(torch.uint8)
-        if torch.cuda.is_available():
-            run_test(torch.float, torch.device('cuda'))
-            run_test(torch.double, torch.device('cuda'))
-            run_test(torch.long, torch.device('cuda'))
-            run_test(torch.uint8, torch.device('cuda'))
-
     def test_show_config(self):
         # We can't usefully test the output; just make sure this doesn't crash
         torch.__config__.show()
@@ -7521,30 +6603,6 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         b_expanded = b.expand(4, 3)
         self.assertEqual(torch._debug_has_internal_overlap(b_expanded), OVERLAP_YES)
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
-    def test_reverse_binary_ops_multiple_device(self):
-        self.assertEqual(2 + torch.tensor(3), 2 + torch.tensor(3).to("cuda:1"))    # __radd__
-        self.assertEqual(2 - torch.tensor(3), 2 - torch.tensor(3).to("cuda:1"))    # __rsub__
-        self.assertEqual(2 * torch.tensor(3), 2 * torch.tensor(3).to("cuda:1"))    # __rmul__
-        self.assertEqual(2 / torch.tensor(3), 2 / torch.tensor(3).to("cuda:1"))    # __rtruediv__
-        self.assertEqual(2 // torch.tensor(3), 2 // torch.tensor(3).to("cuda:1"))  # __rfloordiv__
-
-        self.assertEqual(
-            torch.tensor(2).to("cuda:1") + torch.tensor(3).to("cuda:0"),
-            torch.tensor(2) + torch.tensor(3))
-        self.assertEqual(
-            torch.tensor(2).to("cuda:1") - torch.tensor(3).to("cuda:0"),
-            torch.tensor(2) - torch.tensor(3))
-        self.assertEqual(
-            torch.tensor(2).to("cuda:1") * torch.tensor(3).to("cuda:0"),
-            torch.tensor(2) * torch.tensor(3))
-        self.assertEqual(
-            torch.tensor(2).to("cuda:1") / torch.tensor(3).to("cuda:0"),
-            torch.tensor(2) / torch.tensor(3))
-        self.assertEqual(
-            torch.tensor(2).to("cuda:1") // torch.tensor(3).to("cuda:0"),
-            torch.tensor(2) // torch.tensor(3))
-
     def test_allow_tensor_metadata_change(self):
         def do_test(t):
             with self.assertRaisesRegex(
@@ -7584,60 +6642,11 @@ tensor([[[1., 1., 1.,  ..., 1., 1., 1.],
         self.assertTrue(nhwc.is_contiguous(memory_format=torch.channels_last))
         self.assertEqual(nhwc, x)
 
-    def test_memory_format_preserved_after_permute(self):
-        x = torch.randn(10, 3, 32, 32)
-        nhwc = x.contiguous(memory_format=torch.channels_last)
-        y = nhwc.permute(0, 1, 3, 2).permute(0, 1, 3, 2)
-        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
-
     def test_memory_format_contiguous_returns_same_tensor_if_already_satisfies(self):
         x = torch.randn(10, 32, 32, 3).permute(0, 3, 1, 2)
         alias = x.contiguous(memory_format=torch.channels_last)
         alias.fill_(7)
         self.assertEqual(x, alias)
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_memory_format_permute_cuda(self):
-        x = torch.randn(10, 3, 32, 32).cuda()
-        nhwc = x.contiguous(memory_format=torch.channels_last)
-        y = nhwc.permute(0, 1, 3, 2).permute(0, 1, 3, 2)
-        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
-
-    @unittest.skipIf(not torch.cuda.is_available(), 'no CUDA')
-    def test_memory_format_empty_like_cuda(self):
-        x = torch.randn(10, 3, 32, 32).cuda()
-        self._test_memory_format_empty_like(x)
-
-    def test_memory_format_empty_like_cpu(self):
-        x = torch.randn(10, 3, 32, 32)
-        self._test_memory_format_empty_like(x)
-
-    def _test_memory_format_empty_like(self, x):
-        nhwc = x.contiguous(memory_format=torch.channels_last)
-
-        like = torch.empty_like(nhwc, memory_format=torch.preserve_format)
-        self.assertFalse(like.is_contiguous())
-        self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
-
-        like_x = torch.empty_like(x, memory_format=torch.preserve_format)
-        self.assertTrue(like_x.is_contiguous())
-        self.assertFalse(like_x.is_contiguous(memory_format=torch.channels_last))
-
-        like = torch.empty_like(x, memory_format=torch.channels_last)
-        self.assertFalse(like.is_contiguous())
-        self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
-
-        like = torch.empty_like(nhwc, memory_format=torch.contiguous_format)
-        self.assertTrue(like.is_contiguous())
-        self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
-
-        like = torch.empty_like(nhwc)
-        self.assertTrue(like.is_contiguous())
-        self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
-
-        sparse = x.to_sparse()
-        with self.assertRaises(RuntimeError):
-            z = torch.empty_like(sparse, memory_format=torch.preserve_format)
 
     def test_memory_format_empty(self):
         with self.assertRaises(RuntimeError):
@@ -12992,6 +12001,920 @@ class TestTorchDeviceType(TestCase, GenericDeviceTypeHelpers):
                         mean2 = x.mean(dim=dim, keepdim=keepdim)
                         self.assertEqual(var1, var2)
                         self.assertEqual(mean1, mean2)
+
+    # passes on ROCm w/ python 2.7, fails w/ python 3.6
+    @skipCUDAIfRocm
+    def test_stft(self, device):
+        if not TEST_LIBROSA:
+            raise unittest.SkipTest('librosa not found')
+
+        def librosa_stft(x, n_fft, hop_length, win_length, window, center):
+            if window is None:
+                window = np.ones(n_fft if win_length is None else win_length)
+            else:
+                window = window.cpu().numpy()
+            input_1d = x.dim() == 1
+            if input_1d:
+                x = x.view(1, -1)
+            result = []
+            for xi in x:
+                ri = librosa.stft(xi.cpu().numpy(), n_fft, hop_length, win_length, window, center=center)
+                result.append(torch.from_numpy(np.stack([ri.real, ri.imag], -1)))
+            result = torch.stack(result, 0)
+            if input_1d:
+                result = result[0]
+            return result
+
+        def _test(sizes, n_fft, hop_length=None, win_length=None, win_sizes=None,
+                  center=True, expected_error=None):
+            x = torch.randn(*sizes, device=device)
+            if win_sizes is not None:
+                window = torch.randn(*win_sizes, device=device)
+            else:
+                window = None
+            if expected_error is None:
+                result = x.stft(n_fft, hop_length, win_length, window, center=center)
+                ref_result = librosa_stft(x, n_fft, hop_length, win_length, window, center)
+                self.assertEqual(result, ref_result, 7e-6, 'stft comparison against librosa')
+            else:
+                self.assertRaises(expected_error,
+                                  lambda: x.stft(n_fft, hop_length, win_length, window, center=center))
+
+        for center in [True, False]:
+            _test((10,), 7, center=center)
+            _test((10, 4000), 1024, center=center)
+
+            _test((10,), 7, 2, center=center)
+            _test((10, 4000), 1024, 512, center=center)
+
+            _test((10,), 7, 2, win_sizes=(7,), center=center)
+            _test((10, 4000), 1024, 512, win_sizes=(1024,), center=center)
+
+            # spectral oversample
+            _test((10,), 7, 2, win_length=5, center=center)
+            _test((10, 4000), 1024, 512, win_length=100, center=center)
+
+        _test((10, 4, 2), 1, 1, expected_error=RuntimeError)
+        _test((10,), 11, 1, center=False, expected_error=RuntimeError)
+        _test((10,), -1, 1, expected_error=RuntimeError)
+        _test((10,), 3, win_length=5, expected_error=RuntimeError)
+        _test((10,), 5, 4, win_sizes=(11,), expected_error=RuntimeError)
+        _test((10,), 5, 4, win_sizes=(1, 1), expected_error=RuntimeError)
+
+    @skipCUDAIfRocm
+    def test_blas_empty(self, device):
+
+        def fn(torchfn, *args):
+            return torchfn(*tuple(torch.randn(shape, device=device) if isinstance(shape, tuple) else shape
+                                  for shape in args))
+
+        # mm, addmm
+        self.assertEqual((0, 0), fn(torch.mm, (0, 0), (0, 0)).shape)
+        self.assertEqual((0, 5), fn(torch.mm, (0, 0), (0, 5)).shape)
+        self.assertEqual((5, 0), fn(torch.mm, (5, 0), (0, 0)).shape)
+        self.assertEqual((3, 0), fn(torch.mm, (3, 2), (2, 0)).shape)
+        self.assertEqual(torch.zeros((5, 6), device=device), fn(torch.mm, (5, 0), (0, 6)))
+
+        self.assertEqual((0, 0), fn(torch.addmm, (0, 0), (0, 0), (0, 0)).shape)
+        self.assertEqual((5, 6), fn(torch.addmm, (5, 6), (5, 0), (0, 6)).shape)
+
+        # mv, addmv
+        self.assertEqual((0,), fn(torch.mv, (0, 0), (0,)).shape)
+        self.assertEqual((0,), fn(torch.mv, (0, 2), (2,)).shape)
+        self.assertEqual(torch.zeros((3,), device=device), fn(torch.mv, (3, 0), (0,)))
+
+        self.assertEqual((0,), fn(torch.addmv, (0,), (0, 0), (0,)).shape)
+        self.assertEqual((3,), fn(torch.addmv, (3,), (3, 0), (0,)).shape)
+
+        # ger, addr
+        self.assertEqual((0, 0), fn(torch.ger, (0,), (0,)).shape)
+        self.assertEqual((5, 0), fn(torch.ger, (5,), (0,)).shape)
+        self.assertEqual((0, 4), fn(torch.ger, (0,), (4,)).shape)
+
+        self.assertEqual((0, 0), fn(torch.addr, (0, 0), (0,), (0,)).shape)
+        self.assertEqual((5, 0), fn(torch.addr, (5, 0), (5,), (0,)).shape)
+        self.assertEqual((0, 4), fn(torch.addr, (0, 4), (0,), (4,)).shape)
+
+        # bmm, baddbmm
+        self.assertEqual((0, 0, 0), fn(torch.bmm, (0, 0, 0), (0, 0, 0)).shape)
+        self.assertEqual((3, 0, 5), fn(torch.bmm, (3, 0, 0), (3, 0, 5)).shape)
+        self.assertEqual((0, 5, 6), fn(torch.bmm, (0, 5, 0), (0, 0, 6)).shape)
+        self.assertEqual(torch.zeros((3, 5, 6), device=device), fn(torch.bmm, (3, 5, 0), (3, 0, 6)))
+
+        self.assertEqual((0, 0, 0), fn(torch.baddbmm, (0, 0, 0), (0, 0, 0), (0, 0, 0)).shape)
+        self.assertEqual((3, 0, 5), fn(torch.baddbmm, (3, 0, 5), (3, 0, 0), (3, 0, 5)).shape)
+        self.assertEqual((0, 5, 6), fn(torch.baddbmm, (0, 5, 6), (0, 5, 0), (0, 0, 6)).shape)
+        self.assertEqual((3, 5, 6), fn(torch.baddbmm, (3, 5, 6), (3, 5, 0), (3, 0, 6)).shape)
+
+        # addbmm
+        self.assertEqual((0, 0), fn(torch.addbmm, (0, 0), (0, 0, 0), (0, 0, 0)).shape)
+        self.assertEqual((0, 5), fn(torch.addbmm, (0, 5), (3, 0, 0), (3, 0, 5)).shape)
+        self.assertEqual((5, 6), fn(torch.addbmm, (5, 6), (0, 5, 0), (0, 0, 6)).shape)
+
+        # matmul
+        self.assertEqual(torch.tensor(0., device=device), fn(torch.matmul, (0,), (0,)))
+        self.assertEqual((0, 0), fn(torch.matmul, (0, 0), (0, 0)).shape)
+        self.assertEqual((0, 0, 0), fn(torch.matmul, (0, 0, 0), (0, 0, 0)).shape)
+        self.assertEqual((5, 0, 0), fn(torch.matmul, (5, 0, 0), (5, 0, 0)).shape)
+        self.assertEqual(torch.zeros((5, 3, 4), device=device), fn(torch.matmul, (5, 3, 0), (5, 0, 4)))
+
+        # dot
+        self.assertEqual(torch.tensor(0., device=device), fn(torch.dot, (0,), (0,)))
+
+        if torch._C.has_lapack:
+            # lu
+            A_LU, pivots = fn(torch.lu, (0, 5, 5))
+            self.assertEqual([(0, 5, 5), (0, 5)], [A_LU.shape, pivots.shape])
+            A_LU, pivots = fn(torch.lu, (0, 0, 0))
+            self.assertEqual([(0, 0, 0), (0, 0)], [A_LU.shape, pivots.shape])
+            A_LU, pivots = fn(torch.lu, (2, 0, 0))
+            self.assertEqual([(2, 0, 0), (2, 0)], [A_LU.shape, pivots.shape])
+
+    @skipCUDAIfRocm
+    def test_blas_alpha_beta_empty(self, device):
+        # ensure beta is respected
+        value = 11
+        input = torch.full((2,), value, device=device)
+        mat = torch.ones((2, 0), device=device)
+        vec = torch.ones((0,), device=device)
+        out = torch.randn((2,), device=device)
+        alpha = 6
+        beta = 3
+        self.assertEqual(torch.full((2,), beta * value, device=device),
+                         torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta))
+        self.assertEqual(torch.full((2,), beta * value, device=device),
+                         torch.addmv(input=input, mat=mat, vec=vec, alpha=alpha, beta=beta, out=out))
+
+        # torch.addmm
+        input = torch.full((2, 3), value, device=device)
+        mat2 = torch.ones((0, 3), device=device)
+        out = torch.randn((2, 3), device=device)
+        self.assertEqual(torch.full((2, 3), beta * value, device=device),
+                         torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta))
+        self.assertEqual(torch.full((2, 3), beta * value, device=device),
+                         torch.addmm(input=input, mat1=mat, mat2=mat2, alpha=alpha, beta=beta, out=out))
+
+    @skipCUDAIfRocm
+    def test_unique_dim(self, device):
+        self.assertFalse(hasattr(torch, 'unique_dim'))
+
+        def run_test(device, dtype):
+            x = torch.tensor([[[1., 1.],
+                               [0., 1.],
+                               [2., 1.],
+                               [0., 1.]],
+                              [[1., 1.],
+                               [0., 1.],
+                               [2., 1.],
+                               [0., 1.]]],
+                             dtype=dtype,
+                             device=device)
+            x_empty = torch.empty(5, 0, dtype=dtype, device=device)
+            x_ill_formed_empty = torch.empty(5, 0, 0, dtype=dtype, device=device)
+            x_ill_formed_empty_another = torch.empty(5, 0, 5, dtype=dtype, device=device)
+            expected_unique_dim0 = torch.tensor([[[1., 1.],
+                                                  [0., 1.],
+                                                  [2., 1.],
+                                                  [0., 1.]]],
+                                                dtype=dtype,
+                                                device=device)
+            expected_inverse_dim0 = torch.tensor([0, 0])
+            expected_counts_dim0 = torch.tensor([2])
+            expected_unique_dim1 = torch.tensor([[[0., 1.],
+                                                  [1., 1.],
+                                                  [2., 1.]],
+                                                 [[0., 1.],
+                                                  [1., 1.],
+                                                  [2., 1.]]],
+                                                dtype=dtype,
+                                                device=device)
+            expected_inverse_dim1 = torch.tensor([1, 0, 2, 0])
+            expected_counts_dim1 = torch.tensor([2, 1, 1])
+            expected_unique_dim2 = torch.tensor([[[1., 1.],
+                                                  [0., 1.],
+                                                  [2., 1.],
+                                                  [0., 1.]],
+                                                 [[1., 1.],
+                                                  [0., 1.],
+                                                  [2., 1.],
+                                                  [0., 1.]]],
+                                                dtype=dtype,
+                                                device=device)
+            expected_inverse_dim2 = torch.tensor([0, 1])
+            expected_counts_dim2 = torch.tensor([1, 1])
+            expected_unique_empty = torch.tensor([], dtype=dtype, device=device)
+            expected_inverse_empty = torch.tensor([], dtype=torch.long, device=device)
+            expected_counts_empty = torch.tensor([], dtype=torch.long, device=device)
+            # dim0
+            x_unique = torch.unique(x, dim=0)
+            self.assertEqual(expected_unique_dim0, x_unique)
+
+            x_unique, x_inverse = torch.unique(
+                x,
+                return_inverse=True,
+                dim=0)
+            self.assertEqual(expected_unique_dim0, x_unique)
+            self.assertEqual(expected_inverse_dim0, x_inverse)
+
+            x_unique, x_counts = torch.unique(
+                x,
+                return_inverse=False,
+                return_counts=True,
+                dim=0)
+            self.assertEqual(expected_unique_dim0, x_unique)
+            self.assertEqual(expected_counts_dim0, x_counts)
+
+            x_unique, x_inverse, x_counts = torch.unique(
+                x,
+                return_inverse=True,
+                return_counts=True,
+                dim=0)
+            self.assertEqual(expected_unique_dim0, x_unique)
+            self.assertEqual(expected_inverse_dim0, x_inverse)
+            self.assertEqual(expected_counts_dim0, x_counts)
+
+            # dim1
+            x_unique = torch.unique(x, dim=1)
+            self.assertEqual(expected_unique_dim1, x_unique)
+
+            x_unique, x_inverse = torch.unique(
+                x,
+                return_inverse=True,
+                dim=1)
+            self.assertEqual(expected_unique_dim1, x_unique)
+            self.assertEqual(expected_inverse_dim1, x_inverse)
+
+            x_unique, x_counts = torch.unique(
+                x,
+                return_inverse=False,
+                return_counts=True,
+                dim=1)
+            self.assertEqual(expected_unique_dim1, x_unique)
+            self.assertEqual(expected_counts_dim1, x_counts)
+
+            x_unique, x_inverse, x_counts = torch.unique(
+                x,
+                return_inverse=True,
+                return_counts=True,
+                dim=1)
+            self.assertEqual(expected_unique_dim1, x_unique)
+            self.assertEqual(expected_inverse_dim1, x_inverse)
+            self.assertEqual(expected_counts_dim1, x_counts)
+
+            # dim2
+            x_unique = torch.unique(x, dim=2)
+            self.assertEqual(expected_unique_dim2, x_unique)
+
+            x_unique, x_inverse = torch.unique(
+                x,
+                return_inverse=True,
+                dim=2)
+            self.assertEqual(expected_unique_dim2, x_unique)
+            self.assertEqual(expected_inverse_dim2, x_inverse)
+
+            x_unique, x_counts = torch.unique(
+                x,
+                return_inverse=False,
+                return_counts=True,
+                dim=2)
+            self.assertEqual(expected_unique_dim2, x_unique)
+            self.assertEqual(expected_counts_dim2, x_counts)
+
+            x_unique, x_inverse, x_counts = torch.unique(
+                x,
+                return_inverse=True,
+                return_counts=True,
+                dim=2)
+            self.assertEqual(expected_unique_dim2, x_unique)
+            self.assertEqual(expected_inverse_dim2, x_inverse)
+            self.assertEqual(expected_counts_dim2, x_counts)
+
+            # test empty tensor
+            x_unique, x_inverse, x_counts = torch.unique(
+                x_empty,
+                return_inverse=True,
+                return_counts=True,
+                dim=1)
+            self.assertEqual(expected_unique_empty, x_unique)
+            self.assertEqual(expected_inverse_empty, x_inverse)
+            self.assertEqual(expected_counts_empty, x_counts)
+
+            # test not a well formed tensor
+            # Checking for runtime error, as this is the expected behaviour
+            with self.assertRaises(RuntimeError):
+                torch.unique(
+                    x_ill_formed_empty,
+                    return_inverse=True,
+                    return_counts=True,
+                    dim=1)
+
+            # test along dim2
+            with self.assertRaises(RuntimeError):
+                torch.unique(
+                    x_ill_formed_empty_another,
+                    return_inverse=True,
+                    return_counts=True,
+                    dim=2)
+
+            # test consecutive version
+            y = torch.tensor(
+                [[0, 1],
+                 [0, 1],
+                 [0, 1],
+                 [1, 2],
+                 [1, 2],
+                 [3, 4],
+                 [0, 1],
+                 [0, 1],
+                 [3, 4],
+                 [1, 2]],
+                dtype=dtype,
+                device=device
+            )
+            expected_y_unique = torch.tensor(
+                [[0, 1],
+                 [1, 2],
+                 [3, 4],
+                 [0, 1],
+                 [3, 4],
+                 [1, 2]],
+                dtype=dtype,
+                device=device
+            )
+            expected_y_inverse = torch.tensor([0, 0, 0, 1, 1, 2, 3, 3, 4, 5], dtype=dtype, device=device)
+            expected_y_counts = torch.tensor([3, 2, 1, 2, 1, 1], dtype=dtype, device=device)
+            y_unique, y_inverse, y_counts = torch.unique_consecutive(y, return_inverse=True, return_counts=True, dim=0)
+            self.assertEqual(expected_y_inverse, y_inverse)
+            self.assertEqual(expected_y_counts, y_counts)
+
+        run_test(device, torch.float)
+        run_test(device, torch.double)
+        run_test(device, torch.long)
+        run_test(device, torch.uint8)
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
+    @onlyCUDA
+    def test_reverse_binary_ops_multiple_device(self, device):
+        self.assertEqual(2 + torch.tensor(3), 2 + torch.tensor(3).to("cuda:1"))    # __radd__
+        self.assertEqual(2 - torch.tensor(3), 2 - torch.tensor(3).to("cuda:1"))    # __rsub__
+        self.assertEqual(2 * torch.tensor(3), 2 * torch.tensor(3).to("cuda:1"))    # __rmul__
+        self.assertEqual(2 / torch.tensor(3), 2 / torch.tensor(3).to("cuda:1"))    # __rtruediv__
+        self.assertEqual(2 // torch.tensor(3), 2 // torch.tensor(3).to("cuda:1"))  # __rfloordiv__
+
+        self.assertEqual(
+            torch.tensor(2).to("cuda:1") + torch.tensor(3).to("cuda:0"),
+            torch.tensor(2) + torch.tensor(3))
+        self.assertEqual(
+            torch.tensor(2).to("cuda:1") - torch.tensor(3).to("cuda:0"),
+            torch.tensor(2) - torch.tensor(3))
+        self.assertEqual(
+            torch.tensor(2).to("cuda:1") * torch.tensor(3).to("cuda:0"),
+            torch.tensor(2) * torch.tensor(3))
+        self.assertEqual(
+            torch.tensor(2).to("cuda:1") / torch.tensor(3).to("cuda:0"),
+            torch.tensor(2) / torch.tensor(3))
+        self.assertEqual(
+            torch.tensor(2).to("cuda:1") // torch.tensor(3).to("cuda:0"),
+            torch.tensor(2) // torch.tensor(3))
+
+    @onlyCUDA
+    def test_ceil_out_mismatch(self, device):
+        a = torch.randn(1)
+        b = torch.randn(1, device=device)
+        self.assertRaises(RuntimeError, lambda: torch.ceil(a, out=b))
+
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_has_storage_numpy(self, device):
+        for dtype in [np.float32, np.float64, np.int64,
+                      np.int32, np.int16, np.uint8]:
+            arr = np.array([1], dtype=dtype)
+            self.assertIsNotNone(torch.tensor(arr, device=device, dtype=torch.float32).storage())
+            self.assertIsNotNone(torch.tensor(arr, device=device, dtype=torch.double).storage())
+            self.assertIsNotNone(torch.tensor(arr, device=device, dtype=torch.int).storage())
+            self.assertIsNotNone(torch.tensor(arr, device=device, dtype=torch.long).storage())
+            self.assertIsNotNone(torch.tensor(arr, device=device, dtype=torch.uint8).storage())
+
+    def test_all_any_empty(self, device):
+        x = torch.ByteTensor().to(device)
+        self.assertTrue(x.all())
+        self.assertFalse(x.any())
+
+        x = torch.BoolTensor().to(device)
+        self.assertTrue(x.all())
+        self.assertFalse(x.any())
+
+    @onlyCUDA
+    def test_multinomial_device_constrain(self, device):
+        x = torch.empty(0, device="cpu")
+        y = torch.empty(0, device=device)
+        self.assertRaisesRegex(
+            RuntimeError, "multinomial arguments must have the same device",
+            lambda: torch.multinomial(x, 2, out=y))
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
+    @onlyCUDA
+    def test_multinomial_gpu_device_constrain(self, device):
+        x = torch.empty(0, device="cuda:0")
+        y = torch.empty(0, device="cuda:1")
+        self.assertRaisesRegex(
+            RuntimeError, "multinomial arguments must have the same device",
+            lambda: torch.multinomial(x, 2, out=y))
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
+    @onlyCUDA
+    def test_zeros_like_multiple_device(self, device):
+        expected = torch.zeros(100, 100, device=device)
+        x = torch.randn(100, 100, device='cuda:1', dtype=torch.float32)
+        output = torch.zeros_like(x)
+        self.assertEqual(output, expected)
+
+    @onlyCUDA
+    def test_ones_like(self, device):
+        expected = torch.ones(100, 100, device=device)
+
+        res1 = torch.ones_like(expected)
+        self.assertEqual(res1, expected)
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, 'only one GPU detected')
+    @onlyCUDA
+    def test_ones_like_multiple_device(self, device):
+        expected = torch.ones(100, 100, device=device)
+        x = torch.randn(100, 100, device='cuda:1', dtype=torch.float32)
+        output = torch.ones_like(x)
+        self.assertEqual(output, expected)
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, 'fewer than 2 GPUs detected')
+    @onlyCUDA
+    def test_device_guard(self, device):
+        # verify that all operators with `device_guard: False` behave properly with multiple devices.
+        # TODO: if we had operator introspection we could figure out this set of operators automatically...
+        current_device = torch.cuda.current_device()
+        device = torch.device('cuda:1') if current_device == 0 else torch.device('cuda:0')
+        x = torch.randn((1, 2, 3), device=device)
+        y = torch.zeros((1, 3, 2), device=device)
+        scalar = torch.tensor(5, device=device)
+
+        # property ops
+        torch.cudnn_is_acceptable(x)
+        x.is_distributed()
+        x.is_floating_point()
+        x.is_complex()
+        x.is_same_size(y)
+        x.is_signed()
+        x.size(0)
+        x.stride(0)
+        x.numel()
+        x.is_set_to(y)
+        x.data_ptr()
+        scalar.is_nonzero()
+
+        # sparse property ops
+        y[0][1] = 5
+        y_sparse = y.to_sparse()
+        y_sparse.sparse_dim()
+        y_sparse._dimI()
+        y_sparse.dense_dim()
+        y_sparse._dimV()
+        y_sparse._nnz()
+        y_sparse.is_coalesced()
+        y_sparse._indices()
+        y_sparse._values()
+        y_sparse.indices()
+        y_sparse.values()
+
+        # in-place ops
+        def inplace():
+            return torch.randn((1, 2, 3), device=device)
+        inplace().as_strided_(y.size(), y.stride())
+        inplace().resize_(y.size())
+        inplace().squeeze_()
+        inplace().squeeze_(0)
+        inplace().unsqueeze_(2)
+        inplace().transpose_(1, 2)
+        inplace().squeeze_().t_()
+        inplace().set_(x.storage())
+        inplace().set_(x.storage(), x.storage_offset(), x.size(), x.stride())
+        inplace().set_(x)
+        inplace().set_()
+        y_sparse._coalesced_(True)
+
+        # shape modification
+        x.as_strided(y.size(), y.stride())
+        x.expand((5, 2, 3))
+        x.expand_as(x)
+        x.sum_to_size((1,))
+        torch.broadcast_tensors(x , x)
+        x.reshape((1, 3, 2))
+        x.reshape_as(y)
+        x.squeeze()
+        x.squeeze(0)
+        x.squeeze().t()
+        x.transpose(1, 2)
+        x.unsqueeze(2)
+        x.view((1, 3, 2))
+        x.view_as(y)
+
+        # chunk, split, etc.
+        x.chunk(2, dim=1)
+        x.split(1, dim=2)
+        x.split_with_sizes([1, 2], dim=2)
+        x.unfold(dimension=2, size=1, step=1)
+
+        x.narrow(1, 1, 1)
+        x.select(1, 1)
+        torch.isnan(x)
+
+        torch.empty((1, 3, 2), out=y)
+        torch.empty_like(x)
+        torch.empty_like(x, dtype=torch.int64)
+
+        # to
+        x.to(x)
+        x.to(y)
+        x.to(x, copy=True)
+
+    @onlyCUDA
+    def test_tensor_factory_cuda_type_inference(self, device):
+        saved_type = torch.Tensor().type()
+        torch.set_default_tensor_type(torch.cuda.DoubleTensor)
+        torch.set_default_dtype(torch.float32)
+        self.assertIs(torch.float32, torch.tensor(0.).dtype)
+        self.assertEqual(torch.device('cuda:0'), torch.tensor(0.).device)
+        torch.set_default_dtype(torch.float64)
+        self.assertIs(torch.float64, torch.tensor(0.).dtype)
+        self.assertEqual(torch.device('cuda:0'), torch.tensor(0.).device)
+        torch.set_default_tensor_type(saved_type)
+
+    @onlyCUDA
+    def test_tensor_factory_cuda_type(self, device):
+        saved_type = torch.Tensor().type()
+        torch.set_default_tensor_type(torch.cuda.FloatTensor)
+        x = torch.zeros((5, 5))
+        self.assertIs(torch.float32, x.dtype)
+        self.assertTrue(x.is_cuda)
+        torch.set_default_tensor_type(torch.cuda.DoubleTensor)
+        x = torch.zeros((5, 5))
+        self.assertIs(torch.float64, x.dtype)
+        self.assertTrue(x.is_cuda)
+        torch.set_default_tensor_type(saved_type)
+
+    @onlyCPU
+    def test_renorm_ps(self, device):
+        # full reduction
+        x = torch.randn(5, 5)
+        xn = x.numpy()
+        for p in [1, 2, 3, 4, inf]:
+            res = x.renorm(p, 1, 1)
+            expected = x / x.norm(p, 0, keepdim=True).clamp(min=1)
+            self.assertEqual(res.numpy(), expected.numpy(), "renorm failed for {}-norm".format(p))
+
+    @onlyCUDA
+    def test_topk_noncontiguous_gpu(self, device):
+        t = torch.randn(20, device=device)[::2]
+        top1, idx1 = t.topk(5)
+        top2, idx2 = t.contiguous().topk(5)
+        self.assertEqual(top1, top2)
+        self.assertEqual(idx1, idx2)
+
+    def test_is_signed(self, device):
+        self.assertEqual(torch.IntTensor(5).to(device).is_signed(), True)
+        self.assertEqual(torch.ByteTensor(5).to(device).is_signed(), False)
+        self.assertEqual(torch.CharTensor(5).to(device).is_signed(), True)
+        self.assertEqual(torch.FloatTensor(5).to(device).is_signed(), True)
+        self.assertEqual(torch.HalfTensor(10).to(device).is_signed(), True)
+
+    @onlyCUDA
+    def test_solve_methods_arg_device(self, device):
+        for b_device, A_device in product(['cpu', 'cuda'], repeat=2):
+            if b_device == A_device:
+                continue
+
+            b = torch.randn(3, 1, device=b_device)
+            A = torch.randn(3, 3, device=A_device)
+            err_str = "Expected b and A to be on the same device"
+            with self.assertRaisesRegex(RuntimeError, err_str):
+                torch.solve(b, A)
+
+            with self.assertRaisesRegex(RuntimeError, err_str):
+                torch.cholesky_solve(b, A)
+
+            with self.assertRaisesRegex(RuntimeError, err_str):
+                torch.triangular_solve(b, A)
+
+            # b and A have to be modified to match accepted inputs sizes for lu_solve
+            b = b.unsqueeze(0)
+            A = A.unsqueeze(0)
+            with self.assertRaisesRegex(RuntimeError, err_str):
+                torch.lu_solve(b, A, torch.rand(A.shape[:-1], device=A_device).int())
+
+            # This checks if a suitable error message is thrown
+            # when LU output and pivots are on the same device
+            with self.assertRaisesRegex(RuntimeError,
+                                        "Expected LU_pivots and LU_data to be on the same device"):
+                torch.lu_solve(b, A, torch.rand(A.shape[:-1], device=b_device).int())
+
+    # Note - reports a leak of 512 bytes on CUDA device 1
+    @unittest.skipIf(torch.cuda.device_count() < 2, 'less than 2 GPUs detected')
+    @skipCUDAMemoryLeakCheckIf(True)
+    @onlyCUDA
+    def test_tensor_set_errors_multigpu(self, device):
+        f_cuda0 = torch.randn((2, 3), dtype=torch.float32, device='cuda:0')
+        f_cuda1 = torch.randn((2, 3), dtype=torch.float32, device='cuda:1')
+
+        self.assertRaises(RuntimeError, lambda: f_cuda0.set_(f_cuda1.storage()))
+        self.assertRaises(RuntimeError,
+                          lambda: f_cuda0.set_(f_cuda1.storage(), 0, f_cuda1.size(), f_cuda1.stride()))
+        self.assertRaises(RuntimeError, lambda: f_cuda0.set_(f_cuda1))
+
+    @onlyCUDA
+    def test_half_tensor(self, device):
+        x = torch.randn(5, 5).half()
+        self.assertEqual(x.to(device), x)
+
+        xc = x.to(device)
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(xc, f)
+            f.seek(0)
+            xc2 = torch.load(f)
+            self.assertIsInstance(xc2, type(xc))
+            self.assertEqual(xc.float(), xc2.float())
+
+    @onlyCUDA
+    def test_serialization(self, device):
+        def _test_serialization(filecontext_lambda):
+            device_count = torch.cuda.device_count()
+            t0 = torch.cuda.FloatTensor(5).fill_(1)
+            torch.cuda.set_device(device_count - 1)
+            tn = torch.cuda.FloatTensor(3).fill_(2)
+            torch.cuda.set_device(0)
+            b = (t0, tn)
+            with filecontext_lambda() as f:
+                torch.save(b, f)
+                f.seek(0)
+                c = torch.load(f)
+                self.assertEqual(b, c, 0)
+                u0, un = c
+                self.assertEqual(u0.get_device(), 0)
+                self.assertEqual(un.get_device(), device_count - 1)
+
+        _test_serialization(tempfile.NamedTemporaryFile)
+        _test_serialization(BytesIOContext)
+
+    def test_memory_format_preserved_after_permute(self, device):
+        x = torch.randn(10, 3, 32, 32, device=device)
+        nhwc = x.contiguous(memory_format=torch.channels_last)
+        y = nhwc.permute(0, 1, 3, 2).permute(0, 1, 3, 2)
+        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
+
+    def test_memory_format_empty_like(self, device):
+        x = torch.randn(10, 3, 32, 32, device=device)
+        nhwc = x.contiguous(memory_format=torch.channels_last)
+
+        like = torch.empty_like(nhwc, memory_format=torch.preserve_format)
+        self.assertFalse(like.is_contiguous())
+        self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
+
+        like_x = torch.empty_like(x, memory_format=torch.preserve_format)
+        self.assertTrue(like_x.is_contiguous())
+        self.assertFalse(like_x.is_contiguous(memory_format=torch.channels_last))
+
+        like = torch.empty_like(x, memory_format=torch.channels_last)
+        self.assertFalse(like.is_contiguous())
+        self.assertTrue(like.is_contiguous(memory_format=torch.channels_last))
+
+        like = torch.empty_like(nhwc, memory_format=torch.contiguous_format)
+        self.assertTrue(like.is_contiguous())
+        self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
+
+        like = torch.empty_like(nhwc)
+        self.assertTrue(like.is_contiguous())
+        self.assertFalse(like.is_contiguous(memory_format=torch.channels_last))
+
+        sparse = x.to_sparse()
+        with self.assertRaises(RuntimeError):
+            z = torch.empty_like(sparse, memory_format=torch.preserve_format)
+
+    def test_unique(self, device):
+        x = torch.tensor([1, 2, 3, 2, 8, 5, 2, 3], device=device)
+        expected_unique = torch.tensor([1, 2, 3, 5, 8], device=device)
+        expected_inverse = torch.tensor([0, 1, 2, 1, 4, 3, 1, 2], device=device)
+        expected_counts = torch.tensor([1, 3, 2, 1, 1], device=device)
+
+        x_unique = torch.unique(x)
+        self.assertEqual(
+            expected_unique.tolist(), sorted(x_unique.tolist()))
+
+        x_unique, x_inverse = x.unique(return_inverse=True)
+        self.assertEqual(
+            expected_unique.tolist(), sorted(x_unique.tolist()))
+        self.assertEqual(expected_inverse.numel(), x_inverse.numel())
+
+        x_unique = x.unique(sorted=True)
+        self.assertEqual(expected_unique, x_unique)
+
+        x_unique, x_counts = torch.unique(x, sorted=True, return_counts=True)
+        self.assertEqual(expected_counts, x_counts)
+
+        x_unique, x_inverse = torch.unique(
+            x, sorted=True, return_inverse=True)
+        self.assertEqual(expected_unique, x_unique)
+        self.assertEqual(expected_inverse, x_inverse)
+
+        x_unique, x_inverse, x_counts = torch.unique(
+            x, sorted=True, return_inverse=True, return_counts=True)
+        self.assertEqual(expected_unique, x_unique)
+        self.assertEqual(expected_inverse, x_inverse)
+        self.assertEqual(expected_counts, x_counts)
+
+        # Tests per-element unique on a higher rank tensor.
+        y = x.view(2, 2, 2)
+        y_unique, y_inverse = y.unique(sorted=True, return_inverse=True)
+        self.assertEqual(expected_unique, y_unique)
+        self.assertEqual(expected_inverse.view(y.size()), y_inverse)
+
+        y_unique, y_inverse, y_counts = torch.unique(
+            y, sorted=True, return_inverse=True, return_counts=True)
+        self.assertEqual(expected_unique, y_unique)
+        self.assertEqual(expected_inverse.view(y.size()), y_inverse)
+        self.assertEqual(expected_counts, y_counts)
+
+        # Tests unique on other types.
+        int_unique, int_inverse, int_counts = torch.unique(
+            torch.tensor([2, 1, 2], dtype=torch.int, device=device),
+            sorted=True,
+            return_inverse=True,
+            return_counts=True
+        )
+        self.assertEqual(torch.tensor([1, 2], dtype=torch.int, device=device), int_unique)
+        self.assertEqual(torch.tensor([1, 0, 1], dtype=torch.long, device=device), int_inverse)
+        self.assertEqual(torch.tensor([1, 2], dtype=torch.long, device=device), int_counts)
+
+        double_unique, double_inverse, double_counts = torch.unique(
+            torch.tensor([2., 1.5, 2.1, 2.], dtype=torch.double, device=device),
+            sorted=True,
+            return_inverse=True,
+            return_counts=True
+        )
+        self.assertEqual(torch.tensor([1.5, 2., 2.1], dtype=torch.double, device=device), double_unique)
+        self.assertEqual(torch.tensor([1, 0, 2, 1], dtype=torch.long, device=device), double_inverse)
+        self.assertEqual(torch.tensor([1, 2, 1], dtype=torch.long, device=device), double_counts)
+
+        byte_unique, byte_inverse, byte_counts = torch.unique(
+            torch.tensor([133, 7, 7, 7, 42, 128], dtype=torch.uint8, device=device),
+            sorted=True,
+            return_inverse=True,
+            return_counts=True
+        )
+        self.assertEqual(torch.tensor([7, 42, 128, 133], dtype=torch.uint8, device=device), byte_unique)
+        self.assertEqual(torch.tensor([3, 0, 0, 0, 1, 2], dtype=torch.long, device=device), byte_inverse)
+        self.assertEqual(torch.tensor([3, 1, 1, 1], dtype=torch.long, device=device), byte_counts)
+
+        # test consecutive version
+        z = torch.tensor([1, 2, 2, 2, 5, 5, 2, 2, 3], device=device)
+        expected_z_unique = torch.tensor([1, 2, 5, 2, 3], device=device)
+        expected_z_inverse = torch.tensor([0, 1, 1, 1, 2, 2, 3, 3, 4], device=device)
+        expected_z_counts = torch.tensor([1, 3, 2, 2, 1], device=device)
+
+        z_unique = torch.unique_consecutive(z)
+        self.assertEqual(z_unique, expected_z_unique)
+
+        z_unique, z_inverse = torch.unique_consecutive(z, return_inverse=True)
+        self.assertEqual(z_unique, expected_z_unique)
+        self.assertEqual(z_inverse, expected_z_inverse)
+
+        z_unique, z_counts = torch.unique_consecutive(z, return_counts=True)
+        self.assertEqual(z_unique, expected_z_unique)
+        self.assertEqual(z_counts, expected_z_counts)
+
+        z_unique, z_inverse, z_counts = torch.unique_consecutive(z, return_inverse=True, return_counts=True)
+        self.assertEqual(z_unique, expected_z_unique)
+        self.assertEqual(z_inverse, expected_z_inverse)
+        self.assertEqual(z_counts, expected_z_counts)
+
+    @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
+    def test_ctor_with_numpy_array(self, device):
+        correct_dtypes = [
+            np.double,
+            np.float,
+            np.float16,
+            np.int64,
+            np.int32,
+            np.int16,
+            np.int8,
+            np.uint8,
+            np.bool,
+        ]
+
+        incorrect_byteorder = '>' if sys.byteorder == 'little' else '<'
+        incorrect_dtypes = map(lambda t: incorrect_byteorder + t, ['d', 'f'])
+
+        for dtype in correct_dtypes:
+            array = np.array([1, 2, 3, 4], dtype=dtype)
+
+            # Upcast
+            tensor = torch.DoubleTensor(array).to(device)
+            for i in range(len(array)):
+                self.assertEqual(tensor[i], array[i])
+
+            # Downcast (sometimes)
+            tensor = torch.FloatTensor(array).to(device)
+            for i in range(len(array)):
+                self.assertEqual(tensor[i], array[i])
+
+            tensor = torch.HalfTensor(array).to(device)
+            for i in range(len(array)):
+                self.assertEqual(tensor[i], array[i])
+
+    def test_dlpack_conversion(self, device):
+        x = torch.randn(1, 2, 3, 4, device=device, dtype=torch.float)
+        z = from_dlpack(to_dlpack(x))
+        self.assertEqual(z, x)
+
+    @onlyCUDA
+    def test_pin_memory_from_constructor(self, device):
+        def _get_like(t, **kwargs):
+            return [
+                torch.rand_like(t, **kwargs),
+                torch.randn_like(t, **kwargs),
+                torch.empty_like(t, **kwargs),
+                torch.full_like(t, 4, **kwargs),
+                torch.zeros_like(t, **kwargs),
+                torch.ones_like(t, **kwargs),
+            ]
+
+        def _get_tensors(**kwargs):
+            return [
+                torch.tensor([10, 11], **kwargs),
+                torch.randn(3, 5, **kwargs),
+                torch.rand(3, **kwargs),
+                # torch.randint(3, 5, **kwargs), // unsupported
+                torch.zeros(3, **kwargs),
+                torch.randperm(3, **kwargs),
+                torch.empty(6, **kwargs),
+                torch.ones(6, **kwargs),
+                torch.eye(6, **kwargs),
+                torch.arange(3, 5, **kwargs)]
+
+        pinned_tensors = _get_tensors(pin_memory=True) + _get_like(torch.empty(5, dtype=torch.float64), pin_memory=True)
+        for x in pinned_tensors:
+            self.assertTrue(x.is_pinned())
+
+        tensors = _get_tensors() + _get_like(torch.empty(5, dtype=torch.float64, pin_memory=True))
+        for x in tensors:
+            self.assertFalse(x.is_pinned())
+
+    def test_storage_device(self, device):
+        x = torch.tensor([], device=device)
+        self.assertEqual(x.dtype, x.storage().dtype)
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, 'less than 2 GPUs detected')
+    @onlyCUDA
+    def test_storage_multigpu(self, device):
+        devices = ['cuda:0', 'cuda:1']
+        for device in devices:
+            x = torch.tensor([], device=device)
+            self.assertEqual(x.dtype, x.storage().dtype)
+
+    @skipCUDAIfNoMagma
+    @skipCPUIfNoLapack
+    def test_lu(self, device):
+        from common_utils import random_fullrank_matrix_distinct_singular_value as fullrank
+
+        def run_test(device, pivot):
+            def run_subtest(matrix_size, batches, device, pivot):
+                a = fullrank(matrix_size, *batches).to(device)
+                a_LU_info, pivots_info, info_ = a.lu(pivot=pivot, get_infos=True)
+                self.assertEqual(a_LU_info.size(), torch.Size(batches + (matrix_size, matrix_size)))
+                self.assertEqual(pivots_info.size(), torch.Size(batches + (matrix_size,)))
+                self.assertEqual(info_.size(), torch.Size(batches))
+                self.assertEqual(info_.abs().sum(), 0)
+                a_LU, pivots = a.lu(pivot=pivot)
+                self.assertEqual(a_LU, a_LU_info)
+                self.assertEqual(pivots_info, pivots)
+                if a.is_cuda:
+                    a_LU_info_nopiv, nopiv, info_nopiv = a.lu(pivot=False, get_infos=True)
+                    self.assertEqual(nopiv, torch.arange(1, 1 + a.size(-1), device=device, dtype=torch.int32).expand(a.shape[:-1]))
+                    self.assertEqual(info_, info_nopiv)
+                P, L, U = torch.lu_unpack(a_LU, pivots)
+                self.assertEqual(P.matmul(L.matmul(U)), a)
+
+            for ms, batch in product([3, 5, 7], [(), (2,), (3,), (3, 5)]):
+                run_subtest(ms, batch, device, pivot)
+
+            # Info should be positive for rank deficient matrices
+            a = torch.ones(5, 3, 3, device=device)
+            self.assertGreater(a.lu(pivot=pivot, get_infos=True)[2][0], 0)
+
+        run_test(device, True)
+
+        if device == 'cpu':
+            # Error checking, no pivoting variant on CPU
+            with self.assertRaisesRegex(RuntimeError, 'lu without pivoting is not implemented on the CPU'):
+                torch.lu(torch.empty(1, 2, 2), pivot=False)
+        else:
+            run_test(device, False)
+
 
 add_neg_dim_tests()
 instantiate_device_type_tests(TestTorchDeviceType, globals())

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -34,7 +34,7 @@ from common_utils import TestCase, iter_indices, TEST_NUMPY, TEST_SCIPY, TEST_MK
     skipCUDANonDefaultStreamIf, skipCUDAMemoryLeakCheckIf
 from multiprocessing.reduction import ForkingPickler
 from common_device_type import instantiate_device_type_tests, \
-    skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU,
+    skipCPUIfNoLapack, skipCUDAIfNoMagma, skipCUDAIfRocm, onlyCUDA, onlyCPU, \
     dtypes, dtypesIfCUDA
 
 # load_tests from common_utils is used to automatically filter tests for
@@ -12511,7 +12511,7 @@ class TestTorchDeviceType(TestCase):
         x.to(x, copy=True)
 
     @onlyCUDA
-    def test_tensor_factory_cuda_type_inference(self, device):
+    def test_tensor_factory_gpu_type_inference(self, device):
         saved_type = torch.Tensor().type()
         torch.set_default_tensor_type(torch.cuda.DoubleTensor)
         torch.set_default_dtype(torch.float32)
@@ -12523,7 +12523,7 @@ class TestTorchDeviceType(TestCase):
         torch.set_default_tensor_type(saved_type)
 
     @onlyCUDA
-    def test_tensor_factory_cuda_type(self, device):
+    def test_tensor_factory_gpu_type(self, device):
         saved_type = torch.Tensor().type()
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
         x = torch.zeros((5, 5))


### PR DESCRIPTION
- Moves all ROCm-requiring test_torch tests to TestTorchDeviceType
- Moves test_stft and test_lu from test_cuda
- Moves many CUDA-only test_torch tests to TestTorchDeviceType
- Combines several test_torch CPU tests with their CUDA variants





