### PR TITLE
[iOS] Add testing script for iOS x86 build

### DIFF
--- a/ios/TestApp/TestApp/ViewController.mm
+++ b/ios/TestApp/TestApp/ViewController.mm
@@ -1,5 +1,5 @@
 #import "ViewController.h"
-#import <LibTorch/LibTorch.h>
+#import <torch/script.h>
 
 @interface ViewController ()
 

--- a/scripts/xcode_ios_x86_build.rb
+++ b/scripts/xcode_ios_x86_build.rb
@@ -1,0 +1,52 @@
+require 'optparse'
+require 'xcodeproj'
+
+options = {}
+option_parser = OptionParser.new do  |opts| 
+ opts.banner = 'Tools for testing the PyTorch iOS x86 build on MacOS'
+ opts.on('-i', '--install ', 'path to the cmake install folder') { |value|
+    options[:install] = value
+ }
+ opts.on('-x', '--xcodeproj ', 'path to the XCode project file') { |value|
+    options[:xcodeproj] = value
+ }
+end.parse!
+puts options.inspect
+
+install_path = File.expand_path(options[:install])
+puts("Libraries install path: #{install_path}")
+if not Dir.exist? (install_path) 
+    puts "path don't exist:#{install_path}!"
+    exit(false)
+end
+xcodeproj_path = File.expand_path(options[:xcodeproj])
+puts("XCode project: #{xcodeproj_path}")
+if not File.exist? (xcodeproj_path) 
+    puts "path don't exist:#{xcodeproj_path}!"
+    exit(false)
+end
+
+project = Xcodeproj::Project.open(xcodeproj_path)
+target = project.targets.first
+header_search_path      = ['$(inherited)', "#{install_path}/include"]
+libraries_search_path   = ['$(inherited)', "#{install_path}/lib"]
+other_linker_flags      = ['$(inherited)', "-all_load"]
+
+target.build_configurations.each do |config|
+    config.build_settings['HEADER_SEARCH_PATHS']    = header_search_path
+    config.build_settings['LIBRARY_SEARCH_PATHS']   = libraries_search_path
+    config.build_settings['OTHER_LINKER_FLAGS']     = other_linker_flags
+end
+
+# link static libraries
+target.frameworks_build_phases.clear
+libs = ['libc10.a', 'libclog.a', 'libcpuinfo.a', 'libpytorch_qnnpack.a', 'libtorch.a']
+for lib in libs do 
+    path = "#{install_path}/lib/#{lib}"
+    libref = project.frameworks_group.new_file(path)
+    target.frameworks_build_phases.add_file_reference(libref)
+end
+project.save
+
+# run xcodebuild
+exec "xcodebuild clean build  -project #{xcodeproj_path}  -target #{target.name} -sdk iphonesimulator -configuration Release"

--- a/scripts/xcode_ios_x86_build.rb
+++ b/scripts/xcode_ios_x86_build.rb
@@ -2,7 +2,7 @@ require 'optparse'
 require 'xcodeproj'
 
 options = {}
-option_parser = OptionParser.new do  |opts| 
+option_parser = OptionParser.new do |opts| 
  opts.banner = 'Tools for testing the PyTorch iOS x86 build on MacOS'
  opts.on('-i', '--install ', 'path to the cmake install folder') { |value|
     options[:install] = value
@@ -14,13 +14,13 @@ end.parse!
 puts options.inspect
 
 install_path = File.expand_path(options[:install])
-puts("Libraries install path: #{install_path}")
+puts("Library install path: #{install_path}")
 if not Dir.exist? (install_path) 
     puts "path don't exist:#{install_path}!"
     exit(false)
 end
 xcodeproj_path = File.expand_path(options[:xcodeproj])
-puts("XCode project: #{xcodeproj_path}")
+puts("XCode project file path: #{xcodeproj_path}")
 if not File.exist? (xcodeproj_path) 
     puts "path don't exist:#{xcodeproj_path}!"
     exit(false)
@@ -40,7 +40,7 @@ end
 
 # link static libraries
 target.frameworks_build_phases.clear
-libs = ['libc10.a', 'libclog.a', 'libcpuinfo.a', 'libpytorch_qnnpack.a', 'libtorch.a']
+libs = ['libc10.a', 'libclog.a', 'libeigen_blas.a', 'libcpuinfo.a', 'libpytorch_qnnpack.a', 'libtorch.a']
 for lib in libs do 
     path = "#{install_path}/lib/#{lib}"
     libref = project.frameworks_group.new_file(path)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26632 [iOS] Add testing script for iOS x86 build**

### Summary

This script builds the TestApp (located in ios folder) to generate an iOS x86 executable via the `xcodebuild` toolchain on macOS. The goal is to provide a quick way to test the generated static libraries to see if there are any linking errors. The script can also be used by the iOS CI jobs. To run the script, simply see description below:

```shell
$ruby scripts/xcode_ios_x86_build.rb --help

-i, --install                    path to the cmake install folder
-x, --xcodeproj                  path to the XCode project file
```

### Note

The script mainly deals with the iOS simulator build. For the arm64 build, I haven't found a way to disable the Code Sign using the `xcodebuiild` tool chain (XCode 10). If anyone knows how to do that, please feel free to leave a comment below.

### Test Plan

- The script can build the TestApp and link the generated static libraries successfully
- Don't break any CI job

Differential Revision: [D17530990](https://our.internmc.facebook.com/intern/diff/D17530990)