### PR TITLE
Implement more size-oriented opcodes in the depickler.

### DIFF
--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -825,7 +825,24 @@ PickleOpCode Unpickler::readInstruction() {
           c10::impl::GenericDict(AnyType::get(), AnyType::get()));
       break;
     case PickleOpCode::APPENDS: {
-      readList();
+      size_t start = marks_.back();
+      auto list_ivalue = stack_.at(start - 1);
+      readList(list_ivalue);
+    } break;
+    case PickleOpCode::LIST: {
+      IValue list_ivalue = c10::impl::GenericList(AnyType::get());
+      readList(list_ivalue);
+      stack_.push_back(std::move(list_ivalue));
+    } break;
+    case PickleOpCode::DICT: {
+      size_t start = marks_.back();
+      marks_.pop_back();
+      auto dict = c10::impl::GenericDict(AnyType::get(), AnyType::get());
+      for (size_t i = start; i < stack_.size(); i += 2) {
+        dict.insert_or_assign(stack_[i], stack_[i + 1]);
+      }
+      stack_.erase(stack_.begin() + start, stack_.end());
+      stack_.push_back(std::move(dict));
     } break;
     case PickleOpCode::SETITEMS: {
       size_t start = marks_.back();
@@ -1067,10 +1084,9 @@ std::string Unpickler::readBytes(size_t length) {
 
 // Pop all the list items off of the stack and append them to the list at
 // the corresponding MARK
-void Unpickler::readList() {
+void Unpickler::readList(IValue& list_ivalue) {
   size_t start = marks_.back();
   marks_.pop_back();
-  auto list_ivalue = stack_.at(start - 1);
   auto num_elements = stack_.size() - start;
   auto elements = at::ArrayRef<IValue>(stack_).slice(start);
   if (list_ivalue.isIntList()) {

--- a/torch/csrc/jit/pickler.cpp
+++ b/torch/csrc/jit/pickler.cpp
@@ -1084,7 +1084,7 @@ std::string Unpickler::readBytes(size_t length) {
 
 // Pop all the list items off of the stack and append them to the list at
 // the corresponding MARK
-void Unpickler::readList(IValue& list_ivalue) {
+void Unpickler::readList(IValue list_ivalue) {
   size_t start = marks_.back();
   marks_.pop_back();
   auto num_elements = stack_.size() - start;

--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -275,7 +275,7 @@ class Unpickler {
   PickleOpCode readInstruction();
   PickleOpCode readOpCode();
   std::string readString();
-  void readList();
+  void readList(IValue& list_ivalue);
   void setInput(size_t memo_id);
   void run();
 

--- a/torch/csrc/jit/pickler.h
+++ b/torch/csrc/jit/pickler.h
@@ -275,7 +275,7 @@ class Unpickler {
   PickleOpCode readInstruction();
   PickleOpCode readOpCode();
   std::string readString();
-  void readList(IValue& list_ivalue);
+  void readList(IValue list_ivalue);
   void setInput(size_t memo_id);
   void run();
 


### PR DESCRIPTION
These are intentionally not yet used by the encoder to avoid backcompat issues.