### PR TITLE
[pytorch][mobile] turn off autograd mode in android JNI wrapper

### DIFF
--- a/torch/script.h
+++ b/torch/script.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/api/include/torch/types.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
+#include <torch/csrc/autograd/grad_mode.h>
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/import.h>
 #include <torch/csrc/jit/pickle.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26508 [pytorch][perf] add eigen blas for mobile build
* **#26477 [pytorch][mobile] turn off autograd mode in android JNI wrapper**
* #26476 [pytorch] expose USE_STATIC_DISPATCH macro to public headers

Summary:
- At inference time we need turn off autograd mode and turn on no-variable
  mode since we strip out these modules for inference-only mobile build.
- Both flags are stored in thread-local variables so we cannot simply
  set them to false glboally.
- Add "autograd/grad_mode.h" header to all-in-one header 'torch/script.h'
  to reduce friction for iOS engs who might need do this manually in their
  project.

P.S. I tried to hide AutoNonVariableTypeMode in codegen but figured it's not
very trivial (e.g. there are manually written part not covered by codegen).
Might try it again later.

Test Plan:
- Integrate with Android demo app to confirm inference runs correctly.

Differential Revision: [D17484259](https://our.internmc.facebook.com/intern/diff/D17484259)