### PR TITLE
use new fbgemm PackedDepthWiseConvMatrix without template parameter

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.h
+++ b/caffe2/quantization/server/conv_dnnlowp_op.h
@@ -115,10 +115,8 @@ class ConvDNNLowPOp : public ConvPoolDNNLowPOpBase<T, ConvFp32Op> {
   // used in fast path for T == uint8_t
   std::shared_ptr<fbgemm::PackBMatrix<std::int8_t>> Wq_packed_;
 
-  // For depthwise 3x3 conv
-  std::shared_ptr<fbgemm::Packed3x3ConvMatrix> Wq_depthwise_3x3_packed_;
-  // For depthwise 3x3x3 conv
-  std::shared_ptr<fbgemm::Packed3x3x3ConvMatrix> Wq_depthwise_3x3x3_packed_;
+  // For depthwise conv
+  std::shared_ptr<fbgemm::PackedDepthWiseConvMatrix> Wq_depthwise_packed_;
   // For small gconv
   std::shared_ptr<fbgemm::PackWeightMatrixForGConv<std::int8_t>>
       Wq_gconv_packed_;

--- a/caffe2/quantization/server/fbgemm_pack_blob.h
+++ b/caffe2/quantization/server/fbgemm_pack_blob.h
@@ -36,8 +36,7 @@ struct Int8FCDNNLowPPackedWeightBlob {
  */
 struct Int8ConvDNNLowPPackedWeightBlob : public Int8FCDNNLowPPackedWeightBlob {
   // Only for 32-bit accumulation
-  std::shared_ptr<fbgemm::Packed3x3ConvMatrix> W_depthwise_3x3;
-  std::shared_ptr<fbgemm::Packed3x3x3ConvMatrix> W_depthwise_3x3x3;
+  std::shared_ptr<fbgemm::PackedDepthWiseConvMatrix> W_depthwise;
   std::shared_ptr<fbgemm::PackWeightMatrixForGConv<std::int8_t>> W_gconv;
 };
 

--- a/caffe2/quantization/server/fbgemm_pack_op.cc
+++ b/caffe2/quantization/server/fbgemm_pack_op.cc
@@ -432,9 +432,9 @@ bool ConvDNNLowPPackWeightOp::RunOnDevice() {
       W_quantized,
       qfactory_.get());
   if (save_unpacked_weights_) {
-        ReinitializeTensor(&Y->original_tensor, filter.sizes(), at::dtype<int8_t>().device(CPU));
-    auto* buffer =
-        Y->original_tensor.template mutable_data<int8_t>();
+    ReinitializeTensor(
+        &Y->original_tensor, filter.sizes(), at::dtype<int8_t>().device(CPU));
+    auto* buffer = Y->original_tensor.template mutable_data<int8_t>();
     CAFFE_ENFORCE_EQ(Y->original_tensor.numel(), W_quantized.size());
     memcpy(buffer, W_quantized.data(), W_quantized.size() * sizeof(int8_t));
   }
@@ -537,11 +537,11 @@ bool ConvDNNLowPPackWeightOp::RunOnDevice() {
       fallback_to_32_bit_accumulation) {
     // acc32
     if (TakeDepthWise3x3FastPath_()) {
-      Y->W_depthwise_3x3.reset(
-          new fbgemm::Packed3x3ConvMatrix(group_, W_quantized.data()));
+      Y->W_depthwise.reset(new fbgemm::PackedDepthWiseConvMatrix(
+          group_, 3 * 3, W_quantized.data()));
     } else if (TakeDepthWise3x3x3FastPath_()) {
-      Y->W_depthwise_3x3x3.reset(
-          new fbgemm::Packed3x3x3ConvMatrix(group_, W_quantized.data()));
+      Y->W_depthwise.reset(new fbgemm::PackedDepthWiseConvMatrix(
+          group_, 3 * 3 * 3, W_quantized.data()));
     } else if (TakeGConvFastPath_()) {
       fbgemm::conv_param_t<> conv_p(
           1,


### PR DESCRIPTION
Summary: Follow-up of D17514003 . Change Caffe2 code to use the new PackedDepthWiseConvMatrix interface.

Test Plan: CI

Reviewed By: dskhudia

Differential Revision: D17514350

