### PR TITLE
Remove _dequantize_per_tensor

### DIFF
--- a/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
+++ b/aten/src/ATen/core/OpsAlreadyMovedToC10.cpp
@@ -1153,7 +1153,6 @@ bool aten_op_is_not_moved_to_c10_yet(const c10::OperatorName& opName) {
     #endif
         {"aten::quantize_per_tensor", ""},
         {"aten::quantize_per_channel", ""},
-        {"aten::_dequantize_per_tensor", ""},
         {"aten::q_per_channel_axis", ""},
         {"aten::qscheme", ""},
         {"aten::to", "dtype_layout"},

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3512,11 +3512,6 @@
   dispatch:
     QuantizedCPU: dequantize_quant
 
-- func: _dequantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor
-  variants: function
-  dispatch:
-    CPU: dequantize_per_tensor_cpu
-
 - func: q_scale(Tensor self) -> float
   use_c10_dispatcher: full
   variants: function, method

--- a/test/test_quantized_tensor.py
+++ b/test/test_quantized_tensor.py
@@ -128,15 +128,7 @@ class TestQuantizedTensor(TestCase):
         rqr = qr.dequantize()
         self.assertTrue(np.allclose(r.numpy(), rqr.numpy(), atol=2 / scale))
 
-    def test_qtensor_dequantize_per_tensor(self):
-        t = torch.arange(-10, 10, dtype=torch.int8)
-        scale = 3
-        zero_point = 2
-        qt = torch._dequantize_per_tensor(t, scale, zero_point, torch.qint8)
-        qt2 = torch._make_per_tensor_quantized_tensor(t, scale, zero_point)
-        self.assertEqual(qt, qt2.dequantize())
-
-    def test_qtensor_per_channel_affine(self):
+    def test_qtensor_quantize_per_channel(self):
         r = torch.rand(3, 2, dtype=torch.float) * 4 - 2
         scales = torch.tensor([0.2, 0.03], dtype=torch.double)
         zero_points = torch.tensor([5, 10], dtype=torch.long)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26681 Remove _dequantize_per_tensor**
* #26680 [quant][graphmode] Remove _dequantize_per_channel in the pattern
* #26679 [rename] _per_channel_affine_qtensor -> _make_per_channel_quantized_tensor
* #26678 [rename] _per_tensor_affine_qtensor -> _make_per_tensor_quantized_tensor

Summary:
att

Test Plan:
ci

Reviewers:
pt1quant

Subscribers:

Tasks:

Tags:

Differential Revision: [D17542833](https://our.internmc.facebook.com/intern/diff/D17542833)