### PR TITLE
[quantization] Throw if someone tries to torch.save() quantized modules

### DIFF
--- a/test/test_quantized_nn_mods.py
+++ b/test/test_quantized_nn_mods.py
@@ -154,15 +154,22 @@ class DynamicModuleAPITest(QuantizationTestCase):
         Z_dq2 = qlinear(X)
         self.assertEqual(Z_dq, Z_dq2)
 
-        # test serialization of module directly
-        b = io.BytesIO()
-        torch.save(qlinear, b)
-        b.seek(0)
-        loaded = torch.load(b)
-        # This check is disabled pending an issue in PyTorch serialization:
+        # The below check is meant to ensure that `torch.save` and `torch.load`
+        # serialization works, however it is currently broken by the following:
         # https://github.com/pytorch/pytorch/issues/24045
+        #
+        # Instead, we currently check that the proper exception is thrown on save.
+        # <start code>
+        # b = io.BytesIO()
+        # torch.save(qlinear, b)
+        # b.seek(0)
+        # loaded = torch.load(b)
         # self.assertEqual(qlinear.weight(), loaded.weight())
-        self.assertEqual(qlinear.zero_point, loaded.zero_point)
+        # self.assertEqual(qlinear.zero_point, loaded.zero_point)
+        # <end code>
+        with self.assertRaisesRegex(RuntimeError, r'torch.save\(\) is not currently supported'):
+            b = io.BytesIO()
+            torch.save(qlinear, b)
 
         # Test JIT
         self.checkScriptable(qlinear, list(zip([X], [Z_ref])), check_save_load=True)
@@ -283,16 +290,23 @@ class ModuleAPITest(QuantizationTestCase):
         Z_q2 = loaded_qlinear(X_q)
         self.assertEqual(Z_q, Z_q2)
 
-        # test serialization of module directly
-        b = io.BytesIO()
-        torch.save(qlinear, b)
-        b.seek(0)
-        loaded = torch.load(b)
-        # This check is disabled pending an issue in PyTorch serialization:
+        # The below check is meant to ensure that `torch.save` and `torch.load`
+        # serialization works, however it is currently broken by the following:
         # https://github.com/pytorch/pytorch/issues/24045
+        #
+        # Instead, we currently check that the proper exception is thrown on save.
+        # <start code>
+        # b = io.BytesIO()
+        # torch.save(qlinear, b)
+        # b.seek(0)
+        # loaded = torch.load(b)
         # self.assertEqual(qlinear.weight(), loaded.weight())
-        self.assertEqual(qlinear.scale, loaded.scale)
-        self.assertEqual(qlinear.zero_point, loaded.zero_point)
+        # self.assertEqual(qlinear.scale, loaded.scale)
+        # self.assertEqual(qlinear.zero_point, loaded.zero_point)
+        # <end code>
+        with self.assertRaisesRegex(RuntimeError, r'torch.save\(\) is not currently supported'):
+            b = io.BytesIO()
+            torch.save(qlinear, b)
 
         # Test JIT
         self.checkScriptable(qlinear, list(zip([X_q], [Z_ref])), check_save_load=True)
@@ -463,14 +477,24 @@ class ModuleAPITest(QuantizationTestCase):
         loaded_result = loaded_conv_under_test(qX)
         self.assertEqual(loaded_result, result_reference)
 
-        b = io.BytesIO()
-        torch.save(conv_under_test, b)
-        b.seek(0)
-        loaded_conv = torch.load(b)
-
-        self.assertEqual(conv_under_test.bias(), loaded_conv.bias())
-        self.assertEqual(conv_under_test.scale, loaded_conv.scale)
-        self.assertEqual(conv_under_test.zero_point, loaded_conv.zero_point)
+        # The below check is meant to ensure that `torch.save` and `torch.load`
+        # serialization works, however it is currently broken by the following:
+        # https://github.com/pytorch/pytorch/issues/24045
+        #
+        # Instead, we currently check that the proper exception is thrown on save.
+        # <start code>
+        # b = io.BytesIO()
+        # torch.save(conv_under_test, b)
+        # b.seek(0)
+        # loaded_conv = torch.load(b)
+        #
+        # self.assertEqual(conv_under_test.bias(), loaded_conv.bias())
+        # self.assertEqual(conv_under_test.scale, loaded_conv.scale)
+        # self.assertEqual(conv_under_test.zero_point, loaded_conv.zero_point)
+        # <end code>
+        with self.assertRaisesRegex(RuntimeError, r'torch.save\(\) is not currently supported'):
+            b = io.BytesIO()
+            torch.save(conv_under_test, b)
 
         # JIT testing
         self.checkScriptable(conv_under_test, list(zip([qX], [result_reference])), check_save_load=True)

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -14,11 +14,6 @@ from torch.nn.utils import fuse_conv_bn_weights
 from torch._ops import ops
 from torch.nn.modules.utils import _pair
 
