### PR TITLE
batch size 0 support in FC DNNLOWP operators

### DIFF
--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.cc
@@ -785,11 +785,14 @@ bool FullyConnectedDNNLowPOp<T, ReluFused>::GetQuantizationParameters_() {
         bias_qparams.scale = this->template Input<int8::Int8TensorCPU>(2).scale;
         bias_qparams.zero_point =
             this->template Input<int8::Int8TensorCPU>(2).zero_point;
-        CAFFE_ENFORCE_LE(
-            std::abs(
-                bias_qparams.scale -
-                in_qparams_[0].scale * filter_qparams_[0].scale),
-            1e-4);
+        const auto M = X.size_to_dim(canonical_axis);
+        if (M > 0) {
+          CAFFE_ENFORCE_LE(
+              std::abs(
+                  bias_qparams.scale -
+                  in_qparams_[0].scale * filter_qparams_[0].scale),
+              1e-4);
+        }
         CAFFE_ENFORCE_EQ(bias_qparams.zero_point, 0);
         b_quantized_data_ = bias.template data<int32_t>();
         if (dequantize_output_) {

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op_test.py
@@ -24,7 +24,7 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
     @given(
         input_channels=st.sampled_from([3, 4, 5, 8, 16, 32]),
         output_channels=st.integers(2, 16),
-        batch_size=st.integers(1, 16),
+        batch_size=st.integers(0, 16),
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
         weight_quantized=st.booleans(),
@@ -59,7 +59,8 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         # input channels 0 and 1 are all X_min to avoid overflow from vpmaddubsw
         # when multiplied with W_min and W_max
         X[:, 0] = X_min
-        X[0, 1] = X_max
+        if batch_size != 0:
+            X[0, 1] = X_max
 
         if preserve_weight_sparsity:
             W_min = -128
@@ -93,13 +94,9 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         Output = collections.namedtuple("Output", ["Y", "op_type", "engine"])
         outputs = []
 
-        op_engine_list = [
-            ("FC", ""),
-        ]
+        op_engine_list = [("FC", "")]
         if fuse_relu:
-            op_engine_list += [
-                ("Int8FCRelu", "DNNLOWP"),
-            ]
+            op_engine_list += [("Int8FCRelu", "DNNLOWP")]
         else:
             op_engine_list += [
                 ("FC", "DNNLOWP"),
@@ -129,8 +126,10 @@ class DNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                 )
                 net.Proto().op.extend([quantize])
 
+            X_min = 0 if X.size == 0 else X.min()
+            X_max = 0 if X.size == 0 else X.max()
             x_q_param = dnnlowp_utils.choose_quantization_params(
-                X.min(), X.max(), preserve_activation_sparsity
+                X_min, X_max, preserve_activation_sparsity
             )
             if do_quantize_weight:
                 int8_given_tensor_fill, w_q_param = dnnlowp_utils.create_int8_given_tensor_fill(

--- a/caffe2/quantization/server/fully_connected_fp16_test.py
+++ b/caffe2/quantization/server/fully_connected_fp16_test.py
@@ -15,7 +15,7 @@ workspace.GlobalInit(["caffe2", "--caffe2_omp_num_threads=11"])
 
 def mse(x, xh):
     d = (x - xh).reshape(-1)
-    return np.sqrt(np.matmul(d, d.transpose())) / len(d)
+    return 0 if len(d) == 0 else np.sqrt(np.matmul(d, d.transpose())) / len(d)
 
 
 class FullyConnectedFP16Test(hu.HypothesisTestCase):
@@ -23,9 +23,12 @@ class FullyConnectedFP16Test(hu.HypothesisTestCase):
         input_channels=st.integers(128, 256),
         output_channels=st.integers(128, 256),
         batch_size=st.integers(128, 256),
+        empty_batch=st.booleans(),
         **hu.gcs_cpu_only
     )
-    def test_fully_connected(self, input_channels, output_channels, batch_size, gc, dc):
+    def test_fully_connected(self, input_channels, output_channels, batch_size, empty_batch, gc, dc):
+        if empty_batch:
+            batch_size = 0
         W = np.random.randn(output_channels, input_channels).astype(np.float32)
         X = np.random.randn(batch_size, input_channels).astype(np.float32)
         b = np.random.randn(output_channels).astype(np.float32)

--- a/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/fully_connected_rowwise_dnnlowp_op_test.py
@@ -24,7 +24,7 @@ class RowWiseDNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
     @given(
         input_channels=st.sampled_from([3, 4, 5, 8, 16, 32]),
         output_channels=st.integers(2, 16),
-        batch_size=st.integers(1, 16),
+        batch_size=st.integers(0, 16),
         in_quantized=st.booleans(),
         out_quantized=st.booleans(),
         prepack_weight=st.booleans(),
@@ -41,9 +41,6 @@ class RowWiseDNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         gc,
         dc,
     ):
-        print("@given M ", batch_size, " K ", input_channels, " N ", output_channels)
-        print("@given in_quantized ", in_quantized, " out_quantized ", out_quantized)
-
         # X has scale 1, so exactly represented after quantization
         X_min = -77
         X_max = X_min + 255
@@ -54,7 +51,8 @@ class RowWiseDNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
         # input channels 0 and 1 are all X_min to avoid overflow from vpmaddubsw
         # when multiplied with W_min and W_max
         X[:, 0:2] = X_min
-        X[0, 2] = X_max
+        if batch_size != 0:
+            X[0, 2] = X_max
 
         # Each row of W has scale 1 but with different offset, so row-wise
         # quantization shouldn't have any input quantization error.
@@ -110,7 +108,9 @@ class RowWiseDNNLowPFullyConnectedOpTest(hu.HypothesisTestCase):
                 )
                 net.Proto().op.extend([quantize])
 
-            x_q_param = dnnlowp_utils.choose_quantization_params(X.min(), X.max())
+            X_min = 0 if X.size == 0 else X.min()
+            X_max = 0 if X.size == 0 else X.max()
+            x_q_param = dnnlowp_utils.choose_quantization_params(X_min, X_max)
 
             if do_prepack_weight:
                 inputs = ["W"]


### PR DESCRIPTION
Summary: Add batch_size == 0 handlings in int8 FC operators. Added associated test cases.

Test Plan: CI

Reviewed By: jianyuh

Differential Revision: D17595385

