### PR TITLE
Upgrade sleef to v3.4.0.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,7 +81,7 @@
 [submodule "third_party/sleef"]
     ignore = dirty
     path = third_party/sleef
-    url = https://github.com/zdevito/sleef
+    url = https://github.com/shibatch/sleef
 [submodule "third_party/ideep"]
     ignore = dirty
     path = third_party/ideep


### PR DESCRIPTION
This reset the sleef submodule to upstream, since everything else except
a small build sanity fix
<https://github.com/zdevito/sleef/commit/191f655caa25526ae226cf88dd2529265176014a>
has been merged to upstream. The new release includes an important fix
for trigonometric functions on MacOS, which would unblock #26431.

This should supersede #20536.

Close #20536.

cc @colesbury @resistor 