### PR TITLE
batch size 0 support in Conv DNNLOWP ops

### DIFF
--- a/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_depthwise_dnnlowp_op_test.py
@@ -4,7 +4,7 @@ import collections
 
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
-from caffe2.python import core, dyndep, utils, workspace
+from caffe2.python import core, dyndep, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import (
     check_quantized_results_close,
@@ -25,7 +25,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         size=st.integers(10, 16),
         # depthwise 3x3 fast path only works for a multiple of 8
         group=st.sampled_from([8, 24, 32]),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         prepack_weight=st.booleans(),
         share_col_buffer=st.booleans(),
         preserve_activation_sparsity=st.booleans(),
@@ -108,8 +108,10 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                 net.Proto().op.extend([quantize])
 
             if do_prepack_weight:
+                X_min = 0 if X.size == 0 else X.min()
+                X_max = 0 if X.size == 0 else X.max()
                 x_q_param = dnnlowp_utils.choose_quantization_params(
-                    X.min(), X.max(), preserve_activation_sparsity
+                    X_min, X_max, preserve_activation_sparsity
                 )
                 inputs = ["W"]
                 if do_dequantize:
@@ -173,7 +175,7 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
         size=st.integers(5, 12),
         # depthwise 3x3x3 fast path only works for a multiple of 8
         group=st.sampled_from([8, 24, 32]),
-        batch_size=st.integers(1, 2),
+        batch_size=st.integers(0, 2),
         prepack_weight=st.booleans(),
         fuse_relu=st.booleans(),
         share_col_buffer=st.booleans(),
@@ -248,8 +250,10 @@ class DNNLowPOpConvDepthWiseTest(hu.HypothesisTestCase):
                 net.Proto().op.extend([quantize])
 
             if do_prepack_weight:
+                X_min = 0 if X.size == 0 else X.min()
+                X_max = 0 if X.size == 0 else X.max()
                 x_q_param = dnnlowp_utils.choose_quantization_params(
-                    X.min(), X.max(), preserve_activation_sparsity
+                    X_min, X_max, preserve_activation_sparsity
                 )
                 inputs = ["W"]
                 if do_dequantize:

--- a/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_acc16_op_test.py
@@ -7,10 +7,7 @@ import hypothesis.strategies as st
 import numpy as np
 from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
-from dnnlowp_test_utils import (
-    check_quantized_results_close,
-    run_conv_or_fc,
-)
+from dnnlowp_test_utils import check_quantized_results_close, run_conv_or_fc
 from hypothesis import assume, given
 
 
@@ -36,7 +33,7 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NCHW", "NHWC"]),
         weight_quantized=st.booleans(),
         share_col_buffer=st.booleans(),
@@ -85,7 +82,8 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
         X = np.round(X).astype(np.float32)
         X[..., 0] = X_min
-        X[0, 0, 0, 1] = X_max
+        if batch_size != 0:
+            X[0, 0, 0, 1] = X_max
 
         if preserve_weight_sparsity:
             W_min = -128
@@ -148,8 +146,10 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
                 net.Proto().op.extend([int8_given_tensor_fill])
 
                 # Bias
+                X_min = 0 if X.size == 0 else X.min()
+                X_max = 0 if X.size == 0 else X.max()
                 x_q_param = dnnlowp_utils.choose_quantization_params(
-                    X.min(), X.max(), preserve_activation_sparsity
+                    X_min, X_max, preserve_activation_sparsity
                 )
                 int8_bias_tensor_fill = dnnlowp_utils.create_int8_bias_tensor_fill(
                     b, "b_q", x_q_param, w_q_param
@@ -207,7 +207,7 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NHWC"]),
         weight_quantized=st.booleans(),
         prepack_weight=st.booleans(),
@@ -249,7 +249,8 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
         X = np.round(X).astype(np.float32)
         X[..., 0] = X_min
-        X[0, 0, 0, 1] = X_max
+        if batch_size != 0:
+            X[0, 0, 0, 1] = X_max
 
         if preserve_weight_sparsity:
             W_min = -128
@@ -304,8 +305,10 @@ class DNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
                 )
                 net.Proto().op.extend([quantize])
 
+            X_min = 0 if X.size == 0 else X.min()
+            X_max = 0 if X.size == 0 else X.max()
             x_q_param = dnnlowp_utils.choose_quantization_params(
-                X.min(), X.max(), preserve_activation_sparsity
+                X_min, X_max, preserve_activation_sparsity
             )
             if do_quantize_weight:
                 int8_given_tensor_fill, w_q_param = dnnlowp_utils.create_int8_given_tensor_fill(

--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -255,11 +255,13 @@ void ConvDNNLowPOp<T, ReluFused>::QuantizeBias_() {
             this->template Input<int8::Int8TensorCPU>(BIAS).scale;
         bias_qparams.zero_point =
             this->template Input<int8::Int8TensorCPU>(BIAS).zero_point;
-        CAFFE_ENFORCE_LE(
-            std::abs(
-                bias_qparams.scale -
-                in_qparams_[INPUT].scale * FilterQuantizationParams(0).scale),
-            1e-4);
+        if (InputTensorCPU_(INPUT).dim32(0) > 0) {
+          CAFFE_ENFORCE_LE(
+              std::abs(
+                  bias_qparams.scale -
+                  in_qparams_[INPUT].scale * FilterQuantizationParams(0).scale),
+              1e-4);
+        }
         CAFFE_ENFORCE_EQ(bias_qparams.zero_point, 0);
         b_quantized_data_ = bias.template data<int32_t>();
       } else {

--- a/caffe2/quantization/server/conv_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_dnnlowp_op_test.py
@@ -4,7 +4,7 @@ import collections
 
 import caffe2.python.hypothesis_test_util as hu
 import hypothesis.strategies as st
-from caffe2.python import core, dyndep, utils, workspace
+from caffe2.python import core, dyndep, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
 from dnnlowp_test_utils import (
     check_quantized_results_close,
@@ -30,7 +30,7 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NCHW", "NHWC"]),
         weight_quantized=st.booleans(),
         prepack_weight=st.booleans(),
@@ -113,8 +113,10 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
                 )
                 net.Proto().op.extend([quantize])
 
+            X_min = 0 if X.size == 0 else X.min()
+            X_max = 0 if X.size == 0 else X.max()
             x_q_param = dnnlowp_utils.choose_quantization_params(
-                X.min(), X.max(), preserve_activation_sparsity
+                X_min, X_max, preserve_activation_sparsity
             )
             if do_quantize_weight:
                 int8_given_tensor_fill, w_q_param = dnnlowp_utils.create_int8_given_tensor_fill(
@@ -197,7 +199,7 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NCHW", "NHWC"]),
         share_col_buffer=st.booleans(),
         **hu.gcs_cpu_only
@@ -357,7 +359,9 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
                 )
                 net.Proto().op.extend([quantize])
 
-            x_q_param = dnnlowp_utils.choose_quantization_params(X.min(), X.max())
+            X_min = 0 if X.size == 0 else X.min()
+            X_max = 0 if X.size == 0 else X.max()
+            x_q_param = dnnlowp_utils.choose_quantization_params(X_min, X_max)
             if do_quantize_weight:
                 int8_given_tensor_fill, w_q_param = dnnlowp_utils.create_int8_given_tensor_fill(
                     W, "W_q"
@@ -434,7 +438,7 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
         group=st.integers(1, 2),
         input_channels_per_group=st.sampled_from([2, 3]),
         output_channels_per_group=st.sampled_from([2, 3]),
-        batch_size=st.integers(1, 2),
+        batch_size=st.integers(0, 2),
         order=st.sampled_from(["NCHW", "NHWC"]),
         prepack_weight=st.booleans(),
         **hu.gcs_cpu_only
@@ -481,7 +485,7 @@ class DNNLowPOpConvTest(hu.HypothesisTestCase):
         group=st.integers(1, 2),
         input_channels_per_group=st.sampled_from([2, 3]),
         output_channels_per_group=st.sampled_from([2, 3]),
-        batch_size=st.integers(1, 2),
+        batch_size=st.integers(0, 2),
         order=st.sampled_from(["NCHW", "NHWC"]),
         prepack_weight=st.booleans(),
         **hu.gcs_cpu_only

--- a/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
+++ b/caffe2/quantization/server/conv_groupwise_dnnlowp_acc16_op_test.py
@@ -7,10 +7,7 @@ import hypothesis.strategies as st
 import numpy as np
 from caffe2.python import core, dyndep, utils, workspace
 from caffe2.quantization.server import utils as dnnlowp_utils
-from dnnlowp_test_utils import (
-    check_quantized_results_close,
-    run_conv_or_fc,
-)
+from dnnlowp_test_utils import check_quantized_results_close, run_conv_or_fc
 from hypothesis import assume, given
 
 
@@ -36,7 +33,7 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NCHW", "NHWC"]),
         share_col_buffer=st.booleans(),
         preserve_activation_sparsity=st.booleans(),
@@ -83,7 +80,8 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
         X = np.round(X).astype(np.float32)
         X[..., 0] = X_min
-        X[0, 0, 0, 1] = X_max
+        if batch_size != 0:
+            X[0, 0, 0, 1] = X_max
 
         if preserve_weight_sparsity:
             W_min = -128
@@ -187,7 +185,7 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NHWC"]),
         prepack_weight=st.booleans(),
         nbits_in_non_outlier=st.sampled_from((0, 1, 6, 8)),
@@ -223,7 +221,8 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
         X = np.random.rand(batch_size, size, size, input_channels) * 4 + X_min
         X = np.round(X).astype(np.float32)
         X[..., 0] = X_min
-        X[0, 0, 0, 1] = X_max
+        if batch_size != 0:
+            X[0, 0, 0, 1] = X_max
 
         W_min = -100
         W_max = W_min + 255
@@ -271,7 +270,9 @@ class GroupWiseDNNLowPOpConvAcc16OpTest(hu.HypothesisTestCase):
                 net.Proto().op.extend([quantize])
 
             if do_prepack_weight:
-                x_q_param = dnnlowp_utils.choose_quantization_params(X.min(), X.max())
+                X_min = 0 if X.size == 0 else X.min()
+                X_max = 0 if X.size == 0 else X.max()
+                x_q_param = dnnlowp_utils.choose_quantization_params(X_min, X_max)
                 inputs = ["W"]
                 if do_dequantize:
                     inputs += ["b"]

--- a/caffe2/quantization/server/conv_groupwise_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/conv_groupwise_dnnlowp_op_test.py
@@ -30,7 +30,7 @@ class GroupWiseDNNLowPOpConvTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NCHW", "NHWC"]),
         prepack_weight=st.booleans(),
         preserve_activation_sparsity=st.booleans(),
@@ -104,9 +104,9 @@ class GroupWiseDNNLowPOpConvTest(hu.HypothesisTestCase):
                 net.Proto().op.extend([quantize])
 
             if do_prepack_weight:
-                x_q_param = hardcode_scale_zp.choose_quantization_params(
-                    X.min(), X.max()
-                )
+                X_min = 0 if X.size == 0 else X.min()
+                X_max = 0 if X.size == 0 else X.max()
+                x_q_param = hardcode_scale_zp.choose_quantization_params(X_min, X_max)
                 inputs = ["W"]
                 if do_dequantize:
                     inputs += ["b"]
@@ -177,7 +177,7 @@ class GroupWiseDNNLowPOpConvTest(hu.HypothesisTestCase):
         group=st.integers(1, 4),
         input_channels_per_group=st.sampled_from([2, 3, 4, 5, 8, 16, 32]),
         output_channels_per_group=st.integers(2, 16),
-        batch_size=st.integers(1, 3),
+        batch_size=st.integers(0, 3),
         order=st.sampled_from(["NCHW", "NHWC"]),
         **hu.gcs_cpu_only
     )

--- a/caffe2/quantization/server/dnnlowp_test_utils.py
+++ b/caffe2/quantization/server/dnnlowp_test_utils.py
@@ -221,7 +221,8 @@ def generate_convnd_inputs(
     )
     X = X.astype(np.float32)
     if (
-        depthwise_convolution
+        batch_size != 0
+        and depthwise_convolution
         and groupwise_quantization
         and not preserve_activation_sparsity
     ):
@@ -273,7 +274,8 @@ def generate_convnd_inputs(
         # input channel 0 is all X_min to avoid overflow from vpmaddubsw when
         # multiplied with W_min and W_max
         X[..., 0] = X_min
-        X[(0,) * (X.ndim - 1) + (1,)] = X_max
+        if batch_size != 0:
+            X[(0,) * (X.ndim - 1) + (1,)] = X_max
 
     if preserve_weight_sparsity:
         W_min = -128


### PR DESCRIPTION
Summary: Add batch_size == 0 handlings in int8 Conv operators. Added associated test cases.

Test Plan: CI

Reviewed By: jianyuh

Differential Revision: D17594809

