### PR TITLE
adding OpProfile proto into ProfDAGProtos to support storing operation cost

### DIFF
--- a/caffe2/proto/prof_dag.proto
+++ b/caffe2/proto/prof_dag.proto
@@ -57,4 +57,13 @@ message ProfDAGProto {
 message ProfDAGProtos {
   repeated ProfDAGProto stats = 1;
   optional string net_name = 2;
+  repeated OpProfile ops_stats = 3;
+}
+
+// Represents specification of an operation cost.
+message OpProfile {
+  optional string idx = 1;
+  optional string net_name = 2;
+  optional string type = 3;
+  optional float exec_time_secs = 4;
 }


### PR DESCRIPTION
Summary: This diff adds OpProfile proto into ProfDAGProtos to support storing operation cost. During performance estimation idx, net_name, type, and exec_time will be stored in this proto.

Test Plan:
```
buck test caffe2/caffe2/fb/net_transforms/tests/:stats_collector_test
buck test caffe2/caffe2/fb/net_transforms/tests/:perf_estimator_test
buck run caffe2/caffe2/fb/distribute/snntest/cogwheel/:cogwheel_snntest_offline_training_simple_online_training
```

Differential Revision: D17533791

