### PR TITLE
Switch static dispatch to use extractLegacyTypeId.

### DIFF
--- a/aten/src/ATen/core/TensorMethods.h
+++ b/aten/src/ATen/core/TensorMethods.h
@@ -213,7 +213,7 @@ inline Tensor Tensor::abs() const {
 }
 inline Tensor & Tensor::abs_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::abs_(const_cast<Tensor&>(*this));
             break;
@@ -237,7 +237,7 @@ inline Tensor Tensor::acos() const {
 }
 inline Tensor & Tensor::acos_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::acos_(const_cast<Tensor&>(*this));
             break;
@@ -252,7 +252,7 @@ inline Tensor & Tensor::acos_() const {
 }
 inline Tensor Tensor::add(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::add(const_cast<Tensor&>(*this), other, alpha);
             break;
@@ -270,7 +270,7 @@ inline Tensor Tensor::add(const Tensor & other, Scalar alpha) const {
 }
 inline Tensor & Tensor::add_(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::add_(const_cast<Tensor&>(*this), other, alpha);
             break;
@@ -306,7 +306,7 @@ inline Tensor & Tensor::add_(Scalar other, Scalar alpha) const {
 }
 inline Tensor Tensor::addmv(const Tensor & mat, const Tensor & vec, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmv(const_cast<Tensor&>(*this), mat, vec, beta, alpha);
             break;
@@ -321,7 +321,7 @@ inline Tensor Tensor::addmv(const Tensor & mat, const Tensor & vec, Scalar beta,
 }
 inline Tensor & Tensor::addmv_(const Tensor & mat, const Tensor & vec, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmv_(const_cast<Tensor&>(*this), mat, vec, beta, alpha);
             break;
@@ -419,7 +419,7 @@ inline Tensor Tensor::argmin(c10::optional<int64_t> dim, bool keepdim) const {
 }
 inline Tensor Tensor::as_strided(IntArrayRef size, IntArrayRef stride, c10::optional<int64_t> storage_offset) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::as_strided(const_cast<Tensor&>(*this), size, stride, storage_offset);
             break;
@@ -455,7 +455,7 @@ inline Tensor Tensor::asin() const {
 }
 inline Tensor & Tensor::asin_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::asin_(const_cast<Tensor&>(*this));
             break;
@@ -479,7 +479,7 @@ inline Tensor Tensor::atan() const {
 }
 inline Tensor & Tensor::atan_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::atan_(const_cast<Tensor&>(*this));
             break;
@@ -494,7 +494,7 @@ inline Tensor & Tensor::atan_() const {
 }
 inline Tensor Tensor::baddbmm(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::baddbmm(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
             break;
@@ -509,7 +509,7 @@ inline Tensor Tensor::baddbmm(const Tensor & batch1, const Tensor & batch2, Scal
 }
 inline Tensor & Tensor::baddbmm_(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::baddbmm_(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
             break;
@@ -532,7 +532,7 @@ inline Tensor Tensor::bernoulli(Generator * generator) const {
 }
 inline Tensor & Tensor::bernoulli_(const Tensor & p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bernoulli_(const_cast<Tensor&>(*this), p, generator);
             break;
@@ -546,7 +546,7 @@ inline Tensor & Tensor::bernoulli_(const Tensor & p, Generator * generator) cons
 }
 inline Tensor & Tensor::bernoulli_(double p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bernoulli_(const_cast<Tensor&>(*this), p, generator);
             break;
@@ -568,7 +568,7 @@ inline Tensor Tensor::bernoulli(double p, Generator * generator) const {
 }
 inline Tensor Tensor::bincount(const Tensor & weights, int64_t minlength) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bincount(const_cast<Tensor&>(*this), weights, minlength);
             break;
@@ -636,7 +636,7 @@ inline Tensor & Tensor::logical_xor_(const Tensor & other) const {
 }
 inline Tensor Tensor::bmm(const Tensor & mat2) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::bmm(const_cast<Tensor&>(*this), mat2);
             break;
@@ -687,7 +687,7 @@ inline Tensor Tensor::clamp(c10::optional<Scalar> min, c10::optional<Scalar> max
 }
 inline Tensor & Tensor::clamp_(c10::optional<Scalar> min, c10::optional<Scalar> max) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clamp_(const_cast<Tensor&>(*this), min, max);
             break;
@@ -711,7 +711,7 @@ inline Tensor Tensor::clamp_max(Scalar max) const {
 }
 inline Tensor & Tensor::clamp_max_(Scalar max) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clamp_max_(const_cast<Tensor&>(*this), max);
             break;
@@ -735,7 +735,7 @@ inline Tensor Tensor::clamp_min(Scalar min) const {
 }
 inline Tensor & Tensor::clamp_min_(Scalar min) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clamp_min_(const_cast<Tensor&>(*this), min);
             break;
@@ -776,7 +776,7 @@ inline Tensor Tensor::cos() const {
 }
 inline Tensor & Tensor::cos_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cos_(const_cast<Tensor&>(*this));
             break;
@@ -800,7 +800,7 @@ inline Tensor Tensor::cosh() const {
 }
 inline Tensor & Tensor::cosh_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cosh_(const_cast<Tensor&>(*this));
             break;
@@ -896,7 +896,7 @@ inline Tensor & Tensor::fill_diagonal_(Scalar fill_value, bool wrap) const {
 }
 inline Tensor Tensor::div(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::div(const_cast<Tensor&>(*this), other);
             break;
@@ -914,7 +914,7 @@ inline Tensor Tensor::div(const Tensor & other) const {
 }
 inline Tensor & Tensor::div_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::div_(const_cast<Tensor&>(*this), other);
             break;
@@ -950,7 +950,7 @@ inline Tensor & Tensor::div_(Scalar other) const {
 }
 inline Tensor Tensor::dot(const Tensor & tensor) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::dot(const_cast<Tensor&>(*this), tensor);
             break;
@@ -981,7 +981,7 @@ inline Tensor Tensor::new_full(IntArrayRef size, Scalar fill_value, const Tensor
 }
 inline Tensor & Tensor::resize_(IntArrayRef size) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::resize_(const_cast<Tensor&>(*this), size);
             break;
@@ -1008,7 +1008,7 @@ inline Tensor Tensor::erf() const {
 }
 inline Tensor & Tensor::erf_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erf_(const_cast<Tensor&>(*this));
             break;
@@ -1032,7 +1032,7 @@ inline Tensor Tensor::erfc() const {
 }
 inline Tensor & Tensor::erfc_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erfc_(const_cast<Tensor&>(*this));
             break;
@@ -1056,7 +1056,7 @@ inline Tensor Tensor::exp() const {
 }
 inline Tensor & Tensor::exp_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::exp_(const_cast<Tensor&>(*this));
             break;
@@ -1080,7 +1080,7 @@ inline Tensor Tensor::expm1() const {
 }
 inline Tensor & Tensor::expm1_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::expm1_(const_cast<Tensor&>(*this));
             break;
@@ -1197,7 +1197,7 @@ inline Tensor Tensor::frac() const {
 }
 inline Tensor & Tensor::frac_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::frac_(const_cast<Tensor&>(*this));
             break;
@@ -1212,7 +1212,7 @@ inline Tensor & Tensor::frac_() const {
 }
 inline Tensor Tensor::ger(const Tensor & vec2) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ger(const_cast<Tensor&>(*this), vec2);
             break;
@@ -1425,7 +1425,7 @@ inline Tensor Tensor::log() const {
 }
 inline Tensor & Tensor::log_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log_(const_cast<Tensor&>(*this));
             break;
@@ -1449,7 +1449,7 @@ inline Tensor Tensor::log10() const {
 }
 inline Tensor & Tensor::log10_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log10_(const_cast<Tensor&>(*this));
             break;
@@ -1473,7 +1473,7 @@ inline Tensor Tensor::log1p() const {
 }
 inline Tensor & Tensor::log1p_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log1p_(const_cast<Tensor&>(*this));
             break;
@@ -1500,7 +1500,7 @@ inline Tensor Tensor::log2() const {
 }
 inline Tensor & Tensor::log2_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log2_(const_cast<Tensor&>(*this));
             break;
@@ -1617,7 +1617,7 @@ inline Tensor Tensor::max_values(DimnameList dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::mean(c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mean(const_cast<Tensor&>(*this), dtype);
             break;
@@ -1634,7 +1634,7 @@ inline Tensor Tensor::mean(c10::optional<ScalarType> dtype) const {
 }
 inline Tensor Tensor::mean(IntArrayRef dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mean(const_cast<Tensor&>(*this), dim, keepdim, dtype);
             break;
@@ -1652,7 +1652,7 @@ inline Tensor Tensor::mean(IntArrayRef dim, bool keepdim, c10::optional<ScalarTy
 #ifdef BUILD_NAMEDTENSOR
 inline Tensor Tensor::mean(DimnameList dim, bool keepdim, c10::optional<ScalarType> dtype) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mean(const_cast<Tensor&>(*this), dim, keepdim, dtype);
             break;
@@ -1724,7 +1724,7 @@ inline Tensor Tensor::min_values(DimnameList dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::mm(const Tensor & mat2) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mm(const_cast<Tensor&>(*this), mat2);
             break;
@@ -1761,7 +1761,7 @@ inline std::tuple<Tensor,Tensor> Tensor::mode(Dimname dim, bool keepdim) const {
 #endif
 inline Tensor Tensor::mul(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mul(const_cast<Tensor&>(*this), other);
             break;
@@ -1779,7 +1779,7 @@ inline Tensor Tensor::mul(const Tensor & other) const {
 }
 inline Tensor & Tensor::mul_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mul_(const_cast<Tensor&>(*this), other);
             break;
@@ -1815,7 +1815,7 @@ inline Tensor & Tensor::mul_(Scalar other) const {
 }
 inline Tensor Tensor::mv(const Tensor & vec) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::mv(const_cast<Tensor&>(*this), vec);
             break;
@@ -1848,7 +1848,7 @@ inline Tensor & Tensor::mvlgamma_(int64_t p) const {
 }
 inline Tensor Tensor::narrow_copy(int64_t dim, int64_t start, int64_t length) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::narrow_copy(const_cast<Tensor&>(*this), dim, start, length);
             break;
@@ -1929,7 +1929,7 @@ inline Tensor Tensor::reciprocal() const {
 }
 inline Tensor & Tensor::reciprocal_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::reciprocal_(const_cast<Tensor&>(*this));
             break;
@@ -2025,7 +2025,7 @@ inline Tensor & Tensor::round_() const {
 }
 inline Tensor Tensor::relu() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::relu(const_cast<Tensor&>(*this));
             break;
@@ -2043,7 +2043,7 @@ inline Tensor Tensor::relu() const {
 }
 inline Tensor & Tensor::relu_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::relu_(const_cast<Tensor&>(*this));
             break;
@@ -2061,7 +2061,7 @@ inline Tensor & Tensor::relu_() const {
 }
 inline Tensor Tensor::prelu(const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::prelu(const_cast<Tensor&>(*this), weight);
             break;
@@ -2076,7 +2076,7 @@ inline Tensor Tensor::prelu(const Tensor & weight) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::prelu_backward(const Tensor & grad_output, const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::prelu_backward(grad_output, const_cast<Tensor&>(*this), weight);
             break;
@@ -2091,7 +2091,7 @@ inline std::tuple<Tensor,Tensor> Tensor::prelu_backward(const Tensor & grad_outp
 }
 inline Tensor Tensor::hardshrink(Scalar lambd) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::hardshrink(const_cast<Tensor&>(*this), lambd);
             break;
@@ -2106,7 +2106,7 @@ inline Tensor Tensor::hardshrink(Scalar lambd) const {
 }
 inline Tensor Tensor::hardshrink_backward(const Tensor & grad_out, Scalar lambd) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::hardshrink_backward(grad_out, const_cast<Tensor&>(*this), lambd);
             break;
@@ -2158,7 +2158,7 @@ inline Tensor Tensor::select(int64_t dim, int64_t index) const {
 }
 inline Tensor Tensor::sigmoid() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sigmoid(const_cast<Tensor&>(*this));
             break;
@@ -2173,7 +2173,7 @@ inline Tensor Tensor::sigmoid() const {
 }
 inline Tensor & Tensor::sigmoid_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sigmoid_(const_cast<Tensor&>(*this));
             break;
@@ -2197,7 +2197,7 @@ inline Tensor Tensor::sin() const {
 }
 inline Tensor & Tensor::sin_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sin_(const_cast<Tensor&>(*this));
             break;
@@ -2221,7 +2221,7 @@ inline Tensor Tensor::sinh() const {
 }
 inline Tensor & Tensor::sinh_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sinh_(const_cast<Tensor&>(*this));
             break;
@@ -2472,7 +2472,7 @@ inline Tensor Tensor::sqrt() const {
 }
 inline Tensor & Tensor::sqrt_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sqrt_(const_cast<Tensor&>(*this));
             break;
@@ -2568,7 +2568,7 @@ inline Tensor Tensor::tan() const {
 }
 inline Tensor & Tensor::tan_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::tan_(const_cast<Tensor&>(*this));
             break;
@@ -2592,7 +2592,7 @@ inline Tensor Tensor::tanh() const {
 }
 inline Tensor & Tensor::tanh_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::tanh_(const_cast<Tensor&>(*this));
             break;
@@ -2635,7 +2635,7 @@ inline Tensor & Tensor::transpose_(int64_t dim0, int64_t dim1) const {
 }
 inline Tensor Tensor::flip(IntArrayRef dims) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::flip(const_cast<Tensor&>(*this), dims);
             break;
@@ -2650,7 +2650,7 @@ inline Tensor Tensor::flip(IntArrayRef dims) const {
 }
 inline Tensor Tensor::roll(IntArrayRef shifts, IntArrayRef dims) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::roll(const_cast<Tensor&>(*this), shifts, dims);
             break;
@@ -2819,7 +2819,7 @@ inline Tensor Tensor::norm(c10::optional<Scalar> p, DimnameList dim, bool keepdi
 #endif
 inline Tensor Tensor::clone() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::clone(const_cast<Tensor&>(*this));
             break;
@@ -2840,7 +2840,7 @@ inline Tensor Tensor::clone() const {
 }
 inline Tensor & Tensor::resize_as_(const Tensor & the_template) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::resize_as_(const_cast<Tensor&>(*this), the_template);
             break;
@@ -2858,7 +2858,7 @@ inline Tensor & Tensor::resize_as_(const Tensor & the_template) const {
 }
 inline Tensor Tensor::pow(Scalar exponent) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow(const_cast<Tensor&>(*this), exponent);
             break;
@@ -2876,7 +2876,7 @@ inline Tensor Tensor::pow(Scalar exponent) const {
 }
 inline Tensor & Tensor::zero_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::zero_(const_cast<Tensor&>(*this));
             break;
@@ -2894,7 +2894,7 @@ inline Tensor & Tensor::zero_() const {
 }
 inline Tensor Tensor::sub(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sub(const_cast<Tensor&>(*this), other, alpha);
             break;
@@ -2912,7 +2912,7 @@ inline Tensor Tensor::sub(const Tensor & other, Scalar alpha) const {
 }
 inline Tensor & Tensor::sub_(const Tensor & other, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sub_(const_cast<Tensor&>(*this), other, alpha);
             break;
@@ -2948,7 +2948,7 @@ inline Tensor & Tensor::sub_(Scalar other, Scalar alpha) const {
 }
 inline Tensor Tensor::addmm(const Tensor & mat1, const Tensor & mat2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmm(const_cast<Tensor&>(*this), mat1, mat2, beta, alpha);
             break;
@@ -2966,7 +2966,7 @@ inline Tensor Tensor::addmm(const Tensor & mat1, const Tensor & mat2, Scalar bet
 }
 inline Tensor & Tensor::addmm_(const Tensor & mat1, const Tensor & mat2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addmm_(const_cast<Tensor&>(*this), mat1, mat2, beta, alpha);
             break;
@@ -2984,7 +2984,7 @@ inline Tensor & Tensor::addmm_(const Tensor & mat1, const Tensor & mat2, Scalar 
 }
 inline Tensor & Tensor::sparse_resize_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_resize_(const_cast<Tensor&>(*this), size, sparse_dim, dense_dim);
             break;
@@ -2999,7 +2999,7 @@ inline Tensor & Tensor::sparse_resize_(IntArrayRef size, int64_t sparse_dim, int
 }
 inline Tensor & Tensor::sparse_resize_and_clear_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_resize_and_clear_(const_cast<Tensor&>(*this), size, sparse_dim, dense_dim);
             break;
@@ -3014,7 +3014,7 @@ inline Tensor & Tensor::sparse_resize_and_clear_(IntArrayRef size, int64_t spars
 }
 inline Tensor Tensor::sparse_mask(const Tensor & mask) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_mask(const_cast<Tensor&>(*this), mask);
             break;
@@ -3029,7 +3029,7 @@ inline Tensor Tensor::sparse_mask(const Tensor & mask) const {
 }
 inline Tensor Tensor::to_dense() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::to_dense(const_cast<Tensor&>(*this));
             break;
@@ -3044,7 +3044,7 @@ inline Tensor Tensor::to_dense() const {
 }
 inline int64_t Tensor::sparse_dim() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::sparse_dim(const_cast<Tensor&>(*this));
             break;
@@ -3059,7 +3059,7 @@ inline int64_t Tensor::sparse_dim() const {
 }
 inline int64_t Tensor::_dimI() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_dimI(const_cast<Tensor&>(*this));
             break;
@@ -3074,7 +3074,7 @@ inline int64_t Tensor::_dimI() const {
 }
 inline int64_t Tensor::dense_dim() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::dense_dim(const_cast<Tensor&>(*this));
             break;
@@ -3089,7 +3089,7 @@ inline int64_t Tensor::dense_dim() const {
 }
 inline int64_t Tensor::_dimV() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_dimV(const_cast<Tensor&>(*this));
             break;
@@ -3104,7 +3104,7 @@ inline int64_t Tensor::_dimV() const {
 }
 inline int64_t Tensor::_nnz() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_nnz(const_cast<Tensor&>(*this));
             break;
@@ -3119,7 +3119,7 @@ inline int64_t Tensor::_nnz() const {
 }
 inline Tensor Tensor::coalesce() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::coalesce(const_cast<Tensor&>(*this));
             break;
@@ -3134,7 +3134,7 @@ inline Tensor Tensor::coalesce() const {
 }
 inline bool Tensor::is_coalesced() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::is_coalesced(const_cast<Tensor&>(*this));
             break;
@@ -3149,7 +3149,7 @@ inline bool Tensor::is_coalesced() const {
 }
 inline Tensor Tensor::_indices() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_indices(const_cast<Tensor&>(*this));
             break;
@@ -3164,7 +3164,7 @@ inline Tensor Tensor::_indices() const {
 }
 inline Tensor Tensor::_values() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_values(const_cast<Tensor&>(*this));
             break;
@@ -3179,7 +3179,7 @@ inline Tensor Tensor::_values() const {
 }
 inline Tensor & Tensor::_coalesced_(bool coalesced) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::_coalesced_(const_cast<Tensor&>(*this), coalesced);
             break;
@@ -3194,7 +3194,7 @@ inline Tensor & Tensor::_coalesced_(bool coalesced) const {
 }
 inline Tensor Tensor::indices() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::indices(const_cast<Tensor&>(*this));
             break;
@@ -3209,7 +3209,7 @@ inline Tensor Tensor::indices() const {
 }
 inline Tensor Tensor::values() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::SparseCPU:
             return SparseCPUType::values(const_cast<Tensor&>(*this));
             break;
@@ -3252,7 +3252,7 @@ inline std::vector<Tensor> Tensor::unbind(Dimname dim) const {
 #endif
 inline Tensor Tensor::to_sparse(int64_t sparse_dim) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::to_sparse(const_cast<Tensor&>(*this), sparse_dim);
             break;
@@ -3267,7 +3267,7 @@ inline Tensor Tensor::to_sparse(int64_t sparse_dim) const {
 }
 inline Tensor Tensor::to_sparse() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::to_sparse(const_cast<Tensor&>(*this));
             break;
@@ -3282,7 +3282,7 @@ inline Tensor Tensor::to_sparse() const {
 }
 inline Tensor Tensor::to_mkldnn() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::to_mkldnn(const_cast<Tensor&>(*this));
             break;
@@ -3297,7 +3297,7 @@ inline Tensor Tensor::to_mkldnn() const {
 }
 inline Tensor Tensor::dequantize() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::dequantize(const_cast<Tensor&>(*this));
             break;
@@ -3312,7 +3312,7 @@ inline Tensor Tensor::dequantize() const {
 }
 inline double Tensor::q_scale() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_scale(const_cast<Tensor&>(*this));
             break;
@@ -3327,7 +3327,7 @@ inline double Tensor::q_scale() const {
 }
 inline int64_t Tensor::q_zero_point() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_zero_point(const_cast<Tensor&>(*this));
             break;
@@ -3342,7 +3342,7 @@ inline int64_t Tensor::q_zero_point() const {
 }
 inline Tensor Tensor::q_per_channel_scales() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_per_channel_scales(const_cast<Tensor&>(*this));
             break;
@@ -3357,7 +3357,7 @@ inline Tensor Tensor::q_per_channel_scales() const {
 }
 inline Tensor Tensor::q_per_channel_zero_points() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_per_channel_zero_points(const_cast<Tensor&>(*this));
             break;
@@ -3372,7 +3372,7 @@ inline Tensor Tensor::q_per_channel_zero_points() const {
 }
 inline int64_t Tensor::q_per_channel_axis() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::q_per_channel_axis(const_cast<Tensor&>(*this));
             break;
@@ -3386,7 +3386,7 @@ inline int64_t Tensor::q_per_channel_axis() const {
 }
 inline Tensor Tensor::int_repr() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::int_repr(const_cast<Tensor&>(*this));
             break;
@@ -3401,7 +3401,7 @@ inline Tensor Tensor::int_repr() const {
 }
 inline QScheme Tensor::qscheme() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::qscheme(const_cast<Tensor&>(*this));
             break;
@@ -3457,7 +3457,7 @@ inline Scalar Tensor::item() const {
 }
 inline Tensor & Tensor::set_(Storage source) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this), source);
             break;
@@ -3471,7 +3471,7 @@ inline Tensor & Tensor::set_(Storage source) const {
 }
 inline Tensor & Tensor::set_(Storage source, int64_t storage_offset, IntArrayRef size, IntArrayRef stride) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this), source, storage_offset, size, stride);
             break;
@@ -3488,7 +3488,7 @@ inline Tensor & Tensor::set_(Storage source, int64_t storage_offset, IntArrayRef
 }
 inline Tensor & Tensor::set_(const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this), source);
             break;
@@ -3503,7 +3503,7 @@ inline Tensor & Tensor::set_(const Tensor & source) const {
 }
 inline Tensor & Tensor::set_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::set_(const_cast<Tensor&>(*this));
             break;
@@ -3518,7 +3518,7 @@ inline Tensor & Tensor::set_() const {
 }
 inline Tensor & Tensor::set_quantizer_(ConstQuantizerPtr quantizer) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::QuantizedCPU:
             return QuantizedCPUType::set_quantizer_(const_cast<Tensor&>(*this), quantizer);
             break;
@@ -3532,7 +3532,7 @@ inline Tensor & Tensor::set_quantizer_(ConstQuantizerPtr quantizer) const {
 }
 inline bool Tensor::is_set_to(const Tensor & tensor) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::is_set_to(const_cast<Tensor&>(*this), tensor);
             break;
@@ -3547,7 +3547,7 @@ inline bool Tensor::is_set_to(const Tensor & tensor) const {
 }
 inline Tensor & Tensor::masked_fill_(const Tensor & mask, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_fill_(const_cast<Tensor&>(*this), mask, value);
             break;
@@ -3571,7 +3571,7 @@ inline Tensor Tensor::masked_fill(const Tensor & mask, Scalar value) const {
 }
 inline Tensor & Tensor::masked_fill_(const Tensor & mask, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_fill_(const_cast<Tensor&>(*this), mask, value);
             break;
@@ -3595,7 +3595,7 @@ inline Tensor Tensor::masked_fill(const Tensor & mask, const Tensor & value) con
 }
 inline Tensor & Tensor::masked_scatter_(const Tensor & mask, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_scatter_(const_cast<Tensor&>(*this), mask, source);
             break;
@@ -3619,7 +3619,7 @@ inline Tensor Tensor::masked_scatter(const Tensor & mask, const Tensor & source)
 }
 inline Tensor Tensor::view(IntArrayRef size) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::view(const_cast<Tensor&>(*this), size);
             break;
@@ -3637,7 +3637,7 @@ inline Tensor Tensor::view(IntArrayRef size) const {
 }
 inline Tensor & Tensor::put_(const Tensor & index, const Tensor & source, bool accumulate) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::put_(const_cast<Tensor&>(*this), index, source, accumulate);
             break;
@@ -3652,7 +3652,7 @@ inline Tensor & Tensor::put_(const Tensor & index, const Tensor & source, bool a
 }
 inline Tensor & Tensor::index_add_(int64_t dim, const Tensor & index, const Tensor & source) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_add_(const_cast<Tensor&>(*this), dim, index, source);
             break;
@@ -3686,7 +3686,7 @@ inline Tensor Tensor::index_add(Dimname dim, const Tensor & index, const Tensor 
 #endif
 inline Tensor & Tensor::index_fill_(int64_t dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_fill_(const_cast<Tensor&>(*this), dim, index, value);
             break;
@@ -3710,7 +3710,7 @@ inline Tensor Tensor::index_fill(int64_t dim, const Tensor & index, Scalar value
 }
 inline Tensor & Tensor::index_fill_(int64_t dim, const Tensor & index, const Tensor & value) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_fill_(const_cast<Tensor&>(*this), dim, index, value);
             break;
@@ -3754,7 +3754,7 @@ inline Tensor Tensor::index_fill(Dimname dim, const Tensor & index, const Tensor
 #endif
 inline Tensor & Tensor::scatter_(int64_t dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::scatter_(const_cast<Tensor&>(*this), dim, index, src);
             break;
@@ -3778,7 +3778,7 @@ inline Tensor Tensor::scatter(int64_t dim, const Tensor & index, const Tensor & 
 }
 inline Tensor & Tensor::scatter_(int64_t dim, const Tensor & index, Scalar value) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::scatter_(const_cast<Tensor&>(*this), dim, index, value);
             break;
@@ -3822,7 +3822,7 @@ inline Tensor Tensor::scatter(Dimname dim, const Tensor & index, Scalar value) c
 #endif
 inline Tensor & Tensor::scatter_add_(int64_t dim, const Tensor & index, const Tensor & src) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::scatter_add_(const_cast<Tensor&>(*this), dim, index, src);
             break;
@@ -3856,7 +3856,7 @@ inline Tensor Tensor::scatter_add(Dimname dim, const Tensor & index, const Tenso
 #endif
 inline Tensor & Tensor::lt_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lt_(const_cast<Tensor&>(*this), other);
             break;
@@ -3871,7 +3871,7 @@ inline Tensor & Tensor::lt_(Scalar other) const {
 }
 inline Tensor & Tensor::lt_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lt_(const_cast<Tensor&>(*this), other);
             break;
@@ -3886,7 +3886,7 @@ inline Tensor & Tensor::lt_(const Tensor & other) const {
 }
 inline Tensor & Tensor::gt_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gt_(const_cast<Tensor&>(*this), other);
             break;
@@ -3901,7 +3901,7 @@ inline Tensor & Tensor::gt_(Scalar other) const {
 }
 inline Tensor & Tensor::gt_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gt_(const_cast<Tensor&>(*this), other);
             break;
@@ -3916,7 +3916,7 @@ inline Tensor & Tensor::gt_(const Tensor & other) const {
 }
 inline Tensor & Tensor::le_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::le_(const_cast<Tensor&>(*this), other);
             break;
@@ -3931,7 +3931,7 @@ inline Tensor & Tensor::le_(Scalar other) const {
 }
 inline Tensor & Tensor::le_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::le_(const_cast<Tensor&>(*this), other);
             break;
@@ -3946,7 +3946,7 @@ inline Tensor & Tensor::le_(const Tensor & other) const {
 }
 inline Tensor & Tensor::ge_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ge_(const_cast<Tensor&>(*this), other);
             break;
@@ -3961,7 +3961,7 @@ inline Tensor & Tensor::ge_(Scalar other) const {
 }
 inline Tensor & Tensor::ge_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ge_(const_cast<Tensor&>(*this), other);
             break;
@@ -3976,7 +3976,7 @@ inline Tensor & Tensor::ge_(const Tensor & other) const {
 }
 inline Tensor & Tensor::eq_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eq_(const_cast<Tensor&>(*this), other);
             break;
@@ -3991,7 +3991,7 @@ inline Tensor & Tensor::eq_(Scalar other) const {
 }
 inline Tensor & Tensor::eq_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eq_(const_cast<Tensor&>(*this), other);
             break;
@@ -4006,7 +4006,7 @@ inline Tensor & Tensor::eq_(const Tensor & other) const {
 }
 inline Tensor & Tensor::ne_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ne_(const_cast<Tensor&>(*this), other);
             break;
@@ -4021,7 +4021,7 @@ inline Tensor & Tensor::ne_(Scalar other) const {
 }
 inline Tensor & Tensor::ne_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ne_(const_cast<Tensor&>(*this), other);
             break;
@@ -4036,7 +4036,7 @@ inline Tensor & Tensor::ne_(const Tensor & other) const {
 }
 inline Tensor Tensor::__and__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__and__(const_cast<Tensor&>(*this), other);
             break;
@@ -4051,7 +4051,7 @@ inline Tensor Tensor::__and__(Scalar other) const {
 }
 inline Tensor Tensor::__and__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__and__(const_cast<Tensor&>(*this), other);
             break;
@@ -4066,7 +4066,7 @@ inline Tensor Tensor::__and__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__iand__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__iand__(const_cast<Tensor&>(*this), other);
             break;
@@ -4081,7 +4081,7 @@ inline Tensor & Tensor::__iand__(Scalar other) const {
 }
 inline Tensor & Tensor::__iand__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__iand__(const_cast<Tensor&>(*this), other);
             break;
@@ -4096,7 +4096,7 @@ inline Tensor & Tensor::__iand__(const Tensor & other) const {
 }
 inline Tensor Tensor::__or__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__or__(const_cast<Tensor&>(*this), other);
             break;
@@ -4111,7 +4111,7 @@ inline Tensor Tensor::__or__(Scalar other) const {
 }
 inline Tensor Tensor::__or__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__or__(const_cast<Tensor&>(*this), other);
             break;
@@ -4126,7 +4126,7 @@ inline Tensor Tensor::__or__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__ior__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ior__(const_cast<Tensor&>(*this), other);
             break;
@@ -4141,7 +4141,7 @@ inline Tensor & Tensor::__ior__(Scalar other) const {
 }
 inline Tensor & Tensor::__ior__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ior__(const_cast<Tensor&>(*this), other);
             break;
@@ -4156,7 +4156,7 @@ inline Tensor & Tensor::__ior__(const Tensor & other) const {
 }
 inline Tensor Tensor::__xor__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__xor__(const_cast<Tensor&>(*this), other);
             break;
@@ -4171,7 +4171,7 @@ inline Tensor Tensor::__xor__(Scalar other) const {
 }
 inline Tensor Tensor::__xor__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__xor__(const_cast<Tensor&>(*this), other);
             break;
@@ -4186,7 +4186,7 @@ inline Tensor Tensor::__xor__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__ixor__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ixor__(const_cast<Tensor&>(*this), other);
             break;
@@ -4201,7 +4201,7 @@ inline Tensor & Tensor::__ixor__(Scalar other) const {
 }
 inline Tensor & Tensor::__ixor__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ixor__(const_cast<Tensor&>(*this), other);
             break;
@@ -4216,7 +4216,7 @@ inline Tensor & Tensor::__ixor__(const Tensor & other) const {
 }
 inline Tensor Tensor::__lshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__lshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4231,7 +4231,7 @@ inline Tensor Tensor::__lshift__(Scalar other) const {
 }
 inline Tensor Tensor::__lshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__lshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4246,7 +4246,7 @@ inline Tensor Tensor::__lshift__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__ilshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ilshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4261,7 +4261,7 @@ inline Tensor & Tensor::__ilshift__(Scalar other) const {
 }
 inline Tensor & Tensor::__ilshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__ilshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4276,7 +4276,7 @@ inline Tensor & Tensor::__ilshift__(const Tensor & other) const {
 }
 inline Tensor Tensor::__rshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__rshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4291,7 +4291,7 @@ inline Tensor Tensor::__rshift__(Scalar other) const {
 }
 inline Tensor Tensor::__rshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__rshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4306,7 +4306,7 @@ inline Tensor Tensor::__rshift__(const Tensor & other) const {
 }
 inline Tensor & Tensor::__irshift__(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__irshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4321,7 +4321,7 @@ inline Tensor & Tensor::__irshift__(Scalar other) const {
 }
 inline Tensor & Tensor::__irshift__(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::__irshift__(const_cast<Tensor&>(*this), other);
             break;
@@ -4336,7 +4336,7 @@ inline Tensor & Tensor::__irshift__(const Tensor & other) const {
 }
 inline Tensor & Tensor::lgamma_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lgamma_(const_cast<Tensor&>(*this));
             break;
@@ -4360,7 +4360,7 @@ inline Tensor & Tensor::atan2_(const Tensor & other) const {
 }
 inline Tensor & Tensor::tril_(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::tril_(const_cast<Tensor&>(*this), diagonal);
             break;
@@ -4375,7 +4375,7 @@ inline Tensor & Tensor::tril_(int64_t diagonal) const {
 }
 inline Tensor & Tensor::triu_(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::triu_(const_cast<Tensor&>(*this), diagonal);
             break;
@@ -4408,7 +4408,7 @@ inline Tensor & Tensor::polygamma_(int64_t n) const {
 }
 inline Tensor & Tensor::renorm_(Scalar p, int64_t dim, Scalar maxnorm) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::renorm_(const_cast<Tensor&>(*this), p, dim, maxnorm);
             break;
@@ -4423,7 +4423,7 @@ inline Tensor & Tensor::renorm_(Scalar p, int64_t dim, Scalar maxnorm) const {
 }
 inline Tensor & Tensor::pow_(Scalar exponent) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow_(const_cast<Tensor&>(*this), exponent);
             break;
@@ -4438,7 +4438,7 @@ inline Tensor & Tensor::pow_(Scalar exponent) const {
 }
 inline Tensor & Tensor::pow_(const Tensor & exponent) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow_(const_cast<Tensor&>(*this), exponent);
             break;
@@ -4453,7 +4453,7 @@ inline Tensor & Tensor::pow_(const Tensor & exponent) const {
 }
 inline Tensor & Tensor::lerp_(const Tensor & end, Scalar weight) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp_(const_cast<Tensor&>(*this), end, weight);
             break;
@@ -4468,7 +4468,7 @@ inline Tensor & Tensor::lerp_(const Tensor & end, Scalar weight) const {
 }
 inline Tensor & Tensor::lerp_(const Tensor & end, const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp_(const_cast<Tensor&>(*this), end, weight);
             break;
@@ -4483,7 +4483,7 @@ inline Tensor & Tensor::lerp_(const Tensor & end, const Tensor & weight) const {
 }
 inline Tensor & Tensor::fmod_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod_(const_cast<Tensor&>(*this), other);
             break;
@@ -4498,7 +4498,7 @@ inline Tensor & Tensor::fmod_(Scalar other) const {
 }
 inline Tensor & Tensor::fmod_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod_(const_cast<Tensor&>(*this), other);
             break;
@@ -4513,7 +4513,7 @@ inline Tensor & Tensor::fmod_(const Tensor & other) const {
 }
 inline Tensor & Tensor::remainder_(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder_(const_cast<Tensor&>(*this), other);
             break;
@@ -4528,7 +4528,7 @@ inline Tensor & Tensor::remainder_(Scalar other) const {
 }
 inline Tensor & Tensor::remainder_(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder_(const_cast<Tensor&>(*this), other);
             break;
@@ -4543,7 +4543,7 @@ inline Tensor & Tensor::remainder_(const Tensor & other) const {
 }
 inline Tensor & Tensor::addbmm_(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addbmm_(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
             break;
@@ -4558,7 +4558,7 @@ inline Tensor & Tensor::addbmm_(const Tensor & batch1, const Tensor & batch2, Sc
 }
 inline Tensor Tensor::addbmm(const Tensor & batch1, const Tensor & batch2, Scalar beta, Scalar alpha) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::addbmm(const_cast<Tensor&>(*this), batch1, batch2, beta, alpha);
             break;
@@ -4582,7 +4582,7 @@ inline Tensor & Tensor::addcdiv_(const Tensor & tensor1, const Tensor & tensor2,
 }
 inline Tensor & Tensor::random_(int64_t from, int64_t to, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::random_(const_cast<Tensor&>(*this), from, to, generator);
             break;
@@ -4596,7 +4596,7 @@ inline Tensor & Tensor::random_(int64_t from, int64_t to, Generator * generator)
 }
 inline Tensor & Tensor::random_(int64_t to, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::random_(const_cast<Tensor&>(*this), to, generator);
             break;
@@ -4610,7 +4610,7 @@ inline Tensor & Tensor::random_(int64_t to, Generator * generator) const {
 }
 inline Tensor & Tensor::random_(Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::random_(const_cast<Tensor&>(*this), generator);
             break;
@@ -4624,7 +4624,7 @@ inline Tensor & Tensor::random_(Generator * generator) const {
 }
 inline Tensor & Tensor::uniform_(double from, double to, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::uniform_(const_cast<Tensor&>(*this), from, to, generator);
             break;
@@ -4638,7 +4638,7 @@ inline Tensor & Tensor::uniform_(double from, double to, Generator * generator) 
 }
 inline Tensor & Tensor::normal_(double mean, double std, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::normal_(const_cast<Tensor&>(*this), mean, std, generator);
             break;
@@ -4652,7 +4652,7 @@ inline Tensor & Tensor::normal_(double mean, double std, Generator * generator) 
 }
 inline Tensor & Tensor::cauchy_(double median, double sigma, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cauchy_(const_cast<Tensor&>(*this), median, sigma, generator);
             break;
@@ -4666,7 +4666,7 @@ inline Tensor & Tensor::cauchy_(double median, double sigma, Generator * generat
 }
 inline Tensor & Tensor::log_normal_(double mean, double std, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::log_normal_(const_cast<Tensor&>(*this), mean, std, generator);
             break;
@@ -4680,7 +4680,7 @@ inline Tensor & Tensor::log_normal_(double mean, double std, Generator * generat
 }
 inline Tensor & Tensor::exponential_(double lambd, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::exponential_(const_cast<Tensor&>(*this), lambd, generator);
             break;
@@ -4694,7 +4694,7 @@ inline Tensor & Tensor::exponential_(double lambd, Generator * generator) const 
 }
 inline Tensor & Tensor::geometric_(double p, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::geometric_(const_cast<Tensor&>(*this), p, generator);
             break;
@@ -4708,7 +4708,7 @@ inline Tensor & Tensor::geometric_(double p, Generator * generator) const {
 }
 inline Tensor Tensor::diag(int64_t diagonal) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::diag(const_cast<Tensor&>(*this), diagonal);
             break;
@@ -4750,7 +4750,7 @@ inline Tensor Tensor::tril(int64_t diagonal) const {
 }
 inline Tensor Tensor::trace() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::trace(const_cast<Tensor&>(*this));
             break;
@@ -4765,7 +4765,7 @@ inline Tensor Tensor::trace() const {
 }
 inline Tensor Tensor::ne(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ne(const_cast<Tensor&>(*this), other);
             break;
@@ -4783,7 +4783,7 @@ inline Tensor Tensor::ne(Scalar other) const {
 }
 inline Tensor Tensor::ne(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ne(const_cast<Tensor&>(*this), other);
             break;
@@ -4801,7 +4801,7 @@ inline Tensor Tensor::ne(const Tensor & other) const {
 }
 inline Tensor Tensor::eq(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eq(const_cast<Tensor&>(*this), other);
             break;
@@ -4819,7 +4819,7 @@ inline Tensor Tensor::eq(Scalar other) const {
 }
 inline Tensor Tensor::eq(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eq(const_cast<Tensor&>(*this), other);
             break;
@@ -4837,7 +4837,7 @@ inline Tensor Tensor::eq(const Tensor & other) const {
 }
 inline Tensor Tensor::ge(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ge(const_cast<Tensor&>(*this), other);
             break;
@@ -4855,7 +4855,7 @@ inline Tensor Tensor::ge(Scalar other) const {
 }
 inline Tensor Tensor::ge(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ge(const_cast<Tensor&>(*this), other);
             break;
@@ -4873,7 +4873,7 @@ inline Tensor Tensor::ge(const Tensor & other) const {
 }
 inline Tensor Tensor::le(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::le(const_cast<Tensor&>(*this), other);
             break;
@@ -4891,7 +4891,7 @@ inline Tensor Tensor::le(Scalar other) const {
 }
 inline Tensor Tensor::le(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::le(const_cast<Tensor&>(*this), other);
             break;
@@ -4909,7 +4909,7 @@ inline Tensor Tensor::le(const Tensor & other) const {
 }
 inline Tensor Tensor::gt(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gt(const_cast<Tensor&>(*this), other);
             break;
@@ -4927,7 +4927,7 @@ inline Tensor Tensor::gt(Scalar other) const {
 }
 inline Tensor Tensor::gt(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gt(const_cast<Tensor&>(*this), other);
             break;
@@ -4945,7 +4945,7 @@ inline Tensor Tensor::gt(const Tensor & other) const {
 }
 inline Tensor Tensor::lt(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lt(const_cast<Tensor&>(*this), other);
             break;
@@ -4963,7 +4963,7 @@ inline Tensor Tensor::lt(Scalar other) const {
 }
 inline Tensor Tensor::lt(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lt(const_cast<Tensor&>(*this), other);
             break;
@@ -4981,7 +4981,7 @@ inline Tensor Tensor::lt(const Tensor & other) const {
 }
 inline Tensor Tensor::take(const Tensor & index) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::take(const_cast<Tensor&>(*this), index);
             break;
@@ -4996,7 +4996,7 @@ inline Tensor Tensor::take(const Tensor & index) const {
 }
 inline Tensor Tensor::index_select(int64_t dim, const Tensor & index) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::index_select(const_cast<Tensor&>(*this), dim, index);
             break;
@@ -5024,7 +5024,7 @@ inline Tensor Tensor::index_select(Dimname dim, const Tensor & index) const {
 #endif
 inline Tensor Tensor::masked_select(const Tensor & mask) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::masked_select(const_cast<Tensor&>(*this), mask);
             break;
@@ -5039,7 +5039,7 @@ inline Tensor Tensor::masked_select(const Tensor & mask) const {
 }
 inline Tensor Tensor::nonzero() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::nonzero(const_cast<Tensor&>(*this));
             break;
@@ -5063,7 +5063,7 @@ inline std::vector<Tensor> Tensor::nonzero_numpy() const {
 }
 inline Tensor Tensor::gather(int64_t dim, const Tensor & index, bool sparse_grad) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::gather(const_cast<Tensor&>(*this), dim, index, sparse_grad);
             break;
@@ -5115,7 +5115,7 @@ inline Tensor Tensor::addcdiv(const Tensor & tensor1, const Tensor & tensor2, Sc
 }
 inline std::tuple<Tensor,Tensor> Tensor::lstsq(const Tensor & A) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lstsq(const_cast<Tensor&>(*this), A);
             break;
@@ -5148,7 +5148,7 @@ inline std::tuple<Tensor,Tensor> Tensor::symeig(bool eigenvectors, bool upper) c
 }
 inline std::tuple<Tensor,Tensor> Tensor::eig(bool eigenvectors) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::eig(const_cast<Tensor&>(*this), eigenvectors);
             break;
@@ -5199,7 +5199,7 @@ inline std::tuple<Tensor,Tensor> Tensor::solve(const Tensor & A) const {
 }
 inline Tensor Tensor::cholesky_inverse(bool upper) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::cholesky_inverse(const_cast<Tensor&>(*this), upper);
             break;
@@ -5223,7 +5223,7 @@ inline std::tuple<Tensor,Tensor> Tensor::qr(bool some) const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::geqrf() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::geqrf(const_cast<Tensor&>(*this));
             break;
@@ -5238,7 +5238,7 @@ inline std::tuple<Tensor,Tensor> Tensor::geqrf() const {
 }
 inline Tensor Tensor::orgqr(const Tensor & input2) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::orgqr(const_cast<Tensor&>(*this), input2);
             break;
@@ -5253,7 +5253,7 @@ inline Tensor Tensor::orgqr(const Tensor & input2) const {
 }
 inline Tensor Tensor::ormqr(const Tensor & input2, const Tensor & input3, bool left, bool transpose) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::ormqr(const_cast<Tensor&>(*this), input2, input3, left, transpose);
             break;
@@ -5277,7 +5277,7 @@ inline Tensor Tensor::lu_solve(const Tensor & LU_data, const Tensor & LU_pivots)
 }
 inline Tensor Tensor::multinomial(int64_t num_samples, bool replacement, Generator * generator) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::multinomial(const_cast<Tensor&>(*this), num_samples, replacement, generator);
             break;
@@ -5291,7 +5291,7 @@ inline Tensor Tensor::multinomial(int64_t num_samples, bool replacement, Generat
 }
 inline Tensor Tensor::lgamma() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lgamma(const_cast<Tensor&>(*this));
             break;
@@ -5324,7 +5324,7 @@ inline Tensor Tensor::polygamma(int64_t n) const {
 }
 inline Tensor Tensor::erfinv() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erfinv(const_cast<Tensor&>(*this));
             break;
@@ -5339,7 +5339,7 @@ inline Tensor Tensor::erfinv() const {
 }
 inline Tensor & Tensor::erfinv_() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::erfinv_(const_cast<Tensor&>(*this));
             break;
@@ -5372,7 +5372,7 @@ inline Tensor & Tensor::sign_() const {
 }
 inline Tensor Tensor::dist(const Tensor & other, Scalar p) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::dist(const_cast<Tensor&>(*this), other, p);
             break;
@@ -5396,7 +5396,7 @@ inline Tensor Tensor::atan2(const Tensor & other) const {
 }
 inline Tensor Tensor::lerp(const Tensor & end, Scalar weight) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp(const_cast<Tensor&>(*this), end, weight);
             break;
@@ -5411,7 +5411,7 @@ inline Tensor Tensor::lerp(const Tensor & end, Scalar weight) const {
 }
 inline Tensor Tensor::lerp(const Tensor & end, const Tensor & weight) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::lerp(const_cast<Tensor&>(*this), end, weight);
             break;
@@ -5426,7 +5426,7 @@ inline Tensor Tensor::lerp(const Tensor & end, const Tensor & weight) const {
 }
 inline Tensor Tensor::histc(int64_t bins, Scalar min, Scalar max) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::histc(const_cast<Tensor&>(*this), bins, min, max);
             break;
@@ -5441,7 +5441,7 @@ inline Tensor Tensor::histc(int64_t bins, Scalar min, Scalar max) const {
 }
 inline Tensor Tensor::fmod(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod(const_cast<Tensor&>(*this), other);
             break;
@@ -5456,7 +5456,7 @@ inline Tensor Tensor::fmod(Scalar other) const {
 }
 inline Tensor Tensor::fmod(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::fmod(const_cast<Tensor&>(*this), other);
             break;
@@ -5471,7 +5471,7 @@ inline Tensor Tensor::fmod(const Tensor & other) const {
 }
 inline Tensor Tensor::remainder(Scalar other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder(const_cast<Tensor&>(*this), other);
             break;
@@ -5486,7 +5486,7 @@ inline Tensor Tensor::remainder(Scalar other) const {
 }
 inline Tensor Tensor::remainder(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::remainder(const_cast<Tensor&>(*this), other);
             break;
@@ -5501,7 +5501,7 @@ inline Tensor Tensor::remainder(const Tensor & other) const {
 }
 inline Tensor Tensor::min(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::min(const_cast<Tensor&>(*this), other);
             break;
@@ -5516,7 +5516,7 @@ inline Tensor Tensor::min(const Tensor & other) const {
 }
 inline Tensor Tensor::min() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::min(const_cast<Tensor&>(*this));
             break;
@@ -5534,7 +5534,7 @@ inline Tensor Tensor::min() const {
 }
 inline Tensor Tensor::max(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::max(const_cast<Tensor&>(*this), other);
             break;
@@ -5549,7 +5549,7 @@ inline Tensor Tensor::max(const Tensor & other) const {
 }
 inline Tensor Tensor::max() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::max(const_cast<Tensor&>(*this));
             break;
@@ -5567,7 +5567,7 @@ inline Tensor Tensor::max() const {
 }
 inline Tensor Tensor::median() const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::median(const_cast<Tensor&>(*this));
             break;
@@ -5582,7 +5582,7 @@ inline Tensor Tensor::median() const {
 }
 inline std::tuple<Tensor,Tensor> Tensor::sort(int64_t dim, bool descending) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::sort(const_cast<Tensor&>(*this), dim, descending);
             break;
@@ -5629,7 +5629,7 @@ inline Tensor Tensor::argsort(Dimname dim, bool descending) const {
 #endif
 inline std::tuple<Tensor,Tensor> Tensor::topk(int64_t k, int64_t dim, bool largest, bool sorted) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::topk(const_cast<Tensor&>(*this), k, dim, largest, sorted);
             break;
@@ -5665,7 +5665,7 @@ inline Tensor Tensor::any() const {
 }
 inline Tensor Tensor::renorm(Scalar p, int64_t dim, Scalar maxnorm) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::renorm(const_cast<Tensor&>(*this), p, dim, maxnorm);
             break;
@@ -5680,7 +5680,7 @@ inline Tensor Tensor::renorm(Scalar p, int64_t dim, Scalar maxnorm) const {
 }
 inline Tensor Tensor::unfold(int64_t dimension, int64_t size, int64_t step) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::unfold(const_cast<Tensor&>(*this), dimension, size, step);
             break;
@@ -5695,7 +5695,7 @@ inline Tensor Tensor::unfold(int64_t dimension, int64_t size, int64_t step) cons
 }
 inline bool Tensor::equal(const Tensor & other) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::equal(const_cast<Tensor&>(*this), other);
             break;
@@ -5713,7 +5713,7 @@ inline bool Tensor::equal(const Tensor & other) const {
 }
 inline Tensor Tensor::pow(const Tensor & exponent) const {
 #ifdef USE_STATIC_DISPATCH
-    switch(tensorTypeIdToBackend(impl::dispatchTypeId(type_set()))) {
+    switch(tensorTypeIdToBackend(legacyExtractTypeId(type_set()))) {
         case Backend::CPU:
             return CPUType::pow(const_cast<Tensor&>(*this), exponent);
             break;

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -231,7 +231,7 @@ STATIC_DISPATCH_FUNCTION_DEFAULT_BODY = CodeTemplate("""\
 ${return_call} TypeDefault::${native_type_method_dispatch}(${native_arguments});
 """)
 STATIC_DISPATCH_FUNCTION_SWITCH_BODY = CodeTemplate("""\
-switch(tensorTypeIdToBackend(impl::dispatchTypeId(${type_set}))) {
+switch(tensorTypeIdToBackend(legacyExtractTypeId(${type_set}))) {
     ${static_dispatch_function_switches}
     default:
         AT_ERROR("${api_name} not implemented for ", at::toString(${type_set}));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26813 Switch static dispatch to use extractLegacyTypeId.**

Attempt to fix #26764

Signed-off-by: Edward Z. Yang <ezyang@fb.com>