### PR TITLE
[JIT] support iterables, rangevalue in list comprehensions

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18369,7 +18369,8 @@ class TestList(JitTestCase):
         def changes_type():
             a = [float(i) for i in range(5)]
             b = [float(i) for i in [1, 2, 3, 4]]
-            return a, b
+            c = [(float(i), j) for i, j in enumerate([1, 2, 3, 8])]
+            return a, b, c
 
         test_func(changes_type, ())
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18351,6 +18351,25 @@ class TestList(JitTestCase):
 
         self.checkScript(list_cast, ())
 
+    def test_comprehension_iterable(self):
+        def test_func(fn, inputs):
+            self.assertEqual(fn(*inputs), torch.jit.script(fn)(*inputs))
+
+        def foo(names, results):
+            # type: (List[int], List[int])
+            return [(k + 5, v - 2) for k, v in zip(names, results)]
+
+        test_func(foo, ([1, 2, 4], [4, 7, 9]))
+        test_func(foo, ([5], [4, 7, 9]))
+
+        def fn(x):
+            # type: (int)
+            return [i for i in range(x)]
+
+        test_func(fn, (9,))
+        test_func(fn, (0,))
+        test_func(fn, (-1,))
+
     def test_mutable_list_append_2(self):
         def test_append_2():
             a = [0, 1]

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18314,6 +18314,10 @@ class TestList(JitTestCase):
             # type: (int)
             return [i for i in range(x)]
 
+        test_func(fn, (9,))
+        test_func(fn, (0,))
+        test_func(fn, (-1,))
+
         def changes_type():
             a = [float(i) for i in range(5)]
             b = [float(i) for i in [1, 2, 3, 4]]
@@ -18322,9 +18326,10 @@ class TestList(JitTestCase):
 
         test_func(changes_type, ())
 
-        test_func(fn, (9,))
-        test_func(fn, (0,))
-        test_func(fn, (-1,))
+        def test_zero_iter():
+            return [str(i) for i, j in zip("", "")]
+
+        test_func(test_zero_iter, ())
 
     def test_mutable_list_append_2(self):
         def test_append_2():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -18366,6 +18366,13 @@ class TestList(JitTestCase):
             # type: (int)
             return [i for i in range(x)]
 
+        def changes_type():
+            a = [float(i) for i in range(5)]
+            b = [float(i) for i in [1, 2, 3, 4]]
+            return a, b
+
+        test_func(changes_type, ())
+
         test_func(fn, (9,))
         test_func(fn, (0,))
         test_func(fn, (-1,))

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1070,7 +1070,7 @@ struct to_ir {
     return emitIfExpr(expr.range(), cond_value, true_expr, false_expr);
   }
 
