### PR TITLE
[pytorch][mobile] remove backward functions from jit-op-registry for mobile build

### DIFF
--- a/tools/jit/gen_jit_dispatch.py
+++ b/tools/jit/gen_jit_dispatch.py
@@ -238,6 +238,10 @@ def is_out_variant(decl):
     return decl['name'].endswith('_out')
 
 
+def is_backward_op(decl):
+    return decl['name'].endswith('_backward') or decl['name'].endswith('_backward_out')
+
+
 # for each argument in decl, the location it should appear in the
 # jit schema declaration. e.g.
 # arguments = [x, y, z] # the order in aten
@@ -248,7 +252,7 @@ def argument_order(decl):
     return decl.get('jit_argument_order') or list(range(len(decl['arguments'])))
 
 
-def gen_jit_dispatch(declarations, out, template_path):
+def gen_jit_dispatch(declarations, out, template_path, disable_autograd=False):
     REGISTER_ATEN_OPS_CPP = CodeTemplate.from_file(template_path + '/register_aten_ops.cpp')
 
     ops = []
@@ -321,6 +325,14 @@ def gen_jit_dispatch(declarations, out, template_path):
                                              op_capture=op_capture,
                                              lvalues=lvalues)
         return constructor
+
+    def filter_decls(jit_decls, disable_autograd):
+        result = []
+        for decl in jit_decls:
+            if disable_autograd and is_backward_op(decl):
+                continue
+            result.append(decl)
+        return result
 
     # This function declares an order on declarations. This is necessary because
     # there is some ambiguity in the choice of overload: if an argument is overloaded
@@ -407,6 +419,7 @@ def gen_jit_dispatch(declarations, out, template_path):
                 additional_jit_decls.append(decl_copy)
 
     jit_decls.extend(additional_jit_decls)
+    jit_decls = filter_decls(jit_decls, disable_autograd)
 
     # Group and sort the generated snippets to ensure that the
     # generation is deterministic

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -48,7 +48,11 @@ def generate_code(ninja_global=None,
             'tools/autograd',
             disable_autograd=disable_autograd,
         )
-        gen_jit_dispatch(declarations_path or DECLARATIONS_PATH, jit_gen_dir, 'tools/jit/templates')
+        gen_jit_dispatch(
+            declarations_path or DECLARATIONS_PATH,
+            jit_gen_dir,
+            'tools/jit/templates',
+            disable_autograd=disable_autograd)
 
 
 def main():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26783 [pytorch][mobile] remove backward functions from jit-op-registry for mobile build**
* #26702 [pytorch][perf] add mobile friendly at:parallel_for backend

Summary:
Add codegen option to remove backward ops from jit-op-registry as they are not
likely to be used for inference only mobile build.

Measured ARM-v7 AAR build size change: 5,804,182 -> 5,331,219.

Test Plan:
- build and integrate with demo app;

Differential Revision: [D17570054](https://our.internmc.facebook.com/intern/diff/D17570054)