### PR TITLE
[reland] Add NoQEngine to QEngine and refactor the name of set/get qengine

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -95,12 +95,30 @@ bool Context::hasLAPACK() const {
 #endif
 }
 
-at::QEngine Context::preferredQuantizedEngine() const {
+at::QEngine Context::qEngine() const {
   return quantized_engine;
 }
 
-void Context::setPreferredQuantizedEngine(at::QEngine e) {
-  quantized_engine = e;
+void Context::setQEngine(at::QEngine e) {
+  const auto& qengines = supportedQEngines();
+  if (std::find(qengines.begin(), qengines.end(), e) != qengines.end()) {
+    quantized_engine = e;
+    return;
+  }
+  TORCH_CHECK(false, "quantized engine ", toString(e), "is not supported");
+}
+
+std::vector<at::QEngine> Context::supportedQEngines() const {
+  static auto supported_qengines = {
+    at::kNoQEngine,
+    #ifdef USE_FBGEMM
+    at::kFBGEMM,
+    #endif
+    #ifdef USE_PYTORCH_QNNPACK
+    at::kQNNPACK,
+    #endif
+  };
+  return supported_qengines;
 }
 
 bool Context::setFlushDenormal(bool on) {

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -106,9 +106,11 @@ class CAFFE2_API Context {
   void setBenchmarkCuDNN(bool);
   bool deterministicCuDNN() const;
   void setDeterministicCuDNN(bool);
-  at::QEngine preferredQuantizedEngine() const;
-  void setPreferredQuantizedEngine(at::QEngine e);
-private:
+  at::QEngine qEngine() const;
+  void setQEngine(at::QEngine e);
+  std::vector<at::QEngine> supportedQEngines() const;
+
+ private:
   void initCUDAIfNeeded(DeviceType p) {
     if (p == DeviceType::CUDA) {
       lazyInitCUDA();
@@ -125,7 +127,14 @@ private:
   bool deterministic_cudnn = false;
   bool benchmark_cudnn = false;
   bool enabled_mkldnn = true;
-  at::QEngine quantized_engine = at::QEngine::FBGEMM;
+  at::QEngine quantized_engine =
+#ifdef USE_FBGEMM
+      at::kFBGEMM;
+#elif defined(USE_PYTORCH_QNNPACK)
+      at::kQNNPACK;
+#else
+      at::kNoQEngine;
+#endif
   std::unique_ptr<THCState, void(*)(THCState*)> thc_state;
   std::unique_ptr<THHState, void(*)(THHState*)> thh_state;
 };

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -361,7 +361,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
       int64_t output_zero_point) {
     auto& ctx = at::globalContext();
 #ifdef USE_FBGEMM
-    if (ctx.preferredQuantizedEngine() == at::QEngine::FBGEMM) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_conv(
           act,
           packed_weight,
@@ -374,7 +374,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
     }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-    if (ctx.preferredQuantizedEngine() == at::QEngine::QNNPACK) {
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_conv(
           act,
           packed_weight,
@@ -388,7 +388,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
 #endif
     TORCH_INTERNAL_ASSERT(
         "Didn't find engine for operation quantized::conv ",
-        toString(ctx.preferredQuantizedEngine()));
+        toString(ctx.qEngine()));
     return at::Tensor();
   }
 };

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -228,20 +228,20 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
       int64_t groups) {
     auto& ctx = at::globalContext();
 #ifdef USE_FBGEMM
-    if (ctx.preferredQuantizedEngine() == at::QEngine::FBGEMM) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_conv_prepack(
           weight, bias, stride, padding, dilation, groups);
     }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-    if (ctx.preferredQuantizedEngine() == at::QEngine::QNNPACK) {
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_conv_prepack(
           weight, bias, stride, padding, dilation, groups);
     }
 #endif
     TORCH_INTERNAL_ASSERT(
         "Didn't find engine for operation quantized::conv_prepack ",
-        toString(ctx.preferredQuantizedEngine()));
+        toString(ctx.qEngine()));
     return at::Tensor();
   }
 };

--- a/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_unpack.cpp
@@ -82,18 +82,18 @@ class QConvUnpackWeightsInt8 final : public c10::OperatorKernel {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.preferredQuantizedEngine() == at::QEngine::FBGEMM) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_conv_unpack(packed_weights);
     }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-    if (ctx.preferredQuantizedEngine() == at::QEngine::QNNPACK) {
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_conv_unpack(packed_weights);
     }
 #endif
     TORCH_INTERNAL_ASSERT(
         "Didn't find engine for operation quantized::conv_unpack ",
-        toString(ctx.preferredQuantizedEngine()));
+        toString(ctx.qEngine()));
     return std::tuple<at::Tensor, c10::optional<Tensor>>(
         at::Tensor(), at::Tensor());
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -292,20 +292,20 @@ class QLinearInt8 final : public torch::OperatorKernel {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.preferredQuantizedEngine() == at::QEngine::FBGEMM) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_linear(
           input, packed_weight, output_scale, output_zero_point);
     }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-    if (ctx.preferredQuantizedEngine() == at::QEngine::QNNPACK) {
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_linear(
           input, packed_weight, output_scale, output_zero_point);
     }
 #endif
     TORCH_INTERNAL_ASSERT(
         "Didn't find engine for operation quantized::linear ",
-        toString(ctx.preferredQuantizedEngine()));
+        toString(ctx.qEngine()));
     return at::Tensor();
   }
 };

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -180,18 +180,18 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.preferredQuantizedEngine() == at::QEngine::FBGEMM) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_linear_prepack(weight, bias);
     }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-    if (ctx.preferredQuantizedEngine() == at::QEngine::QNNPACK) {
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_linear_prepack(weight, bias);
     }
 #endif
     TORCH_INTERNAL_ASSERT(
         "Didn't find engine for operation quantized::linear_prepack ",
-        toString(ctx.preferredQuantizedEngine()));
+        toString(ctx.qEngine()));
     return at::Tensor();
   }
 };

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -69,18 +69,18 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.preferredQuantizedEngine() == at::QEngine::FBGEMM) {
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_linear_unpack(packed_weight);
     }
 #endif
 #ifdef USE_PYTORCH_QNNPACK
