### PR TITLE
[pytorch][namedtensor] ensure c10/macros included before using

### DIFF
--- a/aten/src/ATen/core/EnableNamedTensor.h
+++ b/aten/src/ATen/core/EnableNamedTensor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
+
 // We are working on removing the BUILD_NAMEDTENSOR flag from the codebase.
 //
 // PyTorch's codegen also uses a similar flag. You can find it in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26440 [pytorch] add script to build mobile library with host toolchain
* **#26439 [pytorch][namedtensor] ensure c10/macros included before using**

Summary:
C10_MOBILE / FEATURE_TORCH_MOBILE are checked in EnableNamedTensor.h but
NamedTensor.h includes it at very beginning - for internal build it's
fine as C10_MOBILE / FEATURE_TORCH_MOBILE are set as compiler flags, but
for cmake build it relies on c10/macros/Macros.h header to derive these
macros from other macros like __ANDROID__, so it won't work as expected.

Test Plan:
- build locally;
- will check CI;
- [namedtensor ci]

Differential Revision: [D17466581](https://our.internmc.facebook.com/intern/diff/D17466581)