### PR TITLE
Include `iteration_` in SGD optimizer serialization

### DIFF
--- a/torch/csrc/api/include/torch/optim/serialize.h
+++ b/torch/csrc/api/include/torch/optim/serialize.h
@@ -16,6 +16,18 @@ namespace optim {
 // inside a template where the archive type is a template type and can thus be
 // passed such that the appropriate overload is selected.
 
+/// Utility function to save a value of `int64_t` type.
+void serialize(
+    serialize::OutputArchive& archive,
+    const std::string& key,
+    const int64_t& value);
+
+/// Utility function to load a value of `int64_t` type.
+void serialize(
+    serialize::InputArchive& archive,
+    const std::string& key,
+    int64_t& value);
+
 /// Utility function to save a vector of step buffers.
 void serialize(
     serialize::OutputArchive& archive,

--- a/torch/csrc/api/include/torch/optim/sgd.h
+++ b/torch/csrc/api/include/torch/optim/sgd.h
@@ -39,6 +39,7 @@ class TORCH_API SGD : public Optimizer {
 
   void save(serialize::OutputArchive& archive) const override;
   void load(serialize::InputArchive& archive) override;
+  int64_t iteration() const;
 
   SGDOptions options;
 
@@ -48,7 +49,7 @@ class TORCH_API SGD : public Optimizer {
   SGD() : options(0) {}
 
   /// Counts how often `step()` is called, for dampening.
-  size_t iteration_{0};
+  int64_t iteration_{0};
 };
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/include/torch/serialize/input-archive.h
+++ b/torch/csrc/api/include/torch/serialize/input-archive.h
@@ -45,6 +45,9 @@ class TORCH_API InputArchive final {
 
   ~InputArchive() = default;
 
+  /// Reads an `IValue` associated with a given `key`.
+  void read(const std::string& key, c10::IValue& ivalue);
+
   /// Reads a `tensor` associated with a given `key`. If there is no `tensor`
   /// associated with the `key`, this returns false, otherwise it returns true.
   /// If the tensor is expected to be a buffer (not differentiable), `is_buffer`

--- a/torch/csrc/api/include/torch/serialize/output-archive.h
+++ b/torch/csrc/api/include/torch/serialize/output-archive.h
@@ -40,6 +40,9 @@ class TORCH_API OutputArchive final {
     return cu_;
   }
 
+  /// Writes an `IValue` to the `OutputArchive`.
+  void write(const std::string& key, const c10::IValue& ivalue);
+
   /// Writes a `(key, tensor)` pair to the `OutputArchive`, and marks it as
   /// being or not being a buffer (non-differentiable tensor).
   void write(

--- a/torch/csrc/api/src/optim/serialize.cpp
+++ b/torch/csrc/api/src/optim/serialize.cpp
@@ -14,6 +14,22 @@ namespace optim {
 void serialize(
     serialize::OutputArchive& archive,
     const std::string& key,
+    const int64_t& value) {
+  archive.write(key, IValue(value));
+}
+
+void serialize(
+    serialize::InputArchive& archive,
+    const std::string& key,
+    int64_t& value) {
+  IValue ivalue;
+  archive.read(key, ivalue);
+  value = ivalue.toInt();
+}
+
+void serialize(
+    serialize::OutputArchive& archive,
+    const std::string& key,
     const std::vector<int64_t>& steps) {
   std::vector<torch::Tensor> tensors;
   tensors.reserve(steps.size());

--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -51,10 +51,16 @@ void SGD::step() {
 
 void SGD::save(serialize::OutputArchive& archive) const {
   optim::serialize(archive, "momentum_buffers", momentum_buffers);
+  optim::serialize(archive, "iteration_", iteration_);
 }
 
 void SGD::load(serialize::InputArchive& archive) {
   optim::serialize(archive, "momentum_buffers", momentum_buffers);
+  optim::serialize(archive, "iteration_", iteration_);
+}
+
+int64_t SGD::iteration() const {
+  return iteration_;
 }
 } // namespace optim
 } // namespace torch

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -18,6 +18,18 @@ namespace serialize {
 
 InputArchive::InputArchive() {}
 
+void InputArchive::read(const std::string& key, c10::IValue& ivalue) {
+  if (auto named_attr = module_.find_attribute(key)) {
+    ivalue = named_attr->value();
+  } else {
+    TORCH_CHECK(
+      false,
+      "No such serialized IValue '",
+      key,
+      "'");
+  }
+}
+
 bool InputArchive::try_read(
     const std::string& key,
     Tensor& tensor,

--- a/torch/csrc/api/src/serialize/output-archive.cpp
+++ b/torch/csrc/api/src/serialize/output-archive.cpp
@@ -18,6 +18,10 @@ OutputArchive::OutputArchive(std::shared_ptr<jit::script::CompilationUnit> cu)
     : cu_(std::move(cu)),
       module_("__torch__.Module", cu_, /*shouldMangle=*/true) {}
 
+void OutputArchive::write(const std::string& key, const c10::IValue& ivalue) {
+  module_.register_attribute(key, ivalue.type(), ivalue);
+}
+
 void OutputArchive::write(
     const std::string& key,
     const Tensor& tensor,


### PR DESCRIPTION
This PR fixes https://github.com/pytorch/pytorch/issues/24192 by including the private field `iteration_` in SGD optimizer serialization. Under the hood, `iteration_` is serialized into an `IValue`, then stored in a JIT module as an attribute.