### PR TITLE
Choose num_threads in parallel_for based on GRAIN_SIZE

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -25,11 +25,15 @@ inline void parallel_for(
 #ifdef _OPENMP
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-#pragma omp parallel if (!omp_in_parallel() && ((end - begin) >= grain_size))
+  // choose number of tasks based on grain size and number of threads
+  int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
+  const int64_t num_iter = end - begin;
+  num_threads = std::min(num_threads, divup(num_iter, grain_size));
+  const int64_t chunk_size = divup(num_iter, num_threads);
+
+#pragma omp parallel num_threads(num_threads)
   {
-    int64_t num_threads = omp_get_num_threads();
     int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = divup((end - begin), num_threads);
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
       try {

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -33,7 +33,7 @@ inline void parallel_for(
   }
   const int64_t chunk_size = divup(num_iter, num_threads);
 
-#pragma omp parallel num_threads(num_threads)
+#pragma omp parallel if(num_threads > 1) num_threads(num_threads)
   {
     int64_t tid = omp_get_thread_num();
     int64_t begin_tid = begin + tid * chunk_size;

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -27,15 +27,15 @@ inline void parallel_for(
   std::exception_ptr eptr;
   // choose number of tasks based on grain size and number of threads
   int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
-  const int64_t num_iter = end - begin;
   if (grain_size > 0) {
-    num_threads = std::min(num_threads, divup(num_iter, grain_size));
+    num_threads = std::min(num_threads, divup((end - begin), grain_size));
   }
-  const int64_t chunk_size = divup(num_iter, num_threads);
 
-#pragma omp parallel if(num_threads > 1) num_threads(num_threads)
+#pragma omp parallel num_threads(num_threads)
   {
+    int64_t num_threads = omp_get_num_threads();
     int64_t tid = omp_get_thread_num();
+    int64_t chunk_size = divup((end - begin), num_threads);
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
       try {

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -28,7 +28,9 @@ inline void parallel_for(
   // choose number of tasks based on grain size and number of threads
   int64_t num_threads = omp_in_parallel() ? 1 : omp_get_max_threads();
   const int64_t num_iter = end - begin;
-  num_threads = std::min(num_threads, divup(num_iter, grain_size));
+  if (grain_size > 0) {
+    num_threads = std::min(num_threads, divup(num_iter, grain_size));
+  }
   const int64_t chunk_size = divup(num_iter, num_threads);
 
 #pragma omp parallel num_threads(num_threads)


### PR DESCRIPTION
Fixes #24080, Continuation of #26886

What @soumith said in https://github.com/pytorch/pytorch/pull/26886#issuecomment-535760635 seems plausible
> I wonder if it has to do with `#pragma omp parallel num_threads(num_threads)` which has unintended consequences, where even if `num_threads=1`, entering an omp block inside an omp block results in bad behavior.

I know for a fact that gcc's openmp doesn't start the thread pool when given `num_threads(1)` but it seems clang behaves differently.