### PR TITLE
Add optimized quantize function for ARM

### DIFF
--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -10,10 +10,9 @@
 
 #ifdef USE_FBGEMM
 #include <fbgemm/QuantUtils.h>
-#else
+#endif
 #ifdef __ARM_NEON__
 #include <arm_neon.h>
-#endif
 #endif
 
 namespace at {
@@ -296,13 +295,12 @@ Tensor quantize_tensor(Tensor rtensor, Tensor qtensor, double scale, int64_t zer
     quantize_tensor_arm<T>(rdata, qtensor, rtensor.numel(), scale, zero_point);
     return qtensor;
   }
-#else
+#endif
   auto qdata = qtensor.data_ptr<T>();
   for (int i = 0; i < rtensor.numel(); ++i) {
     qdata[i] = quantize_val<T>(scale, zero_point, rdata[i]);
   }
   return qtensor;
-#endif
 }
 
 template <typename T>

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -262,6 +262,9 @@ void Int8Quantize(
     out += 8;
   }
 #endif
+  for (; i < N; ++i) {
+    (*out++) = Uint8Quantize(Y_scale, Y_offset, (*in++));
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26867 Add optimized quantize function for ARM**

Summary:
Use caffe2::Int8Quantize for pytorch mobile. Currently this is only implemented for uint8 tensors and runs using NEON intrinsics.
For all other cases it falls back to naive pytorch quantize_val implementation.

Previously, naive implementation of quantize_val is slow on mobile, taking up more than 50% of the execution time.

Results
Before
aten::quantize_per_tensor 42.893 ms
Total model runtime 70.5ms

After
aten::quantize_per_tensor 0.340 ms
Total model runtime 27.5ms

Test Plan:
Tested current python tests work python test/test_quantized.py TestQNNPackOps
Also tested using quantized mobilenetV2 on mobile and compared output

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D17638732](https://our.internmc.facebook.com/intern/diff/D17638732)