### PR TITLE
Use noop observer to pass dtype for dynamic quantization

### DIFF
--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -485,20 +485,8 @@ class PostTrainingDynamicQuantTest(QuantizationTestCase):
 
         ref = copy.deepcopy(cell)
 
-        qconfig_dynamic_dict = {
-            torch.nn.LSTM: default_dynamic_qconfig,
-        }
-        default_dynamic_module_mapping = {
-            torch.nn.LSTM: torch.nn.quantized.dynamic.LSTM,
-        }
-        model_int8 = quantize_dynamic(
-            model=model, qconfig_dict=qconfig_dynamic_dict, mapping=default_dynamic_module_mapping,
-            dtype=torch.qint8
-        )
-        model_fp16 = quantize_dynamic(
-            model=model, qconfig_dict=qconfig_dynamic_dict, mapping=default_dynamic_module_mapping,
-            dtype=torch.float16
-        )
+        model_int8 = quantize_dynamic(model=model, dtype=torch.qint8)
+        model_fp16 = quantize_dynamic(model=model, dtype=torch.float16)
         cell_int8 = model_int8.lstm
         cell_fp16 = model_fp16.lstm
 

--- a/torch/nn/quantized/dynamic/modules/linear.py
+++ b/torch/nn/quantized/dynamic/modules/linear.py
@@ -52,7 +52,7 @@ class Linear(nnq.Linear):
         """
         assert type(mod) == NNLinear, 'nn.quantized.dynamic.Linear.from_float only works for nn.Linear'
         assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
-        if mod.qconfig is not None and mod.qconfig.weight() is not None:
+        if mod.qconfig is not None and mod.qconfig.weight is not None:
             weight_observer = mod.qconfig.weight()
         else:
             # We have the circular import issues if we import the qconfig in the beginning of this file:

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -201,38 +201,34 @@ class RNNBase(torch.nn.Module):
             self._all_weight_values.append(torch.ops.quantized.linear_prepack(*dynamic_vals[i]))
 
     @classmethod
-    def from_float(cls, mod, dtype=torch.qint8):
+    def from_float(cls, mod):
         assert type(mod) == torch.nn.LSTM, 'nn.quantized.dynamic.RNNBase.from_float only works for nn.LSTM'
         assert hasattr(
             mod, 'qconfig'), 'Input float module must have qconfig defined'
 
+        if mod.qconfig is not None and mod.qconfig.weight is not None:
+            weight_observer = mod.qconfig.weight()
+        else:
+            # We have the circular import issues if we import the qconfig in the beginning of this file:
+            # https://github.com/pytorch/pytorch/pull/24231. The current workaround is to postpone the
+            # import until we need it.
+            from torch.quantization.QConfig import default_dynamic_qconfig
+            weight_observer = default_dynamic_qconfig.weight()
+
+        dtype = weight_observer.dtype
         supported_scalar_types = [torch.qint8, torch.float16]
         if dtype not in supported_scalar_types:
-            raise RuntimeError('Unsupported dtype: {}'.format(dtype))
-
-        # When dtype = torch.float16, we don't need weight_observer
-        if dtype == torch.qint8:
-            if mod.qconfig is not None and mod.qconfig.weight() is not None:
-                weight_observer = mod.qconfig.weight()
-            else:
-                # We have the circular import issues if we import the qconfig in the beginning of this file:
-                # https://github.com/pytorch/pytorch/pull/24231. The current workaround is to postpone the
-                # import until we need it.
-                from torch.quantization.QConfig import default_dynamic_qconfig
-                weight_observer = default_dynamic_qconfig.weight()
-            assert weight_observer.dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
+            raise RuntimeError('Unsupported dtype for dynamic RNN quantization: {}'.format(dtype))
 
         if mod.mode == 'LSTM':
             qRNNBase = LSTM(mod.input_size, mod.hidden_size, mod.num_layers,
                             mod.bias, mod.batch_first, mod.dropout, mod.bidirectional, dtype)
+        else:
+            raise NotImplementedError('Only LSTM is supported for QuantizedRNN for now')
 
         num_directions = 2 if mod.bidirectional else 1
 
         assert mod.bias
-
-        # TODO: support more than just LSTM
-        if qRNNBase.mode != 'LSTM':
-            raise RuntimeError('Only LSTM is supported for QuantizedRNN')
 
         qRNNBase._all_weight_names = []
         qRNNBase._all_weight_values = []
@@ -372,5 +368,5 @@ class LSTM(RNNBase):
             return self.forward_tensor(input, hx)
 
     @classmethod
-    def from_float(cls, mod, dtype=torch.qint8):
-        return super(LSTM, cls).from_float(mod, dtype)
+    def from_float(cls, mod):
+        return super(LSTM, cls).from_float(mod)

--- a/torch/quantization/QConfig.py
+++ b/torch/quantization/QConfig.py
@@ -58,6 +58,7 @@ class QConfigDynamic(namedtuple('QConfigDynamic', ['weight'])):
         return super(QConfigDynamic, cls).__new__(cls, weight)
 
 default_dynamic_qconfig = QConfigDynamic(weight=default_weight_observer)
+float16_dynamic_qconfig = QConfigDynamic(weight=NoopObserver.with_args(dtype=torch.float16))
 
 default_qat_qconfig = QConfig(activation=default_fake_quant,
                               weight=default_weight_fake_quant)

--- a/torch/quantization/__init__.py
+++ b/torch/quantization/__init__.py
@@ -26,7 +26,7 @@ _all__ = [
     'Observer', 'WeightObserver', 'observer', 'default_observer',
     'default_weight_observer',
     # QConfig
-    'QConfig', 'default_qconfig', 'default_dynamic_qconfig',
+    'QConfig', 'default_qconfig', 'default_dynamic_qconfig', 'float16_dynamic_qconfig',
     # QAT utilities
     'default_qat_qconfig', 'prepare_qat', 'quantize_qat',
     # module transformations


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26709 Use noop observer to pass dtype for dynamic quantization**

Polishes implementation from #25975. Primarily, we use NoopObserver to communicate that weights need to be quantized to float16. The very top-level API (quantize_dynamic) stays the same with `dtype` argument but the implementation follows the common flow.

One can argue that dynamic fp16 quantization doesn't really fit into the 'observer' mechanism. It's in fact not ideal, but it's better to have the same flow than branching on both dtype and qconfig.

Differential Revision: [D17544103](https://our.internmc.facebook.com/intern/diff/D17544103)