### PR TITLE
[rename] _per_tensor_affine_qtensor -> _make_per_tensor_quantized_tensor

### DIFF
--- a/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
+++ b/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
@@ -455,7 +455,7 @@ bool aten_op_is_already_moved_to_c10(const c10::OperatorName& opName) {
         {"aten::q_per_channel_scales", ""},
         {"aten::q_per_channel_zero_points", ""},
         {"aten::int_repr", ""},
-        {"aten::_per_tensor_affine_qtensor", ""},
+        {"aten::_make_per_tensor_quantized_tensor", ""},
         {"aten::_per_channel_affine_qtensor", ""},
         {"aten::fake_quantize_per_tensor_affine", ""},
         {"aten::fake_quantize_per_tensor_affine_backward", ""},

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -170,7 +170,7 @@ std::tuple<Tensor, Tensor> max(const Tensor& self, int64_t dim, bool keepdim) {
     Tensor max = at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
     at::native::max_out(max, max_indices, self.int_repr(), dim, keepdim);
     // TODO: qscheme
-    return std::tuple<Tensor, Tensor>(at::_per_tensor_affine_qtensor(max, self.q_scale(), self.q_zero_point()), max_indices);
+    return std::tuple<Tensor, Tensor>(at::_make_per_tensor_quantized_tensor(max, self.q_scale(), self.q_zero_point()), max_indices);
   } else {
     Tensor  max = at::empty({0}, self.options());
     return at::native::max_out(max, max_indices, self, dim, keepdim);
@@ -215,7 +215,7 @@ std::tuple<Tensor, Tensor> min(const Tensor& self, int64_t dim, bool keepdim) {
   if (self.is_quantized()) {
     Tensor min = at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
     at::native::min_out(min, min_indices, self.int_repr(), dim, keepdim);
-    return std::tuple<Tensor, Tensor>(at::_per_tensor_affine_qtensor(min, self.q_scale(), self.q_zero_point()), min_indices);
+    return std::tuple<Tensor, Tensor>(at::_make_per_tensor_quantized_tensor(min, self.q_scale(), self.q_zero_point()), min_indices);
   } else {
     Tensor min = at::empty({0}, self.options());
     return at::native::min_out(min, min_indices, self, dim, keepdim);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3552,10 +3552,10 @@
   dispatch:
     QuantizedCPU: int_repr_quant
 
-- func: _per_tensor_affine_qtensor(Tensor self, float scale, int zero_point) -> Tensor
+- func: _make_per_tensor_quantized_tensor(Tensor self, float scale, int zero_point) -> Tensor
   use_c10_dispatcher: full
   dispatch:
-    CPU: per_tensor_affine_qtensor_cpu
+    CPU: make_per_tensor_quantized_tensor_cpu
 
 - func: _per_channel_affine_qtensor(Tensor self, Tensor scale, Tensor zero_point, int[] axis) -> Tensor
   use_c10_dispatcher: unboxed_only

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -116,7 +116,7 @@ Tensor int_repr_quant(const Tensor& self) {
   return dst;
 }
 
-Tensor per_tensor_affine_qtensor_cpu(
+Tensor make_per_tensor_quantized_tensor_cpu(
     const Tensor& self,
     double scale,
     int64_t zero_point) {
@@ -126,7 +126,7 @@ Tensor per_tensor_affine_qtensor_cpu(
       scale,
       zero_point);
   Tensor self_contig = self.contiguous();
-  AT_DISPATCH_QINT_TYPES(dst.scalar_type(), "per_tensor_affine_qtensor", [&]() {
+  AT_DISPATCH_QINT_TYPES(dst.scalar_type(), "make_per_tensor_quantized_tensor", [&]() {
     underlying_t* self_data = self_contig.data_ptr<underlying_t>();
     underlying_t* dst_data =
         reinterpret_cast<underlying_t*>(dst.data_ptr<scalar_t>());

--- a/aten/src/ATen/native/quantized/TensorCompare.cpp
+++ b/aten/src/ATen/native/quantized/TensorCompare.cpp
@@ -29,7 +29,7 @@ std::tuple<Tensor, Tensor> sort_quant(
   std::tie(sort_int, sort_indicies) =
       at::sort(self.int_repr(), dim, descending);
   return std::forward_as_tuple(
-      at::_per_tensor_affine_qtensor(
+      at::_make_per_tensor_quantized_tensor(
           sort_int, self.q_scale(), self.q_zero_point()),
       sort_indicies);
 }

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -98,7 +98,7 @@ class TestQuantizedTensor(TestCase):
 
         # create Tensor from uint8_t Tensor, scale and zero_point
         int_tensor = torch.randint(0, 100, size=(10,), dtype=torch.uint8)
-        q = torch._per_tensor_affine_qtensor(int_tensor, scale, zero_point)
+        q = torch._make_per_tensor_quantized_tensor(int_tensor, scale, zero_point)
         self.assertEqual(int_tensor, q.int_repr())
         self.assertEqual(scale, q.q_scale())
         self.assertEqual(zero_point, q.q_zero_point())
@@ -133,7 +133,7 @@ class TestQuantizedTensor(TestCase):
         scale = 3
         zero_point = 2
         qt = torch._dequantize_per_tensor(t, scale, zero_point, torch.qint8)
-        qt2 = torch._per_tensor_affine_qtensor(t, scale, zero_point)
+        qt2 = torch._make_per_tensor_quantized_tensor(t, scale, zero_point)
         self.assertEqual(qt, qt2.dequantize())
 
     def test_qtensor_per_channel_affine(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26681 Remove _dequantize_per_tensor
* #26680 [quant][graphmode] Remove _dequantize_per_channel in the pattern
* #26679 [rename] _per_channel_affine_qtensor -> _make_per_channel_quantized_tensor
* **#26678 [rename] _per_tensor_affine_qtensor -> _make_per_tensor_quantized_tensor**

Summary:
making it more explicit that it's a factory function.

Test Plan:
ci

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D17540862](https://our.internmc.facebook.com/intern/diff/D17540862)