### PR TITLE
[rename] _per_channel_affine_qtensor -> _make_per_channel_quantized_tensor

### DIFF
--- a/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
+++ b/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
@@ -456,7 +456,7 @@ bool aten_op_is_already_moved_to_c10(const c10::OperatorName& opName) {
         {"aten::q_per_channel_zero_points", ""},
         {"aten::int_repr", ""},
         {"aten::_make_per_tensor_quantized_tensor", ""},
-        {"aten::_per_channel_affine_qtensor", ""},
+        {"aten::_make_per_channel_quantized_tensor", ""},
         {"aten::fake_quantize_per_tensor_affine", ""},
         {"aten::fake_quantize_per_tensor_affine_backward", ""},
         {"aten::to", "other"},

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3557,10 +3557,10 @@
   dispatch:
     CPU: make_per_tensor_quantized_tensor_cpu
 
-- func: _per_channel_affine_qtensor(Tensor self, Tensor scale, Tensor zero_point, int[] axis) -> Tensor
+- func: _make_per_channel_quantized_tensor(Tensor self, Tensor scale, Tensor zero_point, int[] axis) -> Tensor
   use_c10_dispatcher: unboxed_only
   dispatch:
-    CPU: per_channel_affine_qtensor_cpu
+    CPU: make_per_channel_quantized_tensor_cpu
 
 - func: qscheme(Tensor self) -> QScheme
   variants: method

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -137,7 +137,7 @@ Tensor make_per_tensor_quantized_tensor_cpu(
   return dst;
 }
 
-Tensor per_channel_affine_qtensor_cpu(
+Tensor make_per_channel_quantized_tensor_cpu(
     const Tensor& self,
     const Tensor& scales,
     const Tensor& zero_points,

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -81,7 +81,7 @@ class TestQuantizedTensor(TestCase):
 
         # create Tensor from uint8_t Tensor, scales and zero_points
         int_tensor = torch.randint(0, 100, size=(numel,), dtype=torch.uint8)
-        q = torch._per_channel_affine_qtensor(int_tensor, scales, zero_points, [ch_axis])
+        q = torch._make_per_channel_quantized_tensor(int_tensor, scales, zero_points, [ch_axis])
         self.assertEqual(int_tensor, q.int_repr())
         self.assertEqual(scales, q.q_per_channel_scales())
         self.assertEqual(zero_points, q.q_per_channel_zero_points())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26681 Remove _dequantize_per_tensor
* #26680 [quant][graphmode] Remove _dequantize_per_channel in the pattern
* **#26679 [rename] _per_channel_affine_qtensor -> _make_per_channel_quantized_tensor**
* #26678 [rename] _per_tensor_affine_qtensor -> _make_per_tensor_quantized_tensor

Summary:
making it more explicit that it's a factory function.

Test Plan:
ci

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D17540861](https://our.internmc.facebook.com/intern/diff/D17540861)