### PR TITLE
Support torch.pow with named tensors

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3039,6 +3039,7 @@
     SparseCUDA: resize_as_sparse_
 
 - func: pow.Tensor_Scalar_out(Tensor self, Scalar exponent, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
   dispatch:
     CPU: pow_out
     CUDA: pow_out
@@ -3048,6 +3049,7 @@
 - func: pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor
   use_c10_dispatcher: True
   variants: function, method
+  supports_named_tensor: True
   dispatch:
     CPU: pow
     CUDA: pow
@@ -4147,6 +4149,7 @@
 
 - func: pow_.Scalar(Tensor(a!) self, Scalar exponent) -> Tensor(a!)
   use_c10_dispatcher: True
+  supports_named_tensor: True
   variants: method
   dispatch:
     CPU: pow_
@@ -4154,6 +4157,7 @@
 
 - func: pow_.Tensor(Tensor(a!) self, Tensor exponent) -> Tensor(a!)
   use_c10_dispatcher: True
+  supports_named_tensor: True
   variants: method
   dispatch:
     CPU: pow_
@@ -5069,11 +5073,13 @@
     QuantizedCPU: quantized_equal
 
 - func: pow.Tensor_Tensor_out(Tensor self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
   dispatch:
     CPU: pow_out
     CUDA: pow_out
 
 - func: pow.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor
+  supports_named_tensor: True
   use_c10_dispatcher: True
   variants: method, function
   dispatch:
@@ -5081,11 +5087,13 @@
     CUDA: pow
 
 - func: pow.Scalar_out(Scalar self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
   dispatch:
     CPU: pow_out
     CUDA: pow_out
 
 - func: pow.Scalar(Scalar self, Tensor exponent) -> Tensor
+  supports_named_tensor: True
   use_c10_dispatcher: True
   dispatch:
     CPU: pow

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -636,6 +636,7 @@ class TestNamedTensor(TestCase):
             fn_method_and_inplace('div'),
             fn_method_and_inplace('mul'),
             fn_method_and_inplace('sub'),
+            fn_method_and_inplace('pow'),
             method('copy_'),
         ]
         tests = flatten(tests)
@@ -644,6 +645,22 @@ class TestNamedTensor(TestCase):
             test_basic(op)
             test_wildcard(op)
             test_mixed_unnamed_named(op, is_inplace=name.endswith('_'))
+
+    def test_pow_special(self):
+        # There are a few pow cases that don't go through TensorIterator.
+        # Test them here.
+        for device in torch.testing.get_all_device_types():
+            named = torch.randn(2, 3, names=('N', 'C'), device=device)
+            unnamed = torch.randn([0], device=device)
+
+            result = torch.pow(named, 0, out=unnamed.clone())
+            self.assertEqual(result.names, named.names)
+
+            result = torch.pow(named, 1, out=unnamed.clone())
+            self.assertEqual(result.names, named.names)
+
+            result = torch.pow(1, named, out=unnamed.clone())
+            self.assertEqual(result.names, named.names)
 
     def test_out_fn_semantics(self):
         out_fn = torch.abs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26543 Named tensor support for: atan2, output_nr, detach{_}, requires_grad_
* **#26541 Support torch.pow with named tensors**
* #26493 Implement resize_, resize_as_ for named tensors

`torch.pow` already supports named tensors; every one of its constituent
codepaths propagates names:
- TensorIterator propagates names
- resize_as_ and fill_ propagate names (exponent == 0 or base == 1)
- resize_as_ and copy_ propagate names (exponent == 1)

This PR adds `supports_named_tensor = True` to the pow overloads,
enabling `pow` to take named tensors.

Test Plan:
- [namedtensor ci]

Differential Revision: [D17501402](https://our.internmc.facebook.com/intern/diff/D17501402)