### PR TITLE
[pytorch][mobile] fix mobile.sh build

### DIFF
--- a/torch/csrc/jit/script/module.cpp
+++ b/torch/csrc/jit/script/module.cpp
@@ -96,12 +96,20 @@ void Module::save(const std::string& filename, const ExtraFilesMap& extra_files)
 }
 
 void Module::_save_for_mobile(std::ostream& out, const ExtraFilesMap& extra_files) const {
+#ifndef C10_MOBILE
   ExportModule(*this, out, extra_files, true);
+#else
+  AT_ERROR("Saving module is not supported on mobile.");
+#endif
 }
 
 void Module::_save_for_mobile(const std::string& filename, const ExtraFilesMap& extra_files)
     const {
+#ifndef C10_MOBILE
   ExportModule(*this, filename, extra_files, true);
+#else
+  AT_ERROR("Saving module is not supported on mobile.");
+#endif
 }
 
 void module_state_to(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26975 [pytorch][mobile] fix mobile.sh build**

Summary:
ExportModule doesn't exist in mobile libtorch.a, it doesn't fail for
regular mobile build guess _save_for_mobile was stripped altogether.
But for host toolchain with different linker flag this will fail.
Add #if macro as Module::save.

Test Plan:
- scripts/build_mobile.sh works;

Differential Revision: [D17629869](https://our.internmc.facebook.com/intern/diff/D17629869)