### PR TITLE
Add threadpool in qlinear and qconv for mobile

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -4,6 +4,7 @@
 #include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
 #include <cmath>
 
 namespace at {
@@ -401,7 +402,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
         output.q_scale(),
         output.q_zero_point(),
         (uint8_t*)output.data_ptr<c10::quint8>(),
-        nullptr);
+        caffe2::mobile_threadpool());
 
     TORCH_INTERNAL_ASSERT(
         runStatus == pytorch_qnnp_status_success,

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -3,6 +3,7 @@
 #include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <caffe2/utils/threadpool/ThreadPoolMobile.h>
 
 #include <algorithm>
 #include <string>
@@ -307,7 +308,7 @@ class QLinearInt8 final : public torch::OperatorKernel {
         packB->getPackedWeights(),
         (uint8_t*)output.data_ptr<c10::quint8>(),
         rows_w /* output_stride */,
-        nullptr /* threadpool */);
+        caffe2::mobile_threadpool() /* threadpool */);
 
     TORCH_INTERNAL_ASSERT(
         runStatus == pytorch_qnnp_status_success,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26728 Add threadpool in qlinear and qconv for mobile**

Summary:
Use Caffe2::mobile_threadpool() in linear and conv operators

Perf
Without threadpool - 76ms
With threadpool - 41 ms

Test Plan:
python test/test_quantized.py TestQNNPackOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D17553510](https://our.internmc.facebook.com/intern/diff/D17553510)