### PR TITLE
Allocate empty tensor instead of empty_like in binary ops, fix pow

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -171,7 +171,7 @@ Tensor& atan2_out(Tensor& result, const Tensor& self, const Tensor& other) {
 }
 
 Tensor atan2(const Tensor& self, const Tensor& other) {
-  Tensor result = at::empty_like(self);
+  Tensor result = at::empty({0}, self.options());
   return native::atan2_out(result, self, other);
 }
 

--- a/aten/src/ATen/native/Pow.cpp
+++ b/aten/src/ATen/native/Pow.cpp
@@ -25,7 +25,7 @@ Tensor& pow_out(Tensor& result, const Tensor& base, Scalar exp) {
   if (exp.toDouble() == 0.0) {
     result.resize_as_(base).fill_(1);
   } else if (exp.toDouble() == 1.0) {
-    result.copy_(base);
+    result.resize_as_(base).copy_(base);
   } else {
     auto iter = TensorIterator::unary_op(result, base,
                                          /*check_mem_overlap=*/true);
@@ -52,7 +52,7 @@ Tensor& pow_(Tensor& base, Scalar alpha) {
 }
 
 Tensor pow(const Tensor& base, const Tensor& exp) {
-  Tensor result = at::empty_like(base);
+  Tensor result = at::empty({0}, base.options());
   return native::pow_out(result, base, exp);
 }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1385,6 +1385,12 @@ class _TestTorchMixin(object):
             res2[i] = math.pow(3, m1[i][4])
         self.assertEqual(res1, res2)
 
+        # resize behavior for exp == 1
+        m1 = torch.randn(2, 2)
+        out = torch.randn([0])
+        torch.pow(m1, 1, out=out)
+        self.assertEqual(out, m1)
+
     def _test_cop(self, torchfn, mathfn):
         def reference_implementation(res2):
             for i, j in iter_indices(sm1):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26498 Allocate empty tensor instead of empty_like in binary ops, fix pow**

We should allocate an empty tensor as a result tensor when performing
binary ops. Currently some ops use `empty_like(self)` as the initial
result tensor before passing it into TensorIterator. This is not very
efficient because TensorIterator may resize the tensor due to
broadcasting, causing more memory allocation. By using an empty tensor
as the result tensor, we only need to allocate/resize memory once as
opposed to twice.

Also fixes https://github.com/pytorch/pytorch/issues/26495. The bug
there is that the implementation of `pow` is missing a resize in one
case.

Test Plan:
- new test
- run tests

Differential Revision: [D17500025](https://our.internmc.facebook.com/intern/diff/D17500025)