### PR TITLE
Adds Device Generic Precision Tests to test_torch.py

### DIFF
--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -166,7 +166,7 @@ if torch.cuda.is_available():
 # The tests in these test cases are derived from the generic tests in
 # generic_test_class.
 # See note "Generic Device Type Testing."
-def instantiate_device_type_tests(generic_test_class, scope):
+def instantiate_device_type_tests(generic_test_class, scope, except_for=None):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.
     del scope[generic_test_class.__name__]
@@ -186,6 +186,10 @@ def instantiate_device_type_tests(generic_test_class, scope):
 
     # Creates device-specific test cases
     for base in device_type_test_bases:
+        # Skips bases listed in except_for
+        if except_for and base.device_type in except_for:
+            continue
+
         class_name = generic_test_class.__name__ + base.device_type.upper()
         device_type_test_class = type(class_name, (base, empty_class), {})
 

--- a/test/common_device_type.py
+++ b/test/common_device_type.py
@@ -187,7 +187,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None):
     # Creates device-specific test cases
     for base in device_type_test_bases:
         # Skips bases listed in except_for
-        if except_for and base.device_type in except_for:
+        if except_for is not None and base.device_type in except_for:
             continue
 
         class_name = generic_test_class.__name__ + base.device_type.upper()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2471,52 +2471,6 @@ class TestCuda(TestCase):
         tensor = tensor.unsqueeze(1)
         self.assertEqual(tensor.var(0), 0.03125)
 
-    def test_digamma(self):
-        def test(use_double=False):
-            cpu_tensor = torch.randn(10, 10, 10)
-            gpu_tensor = cpu_tensor.cuda()
-            zeros = torch.zeros(10, 10, 10)
-            if (use_double):
-                cpu_tensor = cpu_tensor.double()
-                gpu_tensor = gpu_tensor.double()
-                zeros = zeros.double()
-            cpu_out = cpu_tensor.digamma()
-            gpu_out = gpu_tensor.digamma()
-            norm_errors = (gpu_out - cpu_out.cuda()) / gpu_out
-            self.assertEqual(norm_errors, zeros)
-
-        test(True)
-        test(False)
-
-        # Test float32 behavior near and at poles.
-        cpu_tensor = torch.tensor([-0.999999994, -1.999999994, -2.0000000111,
-                                  -100.99999994, -1931.99999994, 0.000000111,
-                                  -0.000000111, 0, -1, -2, -931])
-        expected_errors = torch.tensor([0, 0, 0, 0, 0, 0, 0, nan, nan, nan, nan])
-        gpu_tensor = cpu_tensor.cuda()
-        cpu_out = cpu_tensor.digamma()
-        gpu_out = gpu_tensor.digamma()
-        norm_errors = (gpu_out - cpu_out.cuda()) / gpu_out
-        self.assertEqual(norm_errors, expected_errors)
-
-    def test_polygamma(self):
-        def test(use_double=False):
-            cpu_tensor = torch.randn(10, 10, 10)
-            gpu_tensor = cpu_tensor.cuda()
-            zeros = torch.zeros(10, 10, 10)
-            if (use_double):
-                cpu_tensor = cpu_tensor.double()
-                gpu_tensor = gpu_tensor.double()
-                zeros = zeros.double()
-            for n in [0, 1]:
-                cpu_out = cpu_tensor.polygamma(n)
-                gpu_out = gpu_tensor.polygamma(n)
-                norm_errors = (gpu_out - cpu_out.cuda()) / gpu_out
-                self.assertEqual(norm_errors, zeros)
-
-        test(True)
-        test(False)
-
     def test_arange(self):
         for t in ['IntTensor', 'LongTensor', 'FloatTensor', 'DoubleTensor']:
             a = torch.cuda.__dict__[t]()
@@ -2524,21 +2478,6 @@ class TestCuda(TestCase):
             b = torch.__dict__[t]()
             torch.arange(0, 10, out=b)
             self.assertEqual(a, b.cuda())
-
-    def test_linspace(self):
-        a = torch.linspace(0, 10, 10, device='cuda')
-        b = torch.linspace(0, 10, 10)
-        self.assertEqual(a, b.cuda())
-
-    def test_logspace(self):
-        a = torch.logspace(1, 10, 10, device='cuda')
-        b = torch.logspace(1, 10, 10)
-        self.assertEqual(a, b.cuda())
-
-        # Check non-default base=2
-        a = torch.logspace(1, 10, 10, 2, device='cuda')
-        b = torch.logspace(1, 10, 10, 2)
-        self.assertEqual(a, b.cuda())
 
     @unittest.skipIf(not TEST_MAGMA, "no MAGMA library detected")
     @skipCUDANonDefaultStreamIf(True)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11861,7 +11861,8 @@ class TestTorchDeviceType(TestCase):
             out_fn = getattr(torch, fn)
             in_fn = getattr(torch.Tensor, fn + '_')
 
