### PR TITLE
[JIT] fix range for non-int inputs and pow implementation

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -5963,7 +5963,7 @@ a")
         checkMath("isinf", 1, ret_type="bool")
         checkMath("ldexp", 2, is_float=False, ret_type="float", args_type="(float, int)",
                   vals=[(i, j) for i in float_vals for j in range(-10, 10)])
-        checkMath("pow", 2, is_float=False, ret_type="int")
+        checkMath("pow", 2, is_float=False, ret_type="float")
         checkMath("pow", 2, is_float=True, ret_type="float")
         if not PY2:
             checkMathWrap("floor", ret_type="int")
@@ -10736,7 +10736,7 @@ a")
                 for _ in range():
                     x += 1
                 return x
-        with self.assertRaisesRegex(RuntimeError, r'found float for argument'):
+        with self.assertRaisesRegex(RuntimeError, r'found float'):
             @torch.jit.script
             def range_non_float():
                 for i in range(.5):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4315,6 +4315,13 @@ a")
             # type: (int, float) -> float
             return a ** b
 
+        def func4():
+            # type: () -> float
+            return 2 ** -2
+
+        def func5(x, y):
+            return x.item() ** y.item()
+
         a = torch.rand(1, requires_grad=True)
         b = torch.rand(1, requires_grad=True)
         c = torch.rand(1, requires_grad=True)
@@ -4322,6 +4329,15 @@ a")
         self.checkScript(func, (a, b), optimize=True)
         self.checkScript(func2, (a, b, c, d), optimize=True)
         self.checkScript(func3, (4, -0.5), optimize=True)
+        self.checkScript(func4, ())
+
+        inputs = [torch.tensor(2), torch.tensor(-2), torch.tensor(.5), torch.tensor(.2)]
+        for x in inputs:
+            for y in inputs:
+                if x < 0:
+                    continue
+                else:
+                    self.checkScript(func5, (x, y))
 
     @unittest.skipIf(not RUN_CUDA, "device tests require CUDA")
     def test_pow_scalar_backward_cuda(self):
@@ -10713,13 +10729,19 @@ a")
         with self.assertRaisesRegex(RuntimeError, "must not be zero"):
             fn()
 
-    def test_for_in_range_no_arg(self):
+    def test_range_args(self):
         with self.assertRaisesRegex(RuntimeError, r'range expected at least 1 arguments, got 0'):
             @torch.jit.script
             def range_no_arg(x):
                 for _ in range():
                     x += 1
                 return x
+        with self.assertRaisesRegex(RuntimeError, r'found float for argument'):
+            @torch.jit.script
+            def range_non_float():
+                for i in range(.5):
+                    print(i)
+
 
     def test_for_in_enumerate(self):
         def fn(x):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -19694,7 +19694,7 @@ class TestClassType(JitTestCase):
 
             def __pow__(self, other):
                 # type: (int) -> int
-                return self.x ** other
+                return int(self.x ** other)
 
             def __truediv__(self, other):
                 # type: (int) -> float

--- a/torch/csrc/jit/register_prim_ops.cpp
+++ b/torch/csrc/jit/register_prim_ops.cpp
@@ -2529,9 +2529,9 @@ RegisterOperators reg2({
     // https://github.com/pytorch/pytorch/issues/24856
     // behavior have been fixed
     Operator(
-      "aten::append(str[](a!) self, str? el) -> str[](a!)",
-      listAppend<std::string>,
-      aliasAnalysisFromSchema()),
+        "aten::append(str[](a!) self, str? el) -> str[](a!)",
+        listAppend<std::string>,
+        aliasAnalysisFromSchema()),
 
 #undef CREATE_IMMUTABLE_LIST_OPS
 #undef CREATE_MUTABLE_LIST_OPS
@@ -2755,7 +2755,23 @@ RegisterOperators reg2({
 
     DEFINE_BINARY_OP(aten::add, a + b),
     DEFINE_BINARY_OP(aten::sub, a - b),
-    DEFINE_BINARY_OP(aten::mul, a * b),
+    DEFINE_BINARY_OP(aten::mul, a* b),
+
+    // int ** int produces a float, because negative exponents produce float
+    // results
+    DEFINE_GENERIC_OP(
+        aten::pow,
+        static_cast<double>(pow(a, b)),
+        static_cast<double>(pow(a, b)),
+        float,
+        float),
+    DEFINE_INT_FLOAT_OP(aten::pow, pow(a, b), float),
+    DEFINE_SCALAR_BINARY_OP(
+        aten::pow,
+        static_cast<double>(pow(a, b)),
+        static_cast<double>(pow(a, b)),
+        float),
+
     DEFINE_BINARY_OP(aten::pow, pow(a, b)),
     // min and max are in prim:: because there is a difference between
     // the python builtin 'min' and 'torch.min'
@@ -2960,7 +2976,7 @@ RegisterOperators reg2({
     DEFINE_COMPARISON_OP(aten::gt, a > b),
     DEFINE_COMPARISON_OP(aten::le, a <= b),
     DEFINE_COMPARISON_OP(aten::ge, a >= b),
-    DEFINE_BOOL_OP(aten::__and__, a && b),
+    DEFINE_BOOL_OP(aten::__and__, a&& b),
     DEFINE_BOOL_OP(aten::__or__, a || b),
     DEFINE_BOOL_OP(aten::__xor__, a != b),
 

--- a/torch/csrc/jit/script/sugared_value.cpp
+++ b/torch/csrc/jit/script/sugared_value.cpp
@@ -339,6 +339,15 @@ RangeValue::RangeValue(
     const SourceRange& loc,
     Function& m,
     std::vector<Value*> inputs) {
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    auto typ = inputs[i]->type();
+    if (!typ->cast<IntType>()) {
+      throw ErrorReport(loc)
+          << "all inputs of range must be ints, found " << typ->python_str()
+          << " in argument " << c10::guts::to_string(i);
+    }
+  }
+
   Graph& g = *m.graph();
   if (inputs.size() == 0) {
     throw ErrorReport(loc) << "range expected at least 1 arguments, got 0";


### PR DESCRIPTION
Previously we did not throw if an input to `range` was a non-integer.

We also typed the result from `int ** int` as an integer but returned a float value. The return type should be a float, because if the exponent is negative `int ** int` returns a float.

Batching these two PRs together because it is easier to land and we're almost at the branch cut. 