-  TypePtr emitInTempEnvironment(std::function<TypePtr()> fn) {
+  TypePtr emitInTempEnvironment(const std::function<TypePtr()>& fn) {
     auto b = graph->insertNode(graph->create(prim::Loop))->addBlock();
     pushFrame(b);
     WithInsertPoint guard(b);

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1107,7 +1107,7 @@ struct to_ir {
 
     TypePtr list_type;
 
-    auto siv = std::dynamic_pointer_cast<SimpleValue>(sv);
+    auto siv = dynamic_cast<SimpleValue*>(sv.get());
     if (siv && siv->getValue()->type()->cast<ListType>()) {
       auto list_elem =
           siv->getValue()->type()->cast<ListType>()->getElementType();
@@ -1115,11 +1115,12 @@ struct to_ir {
     } else if (auto iterable_tree = dynamic_cast<IterableTree*>(sv.get())) {
       list_type =
           getListCompType(lc, getIterableChildrenType(lc, *iterable_tree));
-    } else if (std::dynamic_pointer_cast<RangeValue>(sv)) {
+    } else if (dynamic_cast<RangeValue*>(sv.get())) {
       list_type = getListCompType(lc, IntType::get());
     } else {
       throw ErrorReport(lc.range())
-          << "iterator expression is expected to be a list, iterable, or range";
+          << "iterator expression is expected to be a list, iterable, or range, found "
+          << (siv ? siv->getValue()->type()->python_str() : siv->kind());
     }
 
     // given `[x*2 for x in my_list]` this generates the following AST:

--- a/torch/csrc/jit/script/compiler.cpp
+++ b/torch/csrc/jit/script/compiler.cpp
@@ -1070,44 +1070,64 @@ struct to_ir {
     return emitIfExpr(expr.range(), cond_value, true_expr, false_expr);
   }
 
-  // emit a single expr from the loop comprehension so that we can correctly
-  // type the list we create, then remove the nodes we emitted
-  TypePtr getListCompType(
-      const ListComp& lc,
-      const ListTypePtr& input_list_type) {
+  TypePtr emitInTempEnvironment(std::function<TypePtr()> fn) {
     auto b = graph->insertNode(graph->create(prim::Loop))->addBlock();
     pushFrame(b);
     WithInsertPoint guard(b);
-    auto li_elem = graph->insertNode(
-        graph->createUninitialized(input_list_type->getElementType()));
-    emitExprsAssign(
-        List<Expr>::create(lc.range(), {lc.target()}),
-        {std::make_shared<SimpleValue>(li_elem->output())},
-        lc.range(),
-        /*n_binders*/ 1);
-    auto ret_type = emitExpr(lc.elt())->type();
+    auto ret_type = fn();
     popFrame();
     b->owningNode()->destroy();
     return ret_type;
   }
 
+  // emit a single expr from the loop comprehension so that we can correctly
+  // type the list we create, then remove the nodes we emitted
+  TypePtr getListCompType(const ListComp& lc, const TypePtr type_ptr) {
+    return emitInTempEnvironment([&]() {
+      auto li_elem = graph->insertNode(graph->createUninitialized(type_ptr));
+      emitExprsAssign(
+          List<Expr>::create(lc.range(), {lc.target()}),
+          {std::make_shared<SimpleValue>(li_elem->output())},
+          lc.range(),
+          /*n_binders*/ 1);
+      return emitExpr(lc.elt())->type();
+    });
+  }
+
+  // emit a single index of the Iterable to get the children type
+  TypePtr getIterableChildrenType(const ListComp& lc, IterableTree& tree) {
+    return emitInTempEnvironment([&]() {
+      return tree.getitem(lc.range(), method, graph->insertConstant(0))->type();
+    });
+  }
+
   Value* emitListComprehension(const ListComp& lc) {
     const auto tmp_name = createTempName("$list_acc");
-    const auto list_value = emitExpr(lc.iter());
-    if (list_value->type()->kind() != TypeKind::ListType) {
-      // TODO: constraining iterators to be simple lists for now
-      // as it makes easy to get list's element type.
+    const auto sv = emitSugaredExpr(lc.iter(), 1);
+
+    TypePtr list_type;
+
+    auto siv = std::dynamic_pointer_cast<SimpleValue>(sv);
+    if (siv && siv->getValue()->type()->cast<ListType>()) {
+      auto list_elem =
+          siv->getValue()->type()->cast<ListType>()->getElementType();
+      list_type = getListCompType(lc, list_elem);
+    } else if (auto iterable_tree = dynamic_cast<IterableTree*>(sv.get())) {
+      list_type =
+          getListCompType(lc, getIterableChildrenType(lc, *iterable_tree));
+    } else if (std::dynamic_pointer_cast<RangeValue>(sv)) {
+      list_type = getListCompType(lc, IntType::get());
+    } else {
       throw ErrorReport(lc.range())
-          << "iterator expression is expected to be a list";
+          << "iterator expression is expected to be a list, iterable, or range";
     }
 
     // given `[x*2 for x in my_list]` this generates the following AST:
     // __list_acc = []
     // for x in my_list:
     //  __list_acc.append(x*2)
-    const auto n = graph->insertNode(graph->createList(
-        getListCompType(lc, list_value->type()->expect<ListType>()),
-        at::ArrayRef<Value*>{}));
+    const auto n =
+        graph->insertNode(graph->createList(list_type, at::ArrayRef<Value*>{}));
     environment_stack->setVar(lc.range(), tmp_name, n->output());
     const auto tmp_list_ident = Ident::create(lc.range(), tmp_name);
     const auto tmp_list_var = Var::create(lc.range(), tmp_list_ident);


### PR DESCRIPTION
Support IterableValue expressions and rangevalue in list comprehensions. Just as with supporting list comprehensions where the expression changes the input list types, we need to correctly type the list we create and it works. 

Fixes #26693
Fixes #22483