### PR TITLE
[pt1][quant] Fix the flaky test_qlinear test caused by hypothesis deadline

### DIFF
--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -816,6 +816,7 @@ class TestQuantizedOps(TestCase):
 )
 class TestDynamicQuantizedLinear(TestCase):
     """Tests the correctness of the dynamic quantized linear and linear_relu op."""
+    @no_deadline
     @given(
         batch_size=st.integers(1, 4),
         input_channels=st.integers(16, 32),
@@ -934,6 +935,7 @@ class TestDynamicQuantizedLinear(TestCase):
 )
 class TestQuantizedLinear(unittest.TestCase):
     """Tests the correctness of the quantized linear and linear_relu op."""
+    @no_deadline
     @given(batch_size=st.integers(1, 4),
            input_channels=st.integers(16, 32),
            output_channels=st.integers(4, 8),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26663 [pt1][quant] Fix the flaky test_qlinear test caused by hypothesis deadline**

As Title says.

Example error:
https://circleci.com/gh/pytorch/pytorch/2894108?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link%2Fconsole

```
Sep 23 19:08:00 Unreliable test timings! On an initial run, this test took 453.13ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took 23.01 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.
```

Differential Revision: [D17534476](https://our.internmc.facebook.com/intern/diff/D17534476/)