-    if (ctx.preferredQuantizedEngine() == at::QEngine::QNNPACK) {
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_linear_unpack(packed_weight);
     }
 #endif
     TORCH_INTERNAL_ASSERT(
         "Didn't find engine for operation quantized::linear_unpack ",
-        toString(ctx.preferredQuantizedEngine()));
+        toString(ctx.qEngine()));
     return std::tuple<at::Tensor, c10::optional<Tensor>>(
         at::Tensor(), at::Tensor());
   }

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -10,18 +10,19 @@ namespace c10 {
  * QEngine is an enum that is used to select the engine to run quantized ops.
  */
 enum class QEngine : uint8_t {
-  FBGEMM = 0,
-  QNNPACK = 1,
-  COMPILE_TIME_NUM_QENGINES = 2,
+  NoQEngine = 0,
+  FBGEMM = 1,
+  QNNPACK = 2,
 };
 
+constexpr auto kNoQEngine = QEngine::NoQEngine;
 constexpr auto kFBGEMM = QEngine::FBGEMM;
 constexpr auto kQNNPACK = QEngine::QNNPACK;
-constexpr int COMPILE_TIME_NUM_QENGINES =
-    static_cast<int>(QEngine::COMPILE_TIME_NUM_QENGINES);
 
 inline std::string toString(QEngine qengine) {
   switch (qengine) {
+    case kNoQEngine:
+      return "NoQEngine";
     case kFBGEMM:
       return "FBGEMM";
     case kQNNPACK:

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -21,8 +21,8 @@ class QuantizedEngine(types.ModuleType):
 
     def __getattr__(self, attr):
         return self.m.__getattribute__(attr)
-
-    engine = ContextProp(torch._C._get_preferred_engine, torch._C._set_preferred_engine)
+    # TODO: replace with strings(https://github.com/pytorch/pytorch/pull/26330/files#r324951460)
+    engine = ContextProp(torch._C._get_qengine, torch._C._set_qengine)
 
 # This is the sys.modules replacement trick, see
 # https://stackoverflow.com/questions/2447353/getattr-on-a-module/7668273#7668273

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -489,17 +489,17 @@ PyObject *THPModule_getDefaultDevice(PyObject *_unused, PyObject *arg) {
   END_HANDLE_TH_ERRORS
 }
 
-PyObject *THPModule_setPreferredQuantizedEngine(PyObject *_unused, PyObject *arg)
+PyObject *THPModule_setQEngine(PyObject */* unused */, PyObject *arg)
 {
   TORCH_CHECK(THPQEngine_Check(arg), "qengine arg must be an instance of the torch.qengine");
   const auto qengine = reinterpret_cast<THPQEngine*>(arg);
-  at::globalContext().setPreferredQuantizedEngine(qengine->qengine);
+  at::globalContext().setQEngine(qengine->qengine);
   Py_RETURN_NONE;
 }
 
-PyObject *THPModule_preferredQuantizedEngine(PyObject *_unused)
+PyObject *THPModule_qEngine(PyObject */* unused */)
 {
-  return THPQEngine_New(at::globalContext().preferredQuantizedEngine(), toString(at::globalContext().preferredQuantizedEngine()));
+  return THPQEngine_New(at::globalContext().qEngine(), toString(at::globalContext().qEngine()));
 }
 
 static PyMethodDef TorchMethods[] = {
@@ -538,8 +538,8 @@ static PyMethodDef TorchMethods[] = {
   {"set_flush_denormal", (PyCFunction)THPModule_setFlushDenormal, METH_O,     nullptr},
   {"get_default_dtype", (PyCFunction)THPModule_getDefaultDtype, METH_NOARGS,  nullptr},
   {"_get_default_device", (PyCFunction)THPModule_getDefaultDevice, METH_NOARGS,   nullptr},
-  {"_get_preferred_engine", (PyCFunction)THPModule_preferredQuantizedEngine, METH_NOARGS, nullptr},
-  {"_set_preferred_engine", (PyCFunction)THPModule_setPreferredQuantizedEngine, METH_O, nullptr},
+  {"_get_qengine", (PyCFunction)THPModule_qEngine, METH_NOARGS, nullptr},
+  {"_set_qengine", (PyCFunction)THPModule_setQEngine, METH_O, nullptr},
   {nullptr, nullptr, 0, nullptr}
 };
 

--- a/torch/csrc/utils/qengines.cpp
+++ b/torch/csrc/utils/qengines.cpp
@@ -28,6 +28,7 @@ void initializeQEngines() {
     throw python_error();
   }
 
+  addQEngine(at::kNoQEngine, "no_qengine", torch_module);
   addQEngine(at::kFBGEMM, "fbgemm", torch_module);
   addQEngine(at::kQNNPACK, "qnnpack", torch_module);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26474 [quant] Expose supportedQEngines to python
* #26331 [quant] Add QuantFusion to graph_executor
* **#26471 [reland] Add NoQEngine to QEngine and refactor the name of set/get qengine**

Summary:
att

Test Plan:
.

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

This reverts commit b1ecf4bc8293191e4d6f16b3764159c67f643cf7.

Differential Revision: [D17491215](https://our.internmc.facebook.com/intern/diff/D17491215)