### PR TITLE
Add namedtensor build & tests to default sets

### DIFF
--- a/.circleci/scripts/should_run_job.py
+++ b/.circleci/scripts/should_run_job.py
@@ -60,6 +60,11 @@ default_set = set([
     # XLA
     'pytorch-xla-linux-xenial-py3.6-clang7',
 
+    # Named tensor
+    "pytorch-namedtensor-linux-xenial-py3.6-gcc5.4",
+    "pytorch-namedtensor-linux-xenial-py3-clang5-asan",
+    "pytorch-namedtensor-linux-xenial-cuda9-cudnn7-py2",
+
     # Other checks
     'pytorch-short-perf-test-gpu',
     'pytorch-python-doc-push',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26633 Add namedtensor build & tests to default sets**

This will enable named tensor CI on all pull requests. Previously, named
tensor CI only ran on master.

This is essential for the experimental release because we would like to
prevent failures in the named tensor tests. In addition, when
cherry-picking changes to the release branch, the first signals appear
on the pull requests and it is good to be able to tell that something is
wrong before the cherry-pick is merged.

Test Plan:
- run CI
- check that the named tensor build / tests are indeed running on this
PR.

Differential Revision: [D17523064](https://our.internmc.facebook.com/intern/diff/D17523064)