### PR TITLE
Update ONNX Export for Interpolate in Opset 11

### DIFF
--- a/test/onnx/expect/TestOperators.test_upsample_nearest.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest.expect
@@ -36,7 +36,7 @@ graph {
     op_type: "Cast"
     attribute {
       name: "to"
-      i: 11
+      i: 1
       type: INT
     }
   }
@@ -46,8 +46,8 @@ graph {
     attribute {
       name: "value"
       t {
-        data_type: 11
-        raw_data: "\000\000\000\000\000\000\000@"
+        data_type: 1
+        raw_data: "\000\000\000@"
       }
       type: TENSOR
     }
@@ -107,7 +107,7 @@ graph {
     op_type: "Cast"
     attribute {
       name: "to"
-      i: 11
+      i: 1
       type: INT
     }
   }
@@ -117,8 +117,8 @@ graph {
     attribute {
       name: "value"
       t {
-        data_type: 11
-        raw_data: "\000\000\000\000\000\000\000@"
+        data_type: 1
+        raw_data: "\000\000\000@"
       }
       type: TENSOR
     }

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -409,43 +409,58 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor(np.arange(6.0).reshape(2, 3))
         self.run_test(MyModule(), x)
 
-    @skipIfUnsupportedMinOpsetVersion(9)
-    def test_interpolate_scale(self):
+    def _interpolate(self, x, mode, use_size, is_upsample):
         class MyModel(torch.nn.Module):
             def forward(self, x):
-                return torch.nn.functional.interpolate(x, mode="nearest", scale_factor=2)
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
+                scale = 2.3 if is_upsample else 0.3
+                if use_size:
+                    size = [int(float(v) * scale) for v in x.size()[2:]]
+                    return torch.nn.functional.interpolate(x, mode=mode, size=size)
+                return torch.nn.functional.interpolate(x, mode=mode, scale_factor=scale)
+
         self.run_test(MyModel(), x)
 
-    # NOTE: Supported in onnxruntime master, enable this after 0.5 release.
-    @skipIfUnsupportedOpsetVersion([10, 11])
-    def test_interpolate_output_size(self):
-        class MyModel(torch.nn.Module):
-            def forward(self, x):
-                return torch.nn.functional.interpolate(x, mode="nearest", size=(6, 8))
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(MyModel(), x)
+    def _interpolate_tests(self, is_upsample):
+        # - cubic mode is not supported for opsets below 11;
+        # - linear mode does not match for opsets below 11;
+        # - nearest mode does not match for opsets below 11,
+        # for some cases where the nearest pixel's index is
+        # not calculated the same way for ONNX and PyTorch
+        # (the operation involves a floor in PyTorch vs
+        # in round_prefer_floor ONNX). (The below tests
+        # do not  show this error for nearest mode for
+        # all opsets)
+        modes = ["nearest", "linear", "cubic"]
+        if self.opset_version < 11:
+            modes = ["nearest"]
+        x = [torch.randn(1, 2, 4, requires_grad=True),
+             torch.randn(1, 2, 4, 4, requires_grad=True),
+             torch.randn(1, 2, 4, 4, 6, requires_grad=True)]
 
-    # NOTE: Supported in onnxruntime master, enable this after 0.5 release.
-    @skipIfUnsupportedOpsetVersion([10, 11])
+        for mode in modes:
+            for xi in x:
+                mode_i = mode
+                if mode == "cubic" and xi.dim() != 4:
+                    continue
+                elif mode == "linear":
+                    if xi.dim() == 4:
+                        mode_i = "bilinear"
+                    elif xi.dim() == 5:
+                        mode_i = "trilinear"
+                self._interpolate(xi, mode_i, True, is_upsample)
+                if self.opset_version >= 9:  # throws unimplemented
+                    self._interpolate(xi, mode_i, False, is_upsample)
+
+    # enable when supported in ORT for opset 11
+    @skipIfUnsupportedOpsetVersion([11])
     def test_interpolate_upsample(self):
-        class MyModel(torch.nn.Module):
-            def forward(self, x):
-                size = [v * 2 for v in x.size()[2:]]
-                # work around for now: turn the dynamic sizes into constant
-                size = [int(i) for i in size]
-                return torch.nn.functional.interpolate(x, mode="nearest", size=size)
+        self._interpolate_tests(True)
 
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(MyModel(), x)
-
-    @skipIfUnsupportedMinOpsetVersion(9)
+    # enable when supported in ORT for opset 11
+    @skipIfUnsupportedMinOpsetVersion(10)
+    @skipIfUnsupportedOpsetVersion([11])
     def test_interpolate_downsample(self):
-        class MyModel(torch.nn.Module):
-            def forward(self, x):
-                return torch.nn.functional.interpolate(x, mode="nearest", scale_factor=[1, 1, 0.5, 0.5])
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(MyModel(), x)
+        self._interpolate_tests(False)
 
     def test_std(self):
         class StandardDeviation(torch.nn.Module):
@@ -473,16 +488,6 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         model = StandardDeviation()
         self.run_test(model, x)
-
-    @skipIfUnsupportedOpsetVersion([7, 8])
-    def test_interpolate_upsample_dynamic_sizes(self):
-        class MyModel(torch.nn.Module):
-            def forward(self, x):
-                size = [v * 2 for v in x.size()[2:]]
-                return torch.nn.functional.interpolate(x, mode="nearest", size=size)
-
-        x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.run_test(MyModel(), x)
 
     def test_narrow(self):
         class NarrowModel(torch.nn.Module):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2477,7 +2477,8 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
 
         # make scale_factor a tensor in tracing so constant doesn't get baked in
         if torch._C._get_tracing_state():
-            return [(torch.floor((input.size(i + 2) * torch.tensor(float(scale_factors[i]))).float())) for i in range(dim)]
+            return [(torch.floor((input.size(i + 2).float() * torch.tensor(scale_factors[i],
+                     dtype=torch.float32)).float())) for i in range(dim)]
         else:
             return [int(math.floor(float(input.size(i + 2)) * scale_factors[i])) for i in range(dim)]
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -192,6 +192,34 @@ def _slice_helper(g, input, axes, starts, ends, steps=None, dynamic_slice=False)
         from torch.onnx.symbolic_opset10 import _slice
         return _slice(g, input, axes, starts, ends, steps, dynamic_slice)
 
+def _interpolate_warning(interpolate_mode):
+    onnx_op = "onnx:Resize" if _export_onnx_opset_version >= 10 else "onnx:Upsample"
+    warnings.warn("You are trying to export the model with " + onnx_op + " for ONNX opset version "
+                  "" + str(_export_onnx_opset_version) + ". "
+                  "This operator might cause results to not match the expected results by PyTorch.\n"
+                  "ONNX's Upsample/Resize operator did not match Pytorch's Interpolation until opset 11. "
+                  "Attributes to determine how to transform the input were added in onnx:Resize in opset 11 "
+                  "to support Pytorch's behavior (like coordinate_transformation_mode and nearest_mode).\n"
+                  "We recommend using opset 11 and above for models using this operator. ")
+
+def _interpolate_size_to_scales(g, input, output_size, dim):
+    output_size = _maybe_get_const(output_size, 'is')
+    if _is_value(output_size):
+        offset = 2
+        offsets = g.op("Constant", value_t=torch.ones(offset))
+        dividend = g.op("Cast", output_size, to_i=cast_pytorch_to_onnx["Float"])
+        divisor = _slice_helper(g, g.op("Shape", input), axes=[0], ends=[dim], starts=[offset])
+        divisor = g.op("Cast", divisor, to_i=cast_pytorch_to_onnx["Float"])
+        scale_dims = g.op("Div", dividend, divisor)
+        scales = g.op("Concat", offsets, scale_dims, axis_i=0)
+    else:
+        scales_constant = [1. if i < 2 else
+                           float(output_size[-(dim - i)]) / float(input.type().sizes()[-(dim - i)])
+                           for i in range(0, dim)]
+        scales = g.op("Constant", value_t=torch.tensor(scales_constant))
+    return scales
+
+
 def _scatter_helper(g, self, dim, index, src):
     if _export_onnx_opset_version <= 10:
         from torch.onnx.symbolic_opset9 import scatter

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import torch
 from torch.nn.modules.utils import _single, _pair, _triple
 import torch.onnx
@@ -131,29 +133,20 @@ avg_pool3d = _avg_pool('avg_pool3d', _triple)
 
 def _interpolate(name, dim, interpolate_mode):
     def symbolic_fn(g, input, output_size, align_corners=None):
+        sym_help._interpolate_warning(interpolate_mode)
+        align_corners = sym_help._maybe_get_scalar(align_corners)
         if align_corners:
             return _unimplemented(name, "align_corners == True")
-
-        output_size = sym_help._maybe_get_const(output_size, 'is')
-        if sym_help._is_value(output_size):
-            offset = 2
-            offsets = g.op("Constant", value_t=torch.tensor([1. for i in range(offset)]))
-            dividend = g.op("Cast", output_size, to_i=sym_help.cast_pytorch_to_onnx["Float"])
-            divisor = sym_help._slice_helper(g, g.op("Shape", input), axes=[0], ends=[dim], starts=[offset])
-            divisor = g.op("Cast", divisor, to_i=sym_help.cast_pytorch_to_onnx["Float"])
-            scale_dims = g.op("Div", dividend, divisor)
-            scales = g.op("Concat", offsets, scale_dims, axis_i=0)
-        else:
-            scales_constant = [1. if i < 2 else
-                               float(output_size[-(dim - i)]) / float(input.type().sizes()[-(dim - i)])
-                               for i in range(0, dim)]
-            scales = g.op("Constant", value_t=torch.tensor(scales_constant))
+        scales = sym_help._interpolate_size_to_scales(g, input, output_size, dim)
         return g.op("Resize", input, scales, mode_s=interpolate_mode)
     return symbolic_fn
 
 upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
 upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
 upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
+upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
+upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
+upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
 
 
 def _slice(g, input, axes, starts, ends, steps=None, dynamic_slice=False):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import torch
 import torch.onnx.symbolic_helper as sym_help
 
@@ -39,6 +41,40 @@ def pixel_shuffle(g, self, upscale_factor):
     if len(dims) != 4:
         return _unimplemented("pixel_shuffle", "only support 4d input")
     return g.op("DepthToSpace", self, blocksize_i=upscale_factor, mode_s="CRD")
+
+
+def _interpolate(name, dim, interpolate_mode):
+    def symbolic_fn(g, input, output_size, align_corners=None):
+        align_corners = sym_help._maybe_get_scalar(align_corners)
+        output_size = sym_help._maybe_get_const(output_size, 'is')
+        if sym_help._is_value(output_size):
+            offsets = g.op("Constant", value_t=torch.ones(offset, dtype=torch.int64))
+            output_size = g.op("Concat", offsets, output_size, axis_i=0)
+        else:
+            output_size = [1 if i < 2 else output_size[-(dim - i)] for i in range(0, dim)]
+            output_size = g.op("Constant", value_t=torch.tensor(output_size))
+        coordinate_transformation_mode = "asymmetric" if interpolate_mode == "nearest" \
+            else "align_corners" if align_corners else "pytorch_half_pixel"
+        empty_tensor = g.op("Constant", value_t=torch.tensor([], dtype=torch.float32))
+        return g.op("Resize",
+                    input,
+                    empty_tensor,  # roi only takes effect whith coordinate_transformation_mode="tf_crop_and_resize"
+                    empty_tensor,  # scales is not needed since we are sending out_size
+                    output_size,
+                    coordinate_transformation_mode_s=coordinate_transformation_mode,
+                    cubic_coeff_a_f=-0.75,  # only valid when mode="cubic"
+                    mode_s=interpolate_mode,  # nearest, linear, or cubic
+                    nearest_mode_s="floor")  # only valid when mode="nearest"
+    return symbolic_fn
+
+
+upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
+upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
+upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
+upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
+upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
+upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
+upsample_bicubic2d = _interpolate('upsample_bicubic2d', 4, "cubic")
 
 
 @parse_args('v', 'i', 'v', 'v')

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import torch
 import torch.onnx.symbolic_helper as sym_help
 import torch.onnx.symbolic_opset9 as sym_opset9
@@ -46,20 +48,29 @@ for black_listed_op in black_listed_operators:
     vars()[black_listed_op] = _black_list_in_opset(black_listed_op)
 
 
-def upsample_nearest2d(g, input, output_size, align_corners=None):
-    align_corners = sym_help._maybe_get_scalar(align_corners)
-    if align_corners:
-        return _unimplemented("upsample_neareset2d", "align_corners == True")
+def _interpolate(name, dim, interpolate_mode):
+    def symbolic_fn(g, input, output_size, align_corners=None):
+        sym_help._interpolate_warning(interpolate_mode)
+        align_corners = sym_help._maybe_get_scalar(align_corners)
+        if align_corners:
+            return _unimplemented(name, "align_corners == True")
+        output_size = sym_help._maybe_get_const(output_size, 'is')
+        if sym_help._is_value(output_size):
+            return _unimplemented(name, "torch._C.Value (output_size) indexing")
+        else:
+            scales = [1. if i < 2 else
+                      float(output_size[-(dim - i)]) / float(input.type().sizes()[-(dim - i)])
+                      for i in range(0, dim)]
+        return g.op("Upsample", input, mode_s=interpolate_mode, scales_f=scales)
+    return symbolic_fn
 
-    output_size = sym_help._maybe_get_const(output_size, 'is')
-    if sym_help._is_value(output_size):
-        return _unimplemented("upsample_nearest2d", "torch._C.Value (output_size) indexing")
-    else:
-        height_scale = float(output_size[-2]) / input.type().sizes()[-2]
-        width_scale = float(output_size[-1]) / input.type().sizes()[-1]
-        scales = [1., 1., height_scale, width_scale]
-        return g.op("Upsample", input, mode_s="nearest",
-                    scales_f=scales)
+
+upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
+upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
+upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
+upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
+upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
+upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
 
 
 # NOTE: We should create a wrapper for this kind of operation, after resolving the shape/type propagation

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -712,24 +712,11 @@ replication_pad3d = replication_pad
 
 def _interpolate(name, dim, interpolate_mode):
     def symbolic_fn(g, input, output_size, align_corners=None):
+        sym_help._interpolate_warning(interpolate_mode)
         align_corners = sym_help._maybe_get_scalar(align_corners)
         if align_corners:
             return _unimplemented(name, "align_corners == True")
-
-        output_size = sym_help._maybe_get_const(output_size, 'is')
-        if sym_help._is_value(output_size):
-            offset = 2
-            offsets = g.op("Constant", value_t=torch.tensor([1. for i in range(offset)]))
-            dividend = g.op("Cast", output_size, to_i=sym_help.cast_pytorch_to_onnx["Float"])
-            divisor = sym_help._slice_helper(g, g.op("Shape", input), axes=[0], ends=[dim], starts=[offset])
-            divisor = g.op("Cast", divisor, to_i=sym_help.cast_pytorch_to_onnx["Float"])
-            scale_dims = g.op("Div", dividend, divisor)
-            scales = g.op("Concat", offsets, scale_dims, axis_i=0)
-        else:
-            scales_constant = [1. if i < 2 else
-                               float(output_size[-(dim - i)]) / float(input.type().sizes()[-(dim - i)])
-                               for i in range(0, dim)]
-            scales = g.op("Constant", value_t=torch.tensor(scales_constant))
+        scales = sym_help._interpolate_size_to_scales(g, input, output_size, dim)
         return g.op("Upsample", input, scales, mode_s=interpolate_mode)
     return symbolic_fn
 
@@ -737,6 +724,9 @@ def _interpolate(name, dim, interpolate_mode):
 upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
 upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
 upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
+upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
+upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
+upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
 
 
 def wrap_logical_op_with_cast_to(to_type):


### PR DESCRIPTION
Summary:
- Add support for linear and cubic interpolate in opset 11.
- Add support for 1d and 3d interpolate in nearest mode for opset 7 and 8.
- Add tests for all cases of interpolate in ORT tests (nearest/linear/cubic, 1d/2d/3d, upsample/downsample).
Original PR resolved: https://github.com/pytorch/pytorch/pull/24805

Differential Revision: D17564911

Pulled By: houseroad

