### PR TITLE
Get rid of -u (expansion of undefined variable) setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,7 +783,9 @@ jobs:
         name: Build
         no_output_timeout: "1h"
         command: |
-          set -eux -o pipefail
+          # Do not set -u here; there is some problem with CircleCI
+          # variable expansion with PROMPT_COMMAND
+          set -ex -o pipefail
           script="/Users/distiller/project/pytorch/.circleci/scripts/binary_macos_build.sh"
           cat "$script"
           source "$script"
@@ -792,7 +794,9 @@ jobs:
         name: Test
         no_output_timeout: "1h"
         command: |
-          set -eux -o pipefail
+          # Do not set -u here; there is some problem with CircleCI
+          # variable expansion with PROMPT_COMMAND
+          set -ex -o pipefail
           script="/Users/distiller/project/pytorch/.circleci/scripts/binary_macos_test.sh"
           cat "$script"
           source "$script"
@@ -864,6 +868,7 @@ jobs:
           script="/Users/distiller/project/.circleci/scripts/binary_ios_upload.sh"
           cat "$script"
           source "$script"
+
   setup:
     docker:
       - image: circleci/python:3.7.3

--- a/.circleci/verbatim-sources/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/binary-job-specs.yml
@@ -174,7 +174,9 @@
         name: Build
         no_output_timeout: "1h"
         command: |
-          set -eux -o pipefail
+          # Do not set -u here; there is some problem with CircleCI
+          # variable expansion with PROMPT_COMMAND
+          set -ex -o pipefail
           script="/Users/distiller/project/pytorch/.circleci/scripts/binary_macos_build.sh"
           cat "$script"
           source "$script"
@@ -183,7 +185,9 @@
         name: Test
         no_output_timeout: "1h"
         command: |
-          set -eux -o pipefail
+          # Do not set -u here; there is some problem with CircleCI
+          # variable expansion with PROMPT_COMMAND
+          set -ex -o pipefail
           script="/Users/distiller/project/pytorch/.circleci/scripts/binary_macos_test.sh"
           cat "$script"
           source "$script"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26907 Get rid of -u (expansion of undefined variable) setting**

Somehow CircleCI broke this on update to their OS X workers;
the error looks like

    /bin/bash: line 1: PROMPT_COMMAND: unbound variable

I'm not sure if I've killed all the occurrences that are necessary,
let's see!

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17607486](https://our.internmc.facebook.com/intern/diff/D17607486)