### PR TITLE
[BatchNorm num_batches_tracked update]

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -38,7 +38,7 @@ class _BatchNorm(Module):
             self.register_parameter('running_mean', None)
             self.register_parameter('running_var', None)
             self.register_parameter('num_batches_tracked', None)
-        self.num_batches_tracked_scalar = -1;
+        self.num_batches_tracked_scalar = -1
         self.reset_parameters()
 
     def reset_running_stats(self):
@@ -57,8 +57,10 @@ class _BatchNorm(Module):
             init.zeros_(self.bias)
 
     def __getattr__(self, name):
-        if self.track_running_stats and name == 'num_batches_tracked' and name in self.__dict__['_buffers'] and self.num_batches_tracked_scalar != -1:
-            return super(_BatchNorm, self).__getattr__(name).fill_(self.num_batches_tracked_scalar)
+        if self.track_running_stats and name == 'num_batches_tracked' and name in self.__dict__[
+                '_buffers'] and self.num_batches_tracked_scalar != -1:
+            return super(_BatchNorm, self).__getattr__(name).fill_(
+                self.num_batches_tracked_scalar)
         return super(_BatchNorm, self).__getattr__(name)
 
     def _check_input_dim(self, input):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -87,7 +87,7 @@ class _BatchNorm(Module):
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         self.num_batches_tracked.fill_(self.num_batches_tracked_scalar)
-        return super(_BatchNorm, self).(destination, prefix, keep_vars)
+        return super(_BatchNorm, self).state_dict(destination, prefix, keep_vars)
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         self.num_batches_tracked.fill_(self.num_batches_tracked_scalar)

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -56,12 +56,11 @@ class _BatchNorm(Module):
             init.ones_(self.weight)
             init.zeros_(self.bias)
 
-    def __getattr__(self, name):
-        if self.track_running_stats and name == 'num_batches_tracked' and name in self.__dict__[
-                '_buffers'] and self.num_batches_tracked_scalar != -1:
-            return super(_BatchNorm, self).__getattr__(name).fill_(
-                self.num_batches_tracked_scalar)
-        return super(_BatchNorm, self).__getattr__(name)
+    @property
+    def num_batches_tracked(self):
+        if self.track_running_stats and self.num_batches_tracked_scalar != -1:
+            super(_BatchNorm, self).__getattr__('num_batches_tracked').fill_(self.num_batches_tracked_scalar)
+        return super(_BatchNorm, self).__getattr__('num_batches_tracked')
 
     def _check_input_dim(self, input):
         raise NotImplementedError


### PR DESCRIPTION
1. remove in-place operator on num_batches_tracked during forward calls:
     a. in-place operator on an input param puts heavy contraint on data
        dependency, as AliasDb assumes all input to alias each other.
     b. moreover, currently we incrementing on a scalar instead of tensor, which
        in-place operator is not supported in scripting.
2. move computation onto a scalar instead of a tensor, this saves a kernel
launch when we have the layer on GPU.

