### PR TITLE
enable double backward for non-cudnn LSTM and GRU

### DIFF
--- a/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
+++ b/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
@@ -1212,6 +1212,7 @@ bool aten_op_is_not_moved_to_c10_yet(const c10::OperatorName& opName) {
         {"aten::result_type", "Scalar_Scalar"},
         {"aten::_thnn_fused_lstm_cell", ""},
         {"aten::_thnn_fused_lstm_cell_backward", ""},
+        {"aten::_thnn_differentiable_lstm_cell_backward", ""},
         {"aten::_thnn_fused_gru_cell", ""},
         {"aten::lstm_cell", ""},
         {"aten::gru_cell", ""},

--- a/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
+++ b/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
@@ -1214,6 +1214,7 @@ bool aten_op_is_not_moved_to_c10_yet(const c10::OperatorName& opName) {
         {"aten::_thnn_fused_lstm_cell_backward", ""},
         {"aten::_thnn_differentiable_lstm_cell_backward", ""},
         {"aten::_thnn_fused_gru_cell", ""},
+        {"aten::_thnn_differentiable_gru_cell_backward", ""},
         {"aten::lstm_cell", ""},
         {"aten::gru_cell", ""},
         {"aten::rnn_tanh_cell", ""},

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1032,47 +1032,91 @@ std::tuple<Tensor, Tensor> lstm_cell(
   return LSTMCell<CellParams>{}(input, std::make_tuple(hx[0], hx[1]), CellParams{w_ih, w_hh, b_ih, b_hh});
 }
 
-std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_differentiable_lstm_cell_backward(
-  const Tensor& grad_hy, const Tensor& grad_cy,
-  const Tensor& input_gates, const Tensor& hidden_gates, const Tensor& input_bias, const Tensor& hidden_bias, const Tensor& cx, const Tensor& cy,
-  bool has_bias) {
-auto gates = input_gates + hidden_gates;
-if (input_bias.defined()) {
-  gates = gates + input_bias;
-}
-if (hidden_bias.defined()) {
-  gates = gates + hidden_bias;
-}
-auto chunked_gates = gates.chunk(4,1);
-auto i = chunked_gates[0].sigmoid();
-auto f = chunked_gates[1].sigmoid();
-auto c = chunked_gates[2].tanh();
-auto o = chunked_gates[3].sigmoid();
-
-auto gcx = cy.tanh();
-Tensor gog;
-TORCH_INTERNAL_ASSERT((grad_hy.defined() || grad_cy.defined()), "either gradient with respect to hy or cy should be defined")
-if (grad_hy.defined()) {
-  gog = grad_hy * gcx;
-  gog = at::sigmoid_backward(gog,o);
-  gcx = at::tanh_backward(grad_hy * o, gcx);
-  if (grad_cy.defined()) {
-    gcx = gcx + grad_cy;
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor>
+_thnn_differentiable_lstm_cell_backward(
+    const Tensor& grad_hy,
+    const Tensor& grad_cy,
+    const Tensor& input_gates,
+    const Tensor& hidden_gates,
+    const Tensor& input_bias,
+    const Tensor& hidden_bias,
+    const Tensor& cx,
+    const Tensor& cy) {
+  Tensor gates = input_gates + hidden_gates;
+  if (input_bias.defined()) {
+    gates = gates + input_bias;
   }
-} else if (grad_cy.defined()){
-  gog = at::zeros_like(cx);
-  gcx = grad_cy;
-} 
-Tensor gig = gcx * c;
-Tensor gfg = gcx * cx;
-Tensor gcg = gcx * i;
-gcx = gcx * f;
-gig = at::sigmoid_backward(gig, i);
-gfg = at::sigmoid_backward(gfg, f);
-gcg = at::tanh_backward(gcg, c);
-Tensor grad_gates = at::cat({gig, gfg, gcg, gog}, 1);
-auto grad_bias = has_bias ? grad_gates.sum(0, /*keepdim=*/false) : at::Tensor{};
-return std::make_tuple(grad_gates, grad_gates, gcx, grad_bias, grad_bias);
+  if (hidden_bias.defined()) {
+    gates = gates + hidden_bias;
+  }
+  auto chunked_gates = gates.chunk(4, 1);
+  Tensor i = chunked_gates[0].sigmoid();
+  Tensor f = chunked_gates[1].sigmoid();
+  Tensor c = chunked_gates[2].tanh();
+  Tensor o = chunked_gates[3].sigmoid();
+
+  Tensor gcx = cy.tanh();
+  Tensor gog;
+  TORCH_INTERNAL_ASSERT((grad_hy.defined() || grad_cy.defined()),"either gradient with respect to hy or cy should be defined");
+  if (grad_hy.defined()) {
+    gog = grad_hy * gcx;
+    gog = at::sigmoid_backward(gog, o);
+    gcx = at::tanh_backward(grad_hy * o, gcx);
+    if (grad_cy.defined()) {
+      gcx = gcx + grad_cy;
+    }
+  } else if (grad_cy.defined()) {
+    gog = at::zeros_like(cx);
+    gcx = grad_cy;
+  }
+  Tensor gig = gcx * c;
+  Tensor gfg = gcx * cx;
+  Tensor gcg = gcx * i;
+  gcx = gcx * f;
+  gig = at::sigmoid_backward(gig, i);
+  gfg = at::sigmoid_backward(gfg, f);
+  gcg = at::tanh_backward(gcg, c);
+  Tensor grad_gates = at::cat({gig, gfg, gcg, gog}, 1);
+  Tensor grad_bias = input_bias.defined() ? grad_gates.sum(0, /*keepdim=*/false) : at::Tensor{};
+  return std::make_tuple(grad_gates, grad_gates, gcx, grad_bias, grad_bias);
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_differentiable_gru_cell_backward(
+    const Tensor& grad_hy,
+    const Tensor& input_gates,
+    const Tensor& hidden_gates,
+    const Tensor& hx,
+    const Tensor& input_bias,
+    const Tensor& hidden_bias){
+  Tensor in_g = input_gates;
+  Tensor h_g = hidden_gates;
+  if (input_bias.defined()){
+    in_g = in_g+input_bias;
+  }
+  if (hidden_bias.defined()){
+    h_g = h_g + hidden_bias;
+  }
+  auto chunked_input_gates = in_g.chunk(3, 1);
+  Tensor ir = chunked_input_gates[0];
+  Tensor ii = chunked_input_gates[1];
+  Tensor in = chunked_input_gates[2];
+  auto chunked_hidden_gates = h_g.chunk(3, 1);
+  Tensor hr = chunked_hidden_gates[0];
+  Tensor hi = chunked_hidden_gates[1];
+  Tensor hn = chunked_hidden_gates[2];
+  Tensor rg = (ir + hr).sigmoid();
+  Tensor ig = (ii + hi).sigmoid();
+  Tensor grad_hx = grad_hy * ig;
+  Tensor ng = (in+rg*hn).tanh();
+  Tensor gig = at::sigmoid_backward(grad_hy * (hx - ng), ig);
+  Tensor gin = at::tanh_backward(grad_hy * (1 - ig), ng);
+  Tensor ghn = gin * rg;
+  Tensor grg = at::sigmoid_backward(gin * hn, rg);
+  Tensor grad_input_gates = at::cat({grg,gig,gin}, 1);
+  Tensor grad_hidden_gates = at::cat({grg,gig,ghn}, 1);
+  Tensor grad_input_bias = input_bias.defined() ? grad_input_gates.sum(0, /*keepdim=*/false) : at::Tensor{};
+  Tensor grad_hidden_bias = input_bias.defined() ? grad_hidden_gates.sum(0, /*keepdim=*/false) : at::Tensor{};
+  return std::make_tuple(grad_input_gates, grad_hidden_gates,  grad_hx, grad_input_bias, grad_hidden_bias);
 }
 
 Tensor gru_cell(

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3750,7 +3750,7 @@
   dispatch:
     CUDA: _thnn_fused_lstm_cell_backward_cuda
 
-- func: _thnn_differentiable_lstm_cell_backward(Tensor? grad_hy, Tensor? grad_cy, Tensor input_gates, Tensor hidden_gates, Tensor? input_bias, Tensor? hidden_bias, Tensor cx, Tensor cy, bool has_bias) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
+- func: _thnn_differentiable_lstm_cell_backward(Tensor? grad_hy, Tensor? grad_cy, Tensor input_gates, Tensor hidden_gates, Tensor? input_bias, Tensor? hidden_bias, Tensor cx, Tensor cy) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
 
 - func: _thnn_fused_gru_cell(Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor)
   dispatch:
@@ -3760,6 +3760,8 @@
   use_c10_dispatcher: unboxed_only
   dispatch:
     CUDA: _thnn_fused_gru_cell_backward_cuda
+
+- func: _thnn_differentiable_gru_cell_backward(Tensor grad_hy, Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias, Tensor? hidden_bias) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
 
 # RNN cells and layers
 - func: lstm.input(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3750,6 +3750,8 @@
   dispatch:
     CUDA: _thnn_fused_lstm_cell_backward_cuda
 
+- func: _thnn_differentiable_lstm_cell_backward(Tensor? grad_hy, Tensor? grad_cy, Tensor input_gates, Tensor hidden_gates, Tensor? input_bias, Tensor? hidden_bias, Tensor cx, Tensor cy, bool has_bias) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
+
 - func: _thnn_fused_gru_cell(Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor)
   dispatch:
     CUDA: _thnn_fused_gru_cell_cuda

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1515,10 +1515,10 @@
 # _thnn_fused_lstm_cell outputs: (hy, cy, workspace)
 - name: _thnn_fused_lstm_cell(Tensor input_gates, Tensor hidden_gates, Tensor cx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor, Tensor)
   output_differentiability: [True, True, False]
-  input_gates, hidden_gates, cx, input_bias, hidden_bias: "GradMode::is_enabled() ? _thnn_differentiable_lstm_cell_backward(grads[0], grads[1], input_gates, hidden_gates, input_bias, hidden_bias, cx, result1, input_bias.defined()) : _thnn_fused_lstm_cell_backward(grads[0], grads[1], cx, result1, result2, input_bias.defined())"
+  input_gates, hidden_gates, cx, input_bias, hidden_bias: "GradMode::is_enabled() ? _thnn_differentiable_lstm_cell_backward(grads[0], grads[1], input_gates, hidden_gates, input_bias, hidden_bias, cx, result1) : _thnn_fused_lstm_cell_backward(grads[0], grads[1], cx, result1, result2, input_bias.defined())"
 
 - name: _thnn_fused_gru_cell(Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor)
-  input_gates, hidden_gates, hx, input_bias, hidden_bias: _thnn_fused_gru_cell_backward(grad, result1, input_bias.defined())
+  input_gates, hidden_gates, hx, input_bias, hidden_bias: "GradMode::is_enabled() ? _thnn_differentiable_gru_cell_backward(grad, input_gates, hidden_gates, hx, input_bias, hidden_bias) : _thnn_fused_gru_cell_backward(grad, result1, input_bias.defined())"
 
 # PackedSequence helpers
 - name: _pack_padded_sequence(Tensor input, Tensor lengths, bool batch_first) -> (Tensor, Tensor)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1515,7 +1515,7 @@
 # _thnn_fused_lstm_cell outputs: (hy, cy, workspace)
 - name: _thnn_fused_lstm_cell(Tensor input_gates, Tensor hidden_gates, Tensor cx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor, Tensor)
   output_differentiability: [True, True, False]
-  input_gates, hidden_gates, cx, input_bias, hidden_bias: _thnn_fused_lstm_cell_backward(grads[0], grads[1], cx, result1, result2, input_bias.defined())
+  input_gates, hidden_gates, cx, input_bias, hidden_bias: "GradMode::is_enabled() ? _thnn_differentiable_lstm_cell_backward(grads[0], grads[1], input_gates, hidden_gates, input_bias, hidden_bias, cx, result1, input_bias.defined()) : _thnn_fused_lstm_cell_backward(grads[0], grads[1], cx, result1, result2, input_bias.defined())"
 
 - name: _thnn_fused_gru_cell(Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor)
   input_gates, hidden_gates, hx, input_bias, hidden_bias: _thnn_fused_gru_cell_backward(grad, result1, input_bias.defined())


### PR DESCRIPTION
An attempt to enable double backward for non-cudnn LSTM and GRU (see #25315, #20449). RNN works already because it does not rely on fused kernels. 
This does not implement double backward function itself, because that is pretty hard to spell out. Instead, it implements backward using differentiable operations, so that double backward can be done automatically. 
The good: seems to work, no effect on performance on the usual case without double backward. because fused lstm backward is used.
The bad: Performance of backward and, especially, double backward, is pretty bad. Scripting would still be a preferred way if we want a performant solution. Performance and/or memory use can be slightly improved if in-place variants can be used for sigmoid_backward and tanh_backward to avoid cat in the end, but I'm not yet sure it's possible, and in any case it is only slight improvement.  
The ugly: I could not figure out a way to reuse workspace that contains the sum of the gates with the applied sigmoid and tanh operations, so that's probably another perf and memory hit. 
cc @soumith, @albanD. If you think this approach is viable, I can extend to GRU and RNN. 
Thanks to @mcarilli whose approach to double backward in weight norm I copied. 

Test plan: added tests to check gradgrad for GRU and LSTM with cudnn disabled. 