### PR TITLE
Expose PiecewiseLinearTransform to PyTorch

### DIFF
--- a/caffe2/operators/piecewise_linear_transform_op.cc
+++ b/caffe2/operators/piecewise_linear_transform_op.cc
@@ -82,3 +82,19 @@ bound.
 
 SHOULD_NOT_DO_GRADIENT(PiecewiseLinearTransform);
 } // namespace caffe2
+
+using PiecewiseLinearTransformOpFloatCPU =
+    caffe2::PiecewiseLinearTransformOp<float, caffe2::CPUContext>;
+
+// clang-format off
+C10_EXPORT_CAFFE2_OP_TO_C10_CPU(
+    PiecewiseLinearTransform,
+    "_caffe2::PiecewiseLinearTransform("
+      "Tensor predictions, "
+      "float[] bounds, "
+      "float[] slopes, "
+      "float[] intercepts, "
+      "bool binary"
+    ") -> (Tensor output_0)",
+    PiecewiseLinearTransformOpFloatCPU);
+// clang-format on

--- a/caffe2/operators/piecewise_linear_transform_op.cu
+++ b/caffe2/operators/piecewise_linear_transform_op.cu
@@ -281,3 +281,10 @@ REGISTER_CUDA_OPERATOR(
     PiecewiseLinearTransformOp<float, CUDAContext>);
 
 } // namespace caffe2
+
+using PiecewiseLinearTransformOpFloatCUDA =
+    caffe2::PiecewiseLinearTransformOp<float, caffe2::CUDAContext>;
+
+C10_EXPORT_CAFFE2_OP_TO_C10_CUDA(
+    PiecewiseLinearTransform,
+    PiecewiseLinearTransformOpFloatCUDA);

--- a/caffe2/operators/piecewise_linear_transform_op.h
+++ b/caffe2/operators/piecewise_linear_transform_op.h
@@ -2,7 +2,10 @@
 #define CAFFE2_OPERATORS_PIECEWISE_LINEAR_TRANSFORM_OP_H_
 
 #include "caffe2/core/context.h"
+#include "caffe2/core/export_caffe2_op_to_c10.h"
 #include "caffe2/core/operator.h"
+
+C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(PiecewiseLinearTransform);
 
 namespace caffe2 {
 


### PR DESCRIPTION
Summary: Followed https://our.intern.facebook.com/intern/wiki/Pytorch/PyTorchDev/SpecialTopics/Exposing_Caffe2_Operators/ to expose PiecewiseLinearTransform operator to PyTorch for converting OC heads to PT

Test Plan: buck test mode/dev caffe2/caffe2/python/operator_test:torch_integration_test

Differential Revision: D17585637

