### PR TITLE
Acquire GIL before creating py::object in RPC python handler

### DIFF
--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -55,8 +55,8 @@ py::object toPyObj(const Message& message) {
       stack.push_back(ret.value());
       {
         AutoGIL ag;
-        // createPyObjectForStack does not acquire GIL but creates a new
-        // py::object
+        // The createPyObjectForStack does not acquire GIL, but creating a new
+        // py::object requires GIL.
         return torch::jit::createPyObjectForStack(std::move(stack));
       }
     }

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -53,7 +53,12 @@ py::object toPyObj(const Message& message) {
       ScriptRet ret = ScriptRet::fromMessage(message);
       Stack stack;
       stack.push_back(ret.value());
-      return torch::jit::createPyObjectForStack(std::move(stack));
+      {
+        AutoGIL ag;
+        // createPyObjectForStack does not acquire GIL but creates a new
+        // py::object
+        return torch::jit::createPyObjectForStack(std::move(stack));
+      }
     }
     case MessageType::PYTHON_RET: {
       return PythonRpcHandler::getInstance().loadPythonUDFResult(message);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#26988 Acquire GIL before creating py::object in RPC python handler**

Differential Revision: [D17635297](https://our.internmc.facebook.com/intern/diff/D17635297)