### PR TITLE
Remove outdated note in cholesky_solve and triangular_solve doc strings

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1055,11 +1055,6 @@ and `c` is returned such that:
 batches of 2D matrices. If the inputs are batches, then returns
 batched outputs `c`
 
-.. note::
-
-    The :attr:`out` keyword only supports 2D matrix inputs, that is,
-    `b, u` must be 2D matrices.
-
 Args:
     input (Tensor): input matrix :math:`b` of size :math:`(*, m, k)`,
                 where :math:`*` is zero or more batch dimensions
@@ -5464,11 +5459,6 @@ with the default keyword arguments.
 `torch.triangular_solve(b, A)` can take in 2D inputs `b, A` or inputs that are
 batches of 2D matrices. If the inputs are batches, then returns
 batched outputs `X`
-
-.. note::
-
-    The :attr:`out` keyword only supports 2D matrix inputs, that is,
-    `b, A` must be 2D matrices.
 
 Args:
     input (Tensor): multiple right-hand sides of size :math:`(*, m, k)` where


### PR DESCRIPTION
We do support inputs with dim > 2 in _out variants

