### PR TITLE
Add <cinttypes> include to resolve PRIu32 macro

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/conv_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/conv_utils.h
@@ -1,6 +1,7 @@
 #pragma once
-#include <cmath>
 #include <array>
+#include <cinttypes>
+#include <cmath>
 #include <string>
 
 #include <pytorch_qnnpack.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26745 Add <cinttypes> include to resolve PRIu32 macro**

This file doesn't appear to be included by default on GCC 7.3 and
causes compilation to fail. Adding this include fixes compilation.

Differential Revision: [D17566444](https://our.internmc.facebook.com/intern/diff/D17566444)