### PR TITLE
Set quantized engine backend for mobile in speed_benchmark_torch

### DIFF
--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -82,10 +82,15 @@ int main(int argc, char** argv) {
     }
   }
 
+  auto qengines = at::globalContext().supportedQEngines();
+  if (std::find(qengines.begin(), qengines.end(), at::QEngine::QNNPACK) != qengines.end()) {
+    at::globalContext().setQEngine(at::QEngine::QNNPACK);
+  }
   torch::autograd::AutoGradMode guard(false);
   auto module = torch::jit::load(FLAGS_model);
 
   at::AutoNonVariableTypeMode non_var_type_mode(true);
+  module.eval();
   if (FLAGS_print_output) {
     std::cout << module.forward(inputs) << std::endl;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26911 Set quantized engine backend for mobile**

Summary:
Check if QNNPACK is present as a backend (should always be present on mobile).
If it is present then set the backend to QNNPACK

Test Plan:
Test on mobile
./speed_benchmark_torch --model mobilenet_quantized_scripted.pt  --input_dims="1,3,224,224" --input_type=float --warmup=5 --iter 20 --print_output True

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D17613908](https://our.internmc.facebook.com/intern/diff/D17613908)