### PR TITLE
Fix the QuantizedAVX2 build issue

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -571,7 +571,7 @@ void qavg_pool2d_nhwc_kernel(
               acc_int32 += val;
             }
           }
-          double acc_fp = acc_int32 * 1.0 - qx.q_zero_point();
+          double acc_fp = acc_int32 * 1.0;
           // clamp
           o_p[c] = at::quantize_val<scalar_t>(
                        1.0f / multiplier, qy.q_zero_point(), acc_fp)

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -396,7 +396,7 @@ void do_avg_pool_on_AVX2(
       acc.store(acc_int);
       vec256::convert(acc_int, acc_fp, vec_width);
       at::quantize_vec<T>(
-          1 / multiplier,
+          1.0f / multiplier,
           output_zero_point,
           acc_fp,
           reinterpret_cast<T*>(o_p + c),

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -395,8 +395,12 @@ void do_avg_pool_on_AVX2(
       float acc_fp[vec_width];
       acc.store(acc_int);
       vec256::convert(acc_int, acc_fp, vec_width);
-      vec256::QuantizeAvx2<T>(
-          acc_fp, o_p + c, vec_width, multiplier, output_zero_point);
+      at::quantize_vec<T>(
+          1 / multiplier,
+          output_zero_point,
+          acc_fp,
+          reinterpret_cast<T*>(o_p + c),
+          vec_width);
     }
   }
 #endif
@@ -470,11 +474,9 @@ void qadaptive_avg_pool2d_nhwc_kernel(
             }
           }
           // clamp
-          o_p[c] = std::min<int32_t>(
-              std::max<int32_t>(
-                  std::nearbyint(acc_int32 * multiplier + qy.q_zero_point()),
-                  minimum),
-              maximum);
+          o_p[c] = at::quantize_val<scalar_t>(
+                       1.0f / multiplier, qy.q_zero_point(), acc_int32)
+                       .val_;
         } // c
       } // oh
     } // ow
@@ -569,13 +571,11 @@ void qavg_pool2d_nhwc_kernel(
               acc_int32 += val;
             }
           }
-          double acc_fp = acc_int32 * 1.0;
+          double acc_fp = acc_int32 * 1.0 - qx.q_zero_point();
           // clamp
-          o_p[c] = std::min<int32_t>(
-              std::max<int32_t>(
-                  std::nearbyint(acc_fp * multiplier + qy.q_zero_point()),
-                  minimum),
-              maximum);
+          o_p[c] = at::quantize_val<scalar_t>(
+                       1.0f / multiplier, qy.q_zero_point(), acc_fp)
+                       .val_;
         } // c
       } // ow
     } // oh
@@ -593,7 +593,7 @@ int64_t do_quantized_bilinear_on_AVX2(
     int64_t channels,
     int32_t output_zero_point,
     int32_t input_zero_point,
-    float multiplier,
+    float inverse_scale,
     const float h0lambda,
     const float h1lambda,
     const float w0lambda,
@@ -628,11 +628,16 @@ int64_t do_quantized_bilinear_on_AVX2(
       Vec256<float> input_zero_point_v(input_zero_point);
       Vec256<float> result =
           h0lambda_v * (w0lambda_v * pos1_fp_v[0] + w1lambda_v * pos1_fp_v[1]) +
-          h1lambda_v * (w0lambda_v * pos1_fp_v[2] + w1lambda_v * pos1_fp_v[3]) - input_zero_point_v;
+          h1lambda_v * (w0lambda_v * pos1_fp_v[2] + w1lambda_v * pos1_fp_v[3]) -
+          input_zero_point_v;
       float result_fp[vec_width];
       result.store(result_fp);
-      vec256::QuantizeAvx2<T>(
-          result_fp, pos2, vec_width, multiplier, output_zero_point);
+      at::quantize_vec<T>(
+          inverse_scale,
+          output_zero_point,
+          result_fp,
+          reinterpret_cast<T*>(pos2),
+          vec_width);
       pos1 += vec_width;
       pos2 += vec_width;
     }
@@ -655,8 +660,7 @@ void qupsample_bilinear2d_nhwc_kernel(
       input.scalar_type(), "upsample_bilinear2d_nhwc", [&]() {
         auto* idata = static_cast<scalar_t*>(input.data_ptr());
         auto* odata = static_cast<scalar_t*>(output.data_ptr());
-        float multiplier = input.q_scale() / output.q_scale();
-        float output_scale = output.q_scale() / input.q_scale();
+        float inverse_scale = output.q_scale() / input.q_scale();
         const auto rheight = area_pixel_compute_scale<float>(
             input_height, output_height, align_corners);
         const auto rwidth = area_pixel_compute_scale<float>(
@@ -704,7 +708,7 @@ void qupsample_bilinear2d_nhwc_kernel(
                   channels,
                   output.q_zero_point(),
                   input.q_zero_point(),
-                  multiplier,
+                  inverse_scale,
                   h0lambda,
                   h1lambda,
                   w0lambda,
@@ -720,7 +724,9 @@ void qupsample_bilinear2d_nhwc_kernel(
                         (w0lambda * pos1[h1p * input_width * channels] +
                          w1lambda * pos1[(h1p * input_width + w1p) * channels]);
                 pos2[0] = at::quantize_val<scalar_t>(
-                              output_scale, output.q_zero_point(), result - input.q_zero_point())
+                              inverse_scale,
+                              output.q_zero_point(),
+                              result - input.q_zero_point())
                               .val_;
                 pos1 += 1;
                 pos2 += 1;

--- a/test/test_quantized.py
+++ b/test/test_quantized.py
@@ -595,10 +595,9 @@ class TestQuantizedOps(TestCase):
     @given(X=hu.tensor(shapes=hu.array_shapes(min_dims=4, max_dims=4,
                                               min_side=1, max_side=10),
                        qparams=hu.qparams(dtypes=torch.quint8)),
-           permute=st.sampled_from(([0, 1, 2, 3], [0, 2, 3, 1], [0, 3, 1, 2])),
            output_size_h=st.integers(1, 10),
            output_size_w=st.integers(1, 10))
-    def test_adaptive_avg_pool2d(self, X, permute, output_size_h, output_size_w):
+    def test_adaptive_avg_pool2d(self, X, output_size_h, output_size_w):
         X, (scale, zero_point, torch_type) = X
 
         H, W = X.shape[-2:]
@@ -610,7 +609,7 @@ class TestQuantizedOps(TestCase):
             output_size = (output_size_h, output_size_w)
         X = torch.from_numpy(X)
         qX = torch.quantize_per_tensor(X, scale=scale, zero_point=zero_point,
-                                       dtype=torch_type).permute(permute)
+                                       dtype=torch_type)
 
         # Run reference on int_repr + round to avoid double rounding error.
         X_ref = torch.nn.functional.adaptive_avg_pool2d(


### PR DESCRIPTION
The QuantizedAVx2 does not support the int32 type. We switch to use at::quantize_vec function instead.