### PR TITLE
Enable INT8 linear and conv op for mkldnn

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -132,10 +132,13 @@ const std::vector<at::QEngine>& Context::supportedQEngines() const {
 #endif // C10_MOBILE
 
 #ifdef USE_FBGEMM
+#if AT_MKLDNN_ENABLED()
+    engines.push_back(at::kQMKLDNN);
+#endif // AT_MKLDNN_ENABLED()
     if (fbgemm::fbgemmSupportedCPU()) {
       engines.push_back(at::kFBGEMM);
     }
-#endif
+#endif // USE_FBGEMM
     return engines;
   }();
   return supported_qengines;

--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -13,12 +13,17 @@ namespace at {
 namespace cpp_custom_type_hack {
 
 template <typename T>
+bool is_type(const Tensor& packed) {
+  return packed.storage().data_ptr().get_deleter() ==
+          caffe2::TypeMeta::Make<T>().deleteFn();
+}
+
+template <typename T>
 T& cast(const Tensor& packed) {
   TORCH_CHECK(
       packed.scalar_type() == kByte, "Expected temporary cpp type wrapper");
   TORCH_CHECK(
-      packed.storage().data_ptr().get_deleter() ==
-          caffe2::TypeMeta::Make<T>().deleteFn(),
+      is_type<T>(packed),
       "Expected temporary cpp type wrapper of type ",
       caffe2::TypeMeta::TypeName<T>());
   return *reinterpret_cast<T*>(packed.storage().data_ptr().get());

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -2,7 +2,6 @@
 
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 
 #include <ATen/native/c10_utils.h>

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -75,6 +75,29 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
            ideep::tensor::data_type::f32},
           tensor.template data_ptr<float>()};
 }
+
+ideep::tensor::data_type get_mkldnn_dtype(ScalarType type) {
+  switch(type) {
+    case ScalarType::Float:
+      return ideep::tensor::data_type::f32;
+    case ScalarType::QInt32:
+      return ideep::tensor::data_type::s32;
+    case ScalarType::QInt8:
+      return ideep::tensor::data_type::s8;
+    case ScalarType::QUInt8:
+      return ideep::tensor::data_type::u8;
+    default:
+      AT_ASSERTM(false, "get_mkldnn_dtype: unsupported data type");
+  }
+}
+
+ideep::scale_t ConvertScales(const std::vector<double> &scales_z) {
+  ideep::scale_t scales(scales_z.size());
+  for (int i = 0; i < scales_z.size(); i++) {
+    scales[i] = 1.0f / scales_z[i];
+  }
+  return scales;
+}
 }}
 
 #endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.h
@@ -30,6 +30,12 @@ ideep::tensor& itensor_from_mkldnn(const Tensor& mkldnn_tensor);
 // Construct an `ideep::tensor` "view" from dense tensor, note the
 // ideep::tensor will share the underlying buffer
 ideep::tensor itensor_view_from_dense(const Tensor& tensor);
+
+// Mapping Aten ScalarType to MKL-DNN tensor type
+ideep::tensor::data_type get_mkldnn_dtype(ScalarType type);
+
+// Calculate MKL-DNN tensor scales from QTensor scales
+ideep::scale_t ConvertScales(const std::vector<double> &scales_z);
 }}
 
 #endif // AT_MKLDNN_ENABLED

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/QScheme.h>
 #include <ATen/Tensor.h>
+#include <ATen/cpp_custom_type_hack.h>
 #ifdef USE_FBGEMM
 #include "fbgemm/Fbgemm.h"
 #include "fbgemm/QuantUtils.h"
@@ -55,4 +56,316 @@ inline void convert_int8_uint8(
   }
 }
 
