### PR TITLE
pytorch 1.3 graph

### DIFF
--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -555,6 +555,35 @@ class TestTensorBoardPytorchGraph(BaseTestCase):
                 model = getattr(torchvision.models, model_name)()
                 w.add_graph(model, torch.zeros(input_shape))
 
+class TestTensorBoardPytorchGraph_single_operator(BaseTestCase):
+    import torch.nn as nn
+    from common_nn import module_tests, new_module_tests
+
+    modules = torch.nn.modules.__all__
+    tested = []
+    untested = []
+    for test_params in module_tests + new_module_tests:
+        if 'module_name' in test_params and 'input_size' in test_params:
+            # print(test_params)
+            if 'constructor_args' in test_params:
+                model = getattr(nn, test_params['module_name'])(*test_params['constructor_args'])
+            else:
+                model = getattr(nn, test_params['module_name'])()
+
+            input = torch.zeros(test_params['input_size'])
+            tested.append(test_params['module_name'])
+            # print(model(input))
+            # add_graph(...)
+        elif 'fullname' in test_params and 'constructor' in test_params and 'input_size' in test_params:
+            model = test_params['constructor']()
+            input = torch.zeros(test_params['input_size'])
+            tested.append(test_params['fullname'])
+            # add_graph(...)
+            # print(model(input))
+        else:  # numerical accuracy tests?
+            untested.append(test_params)
+
+
 class TestTensorBoardFigure(BaseTestCase):
     @skipIfNoMatplotlib
     def test_figure(self):

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -192,7 +192,10 @@ def parse(graph, args=None, omit_useless_nodes=True):
       args (tuple): input tensor[s] for the model.
       omit_useless_nodes (boolean): Whether to remove nodes from the graph.
     """
-    n_inputs = len(args)
+    if isinstance(args, list) or isinstance(args, tuple):
+        n_inputs = len(args)
+    else:
+        n_inputs = 1
 
     scope = {}
     nodes_py = GraphPy()

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -208,16 +208,16 @@ def parse(graph, args=None, omit_useless_nodes=True):
         # p.s. Those Constant will be composed by 'prim::listConstruct' and then
         # send to common OPs such as Maxpool, Conv, Linear.
         # We can let user pass verbosity value to dicide how detailed the graph is.
-        if node.kind()=='prim::Constant':
+        if node.kind() == 'prim::Constant':
             continue
 
         # By observation, prim::GetAttr are parameter related. ClassType is used to decorate its scope.
-        if node.kind()=='prim::GetAttr':
+        if node.kind() == 'prim::GetAttr':
             assert node.scopeName() == ''
 
             # Since `populate_namespace_from_OP_to_IO` is already available, we just ignore this.
             # TODO: When it comes to shared parameter, will it still work?
-            if " : ClassType" in  node.__repr__():
+            if " : ClassType" in node.__repr__():
                 continue
 
             nodes_py.append(NodePyIO(node, debugName=list(node.outputs())[0].debugName()))


### PR DESCRIPTION
This patch fixes the problem that the rendered graph is not meaningful.

Since pytorch 1.2, the representation of the traced graph has changed alot, which includes:

1. Many operators were added.
2. The parameter node is moved to graph.nodes(), rather than graph.inputs()
3. The graph is been traced in detail. Take convolution for example, the traced result looks like
aten::_convolution(%input.5, %weight.2, %7, %66, %69, %72, %73, %76, %77, %78, %79, %80)
Besides input, weight, and bias, other nodes are parameters such as stride, kernel size, etc. This information are encoded as "attributes" before.

cc @orionr @sanekmelnikov 