### PR TITLE
[reland][fix] quantized_tensor tests

### DIFF
--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -1,5 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cpu/Loops.h>
 #include <ATen/quantized/QTensorImpl.h>
 #include <ATen/quantized/Quantizer.h>
 
@@ -64,18 +66,23 @@ int64_t q_per_channel_axis_quant(const Tensor& self) {
   return static_cast<PerChannelAffineQuantizer*>(quantizer.get())->axis();
 }
 
+// When input Tensor is non-dense, i.e. the allocated memory
+// is larger than the memory used by all the elements, we'll
+// convert it to dense tensor, otherwise we'll keep the memory
+// format of the output the same as input
 Tensor int_repr_quant(const Tensor& self) {
   Tensor dst;
-  // TODO: replace with TensorIterator
-  auto self_c = self.contiguous();
   AT_DISPATCH_QINT_TYPES(self.scalar_type(), "int_repr", [&]() {
-    dst = at::empty(self.sizes(), self.options().dtype(UNDERLYING_TYPE));
-    underlying_t* self_data =
-        reinterpret_cast<underlying_t*>(self_c.data_ptr<scalar_t>());
-    underlying_t* dst_data = dst.data_ptr<underlying_t>();
-    if (self.numel() > 0) {
-      memcpy(dst_data, self_data, self.nbytes());
-    }
+    dst = at::empty(
+        self.sizes(),
+        self.options().dtype(UNDERLYING_TYPE),
+        self.suggest_memory_format());
+    auto iter = TensorIterator();
+    iter.add_output(dst);
+    iter.add_input(self);
+    iter.dont_compute_common_dtype();
+    iter.build();
+    cpu_kernel(iter, [](scalar_t value) -> underlying_t { return value.val_; });
   });
   return dst;
 }

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -377,7 +377,10 @@ static inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
 
   if (isQIntType(a) || isQIntType(b)) {
     AT_ERROR(
-        "promoteTypes with quantized numbers is not handled yet; figure out what the correct rules should be");
+        "promoteTypes with quantized numbers is not handled yet; figure out what the correct rules should be, offending types: ",
+        toString(a),
+        " ",
+        toString(b));
   }
 
   // this matrix has to be consistent with AT_FORALL_SCALAR_TYPES_WITH_COMPLEX


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26784 [reland][fix] quantized_tensor tests**

Summary:
Previously we are using empty to generate test tensors, this PR changes the test tensors to use
randint so that we can test things properly
Also added a set_sizes_and_strides and removed .contiguous() in int_repr function to preserve the
original size and strides

Test Plan:
python test/test_quantized_tensor.py

Reviewers:
pt1quant
Subscribers:

Tasks:

Tags:

reland: some recent API changes was not updated in this PR previously

This reverts commit 0c0b4b63263ed00e66c2b5c91130900c747f1b4b.

Differential Revision: [D17566575](https://our.internmc.facebook.com/intern/diff/D17566575)