### PR TITLE
Disable tagged names

### DIFF
--- a/aten/src/ATen/core/Dimname.cpp
+++ b/aten/src/ATen/core/Dimname.cpp
@@ -54,26 +54,8 @@ Dimname Dimname::fromSymbol(Symbol full_name) {
   if (full_name == kWildcard) {
     return Dimname::wildcard();
   }
-  const std::string delimiter = ".";
-  const std::string str(full_name.toUnqualString());
-  auto it = str.find(delimiter);
-
-  // Check for normal name
-  if (it == std::string::npos) {
-    check_valid_identifier(str);
-    return Dimname(full_name);
-  }
-
-  // Check for tagged name
-  auto second_dot = str.find(delimiter, it + 1);
-  TORCH_CHECK(
-      second_dot == std::string::npos,
-      "Invalid name '", str, "': A tagged name can only contain one '.'");
-  auto untagged_name = str.substr(0, it);
-  auto tag = str.substr(it + 1);
-  check_valid_identifier(untagged_name); 
-  check_valid_identifier(tag);
-  return Dimname(NameType::TAGGED, full_name, Symbol::dimname(untagged_name));
+  check_valid_identifier(full_name.toUnqualString());
+  return Dimname(full_name);
 }
 
 Dimname Dimname::wildcard() {

--- a/aten/src/ATen/test/Dimname_test.cpp
+++ b/aten/src/ATen/test/Dimname_test.cpp
@@ -31,7 +31,6 @@ TEST(DimnameTest, wildcardName) {
   Dimname wildcard = Dimname::wildcard();
   ASSERT_EQ(wildcard.type(), NameType::WILDCARD);
   ASSERT_EQ(wildcard.full_name(), Symbol::dimname("*"));
-  ASSERT_EQ(wildcard.untagged_name(), Symbol::dimname("*"));
 }
 
 TEST(DimnameTest, createNormalName) {
@@ -39,22 +38,8 @@ TEST(DimnameTest, createNormalName) {
   auto dimname = Dimname::fromSymbol(foo);
   ASSERT_EQ(dimname.type(), NameType::NORMAL);
   ASSERT_EQ(dimname.full_name(), foo);
-  ASSERT_EQ(dimname.untagged_name(), foo);
-
+  ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname("inva.lid")), c10::Error);
   ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname("invalid1")), c10::Error);
-}
-
-TEST(DimnameTest, createTaggedName) {
-  auto foo_bar = Symbol::dimname("foo.bar");
-  auto foo = Symbol::dimname("foo");
-  auto dimname = Dimname::fromSymbol(foo_bar);
-  ASSERT_EQ(dimname.type(), NameType::TAGGED);
-  ASSERT_EQ(dimname.full_name(), foo_bar);
-  ASSERT_EQ(dimname.untagged_name(), foo);
-
-  ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname(".bar")), c10::Error);
-  ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname("foo.")), c10::Error);
-  ASSERT_THROW(Dimname::fromSymbol(Symbol::dimname("foo.bar.baz")), c10::Error);
 }
 
 static void check_unify_and_match(
@@ -82,13 +67,5 @@ TEST(DimnameTest, unifyAndMatch) {
   check_unify_and_match("*", "a", "a");
   check_unify_and_match("*", "*", "*");
   check_unify_and_match("a", "b", c10::nullopt);
-
-  check_unify_and_match("*", "a.b", "a.b");
-  check_unify_and_match("a", "a.b", "a");
-  check_unify_and_match("c", "a.b", c10::nullopt);
-  check_unify_and_match("a.b", "a.c", "a");
-  check_unify_and_match("a.b", "a.b", "a.b");
-  check_unify_and_match("c.b", "a.b", c10::nullopt);
-  check_unify_and_match("c.b", "a", c10::nullopt);
 }
 #endif

--- a/aten/src/ATen/test/NamedTensor_test.cpp
+++ b/aten/src/ATen/test/NamedTensor_test.cpp
@@ -129,17 +129,6 @@ TEST(NamedTensorTest, dimnameToPosition) {
 
   tensor = at::empty({1, 1, 1, 1}, names);
   ASSERT_EQ(dimname_to_position(tensor, H), 2);
-
-  auto Cin = dimnameFromString("C.in");
-  auto Cout = dimnameFromString("C.out");
-  tensor = at::empty({1, 1, 1, 1}, names);
-  ASSERT_THROW(dimname_to_position(tensor, Cin), c10::Error);
-
-  tensor = at::empty({1, 1}, std::vector<Dimname>({ Cin, Cout }));
-  ASSERT_THROW(dimname_to_position(tensor, C), c10::Error);
-
-  tensor = at::empty({1, 1}, std::vector<Dimname>({ Cin, N }));
-  ASSERT_EQ(dimname_to_position(tensor, C), 0);
 }
 
 static void check_unify(

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -154,18 +154,6 @@ class TestNamedTensor(TestCase):
             names65 = ['A' * i for i in range(1, 66)]
             x = factory([1] * 65, names=names64, device=device)
 
-        # Tests for tagged names
-        x = factory(2, 3, 1, names=('C.in', 'H', 'C.out'), device=device)
-        self.assertEqual(x.names, ('C.in', 'H', 'C.out'))
-
-        with self.assertRaisesRegex(RuntimeError, 'construct a tensor with duplicate names'):
-            x = factory(2, 1, 1, names=('C.in', 'H', 'C.in'), device=device)
-
-        with self.assertRaisesRegex(
-                RuntimeError,
-                'with duplicate names unless they are tagged and have different tags'):
-            x = factory(2, 1, 1, names=('C.in', 'H', 'C'), device=device)
-
     def test_has_names(self):
         unnamed = torch.empty(2, 3)
         none_named = torch.empty(2, 3, names=(None, None))
@@ -1104,23 +1092,6 @@ class TestNamedTensor(TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, 'Please look up dimensions by name'):
             y = x.select(None, 1)
-
-        with self.assertRaisesRegex(
-                RuntimeError, 'Name \'C.in\' not found in'):
-            y = x.select('C.in', 1)
-
-        x = torch.empty(2, 3, 4, 5, names=('N', 'C.in', 'H', 'W'), device=device)
-        y = x.select('C', 1)
-        self.assertEqual(y.names, ('N', 'H', 'W'))
-
-        x = torch.empty(2, 3, 4, 5, names=('C.out', 'C.in', 'H', 'W'), device=device)
-        y = x.select('C.in', 1)
-        self.assertEqual(y.names, ('C.out', 'H', 'W'))
-
-        with self.assertRaisesRegex(
-                RuntimeError, 'Name \'C\' could refer to multiple dimensions'):
-            y = x.select('C', 1)
-
 
     def test_select(self):
         self._test_select('cpu')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26366 Refactor Dimname.h API to be nicer
* #26365 Delete tagged names
* **#26479 Disable tagged names**

This PR doesn't delete the code for them yet because it takes some effort to
determine what to delete. I will send a followup PR fully deleting
tagged names, but this PR disables their creation.

Test Plan:
- [namedtensor ci]

Differential Revision: [D17484758](https://our.internmc.facebook.com/intern/diff/D17484758)