-def _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED():
-    # type: () -> bool
-    x = 0x7FFFFFFFFFFFFFFF
-    return x + 1 < 0
-
 class Conv2d(torch.nn.Module):
     r"""Applies a 2D convolution over a quantized input signal composed of
     several quantized input planes.
@@ -150,7 +145,7 @@ class Conv2d(torch.nn.Module):
 
     @torch.jit.export
     def __getstate__(self):
-        if (not _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED()):
+        if not torch.jit.is_scripting():
             raise RuntimeError('torch.save() is not currently supported for quantized modules.'
                                ' See https://github.com/pytorch/pytorch/issues/24045.'
                                ' Please use state_dict or torch.jit serialization.')

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -14,6 +14,11 @@ from torch.nn.utils import fuse_conv_bn_weights
 from torch._ops import ops
 from torch.nn.modules.utils import _pair
 
+def _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED():
+    # type: () -> bool
+    x = 0x7FFFFFFFFFFFFFFF
+    return x + 1 < 0
+
 class Conv2d(torch.nn.Module):
     r"""Applies a 2D convolution over a quantized input signal composed of
     several quantized input planes.
@@ -145,6 +150,10 @@ class Conv2d(torch.nn.Module):
 
     @torch.jit.export
     def __getstate__(self):
+        if (not _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED()):
+            raise RuntimeError('torch.save() is not currently supported for quantized modules.'
+                               ' See https://github.com/pytorch/pytorch/issues/24045.'
+                               ' Please use state_dict or torch.jit serialization.')
         (w, b) = self._weight_bias()
         return (
             self.in_channels,

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -72,11 +72,6 @@ class DeQuantize(Module):
     def from_float(mod):
         return DeQuantize()
 
-def _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED():
-    # type: () -> bool
-    x = 0x7FFFFFFFFFFFFFFF
-    return x + 1 < 0
-
 class Linear(torch.nn.Module):
     r"""
     A quantized linear module with quantized tensor as inputs and outputs.
@@ -150,7 +145,7 @@ class Linear(torch.nn.Module):
 
     @torch.jit.export
     def __getstate__(self):
-        if (not _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED()):
+        if not torch.jit.is_scripting():
             raise RuntimeError('torch.save() is not currently supported for quantized modules.'
                                ' See https://github.com/pytorch/pytorch/issues/24045.'
                                ' Please use state_dict or torch.jit serialization.')

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -72,6 +72,11 @@ class DeQuantize(Module):
     def from_float(mod):
         return DeQuantize()
 
+def _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED():
+    # type: () -> bool
+    x = 0x7FFFFFFFFFFFFFFF
+    return x + 1 < 0
+
 class Linear(torch.nn.Module):
     r"""
     A quantized linear module with quantized tensor as inputs and outputs.
@@ -145,6 +150,10 @@ class Linear(torch.nn.Module):
 
     @torch.jit.export
     def __getstate__(self):
+        if (not _is_jit_script_DO_NOT_CALL_OR_YOU_WILL_BE_FIRED()):
+            raise RuntimeError('torch.save() is not currently supported for quantized modules.'
+                               ' See https://github.com/pytorch/pytorch/issues/24045.'
+                               ' Please use state_dict or torch.jit serialization.')
         (w, b) = self._weight_bias()
         return (
             self.in_features,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26828 [quantization] Throw if someone tries to torch.save() quantized modules**

Pickle serialization for quantized modules is currently broken by https://github.com/pytorch/pytorch/issues/24045, so let's be loud and fail if the user tries to do it

Differential Revision: [D17579127](https://our.internmc.facebook.com/intern/diff/D17579127)