### PR TITLE
[qconv] fix operator level benchmark to have NHWC layout

### DIFF
--- a/benchmarks/operator_benchmark/pt/qconv_test.py
+++ b/benchmarks/operator_benchmark/pt/qconv_test.py
@@ -64,12 +64,14 @@ class QConv2dBenchmark(op_bench.TorchBenchmarkBase):
         qX = torch.quantize_linear(
             X, scale=scale, zero_point=zero_point, dtype=torch.quint8
         )
+        # Convert the tensor to NHWC format
+        qX = qX.contiguous(memory_format=torch.channels_last)
         W = torch.randn(OC, IC // G, kernel, kernel, dtype=torch.float32)
         qW = torch.quantize_linear(W, scale=scale, zero_point=0, dtype=torch.qint8)
 
         self.input = qX
         self.qconv2d = nnq.Conv2d(IC, OC, kernel, stride=stride, padding=pad, groups=G)
-        self.qconv2d.weight = qW
+        self.qconv2d.set_weight_bias(qW, None)
         self.qconv2d.scale = torch.tensor([scale], dtype=torch.double)
         self.qconv2d.zero_point = torch.tensor([zero_point], dtype=torch.int)
         self.set_module_name("QConv2d")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26577 [qconv] fix operator level benchmark to have NHWC layout**

Have the NHWC layout expected by qconv kernel.
for rexnext101-32x4d shapes

Before :
```
Forward Execution Time (us) : 4787.046
Forward Execution Time (us) : 1320.065
Forward Execution Time (us) : 2611.631
Forward Execution Time (us) : 2562.389
Forward Execution Time (us) : 1072.342
Forward Execution Time (us) : 2330.658
Forward Execution Time (us) : 1894.549
Forward Execution Time (us) : 3446.532
Forward Execution Time (us) : 2381.251
Forward Execution Time (us) : 1157.339
Forward Execution Time (us) : 2712.621
Forward Execution Time (us) : 3789.905
Forward Execution Time (us) : 4057.886
Forward Execution Time (us) : 6104.570
Forward Execution Time (us) : 11328.552
Forward Execution Time (us) : 3707.519
Forward Execution Time (us) : 4681.272
Forward Execution Time (us) : 2459.266
Forward Execution Time (us) : 849.564
Forward Execution Time (us) : 3000.764
Forward Execution Time (us) : 3019.704
Forward Execution Time (us) : 5216.046
Forward Execution Time (us) : 3403.549
Forward Execution Time (us) : 1291.878
Forward Execution Time (us) : 2057.147
```

After
```
Forward Execution Time (us) : 4398.649
Forward Execution Time (us) : 993.619
Forward Execution Time (us) : 2252.265
Forward Execution Time (us) : 2230.500
Forward Execution Time (us) : 977.389
Forward Execution Time (us) : 2233.356
Forward Execution Time (us) : 1223.085
Forward Execution Time (us) : 2758.765
Forward Execution Time (us) : 2208.028
Forward Execution Time (us) : 821.816
Forward Execution Time (us) : 2396.748
Forward Execution Time (us) : 2505.803
Forward Execution Time (us) : 2771.251
Forward Execution Time (us) : 4816.474
Forward Execution Time (us) : 10065.299
Forward Execution Time (us) : 2424.949
Forward Execution Time (us) : 3854.800
Forward Execution Time (us) : 2297.426
Forward Execution Time (us) : 682.403
Forward Execution Time (us) : 2297.541
Forward Execution Time (us) : 2317.828
Forward Execution Time (us) : 4517.372
Forward Execution Time (us) : 2716.691
Forward Execution Time (us) : 942.385
Forward Execution Time (us) : 1717.172
```

Differential Revision: [D17512291](https://our.internmc.facebook.com/intern/diff/D17512291/)