### PR TITLE
[pytorch] fix JNI wrapper for IValue interface change

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni.cpp
@@ -324,7 +324,7 @@ class JIValue : public facebook::jni::JavaClass<JIValue> {
       return jMethodListArr(JIValue::javaClassStatic(), jArray);
     } else if (ivalue.isGenericDict()) {
       auto dict = ivalue.toGenericDict();
-      const auto keyType = dict._keyType();
+      const auto keyType = dict.keyType();
 
       if (!keyType) {
         facebook::jni::throwNewJavaException(
@@ -332,7 +332,7 @@ class JIValue : public facebook::jni::JavaClass<JIValue> {
             "Unknown IValue-Dict key type");
       }
 
-      const auto keyTypeKind = keyType.value()->kind();
+      const auto keyTypeKind = keyType->kind();
       if (c10::TypeKind::StringType == keyTypeKind) {
         static auto jMethodDictStringKey =
             JIValue::javaClassStatic()
@@ -421,17 +421,12 @@ class JIValue : public facebook::jni::JavaClass<JIValue> {
 
       std::vector<at::IValue> elements;
       elements.reserve(n);
-      std::vector<c10::TypePtr> types;
-      types.reserve(n);
       for (auto i = 0; i < n; ++i) {
         auto jivalue_element = jarray->getElement(i);
         auto element = JIValue::JIValueToAtIValue(jivalue_element);
-        c10::TypePtr typePtr = c10::attemptToRecoverType(element);
         elements.push_back(std::move(element));
-        types.push_back(std::move(typePtr));
       }
-      return c10::ivalue::Tuple::create(
-          std::move(elements), c10::TupleType::create(std::move(types)));
+      return c10::ivalue::Tuple::create(std::move(elements));
     } else if (JIValue::kTypeCodeBoolList == typeCode) {
       static const auto jMethodGetBoolList =
           JIValue::javaClassStatic()->getMethod<jbooleanArray()>("getBoolList");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26448 [pytorch] fix JNI wrapper for IValue interface change**

Summary:
Seems CI was broken by PR #25439 - fix based on interface change.

Test Plan:
- build locally

Differential Revision: [D17468987](https://our.internmc.facebook.com/intern/diff/D17468987)