+// Calculate the column offsets.
+// Note this includes the sum of the columns as well as the scalar term
+// B_zero_point * K, whereas the row_offsets created by
+// PackAWithQuantRowOffset is only the sum of the A rows.
+inline void calc_col_offsets_transpose(
+    int K,
+    int N,
+    const int8_t* Bint8,
+    int32_t* B_zero_point,
+    int32_t* col_offsets,
+    c10::QScheme qtype) {
+  for (size_t i = 0; i < N; ++i) {
+    int32_t sum = 0;
+    for (size_t j = 0; j < K; ++j) {
+      sum += Bint8[i * K + j];
+    }
+    if (qtype == c10::kPerTensorAffine) {
+      col_offsets[i] = sum - B_zero_point[0] * K;
+    } else {
+      col_offsets[i] = sum - B_zero_point[i] * K;
+    }
+  }
+}
+
+static at::Tensor fbgemm_linear_prepack(
+    at::Tensor weight,
+    c10::optional<at::Tensor> bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "The weight tensor for quantized::linear_prepack (fbgemm) should"
+      " be 2-dimensional.");
+
+  auto N = weight.size(0);
+  auto K = weight.size(1);
+
+  // TODO: contiguous is called for further JIT optimizations.
+  auto weight_contig = weight.contiguous();
+  const auto qtype = weight.qscheme();
+  std::vector<int32_t> weight_zero_points_int32(1, 0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_zero_points_int32[0] = weight.q_zero_point();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_zero_points_int32.resize(N, 0);
+    for (int i = 0; i < N; ++i) {
+      weight_zero_points_int32[i] =
+          weight.q_per_channel_zero_points()[i].item<int32_t>();
+    }
+  }
+  std::vector<float> weight_scales_float(1, 0.0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_scales_float[0] = weight.q_scale();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_scales_float.resize(N, 0.0);
+    for (int i = 0; i < N; ++i) {
+      weight_scales_float[i] = weight.q_per_channel_scales()[i].item<float>();
+    }
+  }
+
+  int8_t* weight_ptr_int8 =
+      reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+
+  std::vector<int32_t> col_offsets(N);
+  calc_col_offsets_transpose(
+      /*K=*/K,
+      /*N=*/N,
+      /*Bint8=*/weight_ptr_int8,
+      /*B_zero_point=*/weight_zero_points_int32.data(),
+      /*col_offsets=*/col_offsets.data(),
+      /*qtype=*/qtype);
+
+  c10::optional<at::Tensor> bias_contig;
+  if (bias.has_value()) {
+    at::Tensor bias_vec = bias.value();
+    TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_vec.size(0) == N,
+        "bias should have N elements: " + std::to_string(N));
+    bias_contig = bias->contiguous();
+  }
+  auto ret_ptr = c10::guts::make_unique<PackedLinearWeight>(PackedLinearWeight{
+      c10::guts::make_unique<fbgemm::PackBMatrix<int8_t>>(
+          /*trans=*/fbgemm::matrix_op_t::Transpose,
+          /*nRow=*/K,
+          /*nCol=*/N,
+          /*smat=*/weight_ptr_int8,
+          /*ld=*/K,
+          /*pmat=*/nullptr, // PackBMatrix manages ownership of pmat
+          /*groups=*/1),
+      bias_contig,
+      col_offsets,
+      weight_scales_float,
+      weight_zero_points_int32,
+      qtype});
+  // TODO: we will need to replace this with torchscript classes at a later
+  // point.
+  return at::cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
+}
+
+static std::tuple<at::Tensor, c10::optional<at::Tensor>> fbgemm_linear_unpack(
+    at::Tensor packed_weight) {
+  // Pull out the PackBMatrix instance from the owning tensor.
+  auto& pack_ptr =
+      at::cpp_custom_type_hack::cast<PackedLinearWeight>(packed_weight);
+  auto packB = pack_ptr.w.get();
+
+  int64_t N = static_cast<int64_t>(packB->numCols());
+  int64_t K = static_cast<int64_t>(packB->numRows());
+
+  at::Tensor weight_origin;
+  if (pack_ptr.q_scheme == c10::kPerTensorAffine) {
+    weight_origin = at::_empty_affine_quantized(
+        {N, K},
+        at::device(c10::kCPU).dtype(c10::kQInt8),
+        pack_ptr.w_scale[0],
+        pack_ptr.w_zp[0]);
+  } else if (pack_ptr.q_scheme == c10::kPerChannelAffine) {
+    auto scales = at::from_blob(
+        pack_ptr.w_scale.data(),
+        pack_ptr.w_scale.size(),
+        device(c10::kCPU).dtype(c10::kFloat));
+    auto zero_points = at::from_blob(
+        pack_ptr.w_zp.data(), pack_ptr.w_zp.size(), device(c10::kCPU).dtype(c10::kInt));
+
+    weight_origin = at::_empty_per_channel_affine_quantized(
+        {N, K},
+        scales.toType(c10::kDouble),
+        zero_points.toType(c10::kLong),
+        0, // The output channel axis is 0
+        device(c10::kCPU).dtype(c10::kQInt8));
+  }
+
+  int8_t* weight_ptr_int8 =
+      reinterpret_cast<int8_t*>(weight_origin.data_ptr<c10::qint8>());
+
+  packB->unpack(weight_ptr_int8);
+
+  return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+      weight_origin, pack_ptr.bias);
+}
+
+static at::Tensor fbgemm_conv_prepack(
+    at::Tensor weight,
+    c10::optional<at::Tensor> bias,
+    torch::List<int64_t> stride,
+    torch::List<int64_t> padding,
+    torch::List<int64_t> dilation,
+    int64_t groups) {
+  TORCH_CHECK(
+      weight.ndimension() == 4, "Weights are expected to have 4 dimensions");
+  TORCH_CHECK(stride.size() == 2, "2D convolution only");
+  TORCH_CHECK(
+      padding.size() == 2,
+      "Specify top/left padding only. \
+    bottom/right padding assumed to be equal to top/left");
+  TORCH_CHECK(dilation.size() == 2, "2D convolution only");
+
+  int output_channels = weight.size(0);
+  int input_channels_per_group = weight.size(1);
+  int kernel_h = weight.size(2);
+  int kernel_w = weight.size(3);
+
+  // mini-batch doesn't have any impact on how we pack weights
+  // so we pass it as 1
+  // Input image height/width also don't have any impact on how we pack
+  // weights so we can pass any values
+  fbgemm::conv_param_t<2> conv_p(
+      1, // Mini-Batch
+      input_channels_per_group * groups, // input channels
+      output_channels,
+      {28, 28}, // Image height and width
+      groups,
+      {kernel_h, kernel_w},
+      {static_cast<int>(stride[0]), static_cast<int>(stride[1])},
+      {static_cast<int>(padding[0]),
+       static_cast<int>(padding[1]),
+       static_cast<int>(padding[0]),
+       static_cast<int>(padding[1])},
+      {static_cast<int>(dilation[0]), static_cast<int>(dilation[1])});
+
+  // FBGEMM expects weights to be in channels last
+  auto weight_contig = weight.contiguous(c10::MemoryFormat::ChannelsLast);
+  const auto qtype = weight.qscheme();
+
+  std::vector<int32_t> zero_points(1, 0);
+  if (qtype == c10::kPerTensorAffine) {
+    zero_points[0] = weight.q_zero_point();
+  } else if (qtype == c10::kPerChannelAffine) {
+    int64_t axis = weight.q_per_channel_axis();
+    TORCH_CHECK(
+        axis == 0,
+        "Only per output channel quantization is supported for the weights");
+    zero_points.resize(output_channels, 0);
+    for (int i = 0; i < output_channels; ++i) {
+      zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
+    }
+  } else {
+    TORCH_CHECK(false, "Unsupported qscheme: ", toString(qtype));
+  }
+  
+  const int8_t* weight_ptr_int8 =
+      reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+
+  std::vector<int32_t> col_offsets(output_channels);
+  // compute column offsets (Similar to
+  // fbgemm::col_offsets_with_zero_pt_s8acc32_ref) please note that offsets
+  // include the sum of columns as well as the scalar term weight_zero_point *
+  // KDim
+  int NDim = output_channels / groups;
+  int KDim_per_group = kernel_h * kernel_w * input_channels_per_group;
+  for (int g = 0; g < groups; ++g) {
+    for (int j = 0; j < NDim; ++j) {
+      int32_t sum = 0;
+      for (int k = 0; k < KDim_per_group; ++k) {
+        sum += weight_ptr_int8[(g * NDim + j) * KDim_per_group + k];
+      }
+      if (qtype == c10::kPerTensorAffine) {
+        col_offsets[g * NDim + j] = sum - zero_points[0] * KDim_per_group;
+      } else {
+        col_offsets[g * NDim + j] =
+            sum - zero_points[g * NDim + j] * KDim_per_group;
+      }
+    }
+  }
+
+  std::vector<float> scales(1, 0.0);
+  if (qtype == c10::kPerTensorAffine) {
+    scales[0] = weight.q_scale();
+  } else if (qtype == c10::kPerChannelAffine) {
+    scales.resize(output_channels, 0.0);
+    for (int i = 0; i < output_channels; ++i) {
+      scales[i] = weight.q_per_channel_scales()[i].item<float>();
+    }
+  }
+
+  c10::optional<at::Tensor> bias_contig;
+  if (bias.has_value()) {
+    at::Tensor bias_vec = bias.value();
+    TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_vec.size(0) == output_channels,
+        "bias should have K elements: " + std::to_string(output_channels));
+    bias_contig = bias->contiguous();
+  }
+
+  auto ret_ptr = c10::guts::make_unique<PackedConvWeight>(
+      PackedConvWeight{c10::guts::make_unique<fbgemm::PackWeightsForConv<2>>(
+                           conv_p, weight_ptr_int8),
+                       bias_contig,
+                       col_offsets,
+                       {kernel_h, kernel_w},
+                       scales,
+                       zero_points,
+                       qtype});
+  // TODO: we will need to replace this with torchscript classes at a later
+  // point.
+  return at::cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
+
+}
+
+static std::tuple<at::Tensor, c10::optional<at::Tensor>> fbgemm_conv_unpack(
+    at::Tensor packed_weights) {
+  // Pull out the packed weight instance from the owning tensor.
+  auto& pack_ptr =
+      at::cpp_custom_type_hack::cast<PackedConvWeight>(packed_weights);
+  auto packed_weights_p = pack_ptr.w.get();
+  // output channels
+  int output_channels = packed_weights_p->outputChannels();
+  int input_channels = packed_weights_p->inputChannels();
+  int groups = packed_weights_p->groups();
+  // R (kernel height)
+  int kernel_h = pack_ptr.kernel[0];
+  // S (kernel width)
+  int kernel_w = pack_ptr.kernel[1];
+
+  int C_per_G = input_channels / groups;
+
+  // Tensor for unpacked weights
+  // Unpacked format would be physical KRS(C/G) but logical KCRS (channels first)
+  // because that's how FBGEMM stores the weights
+  at::Tensor unpacked_weights;
+  if (pack_ptr.q_scheme == c10::kPerTensorAffine) {
+    unpacked_weights = at::_empty_affine_quantized(
+        {output_channels, C_per_G, kernel_h, kernel_w},
+        device(c10::kCPU).dtype(c10::kQInt8),
+        pack_ptr.w_scale[0],
+        pack_ptr.w_zp[0],
+        c10::MemoryFormat::ChannelsLast);
+  } else if (pack_ptr.q_scheme == c10::kPerChannelAffine) {
+    auto scales = at::from_blob(
+        pack_ptr.w_scale.data(),
+        pack_ptr.w_scale.size(),
+        device(c10::kCPU).dtype(c10::kFloat));
+    auto zero_points = at::from_blob(
+        pack_ptr.w_zp.data(), pack_ptr.w_zp.size(), device(c10::kCPU).dtype(c10::kInt));
+    unpacked_weights = at::_empty_per_channel_affine_quantized(
+        {output_channels, C_per_G, kernel_h, kernel_w},
+        scales.toType(c10::kDouble),
+        zero_points.toType(c10::kLong),
+        0, /* The output channel axis is 0 */
+        device(c10::kCPU).dtype(c10::kQInt8),
+        c10::MemoryFormat::ChannelsLast);
+  } else {
+    TORCH_CHECK(false, "Unsupported qscheme: ", toString(pack_ptr.q_scheme));
+  }
+
+  int8_t* unpacked_weights_p =
+      reinterpret_cast<int8_t*>(unpacked_weights.data_ptr<c10::qint8>());
+
+  packed_weights_p->unpack(unpacked_weights_p);
+  return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+      unpacked_weights, pack_ptr.bias);
+}
 #endif // USE_FBGEMM

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -2,8 +2,8 @@
 #include <ATen/SmallVector.h>
 #include <ATen/Parallel.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/quantized/cpu/qmkldnn_utils.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <caffe2/utils/threadpool/ThreadPoolMobile.h>
 #include <cmath>
@@ -121,7 +121,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
     const uint8_t* act_ptr =
         reinterpret_cast<uint8_t*>(act_contig.data_ptr<c10::quint8>());
 
-    PackedConvWeight& pack_ptr =
+    auto& pack_ptr =
         cpp_custom_type_hack::cast<PackedConvWeight>(packed_weight);
     auto packB = pack_ptr.w.get();
     auto& col_offsets = pack_ptr.col_offsets;
@@ -274,6 +274,129 @@ class QConv2dInt8 final : public c10::OperatorKernel {
     // TODO: remove permute once MemoryLayout is added above
     return output.permute({0, 3, 1, 2});
   }
