### PR TITLE
Add some missing constructors to IValue.

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -364,16 +364,19 @@ struct CAFFE2_API IValue final {
   }
 
   // ScalarType
+  IValue(ScalarType s) : IValue(static_cast<int64_t>(s)) {}
   at::ScalarType toScalarType() const {
     return static_cast<at::ScalarType>(toInt());
   }
 
   // Layout
+  IValue(Layout l) : IValue(static_cast<int64_t>(l)) {}
   at::Layout toLayout() const {
     return static_cast<at::Layout>(toInt());
   }
 
   // MemoryFormat
+  IValue(MemoryFormat m) : IValue(static_cast<int64_t>(m)) {}
   at::MemoryFormat toMemoryFormat() const {
     return static_cast<at::MemoryFormat>(toInt());
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26719 Tests for fallback boxed dispatch.
* #26368 Add boxed fallback
* #26367 Refactor dispatch structure so fallback code lives inline.
* #26361 Change calling convention of ATenDispatch from getOp to callUnboxed.
* **#26718 Add some missing constructors to IValue.**
* #26360 Remove unnecessary include from TensorBody
* #26118 Implement multiple dispatch in boxed c10 dispatcher
* #25914 Delete backwards compatibility Backend overload for registerOp

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17549623](https://our.internmc.facebook.com/intern/diff/D17549623)