### PR TITLE
Add whitelist for backward compatible checks for function schemas

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -1,14 +1,35 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
+import datetime
+import re
 import sys
 import torch
 from torch._C import parse_schema
 
 
+white_list = [
+    ('quantize', datetime.date(2019, 10, 1)),
+    ('q_per_channel_axis', datetime.date(2019, 10, 1)),
+]
+
+
+def white_listed(schema, white_list):
+    for item in white_list:
+        if item[1] < datetime.date.today():
+            continue
+        regexp = re.compile(item[0])
+        if regexp.search(schema.name):
+            return True
+    return False
+
+
 def check_bc(new_schema_dict):
     existing_schemas = torch._C._jit_get_all_schemas()
     for existing_schema in existing_schemas:
+        if white_listed(existing_schema, white_list):
+            print("skipping schema: ", str(existing_schema))
+            continue
         print("processing existing schema: ", str(existing_schema))
         new_schemas = new_schema_dict.get(existing_schema.name, [])
         found = False


### PR DESCRIPTION
Now, we skip all function schema contains quantize key word