### PR TITLE
[iOS] Add testing script for iOS x86 build

### DIFF
--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -1,5 +1,5 @@
 #import "ViewController.h"
-#import <LibTorch/LibTorch.h>
+#import <torch/script.h>
 
 @interface ViewController ()
 

--- a/scripts/xcode_ios_x86_build.rb
+++ b/scripts/xcode_ios_x86_build.rb
@@ -1,0 +1,58 @@
+require 'optparse'
+require 'xcodeproj'
+
+options = {}
+option_parser = OptionParser.new do  |opts| 
+ opts.banner = 'Tools for testing the PyTorch iOS x86 build on MacOS'
+ opts.on('-i', '--install ', 'path to the cmake install folder') { |value|
+    options[:install] = value
+ }
+ opts.on('-x', '--xcodeproj ', 'path to the XCode project file') { |value|
+    options[:xcodeproj] = value
+ }
+end.parse!
+puts options.inspect
+
+install_path = File.expand_path(options[:install])
+puts("Libraries install path: #{install_path}")
+if not Dir.exist? (install_path) 
+    puts "path don't exist:#{install_path}!"
+    exit(false)
+end
+xcodeproj_path = File.expand_path(options[:xcodeproj])
+puts("XCode project: #{xcodeproj_path}")
+if not File.exist? (xcodeproj_path) 
+    puts "path don't exist:#{xcodeproj_path}!"
+    exit(false)
+end
+
+project = Xcodeproj::Project.open(xcodeproj_path)
+target = project.targets.first
+header_search_path      = ['$(inherited)', "#{install_path}/include"]
+libraries_search_path   = ['$(inherited)', "#{install_path}/lib"]
+other_linker_flags      = ['$(inherited)', "-all_load"]
+
+target.build_configurations.each do |config|
+    config.build_settings['HEADER_SEARCH_PATHS']    = header_search_path
+    config.build_settings['LIBRARY_SEARCH_PATHS']   = libraries_search_path
+    config.build_settings['OTHER_LINKER_FLAGS']     = other_linker_flags
+end
+
+# link static libraries
+target.frameworks_build_phases.clear
+libs = ['libc10.a', 'libclog.a', 'libcpuinfo.a', 'libpytorch_qnnpack.a', 'libtorch.a']
+for lib in libs do 
+    path = "#{install_path}/lib/#{lib}"
+    libref = project.frameworks_group.new_file(path)
+    target.frameworks_build_phases.add_file_reference(libref)
+end
+project.save
+
+# run xcodebuild
+exec "xcodebuild clean build 
+-project #{xcodeproj_path}  
+-target #{target.name} 
+-sdk iphonesimulator 
+-configuration Release"
+
+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26621 [iOS] Add x86 testing script for iOS build**

### Summary

This script builds the TestApp located in ios folder to produce an iOS x86 executable via the `xcodebuild` toolchain on macOS. The goal is to test the generated static libraries to see if there is a linking error. To use the script, simply check the usage description below:

```
$ruby scripts/xcode_ios_x86_build.rb --help

-i, --install                    path to the cmake install folder
-x, --xcodeproj                  path to the XCode project file
```
The script will also be used by the iOS CI jobs in the following PR.

### Note

The script mainly deals with the iOS simulator build. For the arm64 build, I haven't found a way to disable the Code Sign using the `xcodebuiild` tool chain (XCode 10). 

### Test Plan

- The script can build the TestApp and link the generated static libraries successfully
- Don't break any CI job