### PR TITLE
Enable batch_size = 0 support in DNNLOWP Concat operator

### DIFF
--- a/caffe2/quantization/server/concat_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/concat_dnnlowp_op_test.py
@@ -16,27 +16,34 @@ workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
 
 class DNNLowPConcatOpTest(hu.HypothesisTestCase):
     @given(
-        dim1=st.integers(128, 256),
-        dim2=st.integers(128, 256),
+        dim1=st.integers(0, 256),
+        dim2=st.integers(0, 256),
+        axis=st.integers(0, 1),
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
         **hu.gcs_cpu_only
     )
-    def test_dnnlowp_concat_int(self, dim1, dim2, in_quantized, out_quantized, gc, dc):
+    def test_dnnlowp_concat_int(
+        self, dim1, dim2, axis, in_quantized, out_quantized, gc, dc
+    ):
 
         # X has scale 1, so exactly represented after quantization
         min_ = -100
         max_ = min_ + 255
         X = np.round(np.random.rand(dim1, dim2) * (max_ - min_) + min_)
         X = X.astype(np.float32)
-        X[0, 0] = min_
-        X[0, 1] = max_
+        if dim1 >= 1 and dim2 >= 2:
+            X[0, 0] = min_
+            X[0, 1] = max_
+        elif dim2 == 1:
+            return
 
         # Y has scale 1/2, so exactly represented after quantization
         Y = np.round(np.random.rand(dim1, dim2) * 255 / 2 - 64)
         Y = Y.astype(np.float32)
-        Y[0, 0] = -64
-        Y[0, 1] = 127.0 / 2
+        if dim1 >= 1 and dim2 >= 2:
+            Y[0, 0] = -64
+            Y[0, 1] = 127.0 / 2
 
         Output = collections.namedtuple("Output", ["Z", "op_type", "engine"])
         outputs = []
@@ -69,7 +76,7 @@ class DNNLowPConcatOpTest(hu.HypothesisTestCase):
                 dequantize_output=not do_dequantize,
                 engine=engine,
                 device_option=gc,
-                axis=0,
+                axis=axis,
             )
             net.Proto().op.extend([concat])
 
@@ -87,4 +94,5 @@ class DNNLowPConcatOpTest(hu.HypothesisTestCase):
                 Output(Z=self.ws.blobs["Z"].fetch(), op_type=op_type, engine=engine)
             )
 
-        check_quantized_results_close(outputs)
+        if Y.size > 0:
+            check_quantized_results_close(outputs)

--- a/caffe2/quantization/server/dnnlowp_partition.cc
+++ b/caffe2/quantization/server/dnnlowp_partition.cc
@@ -27,7 +27,7 @@ void Get1DPartitionOf2D(
     int* n_begin,
     int* n_end,
     int n_align /*=1*/) {
-  if (m >= nthreads) {
+  if (m >= nthreads || m == 0) {
     // When m >= nthreads, just parallelize over m.
     std::tie(*m_begin, *m_end) = Get1DPartition(m, nthreads, tid);
     *n_begin = 0;


### PR DESCRIPTION
Summary:
We were having division-by-zero errors when one of the input tensor dimension is 0 . Examples: P111481720 and P111481374
This diff adds unit tests for empty input tensors and fixes division-by-zero errors in the partition function.

Test Plan: buck test caffe2/caffe2/quantization/server:concat_dnnlowp_op_test -- --stress-runs=100

Differential Revision: D17574566

