### PR TITLE
Fix CUDA named tensor `copy_`

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -225,14 +225,6 @@ void propagate_names(TensorImpl* result, TensorImpl* src) {
   propagate_names(result, impl::get_opt_names(src));
 }
 
-void propagate_names_for_copy(Tensor& result, const Tensor& src) {
-  if (!result.has_names() && !src.has_names()) {
-    return;
-  }
-  auto outnames = unify_from_right(result.names(), src.names());
-  propagate_names(result, std::move(outnames), /*validate_names=*/false);
-}
-
 // tensor_dotted_dim and other_dotted_dim are the dimensions of the two
 // tensors that we contract together. Usually other_dotted_dim is 0
 // and tensor_dotted_dim is the last dim of tensor, but there are some special

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -62,9 +62,6 @@ void propagate_names_except(Tensor& result, const Tensor& src, IntArrayRef exclu
 // Used for reduction ops that have a `keepdim` arg.
 void propagate_names_for_reduction(Tensor& result, const Tensor& src, IntArrayRef excluded_idxs, bool keepdim);
 
-// Tensor::copy_ name inference rule.
-void propagate_names_for_copy(Tensor& result, const Tensor& src);
-
 // result = m1 @ m2 + bias
 void propagate_names_for_addmm(
     TensorImpl* result,

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -72,9 +72,6 @@ void copy_same_type_transpose_(Tensor& self, const Tensor& src) {
       }
     }
   });
-#ifdef BUILD_NAMEDTENSOR
-  namedinference::propagate_names_for_copy(self, src);
-#endif
 }
 
 // Devices directly supported by this copy implementation. Other device types
@@ -89,7 +86,7 @@ bool is_supported_device(Device device) {
 namespace at {
 namespace native {
 
-Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
+static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) {
   // TODO: this should be handled during dispatch, but that's missing...
   TORCH_CHECK(self.defined(), "self is undefined");
   TORCH_CHECK(src.defined(), "src is undefined");
@@ -148,6 +145,20 @@ Tensor & copy_(Tensor & self, const Tensor & src, bool non_blocking) {
   }
 
   copy_stub(device_type, iter, non_blocking);
+  return self;
+}
+
+Tensor& copy_(Tensor& self, const Tensor& src, bool non_blocking) {
+#ifdef BUILD_NAMEDTENSOR
+  auto outnames = namedinference::compute_broadcast_outnames(self, src);
+  {
+    NoNamesGuard guard;
+#endif
+    copy_impl(self, src, non_blocking);
+#ifdef BUILD_NAMEDTENSOR
+  }
+  namedinference::propagate_names(self, std::move(outnames), /*validate_names=*/false);
+#endif
   return self;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26829 Fix CUDA named tensor `copy_`**
* #26815 Named tensor support for: all, any, bitwise_not, cumprod, cumsum, and more
* #26563 Named tensor support for logsumexp, mode, kthvalue, median, min, max

The TensorIterator loop for `copy_` uses operations that are currently
unsupported by named tensors. The solution is to wrap `copy_` in a
function that does the name propagation and ignore names when running
the implementation of `copy_`. There is no test case because I'm not
sure how to trigger the incorrect behavior, but there is definitely code
in CUDA copy that doesn't support named tensors (expand_as isn't
supported):

https://github.com/pytorch/pytorch/blob/aaf30cdf36839bc3f21b1622fb91ff3e2983e8ea/aten/src/ATen/native/cuda/Copy.cu#L141-L148

Test Plan:
- [namedtensor ci]

Differential Revision: [D17577310](https://our.internmc.facebook.com/intern/diff/D17577310)