### PR TITLE
In-place after view in no_grad (issue #26546)

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3083,6 +3083,15 @@ class TestAutograd(TestCase):
 
         assert y.grad_fn is None
 
+    def test_view_no_grad(self):
+        # Issue 26546: View result under torch.no_grad() should not require grad.
+        x = torch.ones(1, requires_grad=True)
+
+        with torch.no_grad():
+            y = x.t()
+
+        assert not y.requires_grad
+
     def test_inplace_view_in_autograd_function(self):
         # Issue 26546: In-place operation on a view inside of a Python autograd
         # function should not break the graph.

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3073,6 +3073,15 @@ class TestAutograd(TestCase):
         with self.assertRaises(RuntimeError):
             c.sum().backward(torch.ones(1, requires_grad=True))
 
+    def test_inplace_view_no_grad(self):
+        # See https://github.com/pytorch/pytorch/issues/26546
+        x = torch.ones(1, requires_grad=True)
+
+        with torch.no_grad():
+            y = x.t()
+            y.add_(0)
+        assert y.grad_fn is None
+
     def test_mul_out(self):
         a = torch.randn(2, 2, requires_grad=True)
         b = torch.randn(2, 2, requires_grad=True)
@@ -3447,15 +3456,6 @@ for shape in [(1,), ()]:
         # compute mean as a proxy for some joint reasoning
         mean_combined = torch.stack(feat_combined).mean()
         mean_combined.backward()
-
-    def test_inplace_after_view(self):
-        # See https://github.com/pytorch/pytorch/issues/26546
-        x = torch.ones(1, requires_grad=True)
-
-        with torch.no_grad():
-            y = x.t()
-            y.add_(0)
-        assert y.grad_fn is None
 
 
 def index_variable(shape, max_indices):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3111,7 +3111,7 @@ class TestAutograd(TestCase):
         y.sum().backward()
 
         assert y.grad_fn.__class__ is F._backward_cls
-        assert x.grad.mean().item() == 42
+        assert x.grad.tolist() == [42, 42, 42]
 
     def test_mul_out(self):
         a = torch.randn(2, 2, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3448,6 +3448,16 @@ for shape in [(1,), ()]:
         mean_combined = torch.stack(feat_combined).mean()
         mean_combined.backward()
 
+    def test_inplace_after_view(self):
+        # See https://github.com/pytorch/pytorch/issues/26546
+        x = torch.ones(1, requires_grad=True)
+
+        with torch.no_grad():
+            y = x.t()
+            y.add_(0)
+        assert y.grad_fn is None
+
+
 def index_variable(shape, max_indices):
     if not isinstance(shape, tuple):
         shape = (shape,)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3074,16 +3074,18 @@ class TestAutograd(TestCase):
             c.sum().backward(torch.ones(1, requires_grad=True))
 
     def test_inplace_view_no_grad(self):
-        # See https://github.com/pytorch/pytorch/issues/26546
+        # Issue 26546: View should respect torch.no_grad() mode.
         x = torch.ones(1, requires_grad=True)
 
         with torch.no_grad():
             y = x.t()
             y.add_(0)
+
         assert y.grad_fn is None
 
     def test_inplace_view_in_autograd_function(self):
-        # See https://github.com/pytorch/pytorch/issues/26546
+        # Issue 26546: In-place operation on a view inside of a Python autograd
+        # function should not break the graph.
         class F(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -282,7 +282,7 @@ class TestCheckpoint(TestCase):
         out = checkpoint(run_fn, input_var, None)
         out.sum().backward()
 
-    def test_checkpoint_inplace_after_view(self):
+    def test_checkpoint_inplace_view(self):
         # See https://github.com/pytorch/pytorch/issues/26546
         def run_fn(input):
             out = input + 1    # add a grad_fn

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -106,6 +106,11 @@ inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
+
+  if (!GradMode::is_enabled()) {
+    is_differentiable = false;
+  }
+
   return make_variable_view(std::move(base_var), std::move(tensor), is_differentiable);
 }
 
@@ -116,6 +121,11 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor> tens
   if (base_var.is_view()) {
     base_var = base_var.base();
   }
+
+  if (!GradMode::is_enabled()) {
+    is_differentiable = false;
+  }
+
   for(Tensor &tensor : tensors) {
     tensor = make_variable_view(base_var, std::move(tensor), is_differentiable);
   }


### PR DESCRIPTION
Issue: #26546

In `torch.no_grad()` mode, an in-place operation on a view tensor (`t()`, `view()`, `squeeze()`, etc.) attaches grad_fn `AsStridedBackward` to the tensor.

For example, `y` in the below code should not have any `grad_fn` because it has passed through `torch.no_grad()`:

```python
x = torch.ones(1, requires_grad=True)
with torch.no_grad():
    y = x.t()
    y.add_(0)
```

But it has `grad_fn`:

```python
>>> y
tensor([1.], grad_fn=<AsStridedBackward>)
```

This behavior may cause a bug difficult to understand when we compose InstanceNorm (it makes a view tensor internally) and in-place ReLU in a checkpoint:

```python
x = torch.ones(3, 2, 1, requires_grad=True)
model = nn.Sequential(
    nn.InstanceNorm1d(2),
    nn.ReLU(inplace=True),
)
y = checkpoint(model, x)
y.norm().backward()

# x.grad should be tensor(...). But it is still None because it didn't receive any gradients.
assert x.grad is not None  # FAILS!

# y.grad_fn should be <CheckpointFunctionBackward>. But it is <AsStridedBackward> actually.
assert y.grad_fn.__class__ is CheckpointFunction._backward_cls  # FAILS!
```

To access `Tensor.grad_fn` in Python triggers `Variable::grad_fn()` in [autograd/variable.cpp](https://github.com/pytorch/pytorch/blob/v1.2.0/torch/csrc/autograd/variable.cpp#L135-L162). This method always returns `<AsStridedBackward>` if the tensor is a view with in-place mutation regardless of the grad mode it has passed through. So I've tried to make the tensor as not a view if the view was created in `no_grad` mode.

To suppress `DifferentiableViewMeta` in `no_grad` mode seems to fix those problems. I just made `as_view()` check `GradMode::is_enabled()` before calling `make_view_variable()`.

```diff
  inline Tensor as_view(const Tensor & base, Tensor tensor, bool is_differentiable = true) {
    auto base_var = Variable(base);
    if (base_var.is_view()) {
      base_var = base_var.base();
    }

+   if (!GradMode::is_enabled()) {
+     is_differentiable = false;
+   }

    return make_variable_view(std::move(base_var), std::move(tensor), is_differentiable);
  }
```

Please review this solution and the following code.