### PR TITLE
[android][scripts] Script for full android build to aars; script to run android tests

### DIFF
--- a/android/run_tests.sh
+++ b/android/run_tests.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -eux
+
+PYTORCH_DIR="$(cd $(dirname $0)/..; pwd -P)"
+PYTORCH_ANDROID_DIR=$PYTORCH_DIR/android
+
+echo "ANDROID_HOME:$ANDROID_HOME"
+if [ ! -z "$ANDROID_HOME" ]; then
+  echo "ANDROID_HOME not set; please set it to Android sdk directory"
+fi
+
+if [ ! -d $ANDROID_HOME ]; then
+  echo "ANDROID_HOME not a directory; did you install it under $ANDROID_HOME?"
+  exit 1
+fi
+
+echo "ANDROID_NDK:$ANDROID_NDK"
+if [ ! -z "$ANDROID_NDK" ]; then
+  echo "ANDROID_NDK not set; please set it to Android sdk directory"
+fi
+
+if [ ! -d $ANDROID_NDK ]; then
+  echo "ANDROID_NDK not a directory; did you install it under $ANDROID_NDK?"
+  exit 1
+fi
+
+GRADLE_PATH=gradle
+GRADLE_NOT_FOUND_MSG="Unable to find gradle, please add it to PATH or set GRADLE_HOME"
+
+if [ ! -x "$(command -v gradle)" ]; then
+  if [ -z "$GRADLE_HOME" ]; then
+    echo GRADLE_NOT_FOUND_MSG 
+    exit 1
+  fi
+  GRADLE_PATH=$GRADLE_HOME/bin/gradle
+  if [ ! -f "$GRADLE_PATH" ]; then
+    echo GRADLE_NOT_FOUND_MSG 
+    exit 1
+  fi
+fi
+echo "GRADLE_PATH:$GRADLE_PATH"
+
+
+# Run android instrumented tests on x86 emulator
+
+ADB_PATH=$ANDROID_HOME/platform-tools/adb
+
+echo "Expecting running emulator"
+$ADB_PATH devices
+
+DEVICES_COUNT=$($ADB_PATH devices | awk 'NF' | wc -l)
+echo "DEVICES_COUNT:$DEVICES_COUNT"
+
+if [ "$DEVICES_COUNT" -eq 1 ]; then
+  echo "Unable to found connected android emulators"
+cat <<- EOF
+  To start android emulator:
+  1. Install android sdkmanager packages
+  $ANDROID_HOME/tools/bin/sdkmanager "system-images;android-25;google_apis;x86"
+
+  to specify proxy add params: --proxy=http --proxy_host=fwdproxy --proxy_port=8080
+
+  2. Create android virtual device
+  $ANDROID_HOME/tools/bin/avdmanager create avd --name "x86_android25" --package "system-images;android-25;google_apis;x86"
+
+  3. Start emulator in headless mode without audio
+  $ANDROID_HOME/tools/emulator -avd x86_android25 -no-audio -no-window
+
+  4. Check that emulator is running
+  $ANDROID_HOME/platform-tools/adb devices
+
+  If everything is ok the output will be:
+  
+  List of devices attached
+  emulator-5554   device
+EOF
+  exit 1
+fi
+
+echo "Waiting for emulator boot completed"
+$ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'
+
+$GRADLE_PATH -PABI_FILTERS=x86 -p $PYTORCH_ANDROID_DIR connectedAndroidTest

