### PR TITLE
Fix the Bernoulli distribution sampler

### DIFF
--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -168,7 +168,7 @@ struct bernoulli_distribution {
 
   inline int operator()(at::CPUGenerator* generator) { 
     uniform_real_distribution<T> uniform(0.0, 1.0);
-    return uniform(generator) <= p;
+    return uniform(generator) < p;
   }
 
   private:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4708,6 +4708,16 @@ class _TestTorchMixin(object):
         # test that it works with bool tensors
         self._test_bernoulli(self, torch.bool, torch.float32, 'cpu')
 
+    def test_bernoulli_edge_cases(self):
+        # Need to draw a lot of samples to cover every random floating point number.
+        a = torch.zeros(10000, 10000, dtype=torch.float32)  # probability of drawing "1" is 0
+        num_ones = (torch.bernoulli(a) == 1).sum()
+        self.assertEqual(num_ones, 0)
+
+        b = torch.ones(10000, 10000, dtype=torch.float32)  # probability of drawing "1" is 1
+        num_zeros = (torch.bernoulli(b) == 0).sum()
+        self.assertEqual(num_zeros, 0)
+
     def test_generator_cpu(self):
         # test default generators are equal
         self.assertEqual(torch.default_generator, torch.default_generator)


### PR DESCRIPTION
The current Bernoulli distribution sampler is slightly off in that it returns true slightly too often. This is most obvious at very low p values, like p = 0, although it theoretically occurs at every probability. See  #26807.
