### PR TITLE
[JIT] resolve ignored module method type annotations

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -3442,6 +3442,21 @@ def foo(x):
 
         FileCheck().check("NamedTuple").run(fn2.graph)
 
+        class MyMod(torch.nn.Module):
+            def __init__(self):
+                super(MyMod, self).__init__()
+
+            @torch.jit.unused
+            def fn(self):
+                # type: () -> MyTuple
+                return MyTuple(1)
+
+            def forward(self, x):
+                return self.fn()
+
+        mod = torch.jit.script(MyMod())
+        FileCheck().check_dag("NamedTuple").check_dag("Exception").run(mod.forward.graph)
+
     def test_inherit_method(self):
         class A(torch.jit.ScriptModule):
             def __init__(self):

--- a/torch/csrc/jit/script/python_sugared_value.cpp
+++ b/torch/csrc/jit/script/python_sugared_value.cpp
@@ -660,6 +660,12 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     if (auto callee = as_function(compiled_fn)) {
       return std::make_shared<FunctionValue>(*callee);
     }
+  }
+
+  py::bool_ isMethod = py::module::import("inspect").attr("ismethod")(obj);
+  // methods here have been explicitly annotated to not be compiled,
+  // so they do not have the same overload and compile checks as for functions
+  if (isFunction || isMethod) {
     auto rcb = py::module::import("torch.jit").attr("_gen_rcb")(obj, 0);
     return std::make_shared<PythonValue>(obj, rcb);
   }


### PR DESCRIPTION
Previously we weren't passing an rcb around, causing NamedTuples with @unused methods to fail.