--- a/scripts/build_pytorch_android.sh
+++ b/scripts/build_pytorch_android.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -eux
+
+# Script's workflow:
+# 1. Builds libtorch for android for specified android abisi (by default for all 4).
+# Custom list of android abis can be specified as a bash argument as comma separated list.
+# For example just for testing on android x86 emulator we need only x86 build.
+# ./scipts/build_pytorch_androis.sh x86
+# 2. Creates symbolic links to android/pytorch_android/src/main/jniLibs/${abi} for libtorch build output,
+# android/pytorch_android/src/main/cpp/libtorch_include/${abi} for headers.
+# 3. Runs pyotrch_android gradle build:
+# gradle assembleRelease
+
+PYTORCH_DIR="$(cd $(dirname $0)/..; pwd -P)"
+
+PYTORCH_ANDROID_DIR=$PYTORCH_DIR/android
+WORK_DIR=$PYTORCH_DIR
+
+echo "PYTORCH_DIR:$PYTORCH_DIR"
+echo "WORK_DIR:$WORK_DIR"
+
+echo "ANDROID_HOME:$ANDROID_HOME"
+if [ ! -z "$ANDROID_HOME" ]; then
+  echo "ANDROID_HOME not set; please set it to Android sdk directory"
+fi
+
+if [ ! -d $ANDROID_HOME ]; then
+  echo "ANDROID_HOME not a directory; did you install it under $ANDROID_HOME?"
+  exit 1
+fi
+
+GRADLE_PATH=gradle
+GRADLE_NOT_FOUND_MSG="Unable to find gradle, please add it to PATH or set GRADLE_HOME"
+
+if [ ! -x "$(command -v gradle)" ]; then
+  if [ -z "$GRADLE_HOME" ]; then
+    echo GRADLE_NOT_FOUND_MSG 
+    exit 1
+  fi
+  GRADLE_PATH=$GRADLE_HOME/bin/gradle
+  if [ ! -f "$GRADLE_PATH" ]; then
+    echo GRADLE_NOT_FOUND_MSG 
+    exit 1
+  fi
+fi
+echo "GRADLE_PATH:$GRADLE_PATH"
+
+ABIS_LIST="armeabi-v7a,arm64-v8a,x86,x86_64"
+CUSTOM_ABIS_LIST=false
+if [ $# -gt 0 ]; then
+  ABIS_LIST=$1
+  CUSTOM_ABIS_LIST=true
+fi
+  
+echo "ABIS_LIST:$ABIS_LIST"
+
+LIB_DIR=$PYTORCH_ANDROID_DIR/pytorch_android/src/main/jniLibs
+INCLUDE_DIR=$PYTORCH_ANDROID_DIR/pytorch_android/src/main/cpp/libtorch_include
+mkdir -p $LIB_DIR
+mkdir -p $INCLUDE_DIR
+
+for abi in $(echo $ABIS_LIST | tr ',' '\n')
+do
+echo "abi:$abi"
+
+OUT_DIR=$WORK_DIR/build_android_$abi
+
+rm -rf $OUT_DIR
+mkdir -p $OUT_DIR
+
+pushd $PYTORCH_DIR
+python $PYTORCH_DIR/setup.py clean
+
+ANDROID_ABI=$abi BUILD_PYTORCH_MOBILE=1 $PYTORCH_DIR/scripts/build_android.sh -DANDROID_CCACHE=$(which ccache)
+
+cp -R $PYTORCH_DIR/build_android/install/lib $OUT_DIR/
+cp -R $PYTORCH_DIR/build_android/install/include $OUT_DIR/
+
+echo "$abi build output lib,include copied to $OUT_DIR" 
+
+LIB_LINK_PATH=$LIB_DIR/$abi
+INCLUDE_LINK_PATH=$INCLUDE_DIR/$abi
+
+rm -f $LIB_LINK_PATH
+rm -f $INCLUDE_LINK_PATH
+
+ln -s $OUT_DIR/lib $LIB_LINK_PATH
+ln -s $OUT_DIR/include $INCLUDE_LINK_PATH
+
+done
+
+# To set proxy for gradle add following lines to ./gradle/gradle.properties:
+# systemProp.http.proxyHost=...
+# systemProp.http.proxyPort=8080
+# systemProp.https.proxyHost=...
+# systemProp.https.proxyPort=8080
+
+if [ "$CUSTOM_ABIS_LIST" = true ]; then
+  $GRADLE_PATH -PABI_FILTERS=$ABIS_LIST -p $PYTORCH_ANDROID_DIR clean assembleRelease
+else
+  $GRADLE_PATH -p $PYTORCH_ANDROID_DIR clean assembleRelease
+fi
+
+find $PYTORCH_ANDROID_DIR -type f -name *aar | xargs ls -lah
+popd
+


### PR DESCRIPTION
1. scripts/build_android_libtorch_and_pytorch_android.sh 
- Builds libtorch for android_abis (by default for all 4: x86, x86_64, armeabi-v7a, arm-v8a) but cab be specified only custom list as a first parameter e.g. "x86"
- Creates symbolic links inside android/pytorch_android to results of the previous builds: 
`pytorch_android/src/main/jniLibs/${abi}` -> `build_android/install/lib`
`pytorch_android/src/main/cpp/libtorch_include/${abi}` -> `build_android/install/include`

- Runs gradle assembleRelease to build aar files
proxy can be specified inside (for devservers)

2. android/run_tests.sh
Running pytorch_android tests, contains instruction how to setup and run android emulator in headless and noaudio mode to run it on devserver
proxy can be specified inside (for devservers)

#Test plan
Scenario to build x86 libtorch and android aars with it and run tests:
```
cd pytorch
sh scripts/build_android_libtorch_and_pytorch_android.sh x86
sh android/run_tests.sh
```
Tested on my devserver - build works, tests passed
