### PR TITLE
Fix ellipsis behavior for `Tensor.align_to` to glob all missing dims

### DIFF
--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -1211,17 +1211,6 @@ class TestNamedTensor(TestCase):
         self.assertEqual(output.names, ['N', 'H', 'W', 'C'])
         self.assertEqual(output.shape, [3, 5, 1, 2])
 
-        # globbing
-        tensor = create('N:7,H:3,W:5,C:2')
-        output = tensor.align_to('...', 'C', 'H', 'W')
-        self.assertEqual(output.names, ['N', 'C', 'H', 'W'])
-        self.assertEqual(output.shape, [7, 2, 3, 5])
-
-        tensor = create('N:7,C:2,H:3,W:5')
-        output = tensor.align_to('...', 'W', 'H')
-        self.assertEqual(output.names, ['N', 'C', 'W', 'H'])
-        self.assertEqual(output.shape, [7, 2, 5, 3])
-
         # All input dimensions must be named
         with self.assertRaisesRegex(RuntimeError, "All input dims must be named"):
             create('None:2,C:3').align_to('N', 'C')
@@ -1233,6 +1222,42 @@ class TestNamedTensor(TestCase):
         # names not found
         with self.assertRaisesRegex(RuntimeError, "Cannot find dim 'C'"):
             create('N:2,C:3').align_to('D', 'N')
+
+    def test_align_to_ellipsis(self):
+        tensor = create('N:7,H:3,W:5,C:2')
+
+        # ... = ['N', 'H', 'W', 'C']
+        output = tensor.align_to('...')
+        self.assertEqual(output.names, ['N', 'H', 'W', 'C'])
+        self.assertEqual(output.shape, [7, 3, 5, 2])
+
+        # ... = ['H', 'C']
+        output = tensor.align_to('...', 'W', 'N')
+        self.assertEqual(output.names, ['H', 'C', 'W', 'N'])
+        self.assertEqual(output.shape, [3, 2, 5, 7])
+
+        # ... = ['H', 'C']
+        output = tensor.align_to('W', '...', 'N')
+        self.assertEqual(output.names, ['W', 'H', 'C', 'N'])
+        self.assertEqual(output.shape, [5, 3, 2, 7])
+
+        # ... = []
+        output = tensor.align_to('N', '...', 'C', 'D', 'H', 'W')
+        self.assertEqual(output.names, ['N', 'C', 'D', 'H', 'W'])
+        self.assertEqual(output.shape, [7, 2, 1, 3, 5])
+
+        # Input tensor partially named
+        partiall_named = create('N:7,None:1')
+        with self.assertRaisesRegex(RuntimeError, "All input dims must be named"):
+            partiall_named.align_to(..., 'N')
+
+        # Input order partially named
+        with self.assertRaisesRegex(RuntimeError, "desired order must not contain None"):
+            tensor.align_to(..., 'N', None)
+
+        # Input order duplicate names
+        with self.assertRaisesRegex(RuntimeError, "Duplicate names"):
+            tensor.align_to(..., 'N', 'N')
 
     def test_align_as(self):
         # align_as calls align_to internally. align_to has pretty substantial tests,

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -1249,15 +1249,15 @@ class TestNamedTensor(TestCase):
         # Input tensor partially named
         partiall_named = create('N:7,None:1')
         with self.assertRaisesRegex(RuntimeError, "All input dims must be named"):
-            partiall_named.align_to(..., 'N')
+            partiall_named.align_to('...', 'N')
 
         # Input order partially named
         with self.assertRaisesRegex(RuntimeError, "desired order must not contain None"):
-            tensor.align_to(..., 'N', None)
+            tensor.align_to('...', 'N', None)
 
         # Input order duplicate names
         with self.assertRaisesRegex(RuntimeError, "Duplicate names"):
-            tensor.align_to(..., 'N', 'N')
+            tensor.align_to('...', 'N', 'N')
 
     def test_align_as(self):
         # align_as calls align_to internally. align_to has pretty substantial tests,

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -485,7 +485,8 @@ class Tensor(torch._C._TensorBase):
         return super(Tensor, self).refine_names(names)
 
     def align_to(self, *names):
-        return super(Tensor, self).align_to(resolve_ellipsis(names, self.names, 'align_to'))
+        return super(Tensor, self).align_to(
+            resolve_ellipsis(names, self.names, 'align_to', is_positional=False))
 
     def unflatten(self, dim, namedshape):
         names, sizes = unzip_namedshape(namedshape)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26648 Fix ellipsis behavior for `Tensor.align_to` to glob all missing dims**

Previously:
- `Tensor.align_to(*names)` only works on fully named tensors. In addition, the
desired ordering `names` must not have any None-names.
- `Tensor.align_to(*names)` accepted `...`, but expanded it based on
position. i.e., in `tensor.align_to('N', ..., 'C', 'H')`, `...` expand
to `*tensor.names[1:-2]`. This is wildly incorrect: see the following
concrete example.

```
tensor = tensor.refine_names('N', 'C', 'H, 'W')
tensor.align_to('W', ...) # ... expands to 'C', 'H, 'W'
```

This PR changes it so that `...` in `tensor.align_to` grabs all
unmentioned dimensions from `tensor`, in the order that they appear.
`align_to` is the only function that takes ellipsis that requires this
change. This is because all other functions (`refine_to`) require their
list of names to work in a positional manner, but `align_to` lets the
user reorder dimensions.

This does not add very much overhead to `align_to`, as shown in the
following benchmark. However, in the future, we should resolve to make
these operations faster; align_to should be as fast as view but isn't
most likely due to Python overhead.

```
[ins] In [2]: import torch
         ...: named = torch.randn(3, 3, 3, 3, names=('N', 'C', 'H', 'W'))
         ...: unnamed = torch.randn(3, 3, 3, 3)
         ...: %timeit unnamed[:]
         ...: %timeit unnamed.view(-1)
         ...: %timeit named.align_to(...)
         ...: %timeit named.align_to('N', 'C', 'H', 'W')

31 µs ± 126 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
43.8 µs ± 146 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
69.6 µs ± 142 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
66.1 µs ± 1.13 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Test Plan:
- new tests [namedtensor ci]

allows the user to transpose and permute dimensions.

Differential Revision: [D17528207](https://our.internmc.facebook.com/intern/diff/D17528207)