### PR TITLE
fixup

### DIFF
--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -2840,16 +2840,7 @@ inline Tensor Tensor::clone() const {
 }
 inline Tensor & Tensor::resize_as_(const Tensor & the_template) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
-        case Backend::CPU:
-            return CPUType::resize_as_(const_cast<Tensor&>(*this), the_template);
-            break;
-        case Backend::SparseCPU:
-            return SparseCPUType::resize_as_(const_cast<Tensor&>(*this), the_template);
-            break;
-        default:
-            AT_ERROR("resize_as_ not implemented for ", at::toString(type_set()));
-    }
+    return TypeDefault::resize_as_(const_cast<Tensor&>(*this), the_template);
 #else
     static c10::OperatorHandle op = c10::Dispatcher::singleton().findSchema({"aten::resize_as_", ""}).value();
     return c10::Dispatcher::singleton().callUnboxedOnly<Tensor &, Tensor &, const Tensor &>(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26368 Add boxed fallback
* #26367 Refactor dispatch structure so fallback code lives inline.
* #26806 Add some missing constructors to IValue.
* #26361 Change calling convention of ATenDispatch from getOp to callUnboxed.
* **#26810 fixup**
* #26809 Make resize_as_ generic, so XLA works.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>