### PR TITLE
Add C++ nn::Identity

### DIFF
--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -199,6 +199,18 @@ TEST_F(ModulesTest, AvgPool3d) {
   ASSERT_EQ(y.sizes(), torch::IntArrayRef({2, 2, 2, 2}));
 }
 
+TEST_F(ModulesTest, Identity) {
+  Identity identity;
+  auto input = torch::tensor({{1, 3, 4}, {2, 3, 4}}, torch::requires_grad());
+  auto output = identity->forward(input);
+  auto expected = torch::tensor({{1, 3, 4}, {2, 3, 4}}, torch::kFloat);
+  auto s = output.sum();
+  s.backward();
+
+  ASSERT_TRUE(torch::equal(output, expected));
+  ASSERT_TRUE(torch::equal(input.grad(), torch::ones_like(input)));
+}
+
 TEST_F(ModulesTest, Linear) {
   Linear model(5, 2);
   auto x = torch::randn({10, 5}, torch::requires_grad());
@@ -473,6 +485,10 @@ TEST_F(ModulesTest, PairwiseDistance) {
 
   ASSERT_TRUE(output.allclose(expected));
   ASSERT_EQ(input1.sizes(), input1.grad().sizes());
+}
+
+TEST_F(ModulesTest, PrettyPrintIdentity) {
+  ASSERT_EQ(c10::str(Identity()), "torch::nn::Identity()");
 }
 
 TEST_F(ModulesTest, PrettyPrintLinear) {

--- a/torch/csrc/api/include/torch/nn/modules/linear.h
+++ b/torch/csrc/api/include/torch/nn/modules/linear.h
@@ -12,6 +12,25 @@
 namespace torch {
 namespace nn {
 
+/// A placeholder identity operator that is argument-insensitive.
+class TORCH_API IdentityImpl : public Cloneable<IdentityImpl> {
+ public:
+  void reset() override;
+
+  /// Pretty prints the `Identity` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override;
+
+  Tensor forward(const Tensor& input);
+};
+
+/// A `ModuleHolder` subclass for `IdentityImpl`.
+/// See the documentation for `IdentityImpl` class to learn what methods it
+/// provides, or the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
+TORCH_MODULE(Identity);
+
+// ============================================================================
+
 /// Applies a linear transformation with optional bias.
 class TORCH_API LinearImpl : public Cloneable<LinearImpl> {
  public:

--- a/torch/csrc/api/src/nn/modules/linear.cpp
+++ b/torch/csrc/api/src/nn/modules/linear.cpp
@@ -9,6 +9,18 @@
 namespace torch {
 namespace nn {
 
+void IdentityImpl::reset() {}
+
+void IdentityImpl::pretty_print(std::ostream& stream) const {
+  stream << "torch::nn::Identity()";
+}
+
+Tensor IdentityImpl::forward(const Tensor& input) {
+  return input;
+}
+
+// ============================================================================
+
 LinearImpl::LinearImpl(const LinearOptions& options_) : options(options_) {
   reset();
 }


### PR DESCRIPTION
**Summary**: 
Adds `torch::nn::Identity` module support for the C++ API.

**Issue**: #25883  

**Reviewer**: @yf225 