### PR TITLE
use new depthwise conv fbgemm interface

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -1175,6 +1175,7 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_quantized_data_,
             ReluFused,
+            nullptr, /*act_times_w_scale*/
             dnnlowp_get_thread_num(),
             dnnlowp_get_num_threads());
       } else {
@@ -1200,6 +1201,7 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_quantized_data_,
             ReluFused,
+            1.0f, /*act_times_w_scale*/
             dnnlowp_get_thread_num(),
             dnnlowp_get_num_threads());
       }
@@ -1217,7 +1219,7 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
 #endif
     {
       if (quantize_groupwise_) {
-        depthwise_3x3_per_channel_quantization_pad_1(
+        depthwise_2d_per_channel_quantization_same_pad(
             N,
             H,
             W,
@@ -1237,10 +1239,11 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_quantized_data_,
             ReluFused,
+            nullptr, /*act_times_w_scale*/
             dnnlowp_get_thread_num(),
             dnnlowp_get_num_threads());
       } else {
-        depthwise_3x3_pad_1(
+        depthwise_2d_same_pad(
             N,
             H,
             W,
@@ -1260,6 +1263,7 @@ void ConvDNNLowPOp<T, ReluFused>::ConvNHWCCore_(
             column_offsets_->empty() ? nullptr : column_offsets_->data(),
             b_quantized_data_,
             ReluFused,
+            1.0f, /*act_times_w_scale*/
             dnnlowp_get_thread_num(),
             dnnlowp_get_num_threads());
       }


### PR DESCRIPTION
Summary: This diff removes call sites using the old depth-wise conv fbgemm interface in Caffe2.

Test Plan: CI

Reviewed By: dskhudia

Differential Revision: D17515368

