### PR TITLE
ChannelShuffle with batch size 0

### DIFF
--- a/caffe2/operators/channel_shuffle_op.cc
+++ b/caffe2/operators/channel_shuffle_op.cc
@@ -74,7 +74,7 @@ bool ChannelShuffleOp<float, CPUContext>::RunOnDeviceWithOrderNCHW() {
   const int G = group_;
   CAFFE_ENFORCE_EQ(C % G, 0);
   const int K = C / G;
-  const int HxW = X.numel() / (N * C);
+  const int HxW = X.size_from_dim(2);
   const float* X_data = X.data<float>();
   float* Y_data = Y->mutable_data<float>();
   RunChannelShuffleNCHW<float>(N, G, K, HxW, X_data, Y_data, &context_);
@@ -92,7 +92,7 @@ bool ChannelShuffleOp<float, CPUContext>::RunOnDeviceWithOrderNHWC() {
   const int G = group_;
   CAFFE_ENFORCE_EQ(C % G, 0);
   const int K = C / G;
-  const int HxW = X.numel() / (N * C);
+  const int HxW = X.size_between_dim(0, ndim - 1);
   const float* X_data = X.data<float>();
   float* Y_data = Y->mutable_data<float>();
   RunChannelShuffleNHWC<float>(N, G, K, HxW, X_data, Y_data, &context_);
@@ -109,7 +109,7 @@ bool ChannelShuffleGradientOp<float, CPUContext>::RunOnDeviceWithOrderNCHW() {
   const int G = group_;
   CAFFE_ENFORCE_EQ(C % G, 0);
   const int K = C / G;
-  const int HxW = dY.numel() / (N * C);
+  const int HxW = dY.size_from_dim(2);
   const float* dY_data = dY.data<float>();
   float* dX_data = dX->mutable_data<float>();
   RunChannelShuffleNCHW<float>(N, K, G, HxW, dY_data, dX_data, &context_);
@@ -127,7 +127,7 @@ bool ChannelShuffleGradientOp<float, CPUContext>::RunOnDeviceWithOrderNHWC() {
   const int G = group_;
   CAFFE_ENFORCE_EQ(C % G, 0);
   const int K = C / G;
-  const int HxW = dY.numel() / (N * C);
+  const int HxW = dY.size_between_dim(0, ndim - 1);
   const float* dY_data = dY.data<float>();
   float* dX_data = dX->mutable_data<float>();
   RunChannelShuffleNHWC<float>(N, K, G, HxW, dY_data, dX_data, &context_);

--- a/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
+++ b/caffe2/quantization/server/channel_shuffle_dnnlowp_op.cc
@@ -41,7 +41,7 @@ bool ChannelShuffleDNNLowPOp<T>::RunOnDeviceWithOrderNCHW() {
   const int G = group_;
   CAFFE_ENFORCE_EQ(C % G, 0);
   const int K = C / G;
-  const int HxW = X.numel() / (N * C);
+  const int HxW = X.size_from_dim(2);
   const int stride = C * HxW;
   const T* X_data = X.template data<T>();
   T* Y_data = Y->template mutable_data<T>();

--- a/caffe2/quantization/server/channel_shuffle_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/channel_shuffle_dnnlowp_op_test.py
@@ -15,7 +15,7 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
     @given(
         channels_per_group=st.integers(min_value=1, max_value=5),
         groups=st.sampled_from([1, 4, 8, 9]),
-        n=st.integers(min_value=1, max_value=2),
+        n=st.integers(0, 2),
         order=st.sampled_from(["NCHW", "NHWC"]),
         **hu.gcs_cpu_only
     )
@@ -23,8 +23,9 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
         X = np.round(np.random.rand(n, channels_per_group * groups, 5, 6) * 255).astype(
             np.float32
         )
-        X[0, 0, 0, 0] = 0
-        X[0, 0, 0, 1] = 255
+        if n != 0:
+            X[0, 0, 0, 0] = 0
+            X[0, 0, 0, 1] = 255
         if order == "NHWC":
             X = utils.NCHW2NHWC(X)
 
@@ -66,7 +67,7 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
 
     @given(
         channels_per_group=st.integers(min_value=32, max_value=128),
-        n=st.integers(min_value=1, max_value=2),
+        n=st.integers(0, 2),
         **hu.gcs_cpu_only
     )
     def test_channel_shuffle_fast_path(self, channels_per_group, n, gc, dc):
@@ -75,8 +76,9 @@ class DNNLowPChannelShuffleOpsTest(hu.HypothesisTestCase):
         X = np.round(np.random.rand(n, channels_per_group * groups, 5, 6) * 255).astype(
             np.float32
         )
-        X[0, 0, 0, 0] = 0
-        X[0, 0, 0, 1] = 255
+        if n != 0:
+            X[0, 0, 0, 0] = 0
+            X[0, 0, 0, 1] = 255
         X = utils.NCHW2NHWC(X)
 
         net = core.Net("test_net")


### PR DESCRIPTION
Summary: Handle batch size = 0 in ChannelShuffle operator

Test Plan: CI

Differential Revision: D17591041