-            self.unary_check_input_output_mem_overlap(inputs, sz, out_fn, expected_failure=not has_input_output_mem_overlap_check)
+            self.unary_check_input_output_mem_overlap(inputs, sz, out_fn,
+                                                      expected_failure=not has_input_output_mem_overlap_check)
 
             self.check_internal_mem_overlap(in_fn, num_inputs=1, device=dev,
                                             expected_failure=not has_internal_mem_overlap_check)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11861,8 +11861,7 @@ class TestTorchDeviceType(TestCase):
             out_fn = getattr(torch, fn)
             in_fn = getattr(torch.Tensor, fn + '_')
 
-            self.unary_check_input_output_mem_overlap(inputs, sz, out_fn,
-                                                      expected_failure=not has_input_output_mem_overlap_check)
+            self.unary_check_input_output_mem_overlap(inputs, sz, out_fn, expected_failure=not has_input_output_mem_overlap_check)
 
             self.check_internal_mem_overlap(in_fn, num_inputs=1, device=dev,
                                             expected_failure=not has_internal_mem_overlap_check)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -12947,8 +12947,58 @@ class TestTorchDeviceType(TestCase):
             run_test(device, False)
 
 
+# Tests that compare a device's computation with the (gold-standard) CPU's.
+class TestDevicePrecision(TestCase):
+    def test_linspace(self, device):
+        a = torch.linspace(0, 10, 10, device=device)
+        b = torch.linspace(0, 10, 10)
+        self.assertEqual(a, b.to(device))
+
+    def test_logspace(self, device):
+        a = torch.logspace(1, 10, 10, device=device)
+        b = torch.logspace(1, 10, 10)
+        self.assertEqual(a, b.to(device))
+
+        # Check non-default base=2
+        a = torch.logspace(1, 10, 10, 2, device=device)
+        b = torch.logspace(1, 10, 10, 2)
+        self.assertEqual(a, b.to(device))
+
+    # Note: ROCm fails when using float tensors
+    def test_polygamma(self, device):
+        cpu_tensor = torch.randn(10, 10, 10)
+        device_tensor = cpu_tensor.to(device)
+        zeros = torch.zeros(10, 10, 10)
+        for n in [0, 1]:
+            cpu_out = cpu_tensor.polygamma(n)
+            device_out = device_tensor.polygamma(n)
+            norm_errors = (device_out - cpu_out.to(device)) / device_out
+            self.assertEqual(norm_errors, zeros)
+
+    # Note: fails when using float tensors
+    def test_digamma(self, device):
+        cpu_tensor = torch.randn(10, 10, 10)
+        device_tensor = cpu_tensor.to(device)
+        zeros = torch.zeros(10, 10, 10)
+        cpu_out = cpu_tensor.digamma()
+        device_out = device_tensor.digamma()
+        norm_errors = (device_out - cpu_out.to(device)) / device_out
+        self.assertEqual(norm_errors, zeros)
+
+        # Tests pole behavior
+        cpu_tensor = torch.tensor([-0.999999994, -1.999999994, -2.0000000111,
+                                   -100.99999994, -1931.99999994, 0.000000111,
+                                   -0.000000111, 0, -1, -2, -931])
+        expected_errors = torch.tensor([0, 0, 0, 0, 0, 0, 0, nan, nan, nan, nan])
+        device_tensor = cpu_tensor.to(device)
+        cpu_out = cpu_tensor.digamma()
+        device_out = device_tensor.digamma()
+        norm_errors = (device_out - cpu_out.to(device)) / device_out
+        self.assertEqual(norm_errors, expected_errors)
+
 add_neg_dim_tests()
 instantiate_device_type_tests(TestTorchDeviceType, globals())
+instantiate_device_type_tests(TestDevicePrecision, globals(), except_for='cpu')
 
 class TestTorch(TestCase, _TestTorchMixin):
     pass


### PR DESCRIPTION
- Lets device generic classes be instantiated for all available device types EXCEPT those specified
- Creates TestDevicePrecision in test_torch.py, letting devices compare their results to the CPU's
- Moves 4 functions from test_cuda.py to TestDevicePrecision
- polygamma and digamma functions were cleaned up

The polygamma and digamma tests always ran with double tensors and will fail when using float tensors, despite former comments and code to the contrary. Notes were added to each function.