### PR TITLE
Correct the test of a big number (2 ^ 31)

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3937,7 +3937,7 @@ class _TestTorchMixin(object):
             self.assertTensorsSlowEqual(byte_tensor, byte_tensor.abs(), 1e-16)
 
         # Checking that the right abs function is called for LongTensor
-        bignumber = 2 ^ 31 + 1
+        bignumber = 2 ** 31 + 1
         res = torch.LongTensor((-bignumber,))
         self.assertGreater(res.abs()[0], 0)
 


### PR DESCRIPTION
2 ^ 31 is 29, which is not a big number. Corrected to 2 ** 31.

