### PR TITLE
[ivalue] Add tuple constructor + to<std::tuple<Args...>>

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <ATen/core/blob.h>
-#include <c10/util/intrusive_ptr.h>
 #include <ATen/core/TensorBody.h>
+#include <ATen/core/blob.h>
+#include <c10/util/C++17.h>
+#include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 namespace torch {
@@ -173,6 +174,16 @@ struct CAFFE2_API IValue final {
 
   // Tuple
   IValue(c10::intrusive_ptr<ivalue::Tuple> v);
+
+  template <
+      typename... Args,
+      c10::guts::enable_if_t<
+          !c10::guts::disjunction<
+              std::is_lvalue_reference<Args>...,
+              c10::guts::negation<std::is_constructible<IValue, Args>>...>::
+              value,
+          std::nullptr_t> = nullptr>
+  IValue(const std::tuple<Args...>& t);
   bool isTuple() const { return Tag::Tuple == tag; }
   c10::intrusive_ptr<ivalue::Tuple> toTuple() &&;
   c10::intrusive_ptr<ivalue::Tuple> toTuple() const &;

--- a/test/cpp/jit/test_ivalue.cpp
+++ b/test/cpp/jit/test_ivalue.cpp
@@ -52,6 +52,15 @@ void testIValue() {
   ASSERT_TRUE(ten2.toTensor().equal(ten.toTensor()));
   std::move(ten2).toTensor();
   ASSERT_EQ(tv.use_count(), 2);
+
+  {
+    std::tuple<int64_t, at::Tensor> t = std::make_tuple(123, at::randn({1}));
+    auto iv = IValue(t);
+    auto t_ = iv.to<std::tuple<int64_t, at::Tensor>>();
+    ASSERT_EQ(std::get<0>(t_), 123);
+    ASSERT_EQ(
+        std::get<1>(t_).item().to<float>(), std::get<1>(t).item().to<float>());
+  }
 }
 
 } // namespace jit


### PR DESCRIPTION
This PR adds the ability to use tuples directly with the IValue constructor rather than the vector<IValue> approach