### PR TITLE
Choose num_threads in parallel_for based on GRAIN_SIZE

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -25,11 +25,15 @@ inline void parallel_for(
 #ifdef _OPENMP
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-#pragma omp parallel if (!omp_in_parallel() && ((end - begin) >= grain_size))
+  // choose number of tasks based on grain size and number of threads
+  int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
+  const int64_t num_iter = end - begin;
+  num_threads = std::min(num_threads, divup(num_iter, grain_size));
+  const int64_t chunk_size = divup(num_iter, num_threads);
+
+#pragma omp parallel num_threads(num_threads)
   {
-    int64_t num_threads = omp_get_num_threads();
     int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = divup((end - begin), num_threads);
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
       try {

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -28,7 +28,9 @@ inline void parallel_for(
   // choose number of tasks based on grain size and number of threads
   int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
   const int64_t num_iter = end - begin;
-  num_threads = std::min(num_threads, divup(num_iter, grain_size));
+  if (grain_size > 0) {
+    num_threads = std::min(num_threads, divup(num_iter, grain_size));
+  }
   const int64_t chunk_size = divup(num_iter, num_threads);
 
 #pragma omp parallel num_threads(num_threads)


### PR DESCRIPTION
Fixes #24080 

The OpenMP implementation of `parallel_for` now chooses the number of cores to use on a sliding scale between 1 and `OMP_NUM_THREADS`. This prevents wasteful core usage on many-core systems such as in #24080.

This is also consistent with the comment on GRAIN_SIZE:
https://github.com/pytorch/pytorch/blob/e327df396564f937d17b5f28e2529229260c65bf/aten/src/ATen/Parallel.h#L10-L11

