### PR TITLE
batch size 0 tests for element-wise DNNLOWP ops

### DIFF
--- a/caffe2/quantization/server/elementwise_add_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/elementwise_add_dnnlowp_op_test.py
@@ -17,14 +17,17 @@ workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
 class DNNLowPAddOpTest(hu.HypothesisTestCase):
     @given(
         N=st.integers(32, 256),
+        is_empty=st.booleans(),
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
         in_place=st.sampled_from([(False, False), (True, False), (False, True)]),
         **hu.gcs_cpu_only
     )
     def test_dnnlowp_elementwise_add_int(
-        self, N, in_quantized, out_quantized, in_place, gc, dc
+        self, N, is_empty, in_quantized, out_quantized, in_place, gc, dc
     ):
+        if is_empty:
+            N = 0
         # FIXME: DNNLOWP Add doesn't support inplace operation and
         # dequantize_output=1 at the same time
         if in_place[0] or in_place[1]:
@@ -36,13 +39,15 @@ class DNNLowPAddOpTest(hu.HypothesisTestCase):
         max_ = min_ + 255
         A = np.round(np.random.rand(N) * (max_ - min_) + min_)
         A = A.astype(np.float32)
-        A[0] = min_
-        A[1] = max_
+        if N != 0:
+            A[0] = min_
+            A[1] = max_
 
         # B has scale 1/2, so exactly represented after quantization
         B = np.round(np.random.rand(N) * 255 / 2 - 64).astype(np.float32)
-        B[0] = -64
-        B[1] = 127.0 / 2
+        if N != 0:
+            B[0] = -64
+            B[1] = 127.0 / 2
 
         Output = collections.namedtuple("Output", ["Y", "op_type", "engine"])
         outputs = []

--- a/caffe2/quantization/server/elementwise_linear_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/elementwise_linear_dnnlowp_op_test.py
@@ -18,20 +18,24 @@ class DNNLowPElementwiseLinearOpTest(hu.HypothesisTestCase):
     @given(
         N=st.integers(32, 256),
         D=st.integers(32, 256),
+        empty_batch=st.booleans(),
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
         **hu.gcs_cpu_only
     )
     def test_dnnlowp_elementwise_linear_int(
-        self, N, D, in_quantized, out_quantized, gc, dc
+        self, N, D, empty_batch, in_quantized, out_quantized, gc, dc
     ):
+        if empty_batch:
+            N = 0
         # All inputs have scale 1, so exactly represented after quantization
         min_ = -100
         max_ = min_ + 255
         X = np.round(np.random.rand(N, D) * (max_ - min_) + min_)
         X = X.astype(np.float32)
-        X[0, 0] = min_
-        X[0, 1] = max_
+        if N != 0:
+            X[0, 0] = min_
+            X[0, 1] = max_
 
         a = np.round(np.random.rand(D) * 255 - 128).astype(np.float32)
         a[0] = -128

--- a/caffe2/quantization/server/elementwise_sum_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/elementwise_sum_dnnlowp_op_test.py
@@ -16,8 +16,15 @@ workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
 
 class DNNLowPOpSumOpTest(hu.HypothesisTestCase):
     # correctness test with no quantization error in inputs
-    @given(N=st.integers(32, 256), M=st.integers(1, 3), **hu.gcs_cpu_only)
-    def test_dnnlowp_elementwise_sum_int(self, N, M, gc, dc):
+    @given(
+        N=st.integers(32, 256),
+        M=st.integers(1, 3),
+        is_empty=st.booleans(),
+        **hu.gcs_cpu_only
+    )
+    def test_dnnlowp_elementwise_sum_int(self, N, M, is_empty, gc, dc):
+        if is_empty:
+            N = 0
         # All inputs have scale 1, so exactly represented after quantization
         inputs = M * [None]
         X_names = M * [None]
@@ -25,8 +32,9 @@ class DNNLowPOpSumOpTest(hu.HypothesisTestCase):
 
         for i in range(M):
             X = np.random.randint(-128, 127, N, np.int8).astype(np.float32)
-            X[0] = -128
-            X[-1] = 127
+            if N != 0:
+                X[0] = -128
+                X[-1] = 127
             inputs[i] = X
             X_names[i] = chr(ord("A") + i)
             X_q_names[i] = X_names[i] + "_q"


### PR DESCRIPTION
Summary: Add batch_size == 0 testings of element-wise DNNLOWP operators.

Test Plan: CI

Reviewed By: jianyuh

Differential Revision: D17595162

