### PR TITLE
[iOS] Disable bitcode for iOS CI jobs

### DIFF
--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -22,6 +22,11 @@ if [ -n "${BUILD_PYTORCH_MOBILE:-}" ]; then
   CMAKE_ARGS+=("-DCMAKE_PREFIX_PATH=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')")
   CMAKE_ARGS+=("-DPYTHON_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')")
   CMAKE_ARGS+=("-DBUILD_CUSTOM_PROTOBUF=OFF")
+  # bitcode
+  if [ "${ENABLE_BITCODE:-}" == '1' ]; then
+    CMAKE_ARGS+=("-DCMAKE_C_FLAGS=-fembed-bitcode")
+    CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-fembed-bitcode")
+  fi 
 else
   # Build protobuf from third_party so we have a host protoc binary.
   echo "Building protoc"
@@ -30,6 +35,9 @@ else
   # Use locally built protoc because we'll build libprotobuf for the
   # target architecture and need an exact version match.
   CMAKE_ARGS+=("-DCAFFE2_CUSTOM_PROTOC_EXECUTABLE=$CAFFE2_ROOT/build_host_protoc/bin/protoc")
+  # Bitcode is enabled by default for caffe2
+  CMAKE_ARGS+=("-DCMAKE_C_FLAGS=-fembed-bitcode")
+  CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-fembed-bitcode")
 fi
 
 # Use ios-cmake to build iOS project from CMake.
@@ -83,8 +91,6 @@ if [ "${VERBOSE:-}" == '1' ]; then
   CMAKE_ARGS+=("-DCMAKE_VERBOSE_MAKEFILE=1")
 fi
 
-CMAKE_ARGS+=("-DCMAKE_C_FLAGS=-fembed-bitcode")
-CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-fembed-bitcode")
 cmake "$CAFFE2_ROOT" \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=MinSizeRel \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26478 [iOS] Disable bitcode for iOS CI jobs**

### Summary

Since QNNPACK [doesn't support bitcode](https://github.com/pytorch/QNNPACK/blob/7d2a4e9931a82adc3814275b6219a03e24e36b4c/scripts/build-ios-arm64.sh#L40), I'm going to disable it in our CMake scripts. This won't hurt any existing functionalities, and will only affect the build size. Any application that wants to integrate our framework needs to turn off bitcode as well.

cc David @dreiss 

### Test plan

- CI job works
- LibTorch.a can be compiled and run on iOS devices

Differential Revision: [D17489020](https://our.internmc.facebook.com/intern/diff/D17489020)