### PR TITLE
[jit] Resolve NamedTuple types in Python

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3366,6 +3366,22 @@ def foo(x):
             else:
                 cu.define(full)
 
+    def test_namedtuple_python(self):
+        MyTuple = namedtuple('MyTuple', ['a'])
+
+        @torch.jit.unused
+        def fn():
+            # type: () -> MyTuple
+            return MyTuple(1)
+
+        # Only check compilation
+        @torch.jit.script
+        def fn2():
+            # type: () -> MyTuple
+            return fn()
+
+        FileCheck().check("NamedTuple").run(fn2.graph)
+
     def test_inherit_method(self):
         class A(torch.jit.ScriptModule):
             def __init__(self):

--- a/torch/csrc/jit/script/init.cpp
+++ b/torch/csrc/jit/script/init.cpp
@@ -994,6 +994,12 @@ void initJitScriptBindings(PyObject* module) {
 
   m.def("_get_graph_executor_optimize", &torch::jit::getGraphExecutorOptimize);
 
+  m.def(
+      "_resolve_type",
+      [](const std::string& name, SourceRange range, ResolutionCallback rcb) {
+        return pythonResolver(rcb)->resolveType(name, range);
+      });
+
   py::class_<logging::LoggerBase, std::shared_ptr<logging::LoggerBase>>(
       m, "LoggerBase");
   py::enum_<logging::LockingLogger::AggregationType>(m, "AggregationType")

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -32,7 +32,7 @@ FunctionSchema PythonValue::getSchema(
     const SourceRange& loc) {
   auto annotations = py::module::import("torch.jit.annotations");
   auto signature =
-      annotations.attr("get_signature")(self, rcb ? *rcb : py::none());
+      annotations.attr("get_signature")(self, rcb ? *rcb : py::none(), loc);
   std::vector<Argument> args, rets;
   // We may mutate this if we can determine the number of args from Python
   // introspection.

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -31,7 +31,8 @@ FunctionSchema PythonValue::getSchema(
     const size_t n_binders,
     const SourceRange& loc) {
   auto annotations = py::module::import("torch.jit.annotations");
-  auto signature = annotations.attr("get_signature")(self);
+  auto signature =
+      annotations.attr("get_signature")(self, rcb ? *rcb : py::none());
   std::vector<Argument> args, rets;
   // We may mutate this if we can determine the number of args from Python
   // introspection.
@@ -659,6 +660,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     if (auto callee = as_function(compiled_fn)) {
       return std::make_shared<FunctionValue>(*callee);
     }
+    auto rcb = py::module::import("torch.jit").attr("_gen_rcb")(obj, 0);
+    return std::make_shared<PythonValue>(obj, rcb);
   }
 
   return std::make_shared<PythonValue>(obj);

--- a/torch/csrc/jit/script/python_sugared_value.h
+++ b/torch/csrc/jit/script/python_sugared_value.h
@@ -30,7 +30,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
 c10::optional<StrongFunctionPtr> as_function(const py::object& obj);
 
 struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
-  PythonValue(py::object the_self) : self(std::move(the_self)) {}
+  PythonValue(py::object the_self, c10::optional<py::object> rcb = c10::nullopt)
+      : self(std::move(the_self)), rcb(std::move(rcb)) {}
 
   FunctionSchema getSchema(
       const size_t n_args,
@@ -63,6 +64,7 @@ struct VISIBILITY_HIDDEN PythonValue : public SugaredValue {
   void checkForAddToConstantsError(std::stringstream& ss);
 
   py::object self;
+  c10::optional<py::object> rcb;
 };
 
 struct VISIBILITY_HIDDEN PythonModuleValue : public PythonValue {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1994,7 +1994,7 @@ def _compile_function_with_overload(qual_name, impl_fn, overload_decl, overload_
     return fn
 
 def _check_no_signature(func):
-    signature = torch.jit.annotations.get_signature(func, None)
+    signature = torch.jit.annotations.get_signature(func, None, None)
     if signature is None:
         qual_name = _qualified_name(func)
         raise RuntimeError("Must explicitly add type annotations to overloaded functions: {}".format(qual_name))

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1214,6 +1214,8 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         return fn
 
 def _gen_rcb(obj, _frames_up):
+    print(obj)
+    print(_frames_up)
     _frames_up = _frames_up + 1  # for invoking _gen_rcb()
 
     closure_rcb = _jit_internal.createResolutionCallbackFromClosure(obj)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1214,8 +1214,6 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         return fn
 
 def _gen_rcb(obj, _frames_up):
-    print(obj)
-    print(_frames_up)
     _frames_up = _frames_up + 1  # for invoking _gen_rcb()
 
     closure_rcb = _jit_internal.createResolutionCallbackFromClosure(obj)
@@ -1996,7 +1994,7 @@ def _compile_function_with_overload(qual_name, impl_fn, overload_decl, overload_
     return fn
 
 def _check_no_signature(func):
-    signature = torch.jit.annotations.get_signature(func)
+    signature = torch.jit.annotations.get_signature(func, None)
     if signature is None:
         qual_name = _qualified_name(func)
         raise RuntimeError("Must explicitly add type annotations to overloaded functions: {}".format(qual_name))

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -53,7 +53,8 @@ class EvalEnv(object):
     def __getitem__(self, name):
         if name in self.env:
             return self.env[name]
-        return self.rcb(name)
+        if self.rcb is not None:
+            return self.rcb(name)
 
 def get_signature(fn, rcb, loc):
     # Python 3.5 adds support for the nice annotation syntax, so try that first.
@@ -121,7 +122,6 @@ def parse_type_line(type_line, rcb, loc):
     if not isinstance(arg_ann, tuple):
         arg_ann = (arg_ann,)
 
-    print(type_line)
     try:
         ret_ann = eval(ret_ann_str, {}, EvalEnv(rcb))  # noqa: P204
     except (NameError, SyntaxError) as e:


### PR DESCRIPTION


When used as annotations on Python functions, `NamedTuple`s go through our Python annotation -> type mapping which previously had no way of lookup up `NamedTuple`s (which are created lazily by checking if the type has certain properties, so the lookup is creating the `TupleType` from scratch). This PR threads through the necessary data to make them work.

Fixes #26437

Differential Revision: [D17486441](https://our.internmc.facebook.com/intern/diff/17486441/)