### PR TITLE
Whitelist ATen/core sources and headers for Caffe2

### DIFF
--- a/caffe2/c2_aten_srcs.bzl
+++ b/caffe2/c2_aten_srcs.bzl
@@ -1,0 +1,14 @@
+ATEN_CORE_HEADER_FILES = [
+    # "aten/src/" prefix is added later
+    "ATen/core/ATenGeneral.h",
+    "ATen/core/blob.h",
+    "ATen/core/context_base.h",
+    "ATen/core/DimVector.h",
+    "ATen/core/grad_mode.h",
+    "ATen/core/UndefinedTensorImpl.h",
+]
+
+ATEN_CORE_SRC_FILES = [
+    "aten/src/ATen/core/context_base.cpp",
+    "aten/src/ATen/core/grad_mode.cpp",
+]


### PR DESCRIPTION
Summary:
Previously, we were globbing all of ATen/core and excluding specific files.
However, this frequently resulted in new files being missed, and PyTorch
diffs triggering Caffe2 builds.  Now, instead, we will list the ATen/core
files that are required for Caffe2.

Test Plan: Ran internal Caffe2Go unit test.

Reviewed By: smessmer

Differential Revision: D17504740

