### PR TITLE
Whenever possible, use function pointers rather than std::function to represent Operation's.

### DIFF
--- a/test/cpp/jit/test_constant_propagation.cpp
+++ b/test/cpp/jit/test_constant_propagation.cpp
@@ -72,7 +72,7 @@ graph():
     RegisterOperators reg({
         Operator(
             "prim::test_tuple() -> (float[])",
-            [](const Node* node) {
+            [](const Node* node) -> Operation {
               return [](Stack& stack) {
                 c10::List<double> list;
                 auto li = IValue(list);
@@ -84,7 +84,7 @@ graph():
             _aliasAnalysisFromSchema()),
         Operator(
             "prim::run_float_list(float[] a) -> (int)",
-            [](const Node* node) {
+            [](const Node* node) -> Operation {
               return [](Stack& stack) {
                 pop(stack);
                 push(stack, 1);

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -905,7 +905,7 @@ void testNoneSchemaMatch() {
   RegisterOperators reg({
       Operator(
           "prim::test_none() -> int?",
-          [](const Node* node) {
+          [](const Node* node) -> Operation {
             return [](Stack& stack) {
               push(stack, IValue());
               return 0;
@@ -914,7 +914,7 @@ void testNoneSchemaMatch() {
           aliasAnalysisFromSchema()),
       Operator(
           "prim::is_none(int? a) -> bool",
-          [](const Node* node) {
+          [](const Node* node) -> Operation {
             return [](Stack& stack) {
               IValue a = pop(stack);
               if (a.isNone()) {

--- a/test/cpp/jit/test_schema_matching.cpp
+++ b/test/cpp/jit/test_schema_matching.cpp
@@ -15,7 +15,7 @@ void testSchemaMatching() {
     RegisterOperators reg({
         Operator(
             "aten::test_vartype(t[] a, t b) -> (t)",
-            [](const Node* node) {
+            [](const Node* node) -> Operation {
               return [](Stack& stack) {
                 c10::List<double> list;
                 double a;
@@ -53,7 +53,7 @@ void testSchemaMatching() {
     RegisterOperators reg({
         Operator(
             "aten::test_vartype2(t a, t[] b) -> (t[])",
-            [](const Node* node) {
+            [](const Node* node) -> Operation {
               return [](Stack& stack) {
                 double a;
                 c10::List<double> list;

--- a/torch/csrc/jit/fuser/fallback.cpp
+++ b/torch/csrc/jit/fuser/fallback.cpp
@@ -25,7 +25,7 @@ c10::OperatorOptions aliasAnalysisIsSpecialCase() {
 // code.
 RegisterOperators reg_fused_operators({Operator(
     prim::FusedConcat,
-    [](const Node* node) {
+    [](const Node* node) -> Operation {
       int64_t dim = node->i(attr::dim);
       int64_t num_inputs = node->inputs().size();
       return [dim, num_inputs](Stack& stack) {

--- a/torch/csrc/jit/operator.h
+++ b/torch/csrc/jit/operator.h
@@ -30,7 +30,7 @@ struct Node;
 using ::c10::Symbol;
 using ::c10::FunctionSchema;
 
-using OperationCreator = std::function<Operation(const Node*)>;
+using OperationCreator = Operation (*)(const Node*);
 
 /*
  * Note: JIT relies on Operator instances having static lifetime, because
@@ -115,7 +115,7 @@ struct TORCH_API Operator {
 
   Operator(
       const std::string& schema,
-      Operation op,
+      int(*op)(Stack&),
       c10::OperatorOptions options = c10::OperatorOptions())
       : schema_string_(schema),
         op_(std::make_shared<Operation>(std::move(op))),

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -110,7 +110,7 @@ bool shape_is_fast_for_reduce(const at::Tensor& lhs, const at::Tensor& rhs) {
 
 RegisterOperators mm_tree_reduction_reg({Operator(
     prim::MMTreeReduce,
-    [](const Node* node) {
+    [](const Node* node) -> Operation {
       size_t num_inputs = node->inputs().size();
       return [num_inputs](Stack& stack) {
         std::vector<at::Tensor> inputs;
@@ -321,7 +321,7 @@ bool shape_is_fast_for_side(const at::Tensor& other_side_input) {
 
 RegisterOperators mm_batch_side_reg({Operator(
     prim::MMBatchSide,
-    [](const Node* node) {
+    [](const Node* node) -> Operation {
       size_t num_other_side_inputs = node->inputs().size() - 1;
       Side single_side = static_cast<Side>(node->i(Symbol::attr("side")));
       return [num_other_side_inputs, single_side](Stack& stack) {

--- a/torch/csrc/jit/passes/decompose_ops.cpp
+++ b/torch/csrc/jit/passes/decompose_ops.cpp
@@ -59,7 +59,7 @@ bool isDecomposableNorm(Node* normalize_op) {
 
 RegisterOperators reg_bn_unsqueeze({Operator(
     "aten::_ncf_unsqueeze(Tensor self, int ndim) -> Tensor",
-    [](const Node* node) {
+    [](const Node* node) -> Operation {
       return [](Stack& stack) {
         const int64_t ndim = pop(stack).toInt();
         auto self = pop(stack).toTensor();
@@ -74,7 +74,7 @@ RegisterOperators reg_bn_unsqueeze({Operator(
 
 RegisterOperators reg_ln_view({Operator(
     "aten::_ncf_view(Tensor self, int[] input_shape, int normalized_ndim) -> Tensor",
-    [](const Node* node) {
+    [](const Node* node) -> Operation {
       return [](Stack& stack) {
         const int64_t normalized_ndim = pop(stack).toInt();
         auto input_shape = pop(stack).toIntList();

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -234,7 +234,7 @@ int64_t normalizeIndex(int64_t idx, int64_t list_size) {
 RegisterOperators reg(
     {Operator(
          prim::profile,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            auto callback = node->cast<ProfileOp>()->getCallback();
            return [callback](Stack& stack) {
              callback(stack);
@@ -244,7 +244,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::FusionGroup,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            const auto key = registerFusion(node);
            return [key](Stack& stack) {
              RECORD_FUNCTION("FusionGroup", std::vector<c10::IValue>());
@@ -255,7 +255,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          "prim::Guard(Tensor(a) t) -> Tensor(a)",
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [](Stack& stack) {
              AT_ERROR("Should be replaced by prim::BailOut");
              return 0;
@@ -264,7 +264,7 @@ RegisterOperators reg(
          aliasAnalysisFromSchema()),
      Operator(
          "prim::BailOut(...) -> Tensor(a)",
-         [](const Node* /* node */) {
+         [](const Node* /* node */) -> Operation {
            return [](Stack& /* stack */) {
              AT_ERROR("prim::BailOut not yet implemented"); // NOLINT
              return 0;
@@ -273,7 +273,7 @@ RegisterOperators reg(
          aliasAnalysisFromSchema()),
      Operator(
          "prim::BailoutTemplate() -> int",
-         [](const Node* /* node */) {
+         [](const Node* /* node */) -> Operation {
            return [](Stack& stack) {
              // TODO: today, we put a single bailout template at the front to
              // carry the un-optimized graph for bailout nodes to use. Ideally
@@ -731,7 +731,7 @@ RegisterOperators reg(
          aliasAnalysisConservative()),
      Operator(
          "prim::AutogradZero() -> Tensor",
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [](Stack& stack) {
              stack.emplace_back(at::Tensor());
              return 0;
@@ -755,7 +755,7 @@ RegisterOperators reg(
          aliasAnalysisFromSchema()),
      Operator(
          prim::Print,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            size_t num_inputs = node->inputs().size();
            return [num_inputs](Stack& stack) {
              std::stringstream ss;
@@ -829,7 +829,7 @@ RegisterOperators reg(
              {Argument("message", StringType::get()),
               Argument("stacklevel", IntType::get(), c10::nullopt, 2, true)},
              {}),
-         [](const Node* node) -> std::function<int(Stack&)> {
+         [](const Node* node) -> Operation {
            auto range = node->sourceRange().source();
            if (range->filename()) {
              auto line = range->starting_line_no() +
@@ -883,7 +883,7 @@ RegisterOperators reg(
      Operator(prim::Store, noop, aliasAnalysisSpecialCase()),
      Operator(
          prim::Drop,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            auto N = node->inputs().size();
            return [=](Stack& stack) {
              drop(stack, N);
@@ -893,7 +893,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          c10::onnx::Reshape,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [=](Stack& stack) {
              at::Tensor input, shape;
              pop(stack, input, shape);
@@ -907,7 +907,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          c10::onnx::Shape,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [=](Stack& stack) {
              auto t = pop(stack).toTensor();
              at::IntArrayRef sizes = t.sizes();
@@ -924,7 +924,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::AutogradAnyNonZero,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            size_t num_inputs = node->inputs().size();
            return [=](Stack& stack) {
              bool result = false;
@@ -942,7 +942,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::AutogradAdd,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [=](Stack& stack) {
              at::Tensor a, b;
              pop(stack, a, b);
@@ -987,7 +987,7 @@ RegisterOperators reg(
          aliasAnalysisFromSchema()),
      Operator(
          prim::TupleUnpack,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            size_t num_elems = node->outputs().size();
            return [=](Stack& stack) {
              auto tuple = pop(stack).toTuple();
@@ -1008,7 +1008,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::TupleSlice,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            int64_t beg_ind = node->i(attr::beg);
            int64_t end_ind = node->i(attr::end);
            return [=](Stack& stack) {
@@ -1025,7 +1025,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::TupleIndex,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [](Stack& stack) {
              int64_t index = pop(stack).toInt();
              auto tuple = pop(stack).toTuple();
@@ -1041,7 +1041,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::TupleConstruct,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            size_t num_inputs = node->inputs().size();
            auto type = node->output()->type()->expect<TupleType>();
            bool named = type->name().has_value();
@@ -1060,7 +1060,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::ConstantChunk,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            int64_t chunks = node->i(attr::chunks);
            int64_t dim = node->i(attr::dim);
            auto outputs_used = fmap(node->outputs(), [](const Value* v) {
@@ -1254,7 +1254,7 @@ RegisterOperators reg(
          aliasAnalysisFromSchema()),
      Operator(
          prim::fork,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            Code code(node->g(attr::Subgraph));
            int n_inputs = node->inputs().size();
            AT_ASSERT(node->blocks().size() == 0);
@@ -1285,7 +1285,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::Uninitialized,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            return [](Stack& stack) {
              push(stack, IValue::uninitialized());
              return 0;
@@ -1294,7 +1294,7 @@ RegisterOperators reg(
          aliasAnalysisSpecialCase()),
      Operator(
          prim::CreateObject,
-         [](const Node* node) {
+         [](const Node* node) -> Operation {
            const auto type = node->output()->type()->expect<ClassType>();
            const size_t numAttrs = type->numAttributes();
            auto cu = type->compilation_unit();
@@ -3170,7 +3170,7 @@ Function* getLtFuncFromListOfClassTypes(const Node* node) {
 RegisterOperators regSort({
     Operator(
         "aten::sorted(t[](a) self) -> (t[])",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return sort_op(
               getLtFuncFromListOfClassTypes(node),
               /*has_reverse_arg*/ false,
@@ -3179,7 +3179,7 @@ RegisterOperators regSort({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::sort(t[](a!) self, bool reverse=False) -> ()",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return sort_op(
               getLtFuncFromListOfClassTypes(node),
               /*has_reverse_arg*/ true,

--- a/torch/csrc/jit/register_special_ops.cpp
+++ b/torch/csrc/jit/register_special_ops.cpp
@@ -278,7 +278,7 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::_infer_size(int[] a, int[] b) -> int[]",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return [](Stack& stack) {
             auto a = pop(stack);
             auto b = pop(stack);
@@ -289,7 +289,7 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::_no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return [](Stack& stack) {
             at::Tensor weight;
             at::Tensor input;
@@ -310,7 +310,7 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::format(str self, ...) -> str",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           size_t num_inputs = node->inputs().size();
           std::regex unsupported_options("\\{(.*)\\}");
           return [num_inputs, unsupported_options](Stack& stack) {
@@ -348,7 +348,7 @@ RegisterOperators reg({
       "aten::tensor(" #operator_type                                       \
       " t, *, ScalarType? dtype=None, Device? device=None"                 \
       ", bool requires_grad=False) -> Tensor",                             \
-      [](const Node* node) {                                               \
+      [](const Node* node) -> Operation {                                               \
         return [](Stack& stack) {                                          \
           c_type scalar_val;                                               \
           IValue dtype;                                                    \
@@ -366,7 +366,7 @@ RegisterOperators reg({
       Operator(                                                            \
           "aten::as_tensor(" #operator_type                                \
           " t, *, ScalarType? dtype=None, Device? device=None) -> Tensor", \
-          [](const Node* node) {                                           \
+          [](const Node* node) -> Operation {                                           \
             return [](Stack& stack) {                                      \
               c_type scalar_val;                                           \
               IValue dtype;                                                \
@@ -391,7 +391,7 @@ RegisterOperators reg({
     // tensor_new.cpp
     Operator(
         "aten::_infer_size(int[] a, int[] b) -> int[]",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return [](Stack& stack) {
             auto a = pop(stack);
             auto b = pop(stack);
@@ -402,7 +402,7 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::_no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return [](Stack& stack) {
             at::Tensor weight;
             at::Tensor input;
@@ -427,7 +427,7 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::as_tensor(Tensor(a) data, *, ScalarType? dtype=None, Device? device=None) -> Tensor(a|b)",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return [](Stack& stack) {
             auto device = pop(stack).toOptional<c10::Device>();
             auto dtype = pop(stack).toOptional<at::ScalarType>();
@@ -451,7 +451,7 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     Operator(
         "aten::_assert_int_or_pair(int[] vals, str name, str message) -> Tensor",
-        [](const Node* node) {
+        [](const Node* node) -> Operation {
           return [](Stack& stack) {
             // Everything is a list at the point this is used, so don't do
             // anything


### PR DESCRIPTION
This takes a lot of pressure off of the C++ typechecker as well as generating much more
efficient and smaller code.  In my not-super-rigorous testing, compile time for
register_prim_ops.cpp went from 68s to 35s, and the size of libtorch went from 72MB to 70MB.

