### PR TITLE
Better named tensor error messages.

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -63,7 +63,7 @@ static void check_for_misalignment(
   TORCH_CHECK(it == other_names.end(),
       "Misaligned dims when attempting to ", action, " dims ", names, " and dims ",
       other_names, ": dim ", name, " appears in a different position from the right "
-      "across both lists");
+      "across both lists.");
 }
 
 // Assumption: A DimnameList can have no duplicate full names with
@@ -124,7 +124,7 @@ static void assert_names_equal(DimnameList a, DimnameList b) {
   TORCH_CHECK(a == b,
       "Name mismatch: specified out tensor with names ", a,
       " are not the same as the computed output names ", b,
-      ". Please rename the out tensor's dimensions.");
+      ". Please rename the out tensor's dims with `Tensor.rename`."
 }
 
 void propagate_names(TensorImpl* result, optional<DimnameList> names) {
@@ -281,7 +281,7 @@ static void check_feature_names_are_distinct(
     " with Tensor", other_names,
     " would produce output tensor with duplicate names ",
     outnames,
-    ". Please rename the input tensors to prevent this.");
+    ". Please rename the input tensors with `Tensor.rename` to prevent this.");
 }
 
 static DimnameList batch_dims(DimnameList names) {

--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -124,7 +124,7 @@ static void assert_names_equal(DimnameList a, DimnameList b) {
   TORCH_CHECK(a == b,
       "Name mismatch: specified out tensor with names ", a,
       " are not the same as the computed output names ", b,
-      ". Please rename the out tensor's dims with `Tensor.rename`."
+      ". Please rename the out tensor's dims with `Tensor.rename`.");
 }
 
 void propagate_names(TensorImpl* result, optional<DimnameList> names) {

--- a/torch/_namedtensor_internals.py
+++ b/torch/_namedtensor_internals.py
@@ -19,7 +19,7 @@ def check_serializing_named_tensor(tensor):
     if torch._C._BUILD_NAMEDTENSOR and tensor.has_names():
         raise RuntimeError(
             "NYI: Named tensors don't support serialization. Please drop "
-            "names before serialization and/or serialize them seperately.")
+            "names via `tensor = tensor.rename(None)` before serialization.")
 
 
 def build_dim_map(tensor):

--- a/torch/csrc/jit/pybind_utils.h
+++ b/torch/csrc/jit/pybind_utils.h
@@ -337,7 +337,8 @@ template <class T>
 inline void guardAgainstNamedTensor(const T& var) {
 #ifdef BUILD_NAMEDTENSOR
   TORCH_CHECK(!var.has_names(),
-      "NYI: Named tensors are currently unsupported in TorchScript.");
+      "NYI: Named tensors are currently unsupported in TorchScript. As a  "
+      "workaround please drop names via `tensor = tensor.rename(None)`.");
 #endif
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26974 Better named tensor error messages.**
* #26968 Make named tensor implementations more robust
* #26914 Named tensor support for: index_fill_, index_fill, squeeze, median(Tensor)

Suggest `Tensor.rename` to rename tensors and/or drop names on named
tensors.

Test Plan:
- [namedtensor ci]

Differential Revision: [D17628950](https://our.internmc.facebook.com/intern/diff/D17628950)