### PR TITLE
C++ API parity: at::Tensor::set_data

### DIFF
--- a/test/cpp/api/tensor.cpp
+++ b/test/cpp/api/tensor.cpp
@@ -489,3 +489,18 @@ TEST(TensorTest, DetachInplace) {
   ASSERT_THROWS_WITH(x.detach_(), message);
   ASSERT_THROWS_WITH(y.detach_(), message);
 }
+
+TEST(TensorTest, SetData) {
+  auto x = torch::randn({5});
+  auto y = torch::randn({5});
+  ASSERT_FALSE(torch::equal(x, y));
+  ASSERT_NE(x.data_ptr<float>(), y.data_ptr<float>());
+
+  x.set_data(y);
+  ASSERT_TRUE(torch::equal(x, y));
+  ASSERT_EQ(x.data_ptr<float>(), y.data_ptr<float>());
+
+  x = at::tensor({5});
+  y = at::tensor({5});
+  ASSERT_THROWS_WITH(x.set_data(y), "set_data is not implemented for Tensor");
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26568 C++ API parity: at::Tensor::register_hook
* #26332 C++ API parity: at::Tensor::requires_grad_
* **#26647 C++ API parity: at::Tensor::set_data**

Differential Revision: [D17542604](https://our.internmc.facebook.com/intern/diff/D17542604)