### PR TITLE
Remove one unnecessary copy of the output during the type promotion.

### DIFF
--- a/aten/src/ATen/native/TensorIterator.cpp
+++ b/aten/src/ATen/native/TensorIterator.cpp
@@ -125,7 +125,12 @@ static void maybe_promote_common_dtype(OperandInfo& op, ScalarType common_dtype)
   {
     op.dtype = common_dtype;
     op.original_tensor = op.tensor;
-    op.tensor = op.tensor.to(common_dtype);
+    if (!op.is_output) {
+      op.tensor = op.tensor.to(common_dtype);
+    } else {
+      op.tensor =
+          at::empty_like(op.tensor, op.tensor.options().dtype(common_dtype));
+    }
     auto original_element_size = op.original_tensor.element_size();
     auto new_element_size = op.tensor.element_size();
 


### PR DESCRIPTION
Output tensors doesn't need to be copied during type promotion as we are not using any data from them. Simple allocation gives steady 10% performance gain.


BEFORE

```
In [1]: x = torch.randn(64, 2048, 7,7)                                                                                                                                                                                                                                                     
In [2]: y = torch.randn(64, 2048, 7,7, dtype=torch.float64)                                                                                                                                                                                                                                
In [3]: timeit x.add_(y)                                                                                                                                                                                                                                                                   
77.3 ms ± 257 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

AFTER

```
In [1]: x = torch.randn(64, 2048, 7,7)                                                                                                                                                                                                                                                     
In [2]: y = torch.randn(64, 2048, 7,7, dtype=torch.float64)                                                                                                                                                                                                                                
In [3]: timeit x.add_(y)                                                                                                                                                                                                                                                                   
68.2 ms ± 713 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```