### PR TITLE
[pytorch] [distributed] [easy] Make distructor virtual for class with virtual function

### DIFF
--- a/torch/csrc/distributed/rpc/script_call.h
+++ b/torch/csrc/distributed/rpc/script_call.h
@@ -27,6 +27,8 @@ class TORCH_API ScriptCall {
   Message toMessage();
   static ScriptCall fromMessage(const Message& message);
 
+  virtual ~ScriptCall() = default;
+
  protected:
   virtual void toIValues(std::vector<at::IValue>& ivalues) const;
   static std::shared_ptr<Operator> fromIValues(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26506 [pytorch] [distributed] [easy] Made test forgiving to allow rpc agent to return one of the two errors
* **#26504 [pytorch] [distributed] [easy] Make distructor virtual for class with virtual function**
* #26503 [pytorch] [distributed] [easy] Corrected variable name and added test

[pytorch] [distributed] Make distructor virtual for class with virtual function
Not having virtual distructor may lead to a memory leak.

Differential Revision: [D17488876](https://our.internmc.facebook.com/intern/diff/D17488876/)