### PR TITLE
Fix all factory invocations in quantized to correctly propagate options.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
@@ -177,7 +177,7 @@ class QConvPackWeightInt8 final : public c10::OperatorKernel {
     if (bias_in.has_value()) {
       bias_fp32 = bias_in.value();
     } else {
-      bias_fp32 = at::zeros(out_ch, at::kFloat);
+      bias_fp32 = at::zeros(out_ch, weight.options().dtype(at::kFloat));
     }
     TORCH_CHECK(
         !bias_fp32.defined() || (bias_fp32.ndimension() == 1 && bias_fp32.size(0) == out_ch),

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -140,7 +140,7 @@ class QLinearPackWeightInt8 final : public c10::OperatorKernel {
     if (bias_in.has_value()) {
       bias_fp32 = bias_in.value();
     } else {
-      bias_fp32 = at::zeros(rows_w, at::kFloat);
+      bias_fp32 = at::zeros(rows_w, weight.options().dtype(at::kFloat));
     }
     TORCH_CHECK(
         !bias_fp32.defined() || (bias_fp32.ndimension() == 1 && bias_fp32.size(0) == rows_w),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26966 Fix all factory invocations in quantized to correctly propagate options.**

Without this, you may allocate intermediates which are non-variables
when you should allocate variables.

Should help with discussion in #26868.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D17629863](https://our.internmc.facebook.com/intern/diff/D17629863)