### PR TITLE
[iOS] Prepare for Cocoapods 1.3 Release

### DIFF
--- a/ios/LibTorch.podspec
+++ b/ios/LibTorch.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
     s.name             = 'LibTorch'
-    s.version          = '0.0.3'
+    s.version          = '1.3.0'
     s.authors          = 'PyTorch Team'
     s.license          = { :type => 'BSD' }
     s.homepage         = 'https://github.com/pytorch/pytorch'
-    s.source           = { :http => 'https://ossci-ios-build.s3.amazonaws.com/libtorch_ios_nightly_build.zip' }
+    s.source           = { :http => "https://ossci-ios.s3.amazonaws.com/libtorch_ios_#{s.version}.zip" }
     s.summary          = 'The PyTorch C++ library for iOS'
     s.description      = <<-DESC
         The PyTorch C++ library for iOS.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,5 +1,28 @@
-## LibTorch
 
-The PyTorch C++ static library for iOS. 
+## LibTorch for iOS
 
-(Detailed documentation  will be added soon)
+### Cocoapods Developers
+
+PyTorch is now available via Cocoapods, to integrate it to your project, simply add the following line to your `Podfile` and run `pod install`
+
+```ruby
+pod 'LibTorch'
+```
+
+### Import the library
+
+For Objective-C developers, simply just import the umbrella header
+
+```
+#import <LibTorch/LibTorch.h>
+```
+
+For Swift developers, you need to create an Objective-C class as a bridge to call the C++ APIs. We highly recommend you to follow the [Image Classification](https://github.com/pytorch/examples) demo where you can find out how C++, Objective-C and Swift work together. 
+
+### Disable Bitcode 
+
+Since PyTorch is not yet built with bitcode support. You need to disable bitcode for your target by selecting the **Build Settings**, searching for **Enable Bitcode** and set the value to **NO**.
+
+## LICENSE
+
+PyTorch is BSD-style licensed, as found in the LICENSE file.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,5 +1,5 @@
 
-## LibTorch for iOS
+## PyTorch for iOS
 
 ### Cocoapods Developers
 
@@ -11,7 +11,7 @@ pod 'LibTorch'
 
 ### Import the library
 
-For Objective-C developers, simply just import the umbrella header
+For Objective-C developers, simply import the umbrella header
 
 ```
 #import <LibTorch/LibTorch.h>
@@ -21,7 +21,7 @@ For Swift developers, you need to create an Objective-C class as a bridge to cal
 
 ### Disable Bitcode 
 
-Since PyTorch is not yet built with bitcode support. You need to disable bitcode for your target by selecting the **Build Settings**, searching for **Enable Bitcode** and set the value to **NO**.
+Since PyTorch is not yet built with bitcode support, you need to disable bitcode for your target by selecting the **Build Settings**, searching for **Enable Bitcode** and set the value to **No**.
 
 ## LICENSE
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26751 [iOS] Prepare for Cocoapods 1.3 Release**

### Summary

We're going to use the AWS s3 bucket - `s3://ossci-ios` to store the release binary. To release the cocoapods, we can follow the steps below:

1.  Open a fake PR to trigger the CI job that pulls the code from the 1.3.0 tag branch and does the building and uploading.
2. Verify the binary locally  - Run tests on both arm64 and simulator
3. Publish the cocoapods officially

### Test plan

- podspec lint command succeeds
    - `pod spec lint --verbose --allow-warnings --no-clean --use-libraries --skip-import-validation`

Differential Revision: [D17577131](https://our.internmc.facebook.com/intern/diff/D17577131)