### PR TITLE
[pytorch][mobile] remove backward functions from jit-op-registry for mobile build

### DIFF
--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -48,7 +48,11 @@ def generate_code(ninja_global=None,
             'tools/autograd',
             disable_autograd=disable_autograd,
         )
-        gen_jit_dispatch(declarations_path or DECLARATIONS_PATH, jit_gen_dir, 'tools/jit/templates')
+        gen_jit_dispatch(
+            declarations_path or DECLARATIONS_PATH,
+            jit_gen_dir,
+            'tools/jit/templates',
+            disable_autograd=disable_autograd)
 
 
 def main():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26851 [pytorch][mobile] remove backward functions from jit-op-registry for mobile build**

Summary:
Add codegen option to remove backward ops from jit-op-registry as they are not
likely to be used for inference only mobile build.

Measured ARM-v7 AAR build size change: 5,804,182 -> 5,331,219.

Test Plan:
- build and integrate with demo app;

Differential Revision: [D17587422](https://our.internmc.facebook.com/intern/diff/D17587422)