+
+#if AT_MKLDNN_ENABLED()
+Tensor mkldnn_qconv2d(
+    Tensor& act,
+    Tensor& packed_weight,
+    torch::List<int64_t>& stride,
+    torch::List<int64_t>& padding,
+    torch::List<int64_t>& dilation,
+    int64_t groups,
+    double output_scale,
+    int64_t output_zero_point) {
+  TORCH_CHECK(
+      act.scalar_type() == ScalarType::QUInt8,
+      "Only QUInt8 ScalarType activations are support")
+  TORCH_CHECK(
+      output_zero_point == 0,
+      "Only 0 point are support for MKL-DNN");
+  conv_checks(
+      act.ndimension(), stride.size(), padding.size(), dilation.size());
+
+  auto& pack_ptr =
+      cpp_custom_type_hack::cast<PackedConvWeightQmkldnn>(packed_weight);
+  TORCH_CHECK(
+      pack_ptr.w_scale.size() == pack_ptr.w_zp.size(),
+      "Weight scales and zero points vectors should have the same size.");
+  ideep::tensor weight_ = *pack_ptr.w.get();
+  TORCH_CHECK(
+      weight_.ndims() == 4 || weight_.ndims() == 5,
+      "Packed weights are supposed to have 4 or 5 dimensions.");
+  
+  int N = act.size(0);
+  int C = act.size(1);
+  int H = act.size(2);
+  int W = act.size(3);
+
+  int K;
+  std::vector<int64_t> kernel;
+  auto weight_shape = weight_.get_dims();
+
+  if (weight_.ndims() == act.ndimension() + 1) {
+    TORCH_CHECK(
+        groups > 1,
+        "Only weights of group 2d convolution could have been prepacked to 5d");
+    K = weight_shape[0] * weight_shape[1];
+    kernel = {weight_shape[3], weight_shape[4]};
+  } else {
+    K = weight_shape[0];
+    kernel = {weight_shape[2], weight_shape[3]};
+  }
+
+  auto outShape =
+      convOutputShape(N, K, H, W, kernel, stride, padding, dilation);
+
+  TORCH_CHECK(
+      std::all_of(
+          outShape.begin(), outShape.end(), [](int64_t i) { return i > 0; }),
+      "[QConv2D] each dimension of output tensor should be greater than 0")
+  ideep::scale_t output_scale_ = ConvertScales({output_scale});
+
+  ideep::tensor act_, output_;
+  float act_scale = act.q_scale();
+  Tensor act_contig = act.contiguous();
+  auto act_dtype = get_mkldnn_dtype(act.scalar_type());
+  auto act_ptr = reinterpret_cast<uint8_t*>(act_contig.data_ptr());
+
+  ideep::tensor::dims inputShape {N, C, H, W};
+  act_.init({inputShape, act_dtype}, act_ptr);
+  act_.set_scale(ConvertScales({act_scale}));
+
+  // TODO fuse sum / sum+relu
+  auto attr_ = ReluFused ?
+      ideep::descriptor_group::attr_t::fuse_relu() :
+      ideep::descriptor_group::attr_t();
+
+  Tensor output = _empty_affine_quantized(
+      outShape, device(kCPU).dtype(kQUInt8), output_scale, output_zero_point);
+  uint8_t* output_ptr = reinterpret_cast<uint8_t*>(output.data_ptr());
+
+  // nhwc format's logical dimensions come in the order: (n, c, h, w) in mkldnn
+  ideep::tensor::dims outShape_in {N, K, outShape[1], outShape[2]};
+  output_.init({outShape_in,
+                ideep::tensor::data_type::u8, ideep::format::nhwc}, output_ptr);
+  output_.set_scale(output_scale_);
+
+  if (pack_ptr.bias.has_value()) {
+    at::Tensor bias = pack_ptr.bias.value();
+    TORCH_CHECK(
+        bias.dtype() == at::kFloat,
+        "[QConv2D] The 'bias' tensor must have 'torch.float' dtype");
+    bias = bias.contiguous();
+    TORCH_CHECK(bias.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias.size(0) == K,
+        "bias should have K elements: " + std::to_string(K));
+    auto bias_ptr = reinterpret_cast<float*>(bias.data_ptr<float>());
+
+    ideep::tensor bias_;
+    bias_.init({{K}, ideep::tensor::data_type::f32}, bias_ptr);
+
+    ideep::convolution_forward::compute<AllocForMKLDNN>(
+        act_, weight_, bias_, outShape_in, output_,
+        {stride.begin(), stride.end()}, {dilation.begin(), dilation.end()},
+        {padding.begin(), padding.end()}, {padding.begin(), padding.end()},
+        groups, ideep::scale_t(), ideep::scale_t(), output_scale_, attr_,
+        ideep::algorithm::convolution_direct, // TODO winograd
+        ideep::prop_kind::forward_inference,
+        ideep::padding_kind::zero,
+        ideep::lowp_kind::LOWP_U8S8); // TODO s8s8
+  } else {
+    ideep::convolution_forward::compute<AllocForMKLDNN>(
+        act_, weight_, outShape_in, output_,
+        {stride.begin(), stride.end()}, {dilation.begin(), dilation.end()},
+        {padding.begin(), padding.end()}, {padding.begin(), padding.end()},
+        groups, ideep::scale_t(), ideep::scale_t(), output_scale_, attr_,
+        ideep::algorithm::convolution_direct,
+        ideep::prop_kind::forward_inference,
+        ideep::padding_kind::zero,
+        ideep::lowp_kind::LOWP_U8S8);
+  }
+  // TODO: remove permute once MemoryLayout is added above
+  return output.permute({0, 3, 1, 2});
+}
+#endif // AT_MKLDNN_ENABLED()
 #endif
 #ifdef USE_PYTORCH_QNNPACK
   at::Tensor qnnpack_conv(
@@ -429,6 +552,48 @@ class QConv2dInt8 final : public c10::OperatorKernel {
       int64_t output_zero_point) {
     auto& ctx = at::globalContext();
 #ifdef USE_FBGEMM
+#if AT_MKLDNN_ENABLED()
+    bool is_mkldnn_weight =
+        cpp_custom_type_hack::is_type<PackedConvWeightQmkldnn>(
+            packed_weight);
+
+    if (is_mkldnn_weight && use_mkldnn(act, output_zero_point, ReluFused)) {
+      return mkldnn_qconv2d(
+          act,
+          packed_weight,
+          stride,
+          padding,
+          dilation,
+          groups,
+          output_scale,
+          output_zero_point);
+      // We will fallback to FBGEMM if input don't meet mkldnn requirement even
+      // if weights is mkldnn tensor.
+    } else if (at::globalContext().qEngine() == at::kQMKLDNN) {
+      Tensor repacked_weight;
+      if (is_mkldnn_weight) {
+        auto weights_org = mkldnn_conv_unpack(packed_weight);
+        repacked_weight = fbgemm_conv_prepack(
+            std::get<0>(weights_org),
+            std::get<1>(weights_org),
+            stride,
+            padding,
+            dilation,
+            groups);
+      } else {
+        repacked_weight = packed_weight;
+      }
+      return fbgemm_conv(
+          act,
+          repacked_weight,
+          stride,
+          padding,
+          dilation,
+          groups,
+          output_scale,
+          output_zero_point);
+    }
+#endif // AT_MKLDNN_ENABLED()
     if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_conv(
           act,
@@ -440,7 +605,7 @@ class QConv2dInt8 final : public c10::OperatorKernel {
           output_scale,
           output_zero_point);
     }
-#endif
+#endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
     if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_conv(

--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/quantized/cpu/qmkldnn_utils.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/quantized/Quantizer.h>
@@ -10,7 +10,10 @@ namespace caffe2 {
 #ifdef USE_FBGEMM
 // Required for cpp_custom_type_hack to work
 CAFFE_KNOWN_TYPE(PackedConvWeight);
+#if AT_MKLDNN_ENABLED()
+CAFFE_KNOWN_TYPE(PackedConvWeightQmkldnn);
 #endif
+#endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
 // Required for cpp_custom_type_hack to work
 CAFFE_KNOWN_TYPE(PackedConvWeightsQnnp);
@@ -22,122 +25,6 @@ namespace native {
 namespace {
 class QConvPackWeightInt8 final : public c10::OperatorKernel {
  public:
-#ifdef USE_FBGEMM
-  Tensor fbgemm_conv_prepack(
-      Tensor weight,
-      c10::optional<Tensor> bias,
-      torch::List<int64_t> stride,
-      torch::List<int64_t> padding,
-      torch::List<int64_t> dilation,
-      int64_t groups) {
-    TORCH_CHECK(
-        weight.ndimension() == 4, "Weights are expected to have 4 dimensions");
-
-    TORCH_CHECK(stride.size() == 2, "2D convolution only");
-    TORCH_CHECK(
-        padding.size() == 2,
-        "Specify top/left padding only. \
-      bottom/right padding assumed to be equal to top/left");
-    TORCH_CHECK(dilation.size() == 2, "2D convolution only");
-    int output_channels = weight.size(0);
-    int input_channels_per_group = weight.size(1);
-    int kernel_h = weight.size(2);
-    int kernel_w = weight.size(3);
-
-    // mini-batch doesn't have any impact on how we pack weights
-    // so we pass it as 1
-    // Input image height/width also don't have any impact on how we pack
-    // weights so we can pass any values
-    fbgemm::conv_param_t<2> conv_p(
-        1, // Mini-Batch
-        input_channels_per_group * groups, // input channels
-        output_channels,
-        {28, 28}, // Image height and width
-        groups,
-        {kernel_h, kernel_w},
-        {static_cast<int>(stride[0]), static_cast<int>(stride[1])},
-        {static_cast<int>(padding[0]),
-         static_cast<int>(padding[1]),
-         static_cast<int>(padding[0]),
-         static_cast<int>(padding[1])},
-        {static_cast<int>(dilation[0]), static_cast<int>(dilation[1])});
-
-    // FBGEMM expects weights to be in channels last
-    auto weight_contig = weight.contiguous(MemoryFormat::ChannelsLast);
-    const auto qtype = weight.qscheme();
-    std::vector<int32_t> zero_points(1, 0);
-    if (qtype == kPerTensorAffine) {
-      zero_points[0] = weight.q_zero_point();
-    } else if (qtype == kPerChannelAffine) {
-      int64_t axis = weight.q_per_channel_axis();
-      TORCH_CHECK(
-          axis == 0,
-          "Only per output channel quantization is supported for the weights");
-      zero_points.resize(output_channels, 0);
-      for (int i = 0; i < output_channels; ++i) {
-        zero_points[i] = weight.q_per_channel_zero_points()[i].item<int32_t>();
-      }
-    } else {
-      TORCH_CHECK(false, "Unsupported qscheme: ", toString(qtype));
-    }
-
-    const int8_t* weight_ptr_int8 =
-        reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
-
-    std::vector<int32_t> col_offsets(output_channels);
-    // compute column offsets (Similar to
-    // fbgemm::col_offsets_with_zero_pt_s8acc32_ref) please note that offsets
-    // include the sum of columns as well as the scalar term weight_zero_point *
-    // KDim
-    int NDim = output_channels / groups;
-    int KDim_per_group = kernel_h * kernel_w * input_channels_per_group;
-    for (int g = 0; g < groups; ++g) {
-      for (int j = 0; j < NDim; ++j) {
-        int32_t sum = 0;
-        for (int k = 0; k < KDim_per_group; ++k) {
-          sum += weight_ptr_int8[(g * NDim + j) * KDim_per_group + k];
-        }
-        if (qtype == kPerTensorAffine) {
-          col_offsets[g * NDim + j] = sum - zero_points[0] * KDim_per_group;
-        } else {
-          col_offsets[g * NDim + j] =
-              sum - zero_points[g * NDim + j] * KDim_per_group;
-        }
-      }
-    }
-
-    std::vector<float> scales(1, 0.0);
-    if (qtype == kPerTensorAffine) {
-      scales[0] = weight.q_scale();
-    } else if (qtype == kPerChannelAffine) {
-      scales.resize(output_channels, 0.0);
-      for (int i = 0; i < output_channels; ++i) {
-        scales[i] = weight.q_per_channel_scales()[i].item<float>();
-      }
-    }
-    c10::optional<at::Tensor> bias_contig;
-    if (bias.has_value()) {
-      Tensor bias_vec = bias.value();
-      TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
-      TORCH_CHECK(
-          bias_vec.size(0) == output_channels,
-          "bias should have K elements: " + std::to_string(output_channels));
-      bias_contig = bias->contiguous();
-    }
-    auto ret_ptr = guts::make_unique<PackedConvWeight>(
-        PackedConvWeight{guts::make_unique<fbgemm::PackWeightsForConv<2>>(
-                             conv_p, weight_ptr_int8),
-                         bias_contig,
-                         col_offsets,
-                         {kernel_h, kernel_w},
-                         scales,
-                         zero_points,
-                         qtype});
-    // TODO: we will need to replace this with torchscript classes at a later
-    // point.
-    return cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
-  }
-#endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
   at::Tensor qnnpack_conv_prepack(
       Tensor weight,
@@ -247,11 +134,28 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
       int64_t groups) {
     auto& ctx = at::globalContext();
 #ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM) {
-      return fbgemm_conv_prepack(
-          weight, bias, stride, padding, dilation, groups);
+#if AT_MKLDNN_ENABLED()
+    bool is_zero = weight.qscheme() == c10::kPerChannelAffine
+        ? is_zeros<>(weight.q_per_channel_zero_points())
+        : weight.q_zero_point() == 0;
+
+    // TODO: Will remove it after mkldnn fix the bug in 1x1 conv op.now mkldnn
+    // will output wrong result when groups > 1,and IC,OC != 8x.
+    bool is_1x1_conv =
+        (groups > 1 && weight.size(2) == 1 && weight.size(3) == 1);
+
+    if ((ctx.qEngine() == at::kQMKLDNN) && is_zero && !is_1x1_conv &&
+        (weight.scalar_type() == at::kQInt8)) {
+      return mkldnn_conv_prepack(weight, bias, stride, padding, dilation, groups);
+    } else if (ctx.qEngine() == at::kQMKLDNN) {
+      return fbgemm_conv_prepack(weight, bias, stride, padding, dilation, groups);
     }
 #endif
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
+      return fbgemm_conv_prepack(weight, bias, stride, padding, dilation, groups);
+    }
+
+#endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
     if (ctx.qEngine() == at::QEngine::QNNPACK) {
       return qnnpack_conv_prepack(

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -1,6 +1,5 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 
 #include <algorithm>

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/quantized/cpu/qmkldnn_utils.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 #include <ATen/quantized/Quantizer.h>
@@ -12,6 +12,9 @@ namespace caffe2 {
 #ifdef USE_FBGEMM
 // Required for cpp_custom_type_hack to work
 CAFFE_KNOWN_TYPE(PackedLinearWeight);
+#if AT_MKLDNN_ENABLED()
+CAFFE_KNOWN_TYPE(PackedLinearWeightQmkldnn);
+#endif
 #endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
 // Required for cpp_custom_type_hack to work
@@ -25,105 +28,6 @@ namespace {
 
 class QLinearPackWeightInt8 final : public c10::OperatorKernel {
  public:
-#ifdef USE_FBGEMM
-  // Calculate the column offsets.
-  // Note this includes the sum of the columns as well as the scalar term
-  // B_zero_point * K, whereas the row_offsets created by
-  // PackAWithQuantRowOffset is only the sum of the A rows.
-  void calc_col_offsets_transpose(
-      int K,
-      int N,
-      const int8_t* Bint8,
-      int32_t* B_zero_point,
-      int32_t* col_offsets,
-      c10::QScheme qtype) {
-    for (size_t i = 0; i < N; ++i) {
-      int32_t sum = 0;
-      for (size_t j = 0; j < K; ++j) {
-        sum += Bint8[i * K + j];
-      }
-      if (qtype == kPerTensorAffine) {
-        col_offsets[i] = sum - B_zero_point[0] * K;
-      } else {
-        col_offsets[i] = sum - B_zero_point[i] * K;
-      }
-    }
-  }
-  at::Tensor fbgemm_linear_prepack(
-      at::Tensor weight,
-      c10::optional<Tensor> bias) {
-    TORCH_CHECK(
-        weight.dim() == 2,
-        "The weight tensor for quantized::linear_prepack (fbgemm) should"
-        " be 2-dimensional.");
-
-    auto N = weight.size(0);
-    auto K = weight.size(1);
-
-    // TODO: contiguous is called for further JIT optimizations.
-    auto weight_contig = weight.contiguous();
-    const auto qtype = weight.qscheme();
-    std::vector<int32_t> weight_zero_points_int32(1, 0);
-    if (qtype == kPerTensorAffine) {
-      weight_zero_points_int32[0] = weight.q_zero_point();
-    } else if (qtype == kPerChannelAffine) {
-      weight_zero_points_int32.resize(N, 0);
-      for (int i = 0; i < N; ++i) {
-        weight_zero_points_int32[i] =
-            weight.q_per_channel_zero_points()[i].item<int32_t>();
-      }
-    }
-    std::vector<float> weight_scales_float(1, 0.0);
-    if (qtype == kPerTensorAffine) {
-      weight_scales_float[0] = weight.q_scale();
-    } else if (qtype == kPerChannelAffine) {
-      weight_scales_float.resize(N, 0.0);
-      for (int i = 0; i < N; ++i) {
-        weight_scales_float[i] = weight.q_per_channel_scales()[i].item<float>();
-      }
-    }
-
-    int8_t* weight_ptr_int8 =
-        reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
-
-    std::vector<int32_t> col_offsets(N);
-    calc_col_offsets_transpose(
-        /*K=*/K,
-        /*N=*/N,
-        /*Bint8=*/weight_ptr_int8,
-        /*B_zero_point=*/weight_zero_points_int32.data(),
-        /*col_offsets=*/col_offsets.data(),
-        /*qtype=*/qtype);
-
-    c10::optional<at::Tensor> bias_contig;
-    if (bias.has_value()) {
-      Tensor bias_vec = bias.value();
-      TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
-      TORCH_CHECK(
-          bias_vec.size(0) == N,
-          "bias should have N elements: " + std::to_string(N));
-      bias_contig = bias->contiguous();
-    }
-    auto ret_ptr = guts::make_unique<PackedLinearWeight>(PackedLinearWeight{
-        guts::make_unique<fbgemm::PackBMatrix<int8_t>>(
-            /*trans=*/fbgemm::matrix_op_t::Transpose,
-            /*nRow=*/K,
-            /*nCol=*/N,
-            /*smat=*/weight_ptr_int8,
-            /*ld=*/K,
-            /*pmat=*/nullptr, // PackBMatrix manages ownership of pmat
-            /*groups=*/1),
-        bias_contig,
-        col_offsets,
-        weight_scales_float,
-        weight_zero_points_int32,
-        qtype});
-
-    // TODO: we will need to replace this with torchscript classes at a later
-    // point.
-    return cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
-  }
-#endif
 #ifdef USE_PYTORCH_QNNPACK
   at::Tensor qnnpack_linear_prepack(
       at::Tensor weight,
@@ -187,6 +91,18 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
+#if AT_MKLDNN_ENABLED()
+    bool is_zero = weight.qscheme() == c10::kPerChannelAffine
+        ? is_zeros<>(weight.q_per_channel_zero_points())
+        : weight.q_zero_point() == 0;
+
+    if ((ctx.qEngine() == at::kQMKLDNN) &&
+          is_zero && (weight.scalar_type() == at::kQInt8)) {
+      return mkldnn_linear_prepack(weight, bias);
+    } else if(ctx.qEngine() == at::kQMKLDNN) {
+      return fbgemm_linear_prepack(weight, bias);
+    }
+#endif
     if (ctx.qEngine() == at::QEngine::FBGEMM) {
       return fbgemm_linear_prepack(weight, bias);
     }

--- a/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_unpack.cpp
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/op_registration/op_registration.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/quantized/cpu/qmkldnn_utils.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
 
 namespace at {
@@ -10,51 +10,6 @@ namespace {
 
 class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
  public:
-#ifdef USE_FBGEMM
-  std::tuple<at::Tensor, c10::optional<Tensor>> fbgemm_linear_unpack(
-      at::Tensor packed_weight) {
-    // Pull out the PackBMatrix instance from the owning tensor.
-    auto& pack_ptr =
-        cpp_custom_type_hack::cast<PackedLinearWeight>(packed_weight);
-    auto packB = pack_ptr.w.get();
-
-    int64_t N = static_cast<int64_t>(packB->numCols());
-    int64_t K = static_cast<int64_t>(packB->numRows());
-
-    Tensor weight_origin;
-    if (pack_ptr.q_scheme == kPerTensorAffine) {
-      weight_origin = _empty_affine_quantized(
-          {N, K},
-          at::device(kCPU).dtype(kQInt8),
-          pack_ptr.w_scale[0],
-          pack_ptr.w_zp[0]);
-    } else if (pack_ptr.q_scheme == kPerChannelAffine) {
-      auto scales = from_blob(
-          pack_ptr.w_scale.data(),
-          pack_ptr.w_scale.size(),
-          device(kCPU).dtype(kFloat));
-      auto zero_points = from_blob(
-          pack_ptr.w_zp.data(), pack_ptr.w_zp.size(), device(kCPU).dtype(kInt));
-
-      weight_origin = _empty_per_channel_affine_quantized(
-          {N, K},
-          scales.toType(kDouble),
-          zero_points.toType(kLong),
-          0, // The output channel axis is 0
-          device(kCPU).dtype(kQInt8));
-    }
-
-    int8_t* weight_ptr_int8 =
-        reinterpret_cast<int8_t*>(weight_origin.data_ptr<c10::qint8>());
-
-    // packB->printPackedMatrix("packedB inside fbgemm_unpack
-    // (QLinearUnpackWeightInt8): ");
-    packB->unpack(weight_ptr_int8);
-
-    return std::tuple<at::Tensor, c10::optional<Tensor>>(
-        weight_origin, pack_ptr.bias);
-  }
-#endif // USE_FBGEMM
 #ifdef USE_PYTORCH_QNNPACK
   std::tuple<at::Tensor, c10::optional<Tensor>> qnnpack_linear_unpack(
       at::Tensor packed_weight) {
@@ -69,7 +24,14 @@ class QLinearUnpackWeightInt8 final : public c10::OperatorKernel {
     auto& ctx = at::globalContext();
 
 #ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM) {
+#if AT_MKLDNN_ENABLED()
+    if (cpp_custom_type_hack::is_type<PackedLinearWeightQmkldnn>(
+            packed_weight)) {
+      return mkldnn_linear_unpack(packed_weight);
+    }
+#endif
+    if (cpp_custom_type_hack::is_type<PackedLinearWeight>(
+            packed_weight)) {
       return fbgemm_linear_unpack(packed_weight);
     }
 #endif

--- a/aten/src/ATen/native/quantized/cpu/qmkldnn_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qmkldnn_utils.h
@@ -1,0 +1,328 @@
+#pragma once
+
+#ifdef USE_FBGEMM
+#include <ATen/Config.h>
+#if AT_MKLDNN_ENABLED()
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#include <ATen/quantized/QTensorImpl.h>
+#include <ATen/quantized/Quantizer.h>
+
+struct FBGEMM_API PackedLinearWeightQmkldnn {
+  std::unique_ptr<ideep::tensor> w;
+  c10::optional<at::Tensor> bias;
+  std::vector<double> w_scale;
+  std::vector<int64_t> w_zp;
+  c10::QScheme q_scheme;
+};
+
+struct FBGEMM_API PackedConvWeightQmkldnn {
+  std::unique_ptr<ideep::tensor> w;
+  c10::optional<at::Tensor> bias;
+  std::vector<double> w_scale;
+  std::vector<int64_t> w_zp;
+  c10::QScheme q_scheme;
+};
+
+static at::Tensor mkldnn_linear_prepack(
+    at::Tensor& weight,
+    c10::optional<at::Tensor> bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "The weight tensor for quantized::linear_prepack should"
+      " be 2-dimensional.");
+  auto N = weight.size(0);
+  // TODO: contiguous is called for further JIT optimizations.
+  auto weight_contig = weight.contiguous();
+  const auto qtype = weight.qscheme();
+
+  c10::optional<at::Tensor> bias_contig;
+  if (bias.has_value()) {
+    at::Tensor bias_vec = bias.value();
+    TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_vec.size(0) == N,
+        "bias should have N elements: " + std::to_string(N));
+    bias_contig = bias->contiguous();
+  }
+
+  // This is a terrible hack to emulate what VariableType is doing
+  at::AutoNonVariableTypeMode non_var_type_mode(true);
+  auto quantizer = at::get_qtensorimpl(weight_contig)->quantizer();
+
+  std::vector<int64_t> weight_zero_points(1, 0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_zero_points[0] = weight_contig.q_zero_point();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_zero_points =
+        static_cast<at::PerChannelAffineQuantizer*>(quantizer.get())
+            ->zero_points();
+  }
+  std::vector<double> weight_scales(1, 0.0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_scales[0] = weight.q_scale();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_scales =
+        static_cast<at::PerChannelAffineQuantizer*>(quantizer.get())->scales();
+  }
+
+  auto scale_ = at::native::ConvertScales(weight_scales);
+  int8_t* weight_ptr = reinterpret_cast<int8_t*>(weight_contig.data_ptr());
+  ideep::tensor weight_;
+  weight_.init(
+      {{weight_contig.sizes().cbegin(), weight_contig.sizes().cend()},
+       ideep::tensor::data_type::s8},
+      weight_ptr);
+  weight_ = weight_.as_weights();
+  weight_.set_scale(scale_);
+  ideep::tensor::descriptor desc =
+      ideep::inner_product_forward::expected_weights_descriptor(
+          weight_.get_dims(),
+          ideep::tensor::data_type::s8,
+          ideep::tensor::data_type::u8);
+  ideep::tensor output;
+  if (weight_.get_descriptor() != desc) {
+    output.init<at::native::AllocForMKLDNN>(desc);
+    output.set_scale(scale_);
+    output.feed_from(weight_);
+  } else {
+    output = weight_;
+  }
+
+  auto ret_ptr = c10::guts::make_unique<PackedLinearWeightQmkldnn>(
+      PackedLinearWeightQmkldnn{
+          c10::guts::make_unique<ideep::tensor>(output),
+          bias_contig,
+          weight_scales,
+          weight_zero_points,
+          qtype});
+  return at::cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
+}
+
+static std::tuple<at::Tensor, c10::optional<at::Tensor>> mkldnn_linear_unpack(
+    at::Tensor packed_weight) {
+  auto& pack_ptr =
+      at::cpp_custom_type_hack::cast<PackedLinearWeightQmkldnn>(
+          packed_weight);
+  auto packB_mkldnn = reinterpret_cast<ideep::tensor*>(pack_ptr.w.get());
+  int64_t N = packB_mkldnn->get_dim(0);
+  int64_t K = packB_mkldnn->get_dim(1);
+  auto w_scale = pack_ptr.w_scale;
+  auto w_zp = pack_ptr.w_zp;
+  auto qscheme = pack_ptr.q_scheme;
+  auto bias = pack_ptr.bias;
+  at::Tensor weight_origin;
+  if (qscheme == c10::kPerTensorAffine) {
+    weight_origin = at::_empty_affine_quantized(
+        {N, K},
+        at::device(c10::kCPU).dtype(c10::kQInt8),
+        w_scale[0],
+        w_zp[0]);
+  } else if (qscheme == c10::kPerChannelAffine) {
+    auto scales = at::from_blob(
+        w_scale.data(),
+        w_scale.size(),
+        device(c10::kCPU).dtype(c10::kDouble));
+    auto zero_points = at::from_blob(
+        w_zp.data(), w_zp.size(), device(c10::kCPU).dtype(c10::kLong));
+
+    weight_origin = at::_empty_per_channel_affine_quantized(
+        {N, K},
+        scales,
+        zero_points,
+        0, // The output channel axis is 0
+        device(c10::kCPU).dtype(c10::kQInt8));
+  }
+
+  int8_t* weight_ptr_int8 =
+      reinterpret_cast<int8_t*>(weight_origin.data_ptr<c10::qint8>());
+
+  packB_mkldnn->to_public_format(weight_ptr_int8);
+
+  return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+      weight_origin, bias);
+}
+
+static at::Tensor mkldnn_conv_prepack(
+    at::Tensor& weight,
+    c10::optional<at::Tensor>& bias,
+    torch::List<int64_t>& stride,
+    torch::List<int64_t>& padding,
+    torch::List<int64_t>& dilation,
+    int64_t groups) {
+  TORCH_CHECK(
+      weight.ndimension() == 4, "Weights are expected to have 4 dimensions");
+  TORCH_CHECK(stride.size() == 2, "2D convolution only");
+  TORCH_CHECK(
+      padding.size() == 2,
+      "Specify top/left padding only. \
+    bottom/right padding assumed to be equal to top/left");
+  TORCH_CHECK(dilation.size() == 2, "2D convolution only");
+
+  int output_channels = weight.size(0);
+
+  const auto qtype = weight.qscheme();
+
+  auto weight_contig = weight.contiguous();
+
+  // This is a terrible hack to emulate what VariableType is doing
+  at::AutoNonVariableTypeMode non_var_type_mode(true);
+  auto quantizer = at::get_qtensorimpl(weight_contig)->quantizer();
+
+  std::vector<int64_t> zero_points(1, 0);
+  if (qtype == c10::kPerTensorAffine) {
+    zero_points[0] = weight_contig.q_zero_point();
+  } else if (qtype == c10::kPerChannelAffine) {
+    int64_t axis = weight_contig.q_per_channel_axis();
+    TORCH_CHECK(
+        axis == 0,
+        "Only per output channel quantization is supported for the weights");
+    zero_points = static_cast<at::PerChannelAffineQuantizer*>(quantizer.get())
+                      ->zero_points();
+  } else {
+    TORCH_CHECK(false, "Unsupported qscheme: ", toString(qtype));
+  }
+
+  std::vector<double> scales(1, 0.0);
+  if (qtype == c10::kPerTensorAffine) {
+    scales[0] = weight.q_scale();
+  } else if (qtype == c10::kPerChannelAffine) {
+    scales =
+        static_cast<at::PerChannelAffineQuantizer*>(quantizer.get())->scales();
+  }
+
+  c10::optional<at::Tensor> bias_contig;
+  if (bias.has_value()) {
+    at::Tensor bias_vec = bias.value();
+    TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_vec.size(0) == output_channels,
+        "bias should have K elements: " + std::to_string(output_channels));
+    bias_contig = bias->contiguous();
+  }
+
+  // packed MKL-DNN weight
+  auto scale_ = at::native::ConvertScales(scales);
+
+
+  int8_t *weight_ptr =
+      reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+  ideep::tensor weight_;
+  weight_.init({{weight_contig.sizes().cbegin(), weight_contig.sizes().cend()},
+                ideep::tensor::data_type::s8}, weight_ptr);
+  weight_ = weight_.as_weights();
+  weight_.set_scale(scale_);
+  weight_.make_group(groups);
+
+  ideep::tensor::descriptor desc =
+      ideep::convolution_forward::expected_weights_descriptor(
+          weight_.get_dims(),
+          ideep::tensor::data_type::s8,
+          {stride.begin(), stride.end()},
+          {padding.begin(), padding.end()},
+          {padding.begin(), padding.end()},
+          {dilation.begin(), dilation.end()},
+          groups,
+          ideep::algorithm::convolution_direct,
+          ideep::prop_kind::forward_inference,
+          ideep::tensor::data_type::u8); // TODO: u8/s8
+  ideep::tensor output;
+  if (weight_.get_descriptor() != desc) {
+    output.init<at::native::AllocForMKLDNN>(desc);
+    output.set_scale(scale_);
+    output.feed_from(weight_);
+  } else {
+    output = weight_;
+  }
+
+  auto ret_ptr = c10::guts::make_unique<PackedConvWeightQmkldnn>(
+      PackedConvWeightQmkldnn{
+          c10::guts::make_unique<ideep::tensor>(output),
+          bias_contig,
+          scales,
+          zero_points,
+          qtype});
+  return at::cpp_custom_type_hack::create(std::move(ret_ptr), weight.options());
+}
+
+static std::tuple<at::Tensor, c10::optional<at::Tensor>> mkldnn_conv_unpack(
+    at::Tensor packed_weights) {
+  int64_t output_channels, C_per_G, kernel_h, kernel_w;
+  auto& pack_ptr =
+      at::cpp_custom_type_hack::cast<PackedConvWeightQmkldnn>(
+          packed_weights);
+  auto qscheme = pack_ptr.q_scheme;
+  auto packB_mkldnn = reinterpret_cast<ideep::tensor*>(pack_ptr.w.get());
+  if (packB_mkldnn->ndims() == 5) {
+    output_channels = packB_mkldnn->get_dim(0) * packB_mkldnn->get_dim(1);
+    C_per_G = packB_mkldnn->get_dim(2);
+    kernel_h = packB_mkldnn->get_dim(3);
+    kernel_w =packB_mkldnn->get_dim(4);
+  } else {
+    output_channels = packB_mkldnn->get_dim(0);
+    C_per_G = packB_mkldnn->get_dim(1);
+    kernel_h = packB_mkldnn->get_dim(2);
+    kernel_w =packB_mkldnn->get_dim(3);
+  }
+
+  auto w_scale = pack_ptr.w_scale;
+  auto w_zp = pack_ptr.w_zp;
+
+  auto bias = pack_ptr.bias;
+
+  at::Tensor unpacked_weights;
+  if (qscheme == c10::kPerTensorAffine) {
+      unpacked_weights = at::_empty_affine_quantized(
+          {output_channels, C_per_G, kernel_h, kernel_w},
+          device(c10::kCPU).dtype(c10::kQInt8),
+          w_scale[0],
+          w_zp[0]);
+  } else if (qscheme == c10::kPerChannelAffine) {
+    auto scales = at::from_blob(
+        w_scale.data(),
+        w_scale.size(),
+        device(c10::kCPU).dtype(c10::kDouble));
+    auto zero_points = at::from_blob(
+        w_zp.data(), w_zp.size(), device(c10::kCPU).dtype(c10::kLong));
+      unpacked_weights = at::_empty_per_channel_affine_quantized(
+          {output_channels, C_per_G, kernel_h, kernel_w},
+          scales,
+          zero_points,
+          0, /* The output channel axis is 0 */
+          device(c10::kCPU).dtype(c10::kQInt8));
+  } else {
+    TORCH_CHECK(false, "Unsupported qscheme: ", toString(qscheme));
+  }
+
+  int8_t* unpacked_weights_p =
+      reinterpret_cast<int8_t*>(unpacked_weights.data_ptr<c10::qint8>());
+
+  packB_mkldnn->to_public_format(unpacked_weights_p);
+  return std::tuple<at::Tensor, c10::optional<at::Tensor>>(
+      unpacked_weights, bias);
+}
+
+inline bool use_mkldnn(
+    at::Tensor& input,
+    int64_t output_zero_point,
+    bool relu_fused) {
+  // Currently, only u8s8->u8 is support for AQ
+  if (!relu_fused || input.scalar_type() != at::kQUInt8 ||
+      input.q_zero_point() || output_zero_point)
+    return false;
+  if (at::globalContext().qEngine() == at::kQMKLDNN)
+    return true;
+  else
+    return false;
+}
+
+template <typename T = int32_t>
+inline bool is_zeros(at::Tensor zero_points) {
+  for (int i = 0; i < zero_points.numel(); i++) {
+    if (zero_points[i].item<T>() != 0)
+      return false;
+  }
+  return true;
+}
+
+#endif // AT_MKLDNN_ENABLED()
+#endif // USE_FBGEMM

--- a/c10/core/QEngine.h
+++ b/c10/core/QEngine.h
@@ -15,11 +15,13 @@ enum class QEngine : uint8_t {
   NoQEngine = 0,
   FBGEMM = 1,
   QNNPACK = 2,
+  QMKLDNN = 3,
 };
 
 constexpr auto kNoQEngine = QEngine::NoQEngine;
 constexpr auto kFBGEMM = QEngine::FBGEMM;
 constexpr auto kQNNPACK = QEngine::QNNPACK;
+constexpr auto kQMKLDNN = QEngine::QMKLDNN;
 
 inline std::string toString(QEngine qengine) {
   switch (qengine) {
@@ -29,6 +31,8 @@ inline std::string toString(QEngine qengine) {
       return "FBGEMM";
     case kQNNPACK:
       return "QNNPACK";
+    case kQMKLDNN:
+      return "QMKLDNN";
     default:
       TORCH_CHECK(
           false,

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -1696,6 +1696,365 @@ class TestComparatorOps(TestCase):
             self.assertEqual(result_ref, result,
                              "'tensor.{}(scalar)'' failed".format(op))
 
+@unittest.skipUnless('fbgemm' in torch.backends.quantized.supported_engines,
+                     " Quantized operations require FBGEMM. FBGEMM is only optimized for CPUs"
+                     " with instruction set support avx2 or newer.")
+@unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
+class TestQMKLDNNOps(TestCase):
+    @given(shapes=hu.array_shapes(2, 5, min_side=7),
+           has_bias=st.booleans(),
+           use_channelwise=st.booleans(),
+           X_scale=st.floats(0.2, 1.6),
+           ZP=st.sampled_from([0, 5]),
+           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_ZP=st.sampled_from([0, 5]),
+           Y_scale=st.floats(0.2, 1.6))
+    def test_linear_qmkldnn(self, shapes, has_bias, use_channelwise, X_scale, ZP, W_scale, W_ZP, Y_scale):
+        """Tests the correctness of the Linear functional.
+        """
+        W_zero_point = [0, W_ZP]
+        Y_zp = 0
+        N = np.random.randint(7, 17)
+        # Random inputs
+        X_zero_point = ZP
+        X_value_min = 0
+        X_value_max = 10
+        X_init = torch.from_numpy(np.random.randint(
+            X_value_min, X_value_max, shapes))
+        X = X_scale * (X_init - X_zero_point).to(dtype=torch.float)
+
+        W_scale = W_scale * N
+        W_zero_point = W_zero_point * N
+        # Resize W_scale and W_zero_points arrays equal to output_channels
+        W_scale = W_scale[:N]
+        W_zero_point = W_zero_point[:N]
+        W_value_min = -10
+        W_value_max = 10
+        W_init = torch.from_numpy(
+            np.random.randint(
+                W_value_min,
+                W_value_max,
+                (N, X_init.shape[-1])),
+        )
+
+        b_init = torch.from_numpy(np.random.randint(0, 10, (N,)))
+
+        if use_channelwise:
+            W_scales_tensor = torch.tensor(W_scale, dtype=torch.float)
+            W_zero_points_tensor = torch.tensor(W_zero_point, dtype=torch.int32)
+            W = W_scales_tensor.reshape(-1, 1) * (W_init.to(dtype=torch.float) -
+                                                  W_zero_points_tensor.reshape(-1, 1)).to(dtype=torch.float)
+            b = X_scale * W_scales_tensor * (b_init - 0).to(dtype=torch.float) if has_bias else None
+        else:
+            W = W_scale[0] * (W_init - W_zero_point[0]).to(dtype=torch.float)
+            b = X_scale * W_scale[0] * (b_init - 0).to(dtype=torch.float) if has_bias else None
+
+        X_q = torch.quantize_per_tensor(X, scale=X_scale, zero_point=X_zero_point, dtype=torch.quint8)
+
+        if use_channelwise:
+            W_q = torch.quantize_per_channel(W,
+                                             W_scales_tensor.to(dtype=torch.double),
+                                             W_zero_points_tensor.to(dtype=torch.long),
+                                             0,
+                                             dtype=torch.qint8)
+        else:
+            W_q = torch.quantize_per_tensor(W, scale=W_scale[0], zero_point=W_zero_point[0], dtype=torch.qint8)
+
+        qlinear_prepack = torch.ops.quantized.linear_prepack
+        qlinear = torch.ops.quantized.linear_relu
+
+        # Reference
+        torch.backends.quantized.engine = 'fbgemm'
+        W_prepack_ref = qlinear_prepack(W_q, b)
+        ref_result = qlinear(X_q, W_prepack_ref, Y_scale, Y_zp)
+
+        torch.backends.quantized.engine = 'qmkldnn'
+        W_prepack = qlinear_prepack(W_q, b)
+        q_result = qlinear(X_q, W_prepack, Y_scale, Y_zp)
+
+        self.assertEqual(ref_result, q_result)
+
+    @given(K=st.integers(3, 7),
+           N=st.integers(3, 7),
+           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_ZP=st.sampled_from([0, 5]),
+           use_bias=st.booleans(),
+           use_channelwise=st.booleans())
+    def test_prepack_unpack_linear_qmkldnn(self, K, N, W_scale, W_ZP, use_bias, use_channelwise):
+        W_zero_point = [0, W_ZP]
+        W_scale = W_scale * N
+        W_zero_point = W_zero_point * N
+        # Resize W_scale and W_zero_points arrays equal to N
+        W_scale = W_scale[:N]
+        W_zero_point = W_zero_point[:N]
+        W_value_min = -128
+        W_value_max = 127
+        W_init = torch.from_numpy(
+            np.random.randint(
+                W_value_min,
+                W_value_max,
+                (N, K)),
+        )
+
+        b_init = torch.from_numpy(np.random.randint(0, 10, (N,)))
+
+        if use_channelwise:
+            W_scales_tensor = torch.tensor(W_scale, dtype=torch.float)
+            W_zero_points_tensor = torch.tensor(W_zero_point, dtype=torch.float)
+            W = W_scales_tensor.reshape(-1, 1) * (W_init.to(dtype=torch.float) -
+                                                  W_zero_points_tensor.reshape(-1, 1)).to(dtype=torch.float)
+            b = W_scales_tensor * (b_init - 0).to(dtype=torch.float)
+        else:
+            W = W_scale[0] * (W_init - W_zero_point[0]).to(dtype=torch.float)
+            b = W_scale[0] * (b_init - 0).to(dtype=torch.float)
+
+        if use_channelwise:
+            W_q = torch.quantize_per_channel(W,
+                                             W_scales_tensor.to(dtype=torch.double),
+                                             W_zero_points_tensor.to(dtype=torch.long),
+                                             0,
+                                             dtype=torch.qint8)
+        else:
+            W_q = torch.quantize_per_tensor(W, scale=W_scale[0], zero_point=W_zero_point[0], dtype=torch.qint8)
+
+        bias_float = b if use_bias else None
+        # Reference result
+        torch.backends.quantized.engine = 'fbgemm'
+        W_q_ref = torch.ops.quantized.linear_prepack(W_q, bias_float)
+        W_q_unpack_ref, bias_ref = torch.ops.quantized.linear_unpack(W_q_ref)
+
+        # mkldnn result
+        torch.backends.quantized.engine = 'qmkldnn'
+        W_q_mkldnn = torch.ops.quantized.linear_prepack(W_q, bias_float)
+        W_q_unpack_mkldnn, bias_mkldnn = torch.ops.quantized.linear_unpack(W_q_mkldnn)
+
+        self.assertEqual(W_q_unpack_ref.qscheme(), W_q_unpack_mkldnn.qscheme())
+        self.assertEqual(W_q_unpack_ref.int_repr().to(torch.int32), W_q_unpack_mkldnn.int_repr().to(torch.int32))
+        if use_bias:
+            self.assertEqual(bias_ref, bias_mkldnn)
+
+    @given(batch_size=st.integers(1, 3),
+           input_channels_per_group=st.sampled_from([2, 4, 5, 8, 16, 32]),
+           height=st.integers(10, 16),
+           width=st.integers(7, 14),
+           output_channels_per_group=st.sampled_from([2, 4, 5, 8, 16, 32]),
+           groups=st.integers(1, 3),
+           kernel_h=st.integers(1, 7),
+           kernel_w=st.integers(1, 7),
+           stride_h=st.integers(1, 2),
+           stride_w=st.integers(1, 2),
+           pad_h=st.integers(0, 2),
+           pad_w=st.integers(0, 2),
+           dilation=st.integers(1, 1),
+           X_scale=st.floats(0.5, 0.9),
+           X_zero_point=st.integers(0, 4),
+           W_scale=st.lists(st.floats(0.5, 0.9), min_size=1, max_size=2),
+           W_ZP=st.sampled_from([0, 5]),
+           Y_scale=st.floats(0.5, 0.9),
+           use_bias=st.booleans(),
+           use_channelwise=st.booleans())
+    def test_qconv_qmkldnn(
+            self,
+            batch_size,
+            input_channels_per_group,
+            height,
+            width,
+            output_channels_per_group,
+            groups,
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dilation,
+            X_scale,
+            X_zero_point,
+            W_scale,
+            W_ZP,
+            Y_scale,
+            use_bias,
+            use_channelwise
+    ):
+        W_zero_point = [0, W_ZP]
+        Y_zero_point = 0
+        qconv = torch.ops.quantized.conv2d_relu
+        qconv_prepack = torch.ops.quantized.conv_prepack
+
+        # C
+        input_channels = input_channels_per_group * groups
+        # K
+        output_channels = output_channels_per_group * groups
+
+        dilation_h = dilation_w = dilation
+
+        # Padded input size should be at least as big as dilated kernel
+        assume(height + 2 * pad_h >= dilation_h * (kernel_h - 1) + 1)
+        assume(width + 2 * pad_w >= dilation_w * (kernel_w - 1) + 1)
+
+        W_scale = W_scale * output_channels
+        W_zero_point = W_zero_point * output_channels
+        # Resize W_scale and W_zero_points arrays equal to output_channels
+        W_scale = W_scale[:output_channels]
+        W_zero_point = W_zero_point[:output_channels]
+
+        # For testing, we use small values for weights and for activations so that no overflow occurs
+        # in vpmaddubsw instruction. If the overflow occurs in qconv implementation and if there is no overflow
+        # in reference we can't exactly match the results with reference.
+        # Please see the comment in qconv implementation file (aten/src/ATen/native/quantized/cpu/qconv.cpp)
+        # for more details.
+        W_value_min = -5
+        W_value_max = 5
+
+        # the operator expects them in the format (output_channels, input_channels/groups, kernel_h, kernel_w)
+        W_init = torch.from_numpy(
+            np.random.randint(
+                W_value_min,
+                W_value_max,
+                (output_channels, int(input_channels / groups), kernel_h, kernel_w)),
+        )
+
+
+        b_init = torch.from_numpy(np.random.randint(0, 10, (output_channels,)))
+
+        stride = [stride_h, stride_w]
+        pad = [pad_h, pad_w]
+        dilation = [dilation_h, dilation_w]
+
+        X_value_min = 0
+        X_value_max = 10
+        X_init = torch.from_numpy(np.random.randint(
+            X_value_min, X_value_max, (batch_size, input_channels, height, width)))
+
+        X = X_scale * (X_init - X_zero_point).to(dtype=torch.float)
+
+        if use_channelwise:
+            W_scales_tensor = torch.tensor(W_scale, dtype=torch.float)
+            W_zero_points_tensor = torch.tensor(W_zero_point, dtype=torch.float)
+            W = W_scales_tensor.reshape(-1, 1, 1, 1) * (W_init.to(dtype=torch.float) -
+                                                        W_zero_points_tensor.reshape(-1, 1, 1, 1)).to(dtype=torch.float)
+            b = X_scale * W_scales_tensor * (b_init - 0).to(dtype=torch.float)
+        else:
+            W = W_scale[0] * (W_init - W_zero_point[0]).to(dtype=torch.float)
+            b = X_scale * W_scale[0] * (b_init - 0).to(dtype=torch.float)
+
+        X_q = torch.quantize_per_tensor(X, scale=X_scale, zero_point=X_zero_point, dtype=torch.quint8)
+        if use_channelwise:
+            W_q = torch.quantize_per_channel(W,
+                                             W_scales_tensor.to(dtype=torch.double),
+                                             W_zero_points_tensor.to(dtype=torch.long),
+                                             0,
+                                             dtype=torch.qint8)
+        else:
+            W_q = torch.quantize_per_tensor(W, scale=W_scale[0], zero_point=W_zero_point[0], dtype=torch.qint8)
+
+        bias_float = b if use_bias else None
+
+        # reference results
+        torch.backends.quantized.engine = 'fbgemm'
+        W_prepack = qconv_prepack(W_q, bias_float, stride, pad, dilation, groups)
+
+        Y_ref_q = qconv(
+            X_q,
+            W_prepack,
+            stride,
+            pad,
+            dilation,
+            groups,
+            Y_scale,
+            Y_zero_point,
+        )
+
+        # MKLDNN results
+        torch.backends.quantized.engine = 'qmkldnn'
+        W_mkldnn_prepack = qconv_prepack(W_q, bias_float, stride, pad, dilation, groups)
+
+        Y_mkldnn_q = qconv(
+            X_q,
+            W_mkldnn_prepack,
+            stride,
+            pad,
+            dilation,
+            groups,
+            Y_scale,
+            Y_zero_point,
+        )
+
+        self.assertEqual(Y_ref_q, Y_mkldnn_q)
+
+    @given(output_channels_per_group=st.integers(3, 7),
+           input_channels_per_group=st.integers(3, 7),
+           H=st.integers(5, 7),
+           W=st.integers(5, 7),
+           padH=st.integers(1, 3), padW=st.integers(1, 3),
+           sH=st.integers(1, 1), sW=st.integers(1, 1),
+           dH=st.integers(1, 1), dW=st.integers(1, 1),
+           G=st.integers(3, 7),
+           W_scale=st.lists(st.floats(0.2, 1.6), min_size=1, max_size=2),
+           W_ZP=st.sampled_from([0, 5]),
+           use_bias=st.booleans(),
+           use_channelwise=st.booleans())
+    def test_prepack_unpack_conv_qmkldnn(self, output_channels_per_group, input_channels_per_group, H, W,
+                                         padH, padW, sH, sW, dH, dW, G, W_scale, W_ZP, use_bias, use_channelwise):
+        output_channels = G * output_channels_per_group
+        input_channels = G * input_channels_per_group
+        stride = (sH, sW)
+        i_padding = (padH, padW)
+        dilation = (dH, dW)
+
+        X_scale = 0.7
+        W_zero_point = [0, W_ZP]
+        W_value_min = -100
+        W_value_max = 100
+
+        W_scale = W_scale * output_channels
+        W_zero_point = W_zero_point * output_channels
+        # Resize W_scale and W_zero_points arrays equal to output_channels
+        W_scale = W_scale[:output_channels]
+        W_zero_point = W_zero_point[:output_channels]
+
+        # the operator expects them in the format (output_channels, input_channels/groups, kernel_h, kernel_w)
+        W_init = torch.from_numpy(
+            np.random.randint(
+                W_value_min,
+                W_value_max,
+                (output_channels, input_channels_per_group, H, W)),
+        )
+        b_init = torch.from_numpy(np.random.randint(0, 10, (output_channels,)))
+        if use_channelwise:
+            W_scales_tensor = torch.tensor(W_scale, dtype=torch.float)
+            W_zero_points_tensor = torch.tensor(W_zero_point, dtype=torch.float)
+            W = W_scales_tensor.reshape(-1, 1, 1, 1) * (W_init.to(dtype=torch.float) -
+                                                        W_zero_points_tensor.reshape(-1, 1, 1, 1)).to(dtype=torch.float)
+            b = X_scale * W_scales_tensor * (b_init - 0).to(dtype=torch.float)
+        else:
+            W = W_scale[0] * (W_init - W_zero_point[0]).to(dtype=torch.float)
+            b = X_scale * W_scale[0] * (b_init - 0).to(dtype=torch.float)
+
+        if use_channelwise:
+            W_q = torch.quantize_per_channel(W,
+                                             W_scales_tensor.to(dtype=torch.double),
+                                             W_zero_points_tensor.to(dtype=torch.long),
+                                             0,
+                                             dtype=torch.qint8)
+        else:
+            W_q = torch.quantize_per_tensor(W, scale=W_scale[0], zero_point=W_zero_point[0], dtype=torch.qint8)
+
+        bias_float = b if use_bias else None
+        # Reference result
+        torch.backends.quantized.engine = 'fbgemm'
+        W_q_ref = torch.ops.quantized.conv_prepack(W_q, bias_float, stride, i_padding, dilation, G)
+        W_q_unpack_ref, bias_ref = torch.ops.quantized.conv_unpack(W_q_ref)
+
+        # mkldnn result
+        torch.backends.quantized.engine = 'qmkldnn'
+        W_q_mkldnn = torch.ops.quantized.conv_prepack(W_q, bias_float, stride, i_padding, dilation, G)
+        W_q_unpack_mkldnn, bias_mkldnn = torch.ops.quantized.conv_unpack(W_q_mkldnn)
+
+        self.assertEqual(W_q_unpack_ref.qscheme(), W_q_unpack_mkldnn.qscheme())
+        self.assertEqual(W_q_unpack_ref.int_repr().to(torch.int32), W_q_unpack_mkldnn.int_repr().to(torch.int32))
+        if use_bias:
+            self.assertEqual(bias_ref, bias_mkldnn)
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/backends/quantized/__init__.py
+++ b/torch/backends/quantized/__init__.py
@@ -12,6 +12,8 @@ def _get_qengine_id(qengine):
         ret = 1
     elif qengine == 'qnnpack':
         ret = 2
+    elif qengine == 'qmkldnn':
+        ret = 3
     else:
         ret = -1
         raise RuntimeError("{} is not a valid value for quantized engine".format(qengine))
@@ -20,7 +22,7 @@ def _get_qengine_id(qengine):
 # This function should correspond to the enums present in c10/core/QEngine.h
 def _get_qengine_str(qengine):
     # type: (int) -> str
-    all_engines = {0 : 'none', 1 : 'fbgemm', 2 : 'qnnpack'}
+    all_engines = {0 : 'none', 1 : 'fbgemm', 2 : 'qnnpack', 3 : 'qmkldnn'}
     return all_engines.get(qengine)
 
 class _QEngineProp(object):


### PR DESCRIPTION
1. add QMKLDNN backend engine.
2. add qconv and qlinear op for mkldnn.
2. prepack weights with mkldnn tensor if weights tensor meets mkldnn requirements.
3. fallback to FBGEMM if input tensor doesn't meet mkldnn requirements. it will unpack weights and re-prepack FBGEMM weights.

