### PR TITLE
Named tensor support for: all, any, bitwise_not, cumprod, cumsum, and more

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -492,26 +492,32 @@
 
 - func: bitwise_not(Tensor self) -> Tensor
   use_c10_dispatcher: full
+  supports_named_tensor: True
   variants: function, method
 
 - func: bitwise_not_(Tensor(a!) self) -> Tensor(a!)
   use_c10_dispatcher: unboxed_only
+  supports_named_tensor: True
   variants: method
 
 - func: bitwise_not.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
   dispatch:
     CPU: bitwise_not_out
     CUDA: bitwise_not_out
 
 - func: logical_not(Tensor self) -> Tensor
   use_c10_dispatcher: unboxed_only
+  supports_named_tensor: True
   variants: function, method
 
 - func: logical_not_(Tensor(a!) self) -> Tensor(a!)
   use_c10_dispatcher: unboxed_only
+  supports_named_tensor: True
   variants: method
 
 - func: logical_not.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
   dispatch:
     CPU: logical_not_out
     CUDA: logical_not_out
@@ -827,25 +833,32 @@
     CUDA: cudnn_grid_sampler_backward
 
 - func: cumsum(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
+  supports_named_tensor: True
   variants: function, method
 
 - func: cumsum.out(Tensor self, int dim, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
 
 - func: cumsum.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor
+  supports_named_tensor: True
   variants: function, method
 
 - func: cumsum.dimname_out(Tensor self, Dimname dim, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
 
 - func: cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor
+  supports_named_tensor: True
   variants: function, method
 
 - func: cumprod.out(Tensor self, int dim, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
+  supports_named_tensor: True
 
 - func: cumprod.dimname(Tensor self, Dimname dim, *, ScalarType? dtype=None) -> Tensor
+  supports_named_tensor: True
   variants: function, method
 
 - func: cumprod.dimname_out(Tensor self, Dimname dim, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
-
+  supports_named_tensor: True
 
 - func: ctc_loss.IntList(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank=0, int reduction=Mean, bool zero_infinity=False) -> Tensor
   use_c10_dispatcher: unboxed_only
@@ -2827,6 +2840,7 @@
 
 - func: type_as(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
+  supports_named_tensor: True
   variants: method
 
 - func: _has_compatible_shallow_copy_type(Tensor self, Tensor from) -> bool
@@ -5173,10 +5187,12 @@
 
 - func: all(Tensor self) -> Tensor
   use_c10_dispatcher: full
+  supports_named_tensor: True
   variants: method, function
 
 - func: any(Tensor self) -> Tensor
   use_c10_dispatcher: full
+  supports_named_tensor: True
   variants: method, function
 
 - func: renorm.out(Tensor self, Scalar p, int dim, Scalar maxnorm, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2840,7 +2840,6 @@
 
 - func: type_as(Tensor self, Tensor other) -> Tensor
   use_c10_dispatcher: full
-  supports_named_tensor: True
   variants: method
 
 - func: _has_compatible_shallow_copy_type(Tensor self, Tensor from) -> bool

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -707,7 +707,7 @@ class TestNamedTensor(TestCase):
                 out = testcase.lambd(tensor)
             except RuntimeError as err:
                 # Get a better error message by catching the error and asserting.
-                assert False, '{}: {}'.format(testcase.name, err)
+                raise RuntimeError('{}: {}'.format(testcase.name, err))
             self.assertEqual(out.names, tensor.names,
                              message=testcase.name)
 

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -558,9 +558,8 @@ class TestNamedTensor(TestCase):
     def test_any_all(self):
         for device in torch.testing.get_all_device_types():
             x = torch.zeros(3, dtype=torch.bool, device=device, names=('C',))
-            # The result can't have any names so this is just a smoke test
-            x.any()
-            x.all()
+            self.assertEqual(x.any().names, [])
+            self.assertEqual(x.all().names, [])
 
     def test_binary_ops(self):
         def test_basic(op):

--- a/test/test_namedtensor.py
+++ b/test/test_namedtensor.py
@@ -704,7 +704,11 @@ class TestNamedTensor(TestCase):
         def _test(testcase, names=('N', 'D'), device='cpu'):
             sizes = [2] * len(names)
             tensor = torch.empty(sizes, names=names, device=device)
-            out = testcase.lambd(tensor)
+            try:
+                out = testcase.lambd(tensor)
+            except RuntimeError as err:
+                # Get a better error message by catching the error and asserting.
+                assert False, '{}: {}'.format(testcase.name, err)
             self.assertEqual(out.names, tensor.names,
                              message=testcase.name)
 
@@ -786,7 +790,6 @@ class TestNamedTensor(TestCase):
             fn('threshold_', 0, 1),
             out_function('threshold', 0, 1),
             fn_method_and_inplace('trunc'),
-            method('type_as', torch.empty([], dtype=torch.float)),
             method('uniform_'),
             method('zero_'),
             method('fill_', 1),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #26829 Fix CUDA named tensor `copy_`
* **#26815 Named tensor support for: all, any, bitwise_not, cumprod, cumsum, and more**
* #26563 Named tensor support for logsumexp, mode, kthvalue, median, min, max

This PR adds named tensor support for:
- any, all, `bitwise_not(_)`, cumprod, cumsum, `logical_not`

In addition, it adds smoke tests for a variety of tensor attributes and
fns:
- is_shared, is_signed
- retain_grad, register_hook

Test Plan:
- [namedtensor ci]

Pull Request resolved: https://github.com/pytorch/pytorch/pull/26815

Differential Revision: [D17575905](https://our.internmc.facebook.com/intern/diff/D17575905)